### PR TITLE
fix(Notion Node): Allow underscores in page URL slug validation

### DIFF
--- a/packages/nodes-base/nodes/Notion/shared/constants.ts
+++ b/packages/nodes-base/nodes/Notion/shared/constants.ts
@@ -8,8 +8,8 @@ const baseUrlRegexp = '(?:https|http)://www\\.notion\\.so/(?:[a-z0-9-]{2,}/)?';
 export const databaseUrlExtractionRegexp = `${baseUrlRegexp}(${notionIdRegexp})`;
 export const databaseUrlValidationRegexp = `${databaseUrlExtractionRegexp}.*`;
 
-export const databasePageUrlExtractionRegexp = `${baseUrlRegexp}(?:[a-zA-Z0-9-]{1,}-)?(${notionIdRegexp})`;
+export const databasePageUrlExtractionRegexp = `${baseUrlRegexp}(?:[a-zA-Z0-9_-]{1,}-)?(${notionIdRegexp})`;
 export const databasePageUrlValidationRegexp = `${databasePageUrlExtractionRegexp}.*`;
 
-export const blockUrlExtractionRegexp = `${baseUrlRegexp}(?:[a-zA-Z0-9-]{2,}-)?(${notionIdRegexp})`;
+export const blockUrlExtractionRegexp = `${baseUrlRegexp}(?:[a-zA-Z0-9_-]{2,}-)?(${notionIdRegexp})`;
 export const blockUrlValidationRegexp = `${blockUrlExtractionRegexp}.*`;

--- a/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
@@ -92,6 +92,14 @@ describe('Test Notion', () => {
 				expect(result).toBe(testId);
 			}
 		});
+
+		test('should return the id when page slug contains underscores', () => {
+			for (const testId of testIds) {
+				const page = `https://www.notion.so/url_with-underscore-${testId}`;
+				const result = extractPageId(extractIdFromUrl(page));
+				expect(result).toBe(testId);
+			}
+		});
 	});
 });
 


### PR DESCRIPTION
## Summary

   Notion page URLs with underscores in the slug (e.g.
   `https://www.notion.so/n8n_tricks-27f2ef157045808491def1d196c81724`) were incorrectly rejected with "Not a valid
   Notion Database Page URL". The URL validation and extraction regexes did not include underscore (`_`) in the allowed
   character set for the slug portion of the URL.

   Fixed by adding `_` to the character class in `databasePageUrlExtractionRegexp` and `blockUrlExtractionRegexp` in
   `constants.ts`.

   **To test:** In the Notion node, use "Database Page > Get > By URL" and paste a URL whose page slug contains an
   underscore — it should now be accepted and resolve correctly.

   ## Related Linear tickets, Github issues, and Community forum posts

   https://linear.app/n8n/issue/NODE-4582
   fixes #24006

   ## Review / Merge checklist

   - [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
   - [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
   - [x] Tests included.
   - [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)