### PR TITLE
chore(editor): Change custom auth JSON

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -1699,7 +1699,7 @@ onUpdated(async () => {
 					data-test-id="credential-json-overlay"
 				>
 					<JsonEditor
-						:model-value="'************\n* REDACTED *\n************'"
+						:model-value="'***\n***\n***'"
 						:is-read-only="true"
 						:rows="editorRows"
 						:class="$style.credentialJsonEditor"


### PR DESCRIPTION
## Summary

This PR updates the display text for redacted JSON values in custom auth credentials to show 3 lines of asterisks (`***`) instead of the previous format with "REDACTED" text.

**Changes:**
- Updated the `ParameterInput.vue` component to display `'***\n***\n***'` when showing redacted custom auth JSON values
- Simplified the visual representation from `'************\n* REDACTED *\n************'` to a cleaner 3-line asterisk format

**How to test:**
1. Create or edit an HTTP Custom Auth credential
2. Add a JSON value to the credential
3. Save the credential
4. Reopen the credential - the JSON field should display 3 lines of asterisks (`***`) instead of the previous "REDACTED" format
5. Verify the "Edit" button still works to allow editing the JSON value

## Related Linear tickets, Github issues, and Community forum posts

<!-- Add Linear ticket link if applicable -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
