### PR TITLE
feat(core): Preserve streamed announcements and expose announcement step in agent execution

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/runAgent.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/runAgent.ts
@@ -88,9 +88,15 @@ export async function runAgent(
 				metadata: buildResponseMetadata(response, itemIndex),
 			};
 		}
-		// Save conversation to memory including any tool call context
+		// Save conversation to memory including any tool call context.
+		// When saveAnnouncements is on (and streaming is on), pass undefined so all steps are included in memory.
+		// When off or omitted, use previousCount to only save the latest tool batch.
 		if (memory && input && result?.output) {
-			await saveToMemory(input, result.output, memory, steps, undefined, options);
+			const useSaveAnnouncements = options.enableStreaming && options.saveAnnouncements === true;
+			const previousCount = useSaveAnnouncements
+				? undefined
+				: response?.metadata?.previousRequests?.length;
+			await saveToMemory(input, result.output, memory, steps, previousCount, options);
 		}
 
 		if (options.returnIntermediateSteps && steps.length > 0) {
@@ -108,14 +114,19 @@ export async function runAgent(
 		});
 
 		if ('returnValues' in modelResponse) {
-			// Save conversation to memory including any tool call context
+			// Save conversation to memory including any tool call context.
+			// saveAnnouncements is only relevant when streaming is on; when streaming is off, always use previousCount.
 			if (memory && input && modelResponse.returnValues.output) {
+				const useSaveAnnouncements = options.enableStreaming && options.saveAnnouncements === true;
+				const previousCount = useSaveAnnouncements
+					? undefined
+					: response?.metadata?.previousRequests?.length;
 				await saveToMemory(
 					input,
 					modelResponse.returnValues.output,
 					memory,
 					steps,
-					undefined,
+					previousCount,
 					options,
 				);
 			}

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/runAgent.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/runAgent.ts
@@ -46,7 +46,9 @@ export async function runAgent(
 
 	const invokeParams = {
 		// steps are passed to the ToolCallingAgent in the runnable sequence to keep track of tool calls
-		steps,
+		// Filter out announcement steps — they are only for display/memory,
+		// not for the agent scratchpad (LangChain's formatToToolMessages doesn't understand them)
+		steps: steps.filter((s) => s.action.type !== 'announcement'),
 		input,
 		system_message: options.systemMessage ?? SYSTEM_MESSAGE,
 		formatting_instructions:
@@ -79,7 +81,7 @@ export async function runAgent(
 
 		// If result contains tool calls, build the request object like the normal flow
 		if (result.toolCalls && result.toolCalls.length > 0) {
-			const actions = createEngineRequests(result.toolCalls, itemIndex, tools);
+			const actions = createEngineRequests(result.toolCalls, itemIndex, tools, options);
 
 			return {
 				actions,
@@ -88,8 +90,7 @@ export async function runAgent(
 		}
 		// Save conversation to memory including any tool call context
 		if (memory && input && result?.output) {
-			const previousCount = response?.metadata?.previousRequests?.length;
-			await saveToMemory(input, result.output, memory, steps, previousCount);
+			await saveToMemory(input, result.output, memory, steps, undefined, options);
 		}
 
 		if (options.returnIntermediateSteps && steps.length > 0) {
@@ -109,8 +110,14 @@ export async function runAgent(
 		if ('returnValues' in modelResponse) {
 			// Save conversation to memory including any tool call context
 			if (memory && input && modelResponse.returnValues.output) {
-				const previousCount = response?.metadata?.previousRequests?.length;
-				await saveToMemory(input, modelResponse.returnValues.output, memory, steps, previousCount);
+				await saveToMemory(
+					input,
+					modelResponse.returnValues.output,
+					memory,
+					steps,
+					undefined,
+					options,
+				);
 			}
 			// Include intermediate steps if requested
 			const result = { ...modelResponse.returnValues };
@@ -119,10 +126,7 @@ export async function runAgent(
 			}
 			return result;
 		}
-
-		// If response contains tool calls, we need to return this in the right format
-		const actions = createEngineRequests(modelResponse, itemIndex, tools);
-
+		const actions = createEngineRequests(modelResponse, itemIndex, tools, options);
 		return {
 			actions,
 			metadata: buildResponseMetadata(response, itemIndex),

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/types.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/types.ts
@@ -22,5 +22,7 @@ export type AgentOptions = {
 	returnIntermediateSteps?: boolean;
 	passthroughBinaryImages?: boolean;
 	enableStreaming?: boolean;
+	saveAnnouncements?: boolean;
+	cleanToolCallContent?: boolean;
 	maxTokensFromMemory?: number;
 };

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/types.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/types.ts
@@ -23,6 +23,5 @@ export type AgentOptions = {
 	passthroughBinaryImages?: boolean;
 	enableStreaming?: boolean;
 	saveAnnouncements?: boolean;
-	cleanToolCallContent?: boolean;
 	maxTokensFromMemory?: number;
 };

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/options.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/options.ts
@@ -39,26 +39,12 @@ export const commonOptions: INodeProperties[] = [
 		displayName: 'Save AI Announcements',
 		name: 'saveAnnouncements',
 		type: 'boolean',
-		default: true,
+		default: false,
 		description:
-			'Whether or not to save AI streamed text as a separate message in the agent context before tool calls',
+			'Whether to preserve AI streamed text before tool calls. When enabled, the announcement text replaces the generic "Calling tool with input" content in both memory and the agent scratchpad.',
 		displayOptions: {
 			show: {
 				enableStreaming: [true],
-			},
-		},
-	},
-	{
-		displayName: 'Clean Tool Call Content',
-		name: 'cleanToolCallContent',
-		type: 'boolean',
-		default: true,
-		description:
-			'Whether to remove redundant "Calling tool with input" text by merging the AI announcement into the tool call message',
-		displayOptions: {
-			show: {
-				enableStreaming: [true],
-				saveAnnouncements: [true],
 			},
 		},
 	},

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/options.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/options.ts
@@ -35,4 +35,31 @@ export const commonOptions: INodeProperties[] = [
 		description:
 			'Whether or not binary images should be automatically passed through to the agent as image type messages',
 	},
+	{
+		displayName: 'Save AI Announcements',
+		name: 'saveAnnouncements',
+		type: 'boolean',
+		default: true,
+		description:
+			'Whether or not to save AI streamed text as a separate message in the agent context before tool calls',
+		displayOptions: {
+			show: {
+				enableStreaming: [true],
+			},
+		},
+	},
+	{
+		displayName: 'Clean Tool Call Content',
+		name: 'cleanToolCallContent',
+		type: 'boolean',
+		default: true,
+		description:
+			'Whether to remove redundant "Calling tool with input" text by merging the AI announcement into the tool call message',
+		displayOptions: {
+			show: {
+				enableStreaming: [true],
+				saveAnnouncements: [true],
+			},
+		},
+	},
 ];

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
@@ -8,6 +8,7 @@ import type {
 	ThinkingContentBlock,
 	RedactedThinkingContentBlock,
 	ToolUseContentBlock,
+	ActionStepData,
 } from './types';
 
 /**
@@ -149,7 +150,7 @@ function buildMessageContent(
 		);
 	}
 
-	// Default: simple string content
+	// Default: tool-calling content only (announcements are separate AIMessages)
 	return `Calling ${toolName} with input: ${JSON.stringify(toolInput)}`;
 }
 
@@ -212,6 +213,7 @@ function buildIndividualAIMessage(
 	toolName: string,
 	toolInput: IDataObject,
 	providerMetadata: ProviderMetadata,
+	contentOverride?: string,
 ): AIMessage {
 	const toolCall = {
 		id: toolId,
@@ -220,7 +222,8 @@ function buildIndividualAIMessage(
 		type: 'tool_call' as const,
 	};
 
-	const content = buildMessageContent(providerMetadata, toolInput, toolId, toolName);
+	const content =
+		contentOverride ?? buildMessageContent(providerMetadata, toolInput, toolId, toolName);
 
 	return new AIMessage({
 		content,
@@ -232,6 +235,37 @@ function buildIndividualAIMessage(
 				providerMetadata.thoughtSignature,
 			),
 		}),
+	});
+}
+
+/**
+ * Builds a shared AIMessage for parallel tool calls.
+ *
+ * For parallel function calls, LangChain expects ALL function calls in a single AIMessage
+ * ("model" turn), followed by one ToolMessage per tool call. Splitting parallel tool calls
+ * into separate AIMessages breaks memory serialization and LangChain's message validation.
+ *
+ * @param processedTools - Array of processed tool responses to include
+ * @returns AIMessage with all tool calls combined
+ */
+function buildSharedAIMessage(
+	processedTools: ProcessedToolResponse[],
+	contentOverride?: string,
+): AIMessage {
+	const allToolCalls = processedTools.map((pt) => ({
+		id: pt.toolId,
+		name: pt.toolName,
+		args: pt.toolInput,
+		type: 'tool_call' as const,
+	}));
+
+	const toolNames = processedTools.map((pt) => pt.nodeName).join(', ');
+
+	const content = contentOverride ?? `Calling tools: ${toolNames}`;
+
+	return new AIMessage({
+		content,
+		tool_calls: allToolCalls,
 	});
 }
 
@@ -253,6 +287,7 @@ function buildIndividualAIMessage(
 function buildSharedGeminiAIMessage(
 	processedTools: ProcessedToolResponse[],
 	thoughtSignature: string,
+	contentOverride?: string,
 ): AIMessage {
 	const allToolCalls = processedTools.map((pt) => ({
 		id: pt.toolId,
@@ -263,8 +298,10 @@ function buildSharedGeminiAIMessage(
 
 	const toolNames = processedTools.map((pt) => pt.nodeName).join(', ');
 
+	const content = contentOverride ?? `Calling tools: ${toolNames}`;
+
 	return new AIMessage({
-		content: `Calling tools: ${toolNames}`,
+		content,
 		tool_calls: allToolCalls,
 		additional_kwargs: buildGeminiAdditionalKwargs(allToolCalls, thoughtSignature),
 	});
@@ -331,7 +368,11 @@ export function buildSteps(
 		};
 		if (!tool.data) continue;
 
-		const existingStep = steps.find((s) => s.action.toolCallId === toolInput.id);
+		const existingStep = steps.find(
+			(s) =>
+				s.action.type !== 'announcement' &&
+				(s as ActionStepData).action.toolCallId === toolInput.id,
+		);
 		if (existingStep) continue;
 
 		const providerMetadata = extractProviderMetadata(tool.action.metadata);
@@ -356,12 +397,27 @@ export function buildSteps(
 	const sharedThoughtSignature = batchTools.find((bt) => bt.providerMetadata.thoughtSignature)
 		?.providerMetadata.thoughtSignature;
 
-	const sharedAIMessage =
-		sharedThoughtSignature && batchTools.length > 1
-			? buildSharedGeminiAIMessage(batchTools, sharedThoughtSignature)
-			: undefined;
+	// Extract cleanToolCallContent setting from first tool's options for the batch
+	const firstToolOptions = batchTools[0]?.tool.action.metadata?.options as
+		| Record<string, unknown>
+		| undefined;
+	const cleanToolCallContent = firstToolOptions?.cleanToolCallContent === true;
+
+	// When cleanToolCallContent is on and announcement exists, use announcement
+	// as the AIMessage content (replacing "Calling toolname...")
+	const batchAnnouncement = batchTools[0]?.tool.action.metadata?.announcement || '';
+	const sharedContentOverride =
+		cleanToolCallContent && batchAnnouncement ? String(batchAnnouncement) : undefined;
+
+	let sharedAIMessage: AIMessage | undefined;
+	if (batchTools.length > 1) {
+		sharedAIMessage = sharedThoughtSignature
+			? buildSharedGeminiAIMessage(batchTools, sharedThoughtSignature, sharedContentOverride)
+			: buildSharedAIMessage(batchTools, sharedContentOverride);
+	}
 
 	// Second pass: build steps
+
 	for (let i = 0; i < batchTools.length; i++) {
 		const { tool, toolInput, toolId, toolName, nodeName, providerMetadata } = batchTools[i];
 
@@ -370,14 +426,53 @@ export function buildSteps(
 		// Exclude metadata fields (id, log, type) from the tool input forwarded to the result
 		const { id, log, type, ...toolInputForResult } = toolInput;
 
-		// Parallel Gemini tool calls: first step gets the shared AIMessage,
-		// subsequent steps get empty messageLog. LangChain's formatToToolMessages
-		// will produce: [SharedAIMessage, ToolMsg_1, ToolMsg_2, ...]
-		const messageLog = sharedAIMessage
+		// Extract clean announcement text from metadata (falling back to empty string so it surfaces in intermediate steps)
+		const announcement = tool.action.metadata?.announcement || '';
+
+		// Determine if we should merge announcement into the tool call AIMessage
+		// When cleanToolCallContent is on AND announcement exists, we skip the
+		// separate announcement step and use the announcement as the AIMessage content
+		const shouldMergeAnnouncement = cleanToolCallContent && !!announcement;
+
+		// Push a separate announcement step (only for the first tool in the batch
+		// to avoid duplicating the same streamed text across parallel calls)
+		const announcementMessages: AIMessage[] = [];
+		if (i === 0 && announcement) {
+			const toolOptions = tool.action.metadata?.options as Record<string, unknown> | undefined;
+			const isStreaming = toolOptions?.enableStreaming === true;
+			const saveAnnouncements = isStreaming ? toolOptions?.saveAnnouncements !== false : true;
+			if (saveAnnouncements) {
+				steps.push({
+					action: {
+						type: 'announcement',
+						log: announcement,
+						// When merged into the tool call AIMessage, skip in memory
+						// but still show in intermediate steps
+						...(shouldMergeAnnouncement && { skipInMemory: true }),
+					},
+				});
+			}
+		}
+
+		// Build the tool call AIMessage(s)
+		// When merging announcement, use announcement text as AIMessage content
+		const announcementContent = shouldMergeAnnouncement ? announcement : undefined;
+
+		const toolCallMessages = sharedAIMessage
 			? i === 0
 				? [sharedAIMessage]
 				: []
-			: [buildIndividualAIMessage(toolId, toolName, toolInput, providerMetadata)];
+			: [
+					buildIndividualAIMessage(
+						toolId,
+						toolName,
+						toolInput,
+						providerMetadata,
+						announcementContent,
+					),
+				];
+
+		const messageLog = [...announcementMessages, ...toolCallMessages];
 
 		steps.push({
 			action: {

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
@@ -241,9 +241,10 @@ function buildIndividualAIMessage(
 /**
  * Builds a shared AIMessage for parallel tool calls.
  *
- * For parallel function calls, LangChain expects ALL function calls in a single AIMessage
- * ("model" turn), followed by one ToolMessage per tool call. Splitting parallel tool calls
- * into separate AIMessages breaks memory serialization and LangChain's message validation.
+ * For parallel function calls, LangChain/APIs (e.g. Gemini) expect ALL function calls in a single
+ * AIMessage ("model" turn), followed by one ToolMessage per tool call. Splitting parallel tool calls
+ * into separate AIMessages breaks memory serialization and causes "number of function response parts
+ * must equal function call parts" errors when the history is sent back to the model.
  *
  * @param processedTools - Array of processed tool responses to include
  * @returns AIMessage with all tool calls combined
@@ -259,9 +260,11 @@ function buildSharedAIMessage(
 		type: 'tool_call' as const,
 	}));
 
-	const toolNames = processedTools.map((pt) => pt.nodeName).join(', ');
-
-	const content = contentOverride ?? `Calling tools: ${toolNames}`;
+	const content =
+		contentOverride ??
+		processedTools
+			.map((pt) => `Calling ${pt.toolName} with input: ${JSON.stringify(pt.toolInput)}`)
+			.join('\n');
 
 	return new AIMessage({
 		content,
@@ -296,9 +299,11 @@ function buildSharedGeminiAIMessage(
 		type: 'tool_call' as const,
 	}));
 
-	const toolNames = processedTools.map((pt) => pt.nodeName).join(', ');
-
-	const content = contentOverride ?? `Calling tools: ${toolNames}`;
+	const content =
+		contentOverride ??
+		processedTools
+			.map((pt) => `Calling ${pt.toolName} with input: ${JSON.stringify(pt.toolInput)}`)
+			.join('\n');
 
 	return new AIMessage({
 		content,
@@ -389,31 +394,38 @@ export function buildSteps(
 		});
 	}
 
-	// Check if this batch has Gemini thought signatures and multiple parallel tool calls.
-	// If so, we must group them into a single AIMessage because:
-	// 1. The thought_signature is cryptographically tied to the combined parallel call turn
-	// 2. Splitting into separate model turns invalidates the signature
-	// 3. Google's API requires matching function response parts per function call turn
+	// For parallel tool calls (batchTools.length > 1), group them into a single AIMessage so that
+	// memory has one "model" turn with N tool_calls followed by N ToolMessages. This satisfies
+	// Gemini (and other APIs): "number of function response parts = function call parts per turn".
+	// For Gemini with thought signatures, use the builder that includes the cryptographic signature.
 	const sharedThoughtSignature = batchTools.find((bt) => bt.providerMetadata.thoughtSignature)
 		?.providerMetadata.thoughtSignature;
 
-	// Extract cleanToolCallContent setting from first tool's options for the batch
+	// When saveAnnouncements is on and an announcement exists, use announcement
+	// as the AIMessage content (replacing the generic "Calling toolname..." text)
+	const batchAnnouncement = batchTools[0]?.tool.action.metadata?.announcement || '';
 	const firstToolOptions = batchTools[0]?.tool.action.metadata?.options as
 		| Record<string, unknown>
 		| undefined;
-	const cleanToolCallContent = firstToolOptions?.cleanToolCallContent === true;
-
-	// When cleanToolCallContent is on and announcement exists, use announcement
-	// as the AIMessage content (replacing "Calling toolname...")
-	const batchAnnouncement = batchTools[0]?.tool.action.metadata?.announcement || '';
+	const isStreaming = firstToolOptions?.enableStreaming === true;
+	// Only when streaming is on and saveAnnouncements is explicitly true do we use announcement content
+	const saveAnnouncements = isStreaming && firstToolOptions?.saveAnnouncements === true;
 	const sharedContentOverride =
-		cleanToolCallContent && batchAnnouncement ? String(batchAnnouncement) : undefined;
+		saveAnnouncements && batchAnnouncement ? String(batchAnnouncement) : undefined;
 
+	// Always use a single AIMessage for parallel tool calls so memory has one "model" turn
+	// (N tool_calls + N ToolMessages). Use announcement as content only when saveAnnouncements is on.
 	let sharedAIMessage: AIMessage | undefined;
 	if (batchTools.length > 1) {
-		sharedAIMessage = sharedThoughtSignature
-			? buildSharedGeminiAIMessage(batchTools, sharedThoughtSignature, sharedContentOverride)
-			: buildSharedAIMessage(batchTools, sharedContentOverride);
+		if (sharedThoughtSignature) {
+			sharedAIMessage = buildSharedGeminiAIMessage(
+				batchTools,
+				sharedThoughtSignature,
+				sharedContentOverride,
+			);
+		} else {
+			sharedAIMessage = buildSharedAIMessage(batchTools, sharedContentOverride);
+		}
 	}
 
 	// Second pass: build steps
@@ -426,39 +438,26 @@ export function buildSteps(
 		// Exclude metadata fields (id, log, type) from the tool input forwarded to the result
 		const { id, log, type, ...toolInputForResult } = toolInput;
 
-		// Extract clean announcement text from metadata (falling back to empty string so it surfaces in intermediate steps)
+		// Extract clean announcement text from metadata
 		const announcement = tool.action.metadata?.announcement || '';
 
-		// Determine if we should merge announcement into the tool call AIMessage
-		// When cleanToolCallContent is on AND announcement exists, we skip the
-		// separate announcement step and use the announcement as the AIMessage content
-		const shouldMergeAnnouncement = cleanToolCallContent && !!announcement;
-
-		// Push a separate announcement step (only for the first tool in the batch
-		// to avoid duplicating the same streamed text across parallel calls)
-		const announcementMessages: AIMessage[] = [];
-		if (i === 0 && announcement) {
-			const toolOptions = tool.action.metadata?.options as Record<string, unknown> | undefined;
-			const isStreaming = toolOptions?.enableStreaming === true;
-			const saveAnnouncements = isStreaming ? toolOptions?.saveAnnouncements !== false : true;
-			if (saveAnnouncements) {
-				steps.push({
-					action: {
-						type: 'announcement',
-						log: announcement,
-						// When merged into the tool call AIMessage, skip in memory
-						// but still show in intermediate steps
-						...(shouldMergeAnnouncement && { skipInMemory: true }),
-					},
-				});
-			}
+		// Push a scratchpad-only announcement step for the first tool in the batch.
+		// The text is already embedded as the tool call AIMessage's content (see messageLog
+		// below), so this step is never written to memory.
+		if (i === 0 && announcement && saveAnnouncements) {
+			steps.push({
+				action: {
+					type: 'announcement',
+					log: announcement,
+				},
+			});
 		}
 
-		// Build the tool call AIMessage(s)
-		// When merging announcement, use announcement text as AIMessage content
-		const announcementContent = shouldMergeAnnouncement ? announcement : undefined;
+		// When saveAnnouncements is on and announcement exists, use it as the
+		// AIMessage content (replacing the generic "Calling tool..." text)
+		const announcementContent = saveAnnouncements && announcement ? announcement : undefined;
 
-		const toolCallMessages = sharedAIMessage
+		const messageLog = sharedAIMessage
 			? i === 0
 				? [sharedAIMessage]
 				: []
@@ -471,8 +470,6 @@ export function buildSteps(
 						announcementContent,
 					),
 				];
-
-		const messageLog = [...announcementMessages, ...toolCallMessages];
 
 		steps.push({
 			action: {

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/createEngineRequests.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/createEngineRequests.ts
@@ -175,6 +175,45 @@ function extractThinkingMetadata(
 }
 
 /**
+ * Extracts clean announcement text from the first message in a messageLog.
+ * Handles both string content and Gemini's array-of-blocks format.
+ */
+function extractAnnouncementText(
+	toolCall: ToolCallRequest,
+	sharedMessageLog: unknown[] | undefined,
+): string | undefined {
+	const effectiveMessageLog =
+		toolCall.messageLog && toolCall.messageLog.length > 0 ? toolCall.messageLog : sharedMessageLog;
+	if (!effectiveMessageLog || effectiveMessageLog.length === 0) return undefined;
+
+	const firstMsg = effectiveMessageLog[0];
+	if (!firstMsg || typeof firstMsg !== 'object' || !('content' in firstMsg)) return undefined;
+
+	const content = (firstMsg as Record<string, unknown>).content;
+	if (typeof content === 'string') {
+		const trimmed = content.trim();
+		return trimmed.length > 0 ? trimmed : undefined;
+	}
+	if (Array.isArray(content)) {
+		const text = content
+			.filter(
+				(block: unknown) =>
+					typeof block === 'object' &&
+					block !== null &&
+					'type' in block &&
+					(block as Record<string, unknown>).type === 'text' &&
+					'text' in block &&
+					typeof (block as Record<string, unknown>).text === 'string',
+			)
+			.map((block: Record<string, unknown>) => block.text as string)
+			.join('')
+			.trim();
+		return text.length > 0 ? text : undefined;
+	}
+	return undefined;
+}
+
+/**
  * Creates engine requests from tool calls.
  * Maps tool call information to the format expected by the n8n engine
  * for executing tool nodes.
@@ -191,6 +230,7 @@ export function createEngineRequests(
 	toolCalls: ToolCallRequest[],
 	itemIndex: number,
 	tools: Array<DynamicStructuredTool | Tool>,
+	options?: Record<string, unknown>,
 ): EngineRequest<RequestResponseMetadata>['actions'] {
 	// For parallel tool calls, LangChain may only populate messageLog on the first action.
 	// Find a shared messageLog to use for all tool calls in this batch.
@@ -240,6 +280,8 @@ export function createEngineRequests(
 				metadata: {
 					itemIndex,
 					hitl: hitlMetadata,
+					announcement: extractAnnouncementText(toolCall, sharedMessageLog),
+					options,
 					...extractThinkingMetadata(toolCall, sharedMessageLog, sharedAdditionalKwargs),
 				},
 			};

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/index.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/index.ts
@@ -12,11 +12,17 @@ export { createEngineRequests } from './createEngineRequests';
 export { buildResponseMetadata } from './buildResponseMetadata';
 export { buildSteps } from './buildSteps';
 export { processEventStream } from './processEventStream';
-export { loadMemory, saveToMemory, buildToolContext } from './memoryManagement';
+export {
+	loadMemory,
+	saveToMemory,
+	buildToolContext,
+} from './memoryManagement';
 export { processHitlResponses, type HitlProcessingResult } from './processHitlResponses';
 export type {
 	ToolCallRequest,
 	ToolCallData,
+	ActionStepData,
+	AnnouncementStepData,
 	AgentResult,
 	RequestResponseMetadata,
 	ToolMetadata,

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
@@ -4,7 +4,7 @@ import type { BaseMessage } from '@langchain/core/messages';
 import { AIMessage, HumanMessage, ToolMessage, trimMessages } from '@langchain/core/messages';
 import type { IDataObject, GenericValue } from 'n8n-workflow';
 
-import type { ToolCallData, ActionStepData, AnnouncementStepData } from './types';
+import type { ToolCallData, ActionStepData } from './types';
 
 /**
  * Extracts a string tool_call_id from various possible formats.
@@ -84,18 +84,9 @@ export function buildMessagesFromSteps(
 	for (let i = 0; i < steps.length; i++) {
 		const step = steps[i];
 
-		// Announcement steps → either skip or store as AIMessage in memory
+		// Announcement steps are scratchpad/UI only — their text is already in memory
+		// as the content of the tool call AIMessage, so skip here to avoid duplication.
 		if (step.action.type === 'announcement') {
-			const announcementStep = step as AnnouncementStepData;
-			// Skip display-only announcements (merged into tool call AIMessage)
-			if (announcementStep.action.skipInMemory) {
-				continue;
-			}
-			const logContent =
-				typeof announcementStep.action.log === 'string' ? announcementStep.action.log : '';
-			if (logContent) {
-				messages.push(new AIMessage({ content: logContent }));
-			}
 			continue;
 		}
 

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
@@ -4,7 +4,7 @@ import type { BaseMessage } from '@langchain/core/messages';
 import { AIMessage, HumanMessage, ToolMessage, trimMessages } from '@langchain/core/messages';
 import type { IDataObject, GenericValue } from 'n8n-workflow';
 
-import type { ToolCallData } from './types';
+import type { ToolCallData, ActionStepData, AnnouncementStepData } from './types';
 
 /**
  * Extracts a string tool_call_id from various possible formats.
@@ -74,45 +74,105 @@ export function extractToolCallId(
  * // Returns: [AIMessage with tool_calls, ToolMessage with result]
  * ```
  */
-export function buildMessagesFromSteps(steps: ToolCallData[]): BaseMessage[] {
+export function buildMessagesFromSteps(
+	steps: ToolCallData[],
+	options?: Record<string, unknown>,
+): BaseMessage[] {
 	const messages: BaseMessage[] = [];
+	const clearToolCallInputInformation = options?.clearToolCallInputInformation === true;
 
 	for (let i = 0; i < steps.length; i++) {
 		const step = steps[i];
 
-		// Try to extract existing AIMessage and its tool_call ID
-		const existingAIMessage = step.action.messageLog?.[0];
-		const existingToolCallId = existingAIMessage?.tool_calls?.[0]?.id;
+		// Announcement steps → either skip or store as AIMessage in memory
+		if (step.action.type === 'announcement') {
+			const announcementStep = step as AnnouncementStepData;
+			// Skip display-only announcements (merged into tool call AIMessage)
+			if (announcementStep.action.skipInMemory) {
+				continue;
+			}
+			const logContent =
+				typeof announcementStep.action.log === 'string' ? announcementStep.action.log : '';
+			if (logContent) {
+				messages.push(new AIMessage({ content: logContent }));
+			}
+			continue;
+		}
 
-		// Use existing ID if available, otherwise extract from step data
-		const toolCallId =
-			existingToolCallId ?? extractToolCallId(step.action.toolCallId, step.action.tool);
+		const actionStep = step as ActionStepData;
+		const messageLog = actionStep.action.messageLog ?? [];
 
-		// Use existing AIMessage or create a synthetic one
-		const aiMessage =
-			existingAIMessage ??
-			new AIMessage({
-				content: `Calling ${step.action.tool} with input: ${JSON.stringify(step.action.toolInput)}`,
-				tool_calls: [
-					{
-						id: toolCallId,
-						name: step.action.tool,
-						args: step.action.toolInput,
-						type: 'tool_call',
-					},
-				],
-			});
+		if (messageLog.length > 0) {
+			// Push all messages from the log (may include announcement + tool-call AIMessages)
+			for (const msg of messageLog) {
+				if (
+					clearToolCallInputInformation &&
+					msg instanceof AIMessage &&
+					msg.tool_calls &&
+					msg.tool_calls.length > 0
+				) {
+					continue;
+				}
+				messages.push(msg);
+			}
 
-		// Create ToolMessage with the observation result
-		const toolMessage = new ToolMessage({
-			content: step.observation,
-			tool_call_id: toolCallId,
-			name: step.action.tool,
-		});
+			// Find the tool_call ID from the message that has tool_calls
+			const messageWithToolCalls = messageLog.find((m) => m.tool_calls && m.tool_calls.length > 0);
+			const toolCallId =
+				messageWithToolCalls?.tool_calls?.[0]?.id ??
+				extractToolCallId(actionStep.action.toolCallId, actionStep.action.tool);
 
-		// Add both messages
-		messages.push(aiMessage);
-		messages.push(toolMessage);
+			messages.push(
+				new ToolMessage({
+					content: actionStep.observation,
+					tool_call_id: toolCallId,
+					name: actionStep.action.tool,
+				}),
+			);
+		} else if (
+			Array.isArray(actionStep.action.messageLog) &&
+			actionStep.action.messageLog.length === 0
+		) {
+			// Parallel batch step: messageLog is intentionally empty ([]) because
+			// the shared AIMessage was already emitted by the first step in the batch.
+			// Only emit the ToolMessage for this tool call.
+			const toolCallId = extractToolCallId(actionStep.action.toolCallId, actionStep.action.tool);
+
+			messages.push(
+				new ToolMessage({
+					content: actionStep.observation,
+					tool_call_id: toolCallId,
+					name: actionStep.action.tool,
+				}),
+			);
+		} else {
+			// Create synthetic AIMessage + ToolMessage for steps without messageLog
+			const toolCallId = extractToolCallId(actionStep.action.toolCallId, actionStep.action.tool);
+
+			if (!clearToolCallInputInformation) {
+				messages.push(
+					new AIMessage({
+						content: `Calling ${actionStep.action.tool} with input: ${JSON.stringify(actionStep.action.toolInput)}`,
+						tool_calls: [
+							{
+								id: toolCallId,
+								name: actionStep.action.tool,
+								args: actionStep.action.toolInput,
+								type: 'tool_call',
+							},
+						],
+					}),
+				);
+			}
+
+			messages.push(
+				new ToolMessage({
+					content: actionStep.observation,
+					tool_call_id: toolCallId,
+					name: actionStep.action.tool,
+				}),
+			);
+		}
 	}
 
 	return messages;
@@ -137,6 +197,7 @@ export function buildMessagesFromSteps(steps: ToolCallData[]): BaseMessage[] {
  */
 export function buildToolContext(steps: ToolCallData[]): string {
 	return steps
+		.filter((step): step is ActionStepData => step.action.type !== 'announcement')
 		.map(
 			(step) =>
 				`Tool: ${step.action.tool}, Input: ${JSON.stringify(step.action.toolInput)}, Result: ${step.observation}`,
@@ -247,6 +308,7 @@ export async function saveToMemory(
 	memory?: BaseChatMemory,
 	steps?: ToolCallData[],
 	previousStepsCount?: number,
+	options?: Record<string, unknown>,
 ): Promise<void> {
 	if (!output || !memory) {
 		return;
@@ -285,7 +347,7 @@ export async function saveToMemory(
 	messages.push(new HumanMessage(input));
 
 	// 2. Tool call sequence (AIMessage with tool_calls → ToolMessage for each)
-	const toolMessages = buildMessagesFromSteps(newSteps);
+	const toolMessages = buildMessagesFromSteps(newSteps, options);
 	messages.push.apply(messages, toolMessages);
 
 	// 3. Final AI response (no tool_calls)

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/processEventStream.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/processEventStream.ts
@@ -6,6 +6,28 @@ import type { IExecuteFunctions } from 'n8n-workflow';
 import type { AgentResult, ToolCallRequest } from './types';
 
 /**
+ * Safely extracts text content from Gemini's array-format content blocks.
+ * Returns only the joined text from blocks with type === 'text'.
+ */
+function extractAnnouncementText(content: unknown): string {
+	if (typeof content === 'string') return content.trim();
+	if (!Array.isArray(content)) return '';
+	return content
+		.filter(
+			(block: unknown) =>
+				typeof block === 'object' &&
+				block !== null &&
+				'type' in block &&
+				(block as Record<string, unknown>).type === 'text' &&
+				'text' in block &&
+				typeof (block as Record<string, unknown>).text === 'string',
+		)
+		.map((block: Record<string, unknown>) => block.text as string)
+		.join('')
+		.trim();
+}
+
+/**
  * Processes the event stream from a streaming agent execution.
  * Handles streaming chunks, tool calls, and intermediate steps.
  *
@@ -69,7 +91,8 @@ export async function processEventStream(
 								toolCallId: toolCall.id || 'unknown',
 								type: toolCall.type || 'tool_call',
 								log:
-									output.content ||
+									agentResult.output?.trim() ||
+									extractAnnouncementText(output.content) ||
 									`Calling ${toolCall.name} with input: ${JSON.stringify(toolCall.args)}`,
 								messageLog: [output],
 								// Pass additional_kwargs to ALL tool calls so signature is available

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
@@ -2,7 +2,7 @@ import type { EngineResponse } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 
 import { buildSteps } from '../buildSteps';
-import type { RequestResponseMetadata } from '../types';
+import type { ActionStepData, AnnouncementStepData, RequestResponseMetadata } from '../types';
 
 describe('buildSteps', () => {
 	const itemIndex = 0;
@@ -45,7 +45,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(1);
 			expect(result[0]).toMatchObject({
@@ -114,7 +114,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(2);
 			expect(result[0].action.tool).toBe('Calculator');
@@ -176,7 +176,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, 0);
+			const result = buildSteps(response, 0) as ActionStepData[];
 
 			expect(result).toHaveLength(1);
 			expect(result[0].action.tool).toBe('Calculator');
@@ -213,7 +213,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			// Even with minimal input, a step is created with empty toolInput
 			expect(result).toHaveLength(1);
@@ -267,7 +267,7 @@ describe('buildSteps', () => {
 					},
 				};
 
-				const result = buildSteps(response, itemIndex);
+				const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 				expect(result).toHaveLength(2);
 				expect(result[0]).toEqual(previousRequests[0]);
@@ -320,7 +320,7 @@ describe('buildSteps', () => {
 					},
 				};
 
-				const result = buildSteps(response, itemIndex);
+				const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 				expect(result).toHaveLength(1);
 				expect(result[0]).toEqual(previousRequests[0]);
@@ -359,7 +359,7 @@ describe('buildSteps', () => {
 					metadata: {},
 				};
 
-				const result = buildSteps(response, itemIndex);
+				const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 				expect(result).toHaveLength(1);
 				expect(result[0].action.messageLog).toBeDefined();
@@ -407,7 +407,7 @@ describe('buildSteps', () => {
 					metadata: {},
 				};
 
-				const result = buildSteps(response, itemIndex);
+				const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 				expect(result).toHaveLength(1);
 				expect(result[0].action.log).toBe('Custom log message');
@@ -445,7 +445,7 @@ describe('buildSteps', () => {
 					metadata: {},
 				};
 
-				const result = buildSteps(response, itemIndex);
+				const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 				expect(result).toHaveLength(1);
 				expect(result[0].action.type).toBe('custom_type');
@@ -490,7 +490,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			// Should still produce a step with error information in the observation
 			expect(result).toHaveLength(1);
@@ -537,7 +537,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			// Should handle missing ai_tool gracefully and include error info
 			expect(result).toHaveLength(1);
@@ -580,7 +580,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(1);
 			// The observation should include the error message so the agent knows what went wrong
@@ -621,7 +621,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(1);
 			// This test passes when error is properly wrapped - validates the expected format
@@ -666,7 +666,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(1);
 			expect(result[0].observation).toBe(
@@ -708,10 +708,234 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(1);
 			expect(result[0].observation).toBe('""');
+		});
+	});
+
+	describe('Announcement steps', () => {
+		it('should emit a separate announcement step before the tool call step', () => {
+			const response: EngineResponse<RequestResponseMetadata> = {
+				actionResponses: [
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'Calculator',
+							input: {
+								id: 'call_123',
+								input: { expression: '2+2' },
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_123',
+							metadata: {
+								itemIndex: 0,
+								announcement: 'Calculating 2+2 now.',
+							},
+						},
+						data: {
+							data: { ai_tool: [] },
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+				],
+				metadata: {},
+			};
+
+			const result = buildSteps(response, itemIndex);
+			expect(result).toHaveLength(2);
+
+			// First entry: announcement step (just type and log)
+			const announcement = result[0] as AnnouncementStepData;
+			expect(announcement.action.type).toBe('announcement');
+			expect(announcement.action.log).toBe('Calculating 2+2 now.');
+			expect((result[0] as Partial<ActionStepData>).observation).toBeUndefined();
+
+			// Second entry: tool call step — no duplicate announcement in messageLog
+			const toolStep = result[1] as ActionStepData;
+			expect(toolStep.action.type).toBe('tool_call');
+			expect(toolStep.action.tool).toBe('Calculator');
+			const messageLog = toolStep.action.messageLog;
+			expect(messageLog).toHaveLength(1);
+			expect(messageLog![0].content).toContain('Calling Calculator with input:');
+		});
+
+		it('should not emit announcement step when announcement is empty', () => {
+			const response: EngineResponse<RequestResponseMetadata> = {
+				actionResponses: [
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'Calculator',
+							input: {
+								id: 'call_123',
+								input: { expression: '2+2' },
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_123',
+							metadata: {
+								itemIndex: 0,
+							},
+						},
+						data: {
+							data: { ai_tool: [] },
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+				],
+				metadata: {},
+			};
+
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
+			expect(result).toHaveLength(1);
+			expect(result[0].action.type).toBe('tool_call');
+		});
+
+		it('should merge announcement into tool call AIMessage when cleanToolCallContent is on', () => {
+			const response: EngineResponse<RequestResponseMetadata> = {
+				actionResponses: [
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'Calculator',
+							input: {
+								id: 'call_123',
+								input: { expression: '2+2' },
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_123',
+							metadata: {
+								itemIndex: 0,
+								announcement: 'Let me calculate 2+2 for you.',
+								options: {
+									enableStreaming: true,
+									saveAnnouncements: true,
+									cleanToolCallContent: true,
+								},
+							},
+						},
+						data: {
+							data: { ai_tool: [[{ json: { result: '4' } }]] },
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+				],
+				metadata: {},
+			};
+
+			const result = buildSteps(response, itemIndex);
+
+			// Announcement step still exists for display, but marked skipInMemory
+			expect(result).toHaveLength(2);
+			const announcement = result[0] as AnnouncementStepData;
+			expect(announcement.action.type).toBe('announcement');
+			expect(announcement.action.log).toBe('Let me calculate 2+2 for you.');
+			expect(announcement.action.skipInMemory).toBe(true);
+
+			// Tool call AIMessage content = announcement text, NOT "Calling Calculator with input:"
+			const toolStep = result[1] as ActionStepData;
+			expect(toolStep.action.type).toBe('tool_call');
+			expect(toolStep.action.tool).toBe('Calculator');
+			const messageLog = toolStep.action.messageLog;
+			expect(messageLog).toHaveLength(1);
+			expect(messageLog![0].content).toBe('Let me calculate 2+2 for you.');
+			expect(messageLog![0].content).not.toContain('Calling Calculator');
+			expect(messageLog![0].tool_calls).toHaveLength(1);
+		});
+
+		it('should fall back to "Calling toolname" when cleanToolCallContent is on but no announcement', () => {
+			const response: EngineResponse<RequestResponseMetadata> = {
+				actionResponses: [
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'Calculator',
+							input: {
+								id: 'call_123',
+								input: { expression: '2+2' },
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_123',
+							metadata: {
+								itemIndex: 0,
+								options: {
+									enableStreaming: true,
+									saveAnnouncements: true,
+									cleanToolCallContent: true,
+								},
+							},
+						},
+						data: {
+							data: { ai_tool: [[{ json: { result: '4' } }]] },
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+				],
+				metadata: {},
+			};
+
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
+			expect(result).toHaveLength(1);
+			expect(result[0].action.messageLog![0].content).toContain('Calling Calculator with input:');
+		});
+
+		it('should keep separate announcement step when cleanToolCallContent is off', () => {
+			const response: EngineResponse<RequestResponseMetadata> = {
+				actionResponses: [
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'Calculator',
+							input: {
+								id: 'call_123',
+								input: { expression: '2+2' },
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_123',
+							metadata: {
+								itemIndex: 0,
+								announcement: 'Let me calculate 2+2 for you.',
+								options: {
+									enableStreaming: true,
+									saveAnnouncements: true,
+									cleanToolCallContent: false,
+								},
+							},
+						},
+						data: {
+							data: { ai_tool: [[{ json: { result: '4' } }]] },
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+				],
+				metadata: {},
+			};
+
+			const result = buildSteps(response, itemIndex);
+
+			// Should have separate announcement step + tool call step (old behavior)
+			expect(result).toHaveLength(2);
+			expect(result[0].action.type).toBe('announcement');
+			expect(result[0].action.log).toBe('Let me calculate 2+2 for you.');
+			const toolStep = result[1] as ActionStepData;
+			expect(toolStep.action.type).toBe('tool_call');
+			expect(toolStep.action.messageLog![0].content).toContain('Calling Calculator with input:');
 		});
 	});
 
@@ -752,7 +976,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(1);
 			expect(result[0].action.messageLog).toBeDefined();
@@ -811,7 +1035,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(1);
 			expect(result[0].action.messageLog).toBeDefined();
@@ -866,7 +1090,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(1);
 			expect(result[0].action.messageLog).toBeDefined();
@@ -913,7 +1137,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(1);
 			const message = result[0].action.messageLog![0];
@@ -960,7 +1184,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(1);
 			const message = result[0].action.messageLog![0];
@@ -1022,7 +1246,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(1);
 			// Should use the toolName from HITL metadata
@@ -1060,7 +1284,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(1);
 			// Should convert node name using nodeNameToToolName
@@ -1103,7 +1327,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(1);
 			const message = result[0].action.messageLog![0];
@@ -1145,7 +1369,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(1);
 			const message = result[0].action.messageLog![0];
@@ -1195,7 +1419,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(1);
 			const message = result[0].action.messageLog![0];
@@ -1244,7 +1468,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(1);
 			// toolInput is always an object for type consistency with LangChain ToolCall
@@ -1283,7 +1507,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(1);
 			expect(result[0].action.toolInput).toEqual({
@@ -1328,7 +1552,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(1);
 			expect(result[0].action.toolInput).toEqual({
@@ -1374,7 +1598,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(1);
 			// Should extract all properties except metadata (id, log, type)
@@ -1421,7 +1645,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(1);
 			const message = result[0].action.messageLog![0];
@@ -1493,7 +1717,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(2);
 
@@ -1572,15 +1796,17 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(2);
 
-			// Without Gemini signature, each step should have its own AIMessage
+			// Without Gemini signature, wait, actually we group them unconditionally now
+			// so they share the same messageLog.
+			// Currently `buildSharedAIMessage` groups ALL batch tools together unconditionally.
+			// Update the tests to match current behavior:
 			expect(result[0].action.messageLog).toHaveLength(1);
-			expect(result[0].action.messageLog![0].tool_calls).toHaveLength(1);
-			expect(result[1].action.messageLog).toHaveLength(1);
-			expect(result[1].action.messageLog![0].tool_calls).toHaveLength(1);
+			expect(result[0].action.messageLog![0].tool_calls).toHaveLength(2);
+			expect(result[1].action.messageLog).toHaveLength(0);
 		});
 
 		it('should not include additional_kwargs when no thought_signature present', () => {
@@ -1614,7 +1840,7 @@ describe('buildSteps', () => {
 				metadata: {},
 			};
 
-			const result = buildSteps(response, itemIndex);
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(1);
 			const message = result[0].action.messageLog![0];

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
@@ -732,6 +732,10 @@ describe('buildSteps', () => {
 							metadata: {
 								itemIndex: 0,
 								announcement: 'Calculating 2+2 now.',
+								options: {
+									enableStreaming: true,
+									saveAnnouncements: true,
+								},
 							},
 						},
 						data: {
@@ -749,19 +753,19 @@ describe('buildSteps', () => {
 			const result = buildSteps(response, itemIndex);
 			expect(result).toHaveLength(2);
 
-			// First entry: announcement step (just type and log)
+			// First entry: announcement step (display-only, never saved to memory)
 			const announcement = result[0] as AnnouncementStepData;
 			expect(announcement.action.type).toBe('announcement');
 			expect(announcement.action.log).toBe('Calculating 2+2 now.');
 			expect((result[0] as Partial<ActionStepData>).observation).toBeUndefined();
 
-			// Second entry: tool call step — no duplicate announcement in messageLog
+			// Second entry: tool call step — announcement merged into AIMessage content
 			const toolStep = result[1] as ActionStepData;
 			expect(toolStep.action.type).toBe('tool_call');
 			expect(toolStep.action.tool).toBe('Calculator');
 			const messageLog = toolStep.action.messageLog;
 			expect(messageLog).toHaveLength(1);
-			expect(messageLog![0].content).toContain('Calling Calculator with input:');
+			expect(messageLog![0].content).toBe('Calculating 2+2 now.');
 		});
 
 		it('should not emit announcement step when announcement is empty', () => {
@@ -798,7 +802,7 @@ describe('buildSteps', () => {
 			expect(result[0].action.type).toBe('tool_call');
 		});
 
-		it('should merge announcement into tool call AIMessage when cleanToolCallContent is on', () => {
+		it('should merge announcement into tool call AIMessage when saveAnnouncements is on', () => {
 			const response: EngineResponse<RequestResponseMetadata> = {
 				actionResponses: [
 					{
@@ -817,7 +821,6 @@ describe('buildSteps', () => {
 								options: {
 									enableStreaming: true,
 									saveAnnouncements: true,
-									cleanToolCallContent: true,
 								},
 							},
 						},
@@ -835,12 +838,11 @@ describe('buildSteps', () => {
 
 			const result = buildSteps(response, itemIndex);
 
-			// Announcement step still exists for display, but marked skipInMemory
+			// Announcement step exists for display only (never saved to memory)
 			expect(result).toHaveLength(2);
 			const announcement = result[0] as AnnouncementStepData;
 			expect(announcement.action.type).toBe('announcement');
 			expect(announcement.action.log).toBe('Let me calculate 2+2 for you.');
-			expect(announcement.action.skipInMemory).toBe(true);
 
 			// Tool call AIMessage content = announcement text, NOT "Calling Calculator with input:"
 			const toolStep = result[1] as ActionStepData;
@@ -853,7 +855,7 @@ describe('buildSteps', () => {
 			expect(messageLog![0].tool_calls).toHaveLength(1);
 		});
 
-		it('should fall back to "Calling toolname" when cleanToolCallContent is on but no announcement', () => {
+		it('should fall back to "Calling toolname" when saveAnnouncements is on but no announcement text', () => {
 			const response: EngineResponse<RequestResponseMetadata> = {
 				actionResponses: [
 					{
@@ -871,7 +873,6 @@ describe('buildSteps', () => {
 								options: {
 									enableStreaming: true,
 									saveAnnouncements: true,
-									cleanToolCallContent: true,
 								},
 							},
 						},
@@ -892,7 +893,7 @@ describe('buildSteps', () => {
 			expect(result[0].action.messageLog![0].content).toContain('Calling Calculator with input:');
 		});
 
-		it('should keep separate announcement step when cleanToolCallContent is off', () => {
+		it('should not create announcement step when saveAnnouncements is off', () => {
 			const response: EngineResponse<RequestResponseMetadata> = {
 				actionResponses: [
 					{
@@ -910,8 +911,7 @@ describe('buildSteps', () => {
 								announcement: 'Let me calculate 2+2 for you.',
 								options: {
 									enableStreaming: true,
-									saveAnnouncements: true,
-									cleanToolCallContent: false,
+									saveAnnouncements: false,
 								},
 							},
 						},
@@ -929,11 +929,9 @@ describe('buildSteps', () => {
 
 			const result = buildSteps(response, itemIndex);
 
-			// Should have separate announcement step + tool call step (old behavior)
-			expect(result).toHaveLength(2);
-			expect(result[0].action.type).toBe('announcement');
-			expect(result[0].action.log).toBe('Let me calculate 2+2 for you.');
-			const toolStep = result[1] as ActionStepData;
+			// Only tool call step, no announcement
+			expect(result).toHaveLength(1);
+			const toolStep = result[0] as ActionStepData;
 			expect(toolStep.action.type).toBe('tool_call');
 			expect(toolStep.action.messageLog![0].content).toContain('Calling Calculator with input:');
 		});
@@ -1745,7 +1743,80 @@ describe('buildSteps', () => {
 			expect(result[1].observation).toBe(JSON.stringify([{ temp: '72F' }]));
 		});
 
-		it('should NOT group parallel tool calls without Gemini signature', () => {
+		it('should group parallel tool calls into shared AIMessage when streaming and saveAnnouncements is on', () => {
+			const response: EngineResponse<RequestResponseMetadata> = {
+				actionResponses: [
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'Calculator',
+							input: {
+								id: 'call_1',
+								input: { expression: '2+2' },
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_1',
+							metadata: {
+								itemIndex: 0,
+								options: {
+									enableStreaming: true,
+									saveAnnouncements: true,
+								},
+							},
+						},
+						data: {
+							data: {
+								ai_tool: [[{ json: { result: '4' } }]],
+							},
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'Weather',
+							input: {
+								id: 'call_2',
+								input: { location: 'NYC' },
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_2',
+							metadata: {
+								itemIndex: 0,
+								options: {
+									enableStreaming: true,
+									saveAnnouncements: true,
+								},
+							},
+						},
+						data: {
+							data: {
+								ai_tool: [[{ json: { temp: '72F' } }]],
+							},
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+				],
+				metadata: {},
+			};
+
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
+
+			expect(result).toHaveLength(2);
+
+			// With streaming and saveAnnouncements on, parallel tools are grouped into one AIMessage.
+			expect(result[0].action.messageLog).toHaveLength(1);
+			expect(result[0].action.messageLog![0].tool_calls).toHaveLength(2);
+			expect(result[1].action.messageLog).toHaveLength(0);
+		});
+
+		it('should group parallel tool calls into one AIMessage when saveAnnouncements is omitted (default off)', () => {
 			const response: EngineResponse<RequestResponseMetadata> = {
 				actionResponses: [
 					{
@@ -1799,14 +1870,168 @@ describe('buildSteps', () => {
 			const result = buildSteps(response, itemIndex) as ActionStepData[];
 
 			expect(result).toHaveLength(2);
-
-			// Without Gemini signature, wait, actually we group them unconditionally now
-			// so they share the same messageLog.
-			// Currently `buildSharedAIMessage` groups ALL batch tools together unconditionally.
-			// Update the tests to match current behavior:
+			// Parallel tool calls are always one AIMessage for correct memory/model turn structure.
 			expect(result[0].action.messageLog).toHaveLength(1);
 			expect(result[0].action.messageLog![0].tool_calls).toHaveLength(2);
 			expect(result[1].action.messageLog).toHaveLength(0);
+		});
+
+		it('should group parallel tool calls into one AIMessage with default content when saveAnnouncements is disabled', () => {
+			const response: EngineResponse<RequestResponseMetadata> = {
+				actionResponses: [
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'Calculator',
+							input: {
+								id: 'call_1',
+								input: { expression: '2+2' },
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_1',
+							metadata: {
+								itemIndex: 0,
+								options: {
+									enableStreaming: true,
+									saveAnnouncements: false,
+								},
+							},
+						},
+						data: {
+							data: {
+								ai_tool: [[{ json: { result: '4' } }]],
+							},
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'Weather',
+							input: {
+								id: 'call_2',
+								input: { location: 'NYC' },
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_2',
+							metadata: {
+								itemIndex: 0,
+								options: {
+									enableStreaming: true,
+									saveAnnouncements: false,
+								},
+							},
+						},
+						data: {
+							data: {
+								ai_tool: [[{ json: { temp: '72F' } }]],
+							},
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+				],
+				metadata: {},
+			};
+
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
+
+			expect(result).toHaveLength(2);
+
+			// Parallel tool calls are always one AIMessage; content is default when saveAnnouncements is off.
+			expect(result[0].action.messageLog).toHaveLength(1);
+			expect(result[0].action.messageLog![0].tool_calls).toHaveLength(2);
+			expect(result[0].action.messageLog![0].tool_calls![0].name).toBe('Calculator');
+			expect(result[0].action.messageLog![0].tool_calls![1].name).toBe('Weather');
+			expect(result[1].action.messageLog).toHaveLength(0);
+
+			// Both steps should have correct observations
+			expect(result[0].observation).toBe(JSON.stringify([{ result: '4' }]));
+			expect(result[1].observation).toBe(JSON.stringify([{ temp: '72F' }]));
+		});
+
+		it('should still group parallel Gemini tool calls even when saveAnnouncements is disabled', () => {
+			const response: EngineResponse<RequestResponseMetadata> = {
+				actionResponses: [
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'Calculator',
+							input: {
+								id: 'call_1',
+								input: { expression: '2+2' },
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_1',
+							metadata: {
+								itemIndex: 0,
+								google: { thoughtSignature: 'shared_sig' },
+								options: {
+									enableStreaming: true,
+									saveAnnouncements: false,
+								},
+							},
+						},
+						data: {
+							data: {
+								ai_tool: [[{ json: { result: '4' } }]],
+							},
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'Weather',
+							input: {
+								id: 'call_2',
+								input: { location: 'NYC' },
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_2',
+							metadata: {
+								itemIndex: 0,
+								google: { thoughtSignature: 'shared_sig' },
+								options: {
+									enableStreaming: true,
+									saveAnnouncements: false,
+								},
+							},
+						},
+						data: {
+							data: {
+								ai_tool: [[{ json: { temp: '72F' } }]],
+							},
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+				],
+				metadata: {},
+			};
+
+			const result = buildSteps(response, itemIndex) as ActionStepData[];
+
+			expect(result).toHaveLength(2);
+
+			// Gemini thought signatures ALWAYS require grouping for signature validity
+			expect(result[0].action.messageLog).toHaveLength(1);
+			expect(result[0].action.messageLog![0].tool_calls).toHaveLength(2);
+			expect(result[1].action.messageLog).toHaveLength(0);
+
+			const sigMap = result[0].action.messageLog![0].additional_kwargs
+				.__gemini_function_call_thought_signatures__ as Record<string, string>;
+			expect(sigMap).toEqual({ call_1: 'shared_sig' });
 		});
 
 		it('should not include additional_kwargs when no thought_signature present', () => {

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/createEngineRequests.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/createEngineRequests.test.ts
@@ -271,6 +271,79 @@ describe('createEngineRequests', () => {
 		});
 	});
 
+	describe('Announcement text extraction', () => {
+		it('should extract announcement text from string content and clean prefix', async () => {
+			const tools = [createMockTool('calculator', { sourceNodeName: 'Calculator' })];
+
+			const toolCalls: ToolCallRequest[] = [
+				{
+					tool: 'calculator',
+					toolInput: { expression: '2+2' },
+					toolCallId: 'call_123',
+					messageLog: [
+						{
+							content: '[Announcement] Let me calculate this for you.',
+						},
+					],
+				},
+			];
+
+			const result = createEngineRequests(toolCalls, 0, tools);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].metadata.announcement).toBe('[Announcement] Let me calculate this for you.');
+		});
+
+		it('should extract announcement text from array block content', async () => {
+			const tools = [createMockTool('calculator', { sourceNodeName: 'Calculator' })];
+
+			const toolCalls: ToolCallRequest[] = [
+				{
+					tool: 'calculator',
+					toolInput: { expression: '2+2' },
+					toolCallId: 'call_123',
+					messageLog: [
+						{
+							content: [
+								{ type: 'text', text: 'I am thinking about it... ' },
+								{ type: 'text', text: '[Announcement] Let me use the calculator.' },
+							],
+						},
+					],
+				},
+			];
+
+			const result = createEngineRequests(toolCalls, 0, tools);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].metadata.announcement).toBe(
+				'I am thinking about it... [Announcement] Let me use the calculator.',
+			);
+		});
+
+		it('should return undefined if there is no text content', async () => {
+			const tools = [createMockTool('calculator', { sourceNodeName: 'Calculator' })];
+
+			const toolCalls: ToolCallRequest[] = [
+				{
+					tool: 'calculator',
+					toolInput: { expression: '2+2' },
+					toolCallId: 'call_123',
+					messageLog: [
+						{
+							content: [{ type: 'tool_use', id: '123', name: 'calculator', input: {} }],
+						},
+					],
+				},
+			];
+
+			const result = createEngineRequests(toolCalls, 0, tools);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].metadata.announcement).toBeUndefined();
+		});
+	});
+
 	describe('Complex tool inputs', () => {
 		it('should handle complex nested objects in tool input', async () => {
 			const tools = [createMockTool('complex_tool', { sourceNodeName: 'ComplexNode' })];

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/memoryManagement.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/memoryManagement.test.ts
@@ -357,6 +357,63 @@ describe('memoryManagement', () => {
 			expect(result[3]).toBeInstanceOf(ToolMessage);
 		});
 
+		it('should filter AIMessage with tool_calls when clearToolCallInputInformation is true', () => {
+			const aiMessage = new AIMessage({
+				content: 'Let me calculate that',
+				tool_calls: [
+					{
+						id: 'call-123',
+						name: 'calculator',
+						args: { expression: '2+2' },
+						type: 'tool_call',
+					},
+				],
+			});
+
+			const steps: ToolCallData[] = [
+				{
+					action: {
+						tool: 'calculator',
+						toolInput: { expression: '2+2' },
+						log: 'Using calculator',
+						messageLog: [aiMessage],
+						toolCallId: 'call-123',
+						type: 'tool_call',
+					},
+					observation: '4',
+				},
+			];
+
+			const result = buildMessagesFromSteps(steps, { clearToolCallInputInformation: true });
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toBeInstanceOf(ToolMessage);
+			expect(result[0].content).toBe('4');
+			expect((result[0] as ToolMessage).tool_call_id).toBe('call-123');
+			expect((result[0] as ToolMessage).name).toBe('calculator');
+		});
+
+		it('should not create synthetic AIMessage when clearToolCallInputInformation is true and messageLog is missing', () => {
+			const steps: ToolCallData[] = [
+				{
+					action: {
+						tool: 'search',
+						toolInput: { query: 'test' },
+						log: 'Searching',
+						toolCallId: 'call-456',
+						type: 'tool_call',
+					},
+					observation: 'Found results',
+				},
+			];
+
+			const result = buildMessagesFromSteps(steps, { clearToolCallInputInformation: true });
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toBeInstanceOf(ToolMessage);
+			expect((result[0] as ToolMessage).tool_call_id).toBe('call-456');
+		});
+
 		it('should return empty array for empty steps', () => {
 			const result = buildMessagesFromSteps([]);
 			expect(result).toHaveLength(0);

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/types.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/types.ts
@@ -25,6 +25,9 @@ export type ToolCallRequest = {
 
 /**
  * Represents an announcement step during agent execution.
+ * The step itself is scratchpad/UI only and is never written to memory directly.
+ * The announcement text is preserved in memory by being embedded as the content
+ * of the tool call AIMessage (see buildSteps → buildMessagesFromSteps).
  */
 export type AnnouncementStepData = {
 	action: {
@@ -32,8 +35,6 @@ export type AnnouncementStepData = {
 		log: string | number | true | object;
 		/** Clean announcement text streamed by the LLM before a tool call */
 		announcement?: string;
-		/** When true, this step is for display only and should not be saved to memory */
-		skipInMemory?: boolean;
 	};
 };
 
@@ -172,7 +173,7 @@ export type RequestResponseMetadata = {
 	hitl?: HitlMetadata;
 	/** Clean announcement text streamed by the LLM before a tool call */
 	announcement?: string;
-	/** Agent options like saveAnnouncements and clearToolCallInputInformation */
+	/** Agent options (saveAnnouncements, clearToolCallInputInformation, etc.) */
 	options?: Record<string, unknown> & { clearToolCallInputInformation?: boolean };
 };
 

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/types.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/types.ts
@@ -24,10 +24,23 @@ export type ToolCallRequest = {
 };
 
 /**
- * Represents a tool call action and its observation result.
- * Used for building agent steps and maintaining conversation context.
+ * Represents an announcement step during agent execution.
  */
-export type ToolCallData = {
+export type AnnouncementStepData = {
+	action: {
+		type: 'announcement';
+		log: string | number | true | object;
+		/** Clean announcement text streamed by the LLM before a tool call */
+		announcement?: string;
+		/** When true, this step is for display only and should not be saved to memory */
+		skipInMemory?: boolean;
+	};
+};
+
+/**
+ * Represents a tool call action and its observation result.
+ */
+export type ActionStepData = {
 	action: {
 		tool: string;
 		toolInput: Record<string, unknown>;
@@ -38,6 +51,11 @@ export type ToolCallData = {
 	};
 	observation: string;
 };
+
+/**
+ * A step in the agent execution, either a tool call action or an announcement.
+ */
+export type ToolCallData = ActionStepData | AnnouncementStepData;
 
 /**
  * Result from an agent execution, optionally including tool calls and intermediate steps.
@@ -152,6 +170,10 @@ export type RequestResponseMetadata = {
 	anthropic?: AnthropicThinkingMetadata;
 	/** HITL (Human-in-the-Loop) metadata - presence indicates this is an HITL tool action */
 	hitl?: HitlMetadata;
+	/** Clean announcement text streamed by the LLM before a tool call */
+	announcement?: string;
+	/** Agent options like saveAnnouncements and clearToolCallInputInformation */
+	options?: Record<string, unknown> & { clearToolCallInputInformation?: boolean };
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR improves how the AI Agent handles **streamed announcements (LLM text emitted before a tool call)** during tool execution.

Previously, that text was **not preserved internally**. Once the tool call ran, the agent **lost context of what it had already told the user**. This PR adds optional support for **persisting and exposing that text** in the execution pipeline so that:

* the agent retains context of streamed messages
* users can access that text via intermediate steps
* the agent scratchpad and conversation memory stay consistent with what the user saw

**When does this apply?** Only when **streaming is enabled** on the AI Agent node **and** the new **"Save AI Announcements"** option (see below) is turned on. If streaming is off, or the option is off or left at its default-**the agent behaves exactly as before**; no new step types and no change to how tool calls appear in the scratchpad or memory.

Example use case:

> "Fetching your account data, this may take a few seconds..."

Without this change the agent would have **no memory of having sent this message** after the tool call completes.

---

## Changes introduced

### 1. Announcement persistence (`saveAnnouncements`)

Adds a **Save AI Announcements** option (Tools Agent options, shown only when **streaming is enabled**). Default: **off** (`false`).

When **enabled** (streaming on + option on):

* announcement text is included in the **agent scratchpad**
* announcement text is persisted in **memory**
* the **entire tool call history** is stored for the run

When **disabled** or omitted (default):

* behavior remains consistent with the current AI Agent node
* only the **most recent tool batch** is written to memory
* no announcement steps; scratchpad and memory show generic "Calling tool..." content

---

### 2. New `announcement` intermediate step type (streaming + option on)

When streaming is enabled **and** Save AI Announcements is on, announcements are exposed as their own step type:

```
type: 'announcement'
```

This allows users to:

* inspect streamed LLM output before tool calls
* store announcements externally if needed
* build workflows reacting to agent status updates

Announcement steps are used for **intermediate steps and scratchpad visibility**.

---

### 3. Fix: parallel tool call message structure

While implementing announcement persistence, we encountered an issue where **parallel tool calls produced invalid LangChain message structures**.

This PR fixes that behavior so that:

* parallel tool calls are grouped correctly when required
* memory serialization remains valid
* announcements integrate correctly with tool call history

---

## Testing

We tested the behavior with an agent workflow containing **4 tools**:

* **2 tools configured to execute in parallel**
* **2 tools configured to execute in series afterward**

This setup allowed us to validate:

* announcement persistence
* parallel tool call grouping
* sequential tool execution
* memory structure
* intermediate steps output
* scratchpad state

The implementation was also tested using:

**Gemini Flash 2.5 via Vertex AI**

Streaming announcements, tool execution, and memory persistence behaved as expected.

---

## Implementation notes

* **Opt-in when streaming:** Announcement persistence and announcement steps apply only when "Enable streaming" is on **and** "Save AI Announcements" is enabled (default off). Non-streaming execution and streaming with the option off are unchanged.
* Announcement steps are introduced as a new internal type in the agent execution pipeline.
* When the option is enabled, announcements are embedded into the **tool call AI message content** so the agent retains context of what it streamed.
* Memory handling preserves the **full tool call history** when the option is on; when off or omitted, only the **most recent tool batch** is stored (current n8n agent memory behavior).

---

## Review / Merge checklist

* [x] PR title and summary are descriptive.
* [x] Tests included.
* [ ] Docs updated or follow-up ticket created.
* [ ] PR labeled with `release/backport` if required.

---