### PR TITLE
feat(core): Add server-side search, pagination, and filtering to GET /projects

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -39,6 +39,7 @@ export { UpdateProjectDto, UpdateProjectWithRelationsDto } from './project/updat
 export { DeleteProjectDto } from './project/delete-project.dto';
 export { AddUsersToProjectDto } from './project/add-users-to-project.dto';
 export { ChangeUserRoleInProject } from './project/change-user-role-in-project.dto';
+export { ListProjectsQueryDto } from './project/list-projects-query.dto';
 
 export { SamlAcsDto } from './saml/saml-acs.dto';
 export { SamlPreferences } from './saml/saml-preferences.dto';

--- a/packages/@n8n/api-types/src/dto/project/__tests__/list-projects-query.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/project/__tests__/list-projects-query.dto.test.ts
@@ -6,7 +6,7 @@ describe('ListProjectsQueryDto', () => {
 			{
 				name: 'no parameters (defaults)',
 				request: {},
-				expected: { skip: 0 },
+				expected: {},
 			},
 			{
 				name: 'with skip and take',
@@ -16,27 +16,27 @@ describe('ListProjectsQueryDto', () => {
 			{
 				name: 'with search',
 				request: { search: ' my project ' },
-				expected: { skip: 0, search: 'my project' },
+				expected: { search: 'my project' },
 			},
 			{
 				name: 'with type personal',
 				request: { type: 'personal' },
-				expected: { skip: 0, type: 'personal' },
+				expected: { type: 'personal' },
 			},
 			{
 				name: 'with type team',
 				request: { type: 'team' },
-				expected: { skip: 0, type: 'team' },
+				expected: { type: 'team' },
 			},
 			{
 				name: 'with activated true',
 				request: { activated: 'true' },
-				expected: { skip: 0, activated: true },
+				expected: { activated: true },
 			},
 			{
 				name: 'with activated false',
 				request: { activated: 'false' },
-				expected: { skip: 0, activated: false },
+				expected: { activated: false },
 			},
 			{
 				name: 'with all parameters',
@@ -64,6 +64,14 @@ describe('ListProjectsQueryDto', () => {
 			expect(result.success).toBe(true);
 			if (result.success) {
 				expect(result.data.take).toBeUndefined();
+			}
+		});
+
+		it('should default skip to undefined when not provided', () => {
+			const result = ListProjectsQueryDto.safeParse({});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.skip).toBeUndefined();
 			}
 		});
 	});

--- a/packages/@n8n/api-types/src/dto/project/__tests__/list-projects-query.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/project/__tests__/list-projects-query.dto.test.ts
@@ -1,0 +1,106 @@
+import { ListProjectsQueryDto } from '../list-projects-query.dto';
+
+describe('ListProjectsQueryDto', () => {
+	describe('Valid requests', () => {
+		test.each([
+			{
+				name: 'no parameters (defaults)',
+				request: {},
+				expected: { skip: 0 },
+			},
+			{
+				name: 'with skip and take',
+				request: { skip: '10', take: '5' },
+				expected: { skip: 10, take: 5 },
+			},
+			{
+				name: 'with search',
+				request: { search: ' my project ' },
+				expected: { skip: 0, search: 'my project' },
+			},
+			{
+				name: 'with type personal',
+				request: { type: 'personal' },
+				expected: { skip: 0, type: 'personal' },
+			},
+			{
+				name: 'with type team',
+				request: { type: 'team' },
+				expected: { skip: 0, type: 'team' },
+			},
+			{
+				name: 'with activated true',
+				request: { activated: 'true' },
+				expected: { skip: 0, activated: true },
+			},
+			{
+				name: 'with activated false',
+				request: { activated: 'false' },
+				expected: { skip: 0, activated: false },
+			},
+			{
+				name: 'with all parameters',
+				request: { skip: '20', take: '10', search: 'test', type: 'team', activated: 'true' },
+				expected: { skip: 20, take: 10, search: 'test', type: 'team', activated: true },
+			},
+		])('should validate $name', ({ request, expected }) => {
+			const result = ListProjectsQueryDto.safeParse(request);
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data).toMatchObject(expected);
+			}
+		});
+
+		it('should cap take at 250', () => {
+			const result = ListProjectsQueryDto.safeParse({ take: '999' });
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.take).toBe(250);
+			}
+		});
+
+		it('should default take to undefined when not provided', () => {
+			const result = ListProjectsQueryDto.safeParse({});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.take).toBeUndefined();
+			}
+		});
+	});
+
+	describe('Invalid requests', () => {
+		test.each([
+			{
+				name: 'invalid type',
+				request: { type: 'invalid' },
+				expectedErrorPath: ['type'],
+			},
+			{
+				name: 'negative skip',
+				request: { skip: '-1' },
+				expectedErrorPath: ['skip'],
+			},
+			{
+				name: 'non-integer skip',
+				request: { skip: 'abc' },
+				expectedErrorPath: ['skip'],
+			},
+			{
+				name: 'negative take',
+				request: { take: '-1' },
+				expectedErrorPath: ['take'],
+			},
+			{
+				name: 'non-integer take',
+				request: { take: 'abc' },
+				expectedErrorPath: ['take'],
+			},
+		])('should fail validation for $name', ({ request, expectedErrorPath }) => {
+			const result = ListProjectsQueryDto.safeParse(request);
+			expect(result.success).toBe(false);
+			if (expectedErrorPath) {
+				expect(result.error?.issues[0].path).toEqual(expectedErrorPath);
+			}
+		});
+	});
+});

