### PR TITLE
fix(DateTime Node): Rewrite parseDate to correctly preserve wall-clock time

### DIFF
--- a/packages/nodes-base/nodes/DateTime/V2/ExtractDateDescription.ts
+++ b/packages/nodes-base/nodes/DateTime/V2/ExtractDateDescription.ts
@@ -5,7 +5,7 @@ import { includeInputFields } from './common.descriptions';
 export const ExtractDateDescription: INodeProperties[] = [
 	{
 		displayName:
-			'You can also do this using an expression, e.g. <code>{{ your_date.extract("month") }}}</code>. <a target="_blank" href="https://docs.n8n.io/code/cookbook/luxon/">More info</a>',
+			'You can also do this using an expression, e.g. <code>{{ your_date.extract("month") }}</code>. <a target="_blank" href="https://docs.n8n.io/code/cookbook/luxon/">More info</a>',
 		name: 'notice',
 		type: 'notice',
 		default: '',
@@ -19,7 +19,7 @@ export const ExtractDateDescription: INodeProperties[] = [
 		displayName: 'Date',
 		name: 'date',
 		type: 'string',
-		description: 'The date that you want to round',
+		description: 'The date that you want to extract a part from',
 		default: '',
 		displayOptions: {
 			show: {

--- a/packages/nodes-base/nodes/DateTime/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/DateTime/V2/GenericFunctions.ts
@@ -44,11 +44,12 @@ export function parseDate(
 
 	// ISO string with an explicit timezone offset: the instant is unambiguous,
 	// so preserve it and convert to the target zone.
-	// Examples: '2023-04-11T14:30:00+05:00', '2023-04-11T14:30:00-03:00', '2023-04-11T14:30:00Z'
+	// Examples: '2023-04-11T14:30:00+05:00', '2023-04-11T14:30:00+0500', '2023-04-11T14:30:00+05',
+	//           '2023-04-11T14:30:00-03:00', '2023-04-11T14:30:00Z'
 	// We check the string directly rather than inspecting the parsed zone type,
 	// because n8n sets Luxon's Settings.defaultZone to the workflow timezone globally,
 	// which causes naive ISO strings to get zone.type === 'iana' instead of 'local'.
-	const hasExplicitOffset = /(?:Z|[+-]\d{2}:\d{2})$/.test(dateStr.trim());
+	const hasExplicitOffset = /(?:Z|[+-]\d{2}(?::?\d{2})?)$/.test(dateStr.trim());
 	const isoDate = DateTime.fromISO(dateStr);
 	if (hasExplicitOffset && isoDate.isValid) {
 		return isoDate.setZone(timezone);

--- a/packages/nodes-base/nodes/DateTime/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/DateTime/V2/GenericFunctions.ts
@@ -49,7 +49,7 @@ export function parseDate(
 	// We check the string directly rather than inspecting the parsed zone type,
 	// because n8n sets Luxon's Settings.defaultZone to the workflow timezone globally,
 	// which causes naive ISO strings to get zone.type === 'iana' instead of 'local'.
-	const hasExplicitOffset = /(?:Z|[+-]\d{2}(?::?\d{2})?)$/.test(dateStr.trim());
+	const hasExplicitOffset = /T.*(?:Z|[+-]\d{2}(?::?\d{2})?)$/.test(dateStr.trim());
 	const isoDate = DateTime.fromISO(dateStr);
 	if (hasExplicitOffset && isoDate.isValid) {
 		return isoDate.setZone(timezone);

--- a/packages/nodes-base/nodes/DateTime/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/DateTime/V2/GenericFunctions.ts
@@ -10,49 +10,63 @@ export function parseDate(
 		timezone: string;
 		fromFormat: string;
 	}> = {},
-) {
-	let parsedDate;
+): DateTime {
+	const timezone = options.timezone ?? 'Etc/UTC';
 
+	// Luxon DateTime instance — e.g. produced by $now, $today, or a previous DateTime node.
+	// Examples: DateTime.now(), DateTime.fromISO('2023-04-11T14:30:00+05:00')
 	if (date instanceof DateTime) {
-		parsedDate = date;
-	} else {
-		// Check if the input is a number, don't convert to number if fromFormat is set
-		if (!Number.isNaN(Number(date)) && !options.fromFormat) {
-			//input is a number, convert to number in case it is a string formatted number
-			date = Number(date);
-			// check if the number is a timestamp in float format and convert to integer
-			if (!Number.isInteger(date)) {
-				date = date * 1000;
-			}
-		}
+		return date.setZone(timezone);
+	}
 
-		let timezone = options.timezone;
-		if (Number.isInteger(date)) {
-			const timestampLengthInMilliseconds1990 = 12;
-			// check if the number is a timestamp in seconds or milliseconds and create a moment object accordingly
-			if (date.toString().length < timestampLengthInMilliseconds1990) {
-				parsedDate = DateTime.fromSeconds(date as number);
-			} else {
-				parsedDate = DateTime.fromMillis(date as number);
-			}
-		} else {
-			if (!timezone && (date as string).includes('+')) {
-				const offset = (date as string).split('+')[1].slice(0, 2) as unknown as number;
-				timezone = `Etc/GMT-${offset * 1}`;
-			}
+	// Numeric Unix timestamp in seconds or milliseconds.
+	// Examples: 1681226400 (seconds), 1681226400000 (ms), 1681226400.5 (fractional seconds)
+	if (!Number.isNaN(Number(date)) && !options.fromFormat) {
+		const ts = Number(date);
+		const tsMs = Number.isInteger(ts) ? ts : ts * 1000; // fractional seconds → milliseconds
+		const parsedDate =
+			tsMs.toString().length < 12 ? DateTime.fromSeconds(tsMs) : DateTime.fromMillis(tsMs);
+		return parsedDate.setZone(timezone);
+	}
 
-			if (options.fromFormat) {
-				parsedDate = DateTime.fromFormat(date as string, options.fromFormat);
-			} else {
-				parsedDate = DateTime.fromISO(moment(date).toISOString());
-			}
-		}
+	const dateStr = date as string;
 
-		parsedDate = parsedDate.setZone(timezone || 'Etc/UTC');
-
+	// User-supplied Luxon format token string.
+	// Examples: '06/08/2014 10:00' with fromFormat 'd/M/yyyy H:mm'
+	//           '11 Apr 2023'       with fromFormat 'dd LLL yyyy'
+	if (options.fromFormat) {
+		const parsedDate = DateTime.fromFormat(dateStr, options.fromFormat);
 		if (parsedDate.invalidReason === 'unparsable') {
 			throw new NodeOperationError(this.getNode(), 'Invalid date format');
 		}
+		return parsedDate.setZone(timezone);
 	}
-	return parsedDate;
+
+	// ISO string with an explicit timezone offset: the instant is unambiguous,
+	// so preserve it and convert to the target zone.
+	// Examples: '2023-04-11T14:30:00+05:00', '2023-04-11T14:30:00-03:00', '2023-04-11T14:30:00Z'
+	// We check the string directly rather than inspecting the parsed zone type,
+	// because n8n sets Luxon's Settings.defaultZone to the workflow timezone globally,
+	// which causes naive ISO strings to get zone.type === 'iana' instead of 'local'.
+	const hasExplicitOffset = /(?:Z|[+-]\d{2}:\d{2})$/.test(dateStr.trim());
+	const isoDate = DateTime.fromISO(dateStr);
+	if (hasExplicitOffset && isoDate.isValid) {
+		return isoDate.setZone(timezone);
+	}
+
+	// Non-ISO or naive date string (no timezone offset): use moment to parse the
+	// wall-clock time, then stamp it into the target timezone directly so the hour
+	// is not shifted by the server's system timezone.
+	// Examples: '2023-04-11T14:30:00'       (ISO with T, no offset)
+	//           '2023-04-11 14:30:00'        (space-separated)
+	//           '2014-08-06 10:00:00 AM'     (AM/PM)
+	//           'April 11, 2023 2:30 PM'     (natural language)
+	//           '11 April 2023 14:30'        (D Month YYYY)
+	//           '2023-04-11'                 (date only)
+	const momentDate = moment(dateStr);
+	if (!momentDate.isValid()) {
+		throw new NodeOperationError(this.getNode(), 'Invalid date format');
+	}
+	const wallClock = momentDate.format('YYYY-MM-DDTHH:mm:ss.SSS');
+	return DateTime.fromISO(wallClock, { zone: timezone });
 }

--- a/packages/nodes-base/nodes/DateTime/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/DateTime/test/GenericFunctions.test.ts
@@ -90,6 +90,15 @@ describe('parseDate', () => {
 			Settings.defaultZone = 'Europe/Athens';
 		});
 
+		it('should keep wall-clock day for a date-only string (must not misread trailing digits as an offset)', () => {
+			// '2023-04-11' ends with '-11'; the regex must not treat that as a +/-HH offset.
+			const result = parseDate.call(mockExecuteFunctions, '2023-04-11', {
+				timezone: 'Europe/Athens',
+			});
+			expect(result.day).toBe(11);
+			expect(result.hour).toBe(0);
+		});
+
 		it('should keep wall-clock hour for a space-separated naive date string', () => {
 			const result = parseDate.call(mockExecuteFunctions, '2023-04-11 14:30:00', {
 				timezone: 'Europe/Athens',

--- a/packages/nodes-base/nodes/DateTime/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/DateTime/test/GenericFunctions.test.ts
@@ -48,6 +48,22 @@ describe('parseDate', () => {
 			});
 			expect(result.hour).toBe(10);
 		});
+
+		it('should correctly convert an ISO string with a compact offset (+HHmm)', () => {
+			// 14:30 +0500 = 09:30 UTC = 05:30 EDT
+			const result = parseDate.call(mockExecuteFunctions, '2023-04-11T14:30:00+0500', {
+				timezone: 'America/New_York',
+			});
+			expect(result.hour).toBe(5);
+		});
+
+		it('should correctly convert an ISO string with an hour-only offset (+HH)', () => {
+			// 14:30 +05 = 09:30 UTC = 05:30 EDT
+			const result = parseDate.call(mockExecuteFunctions, '2023-04-11T14:30:00+05', {
+				timezone: 'America/New_York',
+			});
+			expect(result.hour).toBe(5);
+		});
 	});
 
 	describe('DateTime instance input', () => {

--- a/packages/nodes-base/nodes/DateTime/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/DateTime/test/GenericFunctions.test.ts
@@ -1,0 +1,111 @@
+import { DateTime, Settings } from 'luxon';
+import { mockDeep } from 'jest-mock-extended';
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+import { parseDate } from '../V2/GenericFunctions';
+
+describe('parseDate', () => {
+	let mockExecuteFunctions: jest.Mocked<IExecuteFunctions>;
+
+	beforeEach(() => {
+		mockExecuteFunctions = mockDeep<IExecuteFunctions>();
+	});
+
+	afterEach(() => {
+		// Reset Luxon's global default zone after each test so n8n's side-effect
+		// (Settings.defaultZone = workflowTimezone in WorkflowDataProxy) does not
+		// bleed between tests.
+		Settings.defaultZone = 'local';
+	});
+
+	describe('when Settings.defaultZone is set to the workflow timezone (production behaviour)', () => {
+		beforeEach(() => {
+			Settings.defaultZone = 'America/New_York';
+		});
+
+		it('should extract the correct hour from a naive ISO string', () => {
+			// Without the fix, zone.type would be 'iana' (not 'local') due to
+			// Settings.defaultZone, causing the ISO path to run and setZone to
+			// shift the hour relative to UTC rather than keeping the wall-clock time.
+			const result = parseDate.call(mockExecuteFunctions, '2023-04-11T14:30:00', {
+				timezone: 'America/New_York',
+			});
+			expect(result.hour).toBe(14);
+		});
+
+		it('should correctly convert an ISO string with an explicit offset', () => {
+			// 14:30 +05:00 = 09:30 UTC = 05:30 EDT
+			const result = parseDate.call(mockExecuteFunctions, '2023-04-11T14:30:00+05:00', {
+				timezone: 'America/New_York',
+			});
+			expect(result.hour).toBe(5);
+		});
+
+		it('should correctly convert a UTC ISO string', () => {
+			// 14:30 UTC = 10:30 EDT
+			const result = parseDate.call(mockExecuteFunctions, '2023-04-11T14:30:00Z', {
+				timezone: 'America/New_York',
+			});
+			expect(result.hour).toBe(10);
+		});
+	});
+
+	describe('DateTime instance input', () => {
+		it('should apply the workflow timezone when a DateTime instance is passed', () => {
+			// 14:30 +05:00 = 09:30 UTC = 05:30 EDT
+			const dt = DateTime.fromISO('2023-04-11T14:30:00+05:00');
+			const result = parseDate.call(mockExecuteFunctions, dt, {
+				timezone: 'America/New_York',
+			});
+			expect(result.hour).toBe(5);
+		});
+
+		it('should return the DateTime in the correct zone when no timezone option is provided', () => {
+			const dt = DateTime.fromISO('2023-04-11T14:30:00+05:00');
+			const result = parseDate.call(mockExecuteFunctions, dt, {});
+			expect(result.zoneName).toBe('Etc/UTC');
+			expect(result.hour).toBe(9);
+		});
+	});
+
+	describe('naive string formats that must preserve wall-clock time regardless of Settings.defaultZone', () => {
+		beforeEach(() => {
+			// Use a UTC+3 defaultZone so any accidental conversion is detectable as a +3h shift.
+			Settings.defaultZone = 'Europe/Athens';
+		});
+
+		it('should keep wall-clock hour for a space-separated naive date string', () => {
+			const result = parseDate.call(mockExecuteFunctions, '2023-04-11 14:30:00', {
+				timezone: 'Europe/Athens',
+			});
+			expect(result.hour).toBe(14);
+		});
+
+		it('should keep wall-clock hour for an AM/PM date string', () => {
+			const result = parseDate.call(mockExecuteFunctions, '2014-08-06 10:00:00 AM', {
+				timezone: 'Europe/Athens',
+			});
+			expect(result.hour).toBe(10);
+		});
+
+		it('should keep wall-clock hour when the target timezone differs from Settings.defaultZone', () => {
+			// Covers the formatDate case where timezone option is off, so parseDate
+			// receives Etc/UTC while Settings.defaultZone is the workflow timezone.
+			const result = parseDate.call(mockExecuteFunctions, '2023-04-11 14:30:00', {
+				timezone: 'Etc/UTC',
+			});
+			expect(result.hour).toBe(14);
+		});
+	});
+
+	describe('invalid date string', () => {
+		it('should throw a NodeOperationError instead of crashing with a TypeError', () => {
+			mockExecuteFunctions.getNode.mockReturnValue({ name: 'DateTime' } as never);
+			expect(() =>
+				parseDate.call(mockExecuteFunctions, 'not-a-date', {
+					timezone: 'America/New_York',
+				}),
+			).toThrow('Invalid date format');
+		});
+	});
+});

--- a/packages/nodes-base/nodes/DateTime/test/node/workflow.extractDate_timezone.json
+++ b/packages/nodes-base/nodes/DateTime/test/node/workflow.extractDate_timezone.json
@@ -1,0 +1,110 @@
+{
+	"name": "Extract Date Hour - Timezone",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [-200, 0]
+		},
+		{
+			"parameters": {
+				"operation": "extractDate",
+				"date": "2023-04-11T14:30:00",
+				"part": "hour",
+				"outputFieldName": "datePart",
+				"options": {}
+			},
+			"id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+			"name": "Extract Naive ISO",
+			"type": "n8n-nodes-base.dateTime",
+			"typeVersion": 2,
+			"position": [0, -160]
+		},
+		{
+			"parameters": {
+				"operation": "extractDate",
+				"date": "April 11, 2023 2:30 PM",
+				"part": "hour",
+				"outputFieldName": "datePart",
+				"options": {}
+			},
+			"id": "d4e5f6a7-b8c9-0123-defa-234567890123",
+			"name": "Extract Non-ISO",
+			"type": "n8n-nodes-base.dateTime",
+			"typeVersion": 2,
+			"position": [0, 0]
+		},
+		{
+			"parameters": {
+				"operation": "extractDate",
+				"date": "2023-04-11T14:30:00+05:00",
+				"part": "hour",
+				"outputFieldName": "datePart",
+				"options": {}
+			},
+			"id": "e5f6a7b8-c9d0-1234-efab-345678901234",
+			"name": "Extract With Offset",
+			"type": "n8n-nodes-base.dateTime",
+			"typeVersion": 2,
+			"position": [0, 160]
+		}
+	],
+	"pinData": {
+		"Extract Naive ISO": [
+			{
+				"json": {
+					"datePart": 14
+				}
+			}
+		],
+		"Extract Non-ISO": [
+			{
+				"json": {
+					"datePart": 14
+				}
+			}
+		],
+		"Extract With Offset": [
+			{
+				"json": {
+					"datePart": 5
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Extract Naive ISO",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "Extract Non-ISO",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "Extract With Offset",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"timezone": "America/New_York"
+	},
+	"versionId": "",
+	"meta": {
+		"instanceId": ""
+	},
+	"tags": []
+}


### PR DESCRIPTION
## Summary

   Rewrites `parseDate` in the DateTime node to fix incorrect hour values when parsing naive or non-ISO date strings (e.g. `2023-04-11 14:30:00`, `2014-08-06 10:00:00 AM`) under non-UTC workflow timezones.

   The old implementation routed all string inputs through `DateTime.fromISO(moment(date).toISOString())`, converting to UTC before applying `setZone`. This leaked the server's system timezone into the result and included a fragile heuristic that mutated the timezone whenever the string contained `+`.

   The rewrite uses five explicit branches with early returns:
   1. **DateTime instance** — `setZone` to workflow timezone
   2. **Numeric epoch** — seconds or milliseconds, detected by string length
   3. **`fromFormat`** — delegates to Luxon's format parser
   4. **ISO with explicit offset** — detected by regex, instant converted via `setZone`
   5. **Naive/non-ISO strings** — moment extracts the wall-clock value, then `DateTime.fromISO(wallClock, { zone: timezone })` stamps it directly into the target timezone, bypassing `Settings.defaultZone` entirely

   Each branch is documented with example inputs.

   ### How to test

   Use the **Extract Part of a Date** operation with a non-UTC workflow timezone (e.g. `Europe/Athens`) and inputs like:
   - `2023-04-11 14:30:00` → hour should be `14`
   - `2014-08-06 10:00:00 AM` → hour should be `10`

   Previously both would return a shifted value (+Nh depending on the timezone offset).

   ## Related Linear tickets, Github issues, and Community forum posts

   https://linear.app/n8n/issue/NODE-4416
   (resolves #25496)

   ## Review / Merge checklist

   - [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
   - [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
   - [x] Tests included.
   - [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)