### PR TITLE
fix(Anthropic Node): Update deprecated credential test model

### DIFF
--- a/packages/@n8n/nodes-langchain/credentials/AnthropicApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/AnthropicApi.credentials.ts
@@ -71,7 +71,7 @@ export class AnthropicApi implements ICredentialType {
 				'anthropic-version': '2023-06-01',
 			},
 			body: {
-				model: 'claude-3-haiku-20240307',
+				model: 'claude-haiku-4-5-20251001',
 				messages: [{ role: 'user', content: 'Hey' }],
 				max_tokens: 1,
 			},


### PR DESCRIPTION
## Summary

Update the hardcoded model in the Anthropic credential test from `claude-3-haiku-20240307` to `claude-haiku-4-5-20251001`. The old model was deprecated by Anthropic and returns 404 on newer accounts, breaking credential verification.

## Why this matters

- [#26637](https://github.com/n8n-io/n8n/issues/26637) - Users with newer Anthropic accounts can't verify credentials
- Confirmed by multiple users: the model is no longer available via `/v1/models` on newer accounts
- Workaround (manual file patching) is overwritten on every n8n update

## Changes

- `packages/@n8n/nodes-langchain/credentials/AnthropicApi.credentials.ts`: Updated `model` field in the credential test request body from `claude-3-haiku-20240307` to `claude-haiku-4-5-20251001`

## Testing

- The credential test sends a minimal message (`max_tokens: 1`) to verify the API key works. The model choice only affects whether the test request returns 200 or 404.
- No behavioral change to workflows - this only affects the credential verification step.

Fixes #26637

This contribution was developed with AI assistance (Claude Code).