### PR TITLE
ci: Skip Chromatic in merge queue to avoid stale baseline failures

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -174,7 +174,7 @@ jobs:
   chromatic:
     name: Chromatic
     needs: install-and-build
-    if: needs.install-and-build.outputs.design_system == 'true'
+    if: needs.install-and-build.outputs.design_system == 'true' && github.event_name == 'pull_request'
     uses: ./.github/workflows/test-visual-chromatic.yml
     with:
       ref: ${{ needs.install-and-build.outputs.commit_sha }}


### PR DESCRIPTION
## Summary
- Skips Chromatic visual regression checks when running in the merge queue (`merge_group` event)
- Chromatic's TurboSnap can't find ephemeral merge queue commit SHAs, causing it to fall back to stale baselines and flag hundreds of unrelated files as changed (e.g. [509 changed files in PR #26891](https://github.com/n8n-io/n8n/actions/runs/23138633961/job/67209195881))
- Chromatic already runs on the `pull_request` event, so the visual check has passed before the merge queue stage

## Test plan
- [ ] Open a PR that touches `packages/frontend/@n8n/design-system/**` — Chromatic should still run on the PR
- [ ] When that PR enters the merge queue — Chromatic should be skipped
- [ ] The `required-checks` gate should still pass (skipped jobs are treated as passing by the ci-filter validator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)