--- a/packages/@n8n/api-types/src/dto/project/list-projects-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/project/list-projects-query.dto.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+import { MAX_ITEMS_PER_PAGE, paginationSchema } from '../pagination/pagination.dto';
+
+const searchValidator = z.string().trim().optional();
+
+const typeValidator = z.enum(['personal', 'team']).optional();
+
+const activatedValidator = z
+	.enum(['true', 'false'])
+	.optional()
+	.transform((val) => (val === undefined ? undefined : val === 'true'));
+
+// Custom take validator that defaults to undefined (no limit) for backward
+// compatibility — existing callers that omit `take` receive all projects.
+// When provided, the value is capped at MAX_ITEMS_PER_PAGE.
+const takeValidator = z
+	.string()
+	.optional()
+	.transform((val) => (val ? parseInt(val, 10) : undefined))
+	.refine((val) => val === undefined || (!isNaN(val) && Number.isInteger(val)), {
+		message: 'Param `take` must be a valid integer',
+	})
+	.refine((val) => val === undefined || val >= 0, {
+		message: 'Param `take` must be a non-negative integer',
+	})
+	.transform((val) => (val !== undefined ? Math.min(val, MAX_ITEMS_PER_PAGE) : undefined));
+
+export class ListProjectsQueryDto extends Z.class({
+	...paginationSchema,
+	take: takeValidator,
+	search: searchValidator,
+	type: typeValidator,
+	activated: activatedValidator,
+}) {}

--- a/packages/@n8n/api-types/src/dto/project/list-projects-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/project/list-projects-query.dto.ts
@@ -1,9 +1,22 @@
 import { z } from 'zod';
 
 import { Z } from '../../zod-class';
-import { MAX_ITEMS_PER_PAGE, paginationSchema } from '../pagination/pagination.dto';
+import { MAX_ITEMS_PER_PAGE } from '../pagination/pagination.dto';
 
 const searchValidator = z.string().trim().optional();
+
+// Custom skip validator that defaults to undefined (not 0) for backward
+// compatibility — existing callers that omit pagination params receive a bare array.
+const skipValidator = z
+	.string()
+	.optional()
+	.transform((val) => (val ? parseInt(val, 10) : undefined))
+	.refine((val) => val === undefined || (!isNaN(val) && Number.isInteger(val)), {
+		message: 'Param `skip` must be a valid integer',
+	})
+	.refine((val) => val === undefined || val >= 0, {
+		message: 'Param `skip` must be a non-negative integer',
+	});
 
 const typeValidator = z.enum(['personal', 'team']).optional();
 
