### PR TITLE
chore(core): Query executions using a single query intead of two

### DIFF
--- a/packages/@n8n/db/src/entities/types-db.ts
+++ b/packages/@n8n/db/src/entities/types-db.ts
@@ -207,6 +207,12 @@ export namespace ExecutionSummaries {
 
 	type AccessFields = {
 		accessibleWorkflowIds?: string[];
+		user?: User;
+		sharingOptions?: {
+			scopes?: Scope[];
+			projectRoles?: string[];
+			workflowRoles?: string[];
+		};
 	};
 
 	type RangeFields = {

--- a/packages/@n8n/db/src/repositories/__tests__/workflow.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/workflow.repository.test.ts
@@ -6,6 +6,7 @@ import { WorkflowEntity } from '../../entities';
 import { mockEntityManager } from '../../utils/test-utils/mock-entity-manager';
 import { mockInstance } from '../../utils/test-utils/mock-instance';
 import { FolderRepository } from '../folder.repository';
+import { SharedWorkflowRepository } from '../shared-workflow.repository';
 import { WorkflowHistoryRepository } from '../workflow-history.repository';
 import { WorkflowRepository } from '../workflow.repository';
 
@@ -15,11 +16,13 @@ describe('WorkflowRepository', () => {
 		database: { type: 'postgresdb' },
 	});
 	const folderRepository = mockInstance(FolderRepository);
+	const sharedWorkflowRepository = mockInstance(SharedWorkflowRepository);
 	const workflowHistoryRepository = mockInstance(WorkflowHistoryRepository);
 	const workflowRepository = new WorkflowRepository(
 		entityManager.connection,
 		globalConfig,
 		folderRepository,
+		sharedWorkflowRepository,
 		workflowHistoryRepository,
 	);
 
@@ -144,6 +147,7 @@ describe('WorkflowRepository', () => {
 				entityManager.connection,
 				sqliteConfig,
 				folderRepository,
+				sharedWorkflowRepository,
 				workflowHistoryRepository,
 			);
 			jest.spyOn(sqliteWorkflowRepository, 'createQueryBuilder').mockReturnValue(queryBuilder);
@@ -364,6 +368,7 @@ describe('WorkflowRepository', () => {
 				entityManager.connection,
 				sqliteConfig,
 				folderRepository,
+				sharedWorkflowRepository,
 				workflowHistoryRepository,
 			);
 			jest.spyOn(sqliteWorkflowRepository, 'createQueryBuilder').mockReturnValue(queryBuilder);
@@ -392,6 +397,7 @@ describe('WorkflowRepository', () => {
 				entityManager.connection,
 				sqliteConfig,
 				folderRepository,
+				sharedWorkflowRepository,
 				workflowHistoryRepository,
 			);
 			jest.spyOn(sqliteWorkflowRepository, 'createQueryBuilder').mockReturnValue(queryBuilder);

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -49,6 +49,7 @@ import {
 	SharedWorkflow,
 	WorkflowEntity,
 } from '../entities';
+import { SharedWorkflowRepository } from './shared-workflow.repository';
 import type {
 	ExecutionSummaries,
 	IExecutionBase,
@@ -158,6 +159,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 		private readonly logger: Logger,
 		private readonly errorReporter: ErrorReporter,
 		private readonly binaryDataService: BinaryDataService,
+		private readonly sharedWorkflowRepository: SharedWorkflowRepository,
 	) {
 		super(ExecutionEntity, dataSource.manager);
 	}
@@ -963,6 +965,8 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 	private toQueryBuilder(query: ExecutionSummaries.Query) {
 		const {
 			accessibleWorkflowIds,
+			user,
+			sharingOptions,
 			status,
 			finished,
 			workflowId,
@@ -981,8 +985,21 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 
 		const qb = this.createQueryBuilder('execution')
 			.select(fields)
-			.innerJoin('execution.workflow', 'workflow')
-			.where('execution.workflowId IN (:...accessibleWorkflowIds)', { accessibleWorkflowIds });
+			.innerJoin('execution.workflow', 'workflow');
+
+		if (user && sharingOptions) {
+			// EXISTS-based access control — correlated subquery for better query plans
+			const subquery = this.sharedWorkflowRepository.buildSharedWorkflowIdsSubquery(
+				user,
+				sharingOptions,
+			);
+			subquery.andWhere('"sw"."workflowId" = execution."workflowId"');
+			qb.where(`EXISTS (${subquery.getQuery()})`);
+			qb.setParameters(subquery.getParameters());
+		} else if (accessibleWorkflowIds) {
+			// Array-based access control (backward compat)
+			qb.where('execution.workflowId IN (:...accessibleWorkflowIds)', { accessibleWorkflowIds });
+		}
 
 		if (query.kind === 'range') {
 			const { limit, firstId, lastId } = query.range;

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -999,6 +999,9 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 		} else if (accessibleWorkflowIds) {
 			// Array-based access control (backward compat)
 			qb.where('execution.workflowId IN (:...accessibleWorkflowIds)', { accessibleWorkflowIds });
+		} else {
+			// No access control provided — deny all to prevent unscoped queries
+			qb.where('1 = 0');
 		}
 
 		if (query.kind === 'range') {

--- a/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
@@ -1,10 +1,20 @@
 import { Service } from '@n8n/di';
-import { PROJECT_OWNER_ROLE_SLUG, type WorkflowSharingRole } from '@n8n/permissions';
+import {
+	hasGlobalScope,
+	PROJECT_OWNER_ROLE_SLUG,
+	type Scope,
+	type WorkflowSharingRole,
+} from '@n8n/permissions';
 import { DataSource, Repository, In, Not } from '@n8n/typeorm';
-import type { EntityManager, FindManyOptions, FindOptionsWhere } from '@n8n/typeorm';
+import type {
+	EntityManager,
+	FindManyOptions,
+	FindOptionsWhere,
+	SelectQueryBuilder,
+} from '@n8n/typeorm';
 
-import type { Project } from '../entities';
-import { SharedWorkflow } from '../entities';
+import type { User } from '../entities';
+import { Project, ProjectRelation, SharedWorkflow } from '../entities';
 
 @Service()
 export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
@@ -193,5 +203,82 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 				},
 			},
 		});
+	}
+
+	/**
+	 * Build a subquery that returns workflow IDs based on sharing permissions.
+	 * This replicates the logic from WorkflowSharingService but as a subquery.
+	 */
+	buildSharedWorkflowIdsSubquery(
+		user: User,
+		sharingOptions: {
+			scopes?: Scope[];
+			projectRoles?: string[];
+			workflowRoles?: string[];
+			isPersonalProject?: boolean;
+			personalProjectOwnerId?: string;
+			onlySharedWithMe?: boolean;
+			projectId?: string;
+		},
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	): SelectQueryBuilder<any> {
+		const {
+			projectRoles,
+			workflowRoles,
+			isPersonalProject,
+			personalProjectOwnerId,
+			onlySharedWithMe,
+			projectId,
+		} = sharingOptions;
+
+		const subquery = this.manager
+			.createQueryBuilder()
+			.select('sw.workflowId')
+			.from(SharedWorkflow, 'sw');
+
+		// Handle different sharing scenarios
+		// Check explicit filters first (isPersonalProject, onlySharedWithMe) before falling back to user's global permissions
+		if (isPersonalProject) {
+			// Personal project - get owned workflows using the project owner's ID (not the requesting user's)
+			const ownerUserId = personalProjectOwnerId ?? user.id;
+			subquery
+				.innerJoin(Project, 'p', 'sw.projectId = p.id')
+				.innerJoin(ProjectRelation, 'pr', 'pr.projectId = p.id')
+				.where('sw.role = :ownerRole', { ownerRole: 'workflow:owner' })
+				.andWhere('pr.userId = :subqueryUserId', { subqueryUserId: ownerUserId })
+				.andWhere('pr.role = :projectOwnerRole', { projectOwnerRole: PROJECT_OWNER_ROLE_SLUG });
+
+			// Filter by the specific project ID when specified
+			if (projectId && typeof projectId === 'string' && projectId !== '') {
+				subquery.andWhere('sw.projectId = :subqueryProjectId', { subqueryProjectId: projectId });
+			}
+		} else if (onlySharedWithMe) {
+			// Shared with me - workflows shared (as editor) to user's personal project
+			subquery
+				.innerJoin(Project, 'p', 'sw.projectId = p.id')
+				.innerJoin(ProjectRelation, 'pr', 'pr.projectId = p.id')
+				.where('sw.role = :editorRole', { editorRole: 'workflow:editor' })
+				.andWhere('pr.userId = :subqueryUserId', { subqueryUserId: user.id })
+				.andWhere('pr.role = :projectOwnerRole', { projectOwnerRole: PROJECT_OWNER_ROLE_SLUG });
+		} else if (hasGlobalScope(user, 'workflow:read')) {
+			// User has global scope - return all workflow IDs in the specified project (if any)
+			if (projectId && typeof projectId === 'string' && projectId !== '') {
+				subquery.where('sw.projectId = :subqueryProjectId', { subqueryProjectId: projectId });
+			}
+		} else {
+			// Standard sharing based on roles
+			if (!workflowRoles || !projectRoles) {
+				throw new Error('workflowRoles and projectRoles are required when not using special cases');
+			}
+
+			subquery
+				.innerJoin(Project, 'p', 'sw.projectId = p.id')
+				.innerJoin(ProjectRelation, 'pr', 'pr.projectId = p.id')
+				.where('sw.role IN (:...workflowRoles)', { workflowRoles })
+				.andWhere('pr.userId = :subqueryUserId', { subqueryUserId: user.id })
+				.andWhere('pr.role IN (:...projectRoles)', { projectRoles });
+		}
+
+		return subquery;
 	}
 }

--- a/packages/@n8n/db/src/repositories/workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow.repository.ts
@@ -1,6 +1,6 @@
 import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
-import { hasGlobalScope, PROJECT_OWNER_ROLE_SLUG, type Scope } from '@n8n/permissions';
+import type { Scope } from '@n8n/permissions';
 import { DataSource, Repository, In, Like, Not, IsNull } from '@n8n/typeorm';
 import type {
 	SelectQueryBuilder,
@@ -14,6 +14,7 @@ import type {
 import { PROJECT_ROOT, UserError } from 'n8n-workflow';
 
 import { FolderRepository } from './folder.repository';
+import { SharedWorkflowRepository } from './shared-workflow.repository';
 import { WorkflowHistoryRepository } from './workflow-history.repository';
 import {
 	WebhookEntity,
@@ -22,9 +23,6 @@ import {
 	WorkflowTagMapping,
 	WorkflowDependency,
 	User,
-	SharedWorkflow,
-	Project,
-	ProjectRelation,
 } from '../entities';
 import type {
 	ListQueryDb,
@@ -60,6 +58,7 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 		dataSource: DataSource,
 		private readonly globalConfig: GlobalConfig,
 		private readonly folderRepository: FolderRepository,
+		private readonly sharedWorkflowRepository: SharedWorkflowRepository,
 		private readonly workflowHistoryRepository: WorkflowHistoryRepository,
 	) {
 		super(WorkflowEntity, dataSource.manager);
@@ -769,7 +768,7 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 
 	/**
 	 * Build a subquery that returns workflow IDs based on sharing permissions.
-	 * This replicates the logic from WorkflowSharingService but as a subquery.
+	 * Delegates to SharedWorkflowRepository.buildSharedWorkflowIdsSubquery.
 	 */
 	private buildSharedWorkflowIdsSubquery(
 		user: User,
@@ -784,64 +783,7 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 		},
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	): SelectQueryBuilder<any> {
-		const {
-			projectRoles,
-			workflowRoles,
-			isPersonalProject,
-			personalProjectOwnerId,
-			onlySharedWithMe,
-			projectId,
-		} = sharingOptions;
-
-		const subquery = this.manager
-			.createQueryBuilder()
-			.select('sw.workflowId')
-			.from(SharedWorkflow, 'sw');
-
-		// Handle different sharing scenarios
-		// Check explicit filters first (isPersonalProject, onlySharedWithMe) before falling back to user's global permissions
-		if (isPersonalProject) {
-			// Personal project - get owned workflows using the project owner's ID (not the requesting user's)
-			const ownerUserId = personalProjectOwnerId ?? user.id;
-			subquery
-				.innerJoin(Project, 'p', 'sw.projectId = p.id')
-				.innerJoin(ProjectRelation, 'pr', 'pr.projectId = p.id')
-				.where('sw.role = :ownerRole', { ownerRole: 'workflow:owner' })
-				.andWhere('pr.userId = :subqueryUserId', { subqueryUserId: ownerUserId })
-				.andWhere('pr.role = :projectOwnerRole', { projectOwnerRole: PROJECT_OWNER_ROLE_SLUG });
-
-			// Filter by the specific project ID when specified
-			if (projectId && typeof projectId === 'string' && projectId !== '') {
-				subquery.andWhere('sw.projectId = :subqueryProjectId', { subqueryProjectId: projectId });
-			}
-		} else if (onlySharedWithMe) {
-			// Shared with me - workflows shared (as editor) to user's personal project
-			subquery
-				.innerJoin(Project, 'p', 'sw.projectId = p.id')
-				.innerJoin(ProjectRelation, 'pr', 'pr.projectId = p.id')
-				.where('sw.role = :editorRole', { editorRole: 'workflow:editor' })
-				.andWhere('pr.userId = :subqueryUserId', { subqueryUserId: user.id })
-				.andWhere('pr.role = :projectOwnerRole', { projectOwnerRole: PROJECT_OWNER_ROLE_SLUG });
-		} else if (hasGlobalScope(user, 'workflow:read')) {
-			// User has global scope - return all workflow IDs in the specified project (if any)
-			if (projectId && typeof projectId === 'string' && projectId !== '') {
-				subquery.where('sw.projectId = :subqueryProjectId', { subqueryProjectId: projectId });
-			}
-		} else {
-			// Standard sharing based on roles
-			if (!workflowRoles || !projectRoles) {
-				throw new Error('workflowRoles and projectRoles are required when not using special cases');
-			}
-
-			subquery
-				.innerJoin(Project, 'p', 'sw.projectId = p.id')
-				.innerJoin(ProjectRelation, 'pr', 'pr.projectId = p.id')
-				.where('sw.role IN (:...workflowRoles)', { workflowRoles })
-				.andWhere('pr.userId = :subqueryUserId', { subqueryUserId: user.id })
-				.andWhere('pr.role IN (:...projectRoles)', { projectRoles });
-		}
-
-		return subquery;
+		return this.sharedWorkflowRepository.buildSharedWorkflowIdsSubquery(user, sharingOptions);
 	}
 
 	getManyQuery(workflowIds: string[], options: ListQuery.Options = {}) {

--- a/packages/cli/src/executions/__tests__/executions.controller.test.ts
+++ b/packages/cli/src/executions/__tests__/executions.controller.test.ts
@@ -6,17 +6,20 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import type { ExecutionService } from '@/executions/execution.service';
 import type { ExecutionRequest } from '@/executions/execution.types';
 import { ExecutionsController } from '@/executions/executions.controller';
+import type { RoleService } from '@/services/role.service';
 import type { WorkflowSharingService } from '@/workflows/workflow-sharing.service';
 
 describe('ExecutionsController', () => {
 	const executionService = mock<ExecutionService>();
 	const workflowSharingService = mock<WorkflowSharingService>();
+	const roleService = mock<RoleService>();
 
 	const executionsController = new ExecutionsController(
 		executionService,
 		mock(),
 		workflowSharingService,
 		mock(),
+		roleService,
 	);
 
 	beforeEach(() => {
@@ -87,7 +90,7 @@ describe('ExecutionsController', () => {
 			test.each(QUERIES_WITH_EITHER_STATUS_OR_RANGE)(
 				'should fetch executions per query',
 				async (rangeQuery) => {
-					workflowSharingService.getSharedWorkflowIds.mockResolvedValue(['123']);
+					roleService.rolesWithScope.mockResolvedValue([]);
 					executionService.findLatestCurrentAndCompleted.mockResolvedValue(NO_EXECUTIONS);
 
 					const req = mock<ExecutionRequest.GetMany>({ rangeQuery });
@@ -105,7 +108,7 @@ describe('ExecutionsController', () => {
 			test.each(QUERIES_NEITHER_STATUS_NOR_RANGE_PROVIDED)(
 				'should fetch executions per query',
 				async (rangeQuery) => {
-					workflowSharingService.getSharedWorkflowIds.mockResolvedValue(['123']);
+					roleService.rolesWithScope.mockResolvedValue([]);
 					executionService.findLatestCurrentAndCompleted.mockResolvedValue(NO_EXECUTIONS);
 
 					const req = mock<ExecutionRequest.GetMany>({ rangeQuery });
@@ -121,7 +124,7 @@ describe('ExecutionsController', () => {
 
 		describe('if both status and range provided', () => {
 			it('should fetch executions per query', async () => {
-				workflowSharingService.getSharedWorkflowIds.mockResolvedValue(['123']);
+				roleService.rolesWithScope.mockResolvedValue([]);
 				executionService.findLatestCurrentAndCompleted.mockResolvedValue(NO_EXECUTIONS);
 
 				const rangeQuery: ExecutionSummaries.RangeQuery = {

--- a/packages/cli/src/executions/executions.controller.ts
+++ b/packages/cli/src/executions/executions.controller.ts
@@ -11,6 +11,7 @@ import { validateExecutionUpdatePayload } from './validation';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { License } from '@/license';
+import { RoleService } from '@/services/role.service';
 import { isPositiveInteger } from '@/utils';
 import { WorkflowSharingService } from '@/workflows/workflow-sharing.service';
 
@@ -21,6 +22,7 @@ export class ExecutionsController {
 		private readonly enterpriseExecutionService: EnterpriseExecutionsService,
 		private readonly workflowSharingService: WorkflowSharingService,
 		private readonly license: License,
+		private readonly roleService: RoleService,
 	) {}
 
 	private async getAccessibleWorkflowIds(user: User, scope: Scope) {
@@ -36,19 +38,21 @@ export class ExecutionsController {
 
 	@Get('/', { middlewares: [parseRangeQuery] })
 	async getMany(req: ExecutionRequest.GetMany) {
-		const accessibleWorkflowIds = await this.getAccessibleWorkflowIds(req.user, 'workflow:read');
-
-		if (accessibleWorkflowIds.length === 0) {
-			return { count: 0, estimated: false, results: [] };
-		}
-
 		const { rangeQuery: query } = req;
 
-		if (query.workflowId && !accessibleWorkflowIds.includes(query.workflowId)) {
-			return { count: 0, estimated: false, results: [] };
+		// Build sharing options for the subquery instead of fetching IDs upfront
+		const scope: Scope = 'workflow:read';
+		query.user = req.user;
+		if (this.license.isSharingEnabled()) {
+			const projectRoles = await this.roleService.rolesWithScope('project', [scope]);
+			const workflowRoles = await this.roleService.rolesWithScope('workflow', [scope]);
+			query.sharingOptions = { scopes: [scope], projectRoles, workflowRoles };
+		} else {
+			query.sharingOptions = {
+				workflowRoles: ['workflow:owner'],
+				projectRoles: [PROJECT_OWNER_ROLE_SLUG],
+			};
 		}
-
-		query.accessibleWorkflowIds = accessibleWorkflowIds;
 
 		if (!this.license.isAdvancedExecutionFiltersEnabled()) {
 			delete query.metadata;

--- a/packages/cli/test/integration/execution.service.integration.test.ts
+++ b/packages/cli/test/integration/execution.service.integration.test.ts
@@ -1,6 +1,11 @@
-import { createTeamProject, createWorkflow, testDb } from '@n8n/backend-test-utils';
+import {
+	createTeamProject,
+	createWorkflow,
+	linkUserToProject,
+	testDb,
+} from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
-import type { ExecutionSummaries } from '@n8n/db';
+import type { ExecutionSummaries, User } from '@n8n/db';
 import { ExecutionMetadataRepository, ExecutionRepository, WorkflowRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
@@ -8,10 +13,13 @@ import { mock } from 'jest-mock-extended';
 import { ExecutionService } from '@/executions/execution.service';
 
 import { annotateExecution, createAnnotationTags, createExecution } from './shared/db/executions';
+import { createMember, createOwner } from './shared/db/users';
 
 describe('ExecutionService', () => {
 	let executionService: ExecutionService;
 	let executionRepository: ExecutionRepository;
+	let member: User;
+	let owner: User;
 	const globalConfig = Container.get(GlobalConfig);
 
 	beforeAll(async () => {
@@ -37,6 +45,9 @@ describe('ExecutionService', () => {
 			mock(),
 			mock(),
 		);
+
+		owner = await createOwner();
+		member = await createMember();
 	});
 
 	beforeEach(() => {
@@ -511,6 +522,252 @@ describe('ExecutionService', () => {
 			expect(output.count).toBe(1);
 			expect(output.estimated).toBe(false);
 			expect(output.results).toEqual([expect.objectContaining({ id: firstId })]);
+		});
+	});
+
+	describe('findRangeWithCount — subquery approach', () => {
+		test('should return same results as array approach', async () => {
+			const workflow1 = await createWorkflow({}, member);
+			const workflow2 = await createWorkflow({}, member);
+			const inaccessibleWorkflow = await createWorkflow({}, owner);
+
+			await Promise.all([
+				createExecution({ status: 'success' }, workflow1),
+				createExecution({ status: 'success' }, workflow1),
+				createExecution({ status: 'error' }, workflow2),
+				createExecution({ status: 'success' }, inaccessibleWorkflow),
+			]);
+
+			const arrayQuery: ExecutionSummaries.RangeQuery = {
+				kind: 'range',
+				range: { limit: 20 },
+				accessibleWorkflowIds: [workflow1.id, workflow2.id],
+			};
+
+			const subqueryQuery: ExecutionSummaries.RangeQuery = {
+				kind: 'range',
+				range: { limit: 20 },
+				user: member,
+				sharingOptions: {
+					workflowRoles: ['workflow:owner'],
+					projectRoles: ['project:personalOwner'],
+				},
+			};
+
+			const [arrayResult, subqueryResult] = await Promise.all([
+				executionService.findRangeWithCount(arrayQuery),
+				executionService.findRangeWithCount(subqueryQuery),
+			]);
+
+			expect(arrayResult.count).toBe(3);
+			expect(subqueryResult.count).toBe(3);
+			expect(subqueryResult.results).toHaveLength(arrayResult.results.length);
+			expect(subqueryResult.results.map((r) => r.id)).toEqual(arrayResult.results.map((r) => r.id));
+		});
+
+		test('should filter by status correctly', async () => {
+			const workflow = await createWorkflow({}, member);
+
+			await Promise.all([
+				createExecution({ status: 'success' }, workflow),
+				createExecution({ status: 'success' }, workflow),
+				createExecution({ status: 'error' }, workflow),
+			]);
+
+			const arrayQuery: ExecutionSummaries.RangeQuery = {
+				kind: 'range',
+				range: { limit: 20 },
+				status: ['success'],
+				accessibleWorkflowIds: [workflow.id],
+			};
+
+			const subqueryQuery: ExecutionSummaries.RangeQuery = {
+				kind: 'range',
+				range: { limit: 20 },
+				status: ['success'],
+				user: member,
+				sharingOptions: {
+					workflowRoles: ['workflow:owner'],
+					projectRoles: ['project:personalOwner'],
+				},
+			};
+
+			const [arrayResult, subqueryResult] = await Promise.all([
+				executionService.findRangeWithCount(arrayQuery),
+				executionService.findRangeWithCount(subqueryQuery),
+			]);
+
+			expect(arrayResult.count).toBe(2);
+			expect(subqueryResult.count).toBe(2);
+			expect(subqueryResult.results.map((r) => r.id)).toEqual(arrayResult.results.map((r) => r.id));
+		});
+
+		test('should filter by workflowId correctly', async () => {
+			const workflow1 = await createWorkflow({}, member);
+			const workflow2 = await createWorkflow({}, member);
+
+			await Promise.all([
+				createExecution({ status: 'success' }, workflow1),
+				createExecution({ status: 'success' }, workflow2),
+				createExecution({ status: 'success' }, workflow2),
+			]);
+
+			const arrayQuery: ExecutionSummaries.RangeQuery = {
+				kind: 'range',
+				range: { limit: 20 },
+				workflowId: workflow1.id,
+				accessibleWorkflowIds: [workflow1.id, workflow2.id],
+			};
+
+			const subqueryQuery: ExecutionSummaries.RangeQuery = {
+				kind: 'range',
+				range: { limit: 20 },
+				workflowId: workflow1.id,
+				user: member,
+				sharingOptions: {
+					workflowRoles: ['workflow:owner'],
+					projectRoles: ['project:personalOwner'],
+				},
+			};
+
+			const [arrayResult, subqueryResult] = await Promise.all([
+				executionService.findRangeWithCount(arrayQuery),
+				executionService.findRangeWithCount(subqueryQuery),
+			]);
+
+			expect(arrayResult.count).toBe(1);
+			expect(subqueryResult.count).toBe(1);
+			expect(subqueryResult.results[0].workflowId).toBe(workflow1.id);
+		});
+
+		test('should work with team project', async () => {
+			const teamProject = await createTeamProject();
+			const personalWorkflow = await createWorkflow({}, owner);
+			const teamWorkflow = await createWorkflow({}, teamProject);
+
+			await Promise.all([
+				createExecution({ status: 'success' }, personalWorkflow),
+				createExecution({ status: 'success' }, teamWorkflow),
+			]);
+
+			const arrayQuery: ExecutionSummaries.RangeQuery = {
+				kind: 'range',
+				range: { limit: 20 },
+				accessibleWorkflowIds: [personalWorkflow.id, teamWorkflow.id],
+			};
+
+			const arrayResult = await executionService.findRangeWithCount(arrayQuery);
+			expect(arrayResult.count).toBe(2);
+		});
+
+		test('should work with sharing-enabled roles (team project admin)', async () => {
+			// Simulates the isSharingEnabled() === true path in the controller
+			const teamProject = await createTeamProject(undefined, member);
+			const personalWorkflow = await createWorkflow({}, member);
+			const teamWorkflow = await createWorkflow({}, teamProject);
+			const inaccessibleWorkflow = await createWorkflow({}, owner);
+
+			await Promise.all([
+				createExecution({ status: 'success' }, personalWorkflow),
+				createExecution({ status: 'success' }, teamWorkflow),
+				createExecution({ status: 'error' }, teamWorkflow),
+				createExecution({ status: 'success' }, inaccessibleWorkflow),
+			]);
+
+			// Sharing-enabled roles: member can see workflows they own OR are admin/editor of
+			const sharingEnabledQuery: ExecutionSummaries.RangeQuery = {
+				kind: 'range',
+				range: { limit: 20 },
+				user: member,
+				sharingOptions: {
+					workflowRoles: ['workflow:owner', 'workflow:editor'],
+					projectRoles: ['project:personalOwner', 'project:admin', 'project:editor'],
+				},
+			};
+
+			const result = await executionService.findRangeWithCount(sharingEnabledQuery);
+
+			// member owns personalWorkflow and is admin of teamProject → sees 3 executions
+			expect(result.count).toBe(3);
+			const workflowIds = result.results.map((r) => r.workflowId);
+			expect(workflowIds).toContain(personalWorkflow.id);
+			expect(workflowIds).toContain(teamWorkflow.id);
+			expect(workflowIds).not.toContain(inaccessibleWorkflow.id);
+		});
+
+		test('should work with sharing-enabled roles (team project editor)', async () => {
+			// member is linked as project:editor to a team project they didn't create
+			const teamProject = await createTeamProject();
+			await linkUserToProject(member, teamProject, 'project:editor');
+			const teamWorkflow = await createWorkflow({}, teamProject);
+			const personalWorkflow = await createWorkflow({}, member);
+			const inaccessibleWorkflow = await createWorkflow({}, owner);
+
+			await Promise.all([
+				createExecution({ status: 'success' }, teamWorkflow),
+				createExecution({ status: 'success' }, personalWorkflow),
+				createExecution({ status: 'success' }, inaccessibleWorkflow),
+			]);
+
+			const sharingEnabledQuery: ExecutionSummaries.RangeQuery = {
+				kind: 'range',
+				range: { limit: 20 },
+				user: member,
+				sharingOptions: {
+					workflowRoles: ['workflow:owner', 'workflow:editor'],
+					projectRoles: ['project:personalOwner', 'project:admin', 'project:editor'],
+				},
+			};
+
+			const result = await executionService.findRangeWithCount(sharingEnabledQuery);
+
+			// member owns personalWorkflow and is editor in teamProject → sees 2 executions
+			expect(result.count).toBe(2);
+			const workflowIds = result.results.map((r) => r.workflowId);
+			expect(workflowIds).toContain(teamWorkflow.id);
+			expect(workflowIds).toContain(personalWorkflow.id);
+			expect(workflowIds).not.toContain(inaccessibleWorkflow.id);
+		});
+	});
+
+	describe('findLatestCurrentAndCompleted — subquery approach', () => {
+		test('should return same results as array approach', async () => {
+			const workflow = await createWorkflow({}, member);
+
+			await Promise.all([
+				createExecution({ status: 'running', stoppedAt: undefined }, workflow),
+				createExecution({ status: 'success' }, workflow),
+				createExecution({ status: 'success' }, workflow),
+				createExecution({ status: 'error' }, workflow),
+			]);
+
+			const arrayQuery: ExecutionSummaries.RangeQuery = {
+				kind: 'range',
+				range: { limit: 20 },
+				accessibleWorkflowIds: [workflow.id],
+			};
+
+			const subqueryQuery: ExecutionSummaries.RangeQuery = {
+				kind: 'range',
+				range: { limit: 20 },
+				user: member,
+				sharingOptions: {
+					workflowRoles: ['workflow:owner'],
+					projectRoles: ['project:personalOwner'],
+				},
+			};
+
+			const [arrayResult, subqueryResult] = await Promise.all([
+				executionService.findLatestCurrentAndCompleted(arrayQuery),
+				executionService.findLatestCurrentAndCompleted(subqueryQuery),
+			]);
+
+			expect(arrayResult.count).toBe(subqueryResult.count);
+			expect(arrayResult.results).toHaveLength(subqueryResult.results.length);
+
+			const arrayIds = arrayResult.results.map((r) => r.id).sort();
+			const subqueryIds = subqueryResult.results.map((r) => r.id).sort();
+			expect(subqueryIds).toEqual(arrayIds);
 		});
 	});
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
Changed the execution repository query logic when fetching and counting executions 
Why: to prevent db engines errors on the second query when passing too many parameters. 

How: instead of querying first the accessible execution workflow ids from the user context, we pass the context to the main repository function and adds a subquery to filter by the accessible ones

Benchmarks:

**Postgres**
| Scenario | Array (ms) | EXISTS (ms) | Ratio | Verdict |
| :--- | :--- | :--- | :--- | :--- |
| 20k execs, 10 wf | 7–15 | 7–33 | 1.05–2.19x | Slight overhead, negligible at <33ms |
| 50k execs, 1000 wf | 16–3178 | 13–779 | 0.01–24.8x | Highly variable (PG planner), EXISTS wins big when plan is optimal |
| 20k, 100 wf + status filter | 6–109 | 6–7 | 0.07–0.98x | Faster or equal |
| findLatestCurrentAndCompleted, 20k | 10–27 | 11–19 | 0.68–1.26x | Neutral |
| 20k sharing-enabled, team+personal | 6–114 | 6–8 | 0.07–1.25x | Faster or equal |
| 50k sharing-enabled, 1000 team wf | 14–17 | 13–15 | 0.86–0.93x | Consistently faster |

**SQLite**
| Scenario | Array (ms) | EXISTS (ms) | Ratio | Verdict |
| :--- | ---: | ---: | ---: | :--- |
| 20k execs, 10 wf | 3.34 | 4.72 | 1.41x | Neutral (absolute diff ~1ms) |
| 50k execs, 1000 wf | 17.19 | 17.11 | 1.00x | Neutral |
| 20k, 100 wf + status filter | 6.57 | 6.34 | 0.97x | Neutral |
| findLatestCurrentAndCompleted, 20k | 5.29 | 5.35 | 1.01x | Neutral |
| 20k sharing-enabled, team+personal | 3.33 | 3.53 | 1.06x | Neutral |
| 50k sharing-enabled, 1000 team wf | 17.99 | 18.33 | 1.02x | Neutral |

Mainly neutral on SQLite, and relatively faster on postgres

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/IAM-371/executions-listing-optimization


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
