### PR TITLE
feat(core): Wire builtin globals onto __data in VM expression isolate

### DIFF
--- a/packages/@n8n/expression-runtime/src/runtime/reset.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/reset.ts
@@ -3,8 +3,16 @@ import { DateTime, IANAZone, Settings } from 'luxon';
 import { extend, extendOptional } from '../extensions/extend';
 import { extendedFunctions } from '../extensions/function-extensions';
 
-import { __sanitize } from './safe-globals';
+import { __sanitize, createSafeErrorSubclass } from './safe-globals';
 import { createDeepLazyProxy } from './lazy-proxy';
+
+// Pre-create safe error subclass wrappers (reused across evaluations)
+const SafeTypeError = createSafeErrorSubclass(TypeError);
+const SafeSyntaxError = createSafeErrorSubclass(SyntaxError);
+const SafeEvalError = createSafeErrorSubclass(EvalError);
+const SafeRangeError = createSafeErrorSubclass(RangeError);
+const SafeReferenceError = createSafeErrorSubclass(ReferenceError);
+const SafeURIError = createSafeErrorSubclass(URIError);
 
 // ============================================================================
 // Reset Function for Data Proxies
@@ -226,4 +234,13 @@ function initializeBuiltins(data: Record<string, unknown>): void {
 
 	// Object — use SafeObject wrapper from the runtime bundle
 	data.Object = globalThis.SafeObject;
+
+	// Error types — use SafeError and safe subclass wrappers
+	data.Error = globalThis.SafeError;
+	data.TypeError = SafeTypeError;
+	data.SyntaxError = SafeSyntaxError;
+	data.EvalError = SafeEvalError;
+	data.RangeError = SafeRangeError;
+	data.ReferenceError = SafeReferenceError;
+	data.URIError = SafeURIError;
 }

--- a/packages/@n8n/expression-runtime/src/runtime/reset.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/reset.ts
@@ -244,4 +244,54 @@ function initializeBuiltins(data: Record<string, unknown>): void {
 	data.RangeError = SafeRangeError;
 	data.ReferenceError = SafeReferenceError;
 	data.URIError = SafeURIError;
+
+	// Arrays
+	data.Array = Array;
+	data.Int8Array = Int8Array;
+	data.Uint8Array = Uint8Array;
+	data.Uint8ClampedArray = Uint8ClampedArray;
+	data.Int16Array = Int16Array;
+	data.Uint16Array = Uint16Array;
+	data.Int32Array = Int32Array;
+	data.Uint32Array = Uint32Array;
+	data.Float32Array = Float32Array;
+	data.Float64Array = Float64Array;
+	data.BigInt64Array = typeof BigInt64Array !== 'undefined' ? BigInt64Array : {};
+	data.BigUint64Array = typeof BigUint64Array !== 'undefined' ? BigUint64Array : {};
+
+	// Collections
+	data.Map = Map;
+	data.WeakMap = WeakMap;
+	data.Set = Set;
+	data.WeakSet = WeakSet;
+
+	// Internationalization
+	data.Intl = typeof Intl !== 'undefined' ? Intl : {};
+
+	// Text
+	data.String = String;
+
+	// Numbers
+	data.Number = Number;
+	data.BigInt = typeof BigInt !== 'undefined' ? BigInt : {};
+	data.Infinity = Infinity;
+	data.parseFloat = parseFloat;
+	data.parseInt = parseInt;
+
+	// Structured data
+	data.JSON = JSON;
+	data.ArrayBuffer = typeof ArrayBuffer !== 'undefined' ? ArrayBuffer : {};
+	data.SharedArrayBuffer = typeof SharedArrayBuffer !== 'undefined' ? SharedArrayBuffer : {};
+	data.Atomics = typeof Atomics !== 'undefined' ? Atomics : {};
+	data.DataView = typeof DataView !== 'undefined' ? DataView : {};
+
+	// Encoding
+	data.encodeURI = encodeURI;
+	data.encodeURIComponent = encodeURIComponent;
+	data.decodeURI = decodeURI;
+	data.decodeURIComponent = decodeURIComponent;
+
+	// Other
+	data.Boolean = Boolean;
+	data.Symbol = Symbol;
 }

