### PR TITLE
fix(Embeddings Google Gemini Node): Update wrong default embeddings model

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsGoogleGemini/EmbeddingsGoogleGemini.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsGoogleGemini/EmbeddingsGoogleGemini.node.ts
@@ -110,7 +110,7 @@ export class EmbeddingsGoogleGemini implements INodeType {
 						property: 'model',
 					},
 				},
-				default: 'models/text-embedding-004',
+				default: 'models/gemini-embedding-001',
 			},
 		],
 	};
@@ -120,7 +120,7 @@ export class EmbeddingsGoogleGemini implements INodeType {
 		const modelName = this.getNodeParameter(
 			'modelName',
 			itemIndex,
-			'models/text-embedding-004',
+			'models/gemini-embedding-001',
 		) as string;
 		const credentials = await this.getCredentials('googlePalmApi');
 		const embeddings = new GoogleGenerativeAIEmbeddings({


### PR DESCRIPTION
## Summary
Updates the default value for gemini embeddings to `gemini-embeddings-001` as the old default model doesn't work anymore.


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-2169/n8n-node-issue



## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
