### PR TITLE
fix(core): Old version of workflow still active after pulling [1.x]

### DIFF
--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
@@ -10,7 +10,9 @@ import {
 	type ProjectRepository,
 	type SharedWorkflowRepository,
 	User,
+	type UserRepository,
 	WorkflowEntity,
+	type WorkflowPublishHistoryRepository,
 	type WorkflowRepository,
 } from '@n8n/db';
 import { In } from '@n8n/typeorm';
@@ -28,6 +30,7 @@ import type { ExportableProject } from '../types/exportable-project';
 import { SourceControlContext } from '../types/source-control-context';
 
 import type { ActiveWorkflowManager } from '@/active-workflow-manager';
+import type { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
 
 jest.mock('fast-glob');
 
@@ -53,6 +56,9 @@ describe('SourceControlImportService', () => {
 	const variableService = mock<VariablesService>();
 	const variablesRepository = mock<VariablesRepository>();
 	const activeWorkflowManager = mock<ActiveWorkflowManager>();
+	const userRepository = mock<UserRepository>();
+	const workflowPublishHistoryRepository = mock<WorkflowPublishHistoryRepository>();
+	const workflowHistoryService = mock<WorkflowHistoryService>();
 	const service = new SourceControlImportService(
 		mockLogger,
 		mock(),
@@ -63,7 +69,7 @@ describe('SourceControlImportService', () => {
 		mock(),
 		sharedWorkflowRepository,
 		mock(),
-		mock(),
+		userRepository,
 		variablesRepository,
 		workflowRepository,
 		mock(),
@@ -73,8 +79,8 @@ describe('SourceControlImportService', () => {
 		folderRepository,
 		mock<InstanceSettings>({ n8nFolder: '/mock/n8n' }),
 		sourceControlScopedService,
-		mock(),
-		mock(),
+		workflowPublishHistoryRepository,
+		workflowHistoryService,
 	);
 
 	const globMock = fastGlob.default as unknown as jest.Mock<Promise<string[]>, string[]>;
@@ -356,7 +362,9 @@ describe('SourceControlImportService', () => {
 			const mockWorkflowData = {
 				id: 'workflow1',
 				name: 'Active Workflow',
+				versionId: 'version-123',
 				nodes: [],
+				connections: {},
 				parentFolderId: null,
 			};
 			const candidates = [mock<SourceControlledFile>({ file: mockWorkflowFile, id: 'workflow1' })];
@@ -379,6 +387,9 @@ describe('SourceControlImportService', () => {
 				generatedMaps: [],
 				raw: [],
 			});
+			workflowRepository.update.mockResolvedValue({ generatedMaps: [], raw: [], affected: 1 });
+			userRepository.findOne.mockResolvedValue(null);
+			workflowHistoryService.findVersion.mockResolvedValue(null);
 
 			fsReadFile.mockResolvedValue(JSON.stringify(mockWorkflowData));
 
@@ -449,7 +460,9 @@ describe('SourceControlImportService', () => {
 			const mockWorkflowData = {
 				id: 'workflow1',
 				name: 'Workflow with activation error',
+				versionId: 'version-123',
 				nodes: [],
+				connections: {},
 				parentFolderId: null,
 			};
 			const candidates = [mock<SourceControlledFile>({ file: mockWorkflowFile, id: 'workflow1' })];
@@ -490,6 +503,76 @@ describe('SourceControlImportService', () => {
 			expect(workflowRepository.update).toHaveBeenCalled();
 			expect(result).toEqual([{ id: 'workflow1', name: mockWorkflowFile }]);
 		});
+
+		it('should update activeVersionId to the pulled versionId when importing an active workflow', async () => {
+			const mockUserId = 'user-id-123';
+			const mockWorkflowFile = '/mock/workflow1.json';
+			const mockWorkflowData = {
+				id: 'workflow1',
+				name: 'Active Workflow',
+				versionId: 'new-version-id',
+				nodes: [],
+				connections: {},
+				parentFolderId: null,
+			};
+			const candidates = [mock<SourceControlledFile>({ file: mockWorkflowFile, id: 'workflow1' })];
+
+			workflowRepository.findByIds.mockResolvedValue([
+				Object.assign(new WorkflowEntity(), {
+					id: 'workflow1',
+					name: 'Active Workflow',
+					active: true,
+					activeVersionId: 'old-version-id',
+					versionId: 'old-version-id',
+				}),
+			]);
+
+			activeWorkflowManager.add.mockResolvedValue({ webhooks: false, triggersAndPollers: false });
+
+			fsReadFile.mockResolvedValue(JSON.stringify(mockWorkflowData));
+
+			await service.importWorkflowFromWorkFolder(candidates, mockUserId);
+
+			expect(workflowRepository.update).toHaveBeenCalledWith(
+				{ id: 'workflow1' },
+				expect.objectContaining({ activeVersionId: 'new-version-id' }),
+			);
+		});
+
+		it('should record workflowPublishHistory with the new versionId when reactivating a pulled workflow', async () => {
+			const mockUserId = 'user-id-123';
+			const mockWorkflowFile = '/mock/workflow1.json';
+			const mockWorkflowData = {
+				id: 'workflow1',
+				name: 'Active Workflow',
+				versionId: 'new-version-id',
+				nodes: [],
+				connections: {},
+				parentFolderId: null,
+			};
+			const candidates = [mock<SourceControlledFile>({ file: mockWorkflowFile, id: 'workflow1' })];
+
+			workflowRepository.findByIds.mockResolvedValue([
+				Object.assign(new WorkflowEntity(), {
+					id: 'workflow1',
+					name: 'Active Workflow',
+					active: true,
+					activeVersionId: 'old-version-id',
+					versionId: 'old-version-id',
+				}),
+			]);
+			activeWorkflowManager.add.mockResolvedValue({ webhooks: false, triggersAndPollers: false });
+
+			fsReadFile.mockResolvedValue(JSON.stringify(mockWorkflowData));
+
+			await service.importWorkflowFromWorkFolder(candidates, mockUserId);
+
+			expect(workflowPublishHistoryRepository.addRecord).toHaveBeenCalledWith(
+				expect.objectContaining({ versionId: 'new-version-id', event: 'activated' }),
+			);
+		});
+
+		// TODO: add test for new "Failed to create workflow history entry for new active version" error
 	});
 
 	describe('getRemoteCredentialsFromFiles', () => {

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
@@ -503,7 +503,7 @@ describe('SourceControlImportService', () => {
 			expect(result).toEqual([{ id: 'workflow1', name: mockWorkflowFile }]);
 		});
 
-		it('should update publish newly pulled version when importing an active workflow', async () => {
+		it('should publish newly pulled version when importing an active workflow', async () => {
 			const mockUserId = 'user-id-123';
 			const mockWorkflowFile = '/mock/workflow1.json';
 			const mockWorkflowData = {

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
@@ -500,11 +500,10 @@ describe('SourceControlImportService', () => {
 				'Failed to activate workflow workflow1',
 				expect.any(Object),
 			);
-			expect(workflowRepository.update).toHaveBeenCalled();
 			expect(result).toEqual([{ id: 'workflow1', name: mockWorkflowFile }]);
 		});
 
-		it('should update activeVersionId to the pulled versionId when importing an active workflow', async () => {
+		it('should update publish newly pulled version when importing an active workflow', async () => {
 			const mockUserId = 'user-id-123';
 			const mockWorkflowFile = '/mock/workflow1.json';
 			const mockWorkflowData = {
@@ -533,10 +532,21 @@ describe('SourceControlImportService', () => {
 
 			await service.importWorkflowFromWorkFolder(candidates, mockUserId);
 
-			expect(workflowRepository.update).toHaveBeenCalledWith(
-				{ id: 'workflow1' },
-				expect.objectContaining({ activeVersionId: 'new-version-id' }),
+			expect(workflowRepository.upsert).toHaveBeenCalledWith(
+				{
+					active: true,
+					activeVersionId: 'old-version-id',
+					connections: {},
+					id: 'workflow1',
+					name: 'Active Workflow',
+					nodes: [],
+					parentFolder: null,
+					parentFolderId: null,
+					versionId: 'new-version-id', // this is important, because updateActiveState will copy the versionId from the workflow entity to the activeVersionId column
+				},
+				['id'],
 			);
+			expect(workflowRepository.updateActiveState).toHaveBeenCalledWith('workflow1', true);
 		});
 
 		it('should record workflowPublishHistory with the new versionId when reactivating a pulled workflow', async () => {
@@ -571,8 +581,6 @@ describe('SourceControlImportService', () => {
 				expect.objectContaining({ versionId: 'new-version-id', event: 'activated' }),
 			);
 		});
-
-		// TODO: add test for new "Failed to create workflow history entry for new active version" error
 	});
 
 	describe('getRemoteCredentialsFromFiles', () => {

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
@@ -581,6 +581,51 @@ describe('SourceControlImportService', () => {
 				expect.objectContaining({ versionId: 'new-version-id', event: 'activated' }),
 			);
 		});
+
+		it('should call updateActiveState() before activeWorkflowManager.add() when reactivating a pulled workflow', async () => {
+			const mockUserId = 'user-id-123';
+			const mockWorkflowFile = '/mock/workflow1.json';
+			const mockWorkflowData = {
+				id: 'workflow1',
+				name: 'Active Workflow',
+				versionId: 'new-version-id',
+				nodes: [],
+				connections: {},
+				parentFolderId: null,
+			};
+			const candidates = [mock<SourceControlledFile>({ file: mockWorkflowFile, id: 'workflow1' })];
+
+			workflowRepository.findByIds.mockResolvedValue([
+				Object.assign(new WorkflowEntity(), {
+					id: 'workflow1',
+					name: 'Active Workflow',
+					active: true,
+					activeVersionId: 'old-version-id',
+					versionId: 'old-version-id',
+				}),
+			]);
+
+			// updateActiveState MUST be called before add() so that findById() inside
+			// add() sees the new activeVersionId and loads the correct WorkflowHistory
+			// for the cron/poll trigger closure. Cron triggers capture a snapshot of the
+			// workflow at activation time, unlike webhooks which re-fetch from DB on
+			// every incoming request.
+			workflowRepository.updateActiveState.mockResolvedValue({
+				generatedMaps: [],
+				raw: [],
+				affected: 1,
+			});
+			activeWorkflowManager.add.mockResolvedValue({ webhooks: false, triggersAndPollers: false });
+
+			fsReadFile.mockResolvedValue(JSON.stringify(mockWorkflowData));
+
+			await service.importWorkflowFromWorkFolder(candidates, mockUserId);
+
+			const updateActiveStateCallOrder =
+				workflowRepository.updateActiveState.mock.invocationCallOrder[0];
+			const addCallOrder = activeWorkflowManager.add.mock.invocationCallOrder[0];
+			expect(updateActiveStateCallOrder).toBeLessThan(addCallOrder);
+		});
 	});
 
 	describe('getRemoteCredentialsFromFiles', () => {

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -1292,7 +1292,7 @@ export class SourceControlImportService {
 	): Promise<void> {
 		if (!importedWorkflow.versionId || !importedWorkflow.nodes || !importedWorkflow.connections) {
 			this.logger.debug('Skipping workflow history - missing versionId, nodes, or connections');
-			return undefined;
+			return;
 		}
 
 		// Fetch user for author info

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -639,6 +639,7 @@ export class SourceControlImportService {
 		};
 	}
 
+	// eslint-disable-next-line complexity
 	async importWorkflowFromWorkFolder(candidates: SourceControlledFile[], userId: string) {
 		const personalProject = await this.projectRepository.getPersonalProjectForUserOrFail(userId);
 		const candidateIds = candidates.map((c) => c.id);
@@ -698,11 +699,12 @@ export class SourceControlImportService {
 			);
 			if (upsertResult?.identifiers?.length !== 1) {
 				throw new UnexpectedError('Failed to upsert workflow', {
+					// TODO: why is this nullish coalescing operator here, when importedWorkflows that don't have an id are skipped via "continue;" above?
 					extra: { workflowId: importedWorkflow.id ?? 'new' },
 				});
 			}
 
-			const savedVersionId = await this.saveOrUpdateWorkflowHistory(importedWorkflow, userId);
+			await this.saveOrUpdateWorkflowHistory(importedWorkflow, userId);
 			const localOwner = allSharedWorkflows.find(
 				(w) => w.workflowId === importedWorkflow.id && w.role === 'workflow:owner',
 			);
@@ -715,22 +717,32 @@ export class SourceControlImportService {
 				repository: this.sharedWorkflowRepository,
 			});
 
-			if (importedWorkflow.active && !savedVersionId) {
-				throw new UnexpectedError(
-					'Failed to create workflow history entry for new active version',
+			if (
+				importedWorkflow.active &&
+				existingWorkflow?.activeVersionId &&
+				importedWorkflow.versionId
+			) {
+				// Ensure the pulled version of a previously active version is now the active one
+				await this.activateImportedWorkflow(
 					{
-						extra: { workflowId: importedWorkflow.id ?? 'new' },
+						workflowId: importedWorkflow.id,
+						versionIdToActivate: importedWorkflow.versionId,
 					},
+					userId,
 				);
+			} else if (importedWorkflow.isArchived && existingWorkflow?.activeVersionId) {
+				await this.activeWorkflowManager.remove(existingWorkflow.id);
+				await this.workflowPublishHistoryRepository.addRecord({
+					workflowId: existingWorkflow.id,
+					versionId: existingWorkflow.activeVersionId,
+					event: 'deactivated',
+					userId,
+				});
+				await this.workflowRepository.updateActiveState(existingWorkflow.id, false);
 			}
 
-			await this.activateImportedWorkflowIfAlreadyActive(
-				{ existingWorkflow, importedWorkflow, versionIdToActivate: savedVersionId! },
-				userId,
-			);
-
 			importWorkflowsResult.push({
-				id: importedWorkflow.id ?? 'unknown',
+				id: importedWorkflow.id,
 				name: candidate.file,
 			});
 		}
@@ -754,49 +766,41 @@ export class SourceControlImportService {
 		}
 	}
 
-	private async activateImportedWorkflowIfAlreadyActive(
+	private async activateImportedWorkflow(
 		{
-			existingWorkflow,
-			importedWorkflow,
+			workflowId,
 			versionIdToActivate,
 		}: {
-			existingWorkflow?: WorkflowEntity;
-			importedWorkflow: IWorkflowToImport;
+			workflowId: string;
 			versionIdToActivate: string;
 		},
 		userId: string,
 	) {
-		if (!existingWorkflow?.activeVersionId) return;
-		let didAdd = false;
+		let didPublish = false;
 		try {
 			// remove active pre-import workflow
-			this.logger.debug(`Deactivating workflow id ${existingWorkflow.id}`);
-			await this.activeWorkflowManager.remove(existingWorkflow.id);
+			this.logger.debug(`Deactivating workflow id ${workflowId}`);
+			await this.activeWorkflowManager.remove(workflowId);
 
-			if (importedWorkflow.activeVersionId) {
+			if (versionIdToActivate) {
 				// try activating the imported workflow
-				this.logger.debug(`Reactivating workflow id ${existingWorkflow.id}`);
-				await this.activeWorkflowManager.add(existingWorkflow.id, 'activate');
-				didAdd = true;
+				this.logger.debug(`Reactivating workflow id ${workflowId}`);
+				await this.activeWorkflowManager.add(workflowId, 'activate');
+				didPublish = true;
 			}
 		} catch (e) {
 			const error = ensureError(e);
-			this.logger.error(`Failed to activate workflow ${existingWorkflow.id}`, { error });
+			this.logger.error(`Failed to activate workflow ${workflowId}`, { error });
 		} finally {
-			// update the versionId of the workflow to match the imported workflow
-			await this.workflowRepository.update(
-				{ id: existingWorkflow.id },
-				{
-					versionId: importedWorkflow.versionId,
-					...(didAdd ? { activeVersionId: versionIdToActivate } : {}),
-				},
-			);
-			await this.workflowPublishHistoryRepository.addRecord({
-				workflowId: existingWorkflow.id,
-				versionId: versionIdToActivate ?? existingWorkflow.activeVersionId,
-				event: didAdd ? 'activated' : 'deactivated',
-				userId,
-			});
+			if (didPublish) {
+				await this.workflowRepository.updateActiveState(workflowId, true);
+				await this.workflowPublishHistoryRepository.addRecord({
+					workflowId,
+					versionId: versionIdToActivate,
+					event: 'activated',
+					userId,
+				});
+			}
 		}
 	}
 
@@ -1277,14 +1281,14 @@ export class SourceControlImportService {
 
 	/**
 	 * Saves or updates workflow version history during import.
-	 * - If versionId is new: Creates new history record
+	 * - If versionId is new: Creates new history record using the versionId stored in the workflow json tracked in git
 	 * - If versionId exists with different nodes/connections: Updates existing record
 	 * - If versionId exists with same content: No action
 	 */
 	private async saveOrUpdateWorkflowHistory(
 		importedWorkflow: IWorkflowToImport,
 		userId: string,
-	): Promise<string | undefined> {
+	): Promise<void> {
 		if (!importedWorkflow.versionId || !importedWorkflow.nodes || !importedWorkflow.connections) {
 			this.logger.debug('Skipping workflow history - missing versionId, nodes, or connections');
 			return undefined;
@@ -1339,13 +1343,11 @@ export class SourceControlImportService {
 					importedWorkflow.id,
 				);
 			}
-			return importedWorkflow.versionId;
 		} catch (error) {
 			this.logger.error(
 				`Failed to save/update workflow history for workflow ${importedWorkflow.id}`,
 				{ error: ensureError(error) },
 			);
-			return undefined;
 		}
 	}
 }

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -1345,6 +1345,7 @@ export class SourceControlImportService {
 				);
 			}
 		} catch (error) {
+			// TODO: this error should be communicated to the user directly, rather than just being logged
 			this.logger.error(
 				`Failed to save/update workflow history for workflow ${importedWorkflow.id}`,
 				{ error: ensureError(error) },

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -6,7 +6,6 @@ import type {
 	TagEntity,
 	User,
 	Variables,
-	WorkflowEntity,
 	WorkflowTagMapping,
 } from '@n8n/db';
 import {
@@ -782,19 +781,17 @@ export class SourceControlImportService {
 			this.logger.debug(`Deactivating workflow id ${workflowId}`);
 			await this.activeWorkflowManager.remove(workflowId);
 
-			if (versionIdToActivate) {
-				// try activating the imported workflow
-				this.logger.debug(`Reactivating workflow id ${workflowId}`);
-				await this.activeWorkflowManager.add(workflowId, 'activate');
-				didPublish = true;
-			}
+			// try activating the imported workflow
+			this.logger.debug(`Reactivating workflow id ${workflowId}`);
+			await this.workflowRepository.updateActiveState(workflowId, true);
+			await this.activeWorkflowManager.add(workflowId, 'activate');
+			didPublish = true;
 		} catch (e) {
 			// TODO: this operation failing should be told to the user in the app, rather than just being logged
 			const error = ensureError(e);
 			this.logger.error(`Failed to activate workflow ${workflowId}`, { error });
 		} finally {
 			if (didPublish) {
-				await this.workflowRepository.updateActiveState(workflowId, true);
 				await this.workflowPublishHistoryRepository.addRecord({
 					workflowId,
 					versionId: versionIdToActivate,

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -789,6 +789,7 @@ export class SourceControlImportService {
 				didPublish = true;
 			}
 		} catch (e) {
+			// TODO: this operation failing should be told to the user in the app, rather than just being logged
 			const error = ensureError(e);
 			this.logger.error(`Failed to activate workflow ${workflowId}`, { error });
 		} finally {

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -702,8 +702,7 @@ export class SourceControlImportService {
 				});
 			}
 
-			await this.saveOrUpdateWorkflowHistory(importedWorkflow, userId);
-
+			const savedVersionId = await this.saveOrUpdateWorkflowHistory(importedWorkflow, userId);
 			const localOwner = allSharedWorkflows.find(
 				(w) => w.workflowId === importedWorkflow.id && w.role === 'workflow:owner',
 			);
@@ -716,8 +715,17 @@ export class SourceControlImportService {
 				repository: this.sharedWorkflowRepository,
 			});
 
+			if (importedWorkflow.active && !savedVersionId) {
+				throw new UnexpectedError(
+					'Failed to create workflow history entry for new active version',
+					{
+						extra: { workflowId: importedWorkflow.id ?? 'new' },
+					},
+				);
+			}
+
 			await this.activateImportedWorkflowIfAlreadyActive(
-				{ existingWorkflow, importedWorkflow },
+				{ existingWorkflow, importedWorkflow, versionIdToActivate: savedVersionId! },
 				userId,
 			);
 
@@ -750,9 +758,11 @@ export class SourceControlImportService {
 		{
 			existingWorkflow,
 			importedWorkflow,
+			versionIdToActivate,
 		}: {
 			existingWorkflow?: WorkflowEntity;
 			importedWorkflow: IWorkflowToImport;
+			versionIdToActivate: string;
 		},
 		userId: string,
 	) {
@@ -776,23 +786,17 @@ export class SourceControlImportService {
 			// update the versionId of the workflow to match the imported workflow
 			await this.workflowRepository.update(
 				{ id: existingWorkflow.id },
-				{ versionId: importedWorkflow.versionId },
+				{
+					versionId: importedWorkflow.versionId,
+					...(didAdd ? { activeVersionId: versionIdToActivate } : {}),
+				},
 			);
-			if (didAdd) {
-				await this.workflowPublishHistoryRepository.addRecord({
-					workflowId: existingWorkflow.id,
-					versionId: existingWorkflow.activeVersionId,
-					event: 'activated',
-					userId,
-				});
-			} else {
-				await this.workflowPublishHistoryRepository.addRecord({
-					workflowId: existingWorkflow.id,
-					versionId: existingWorkflow.activeVersionId,
-					event: 'deactivated',
-					userId,
-				});
-			}
+			await this.workflowPublishHistoryRepository.addRecord({
+				workflowId: existingWorkflow.id,
+				versionId: versionIdToActivate ?? existingWorkflow.activeVersionId,
+				event: didAdd ? 'activated' : 'deactivated',
+				userId,
+			});
 		}
 	}
 
@@ -1280,10 +1284,10 @@ export class SourceControlImportService {
 	private async saveOrUpdateWorkflowHistory(
 		importedWorkflow: IWorkflowToImport,
 		userId: string,
-	): Promise<void> {
+	): Promise<string | undefined> {
 		if (!importedWorkflow.versionId || !importedWorkflow.nodes || !importedWorkflow.connections) {
 			this.logger.debug('Skipping workflow history - missing versionId, nodes, or connections');
-			return;
+			return undefined;
 		}
 
 		// Fetch user for author info
@@ -1335,11 +1339,13 @@ export class SourceControlImportService {
 					importedWorkflow.id,
 				);
 			}
+			return importedWorkflow.versionId;
 		} catch (error) {
 			this.logger.error(
 				`Failed to save/update workflow history for workflow ${importedWorkflow.id}`,
 				{ error: ensureError(error) },
 			);
+			return undefined;
 		}
 	}
 }


### PR DESCRIPTION


## Summary

Hint to reviewer: This PR is deployed to two test instances (for positive test) as well as one test instance with the latest state of 1.x (for negative test).
See this slack message for more details: https://n8nio.slack.com/archives/C0A9PM073QW/p1773822807520939

This PR targets 1.x only, it is not needed for 2.x.

Fixes a regression on the environments feature introduced in https://github.com/n8n-io/n8n/pull/21202/ (v 1.122.2)

Video demo of the unexpected behaviour: https://www.loom.com/share/4e3efc2aa6934399bb2d4ffe4b80a83c

In the 1.x world, where a workflow can either by active or inactive, pulling a new version of an active workflow used to have that new version be the new active one.
PR #21202 (linked above) resulted in the new version being pulled, but the old version of the workflow being the one that was still active. As a 1.x user, I have no easy way to detect that my active workflow is actually using an older version for production executions.

The only known workaround is to deactivate and activate an active workflow after pulling.

**For a follow-up:** Should we build the means to inform admins of n8n instances using versions 1.122.2 to 1.123.25 that they have active workflows where the active version is not the latest version of the workflow, and provide them with an API to set the `activeVersionId` of all diverged active workflows to the latest version of each workflow?


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-331/be-environments-pulled-active-workflow-on-1x-will-keep-executing-older


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
