### PR TITLE
fix(core): Retry multi-main follower license check during startup

### DIFF
--- a/packages/cli/src/commands/__tests__/start.test.ts
+++ b/packages/cli/src/commands/__tests__/start.test.ts
@@ -7,6 +7,7 @@ import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import { InstanceSettings } from 'n8n-core';
 
+import { FeatureNotLicensedError } from '@/errors/feature-not-licensed.error';
 import { ActiveWorkflowManager } from '@/active-workflow-manager';
 import { AuthHandlerRegistry } from '@/auth/auth-handler.registry';
 import { DeprecationService } from '@/deprecation/deprecation.service';
@@ -223,6 +224,95 @@ describe('Start - AuthRolesService initialization', () => {
 			await start.init();
 
 			expect(authRolesService.init).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('init - multi-main follower license retry', () => {
+		const multiMainConfig = {
+			executions: { mode: 'queue' as const },
+			multiMainSetup: { enabled: true },
+			endpoints: { disableUi: true, metrics: { enable: false }, health: '/health' },
+			database: { type: 'sqlite' },
+			sentry: {
+				backendDsn: '',
+				environment: 'test',
+				deploymentName: 'test',
+				profilesSampleRate: 0,
+				tracesSampleRate: 0,
+				eventLoopBlockThreshold: 0,
+			},
+			cache: { backend: 'memory' },
+			taskRunners: {},
+		};
+
+		beforeEach(() => {
+			jest.useFakeTimers();
+		});
+
+		afterEach(() => {
+			jest.useRealTimers();
+			// Restore original mock so other tests aren't affected
+			license.isMultiMainLicensed = (() => true) as unknown as typeof license.isMultiMainLicensed;
+		});
+
+		it('should retry and succeed when follower finds license cert on retry', async () => {
+			setupInstanceSettings('main', true, false);
+			// @ts-expect-error - Accessing protected property for testing
+			start.globalConfig = multiMainConfig;
+
+			// First call returns false (no cert yet), second call returns true (leader wrote cert)
+			license.isMultiMainLicensed = jest
+				.fn()
+				.mockReturnValueOnce(false)
+				.mockReturnValue(true) as unknown as typeof license.isMultiMainLicensed;
+
+			const initPromise = start.init();
+
+			// Advance past the first retry delay (2s)
+			await jest.advanceTimersByTimeAsync(2_000);
+
+			await initPromise;
+
+			expect(license.init).toHaveBeenCalledWith({ forceRecreate: true });
+		});
+
+		it('should throw FeatureNotLicensedError when follower exhausts all retries', async () => {
+			setupInstanceSettings('main', true, false);
+			// @ts-expect-error - Accessing protected property for testing
+			start.globalConfig = multiMainConfig;
+
+			license.isMultiMainLicensed = jest
+				.fn()
+				.mockReturnValue(false) as unknown as typeof license.isMultiMainLicensed;
+
+			const initPromise = start.init().catch((error) => {
+				expect(error).toBeInstanceOf(FeatureNotLicensedError);
+				return 'rejected';
+			});
+
+			// Advance past all retry delays: 2s + 4s + 8s + 16s + 32s = 62s
+			await jest.advanceTimersByTimeAsync(62_000);
+
+			const result = await initPromise;
+			expect(result).toBe('rejected');
+			// 5 retries = 5 calls to license.init with forceRecreate
+			expect(license.init).toHaveBeenCalledTimes(5);
+			expect(license.init).toHaveBeenCalledWith({ forceRecreate: true });
+		});
+
+		it('should not retry when leader fails the license check', async () => {
+			setupInstanceSettings('main', true, true);
+			// @ts-expect-error - Accessing protected property for testing
+			start.globalConfig = multiMainConfig;
+
+			license.isMultiMainLicensed = jest
+				.fn()
+				.mockReturnValue(false) as unknown as typeof license.isMultiMainLicensed;
+
+			await expect(start.init()).rejects.toThrow(FeatureNotLicensedError);
+
+			// license.init should NOT have been called with forceRecreate (no retry for leaders)
+			expect(license.init).not.toHaveBeenCalledWith({ forceRecreate: true });
 		});
 	});
 });

