### PR TITLE
chore: Migrate zod from v3 to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
       "tmp": "0.2.4",
       "nodemailer": "7.0.11",
       "validator": "13.15.26",
-      "zod": "3.25.67",
+      "zod": "4.3.6",
       "js-yaml": "4.1.1",
       "node-forge": "1.3.2",
       "body-parser": "2.2.1",

--- a/packages/@n8n/ai-utilities/src/converters/tool.ts
+++ b/packages/@n8n/ai-utilities/src/converters/tool.ts
@@ -2,7 +2,7 @@ import type { FunctionDefinition } from '@langchain/core/language_models/base';
 import type * as LangchainChatModels from '@langchain/core/language_models/chat_models';
 import type * as LangchainTools from '@langchain/core/tools';
 import type { JSONSchema7 } from 'json-schema';
-import { ZodSchema, type ZodTypeAny } from 'zod';
+import { ZodSchema, ZodType } from 'zod';
 import zodToJsonSchema from 'zod-to-json-schema';
 
 import type * as N8nTools from '../types/tool';
@@ -17,7 +17,7 @@ export function fromLcTool(tool: LangchainChatModels.BindToolsInput): N8nTools.T
 			type: 'function',
 			name: structuredTool.name,
 			description: structuredTool.description,
-			inputSchema: structuredTool.schema as JSONSchema7 | ZodTypeAny,
+			inputSchema: structuredTool.schema as JSONSchema7 | ZodType,
 		};
 	}
 	if ('schema' in tool && 'func' in tool) {
@@ -26,7 +26,7 @@ export function fromLcTool(tool: LangchainChatModels.BindToolsInput): N8nTools.T
 			type: 'function',
 			name: structuredTool.name,
 			description: structuredTool.description,
-			inputSchema: structuredTool.schema as JSONSchema7 | ZodTypeAny,
+			inputSchema: structuredTool.schema as JSONSchema7 | ZodType,
 		};
 	}
 	if ('name' in tool && 'schema' in tool) {
@@ -35,7 +35,7 @@ export function fromLcTool(tool: LangchainChatModels.BindToolsInput): N8nTools.T
 			type: 'function',
 			name: structuredTool.name,
 			description: structuredTool.description,
-			inputSchema: structuredTool.schema as JSONSchema7 | ZodTypeAny,
+			inputSchema: structuredTool.schema as JSONSchema7 | ZodType,
 		};
 	}
 	if ('function' in tool && 'type' in tool && tool.type === 'function') {

--- a/packages/@n8n/ai-utilities/src/types/tool.ts
+++ b/packages/@n8n/ai-utilities/src/types/tool.ts
@@ -1,5 +1,5 @@
 import type { JSONSchema7 } from 'json-schema';
-import type { ZodTypeAny, ZodEffects, ZodSchema } from 'zod';
+import type { ZodEffects, ZodSchema, ZodType } from 'zod';
 
 export interface FunctionTool {
 	type: 'function';
@@ -16,7 +16,7 @@ export interface FunctionTool {
 	/**
 	 * JSON or Zod schema describing the tool's parameters
 	 */
-	inputSchema: JSONSchema7 | ZodSchema<any> | ZodEffects<ZodTypeAny>;
+	inputSchema: JSONSchema7 | ZodSchema<any> | ZodEffects<ZodType>;
 
 	/**
 	 * Whether this tool should be called strictly according to schema

--- a/packages/@n8n/ai-utilities/src/utils/fromai-tool-factory.ts
+++ b/packages/@n8n/ai-utilities/src/utils/fromai-tool-factory.ts
@@ -39,7 +39,7 @@ export function extractFromAIParameters(nodeParameters: INodeParameters): FromAI
  * Creates a Zod schema from $fromAI arguments.
  */
 export function createZodSchemaFromArgs(args: FromAIArgument[]): z.ZodObject<z.ZodRawShape> {
-	const schemaObj = args.reduce((acc: Record<string, z.ZodTypeAny>, placeholder) => {
+	const schemaObj = args.reduce((acc: Record<string, z.ZodType>, placeholder) => {
 		acc[placeholder.key] = generateZodSchema(placeholder);
 		return acc;
 	}, {});

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/argument-parser.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/argument-parser.ts
@@ -100,64 +100,55 @@ type FlagGroup =
 // Model ID validation schema
 const modelIdSchema = z.enum(AVAILABLE_MODELS as [ModelId, ...ModelId[]]);
 
-const cliSchema = z
-	.object({
-		suite: z
-			.enum([
-				'llm-judge',
-				'pairwise',
-				'programmatic',
-				'similarity',
-				'introspection',
-				'binary-checks',
-			])
-			.default('llm-judge'),
-		backend: z.enum(['local', 'langsmith']).default('local'),
-		agent: z.enum(['code-builder', 'multi-agent']).default('code-builder'),
+const cliSchema = z.strictObject({
+	suite: z
+		.enum(['llm-judge', 'pairwise', 'programmatic', 'similarity', 'introspection', 'binary-checks'])
+		.default('llm-judge'),
+	backend: z.enum(['local', 'langsmith']).default('local'),
+	agent: z.enum(['code-builder', 'multi-agent']).default('code-builder'),
 
-		verbose: z.boolean().default(false),
-		repetitions: z.coerce.number().int().positive().default(DEFAULTS.REPETITIONS),
-		concurrency: z.coerce.number().int().positive().default(DEFAULTS.CONCURRENCY),
-		timeoutMs: z.coerce.number().int().positive().default(DEFAULTS.TIMEOUT_MS),
-		experimentName: z.string().min(1).optional(),
-		outputDir: z.string().min(1).optional(),
-		outputCsv: z.string().min(1).optional(),
-		datasetName: z.string().min(1).optional(),
-		maxExamples: z.coerce.number().int().positive().optional(),
-		filter: z.array(z.string().min(1)).default([]),
-		notionId: z.string().min(1).optional(),
-		technique: z.string().min(1).optional(),
+	verbose: z.boolean().default(false),
+	repetitions: z.int().positive().default(DEFAULTS.REPETITIONS),
+	concurrency: z.int().positive().default(DEFAULTS.CONCURRENCY),
+	timeoutMs: z.int().positive().default(DEFAULTS.TIMEOUT_MS),
+	experimentName: z.string().min(1).optional(),
+	outputDir: z.string().min(1).optional(),
+	outputCsv: z.string().min(1).optional(),
+	datasetName: z.string().min(1).optional(),
+	maxExamples: z.coerce.number().int().positive().optional(),
+	filter: z.array(z.string().min(1)).default([]),
+	notionId: z.string().min(1).optional(),
+	technique: z.string().min(1).optional(),
 
-		subgraph: z.enum(['responder', 'discovery', 'builder', 'configurator']).optional(),
-		datasetFile: z.string().min(1).optional(),
-		regenerate: z.boolean().default(false),
-		writeBack: z.boolean().default(false),
+	subgraph: z.enum(['responder', 'discovery', 'builder', 'configurator']).optional(),
+	datasetFile: z.string().min(1).optional(),
+	regenerate: z.boolean().default(false),
+	writeBack: z.boolean().default(false),
 
-		testCase: z.string().min(1).optional(),
-		promptsCsv: z.string().min(1).optional(),
+	testCase: z.string().min(1).optional(),
+	promptsCsv: z.string().min(1).optional(),
 
-		prompt: z.string().min(1).optional(),
-		dos: z.string().min(1).optional(),
-		donts: z.string().min(1).optional(),
+	prompt: z.string().min(1).optional(),
+	dos: z.string().min(1).optional(),
+	donts: z.string().min(1).optional(),
 
-		numJudges: z.coerce.number().int().positive().default(DEFAULTS.NUM_JUDGES),
+	numJudges: z.int().positive().default(DEFAULTS.NUM_JUDGES),
 
-		checks: z.string().min(1).optional(),
-		langsmith: z.boolean().optional(),
-		templateExamples: z.boolean().default(false),
-		webhookUrl: z.string().url().optional(),
-		webhookSecret: z.string().min(16).optional(),
+	checks: z.string().min(1).optional(),
+	langsmith: z.boolean().optional(),
+	templateExamples: z.boolean().default(false),
+	webhookUrl: z.url().optional(),
+	webhookSecret: z.string().min(16).optional(),
 
-		// Model configuration
-		model: modelIdSchema.default(DEFAULT_MODEL),
-		judgeModel: modelIdSchema.optional(),
-		supervisorModel: modelIdSchema.optional(),
-		responderModel: modelIdSchema.optional(),
-		discoveryModel: modelIdSchema.optional(),
-		builderModel: modelIdSchema.optional(),
-		parameterUpdaterModel: modelIdSchema.optional(),
-	})
-	.strict();
+	// Model configuration
+	model: modelIdSchema.default(DEFAULT_MODEL),
+	judgeModel: modelIdSchema.optional(),
+	supervisorModel: modelIdSchema.optional(),
+	responderModel: modelIdSchema.optional(),
+	discoveryModel: modelIdSchema.optional(),
+	builderModel: modelIdSchema.optional(),
+	parameterUpdaterModel: modelIdSchema.optional(),
+});
 
 type CliKey = keyof z.infer<typeof cliSchema>;
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/ai-workflow-builder-agent.service.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/ai-workflow-builder-agent.service.ts
@@ -549,7 +549,7 @@ export class AiWorkflowBuilderService {
 				const parsed = AiWorkflowBuilderService.questionsInterruptSchema.safeParse(m);
 				if (parsed.success) return parsed.data;
 				this.logger?.warn('[HITL] Invalid questions interrupt data', {
-					errors: parsed.error.errors,
+					errors: parsed.error.issues,
 				});
 				continue;
 			}
@@ -558,7 +558,7 @@ export class AiWorkflowBuilderService {
 				const parsed = AiWorkflowBuilderService.planInterruptSchema.safeParse(m);
 				if (parsed.success) return parsed.data;
 				this.logger?.warn('[HITL] Invalid plan interrupt data', {
-					errors: parsed.error.errors,
+					errors: parsed.error.issues,
 				});
 				continue;
 			}
@@ -567,7 +567,7 @@ export class AiWorkflowBuilderService {
 				const parsed = AiWorkflowBuilderService.webFetchApprovalInterruptSchema.safeParse(m);
 				if (parsed.success) return parsed.data;
 				this.logger?.warn('[HITL] Invalid web_fetch_approval interrupt data', {
-					errors: parsed.error.errors,
+					errors: parsed.error.issues,
 				});
 				continue;
 			}

--- a/packages/@n8n/ai-workflow-builder.ee/src/chains/parameter-updater.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/chains/parameter-updater.ts
@@ -22,8 +22,7 @@ import type { ParameterUpdaterOptions } from '../types/config';
 export const parametersSchema = z
 	.object({
 		parameters: z
-			.object({})
-			.passthrough()
+			.looseObject({})
 			.describe(
 				"The complete updated parameters object for the node. This should be a JSON object that matches the node's parameter structure. Include ALL existing parameters plus the requested changes.",
 			),

--- a/packages/@n8n/ai-workflow-builder.ee/src/chains/prompt-categorization.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/chains/prompt-categorization.ts
@@ -13,7 +13,7 @@ export async function promptCategorizationChain(
 ): Promise<PromptCategorization> {
 	const categorizationSchema = z.object({
 		techniques: z
-			.array(z.nativeEnum(WorkflowTechnique))
+			.array(z.enum(WorkflowTechnique))
 			.min(0)
 			.describe('Workflow techniques identified in the prompt'),
 		confidence: z

--- a/packages/@n8n/ai-workflow-builder.ee/src/subgraphs/discovery.subgraph.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/subgraphs/discovery.subgraph.ts
@@ -521,7 +521,7 @@ export class DiscoverySubgraph extends BaseSubgraph<
 					this.logger?.error(
 						'[Discovery] Invalid discovery output schema - returning empty results',
 						{
-							errors: parseResult.error.errors,
+							errors: parseResult.error.issues,
 							lastMessageContent:
 								typeof lastMessage?.content === 'string'
 									? lastMessage.content.substring(0, 200)

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/add-node.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/add-node.tool.ts
@@ -51,8 +51,7 @@ const baseSchema = {
 			'REQUIRED: Explain your reasoning about initial parameters. Consider: Does this node have dynamic inputs/outputs? Does it need mode/operation/resource parameters? For example: "Vector Store has dynamic inputs based on mode, so I need to set mode:insert for document input" or "Gmail needs resource:message and operation:send to send emails"',
 		),
 	initialParameters: z
-		.object({})
-		.passthrough()
+		.looseObject({})
 		.describe(
 			'Initial parameters to set on the node. This includes: (1) connection-affecting parameters like mode, hasOutputParser, textSplittingMode; (2) resource/operation for nodes with multiple resources (Gmail, Notion, Google Sheets, etc.). Pass an empty object {} if no initial parameters are needed.',
 		),
@@ -241,7 +240,7 @@ export function createAddNodeTool(nodeTypes: INodeTypeDescription[]): BuilderToo
 				// Handle validation or unexpected errors
 				if (error instanceof z.ZodError) {
 					const validationError = new ValidationError('Invalid input parameters', {
-						extra: { errors: error.errors },
+						extra: { errors: error.issues },
 					});
 					reporter.error(validationError);
 					return createErrorResponse(config, validationError);

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/connect-nodes.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/connect-nodes.tool.ts
@@ -282,13 +282,13 @@ export function createConnectNodesTool(
 
 				if (error instanceof z.ZodError) {
 					const validationError = new ValidationError('Invalid connection parameters', {
-						field: error.errors[0]?.path.join('.'),
-						value: error.errors[0]?.message,
+						field: error.issues[0]?.path.join('.'),
+						value: error.issues[0]?.message,
 					});
 					toolError = {
 						message: validationError.message,
 						code: 'VALIDATION_ERROR',
-						details: error.errors,
+						details: error.issues,
 					};
 				} else {
 					toolError = {

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/get-documentation.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/get-documentation.tool.ts
@@ -28,7 +28,7 @@ export const DocumentationType = {
 const bestPracticesRequestSchema = z.object({
 	type: z.literal(DocumentationType.BEST_PRACTICES),
 	techniques: z
-		.array(z.nativeEnum(WorkflowTechnique))
+		.array(z.enum(WorkflowTechnique))
 		.min(1)
 		.describe('Workflow techniques to get best practices for'),
 });
@@ -39,7 +39,7 @@ const bestPracticesRequestSchema = z.object({
 const nodeRecommendationsRequestSchema = z.object({
 	type: z.literal(DocumentationType.NODE_RECOMMENDATIONS),
 	categories: z
-		.array(z.nativeEnum(RecommendationCategory))
+		.array(z.enum(RecommendationCategory))
 		.min(1)
 		.describe('Task categories to get node recommendations for'),
 });
@@ -176,7 +176,7 @@ export function createGetDocumentationTool() {
 			} catch (error) {
 				if (error instanceof z.ZodError) {
 					const validationError = new ValidationError('Invalid input parameters', {
-						extra: { errors: error.errors },
+						extra: { errors: error.issues },
 					});
 					reporter.error(validationError);
 					return createErrorResponse(config, validationError);

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/get-execution-logs.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/get-execution-logs.tool.ts
@@ -125,7 +125,7 @@ export function createGetExecutionLogsTool(logger?: Logger): BuilderTool {
 				// Handle validation or unexpected errors
 				if (error instanceof z.ZodError) {
 					const validationError = new ValidationError('Invalid input parameters', {
-						extra: { errors: error.errors },
+						extra: { errors: error.issues },
 					});
 					reporter.error(validationError);
 					return createErrorResponse(config, validationError);

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/get-execution-schema.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/get-execution-schema.tool.ts
@@ -93,7 +93,7 @@ export function createGetExecutionSchemaTool(logger?: Logger): BuilderTool {
 				// Handle validation or unexpected errors
 				if (error instanceof z.ZodError) {
 					const validationError = new ValidationError('Invalid input parameters', {
-						extra: { errors: error.errors },
+						extra: { errors: error.issues },
 					});
 					reporter.error(validationError);
 					return createErrorResponse(config, validationError);

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/get-expression-data-mapping.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/get-expression-data-mapping.tool.ts
@@ -98,7 +98,7 @@ export function createGetExpressionDataMappingTool(logger?: Logger): BuilderTool
 				// Handle validation or unexpected errors
 				if (error instanceof z.ZodError) {
 					const validationError = new ValidationError('Invalid input parameters', {
-						extra: { errors: error.errors },
+						extra: { errors: error.issues },
 					});
 					reporter.error(validationError);
 					return createErrorResponse(config, validationError);

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/get-node-context.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/get-node-context.tool.ts
@@ -329,7 +329,7 @@ export function createGetNodeContextTool(logger?: Logger): BuilderTool {
 				// Handle validation or unexpected errors
 				if (error instanceof z.ZodError) {
 					const validationError = new ValidationError('Invalid input parameters', {
-						extra: { errors: error.errors },
+						extra: { errors: error.issues },
 					});
 					reporter.error(validationError);
 					return createErrorResponse(config, validationError);

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/get-node-examples.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/get-node-examples.tool.ts
@@ -206,7 +206,7 @@ function handleToolError(
 ) {
 	if (error instanceof z.ZodError) {
 		const validationError = new ValidationError('Invalid input parameters', {
-			extra: { errors: error.errors },
+			extra: { errors: error.issues },
 		});
 		reporter.error(validationError);
 		return createErrorResponse(config, validationError);

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/get-node-parameter.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/get-node-parameter.tool.ts
@@ -130,7 +130,7 @@ export function createGetNodeParameterTool(logger?: Logger): BuilderTool {
 				// Handle validation or unexpected errors
 				if (error instanceof z.ZodError) {
 					const validationError = new ValidationError('Invalid input parameters', {
-						extra: { errors: error.errors },
+						extra: { errors: error.issues },
 					});
 					reporter.error(validationError);
 					return createErrorResponse(config, validationError);

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/get-resource-locator-options.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/get-resource-locator-options.tool.ts
@@ -218,7 +218,7 @@ export function createGetResourceLocatorOptionsTool(
 			} catch (error) {
 				if (error instanceof z.ZodError) {
 					const validationError = new ValidationError('Invalid input parameters', {
-						extra: { errors: error.errors },
+						extra: { errors: error.issues },
 					});
 					reporter.error(validationError);
 					return createErrorResponse(config, validationError);

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/get-workflow-examples.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/get-workflow-examples.tool.ts
@@ -182,7 +182,7 @@ export function createGetWorkflowExamplesTool(logger?: Logger) {
 				// Handle validation or unexpected errors
 				if (error instanceof z.ZodError) {
 					const validationError = new ValidationError('Invalid input parameters', {
-						extra: { errors: error.errors },
+						extra: { errors: error.issues },
 					});
 					reporter.error(validationError);
 					return createErrorResponse(config, validationError);

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/get-workflow-overview.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/get-workflow-overview.tool.ts
@@ -211,7 +211,7 @@ export function createGetWorkflowOverviewTool(logger?: Logger): BuilderTool {
 				// Handle validation or unexpected errors
 				if (error instanceof z.ZodError) {
 					const validationError = new ValidationError('Invalid input parameters', {
-						extra: { errors: error.errors },
+						extra: { errors: error.issues },
 					});
 					reporter.error(validationError);
 					return createErrorResponse(config, validationError);

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/introspect.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/introspect.tool.ts
@@ -134,7 +134,7 @@ export function createIntrospectTool(logger?: Logger) {
 			} catch (error) {
 				if (error instanceof z.ZodError) {
 					const validationError = new ValidationError('Invalid input parameters', {
-						extra: { errors: error.errors },
+						extra: { errors: error.issues },
 					});
 					reporter.error(validationError);
 					return createErrorResponse(config, validationError);

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/node-details.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/node-details.tool.ts
@@ -323,7 +323,7 @@ export function createNodeDetailsTool(nodeTypes: INodeTypeDescription[], logger?
 				// Handle validation or unexpected errors
 				if (error instanceof z.ZodError) {
 					const validationError = new ValidationError('Invalid input parameters', {
-						extra: { errors: error.errors },
+						extra: { errors: error.issues },
 					});
 					reporter.error(validationError);
 					return createErrorResponse(config, validationError);

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/node-search.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/node-search.tool.ts
@@ -18,7 +18,7 @@ const searchQuerySchema = z.object({
 	queryType: z.enum(['name', 'subNodeSearch']).describe('Type of search to perform'),
 	query: z.string().optional().describe('Search term to filter results'),
 	connectionType: z
-		.nativeEnum(NodeConnectionTypes)
+		.enum(NodeConnectionTypes)
 		.optional()
 		.describe('For subNodeSearch: connection type like ai_languageModel, ai_tool, etc.'),
 });
@@ -178,7 +178,7 @@ export function createNodeSearchTool(nodeTypes: INodeTypeDescription[]) {
 				// Handle validation or unexpected errors
 				if (error instanceof z.ZodError) {
 					const validationError = new ValidationError('Invalid input parameters', {
-						extra: { errors: error.errors },
+						extra: { errors: error.issues },
 					});
 					reporter.error(validationError);
 					return createErrorResponse(config, validationError);

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/remove-connection.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/remove-connection.tool.ts
@@ -269,13 +269,13 @@ export function createRemoveConnectionTool(logger?: Logger): BuilderTool {
 
 				if (error instanceof z.ZodError) {
 					const validationError = new ValidationError('Invalid connection removal parameters', {
-						field: error.errors[0]?.path.join('.'),
-						value: error.errors[0]?.message,
+						field: error.issues[0]?.path.join('.'),
+						value: error.issues[0]?.message,
 					});
 					toolError = {
 						message: validationError.message,
 						code: 'VALIDATION_ERROR',
-						details: error.errors,
+						details: error.issues,
 					};
 				} else {
 					toolError = {

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/remove-node.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/remove-node.tool.ts
@@ -139,7 +139,7 @@ export function createRemoveNodeTool(_logger?: Logger): BuilderTool {
 				// Handle validation or unexpected errors
 				if (error instanceof z.ZodError) {
 					const validationError = new ValidationError('Invalid input parameters', {
-						extra: { errors: error.errors },
+						extra: { errors: error.issues },
 					});
 					reporter.error(validationError);
 					return createErrorResponse(config, validationError);

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/rename-node.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/rename-node.tool.ts
@@ -127,13 +127,13 @@ export function createRenameNodeTool(logger?: Logger): BuilderTool {
 
 				if (error instanceof z.ZodError) {
 					const validationError = new ValidationError('Invalid rename node parameters', {
-						field: error.errors[0]?.path.join('.'),
-						value: error.errors[0]?.message,
+						field: error.issues[0]?.path.join('.'),
+						value: error.issues[0]?.message,
 					});
 					toolError = {
 						message: validationError.message,
 						code: 'VALIDATION_ERROR',
-						details: error.errors,
+						details: error.issues,
 					};
 				} else {
 					toolError = {

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/submit-questions.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/submit-questions.tool.ts
@@ -23,7 +23,7 @@ const questionResponseSchema = z.object({
 });
 
 const answersArraySchema = z.array(questionResponseSchema);
-const answersRecordSchema = z.record(z.union([z.string(), z.array(z.string())]));
+const answersRecordSchema = z.record(z.string(), z.union([z.string(), z.array(z.string())]));
 
 type PlannerQuestionInput = z.infer<typeof plannerQuestionSchema>;
 type SubmitQuestionsInput = z.infer<typeof submitQuestionsInputSchema>;

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/update-node-parameters.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/update-node-parameters.tool.ts
@@ -495,7 +495,7 @@ export function createUpdateNodeParametersTool(
 				// Handle validation or unexpected errors
 				if (error instanceof z.ZodError) {
 					const validationError = new ValidationError('Invalid input parameters', {
-						extra: { errors: error.errors },
+						extra: { errors: error.issues },
 					});
 					reporter.error(validationError);
 					return createErrorResponse(config, validationError);

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/validate-configuration.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/validate-configuration.tool.ts
@@ -15,7 +15,7 @@ import { createProgressReporter, reportProgress } from './helpers/progress';
 import { createErrorResponse, createSuccessResponse } from './helpers/response';
 import { getEffectiveWorkflow } from './helpers/state';
 
-const validateConfigurationSchema = z.object({}).strict().default({});
+const validateConfigurationSchema = z.strictObject({}).default({});
 
 export const VALIDATE_CONFIGURATION_TOOL: BuilderToolBase = {
 	toolName: 'validate_configuration',
@@ -79,7 +79,7 @@ export function createValidateConfigurationTool(
 			} catch (error) {
 				if (error instanceof z.ZodError) {
 					const validationError = new ValidationError('Invalid input parameters', {
-						extra: { errors: error.errors },
+						extra: { errors: error.issues },
 					});
 					reporter.error(validationError);
 					return createErrorResponse(config, validationError);

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/validate-structure.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/validate-structure.tool.ts
@@ -10,7 +10,7 @@ import { createProgressReporter, reportProgress } from './helpers/progress';
 import { createErrorResponse, createSuccessResponse } from './helpers/response';
 import { getEffectiveWorkflow } from './helpers/state';
 
-const validateStructureSchema = z.object({}).strict().default({});
+const validateStructureSchema = z.strictObject({}).default({});
 
 export const VALIDATE_STRUCTURE_TOOL: BuilderToolBase = {
 	toolName: 'validate_structure',
@@ -60,7 +60,7 @@ export function createValidateStructureTool(parsedNodeTypes: INodeTypeDescriptio
 			} catch (error) {
 				if (error instanceof z.ZodError) {
 					const validationError = new ValidationError('Invalid input parameters', {
-						extra: { errors: error.errors },
+						extra: { errors: error.issues },
 					});
 					reporter.error(validationError);
 					return createErrorResponse(config, validationError);

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/web-fetch.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/web-fetch.tool.ts
@@ -78,7 +78,7 @@ export const WEB_FETCH_TOOL: BuilderToolBase = {
 };
 
 const webFetchSchema = z.object({
-	url: z.string().url().describe('The URL to fetch content from'),
+	url: z.url().describe('The URL to fetch content from'),
 });
 
 /**
@@ -289,7 +289,7 @@ export function createWebFetchTool(createSecurity: () => WebFetchSecurityManager
 			} catch (error) {
 				if (error instanceof z.ZodError) {
 					const validationError = new ValidationError('Invalid URL input', {
-						extra: { errors: error.errors },
+						extra: { errors: error.issues },
 					});
 					reporter.error(validationError);
 					return createErrorResponse(config, validationError);

--- a/packages/@n8n/api-types/src/chat-hub.ts
+++ b/packages/@n8n/api-types/src/chat-hub.ts
@@ -323,7 +323,7 @@ export const StrictTimeZoneSchema = z
 	.max(50)
 	.regex(/^[A-Za-z0-9_/+-]+$/)
 	.refine(isValidTimeZone, {
-		message: 'Unknown or invalid time zone',
+		error: 'Unknown or invalid time zone',
 	});
 
 export const TimeZoneSchema = StrictTimeZoneSchema.optional().catch(undefined);
@@ -331,12 +331,13 @@ export const TimeZoneSchema = StrictTimeZoneSchema.optional().catch(undefined);
 export type ChatAttachment = z.infer<typeof chatAttachmentSchema>;
 
 export class ChatHubSendMessageRequest extends Z.class({
-	messageId: z.string().uuid(),
-	sessionId: z.string().uuid(),
+	messageId: z.uuid(),
+	sessionId: z.uuid(),
 	message: z.string(),
 	model: chatHubConversationModelSchema,
-	previousMessageId: z.string().uuid().nullable(),
+	previousMessageId: z.uuid().nullable(),
 	credentials: z.record(
+		z.string(),
 		z.object({
 			id: z.string(),
 			name: z.string(),
@@ -350,6 +351,7 @@ export class ChatHubSendMessageRequest extends Z.class({
 export class ChatHubRegenerateMessageRequest extends Z.class({
 	model: chatHubConversationModelSchema,
 	credentials: z.record(
+		z.string(),
 		z.object({
 			id: z.string(),
 			name: z.string(),
@@ -360,9 +362,10 @@ export class ChatHubRegenerateMessageRequest extends Z.class({
 
 export class ChatHubEditMessageRequest extends Z.class({
 	message: z.string(),
-	messageId: z.string().uuid(),
+	messageId: z.uuid(),
 	model: chatHubConversationModelSchema,
 	credentials: z.record(
+		z.string(),
 		z.object({
 			id: z.string(),
 			name: z.string(),
@@ -382,7 +385,7 @@ export class ChatHubUpdateConversationRequest extends Z.class({
 			name: z.string(),
 		})
 		.optional(),
-	toolIds: z.array(z.string().uuid()).optional(),
+	toolIds: z.array(z.uuid()).optional(),
 }) {}
 
 export type ChatHubMessageType = 'human' | 'ai' | 'system' | 'tool' | 'generic';
@@ -454,7 +457,7 @@ export interface ChatHubMessageDto {
 
 export class ChatHubConversationsRequest extends Z.class({
 	limit: z.coerce.number().int().min(1).max(100),
-	cursor: z.string().uuid().optional(),
+	cursor: z.uuid().optional(),
 }) {}
 
 export interface ChatHubConversationsResponse {
@@ -507,7 +510,7 @@ export class ChatHubCreateAgentRequest extends Z.class({
 	credentialId: z.string(),
 	provider: chatHubLLMProviderSchema,
 	model: z.string().max(64),
-	toolIds: z.array(z.string().uuid()),
+	toolIds: z.array(z.uuid()),
 }) {}
 
 export class ChatHubUpdateAgentRequest extends Z.class({
@@ -519,7 +522,7 @@ export class ChatHubUpdateAgentRequest extends Z.class({
 	credentialId: z.string().optional(),
 	provider: chatHubLLMProviderSchema.optional(),
 	model: z.string().max(64).optional(),
-	toolIds: z.array(z.string().uuid()).optional(),
+	toolIds: z.array(z.uuid()).optional(),
 }) {}
 
 export interface MessageChunk {

--- a/packages/@n8n/api-types/src/dto/ai/ai-build-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/ai/ai-build-request.dto.ts
@@ -1,4 +1,3 @@
-import type { IRunExecutionData, IWorkflowBase, NodeExecutionSchema } from 'n8n-workflow';
 import { z } from 'zod';
 
 import { Z } from '../../zod-class';
@@ -34,70 +33,56 @@ export class AiBuilderChatRequestDto extends Z.class({
 		versionId: z.string().optional(),
 		workflowContext: z.object({
 			currentWorkflow: z
-				.custom<Partial<IWorkflowBase>>((val: Partial<IWorkflowBase>) => {
+				.looseObject({
+					nodes: z.unknown(),
+					connections: z.unknown(),
+				})
+				.refine((val) => {
 					if (!val.nodes && !val.connections) {
 						return false;
 					}
-
-					return val;
+					return true;
 				})
 				.optional(),
 
 			executionData: z
-				.custom<IRunExecutionData['resultData']>((val: IRunExecutionData['resultData']) => {
+				.looseObject({
+					runData: z.unknown(),
+					error: z.unknown(),
+				})
+				.refine((val) => {
 					if (!val.runData && !val.error) {
 						return false;
 					}
 
-					return val;
+					return true;
 				})
 				.optional(),
 
 			executionSchema: z
-				.custom<NodeExecutionSchema[]>((val: NodeExecutionSchema[]) => {
-					// Check if the array is empty or if all items have nodeName and schema properties
-					if (!Array.isArray(val) || val.every((item) => !item.nodeName || !item.schema)) {
-						return false;
-					}
-
-					return val;
-				})
+				.array(
+					z.object({
+						nodeName: z.string(),
+						schema: z.unknown(),
+					}),
+				)
 				.optional(),
 
 			expressionValues: z
-				.custom<Record<string, ExpressionValue[]>>((val: Record<string, ExpressionValue[]>) => {
-					const keys = Object.keys(val);
-					// Check if the array is empty or if all items have nodeName and schema properties
-					if (keys.length > 0 && keys.every((key) => val[key].every((v) => !v.expression))) {
-						return false;
-					}
-
-					return val;
-				})
+				.record(z.string(), z.array(z.object({ expression: z.string().min(1) })))
 				.optional(),
+
 			valuesExcluded: z.boolean().optional(),
 			pinnedNodes: z.array(z.string()).optional(),
 
-			selectedNodes: z
-				.custom<SelectedNodeContext[]>((val: SelectedNodeContext[]) => {
-					if (!Array.isArray(val)) {
-						return false;
-					}
-					if (val.length === 0) {
-						return val;
-					}
-					if (
-						val.every(
-							(item) =>
-								typeof item.name === 'string' &&
-								Array.isArray(item.incomingConnections) &&
-								Array.isArray(item.outgoingConnections),
-						)
-					) {
-						return val;
-					}
-					return false;
-				})
+			selected: z
+				.array(
+					z.object({
+						name: z.string(),
+						incomingConnections: z.array(z.unknown()),
+						outgoingConnections: z.array(z.unknown()),
+					}),
+				)
 				.optional(),
 		}),
 		featureFlags: z

--- a/packages/@n8n/api-types/src/dto/ai/ai-build-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/ai/ai-build-request.dto.ts
@@ -110,6 +110,6 @@ export class AiBuilderChatRequestDto extends Z.class({
 			})
 			.optional(),
 		mode: z.enum(['build', 'plan']).optional(),
-		resumeData: z.union([z.record(z.unknown()), z.array(z.unknown())]).optional(),
+		resumeData: z.union([z.record(z.string(), z.unknown()), z.array(z.unknown())]).optional(),
 	}),
 }) {}

--- a/packages/@n8n/api-types/src/dto/ai/ai-chat-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/ai/ai-chat-request.dto.ts
@@ -5,7 +5,7 @@ import { Z } from '../../zod-class';
 
 export class AiChatRequestDto
 	extends Z.class({
-		payload: z.object({}).passthrough(), // Allow any object shape
+		payload: z.looseObject({}), // Allow any object shape
 		sessionId: z.string().optional(),
 	})
 	implements AiAssistantSDK.ChatRequestPayload {}

--- a/packages/@n8n/api-types/src/dto/api-keys/create-api-key-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/api-keys/create-api-key-request.dto.ts
@@ -8,8 +8,7 @@ const isTimeNullOrInFuture = (value: number | null) => {
 };
 
 export class CreateApiKeyRequestDto extends UpdateApiKeyRequestDto.extend({
-	expiresAt: z
-		.number()
-		.nullable()
-		.refine(isTimeNullOrInFuture, { message: 'Expiration date must be in the future or null' }),
+	expiresAt: z.number().nullable().refine(isTimeNullOrInFuture, {
+		error: 'Expiration date must be in the future or null',
+	}),
 }) {}

--- a/packages/@n8n/api-types/src/dto/auth/resolve-signup-token-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/auth/resolve-signup-token-query.dto.ts
@@ -5,8 +5,8 @@ import { Z } from '../../zod-class';
 // Support both legacy format (inviterId + inviteeId) and new JWT format (token)
 // All fields are optional at the schema level, but validation ensures either token OR (inviterId AND inviteeId) are provided
 const resolveSignupTokenShape = {
-	inviterId: z.string().uuid().optional(),
-	inviteeId: z.string().uuid().optional(),
+	inviterId: z.uuid().optional(),
+	inviteeId: z.uuid().optional(),
 	token: z.string().optional(),
 };
 

--- a/packages/@n8n/api-types/src/dto/binary-data/binary-data-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/binary-data/binary-data-query.dto.ts
@@ -6,7 +6,7 @@ export class BinaryDataQueryDto extends Z.class({
 	id: z
 		.string()
 		.refine((id) => id.includes(':'), {
-			message: 'Missing binary data mode',
+			error: 'Missing binary data mode',
 		})
 		.refine(
 			(id) => {
@@ -14,7 +14,7 @@ export class BinaryDataQueryDto extends Z.class({
 				return ['database', 'filesystem', 'filesystem-v2', 's3'].includes(mode);
 			},
 			{
-				message: 'Invalid binary data mode',
+				error: 'Invalid binary data mode',
 			},
 		),
 	action: z.enum(['view', 'download']),

--- a/packages/@n8n/api-types/src/dto/binary-data/binary-data-signed-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/binary-data/binary-data-signed-query.dto.ts
@@ -4,6 +4,6 @@ import { Z } from '../../zod-class';
 
 export class BinaryDataSignedQueryDto extends Z.class({
 	token: z.string().regex(/^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/, {
-		message: 'Token must be a valid JWT format',
+		error: 'Token must be a valid JWT format',
 	}),
 }) {}

--- a/packages/@n8n/api-types/src/dto/credentials/credentials-get-many-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/credentials-get-many-request.dto.ts
@@ -27,7 +27,7 @@ export class CredentialsGetManyRequestQuery extends Z.class({
 	 * Includes global credentials (credentials available to all users).
 	 * Defaults to false.
 	 */
-	includeGlobal: booleanFromString.optional().default('false'),
+	includeGlobal: booleanFromString.optional().default(false),
 
 	/**
 	 * Filters credentials to only include those that are using a specific external secrets provider.

--- a/packages/@n8n/api-types/src/dto/credentials/credentials-get-one-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/credentials-get-one-request.dto.ts
@@ -8,5 +8,5 @@ export class CredentialsGetOneRequestQuery extends Z.class({
 	 * It only does this for credentials for which the user has the
 	 * `credential:update` scope.
 	 */
-	includeData: booleanFromString.optional().default('false'),
+	includeData: booleanFromString.optional().default(false),
 }) {}

--- a/packages/@n8n/api-types/src/dto/data-table/delete-data-table-rows.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-table/delete-data-table-rows.dto.ts
@@ -7,7 +7,7 @@ import { Z } from '../../zod-class';
 const dataTableFilterQueryValidator = z.string().transform((val, ctx) => {
 	if (!val) {
 		ctx.addIssue({
-			code: z.ZodIssueCode.custom,
+			code: 'custom',
 			message: 'Filter is required for delete operations',
 			path: ['filter'],
 		});
@@ -21,7 +21,7 @@ const dataTableFilterQueryValidator = z.string().transform((val, ctx) => {
 			// Ensure filters array is not empty
 			if (!result.filters || result.filters.length === 0) {
 				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
+					code: 'custom',
 					message: 'At least one filter condition is required for delete operations',
 					path: ['filter'],
 				});
@@ -30,7 +30,7 @@ const dataTableFilterQueryValidator = z.string().transform((val, ctx) => {
 			return result;
 		} catch (e) {
 			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
+				code: 'custom',
 				message: 'Invalid filter fields',
 				path: ['filter'],
 			});
@@ -38,7 +38,7 @@ const dataTableFilterQueryValidator = z.string().transform((val, ctx) => {
 		}
 	} catch (e) {
 		ctx.addIssue({
-			code: z.ZodIssueCode.custom,
+			code: 'custom',
 			message: 'Invalid filter format',
 			path: ['filter'],
 		});

--- a/packages/@n8n/api-types/src/dto/data-table/list-data-table-content-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-table/list-data-table-content-query.dto.ts
@@ -17,7 +17,7 @@ const filterValidator = z
 				return dataTableFilterSchema.parse(parsed);
 			} catch (e) {
 				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
+					code: 'custom',
 					message: 'Invalid filter fields',
 					path: ['filter'],
 				});
@@ -25,7 +25,7 @@ const filterValidator = z
 			}
 		} catch (e) {
 			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
+				code: 'custom',
 				message: 'Invalid filter format',
 				path: ['filter'],
 			});
@@ -41,7 +41,7 @@ const sortByValidator = z
 
 		if (!val.includes(':')) {
 			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
+				code: 'custom',
 				message: 'Invalid sort format, expected <columnName>:<asc/desc>',
 				path: ['sort'],
 			});
@@ -56,7 +56,7 @@ const sortByValidator = z
 			const errorMessage =
 				e instanceof z.ZodError ? e.errors[0]?.message : 'Invalid sort columnName';
 			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
+				code: 'custom',
 				message: errorMessage,
 				path: ['sortBy'],
 			});
@@ -66,7 +66,7 @@ const sortByValidator = z
 		direction = direction?.toUpperCase();
 		if (direction !== 'ASC' && direction !== 'DESC') {
 			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
+				code: 'custom',
 				message: 'Invalid sort direction',
 				path: ['sort'],
 			});

--- a/packages/@n8n/api-types/src/dto/data-table/list-data-table-content-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-table/list-data-table-content-query.dto.ts
@@ -54,7 +54,7 @@ const sortByValidator = z
 			column = dataTableColumnNameSchema.parse(column);
 		} catch (e) {
 			const errorMessage =
-				e instanceof z.ZodError ? e.errors[0]?.message : 'Invalid sort columnName';
+				e instanceof z.ZodError ? e.issues[0]?.message : 'Invalid sort columnName';
 			ctx.addIssue({
 				code: 'custom',
 				message: errorMessage,

--- a/packages/@n8n/api-types/src/dto/data-table/list-data-table-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-table/list-data-table-query.dto.ts
@@ -25,7 +25,7 @@ const FILTER_OPTIONS = {
 };
 
 // Filter schema - only allow specific properties
-const filterSchema = z.object(FILTER_OPTIONS).strict();
+const filterSchema = z.strictObject(FILTER_OPTIONS);
 // ---------------------
 // Parameter Validators
 // ---------------------
@@ -42,7 +42,7 @@ const filterValidator = z
 				return filterSchema.parse(parsed);
 			} catch (e) {
 				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
+					code: 'custom',
 					message: 'Invalid filter fields',
 					path: ['filter'],
 				});
@@ -50,7 +50,7 @@ const filterValidator = z
 			}
 		} catch (e) {
 			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
+				code: 'custom',
 				message: 'Invalid filter format',
 				path: ['filter'],
 			});

--- a/packages/@n8n/api-types/src/dto/data-table/move-data-table-column.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-table/move-data-table-column.dto.ts
@@ -3,5 +3,5 @@ import { z } from 'zod';
 import { Z } from '../../zod-class';
 
 export class MoveDataTableColumnDto extends Z.class({
-	targetIndex: z.number().int().nonnegative(),
+	targetIndex: z.int().nonnegative(),
 }) {}

--- a/packages/@n8n/api-types/src/dto/data-table/update-data-table-row.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-table/update-data-table-row.dto.ts
@@ -16,7 +16,7 @@ const updateDataTableRowShape = {
 	data: z
 		.record(dataTableColumnNameSchema, dataTableColumnValueSchema)
 		.refine((obj) => Object.keys(obj).length > 0, {
-			message: 'data must not be empty',
+			error: 'data must not be empty',
 		}),
 	returnData: z.boolean().optional().default(false),
 	dryRun: z.boolean().optional().default(false),

--- a/packages/@n8n/api-types/src/dto/data-table/upsert-data-table-row.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-table/upsert-data-table-row.dto.ts
@@ -16,7 +16,7 @@ const upsertDataTableRowShape = {
 	data: z
 		.record(dataTableColumnNameSchema, dataTableColumnValueSchema)
 		.refine((obj) => Object.keys(obj).length > 0, {
-			message: 'data must not be empty',
+			error: 'data must not be empty',
 		}),
 	returnData: z.boolean().optional().default(false),
 	dryRun: z.boolean().optional().default(false),

--- a/packages/@n8n/api-types/src/dto/executions/execution-redaction-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/executions/execution-redaction-query.dto.ts
@@ -2,10 +2,8 @@ import { z } from 'zod';
 
 import { booleanFromString } from '../../schemas/boolean-from-string';
 
-export const ExecutionRedactionQueryDtoSchema = z
-	.object({
-		redactExecutionData: booleanFromString.optional(),
-	})
-	.passthrough();
+export const ExecutionRedactionQueryDtoSchema = z.looseObject({
+	redactExecutionData: booleanFromString.optional(),
+});
 
 export type ExecutionRedactionQueryDto = z.output<typeof ExecutionRedactionQueryDtoSchema>;

--- a/packages/@n8n/api-types/src/dto/folders/list-folder-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/folders/list-folder-query.dto.ts
@@ -26,14 +26,12 @@ const VALID_SORT_OPTIONS = [
 ] as const;
 
 // Filter schema - only allow specific properties
-export const filterSchema = z
-	.object({
-		parentFolderId: z.string().optional(),
-		name: z.string().optional(),
-		tags: z.array(z.string()).optional(),
-		excludeFolderIdAndDescendants: z.string().optional(),
-	})
-	.strict();
+export const filterSchema = z.strictObject({
+	parentFolderId: z.string().optional(),
+	name: z.string().optional(),
+	tags: z.array(z.string()).optional(),
+	excludeFolderIdAndDescendants: z.string().optional(),
+});
 
 // ---------------------
 // Parameter Validators
@@ -51,7 +49,7 @@ const filterValidator = z
 				return filterSchema.parse(parsed);
 			} catch (e) {
 				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
+					code: 'custom',
 					message: 'Invalid filter fields',
 					path: ['filter'],
 				});
@@ -59,7 +57,7 @@ const filterValidator = z
 			}
 		} catch (e) {
 			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
+				code: 'custom',
 				message: 'Invalid filter format',
 				path: ['filter'],
 			});
@@ -73,7 +71,7 @@ const skipValidator = z
 	.optional()
 	.transform((val) => (val ? parseInt(val, 10) : 0))
 	.refine((val) => !isNaN(val), {
-		message: 'Skip must be a valid number',
+		error: 'Skip must be a valid number',
 	});
 
 // Take parameter validation
@@ -82,7 +80,7 @@ const takeValidator = z
 	.optional()
 	.transform((val) => (val ? parseInt(val, 10) : 10))
 	.refine((val) => !isNaN(val), {
-		message: 'Take must be a valid number',
+		error: 'Take must be a valid number',
 	});
 
 // Select parameter validation
@@ -104,7 +102,7 @@ const selectValidator = z
 				);
 			} catch (e) {
 				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
+					code: 'custom',
 					message: `Invalid select fields. Valid fields are: ${VALID_SELECT_FIELDS.join(', ')}`,
 					path: ['select'],
 				});
@@ -112,7 +110,7 @@ const selectValidator = z
 			}
 		} catch (e) {
 			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
+				code: 'custom',
 				message: 'Invalid select format',
 				path: ['select'],
 			});

--- a/packages/@n8n/api-types/src/dto/invitation/accept-invitation-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/invitation/accept-invitation-request.dto.ts
@@ -6,8 +6,8 @@ import { Z } from '../../zod-class';
 // Support both legacy format (inviterId) and new JWT format (token)
 // All fields are optional at the schema level, but validation ensures either token OR inviterId is provided
 export class AcceptInvitationRequestDto extends Z.class({
-	inviterId: z.string().uuid().optional(),
-	inviteeId: z.string().uuid().optional(),
+	inviterId: z.uuid().optional(),
+	inviteeId: z.uuid().optional(),
 	token: z.string().optional(),
 	firstName: z.string().min(1, 'First name is required'),
 	lastName: z.string().min(1, 'Last name is required'),

--- a/packages/@n8n/api-types/src/dto/invitation/invite-users-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/invitation/invite-users-request.dto.ts
@@ -2,7 +2,7 @@ import { assignableGlobalRoleSchema } from '@n8n/permissions';
 import { z } from 'zod';
 
 const invitedUserSchema = z.object({
-	email: z.string().email(),
+	email: z.email(),
 	role: assignableGlobalRoleSchema.default('global:member'),
 });
 

--- a/packages/@n8n/api-types/src/dto/license/community-registered-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/license/community-registered-request.dto.ts
@@ -2,4 +2,4 @@ import { z } from 'zod';
 
 import { Z } from '../../zod-class';
 
-export class CommunityRegisteredRequestDto extends Z.class({ email: z.string().email() }) {}
+export class CommunityRegisteredRequestDto extends Z.class({ email: z.email() }) {}

--- a/packages/@n8n/api-types/src/dto/oauth/oauth-client.dto.ts
+++ b/packages/@n8n/api-types/src/dto/oauth/oauth-client.dto.ts
@@ -11,8 +11,8 @@ export class OAuthClientResponseDto extends Z.class({
 	redirectUris: z.array(z.string()),
 	grantTypes: z.array(z.string()),
 	tokenEndpointAuthMethod: z.string(),
-	createdAt: z.string().datetime(), // Using string for date serialization over HTTP
-	updatedAt: z.string().datetime(),
+	createdAt: z.iso.datetime(), // Using string for date serialization over HTTP
+	updatedAt: z.iso.datetime(),
 }) {}
 
 /**
@@ -26,8 +26,8 @@ export class ListOAuthClientsResponseDto extends Z.class({
 			redirectUris: z.array(z.string()),
 			grantTypes: z.array(z.string()),
 			tokenEndpointAuthMethod: z.string(),
-			createdAt: z.string().datetime(),
-			updatedAt: z.string().datetime(),
+			createdAt: z.iso.datetime(),
+			updatedAt: z.iso.datetime(),
 		}),
 	),
 	count: z.number(),

--- a/packages/@n8n/api-types/src/dto/oidc/config.dto.ts
+++ b/packages/@n8n/api-types/src/dto/oidc/config.dto.ts
@@ -5,7 +5,7 @@ import { Z } from '../../zod-class';
 export class OidcConfigDto extends Z.class({
 	clientId: z.string().min(1),
 	clientSecret: z.string().min(1),
-	discoveryEndpoint: z.string().url(),
+	discoveryEndpoint: z.url(),
 	loginEnabled: z.boolean().optional().default(false),
 	prompt: z
 		.enum(['none', 'login', 'consent', 'select_account', 'create'])

--- a/packages/@n8n/api-types/src/dto/owner/owner-setup-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/owner/owner-setup-request.dto.ts
@@ -4,7 +4,7 @@ import { passwordSchema } from '../../schemas/password.schema';
 import { Z } from '../../zod-class';
 
 export class OwnerSetupRequestDto extends Z.class({
-	email: z.string().email(),
+	email: z.email(),
 	firstName: z.string().min(1, 'First name is required'),
 	lastName: z.string().min(1, 'Last name is required'),
 	password: passwordSchema,

--- a/packages/@n8n/api-types/src/dto/pagination/pagination.dto.ts
+++ b/packages/@n8n/api-types/src/dto/pagination/pagination.dto.ts
@@ -9,10 +9,10 @@ const skipValidator = z
 	.optional()
 	.transform((val) => (val ? parseInt(val, 10) : 0))
 	.refine((val) => !isNaN(val) && Number.isInteger(val), {
-		message: 'Param `skip` must be a valid integer',
+		error: 'Param `skip` must be a valid integer',
 	})
 	.refine((val) => val >= 0, {
-		message: 'Param `skip` must be a non-negative integer',
+		error: 'Param `skip` must be a non-negative integer',
 	});
 
 export const createTakeValidator = (maxItems: number, allowInfinity: boolean = false) =>
@@ -21,7 +21,7 @@ export const createTakeValidator = (maxItems: number, allowInfinity: boolean = f
 		.optional()
 		.transform((val) => (val ? parseInt(val, 10) : 10))
 		.refine((val) => !isNaN(val) && Number.isInteger(val), {
-			message: 'Param `take` must be a valid integer',
+			error: 'Param `take` must be a valid integer',
 		})
 		.refine(
 			(val) => {
@@ -29,7 +29,7 @@ export const createTakeValidator = (maxItems: number, allowInfinity: boolean = f
 				return true;
 			},
 			{
-				message: 'Param `take` must be a non-negative integer',
+				error: 'Param `take` must be a non-negative integer',
 			},
 		)
 		.transform((val) => Math.min(val, maxItems));
@@ -46,10 +46,10 @@ const offsetValidator = z
 	.optional()
 	.transform((val) => (val ? parseInt(val, 10) : 0))
 	.refine((val) => !isNaN(val) && Number.isInteger(val), {
-		message: 'Param `offset` must be a valid integer',
+		error: 'Param `offset` must be a valid integer',
 	})
 	.refine((val) => val >= 0, {
-		message: 'Param `offset` must be a non-negative integer',
+		error: 'Param `offset` must be a non-negative integer',
 	});
 
 const createLimitValidator = (maxItems: number) =>
@@ -58,10 +58,10 @@ const createLimitValidator = (maxItems: number) =>
 		.optional()
 		.transform((val) => (val ? parseInt(val, 10) : 100))
 		.refine((val) => !isNaN(val) && Number.isInteger(val), {
-			message: 'Param `limit` must be a valid integer',
+			error: 'Param `limit` must be a valid integer',
 		})
 		.refine((val) => val >= 0, {
-			message: 'Param `limit` must be a non-negative integer',
+			error: 'Param `limit` must be a non-negative integer',
 		})
 		.transform((val) => Math.min(val, maxItems));
 

--- a/packages/@n8n/api-types/src/dto/password-reset/forgot-password-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/password-reset/forgot-password-request.dto.ts
@@ -3,5 +3,5 @@ import { z } from 'zod';
 import { Z } from '../../zod-class';
 
 export class ForgotPasswordRequestDto extends Z.class({
-	email: z.string().email().max(255),
+	email: z.email().max(255),
 }) {}

--- a/packages/@n8n/api-types/src/dto/roles/role-get-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/roles/role-get-query.dto.ts
@@ -5,5 +5,5 @@ import { Z } from '../../zod-class';
  * Query DTO for retrieving a single role with optional usage count
  */
 export class RoleGetQueryDto extends Z.class({
-	withUsageCount: booleanFromString.optional().default('false'),
+	withUsageCount: booleanFromString.optional().default(false),
 }) {}

--- a/packages/@n8n/api-types/src/dto/roles/role-list-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/roles/role-list-query.dto.ts
@@ -5,5 +5,5 @@ import { Z } from '../../zod-class';
  * Query DTO for listing roles with optional usage count
  */
 export class RoleListQueryDto extends Z.class({
-	withUsageCount: booleanFromString.optional().default('false'),
+	withUsageCount: booleanFromString.optional().default(false),
 }) {}

--- a/packages/@n8n/api-types/src/dto/source-control/pull-work-folder-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/source-control/pull-work-folder-request.dto.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { Z } from '../../zod-class';
 
 const AutoPublishModeSchema = z.enum(['none', 'all', 'published']);
-export const AUTO_PUBLISH_MODE = AutoPublishModeSchema.Values;
+export const AUTO_PUBLISH_MODE = AutoPublishModeSchema.enum;
 
 export class PullWorkFolderRequestDto extends Z.class({
 	force: z.boolean().optional(),

--- a/packages/@n8n/api-types/src/dto/tag/retrieve-tag-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/tag/retrieve-tag-query.dto.ts
@@ -2,5 +2,5 @@ import { booleanFromString } from '../../schemas/boolean-from-string';
 import { Z } from '../../zod-class';
 
 export class RetrieveTagQueryDto extends Z.class({
-	withUsageCount: booleanFromString.optional().default('false'),
+	withUsageCount: booleanFromString.optional().default(false),
 }) {}

--- a/packages/@n8n/api-types/src/dto/user/user-update-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/user/user-update-request.dto.ts
@@ -18,14 +18,14 @@ const nameSchema = () =>
 		.min(1)
 		.max(32)
 		.refine(xssCheck, {
-			message: 'Potentially malicious string',
+			error: 'Potentially malicious string',
 		})
 		.refine(urlCheck, {
-			message: 'Potentially malicious string',
+			error: 'Potentially malicious string',
 		});
 
 export class UserUpdateRequestDto extends Z.class({
-	email: z.string().email(),
+	email: z.email(),
 	firstName: nameSchema().optional(),
 	lastName: nameSchema().optional(),
 	mfaCode: z.string().optional(),

--- a/packages/@n8n/api-types/src/dto/user/users-list-filter.dto.ts
+++ b/packages/@n8n/api-types/src/dto/user/users-list-filter.dto.ts
@@ -55,7 +55,7 @@ const filterValidatorSchema = z
 				return userFilterSchema.parse(parsed);
 			} catch (e) {
 				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
+					code: 'custom',
 					message: 'Invalid filter fields',
 					path: ['filter'],
 				});
@@ -63,7 +63,7 @@ const filterValidatorSchema = z
 			}
 		} catch (e) {
 			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
+				code: 'custom',
 				message: 'Invalid filter format',
 				path: ['filter'],
 			});

--- a/packages/@n8n/api-types/src/dto/workflows/base-workflow.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/base-workflow.dto.ts
@@ -5,7 +5,9 @@ export const WORKFLOW_NAME_MAX_LENGTH = 128;
 
 export const workflowNameSchema = z
 	.string()
-	.min(1, { message: 'Workflow name is required' })
+	.min(1, {
+		error: 'Workflow name is required',
+	})
 	.max(WORKFLOW_NAME_MAX_LENGTH, {
 		message: `Workflow name must be ${WORKFLOW_NAME_MAX_LENGTH} characters or less`,
 	});
@@ -14,20 +16,20 @@ export const workflowDescriptionSchema = z.string().nullable();
 
 // Use z.custom() with type predicates for better type safety
 export const workflowNodesSchema = z.custom<INode[]>((val) => Array.isArray(val), {
-	message: 'Nodes must be an array',
+	error: 'Nodes must be an array',
 });
 
 export const workflowConnectionsSchema = z.custom<IConnections>(
 	(val) => typeof val === 'object' && val !== null && !Array.isArray(val),
 	{
-		message: 'Connections must be an object',
+		error: 'Connections must be an object',
 	},
 );
 
 export const workflowSettingsSchema = z.custom<IWorkflowSettings>(
 	(val) => val === null || (typeof val === 'object' && val !== null && !Array.isArray(val)),
 	{
-		message: 'Settings must be an object or null',
+		error: 'Settings must be an object or null',
 	},
 );
 
@@ -46,7 +48,7 @@ export const workflowStaticDataSchema = z.preprocess(
 	z.custom<IDataObject | null>(
 		(val) => val === null || (typeof val === 'object' && val !== null && !Array.isArray(val)),
 		{
-			message: 'Static data must be an object or null',
+			error: 'Static data must be an object or null',
 		},
 	),
 );
@@ -55,7 +57,7 @@ export const workflowStaticDataSchema = z.preprocess(
 export const workflowPinDataSchema = z.custom<IPinData | null>(
 	(val) => val === null || (typeof val === 'object' && val !== null && !Array.isArray(val)),
 	{
-		message: 'Pin data must be an object or null',
+		error: 'Pin data must be an object or null',
 	},
 );
 

--- a/packages/@n8n/api-types/src/dto/workflows/import-workflow-from-url.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/import-workflow-from-url.dto.ts
@@ -3,6 +3,6 @@ import { z } from 'zod';
 import { Z } from '../../zod-class';
 
 export class ImportWorkflowFromUrlDto extends Z.class({
-	url: z.string().url(),
+	url: z.url(),
 	projectId: z.string(),
 }) {}

--- a/packages/@n8n/api-types/src/instance-registry-types.ts
+++ b/packages/@n8n/api-types/src/instance-registry-types.ts
@@ -1,18 +1,16 @@
 import { z } from 'zod';
 
 // Versioned schema (V1 with all fields from RFC)
-const InstanceRegistrationSchemaV1 = z
-	.object({
-		schemaVersion: z.literal(1),
-		instanceKey: z.string(),
-		hostId: z.string(),
-		instanceType: z.enum(['main', 'worker', 'webhook']),
-		instanceRole: z.enum(['leader', 'follower', 'unset']),
-		version: z.string(),
-		registeredAt: z.number(),
-		lastSeen: z.number(),
-	})
-	.passthrough();
+const InstanceRegistrationSchemaV1 = z.looseObject({
+	schemaVersion: z.literal(1),
+	instanceKey: z.string(),
+	hostId: z.string(),
+	instanceType: z.enum(['main', 'worker', 'webhook']),
+	instanceRole: z.enum(['leader', 'follower', 'unset']),
+	version: z.string(),
+	registeredAt: z.number(),
+	lastSeen: z.number(),
+});
 
 // Discriminated union for future schema versions
 export const instanceRegistrationSchema = z.discriminatedUnion('schemaVersion', [

--- a/packages/@n8n/api-types/src/schemas/breaking-changes.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/breaking-changes.schema.ts
@@ -79,7 +79,7 @@ const breakingChangeReportDataSchema = {
 	workflowResults: z.array(workflowRuleResultsSchema),
 } as const;
 
-const breakingChangeReportSchema = z.object(breakingChangeReportDataSchema).strict();
+const breakingChangeReportSchema = z.strictObject(breakingChangeReportDataSchema);
 
 const breakingChangeLightReportDataSchema = {
 	generatedAt: z.date(),
@@ -93,7 +93,7 @@ const breakingChangeLightReportDataSchema = {
 	),
 } as const;
 
-const breakingChangeLightReportSchema = z.object(breakingChangeLightReportDataSchema).strict();
+const breakingChangeLightReportSchema = z.strictObject(breakingChangeLightReportDataSchema);
 
 const breakingChangeReportResultDataSchema = z.object({
 	report: breakingChangeReportSchema,

--- a/packages/@n8n/api-types/src/schemas/credential-resolver.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/credential-resolver.schema.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const credentialResolverIdSchema = z.string().max(36);
 export const credentialResolverNameSchema = z.string().trim().min(1).max(255);
 export const credentialResolverTypeNameSchema = z.string().trim().min(1).max(255);
-export const credentialResolverConfigSchema = z.record(z.unknown());
+export const credentialResolverConfigSchema = z.record(z.string(), z.unknown());
 
 export const credentialResolverSchema = z.object({
 	id: credentialResolverIdSchema,
@@ -19,7 +19,7 @@ export const credentialResolverTypeSchema = z.object({
 	name: credentialResolverTypeNameSchema,
 	displayName: z.string().trim().min(1).max(255),
 	description: z.string().trim().max(1024).optional(),
-	options: z.array(z.record(z.unknown())).optional(),
+	options: z.array(z.record(z.string(), z.unknown())).optional(),
 });
 
 export const credentialResolverTypesSchema = z.array(credentialResolverTypeSchema);

--- a/packages/@n8n/api-types/src/schemas/data-table.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/data-table.schema.ts
@@ -36,8 +36,8 @@ export const dataTableSchema = z.object({
 	id: dataTableIdSchema,
 	name: dataTableNameSchema,
 	columns: z.array(dataTableColumnSchema),
-	createdAt: z.string().datetime(),
-	updatedAt: z.string().datetime(),
+	createdAt: z.iso.datetime(),
+	updatedAt: z.iso.datetime(),
 });
 export type DataTable = z.infer<typeof dataTableSchema>;
 export type DataTableColumn = z.infer<typeof dataTableColumnSchema>;
@@ -54,8 +54,7 @@ export type DataTableListOptions = Partial<ListDataTableQueryDto> & {
 
 export type DataTableListSortBy = ListDataTableQueryDto['sortBy'];
 
-export const dateTimeSchema = z
-	.string()
+export const dateTimeSchema = z.iso
 	.datetime({ offset: true })
 	.transform((s) => new Date(s))
 	.pipe(z.date());

--- a/packages/@n8n/api-types/src/schemas/folder.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/folder.schema.ts
@@ -10,7 +10,7 @@ export const folderNameSchema = z
 	.superRefine((name, ctx) => {
 		if (name === '') {
 			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
+				code: 'custom',
 				message: 'Folder name cannot be empty',
 			});
 			return;
@@ -18,7 +18,7 @@ export const folderNameSchema = z
 
 		if (illegalCharacterRegex.test(name)) {
 			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
+				code: 'custom',
 				message: 'Folder name contains invalid characters',
 			});
 			return;
@@ -26,7 +26,7 @@ export const folderNameSchema = z
 
 		if (dotsOnlyRegex.test(name)) {
 			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
+				code: 'custom',
 				message: 'Folder name cannot consist of dots only',
 			});
 			return;
@@ -34,7 +34,7 @@ export const folderNameSchema = z
 
 		if (name.startsWith('.')) {
 			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
+				code: 'custom',
 				message: 'Folder name cannot start with a dot',
 			});
 		}

--- a/packages/@n8n/api-types/src/schemas/insights.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/insights.schema.ts
@@ -40,71 +40,63 @@ export const insightsSummaryDataSchemas = {
 	}),
 } as const;
 
-export const insightsSummarySchema = z.object(insightsSummaryDataSchemas).strict();
+export const insightsSummarySchema = z.strictObject(insightsSummaryDataSchemas);
 export type InsightsSummary = z.infer<typeof insightsSummarySchema>;
 
 export const insightsByWorkflowDataSchemas = {
 	count: z.number(),
 	data: z.array(
-		z
-			.object({
-				// Workflow id will be null if the workflow has been deleted
-				workflowId: z.string().nullable(),
-				workflowName: z.string(),
-				// Project id will be null if the project has been deleted
-				projectId: z.string().nullable(),
-				projectName: z.string(),
-				total: z.number(),
-				succeeded: z.number(),
-				failed: z.number(),
-				failureRate: z.number(),
-				runTime: z.number(),
-				averageRunTime: z.number(),
-				timeSaved: z.number(),
-			})
-			.strict(),
-	),
-} as const;
-
-export const insightsByWorkflowSchema = z.object(insightsByWorkflowDataSchemas).strict();
-export type InsightsByWorkflow = z.infer<typeof insightsByWorkflowSchema>;
-
-export const insightsByTimeDataSchemas = {
-	date: z.string().refine((val) => !isNaN(Date.parse(val)) && new Date(val).toISOString() === val, {
-		message: 'Invalid date format, must be ISO 8601 format',
-	}),
-	values: z
-		.object({
+		z.strictObject({
+			// Workflow id will be null if the workflow has been deleted
+			workflowId: z.string().nullable(),
+			workflowName: z.string(),
+			// Project id will be null if the project has been deleted
+			projectId: z.string().nullable(),
+			projectName: z.string(),
 			total: z.number(),
 			succeeded: z.number(),
 			failed: z.number(),
 			failureRate: z.number(),
+			runTime: z.number(),
 			averageRunTime: z.number(),
 			timeSaved: z.number(),
-		})
-		.strict(),
+		}),
+	),
 } as const;
-export const insightsByTimeSchema = z.object(insightsByTimeDataSchemas).strict();
+
+export const insightsByWorkflowSchema = z.strictObject(insightsByWorkflowDataSchemas);
+export type InsightsByWorkflow = z.infer<typeof insightsByWorkflowSchema>;
+
+export const insightsByTimeDataSchemas = {
+	date: z.string().refine((val) => !isNaN(Date.parse(val)) && new Date(val).toISOString() === val, {
+		error: 'Invalid date format, must be ISO 8601 format',
+	}),
+	values: z.strictObject({
+		total: z.number(),
+		succeeded: z.number(),
+		failed: z.number(),
+		failureRate: z.number(),
+		averageRunTime: z.number(),
+		timeSaved: z.number(),
+	}),
+} as const;
+export const insightsByTimeSchema = z.strictObject(insightsByTimeDataSchemas);
 export type InsightsByTime = z.infer<typeof insightsByTimeSchema>;
 
 export const restrictedInsightsByTimeDataSchema = {
 	date: z.string().refine((val) => !isNaN(Date.parse(val)) && new Date(val).toISOString() === val, {
-		message: 'Invalid date format, must be ISO 8601 format',
+		error: 'Invalid date format, must be ISO 8601 format',
 	}),
-	values: z
-		.object({
-			timeSaved: z.number(),
-		})
-		.strict(),
+	values: z.strictObject({
+		timeSaved: z.number(),
+	}),
 } as const;
-export const restrictedInsightsByTimeSchema = z.object(restrictedInsightsByTimeDataSchema).strict();
+export const restrictedInsightsByTimeSchema = z.strictObject(restrictedInsightsByTimeDataSchema);
 export type RestrictedInsightsByTime = z.infer<typeof restrictedInsightsByTimeSchema>;
 
-export const insightsDateRangeSchema = z
-	.object({
-		key: z.enum(['day', 'week', '2weeks', 'month', 'quarter', '6months', 'year']),
-		licensed: z.boolean(),
-		granularity: z.enum(['hour', 'day', 'week']),
-	})
-	.strict();
+export const insightsDateRangeSchema = z.strictObject({
+	key: z.enum(['day', 'week', '2weeks', 'month', 'quarter', '6months', 'year']),
+	licensed: z.boolean(),
+	granularity: z.enum(['hour', 'day', 'week']),
+});
 export type InsightsDateRange = z.infer<typeof insightsDateRangeSchema>;

--- a/packages/@n8n/api-types/src/schemas/node-version.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/node-version.schema.ts
@@ -12,6 +12,6 @@ export const nodeVersionSchema = z
 			);
 		},
 		{
-			message: 'Invalid node version. Must be in format: major.minor',
+			error: 'Invalid node version. Must be in format: major.minor',
 		},
 	);

--- a/packages/@n8n/api-types/src/schemas/password.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/password.schema.ts
@@ -9,8 +9,8 @@ export const passwordSchema = z
 	.min(minLength, `Password must be ${minLength} to ${maxLength} characters long.`)
 	.max(maxLength, `Password must be ${minLength} to ${maxLength} characters long.`)
 	.refine((password) => /\d/.test(password), {
-		message: 'Password must contain at least 1 number.',
+		error: 'Password must contain at least 1 number.',
 	})
 	.refine((password) => /[A-Z]/.test(password), {
-		message: 'Password must contain at least 1 uppercase letter.',
+		error: 'Password must contain at least 1 uppercase letter.',
 	});

--- a/packages/@n8n/api-types/src/schemas/source-controlled-file.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/source-controlled-file.schema.ts
@@ -10,7 +10,7 @@ const FileTypeSchema = z.enum([
 	'project',
 	'datatable',
 ]);
-export const SOURCE_CONTROL_FILE_TYPE = FileTypeSchema.Values;
+export const SOURCE_CONTROL_FILE_TYPE = FileTypeSchema.enum;
 
 const FileStatusSchema = z.enum([
 	'new',
@@ -23,7 +23,7 @@ const FileStatusSchema = z.enum([
 	'staged',
 	'unknown',
 ]);
-export const SOURCE_CONTROL_FILE_STATUS = FileStatusSchema.Values;
+export const SOURCE_CONTROL_FILE_STATUS = FileStatusSchema.enum;
 
 export type SourceControlledFileStatus = z.infer<typeof FileStatusSchema>;
 
@@ -32,7 +32,7 @@ export function isSourceControlledFileStatus(value: unknown): value is SourceCon
 }
 
 const FileLocationSchema = z.enum(['local', 'remote']);
-export const SOURCE_CONTROL_FILE_LOCATION = FileLocationSchema.Values;
+export const SOURCE_CONTROL_FILE_LOCATION = FileLocationSchema.enum;
 
 const ResourceOwnerSchema = z.object({
 	type: z.enum(['personal', 'team']),

--- a/packages/@n8n/api-types/src/schemas/user-settings.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/user-settings.schema.ts
@@ -22,6 +22,6 @@ export const userSettingsSchema = z.object({
 	npsSurvey: npsSurveySchema.optional(),
 	easyAIWorkflowOnboarded: z.boolean().optional(),
 	userClaimedAiCredits: z.boolean().optional(),
-	dismissedCallouts: z.record(z.boolean()).optional(),
+	dismissedCallouts: z.record(z.string(), z.boolean()).optional(),
 });
 export type UserSettings = z.infer<typeof userSettingsSchema>;

--- a/packages/@n8n/api-types/src/schemas/user.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/user.schema.ts
@@ -27,7 +27,7 @@ export const userBaseSchema = z.object({
 	id: z.string(),
 	firstName: z.string().nullable().optional(),
 	lastName: z.string().nullable().optional(),
-	email: z.string().email().nullable().optional(),
+	email: z.email().nullable().optional(),
 	role: roleSchema.optional(),
 });
 
@@ -36,7 +36,7 @@ export const userDetailSchema = userBaseSchema.extend({
 	isOwner: z.boolean().optional(),
 	signInType: z.string().optional(),
 	settings: userSettingsSchema.nullable().optional(),
-	personalizationAnswers: z.object({}).passthrough().nullable().optional(),
+	personalizationAnswers: z.looseObject({}).nullable().optional(),
 	projectRelations: z.array(userProjectSchema).nullable().optional(),
 	mfaEnabled: z.boolean().optional(),
 	lastActiveAt: z.string().nullable().optional(),

--- a/packages/@n8n/api-types/src/zod-class.ts
+++ b/packages/@n8n/api-types/src/zod-class.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export interface ZodClass<T = unknown, Shape extends z.ZodRawShape = z.ZodRawShape> {
 	new (data: T): T;
 	schema: z.ZodObject<Shape>;
-	safeParse(data: unknown): z.SafeParseReturnType<unknown, T>;
+	safeParse(data: unknown): z.ZodSafeParseResult<T>;
 	parse(data: unknown): T;
 	extend<U extends z.ZodRawShape>(shape: U): ZodClass<T & z.infer<z.ZodObject<U>>, Shape & U>;
 }
@@ -29,9 +29,9 @@ export interface ZodClass<T = unknown, Shape extends z.ZodRawShape = z.ZodRawSha
  * ```
  */
 export const Z = {
-	class: <T extends z.ZodRawShape>(shape: T): ZodClass<z.objectOutputType<T, z.ZodTypeAny>, T> => {
+	class: <T extends z.ZodRawShape>(shape: T): ZodClass<z.objectOutputType<T, z.ZodType>, T> => {
 		const schema = z.object(shape);
-		type Output = z.objectOutputType<T, z.ZodTypeAny>;
+		type Output = z.objectOutputType<T, z.ZodType>;
 
 		const DtoClass = class {
 			static schema = schema;

--- a/packages/@n8n/api-types/src/zod-class.ts
+++ b/packages/@n8n/api-types/src/zod-class.ts
@@ -29,9 +29,9 @@ export interface ZodClass<T = unknown, Shape extends z.ZodRawShape = z.ZodRawSha
  * ```
  */
 export const Z = {
-	class: <T extends z.ZodRawShape>(shape: T): ZodClass<z.objectOutputType<T, z.ZodType>, T> => {
+	class: <T extends z.ZodRawShape>(shape: T): ZodClass<z.infer<z.ZodObject<T>>, T> => {
 		const schema = z.object(shape);
-		type Output = z.objectOutputType<T, z.ZodType>;
+		type Output = z.infer<z.ZodObject<T>>;
 
 		const DtoClass = class {
 			static schema = schema;

--- a/packages/@n8n/backend-common/src/__tests__/cli-parser.test.ts
+++ b/packages/@n8n/backend-common/src/__tests__/cli-parser.test.ts
@@ -82,7 +82,7 @@ describe('parse', () => {
 		});
 
 		// @ts-expect-error zod was monkey-patched to support aliases
-		flagsSchema.shape.name._def._alias = 'n';
+		flagsSchema.shape.name._zod.def._alias = 'n';
 
 		const result = cliParser.parse({
 			argv: ['node', 'script.js', '-n', 'test', 'arg1'],
@@ -102,7 +102,7 @@ describe('parse', () => {
 		});
 
 		// @ts-expect-error zod was monkey-patched to support aliases
-		flagsSchema.shape.name._def.innerType._def._alias = 'n';
+		flagsSchema.shape.name._zod.def.innerType._zod.def._alias = 'n';
 
 		const result = cliParser.parse({
 			argv: ['node', 'script.js', '-n', 'test', 'arg1'],

--- a/packages/@n8n/backend-common/src/cli-parser.ts
+++ b/packages/@n8n/backend-common/src/cli-parser.ts
@@ -30,14 +30,14 @@ export class CliParser {
 		if (input.flagsSchema) {
 			for (const key in input.flagsSchema.shape) {
 				const flagSchema = input.flagsSchema.shape[key];
-				let schemaDef = flagSchema._def as z.ZodTypeDef & {
-					typeName: string;
+				let schemaDef = flagSchema._zod.def as {
+					type: string;
 					innerType?: z.ZodType;
 					_alias?: string;
 				};
 
-				if (schemaDef.typeName === 'ZodOptional' && schemaDef.innerType) {
-					schemaDef = schemaDef.innerType._def as typeof schemaDef;
+				if (schemaDef.type === 'optional' && schemaDef.innerType) {
+					schemaDef = schemaDef.innerType._zod.def as typeof schemaDef;
 				}
 
 				const alias = schemaDef._alias;

--- a/packages/@n8n/config/src/configs/sentry.config.ts
+++ b/packages/@n8n/config/src/configs/sentry.config.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { Config, Env } from '../decorators';
 
 /** Schema for sample rates (0.0 to 1.0). */
-export const sampleRateSchema = z.number({ coerce: true }).min(0).max(1);
+export const sampleRateSchema = z.coerce.number().min(0).max(1);
 
 @Config
 export class SentryConfig {
@@ -42,7 +42,7 @@ export class SentryConfig {
 	 *
 	 * @default 500
 	 */
-	@Env('N8N_SENTRY_EVENT_LOOP_BLOCK_THRESHOLD', z.number({ coerce: true }).int().positive())
+	@Env('N8N_SENTRY_EVENT_LOOP_BLOCK_THRESHOLD', z.int().positive())
 	eventLoopBlockThreshold: number = 500;
 
 	/**

--- a/packages/@n8n/decorators/src/command/types.ts
+++ b/packages/@n8n/decorators/src/command/types.ts
@@ -1,7 +1,7 @@
 import type { Constructable } from '@n8n/di';
-import type { ZodObject, ZodTypeAny } from 'zod';
+import type { ZodObject, ZodType } from 'zod';
 
-type FlagsSchema = ZodObject<Record<string, ZodTypeAny>>;
+type FlagsSchema = ZodObject<Record<string, ZodType>>;
 
 export type CommandOptions = {
 	name: string;

--- a/packages/@n8n/json-schema-to-zod/package.json
+++ b/packages/@n8n/json-schema-to-zod/package.json
@@ -60,7 +60,7 @@
     "url": "https://github.com/n8n-io/n8n"
   },
   "peerDependencies": {
-    "zod": "^3.0.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@n8n/typescript-config": "workspace:*",

--- a/packages/@n8n/json-schema-to-zod/src/json-schema-to-zod.ts
+++ b/packages/@n8n/json-schema-to-zod/src/json-schema-to-zod.ts
@@ -3,7 +3,7 @@ import type { z } from 'zod';
 import { parseSchema } from './parsers/parse-schema';
 import type { JsonSchemaToZodOptions, JsonSchema } from './types';
 
-export const jsonSchemaToZod = <T extends z.ZodTypeAny = z.ZodTypeAny>(
+export const jsonSchemaToZod = <T extends z.ZodType = z.ZodType>(
 	schema: JsonSchema,
 	options: JsonSchemaToZodOptions = {},
 ): T => {

--- a/packages/@n8n/json-schema-to-zod/src/parsers/parse-all-of.ts
+++ b/packages/@n8n/json-schema-to-zod/src/parsers/parse-all-of.ts
@@ -26,7 +26,7 @@ const ensureOriginalIndex = (arr: JsonSchema[]) => {
 export function parseAllOf(
 	jsonSchema: JsonSchemaObject & { allOf: JsonSchema[] },
 	refs: Refs,
-): z.ZodTypeAny {
+): z.ZodType {
 	if (jsonSchema.allOf.length === 0) {
 		return z.never();
 	}

--- a/packages/@n8n/json-schema-to-zod/src/parsers/parse-any-of.ts
+++ b/packages/@n8n/json-schema-to-zod/src/parsers/parse-any-of.ts
@@ -13,7 +13,7 @@ export const parseAnyOf = (jsonSchema: JsonSchemaObject & { anyOf: JsonSchema[] 
 			: z.union(
 					jsonSchema.anyOf.map((schema, i) =>
 						parseSchema(schema, { ...refs, path: [...refs.path, 'anyOf', i] }),
-					) as [z.ZodTypeAny, z.ZodTypeAny],
+					) as [z.ZodType, z.ZodType],
 				)
 		: z.any();
 };

--- a/packages/@n8n/json-schema-to-zod/src/parsers/parse-array.ts
+++ b/packages/@n8n/json-schema-to-zod/src/parsers/parse-array.ts
@@ -9,7 +9,7 @@ export const parseArray = (jsonSchema: JsonSchemaObject & { type: 'array' }, ref
 		return z.tuple(
 			jsonSchema.items.map((v, i) =>
 				parseSchema(v, { ...refs, path: [...refs.path, 'items', i] }),
-			) as [z.ZodTypeAny],
+			) as [z.ZodType],
 		);
 	}
 

--- a/packages/@n8n/json-schema-to-zod/src/parsers/parse-const.ts
+++ b/packages/@n8n/json-schema-to-zod/src/parsers/parse-const.ts
@@ -3,5 +3,5 @@ import { z } from 'zod';
 import type { JsonSchemaObject, Serializable } from '../types';
 
 export const parseConst = (jsonSchema: JsonSchemaObject & { const: Serializable }) => {
-	return z.literal(jsonSchema.const as z.Primitive);
+	return z.literal(jsonSchema.const as z.core.util.Literal);
 };

--- a/packages/@n8n/json-schema-to-zod/src/parsers/parse-enum.ts
+++ b/packages/@n8n/json-schema-to-zod/src/parsers/parse-enum.ts
@@ -9,7 +9,7 @@ export const parseEnum = (jsonSchema: JsonSchemaObject & { enum: Serializable[] 
 
 	if (jsonSchema.enum.length === 1) {
 		// union does not work when there is only one element
-		return z.literal(jsonSchema.enum[0] as z.Primitive);
+		return z.literal(jsonSchema.enum[0] as z.core.util.Literal);
 	}
 
 	if (jsonSchema.enum.every((x) => typeof x === 'string')) {
@@ -17,9 +17,9 @@ export const parseEnum = (jsonSchema: JsonSchemaObject & { enum: Serializable[] 
 	}
 
 	return z.union(
-		jsonSchema.enum.map((x) => z.literal(x as z.Primitive)) as unknown as [
-			z.ZodTypeAny,
-			z.ZodTypeAny,
+		jsonSchema.enum.map((x) => z.literal(x as z.core.util.Literal)) as unknown as [
+			z.ZodType,
+			z.ZodType,
 		],
 	);
 };

--- a/packages/@n8n/json-schema-to-zod/src/parsers/parse-if-then-else.ts
+++ b/packages/@n8n/json-schema-to-zod/src/parsers/parse-if-then-else.ts
@@ -25,7 +25,7 @@ export const parseIfThenElse = (
 		const result = $if.safeParse(value).success ? $then.safeParse(value) : $else.safeParse(value);
 
 		if (!result.success) {
-			result.error.errors.forEach((error) => ctx.addIssue(error));
+			result.error.issues.forEach((error) => ctx.addIssue({ ...error }));
 		}
 	});
 };

--- a/packages/@n8n/json-schema-to-zod/src/parsers/parse-multiple-type.ts
+++ b/packages/@n8n/json-schema-to-zod/src/parsers/parse-multiple-type.ts
@@ -9,8 +9,8 @@ export const parseMultipleType = (
 ) => {
 	return z.union(
 		jsonSchema.type.map((type) => parseSchema({ ...jsonSchema, type } as JsonSchema, refs)) as [
-			z.ZodTypeAny,
-			z.ZodTypeAny,
+			z.ZodType,
+			z.ZodType,
 		],
 	);
 };

--- a/packages/@n8n/json-schema-to-zod/src/parsers/parse-object.ts
+++ b/packages/@n8n/json-schema-to-zod/src/parsers/parse-object.ts
@@ -47,9 +47,8 @@ export function parseObject(
 ): z.ZodTypeAny {
 	const hasPatternProperties = Object.keys(objectSchema.patternProperties ?? {}).length > 0;
 
-	const propertiesSchema:
-		| z.ZodObject<Record<string, z.ZodTypeAny>, 'strip', z.ZodTypeAny>
-		| undefined = parseObjectProperties(objectSchema, refs);
+	const propertiesSchema: z.ZodObject<Record<string, z.ZodType>> | undefined =
+		parseObjectProperties(objectSchema, refs);
 	let zodSchema: z.ZodTypeAny | undefined = propertiesSchema;
 
 	const additionalProperties =
@@ -89,30 +88,50 @@ export function parseObject(
 		} else {
 			if (additionalProperties) {
 				zodSchema = z.record(
+					z.string(),
 					z.union([...patternPropertyValues, additionalProperties] as [z.ZodTypeAny, z.ZodTypeAny]),
 				);
 			} else if (patternPropertyValues.length > 1) {
-				zodSchema = z.record(z.union(patternPropertyValues as [z.ZodTypeAny, z.ZodTypeAny]));
+				zodSchema = z.record(
+					z.string(),
+					z.union(patternPropertyValues as [z.ZodTypeAny, z.ZodTypeAny]),
+				);
 			} else {
-				zodSchema = z.record(patternPropertyValues[0]);
+				zodSchema = z.record(z.string(), patternPropertyValues[0]);
 			}
 		}
 
 		const objectPropertyKeys = new Set(Object.keys(objectSchema.properties ?? {}));
-		zodSchema = zodSchema.superRefine((value: Record<string, unknown>, ctx) => {
-			for (const key in value) {
-				let wasMatched = objectPropertyKeys.has(key);
+		zodSchema = (zodSchema as z.ZodObject<Record<string, z.ZodType>>).superRefine(
+			(value: Record<string, unknown>, ctx) => {
+				for (const key in value) {
+					let wasMatched = objectPropertyKeys.has(key);
 
-				for (const patternPropertyKey in objectSchema.patternProperties) {
-					const regex = new RegExp(patternPropertyKey);
-					if (key.match(regex)) {
-						wasMatched = true;
-						const result = parsedPatternProperties[patternPropertyKey].safeParse(value[key]);
+					for (const patternPropertyKey in objectSchema.patternProperties) {
+						const regex = new RegExp(patternPropertyKey);
+						if (key.match(regex)) {
+							wasMatched = true;
+							const result = parsedPatternProperties[patternPropertyKey].safeParse(value[key]);
+							if (!result.success) {
+								ctx.addIssue({
+									path: [key],
+									code: 'custom',
+									message: `Invalid input: Key matching regex /${key}/ must match schema`,
+									params: {
+										issues: result.error.issues,
+									},
+								});
+							}
+						}
+					}
+
+					if (!wasMatched && additionalProperties) {
+						const result = additionalProperties.safeParse(value[key]);
 						if (!result.success) {
 							ctx.addIssue({
-								path: [...ctx.path, key],
+								path: [key],
 								code: 'custom',
-								message: `Invalid input: Key matching regex /${key}/ must match schema`,
+								message: 'Invalid input: must match catchall schema',
 								params: {
 									issues: result.error.issues,
 								},
@@ -120,22 +139,8 @@ export function parseObject(
 						}
 					}
 				}
-
-				if (!wasMatched && additionalProperties) {
-					const result = additionalProperties.safeParse(value[key]);
-					if (!result.success) {
-						ctx.addIssue({
-							path: [...ctx.path, key],
-							code: 'custom',
-							message: 'Invalid input: must match catchall schema',
-							params: {
-								issues: result.error.issues,
-							},
-						});
-					}
-				}
-			}
-		});
+			},
+		);
 	}
 
 	let output: z.ZodTypeAny;
@@ -155,9 +160,9 @@ export function parseObject(
 		if (hasPatternProperties) {
 			output = zodSchema!;
 		} else if (additionalProperties) {
-			output = z.record(additionalProperties);
+			output = z.record(z.string(), additionalProperties);
 		} else {
-			output = z.record(z.any());
+			output = z.record(z.string(), z.any());
 		}
 	}
 

--- a/packages/@n8n/json-schema-to-zod/src/parsers/parse-one-of.ts
+++ b/packages/@n8n/json-schema-to-zod/src/parsers/parse-one-of.ts
@@ -31,9 +31,8 @@ export const parseOneOf = (jsonSchema: JsonSchemaObject & { oneOf: JsonSchema[] 
 
 		if (schemas.length - unionErrors.length !== 1) {
 			ctx.addIssue({
-				path: ctx.path,
 				code: 'invalid_union',
-				unionErrors,
+				errors: unionErrors.map((error) => error.issues),
 				message: 'Invalid input: Should pass single schema',
 			});
 		}

--- a/packages/@n8n/json-schema-to-zod/src/parsers/parse-string.ts
+++ b/packages/@n8n/json-schema-to-zod/src/parsers/parse-string.ts
@@ -4,54 +4,65 @@ import type { JsonSchemaObject } from '../types';
 import { extendSchemaWithMessage } from '../utils/extend-schema';
 
 export const parseString = (jsonSchema: JsonSchemaObject & { type: 'string' }) => {
-	let zodSchema = z.string();
+	let stringSchema = z.string();
+
+	stringSchema = extendSchemaWithMessage(
+		stringSchema,
+		jsonSchema,
+		'pattern',
+		(zs, pattern, errorMsg) => zs.regex(new RegExp(pattern), errorMsg),
+	);
+
+	stringSchema = extendSchemaWithMessage(
+		stringSchema,
+		jsonSchema,
+		'minLength',
+		(zs, minLength, errorMsg) => zs.min(minLength, errorMsg),
+	);
+
+	stringSchema = extendSchemaWithMessage(
+		stringSchema,
+		jsonSchema,
+		'maxLength',
+		(zs, maxLength, errorMsg) => zs.max(maxLength, errorMsg),
+	);
+
+	let zodSchema: z.ZodType<string> = stringSchema;
 
 	zodSchema = extendSchemaWithMessage(zodSchema, jsonSchema, 'format', (zs, format, errorMsg) => {
 		switch (format) {
 			case 'email':
-				return zs.email(errorMsg);
+				return z.email(errorMsg);
 			case 'ip':
-				return zs.ip(errorMsg);
+				return z.union([z.ipv4(), z.ipv6()]);
 			case 'ipv4':
-				return zs.ip({ version: 'v4', message: errorMsg });
+				return z.ipv4();
 			case 'ipv6':
-				return zs.ip({ version: 'v6', message: errorMsg });
+				return z.ipv6();
 			case 'uri':
-				return zs.url(errorMsg);
+				return z.url(errorMsg);
 			case 'uuid':
-				return zs.uuid(errorMsg);
+				return z.uuid(errorMsg);
 			case 'date-time':
-				return zs.datetime({ offset: true, message: errorMsg });
+				return z.iso.datetime({ offset: true, message: errorMsg });
 			case 'time':
-				return zs.time(errorMsg);
+				return z.iso.time(errorMsg);
 			case 'date':
-				return zs.date(errorMsg);
+				return z.iso.date(errorMsg);
 			case 'binary':
-				return zs.base64(errorMsg);
+				return z.base64(errorMsg);
 			case 'duration':
-				return zs.duration(errorMsg);
+				return z.iso.duration(errorMsg);
 			default:
 				return zs;
 		}
 	});
 
-	zodSchema = extendSchemaWithMessage(zodSchema, jsonSchema, 'contentEncoding', (zs, _, errorMsg) =>
-		zs.base64(errorMsg),
-	);
-	zodSchema = extendSchemaWithMessage(zodSchema, jsonSchema, 'pattern', (zs, pattern, errorMsg) =>
-		zs.regex(new RegExp(pattern), errorMsg),
-	);
 	zodSchema = extendSchemaWithMessage(
 		zodSchema,
 		jsonSchema,
-		'minLength',
-		(zs, minLength, errorMsg) => zs.min(minLength, errorMsg),
-	);
-	zodSchema = extendSchemaWithMessage(
-		zodSchema,
-		jsonSchema,
-		'maxLength',
-		(zs, maxLength, errorMsg) => zs.max(maxLength, errorMsg),
+		'contentEncoding',
+		(_zs, _pattern, errorMsg) => z.base64(errorMsg),
 	);
 
 	return zodSchema;

--- a/packages/@n8n/json-schema-to-zod/src/types.ts
+++ b/packages/@n8n/json-schema-to-zod/src/types.ts
@@ -1,4 +1,4 @@
-import type { ZodTypeAny } from 'zod';
+import type { ZodType } from 'zod';
 
 export type Serializable =
 	| { [key: string]: Serializable }
@@ -7,6 +7,8 @@ export type Serializable =
 	| number
 	| boolean
 	| null;
+
+export type Primitive = string | number | symbol | bigint | boolean | null | undefined;
 
 export type JsonSchema = JsonSchemaObject | boolean;
 export type JsonSchemaObject = {
@@ -66,8 +68,8 @@ export type JsonSchemaObject = {
 	nullable?: boolean;
 };
 
-export type ParserSelector = (schema: JsonSchemaObject, refs: Refs) => ZodTypeAny;
-export type ParserOverride = (schema: JsonSchemaObject, refs: Refs) => ZodTypeAny | undefined;
+export type ParserSelector = (schema: JsonSchemaObject, refs: Refs) => ZodType;
+export type ParserOverride = (schema: JsonSchemaObject, refs: Refs) => ZodType | undefined;
 
 export type JsonSchemaToZodOptions = {
 	withoutDefaults?: boolean;
@@ -78,5 +80,5 @@ export type JsonSchemaToZodOptions = {
 
 export type Refs = JsonSchemaToZodOptions & {
 	path: Array<string | number>;
-	seen: Map<object | boolean, { n: number; r: ZodTypeAny | undefined }>;
+	seen: Map<object | boolean, { n: number; r: ZodType | undefined }>;
 };

--- a/packages/@n8n/json-schema-to-zod/src/utils/extend-schema.ts
+++ b/packages/@n8n/json-schema-to-zod/src/utils/extend-schema.ts
@@ -3,15 +3,16 @@ import type { z } from 'zod';
 import type { JsonSchemaObject } from '../types';
 
 export function extendSchemaWithMessage<
-	TZod extends z.ZodTypeAny,
+	TIn extends z.ZodType,
+	TOut extends z.ZodType,
 	TJson extends JsonSchemaObject,
 	TKey extends keyof TJson,
 >(
-	zodSchema: TZod,
+	zodSchema: TIn,
 	jsonSchema: TJson,
 	key: TKey,
-	extend: (zodSchema: TZod, value: NonNullable<TJson[TKey]>, errorMessage?: string) => TZod,
-) {
+	extend: (zodSchema: TIn, value: NonNullable<TJson[TKey]>, errorMessage?: string) => TOut,
+): TIn | TOut {
 	const value = jsonSchema[key];
 
 	if (value !== undefined) {

--- a/packages/@n8n/json-schema-to-zod/test/extend-expect.ts
+++ b/packages/@n8n/json-schema-to-zod/test/extend-expect.ts
@@ -1,7 +1,7 @@
 import type { z } from 'zod';
 
 expect.extend({
-	toMatchZod(this: jest.MatcherContext, actual: z.ZodTypeAny, expected: z.ZodTypeAny) {
+	toMatchZod(this: jest.MatcherContext, actual: z.ZodType, expected: z.ZodType) {
 		const actualSerialized = JSON.stringify(actual._def, null, 2);
 		const expectedSerialized = JSON.stringify(expected._def, null, 2);
 		const pass = this.equals(actualSerialized, expectedSerialized);

--- a/packages/@n8n/json-schema-to-zod/test/parsers/parse-number.test.ts
+++ b/packages/@n8n/json-schema-to-zod/test/parsers/parse-number.test.ts
@@ -8,21 +8,21 @@ describe('parseNumber', () => {
 			parseNumber({
 				type: 'integer',
 			}),
-		).toMatchZod(z.number().int());
+		).toMatchZod(z.int());
 
 		expect(
 			parseNumber({
 				type: 'integer',
 				multipleOf: 1,
 			}),
-		).toMatchZod(z.number().int());
+		).toMatchZod(z.int());
 
 		expect(
 			parseNumber({
 				type: 'number',
 				multipleOf: 1,
 			}),
-		).toMatchZod(z.number().int());
+		).toMatchZod(z.int());
 	});
 
 	test('should handle maximum with exclusiveMinimum', () => {
@@ -78,6 +78,6 @@ describe('parseNumber', () => {
 					maximum: 'nuts',
 				},
 			}),
-		).toMatchZod(z.number().int('ayy').multipleOf(2, 'lmao').gt(0, 'deez').lte(2, 'nuts'));
+		).toMatchZod(z.int('ayy').multipleOf(2, 'lmao').gt(0, 'deez').lte(2, 'nuts'));
 	});
 });

--- a/packages/@n8n/json-schema-to-zod/test/parsers/parse-object.test.ts
+++ b/packages/@n8n/json-schema-to-zod/test/parsers/parse-object.test.ts
@@ -13,7 +13,7 @@ describe('parseObject', () => {
 				},
 				{ path: [], seen: new Map() },
 			),
-		).toMatchZod(z.record(z.any()));
+		).toMatchZod(z.record(z.string(), z.any()));
 	});
 
 	test('should handle with empty properties', () => {
@@ -65,7 +65,7 @@ describe('parseObject', () => {
 				},
 				{ path: [], seen: new Map() },
 			),
-		).toMatchZod(z.object({ myString: z.string() }).strict());
+		).toMatchZod(z.strictObject({ myString: z.string() }));
 	});
 
 	test('With properties - should handle additionalProperties when set to true', () => {
@@ -113,7 +113,7 @@ describe('parseObject', () => {
 				},
 				{ path: [], seen: new Map() },
 			),
-		).toMatchZod(z.record(z.never()));
+		).toMatchZod(z.record(z.string(), z.never()));
 	});
 
 	test('Without properties - should handle additionalProperties when set to true', () => {
@@ -125,7 +125,7 @@ describe('parseObject', () => {
 				},
 				{ path: [], seen: new Map() },
 			),
-		).toMatchZod(z.record(z.any()));
+		).toMatchZod(z.record(z.string(), z.any()));
 	});
 
 	test('Without properties - should handle additionalProperties when provided a schema', () => {
@@ -138,7 +138,7 @@ describe('parseObject', () => {
 
 				{ path: [], seen: new Map() },
 			),
-		).toMatchZod(z.record(z.number()));
+		).toMatchZod(z.record(z.string(), z.number()));
 	});
 
 	test('Without properties - should include falsy defaults', () => {
@@ -389,7 +389,7 @@ describe('parseObject', () => {
 		);
 	});
 
-	const run = (zodSchema: z.ZodTypeAny, data: unknown) => zodSchema.safeParse(data);
+	const run = (zodSchema: z.ZodType, data: unknown) => zodSchema.safeParse(data);
 
 	test('Functional tests - run', () => {
 		expect(run(z.string(), 'hello')).toEqual({
@@ -440,14 +440,14 @@ describe('parseObject', () => {
 					expected: 'string',
 					received: 'undefined',
 					path: ['a'],
-					message: 'Required',
+					error: 'Required',
 				},
 				{
 					code: 'invalid_type',
 					expected: 'number',
 					received: 'string',
 					path: ['b'],
-					message: 'Expected number, received string',
+					error: 'Expected number, received string',
 				},
 			]),
 		});
@@ -482,21 +482,21 @@ describe('parseObject', () => {
 					expected: 'string',
 					received: 'undefined',
 					path: ['a'],
-					message: 'Required',
+					error: 'Required',
 				},
 				{
 					code: 'invalid_type',
 					expected: 'number',
 					received: 'string',
 					path: ['b'],
-					message: 'Expected number, received string',
+					error: 'Expected number, received string',
 				},
 				{
 					code: 'invalid_type',
 					expected: 'boolean',
 					received: 'string',
 					path: ['x'],
-					message: 'Expected boolean, received string',
+					error: 'Expected boolean, received string',
 				},
 			]),
 		});
@@ -557,7 +557,7 @@ describe('parseObject', () => {
 					expected: 'array',
 					received: 'string',
 					path: ['.'],
-					message: 'Expected array, received string',
+					error: 'Expected array, received string',
 				},
 			]),
 		});
@@ -643,7 +643,7 @@ describe('parseObject', () => {
 			additionalProperties: { type: 'boolean' },
 		};
 
-		const expected = z.record(z.boolean());
+		const expected = z.record(z.string(), z.boolean());
 
 		const result = parseObject(schema, { path: [], seen: new Map() });
 
@@ -661,7 +661,7 @@ describe('parseObject', () => {
 		};
 
 		const expected = z
-			.record(z.union([z.array(z.any()), z.array(z.any()).min(1), z.boolean()]))
+			.record(z.string(), z.union([z.array(z.any()), z.array(z.any()).min(1), z.boolean()]))
 			.superRefine((value, ctx) => {
 				for (const key in value) {
 					let evaluated = false;
@@ -719,7 +719,6 @@ describe('parseObject', () => {
 				{
 					path: [','],
 					code: 'custom',
-					message: 'Invalid input: Key matching regex /,/ must match schema',
 					params: {
 						issues: [
 							{
@@ -728,11 +727,12 @@ describe('parseObject', () => {
 								type: 'array',
 								inclusive: true,
 								exact: false,
-								message: 'Array must contain at least 1 element(s)',
 								path: [],
+								error: 'Array must contain at least 1 element(s)',
 							},
 						],
 					},
+					error: 'Invalid input: Key matching regex /,/ must match schema',
 				},
 			]),
 		});
@@ -746,7 +746,7 @@ describe('parseObject', () => {
 			},
 		};
 
-		const expected = z.record(z.array(z.any())).superRefine((value, ctx) => {
+		const expected = z.record(z.string(), z.array(z.any())).superRefine((value, ctx) => {
 			for (const key in value) {
 				if (key.match(new RegExp('\\\\.'))) {
 					const result = z.array(z.any()).safeParse(value[key]);
@@ -779,7 +779,7 @@ describe('parseObject', () => {
 		};
 
 		const expected = z
-			.record(z.union([z.array(z.any()), z.array(z.any()).min(1)]))
+			.record(z.string(), z.union([z.array(z.any()), z.array(z.any()).min(1)]))
 			.superRefine((value, ctx) => {
 				for (const key in value) {
 					if (key.match(new RegExp('\\.'))) {
@@ -824,7 +824,6 @@ describe('parseObject', () => {
 				{
 					path: [','],
 					code: 'custom',
-					message: 'Invalid input: Key matching regex /,/ must match schema',
 					params: {
 						issues: [
 							{
@@ -833,11 +832,12 @@ describe('parseObject', () => {
 								type: 'array',
 								inclusive: true,
 								exact: false,
-								message: 'Array must contain at least 1 element(s)',
 								path: [],
+								error: 'Array must contain at least 1 element(s)',
 							},
 						],
 					},
+					error: 'Invalid input: Key matching regex /,/ must match schema',
 				},
 			]),
 		});

--- a/packages/@n8n/json-schema-to-zod/test/parsers/parse-schema.test.ts
+++ b/packages/@n8n/json-schema-to-zod/test/parsers/parse-schema.test.ts
@@ -62,7 +62,7 @@ describe('parseSchema', () => {
 					? z.number().safeParse(value)
 					: z.boolean().safeParse(value);
 				if (!result.success) {
-					result.error.errors.forEach((error) => ctx.addIssue(error));
+					result.error.issues.forEach((error) => ctx.addIssue(error));
 				}
 			}),
 		);

--- a/packages/@n8n/json-schema-to-zod/test/parsers/parse-string.test.ts
+++ b/packages/@n8n/json-schema-to-zod/test/parsers/parse-string.test.ts
@@ -14,7 +14,7 @@ describe('parseString', () => {
 			errorMessage: { format: 'hello' },
 		});
 
-		expect(code).toMatchZod(z.string().datetime({ offset: true, message: 'hello' }));
+		expect(code).toMatchZod(z.iso.datetime({ offset: true, error: 'hello' }));
 
 		expect(run(code, datetime)).toEqual({ success: true, data: datetime });
 	});
@@ -25,7 +25,7 @@ describe('parseString', () => {
 				type: 'string',
 				format: 'email',
 			}),
-		).toMatchZod(z.string().email());
+		).toMatchZod(z.email());
 	});
 
 	test('ip', () => {
@@ -34,14 +34,14 @@ describe('parseString', () => {
 				type: 'string',
 				format: 'ip',
 			}),
-		).toMatchZod(z.string().ip());
+		).toMatchZod(z.union([z.ipv4(), z.ipv6()]));
 
 		expect(
 			parseString({
 				type: 'string',
 				format: 'ipv6',
 			}),
-		).toMatchZod(z.string().ip({ version: 'v6' }));
+		).toMatchZod(z.ipv6());
 	});
 
 	test('uri', () => {
@@ -50,7 +50,7 @@ describe('parseString', () => {
 				type: 'string',
 				format: 'uri',
 			}),
-		).toMatchZod(z.string().url());
+		).toMatchZod(z.url());
 	});
 
 	test('uuid', () => {
@@ -59,7 +59,7 @@ describe('parseString', () => {
 				type: 'string',
 				format: 'uuid',
 			}),
-		).toMatchZod(z.string().uuid());
+		).toMatchZod(z.uuid());
 	});
 
 	test('time', () => {
@@ -68,7 +68,7 @@ describe('parseString', () => {
 				type: 'string',
 				format: 'time',
 			}),
-		).toMatchZod(z.string().time());
+		).toMatchZod(z.iso.time());
 	});
 
 	test('date', () => {
@@ -77,7 +77,7 @@ describe('parseString', () => {
 				type: 'string',
 				format: 'date',
 			}),
-		).toMatchZod(z.string().date());
+		).toMatchZod(z.iso.date());
 	});
 
 	test('duration', () => {
@@ -86,7 +86,7 @@ describe('parseString', () => {
 				type: 'string',
 				format: 'duration',
 			}),
-		).toMatchZod(z.string().duration());
+		).toMatchZod(z.iso.duration());
 	});
 
 	test('base64', () => {
@@ -95,7 +95,7 @@ describe('parseString', () => {
 				type: 'string',
 				contentEncoding: 'base64',
 			}),
-		).toMatchZod(z.string().base64());
+		).toMatchZod(z.base64());
 
 		expect(
 			parseString({
@@ -105,14 +105,14 @@ describe('parseString', () => {
 					contentEncoding: 'x',
 				},
 			}),
-		).toMatchZod(z.string().base64('x'));
+		).toMatchZod(z.base64('x'));
 
 		expect(
 			parseString({
 				type: 'string',
 				format: 'binary',
 			}),
-		).toMatchZod(z.string().base64());
+		).toMatchZod(z.base64());
 
 		expect(
 			parseString({
@@ -122,7 +122,7 @@ describe('parseString', () => {
 					format: 'x',
 				},
 			}),
-		).toMatchZod(z.string().base64('x'));
+		).toMatchZod(z.base64('x'));
 	});
 
 	test('should accept errorMessage', () => {
@@ -140,13 +140,6 @@ describe('parseString', () => {
 					maxLength: 'nuts',
 				},
 			}),
-		).toMatchZod(
-			z
-				.string()
-				.ip({ version: 'v4', message: 'ayy' })
-				.regex(new RegExp('x'), 'lmao')
-				.min(1, 'deez')
-				.max(2, 'nuts'),
-		);
+		).toMatchZod(z.ipv4().regex(new RegExp('x'), 'lmao').min(1, 'deez').max(2, 'nuts'));
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/Guardrails/helpers/model.ts
+++ b/packages/@n8n/nodes-langchain/nodes/Guardrails/helpers/model.ts
@@ -8,12 +8,10 @@ import { z } from 'zod';
 
 import { GuardrailError, type GuardrailResult, type LLMConfig } from '../actions/types';
 
-const LlmResponseSchema = z
-	.object({
-		confidenceScore: z.number().min(0).max(1).describe('Confidence score between 0.0 and 1.0'),
-		flagged: z.boolean().describe('Whether the input violates the guardrail (true) or not (false)'),
-	})
-	.strict();
+const LlmResponseSchema = z.strictObject({
+	confidenceScore: z.number().min(0).max(1).describe('Confidence score between 0.0 and 1.0'),
+	flagged: z.boolean().describe('Whether the input violates the guardrail (true) or not (false)'),
+});
 
 export const LLM_SYSTEM_RULES = `Only respond with the json object and nothing else.
 

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/utils.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/utils.test.ts
@@ -52,9 +52,9 @@ describe('checkForStructuredTools', () => {
 		await expect(
 			checkForStructuredTools(tools, mockNode, 'Conversation Agent'),
 		).rejects.toMatchObject({
-			message:
-				'The selected tools are not supported by "Conversation Agent", please use "Tools Agent" instead',
 			description: 'Incompatible connected tools: "dynamic-tool"',
+			error:
+				'The selected tools are not supported by "Conversation Agent", please use "Tools Agent" instead',
 		});
 	});
 
@@ -100,9 +100,9 @@ describe('checkForStructuredTools', () => {
 		await expect(
 			checkForStructuredTools(tools, mockNode, 'Conversation Agent'),
 		).rejects.toMatchObject({
-			message:
-				'The selected tools are not supported by "Conversation Agent", please use "Tools Agent" instead',
 			description: 'Incompatible connected tools: "dynamic-tool"',
+			error:
+				'The selected tools are not supported by "Conversation Agent", please use "Tools Agent" instead',
 		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/InformationExtractor.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/InformationExtractor.node.ts
@@ -267,7 +267,7 @@ export class InformationExtractor implements INodeType {
 				jsonSchema = jsonParse<JSONSchema7>(inputSchema);
 			}
 
-			const zodSchema = convertJsonSchemaToZod<z.ZodSchema<object>>(jsonSchema);
+			const zodSchema = convertJsonSchemaToZod<z.ZodType<object>>(jsonSchema);
 
 			parser = OutputFixingParser.fromLLM(llm, StructuredOutputParser.fromZodSchema(zodSchema));
 		}

--- a/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/helpers.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/helpers.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import type { AttributeDefinition } from './types';
 
 function makeAttributeSchema(attributeDefinition: AttributeDefinition, required: boolean = true) {
-	let schema: z.ZodTypeAny;
+	let schema: z.ZodType;
 
 	if (attributeDefinition.type === 'string') {
 		schema = z.string();
@@ -12,7 +12,7 @@ function makeAttributeSchema(attributeDefinition: AttributeDefinition, required:
 	} else if (attributeDefinition.type === 'boolean') {
 		schema = z.boolean();
 	} else if (attributeDefinition.type === 'date') {
-		schema = z.string().date();
+		schema = z.iso.date();
 	} else {
 		schema = z.unknown();
 	}

--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
@@ -215,7 +215,7 @@ export class OutputParserStructured implements INodeType {
 				? generateSchemaFromExample(jsonExample, jsonExampleAllFieldsRequired)
 				: jsonParse<JSONSchema7>(inputSchema);
 
-		const zodSchema = convertJsonSchemaToZod<z.ZodSchema<object>>(jsonSchema);
+		const zodSchema = convertJsonSchemaToZod<z.ZodType<object>>(jsonSchema);
 		const nodeVersion = this.getNode().typeVersion;
 
 		const autoFix = this.getNodeParameter('autoFix', itemIndex, false) as boolean;

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
@@ -791,7 +791,7 @@ export const configureToolFunction = (
 };
 
 function makeParameterZodSchema(parameter: ToolParameter) {
-	let schema: z.ZodTypeAny;
+	let schema: z.ZodType;
 
 	if (parameter.type === 'string') {
 		schema = z.string();
@@ -800,7 +800,7 @@ function makeParameterZodSchema(parameter: ToolParameter) {
 	} else if (parameter.type === 'boolean') {
 		schema = z.boolean();
 	} else if (parameter.type === 'json') {
-		schema = z.record(z.any());
+		schema = z.record(z.string(), z.any());
 	} else {
 		schema = z.string();
 	}

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/utils.ts
@@ -4,6 +4,7 @@ import type { OpenAIClient } from '@langchain/openai';
 import type { BufferWindowMemory } from '@langchain/classic/memory';
 import { isObjectEmpty } from 'n8n-workflow';
 import { zodToJsonSchema } from 'zod-to-json-schema';
+import z from 'zod';
 
 // Copied from langchain(`langchain/src/tools/convert_to_openai.ts`)
 // since these functions are not exported

--- a/packages/@n8n/nodes-langchain/utils/N8nTool.ts
+++ b/packages/@n8n/nodes-langchain/utils/N8nTool.ts
@@ -3,12 +3,12 @@ import { DynamicStructuredTool, DynamicTool } from '@langchain/core/tools';
 import { StructuredOutputParser } from '@langchain/classic/output_parsers';
 import type { ISupplyDataFunctions, IDataObject } from 'n8n-workflow';
 import { NodeConnectionTypes, jsonParse, NodeOperationError } from 'n8n-workflow';
-import type { ZodTypeAny } from 'zod';
+import type { ZodType } from 'zod';
 import { ZodBoolean, ZodNullable, ZodNumber, ZodObject, ZodOptional } from 'zod';
 
 import type { ZodObjectAny } from '../types/types';
 
-const getSimplifiedType = (schema: ZodTypeAny) => {
+const getSimplifiedType = (schema: ZodType) => {
 	if (schema instanceof ZodObject) {
 		return 'object';
 	} else if (schema instanceof ZodNumber) {
@@ -22,7 +22,7 @@ const getSimplifiedType = (schema: ZodTypeAny) => {
 	return 'string';
 };
 
-const getParametersDescription = (parameters: Array<[string, ZodTypeAny]>) =>
+const getParametersDescription = (parameters: Array<[string, ZodType]>) =>
 	parameters
 		.map(
 			([name, schema]) =>
@@ -33,7 +33,7 @@ const getParametersDescription = (parameters: Array<[string, ZodTypeAny]>) =>
 export const prepareFallbackToolDescription = (toolDescription: string, schema: ZodObject<any>) => {
 	let description = `${toolDescription}`;
 
-	const toolParameters = Object.entries<ZodTypeAny>(schema.shape);
+	const toolParameters = Object.entries<ZodType>(schema.shape);
 
 	if (toolParameters.length) {
 		description += `

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/N8nStructuredOutputParser.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/N8nStructuredOutputParser.test.ts
@@ -47,8 +47,8 @@ describe('N8nStructuredOutputParser', () => {
 
 			expect(result).toEqual({
 				output: {
-					message: '## Example\n```bash\n--set globals.enable=false\n```\n',
 					status: 'completed',
+					error: '## Example\n```bash\n--set globals.enable=false\n```\n',
 				},
 			});
 		});
@@ -147,8 +147,8 @@ describe('N8nStructuredOutputParser', () => {
 
 			expect(result).toEqual({
 				output: {
-					message: 'Simple message',
 					status: 'completed',
+					error: 'Simple message',
 				},
 			});
 		});
@@ -176,8 +176,8 @@ describe('N8nStructuredOutputParser', () => {
 
 			expect(result).toEqual({
 				output: {
-					message: 'Simple message',
 					status: 'completed',
+					error: 'Simple message',
 				},
 			});
 		});
@@ -201,7 +201,7 @@ describe('N8nStructuredOutputParser', () => {
 
 			expect(result).toEqual({
 				output: {
-					message: 'Line 1\nLine 2\n"quoted"',
+					error: 'Line 1\nLine 2\n"quoted"',
 				},
 			});
 		});

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/N8nStructuredOutputParser.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/N8nStructuredOutputParser.ts
@@ -17,7 +17,7 @@ export class N8nStructuredOutputParser extends StructuredOutputParser<
 > {
 	constructor(
 		private context: ISupplyDataFunctions,
-		zodSchema: z.ZodSchema<object>,
+		zodSchema: z.ZodType<object>,
 	) {
 		super(zodSchema);
 	}
@@ -121,7 +121,7 @@ export class N8nStructuredOutputParser extends StructuredOutputParser<
 	}
 
 	static async fromZodJsonSchema(
-		zodSchema: z.ZodSchema<object>,
+		zodSchema: z.ZodType<object>,
 		nodeVersion: number,
 		context: ISupplyDataFunctions,
 	): Promise<N8nStructuredOutputParser> {
@@ -145,9 +145,9 @@ export class N8nStructuredOutputParser extends StructuredOutputParser<
 							);
 						},
 						{
-							message:
-								'One and only one of __structured__output__object and __structured__output__array should be present.',
 							path: [STRUCTURED_OUTPUT_KEY],
+							error:
+								'One and only one of __structured__output__object and __structured__output__array should be present.',
 						},
 					),
 			});

--- a/packages/@n8n/nodes-langchain/utils/schemaParsing.ts
+++ b/packages/@n8n/nodes-langchain/utils/schemaParsing.ts
@@ -48,7 +48,7 @@ export function generateSchemaFromExample(
 	return schema;
 }
 
-export function convertJsonSchemaToZod<T extends z.ZodTypeAny = z.ZodTypeAny>(schema: JSONSchema7) {
+export function convertJsonSchemaToZod<T extends z.ZodType = z.ZodType>(schema: JSONSchema7) {
 	return jsonSchemaToZod<T>(schema);
 }
 

--- a/packages/@n8n/permissions/src/schemas.ee.ts
+++ b/packages/@n8n/permissions/src/schemas.ee.ts
@@ -15,7 +15,7 @@ const customGlobalRoleSchema = z
 	.string()
 	.nonempty()
 	.refine((val) => !globalRoleSchema.safeParse(val).success, {
-		message: 'This global role value is not assignable',
+		error: 'This global role value is not assignable',
 	});
 
 export const assignableGlobalRoleSchema = z.union([
@@ -42,7 +42,7 @@ export const customProjectRoleSchema = z
 	.string()
 	.nonempty()
 	.refine((val) => !systemProjectRoleSchema.safeParse(val).success, {
-		message: 'This global role value is not assignable',
+		error: 'This global role value is not assignable',
 	});
 
 // Those are all the system roles for projects
@@ -60,7 +60,7 @@ export const workflowSharingRoleSchema = z.enum(['workflow:owner', 'workflow:edi
 const ALL_SCOPES_LOOKUP_SET = new Set(ALL_SCOPES as string[]);
 
 export const scopeSchema = z.string().refine((val) => ALL_SCOPES_LOOKUP_SET.has(val), {
-	message: 'Invalid scope',
+	error: 'Invalid scope',
 });
 
 export const roleSchema = z.object({

--- a/packages/@n8n/syslog-client/src/client.ts
+++ b/packages/@n8n/syslog-client/src/client.ts
@@ -82,7 +82,7 @@ export class SyslogClient extends EventEmitter {
 
 		const validationResult = clientOptionsSchema.safeParse(options ?? {});
 		if (!validationResult.success) {
-			throw ValidationError.fromZod('Invalid client options', validationResult.error.errors);
+			throw ValidationError.fromZod('Invalid client options', validationResult.error.issues);
 		}
 
 		const opts = validationResult.data;
@@ -163,7 +163,7 @@ export class SyslogClient extends EventEmitter {
 		// Validate options
 		const validationResult = logOptionsSchema.safeParse(options);
 		if (!validationResult.success) {
-			errorCb(ValidationError.fromZod('Invalid log options', validationResult.error.errors));
+			errorCb(ValidationError.fromZod('Invalid log options', validationResult.error.issues));
 			return;
 		}
 

--- a/packages/@n8n/syslog-client/src/schemas.ts
+++ b/packages/@n8n/syslog-client/src/schemas.ts
@@ -18,14 +18,14 @@ const createEnumSchema = (enumObject: object, name: string) => {
  */
 export const clientOptionsSchema = z.object({
 	syslogHostname: z.string().optional(),
-	port: z.number().int().positive().max(65535).optional(),
-	tcpTimeout: z.number().int().positive().optional(),
+	port: z.int().positive().max(65535).optional(),
+	tcpTimeout: z.int().positive().optional(),
 	facility: createEnumSchema(Facility, 'facility').optional(),
 	severity: createEnumSchema(Severity, 'severity').optional(),
 	rfc3164: z.boolean().optional(),
 	appName: z.string().max(48).optional(), // RFC 5424 limit
-	dateFormatter: z.function().args(z.date()).returns(z.string()).optional(),
-	udpBindAddress: z.string().ip().optional(),
+	dateFormatter: z.function({ input: [z.date()], output: z.string() }).optional(),
+	udpBindAddress: z.union([z.ipv4(), z.ipv6()]).optional(),
 	transport: createEnumSchema(Transport, 'transport').optional(),
 	tlsCA: z
 		.union([z.string(), z.array(z.string()), z.instanceof(Buffer), z.array(z.instanceof(Buffer))])

--- a/packages/@n8n/workflow-sdk/src/generate-types/zod-helpers.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/zod-helpers.ts
@@ -169,7 +169,7 @@ export function optionsWithExpression<T extends string | number | boolean>(
  */
 export function multiOptionsSchema<T extends string | number | boolean>(
 	values: T[],
-): z.ZodArray<z.ZodTypeAny> {
+): z.ZodArray<z.ZodType> {
 	if (values.length === 0) {
 		return z.array(z.string());
 	}

--- a/packages/@n8n/workflow-sdk/src/validation/resolve-schema.ts
+++ b/packages/@n8n/workflow-sdk/src/validation/resolve-schema.ts
@@ -117,7 +117,7 @@ function formatDisplayOptionsRequirements(displayOptions: DisplayOptions): strin
 
 export type ResolveSchemaConfig = {
 	parameters: Record<string, unknown>;
-	schema: z.ZodTypeAny;
+	schema: z.ZodType;
 	required: boolean;
 	displayOptions: DisplayOptions;
 	/** Default values for properties referenced in displayOptions (used when property is not set) */
@@ -126,7 +126,7 @@ export type ResolveSchemaConfig = {
 	isToolNode?: boolean;
 };
 
-export type ResolveSchemaFn = (config: ResolveSchemaConfig) => z.ZodTypeAny;
+export type ResolveSchemaFn = (config: ResolveSchemaConfig) => z.ZodType;
 
 /**
  * Check if a field should be visible based on displayOptions and current parameter values.
@@ -154,7 +154,7 @@ export function resolveSchema({
 	displayOptions,
 	defaults = {},
 	isToolNode,
-}: ResolveSchemaConfig): z.ZodTypeAny {
+}: ResolveSchemaConfig): z.ZodType {
 	const context: DisplayOptionsContext = { parameters, defaults, isToolNode };
 	const isVisible = matchesDisplayOptionsCore(context, displayOptions);
 

--- a/packages/@n8n/workflow-sdk/src/validation/schema-helpers.ts
+++ b/packages/@n8n/workflow-sdk/src/validation/schema-helpers.ts
@@ -41,14 +41,12 @@ export type { ResolveSchemaConfig, ResolveSchemaFn } from './resolve-schema';
  * Resource Mapper Value schema (object format)
  * Used for mapping input data to columns/fields
  */
-const resourceMapperObjectSchema = z
-	.object({
-		mappingMode: z.string(),
-		value: z.unknown().optional(),
-		schema: z.array(z.unknown()).optional(),
-		cachedResultName: z.string().optional(),
-	})
-	.passthrough();
+const resourceMapperObjectSchema = z.looseObject({
+	mappingMode: z.string(),
+	value: z.unknown().optional(),
+	schema: z.array(z.unknown()).optional(),
+	cachedResultName: z.string().optional(),
+});
 
 /**
  * Resource Mapper Value schema - accepts object format OR expression

--- a/packages/cli/src/chat/chat-service.ts
+++ b/packages/cli/src/chat/chat-service.ts
@@ -317,7 +317,7 @@ export class ChatService {
 		} catch (error) {
 			if (error instanceof z.ZodError) {
 				throw new UnexpectedError(
-					`Chat message validation error: ${error.errors.map((error) => error.message).join(', ')}`,
+					`Chat message validation error: ${error.issues.map((error) => error.message).join(', ')}`,
 				);
 			}
 			throw error;

--- a/packages/cli/src/collaboration/collaboration.message.ts
+++ b/packages/cli/src/collaboration/collaboration.message.ts
@@ -7,41 +7,31 @@ export type CollaborationMessage =
 	| WriteAccessReleaseRequestedMessage
 	| WriteAccessHeartbeatMessage;
 
-export const workflowOpenedMessageSchema = z
-	.object({
-		type: z.literal('workflowOpened'),
-		workflowId: z.string().min(1),
-	})
-	.strict();
+export const workflowOpenedMessageSchema = z.strictObject({
+	type: z.literal('workflowOpened'),
+	workflowId: z.string().min(1),
+});
 
-export const workflowClosedMessageSchema = z
-	.object({
-		type: z.literal('workflowClosed'),
-		workflowId: z.string().min(1),
-	})
-	.strict();
+export const workflowClosedMessageSchema = z.strictObject({
+	type: z.literal('workflowClosed'),
+	workflowId: z.string().min(1),
+});
 
-export const writeAccessRequestedMessageSchema = z
-	.object({
-		type: z.literal('writeAccessRequested'),
-		workflowId: z.string().min(1),
-		force: z.boolean().optional(),
-	})
-	.strict();
+export const writeAccessRequestedMessageSchema = z.strictObject({
+	type: z.literal('writeAccessRequested'),
+	workflowId: z.string().min(1),
+	force: z.boolean().optional(),
+});
 
-export const writeAccessReleaseRequestedMessageSchema = z
-	.object({
-		type: z.literal('writeAccessReleaseRequested'),
-		workflowId: z.string().min(1),
-	})
-	.strict();
+export const writeAccessReleaseRequestedMessageSchema = z.strictObject({
+	type: z.literal('writeAccessReleaseRequested'),
+	workflowId: z.string().min(1),
+});
 
-export const writeAccessHeartbeatMessageSchema = z
-	.object({
-		type: z.literal('writeAccessHeartbeat'),
-		workflowId: z.string().min(1),
-	})
-	.strict();
+export const writeAccessHeartbeatMessageSchema = z.strictObject({
+	type: z.literal('writeAccessHeartbeat'),
+	workflowId: z.string().min(1),
+});
 
 export const workflowMessageSchema = z.discriminatedUnion('type', [
 	workflowOpenedMessageSchema,

--- a/packages/cli/src/command-registry.ts
+++ b/packages/cli/src/command-registry.ts
@@ -129,7 +129,7 @@ export class CommandRegistry {
 					.object({
 						help: z.boolean().alias('h').describe('Show CLI help'),
 					})
-					.merge(flagsSchema).shape,
+					.extend(flagsSchema.shape).shape,
 			);
 			for (const [flagName, flagSchema] of flagEntries) {
 				let schemaDef = flagSchema._def as z.ZodTypeDef & {

--- a/packages/cli/src/commands/execute-batch.ts
+++ b/packages/cli/src/commands/execute-batch.ts
@@ -46,7 +46,6 @@ const flagsSchema = z.object({
 		)
 		.optional(),
 	concurrency: z
-		.number()
 		.int()
 		.default(1)
 		.describe('How many workflows can run in parallel. Defaults to 1 which means no concurrency.'),
@@ -85,7 +84,6 @@ const flagsSchema = z.object({
 		.describe('File containing a comma separated list of workflow IDs to skip.')
 		.optional(),
 	retries: z
-		.number()
 		.int()
 		.default(1)
 		.describe('Retries failed workflows up to N tries. Default is 1. Set 0 to disable.'),

--- a/packages/cli/src/commands/export/entities.ts
+++ b/packages/cli/src/commands/export/entities.ts
@@ -16,7 +16,7 @@ const flagsSchema = z.object({
 		.describe(
 			'Include execution history data tables, these are excluded by default as they can be very large',
 		)
-		.default(false),
+		.prefault(false),
 	keyFile: z
 		.string()
 		.describe('Optional path to a file containing a custom encryption key')

--- a/packages/cli/src/commands/import/entities.ts
+++ b/packages/cli/src/commands/import/entities.ts
@@ -11,7 +11,7 @@ const flagsSchema = z.object({
 		.string()
 		.describe('Input directory that holds output files for import')
 		.default('./outputs'),
-	truncateTables: z.coerce.boolean().describe('Truncate tables before import').default(false),
+	truncateTables: z.coerce.boolean().describe('Truncate tables before import').prefault(false),
 	keyFile: z
 		.string()
 		.describe('Optional path to a file containing a custom encryption key')
@@ -19,11 +19,11 @@ const flagsSchema = z.object({
 	skipMigrationChecks: z.coerce
 		.boolean()
 		.describe('Skip migration validation checks')
-		.default(false),
+		.prefault(false),
 	skipTogglingForeignKeyConstraints: z.coerce
 		.boolean()
 		.describe('Skip disabling foreign key constraints')
-		.default(false),
+		.prefault(false),
 });
 
 @Command({

--- a/packages/cli/src/commands/ttwf/generate.ts
+++ b/packages/cli/src/commands/ttwf/generate.ts
@@ -47,13 +47,11 @@ const flagsSchema = z.object({
 		.describe('Output file name to save the results. Default is ttwf-results.jsonl')
 		.default('ttwf-results.jsonl'),
 	limit: z
-		.number()
 		.int()
 		.alias('l')
 		.describe('Number of items from the dataset to process. Only valid with --input.')
 		.default(-1),
 	concurrency: z
-		.number()
 		.int()
 		.alias('c')
 		.describe('Number of items to process in parallel. Only valid with --input.')

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -20,7 +20,7 @@ import { BaseCommand } from './base-command';
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 
 const flagsSchema = z.object({
-	concurrency: z.number().int().default(10).describe('How many jobs can run in parallel.'),
+	concurrency: z.int().default(10).describe('How many jobs can run in parallel.'),
 });
 
 @Command({

--- a/packages/cli/src/controller.registry.ts
+++ b/packages/cli/src/controller.registry.ts
@@ -102,7 +102,7 @@ export class ControllerRegistry {
 							const output = paramType.safeParse(req[arg.type]);
 							if (output.success) args.push(output.data);
 							else {
-								return res.status(400).json(output.error.errors[0]);
+								return res.status(400).json(output.error.issues[0]);
 							}
 						}
 					} else throw new UnexpectedError('Unknown arg type: ' + arg.type);

--- a/packages/cli/src/controllers/me.controller.ts
+++ b/packages/cli/src/controllers/me.controller.ts
@@ -198,7 +198,7 @@ export class MeController {
 		const passwordValidation = passwordSchema.safeParse(newPassword);
 		if (!passwordValidation.success) {
 			throw new BadRequestError(
-				passwordValidation.error.errors.map(({ message }) => message).join(' '),
+				passwordValidation.error.issues.map(({ message }) => message).join(' '),
 			);
 		}
 

--- a/packages/cli/src/modules/chat-hub/chat-hub-extractor.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-extractor.ts
@@ -102,7 +102,7 @@ export class ChatHubExtractor implements IContextEstablishmentHook {
 					};
 				} else {
 					this.logger.warn('Invalid format for encryptedMetadata in chathub extractor', {
-						errors: chatHubInformation.error.errors,
+						errors: chatHubInformation.error.issues,
 					});
 				}
 			} catch (error) {

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-introspection-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-introspection-identifier.ts
@@ -27,8 +27,8 @@ export const OAuth2IntrospectionOptionsSchema = z.object({
 type OAuth2IntrospectionOptions = z.infer<typeof OAuth2IntrospectionOptionsSchema>;
 
 const OAuth2MetadataSchema = z.object({
-	issuer: z.string().url(),
-	introspection_endpoint: z.string().url(),
+	issuer: z.url(),
+	introspection_endpoint: z.url(),
 	// This could be an well defined enum, but to make sure we are not failing validation
 	// of unknown values, we keep it as string
 	introspection_endpoint_auth_methods_supported: z.array(z.string()).optional(),
@@ -36,25 +36,23 @@ const OAuth2MetadataSchema = z.object({
 
 type OAuth2Metadata = z.infer<typeof OAuth2MetadataSchema>;
 
-export const TokenIntrospectionResponseSchema = z
-	.object({
-		// Core fields
-		active: z.boolean(),
+export const TokenIntrospectionResponseSchema = z.looseObject({
+	// Core fields
+	active: z.boolean(),
 
-		// Standard optional fields
-		scope: z.string().optional(),
-		client_id: z.string().optional(),
-		username: z.string().optional(),
-		token_type: z.string().optional(),
-		exp: z.number().int().optional(),
-		iat: z.number().int().optional(),
-		nbf: z.number().int().optional(),
-		sub: z.string().optional(),
-		aud: z.union([z.string(), z.array(z.string())]).optional(),
-		iss: z.string().optional(),
-		jti: z.string().optional(),
-	})
-	.passthrough(); // Allow additional custom claims
+	// Standard optional fields
+	scope: z.string().optional(),
+	client_id: z.string().optional(),
+	username: z.string().optional(),
+	token_type: z.string().optional(),
+	exp: z.int().optional(),
+	iat: z.int().optional(),
+	nbf: z.int().optional(),
+	sub: z.string().optional(),
+	aud: z.union([z.string(), z.array(z.string())]).optional(),
+	iss: z.string().optional(),
+	jti: z.string().optional(),
+}); // Allow additional custom claims
 
 export type TokenIntrospectionResponse = z.infer<typeof TokenIntrospectionResponseSchema>;
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-userinfo-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-userinfo-identifier.ts
@@ -25,18 +25,16 @@ export const OAuth2UserInfoOptionsSchema = z.object({
 type OAuth2UserInfoOptions = z.infer<typeof OAuth2UserInfoOptionsSchema>;
 
 const OAuth2MetadataSchema = z.object({
-	issuer: z.string().url(),
-	userinfo_endpoint: z.string().url(),
+	issuer: z.url(),
+	userinfo_endpoint: z.url(),
 });
 
 type OAuth2Metadata = z.infer<typeof OAuth2MetadataSchema>;
 
-export const UserInfoResponseSchema = z
-	.object({
-		// Standard optional fields
-		sub: z.string().optional(),
-	})
-	.passthrough();
+export const UserInfoResponseSchema = z.looseObject({
+	// Standard optional fields
+	sub: z.string().optional(),
+});
 
 export type UserInfoResponse = z.infer<typeof UserInfoResponseSchema>;
 

--- a/packages/cli/src/modules/insights/insights.controller.ts
+++ b/packages/cli/src/modules/insights/insights.controller.ts
@@ -113,14 +113,14 @@ export class InsightsController {
 					return true;
 				},
 				{
-					message: 'endDate must be the same as or after startDate',
 					path: ['endDate'],
+					error: 'endDate must be the same as or after startDate',
 				},
 			);
 
 		const result = schema.safeParse(query);
 		if (!result.success) {
-			throw new BadRequestError(result.error.errors.map(({ message }) => message).join(' '));
+			throw new BadRequestError(result.error.issues.map(({ message }) => message).join(' '));
 		}
 	}
 

--- a/packages/cli/src/modules/log-streaming.ee/log-streaming.controller.ts
+++ b/packages/cli/src/modules/log-streaming.ee/log-streaming.controller.ts
@@ -55,7 +55,7 @@ export class EventBusController {
 		// And ZodClass doesn't support discriminated unions directly
 		const parseResult = CreateDestinationDto.safeParse(req.body);
 		if (!parseResult.success) {
-			throw new BadRequestError(parseResult.error.errors[0].message);
+			throw new BadRequestError(parseResult.error.issues[0].message);
 		}
 
 		const body = parseResult.data;

--- a/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.handler.ts
@@ -76,7 +76,7 @@ export = {
 				const payload = PublicApiListDataTableQueryDto.safeParse(stringifyQuery(req.query));
 				if (!payload.success) {
 					return res.status(400).json({
-						message: payload.error.errors[0]?.message || 'Invalid query parameters',
+						message: payload.error.issues[0]?.message || 'Invalid query parameters',
 					});
 				}
 
@@ -142,7 +142,7 @@ export = {
 				const payload = CreateDataTableDto.safeParse(req.body);
 				if (!payload.success) {
 					return res.status(400).json({
-						message: payload.error.errors[0]?.message || 'Invalid request body',
+						message: payload.error.issues[0]?.message || 'Invalid request body',
 					});
 				}
 
@@ -201,7 +201,7 @@ export = {
 				const payload = UpdateDataTableDto.safeParse(req.body);
 				if (!payload.success) {
 					return res.status(400).json({
-						message: payload.error.errors[0]?.message || 'Invalid request body',
+						message: payload.error.issues[0]?.message || 'Invalid request body',
 					});
 				}
 

--- a/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.rows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.rows.handler.ts
@@ -76,7 +76,7 @@ export = {
 				const payload = PublicApiListDataTableContentQueryDto.safeParse(stringifyQuery(req.query));
 				if (!payload.success) {
 					return res.status(400).json({
-						message: payload.error.errors[0]?.message || 'Invalid query parameters',
+						message: payload.error.issues[0]?.message || 'Invalid query parameters',
 					});
 				}
 
@@ -120,7 +120,7 @@ export = {
 				const payload = AddDataTableRowsDto.safeParse(req.body);
 				if (!payload.success) {
 					return res.status(400).json({
-						message: payload.error.errors[0]?.message || 'Invalid request body',
+						message: payload.error.issues[0]?.message || 'Invalid request body',
 					});
 				}
 
@@ -150,7 +150,7 @@ export = {
 				const payload = UpdateDataTableRowDto.safeParse(req.body);
 				if (!payload.success) {
 					return res.status(400).json({
-						message: payload.error.errors[0]?.message || 'Invalid request body',
+						message: payload.error.issues[0]?.message || 'Invalid request body',
 					});
 				}
 
@@ -182,7 +182,7 @@ export = {
 				const payload = UpsertDataTableRowDto.safeParse(req.body);
 				if (!payload.success) {
 					return res.status(400).json({
-						message: payload.error.errors[0]?.message || 'Invalid request body',
+						message: payload.error.issues[0]?.message || 'Invalid request body',
 					});
 				}
 
@@ -214,7 +214,7 @@ export = {
 				const payload = DeleteDataTableRowsDto.safeParse(stringifyQuery(req.query));
 				if (!payload.success) {
 					return res.status(400).json({
-						message: payload.error.errors[0]?.message || 'Invalid query parameters',
+						message: payload.error.issues[0]?.message || 'Invalid query parameters',
 					});
 				}
 

--- a/packages/cli/src/public-api/v1/handlers/projects/projects.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/projects/projects.handler.ts
@@ -32,7 +32,7 @@ export = {
 		async (req: AuthenticatedRequest, res: Response) => {
 			const payload = CreateProjectDto.safeParse(req.body);
 			if (payload.error) {
-				return res.status(400).json(payload.error.errors[0]);
+				return res.status(400).json(payload.error.issues[0]);
 			}
 
 			const project = await Container.get(ProjectController).createProject(req, res, payload.data);
@@ -46,7 +46,7 @@ export = {
 		async (req: AuthenticatedRequest<{ projectId: string }>, res: Response) => {
 			const payload = UpdateProjectWithRelationsDto.safeParse(req.body);
 			if (payload.error) {
-				return res.status(400).json(payload.error.errors[0]);
+				return res.status(400).json(payload.error.issues[0]);
 			}
 
 			await Container.get(ProjectController).updateProject(
@@ -65,7 +65,7 @@ export = {
 		async (req: AuthenticatedRequest<{ projectId: string }>, res: Response) => {
 			const query = DeleteProjectDto.safeParse(req.query);
 			if (query.error) {
-				return res.status(400).json(query.error.errors[0]);
+				return res.status(400).json(query.error.issues[0]);
 			}
 
 			await Container.get(ProjectController).deleteProject(
@@ -161,7 +161,7 @@ export = {
 		async (req: AuthenticatedRequest<{ projectId: string }>, res: Response) => {
 			const payload = AddUsersToProjectDto.safeParse(req.body);
 			if (payload.error) {
-				return res.status(400).json(payload.error.errors[0]);
+				return res.status(400).json(payload.error.issues[0]);
 			}
 
 			try {
@@ -185,7 +185,7 @@ export = {
 		async (req: AuthenticatedRequest<{ projectId: string; userId: string }>, res: Response) => {
 			const payload = ChangeUserRoleInProject.safeParse(req.body);
 			if (payload.error) {
-				return res.status(400).json(payload.error.errors[0]);
+				return res.status(400).json(payload.error.issues[0]);
 			}
 
 			const { projectId, userId } = req.params;

--- a/packages/cli/src/public-api/v1/handlers/users/users.handler.ee.ts
+++ b/packages/cli/src/public-api/v1/handlers/users/users.handler.ee.ts
@@ -85,7 +85,7 @@ export = {
 		async (req: Create, res: Response) => {
 			const { data, error } = InviteUsersRequestDto.safeParse(req.body);
 			if (error) {
-				return res.status(400).json(error.errors[0]);
+				return res.status(400).json(error.issues[0]);
 			}
 
 			const usersInvited = await Container.get(InvitationController).inviteUser(
@@ -111,7 +111,7 @@ export = {
 			const validation = RoleChangeRequestDto.safeParse(req.body);
 			if (validation.error) {
 				return res.status(400).json({
-					message: validation.error.errors[0],
+					message: validation.error.issues[0],
 				});
 			}
 

--- a/packages/cli/src/public-api/v1/handlers/variables/variables.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/variables/variables.handler.ts
@@ -23,7 +23,7 @@ export = {
 		async (req: AuthenticatedRequest, res: Response) => {
 			const payload = CreateVariableRequestDto.safeParse(req.body);
 			if (payload.error) {
-				return res.status(400).json(payload.error.errors[0]);
+				return res.status(400).json(payload.error.issues[0]);
 			}
 			await Container.get(VariablesController).createVariable(req, res, payload.data);
 
@@ -36,7 +36,7 @@ export = {
 		async (req: AuthenticatedRequest<{ id: string }>, res: Response) => {
 			const payload = UpdateVariableRequestDto.safeParse(req.body);
 			if (payload.error) {
-				return res.status(400).json(payload.error.errors[0]);
+				return res.status(400).json(payload.error.issues[0]);
 			}
 			await Container.get(VariablesController).updateVariable(req, res, payload.data);
 

--- a/packages/cli/src/services/rate-limit.service.ts
+++ b/packages/cli/src/services/rate-limit.service.ts
@@ -6,7 +6,7 @@ import { Service } from '@n8n/di';
 import type { Request, RequestHandler } from 'express';
 import { rateLimit as expressRateLimit } from 'express-rate-limit';
 import assert from 'node:assert';
-import type { ZodTypeAny } from 'zod';
+import type { ZodType } from 'zod';
 import type { ZodClass } from '@n8n/api-types';
 
 const defaultLimits: Required<RateLimiterLimits> = {
@@ -74,7 +74,7 @@ export class RateLimitService {
 		});
 	}
 
-	private extractBodyIdentifier(body: unknown, fieldName: string, fieldSchema: ZodTypeAny): string {
+	private extractBodyIdentifier(body: unknown, fieldName: string, fieldSchema: ZodType): string {
 		if (!body || typeof body !== 'object') {
 			return 'skip:empty-body';
 		}

--- a/packages/cli/src/services/ssrf/ip-range-builder.ts
+++ b/packages/cli/src/services/ssrf/ip-range-builder.ts
@@ -65,7 +65,7 @@ function parseCidr(
 	return { network, prefix, family };
 }
 
-const cidrSchema = z.string().cidr();
+const cidrSchema = z.union([z.cidrv4(), z.cidrv6()]);
 
 function validateIp(ip: string): 'ipv4' | 'ipv6' | null {
 	const version = isIP(ip);

--- a/packages/cli/src/task-runners/task-broker/auth/task-broker-auth.controller.ts
+++ b/packages/cli/src/task-runners/task-broker/auth/task-broker-auth.controller.ts
@@ -21,7 +21,7 @@ export class TaskBrokerAuthController {
 	async createGrantToken(req: AuthlessRequest) {
 		const result = await taskBrokerAuthRequestBodySchema.safeParseAsync(req.body);
 		if (!result.success) {
-			throw new BadRequestError(result.error.errors[0].code);
+			throw new BadRequestError(result.error.issues[0].code);
 		}
 
 		const { token: authToken } = result.data;

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/create-node-as-tool.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/create-node-as-tool.test.ts
@@ -397,7 +397,7 @@ describe('createNodeAsTool', () => {
 
 			const tool = createNodeAsTool(options).response;
 
-			expect(tool.schema.shape.complexJson._def.innerType).toBeInstanceOf(z.ZodEffects);
+			expect(tool.schema.shape.complexJson._zod.def.innerType).toBeInstanceOf(z.ZodEffects);
 			expect(tool.schema.shape.complexJson.description).toBe('Param with complex JSON default');
 			expect(tool.schema.shape.complexJson._def.defaultValue()).toEqual({
 				nested: { key: 'value' },
@@ -498,7 +498,7 @@ describe('createNodeAsTool', () => {
 
 			const tool = createNodeAsTool(options).response;
 
-			expect(tool.schema.shape.excessArgs._def.innerType).toBeInstanceOf(z.ZodString);
+			expect(tool.schema.shape.excessArgs._zod.def.innerType).toBeInstanceOf(z.ZodString);
 			expect(tool.schema.shape.excessArgs.description).toBe('Param with excess arguments');
 			expect(tool.schema.shape.excessArgs._def.defaultValue()).toBe('default');
 		});

--- a/packages/core/src/execution-engine/node-execution-context/utils/create-node-as-tool.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/create-node-as-tool.ts
@@ -81,7 +81,7 @@ export function getSchema(node: INode) {
 	const uniqueArguments = Array.from(uniqueArgsMap.values());
 
 	// Generate Zod schema from unique arguments
-	const schemaObj = uniqueArguments.reduce((acc: Record<string, z.ZodTypeAny>, placeholder) => {
+	const schemaObj = uniqueArguments.reduce((acc: Record<string, z.ZodType>, placeholder) => {
 		acc[placeholder.key] = generateZodSchema(placeholder);
 		return acc;
 	}, {});

--- a/packages/core/src/execution-engine/ssh-clients-manager.ts
+++ b/packages/core/src/execution-engine/ssh-clients-manager.ts
@@ -16,20 +16,22 @@ export class SSHClientsConfig {
 			.transform((value) => Number.parseInt(value))
 			.superRefine((value, ctx) => {
 				if (Number.isNaN(value)) {
-					return ctx.addIssue({
+					ctx.addIssue({
 						message: 'must be a valid integer',
 						code: 'custom',
 					});
+					return;
 				}
 
 				if (value <= 0) {
-					return ctx.addIssue({
+					ctx.addIssue({
 						message: 'must be positive',
 						code: 'too_small',
 						minimum: 0,
 						inclusive: false,
 						type: 'number',
 					});
+					return;
 				}
 			}),
 	)

--- a/packages/nodes-base/nodes/Evaluation/utils/metricHandlers.ts
+++ b/packages/nodes-base/nodes/Evaluation/utils/metricHandlers.ts
@@ -214,7 +214,6 @@ export const metricHandlers = {
 				.describe('detailed step-by-step analysis of the response helpfulness'),
 			reasoning_summary: z.string().describe('one sentence summary of the response helpfulness'),
 			score: z
-				.number()
 				.int()
 				.min(1)
 				.max(5)
@@ -307,7 +306,6 @@ export const metricHandlers = {
 				.describe('detailed step-by-step analysis of factual accuracy and similarity'),
 			reasoning_summary: z.string().describe('one sentence summary focusing on key differences'),
 			score: z
-				.number()
 				.int()
 				.min(1)
 				.max(5)

--- a/packages/nodes-base/nodes/Freshservice/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Freshservice/GenericFunctions.ts
@@ -51,11 +51,11 @@ export async function freshserviceApiRequest(
 		return await this.helpers.request(options);
 	} catch (error) {
 		if (error.error.description === 'Validation failed') {
-			const numberOfErrors = error.error.errors.length;
+			const numberOfErrors = error.error.issues.length;
 			const message = 'Please check your parameters';
 
 			if (numberOfErrors === 1) {
-				const [validationError] = error.error.errors;
+				const [validationError] = error.error.issues;
 				throw new NodeApiError(this.getNode(), error as JsonObject, {
 					message,
 					description: `For ${validationError.field}: ${validationError.message}`,

--- a/packages/nodes-base/nodes/Twitter/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Twitter/V2/GenericFunctions.ts
@@ -49,8 +49,8 @@ export async function twitterApiRequest(
 				this.getNode(),
 				'The operation requires Twitter Api to be either Basic or Pro.',
 			);
-		} else if (error.errors && error.error?.errors[0].message.includes('must be ')) {
-			throw new NodeOperationError(this.getNode(), error.error.errors[0].message as string);
+		} else if (error.issues && error.error?.errors[0].message.includes('must be ')) {
+			throw new NodeOperationError(this.getNode(), error.error.issues[0].message as string);
 		}
 		throw new NodeApiError(this.getNode(), error as JsonObject);
 	}

--- a/packages/nodes-base/nodes/Venafi/Datacenter/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Venafi/Datacenter/GenericFunctions.ts
@@ -46,7 +46,7 @@ export async function venafiApiRequest(
 		);
 	} catch (error) {
 		if (error.response?.body?.error) {
-			let errors = error.response.body.error.errors;
+			let errors = error.response.body.error.issues;
 
 			errors = errors.map((e: IDataObject) => e.message);
 			// Try to return the error prettier

--- a/packages/workflow/src/from-ai-parse-utils.ts
+++ b/packages/workflow/src/from-ai-parse-utils.ts
@@ -23,8 +23,8 @@ class ParseError extends Error {}
  * @param placeholder The FromAIArgument object containing key, type, description, and defaultValue.
  * @returns A Zod schema corresponding to the placeholder's type and constraints.
  */
-export function generateZodSchema(placeholder: FromAIArgument): z.ZodTypeAny {
-	let schema: z.ZodTypeAny;
+export function generateZodSchema(placeholder: FromAIArgument): z.ZodType {
+	let schema: z.ZodType;
 
 	switch (placeholder.type?.toLowerCase()) {
 		case 'string':
@@ -37,7 +37,7 @@ export function generateZodSchema(placeholder: FromAIArgument): z.ZodTypeAny {
 			schema = z.boolean();
 			break;
 		case 'json': {
-			interface CustomSchemaDef extends z.ZodTypeDef {
+			interface CustomSchemaDef {
 				jsonSchema?: {
 					anyOf: [
 						{
@@ -63,7 +63,7 @@ export function generateZodSchema(placeholder: FromAIArgument): z.ZodTypeAny {
 					return Object.keys(data).length > 0;
 				},
 				{
-					message: 'Value must be a non-empty object or a non-empty array',
+					error: 'Value must be a non-empty object or a non-empty array',
 				},
 			);
 
@@ -74,7 +74,7 @@ export function generateZodSchema(placeholder: FromAIArgument): z.ZodTypeAny {
 			>;
 
 			// Attach the updated `jsonSchema` metadata to the internal definition.
-			typedSchema._def.jsonSchema = {
+			typedSchema._zod.def.jsonSchema = {
 				anyOf: [
 					{
 						type: 'object',

--- a/packages/workflow/src/from-ai-parse-utils.ts
+++ b/packages/workflow/src/from-ai-parse-utils.ts
@@ -74,7 +74,7 @@ export function generateZodSchema(placeholder: FromAIArgument): z.ZodType {
 			>;
 
 			// Attach the updated `jsonSchema` metadata to the internal definition.
-			typedSchema._zod.def.jsonSchema = {
+			typedSchema._zod.toJSONSchema = () => ({
 				anyOf: [
 					{
 						type: 'object',
@@ -86,7 +86,7 @@ export function generateZodSchema(placeholder: FromAIArgument): z.ZodType {
 						minItems: 1,
 					},
 				],
-			};
+			});
 
 			schema = typedSchema;
 			break;

--- a/packages/workflow/src/message-event-bus.ts
+++ b/packages/workflow/src/message-event-bus.ts
@@ -59,11 +59,11 @@ export interface IAbstractEventMessage {
 // Circuit Breaker Options Schema
 const circuitBreakerSchema = z
 	.object({
-		maxFailures: z.number().int().positive().optional(),
-		maxDuration: z.number().int().positive().optional(),
-		halfOpenRequests: z.number().int().positive().optional(),
-		failureWindow: z.number().int().positive().optional(),
-		maxConcurrentHalfOpenRequests: z.number().int().positive().optional(),
+		maxFailures: z.int().positive().optional(),
+		maxDuration: z.int().positive().optional(),
+		halfOpenRequests: z.int().positive().optional(),
+		failureWindow: z.int().positive().optional(),
+		maxConcurrentHalfOpenRequests: z.int().positive().optional(),
 	})
 	.optional();
 
@@ -82,8 +82,8 @@ const webhookParameterOptionsSchema = z
 	.object({
 		batch: z
 			.object({
-				batchSize: z.number().int().positive().optional(),
-				batchInterval: z.number().int().positive().optional(),
+				batchSize: z.int().positive().optional(),
+				batchInterval: z.int().positive().optional(),
 			})
 			.optional(),
 		allowUnauthorizedCerts: z.boolean().optional(),
@@ -92,7 +92,7 @@ const webhookParameterOptionsSchema = z
 			.object({
 				redirect: z.object({
 					followRedirects: z.boolean().optional(),
-					maxRedirects: z.number().int().positive().optional(),
+					maxRedirects: z.int().positive().optional(),
 				}),
 			})
 			.transform((val) => val.redirect)
@@ -114,17 +114,17 @@ const webhookParameterOptionsSchema = z
 				proxy: z.object({
 					protocol: z.enum(['https', 'http']),
 					host: z.string(),
-					port: z.number().int().positive(),
+					port: z.int().positive(),
 				}),
 			})
 			.transform((val) => val.proxy)
 			.optional(),
-		timeout: z.number().int().positive().optional(),
+		timeout: z.int().positive().optional(),
 		socket: z
 			.object({
 				keepAlive: z.boolean().optional(),
-				maxSockets: z.number().int().positive().optional(),
-				maxFreeSockets: z.number().int().positive().optional(),
+				maxSockets: z.int().positive().optional(),
+				maxFreeSockets: z.int().positive().optional(),
 			})
 			.optional(),
 	})
@@ -144,7 +144,7 @@ export const MessageEventBusDestinationOptionsSchema = z.object({
 	label: z.string().min(1).optional(),
 	enabled: z.boolean().optional(),
 	subscribedEvents: z.array(z.string()).optional(),
-	credentials: z.record(z.unknown()).optional(),
+	credentials: z.record(z.string(), z.unknown()).optional(),
 	anonymizeAuditMessages: z.boolean().optional(),
 	circuitBreaker: circuitBreakerSchema,
 });
@@ -153,9 +153,9 @@ export const MessageEventBusDestinationOptionsSchema = z.object({
 export const MessageEventBusDestinationWebhookOptionsSchema =
 	MessageEventBusDestinationOptionsSchema.extend({
 		__type: z.literal('$$MessageEventBusDestinationWebhook'),
-		url: z.string().url(),
+		url: z.url(),
 		responseCodeMustMatch: z.boolean().optional(),
-		expectedStatusCode: z.number().int().optional(),
+		expectedStatusCode: z.int().optional(),
 		method: z.string().optional(),
 		authentication: z
 			.enum(['predefinedCredentialType', 'genericCredentialType', 'none'])
@@ -178,7 +178,7 @@ export const MessageEventBusDestinationWebhookOptionsSchema =
 export const MessageEventBusDestinationSentryOptionsSchema =
 	MessageEventBusDestinationOptionsSchema.extend({
 		__type: z.literal('$$MessageEventBusDestinationSentry'),
-		dsn: z.string().url(),
+		dsn: z.url(),
 		tracesSampleRate: z.number().min(0).max(1).optional(),
 		sendPayload: z.boolean().optional(),
 	});
@@ -187,11 +187,11 @@ export const MessageEventBusDestinationSentryOptionsSchema =
 export const MessageEventBusDestinationSyslogOptionsSchema =
 	MessageEventBusDestinationOptionsSchema.extend({
 		__type: z.literal('$$MessageEventBusDestinationSyslog'),
-		expectedStatusCode: z.number().int().optional(),
+		expectedStatusCode: z.int().optional(),
 		host: z.string().min(1),
-		port: z.number().int().positive().optional(),
+		port: z.int().positive().optional(),
 		protocol: z.enum(['udp', 'tcp', 'tls']).optional(),
-		facility: z.number().int().min(0).max(23).optional(),
+		facility: z.int().min(0).max(23).optional(),
 		app_name: z.string().optional(),
 		eol: z.string().optional(),
 		tlsCa: z.string().optional(),

--- a/packages/workflow/src/schemas.ts
+++ b/packages/workflow/src/schemas.ts
@@ -87,7 +87,9 @@ export const FieldTypeSchema: z.ZodType<FieldType> = z.enum([
 // it's unclear whether functions are really expected.
 const ObjectLikeSchema = z.custom<object>(
 	(v) => (typeof v === 'object' && v !== null) || typeof v === 'function',
-	{ message: 'Expected a non-primitive object' },
+	{
+		error: 'Expected a non-primitive object',
+	},
 );
 
 export const GenericValueSchema: z.ZodType<GenericValue> = z.union([
@@ -219,7 +221,7 @@ export const IPostReceiveSetSchema: z.ZodType<IPostReceiveSet> = IPostReceiveBas
 export const IPostReceiveSetKeyValueSchema: z.ZodType<IPostReceiveSetKeyValue> =
 	IPostReceiveBaseSchema.extend({
 		type: z.literal('setKeyValue'),
-		properties: z.record(z.union([z.string(), z.number()])),
+		properties: z.record(z.string(), z.union([z.string(), z.number()])),
 	});
 
 export const IPostReceiveSortSchema: z.ZodType<IPostReceiveSort> = IPostReceiveBaseSchema.extend({
@@ -362,7 +364,7 @@ export const ResourceMapperFieldSchema: z.ZodType<ResourceMapperField> = z.objec
 
 export const ResourceMapperValueSchema: z.ZodType<ResourceMapperValue> = z.object({
 	mappingMode: z.string(),
-	value: z.record(z.union([z.string(), z.number(), z.boolean(), z.null()])),
+	value: z.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.null()])),
 	matchingColumns: z.array(z.string()),
 	schema: z.array(ResourceMapperFieldSchema),
 	attemptToConvertTypes: z.boolean(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,7 +338,7 @@ overrides:
   tmp: 0.2.4
   nodemailer: 7.0.11
   validator: 13.15.26
-  zod: 3.25.67
+  zod: 4.3.6
   js-yaml: 4.1.1
   node-forge: 1.3.2
   body-parser: 2.2.1
@@ -518,19 +518,19 @@ importers:
     dependencies:
       '@langchain/classic':
         specifier: 1.0.5
-        version: 1.0.5(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(cheerio@1.0.0)(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 1.0.5(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(cheerio@1.0.0)(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@langchain/community':
         specifier: 'catalog:'
-        version: 1.1.14(662793aac25613aa4fb87ba728645868)
+        version: 1.1.14(fe96f87a5002a25a003521315432e08e)
       '@langchain/core':
         specifier: 'catalog:'
-        version: 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+        version: 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       '@langchain/openai':
         specifier: 'catalog:'
-        version: 1.1.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 1.1.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@langchain/textsplitters':
         specifier: 1.0.1
-        version: 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))
+        version: 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))
       '@n8n/config':
         specifier: workspace:*
         version: link:../config
@@ -545,7 +545,7 @@ importers:
         version: 1.0.12
       langchain:
         specifier: 'catalog:'
-        version: 1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(zod-to-json-schema@3.23.3(zod@3.25.67))
+        version: 1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(zod-to-json-schema@3.23.3(zod@4.3.6))
       proxy-from-env:
         specifier: ^1.1.0
         version: 1.1.0
@@ -556,11 +556,11 @@ importers:
         specifier: ^6.23.0
         version: 6.23.0
       zod:
-        specifier: 3.25.67
-        version: 3.25.67
+        specifier: 4.3.6
+        version: 4.3.6
       zod-to-json-schema:
         specifier: 'catalog:'
-        version: 3.23.3(zod@3.25.67)
+        version: 3.23.3(zod@4.3.6)
     devDependencies:
       '@types/json-schema':
         specifier: ^7.0.15
@@ -585,16 +585,16 @@ importers:
     dependencies:
       '@langchain/anthropic':
         specifier: 'catalog:'
-        version: 1.1.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(zod@3.25.67)
+        version: 1.1.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(zod@4.3.6)
       '@langchain/core':
         specifier: 'catalog:'
-        version: 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+        version: 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       '@langchain/langgraph':
         specifier: 1.0.2
-        version: 1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.25.1(zod@3.25.67))(zod@3.25.67)
+        version: 1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.3.6)
       '@langchain/openai':
         specifier: 'catalog:'
-        version: 1.1.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 1.1.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@mozilla/readability':
         specifier: 0.6.0
         version: 0.6.0
@@ -627,10 +627,10 @@ importers:
         version: 23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       langchain:
         specifier: 'catalog:'
-        version: 1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.25.1(zod@3.25.67))
+        version: 1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.25.1(zod@4.3.6))
       langsmith:
         specifier: '>=0.4.6'
-        version: 0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+        version: 0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       lodash:
         specifier: 'catalog:'
         version: 4.17.23
@@ -644,8 +644,8 @@ importers:
         specifier: ^7.2.2
         version: 7.2.2
       zod:
-        specifier: 3.25.67
-        version: 3.25.67
+        specifier: 4.3.6
+        version: 4.3.6
     devDependencies:
       '@n8n/typescript-config':
         specifier: workspace:*
@@ -684,8 +684,8 @@ importers:
         specifier: 'catalog:'
         version: 1.0.15
       zod:
-        specifier: 3.25.67
-        version: 3.25.67
+        specifier: 4.3.6
+        version: 4.3.6
     devDependencies:
       '@n8n/config':
         specifier: workspace:*
@@ -743,8 +743,8 @@ importers:
         specifier: 21.0.0
         version: 21.0.0
       zod:
-        specifier: 3.25.67
-        version: 3.25.67
+        specifier: 4.3.6
+        version: 4.3.6
 
   packages/@n8n/backend-test-utils:
     dependencies:
@@ -948,8 +948,8 @@ importers:
         specifier: 'catalog:'
         version: 0.2.2
       zod:
-        specifier: 3.25.67
-        version: 3.25.67
+        specifier: 4.3.6
+        version: 4.3.6
     devDependencies:
       '@n8n/typescript-config':
         specifier: workspace:*
@@ -1053,8 +1053,8 @@ importers:
         specifier: 'catalog:'
         version: 1.0.15
       zod:
-        specifier: 3.25.67
-        version: 3.25.67
+        specifier: 4.3.6
+        version: 4.3.6
     devDependencies:
       '@n8n/typescript-config':
         specifier: workspace:*
@@ -1100,8 +1100,8 @@ importers:
         specifier: 'catalog:'
         version: 3.1.3(@types/debug@4.1.12)(@types/node@20.19.21)(jiti@2.6.1)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(sass@1.89.2)(terser@5.16.1)(tsx@4.19.3)
       zod:
-        specifier: 3.25.67
-        version: 3.25.67
+        specifier: 4.3.6
+        version: 4.3.6
 
   packages/@n8n/di:
     dependencies:
@@ -1282,8 +1282,8 @@ importers:
   packages/@n8n/extension-sdk:
     dependencies:
       zod:
-        specifier: 3.25.67
-        version: 3.25.67
+        specifier: 4.3.6
+        version: 4.3.6
     devDependencies:
       '@n8n/typescript-config':
         specifier: workspace:*
@@ -1317,7 +1317,7 @@ importers:
         version: 2.2.8(patch_hash=e2aee939ccac8a57fe449bfd92bedd8117841579526217bc39aca26c6b8c317f)(typescript@5.9.2)
       zod-to-json-schema:
         specifier: 'catalog:'
-        version: 3.23.3(zod@3.25.67)
+        version: 3.23.3(zod@4.3.6)
 
   packages/@n8n/imap:
     dependencies:
@@ -1368,8 +1368,8 @@ importers:
         specifier: ^7.0.15
         version: 7.0.15
       zod:
-        specifier: 3.25.67
-        version: 3.25.67
+        specifier: 4.3.6
+        version: 4.3.6
 
   packages/@n8n/node-cli:
     dependencies:
@@ -1460,7 +1460,7 @@ importers:
         version: 12.1.0
       '@getzep/zep-cloud':
         specifier: 1.0.6
-        version: 1.0.6(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(encoding@0.1.13)(langchain@1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@3.25.67)))
+        version: 1.0.6(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(encoding@0.1.13)(langchain@1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@4.3.6)))
       '@getzep/zep-js':
         specifier: 0.9.0
         version: 0.9.0
@@ -1469,7 +1469,7 @@ importers:
         version: 5.3.0(encoding@0.1.13)
       '@google/genai':
         specifier: 1.19.0
-        version: 1.19.0(@modelcontextprotocol/sdk@1.26.0(zod@3.25.67))(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+        version: 1.19.0(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@google/generative-ai':
         specifier: 0.24.0
         version: 0.24.0
@@ -1478,58 +1478,58 @@ importers:
         version: 4.0.5
       '@langchain/anthropic':
         specifier: 'catalog:'
-        version: 1.1.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(zod@3.25.67)
+        version: 1.1.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(zod@4.3.6)
       '@langchain/aws':
         specifier: 1.0.3
-        version: 1.0.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))
+        version: 1.0.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))
       '@langchain/classic':
         specifier: 1.0.5
-        version: 1.0.5(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(cheerio@1.0.0)(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 1.0.5(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(cheerio@1.0.0)(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@langchain/cohere':
         specifier: 1.0.1
-        version: 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(encoding@0.1.13)
+        version: 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(encoding@0.1.13)
       '@langchain/community':
         specifier: 'catalog:'
-        version: 1.1.14(35bfb1ec004a708b83adbf7354136544)
+        version: 1.1.14(66443f2513df5c253f6701b6db65a72a)
       '@langchain/core':
         specifier: 'catalog:'
-        version: 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+        version: 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       '@langchain/google-genai':
         specifier: 2.1.10
-        version: 2.1.10(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))
+        version: 2.1.10(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))
       '@langchain/google-vertexai':
         specifier: 2.1.10
-        version: 2.1.10(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))
+        version: 2.1.10(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))
       '@langchain/groq':
         specifier: 1.0.2
-        version: 1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(encoding@0.1.13)
+        version: 1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(encoding@0.1.13)
       '@langchain/mistralai':
         specifier: 1.0.1
-        version: 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))
+        version: 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))
       '@langchain/mongodb':
         specifier: 1.0.1
-        version: 1.0.1(@aws-sdk/credential-providers@3.808.0)(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(gcp-metadata@5.3.0)(socks@2.8.3)
+        version: 1.0.1(@aws-sdk/credential-providers@3.808.0)(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(gcp-metadata@5.3.0)(socks@2.8.3)
       '@langchain/ollama':
         specifier: 1.0.2
-        version: 1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))
+        version: 1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))
       '@langchain/openai':
         specifier: 'catalog:'
-        version: 1.1.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 1.1.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@langchain/pinecone':
         specifier: 1.0.1
-        version: 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@pinecone-database/pinecone@5.1.2)
+        version: 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@pinecone-database/pinecone@5.1.2)
       '@langchain/qdrant':
         specifier: 1.0.1
-        version: 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(typescript@5.9.2)
+        version: 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(typescript@5.9.2)
       '@langchain/redis':
         specifier: 1.0.1
-        version: 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))
+        version: 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))
       '@langchain/textsplitters':
         specifier: 1.0.1
-        version: 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))
+        version: 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))
       '@langchain/weaviate':
         specifier: 1.0.1
-        version: 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(encoding@0.1.13)
+        version: 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(encoding@0.1.13)
       '@microsoft/agents-a365-notifications':
         specifier: 0.1.0-preview.113
         version: 0.1.0-preview.113
@@ -1541,10 +1541,10 @@ importers:
         version: 0.1.0-preview.113
       '@microsoft/agents-a365-tooling':
         specifier: 0.1.0-preview.113
-        version: 0.1.0-preview.113(zod@3.25.67)
+        version: 0.1.0-preview.113(zod@4.3.6)
       '@microsoft/agents-a365-tooling-extensions-langchain':
         specifier: 0.1.0-preview.113
-        version: 0.1.0-preview.113(@langchain/langgraph@1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@3.25.67))(zod@3.25.67))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@3.25.67))(zod@3.25.67)
+        version: 0.1.0-preview.113(@langchain/langgraph@1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@4.3.6))(zod@4.3.6))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@4.3.6))(zod@4.3.6)
       '@microsoft/agents-activity':
         specifier: 1.2.3
         version: 1.2.3
@@ -1553,7 +1553,7 @@ importers:
         version: 1.2.3
       '@modelcontextprotocol/sdk':
         specifier: 1.26.0
-        version: 1.26.0(zod@3.25.67)
+        version: 1.26.0(zod@4.3.6)
       '@mozilla/readability':
         specifier: 0.6.0
         version: 0.6.0
@@ -1634,7 +1634,7 @@ importers:
         version: 23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       langchain:
         specifier: 'catalog:'
-        version: 1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@3.25.67))
+        version: 1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@4.3.6))
       lodash:
         specifier: 'catalog:'
         version: 4.17.23
@@ -1655,7 +1655,7 @@ importers:
         version: link:../../workflow
       openai:
         specifier: ^6.9.0
-        version: 6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)
+        version: 6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)
       pdf-parse:
         specifier: 1.1.1
         version: 1.1.1
@@ -1684,11 +1684,11 @@ importers:
         specifier: 3.9.0
         version: 3.9.0(encoding@0.1.13)
       zod:
-        specifier: 3.25.67
-        version: 3.25.67
+        specifier: 4.3.6
+        version: 4.3.6
       zod-to-json-schema:
         specifier: 3.23.3
-        version: 3.23.3(zod@3.25.67)
+        version: 3.23.3(zod@4.3.6)
     devDependencies:
       '@n8n/eslint-plugin-community-nodes':
         specifier: workspace:*
@@ -1730,8 +1730,8 @@ importers:
   packages/@n8n/permissions:
     dependencies:
       zod:
-        specifier: 3.25.67
-        version: 3.25.67
+        specifier: 4.3.6
+        version: 4.3.6
     devDependencies:
       '@n8n/typescript-config':
         specifier: workspace:*
@@ -1789,8 +1789,8 @@ importers:
   packages/@n8n/syslog-client:
     dependencies:
       zod:
-        specifier: 3.25.67
-        version: 3.25.67
+        specifier: 4.3.6
+        version: 4.3.6
     devDependencies:
       '@n8n/typescript-config':
         specifier: workspace:*
@@ -1915,8 +1915,8 @@ importers:
         specifier: 'catalog:'
         version: 10.0.0
       zod:
-        specifier: 3.25.67
-        version: 3.25.67
+        specifier: 4.3.6
+        version: 4.3.6
     devDependencies:
       '@n8n/typescript-config':
         specifier: workspace:*
@@ -1950,7 +1950,7 @@ importers:
         version: 5.6.0(encoding@0.1.13)
       '@modelcontextprotocol/sdk':
         specifier: 1.26.0
-        version: 1.26.0(zod@3.25.67)
+        version: 1.26.0(zod@4.3.6)
       '@n8n/ai-utilities':
         specifier: workspace:*
         version: link:../@n8n/ai-utilities
@@ -2240,8 +2240,8 @@ importers:
         specifier: 21.1.1
         version: 21.1.1
       zod:
-        specifier: 3.25.67
-        version: 3.25.67
+        specifier: 4.3.6
+        version: 4.3.6
     devDependencies:
       '@n8n/backend-test-utils':
         specifier: workspace:*
@@ -2353,7 +2353,7 @@ importers:
         version: 3.808.0
       '@langchain/core':
         specifier: 'catalog:'
-        version: 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+        version: 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       '@n8n/backend-common':
         specifier: workspace:*
         version: link:../@n8n/backend-common
@@ -2466,8 +2466,8 @@ importers:
         specifier: 'catalog:'
         version: 0.6.2
       zod:
-        specifier: 3.25.67
-        version: 3.25.67
+        specifier: 4.3.6
+        version: 4.3.6
     devDependencies:
       '@n8n/errors':
         specifier: workspace:*
@@ -3668,7 +3668,7 @@ importers:
         version: 3.0.3
       ts-ics:
         specifier: 1.2.2
-        version: 1.2.2(date-fns@2.30.0)(lodash@4.17.23)(zod@4.1.12)
+        version: 1.2.2(date-fns@2.30.0)(lodash@4.17.23)(zod@4.3.6)
       uuid:
         specifier: 'catalog:'
         version: 10.0.0
@@ -3924,8 +3924,8 @@ importers:
         specifier: 'catalog:'
         version: 4.19.3
       zod:
-        specifier: 3.25.67
-        version: 3.25.67
+        specifier: 4.3.6
+        version: 4.3.6
 
   packages/workflow:
     dependencies:
@@ -3984,12 +3984,12 @@ importers:
         specifier: 'catalog:'
         version: 0.6.2
       zod:
-        specifier: 3.25.67
-        version: 3.25.67
+        specifier: 4.3.6
+        version: 4.3.6
     devDependencies:
       '@langchain/core':
         specifier: 'catalog:'
-        version: 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+        version: 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       '@n8n/config':
         specifier: workspace:*
         version: link:../@n8n/config
@@ -4079,7 +4079,7 @@ packages:
     resolution: {integrity: sha512-go1XeWXmpxuiTkosSXpb8tokLk2ZLkIRcXpbWVwJM6gH5OBtHOVsfPfGuqI1oW7RRt4qc59EmYbrXRZ0Ng06Jw==}
     hasBin: true
     peerDependencies:
-      zod: 3.25.67
+      zod: 4.3.6
     peerDependenciesMeta:
       zod:
         optional: true
@@ -5325,7 +5325,7 @@ packages:
       deepmerge: ^4.3.1
       dotenv: ^16.4.5
       openai: ^4.62.1
-      zod: 3.25.67
+      zod: 4.3.6
 
   '@cfworker/json-schema@4.1.0':
     resolution: {integrity: sha512-/vYKi/qMxwNsuIJ9WGWwM2rflY40ZenK3Kh4uR5vB9/Nz12Y7IUN/Xf4wDA7vzPfw0VNh3b/jz4+MjcVgARKJg==}
@@ -6669,7 +6669,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@langchain/core': ^1.0.1
-      zod: 3.25.67
+      zod: 4.3.6
       zod-to-json-schema: ^3.x
     peerDependenciesMeta:
       zod-to-json-schema:
@@ -6837,7 +6837,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
-      zod: 3.25.67
+      zod: 4.3.6
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -15731,7 +15731,7 @@ packages:
     hasBin: true
     peerDependencies:
       ws: '>=8.17.1'
-      zod: 3.25.67
+      zod: 4.3.6
     peerDependenciesMeta:
       ws:
         optional: true
@@ -15743,7 +15743,7 @@ packages:
     hasBin: true
     peerDependencies:
       ws: '>=8.17.1'
-      zod: 3.25.67
+      zod: 4.3.6
     peerDependenciesMeta:
       ws:
         optional: true
@@ -18066,7 +18066,7 @@ packages:
     peerDependencies:
       date-fns: 2.30.0
       lodash: ^4
-      zod: 3.25.67
+      zod: 4.3.6
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -19393,23 +19393,20 @@ packages:
   zod-to-json-schema@3.23.3:
     resolution: {integrity: sha512-TYWChTxKQbRJp5ST22o/Irt9KC5nj7CdBKYB/AosCRdj/wxEMvv4NNaj9XVUHDOIp53ZxArGhnw5HMZziPFjog==}
     peerDependencies:
-      zod: 3.25.67
+      zod: 4.3.6
 
   zod-to-json-schema@3.25.0:
     resolution: {integrity: sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==}
     peerDependencies:
-      zod: 3.25.67
+      zod: 4.3.6
 
   zod-to-json-schema@3.25.1:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
     peerDependencies:
-      zod: 3.25.67
+      zod: 4.3.6
 
-  zod@3.25.67:
-    resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
-
-  zod@4.1.12:
-    resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
   zx@8.8.5:
     resolution: {integrity: sha512-SNgDF5L0gfN7FwVOdEFguY3orU5AkfFZm9B5YSHog/UDHv+lvmd82ZAsOenOkQixigwH2+yyH198AwNdKhj+RA==}
@@ -19496,11 +19493,11 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@anthropic-ai/sdk@0.71.0(zod@3.25.67)':
+  '@anthropic-ai/sdk@0.71.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
-      zod: 3.25.67
+      zod: 4.3.6
 
   '@apidevtools/json-schema-ref-parser@12.0.2':
     dependencies:
@@ -22112,35 +22109,35 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@browserbasehq/stagehand@1.9.0(@playwright/test@1.58.0)(bufferutil@4.0.9)(deepmerge@4.3.1)(dotenv@17.2.3)(encoding@0.1.13)(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(utf-8-validate@5.0.10)(zod@3.25.67)':
+  '@browserbasehq/stagehand@1.9.0(@playwright/test@1.58.0)(bufferutil@4.0.9)(deepmerge@4.3.1)(dotenv@17.2.3)(encoding@0.1.13)(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.27.3(encoding@0.1.13)
       '@browserbasehq/sdk': 2.6.0(encoding@0.1.13)
       '@playwright/test': 1.58.0
       deepmerge: 4.3.1
       dotenv: 17.2.3
-      openai: 6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)
+      openai: 6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)
       sharp: 0.33.5
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      zod: 3.25.67
-      zod-to-json-schema: 3.25.1(zod@3.25.67)
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - encoding
       - utf-8-validate
 
-  '@browserbasehq/stagehand@1.9.0(@playwright/test@1.58.0)(bufferutil@4.0.9)(deepmerge@4.3.1)(dotenv@17.2.3)(encoding@0.1.13)(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(utf-8-validate@5.0.10)(zod@3.25.67)':
+  '@browserbasehq/stagehand@1.9.0(@playwright/test@1.58.0)(bufferutil@4.0.9)(deepmerge@4.3.1)(dotenv@17.2.3)(encoding@0.1.13)(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.27.3(encoding@0.1.13)
       '@browserbasehq/sdk': 2.6.0(encoding@0.1.13)
       '@playwright/test': 1.58.0
       deepmerge: 4.3.1
       dotenv: 17.2.3
-      openai: 6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)
+      openai: 6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)
       sharp: 0.33.5
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      zod: 3.25.67
-      zod-to-json-schema: 3.25.1(zod@3.25.67)
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -22178,7 +22175,7 @@ snapshots:
       chalk: 4.1.2
       semver: 7.7.3
       unplugin: 1.11.0
-      zod: 3.25.67
+      zod: 4.3.6
 
   '@codecov/vite-plugin@1.9.1(rolldown-vite@7.3.1(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass@1.89.2)(terser@5.16.1)(tsx@4.19.3))':
     dependencies:
@@ -22599,30 +22596,30 @@ snapshots:
   '@gar/promisify@1.1.3':
     optional: true
 
-  '@getzep/zep-cloud@1.0.6(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(encoding@0.1.13)(langchain@1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(zod-to-json-schema@3.23.3(zod@3.25.67)))':
+  '@getzep/zep-cloud@1.0.6(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(encoding@0.1.13)(langchain@1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(zod-to-json-schema@3.23.3(zod@4.3.6)))':
     dependencies:
       form-data: 4.0.4
       node-fetch: 2.7.0(encoding@0.1.13)
       qs: 6.14.2
       url-join: 4.0.1
-      zod: 3.25.67
+      zod: 4.3.6
     optionalDependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
-      langchain: 1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(zod-to-json-schema@3.23.3(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
+      langchain: 1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(zod-to-json-schema@3.23.3(zod@4.3.6))
     transitivePeerDependencies:
       - encoding
     optional: true
 
-  '@getzep/zep-cloud@1.0.6(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(encoding@0.1.13)(langchain@1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@3.25.67)))':
+  '@getzep/zep-cloud@1.0.6(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(encoding@0.1.13)(langchain@1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@4.3.6)))':
     dependencies:
       form-data: 4.0.4
       node-fetch: 2.7.0(encoding@0.1.13)
       qs: 6.14.2
       url-join: 4.0.1
-      zod: 3.25.67
+      zod: 4.3.6
     optionalDependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
-      langchain: 1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
+      langchain: 1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@4.3.6))
     transitivePeerDependencies:
       - encoding
 
@@ -22676,12 +22673,12 @@ snapshots:
       - encoding
       - supports-color
 
-  '@google/genai@1.19.0(@modelcontextprotocol/sdk@1.26.0(zod@3.25.67))(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+  '@google/genai@1.19.0(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
     dependencies:
       google-auth-library: 9.15.1
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.67)
+      '@modelcontextprotocol/sdk': 1.26.0(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -23283,45 +23280,45 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@langchain/anthropic@1.1.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(zod@3.25.67)':
+  '@langchain/anthropic@1.1.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(zod@4.3.6)':
     dependencies:
-      '@anthropic-ai/sdk': 0.71.0(zod@3.25.67)
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@anthropic-ai/sdk': 0.71.0(zod@4.3.6)
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
     transitivePeerDependencies:
       - zod
 
-  '@langchain/anthropic@1.1.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(zod@3.25.67)':
+  '@langchain/anthropic@1.1.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(zod@4.3.6)':
     dependencies:
-      '@anthropic-ai/sdk': 0.71.0(zod@3.25.67)
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@anthropic-ai/sdk': 0.71.0(zod@4.3.6)
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
     transitivePeerDependencies:
       - zod
 
-  '@langchain/aws@1.0.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))':
+  '@langchain/aws@1.0.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))':
     dependencies:
       '@aws-sdk/client-bedrock-agent-runtime': 3.808.0
       '@aws-sdk/client-bedrock-runtime': 3.938.0
       '@aws-sdk/client-kendra': 3.808.0
       '@aws-sdk/credential-provider-node': 3.918.0
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
     transitivePeerDependencies:
       - aws-crt
 
-  '@langchain/classic@1.0.17(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(cheerio@1.0.0)(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@langchain/classic@1.0.17(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(cheerio@1.0.0)(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
-      '@langchain/openai': 1.2.7(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@langchain/textsplitters': 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
+      '@langchain/openai': 1.2.7(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@langchain/textsplitters': 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))
       handlebars: 4.7.8
       js-yaml: 4.1.1
       jsonpointer: 5.0.1
       openapi-types: 12.1.3
       uuid: 10.0.0
       yaml: 2.3.4
-      zod: 3.25.67
+      zod: 4.3.6
     optionalDependencies:
       cheerio: 1.0.0
-      langsmith: 0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      langsmith: 0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -23329,21 +23326,21 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/classic@1.0.17(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(cheerio@1.0.0)(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@langchain/classic@1.0.17(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(cheerio@1.0.0)(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
-      '@langchain/openai': 1.2.7(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@langchain/textsplitters': 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
+      '@langchain/openai': 1.2.7(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@langchain/textsplitters': 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))
       handlebars: 4.7.8
       js-yaml: 4.1.1
       jsonpointer: 5.0.1
       openapi-types: 12.1.3
       uuid: 10.0.0
       yaml: 2.3.4
-      zod: 3.25.67
+      zod: 4.3.6
     optionalDependencies:
       cheerio: 1.0.0
-      langsmith: 0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      langsmith: 0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -23351,34 +23348,11 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/classic@1.0.5(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(cheerio@1.0.0)(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@langchain/classic@1.0.5(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(cheerio@1.0.0)(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
-      '@langchain/openai': 1.1.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@langchain/textsplitters': 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))
-      handlebars: 4.7.8
-      js-yaml: 4.1.1
-      jsonpointer: 5.0.1
-      openapi-types: 12.1.3
-      p-retry: 7.1.0
-      uuid: 10.0.0
-      yaml: 2.3.4
-      zod: 3.25.67
-    optionalDependencies:
-      cheerio: 1.0.0
-      langsmith: 0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - openai
-      - ws
-
-  '@langchain/classic@1.0.5(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(cheerio@1.0.0)(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
-      '@langchain/openai': 1.1.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@langchain/textsplitters': 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
+      '@langchain/openai': 1.1.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@langchain/textsplitters': 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))
       handlebars: 4.7.8
       js-yaml: 4.1.1
       jsonpointer: 5.0.1
@@ -23386,10 +23360,10 @@ snapshots:
       p-retry: 7.1.0
       uuid: 10.0.0
       yaml: 2.3.4
-      zod: 3.25.67
+      zod: 4.3.6
     optionalDependencies:
       cheerio: 1.0.0
-      langsmith: 0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      langsmith: 0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -23397,36 +23371,59 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/cohere@1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(encoding@0.1.13)':
+  '@langchain/classic@1.0.5(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(cheerio@1.0.0)(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
+      '@langchain/openai': 1.1.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@langchain/textsplitters': 1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))
+      handlebars: 4.7.8
+      js-yaml: 4.1.1
+      jsonpointer: 5.0.1
+      openapi-types: 12.1.3
+      p-retry: 7.1.0
+      uuid: 10.0.0
+      yaml: 2.3.4
+      zod: 4.3.6
+    optionalDependencies:
+      cheerio: 1.0.0
+      langsmith: 0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
+
+  '@langchain/cohere@1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(encoding@0.1.13)':
+    dependencies:
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       cohere-ai: 7.14.0(encoding@0.1.13)
       uuid: 10.0.0
     transitivePeerDependencies:
       - aws-crt
       - encoding
 
-  '@langchain/community@1.1.14(35bfb1ec004a708b83adbf7354136544)':
+  '@langchain/community@1.1.14(66443f2513df5c253f6701b6db65a72a)':
     dependencies:
-      '@browserbasehq/stagehand': 1.9.0(@playwright/test@1.58.0)(bufferutil@4.0.9)(deepmerge@4.3.1)(dotenv@17.2.3)(encoding@0.1.13)(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(utf-8-validate@5.0.10)(zod@3.25.67)
+      '@browserbasehq/stagehand': 1.9.0(@playwright/test@1.58.0)(bufferutil@4.0.9)(deepmerge@4.3.1)(dotenv@17.2.3)(encoding@0.1.13)(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(utf-8-validate@5.0.10)(zod@4.3.6)
       '@ibm-cloud/watsonx-ai': 1.1.2
-      '@langchain/classic': 1.0.17(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(cheerio@1.0.0)(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
-      '@langchain/openai': 1.2.7(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@langchain/classic': 1.0.17(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(cheerio@1.0.0)(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
+      '@langchain/openai': 1.2.7(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       binary-extensions: 2.2.0
       flat: 5.0.2
       ibm-cloud-sdk-core: 5.3.2
       js-yaml: 4.1.1
       math-expression-evaluator: 2.0.7
-      openai: 6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)
+      openai: 6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)
       uuid: 10.0.0
-      zod: 3.25.67
+      zod: 4.3.6
     optionalDependencies:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-sdk/credential-provider-node': 3.936.0
       '@azure/search-documents': 12.1.0
       '@browserbasehq/sdk': 2.6.0(encoding@0.1.13)
-      '@getzep/zep-cloud': 1.0.6(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(encoding@0.1.13)(langchain@1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@3.25.67)))
+      '@getzep/zep-cloud': 1.0.6(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(encoding@0.1.13)(langchain@1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@4.3.6)))
       '@getzep/zep-js': 0.9.0
       '@google-cloud/storage': 7.12.1(encoding@0.1.13)
       '@huggingface/inference': 4.0.5
@@ -23468,26 +23465,26 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - peggy
 
-  '@langchain/community@1.1.14(662793aac25613aa4fb87ba728645868)':
+  '@langchain/community@1.1.14(fe96f87a5002a25a003521315432e08e)':
     dependencies:
-      '@browserbasehq/stagehand': 1.9.0(@playwright/test@1.58.0)(bufferutil@4.0.9)(deepmerge@4.3.1)(dotenv@17.2.3)(encoding@0.1.13)(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(utf-8-validate@5.0.10)(zod@3.25.67)
+      '@browserbasehq/stagehand': 1.9.0(@playwright/test@1.58.0)(bufferutil@4.0.9)(deepmerge@4.3.1)(dotenv@17.2.3)(encoding@0.1.13)(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(utf-8-validate@5.0.10)(zod@4.3.6)
       '@ibm-cloud/watsonx-ai': 1.1.2
-      '@langchain/classic': 1.0.17(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(cheerio@1.0.0)(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
-      '@langchain/openai': 1.2.7(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@langchain/classic': 1.0.17(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(cheerio@1.0.0)(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
+      '@langchain/openai': 1.2.7(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       binary-extensions: 2.2.0
       flat: 5.0.2
       ibm-cloud-sdk-core: 5.3.2
       js-yaml: 4.1.1
       math-expression-evaluator: 2.0.7
-      openai: 6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)
+      openai: 6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)
       uuid: 10.0.0
-      zod: 3.25.67
+      zod: 4.3.6
     optionalDependencies:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-sdk/credential-provider-node': 3.936.0
       '@browserbasehq/sdk': 2.6.0(encoding@0.1.13)
-      '@getzep/zep-cloud': 1.0.6(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(encoding@0.1.13)(langchain@1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(zod-to-json-schema@3.23.3(zod@3.25.67)))
+      '@getzep/zep-cloud': 1.0.6(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(encoding@0.1.13)(langchain@1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(zod-to-json-schema@3.23.3(zod@4.3.6)))
       '@getzep/zep-js': 0.9.0
       '@google-cloud/storage': 7.12.1(encoding@0.1.13)
       '@mozilla/readability': 0.6.0
@@ -23522,166 +23519,166 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - peggy
 
-  '@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))':
+  '@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))':
     dependencies:
       '@cfworker/json-schema': 4.1.0
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.12
-      langsmith: 0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      langsmith: 0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       mustache: 4.2.0
       p-queue: 6.6.2
       uuid: 10.0.0
-      zod: 3.25.67
+      zod: 4.3.6
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
       - '@opentelemetry/sdk-trace-base'
       - openai
 
-  '@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))':
+  '@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))':
     dependencies:
       '@cfworker/json-schema': 4.1.0
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.12
-      langsmith: 0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      langsmith: 0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       mustache: 4.2.0
       p-queue: 6.6.2
       uuid: 10.0.0
-      zod: 3.25.67
+      zod: 4.3.6
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
       - '@opentelemetry/sdk-trace-base'
       - openai
 
-  '@langchain/google-common@2.1.10(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))':
+  '@langchain/google-common@2.1.10(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       uuid: 10.0.0
 
-  '@langchain/google-gauth@2.1.10(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))':
+  '@langchain/google-gauth@2.1.10(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))':
     dependencies:
-      '@langchain/google-common': 2.1.10(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))
+      '@langchain/google-common': 2.1.10(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))
       google-auth-library: 10.1.0
     transitivePeerDependencies:
       - '@langchain/core'
       - supports-color
 
-  '@langchain/google-genai@2.1.10(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))':
+  '@langchain/google-genai@2.1.10(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))':
     dependencies:
       '@google/generative-ai': 0.24.0
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       uuid: 11.1.0
 
-  '@langchain/google-vertexai@2.1.10(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))':
+  '@langchain/google-vertexai@2.1.10(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))':
     dependencies:
-      '@langchain/google-gauth': 2.1.10(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))
+      '@langchain/google-gauth': 2.1.10(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))
     transitivePeerDependencies:
       - '@langchain/core'
       - supports-color
 
-  '@langchain/groq@1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(encoding@0.1.13)':
+  '@langchain/groq@1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(encoding@0.1.13)':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       groq-sdk: 0.19.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
 
-  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))':
+  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       uuid: 10.0.0
 
-  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))':
+  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@langchain/langgraph-sdk@1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       p-queue: 6.6.2
       p-retry: 4.6.2
       uuid: 9.0.1
     optionalDependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@langchain/langgraph-sdk@1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@langchain/langgraph-sdk@1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       p-queue: 6.6.2
       p-retry: 4.6.2
       uuid: 9.0.1
     optionalDependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@langchain/langgraph@1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.25.1(zod@3.25.67))(zod@3.25.67)':
+  '@langchain/langgraph@1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.3.6)':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))
-      '@langchain/langgraph-sdk': 1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))
+      '@langchain/langgraph-sdk': 1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       uuid: 10.0.0
-      zod: 3.25.67
+      zod: 4.3.6
     optionalDependencies:
-      zod-to-json-schema: 3.25.1(zod@3.25.67)
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@langchain/langgraph@1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(zod-to-json-schema@3.23.3(zod@3.25.67))(zod@3.25.67)':
+  '@langchain/langgraph@1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(zod-to-json-schema@3.23.3(zod@4.3.6))(zod@4.3.6)':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))
-      '@langchain/langgraph-sdk': 1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))
+      '@langchain/langgraph-sdk': 1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       uuid: 10.0.0
-      zod: 3.25.67
+      zod: 4.3.6
     optionalDependencies:
-      zod-to-json-schema: 3.23.3(zod@3.25.67)
+      zod-to-json-schema: 3.23.3(zod@4.3.6)
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@langchain/langgraph@1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@3.25.67))(zod@3.25.67)':
+  '@langchain/langgraph@1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@4.3.6))(zod@4.3.6)':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))
-      '@langchain/langgraph-sdk': 1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))
+      '@langchain/langgraph-sdk': 1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       uuid: 10.0.0
-      zod: 3.25.67
+      zod: 4.3.6
     optionalDependencies:
-      zod-to-json-schema: 3.23.3(zod@3.25.67)
+      zod-to-json-schema: 3.23.3(zod@4.3.6)
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@langchain/mcp-adapters@1.1.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@langchain/langgraph@1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@3.25.67))(zod@3.25.67))':
+  '@langchain/mcp-adapters@1.1.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@langchain/langgraph@1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@4.3.6))(zod@4.3.6))':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
-      '@langchain/langgraph': 1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@3.25.67))(zod@3.25.67)
-      '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.67)
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
+      '@langchain/langgraph': 1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@4.3.6))(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.26.0(zod@4.3.6)
       debug: 4.4.3(supports-color@8.1.1)
-      zod: 3.25.67
+      zod: 4.3.6
     optionalDependencies:
       extended-eventsource: 1.7.0
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@langchain/mistralai@1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))':
+  '@langchain/mistralai@1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       '@mistralai/mistralai': 1.10.0
       uuid: 10.0.0
 
-  '@langchain/mongodb@1.0.1(@aws-sdk/credential-providers@3.808.0)(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(gcp-metadata@5.3.0)(socks@2.8.3)':
+  '@langchain/mongodb@1.0.1(@aws-sdk/credential-providers@3.808.0)(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(gcp-metadata@5.3.0)(socks@2.8.3)':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       mongodb: 6.21.0(@aws-sdk/credential-providers@3.808.0)(gcp-metadata@5.3.0)(socks@2.8.3)
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
@@ -23692,81 +23689,81 @@ snapshots:
       - snappy
       - socks
 
-  '@langchain/ollama@1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))':
+  '@langchain/ollama@1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       ollama: 0.6.3
       uuid: 10.0.0
 
-  '@langchain/openai@1.1.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@langchain/openai@1.1.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       js-tiktoken: 1.0.12
-      openai: 6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)
-      zod: 3.25.67
+      openai: 6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)
+      zod: 4.3.6
     transitivePeerDependencies:
       - ws
 
-  '@langchain/openai@1.1.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@langchain/openai@1.1.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       js-tiktoken: 1.0.12
-      openai: 6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)
-      zod: 3.25.67
+      openai: 6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)
+      zod: 4.3.6
     transitivePeerDependencies:
       - ws
 
-  '@langchain/openai@1.2.7(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@langchain/openai@1.2.7(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       js-tiktoken: 1.0.12
-      openai: 6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)
-      zod: 3.25.67
+      openai: 6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)
+      zod: 4.3.6
     transitivePeerDependencies:
       - ws
 
-  '@langchain/openai@1.2.7(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@langchain/openai@1.2.7(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       js-tiktoken: 1.0.12
-      openai: 6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)
-      zod: 3.25.67
+      openai: 6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)
+      zod: 4.3.6
     transitivePeerDependencies:
       - ws
 
-  '@langchain/pinecone@1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@pinecone-database/pinecone@5.1.2)':
+  '@langchain/pinecone@1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@pinecone-database/pinecone@5.1.2)':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       '@pinecone-database/pinecone': 5.1.2
       flat: 5.0.2
       uuid: 10.0.0
 
-  '@langchain/qdrant@1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(typescript@5.9.2)':
+  '@langchain/qdrant@1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(typescript@5.9.2)':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       '@qdrant/js-client-rest': 1.16.2(typescript@5.9.2)
       uuid: 10.0.0
     transitivePeerDependencies:
       - typescript
 
-  '@langchain/redis@1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))':
+  '@langchain/redis@1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       redis: 4.6.14
 
-  '@langchain/textsplitters@1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))':
+  '@langchain/textsplitters@1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       js-tiktoken: 1.0.12
 
-  '@langchain/textsplitters@1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))':
+  '@langchain/textsplitters@1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       js-tiktoken: 1.0.12
 
-  '@langchain/weaviate@1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(encoding@0.1.13)':
+  '@langchain/weaviate@1.0.1(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(encoding@0.1.13)':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       uuid: 10.0.0
       weaviate-client: 3.9.0(encoding@0.1.13)
     transitivePeerDependencies:
@@ -23850,18 +23847,18 @@ snapshots:
       - debug
       - supports-color
 
-  '@microsoft/agents-a365-tooling-extensions-langchain@0.1.0-preview.113(@langchain/langgraph@1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@3.25.67))(zod@3.25.67))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@3.25.67))(zod@3.25.67)':
+  '@microsoft/agents-a365-tooling-extensions-langchain@0.1.0-preview.113(@langchain/langgraph@1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@4.3.6))(zod@4.3.6))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@4.3.6))(zod@4.3.6)':
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
-      '@langchain/mcp-adapters': 1.1.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@langchain/langgraph@1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@3.25.67))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
+      '@langchain/mcp-adapters': 1.1.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@langchain/langgraph@1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@4.3.6))(zod@4.3.6))
       '@microsoft/agents-a365-runtime': 0.1.0-preview.113
-      '@microsoft/agents-a365-tooling': 0.1.0-preview.113(zod@3.25.67)
+      '@microsoft/agents-a365-tooling': 0.1.0-preview.113(zod@4.3.6)
       '@microsoft/agents-hosting': 1.2.3
       hono: 4.11.10
-      langchain: 1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@3.25.67))
+      langchain: 1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@4.3.6))
       uuid: 9.0.1
     optionalDependencies:
-      '@langchain/langgraph': 1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@3.25.67))(zod@3.25.67)
+      '@langchain/langgraph': 1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@4.3.6))(zod@4.3.6)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - '@opentelemetry/api'
@@ -23875,11 +23872,11 @@ snapshots:
       - zod
       - zod-to-json-schema
 
-  '@microsoft/agents-a365-tooling@0.1.0-preview.113(zod@3.25.67)':
+  '@microsoft/agents-a365-tooling@0.1.0-preview.113(zod@4.3.6)':
     dependencies:
       '@microsoft/agents-a365-runtime': 0.1.0-preview.113
       '@microsoft/agents-hosting': 1.2.3
-      '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.67)
+      '@modelcontextprotocol/sdk': 1.26.0(zod@4.3.6)
       express: 5.2.1
       hono: 4.11.10
     transitivePeerDependencies:
@@ -23892,7 +23889,7 @@ snapshots:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       uuid: 11.1.0
-      zod: 3.25.67
+      zod: 4.3.6
     transitivePeerDependencies:
       - supports-color
 
@@ -23905,7 +23902,7 @@ snapshots:
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
-      zod: 3.25.67
+      zod: 4.3.6
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -23949,12 +23946,12 @@ snapshots:
 
   '@mistralai/mistralai@1.10.0':
     dependencies:
-      zod: 3.25.67
-      zod-to-json-schema: 3.25.0(zod@3.25.67)
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.0(zod@4.3.6)
 
   '@mixmark-io/domino@2.2.0': {}
 
-  '@modelcontextprotocol/sdk@1.26.0(zod@3.25.67)':
+  '@modelcontextprotocol/sdk@1.26.0(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.10)
       ajv: 8.18.0
@@ -23971,8 +23968,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0(patch_hash=651e785d0b7bbf5be9210e1e895c39a16dc3ce8a5a3843b4819565fb6e175b90)
       raw-body: 3.0.0
-      zod: 3.25.67
-      zod-to-json-schema: 3.25.1(zod@3.25.67)
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -33337,14 +33334,14 @@ snapshots:
 
   kuler@2.0.0: {}
 
-  langchain@1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.25.1(zod@3.25.67)):
+  langchain@1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.25.1(zod@4.3.6)):
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
-      '@langchain/langgraph': 1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.25.1(zod@3.25.67))(zod@3.25.67)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))
-      langsmith: 0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
+      '@langchain/langgraph': 1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.3.6)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))
+      langsmith: 0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       uuid: 10.0.0
-      zod: 3.25.67
+      zod: 4.3.6
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -33354,14 +33351,14 @@ snapshots:
       - react-dom
       - zod-to-json-schema
 
-  langchain@1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(zod-to-json-schema@3.23.3(zod@3.25.67)):
+  langchain@1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(zod-to-json-schema@3.23.3(zod@4.3.6)):
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
-      '@langchain/langgraph': 1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(zod-to-json-schema@3.23.3(zod@3.25.67))(zod@3.25.67)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))
-      langsmith: 0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
+      '@langchain/langgraph': 1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(zod-to-json-schema@3.23.3(zod@4.3.6))(zod@4.3.6)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))
+      langsmith: 0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       uuid: 10.0.0
-      zod: 3.25.67
+      zod: 4.3.6
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -33371,14 +33368,14 @@ snapshots:
       - react-dom
       - zod-to-json-schema
 
-  langchain@1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@3.25.67)):
+  langchain@1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@4.3.6)):
     dependencies:
-      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
-      '@langchain/langgraph': 1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@3.25.67))(zod@3.25.67)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))
-      langsmith: 0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
+      '@langchain/core': 1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
+      '@langchain/langgraph': 1.0.2(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(zod-to-json-schema@3.23.3(zod@4.3.6))(zod@4.3.6)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)))
+      langsmith: 0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6))
       uuid: 10.0.0
