### PR TITLE
ci: Prevent forks from targeting release/**

### DIFF
--- a/.github/workflows/ci-check-release-from-fork.yml
+++ b/.github/workflows/ci-check-release-from-fork.yml
@@ -9,6 +9,7 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+      - edited
 
 jobs:
   block-fork-prs:

--- a/.github/workflows/ci-check-release-from-fork.yml
+++ b/.github/workflows/ci-check-release-from-fork.yml
@@ -33,22 +33,34 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
-            const body = `
-            🚫 **Pull request blocked**
-
-            Pull requests from **forked repositories** are not allowed to target **release branches** in this repository.
-
-            **Target branch:** \`${context.payload.pull_request.base.ref}\`
-
-            If you believe this was blocked in error, contact the repository maintainers.
-            `;
-
-            await github.rest.issues.createComment({
+            const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body
             });
+
+            const alreadyCommented = comments.some(
+              (c) => c.user.login === 'github-actions[bot]' && c.body.includes('Pull request blocked')
+            );
+
+            if (!alreadyCommented) {
+                const body = `
+              🚫 **Pull request blocked**
+
+              Pull requests from **forked repositories** are not allowed to target **release branches** in this repository.
+
+              **Target branch:** \`${context.payload.pull_request.base.ref}\`
+
+              If you believe this was blocked in error, contact the repository maintainers.
+              `;
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  body
+                });
+            }
 
       - name: Fail workflow if from fork
         if: steps.check.outputs.fork == 'true'

--- a/.github/workflows/ci-check-release-from-fork.yml
+++ b/.github/workflows/ci-check-release-from-fork.yml
@@ -1,0 +1,56 @@
+name: 'CI: Block fork PRs to release branches'
+
+on:
+  pull_request:
+    branches:
+      - 'release/**'
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  block-fork-prs:
+    runs-on: ubuntu-slim
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - name: Check if PR is from a fork
+        id: check
+        run: |
+          if [ "${{ github.event.pull_request.head.repo.fork }}" = "true" ]; then
+            echo "fork=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "fork=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Comment on PR explaining the block
+        if: steps.check.outputs.fork == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = `
+            🚫 **Pull request blocked**
+
+            Pull requests from **forked repositories** are not allowed to target **release branches** in this repository.
+
+            **Target branch:** \`${context.payload.pull_request.base.ref}\`
+
+            If you believe this was blocked in error, contact the repository maintainers.
+            `;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body
+            });
+
+      - name: Fail workflow if from fork
+        if: steps.check.outputs.fork == 'true'
+        run: |
+          echo "PR from fork targeting a release branch is not allowed."
+          exit 1

--- a/.github/workflows/ci-check-release-from-fork.yml
+++ b/.github/workflows/ci-check-release-from-fork.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Comment on PR explaining the block
         if: steps.check.outputs.fork == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const body = `


### PR DESCRIPTION
## Summary

Automatically fail PR's from forks targeting release/** branches.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
