### PR TITLE
fix(core): Return 409 instead of 500 on double-resume of waiting webhook

### DIFF
--- a/packages/cli/src/webhooks/__tests__/waiting-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/waiting-webhooks.test.ts
@@ -4,8 +4,9 @@ import { mock } from 'jest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
 import { WAITING_TOKEN_QUERY_PARAM } from 'n8n-core';
 import type { IWorkflowBase, Workflow } from 'n8n-workflow';
-import { SEND_AND_WAIT_OPERATION } from 'n8n-workflow';
+import { OperationalError, SEND_AND_WAIT_OPERATION } from 'n8n-workflow';
 
+import { ExecutionAlreadyResumingError } from '@/errors/execution-already-resuming.error';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import type { EventService } from '@/events/event.service';
@@ -983,6 +984,137 @@ describe('WaitingWebhooks', () => {
 
 			// Should have empty array after popping and not adding placeholder
 			expect(runDataArray).toHaveLength(0);
+		});
+
+		it('should throw ConflictError when execution is already being resumed', async () => {
+			/**
+			 * Arrange
+			 */
+			const executionId = 'test-execution-id';
+			const lastNodeExecuted = 'WaitNode';
+
+			const mockExecution = mock<IExecutionResponse>({
+				id: executionId,
+				status: 'waiting',
+				finished: false,
+				mode: 'manual',
+				data: {
+					executionData: {
+						nodeExecutionStack: [
+							{
+								node: {
+									name: lastNodeExecuted,
+									type: 'n8n-nodes-base.wait',
+									typeVersion: 1,
+									parameters: {},
+									id: 'node-id',
+									position: [0, 0],
+									disabled: false,
+								},
+								data: {},
+								source: null,
+							},
+						],
+					},
+					resultData: {
+						runData: {
+							[lastNodeExecuted]: [
+								{
+									startTime: 123,
+									executionTime: 456,
+									executionIndex: 0,
+									source: [],
+								},
+							],
+						},
+						lastNodeExecuted,
+					},
+				},
+				workflowData: {
+					id: 'workflow-id',
+					name: 'Test Workflow',
+					nodes: [
+						{
+							name: lastNodeExecuted,
+							type: 'n8n-nodes-base.wait',
+							typeVersion: 1,
+							parameters: {},
+							id: 'node-id',
+							position: [0, 0],
+						},
+					],
+					connections: {},
+					active: true,
+					settings: {},
+					staticData: {},
+					isArchived: false,
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				},
+			});
+
+			// Explicitly set error to undefined to avoid mock function
+			mockExecution.data.resultData.error = undefined;
+
+			executionRepository.findSingleExecution.mockResolvedValue(mockExecution);
+
+			const mockReq = mock<WaitingWebhookRequest>({
+				params: { path: executionId, suffix: undefined },
+				method: 'POST',
+			});
+			const mockRes = mock<express.Response>();
+
+			jest
+				.spyOn(WebhookHelpers, 'executeWebhook')
+				.mockImplementation(
+					async (
+						_workflow,
+						_webhookData,
+						_workflowData,
+						_workflowStartNode,
+						_mode,
+						_pushRef,
+						_runExecutionData,
+						_executionId,
+						_req,
+						_res,
+						callback,
+					) => {
+						callback(
+							new OperationalError('There was a problem executing the workflow', {
+								cause: new ExecutionAlreadyResumingError(executionId),
+							}),
+							{},
+						);
+						return undefined;
+					},
+				);
+
+			mockWebhookService.getNodeWebhooks.mockReturnValue([
+				{
+					httpMethod: 'POST',
+					path: '',
+					webhookDescription: {
+						restartWebhook: true,
+						httpMethod: 'POST',
+						name: 'default',
+						path: '',
+						nodeType: undefined,
+					} as any,
+				},
+			] as any);
+
+			jest.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue({} as any);
+
+			/**
+			 * Act
+			 */
+			const promise = waitingWebhooks.executeWebhook(mockReq, mockRes);
+
+			/**
+			 * Assert
+			 */
+			await expect(promise).rejects.toThrowError(ConflictError);
 		});
 
 		it('should not set rewireOutputLogTo for non-HITL nodes', async () => {

--- a/packages/cli/src/webhooks/waiting-webhooks.ts
+++ b/packages/cli/src/webhooks/waiting-webhooks.ts
@@ -22,7 +22,7 @@ import type {
 } from './webhook.types';
 
 import { EventService } from '@/events/event.service';
-
+import { ExecutionAlreadyResumingError } from '@/errors/execution-already-resuming.error';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { getWorkflowActiveStatusFromWorkflowData } from '@/executions/execution.utils';
@@ -356,6 +356,16 @@ export class WaitingWebhooks implements IWebhookManager {
 
 					(error: Error | null, data: object) => {
 						if (error !== null) {
+							if (
+								error instanceof ExecutionAlreadyResumingError ||
+								error.cause instanceof ExecutionAlreadyResumingError
+							) {
+								return reject(
+									new ConflictError(
+										`The execution "${executionId}" is already being resumed.`,
+									),
+								);
+							}
 							return reject(error);
 						}
 						resolve(data);


### PR DESCRIPTION
## Summary

- Detect `ExecutionAlreadyResumingError` (direct or wrapped in `OperationalError.cause`) in `WaitingWebhooks` callback and convert to `ConflictError` (HTTP 409)
- Add test for the double-resume → 409 path

## Related Linear tickets, Github issues, and Community forum posts

<!-- N/A -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)