### PR TITLE
fix(core): Support all known execution statuses on public API

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.yml
@@ -13,7 +13,7 @@ get:
       required: false
       schema:
         type: string
-        enum: ['canceled', 'error', 'running', 'success', 'waiting']
+        enum: ['canceled', 'crashed', 'error', 'new', 'running', 'success', 'unknown', 'waiting']
     - name: workflowId
       in: query
       description: Workflow to filter the executions by.


### PR DESCRIPTION


## Summary

The public API to fetch executions does not include all known execution statuses.
This PR adds the missing statuses.

### Before

<img width="628" height="312" alt="Screenshot 2026-03-16 at 09 56 34" src="https://github.com/user-attachments/assets/c7eb354a-d8f1-486d-8cf6-4be660853fe3" />


### After

<img width="627" height="292" alt="Screenshot 2026-03-16 at 09 54 24" src="https://github.com/user-attachments/assets/7dc39974-06b7-4253-83d3-da9b74c0c266" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-288/api-add-queued-as-supported-status-filter-for-get-executions-endpoint


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
