### PR TITLE
feat(editor): Enable project editors to view external secret vaults

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4322,7 +4322,7 @@
 	"projects.settings.member.removed.title": "Member removed successfully",
 	"projects.settings.member.added.title": "Member added successfully",
 	"projects.settings.users.search.error": "An error occurred while searching for users",
-	"projects.settings.externalSecrets": "External secret stores",
+	"projects.settings.externalSecrets": "External secret vaults",
 	"projects.settings.externalSecrets.emptyState.heading": "No external secrets available yet",
 	"projects.settings.externalSecrets.emptyState.instanceAdmin.noProjectProviders.description": "Share secrets vault with this project to make external secrets available here. Once shared, secrets will appear automatically and can be referenced through aliases in credentials.",
 	"projects.settings.externalSecrets.emptyState.projectAdmin.description": "Add a secrets vault and share it with this project to make external secrets available here. Once shared, secrets will appear automatically and can be referenced through aliases in credentials.",

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectHeader.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectHeader.test.ts
@@ -233,7 +233,7 @@ describe('ProjectHeader', () => {
 		);
 	});
 
-	it('should render ProjectTabs without Settings if no project update permission', () => {
+	it('should render ProjectTabs without Settings if no project update or externalSecretsProvider:read permission', () => {
 		route.params.projectId = '123';
 		projectsStore.currentProject = createTestProject({
 			scopes: ['project:read'],
@@ -243,6 +243,21 @@ describe('ProjectHeader', () => {
 		expect(projectTabsSpy).toHaveBeenCalledWith(
 			expect.objectContaining({
 				'show-settings': false,
+			}),
+			null,
+		);
+	});
+
+	it('should render ProjectTabs Settings if project editor has externalSecretsProvider:read scope', () => {
+		route.params.projectId = '123';
+		projectsStore.currentProject = createTestProject({
+			scopes: ['project:read', 'externalSecretsProvider:read', 'externalSecretsProvider:list'],
+		});
+		renderComponent();
+
+		expect(projectTabsSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				'show-settings': true,
 			}),
 			null,
 		);

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectHeader.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectHeader.vue
@@ -92,10 +92,14 @@ const globalVariablesPermissions = computed(
 	() => getResourcePermissions(usersStore.currentUser?.globalScopes).variable,
 );
 
+const externalSecretsProviderPermissions = computed(
+	() => getResourcePermissions(projectsStore.currentProject?.scopes).externalSecretsProvider,
+);
+
 const showSettings = computed(
 	() =>
 		!!route?.params?.projectId &&
-		!!projectPermissions.value.update &&
+		(!!projectPermissions.value.update || !!externalSecretsProviderPermissions.value.read) &&
 		projectsStore.currentProject?.type === ProjectTypes.Team,
 );
 

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/projects.routes.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/projects.routes.ts
@@ -147,7 +147,10 @@ export const projectsRoutes: RouteRecordRaw[] = [
 										const project = useProjectsStore().myProjects.find(
 											(p) => p.id === options?.to.params.projectId,
 										);
-										return !!getResourcePermissions(project?.scopes).project.update;
+										const permissions = getResourcePermissions(project?.scopes);
+										return (
+											!!permissions.project.update || !!permissions.externalSecretsProvider.read
+										);
 									},
 								},
 							},

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.test.ts
@@ -19,6 +19,7 @@ import { createUser } from '@/__tests__/data/users';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useRolesStore } from '@/app/stores/roles.store';
+import { useRBACStore } from '@/app/stores/rbac.store';
 import type { FrontendSettings } from '@n8n/api-types';
 
 const mockTrack = vi.fn();
@@ -229,7 +230,7 @@ describe('ProjectSettings', () => {
 					role: 'project:admin',
 				},
 			],
-			scopes: ['project:read'],
+			scopes: ['project:read', 'project:update'],
 		};
 
 		projectsStore.currentProject = mockProject;
@@ -714,6 +715,51 @@ describe('ProjectSettings', () => {
 			expect(nameInput).toBeInTheDocument();
 			expect(descInput).toBeInTheDocument();
 			expect(getByTestId('project-members-select')).toBeInTheDocument();
+		});
+	});
+
+	describe('External secrets permission (no project:update)', () => {
+		beforeEach(() => {
+			projectsStore.currentProject = {
+				...projectsStore.currentProject!,
+				scopes: ['project:read', 'externalSecretsProvider:read', 'externalSecretsProvider:list'],
+			};
+			settingsStore.moduleSettings = {
+				'external-secrets': {
+					multipleConnections: false,
+					forProjects: true,
+					roleBasedAccess: false,
+					systemRolesEnabled: false,
+				},
+			};
+			const rbacStore = mockedStore(useRBACStore);
+			rbacStore.hasScope.mockReturnValue(false);
+			projectsStore.getProjectSecretProviders.mockResolvedValue([]);
+		});
+
+		it('hides name, description, members, and danger zone sections', async () => {
+			const { queryByTestId } = renderComponent();
+			await nextTick();
+
+			expect(queryByTestId('project-settings-name-input')).not.toBeInTheDocument();
+			expect(queryByTestId('project-settings-description-input')).not.toBeInTheDocument();
+			expect(queryByTestId('project-members-select')).not.toBeInTheDocument();
+			expect(queryByTestId('project-settings-delete-button')).not.toBeInTheDocument();
+		});
+
+		it('hides the save and cancel buttons', async () => {
+			const { queryByTestId } = renderComponent();
+			await nextTick();
+
+			expect(queryByTestId('project-settings-save-button')).not.toBeInTheDocument();
+			expect(queryByTestId('project-settings-cancel-button')).not.toBeInTheDocument();
+		});
+
+		it('renders the external secrets section', async () => {
+			const { getByTestId } = renderComponent();
+			await nextTick();
+
+			expect(getByTestId('external-secrets-section')).toBeInTheDocument();
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.vue
@@ -26,6 +26,7 @@ import { isProjectRole } from '@/app/utils/typeGuards';
 import { useUserRoleProvisioningStore } from '@/features/settings/sso/provisioning/composables/userRoleProvisioning.store';
 import { N8nAlert } from '@n8n/design-system';
 import ProjectExternalSecrets from '../components/ProjectExternalSecrets.vue';
+import { getResourcePermissions } from '@n8n/permissions';
 
 import {
 	N8nButton,
@@ -54,6 +55,10 @@ const toast = useToast();
 const router = useRouter();
 const telemetry = useTelemetry();
 const documentTitle = useDocumentTitle();
+
+const canUpdateProject = computed(
+	() => !!getResourcePermissions(projectsStore.currentProject?.scopes).project.update,
+);
 
 const showSaveError = (error: Error) => {
 	toast.showError(error, i18n.baseText('projects.settings.save.error.title'));
@@ -524,7 +529,7 @@ const searchUsers = async (query: string) => {
 const debouncedUserSearch = useDebounceFn(searchUsers, getDebounceTime(DEBOUNCE_TIME.INPUT.SEARCH));
 
 onBeforeMount(async () => {
-	// Load initial set of users for dropdown
+	if (!canUpdateProject.value) return;
 	await searchUsers('');
 });
 
@@ -534,8 +539,10 @@ const isProjectRoleProvisioningEnabled = computed(
 
 onMounted(async () => {
 	documentTitle.set(i18n.baseText('projects.settings'));
-	selectProjectNameIfMatchesDefault();
 
+	if (!canUpdateProject.value) return;
+
+	selectProjectNameIfMatchesDefault();
 	await Promise.all([userRoleProvisioningStore.getProvisioningConfig(), rolesStore.fetchRoles()]);
 });
 </script>
@@ -544,7 +551,7 @@ onMounted(async () => {
 	<div :class="$style.projectSettings" data-test-id="project-settings-container">
 		<div :class="$style.header">
 			<ProjectHeader />
-			<div :class="$style.headerRow">
+			<div v-if="canUpdateProject" :class="$style.headerRow">
 				<N8nText tag="h1" size="xlarge" class="pt-xs pb-m">
 					{{ i18n.baseText('projects.settings.info') }}
 				</N8nText>
@@ -569,126 +576,132 @@ onMounted(async () => {
 			</div>
 		</div>
 		<form @submit.prevent="onSubmit">
-			<fieldset>
-				<label for="projectName">{{ i18n.baseText('projects.settings.name') }}</label>
-				<div :class="$style.projectName">
-					<N8nIconPicker
-						v-model="projectIcon"
-						:button-tooltip="i18n.baseText('projects.settings.iconPicker.button.tooltip')"
-						@update:model-value="onIconUpdated"
-					/>
+			<template v-if="canUpdateProject">
+				<fieldset>
+					<label for="projectName">{{ i18n.baseText('projects.settings.name') }}</label>
+					<div :class="$style.projectName">
+						<N8nIconPicker
+							v-model="projectIcon"
+							:button-tooltip="i18n.baseText('projects.settings.iconPicker.button.tooltip')"
+							@update:model-value="onIconUpdated"
+						/>
+						<N8nFormInput
+							id="projectName"
+							ref="nameInput"
+							v-model="formData.name"
+							label=""
+							type="text"
+							name="name"
+							required
+							data-test-id="project-settings-name-input"
+							:class="$style.projectNameInput"
+							@enter="onSubmit"
+							@input="onTextInput"
+							@validate="isValid = $event"
+						/>
+					</div>
+				</fieldset>
+				<fieldset>
+					<label for="projectDescription">{{
+						i18n.baseText('projects.settings.description')
+					}}</label>
 					<N8nFormInput
-						id="projectName"
-						ref="nameInput"
-						v-model="formData.name"
+						id="projectDescription"
+						v-model="formData.description"
 						label=""
-						type="text"
-						name="name"
-						required
-						data-test-id="project-settings-name-input"
-						:class="$style.projectNameInput"
+						name="description"
+						type="textarea"
+						:maxlength="512"
+						:autosize="true"
+						data-test-id="project-settings-description-input"
+						:class="$style.projectDescriptionInput"
 						@enter="onSubmit"
 						@input="onTextInput"
 						@validate="isValid = $event"
 					/>
-				</div>
-			</fieldset>
-			<fieldset>
-				<label for="projectDescription">{{ i18n.baseText('projects.settings.description') }}</label>
-				<N8nFormInput
-					id="projectDescription"
-					v-model="formData.description"
-					label=""
-					name="description"
-					type="textarea"
-					:maxlength="512"
-					:autosize="true"
-					data-test-id="project-settings-description-input"
-					:class="$style.projectDescriptionInput"
-					@enter="onSubmit"
-					@input="onTextInput"
-					@validate="isValid = $event"
-				/>
-			</fieldset>
+				</fieldset>
+			</template>
 
 			<ProjectExternalSecrets :class="$style.externalSecrets" />
 
-			<fieldset id="projectMembers">
-				<h3>
-					<label for="projectMembers">{{
-						i18n.baseText('projects.settings.projectMembers')
-					}}</label>
-				</h3>
-				<div :class="[$style.membersInputRow, 'mb-s']">
-					<N8nUserSelect
-						id="projectMembers"
-						:class="$style.userSelect"
+			<template v-if="canUpdateProject">
+				<fieldset id="projectMembers">
+					<h3>
+						<label for="projectMembers">{{
+							i18n.baseText('projects.settings.projectMembers')
+						}}</label>
+					</h3>
+					<div :class="[$style.membersInputRow, 'mb-s']">
+						<N8nUserSelect
+							id="projectMembers"
+							:class="$style.userSelect"
+							size="large"
+							:users="usersList"
+							:current-user-id="usersStore.currentUser?.id"
+							:placeholder="i18n.baseText('workflows.shareModal.select.placeholder')"
+							data-test-id="project-members-select"
+							remote
+							:remote-method="debouncedUserSearch"
+							:loading="isLoadingUsers"
+							@update:model-value="onAddMember"
+							:disabled="isProjectRoleProvisioningEnabled"
+						>
+							<template #prefix>
+								<N8nIcon icon="search" />
+							</template>
+						</N8nUserSelect>
+						<N8nInput
+							v-if="shouldShowSearch"
+							:class="$style.search"
+							:model-value="search"
+							:placeholder="i18n.baseText('projects.settings.members.search.placeholder')"
+							clearable
+							data-test-id="project-members-search"
+							@update:model-value="onSearch"
+						>
+							<template #prefix>
+								<N8nIcon icon="search" />
+							</template>
+						</N8nInput>
+					</div>
+					<div v-if="isProjectRoleProvisioningEnabled" class="mb-m">
+						<N8nAlert
+							type="info"
+							:title="
+								i18n.baseText('settings.provisioningProjectRolesHandledBySsoProvider.description')
+							"
+						/>
+					</div>
+					<div v-if="relationUsers.length > 0" :class="$style.membersTableContainer">
+						<ProjectMembersTable
+							v-model:table-options="membersTableState"
+							data-test-id="project-members-table"
+							:data="filteredMembersData"
+							:current-user-id="usersStore.currentUser?.id"
+							:project-roles="rolesStore.processedProjectRoles"
+							:actions="projectMembersActions"
+							:can-edit-role="!isProjectRoleProvisioningEnabled"
+							@update:options="onUpdateMembersTableOptions"
+							@update:role="onUpdateMemberRole"
+							@action="onMembersListAction"
+						/>
+					</div>
+				</fieldset>
+				<fieldset>
+					<h3 class="mb-m">{{ i18n.baseText('projects.settings.danger.title') }}</h3>
+					<small :class="$style.danger">{{
+						i18n.baseText('projects.settings.danger.message')
+					}}</small>
+					<N8nButton
+						variant="subtle"
 						size="large"
-						:users="usersList"
-						:current-user-id="usersStore.currentUser?.id"
-						:placeholder="i18n.baseText('workflows.shareModal.select.placeholder')"
-						data-test-id="project-members-select"
-						remote
-						:remote-method="debouncedUserSearch"
-						:loading="isLoadingUsers"
-						@update:model-value="onAddMember"
-						:disabled="isProjectRoleProvisioningEnabled"
+						native-type="button"
+						data-test-id="project-settings-delete-button"
+						@click.stop.prevent="onDelete"
+						>{{ i18n.baseText('projects.settings.danger.deleteProject') }}</N8nButton
 					>
-						<template #prefix>
-							<N8nIcon icon="search" />
-						</template>
-					</N8nUserSelect>
-					<N8nInput
-						v-if="shouldShowSearch"
-						:class="$style.search"
-						:model-value="search"
-						:placeholder="i18n.baseText('projects.settings.members.search.placeholder')"
-						clearable
-						data-test-id="project-members-search"
-						@update:model-value="onSearch"
-					>
-						<template #prefix>
-							<N8nIcon icon="search" />
-						</template>
-					</N8nInput>
-				</div>
-				<div v-if="isProjectRoleProvisioningEnabled" class="mb-m">
-					<N8nAlert
-						type="info"
-						:title="
-							i18n.baseText('settings.provisioningProjectRolesHandledBySsoProvider.description')
-						"
-					/>
-				</div>
-				<div v-if="relationUsers.length > 0" :class="$style.membersTableContainer">
-					<ProjectMembersTable
-						v-model:table-options="membersTableState"
-						data-test-id="project-members-table"
-						:data="filteredMembersData"
-						:current-user-id="usersStore.currentUser?.id"
-						:project-roles="rolesStore.processedProjectRoles"
-						:actions="projectMembersActions"
-						:can-edit-role="!isProjectRoleProvisioningEnabled"
-						@update:options="onUpdateMembersTableOptions"
-						@update:role="onUpdateMemberRole"
-						@action="onMembersListAction"
-					/>
-				</div>
-			</fieldset>
-			<fieldset>
-				<h3 class="mb-m">{{ i18n.baseText('projects.settings.danger.title') }}</h3>
-				<small :class="$style.danger">{{
-					i18n.baseText('projects.settings.danger.message')
-				}}</small>
-				<N8nButton
-					variant="subtle"
-					size="large"
-					native-type="button"
-					data-test-id="project-settings-delete-button"
-					@click.stop.prevent="onDelete"
-					>{{ i18n.baseText('projects.settings.danger.deleteProject') }}</N8nButton
-				>
-			</fieldset>
+				</fieldset>
+			</template>
 		</form>
 		<ProjectDeleteDialog
 			v-model="dialogVisible"


### PR DESCRIPTION
## Summary

- Added support for externalSecretsProvider permissions in project settings.
- Updated ProjectHeader and ProjectSettings components to conditionally render settings based on permissions.
- Added tests to cover new permission scenarios for project scoped external secrets access.

## Screenshot

<img width="1089" height="610" alt="Screenshot 2026-03-13 at 14 17 13" src="https://github.com/user-attachments/assets/7c9e78ba-8346-4e4d-897f-285e489ec0c2" />

## Related Linear tickets, Github issues, and Community forum posts

Closes [LIGO-355](https://linear.app/n8n/issue/LIGO-355/enable-project-editors-with-external-secrets-access-to-view-settings)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
