### PR TITLE
fix(AWS Bedrock Chat Model Node): Extract region from modelName ARNs

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
@@ -238,10 +238,18 @@ export class LmChatAwsBedrock implements INodeType {
 			maxTokensToSample: number;
 		};
 
+		// If the model is specified as a full ARN, extract the region from it
+		// ARN format: arn:aws:bedrock:<region>:<account-id>:inference-profile/<profile-id>
+		let region = credentials.region;
+		const arnMatch = modelName.match(/^arn:aws:bedrock:([a-z0-9-]+):/);
+		if (arnMatch) {
+			region = arnMatch[1];
+		}
+
 		// We set-up client manually to pass httpAgent and httpsAgent
 		const proxyAgent = getNodeProxyAgent();
 		const clientConfig: BedrockRuntimeClientConfig = {
-			region: credentials.region,
+			region,
 			credentials: {
 				secretAccessKey: credentials.secretAccessKey,
 				accessKeyId: credentials.accessKeyId,
@@ -262,7 +270,7 @@ export class LmChatAwsBedrock implements INodeType {
 		const model = new ChatBedrockConverse({
 			client,
 			model: modelName,
-			region: credentials.region,
+			region,
 			temperature: options.temperature,
 			maxTokens: options.maxTokensToSample,
 			callbacks: [new N8nLlmTracing(this)],

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/test/LmChatAwsBedrock.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/test/LmChatAwsBedrock.test.ts
@@ -1,0 +1,170 @@
+import { BedrockRuntimeClient } from '@aws-sdk/client-bedrock-runtime';
+import { ChatBedrockConverse } from '@langchain/aws';
+import {
+	makeN8nLlmFailedAttemptHandler,
+	N8nLlmTracing,
+	getNodeProxyAgent,
+} from '@n8n/ai-utilities';
+import { createMockExecuteFunction } from 'n8n-nodes-base/test/nodes/Helpers';
+import type { INode, ISupplyDataFunctions } from 'n8n-workflow';
+
+import { LmChatAwsBedrock } from '../LmChatAwsBedrock.node';
+
+jest.mock('@aws-sdk/client-bedrock-runtime');
+jest.mock('@langchain/aws');
+jest.mock('@n8n/ai-utilities', () => ({
+	getConnectionHintNoticeField: jest
+		.fn()
+		.mockReturnValue({ displayName: '', name: 'notice', type: 'notice', default: '' }),
+	makeN8nLlmFailedAttemptHandler: jest.fn(),
+	N8nLlmTracing: jest.fn(),
+	getNodeProxyAgent: jest.fn(),
+}));
+
+const MockedBedrockRuntimeClient = jest.mocked(BedrockRuntimeClient);
+const MockedChatBedrockConverse = jest.mocked(ChatBedrockConverse);
+const MockedN8nLlmTracing = jest.mocked(N8nLlmTracing);
+const mockedMakeN8nLlmFailedAttemptHandler = jest.mocked(makeN8nLlmFailedAttemptHandler);
+const mockedGetNodeProxyAgent = jest.mocked(getNodeProxyAgent);
+
+describe('LmChatAwsBedrock', () => {
+	let node: LmChatAwsBedrock;
+	let mockContext: jest.Mocked<ISupplyDataFunctions>;
+
+	const mockNode: INode = {
+		id: '1',
+		name: 'AWS Bedrock Chat Model',
+		typeVersion: 1.1,
+		type: 'n8n-nodes-langchain.lmChatAwsBedrock',
+		position: [0, 0],
+		parameters: {},
+	};
+
+	const defaultCredentials = {
+		region: 'us-east-1',
+		secretAccessKey: 'test-secret',
+		accessKeyId: 'test-key',
+		sessionToken: '',
+	};
+
+	const setupMockContext = (overrides: { credentials?: Record<string, unknown> } = {}) => {
+		mockContext = createMockExecuteFunction<ISupplyDataFunctions>(
+			{},
+			mockNode,
+		) as jest.Mocked<ISupplyDataFunctions>;
+
+		mockContext.getCredentials = jest
+			.fn()
+			.mockResolvedValue(overrides.credentials ?? defaultCredentials);
+		mockContext.getNode = jest.fn().mockReturnValue(mockNode);
+		mockContext.getNodeParameter = jest.fn();
+
+		MockedN8nLlmTracing.mockImplementation(() => ({}) as N8nLlmTracing);
+		mockedMakeN8nLlmFailedAttemptHandler.mockReturnValue(jest.fn());
+		mockedGetNodeProxyAgent.mockReturnValue(undefined);
+		MockedBedrockRuntimeClient.mockImplementation(() => ({}) as BedrockRuntimeClient);
+		MockedChatBedrockConverse.mockImplementation(() => ({}) as unknown as ChatBedrockConverse);
+
+		return mockContext;
+	};
+
+	beforeEach(() => {
+		node = new LmChatAwsBedrock();
+		jest.clearAllMocks();
+	});
+
+	describe('supplyData', () => {
+		it('should use credential region for standard model IDs', async () => {
+			const ctx = setupMockContext();
+			ctx.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model') return 'amazon.nova-pro-v1:0';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await node.supplyData.call(ctx, 0);
+
+			expect(MockedBedrockRuntimeClient).toHaveBeenCalledWith(
+				expect.objectContaining({ region: 'us-east-1' }),
+			);
+			expect(MockedChatBedrockConverse).toHaveBeenCalledWith(
+				expect.objectContaining({ region: 'us-east-1' }),
+			);
+		});
+
+		it('should use credential region for inference profile IDs (not ARNs)', async () => {
+			const ctx = setupMockContext();
+			ctx.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model') return 'eu.amazon.nova-pro-v1:0';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await node.supplyData.call(ctx, 0);
+
+			expect(MockedBedrockRuntimeClient).toHaveBeenCalledWith(
+				expect.objectContaining({ region: 'us-east-1' }),
+			);
+			expect(MockedChatBedrockConverse).toHaveBeenCalledWith(
+				expect.objectContaining({ region: 'us-east-1' }),
+			);
+		});
+
+		it('should extract region from inference profile ARN and use it', async () => {
+			const ctx = setupMockContext();
+			ctx.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model')
+					return 'arn:aws:bedrock:eu-west-3:851725222089:inference-profile/eu.amazon.nova-pro-v1:0';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await node.supplyData.call(ctx, 0);
+
+			expect(MockedBedrockRuntimeClient).toHaveBeenCalledWith(
+				expect.objectContaining({ region: 'eu-west-3' }),
+			);
+			expect(MockedChatBedrockConverse).toHaveBeenCalledWith(
+				expect.objectContaining({ region: 'eu-west-3' }),
+			);
+		});
+
+		it('should extract region from foundation model ARN', async () => {
+			const ctx = setupMockContext();
+			ctx.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model')
+					return 'arn:aws:bedrock:ap-southeast-1::foundation-model/anthropic.claude-v2';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await node.supplyData.call(ctx, 0);
+
+			expect(MockedBedrockRuntimeClient).toHaveBeenCalledWith(
+				expect.objectContaining({ region: 'ap-southeast-1' }),
+			);
+			expect(MockedChatBedrockConverse).toHaveBeenCalledWith(
+				expect.objectContaining({ region: 'ap-southeast-1' }),
+			);
+		});
+
+		it('should pass model name and options to ChatBedrockConverse', async () => {
+			const ctx = setupMockContext();
+			ctx.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model') return 'amazon.nova-pro-v1:0';
+				if (paramName === 'options') return { temperature: 0.5, maxTokensToSample: 1000 };
+				return undefined;
+			});
+
+			await node.supplyData.call(ctx, 0);
+
+			expect(MockedChatBedrockConverse).toHaveBeenCalledWith(
+				expect.objectContaining({
+					model: 'amazon.nova-pro-v1:0',
+					temperature: 0.5,
+					maxTokens: 1000,
+				}),
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
When using the AWS Bedrock Chat Model node with an inference profile specified as a full ARN (e.g. arn:aws:bedrock:eu-west-3:123456:inference-profile/eu.amazon.nova-pro-v1:0), the node ignored the region in the ARN and always used the credential’s region instead. This caused AccessDenied errors for users whose AWS organizations restrict which regions can be used via Service Control Policies.

The fix parses the region from the ARN when one is provided and uses it for the BedrockRuntimeClient and ChatBedrockConverse configuration. When the model is specified as a short ID (e.g. amazon.nova-pro-v1:0 or eu.amazon.nova-pro-v1:0), the credential region is used as before.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-2174

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