@@ -28,7 +41,7 @@ const takeValidator = z
 	.transform((val) => (val !== undefined ? Math.min(val, MAX_ITEMS_PER_PAGE) : undefined));
 
 export class ListProjectsQueryDto extends Z.class({
-	...paginationSchema,
+	skip: skipValidator,
 	take: takeValidator,
 	search: searchValidator,
 	type: typeValidator,

--- a/packages/@n8n/db/src/repositories/index.ts
+++ b/packages/@n8n/db/src/repositories/index.ts
@@ -19,7 +19,7 @@ export { ScopeRepository } from './scope.repository';
 export { InvalidAuthTokenRepository } from './invalid-auth-token.repository';
 export { LicenseMetricsRepository } from './license-metrics.repository';
 export { ProjectRelationRepository } from './project-relation.repository';
-export { ProjectRepository } from './project.repository';
+export { ProjectRepository, type ProjectListOptions } from './project.repository';
 export { RoleRepository } from './role.repository';
 export { ProcessedDataRepository } from './processed-data.repository';
 export { SettingsRepository } from './settings.repository';

--- a/packages/@n8n/db/src/repositories/project.repository.ts
+++ b/packages/@n8n/db/src/repositories/project.repository.ts
@@ -1,6 +1,6 @@
 import { Service } from '@n8n/di';
-import type { EntityManager } from '@n8n/typeorm';
-import { DataSource, Repository } from '@n8n/typeorm';
+import type { EntityManager, SelectQueryBuilder } from '@n8n/typeorm';
+import { Brackets, DataSource, Repository } from '@n8n/typeorm';
 
 import { Project } from '../entities';
 
@@ -47,10 +47,123 @@ export class ProjectRepository extends Repository<Project> {
 		});
 	}
 
+	async findAllProjectsAndCount(options: ProjectListOptions): Promise<[Project[], number]> {
+		const query = this.createQueryBuilder('project').leftJoin('project.creator', 'creator');
+
+		this.applyFilters(query, options);
+		this.applyActivationOrder(query);
+		this.applyPagination(query, options);
+
+		return await query.getManyAndCount();
+	}
+
+	async getAccessibleProjectsAndCount(
+		userId: string,
+		options: ProjectListOptions,
+	): Promise<[Project[], number]> {
+		// Build a subquery that finds the IDs of accessible projects, avoiding
+		// duplicate rows from the LEFT JOIN on projectRelations which would
+		// produce incorrect counts with getManyAndCount().
+		const idsQuery = this.createQueryBuilder('p')
+			.select('DISTINCT p.id', 'id')
+			.leftJoin('p.projectRelations', 'pr')
+			.where(
+				new Brackets((qb) => {
+					qb.where('p.type = :personalType', { personalType: 'personal' }).orWhere(
+						'pr.userId = :userId',
+						{ userId },
+					);
+				}),
+			);
+
+		if (options.search) {
+			idsQuery.andWhere('LOWER(p.name) LIKE LOWER(:search)', {
+				search: `%${options.search}%`,
+			});
+		}
+
+		if (options.type) {
+			idsQuery.andWhere('p.type = :type', { type: options.type });
+		}
+
+		if (options.activated === true) {
+			idsQuery.leftJoin('p.creator', 'creator').andWhere(
+				new Brackets((qb) => {
+					qb.where('p.type != :personalTypeFilter', {
+						personalTypeFilter: 'personal',
+					}).orWhere('creator.password IS NOT NULL');
+				}),
+			);
+		}
+
+		const query = this.createQueryBuilder('project')
+			.leftJoin('project.creator', 'creator')
+			.where(`project.id IN (${idsQuery.getQuery()})`);
+		query.setParameters(idsQuery.getParameters());
+
+		// Sort: team projects first, then activated personal projects, then pending ones
+		this.applyActivationOrder(query);
+		this.applyPagination(query, options);
+
+		return await query.getManyAndCount();
+	}
+
+	private applyFilters(query: SelectQueryBuilder<Project>, options: ProjectListOptions): void {
+		if (options.search) {
+			query.andWhere('LOWER(project.name) LIKE LOWER(:search)', {
+				search: `%${options.search}%`,
+			});
+		}
+
+		if (options.type) {
+			query.andWhere('project.type = :type', { type: options.type });
+		}
+
+		if (options.activated === true) {
+			query.andWhere(
+				new Brackets((qb) => {
+					qb.where('project.type != :personalTypeFilter', {
+						personalTypeFilter: 'personal',
+					}).orWhere('creator.password IS NOT NULL');
+				}),
+			);
+		}
+	}
+
+	/**
+	 * Sort: team projects first, then activated personal projects, then pending ones.
+	 * Uses addSelect + alias so TypeORM doesn't try to parse the CASE as a property path.
+	 * The `creator` relation must already be joined on the query.
+	 */
+	private applyActivationOrder(query: SelectQueryBuilder<Project>): void {
+		query
+			.addSelect(
+				"CASE WHEN project.type != 'personal' THEN 0 WHEN creator.password IS NOT NULL THEN 1 ELSE 2 END",
+				'activation_order',
+			)
+			.orderBy('activation_order', 'ASC')
+			.addOrderBy('project.name', 'ASC');
+	}
+
+	private applyPagination(query: SelectQueryBuilder<Project>, options: ProjectListOptions): void {
+		query.skip(options.skip ?? 0);
+		if (options.take !== undefined) {
+			query.take(options.take);
+		}
+	}
+
 	async getProjectCounts() {
 		return {
 			personal: await this.count({ where: { type: 'personal' } }),
 			team: await this.count({ where: { type: 'team' } }),
 		};
 	}
