### PR TITLE
feat: Add saml feature flag

### DIFF
--- a/packages/cli/src/modules/sso-saml/__tests__/saml.service.ee.test.ts
+++ b/packages/cli/src/modules/sso-saml/__tests__/saml.service.ee.test.ts
@@ -184,6 +184,8 @@ describe('SamlService', () => {
 		await validator.init();
 	});
 
+	const originalEnv = process.env.N8N_ENV_FEAT_SIGNED_SAML_REQUESTS;
+
 	beforeEach(async () => {
 		jest.resetAllMocks();
 		Container.reset();
@@ -215,6 +217,39 @@ describe('SamlService', () => {
 		);
 		// Mock GlobalConfig container access
 		Container.set(require('@n8n/config').GlobalConfig, globalConfig);
+	});
+
+	afterEach(() => {
+		// Restore original environment variable
+		if (originalEnv !== undefined) {
+			process.env.N8N_ENV_FEAT_SIGNED_SAML_REQUESTS = originalEnv;
+		} else {
+			delete process.env.N8N_ENV_FEAT_SIGNED_SAML_REQUESTS;
+		}
+	});
+
+	describe('isSignedSamlRequestsEnabled', () => {
+		it.each([
+			['not set', undefined],
+			['"false"', 'false'],
+			['empty string', ''],
+			['"0"', '0'],
+			['"no"', 'no'],
+		])('should return false when N8N_ENV_FEAT_SIGNED_SAML_REQUESTS is %s', (_, value) => {
+			if (value === undefined) {
+				delete process.env.N8N_ENV_FEAT_SIGNED_SAML_REQUESTS;
+			} else {
+				process.env.N8N_ENV_FEAT_SIGNED_SAML_REQUESTS = value;
+			}
+
+			expect(samlService.isSignedSamlRequestsEnabled()).toBe(false);
+		});
+
+		it('should return true when N8N_ENV_FEAT_SIGNED_SAML_REQUESTS is "true"', () => {
+			process.env.N8N_ENV_FEAT_SIGNED_SAML_REQUESTS = 'true';
+
+			expect(samlService.isSignedSamlRequestsEnabled()).toBe(true);
+		});
 	});
 
 	describe('getAttributesFromLoginResponse', () => {

--- a/packages/cli/src/modules/sso-saml/saml.service.ee.ts
+++ b/packages/cli/src/modules/sso-saml/saml.service.ee.ts
@@ -90,6 +90,14 @@ export class SamlService {
 		private readonly provisioningService: ProvisioningService,
 	) {}
 
+	/**
+	 * Checks if SAML request signing is enabled via feature flag.
+	 * @returns true if N8N_ENV_FEAT_SIGNED_SAML_REQUESTS is set to 'true', false otherwise
+	 */
+	isSignedSamlRequestsEnabled(): boolean {
+		return process.env.N8N_ENV_FEAT_SIGNED_SAML_REQUESTS === 'true';
+	}
+
 	async init(): Promise<void> {
 		try {
 			// load preferences first but do not apply so as to not load samlify unnecessarily


### PR DESCRIPTION
## Summary

This PR adds a feature flag `N8N_ENV_FEAT_SIGNED_SAML_REQUESTS` to control SAML request signing functionality during development and rollout. The feature flag is implemented as a method on the `SamlService` class that checks the environment variable.

**Changes:**
- Added `isSignedSamlRequestsEnabled()` method to `SamlService` class that returns `true` when `N8N_ENV_FEAT_SIGNED_SAML_REQUESTS` is set to `'true'`, and `false` otherwise
- Added comprehensive unit tests covering various environment variable values (unset, `'false'`, empty string, `'0'`, `'no'`, and `'true'`)

**How to test:**
1. Set `N8N_ENV_FEAT_SIGNED_SAML_REQUESTS=true` in your environment
2. Call `samlService.isSignedSamlRequestsEnabled()` - should return `true`
3. Unset the variable or set it to any other value - should return `false`
4. Run the unit tests: `cd packages/cli && pnpm test saml.service.ee.test.ts`

**Note:** The frontend automatically collects this feature flag via `FrontendService.collectEnvFeatureFlags()` and can be accessed using the `useEnvFeatureFlag` composable.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-387

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
