### PR TITLE
feat(core): Serialize Luxon types at V8 isolate boundary

### DIFF
--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -1,3 +1,4 @@
+import { DateTime, Duration, Interval } from 'luxon';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { ExpressionEvaluator } from '../evaluator/expression-evaluator';
 import { IsolatedVmBridge } from '../bridge/isolated-vm-bridge';
@@ -207,6 +208,65 @@ describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
 
 		// Midnight UTC = 9am in Tokyo (JST = UTC+9)
 		expect(result).toBe('09:00 +09:00');
+	});
+
+	describe('Luxon type serialization at boundary', () => {
+		it('should return DateTime as ISO string', () => {
+			const data = { $json: {} };
+			const result = evaluator.evaluate('{{ DateTime.now() }}', data);
+			expect(typeof result).toBe('string');
+			const dt = DateTime.fromISO(result as string);
+			expect(dt.isValid).toBe(true);
+		});
+
+		it('should return Duration as ISO string', () => {
+			const data = { $json: {} };
+			const result = evaluator.evaluate('{{ Duration.fromMillis(3600000) }}', data);
+			expect(typeof result).toBe('string');
+			const duration = Duration.fromISO(result as string);
+			expect(duration.isValid).toBe(true);
+			expect(duration.toMillis()).toBe(3600000);
+		});
+
+		it('should return Interval as ISO string', () => {
+			const data = { $json: {} };
+			const result = evaluator.evaluate(
+				'{{ Interval.after(DateTime.fromISO("2024-01-01"), 86400000) }}',
+				data,
+			);
+			expect(typeof result).toBe('string');
+			const interval = Interval.fromISO(result as string);
+			expect(interval.isValid).toBe(true);
+			expect(interval.length('milliseconds')).toBe(86400000);
+		});
+
+		it('should serialize nested DateTime in objects', () => {
+			const data = { $json: {} };
+			const result = evaluator.evaluate(
+				'{{ ({ date: DateTime.fromISO("2024-01-15") }) }}',
+				data,
+			) as Record<string, unknown>;
+			expect(typeof result.date).toBe('string');
+			const dt = DateTime.fromISO(result.date as string);
+			expect(dt.isValid).toBe(true);
+			expect(dt.toISODate()).toBe('2024-01-15');
+		});
+
+		it('should not affect primitive return values', () => {
+			const data = { $json: { count: 42 } };
+			expect(evaluator.evaluate('{{ $json.count }}', data)).toBe(42);
+			expect(evaluator.evaluate('{{ $json.count > 10 }}', data)).toBe(true);
+			expect(evaluator.evaluate('{{ "hello" }}', data)).toBe('hello');
+		});
+
+		it('should preserve Date objects (structured-cloneable)', () => {
+			const data = { $json: {} };
+			const result = evaluator.evaluate('{{ new Date(2024, 0, 15) }}', data);
+			expect(result).toBeInstanceOf(Date);
+			expect((result as Date).getFullYear()).toBe(2024);
+			expect((result as Date).getMonth()).toBe(0);
+			expect((result as Date).getDate()).toBe(15);
+		});
 	});
 
 	it('should throw on invalid timezone', async () => {

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -259,6 +259,12 @@ describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
 			expect(evaluator.evaluate('{{ "hello" }}', data)).toBe('hello');
 		});
 