+}
+
+export interface ProjectListOptions {
+	skip?: number;
+	take?: number;
+	search?: string;
+	type?: 'personal' | 'team';
+	activated?: boolean;
 }

--- a/packages/cli/src/controllers/__tests__/project.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/project.controller.test.ts
@@ -1,4 +1,5 @@
 import type { AuthenticatedRequest, ProjectRepository } from '@n8n/db';
+import { ListProjectsQueryDto } from '@n8n/api-types';
 import { mock } from 'jest-mock-extended';
 
 import type { EventService } from '@/events/event.service';
@@ -59,11 +60,14 @@ describe('ProjectController', () => {
 			(projectsService.getAccessibleProjectsAndCount as jest.Mock).mockResolvedValue([projects, 1]);
 
 			const res = makeRes();
-			const query = {};
+			// Simulate DTO-parsed output: when no query params are provided,
+			// both skip and take must default to undefined for backward compat.
+			const parsed = ListProjectsQueryDto.safeParse({});
+			expect(parsed.success).toBe(true);
+			const query = parsed.data!;
 
-			const result = await controller.getAllProjects(req, res, query as any);
+			const result = await controller.getAllProjects(req, res, query);
 
-			expect(projectsService.getAccessibleProjectsAndCount).toHaveBeenCalledWith(req.user, query);
 			expect(res.json).not.toHaveBeenCalled();
 			expect(result).toEqual(projects);
 		});

--- a/packages/cli/src/controllers/__tests__/project.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/project.controller.test.ts
@@ -7,7 +7,7 @@ import { ProjectController } from '@/controllers/project.controller';
 import type { ProjectService } from '@/services/project.service.ee';
 import type { UserManagementMailer } from '@/user-management/email';
 
