### PR TITLE
chore(core): Query executions using a single query intead of two

### DIFF
--- a/packages/@n8n/db/src/entities/types-db.ts
+++ b/packages/@n8n/db/src/entities/types-db.ts
@@ -208,7 +208,6 @@ export namespace ExecutionSummaries {
 	>; // parsed from query params
 
 	type AccessFields = {
-		accessibleWorkflowIds?: string[];
 		user?: User;
 		sharingOptions?: {
 			scopes?: Scope[];

--- a/packages/@n8n/db/src/entities/types-db.ts
+++ b/packages/@n8n/db/src/entities/types-db.ts
@@ -209,6 +209,12 @@ export namespace ExecutionSummaries {
 
 	type AccessFields = {
 		accessibleWorkflowIds?: string[];
+		user?: User;
+		sharingOptions?: {
+			scopes?: Scope[];
+			projectRoles?: string[];
+			workflowRoles?: string[];
+		};
 	};
 
 	type RangeFields = {

--- a/packages/@n8n/db/src/repositories/__tests__/workflow.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/workflow.repository.test.ts
@@ -6,6 +6,7 @@ import { WorkflowEntity } from '../../entities';
 import { mockEntityManager } from '../../utils/test-utils/mock-entity-manager';
 import { mockInstance } from '../../utils/test-utils/mock-instance';
 import { FolderRepository } from '../folder.repository';
+import { SharedWorkflowRepository } from '../shared-workflow.repository';
 import { WorkflowHistoryRepository } from '../workflow-history.repository';
 import { WorkflowRepository } from '../workflow.repository';
 
@@ -15,11 +16,13 @@ describe('WorkflowRepository', () => {
 		database: { type: 'postgresdb' },
 	});
 	const folderRepository = mockInstance(FolderRepository);
+	const sharedWorkflowRepository = mockInstance(SharedWorkflowRepository);
 	const workflowHistoryRepository = mockInstance(WorkflowHistoryRepository);
 	const workflowRepository = new WorkflowRepository(
 		entityManager.connection,
 		globalConfig,
 		folderRepository,
+		sharedWorkflowRepository,
 		workflowHistoryRepository,
 	);
 
@@ -144,6 +147,7 @@ describe('WorkflowRepository', () => {
 				entityManager.connection,
 				sqliteConfig,
 				folderRepository,
+				sharedWorkflowRepository,
 				workflowHistoryRepository,
 			);
 			jest.spyOn(sqliteWorkflowRepository, 'createQueryBuilder').mockReturnValue(queryBuilder);
@@ -364,6 +368,7 @@ describe('WorkflowRepository', () => {
 				entityManager.connection,
 				sqliteConfig,
 				folderRepository,
+				sharedWorkflowRepository,
 				workflowHistoryRepository,
 			);
 			jest.spyOn(sqliteWorkflowRepository, 'createQueryBuilder').mockReturnValue(queryBuilder);
@@ -392,6 +397,7 @@ describe('WorkflowRepository', () => {
 				entityManager.connection,
 				sqliteConfig,
 				folderRepository,
+				sharedWorkflowRepository,
 				workflowHistoryRepository,
 			);
 			jest.spyOn(sqliteWorkflowRepository, 'createQueryBuilder').mockReturnValue(queryBuilder);

--- a/packages/@n8n/db/src/repositories/__tests__/workflow.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/workflow.repository.test.ts
@@ -597,6 +597,7 @@ describe('WorkflowRepository', () => {
 				entityManager.connection,
 				sqliteConfig,
 				folderRepository,
+				sharedWorkflowRepository,
 				workflowHistoryRepository,
 			);
 			jest.spyOn(sqliteWorkflowRepository, 'createQueryBuilder').mockReturnValue(queryBuilder);
@@ -657,6 +658,7 @@ describe('WorkflowRepository', () => {
 				entityManager.connection,
 				sqliteConfig,
 				folderRepository,
+				sharedWorkflowRepository,
 				workflowHistoryRepository,
 			);
 			jest.spyOn(sqliteWorkflowRepository, 'createQueryBuilder').mockReturnValue(updateQb);

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -49,6 +49,7 @@ import {
 	SharedWorkflow,
 	WorkflowEntity,
 } from '../entities';
+import { SharedWorkflowRepository } from './shared-workflow.repository';
 import type {
 	ExecutionSummaries,
 	IExecutionBase,
@@ -158,6 +159,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 		private readonly logger: Logger,
 		private readonly errorReporter: ErrorReporter,
 		private readonly binaryDataService: BinaryDataService,
+		private readonly sharedWorkflowRepository: SharedWorkflowRepository,
 	) {
 		super(ExecutionEntity, dataSource.manager);
 	}
@@ -976,6 +978,8 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 	private toQueryBuilder(query: ExecutionSummaries.Query) {
 		const {
 			accessibleWorkflowIds,
+			user,
+			sharingOptions,
 			status,
 			finished,
 			workflowId,
@@ -995,8 +999,21 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 
 		const qb = this.createQueryBuilder('execution')
 			.select(fields)
-			.innerJoin('execution.workflow', 'workflow')
-			.where('execution.workflowId IN (:...accessibleWorkflowIds)', { accessibleWorkflowIds });
+			.innerJoin('execution.workflow', 'workflow');
+
+		if (user && sharingOptions) {
+			// EXISTS-based access control — correlated subquery for better query plans
+			const subquery = this.sharedWorkflowRepository.buildSharedWorkflowIdsSubquery(
+				user,
+				sharingOptions,
+			);
+			subquery.andWhere('"sw"."workflowId" = execution."workflowId"');
+			qb.where(`EXISTS (${subquery.getQuery()})`);
+			qb.setParameters(subquery.getParameters());
+		} else if (accessibleWorkflowIds) {
+			// Array-based access control (backward compat)
+			qb.where('execution.workflowId IN (:...accessibleWorkflowIds)', { accessibleWorkflowIds });
+		}
 
 		if (query.kind === 'range') {
 			const { limit, firstId, lastId } = query.range;

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -1,6 +1,7 @@
 import { Logger, parseFlatted } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
+import { hasGlobalScope } from '@n8n/permissions';
 import type {
 	FindManyOptions,
 	FindOneOptions,
@@ -1005,12 +1006,12 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			subquery.andWhere('"sw"."workflowId" = execution."workflowId"');
 			qb.where(`EXISTS (${subquery.getQuery()})`);
 			qb.setParameters(subquery.getParameters());
-		} else if (!user) {
-			// No access control provided — deny all to prevent unscoped queries
+		} else if (user && hasGlobalScope(user, 'workflow:read')) {
+			// Global-scope admin without sharingOptions — no access-control filter needed
+		} else {
+			// No user or insufficient scope — deny all to prevent unscoped queries
 			qb.where('1 = 0');
 		}
-		// When user is provided without sharingOptions (e.g. global-scope admin),
-		// no access-control filter is applied — the user can see all executions.
 
 		if (query.kind === 'range') {
 			const { limit, firstId, lastId } = query.range;

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -883,10 +883,6 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 	}
 
 	async findManyByRangeQuery(query: ExecutionSummaries.RangeQuery): Promise<ExecutionSummary[]> {
-		if (query?.accessibleWorkflowIds?.length === 0) {
-			throw new UnexpectedError('Expected accessible workflow IDs');
-		}
-
 		// Due to performance reasons, we use custom query builder with raw SQL.
 		// IMPORTANT: it produces duplicate rows for executions with multiple tags, which we need to reduce manually
 		const qb = this.toQueryBuilderWithAnnotations(query);
@@ -977,7 +973,6 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 
 	private toQueryBuilder(query: ExecutionSummaries.Query) {
 		const {
-			accessibleWorkflowIds,
 			user,
 			sharingOptions,
 			status,
@@ -1010,9 +1005,6 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			subquery.andWhere('"sw"."workflowId" = execution."workflowId"');
 			qb.where(`EXISTS (${subquery.getQuery()})`);
 			qb.setParameters(subquery.getParameters());
-		} else if (accessibleWorkflowIds?.length) {
-			// Array-based access control (backward compat)
-			qb.where('execution.workflowId IN (:...accessibleWorkflowIds)', { accessibleWorkflowIds });
 		} else {
 			// No access control provided — deny all to prevent unscoped queries
 			qb.where('1 = 0');

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -1005,10 +1005,12 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			subquery.andWhere('"sw"."workflowId" = execution."workflowId"');
 			qb.where(`EXISTS (${subquery.getQuery()})`);
 			qb.setParameters(subquery.getParameters());
-		} else {
+		} else if (!user) {
 			// No access control provided — deny all to prevent unscoped queries
 			qb.where('1 = 0');
 		}
+		// When user is provided without sharingOptions (e.g. global-scope admin),
+		// no access-control filter is applied — the user can see all executions.
 
 		if (query.kind === 'range') {
 			const { limit, firstId, lastId } = query.range;

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -1013,6 +1013,9 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 		} else if (accessibleWorkflowIds) {
 			// Array-based access control (backward compat)
 			qb.where('execution.workflowId IN (:...accessibleWorkflowIds)', { accessibleWorkflowIds });
+		} else {
+			// No access control provided — deny all to prevent unscoped queries
+			qb.where('1 = 0');
 		}
 
 		if (query.kind === 'range') {

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -1010,7 +1010,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			subquery.andWhere('"sw"."workflowId" = execution."workflowId"');
 			qb.where(`EXISTS (${subquery.getQuery()})`);
 			qb.setParameters(subquery.getParameters());
-		} else if (accessibleWorkflowIds) {
+		} else if (accessibleWorkflowIds?.length) {
 			// Array-based access control (backward compat)
 			qb.where('execution.workflowId IN (:...accessibleWorkflowIds)', { accessibleWorkflowIds });
 		} else {

--- a/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
@@ -1,10 +1,20 @@
 import { Service } from '@n8n/di';
-import { PROJECT_OWNER_ROLE_SLUG, type WorkflowSharingRole } from '@n8n/permissions';
+import {
+	hasGlobalScope,
+	PROJECT_OWNER_ROLE_SLUG,
+	type Scope,
+	type WorkflowSharingRole,
+} from '@n8n/permissions';
 import { DataSource, Repository, In, Not } from '@n8n/typeorm';
-import type { EntityManager, FindManyOptions, FindOptionsWhere } from '@n8n/typeorm';
+import type {
+	EntityManager,
+	FindManyOptions,
+	FindOptionsWhere,
+	SelectQueryBuilder,
+} from '@n8n/typeorm';
 
-import type { Project } from '../entities';
-import { SharedWorkflow } from '../entities';
+import type { User } from '../entities';
+import { Project, ProjectRelation, SharedWorkflow } from '../entities';
 
 @Service()
 export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
@@ -193,5 +203,82 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 				},
 			},
 		});
+	}
+
+	/**
+	 * Build a subquery that returns workflow IDs based on sharing permissions.
+	 * This replicates the logic from WorkflowSharingService but as a subquery.
+	 */
+	buildSharedWorkflowIdsSubquery(
+		user: User,
+		sharingOptions: {
+			scopes?: Scope[];
+			projectRoles?: string[];
+			workflowRoles?: string[];
+			isPersonalProject?: boolean;
+			personalProjectOwnerId?: string;
+			onlySharedWithMe?: boolean;
+			projectId?: string;
+		},
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	): SelectQueryBuilder<any> {
+		const {
+			projectRoles,
+			workflowRoles,
+			isPersonalProject,
+			personalProjectOwnerId,
+			onlySharedWithMe,
+			projectId,
+		} = sharingOptions;
+
+		const subquery = this.manager
+			.createQueryBuilder()
+			.select('sw.workflowId')
+			.from(SharedWorkflow, 'sw');
+
+		// Handle different sharing scenarios
+		// Check explicit filters first (isPersonalProject, onlySharedWithMe) before falling back to user's global permissions
+		if (isPersonalProject) {
+			// Personal project - get owned workflows using the project owner's ID (not the requesting user's)
+			const ownerUserId = personalProjectOwnerId ?? user.id;
+			subquery
+				.innerJoin(Project, 'p', 'sw.projectId = p.id')
+				.innerJoin(ProjectRelation, 'pr', 'pr.projectId = p.id')
+				.where('sw.role = :ownerRole', { ownerRole: 'workflow:owner' })
+				.andWhere('pr.userId = :subqueryUserId', { subqueryUserId: ownerUserId })
+				.andWhere('pr.role = :projectOwnerRole', { projectOwnerRole: PROJECT_OWNER_ROLE_SLUG });
+
+			// Filter by the specific project ID when specified
+			if (projectId && typeof projectId === 'string' && projectId !== '') {
+				subquery.andWhere('sw.projectId = :subqueryProjectId', { subqueryProjectId: projectId });
+			}
+		} else if (onlySharedWithMe) {
+			// Shared with me - workflows shared (as editor) to user's personal project
+			subquery
+				.innerJoin(Project, 'p', 'sw.projectId = p.id')
+				.innerJoin(ProjectRelation, 'pr', 'pr.projectId = p.id')
+				.where('sw.role = :editorRole', { editorRole: 'workflow:editor' })
+				.andWhere('pr.userId = :subqueryUserId', { subqueryUserId: user.id })
+				.andWhere('pr.role = :projectOwnerRole', { projectOwnerRole: PROJECT_OWNER_ROLE_SLUG });
+		} else if (hasGlobalScope(user, 'workflow:read')) {
+			// User has global scope - return all workflow IDs in the specified project (if any)
+			if (projectId && typeof projectId === 'string' && projectId !== '') {
+				subquery.where('sw.projectId = :subqueryProjectId', { subqueryProjectId: projectId });
+			}
+		} else {
+			// Standard sharing based on roles
+			if (!workflowRoles || !projectRoles) {
+				throw new Error('workflowRoles and projectRoles are required when not using special cases');
+			}
+
+			subquery
+				.innerJoin(Project, 'p', 'sw.projectId = p.id')
+				.innerJoin(ProjectRelation, 'pr', 'pr.projectId = p.id')
+				.where('sw.role IN (:...workflowRoles)', { workflowRoles })
+				.andWhere('pr.userId = :subqueryUserId', { subqueryUserId: user.id })
+				.andWhere('pr.role IN (:...projectRoles)', { projectRoles });
+		}
+
+		return subquery;
 	}
 }

--- a/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
@@ -277,6 +277,10 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 				.where('sw.role IN (:...workflowRoles)', { workflowRoles })
 				.andWhere('pr.userId = :subqueryUserId', { subqueryUserId: user.id })
 				.andWhere('pr.role IN (:...projectRoles)', { projectRoles });
+
+			if (projectId && typeof projectId === 'string' && projectId !== '') {
+				subquery.andWhere('sw.projectId = :subqueryProjectId', { subqueryProjectId: projectId });
+			}
 		}
 
 		return subquery;

--- a/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
@@ -247,11 +247,6 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 				.where('sw.role = :ownerRole', { ownerRole: 'workflow:owner' })
 				.andWhere('pr.userId = :subqueryUserId', { subqueryUserId: ownerUserId })
 				.andWhere('pr.role = :projectOwnerRole', { projectOwnerRole: PROJECT_OWNER_ROLE_SLUG });
-
-			// Filter by the specific project ID when specified
-			if (projectId && typeof projectId === 'string' && projectId !== '') {
-				subquery.andWhere('sw.projectId = :subqueryProjectId', { subqueryProjectId: projectId });
-			}
 		} else if (onlySharedWithMe) {
 			// Shared with me - workflows shared (as editor) to user's personal project
 			subquery
@@ -260,13 +255,8 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 				.where('sw.role = :editorRole', { editorRole: 'workflow:editor' })
 				.andWhere('pr.userId = :subqueryUserId', { subqueryUserId: user.id })
 				.andWhere('pr.role = :projectOwnerRole', { projectOwnerRole: PROJECT_OWNER_ROLE_SLUG });
-		} else if (hasGlobalScope(user, 'workflow:read')) {
-			// User has global scope - return all workflow IDs in the specified project (if any)
-			if (projectId && typeof projectId === 'string' && projectId !== '') {
-				subquery.where('sw.projectId = :subqueryProjectId', { subqueryProjectId: projectId });
-			}
-		} else {
-			// Standard sharing based on roles
+		} else if (!hasGlobalScope(user, 'workflow:read')) {
+			// Standard sharing based on roles (global-scope users need no additional filtering)
 			if (!workflowRoles || !projectRoles) {
 				throw new Error('workflowRoles and projectRoles are required when not using special cases');
 			}
@@ -277,10 +267,11 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 				.where('sw.role IN (:...workflowRoles)', { workflowRoles })
 				.andWhere('pr.userId = :subqueryUserId', { subqueryUserId: user.id })
 				.andWhere('pr.role IN (:...projectRoles)', { projectRoles });
+		}
 
-			if (projectId && typeof projectId === 'string' && projectId !== '') {
-				subquery.andWhere('sw.projectId = :subqueryProjectId', { subqueryProjectId: projectId });
-			}
+		// Apply project filter across all branches (except onlySharedWithMe which is personal-project scoped)
+		if (!onlySharedWithMe && projectId) {
+			subquery.andWhere('sw.projectId = :subqueryProjectId', { subqueryProjectId: projectId });
 		}
 
 		return subquery;

--- a/packages/@n8n/db/src/repositories/workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow.repository.ts
@@ -1,6 +1,6 @@
 import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
-import { hasGlobalScope, PROJECT_OWNER_ROLE_SLUG, type Scope } from '@n8n/permissions';
+import type { Scope } from '@n8n/permissions';
 import { DataSource, Repository, In, Like, Not, IsNull } from '@n8n/typeorm';
 import type {
 	SelectQueryBuilder,
@@ -14,6 +14,7 @@ import type {
 import { PROJECT_ROOT, UserError } from 'n8n-workflow';
 
 import { FolderRepository } from './folder.repository';
+import { SharedWorkflowRepository } from './shared-workflow.repository';
 import { WorkflowHistoryRepository } from './workflow-history.repository';
 import {
 	WebhookEntity,
@@ -22,9 +23,6 @@ import {
 	WorkflowTagMapping,
 	WorkflowDependency,
 	User,
-	SharedWorkflow,
-	Project,
-	ProjectRelation,
 } from '../entities';
 import type {
 	ListQueryDb,
@@ -60,6 +58,7 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 		dataSource: DataSource,
 		private readonly globalConfig: GlobalConfig,
 		private readonly folderRepository: FolderRepository,
+		private readonly sharedWorkflowRepository: SharedWorkflowRepository,
 		private readonly workflowHistoryRepository: WorkflowHistoryRepository,
 	) {
 		super(WorkflowEntity, dataSource.manager);
@@ -830,7 +829,7 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 
 	/**
 	 * Build a subquery that returns workflow IDs based on sharing permissions.
-	 * This replicates the logic from WorkflowSharingService but as a subquery.
+	 * Delegates to SharedWorkflowRepository.buildSharedWorkflowIdsSubquery.
 	 */
 	private buildSharedWorkflowIdsSubquery(
 		user: User,
@@ -845,64 +844,7 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 		},
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	): SelectQueryBuilder<any> {
-		const {
-			projectRoles,
-			workflowRoles,
-			isPersonalProject,
-			personalProjectOwnerId,
-			onlySharedWithMe,
-			projectId,
-		} = sharingOptions;
-
-		const subquery = this.manager
-			.createQueryBuilder()
-			.select('sw.workflowId')
-			.from(SharedWorkflow, 'sw');
-
-		// Handle different sharing scenarios
-		// Check explicit filters first (isPersonalProject, onlySharedWithMe) before falling back to user's global permissions
-		if (isPersonalProject) {
-			// Personal project - get owned workflows using the project owner's ID (not the requesting user's)
-			const ownerUserId = personalProjectOwnerId ?? user.id;
-			subquery
-				.innerJoin(Project, 'p', 'sw.projectId = p.id')
-				.innerJoin(ProjectRelation, 'pr', 'pr.projectId = p.id')
-				.where('sw.role = :ownerRole', { ownerRole: 'workflow:owner' })
-				.andWhere('pr.userId = :subqueryUserId', { subqueryUserId: ownerUserId })
-				.andWhere('pr.role = :projectOwnerRole', { projectOwnerRole: PROJECT_OWNER_ROLE_SLUG });
-
-			// Filter by the specific project ID when specified
-			if (projectId && typeof projectId === 'string' && projectId !== '') {
-				subquery.andWhere('sw.projectId = :subqueryProjectId', { subqueryProjectId: projectId });
-			}
-		} else if (onlySharedWithMe) {
-			// Shared with me - workflows shared (as editor) to user's personal project
-			subquery
-				.innerJoin(Project, 'p', 'sw.projectId = p.id')
-				.innerJoin(ProjectRelation, 'pr', 'pr.projectId = p.id')
-				.where('sw.role = :editorRole', { editorRole: 'workflow:editor' })
-				.andWhere('pr.userId = :subqueryUserId', { subqueryUserId: user.id })
-				.andWhere('pr.role = :projectOwnerRole', { projectOwnerRole: PROJECT_OWNER_ROLE_SLUG });
-		} else if (hasGlobalScope(user, 'workflow:read')) {
-			// User has global scope - return all workflow IDs in the specified project (if any)
-			if (projectId && typeof projectId === 'string' && projectId !== '') {
-				subquery.where('sw.projectId = :subqueryProjectId', { subqueryProjectId: projectId });
-			}
-		} else {
-			// Standard sharing based on roles
-			if (!workflowRoles || !projectRoles) {
-				throw new Error('workflowRoles and projectRoles are required when not using special cases');
-			}
-
-			subquery
-				.innerJoin(Project, 'p', 'sw.projectId = p.id')
-				.innerJoin(ProjectRelation, 'pr', 'pr.projectId = p.id')
-				.where('sw.role IN (:...workflowRoles)', { workflowRoles })
-				.andWhere('pr.userId = :subqueryUserId', { subqueryUserId: user.id })
-				.andWhere('pr.role IN (:...projectRoles)', { projectRoles });
-		}
-
-		return subquery;
+		return this.sharedWorkflowRepository.buildSharedWorkflowIdsSubquery(user, sharingOptions);
 	}
 
 	getManyQuery(workflowIds: string[], options: ListQuery.Options = {}) {

--- a/packages/cli/src/executions/__tests__/executions.controller.test.ts
+++ b/packages/cli/src/executions/__tests__/executions.controller.test.ts
@@ -6,17 +6,20 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import type { ExecutionService } from '@/executions/execution.service';
 import type { ExecutionRequest } from '@/executions/execution.types';
 import { ExecutionsController } from '@/executions/executions.controller';
+import type { RoleService } from '@/services/role.service';
 import type { WorkflowSharingService } from '@/workflows/workflow-sharing.service';
 
 describe('ExecutionsController', () => {
 	const executionService = mock<ExecutionService>();
 	const workflowSharingService = mock<WorkflowSharingService>();
+	const roleService = mock<RoleService>();
 
 	const executionsController = new ExecutionsController(
 		executionService,
 		mock(),
 		workflowSharingService,
 		mock(),
+		roleService,
 	);
 
 	beforeEach(() => {
@@ -87,7 +90,7 @@ describe('ExecutionsController', () => {
 			test.each(QUERIES_WITH_EITHER_STATUS_OR_RANGE)(
 				'should fetch executions per query',
 				async (rangeQuery) => {
-					workflowSharingService.getSharedWorkflowIds.mockResolvedValue(['123']);
+					roleService.rolesWithScope.mockResolvedValue([]);
 					executionService.findLatestCurrentAndCompleted.mockResolvedValue(NO_EXECUTIONS);
 
 					const req = mock<ExecutionRequest.GetMany>({ rangeQuery });
@@ -105,7 +108,7 @@ describe('ExecutionsController', () => {
 			test.each(QUERIES_NEITHER_STATUS_NOR_RANGE_PROVIDED)(
 				'should fetch executions per query',
 				async (rangeQuery) => {
-					workflowSharingService.getSharedWorkflowIds.mockResolvedValue(['123']);
+					roleService.rolesWithScope.mockResolvedValue([]);
 					executionService.findLatestCurrentAndCompleted.mockResolvedValue(NO_EXECUTIONS);
 
 					const req = mock<ExecutionRequest.GetMany>({ rangeQuery });
@@ -121,7 +124,7 @@ describe('ExecutionsController', () => {
 
 		describe('if both status and range provided', () => {
 			it('should fetch executions per query', async () => {
-				workflowSharingService.getSharedWorkflowIds.mockResolvedValue(['123']);
+				roleService.rolesWithScope.mockResolvedValue([]);
 				executionService.findLatestCurrentAndCompleted.mockResolvedValue(NO_EXECUTIONS);
 
 				const rangeQuery: ExecutionSummaries.RangeQuery = {

--- a/packages/cli/src/executions/executions.controller.ts
+++ b/packages/cli/src/executions/executions.controller.ts
@@ -11,6 +11,7 @@ import { validateExecutionUpdatePayload } from './validation';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { License } from '@/license';
+import { RoleService } from '@/services/role.service';
 import { isPositiveInteger } from '@/utils';
 import { WorkflowSharingService } from '@/workflows/workflow-sharing.service';
 
@@ -21,6 +22,7 @@ export class ExecutionsController {
 		private readonly enterpriseExecutionService: EnterpriseExecutionsService,
 		private readonly workflowSharingService: WorkflowSharingService,
 		private readonly license: License,
+		private readonly roleService: RoleService,
 	) {}
 
 	private async getAccessibleWorkflowIds(user: User, scope: Scope) {
@@ -36,19 +38,21 @@ export class ExecutionsController {
 
 	@Get('/', { middlewares: [parseRangeQuery] })
 	async getMany(req: ExecutionRequest.GetMany) {
-		const accessibleWorkflowIds = await this.getAccessibleWorkflowIds(req.user, 'workflow:read');
-
-		if (accessibleWorkflowIds.length === 0) {
-			return { count: 0, estimated: false, results: [] };
-		}
-
 		const { rangeQuery: query } = req;
 
-		if (query.workflowId && !accessibleWorkflowIds.includes(query.workflowId)) {
-			return { count: 0, estimated: false, results: [] };
+		// Build sharing options for the subquery instead of fetching IDs upfront
+		const scope: Scope = 'workflow:read';
+		query.user = req.user;
+		if (this.license.isSharingEnabled()) {
+			const projectRoles = await this.roleService.rolesWithScope('project', [scope]);
+			const workflowRoles = await this.roleService.rolesWithScope('workflow', [scope]);
+			query.sharingOptions = { scopes: [scope], projectRoles, workflowRoles };
+		} else {
+			query.sharingOptions = {
+				workflowRoles: ['workflow:owner'],
+				projectRoles: [PROJECT_OWNER_ROLE_SLUG],
+			};
 		}
-
-		query.accessibleWorkflowIds = accessibleWorkflowIds;
 
 		if (!this.license.isAdvancedExecutionFiltersEnabled()) {
 			delete query.metadata;

--- a/packages/cli/test/integration/execution.repository.test.ts
+++ b/packages/cli/test/integration/execution.repository.test.ts
@@ -1,7 +1,9 @@
 import { createWorkflow, testDb } from '@n8n/backend-test-utils';
+import type { User } from '@n8n/db';
 import { ExecutionRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { createExecution } from '@test-integration/db/executions';
+import { createOwner } from '@test-integration/db/users';
 import { stringify, parse } from 'flatted';
 import { DateTime } from 'luxon';
 import type { ExecutionStatus } from 'n8n-workflow';
@@ -9,10 +11,12 @@ import { createEmptyRunExecutionData, createRunExecutionData } from 'n8n-workflo
 
 describe('UserRepository', () => {
 	let executionRepository: ExecutionRepository;
+	let owner: User;
 
 	beforeAll(async () => {
 		await testDb.init();
 		executionRepository = Container.get(ExecutionRepository);
+		owner = await createOwner();
 	});
 
 	beforeEach(async () => {
@@ -26,7 +30,7 @@ describe('UserRepository', () => {
 	describe('findManyByRangeQuery', () => {
 		test('sort by `createdAt` if `startedAt` is null', async () => {
 			const now = DateTime.utc();
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 			const execution1 = await createExecution(
 				{
 					createdAt: now.plus({ minute: 1 }).toJSDate(),
@@ -51,7 +55,7 @@ describe('UserRepository', () => {
 
 			const executions = await executionRepository.findManyByRangeQuery({
 				workflowId: workflow.id,
-				accessibleWorkflowIds: [workflow.id],
+				user: owner,
 				kind: 'range',
 				range: { limit: 10 },
 				order: { startedAt: 'DESC' },
@@ -124,7 +128,7 @@ describe('UserRepository', () => {
 			async ({ statusInDB, statusUpdate, conditions, updateExpected }) => {
 				// ARRANGE
 
-				const workflow = await createWorkflow();
+				const workflow = await createWorkflow({}, owner);
 				const executionData = createEmptyRunExecutionData();
 				const execution = await createExecution(
 					{ status: statusInDB, data: stringify(executionData) },
@@ -166,7 +170,7 @@ describe('UserRepository', () => {
 		});
 
 		test('requireNotFinished: should update when finished is false', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 			const executionData = createEmptyRunExecutionData();
 			const execution = await createExecution(
 				{ status: 'running', finished: false, data: stringify(executionData) },
@@ -183,7 +187,7 @@ describe('UserRepository', () => {
 		});
 
 		test('requireNotFinished: should not update when finished is true', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 			const executionData = createEmptyRunExecutionData();
 			const execution = await createExecution(
 				{ status: 'success', finished: true, data: stringify(executionData) },
@@ -202,7 +206,7 @@ describe('UserRepository', () => {
 		});
 
 		test('requireNotCanceled: should update when status is not canceled', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 			const executionData = createEmptyRunExecutionData();
 			const execution = await createExecution(
 				{ status: 'running', data: stringify(executionData) },
@@ -219,7 +223,7 @@ describe('UserRepository', () => {
 		});
 
 		test('requireNotCanceled: should not update when status is canceled', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 			const executionData = createEmptyRunExecutionData();
 			const execution = await createExecution(
 				{ status: 'canceled', data: stringify(executionData) },
@@ -238,7 +242,7 @@ describe('UserRepository', () => {
 		});
 
 		test('requireNotFinished + requireNotCanceled: should update running unfinished execution', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 			const executionData = createEmptyRunExecutionData();
 			const execution = await createExecution(
 				{ status: 'running', finished: false, data: stringify(executionData) },
@@ -265,7 +269,7 @@ describe('UserRepository', () => {
 		});
 
 		test('requireNotFinished + requireNotCanceled: should not update canceled execution', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 			const executionData = createEmptyRunExecutionData();
 			const execution = await createExecution(
 				{ status: 'canceled', finished: false, data: stringify(executionData) },

--- a/packages/cli/test/integration/execution.service.integration.test.ts
+++ b/packages/cli/test/integration/execution.service.integration.test.ts
@@ -1,6 +1,11 @@
-import { createTeamProject, createWorkflow, testDb } from '@n8n/backend-test-utils';
+import {
+	createTeamProject,
+	createWorkflow,
+	linkUserToProject,
+	testDb,
+} from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
-import type { ExecutionSummaries } from '@n8n/db';
+import type { ExecutionSummaries, User } from '@n8n/db';
 import { ExecutionMetadataRepository, ExecutionRepository, WorkflowRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
@@ -8,10 +13,13 @@ import { mock } from 'jest-mock-extended';
 import { ExecutionService } from '@/executions/execution.service';
 
 import { annotateExecution, createAnnotationTags, createExecution } from './shared/db/executions';
+import { createMember, createOwner } from './shared/db/users';
 
 describe('ExecutionService', () => {
 	let executionService: ExecutionService;
 	let executionRepository: ExecutionRepository;
+	let member: User;
+	let owner: User;
 	const globalConfig = Container.get(GlobalConfig);
 
 	beforeAll(async () => {
@@ -38,6 +46,9 @@ describe('ExecutionService', () => {
 			mock(),
 			mock(),
 		);
+
+		owner = await createOwner();
+		member = await createMember();
 	});
 
 	beforeEach(() => {
@@ -512,6 +523,252 @@ describe('ExecutionService', () => {
 			expect(output.count).toBe(1);
 			expect(output.estimated).toBe(false);
 			expect(output.results).toEqual([expect.objectContaining({ id: firstId })]);
+		});
+	});
+
+	describe('findRangeWithCount — subquery approach', () => {
+		test('should return same results as array approach', async () => {
+			const workflow1 = await createWorkflow({}, member);
+			const workflow2 = await createWorkflow({}, member);
+			const inaccessibleWorkflow = await createWorkflow({}, owner);
+
+			await Promise.all([
+				createExecution({ status: 'success' }, workflow1),
+				createExecution({ status: 'success' }, workflow1),
+				createExecution({ status: 'error' }, workflow2),
+				createExecution({ status: 'success' }, inaccessibleWorkflow),
+			]);
+
+			const arrayQuery: ExecutionSummaries.RangeQuery = {
+				kind: 'range',
+				range: { limit: 20 },
+				accessibleWorkflowIds: [workflow1.id, workflow2.id],
+			};
+
+			const subqueryQuery: ExecutionSummaries.RangeQuery = {
+				kind: 'range',
+				range: { limit: 20 },
+				user: member,
+				sharingOptions: {
+					workflowRoles: ['workflow:owner'],
+					projectRoles: ['project:personalOwner'],
+				},
+			};
+
+			const [arrayResult, subqueryResult] = await Promise.all([
+				executionService.findRangeWithCount(arrayQuery),
+				executionService.findRangeWithCount(subqueryQuery),
+			]);
+
+			expect(arrayResult.count).toBe(3);
+			expect(subqueryResult.count).toBe(3);
+			expect(subqueryResult.results).toHaveLength(arrayResult.results.length);
+			expect(subqueryResult.results.map((r) => r.id)).toEqual(arrayResult.results.map((r) => r.id));
+		});
+
+		test('should filter by status correctly', async () => {
+			const workflow = await createWorkflow({}, member);
+
+			await Promise.all([
+				createExecution({ status: 'success' }, workflow),
+				createExecution({ status: 'success' }, workflow),
+				createExecution({ status: 'error' }, workflow),
+			]);
+
+			const arrayQuery: ExecutionSummaries.RangeQuery = {
+				kind: 'range',
+				range: { limit: 20 },
+				status: ['success'],
+				accessibleWorkflowIds: [workflow.id],
+			};
+
+			const subqueryQuery: ExecutionSummaries.RangeQuery = {
+				kind: 'range',
+				range: { limit: 20 },
+				status: ['success'],
+				user: member,
+				sharingOptions: {
+					workflowRoles: ['workflow:owner'],
+					projectRoles: ['project:personalOwner'],
+				},
+			};
+
+			const [arrayResult, subqueryResult] = await Promise.all([
+				executionService.findRangeWithCount(arrayQuery),
+				executionService.findRangeWithCount(subqueryQuery),
+			]);
+
+			expect(arrayResult.count).toBe(2);
+			expect(subqueryResult.count).toBe(2);
+			expect(subqueryResult.results.map((r) => r.id)).toEqual(arrayResult.results.map((r) => r.id));
+		});
+
+		test('should filter by workflowId correctly', async () => {
+			const workflow1 = await createWorkflow({}, member);
+			const workflow2 = await createWorkflow({}, member);
+
+			await Promise.all([
+				createExecution({ status: 'success' }, workflow1),
+				createExecution({ status: 'success' }, workflow2),
+				createExecution({ status: 'success' }, workflow2),
+			]);
+
+			const arrayQuery: ExecutionSummaries.RangeQuery = {
+				kind: 'range',
+				range: { limit: 20 },
+				workflowId: workflow1.id,
+				accessibleWorkflowIds: [workflow1.id, workflow2.id],
+			};
+
+			const subqueryQuery: ExecutionSummaries.RangeQuery = {
+				kind: 'range',
+				range: { limit: 20 },
+				workflowId: workflow1.id,
+				user: member,
+				sharingOptions: {
+					workflowRoles: ['workflow:owner'],
+					projectRoles: ['project:personalOwner'],
+				},
+			};
+
+			const [arrayResult, subqueryResult] = await Promise.all([
+				executionService.findRangeWithCount(arrayQuery),
+				executionService.findRangeWithCount(subqueryQuery),
+			]);
+
+			expect(arrayResult.count).toBe(1);
+			expect(subqueryResult.count).toBe(1);
+			expect(subqueryResult.results[0].workflowId).toBe(workflow1.id);
+		});
+
+		test('should work with team project', async () => {
+			const teamProject = await createTeamProject();
+			const personalWorkflow = await createWorkflow({}, owner);
+			const teamWorkflow = await createWorkflow({}, teamProject);
+
+			await Promise.all([
+				createExecution({ status: 'success' }, personalWorkflow),
+				createExecution({ status: 'success' }, teamWorkflow),
+			]);
+
+			const arrayQuery: ExecutionSummaries.RangeQuery = {
+				kind: 'range',
+				range: { limit: 20 },
+				accessibleWorkflowIds: [personalWorkflow.id, teamWorkflow.id],
+			};
+
+			const arrayResult = await executionService.findRangeWithCount(arrayQuery);
+			expect(arrayResult.count).toBe(2);
+		});
+
+		test('should work with sharing-enabled roles (team project admin)', async () => {
+			// Simulates the isSharingEnabled() === true path in the controller
+			const teamProject = await createTeamProject(undefined, member);
+			const personalWorkflow = await createWorkflow({}, member);
+			const teamWorkflow = await createWorkflow({}, teamProject);
+			const inaccessibleWorkflow = await createWorkflow({}, owner);
+
+			await Promise.all([
+				createExecution({ status: 'success' }, personalWorkflow),
+				createExecution({ status: 'success' }, teamWorkflow),
+				createExecution({ status: 'error' }, teamWorkflow),
+				createExecution({ status: 'success' }, inaccessibleWorkflow),
+			]);
+
+			// Sharing-enabled roles: member can see workflows they own OR are admin/editor of
+			const sharingEnabledQuery: ExecutionSummaries.RangeQuery = {
+				kind: 'range',
+				range: { limit: 20 },
+				user: member,
+				sharingOptions: {
+					workflowRoles: ['workflow:owner', 'workflow:editor'],
+					projectRoles: ['project:personalOwner', 'project:admin', 'project:editor'],
+				},
+			};
+
+			const result = await executionService.findRangeWithCount(sharingEnabledQuery);
+
+			// member owns personalWorkflow and is admin of teamProject → sees 3 executions
+			expect(result.count).toBe(3);
+			const workflowIds = result.results.map((r) => r.workflowId);
+			expect(workflowIds).toContain(personalWorkflow.id);
+			expect(workflowIds).toContain(teamWorkflow.id);
+			expect(workflowIds).not.toContain(inaccessibleWorkflow.id);
+		});
+
+		test('should work with sharing-enabled roles (team project editor)', async () => {
+			// member is linked as project:editor to a team project they didn't create
+			const teamProject = await createTeamProject();
+			await linkUserToProject(member, teamProject, 'project:editor');
+			const teamWorkflow = await createWorkflow({}, teamProject);
+			const personalWorkflow = await createWorkflow({}, member);
+			const inaccessibleWorkflow = await createWorkflow({}, owner);
+
+			await Promise.all([
+				createExecution({ status: 'success' }, teamWorkflow),
+				createExecution({ status: 'success' }, personalWorkflow),
+				createExecution({ status: 'success' }, inaccessibleWorkflow),
+			]);
+
+			const sharingEnabledQuery: ExecutionSummaries.RangeQuery = {
+				kind: 'range',
+				range: { limit: 20 },
+				user: member,
+				sharingOptions: {
+					workflowRoles: ['workflow:owner', 'workflow:editor'],
+					projectRoles: ['project:personalOwner', 'project:admin', 'project:editor'],
+				},
+			};
+
+			const result = await executionService.findRangeWithCount(sharingEnabledQuery);
+
+			// member owns personalWorkflow and is editor in teamProject → sees 2 executions
+			expect(result.count).toBe(2);
+			const workflowIds = result.results.map((r) => r.workflowId);
+			expect(workflowIds).toContain(teamWorkflow.id);
+			expect(workflowIds).toContain(personalWorkflow.id);
+			expect(workflowIds).not.toContain(inaccessibleWorkflow.id);
+		});
+	});
+
+	describe('findLatestCurrentAndCompleted — subquery approach', () => {
+		test('should return same results as array approach', async () => {
+			const workflow = await createWorkflow({}, member);
+
+			await Promise.all([
+				createExecution({ status: 'running', stoppedAt: undefined }, workflow),
+				createExecution({ status: 'success' }, workflow),
+				createExecution({ status: 'success' }, workflow),
+				createExecution({ status: 'error' }, workflow),
+			]);
+
+			const arrayQuery: ExecutionSummaries.RangeQuery = {
+				kind: 'range',
+				range: { limit: 20 },
+				accessibleWorkflowIds: [workflow.id],
+			};
+
+			const subqueryQuery: ExecutionSummaries.RangeQuery = {
+				kind: 'range',
+				range: { limit: 20 },
+				user: member,
+				sharingOptions: {
+					workflowRoles: ['workflow:owner'],
+					projectRoles: ['project:personalOwner'],
+				},
+			};
+
+			const [arrayResult, subqueryResult] = await Promise.all([
+				executionService.findLatestCurrentAndCompleted(arrayQuery),
+				executionService.findLatestCurrentAndCompleted(subqueryQuery),
+			]);
+
+			expect(arrayResult.count).toBe(subqueryResult.count);
+			expect(arrayResult.results).toHaveLength(subqueryResult.results.length);
+
+			const arrayIds = arrayResult.results.map((r) => r.id).sort();
+			const subqueryIds = subqueryResult.results.map((r) => r.id).sort();
+			expect(subqueryIds).toEqual(arrayIds);
 		});
 	});
 

--- a/packages/cli/test/integration/execution.service.integration.test.ts
+++ b/packages/cli/test/integration/execution.service.integration.test.ts
@@ -66,7 +66,7 @@ describe('ExecutionService', () => {
 
 	describe('findRangeWithCount', () => {
 		test('should return execution summaries', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 
 			await Promise.all([
 				createExecution({ status: 'success' }, workflow),
@@ -77,7 +77,7 @@ describe('ExecutionService', () => {
 				kind: 'range',
 				status: ['success'],
 				range: { limit: 20 },
-				accessibleWorkflowIds: [workflow.id],
+				user: owner,
 			};
 
 			const output = await executionService.findRangeWithCount(query);
@@ -106,7 +106,7 @@ describe('ExecutionService', () => {
 		});
 
 		test('should limit executions', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 
 			await Promise.all([
 				createExecution({ status: 'success' }, workflow),
@@ -118,7 +118,7 @@ describe('ExecutionService', () => {
 				kind: 'range',
 				status: ['success'],
 				range: { limit: 2 },
-				accessibleWorkflowIds: [workflow.id],
+				user: owner,
 			};
 
 			const output = await executionService.findRangeWithCount(query);
@@ -129,7 +129,7 @@ describe('ExecutionService', () => {
 		});
 
 		test('should retrieve executions before `lastId`, excluding it', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 
 			await Promise.all([
 				createExecution({ status: 'success' }, workflow),
@@ -143,7 +143,7 @@ describe('ExecutionService', () => {
 			const query: ExecutionSummaries.RangeQuery = {
 				kind: 'range',
 				range: { limit: 20, lastId: secondId },
-				accessibleWorkflowIds: [workflow.id],
+				user: owner,
 			};
 
 			const output = await executionService.findRangeWithCount(query);
@@ -156,7 +156,7 @@ describe('ExecutionService', () => {
 		});
 
 		test('should retrieve executions after `firstId`, excluding it', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 
 			await Promise.all([
 				createExecution({ status: 'success' }, workflow),
@@ -170,7 +170,7 @@ describe('ExecutionService', () => {
 			const query: ExecutionSummaries.RangeQuery = {
 				kind: 'range',
 				range: { limit: 20, firstId },
-				accessibleWorkflowIds: [workflow.id],
+				user: owner,
 			};
 
 			const output = await executionService.findRangeWithCount(query);
@@ -187,7 +187,7 @@ describe('ExecutionService', () => {
 		});
 
 		test('should filter executions by `status`', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 
 			await Promise.all([
 				createExecution({ status: 'success' }, workflow),
@@ -200,7 +200,7 @@ describe('ExecutionService', () => {
 				kind: 'range',
 				status: ['success'],
 				range: { limit: 20 },
-				accessibleWorkflowIds: [workflow.id],
+				user: owner,
 			};
 
 			const output = await executionService.findRangeWithCount(query);
@@ -214,8 +214,8 @@ describe('ExecutionService', () => {
 		});
 
 		test('should filter executions by `workflowId`', async () => {
-			const firstWorkflow = await createWorkflow();
-			const secondWorkflow = await createWorkflow();
+			const firstWorkflow = await createWorkflow({}, owner);
+			const secondWorkflow = await createWorkflow({}, owner);
 
 			await Promise.all([
 				createExecution({ status: 'success' }, firstWorkflow),
@@ -228,7 +228,7 @@ describe('ExecutionService', () => {
 				kind: 'range',
 				range: { limit: 20 },
 				workflowId: firstWorkflow.id,
-				accessibleWorkflowIds: [firstWorkflow.id, secondWorkflow.id],
+				user: owner,
 			};
 
 			const output = await executionService.findRangeWithCount(query);
@@ -241,7 +241,7 @@ describe('ExecutionService', () => {
 		});
 
 		test('should filter executions by `startedBefore`', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 
 			await Promise.all([
 				createExecution({ startedAt: new Date('2020-06-01') }, workflow),
@@ -252,7 +252,7 @@ describe('ExecutionService', () => {
 				kind: 'range',
 				range: { limit: 20 },
 				startedBefore: '2020-07-01',
-				accessibleWorkflowIds: [workflow.id],
+				user: owner,
 			};
 
 			const output = await executionService.findRangeWithCount(query);
@@ -265,7 +265,7 @@ describe('ExecutionService', () => {
 		});
 
 		test('should filter executions by `startedAfter`', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 
 			await Promise.all([
 				createExecution({ startedAt: new Date('2020-06-01') }, workflow),
@@ -276,7 +276,7 @@ describe('ExecutionService', () => {
 				kind: 'range',
 				range: { limit: 20 },
 				startedAfter: '2020-07-01',
-				accessibleWorkflowIds: [workflow.id],
+				user: owner,
 			};
 
 			const output = await executionService.findRangeWithCount(query);
@@ -289,7 +289,7 @@ describe('ExecutionService', () => {
 		});
 
 		test('should filter executions by `metadata` with an exact match by default', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 
 			const key = 'myKey';
 			const value = 'myValue';
@@ -302,7 +302,7 @@ describe('ExecutionService', () => {
 			const query: ExecutionSummaries.RangeQuery = {
 				kind: 'range',
 				range: { limit: 20 },
-				accessibleWorkflowIds: [workflow.id],
+				user: owner,
 				metadata: [{ key, value, exactMatch: true }],
 			};
 
@@ -316,7 +316,7 @@ describe('ExecutionService', () => {
 		});
 
 		test('should filter executions by `metadata` with a partial match', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 
 			const key = 'myKey';
 
@@ -329,7 +329,7 @@ describe('ExecutionService', () => {
 			const query: ExecutionSummaries.RangeQuery = {
 				kind: 'range',
 				range: { limit: 20 },
-				accessibleWorkflowIds: [workflow.id],
+				user: owner,
 				metadata: [{ key, value: 'val', exactMatch: false }],
 			};
 
@@ -359,7 +359,7 @@ describe('ExecutionService', () => {
 			const query: ExecutionSummaries.RangeQuery = {
 				kind: 'range',
 				range: { limit: 20 },
-				accessibleWorkflowIds: [firstWorkflow.id],
+				user: owner,
 				projectId: firstProject.id,
 			};
 
@@ -390,7 +390,7 @@ describe('ExecutionService', () => {
 			const query: ExecutionSummaries.RangeQuery = {
 				kind: 'range',
 				range: { limit: 20 },
-				accessibleWorkflowIds: [firstWorkflow.id],
+				user: owner,
 				projectId: firstProject.id,
 				status: ['error'],
 			};
@@ -448,7 +448,7 @@ describe('ExecutionService', () => {
 				const query: ExecutionSummaries.RangeQuery = {
 					kind: 'range',
 					range: { limit: 20 },
-					accessibleWorkflowIds: [firstWorkflow.id],
+					user: owner,
 					projectId: firstProject.id,
 					...filter,
 				};
@@ -466,8 +466,8 @@ describe('ExecutionService', () => {
 		);
 
 		test('should exclude executions by inaccessible `workflowId`', async () => {
-			const accessibleWorkflow = await createWorkflow();
-			const inaccessibleWorkflow = await createWorkflow();
+			const accessibleWorkflow = await createWorkflow({}, member);
+			const inaccessibleWorkflow = await createWorkflow({}, owner);
 
 			await Promise.all([
 				createExecution({ status: 'success' }, accessibleWorkflow),
@@ -480,7 +480,11 @@ describe('ExecutionService', () => {
 				kind: 'range',
 				range: { limit: 20 },
 				workflowId: inaccessibleWorkflow.id,
-				accessibleWorkflowIds: [accessibleWorkflow.id],
+				user: member,
+				sharingOptions: {
+					workflowRoles: ['workflow:owner'],
+					projectRoles: ['project:personalOwner'],
+				},
 			};
 
 			const output = await executionService.findRangeWithCount(query);
@@ -491,7 +495,7 @@ describe('ExecutionService', () => {
 		});
 
 		test('should support advanced filters', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 
 			await Promise.all([createExecution({}, workflow), createExecution({}, workflow)]);
 
@@ -515,7 +519,7 @@ describe('ExecutionService', () => {
 				kind: 'range',
 				range: { limit: 20 },
 				metadata: [{ key: 'key1', value: 'value1' }],
-				accessibleWorkflowIds: [workflow.id],
+				user: owner,
 			};
 
 			const output = await executionService.findRangeWithCount(query);
@@ -527,7 +531,7 @@ describe('ExecutionService', () => {
 	});
 
 	describe('findRangeWithCount — subquery approach', () => {
-		test('should return same results as array approach', async () => {
+		test('should scope results to user accessible workflows', async () => {
 			const workflow1 = await createWorkflow({}, member);
 			const workflow2 = await createWorkflow({}, member);
 			const inaccessibleWorkflow = await createWorkflow({}, owner);
@@ -539,13 +543,7 @@ describe('ExecutionService', () => {
 				createExecution({ status: 'success' }, inaccessibleWorkflow),
 			]);
 
-			const arrayQuery: ExecutionSummaries.RangeQuery = {
-				kind: 'range',
-				range: { limit: 20 },
-				accessibleWorkflowIds: [workflow1.id, workflow2.id],
-			};
-
-			const subqueryQuery: ExecutionSummaries.RangeQuery = {
+			const query: ExecutionSummaries.RangeQuery = {
 				kind: 'range',
 				range: { limit: 20 },
 				user: member,
@@ -555,15 +553,14 @@ describe('ExecutionService', () => {
 				},
 			};
 
-			const [arrayResult, subqueryResult] = await Promise.all([
-				executionService.findRangeWithCount(arrayQuery),
-				executionService.findRangeWithCount(subqueryQuery),
-			]);
+			const result = await executionService.findRangeWithCount(query);
 
-			expect(arrayResult.count).toBe(3);
-			expect(subqueryResult.count).toBe(3);
-			expect(subqueryResult.results).toHaveLength(arrayResult.results.length);
-			expect(subqueryResult.results.map((r) => r.id)).toEqual(arrayResult.results.map((r) => r.id));
+			// member owns workflow1 and workflow2 → sees 3 executions, not the inaccessible one
+			expect(result.count).toBe(3);
+			const workflowIds = result.results.map((r) => r.workflowId);
+			expect(workflowIds).toContain(workflow1.id);
+			expect(workflowIds).toContain(workflow2.id);
+			expect(workflowIds).not.toContain(inaccessibleWorkflow.id);
 		});
 
 		test('should filter by status correctly', async () => {
@@ -579,7 +576,7 @@ describe('ExecutionService', () => {
 				kind: 'range',
 				range: { limit: 20 },
 				status: ['success'],
-				accessibleWorkflowIds: [workflow.id],
+				user: owner,
 			};
 
 			const subqueryQuery: ExecutionSummaries.RangeQuery = {
@@ -617,7 +614,7 @@ describe('ExecutionService', () => {
 				kind: 'range',
 				range: { limit: 20 },
 				workflowId: workflow1.id,
-				accessibleWorkflowIds: [workflow1.id, workflow2.id],
+				user: owner,
 			};
 
 			const subqueryQuery: ExecutionSummaries.RangeQuery = {
@@ -654,7 +651,7 @@ describe('ExecutionService', () => {
 			const arrayQuery: ExecutionSummaries.RangeQuery = {
 				kind: 'range',
 				range: { limit: 20 },
-				accessibleWorkflowIds: [personalWorkflow.id, teamWorkflow.id],
+				user: owner,
 			};
 
 			const arrayResult = await executionService.findRangeWithCount(arrayQuery);
@@ -745,7 +742,7 @@ describe('ExecutionService', () => {
 			const arrayQuery: ExecutionSummaries.RangeQuery = {
 				kind: 'range',
 				range: { limit: 20 },
-				accessibleWorkflowIds: [workflow.id],
+				user: owner,
 			};
 
 			const subqueryQuery: ExecutionSummaries.RangeQuery = {
@@ -776,7 +773,7 @@ describe('ExecutionService', () => {
 		test('should return concurrentExecutionsCount when concurrency is enabled', async () => {
 			globalConfig.executions.concurrency.productionLimit = 4;
 
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 			const concurrentExecutionsData = await Promise.all([
 				createExecution({ status: 'running', mode: 'webhook' }, workflow),
 				createExecution({ status: 'running', mode: 'trigger' }, workflow),
@@ -796,7 +793,7 @@ describe('ExecutionService', () => {
 		test('should set concurrentExecutionsCount to -1 when concurrency is disabled', async () => {
 			globalConfig.executions.concurrency.productionLimit = -1;
 
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 
 			await Promise.all([
 				createExecution({ status: 'running', mode: 'webhook' }, workflow),
@@ -816,7 +813,7 @@ describe('ExecutionService', () => {
 			globalConfig.executions.mode = 'queue';
 			globalConfig.executions.concurrency.productionLimit = 4;
 
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 
 			await Promise.all([
 				createExecution({ status: 'running', mode: 'webhook' }, workflow),
@@ -835,7 +832,7 @@ describe('ExecutionService', () => {
 
 	describe('findLatestCurrentAndCompleted', () => {
 		test('should return latest current and completed executions', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 
 			const totalCompleted = 21;
 
@@ -851,7 +848,7 @@ describe('ExecutionService', () => {
 			const query: ExecutionSummaries.RangeQuery = {
 				kind: 'range',
 				range: { limit: 20 },
-				accessibleWorkflowIds: [workflow.id],
+				user: owner,
 			};
 
 			const output = await executionService.findLatestCurrentAndCompleted(query);
@@ -862,7 +859,7 @@ describe('ExecutionService', () => {
 		});
 
 		test('should handle zero current executions', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 
 			const totalFinished = 5;
 
@@ -875,7 +872,7 @@ describe('ExecutionService', () => {
 			const query: ExecutionSummaries.RangeQuery = {
 				kind: 'range',
 				range: { limit: 20 },
-				accessibleWorkflowIds: [workflow.id],
+				user: owner,
 			};
 
 			const output = await executionService.findLatestCurrentAndCompleted(query);
@@ -886,7 +883,7 @@ describe('ExecutionService', () => {
 		});
 
 		test('should handle zero completed executions', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 
 			await Promise.all([
 				createExecution({ status: 'running' }, workflow),
@@ -897,7 +894,7 @@ describe('ExecutionService', () => {
 			const query: ExecutionSummaries.RangeQuery = {
 				kind: 'range',
 				range: { limit: 20 },
-				accessibleWorkflowIds: [workflow.id],
+				user: owner,
 			};
 
 			const output = await executionService.findLatestCurrentAndCompleted(query);
@@ -908,12 +905,10 @@ describe('ExecutionService', () => {
 		});
 
 		test('should handle zero executions', async () => {
-			const workflow = await createWorkflow();
-
 			const query: ExecutionSummaries.RangeQuery = {
 				kind: 'range',
 				range: { limit: 20 },
-				accessibleWorkflowIds: [workflow.id],
+				user: owner,
 			};
 
 			const output = await executionService.findLatestCurrentAndCompleted(query);
@@ -924,7 +919,7 @@ describe('ExecutionService', () => {
 		});
 
 		test('should prioritize `running` over `new` executions', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 
 			await Promise.all([
 				createExecution({ status: 'new' }, workflow),
@@ -938,7 +933,7 @@ describe('ExecutionService', () => {
 			const query: ExecutionSummaries.RangeQuery = {
 				kind: 'range',
 				range: { limit: 2 },
-				accessibleWorkflowIds: [workflow.id],
+				user: owner,
 			};
 
 			const { results } = await executionService.findLatestCurrentAndCompleted(query);
@@ -969,7 +964,7 @@ describe('ExecutionService', () => {
 		});
 
 		test('should add and retrieve annotation', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 
 			const execution1 = await createExecution({ status: 'success' }, workflow);
 			const execution2 = await createExecution({ status: 'success' }, workflow);
@@ -989,7 +984,7 @@ describe('ExecutionService', () => {
 				kind: 'range',
 				status: ['success'],
 				range: { limit: 20 },
-				accessibleWorkflowIds: [workflow.id],
+				user: owner,
 			};
 
 			const output = await executionService.findRangeWithCount(query);
@@ -1020,7 +1015,7 @@ describe('ExecutionService', () => {
 		});
 
 		test('should update annotation', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 
 			const execution = await createExecution({ status: 'success' }, workflow);
 
@@ -1038,7 +1033,7 @@ describe('ExecutionService', () => {
 				kind: 'range',
 				status: ['success'],
 				range: { limit: 20 },
-				accessibleWorkflowIds: [workflow.id],
+				user: owner,
 			};
 
 			const output = await executionService.findRangeWithCount(query);
@@ -1057,7 +1052,7 @@ describe('ExecutionService', () => {
 		});
 
 		test('should filter by annotation tags', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 
 			const executions = await Promise.all([
 				createExecution({ status: 'success' }, workflow),
@@ -1079,7 +1074,7 @@ describe('ExecutionService', () => {
 				kind: 'range',
 				status: ['success'],
 				range: { limit: 20 },
-				accessibleWorkflowIds: [workflow.id],
+				user: owner,
 				annotationTags: [annotationTags[0].id],
 			};
 
@@ -1102,7 +1097,7 @@ describe('ExecutionService', () => {
 		});
 
 		test('should filter by annotation vote', async () => {
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({}, owner);
 
 			const executions = await Promise.all([
 				createExecution({ status: 'success' }, workflow),
@@ -1124,7 +1119,7 @@ describe('ExecutionService', () => {
 				kind: 'range',
 				status: ['success'],
 				range: { limit: 20 },
-				accessibleWorkflowIds: [workflow.id],
+				user: owner,
 				vote: 'up',
 			};
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
Changed the execution repository query logic when fetching and counting executions 
Why: to prevent db engines errors on the second query when passing too many parameters. 

How: instead of querying first the accessible execution workflow ids from the user context, we pass the context to the main repository function and adds a subquery to filter by the accessible ones

Benchmarks:

**Postgres**
| Scenario | Array (ms) | EXISTS (ms) | Ratio | Verdict |
| :--- | :--- | :--- | :--- | :--- |
| 20k execs, 10 wf | 7–15 | 7–33 | 1.05–2.19x | Slight overhead, negligible at <33ms |
| 50k execs, 1000 wf | 16–3178 | 13–779 | 0.01–24.8x | Highly variable (PG planner), EXISTS wins big when plan is optimal |
| 20k, 100 wf + status filter | 6–109 | 6–7 | 0.07–0.98x | Faster or equal |
| findLatestCurrentAndCompleted, 20k | 10–27 | 11–19 | 0.68–1.26x | Neutral |
| 20k sharing-enabled, team+personal | 6–114 | 6–8 | 0.07–1.25x | Faster or equal |
| 50k sharing-enabled, 1000 team wf | 14–17 | 13–15 | 0.86–0.93x | Consistently faster |

For the "50k execs, 1000 wf" scenario, In production this is less of an issue because:
- PG has warmed-up statistics from ANALYZE / autovacuum
- shared_buffers keeps hot pages cached
- The planner stabilizes after a few queries

The benchmark creates fresh tables each run with no statistics, which is worst-case for PG’s planner.

**SQLite**
| Scenario | Array (ms) | EXISTS (ms) | Ratio | Verdict |
| :--- | ---: | ---: | ---: | :--- |
| 20k execs, 10 wf | 3.34 | 4.72 | 1.41x | Neutral (absolute diff ~1ms) |
| 50k execs, 1000 wf | 17.19 | 17.11 | 1.00x | Neutral |
| 20k, 100 wf + status filter | 6.57 | 6.34 | 0.97x | Neutral |
| findLatestCurrentAndCompleted, 20k | 5.29 | 5.35 | 1.01x | Neutral |
| 20k sharing-enabled, team+personal | 3.33 | 3.53 | 1.06x | Neutral |
| 50k sharing-enabled, 1000 team wf | 17.99 | 18.33 | 1.02x | Neutral |

Mainly neutral on SQLite, and relatively faster on postgres

### Additional benchmarks for the high values
Those benchmark were run on the new code version only, as the previous one throws error because of the bind parameters limit

#### Personal project (single user owns all workflows)

| Scenario | SQLite | Postgres |
| :--- | ---: | ---: |
| 1k workflows, 50k execs | 15ms | 15ms |
| 10k workflows, 50k execs | 24ms | 24ms |
| 50k workflows, 50k execs | 72ms | 77ms |
| 150k workflows, 150k execs (customer scale) | 329ms | 321ms |
| 300k workflows, 300k execs | 813ms | 856ms |
| 500k workflows, 500k execs | 1542ms | 1362ms |
| 1M workflows, 1M execs | 3692ms | 3782ms |
| 100 workflows × 1k execs (100k deep) | 36ms | 26ms |
| 1k workflows × 1k execs (1M deep) | 500ms | 424ms |
| 10k workflows × 1M execs (1M mixed) | 376ms | 343ms |

#### Multi-project (user is member of many team projects)
| Scenario | SQLite | Postgres |
| :--- | ---: | ---: |
| 100 projects × 10 wf (1k total) | 2ms | 4ms |
| 1k projects × 10 wf (10k total) | 8ms | 8ms |
| 5k projects × 10 wf (50k total) | 138ms | 126ms |
| 100 projects × 1.5k wf (150k, few large) | 351ms | 404ms |
| 1k projects × 150 wf (150k) | 338ms | 317ms |
| 10k projects × 15 wf (150k, many small) | 295ms | 325ms |
| 1k projects × 1k wf (1M worst-case) | 6.8s | 4.2s |


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/IAM-371/executions-listing-optimization


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
