### PR TITLE
feat(ado-4896): Address PR review feedback for CSV import

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,6 +21,7 @@ const esmDependencies = [
 	'jose',
 	'p-retry',
 	'is-network-error',
+	'uuid',
 	// Add other ESM dependencies that need to be transformed here
 ];
 

--- a/packages/cli/src/modules/data-table/__tests__/csv-parser.service.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/csv-parser.service.test.ts
@@ -1,78 +1,144 @@
 import { testModules } from '@n8n/backend-test-utils';
 import type { GlobalConfig } from '@n8n/config';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
 import { mock } from 'jest-mock-extended';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 import { CsvParserService } from '../csv-parser.service';
 
 beforeAll(async () => {
 	await testModules.loadModules(['data-table']);
 });
+
 describe('CsvParserService', () => {
+	let tempDir: string;
+	let csvParserService: CsvParserService;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), 'csv-test-'));
+		const globalConfig = mock<GlobalConfig>({
+			dataTable: { uploadDir: tempDir },
+		});
+		csvParserService = new CsvParserService(globalConfig);
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	const writeCsv = (filename: string, content: string) => {
+		writeFileSync(join(tempDir, filename), content);
+		return filename;
+	};
+
 	describe('parseFile', () => {
 		it('should not allow path traversal when parsing CSV file metadata', async () => {
 			const globalConfig = mock<GlobalConfig>({
-				dataTable: {
-					uploadDir: '/safe/upload/dir',
-				},
+				dataTable: { uploadDir: '/safe/upload/dir' },
 			});
+			const service = new CsvParserService(globalConfig);
 
-			const csvParserService = new CsvParserService(globalConfig);
-
-			const maliciousFileId = '../some/other/directory/malicious-file.csv';
-
-			await expect(csvParserService.parseFile(maliciousFileId)).rejects.toThrowError(
-				'Path traversal detected',
-			);
+			await expect(
+				service.parseFile('../some/other/directory/malicious-file.csv'),
+			).rejects.toThrowError('Path traversal detected');
 		});
 
-		it('should try to access file if it is within upload directory', async () => {
-			const globalConfig = mock<GlobalConfig>({
-				dataTable: {
-					uploadDir: '/safe/upload/dir',
-				},
-			});
+		it('should parse CSV with headers and infer column types', async () => {
+			const fileId = writeCsv('test.csv', 'name,age,active\nAlice,30,true\nBob,25,false\n');
 
-			const csvParserService = new CsvParserService(globalConfig);
-			const safeFileId = 'valid-file.csv';
+			const result = await csvParserService.parseFile(fileId, true);
 
-			// Since we are not actually testing file reading here, just ensure no error is thrown
-			await expect(csvParserService.parseFile(safeFileId)).rejects.toThrowError(
-				"ENOENT: no such file or directory, open '/safe/upload/dir/valid-file.csv",
-			);
+			expect(result.rowCount).toBe(2);
+			expect(result.columnCount).toBe(3);
+			expect(result.columns).toEqual([
+				expect.objectContaining({ name: 'name', type: 'string' }),
+				expect.objectContaining({ name: 'age', type: 'number' }),
+				expect.objectContaining({ name: 'active', type: 'boolean' }),
+			]);
+		});
+
+		it('should trim header names', async () => {
+			const fileId = writeCsv('test.csv', ' name , age \nAlice,30\n');
+
+			const result = await csvParserService.parseFile(fileId, true);
+
+			expect(result.columns[0].name).toBe('name');
+			expect(result.columns[1].name).toBe('age');
+		});
+
+		it('should generate column names when no headers', async () => {
+			const fileId = writeCsv('test.csv', 'Alice,30,true\nBob,25,false\n');
+
+			const result = await csvParserService.parseFile(fileId, false);
+
+			expect(result.rowCount).toBe(2);
+			expect(result.columns[0].name).toBe('Column_1');
+			expect(result.columns[1].name).toBe('Column_2');
+			expect(result.columns[2].name).toBe('Column_3');
 		});
 	});
 
 	describe('parseFileData', () => {
 		it('should not allow path traversal when parsing CSV file data', async () => {
 			const globalConfig = mock<GlobalConfig>({
-				dataTable: {
-					uploadDir: '/safe/upload/dir',
-				},
+				dataTable: { uploadDir: '/safe/upload/dir' },
 			});
+			const service = new CsvParserService(globalConfig);
 
-			const csvParserService = new CsvParserService(globalConfig);
-
-			const maliciousFileId = '../some/other/directory/malicious-file.csv';
-
-			await expect(csvParserService.parseFileData(maliciousFileId)).rejects.toThrowError(
-				'Path traversal detected',
-			);
+			await expect(
+				service.parseFileData('../some/other/directory/malicious-file.csv'),
+			).rejects.toThrowError('Path traversal detected');
 		});
 
-		it('should try to access file if it is within upload directory', async () => {
-			const globalConfig = mock<GlobalConfig>({
-				dataTable: {
-					uploadDir: '/safe/upload/dir',
-				},
-			});
+		it('should return rows as objects with header keys', async () => {
+			const fileId = writeCsv('test.csv', 'name,age\nAlice,30\nBob,25\n');
 
-			const csvParserService = new CsvParserService(globalConfig);
-			const safeFileId = 'valid-file.csv';
+			const rows = await csvParserService.parseFileData(fileId, true);
 
-			// Since we are not actually testing file reading here, just ensure no error is thrown
-			await expect(csvParserService.parseFileData(safeFileId)).rejects.toThrowError(
-				"ENOENT: no such file or directory, open '/safe/upload/dir/valid-file.csv",
-			);
+			expect(rows).toEqual([
+				{ name: 'Alice', age: '30' },
+				{ name: 'Bob', age: '25' },
+			]);
+		});
+
+		it('should return rows with generated column names when no headers', async () => {
+			const fileId = writeCsv('test.csv', 'Alice,30\nBob,25\n');
+
+			const rows = await csvParserService.parseFileData(fileId, false);
+
+			expect(rows).toEqual([
+				{ Column_1: 'Alice', Column_2: '30' },
+				{ Column_1: 'Bob', Column_2: '25' },
+			]);
+		});
+	});
+
+	describe('parseFileWithData', () => {
+		it('should return both metadata and rows in a single pass', async () => {
+			const fileId = writeCsv('test.csv', 'name,age\nAlice,30\nBob,25\n');
+
+			const result = await csvParserService.parseFileWithData(fileId, true);
+
+			expect(result.metadata.rowCount).toBe(2);
+			expect(result.metadata.columnCount).toBe(2);
+			expect(result.metadata.columns).toEqual([
+				{ name: 'name', type: 'string' },
+				{ name: 'age', type: 'string' },
+			]);
+			expect(result.rows).toEqual([
+				{ name: 'Alice', age: '30' },
+				{ name: 'Bob', age: '25' },
+			]);
+		});
+
+		it('should handle CSV without headers', async () => {
+			const fileId = writeCsv('test.csv', 'Alice,30\nBob,25\n');
+
+			const result = await csvParserService.parseFileWithData(fileId, false);
+
+			expect(result.metadata.columns[0].name).toBe('Column_1');
+			expect(result.rows[0]).toEqual({ Column_1: 'Alice', Column_2: '30' });
 		});
 	});
 });

--- a/packages/cli/src/modules/data-table/csv-parser.service.ts
+++ b/packages/cli/src/modules/data-table/csv-parser.service.ts
@@ -90,17 +90,17 @@ export class CsvParserService {
 		});
 	}
 