-describe('ProjectController (members endpoints)', () => {
+describe('ProjectController', () => {
 	const eventService = mock<EventService>();
 	const projectsService = mock<ProjectService>();
 	const projectRepository = mock<ProjectRepository>();
@@ -35,6 +35,38 @@ describe('ProjectController (members endpoints)', () => {
 
 	beforeEach(() => {
 		jest.resetAllMocks();
+	});
+
+	describe('getAllProjects', () => {
+		it('calls service with query options and returns { count, data }', async () => {
+			const projects = [
+				{ id: 'p1', name: 'Project 1' },
+				{ id: 'p2', name: 'Project 2' },
+			];
+			(projectsService.getAccessibleProjectsAndCount as jest.Mock).mockResolvedValue([projects, 2]);
+
+			const res = makeRes();
+			const query = { skip: 0, take: 10, search: 'test', type: 'team' as const };
+
+			await controller.getAllProjects(req, res, query as any);
+
+			expect(projectsService.getAccessibleProjectsAndCount).toHaveBeenCalledWith(req.user, query);
+			expect(res.json).toHaveBeenCalledWith({ count: 2, data: projects });
+		});
+
+		it('returns bare array when no pagination params given', async () => {
+			const projects = [{ id: 'p1', name: 'Project 1' }];
+			(projectsService.getAccessibleProjectsAndCount as jest.Mock).mockResolvedValue([projects, 1]);
+
+			const res = makeRes();
+			const query = {};
+
+			const result = await controller.getAllProjects(req, res, query as any);
+
+			expect(projectsService.getAccessibleProjectsAndCount).toHaveBeenCalledWith(req.user, query);
+			expect(res.json).not.toHaveBeenCalled();
+			expect(result).toEqual(projects);
+		});
 	});
 
 	it('emits team-project-updated with full members list on addProjectUsers', async () => {

--- a/packages/cli/src/controllers/project.controller.ts
+++ b/packages/cli/src/controllers/project.controller.ts
@@ -4,8 +4,8 @@ import {
 	UpdateProjectDto,
 	AddUsersToProjectDto,
 	ChangeUserRoleInProject,
+	ListProjectsQueryDto,
 } from '@n8n/api-types';
-import type { Project } from '@n8n/db';
 import { AuthenticatedRequest, ProjectRepository } from '@n8n/db';
 import {
 	Get,
@@ -47,8 +47,22 @@ export class ProjectController {
 	) {}
 
 	@Get('/')
-	async getAllProjects(req: AuthenticatedRequest): Promise<Project[]> {
-		return await this.projectsService.getAccessibleProjects(req.user);
+	async getAllProjects(
+		req: AuthenticatedRequest,
+		res: Response,
+		@Query payload: ListProjectsQueryDto,
+	) {
+		const [data, count] = await this.projectsService.getAccessibleProjectsAndCount(
+			req.user,
+			payload,
+		);
+
+		// When pagination params are provided, return { count, data } envelope.
+		// Otherwise return a bare array for backward compatibility with existing callers.
+		if (payload.take !== undefined || payload.skip !== undefined) {
+			return res.json({ count, data });
+		}
+		return data;
 	}
 
 	@Get('/count')

--- a/packages/cli/src/services/__tests__/project.service.ee.test.ts
+++ b/packages/cli/src/services/__tests__/project.service.ee.test.ts
@@ -32,6 +32,47 @@ describe('ProjectService', () => {
 		moduleRegistry,
 	);
 
+	describe('getAccessibleProjectsAndCount', () => {
+		const options = { skip: 0, take: 10, search: 'test' };
+
+		beforeEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it('should call findAllProjectsAndCount for admin users', async () => {
+			const adminUser = {
+				id: 'admin-user',
+				role: { scopes: [{ slug: 'project:read' }] },
+			} as any;
+
+			const expected: [Project[], number] = [[mock<Project>({ id: 'p1', name: 'Project 1' })], 1];
+			projectRepository.findAllProjectsAndCount.mockResolvedValueOnce(expected);
+
+			const result = await projectService.getAccessibleProjectsAndCount(adminUser, options);
+
+			expect(projectRepository.findAllProjectsAndCount).toHaveBeenCalledWith(options);
+			expect(result).toEqual(expected);
+		});
+
+		it('should call getAccessibleProjectsAndCount for non-admin users', async () => {
+			const memberUser = {
+				id: 'member-user',
+				role: { scopes: [] },
+			} as any;
+
+			const expected: [Project[], number] = [[mock<Project>({ id: 'p2', name: 'Project 2' })], 1];
+			projectRepository.getAccessibleProjectsAndCount.mockResolvedValueOnce(expected);
+
+			const result = await projectService.getAccessibleProjectsAndCount(memberUser, options);
+
+			expect(projectRepository.getAccessibleProjectsAndCount).toHaveBeenCalledWith(
+				'member-user',
+				options,
+			);
+			expect(result).toEqual(expected);
+		});
+	});
+
 	describe('addUsersToProject', () => {
 		it('throws if called with a personal project', async () => {
 			// ARRANGE

--- a/packages/cli/src/services/project.service.ee.ts
+++ b/packages/cli/src/services/project.service.ee.ts
@@ -1,14 +1,15 @@
 import type { CreateProjectDto, ProjectType, UpdateProjectDto } from '@n8n/api-types';
 import { LicenseState, ModuleRegistry } from '@n8n/backend-common';
 import { UNLIMITED_LICENSE_QUOTA } from '@n8n/constants';
-import type { User } from '@n8n/db';
 import {
+	type User,
 	Project,
 	ProjectRelation,
 	ProjectRelationRepository,
 	ProjectRepository,
 	SharedCredentialsRepository,
 	SharedWorkflowRepository,
+	type ProjectListOptions,
 } from '@n8n/db';
 import { Container, Service } from '@n8n/di';
 import {
@@ -212,6 +213,16 @@ export class ProjectService {
 			return await this.projectRepository.find();
 		}
 		return await this.projectRepository.getAccessibleProjects(user.id);
+	}
+
+	async getAccessibleProjectsAndCount(
+		user: User,
+		options: ProjectListOptions,
+	): Promise<[Project[], number]> {
+		if (hasGlobalScope(user, 'project:read')) {
+			return await this.projectRepository.findAllProjectsAndCount(options);
+		}
+		return await this.projectRepository.getAccessibleProjectsAndCount(user.id, options);
 	}
 
 	async getPersonalProjectOwners(projectIds: string[]): Promise<ProjectRelation[]> {

--- a/packages/cli/test/integration/database/repositories/project.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/project.repository.test.ts
@@ -283,20 +283,27 @@ describe('ProjectRepository', () => {
 			expect(projects[0].name).toBe('Alpha Project');
 		});
 
-		it('does not produce duplicate rows from multiple project relations', async () => {
+		it('does not produce duplicate rows when project matches multiple OR branches', async () => {
 			const owner = await createOwner();
 			const member = await createMember();
 
-			// Member has a relation to the team project (via linkUserToProject)
-			// This tests that the subquery deduplicates correctly
+			// Every user's personal project is visible via `p.type = 'personal'`.
+			// The member also has a projectRelation to their own personal project
+			// (as personal owner). Without DISTINCT, the LEFT JOIN + OR would
+			// produce the personal project twice: once via the type branch and
+			// once via the relation branch.
 			const team = await createTeamProject('Shared Team', owner);
 			await linkUserToProject(member, team, 'project:editor');
 
 			const repo = Container.get(ProjectRepository);
 			const [projects, count] = await repo.getAccessibleProjectsAndCount(member.id, {});
 
-			const teamOccurrences = projects.filter((p) => p.name === 'Shared Team');
-			expect(teamOccurrences).toHaveLength(1);
+			// member's personal project should appear exactly once despite
+			// matching both OR branches (type=personal AND pr.userId=member)
+			const memberPersonalProjects = projects.filter(
+				(p) => p.type === 'personal' && p.creatorId === member.id,
+			);
+			expect(memberPersonalProjects).toHaveLength(1);
 			expect(count).toBe(projects.length);
 		});
 

--- a/packages/cli/test/integration/database/repositories/project.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/project.repository.test.ts
@@ -1,9 +1,9 @@
-import { createTeamProject, testDb } from '@n8n/backend-test-utils';
-import { AuthIdentity, ProjectRepository, UserRepository } from '@n8n/db';
+import { createTeamProject, linkUserToProject, testDb } from '@n8n/backend-test-utils';
+import { AuthIdentity, GLOBAL_MEMBER_ROLE, ProjectRepository, UserRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { EntityNotFoundError } from '@n8n/typeorm';
 
-import { createMember, createOwner } from '../../shared/db/users';
+import { createMember, createOwner, createUserShell } from '../../shared/db/users';
 
 describe('ProjectRepository', () => {
 	beforeAll(async () => {
@@ -111,6 +111,230 @@ describe('ProjectRepository', () => {
 			// ASSERT
 			//
 			await expect(promise).rejects.toThrowError(EntityNotFoundError);
+		});
+	});
+
+	describe('findAllProjectsAndCount', () => {
+		it('returns all projects with count', async () => {
+			const owner = await createOwner();
+			await createTeamProject('Alpha', owner);
+			await createTeamProject('Beta', owner);
+			await createTeamProject('Gamma', owner);
+
+			const repo = Container.get(ProjectRepository);
+			const [projects, count] = await repo.findAllProjectsAndCount({});
+
+			// 3 team projects + 1 personal project for the owner
+			expect(count).toBe(4);
+			expect(projects).toHaveLength(4);
+		});
+
+		it('paginates results', async () => {
+			const owner = await createOwner();
+			for (let i = 0; i < 5; i++) {
+				await createTeamProject(`Project ${i}`, owner);
+			}
+
+			const repo = Container.get(ProjectRepository);
+			const [page, count] = await repo.findAllProjectsAndCount({ skip: 0, take: 2 });
+
+			expect(count).toBe(6); // 5 team + 1 personal
+			expect(page).toHaveLength(2);
+		});
+
+		it('filters by search', async () => {
+			const owner = await createOwner();
+			await createTeamProject('Marketing Campaign', owner);
+			await createTeamProject('Engineering Sprint', owner);
+			await createTeamProject('Marketing Report', owner);
+
+			const repo = Container.get(ProjectRepository);
+			const [projects, count] = await repo.findAllProjectsAndCount({ search: 'Marketing' });
+
+			expect(count).toBe(2);
+			expect(projects).toHaveLength(2);
+			expect(projects.every((p) => p.name.includes('Marketing'))).toBe(true);
+		});
+
+		it('filters by type', async () => {
+			const owner = await createOwner();
+			await createTeamProject('Team One', owner);
+			await createTeamProject('Team Two', owner);
+
+			const repo = Container.get(ProjectRepository);
+			const [teamProjects, teamCount] = await repo.findAllProjectsAndCount({ type: 'team' });
+			const [personalProjects, personalCount] = await repo.findAllProjectsAndCount({
+				type: 'personal',
+			});
+
+			expect(teamCount).toBe(2);
+			expect(teamProjects).toHaveLength(2);
+			expect(personalCount).toBe(1);
+			expect(personalProjects).toHaveLength(1);
+		});
+
+		it('orders by name ASC', async () => {
+			const owner = await createOwner();
+			await createTeamProject('Zebra', owner);
+			await createTeamProject('Apple', owner);
+			await createTeamProject('Mango', owner);
+
+			const repo = Container.get(ProjectRepository);
+			const [projects] = await repo.findAllProjectsAndCount({ type: 'team' });
+			const names = projects.map((p) => p.name);
+
+			expect(names).toEqual(['Apple', 'Mango', 'Zebra']);
+		});
+
+		it('filters out non-activated personal projects when activated=true', async () => {
+			const owner = await createOwner();
+			await createUserShell(GLOBAL_MEMBER_ROLE); // pending user (no password)
+			await createTeamProject('Team A', owner);
+
+			const repo = Container.get(ProjectRepository);
+			const [projects, count] = await repo.findAllProjectsAndCount({ activated: true });
+
+			// owner's personal + Team A, but NOT the pending user's personal project
+			expect(count).toBe(2);
+			expect(projects).toHaveLength(2);
+			const types = projects.map((p) => p.type);
+			expect(types).toContain('team');
+			expect(types).toContain('personal');
+		});
+
+		it('orders team projects first, then activated personal, then pending personal', async () => {
+			const owner = await createOwner();
+			const pendingUser = await createUserShell(GLOBAL_MEMBER_ROLE);
+			await createTeamProject('Alpha Team', owner);
+
+			const repo = Container.get(ProjectRepository);
+			const [projects] = await repo.findAllProjectsAndCount({});
+
+			const types = projects.map((p) => p.type);
+			// Team projects come first, then personal projects
+			const firstPersonalIndex = types.indexOf('personal');
+			const lastTeamIndex = types.lastIndexOf('team');
+			expect(lastTeamIndex).toBeLessThan(firstPersonalIndex);
+
+			// Among personal projects, activated (owner) should come before pending
+			const personalProjects = projects.filter((p) => p.type === 'personal');
+			expect(personalProjects).toHaveLength(2);
+			// Owner has a password, pending user does not — owner should be first
+			expect(personalProjects[0].creatorId).toBe(owner.id);
+			expect(personalProjects[1].creatorId).toBe(pendingUser.id);
+		});
+	});
+
+	describe('getAccessibleProjectsAndCount', () => {
+		it('returns personal projects and team projects the user belongs to', async () => {
+			const owner = await createOwner();
+			const member = await createMember();
+
+			const teamA = await createTeamProject('Accessible Team', owner);
+			await linkUserToProject(member, teamA, 'project:viewer');
+			await createTeamProject('Not Accessible Team', owner);
+
+			const repo = Container.get(ProjectRepository);
+			const [projects, count] = await repo.getAccessibleProjectsAndCount(member.id, {});
+
+			// member sees: all personal projects (owner's + member's) + teamA
+			const projectNames = projects.map((p) => p.name);
+			expect(projectNames).toContain('Accessible Team');
+			expect(projectNames).not.toContain('Not Accessible Team');
+			expect(count).toBe(projects.length);
+		});
+
+		it('paginates correctly with accurate count', async () => {
+			const owner = await createOwner();
+			const member = await createMember();
+
+			for (let i = 0; i < 10; i++) {
+				const project = await createTeamProject(`Team ${i}`, owner);
+				await linkUserToProject(member, project, 'project:viewer');
+			}
+
+			const repo = Container.get(ProjectRepository);
+			const [page, count] = await repo.getAccessibleProjectsAndCount(member.id, {
+				skip: 0,
+				take: 3,
+			});
+
+			expect(page).toHaveLength(3);
+			// 10 team projects + 2 personal projects (owner + member)
+			expect(count).toBe(12);
+		});
+
+		it('filters by search', async () => {
+			const owner = await createOwner();
+			const member = await createMember();
+
+			const alpha = await createTeamProject('Alpha Project', owner);
+			const beta = await createTeamProject('Beta Project', owner);
+			await linkUserToProject(member, alpha, 'project:viewer');
+			await linkUserToProject(member, beta, 'project:viewer');
+
+			const repo = Container.get(ProjectRepository);
+			const [projects, count] = await repo.getAccessibleProjectsAndCount(member.id, {
+				search: 'Alpha',
+			});
+
+			expect(count).toBe(1);
+			expect(projects).toHaveLength(1);
+			expect(projects[0].name).toBe('Alpha Project');
+		});
+
+		it('does not produce duplicate rows from multiple project relations', async () => {
+			const owner = await createOwner();
+			const member = await createMember();
+
+			// Member has a relation to the team project (via linkUserToProject)
+			// This tests that the subquery deduplicates correctly
+			const team = await createTeamProject('Shared Team', owner);
+			await linkUserToProject(member, team, 'project:editor');
+
+			const repo = Container.get(ProjectRepository);
+			const [projects, count] = await repo.getAccessibleProjectsAndCount(member.id, {});
+
+			const teamOccurrences = projects.filter((p) => p.name === 'Shared Team');
+			expect(teamOccurrences).toHaveLength(1);
+			expect(count).toBe(projects.length);
+		});
+
+		it('filters out non-activated personal projects when activated=true', async () => {
+			await createOwner();
+			const member = await createMember();
+			await createUserShell(GLOBAL_MEMBER_ROLE); // pending user
+
+			const repo = Container.get(ProjectRepository);
+			const [projects, count] = await repo.getAccessibleProjectsAndCount(member.id, {
+				activated: true,
+			});
+
+			// member sees: owner's personal + member's personal, but NOT pending user's personal
+			const personalProjects = projects.filter((p) => p.type === 'personal');
+			expect(personalProjects).toHaveLength(2); // owner + member
+			expect(count).toBe(2);
+		});
+
+		it('orders team projects first, then activated personal, then pending personal', async () => {
+			const owner = await createOwner();
+			const member = await createMember();
+			const pendingUser = await createUserShell(GLOBAL_MEMBER_ROLE);
+			const team = await createTeamProject('Alpha Team', owner);
+			await linkUserToProject(member, team, 'project:viewer');
+
+			const repo = Container.get(ProjectRepository);
+			const [projects] = await repo.getAccessibleProjectsAndCount(member.id, {});
+
+			const types = projects.map((p) => p.type);
+			const firstPersonalIndex = types.indexOf('personal');
+			const lastTeamIndex = types.lastIndexOf('team');
+			expect(lastTeamIndex).toBeLessThan(firstPersonalIndex);
+
+			// Among personal projects, pending user should be last
+			const personalProjects = projects.filter((p) => p.type === 'personal');
+			const lastPersonal = personalProjects[personalProjects.length - 1];
+			expect(lastPersonal.creatorId).toBe(pendingUser.id);
 		});
 	});
 


### PR DESCRIPTION
## Summary

Add `skip`, `take`, `search`, `type`, and `activated` query parameters to the `GET /projects` endpoint to support server-side pagination, search, and filtering.

- **Admin users** (`project:read` scope): queries all projects via `findAllProjectsAndCount`
- **Non-admin users**: queries accessible projects (all personal + team projects where user is a member) via `getAccessibleProjectsAndCount`, using a `DISTINCT` subquery to avoid duplicate rows
- **Activation-aware ordering**: team projects → activated personal projects → pending personal projects, alphabetically within each group
- **Backward-compatible response**: when `take` or `skip` params are present, returns `{ count, data }` envelope; otherwise returns a bare array preserving existing behavior

### New query parameters

| Param | Type | Default | Description |
|-------|------|---------|-------------|
| `skip` | number | `0` | Offset for pagination |
| `take` | number | — | Limit for pagination (max 250) |
| `search` | string | — | Case-insensitive name search (LIKE %search%) |
| `type` | `personal` \| `team` | — | Filter by project type |
| `activated` | `true` \| `false` | — | When true, excludes personal projects of pending users |

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-393/add-server-side-search-pagination-and-filtering-to-project-list

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.