+		it('should return null for invalid DateTime', () => {
+			const data = { $json: {} };
+			const result = evaluator.evaluate('{{ DateTime.invalid("test") }}', data);
+			expect(result).toBeNull();
+		});
+
 		it('should preserve Date objects (structured-cloneable)', () => {
 			const data = { $json: {} };
 			const result = evaluator.evaluate('{{ new Date(2024, 0, 15) }}', data);

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -455,10 +455,10 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			// __data has $json, $items, etc. as lazy proxies (set in resetDataProxies).
 			const wrappedCode = `(function() { var __result = (function() {\n${code}\n}).call(__data); return __prepareForTransfer(__result); })()`;
 
-			let script = this.scriptCache.get(code);
+			let script = this.scriptCache.get(wrappedCode);
 			if (!script) {
 				script = this.isolate.compileScriptSync(wrappedCode);
-				this.scriptCache.set(code, script);
+				this.scriptCache.set(wrappedCode, script);
 
 				if (this.config.debug) {
 					console.log('[IsolatedVmBridge] Script compiled and cached');

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -455,10 +455,10 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			// __data has $json, $items, etc. as lazy proxies (set in resetDataProxies).
 			const wrappedCode = `(function() { var __result = (function() {\n${code}\n}).call(__data); return __prepareForTransfer(__result); })()`;
 
-			let script = this.scriptCache.get(wrappedCode);
+			let script = this.scriptCache.get(code);
 			if (!script) {
 				script = this.isolate.compileScriptSync(wrappedCode);
-				this.scriptCache.set(wrappedCode, script);
+				this.scriptCache.set(code, script);
 
 				if (this.config.debug) {
 					console.log('[IsolatedVmBridge] Script compiled and cached');

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -453,7 +453,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			// Step 3: Wrap transformed code so 'this' === __data in the isolate.
 			// Tournament generates: this.$json.email, this.$items(), etc.
 			// __data has $json, $items, etc. as lazy proxies (set in resetDataProxies).
-			const wrappedCode = `(function() {\n${code}\n}).call(__data)`;
+			const wrappedCode = `(function() { var __result = (function() {\n${code}\n}).call(__data); return __prepareForTransfer(__result); })()`;
 
 			let script = this.scriptCache.get(code);
 			if (!script) {

--- a/packages/@n8n/expression-runtime/src/runtime/index.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/index.ts
@@ -1,10 +1,11 @@
-import { DateTime } from 'luxon';
+import { DateTime, Duration, Interval } from 'luxon';
 
 import { extend, extendOptional } from '../extensions/extend';
 
 import { SafeObject, SafeError, ExpressionError } from './safe-globals';
 import { createDeepLazyProxy } from './lazy-proxy';
 import { resetDataProxies } from './reset';
+import { __prepareForTransfer } from './serialize';
 
 // Augment globalThis with runtime properties
 declare global {
@@ -29,6 +30,9 @@ declare global {
 
 		// Expression engine globals
 		var DateTime: typeof import('luxon').DateTime;
+		var Duration: typeof import('luxon').Duration;
+		var Interval: typeof import('luxon').Interval;
+		var __prepareForTransfer: (value: unknown) => unknown;
 		var extend: typeof import('../extensions/extend').extend;
 		var extendOptional: typeof import('../extensions/extend').extendOptional;
 
@@ -58,6 +62,8 @@ declare global {
 globalThis.extend = extend;
 globalThis.extendOptional = extendOptional;
 globalThis.DateTime = DateTime;
+globalThis.Duration = Duration;
+globalThis.Interval = Interval;
 
 // ============================================================================
 // Expose security globals and runtime functions
@@ -69,6 +75,7 @@ globalThis.SafeError = SafeError;
 
 globalThis.createDeepLazyProxy = createDeepLazyProxy;
 globalThis.resetDataProxies = resetDataProxies;
+globalThis.__prepareForTransfer = __prepareForTransfer;
 
 // Initialize empty __data object (populated by resetDataProxies before each evaluation)
 globalThis.__data = {};

--- a/packages/@n8n/expression-runtime/src/runtime/reset.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/reset.ts
@@ -151,6 +151,8 @@ export function resetDataProxies(timezone?: string): void {
 	// -------------------------------------------------------------------------
 
 	globalThis.__data.DateTime = globalThis.DateTime;
+	globalThis.__data.Duration = globalThis.Duration;
+	globalThis.__data.Interval = globalThis.Interval;
 
 	// Expose extend/extendOptional on __data so tournament's "x in this ? this.x : global.x"
 	// pattern resolves them correctly when the VM checks __data first

--- a/packages/@n8n/expression-runtime/src/runtime/serialize.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/serialize.ts
@@ -1,5 +1,11 @@
 import { DateTime, Duration, Interval } from 'luxon';
 
+/** Type guard: plain object with Object.prototype or null prototype. */
+function isPlainObject(value: object): value is Record<string, unknown> {
+	const proto = Object.getPrototypeOf(value);
+	return proto === Object.prototype || proto === null;
+}
+
 /**
  * Prepare a value for transfer across the V8 isolate boundary.
  *
@@ -36,13 +42,12 @@ export function __prepareForTransfer(value: unknown): unknown {
 
 	// Only walk plain objects — structured-cloneable types like Date, Map, Set,
 	// RegExp, Error, typed arrays survive copy:true with prototypes intact.
-	const proto = Object.getPrototypeOf(value);
-	if (proto !== Object.prototype && proto !== null) return value;
+	if (!isPlainObject(value)) return value;
 
 	// Plain object — walk values
 	const result: Record<string, unknown> = {};
 	for (const key of Object.keys(value)) {
-		result[key] = __prepareForTransfer((value as Record<string, unknown>)[key]);
+		result[key] = __prepareForTransfer(value[key]);
 	}
 	return result;
 }

--- a/packages/@n8n/expression-runtime/src/runtime/serialize.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/serialize.ts
@@ -1,3 +1,5 @@
+import { DateTime, Duration, Interval } from 'luxon';
+
 /**
  * Prepare a value for transfer across the V8 isolate boundary.
  *
@@ -20,12 +22,12 @@ export function __prepareForTransfer(value: unknown): unknown {
 	if (typeof value !== 'object') return value;
 
 	// Luxon DateTime -> ISO string (toISO() returns null for invalid DateTime)
-	if ((value as any).isLuxonDateTime) return (value as any).toISO() ?? null;
+	if (DateTime.isDateTime(value)) return value.toISO() ?? null;
 	// Luxon Duration -> ISO string (toISO() returns null for invalid Duration)
-	if ((value as any).isLuxonDuration) return (value as any).toISO() ?? null;
+	if (Duration.isDuration(value)) return value.toISO() ?? null;
 	// Luxon Interval -> ISO string (toISO() returns "Invalid Interval" for invalid Interval)
-	if ((value as any).isLuxonInterval) {
-		const iso = (value as any).toISO();
+	if (Interval.isInterval(value)) {
+		const iso = value.toISO();
 		return iso === 'Invalid Interval' ? null : iso;
 	}
 
@@ -40,7 +42,7 @@ export function __prepareForTransfer(value: unknown): unknown {
 	// Plain object — walk values
 	const result: Record<string, unknown> = {};
 	for (const key of Object.keys(value)) {
-		result[key] = __prepareForTransfer((value as any)[key]);
+		result[key] = __prepareForTransfer((value as Record<string, unknown>)[key]);
 	}
 	return result;
 }

--- a/packages/@n8n/expression-runtime/src/runtime/serialize.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/serialize.ts
@@ -19,12 +19,15 @@ export function __prepareForTransfer(value: unknown): unknown {
 	if (value === null || value === undefined) return value;
 	if (typeof value !== 'object') return value;
 
-	// Luxon DateTime -> ISO string
-	if ((value as any).isLuxonDateTime) return (value as any).toISO();
-	// Luxon Duration -> ISO string (e.g., "PT1H30M")
-	if ((value as any).isLuxonDuration) return (value as any).toISO();
-	// Luxon Interval -> ISO string (e.g., "2024-01-01T00:00/2024-01-02T00:00")
-	if ((value as any).isLuxonInterval) return (value as any).toISO();
+	// Luxon DateTime -> ISO string (toISO() returns null for invalid DateTime)
+	if ((value as any).isLuxonDateTime) return (value as any).toISO() ?? null;
+	// Luxon Duration -> ISO string (toISO() returns null for invalid Duration)
+	if ((value as any).isLuxonDuration) return (value as any).toISO() ?? null;
+	// Luxon Interval -> ISO string (toISO() returns "Invalid Interval" for invalid Interval)
+	if ((value as any).isLuxonInterval) {
+		const iso = (value as any).toISO();
+		return iso === 'Invalid Interval' ? null : iso;
+	}
 
 	// Array — walk elements
 	if (Array.isArray(value)) return value.map(__prepareForTransfer);

--- a/packages/@n8n/expression-runtime/src/runtime/serialize.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/serialize.ts
@@ -1,0 +1,43 @@
+/**
+ * Prepare a value for transfer across the V8 isolate boundary.
+ *
+ * isolated-vm's `copy: true` uses structured clone, which strips prototypes
+ * from non-standard types. Luxon DateTime/Duration/Interval lose their class
+ * identity and arrive on the host as plain objects.
+ *
+ * This function recursively walks a value and converts types that don't
+ * survive structured clone into their string representations. It runs
+ * inside the isolate before the result is transferred.
+ *
+ * Note: JS Date objects survive structured clone with prototype intact
+ * (Date is a standard structured-cloneable type) and are not converted.
+ *
+ * Circular references are not handled — expression results should not
+ * contain cycles.
+ */
+export function __prepareForTransfer(value: unknown): unknown {
+	if (value === null || value === undefined) return value;
+	if (typeof value !== 'object') return value;
+
+	// Luxon DateTime -> ISO string
+	if ((value as any).isLuxonDateTime) return (value as any).toISO();
+	// Luxon Duration -> ISO string (e.g., "PT1H30M")
+	if ((value as any).isLuxonDuration) return (value as any).toISO();
+	// Luxon Interval -> ISO string (e.g., "2024-01-01T00:00/2024-01-02T00:00")
+	if ((value as any).isLuxonInterval) return (value as any).toISO();
+
+	// Array — walk elements
+	if (Array.isArray(value)) return value.map(__prepareForTransfer);
+
+	// Only walk plain objects — structured-cloneable types like Date, Map, Set,
+	// RegExp, Error, typed arrays survive copy:true with prototypes intact.
+	const proto = Object.getPrototypeOf(value);
+	if (proto !== Object.prototype && proto !== null) return value;
+
+	// Plain object — walk values
+	const result: Record<string, unknown> = {};
+	for (const key of Object.keys(value)) {
+		result[key] = __prepareForTransfer((value as any)[key]);
+	}
+	return result;
+}

--- a/packages/workflow/test/ExpressionExtensions/date-extensions.test.ts
+++ b/packages/workflow/test/ExpressionExtensions/date-extensions.test.ts
@@ -2,7 +2,7 @@
 
 import { DateTime } from 'luxon';
 
-import { evaluate, getLocalISOString } from './helpers';
+import { evaluate, getLocalISOString, asDateTime } from './helpers';
 import { dateExtensions } from '../../src/extensions/date-extensions';
 import { getGlobalState } from '../../src/global-state';
 
@@ -19,9 +19,13 @@ describe('Data Transformation Functions', () => {
 
 		describe('.beginningOf', () => {
 			test('.beginningOf("week") should work correctly on a date', () => {
-				expect(evaluate('={{ DateTime.local(2023, 1, 20).beginningOf("week") }}')).toEqual(
-					DateTime.local(2023, 1, 16, { zone: defaultTimezone }),
+				const result = asDateTime(
+					evaluate('={{ DateTime.local(2023, 1, 20).beginningOf("week") }}'),
 				);
+				expect(result).toBeInstanceOf(DateTime);
+				expect(result.toISODate()).toEqual('2023-01-16');
+				expect(result.hour).toEqual(0);
+				expect(result.minute).toEqual(0);
 
 				expect(evaluate('={{ new Date(2023, 0, 20).beginningOf("week") }}')).toEqual(
 					DateTime.local(2023, 1, 16, { zone: defaultTimezone }).toJSDate(),
@@ -57,9 +61,12 @@ describe('Data Transformation Functions', () => {
 		});
 
 		test('.endOfMonth() should work correctly on a date', () => {
-			expect(evaluate('={{ DateTime.local(2023, 1, 16).endOfMonth() }}')).toEqual(
-				DateTime.local(2023, 1, 31, 23, 59, 59, 999, { zone: defaultTimezone }),
-			);
+			const result = asDateTime(evaluate('={{ DateTime.local(2023, 1, 16).endOfMonth() }}'));
+			expect(result).toBeInstanceOf(DateTime);
+			expect(result.toISODate()).toEqual('2023-01-31');
+			expect(result.hour).toEqual(23);
+			expect(result.minute).toEqual(59);
+
 			expect(evaluate('={{ new Date(2023, 0, 16).endOfMonth() }}')).toEqual(
 				DateTime.local(2023, 1, 31, 23, 59, 59, 999, { zone: defaultTimezone }).toJSDate(),
 			);
@@ -239,9 +246,9 @@ describe('Data Transformation Functions', () => {
 
 		describe('.toDateTime', () => {
 			test('should return itself for DateTime', () => {
-				const result = evaluate(
-					"={{ DateTime.fromFormat('01-01-2024', 'dd-MM-yyyy').toDateTime() }}",
-				) as unknown as DateTime;
+				const result = asDateTime(
+					evaluate("={{ DateTime.fromFormat('01-01-2024', 'dd-MM-yyyy').toDateTime() }}"),
+				);
 				expect(result).toBeInstanceOf(DateTime);
 				expect(result.day).toEqual(1);
 				expect(result.month).toEqual(1);
@@ -249,9 +256,7 @@ describe('Data Transformation Functions', () => {
 			});
 
 			test('should return a DateTime for JS Date', () => {
-				const result = evaluate(
-					'={{ new Date(2024, 0, 1, 12).toDateTime() }}',
-				) as unknown as DateTime;
+				const result = asDateTime(evaluate('={{ new Date(2024, 0, 1, 12).toDateTime() }}'));
 				expect(result).toBeInstanceOf(DateTime);
 				expect(result.day).toEqual(1);
 				expect(result.month).toEqual(1);

--- a/packages/workflow/test/ExpressionExtensions/helpers.ts
+++ b/packages/workflow/test/ExpressionExtensions/helpers.ts
@@ -43,14 +43,23 @@ export const evaluate = (value: string, values?: IDataObject[]) =>
  * engine remains, these helpers become unnecessary — all results will be
  * strings. Replace usages with fromISO() directly.
  */
-export const asDateTime = (v: unknown): DateTime =>
-	DateTime.isDateTime(v) ? v : DateTime.fromISO(v as string);
+export const asDateTime = (v: unknown): DateTime => {
+	if (DateTime.isDateTime(v)) return v;
+	if (typeof v !== 'string') throw new Error(`Expected DateTime or ISO string, got ${typeof v}`);
+	return DateTime.fromISO(v);
+};
 
-export const asDuration = (v: unknown): Duration =>
-	Duration.isDuration(v) ? v : Duration.fromISO(v as string);
+export const asDuration = (v: unknown): Duration => {
+	if (Duration.isDuration(v)) return v;
+	if (typeof v !== 'string') throw new Error(`Expected Duration or ISO string, got ${typeof v}`);
+	return Duration.fromISO(v);
+};
 
-export const asInterval = (v: unknown): Interval =>
-	Interval.isInterval(v) ? v : Interval.fromISO(v as string);
+export const asInterval = (v: unknown): Interval => {
+	if (Interval.isInterval(v)) return v;
+	if (typeof v !== 'string') throw new Error(`Expected Interval or ISO string, got ${typeof v}`);
+	return Interval.fromISO(v);
+};
 
 export const getLocalISOString = (date: Date) => {
 	const offset = date.getTimezoneOffset();

--- a/packages/workflow/test/ExpressionExtensions/helpers.ts
+++ b/packages/workflow/test/ExpressionExtensions/helpers.ts
@@ -1,3 +1,5 @@
+import { DateTime, Duration, Interval } from 'luxon';
+
 import type { IDataObject } from '../../src/interfaces';
 import { Workflow } from '../../src/workflow';
 import * as Helpers from '../helpers';
@@ -31,6 +33,24 @@ export const evaluate = (value: string, values?: IDataObject[]) =>
 		'manual',
 		{},
 	);
+
+/**
+ * Normalize expression results that may be Luxon instances (current engine)
+ * or ISO strings (VM engine). The VM engine serializes Luxon types to ISO
+ * strings at the isolate boundary via __prepareForTransfer.
+ *
+ * TODO: When the current (Tournament) engine is removed and only the VM
+ * engine remains, these helpers become unnecessary — all results will be
+ * strings. Replace usages with fromISO() directly.
+ */
+export const asDateTime = (v: unknown): DateTime =>
+	DateTime.isDateTime(v) ? v : DateTime.fromISO(v as string);
+
+export const asDuration = (v: unknown): Duration =>
+	Duration.isDuration(v) ? v : Duration.fromISO(v as string);
+
+export const asInterval = (v: unknown): Interval =>
+	Interval.isInterval(v) ? v : Interval.fromISO(v as string);
 
 export const getLocalISOString = (date: Date) => {
 	const offset = date.getTimezoneOffset();

--- a/packages/workflow/test/ExpressionExtensions/helpers.ts
+++ b/packages/workflow/test/ExpressionExtensions/helpers.ts
@@ -39,9 +39,9 @@ export const evaluate = (value: string, values?: IDataObject[]) =>
  * or ISO strings (VM engine). The VM engine serializes Luxon types to ISO
  * strings at the isolate boundary via __prepareForTransfer.
  *
- * TODO: When the current (Tournament) engine is removed and only the VM
- * engine remains, these helpers become unnecessary — all results will be
- * strings. Replace usages with fromISO() directly.
+ * TODO(CAT-2541): When the current (Tournament) engine is removed and only
+ * the VM engine remains, these helpers become unnecessary — all results will
+ * be strings. Replace usages with fromISO() directly.
  */
 export const asDateTime = (v: unknown): DateTime => {
 	if (DateTime.isDateTime(v)) return v;

--- a/packages/workflow/test/ExpressionExtensions/helpers.ts
+++ b/packages/workflow/test/ExpressionExtensions/helpers.ts
@@ -39,9 +39,9 @@ export const evaluate = (value: string, values?: IDataObject[]) =>
  * or ISO strings (VM engine). The VM engine serializes Luxon types to ISO
  * strings at the isolate boundary via __prepareForTransfer.
  *
- * TODO: When the current (Tournament) engine is removed and only the VM
- * engine remains, these helpers become unnecessary — all results will be
- * strings. Replace usages with fromISO() directly.
+ * TODO: When the non-VM expression engine is removed and only the VM engine
+ * remains, these helpers become unnecessary — all results will be strings.
+ * Replace usages with fromISO() directly.
  */
 export const asDateTime = (v: unknown): DateTime => {
 	if (DateTime.isDateTime(v)) return v;

--- a/packages/workflow/test/ExpressionExtensions/helpers.ts
+++ b/packages/workflow/test/ExpressionExtensions/helpers.ts
@@ -39,9 +39,9 @@ export const evaluate = (value: string, values?: IDataObject[]) =>
  * or ISO strings (VM engine). The VM engine serializes Luxon types to ISO
  * strings at the isolate boundary via __prepareForTransfer.
  *
- * TODO(CAT-2541): When the current (Tournament) engine is removed and only
- * the VM engine remains, these helpers become unnecessary — all results will
- * be strings. Replace usages with fromISO() directly.
+ * TODO: When the current (Tournament) engine is removed and only the VM
+ * engine remains, these helpers become unnecessary — all results will be
+ * strings. Replace usages with fromISO() directly.
  */
 export const asDateTime = (v: unknown): DateTime => {
 	if (DateTime.isDateTime(v)) return v;

--- a/packages/workflow/test/ExpressionExtensions/string-extensions.test.ts
+++ b/packages/workflow/test/ExpressionExtensions/string-extensions.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { DateTime } from 'luxon';
 
-import { evaluate } from './helpers';
+import { evaluate, asDateTime } from './helpers';
 import { ExpressionExtensionError } from '../../src/errors';
 
 describe('Data Transformation Functions', () => {
@@ -276,13 +276,17 @@ describe('Data Transformation Functions', () => {
 		});
 
 		test('.toDateTime should work on a variety of formats', () => {
-			expect(evaluate('={{ "Wed, 21 Oct 2015 07:28:00 GMT".toDateTime() }}')).toBeInstanceOf(
+			expect(
+				asDateTime(evaluate('={{ "Wed, 21 Oct 2015 07:28:00 GMT".toDateTime() }}')),
+			).toBeInstanceOf(DateTime);
+			expect(asDateTime(evaluate('={{ "2008-11-11".toDateTime() }}'))).toBeInstanceOf(DateTime);
+			expect(asDateTime(evaluate('={{ "1-Feb-2024".toDateTime() }}'))).toBeInstanceOf(DateTime);
+			expect(asDateTime(evaluate('={{ "1713976144063".toDateTime("ms") }}'))).toBeInstanceOf(
 				DateTime,
 			);
-			expect(evaluate('={{ "2008-11-11".toDateTime() }}')).toBeInstanceOf(DateTime);
-			expect(evaluate('={{ "1-Feb-2024".toDateTime() }}')).toBeInstanceOf(DateTime);
-			expect(evaluate('={{ "1713976144063".toDateTime("ms") }}')).toBeInstanceOf(DateTime);
-			expect(evaluate('={{ "31-01-2024".toDateTime("dd-MM-yyyy") }}')).toBeInstanceOf(DateTime);
+			expect(asDateTime(evaluate('={{ "31-01-2024".toDateTime("dd-MM-yyyy") }}'))).toBeInstanceOf(
+				DateTime,
+			);
 
 			vi.useFakeTimers({ now: new Date() });
 			expect(() => evaluate('={{ "hi".toDateTime() }}')).toThrow(

--- a/packages/workflow/test/expression.test.ts
+++ b/packages/workflow/test/expression.test.ts
@@ -2,7 +2,7 @@
 
 import { DateTime, Duration, Interval } from 'luxon';
 
-import { workflow } from './ExpressionExtensions/helpers';
+import { workflow, asDuration, asInterval } from './ExpressionExtensions/helpers';
 import { baseFixtures } from './ExpressionFixtures/base';
 import type { ExpressionTestEvaluation, ExpressionTestTransform } from './ExpressionFixtures/base';
 import * as Helpers from './helpers';
@@ -88,12 +88,14 @@ describe('Expression', () => {
 			);
 
 			vi.useFakeTimers({ now: new Date() });
-			expect(evaluate('={{Interval.after(new Date(), 100)}}')).toEqual(
-				Interval.after(new Date(), 100),
-			);
+			const intervalResult = asInterval(evaluate('={{Interval.after(new Date(), 100)}}'));
+			expect(intervalResult).toBeInstanceOf(Interval);
+			expect(intervalResult.length('milliseconds')).toEqual(100);
 			vi.useRealTimers();
 
-			expect(evaluate('={{Duration.fromMillis(100)}}')).toEqual(Duration.fromMillis(100));
+			const durationResult = asDuration(evaluate('={{Duration.fromMillis(100)}}'));
+			expect(durationResult).toBeInstanceOf(Duration);
+			expect(durationResult.toMillis()).toEqual(100);
 
 			expect(evaluate('={{new Object()}}')).toEqual(new Object());
 


### PR DESCRIPTION
## Summary

Luxon DateTime/Duration/Interval objects lose their class identity when returned from the V8 isolate via `copy: true` (structured clone). This PR adds a `__prepareForTransfer` function that runs inside the isolate after expression evaluation, converting Luxon types to ISO strings before the result crosses the boundary.

Also exposes `Duration` and `Interval` on `globalThis` in the runtime bundle so expressions like `Interval.after(...)` work inside the isolate.

**Key design decisions:**
- Conversion happens inside the isolate where Luxon objects still have working methods — no duck-typing needed on the host side
- Only plain objects are recursively walked; structured-cloneable types (Date, Map, Set, RegExp) pass through untouched
- Chaining within expressions is unaffected — DateTime stays a real instance inside the isolate, only converted at the exit boundary
- Tests use shared `asDateTime`/`asDuration`/`asInterval` helpers that normalize results for both engines

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2541

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.