### PR TITLE
chore(core): Add additional validation on resolver config and better error specs

### DIFF
--- a/packages/cli/src/modules/dynamic-credentials.ee/__tests__/credential-resolvers.controller.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/__tests__/credential-resolvers.controller.test.ts
@@ -1,0 +1,118 @@
+import type { AuthenticatedRequest } from '@n8n/db';
+import { CredentialResolverValidationError } from '@n8n/decorators';
+import type { Response } from 'express';
+import { mock } from 'jest-mock-extended';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { InternalServerError } from '@/errors/response-errors/internal-server.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+
+import { IdentifierValidationError } from '../credential-resolvers/identifiers/identifier-interface';
+import { CredentialResolversController } from '../credential-resolvers.controller';
+import { CredentialResolutionError } from '../errors/credential-resolution.error';
+import { DynamicCredentialResolverNotFoundError } from '../errors/credential-resolver-not-found.error';
+import type { DynamicCredentialResolverService } from '../services/credential-resolver.service';
+
+describe('CredentialResolversController', () => {
+	const service = mock<DynamicCredentialResolverService>();
+	const controller = new CredentialResolversController(service);
+	const req = mock<AuthenticatedRequest>();
+	const res = mock<Response>();
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('createResolver', () => {
+		it('should throw BadRequestError when service throws CredentialResolverValidationError', async () => {
+			service.create.mockRejectedValue(new CredentialResolverValidationError('Invalid config'));
+
+			await expect(
+				controller.createResolver(req, res, { name: 'test', type: 'oauth2', config: {} }),
+			).rejects.toThrow(BadRequestError);
+		});
+
+		it('should throw BadRequestError when service throws CredentialResolutionError', async () => {
+			service.create.mockRejectedValue(
+				new CredentialResolutionError('Failed to fetch OAuth2 metadata, status code: 404'),
+			);
+
+			await expect(
+				controller.createResolver(req, res, { name: 'test', type: 'oauth2', config: {} }),
+			).rejects.toThrow(BadRequestError);
+		});
+
+		it('should throw BadRequestError when service throws IdentifierValidationError', async () => {
+			service.create.mockRejectedValue(
+				new IdentifierValidationError('Failed to fetch OAuth2 metadata, status code: 404'),
+			);
+
+			await expect(
+				controller.createResolver(req, res, { name: 'test', type: 'oauth2', config: {} }),
+			).rejects.toThrow(BadRequestError);
+		});
+
+		it('should preserve the error message from IdentifierValidationError', async () => {
+			const errorMessage = 'Metadata does not contain an introspection endpoint';
+			service.create.mockRejectedValue(new IdentifierValidationError(errorMessage));
+
+			await expect(
+				controller.createResolver(req, res, { name: 'test', type: 'oauth2', config: {} }),
+			).rejects.toThrow(errorMessage);
+		});
+
+		it('should throw InternalServerError for unknown errors', async () => {
+			service.create.mockRejectedValue(new Error('unexpected'));
+
+			await expect(
+				controller.createResolver(req, res, { name: 'test', type: 'oauth2', config: {} }),
+			).rejects.toThrow(InternalServerError);
+		});
+	});
+
+	describe('updateResolver', () => {
+		it('should throw NotFoundError when resolver not found', async () => {
+			service.update.mockRejectedValue(new DynamicCredentialResolverNotFoundError('not-found-id'));
+
+			await expect(
+				controller.updateResolver(req, res, 'not-found-id', { name: 'test' }),
+			).rejects.toThrow(NotFoundError);
+		});
+
+		it('should throw BadRequestError when service throws CredentialResolverValidationError', async () => {
+			service.update.mockRejectedValue(new CredentialResolverValidationError('Invalid config'));
+
+			await expect(controller.updateResolver(req, res, 'id', { config: {} })).rejects.toThrow(
+				BadRequestError,
+			);
+		});
+
+		it('should throw BadRequestError when service throws CredentialResolutionError', async () => {
+			service.update.mockRejectedValue(
+				new CredentialResolutionError('Failed to fetch OAuth2 metadata, status code: 404'),
+			);
+
+			await expect(controller.updateResolver(req, res, 'id', { config: {} })).rejects.toThrow(
+				BadRequestError,
+			);
+		});
+
+		it('should throw BadRequestError when service throws IdentifierValidationError', async () => {
+			service.update.mockRejectedValue(
+				new IdentifierValidationError('Invalid OAuth2 metadata format'),
+			);
+
+			await expect(controller.updateResolver(req, res, 'id', { config: {} })).rejects.toThrow(
+				BadRequestError,
+			);
+		});
+
+		it('should throw InternalServerError for unknown errors', async () => {
+			service.update.mockRejectedValue(new Error('unexpected'));
+
+			await expect(controller.updateResolver(req, res, 'id', { config: {} })).rejects.toThrow(
+				InternalServerError,
+			);
+		});
+	});
+});

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers.controller.ts
@@ -21,12 +21,13 @@ import {
 } from '@n8n/decorators';
 import { Response } from 'express';
 