--- a/packages/cli/src/commands/__tests__/start.test.ts
+++ b/packages/cli/src/commands/__tests__/start.test.ts
@@ -273,7 +273,7 @@ describe('Start - AuthRolesService initialization', () => {
 
 			await initPromise;
 
-			expect(license.init).toHaveBeenCalledWith({ forceRecreate: true });
+			expect(license.reload).toHaveBeenCalledTimes(1);
 		});
 
 		it('should throw FeatureNotLicensedError when follower exhausts all retries', async () => {
@@ -295,9 +295,8 @@ describe('Start - AuthRolesService initialization', () => {
 
 			const result = await initPromise;
 			expect(result).toBe('rejected');
-			// 5 retries = 5 calls to license.init with forceRecreate
-			expect(license.init).toHaveBeenCalledTimes(5);
-			expect(license.init).toHaveBeenCalledWith({ forceRecreate: true });
+			// 5 retries = 5 reload calls
+			expect(license.reload).toHaveBeenCalledTimes(5);
 		});
 
 		it('should not retry when leader fails the license check', async () => {
@@ -311,8 +310,8 @@ describe('Start - AuthRolesService initialization', () => {
 
 			await expect(start.init()).rejects.toThrow(FeatureNotLicensedError);
 
-			// license.init should NOT have been called with forceRecreate (no retry for leaders)
-			expect(license.init).not.toHaveBeenCalledWith({ forceRecreate: true });
+			// Followers only retry via reload; leaders should fail immediately
+			expect(license.reload).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -8,7 +8,7 @@ import { McpServer } from '@n8n/n8n-nodes-langchain/mcp/core';
 import glob from 'fast-glob';
 import { createReadStream, createWriteStream, existsSync } from 'fs';
 import { mkdir } from 'fs/promises';
-import { jsonParse, type IWorkflowExecutionDataProcess } from 'n8n-workflow';
+import { jsonParse, sleep, type IWorkflowExecutionDataProcess } from 'n8n-workflow';
 import path from 'path';
 import replaceStream from 'replacestream';
 import { pipeline } from 'stream/promises';
@@ -226,8 +226,8 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 
 		await this.initLicense();
 
-		if (isMultiMainEnabled && !this.license.isMultiMainLicensed()) {
-			throw new FeatureNotLicensedError(LICENSE_FEATURES.MULTIPLE_MAIN_INSTANCES);
+		if (isMultiMainEnabled) {
+			await this.ensureMultiMainLicensed();
 		}
 
 		// Initialize the auth roles service to make sure that roles are correctly setup for the instance.
@@ -310,6 +310,30 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 		} else {
 			this.instanceSettings.markAsLeader();
 		}
+	}
+
+	/**
+	 * Ensures the multi-main license entitlement is present. Followers retry with
+	 * exponential backoff because the leader may not have written the cert to the
+	 * database yet when the follower starts up.
+	 */
+	private async ensureMultiMainLicensed() {
+		if (this.license.isMultiMainLicensed()) return;
+
+		if (!this.instanceSettings.isLeader) {
+			const maxRetries = 5;
+			for (let attempt = 1; attempt <= maxRetries; attempt++) {
+				const delayMs = 2 ** attempt * 1000; // 2s, 4s, 8s, 16s, 32s (~62s total)
+				this.logger.warn(
+					`License cert not found in database — retrying in ${delayMs / 1000}s (attempt ${attempt}/${maxRetries})`,
+				);
+				await sleep(delayMs);
+				await this.license.init({ forceRecreate: true });
+				if (this.license.isMultiMainLicensed()) return;
+			}
+		}
+
+		throw new FeatureNotLicensedError(LICENSE_FEATURES.MULTIPLE_MAIN_INSTANCES);
 	}
 
 	async run() {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -325,10 +325,10 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 			for (let attempt = 1; attempt <= maxRetries; attempt++) {
 				const delayMs = 2 ** attempt * 1000; // 2s, 4s, 8s, 16s, 32s (~62s total)
 				this.logger.warn(
-					`License cert not found in database — retrying in ${delayMs / 1000}s (attempt ${attempt}/${maxRetries})`,
+					`Instance not licensed for multi-main — retrying license check in ${delayMs / 1000}s (attempt ${attempt}/${maxRetries})`,
 				);
 				await sleep(delayMs);
-				await this.license.init({ forceRecreate: true });
+				await this.license.reload();
 				if (this.license.isMultiMainLicensed()) return;
 			}
 		}


### PR DESCRIPTION
## Summary

Adds a startup license-check retry path for multi-main followers so they can wait for the leader-written cert instead of failing immediately.
Followers now retry with exponential backoff and `license.reload()`, while leaders still fail fast when multi-main is not licensed.
Includes regression tests for follower success-after-retry, follower failure-after-retries, and leader no-retry behavior.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2572

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)