### PR TITLE
fix(editor): Fix markdown list item wrapping in chat messages (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMarkdownChunk.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMarkdownChunk.vue
@@ -296,7 +296,7 @@ defineExpose({
 	ol {
 		padding-left: calc(var(--markdown--spacing) * 2);
 		list-style-type: decimal;
-		list-style-position: inside;
+		list-style-position: outside;
 		margin: calc(var(--markdown--spacing) * 2) 0;
 
 		li + li {
@@ -313,7 +313,7 @@ defineExpose({
 	ul {
 		padding-left: calc(var(--markdown--spacing) * 2);
 		list-style-type: disc;
-		list-style-position: inside;
+		list-style-position: outside;
 		margin: calc(var(--markdown--spacing) * 2) 0;
 
 		li + li {

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMarkdownChunk.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMarkdownChunk.vue
@@ -160,7 +160,6 @@ defineExpose({
 	// Headings inside list items should have no top margin
 	li > :is(h1, h2, h3, h4, h5, h6, p, strong):first-child {
 		margin-top: 0;
-		display: inline-block;
 	}
 
 	// Strong/bold text
@@ -294,7 +293,7 @@ defineExpose({
 
 	// Ordered lists
 	ol {
-		padding-left: calc(var(--markdown--spacing) * 2);
+		padding-left: calc(var(--markdown--spacing) * 4);
 		list-style-type: decimal;
 		list-style-position: outside;
 		margin: calc(var(--markdown--spacing) * 2) 0;
@@ -311,7 +310,7 @@ defineExpose({
 
 	// Unordered lists
 	ul {
-		padding-left: calc(var(--markdown--spacing) * 2);
+		padding-left: calc(var(--markdown--spacing) * 4);
 		list-style-type: disc;
 		list-style-position: outside;
 		margin: calc(var(--markdown--spacing) * 2) 0;


### PR DESCRIPTION
## Summary
- switch `ol` and `ul` in `ChatMarkdownChunk` from `list-style-position: inside` to `list-style-position: outside`
- preserve existing list spacing and marker styling while fixing wrapped-line alignment
- this prevents multiline `<li>` content from wrapping under bullets/numbers and keeps wrapped text aligned with the list content

| Before | After |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/ded45f35-e8a5-463b-a2be-a1127beecd04" width="960px" alt="before" /> | <img src="https://github.com/user-attachments/assets/1eaf961d-166c-4857-8327-56933d7a8a6c" width="960px" alt="after" /> |


## Related Linear tickets, Github issues, and Community forum posts
- https://linear.app/n8n/issue/CHA-150/bug-li-shouldnt-wrap-under-the-bullet-or-number

## Review / Merge checklist
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
