### PR TITLE
fix(OracleNode): Prevent 'Maximum call stack size exceeded' when handling large query result sets

### DIFF
--- a/packages/nodes-base/nodes/Oracle/Sql/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Oracle/Sql/helpers/utils.ts
@@ -415,7 +415,9 @@ function _getResponseForOutbinds(
 				itemData: { item: j },
 			});
 			if (executionData) {
-				returnData.push(...executionData);
+				for (const item of executionData) {
+					returnData.push(item);
+				}
 			}
 		}
 	}
@@ -582,10 +584,13 @@ export function configureQueryRunner(
 								wrapData(rowData as IDataObject[]),
 								{ itemData: { item: i } },
 							);
-
-							returnData.push.apply(returnData, executionData);
+							for (const item of executionData) {
+								returnData.push(item);
+							}
 						} else {
-							returnData.push.apply(returnData, resultOutBinds);
+							for (const item of resultOutBinds) {
+								returnData.push(item);
+							}
 						}
 					} catch (caughtError) {
 						const error = parseOracleError(node, caughtError, i);
@@ -639,9 +644,13 @@ export function configureQueryRunner(
 								wrapData(rowData as IDataObject[]),
 								{ itemData: { item: i } },
 							);
-							returnData.push.apply(returnData, executionData);
+							for (const item of executionData) {
+								returnData.push(item);
+							}
 						} else {
-							returnData.push.apply(returnData, resultOutBinds);
+							for (const item of resultOutBinds) {
+								returnData.push(item);
+							}
 						}
 					} catch (caughtError) {
 						const error = parseOracleError(node, caughtError, i);


### PR DESCRIPTION
## Summary
As noted in issue #26985, querying large result sets can trigger a `RangeError: Maximum call stack size exceeded`. This occurs when `Array.prototype.push.apply()` or spread operations expand large arrays into function arguments, exceeding the argument limits imposed by JavaScript engines.

This PR updates the implementation to use a safer append strategy when handling query results, following the same fix pattern applied to other database nodes. 

**Imp:** The loop-based append approach avoids argument expansion limits while preserving the original `returnData` reference through mutation. This ensures the Oracle node can safely handle large result sets without triggering stack overflow errors.

- MySQL Node: #10965 
- MongoDB Node: #8530 
- Microsoft SQL Node: #8334 
- FTP Node: #8657 
- Google Sheets Node: #7384 


## Related Linear tickets, Github issues, and Community forum posts
fixes #26985 

## Review / Merge checklist

- [ ] PR title and summary are descriptive.