--- a/packages/@n8n/expression-runtime/src/runtime/reset.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/reset.ts
@@ -159,5 +159,66 @@ export function resetDataProxies(timezone?: string): void {
 	globalThis.__data.extend = extend;
 	globalThis.__data.extendOptional = extendOptional;
 
+	// Wire builtins so tournament's VariablePolyfill resolves them from __data
+	initializeBuiltins(globalThis.__data as Record<string, unknown>);
+
 	// TODO: Add other function properties as needed ($item, $vars, etc.)
+}
+
+/**
+ * Wire builtins onto __data so tournament's VariablePolyfill resolves them.
+ *
+ * Tournament transforms `Object` → `("Object" in this ? this : window).Object`.
+ * `this` = __data. Without these entries on __data, builtins fall through to
+ * `window` which doesn't exist in the isolate, causing a ReferenceError.
+ *
+ * Mirrors Expression.initializeGlobalContext() in packages/workflow/src/expression.ts.
+ */
+function initializeBuiltins(data: Record<string, unknown>): void {
+	// ── Denylist: dangerous globals → empty objects ──
+	// Matches initializeGlobalContext() lines 262-318
+	const denylisted = [
+		'document',
+		'global',
+		'window',
+		'Window',
+		'globalThis',
+		'self',
+		'alert',
+		'prompt',
+		'confirm',
+		'eval',
+		'uneval',
+		'setTimeout',
+		'setInterval',
+		'setImmediate',
+		'clearImmediate',
+		'queueMicrotask',
+		'Function',
+		'require',
+		'module',
+		'Buffer',
+		'__dirname',
+		'__filename',
+		'fetch',
+		'XMLHttpRequest',
+		'Promise',
+		'Generator',
+		'GeneratorFunction',
+		'AsyncFunction',
+		'AsyncGenerator',
+		'AsyncGeneratorFunction',
+		'WebAssembly',
+		'Reflect',
+		'Proxy',
+		'escape',
+		'unescape',
+	];
+	for (const key of denylisted) {
+		data[key] = {};
+	}
+	data.__lookupGetter__ = undefined;
+	data.__lookupSetter__ = undefined;
+	data.__defineGetter__ = undefined;
+	data.__defineSetter__ = undefined;
 }

--- a/packages/@n8n/expression-runtime/src/runtime/reset.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/reset.ts
@@ -221,4 +221,9 @@ function initializeBuiltins(data: Record<string, unknown>): void {
 	data.__lookupSetter__ = undefined;
 	data.__defineGetter__ = undefined;
 	data.__defineSetter__ = undefined;
+
+	// ── Allowlist: safe versions of builtins ──
+
+	// Object — use SafeObject wrapper from the runtime bundle
+	data.Object = globalThis.SafeObject;
 }

--- a/packages/@n8n/expression-runtime/src/runtime/reset.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/reset.ts
@@ -173,6 +173,45 @@ export function resetDataProxies(timezone?: string): void {
 	// TODO: Add other function properties as needed ($item, $vars, etc.)
 }
 
