### PR TITLE
ci: Reduce noisy Codecov PR comments and fix double bundle upload

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,7 +8,8 @@ bundle_analysis:
 
 comment:
   require_bundle_changes: bundle_increase
-  bundle_change_threshold: 100Kb
+  bundle_change_threshold: 50Kb
+  require_changes: "coverage_drop OR uncovered_patch"
 
 coverage:
   status:

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -203,7 +203,8 @@ const plugins: UserConfig['plugins'] = [
 				}),
 			]
 		: []),
-	...(process.env.CODECOV_TOKEN
+	// Only run on non-release builds to prevent double upload from @vitejs/plugin-legacy
+	...(process.env.CODECOV_TOKEN && !release
 		? [
 				codecovVitePlugin({
 					enableBundleAnalysis: true,


### PR DESCRIPTION
## Summary
- Suppress Codecov PR comments unless there is a coverage drop or uncovered patch (`require_changes`)
- Lower bundle change comment threshold from 100Kb to 50Kb
- Disable Codecov Vite plugin on release builds to prevent double uploads caused by `@vitejs/plugin-legacy`

## Test plan
These have to be done after it's merged to master and the config takes affect.
- [ ] Verify Codecov comments only appear on PRs with coverage drops or uncovered patches
- [ ] Verify bundle analysis still uploads on non-release CI builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)