### PR TITLE
fix(editor): Prevent reference sharing connections in workflow save data (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
@@ -337,7 +337,7 @@ describe('useWorkflowHelpers', () => {
 			const workflowData = await getWorkflowDataToSave();
 
 			// Simulate a node + connection being added to the store after snapshot
-			// but before the HTTP request serializes the data (race condition)
+			// It should not mutate the connections in the saved workflow data (reference sharing)
 			initialConnections['New Node'] = {
 				main: [[{ node: 'Node B', index: 0, type: NodeConnectionTypes.Main }]],
 			};

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
@@ -315,7 +315,7 @@ describe('useWorkflowHelpers', () => {
 	describe('getWorkflowDataToSave', () => {
 		it('should snapshot connections so later store mutations do not affect saved data', async () => {
 			const workflowId = 'test-workflow-id';
-			const initialConnections = {
+			const initialConnections: IConnections = {
 				'Node A': {
 					main: [[{ node: 'Node B', index: 0, type: NodeConnectionTypes.Main }]],
 				},

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
@@ -313,6 +313,39 @@ describe('useWorkflowHelpers', () => {
 	});
 
 	describe('getWorkflowDataToSave', () => {
+		it('should snapshot connections so later store mutations do not affect saved data', async () => {
+			const workflowId = 'test-workflow-id';
+			const initialConnections = {
+				'Node A': {
+					main: [[{ node: 'Node B', index: 0, type: NodeConnectionTypes.Main }]],
+				},
+			};
+
+			workflowsStore.workflowId = workflowId;
+			workflowsStore.workflowName = 'Test Workflow';
+			workflowsStore.allNodes = [];
+			workflowsStore.allConnections = initialConnections;
+			workflowsStore.workflow.versionId = 'v1';
+
+			const documentId = createWorkflowDocumentId(workflowId);
+			const workflowDocumentStore = useWorkflowDocumentStore(documentId);
+			vi.mocked(workflowDocumentStore.getSettingsSnapshot).mockReturnValue({
+				executionOrder: 'v1',
+			});
+
+			const { getWorkflowDataToSave } = useWorkflowHelpers();
+			const workflowData = await getWorkflowDataToSave();
+
+			// Simulate a node + connection being added to the store after snapshot
+			// but before the HTTP request serializes the data (race condition)
+			initialConnections['New Node'] = {
+				main: [[{ node: 'Node B', index: 0, type: NodeConnectionTypes.Main }]],
+			};
+
+			// The saved data must not include the late-added connection
+			expect(workflowData.connections).not.toHaveProperty('New Node');
+		});
+
 		it('should read tags from workflowDocumentStore', async () => {
 			const workflowId = 'test-workflow-id';
 			const tagIds = ['tag1', 'tag2'];

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -21,6 +21,7 @@ import type {
 import {
 	CHAT_TRIGGER_NODE_TYPE,
 	createEmptyRunExecutionData,
+	deepCopy,
 	FORM_TRIGGER_NODE_TYPE,
 	isHitlToolType,
 	NodeConnectionTypes,
@@ -591,6 +592,12 @@ export function useWorkflowHelpers() {
 			nodes.push(nodeData);
 		}
 
+		// Deep-copy connections to create an in-time snapshot consistent with nodes.
+		// Without this, connections is a reference to the reactive store object, so
+		// mutations between now and request serialization can include connections to
+		// nodes not present in the nodes snapshot, violating a BE invariant.
+		const connections = deepCopy(workflowConnections);
+
 		const workflowDocumentStore = useWorkflowDocumentStore(
 			createWorkflowDocumentId(workflowsStore.workflowId),
 		);
@@ -599,7 +606,7 @@ export function useWorkflowHelpers() {
 			name: workflowsStore.workflowName,
 			nodes,
 			pinData: workflowDocumentStore.getPinDataSnapshot(),
-			connections: workflowConnections,
+			connections,
 			active: workflowDocumentStore.active,
 			settings: workflowDocumentStore.settings,
 			tags: [...workflowDocumentStore.tags],


### PR DESCRIPTION
## Summary

Deep-copy connections at snapshot time to avoid reference sharing where store mutations between node snapshot and request serialization could include connections to nodes not present in the nodes array.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2274/internal-keeps-erroring-with-expression-evaluated-to-a-falsy-value


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
