### PR TITLE
fix(core): Prevent credential theft via name-based resolution and permission bypass

### DIFF
--- a/packages/@n8n/db/src/repositories/credentials.repository.ts
+++ b/packages/@n8n/db/src/repositories/credentials.repository.ts
@@ -224,6 +224,18 @@ export class CredentialsRepository extends Repository<CredentialsEntity> {
 	}
 
 	/**
+	 * Find credentials by name and type, scoped to a specific project.
+	 * Used by replaceInvalidCredentials to prevent cross-project credential resolution.
+	 */
+	async findByNameAndTypeInProject(
+		name: string,
+		type: string,
+		projectId: string,
+	): Promise<CredentialsEntity[]> {
+		return await this.findBy({ name, type, shared: { projectId } });
+	}
+
+	/**
 	 * Get credentials with sharing permissions using a subquery instead of pre-fetched IDs.
 	 * This combines the credential and sharing queries into a single database query.
 	 */

--- a/packages/cli/src/__tests__/workflow-helpers.test.ts
+++ b/packages/cli/src/__tests__/workflow-helpers.test.ts
@@ -1,6 +1,7 @@
 import { mockInstance } from '@n8n/backend-test-utils';
-import type { Project, Variables } from '@n8n/db';
-import type { ITaskData, IWorkflowSettings } from 'n8n-workflow';
+import type { CredentialsEntity, Project, Variables } from '@n8n/db';
+import { CredentialsRepository } from '@n8n/db';
+import type { ITaskData, IWorkflowBase, IWorkflowSettings } from 'n8n-workflow';
 
 import { VariablesService } from '@/environments.ee/variables/variables.service.ee';
 import { OwnershipService } from '@/services/ownership.service';
@@ -8,6 +9,7 @@ import {
 	getVariables,
 	preserveInputOverride,
 	removeDefaultValues,
+	replaceInvalidCredentials,
 	shouldRestartParentExecution,
 } from '@/workflow-helpers';
 
@@ -173,6 +175,94 @@ describe('preserveInputOverride', () => {
 		preserveInputOverride(runDataArray);
 		expect(runDataArray).toHaveLength(1);
 		expect(runDataArray[0]).toBe(first);
+	});
+});
+
+describe('replaceInvalidCredentials', () => {
+	const credentialsRepository = mockInstance(CredentialsRepository);
+
+	afterEach(() => jest.clearAllMocks());
+
+	function makeWorkflow(credentials: Record<string, { id: string | null; name: string }>) {
+		return {
+			nodes: [
+				{
+					id: 'node-1',
+					name: 'HTTP Request',
+					type: 'n8n-nodes-base.httpRequest',
+					typeVersion: 4.2,
+					position: [0, 0] as [number, number],
+					parameters: {},
+					credentials,
+				},
+			],
+			connections: {},
+		} as unknown as IWorkflowBase;
+	}
+
+	it('should resolve credentials by name scoped to the given project', async () => {
+		const cred = { id: 'cred-1', name: 'My Cred' } as CredentialsEntity;
+		credentialsRepository.findByNameAndTypeInProject.mockResolvedValueOnce([cred]);
+
+		const workflow = makeWorkflow({ httpHeaderAuth: { id: null, name: 'My Cred' } });
+		await replaceInvalidCredentials(workflow, 'project-1');
+
+		expect(credentialsRepository.findByNameAndTypeInProject).toHaveBeenCalledWith(
+			'My Cred',
+			'httpHeaderAuth',
+			'project-1',
+		);
+		expect(workflow.nodes[0].credentials!.httpHeaderAuth).toEqual({
+			id: 'cred-1',
+			name: 'My Cred',
+		});
+	});
+
+	it('should not resolve when no matching credential exists in the project', async () => {
+		credentialsRepository.findByNameAndTypeInProject.mockResolvedValueOnce([]);
+
+		const workflow = makeWorkflow({ httpHeaderAuth: { id: null, name: 'Unknown' } });
+		await replaceInvalidCredentials(workflow, 'project-1');
+
+		expect(workflow.nodes[0].credentials!.httpHeaderAuth).toEqual({
+			id: null,
+			name: 'Unknown',
+		});
+	});
+
+	it('should not resolve when multiple credentials match in the project', async () => {
+		const cred1 = { id: 'cred-1', name: 'Dup' } as CredentialsEntity;
+		const cred2 = { id: 'cred-2', name: 'Dup' } as CredentialsEntity;
+		credentialsRepository.findByNameAndTypeInProject.mockResolvedValueOnce([cred1, cred2]);
+
+		const workflow = makeWorkflow({ httpHeaderAuth: { id: null, name: 'Dup' } });
+		await replaceInvalidCredentials(workflow, 'project-1');
+
+		expect(workflow.nodes[0].credentials!.httpHeaderAuth).toEqual({
+			id: null,
+			name: 'Dup',
+		});
+	});
+
+	it('should fall back to name lookup within project when credential ID is not found', async () => {
+		const cred = { id: 'cred-new', name: 'My Cred' } as CredentialsEntity;
+		credentialsRepository.findOneBy.mockResolvedValueOnce(null);
+		credentialsRepository.findByNameAndTypeInProject.mockResolvedValueOnce([cred]);
+
+		const workflow = makeWorkflow({
+			httpHeaderAuth: { id: 'cred-deleted', name: 'My Cred' },
+		});
+		await replaceInvalidCredentials(workflow, 'project-1');
+
+		expect(credentialsRepository.findByNameAndTypeInProject).toHaveBeenCalledWith(
+			'My Cred',
+			'httpHeaderAuth',
+			'project-1',
+		);
+		expect(workflow.nodes[0].credentials!.httpHeaderAuth).toEqual({
+			id: 'cred-new',
+			name: 'My Cred',
+		});
 	});
 });
 