-      zod: 3.25.67
+      zod: 4.3.6
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -33388,7 +33385,7 @@ snapshots:
       - react-dom
       - zod-to-json-schema
 
-  langsmith@0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)):
+  langsmith@0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -33400,9 +33397,9 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/exporter-trace-otlp-proto': 0.204.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.5.0(@opentelemetry/api@1.9.0)
-      openai: 6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)
+      openai: 6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)
 
-  langsmith@0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)):
+  langsmith@0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -33414,7 +33411,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/exporter-trace-otlp-proto': 0.204.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.5.0(@opentelemetry/api@1.9.0)
-      openai: 6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)
+      openai: 6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)
 
   lazy-ass@1.6.0: {}
 
@@ -35039,15 +35036,15 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67):
+  openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6):
     optionalDependencies:
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      zod: 3.25.67
+      zod: 4.3.6
 
-  openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67):
+  openai@6.9.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6):
     optionalDependencies:
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      zod: 3.25.67
+      zod: 4.3.6
 
   openapi-sampler@1.5.1:
     dependencies:
@@ -37886,12 +37883,12 @@ snapshots:
       '@ts-graphviz/common': 2.1.5
       '@ts-graphviz/core': 2.0.7
 
-  ts-ics@1.2.2(date-fns@2.30.0)(lodash@4.17.23)(zod@4.1.12):
+  ts-ics@1.2.2(date-fns@2.30.0)(lodash@4.17.23)(zod@4.3.6):
     dependencies:
       date-fns: 2.30.0
       date-fns-tz: 2.0.0(date-fns@2.30.0)
       lodash: 4.17.23