-import { DynamicCredentialResolverNotFoundError } from './errors/credential-resolver-not-found.error';
-import { DynamicCredentialResolverService } from './services/credential-resolver.service';
-
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+
+import { CredentialResolutionError } from './errors/credential-resolution.error';
+import { DynamicCredentialResolverNotFoundError } from './errors/credential-resolver-not-found.error';
+import { DynamicCredentialResolverService } from './services/credential-resolver.service';
 
 @RestController('/credential-resolvers')
 export class CredentialResolversController {
@@ -79,6 +80,9 @@ export class CredentialResolversController {
 			if (e instanceof CredentialResolverValidationError) {
 				throw new BadRequestError(e.message);
 			}
+			if (e instanceof CredentialResolutionError) {
+				throw new BadRequestError(e.message);
+			}
 			if (e instanceof Error) {
 				throw new InternalServerError(e.message, e);
 			}
@@ -129,6 +133,9 @@ export class CredentialResolversController {
 				throw new NotFoundError(e.message);
 			}
 			if (e instanceof CredentialResolverValidationError) {
+				throw new BadRequestError(e.message);
+			}
+			if (e instanceof CredentialResolutionError) {
 				throw new BadRequestError(e.message);
 			}
 			if (e instanceof Error) {

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-introspection-identifier.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-introspection-identifier.test.ts
@@ -182,6 +182,64 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 		});
 	});
 
