### PR TITLE
ci: Add track name to run-name in patch release workflow

### DIFF
--- a/.github/workflows/release-create-patch-pr.yml
+++ b/.github/workflows/release-create-patch-pr.yml
@@ -1,4 +1,5 @@
 name: 'Release: Create Patch Release PR'
+run-name: 'Release: Create Patch Release PR for track ${{ inputs.track }}'
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Add track name to the run-name for easier observability

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/actions/workflows/release-create-patch-pr.yml

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
