### PR TITLE
refactor(editor): Refactor app stores and utils to use `workflowDocumentStore` (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useFloatingUiOffsets.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useFloatingUiOffsets.test.ts
@@ -3,6 +3,10 @@ import { useLogsStore } from '@/app/stores/logs.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { setActivePinia } from 'pinia';
 import { useFloatingUiOffsets } from './useFloatingUiOffsets';
 import { reactive } from 'vue';
@@ -28,7 +32,12 @@ describe(useFloatingUiOffsets, () => {
 	beforeEach(() => {
 		setActivePinia(createTestingPinia({ stubActions: false }));
 		currentRouteName = '';
-		useWorkflowsStore().setNodes([createTestNode({ name: 'n0' })]);
+		const workflowsStore = useWorkflowsStore();
+		workflowsStore.workflow.id = 'test-workflow';
+		const workflowDocumentStore = useWorkflowDocumentStore(
+			createWorkflowDocumentId(workflowsStore.workflowId),
+		);
+		workflowDocumentStore.setNodes([createTestNode({ name: 'n0' })]);
 	});
 
 	describe('toastBottomOffset', () => {

--- a/packages/frontend/editor-ui/src/app/stores/focusPanel.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/focusPanel.store.ts
@@ -10,6 +10,10 @@ import {
 	jsonParse,
 } from 'n8n-workflow';
 import { useWorkflowsStore } from './workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { LOCAL_STORAGE_FOCUS_PANEL } from '@/app/constants';
 import { useStorage } from '@/app/composables/useStorage';
 import { watchOnce } from '@vueuse/core';
@@ -42,6 +46,11 @@ const DEFAULT_FOCUS_PANEL_DATA: FocusPanelData = { isActive: false, parameters: 
 
 export const useFocusPanelStore = defineStore(STORES.FOCUS_PANEL, () => {
 	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 	const focusPanelStorage = useStorage(LOCAL_STORAGE_FOCUS_PANEL);
 
 	const focusPanelData = computed((): FocusPanelDataByWid => {
@@ -70,7 +79,7 @@ export const useFocusPanelStore = defineStore(STORES.FOCUS_PANEL, () => {
 	const focusedNodeParameters = computed<Array<RichFocusedNodeParameter | FocusedNodeParameter>>(
 		() =>
 			_focusedNodeParameters.value.map((x) => {
-				const node = workflowsStore.getNodeById(x.nodeId);
+				const node = workflowDocumentStore.value?.getNodeById(x.nodeId);
 				if (!node) return x;
 
 				const value = get(node?.parameters ?? {}, x.parameterPath.replace(/parameters\./, ''));

--- a/packages/frontend/editor-ui/src/app/stores/ui.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/ui.store.ts
@@ -86,6 +86,10 @@ import type {
 } from '@/Interface';
 import { defineStore } from 'pinia';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { applyThemeToBody, getThemeOverride, isValidTheme } from './ui.utils';
 import { computed, ref } from 'vue';
@@ -331,6 +335,11 @@ export const useUIStore = defineStore(STORES.UI, () => {
 
 	const settingsStore = useSettingsStore();
 	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 
 	const isDarkThemePreferred = useMediaQuery('(prefers-color-scheme: dark)');
 	const preferredSystemTheme = computed<AppliedThemeOption>(() =>
@@ -401,7 +410,7 @@ export const useUIStore = defineStore(STORES.UI, () => {
 
 	const lastInteractedWithNode = computed(() => {
 		if (lastInteractedWithNodeId.value) {
-			return workflowsStore.getNodeById(lastInteractedWithNodeId.value);
+			return workflowDocumentStore.value?.getNodeById(lastInteractedWithNodeId.value) ?? null;
 		}
 
 		return null;

--- a/packages/frontend/editor-ui/src/app/utils/nodeTypesUtils.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodeTypesUtils.ts
@@ -1,4 +1,9 @@
-import type { AppliedThemeOption, INodeUi, NodeAuthenticationOption } from '@/Interface';
+import type {
+	AppliedThemeOption,
+	INodeUi,
+	INodeUpdatePropertiesInformation,
+	NodeAuthenticationOption,
+} from '@/Interface';
 import type { ITemplatesNode } from '@n8n/rest-api-client/api/templates';
 import {
 	CORE_NODES_CATEGORY,
@@ -22,8 +27,6 @@ import {
 	type ResourceMapperField,
 	type Themed,
 } from 'n8n-workflow';
-import type { WorkflowState } from '@/app/composables/useWorkflowState';
-
 /*
 	Constants and utility functions mainly used to get information about
 	or manipulate node types and nodes.
@@ -361,11 +364,14 @@ export const getCredentialsRelatedFields = (
 };
 
 export const updateNodeAuthType = (
-	workflowState: WorkflowState,
+	workflowDocumentStore:
+		| { updateNodeProperties: (info: INodeUpdatePropertiesInformation) => void }
+		| null
+		| undefined,
 	node: INodeUi | null,
 	type: string,
 ) => {
-	if (!node) {
+	if (!node || !workflowDocumentStore) {
 		return;
 	}
 	const nodeType = useNodeTypesStore().getNodeType(node.type, node.typeVersion);
@@ -381,7 +387,7 @@ export const updateNodeAuthType = (
 					},
 				},
 			};
-			workflowState.updateNodeProperties(updateInformation);
+			workflowDocumentStore.updateNodeProperties(updateInformation);
 		}
 	}
 };

--- a/packages/frontend/editor-ui/src/app/utils/nodeTypesUtils.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodeTypesUtils.ts
@@ -1,9 +1,4 @@
-import type {
-	AppliedThemeOption,
-	INodeUi,
-	INodeUpdatePropertiesInformation,
-	NodeAuthenticationOption,
-} from '@/Interface';
+import type { AppliedThemeOption, INodeUi, NodeAuthenticationOption } from '@/Interface';
 import type { ITemplatesNode } from '@n8n/rest-api-client/api/templates';
 import {
 	CORE_NODES_CATEGORY,
@@ -15,6 +10,10 @@ import {
 import { i18n as locale } from '@n8n/i18n';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { isJsonKeyObject } from '@/app/utils/typesUtils';
 import {
 	isResourceLocatorValue,
@@ -364,14 +363,11 @@ export const getCredentialsRelatedFields = (
 };
 
 export const updateNodeAuthType = (
-	workflowDocumentStore:
-		| { updateNodeProperties: (info: INodeUpdatePropertiesInformation) => void }
-		| null
-		| undefined,
+	workflowId: string | undefined | null,
 	node: INodeUi | null,
 	type: string,
 ) => {
-	if (!node || !workflowDocumentStore) {
+	if (!node || !workflowId) {
 		return;
 	}
 	const nodeType = useNodeTypesStore().getNodeType(node.type, node.typeVersion);
@@ -387,7 +383,8 @@ export const updateNodeAuthType = (
 					},
 				},
 			};
-			workflowDocumentStore.updateNodeProperties(updateInformation);
+			const store = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+			store.updateNodeProperties(updateInformation);
 		}
 	}
 };

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -607,7 +607,7 @@ function onRenameNode(name: string) {
 }
 
 async function onOpenRenameNodeModal(id: string) {
-	const currentName = workflowsStore.getNodeById(id)?.name ?? '';
+	const currentName = workflowDocumentStore?.value?.getNodeById(id)?.name ?? '';
 
 	const activeElement = document.activeElement;
 
@@ -886,7 +886,7 @@ async function onRevertAddNode({ node }: { node: INodeUi }) {
 }
 
 function onSwitchActiveNode(nodeName: string) {
-	const node = workflowsStore.getNodeByName(nodeName);
+	const node = workflowDocumentStore?.value?.getNodeByName(nodeName) ?? null;
 	if (!node) return;
 
 	setNodeActiveByName(nodeName, 'other');
@@ -956,7 +956,7 @@ function onClickConnectionAdd(connection: Connection) {
 }
 
 function onClickReplaceNode(nodeId: string) {
-	const node = workflowsStore.getNodeById(nodeId);
+	const node = workflowDocumentStore?.value?.getNodeById(nodeId);
 	if (!node) return;
 	const nodeType = nodeTypesStore.getNodeType(node.type);
 	if (!nodeType) return;
@@ -1039,7 +1039,7 @@ const isStopWaitingForWebhookButtonVisible = computed(
 );
 
 async function onRunWorkflowToNode(id: string) {
-	const node = workflowsStore.getNodeById(id);
+	const node = workflowDocumentStore?.value?.getNodeById(id);
 	if (!node) return;
 
 	if (needsAgentInput(node) && nodeTypesStore.isToolNode(node.type)) {
@@ -1072,7 +1072,7 @@ async function copyWebhookUrl(id: string, webhookType: 'test' | 'production') {
 }
 
 async function onCopyTestUrl(id: string) {
-	const node = workflowsStore.getNodeById(id);
+	const node = workflowDocumentStore?.value?.getNodeById(id);
 	const isProductionOnly = PRODUCTION_ONLY_TRIGGER_NODE_TYPES.includes(node?.type ?? '');
 
 	if (isProductionOnly) {

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -886,7 +886,7 @@ async function onRevertAddNode({ node }: { node: INodeUi }) {
 }
 
 function onSwitchActiveNode(nodeName: string) {
-	const node = workflowDocumentStore?.value?.getNodeByName(nodeName) ?? null;
+	const node = workflowDocumentStore?.value?.getNodeByName(nodeName);
 	if (!node) return;
 
 	setNodeActiveByName(nodeName, 'other');

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -64,7 +64,7 @@ import {
 	N8nText,
 	type IMenuItem,
 } from '@n8n/design-system';
-import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { setParameterValue } from '@/app/utils/parameterUtils';
 import get from 'lodash/get';
 import { useDynamicCredentials } from '@/features/resolvers/composables/useDynamicCredentials';
@@ -84,7 +84,7 @@ const ndvStore = useNDVStore();
 const settingsStore = useSettingsStore();
 const uiStore = useUIStore();
 const workflowsStore = useWorkflowsStore();
-const workflowState = injectWorkflowState();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const nodeTypesStore = useNodeTypesStore();
 const projectsStore = useProjectsStore();
 const externalSecretsStore = useExternalSecretsStore();
@@ -834,7 +834,7 @@ async function saveCredential(): Promise<ICredentialsResponse | null> {
 
 	const appliedAuthType = pendingAuthType.value;
 	if (appliedAuthType && ndvStore.activeNode) {
-		updateNodeAuthType(workflowState, ndvStore.activeNode, appliedAuthType);
+		updateNodeAuthType(workflowDocumentStore?.value, ndvStore.activeNode, appliedAuthType);
 		pendingAuthType.value = null;
 	}
 

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -64,7 +64,6 @@ import {
 	N8nText,
 	type IMenuItem,
 } from '@n8n/design-system';
-import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { setParameterValue } from '@/app/utils/parameterUtils';
 import get from 'lodash/get';
 import { useDynamicCredentials } from '@/features/resolvers/composables/useDynamicCredentials';
@@ -84,7 +83,6 @@ const ndvStore = useNDVStore();
 const settingsStore = useSettingsStore();
 const uiStore = useUIStore();
 const workflowsStore = useWorkflowsStore();
-const workflowDocumentStore = injectWorkflowDocumentStore();
 const nodeTypesStore = useNodeTypesStore();
 const projectsStore = useProjectsStore();
 const externalSecretsStore = useExternalSecretsStore();
@@ -834,7 +832,7 @@ async function saveCredential(): Promise<ICredentialsResponse | null> {
 
 	const appliedAuthType = pendingAuthType.value;
 	if (appliedAuthType && ndvStore.activeNode) {
-		updateNodeAuthType(workflowDocumentStore?.value, ndvStore.activeNode, appliedAuthType);
+		updateNodeAuthType(workflowsStore.workflowId, ndvStore.activeNode, appliedAuthType);
 		pendingAuthType.value = null;
 	}
 

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -445,7 +445,7 @@ function onCredentialSelected(
 		);
 		const authOption = getAuthTypeForNodeCredential(nodeType.value, nodeCredentialDescription);
 		if (authOption) {
-			updateNodeAuthType(workflowDocumentStore?.value, props.node, authOption.value);
+			updateNodeAuthType(workflowsStore.workflowId, props.node, authOption.value);
 			const parameterData = {
 				name: `parameters.${mainNodeAuthField.value.name}`,
 				value: authOption.value,

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -52,7 +52,6 @@ import {
 	N8nText,
 	N8nTooltip,
 } from '@n8n/design-system';
-import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 type Props = {
 	node: INodeUi;
@@ -85,7 +84,6 @@ const ndvStore = useNDVStore();
 const uiStore = useUIStore();
 const workflowsStore = useWorkflowsStore();
 const projectsStore = useProjectsStore();
-const workflowState = injectWorkflowState();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const { isEnabled: isDynamicCredentialsEnabled } = useDynamicCredentials();
 
@@ -447,7 +445,7 @@ function onCredentialSelected(
 		);
 		const authOption = getAuthTypeForNodeCredential(nodeType.value, nodeCredentialDescription);
 		if (authOption) {
-			updateNodeAuthType(workflowState, props.node, authOption.value);
+			updateNodeAuthType(workflowDocumentStore?.value, props.node, authOption.value);
 			const parameterData = {
 				name: `parameters.${mainNodeAuthField.value.name}`,
 				value: authOption.value,

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/composables/useActions.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/composables/useActions.test.ts
@@ -18,6 +18,13 @@ import {
 	WEBHOOK_NODE_TYPE,
 } from '@/app/constants';
 import { CHAT_TRIGGER_NODE_TYPE } from 'n8n-workflow';
+import type { INodeUi } from '@/Interface';
+
+let mockAllNodes: INodeUi[] = [];
+vi.mock('@/app/stores/workflowDocument.store', () => ({
+	useWorkflowDocumentStore: () => ({ allNodes: mockAllNodes }),
+	createWorkflowDocumentId: (id: string) => `${id}@latest`,
+}));
 
 describe('useActions', () => {
 	beforeAll(() => {
@@ -26,6 +33,7 @@ describe('useActions', () => {
 
 	afterEach(() => {
 		vi.clearAllMocks();
+		mockAllNodes = [];
 	});
 
 	describe('getAddedNodesAndConnections', () => {
@@ -76,8 +84,9 @@ describe('useActions', () => {
 		test('should insert a ChatTrigger node when an AI Agent is added on an empty canvas', () => {
 			const workflowsStore = useWorkflowsStore();
 
+			vi.spyOn(workflowsStore, 'workflowId', 'get').mockReturnValue('test-id');
 			vi.spyOn(workflowsStore, 'workflowTriggerNodes', 'get').mockReturnValue([]);
-			vi.spyOn(workflowsStore, 'allNodes', 'get').mockReturnValue([]);
+			mockAllNodes = [];
 
 			const { getAddedNodesAndConnections } = useActions();
 
@@ -102,12 +111,11 @@ describe('useActions', () => {
 		test('should insert a ChatTrigger node when an AI Agent is added with only a Manual Trigger present', () => {
 			const workflowsStore = useWorkflowsStore();
 
+			vi.spyOn(workflowsStore, 'workflowId', 'get').mockReturnValue('test-id');
 			vi.spyOn(workflowsStore, 'workflowTriggerNodes', 'get').mockReturnValue([
 				{ type: MANUAL_TRIGGER_NODE_TYPE } as never,
 			]);
-			vi.spyOn(workflowsStore, 'allNodes', 'get').mockReturnValue([
-				{ type: MANUAL_TRIGGER_NODE_TYPE } as never,
-			]);
+			mockAllNodes = [{ type: MANUAL_TRIGGER_NODE_TYPE } as INodeUi];
 
 			const { getAddedNodesAndConnections } = useActions();
 
@@ -132,14 +140,14 @@ describe('useActions', () => {
 		test('should not insert a ChatTrigger node when an AI Agent is added with a non-trigger node prseent', () => {
 			const workflowsStore = useWorkflowsStore();
 
+			vi.spyOn(workflowsStore, 'workflowId', 'get').mockReturnValue('test-id');
 			vi.spyOn(workflowsStore, 'workflowTriggerNodes', 'get').mockReturnValue([
 				{ type: GITHUB_TRIGGER_NODE_TYPE } as never,
 			]);
-
-			vi.spyOn(workflowsStore, 'allNodes', 'get').mockReturnValue([
-				{ type: GITHUB_TRIGGER_NODE_TYPE } as never,
-				{ type: HTTP_REQUEST_NODE_TYPE } as never,
-			]);
+			mockAllNodes = [
+				{ type: GITHUB_TRIGGER_NODE_TYPE } as INodeUi,
+				{ type: HTTP_REQUEST_NODE_TYPE } as INodeUi,
+			];
 
 			const { getAddedNodesAndConnections } = useActions();
 
@@ -152,12 +160,11 @@ describe('useActions', () => {
 		test('should not insert a ChatTrigger node when an AI Agent is added with a Chat Trigger already present', () => {
 			const workflowsStore = useWorkflowsStore();
 
+			vi.spyOn(workflowsStore, 'workflowId', 'get').mockReturnValue('test-id');
 			vi.spyOn(workflowsStore, 'workflowTriggerNodes', 'get').mockReturnValue([
 				{ type: CHAT_TRIGGER_NODE_TYPE } as never,
 			]);
-			vi.spyOn(workflowsStore, 'allNodes', 'get').mockReturnValue([
-				{ type: CHAT_TRIGGER_NODE_TYPE } as never,
-			]);
+			mockAllNodes = [{ type: CHAT_TRIGGER_NODE_TYPE } as INodeUi];
 
 			const { getAddedNodesAndConnections } = useActions();
 

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/composables/useActions.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/composables/useActions.ts
@@ -39,7 +39,10 @@ import type { BaseTextKey } from '@n8n/i18n';
 import type { Telemetry } from '@/app/plugins/telemetry';
 import { useNodeCreatorStore } from '@/features/shared/nodeCreator/nodeCreator.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useExternalHooks } from '@/app/composables/useExternalHooks';
 
@@ -53,7 +56,12 @@ import { PUSH_NODES_OFFSET } from '@/app/utils/nodeViewUtils';
 import { useCanvasStore } from '@/app/stores/canvas.store';
 
 export const useActions = () => {
-	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 	const nodeCreatorStore = useNodeCreatorStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const i18n = useI18n();

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/composables/useActions.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/composables/useActions.ts
@@ -39,6 +39,7 @@ import type { BaseTextKey } from '@n8n/i18n';
 import type { Telemetry } from '@/app/plugins/telemetry';
 import { useNodeCreatorStore } from '@/features/shared/nodeCreator/nodeCreator.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useExternalHooks } from '@/app/composables/useExternalHooks';
 
@@ -50,10 +51,9 @@ import {
 import { useI18n } from '@n8n/i18n';
 import { PUSH_NODES_OFFSET } from '@/app/utils/nodeViewUtils';
 import { useCanvasStore } from '@/app/stores/canvas.store';
-import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 
 export const useActions = () => {
-	const workflowState = injectWorkflowState();
+	const workflowDocumentStore = injectWorkflowDocumentStore();
 	const nodeCreatorStore = useNodeCreatorStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const i18n = useI18n();
@@ -280,7 +280,7 @@ export const useActions = () => {
 		const isCompatibleNode = addedNodes.some((node) => COMPATIBLE_CHAT_NODES.includes(node.type));
 		if (!isCompatibleNode) return false;
 
-		const { allNodes } = useWorkflowsStore();
+		const allNodes = workflowDocumentStore?.value?.allNodes ?? [];
 		return allNodes.filter((x) => x.type !== MANUAL_TRIGGER_NODE_TYPE).length === 0;
 	}
 
@@ -383,7 +383,7 @@ export const useActions = () => {
 		const storeWatcher = onWorkflowStoreAction(({ name, after, args }) => {
 			if (name !== 'addNode' || args[0].type !== action.key) return;
 			after(() => {
-				workflowState.setLastNodeParameters(action);
+				workflowDocumentStore?.value?.setLastNodeParameters(action);
 				if (telemetry) trackActionSelected(action, telemetry, rootView);
 				// Unsubscribe from the store watcher
 				storeWatcher();

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.store.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.store.ts
@@ -23,6 +23,10 @@ import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import type { TelemetryNdvType } from '@/app/types/telemetry';
 import { getNodeIconSource } from '@/app/utils/nodeIcon';
 import { isVueFlowConnection } from '@/app/utils/typeGuards';
@@ -44,6 +48,11 @@ import { prepareCommunityNodeDetailsViewStack, transformNodeType } from './nodeC
 
 export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 	const ndvStore = useNDVStore();
 	const uiStore = useUIStore();
 	const nodeTypesStore = useNodeTypesStore();
@@ -104,7 +113,9 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 		connectionIndex?: number;
 	}) {
 		const nodeName = node ?? ndvStore.activeNodeName;
-		const nodeData = nodeName ? workflowsStore.getNodeByName(nodeName) : null;
+		const nodeData = nodeName
+			? (workflowDocumentStore.value?.getNodeByName(nodeName) ?? null)
+			: null;
 
 		ndvStore.unsetActiveNodeName();
 
@@ -180,7 +191,7 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 		// Get the node and set it as active that new nodes
 		// which get created get automatically connected
 		// to it.
-		const sourceNode = workflowsStore.getNodeById(connection.source);
+		const sourceNode = workflowDocumentStore.value?.getNodeById(connection.source);
 		if (!sourceNode) {
 			return;
 		}
@@ -219,7 +230,9 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 	}
 
 	async function openNodeCreatorWithNode(nodeName: string) {
-		const nodeData = nodeName ? workflowsStore.getNodeByName(nodeName) : null;
+		const nodeData = nodeName
+			? (workflowDocumentStore.value?.getNodeByName(nodeName) ?? null)
+			: null;
 		if (!nodeData) {
 			return;
 		}


### PR DESCRIPTION
## Summary

This pull request refactors several parts of the frontend editor UI to consistently use the `workflowDocumentStore` for node and workflow data access, replacing direct usage of the `workflowsStore` and removing the now-obsolete `workflowState` injection. This change improves data consistency and aligns with the application's multi-document architecture.

### Store access refactoring

* Replaced direct calls to `workflowsStore.getNodeById` and `workflowsStore.getNodeByName` with calls to `workflowDocumentStore.value?.getNodeById` and `workflowDocumentStore.value?.getNodeByName` across multiple files, including `NodeView.vue`, `ui.store.ts`, `nodeCreator.store.ts`, and composables. [[1]](diffhunk://#diff-44b815ef09797b984866c997998d7a59479906d18041d1bacb4d809aa4aba432L610-R610) [[2]](diffhunk://#diff-44b815ef09797b984866c997998d7a59479906d18041d1bacb4d809aa4aba432L889-R889) [[3]](diffhunk://#diff-44b815ef09797b984866c997998d7a59479906d18041d1bacb4d809aa4aba432L959-R959) [[4]](diffhunk://#diff-44b815ef09797b984866c997998d7a59479906d18041d1bacb4d809aa4aba432L1042-R1042) [[5]](diffhunk://#diff-44b815ef09797b984866c997998d7a59479906d18041d1bacb4d809aa4aba432L1075-R1075) [[6]](diffhunk://#diff-f9aecd70932440b87ae1eb51e396a092419c096757c391e161d86fc1d5a900c4L404-R413) [[7]](diffhunk://#diff-8e0ec4c97caffe8e9289836eaf74695f84bb458d2b97ecf402b62b7f813f4181L107-R118) [[8]](diffhunk://#diff-8e0ec4c97caffe8e9289836eaf74695f84bb458d2b97ecf402b62b7f813f4181L183-R194) [[9]](diffhunk://#diff-f0c40e7a81082acba848b5d049d8a8371bf965703c51439d6260f89e41d9940aL283-R283)
* Updated store initialization in Pinia stores and composables to compute and use the correct `workflowDocumentStore` instance based on the current `workflowId`. [[1]](diffhunk://#diff-37bfbb6a45d39175ef45e3e469dad6a7633a17ed720e95f53c552d65140b1383R49-R53) [[2]](diffhunk://#diff-f9aecd70932440b87ae1eb51e396a092419c096757c391e161d86fc1d5a900c4R338-R342) [[3]](diffhunk://#diff-8e0ec4c97caffe8e9289836eaf74695f84bb458d2b97ecf402b62b7f813f4181R51-R55)

### Removal of obsolete workflow state injection

* Removed `injectWorkflowState` and references to `WorkflowState` from components and utility functions, replacing them with direct usage of `workflowDocumentStore` or passing `workflowId` as needed. [[1]](diffhunk://#diff-4a084f7559256ae9a7b1f4ffff6ecd2beea1dde181ac9e6b6a7d1b6c30bc2537L67) [[2]](diffhunk://#diff-4a084f7559256ae9a7b1f4ffff6ecd2beea1dde181ac9e6b6a7d1b6c30bc2537L87) [[3]](diffhunk://#diff-482cab688da7c590f0be737ad690ab19790e0be720f0dd0cfcd2906aee9cada4L55) [[4]](diffhunk://#diff-482cab688da7c590f0be737ad690ab19790e0be720f0dd0cfcd2906aee9cada4L88) [[5]](diffhunk://#diff-f0c40e7a81082acba848b5d049d8a8371bf965703c51439d6260f89e41d9940aL53-R56) [[6]](diffhunk://#diff-7284812a4b5dacee7cf4ee8da288b0a358a8cef160ee52a35b84c64028cd17e8L25-L26)

### Node authentication updates

* Refactored `updateNodeAuthType` utility to accept `workflowId` instead of `workflowState`, and updated all callers to use this new signature and update node properties via `workflowDocumentStore`. [[1]](diffhunk://#diff-7284812a4b5dacee7cf4ee8da288b0a358a8cef160ee52a35b84c64028cd17e8L364-R370) [[2]](diffhunk://#diff-7284812a4b5dacee7cf4ee8da288b0a358a8cef160ee52a35b84c64028cd17e8L384-R387) [[3]](diffhunk://#diff-4a084f7559256ae9a7b1f4ffff6ecd2beea1dde181ac9e6b6a7d1b6c30bc2537L837-R835) [[4]](diffhunk://#diff-482cab688da7c590f0be737ad690ab19790e0be720f0dd0cfcd2906aee9cada4L450-R448)

### Test updates

* Updated tests for `useFloatingUiOffsets` to use `workflowDocumentStore` for node setup, ensuring test consistency with new store architecture. [[1]](diffhunk://#diff-10262749d6f53c7e6a8acd0b7d91a86315ea1b10983be69260b55e80decd9dcaR6-R9) [[2]](diffhunk://#diff-10262749d6f53c7e6a8acd0b7d91a86315ea1b10983be69260b55e80decd9dcaL31-R40)

### Node creator and shared actions refactoring

* Updated node creator and shared node actions to use `workflowDocumentStore` for node and workflow data, improving compatibility with multi-document workflows. [[1]](diffhunk://#diff-8e0ec4c97caffe8e9289836eaf74695f84bb458d2b97ecf402b62b7f813f4181R26-R29) [[2]](diffhunk://#diff-f0c40e7a81082acba848b5d049d8a8371bf965703c51439d6260f89e41d9940aR42) [[3]](diffhunk://#diff-8e0ec4c97caffe8e9289836eaf74695f84bb458d2b97ecf402b62b7f813f4181R51-R55) [[4]](diffhunk://#diff-8e0ec4c97caffe8e9289836eaf74695f84bb458d2b97ecf402b62b7f813f4181L107-R118) [[5]](diffhunk://#diff-8e0ec4c97caffe8e9289836eaf74695f84bb458d2b97ecf402b62b7f813f4181L183-R194) [[6]](diffhunk://#diff-f0c40e7a81082acba848b5d049d8a8371bf965703c51439d6260f89e41d9940aL283-R283) [[7]](diffhunk://#diff-f0c40e7a81082acba848b5d049d8a8371bf965703c51439d6260f89e41d9940aL386-R386)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2520


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
