### PR TITLE
fix(core): Handle invalid JSON responses from OAuth2 token endpoints

### DIFF
--- a/packages/@n8n/client-oauth2/src/client-oauth2.ts
+++ b/packages/@n8n/client-oauth2/src/client-oauth2.ts
@@ -127,7 +127,17 @@ export class ClientOAuth2 {
 		const body = response.data as string;
 
 		if (contentType.startsWith('application/json')) {
-			return JSON.parse(body) as T;
+			try {
+				return JSON.parse(body) as T;
+			} catch {
+				const preview = body.length > 100 ? body.slice(0, 100) + '...' : body;
+				throw new ResponseError(
+					response.status,
+					body,
+					undefined,
+					`Expected JSON response from OAuth2 token endpoint but received: ${preview}`,
+				);
+			}
 		}
 
 		if (contentType.startsWith('application/x-www-form-urlencoded')) {

--- a/packages/@n8n/client-oauth2/test/client-oauth2.test.ts
+++ b/packages/@n8n/client-oauth2/test/client-oauth2.test.ts
@@ -139,6 +139,38 @@ describe('ClientOAuth2', () => {
 			expect(result.message).toEqual(`Unsupported content type: ${contentType}`);
 		});
 
+		it('should throw ResponseError when application/json response contains invalid JSON', async () => {
+			const htmlBody = '<!DOCTYPE html><html><body>Service Unavailable</body></html>';
+			mockTokenResponse({
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+				body: htmlBody,
+			});
+
+			const result = await makeTokenCall().catch((err) => err);
+			expect(result).toBeInstanceOf(ResponseError);
+			expect(result.status).toBe(200);
+			expect(result.body).toBe(htmlBody);
+			expect(result.message).toContain(
+				'Expected JSON response from OAuth2 token endpoint but received:',
+			);
+			expect(result.message).toContain('<!DOCTYPE html>');
+		});
+
+		it('should truncate long invalid JSON response bodies in the error message', async () => {
+			const longBody = 'x'.repeat(200);
+			mockTokenResponse({
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+				body: longBody,
+			});
+
+			const result = await makeTokenCall().catch((err) => err);
+			expect(result).toBeInstanceOf(ResponseError);
+			expect(result.status).toBe(200);
+			expect(result.message).toContain('x'.repeat(100) + '...');
+		});
+
 		it('should reject 4xx responses with auth errors', async () => {
 			mockTokenResponse({
 				status: 401,


### PR DESCRIPTION
## Summary

Wraps `JSON.parse()` in the shared OAuth2 client library (`@n8n/client-oauth2`) with a try-catch so that when a token endpoint returns HTML (e.g. an error page, WAF block, or redirect) with a `Content-Type: application/json` header, a descriptive `ResponseError` is thrown instead of an uncaught `SyntaxError`.

Previously this surfaced as `"Unexpected token '<', "<!DOCTYPE "... is not valid JSON"`, which was confusing and provided no actionable context. The error message now includes a truncated preview of the unexpected response body.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-379

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.