--- a/packages/cli/src/executions/pre-execution-checks/__tests__/credentials-permission-checker.test.ts
+++ b/packages/cli/src/executions/pre-execution-checks/__tests__/credentials-permission-checker.test.ts
@@ -240,6 +240,52 @@ describe('CredentialsPermissionChecker', () => {
 			);
 		});
 
+		it('should check generic credential types specified by genericAuthType', async () => {
+			const genericCredentialId = 'generic-cred';
+			const httpRequestNodeWithGenericAuth: INode = {
+				id: 'node-2',
+				name: 'HTTP Request',
+				type: 'n8n-nodes-base.httpRequest',
+				typeVersion: 4.2,
+				position: [0, 0],
+				parameters: {
+					authentication: 'genericCredentialType',
+					genericAuthType: 'httpHeaderAuth',
+				},
+				credentials: {
+					httpHeaderAuth: {
+						id: genericCredentialId,
+						name: 'Header Auth',
+					},
+				},
+			};
+
+			nodeTypes.getByNameAndVersion.mockReturnValue({
+				description: {
+					credentials: [
+						{
+							name: 'httpSslAuth',
+							required: true,
+							displayOptions: { show: { provideSslCertificates: [true] } },
+						},
+					],
+				},
+			} as never);
+
+			sharedCredentialsRepository.getFilteredAccessibleCredentials.mockResolvedValue([]);
+			credentialsRepository.find.mockResolvedValue([]);
+
+			await expect(
+				permissionChecker.check(workflowId, [httpRequestNodeWithGenericAuth]),
+			).rejects.toThrow('Node "HTTP Request" does not have access to the credential');
+
+			// Should check the generic credential type, not skip it
+			expect(sharedCredentialsRepository.getFilteredAccessibleCredentials).toHaveBeenCalledWith(
+				[teamProject.id],
+				[genericCredentialId],
+			);
+		});
+
 		it('should fall back to checking all credentials if node type cannot be resolved', async () => {
 			nodeTypes.getByNameAndVersion.mockImplementation(() => {
 				throw new Error('Unknown node type');

--- a/packages/cli/src/executions/pre-execution-checks/credentials-permission-checker.ts
+++ b/packages/cli/src/executions/pre-execution-checks/credentials-permission-checker.ts
@@ -140,6 +140,14 @@ export class CredentialsPermissionChecker {
 				activeTypes.add(nodeCredentialType);
 			}
 
+			// For nodes using generic credential types (e.g., HTTP Request with
+			// authentication=genericCredentialType), the active credential type is
+			// specified by the genericAuthType parameter
+			const { genericAuthType } = node.parameters;
+			if (typeof genericAuthType === 'string' && genericAuthType) {
+				activeTypes.add(genericAuthType);
+			}
+
 			return activeTypes;
 		} catch {
 			// If we can't resolve the node type, fall back to checking all credentials

--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
@@ -36,13 +36,13 @@ export = {
 			workflow.active = false;
 			workflow.versionId = uuid();
 
-			await replaceInvalidCredentials(workflow);
-
-			addNodeIds(workflow);
-
 			const project = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(
 				req.user.id,
 			);
+
+			await replaceInvalidCredentials(workflow, project.id);
+
+			addNodeIds(workflow);
 			const createdWorkflow = await createWorkflow(workflow, req.user, project, 'workflow:owner');
 
 			await Container.get(WorkflowHistoryService).saveVersion(

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -97,7 +97,7 @@ export class ImportService {
 
 			const hasInvalidCreds = workflow.nodes.some((node) => !node.credentials?.id);
 
-			if (hasInvalidCreds) await this.replaceInvalidCreds(workflow);
+			if (hasInvalidCreds) await this.replaceInvalidCreds(workflow, projectId);
 
 			// Remove workflows from ActiveWorkflowManager BEFORE transaction to prevent orphaned trigger listeners
 			// Only remove if the workflow already exists in the database and is active
@@ -189,9 +189,9 @@ export class ImportService {
 		}
 	}
 
-	async replaceInvalidCreds(workflow: IWorkflowBase) {
+	async replaceInvalidCreds(workflow: IWorkflowBase, projectId: string) {
 		try {
-			await replaceInvalidCredentials(workflow);
+			await replaceInvalidCredentials(workflow, projectId);
 		} catch (e) {
 			this.logger.error('Failed to replace invalid credential', { error: e });
 		}

--- a/packages/cli/src/workflow-helpers.ts
+++ b/packages/cli/src/workflow-helpers.ts
@@ -112,7 +112,10 @@ export function removeDefaultValues(
 }
 
 // Checking if credentials of old format are in use and run a DB check if they might exist uniquely
-export async function replaceInvalidCredentials<T extends IWorkflowBase>(workflow: T): Promise<T> {
+export async function replaceInvalidCredentials<T extends IWorkflowBase>(
+	workflow: T,
+	projectId: string,
+): Promise<T> {
 	const { nodes } = workflow;
 	if (!nodes) return workflow;
 
@@ -142,10 +145,11 @@ export async function replaceInvalidCredentials<T extends IWorkflowBase>(workflo
 					credentialsByName[nodeCredentialType] = {};
 				}
 				if (credentialsByName[nodeCredentialType][name] === undefined) {
-					const credentials = await Container.get(CredentialsRepository).findBy({
+					const credentials = await Container.get(CredentialsRepository).findByNameAndTypeInProject(
 						name,
-						type: nodeCredentialType,
-					});
+						nodeCredentialType,
+						projectId,
+					);
 					// if credential name-type combination is unique, use it
 					if (credentials?.length === 1) {
 						credentialsByName[nodeCredentialType][name] = {
@@ -192,10 +196,11 @@ export async function replaceInvalidCredentials<T extends IWorkflowBase>(workflo
 					continue;
 				}
 				// no credentials found for ID, check if some exist for name
-				const credsByName = await Container.get(CredentialsRepository).findBy({
-					name: nodeCredentials.name,
-					type: nodeCredentialType,
-				});
+				const credsByName = await Container.get(CredentialsRepository).findByNameAndTypeInProject(
+					nodeCredentials.name,
+					nodeCredentialType,
+					projectId,
+				);
 				// if credential name-type combination is unique, take it
 				if (credsByName?.length === 1) {
 					// add found credential to cache

--- a/packages/cli/src/workflows/__tests__/workflow-creation.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-creation.service.test.ts
@@ -235,7 +235,6 @@ describe('WorkflowCreationService', () => {
 			 */
 			expect(projectRepositoryMock.getPersonalProjectForUserOrFail).toHaveBeenCalledWith(
 				'user-456',
-				expect.anything(),
 			);
 			expect(userHasScopesMock).toHaveBeenCalledWith(
 				user,

--- a/packages/cli/src/workflows/__tests__/workflow.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.test.ts
@@ -1,9 +1,10 @@
-import type { User, WorkflowEntity } from '@n8n/db';
+import type { Project, User, WorkflowEntity } from '@n8n/db';
 import type { Scope } from '@n8n/permissions';
 import type { MockProxy } from 'jest-mock-extended';
 import { mock } from 'jest-mock-extended';
 
 import { userHasScopes } from '@/permissions.ee/check-access';
+import type { OwnershipService } from '@/services/ownership.service';
 import type { RoleService } from '@/services/role.service';
 import type { WebhookService } from '@/webhooks/webhook.service';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
@@ -173,13 +174,18 @@ describe('WorkflowService', () => {
 			workflowFinderServiceMock = mock<WorkflowFinderService>();
 			workflowRepositoryMock = mock();
 
+			const ownershipServiceMock = mock<OwnershipService>();
+			ownershipServiceMock.getWorkflowProjectCached.mockResolvedValue(
+				mock<Project>({ id: 'project-1' }),
+			);
+
 			workflowService = new WorkflowService(
 				mock(), // logger
 				mock(), // sharedWorkflowRepository
 				workflowRepositoryMock as never, // workflowRepository
 				mock(), // workflowTagMappingRepository
 				mock(), // binaryDataService
-				mock(), // ownershipService
+				ownershipServiceMock, // ownershipService
 				mock(), // tagService
 				mock(), // workflowHistoryService
 				mock(), // externalHooks

--- a/packages/cli/src/workflows/workflow-creation.service.ts
+++ b/packages/cli/src/workflows/workflow-creation.service.ts
@@ -72,7 +72,14 @@ export class WorkflowCreationService {
 			newWorkflow.tags = await this.tagRepository.findMany(tagIds);
 		}
 
-		await WorkflowHelpers.replaceInvalidCredentials(newWorkflow);
+		// Resolve the effective project before credential replacement to scope lookups
+		let effectiveProjectId = projectId;
+		if (effectiveProjectId === undefined) {
+			const personalProject = await this.projectRepository.getPersonalProjectForUserOrFail(user.id);
+			effectiveProjectId = personalProject.id;
+		}
+
+		await WorkflowHelpers.replaceInvalidCredentials(newWorkflow, effectiveProjectId);
 
 		WorkflowHelpers.addNodeIds(newWorkflow);
 
@@ -100,18 +107,6 @@ export class WorkflowCreationService {
 
 		let project: Project | null = null;
 		const savedWorkflow = await dbManager.transaction(async (transactionManager) => {
-			let effectiveProjectId = projectId;
-
-			if (effectiveProjectId === undefined) {
-				const personalProject = await this.projectRepository.getPersonalProjectForUserOrFail(
-					user.id,
-					transactionManager,
-				);
-				// Chat users are not allowed to create workflows even within their personal project,
-				// so even though we found the project ensure it gets found via expected scope too.
-				effectiveProjectId = personalProject.id;
-			}
-
 			project = await this.projectService.getProjectWithScope(
 				user,
 				effectiveProjectId,

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -359,8 +359,9 @@ export class WorkflowService {
 			workflowUpdateData.versionId = workflow.versionId;
 		}
 
-		// check credentials for old format
-		await WorkflowHelpers.replaceInvalidCredentials(workflowUpdateData);
+		// check credentials for old format - scope to the workflow's owner project
+		const ownerProject = await this.ownershipService.getWorkflowProjectCached(workflowId);
+		await WorkflowHelpers.replaceInvalidCredentials(workflowUpdateData, ownerProject.id);
 
 		WorkflowHelpers.addNodeIds(workflowUpdateData);
 


### PR DESCRIPTION
## Summary

Fixes two security vulnerabilities that allow users to steal credentials in Community Edition:

1. **Name-based credential resolution vulnerability**: `replaceInvalidCredentials()` queried ALL credentials by `(name, type)` with no project/ownership filter, allowing users to resolve any credential by guessing its name. Now scoped to the workflow's project.

2. **Generic HTTP credential type bypass**: `CredentialsPermissionChecker.getActiveCredentialTypes()` didn't include `genericAuthType` parameter, allowing generic HTTP credential types (`httpBasicAuth`, `httpHeaderAuth`, `httpQueryAuth`) to bypass permission checks entirely. Now included in active type filtering.

Tests added to verify both fixes work correctly.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-366

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created
- [x] Tests included
- [ ] PR Labeled with `release/backport` (if applicable)