### PR TITLE
refactor(cli): Increase community nodes metadata page size to 1000

### DIFF
--- a/packages/cli/src/modules/community-packages/community-node-types-utils.ts
+++ b/packages/cli/src/modules/community-packages/community-node-types-utils.ts
@@ -64,7 +64,7 @@ export async function getCommunityNodesMetadata(
 		maxAiNodeSdkVersion,
 		pagination: {
 			page: 1,
-			pageSize: 500,
+			pageSize: 1000,
 		},
 	};
 	// we want to make sure this throws on error


### PR DESCRIPTION
## Summary
- Increases the `pageSize` for the community nodes metadata endpoint from 500 to 1000
- As the community node catalog grows toward 500 entries (currently at 412), this ensures the metadata check (used for incremental updates) completes in a single request rather than requiring pagination

## Test plan
- [ ] Verify community node types still load correctly on cloud staging
- [ ] Confirm no regressions in the community nodes panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)