### PR TITLE
fix(editor): Update Add node context menu shortcut hint from Tab to N (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenuItems.ts
+++ b/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenuItems.ts
@@ -192,7 +192,7 @@ export function useContextMenuItems(targetNodeIds: ComputedRef<string[]>): Compu
 			return [
 				{
 					id: 'add_node',
-					shortcut: { keys: ['Tab'] },
+					shortcut: { keys: ['N'] },
 					label: i18n.baseText('contextMenu.addNode'),
 					disabled: isReadOnly.value,
 				},


### PR DESCRIPTION
## Summary

Updates the right-click context menu shortcut hint for "Add node" to show "N" instead of "Tab", matching the actual keyboard shortcut that was previously migrated in the node creator.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DS-504

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] No docs changes needed (UI text only)
- [x] No tests needed (display-only change, existing tests cover no assertions on this field)
- [ ] PR Labeled with `release/backport` (if applicable)