+	describe('Validation', () => {
+		test('should reject empty clientId', async () => {
+			const optionsWithEmptyClientId = { ...validOptions, clientId: '' };
+
+			await expect(identifier.resolve(mockContext, optionsWithEmptyClientId)).rejects.toThrow(
+				IdentifierValidationError,
+			);
+		});
+
+		test('should reject whitespace-only clientId', async () => {
+			const optionsWithWhitespaceClientId = { ...validOptions, clientId: '   ' };
+
+			await expect(identifier.resolve(mockContext, optionsWithWhitespaceClientId)).rejects.toThrow(
+				IdentifierValidationError,
+			);
+		});
+
+		test('should reject empty clientSecret', async () => {
+			const optionsWithEmptyClientSecret = { ...validOptions, clientSecret: '' };
+
+			await expect(identifier.resolve(mockContext, optionsWithEmptyClientSecret)).rejects.toThrow(
+				IdentifierValidationError,
+			);
+		});
+
+		test('should reject whitespace-only clientSecret', async () => {
+			const optionsWithWhitespaceClientSecret = { ...validOptions, clientSecret: '   ' };
+
+			await expect(
+				identifier.resolve(mockContext, optionsWithWhitespaceClientSecret),
+			).rejects.toThrow(IdentifierValidationError);
+		});
+
+		test('should throw IdentifierValidationError when metadata URL is unreachable', async () => {
+			mockedAxios.get.mockRejectedValue(new Error('connect ECONNREFUSED 127.0.0.1:443'));
+
+			const error = await identifier.validateOptions(validOptions).catch((e) => e);
+			expect(error).toBeInstanceOf(IdentifierValidationError);
+			expect(error.message).toContain('Could not reach metadata URL');
+		});
+
+		test('should throw IdentifierValidationError on DNS resolution failure', async () => {
+			mockedAxios.get.mockRejectedValue(new Error('getaddrinfo ENOTFOUND auth.example.com'));
+
+			const error = await identifier.validateOptions(validOptions).catch((e) => e);
+			expect(error).toBeInstanceOf(IdentifierValidationError);
+			expect(error.message).toContain('Could not reach metadata URL');
+		});
+
+		test('should throw IdentifierValidationError on request timeout', async () => {
+			mockedAxios.get.mockRejectedValue(new Error('timeout of 10000ms exceeded'));
+
+			const error = await identifier.validateOptions(validOptions).catch((e) => e);
+			expect(error).toBeInstanceOf(IdentifierValidationError);
+			expect(error.message).toContain('Could not reach metadata URL');
+		});
+	});
+
 	describe('Edge Cases', () => {
 		test('should default to client_secret_basic when auth methods not specified', async () => {
 			const metadataWithoutAuthMethods = {

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-userinfo-identifier.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-userinfo-identifier.test.ts
@@ -136,6 +136,32 @@ describe('OAuth2UserInfoIdentifier', () => {
 		});
 	});
 
+	describe('Network Errors', () => {
+		test('should throw IdentifierValidationError when metadata URL is unreachable', async () => {
+			mockedAxios.get.mockRejectedValue(new Error('connect ECONNREFUSED 127.0.0.1:443'));
+
+			const error = await identifier.validateOptions(validOptions).catch((e) => e);
+			expect(error).toBeInstanceOf(IdentifierValidationError);
+			expect(error.message).toContain('Could not reach metadata URL');
+		});
+
+		test('should throw IdentifierValidationError on DNS resolution failure', async () => {
+			mockedAxios.get.mockRejectedValue(new Error('getaddrinfo ENOTFOUND auth.example.com'));
+
+			const error = await identifier.validateOptions(validOptions).catch((e) => e);
+			expect(error).toBeInstanceOf(IdentifierValidationError);
+			expect(error.message).toContain('Could not reach metadata URL');
+		});
+
+		test('should throw IdentifierValidationError on request timeout', async () => {
+			mockedAxios.get.mockRejectedValue(new Error('timeout of 10000ms exceeded'));
+
+			const error = await identifier.validateOptions(validOptions).catch((e) => e);
+			expect(error).toBeInstanceOf(IdentifierValidationError);
+			expect(error.message).toContain('Could not reach metadata URL');
+		});
+	});
+
 	describe('Critical Errors', () => {
 		test('should throw IdentifierValidationError for invalid options', async () => {
 			const invalidOptions = { metadataUri: 'not-a-url' };

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-introspection-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-introspection-identifier.ts
@@ -20,8 +20,8 @@ const METADATA_CACHE_TIMEOUT = 1 * Time.hours.toMilliseconds; // 1 hour
 export const OAuth2IntrospectionOptionsSchema = z.object({
 	...OAuth2OptionsSchema.shape,
 	validation: z.literal('oauth2-introspection'),
-	clientId: z.string().min(1, 'Client ID is required'),
-	clientSecret: z.string().min(1, 'Client Secret is required'),
+	clientId: z.string().trim().min(1, 'Client ID is required'),
+	clientSecret: z.string().trim().min(1, 'Client Secret is required'),
 });
 
 type OAuth2IntrospectionOptions = z.infer<typeof OAuth2IntrospectionOptionsSchema>;
@@ -144,10 +144,21 @@ export class OAuth2TokenIntrospectionIdentifier implements ITokenIdentifier {
 			}
 		}
 
-		const response = await axios.get(options.metadataUri, {
-			validateStatus: () => true,
-			timeout: 10 * Time.seconds.toMilliseconds,
-		});
+		let response;
+		try {
+			response = await axios.get(options.metadataUri, {
+				validateStatus: () => true,
+				timeout: 10 * Time.seconds.toMilliseconds,
+			});
+		} catch (error) {
+			this.logger.error(`Failed to reach OAuth2 metadata URL ${options.metadataUri}`, {
+				error,
+			});
+			throw new IdentifierValidationError(
+				`Could not reach metadata URL: ${error instanceof Error ? error.message : String(error)}`,
+				{ cause: error },
+			);
+		}
 
 		if (response.status !== 200) {
 			this.logger.error(

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-introspection-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-introspection-identifier.ts
@@ -69,7 +69,21 @@ export class OAuth2TokenIntrospectionIdentifier implements ITokenIdentifier {
 
 	async validateOptions(identifierOptions: Record<string, unknown>): Promise<void> {
 		const options = this.parseOptions(identifierOptions);
-		const metadata = await this.fetchMetadata(options, true);
+		let metadata;
+		try {
+			metadata = await this.fetchMetadata(options, true);
+		} catch (error) {
+			if (error instanceof IdentifierValidationError) {
+				throw error;
+			}
+			this.logger.error(`Failed to reach OAuth2 metadata URL ${options.metadataUri}`, {
+				error,
+			});
+			throw new IdentifierValidationError(
+				`Could not reach metadata URL: ${error instanceof Error ? error.message : String(error)}`,
+				{ cause: error },
+			);
+		}
 		if (!metadata.introspection_endpoint) {
 			this.logger.error('Metadata does not contain an introspection endpoint');
 			throw new IdentifierValidationError('Metadata does not contain an introspection endpoint');
@@ -144,21 +158,10 @@ export class OAuth2TokenIntrospectionIdentifier implements ITokenIdentifier {
 			}
 		}
 
-		let response;
-		try {
-			response = await axios.get(options.metadataUri, {
-				validateStatus: () => true,
-				timeout: 10 * Time.seconds.toMilliseconds,
-			});
-		} catch (error) {
-			this.logger.error(`Failed to reach OAuth2 metadata URL ${options.metadataUri}`, {
-				error,
-			});
-			throw new IdentifierValidationError(
-				`Could not reach metadata URL: ${error instanceof Error ? error.message : String(error)}`,
-				{ cause: error },
-			);
-		}
+		const response = await axios.get(options.metadataUri, {
+			validateStatus: () => true,
+			timeout: 10 * Time.seconds.toMilliseconds,
+		});
 
 		if (response.status !== 200) {
 			this.logger.error(

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-introspection-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-introspection-identifier.ts
@@ -20,8 +20,8 @@ const METADATA_CACHE_TIMEOUT = 1 * Time.hours.toMilliseconds; // 1 hour
 export const OAuth2IntrospectionOptionsSchema = z.object({
 	...OAuth2OptionsSchema.shape,
 	validation: z.literal('oauth2-introspection'),
-	clientId: z.string(),
-	clientSecret: z.string(),
+	clientId: z.string().min(1, 'Client ID is required'),
+	clientSecret: z.string().min(1, 'Client Secret is required'),
 });
 
 type OAuth2IntrospectionOptions = z.infer<typeof OAuth2IntrospectionOptionsSchema>;

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-userinfo-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-userinfo-identifier.ts
@@ -112,10 +112,21 @@ export class OAuth2UserInfoIdentifier implements ITokenIdentifier {
 			}
 		}
 
-		const response = await axios.get(options.metadataUri, {
-			validateStatus: () => true,
-			timeout: 10 * Time.seconds.toMilliseconds,
-		});
+		let response;
+		try {
+			response = await axios.get(options.metadataUri, {
+				validateStatus: () => true,
+				timeout: 10 * Time.seconds.toMilliseconds,
+			});
+		} catch (error) {
+			this.logger.error(`Failed to reach OAuth2 metadata URL ${options.metadataUri}`, {
+				error,
+			});
+			throw new IdentifierValidationError(
+				`Could not reach metadata URL: ${error instanceof Error ? error.message : String(error)}`,
+				{ cause: error },
+			);
+		}
 
 		if (response.status !== 200) {
 			this.logger.error(

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-userinfo-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-userinfo-identifier.ts
@@ -51,7 +51,21 @@ export class OAuth2UserInfoIdentifier implements ITokenIdentifier {
 
 	async validateOptions(identifierOptions: Record<string, unknown>): Promise<void> {
 		const options = this.parseOptions(identifierOptions);
-		const metadata = await this.fetchMetadata(options, true);
+		let metadata;
+		try {
+			metadata = await this.fetchMetadata(options, true);
+		} catch (error) {
+			if (error instanceof IdentifierValidationError) {
+				throw error;
+			}
+			this.logger.error(`Failed to reach OAuth2 metadata URL ${options.metadataUri}`, {
+				error,
+			});
+			throw new IdentifierValidationError(
+				`Could not reach metadata URL: ${error instanceof Error ? error.message : String(error)}`,
+				{ cause: error },
+			);
+		}
 		if (!metadata.userinfo_endpoint) {
 			this.logger.error('Metadata does not contain an userinfo endpoint');
 			throw new IdentifierValidationError('Metadata does not contain an userinfo endpoint');
@@ -112,21 +126,10 @@ export class OAuth2UserInfoIdentifier implements ITokenIdentifier {
 			}
 		}
 
-		let response;
-		try {
-			response = await axios.get(options.metadataUri, {
-				validateStatus: () => true,
-				timeout: 10 * Time.seconds.toMilliseconds,
-			});
-		} catch (error) {
-			this.logger.error(`Failed to reach OAuth2 metadata URL ${options.metadataUri}`, {
-				error,
-			});
-			throw new IdentifierValidationError(
-				`Could not reach metadata URL: ${error instanceof Error ? error.message : String(error)}`,
-				{ cause: error },
-			);
-		}
+		const response = await axios.get(options.metadataUri, {
+			validateStatus: () => true,
+			timeout: 10 * Time.seconds.toMilliseconds,
+		});
 
 		if (response.status !== 200) {
 			this.logger.error(


### PR DESCRIPTION

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Fixes validation error propagation for credential resolvers. IdentifierValidationError (e.g., unreachable metadata URL, missing introspection endpoint) was returning HTTP 500 instead of 400. 
Also adds min(1) validation on clientId and clientSecret for introspection mode.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/IAM-147

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
