### PR TITLE
fix(editor): Use text shade token in N8nInput

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
@@ -514,7 +514,7 @@ defineExpose({ focus, blur, select });
 	outline: none;
 	font-family: inherit;
 	font-size: var(--input--font-size, var(--font-size--md));
-	color: var(--color--text);
+	color: var(--color--text--shade-1);
 }
 
 .input::placeholder {
@@ -561,7 +561,7 @@ defineExpose({ focus, blur, select });
 	display: flex;
 	align-items: center;
 	flex-shrink: 0;
-	color: var(--color--text);
+	color: var(--color--text--shade-1);
 	opacity: 0.7;
 
 	svg {


### PR DESCRIPTION
## Summary

- Update `N8nInput` design-system component to use `--color--text--shade-1` instead of `--color--text` for base input text color.
- Update prefix/suffix icon text color to `--color--text--shade-1` for consistency with the input text token.
- Keep placeholder colors unchanged (`--color--text--subtler`) as requested.

Reason for change:
- Align the component with the newer design token usage while preserving placeholder behavior and readability.
- Fixes https://n8nio.slack.com/archives/C035PCSN74K/p1773298920253759

## Related Linear tickets, Github issues, and Community forum posts

- No Linear ticket was provided for this change.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
