### PR TITLE
ci: Use n8n assistant for releases

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -108,9 +108,17 @@ jobs:
       id-token: write
 
     steps:
+      - name: Generate GitHub App Token
+        id: generate_token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.N8N_ASSISTANT_APP_ID }}
+          private-key: ${{ secrets.N8N_ASSISTANT_PRIVATE_KEY }}
+
       - name: Create a Release on GitHub
         uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1.20.0
         with:
+          token: ${{ steps.generate_token.outputs.token }}
           commit: ${{github.event.pull_request.base.ref}}
           tag: 'n8n@${{ needs.determine-version-info.outputs.version }}'
           prerelease: ${{ needs.determine-version-info.outputs.track == 'beta' }}


### PR DESCRIPTION
## Summary

Make n8n assistant create releases from now on. Let's see if this reduces the flakiness with permissions. Also allows for more fine-grained control when we actually control the github app.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
