### PR TITLE
feat(core): Enable role-based access for external secrets by default

### DIFF
--- a/packages/cli/src/modules/external-secrets.ee/external-secrets.config.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets.config.ts
@@ -20,5 +20,5 @@ export class ExternalSecretsConfig {
 
 	/** Whether to enable role based access control to manage secret providers */
 	@Env('N8N_ENV_FEAT_EXTERNAL_SECRETS_ROLE_BASED_ACCESS')
-	externalSecretsRoleBasedAccess: boolean = false;
+	externalSecretsRoleBasedAccess: boolean = true;
 }


### PR DESCRIPTION
## Summary

Set`externalSecretsRoleBasedAccess` to `true` by default. This completes the rollout of role-based access control for external secret providers.

The env var `N8N_ENV_FEAT_EXTERNAL_SECRETS_ROLE_BASED_ACCESS` remains available if we need to disable the feature for a given instance

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-314/open-secrets-feature-flag-transitions

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)