-      zod: 4.1.12
+      zod: 4.3.6
 
   ts-interface-checker@0.1.13: {}
 
@@ -39359,20 +39356,18 @@ snapshots:
       compress-commons: 6.0.2
       readable-stream: 4.5.2
 
-  zod-to-json-schema@3.23.3(zod@3.25.67):
+  zod-to-json-schema@3.23.3(zod@4.3.6):
     dependencies:
-      zod: 3.25.67
+      zod: 4.3.6
 
-  zod-to-json-schema@3.25.0(zod@3.25.67):
+  zod-to-json-schema@3.25.0(zod@4.3.6):
     dependencies:
-      zod: 3.25.67
+      zod: 4.3.6
 
-  zod-to-json-schema@3.25.1(zod@3.25.67):
+  zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:
-      zod: 3.25.67
+      zod: 4.3.6
 
-  zod@3.25.67: {}
-
-  zod@4.1.12: {}
+  zod@4.3.6: {}
 
   zx@8.8.5: {}


### PR DESCRIPTION
## Summary

> [!WARNING]
> This branch is still WIP and doesn't build yet

### Steps already done

- Update zod Version across project to latest v4 release
- Run [zod-v3-to-v4](https://github.com/nicoespeon/zod-v3-to-v4) on every project in the repository
- Run through the [Migration guide](https://zod.dev/v4/changelog) for special cases
    - Migrate ZodError.errors to ZodError.issues (https://github.com/colinhacks/zod/issues/5063)
        - The codemod didn't hit all places as the AST was a bit unclear at times.
- Migrate from using internal types like `z.Primitive`
- Migrate from passing `zs` (zod.string()) to direct access (e.g. `zs.email()` => `z.email()`)
- Update generics access and internal object usage
- Remove as much of the `z.custom` calls as possible
    - Use `object` + `refine` wherever possible



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-857

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
