### PR TITLE
fix(credentials): skip OAuth URL validation for expression-prefixed values

### DIFF
--- a/packages/cli/src/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.service.test.ts
@@ -2268,5 +2268,70 @@ describe('CredentialsService', () => {
 				service.checkCredentialData('apiCredential', data, ownerUser, testProjectId),
 			).rejects.toThrow('The field "apiKey" is mandatory for credentials of type "apiCredential"');
 		});
+
+		describe('OAuth URL validation', () => {
+			beforeEach(() => {
+				credentialsHelper.getCredentialsProperties.mockReturnValue([]);
+			});
+
+			it('should not throw for OAuth2 fields that are expressions', async () => {
+				credentialTypes.getParentTypes.mockReturnValue([]);
+
+				const expressionValues = ['={{ $env.OAUTH_URL }}', '={{$secrets.oauthUrl}}'];
+				for (const expr of expressionValues) {
+					const data = {
+						authUrl: expr,
+						accessTokenUrl: expr,
+						serverUrl: expr,
+					};
+					await expect(
+						service.checkCredentialData('oAuth2Api', data, ownerUser, testProjectId),
+					).resolves.not.toThrow();
+				}
+			});
+
+			it('should not throw for OAuth1 fields that are expressions', async () => {
+				credentialTypes.getParentTypes.mockReturnValue([]);
+
+				const data = {
+					authUrl: '={{ $env.AUTH_URL }}',
+					requestTokenUrl: '={{ $env.TOKEN_URL }}',
+					accessTokenUrl: '={{ $env.ACCESS_TOKEN_URL }}',
+				};
+				await expect(
+					service.checkCredentialData('oAuth1Api', data, ownerUser, testProjectId),
+				).resolves.not.toThrow();
+			});
+
+			it('should throw for OAuth2 fields with invalid (non-expression) URLs', async () => {
+				credentialTypes.getParentTypes.mockReturnValue([]);
+
+				const data = { authUrl: 'not-a-valid-url' };
+				await expect(
+					service.checkCredentialData('oAuth2Api', data, ownerUser, testProjectId),
+				).rejects.toThrow('OAuth url is not a valid URL.');
+			});
+
+			it('should throw for OAuth2 fields with disallowed protocol', async () => {
+				credentialTypes.getParentTypes.mockReturnValue([]);
+
+				const data = { authUrl: 'javascript:alert(1)' };
+				await expect(
+					service.checkCredentialData('oAuth2Api', data, ownerUser, testProjectId),
+				).rejects.toThrow('OAuth url must use HTTP or HTTPS protocol.');
+			});
+
+			it('should not throw for OAuth2 fields with valid https URLs', async () => {
+				credentialTypes.getParentTypes.mockReturnValue([]);
+
+				const data = {
+					authUrl: 'https://auth.example.com/authorize',
+					accessTokenUrl: 'https://auth.example.com/token',
+				};
+				await expect(
+					service.checkCredentialData('oAuth2Api', data, ownerUser, testProjectId),
+				).resolves.not.toThrow();
+			});
+		});
 	});
 });

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -32,6 +32,7 @@ import {
 	CREDENTIAL_EMPTY_VALUE,
 	deepCopy,
 	displayParameter,
+	isExpression,
 	isINodePropertyCollection,
 	NodeHelpers,
 } from 'n8n-workflow';
@@ -1073,7 +1074,7 @@ export class CredentialsService {
 			const oauthUrlFields = ['authUrl', 'accessTokenUrl', 'serverUrl'] as const;
 			for (const field of oauthUrlFields) {
 				const value = data[field];
-				if (typeof value === 'string' && value.trim() !== '') {
+				if (typeof value === 'string' && value.trim() !== '' && !isExpression(value)) {
 					validateOAuthUrl(value);
 				}
 			}
@@ -1082,7 +1083,7 @@ export class CredentialsService {
 			const oauthUrlFields = ['authUrl', 'requestTokenUrl', 'accessTokenUrl'] as const;
 			for (const field of oauthUrlFields) {
 				const value = data[field];
-				if (typeof value === 'string' && value.trim() !== '') {
+				if (typeof value === 'string' && value.trim() !== '' && !isExpression(value)) {
 					validateOAuthUrl(value);
 				}
 			}


### PR DESCRIPTION
## What

Skip `validateOAuthUrl()` when the credential URL field contains an n8n expression (value starts with `=`), so expressions like `={{ $env.OAUTH_URL }}` are accepted without error.

Fixes #26940

## Root Cause

`validateOAuthCredentialUrls()` in `packages/cli/src/credentials/credentials.service.ts` called `validateOAuthUrl(value)` on OAuth URL fields (`authUrl`, `accessTokenUrl`, `serverUrl`, `requestTokenUrl`) without checking if the value was an n8n expression. Expressions are syntactically valid at credential save time but fail URL parsing, producing a spurious:

```
OAuth url is not a valid URL
```

## Fix

Added an `isExpression` guard (already exported from `n8n-workflow` and used elsewhere in the credentials layer) to both the OAuth2 and OAuth1 URL validation paths:

```ts
if (typeof value === 'string' && value.trim() !== '' && !isExpression(value)) {
    validateOAuthUrl(value);
}
```

## Tests

5 new tests in `credentials.service.test.ts`:
- Expression values on OAuth2 fields → no error ✅
- Expression values on OAuth1 fields → no error ✅
- Invalid URL on OAuth2 → throws "not a valid URL" ✅
- `javascript:` protocol → throws "must use HTTP or HTTPS" ✅
- Valid `https://` URL → passes ✅