+// Matches initializeGlobalContext() lines 262-318 in packages/workflow/src/expression.ts
+const DENYLISTED_GLOBALS = [
+	'document',
+	'global',
+	'window',
+	'Window',
+	'globalThis',
+	'self',
+	'alert',
+	'prompt',
+	'confirm',
+	'eval',
+	'uneval',
+	'setTimeout',
+	'setInterval',
+	'setImmediate',
+	'clearImmediate',
+	'queueMicrotask',
+	'Function',
+	'require',
+	'module',
+	'Buffer',
+	'__dirname',
+	'__filename',
+	'fetch',
+	'XMLHttpRequest',
+	'Promise',
+	'Generator',
+	'GeneratorFunction',
+	'AsyncFunction',
+	'AsyncGenerator',
+	'AsyncGeneratorFunction',
+	'WebAssembly',
+	'Reflect',
+	'Proxy',
+	'escape',
+	'unescape',
+] as const;
+
 /**
  * Wire builtins onto __data so tournament's VariablePolyfill resolves them.
  *
@@ -184,45 +223,7 @@ export function resetDataProxies(timezone?: string): void {
  */
 function initializeBuiltins(data: Record<string, unknown>): void {
 	// ── Denylist: dangerous globals → empty objects ──
-	// Matches initializeGlobalContext() lines 262-318
-	const denylisted = [
-		'document',
-		'global',
-		'window',
-		'Window',
-		'globalThis',
-		'self',
-		'alert',
-		'prompt',
-		'confirm',
-		'eval',
-		'uneval',
-		'setTimeout',
-		'setInterval',
-		'setImmediate',
-		'clearImmediate',
-		'queueMicrotask',
-		'Function',
-		'require',
-		'module',
-		'Buffer',
-		'__dirname',
-		'__filename',
-		'fetch',
-		'XMLHttpRequest',
-		'Promise',
-		'Generator',
-		'GeneratorFunction',
-		'AsyncFunction',
-		'AsyncGenerator',
-		'AsyncGeneratorFunction',
-		'WebAssembly',
-		'Reflect',
-		'Proxy',
-		'escape',
-		'unescape',
-	];
-	for (const key of denylisted) {
+	for (const key of DENYLISTED_GLOBALS) {
 		data[key] = {};
 	}
 	data.__lookupGetter__ = undefined;

--- a/packages/@n8n/expression-runtime/src/runtime/safe-globals.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/safe-globals.ts
@@ -34,6 +34,11 @@ export const SafeObject = new Proxy(Object, {
 			throw new Error('Object.getPrototypeOf is not allowed');
 		}
 
+		// Wrap Object.create to accept only one argument (blocks property descriptor injection)
+		if (prop === 'create') {
+			return (proto: object | null) => Object.create(proto);
+		}
+
 		// Allow other Object methods
 		const value = (target as any)[prop];
 		if (typeof value === 'function') {

--- a/packages/@n8n/expression-runtime/src/runtime/safe-globals.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/safe-globals.ts
@@ -50,25 +50,27 @@ export const SafeObject = new Proxy(Object, {
 });
 
 /**
- * SafeError - Blocks stack manipulation methods
- *
- * Blocked properties:
- * - stackTraceLimit, captureStackTrace, prepareStackTrace: Prevent stack manipulation attacks
+ * Properties blocked on Error and all Error subclasses.
+ * These can be exploited for sandbox escape via V8's stack trace API.
+ */
+const blockedErrorProperties = new Set([
+	'captureStackTrace',
+	'prepareStackTrace',
+	'stackTraceLimit',
+	'__defineGetter__',
+	'__defineSetter__',
+	'__lookupGetter__',
+	'__lookupSetter__',
+]);
+
+/**
+ * SafeError - Blocks stack manipulation methods on Error constructor.
  */
 export const SafeError = new Proxy(Error, {
 	get(target, prop) {
-		// Block stack manipulation (return undefined)
-		const blockedProps = ['stackTraceLimit', 'captureStackTrace', 'prepareStackTrace'];
-		if (blockedProps.includes(prop as string)) {
+		if (blockedErrorProperties.has(prop as string)) {
 			return undefined;
 		}
-
-		// Block dangerous methods
-		const blockedMethods = ['__defineGetter__', '__defineSetter__'];
-		if (blockedMethods.includes(prop as string)) {
-			return undefined;
-		}
-
 		const value = (target as any)[prop];
 		if (typeof value === 'function') {
 			return (...args: any[]) => value.apply(target, args);
@@ -83,7 +85,35 @@ export const SafeError = new Proxy(Error, {
 		(target as any)[prop] = value;
 		return true;
 	},
+	defineProperty() {
+		return false;
+	},
 });
+
+/**
+ * Creates a safe wrapper for Error subclasses (TypeError, SyntaxError, etc.)
+ * Blocks the same dangerous properties as SafeError for defense in depth.
+ */
+export function createSafeErrorSubclass<T extends ErrorConstructor>(ErrorClass: T): T {
+	return new Proxy(ErrorClass, {
+		get(target, prop) {
+			if (blockedErrorProperties.has(prop as string)) {
+				return undefined;
+			}
+			const value = (target as any)[prop];
+			if (typeof value === 'function') {
+				return (...args: any[]) => value.apply(target, args);
+			}
+			return value;
+		},
+		set() {
+			return false;
+		},
+		defineProperty() {
+			return false;
+		},
+	}) as T;
+}
 
 // ============================================================================
 // ExpressionError - used by tournament-generated error handlers


### PR DESCRIPTION
## Summary

Wire denylist/allowlist builtins onto `__data` inside the V8 isolate so tournament's `VariablePolyfill` resolves them correctly.

**Root cause:** Tournament transforms bare identifiers like `Object` into `("Object" in this ? this : window).Object`. In the VM engine, `this` = `__data`. Since builtins weren't on `__data`, the `in` check failed, falling through to `window` which doesn't exist in the isolate — causing a `ReferenceError` that tournament's error handler swallowed, returning `undefined`.

**Changes:**
- Add `initializeBuiltins()` to `resetDataProxies()` that mirrors `Expression.initializeGlobalContext()`:
  - **Denylist**: `document`, `window`, `eval`, `Function`, `Promise`, etc. → `{}`
  - **Allowlist**: `SafeObject` as `Object`, `SafeError` as `Error`, safe error subclasses, `Array`, typed arrays, `Map`, `Set`, `String`, `Number`, `JSON`, `Boolean`, `Symbol`, encoding functions, etc.
- Add `Object.create` single-arg restriction to `SafeObject` (matches host-side `createSafeObject`)
- Add `createSafeErrorSubclass()` factory for `TypeError`, `SyntaxError`, etc.
- Fix `SafeError` parity: add `__lookupGetter__`/`__lookupSetter__` to blocked set, add `defineProperty` trap
- Hoist `DENYLISTED_GLOBALS` array to module scope (avoids re-creation per eval)

**Fixes 5 of 6 tests** from the ticket under `N8N_EXPRESSION_ENGINE=vm`:
- ✅ "should not be able to use global built-ins from denylist"
- ✅ "should allow safe Object methods" (Object.keys, Object.values, etc.)
- ✅ "should allow Object.create with single argument"
- ✅ "should allow normal Error functionality"
- ✅ "should allow normal Error subclass functionality"
- ❌ "should be able to use global built-ins from allowlist" — `Int8Array` `toEqual` fails across jsdom realm boundary (CAT-2623)

**How to test:**
```bash
cd packages/workflow
N8N_EXPRESSION_ENGINE=vm pnpm test test/expression.test.ts -t "denylist"
N8N_EXPRESSION_ENGINE=vm pnpm test test/expression.test.ts -t "Object"
N8N_EXPRESSION_ENGINE=vm pnpm test test/expression.test.ts -t "Error"
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2542

Remaining allowlist failure tracked in: https://linear.app/n8n/issue/CAT-2623

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)