### PR TITLE
chore: Update CODEOWNERS with ci-admins

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 packages/@n8n/db/src/migrations/ @n8n-io/migrations-review
+.github/workflows @n8n-io/ci-admins
+.github/scripts @n8n-io/ci-admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
 packages/@n8n/db/src/migrations/ @n8n-io/migrations-review
 .github/workflows @n8n-io/ci-admins
 .github/scripts @n8n-io/ci-admins
+.github/actions @n8n-io/ci-admins
+.github/poutine-rules @n8n-io/ci-admins
+


### PR DESCRIPTION
## Summary

Add n8n-io/ci-admins as the CODEOWNERS of .github/workflows and .github/scripts

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2552

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