-	/**
-	 * Parses a CSV file and returns metadata including row count, column count, and inferred column types.
-	 * Samples up to 100 rows to find the first non-empty value per column for type inference.
-	 */
-	async parseFile(fileId: string, hasHeaders: boolean = true): Promise<CsvMetadata> {
+	private parseCsvFile<T>(
+		fileId: string,
+		hasHeaders: boolean,
+		onRow: (rowObject: Record<string, string>, columnNames: string[], rowNumber: number) => void,
+		onEnd: (columnNames: string[], totalRows: number) => T,
+	): Promise<T> {
 		const filePath = safeJoinPath(this.uploadDir, fileId);
-		let rowCount = 0;
 		let columnNames: string[] = [];
-		const firstNonEmptyValues = new Map<string, string>();
+		let rowCount = 0;
 
-		return await new Promise((resolve, reject) => {
+		return new Promise((resolve, reject) => {
 			const parser = parse({
 				...this.createParserOptions(hasHeaders),
 				...(hasHeaders && {
@@ -112,25 +112,40 @@ export class CsvParserService {
 			})
 				.on('data', (row: Record<string, string> | string[]) => {
 					rowCount++;
-					// When there are no headers, generate column names from the first row
 					if (!hasHeaders && Array.isArray(row) && columnNames.length === 0) {
 						columnNames = this.generateColumnNames(row.length);
 					}
 					const rowObject = this.normalizeRow(row, hasHeaders, columnNames);
 					if (!rowObject) return;
-
-					if (rowCount <= this.TYPE_INFERENCE_SAMPLE_SIZE) {
-						this.collectTypeSamples(rowObject, columnNames, firstNonEmptyValues);
-					}
+					onRow(rowObject, columnNames, rowCount);
 				})
-				.on('end', () => {
-					const columns = this.buildColumnMetadata(columnNames, firstNonEmptyValues);
-					resolve({ rowCount, columnCount: columns.length, columns });
-				})
+				.on('end', () => resolve(onEnd(columnNames, rowCount)))
 				.on('error', reject);
 
 			createReadStream(filePath).on('error', reject).pipe(parser);
 		});
+	}
+
+	/**
+	 * Parses a CSV file and returns metadata including row count, column count, and inferred column types.
+	 * Samples up to 100 rows to find the first non-empty value per column for type inference.
+	 */
+	async parseFile(fileId: string, hasHeaders: boolean = true): Promise<CsvMetadata> {
+		const firstNonEmptyValues = new Map<string, string>();
+
+		return await this.parseCsvFile(
+			fileId,
+			hasHeaders,
+			(rowObject, colNames, rowNumber) => {
+				if (rowNumber <= this.TYPE_INFERENCE_SAMPLE_SIZE) {
+					this.collectTypeSamples(rowObject, colNames, firstNonEmptyValues);
+				}
+			},
+			(colNames, totalRows) => {
+				const columns = this.buildColumnMetadata(colNames, firstNonEmptyValues);
+				return { rowCount: totalRows, columnCount: columns.length, columns };
+			},
+		);
 	}
 
 	/**
@@ -140,36 +155,14 @@ export class CsvParserService {
 		fileId: string,
 		hasHeaders: boolean = true,
 	): Promise<Array<Record<string, string>>> {
-		const filePath = safeJoinPath(this.uploadDir, fileId);
 		const rows: Array<Record<string, string>> = [];
-		let columnNames: string[] = [];
 
-		return await new Promise((resolve, reject) => {
-			const parser = parse({
-				...this.createParserOptions(hasHeaders),
-				...(hasHeaders && {
-					columns: (header: string[]) => {
-						columnNames = this.trimColumnNames(header);
-						return columnNames;
-					},
-				}),
-			})
-				.on('data', (row: Record<string, string> | string[]) => {
-					// When there are no headers, generate column names from the first row
-					if (!hasHeaders && Array.isArray(row) && columnNames.length === 0) {
-						columnNames = this.generateColumnNames(row.length);
-					}
-					const rowObject = this.normalizeRow(row, hasHeaders, columnNames);
-					if (!rowObject) return;
-					rows.push(rowObject);
-				})
-				.on('end', () => {
-					resolve(rows);
-				})
-				.on('error', reject);
-
-			createReadStream(filePath).on('error', reject).pipe(parser);
-		});
+		return await this.parseCsvFile(
+			fileId,
+			hasHeaders,
+			(rowObject) => rows.push(rowObject),
+			() => rows,
+		);
 	}
 
 	/**
@@ -180,40 +173,20 @@ export class CsvParserService {
 		fileId: string,
 		hasHeaders: boolean = true,
 	): Promise<{ metadata: CsvMetadata; rows: Array<Record<string, string>> }> {
-		const filePath = safeJoinPath(this.uploadDir, fileId);
-		let columnNames: string[] = [];
 		const rows: Array<Record<string, string>> = [];
 
-		return await new Promise((resolve, reject) => {
-			const parser = parse({
-				...this.createParserOptions(hasHeaders),
-				...(hasHeaders && {
-					columns: (header: string[]) => {
-						columnNames = this.trimColumnNames(header);
-						return columnNames;
-					},
-				}),
-			})
-				.on('data', (row: Record<string, string> | string[]) => {
-					// When there are no headers, generate column names from the first row
-					if (!hasHeaders && Array.isArray(row) && columnNames.length === 0) {
-						columnNames = this.generateColumnNames(row.length);
-					}
-					const rowObject = this.normalizeRow(row, hasHeaders, columnNames);
-					if (!rowObject) return;
-					rows.push(rowObject);
-				})
-				.on('end', () => {
-					const columns = columnNames.map((name) => ({ name, type: 'string' as const }));
-					resolve({
-						metadata: { rowCount: rows.length, columnCount: columns.length, columns },
-						rows,
-					});
-				})
-				.on('error', reject);
-
-			createReadStream(filePath).on('error', reject).pipe(parser);
-		});
+		return await this.parseCsvFile(
+			fileId,
+			hasHeaders,
+			(rowObject) => rows.push(rowObject),
+			(colNames) => {
+				const columns = colNames.map((name) => ({ name, type: 'string' as const }));
+				return {
+					metadata: { rowCount: rows.length, columnCount: columns.length, columns },
+					rows,
+				};
+			},
+		);
 	}
 
 	/**

--- a/packages/cli/src/modules/data-table/csv-parser.service.ts
+++ b/packages/cli/src/modules/data-table/csv-parser.service.ts
@@ -90,7 +90,7 @@ export class CsvParserService {
 		});
 	}
 
-	private parseCsvFile<T>(
+	private async parseCsvFile<T>(
 		fileId: string,
 		hasHeaders: boolean,
 		onRow: (rowObject: Record<string, string>, columnNames: string[], rowNumber: number) => void,
@@ -100,7 +100,7 @@ export class CsvParserService {
 		let columnNames: string[] = [];
 		let rowCount = 0;
 
-		return new Promise((resolve, reject) => {
+		return await new Promise((resolve, reject) => {
 			const parser = parse({
 				...this.createParserOptions(hasHeaders),
 				...(hasHeaders && {

--- a/packages/cli/src/modules/data-table/csv-parser.service.ts
+++ b/packages/cli/src/modules/data-table/csv-parser.service.ts
@@ -39,18 +39,16 @@ export class CsvParserService {
 
 	private readonly TYPE_INFERENCE_SAMPLE_SIZE = 100;
 
-	private createParserOptions(hasHeaders: boolean, onColumnNames: (names: string[]) => void) {
+	private createParserOptions(hasHeaders: boolean) {
 		return {
-			columns: hasHeaders
-				? (header: string[]) => {
-						const trimmed = header.map((h) => h.trim());
-						onColumnNames(trimmed);
-						return trimmed;
-					}
-				: (false as const),
+			columns: hasHeaders ? true : (false as const),
 			skip_empty_lines: true,
 			bom: true,
 		};
+	}
+
+	private trimColumnNames(columns: string[]): string[] {
+		return columns.map((h) => h.trim());
 	}
 
 	private normalizeRow(
@@ -103,11 +101,15 @@ export class CsvParserService {
 		const firstNonEmptyValues = new Map<string, string>();
 
 		return await new Promise((resolve, reject) => {
-			const parser = parse(
-				this.createParserOptions(hasHeaders, (names) => {
-					columnNames = names;
+			const parser = parse({
+				...this.createParserOptions(hasHeaders),
+				...(hasHeaders && {
+					columns: (header: string[]) => {
+						columnNames = this.trimColumnNames(header);
+						return columnNames;
+					},
 				}),
-			)
+			})
 				.on('data', (row: Record<string, string> | string[]) => {
 					rowCount++;
 					// When there are no headers, generate column names from the first row
@@ -143,11 +145,15 @@ export class CsvParserService {
 		let columnNames: string[] = [];
 
 		return await new Promise((resolve, reject) => {
-			const parser = parse(
-				this.createParserOptions(hasHeaders, (names) => {
-					columnNames = names;
+			const parser = parse({
+				...this.createParserOptions(hasHeaders),
+				...(hasHeaders && {
+					columns: (header: string[]) => {
+						columnNames = this.trimColumnNames(header);
+						return columnNames;
+					},
 				}),
-			)
+			})
 				.on('data', (row: Record<string, string> | string[]) => {
 					// When there are no headers, generate column names from the first row
 					if (!hasHeaders && Array.isArray(row) && columnNames.length === 0) {
@@ -179,11 +185,15 @@ export class CsvParserService {
 		const rows: Array<Record<string, string>> = [];
 
 		return await new Promise((resolve, reject) => {
-			const parser = parse(
-				this.createParserOptions(hasHeaders, (names) => {
-					columnNames = names;
+			const parser = parse({
+				...this.createParserOptions(hasHeaders),
+				...(hasHeaders && {
+					columns: (header: string[]) => {
+						columnNames = this.trimColumnNames(header);
+						return columnNames;
+					},
 				}),
-			)
+			})
 				.on('data', (row: Record<string, string> | string[]) => {
 					// When there are no headers, generate column names from the first row
 					if (!hasHeaders && Array.isArray(row) && columnNames.length === 0) {

--- a/packages/cli/src/modules/data-table/data-table-csv-import.service.ts
+++ b/packages/cli/src/modules/data-table/data-table-csv-import.service.ts
@@ -146,11 +146,12 @@ export class DataTableCsvImportService {
 
 		const hasCsvColumnNames = dtoColumns?.some((c) => c.csvColumnName);
 		if (hasCsvColumnNames) {
+			const tableColByName = new Map(tableColumns.map((tc) => [tc.name, tc.name]));
 			for (const dtoCol of dtoColumns!) {
 				if (dtoCol.csvColumnName) {
-					const tableCol = tableColumns.find((tc) => tc.name === dtoCol.name);
-					if (tableCol) {
-						columnMapping.set(dtoCol.csvColumnName, tableCol.name);
+					const tableName = tableColByName.get(dtoCol.name);
+					if (tableName) {
+						columnMapping.set(dtoCol.csvColumnName, tableName);
 					}
 				}
 			}

--- a/packages/cli/src/modules/data-table/data-table.service.ts
+++ b/packages/cli/src/modules/data-table/data-table.service.ts
@@ -87,11 +87,11 @@ export class DataTableService {
 				if (rows.length > 0) {
 					await this.insertRows(result.id, projectId, rows);
 				}
-
-				await this.csvImportService.cleanupFile(dto.fileId);
 			} catch (error) {
 				await this.deleteDataTable(result.id, projectId);
 				throw error;
+			} finally {
+				await this.csvImportService.cleanupFile(dto.fileId);
 			}
 		}
 

--- a/packages/frontend/editor-ui/src/features/core/dataTable/components/ImportCsvModal.vue
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/components/ImportCsvModal.vue
@@ -175,6 +175,7 @@ const onClose = () => {
 					:show-file-list="false"
 					accept=".csv"
 					:on-change="handleFileChange"
+					data-test-id="import-csv-upload"
 					@mouseenter="isUploadHovered = true"
 					@mouseleave="isUploadHovered = false"
 				>
@@ -301,7 +302,7 @@ const onClose = () => {
 		width: 100%;
 		padding: var(--spacing--2xl) var(--spacing--lg);
 		border: 1px solid var(--color--foreground);
-		background-color: var(--color--background-base);
+		background-color: var(--color--background);
 		border-radius: var(--radius--lg);
 		transition: all 0.2s ease;
 		display: flex;


### PR DESCRIPTION
## Summary
- Move header trimming out of `createParserOptions` into each caller's `columns` callback, separating concerns
- Move `cleanupFile` to `finally` block in `createDataTable` to prevent temp file leaks on error
- Replace O(n²) `tableColumns.find()` with `Map` lookup in `buildColumnMappingForNewTable`
- Fix invalid CSS variable `--color--background-base` → `--color--background`
- Add `data-test-id="import-csv-upload"` to the upload drop zone

## Test plan
- [x] Backend tests pass (`csv-parser.service.test.ts`, `data-table-csv-import.service.test.ts`, `data-table.service.test.ts`)
- [x] Full build passes
- [ ] Verify CSV import flow works end-to-end in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)