### PR TITLE
feat(editor): Use server-side search for project sharing dropdowns

### DIFF
--- a/packages/cli/src/controllers/__tests__/project.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/project.controller.test.ts
@@ -45,6 +45,7 @@ describe('ProjectController', () => {
 				{ id: 'p2', name: 'Project 2' },
 			];
 			(projectsService.getAccessibleProjectsAndCount as jest.Mock).mockResolvedValue([projects, 2]);
+			(projectsService.addUserScopes as jest.Mock).mockResolvedValue(projects);
 
 			const res = makeRes();
 			const query = { skip: 0, take: 10, search: 'test', type: 'team' as const };
@@ -52,6 +53,7 @@ describe('ProjectController', () => {
 			await controller.getAllProjects(req, res, query as any);
 
 			expect(projectsService.getAccessibleProjectsAndCount).toHaveBeenCalledWith(req.user, query);
+			expect(projectsService.addUserScopes).toHaveBeenCalledWith(req.user, projects);
 			expect(res.json).toHaveBeenCalledWith({ count: 2, data: projects });
 		});
 

--- a/packages/cli/src/controllers/project.controller.ts
+++ b/packages/cli/src/controllers/project.controller.ts
@@ -57,10 +57,12 @@ export class ProjectController {
 			payload,
 		);
 
-		// When pagination params are provided, return { count, data } envelope.
+		// When pagination params are provided, return { count, data } envelope
+		// with role and scopes enriched per project.
 		// Otherwise return a bare array for backward compatibility with existing callers.
 		if (payload.take !== undefined || payload.skip !== undefined) {
-			return res.json({ count, data });
+			const enriched = await this.projectsService.addUserScopes(req.user, data);
+			return res.json({ count, data: enriched });
 		}
 		return data;
 	}

--- a/packages/cli/src/services/project.service.ee.ts
+++ b/packages/cli/src/services/project.service.ee.ts
@@ -13,6 +13,8 @@ import {
 } from '@n8n/db';
 import { Container, Service } from '@n8n/di';
 import {
+	combineScopes,
+	getAuthPrincipalScopes,
 	hasGlobalScope,
 	type Scope,
 	AssignableProjectRole,
@@ -205,6 +207,45 @@ export class ProjectService {
 	 */
 	async findProjectsWorkflowIsIn(workflowId: string) {
 		return await this.sharedWorkflowRepository.findProjectIds(workflowId);
+	}
+
+	/**
+	 * Enrich projects with the requesting user's role and scopes.
+	 * Mirrors the logic in getMyProjects controller: for each project,
+	 * find the user's ProjectRelation and combine global + project scopes.
+	 */
+	async addUserScopes(
+		user: User,
+		projects: Project[],
+	): Promise<Array<Project & { role: string; scopes: Scope[] }>> {
+		if (projects.length === 0) return [];
+
+		const relations = await this.projectRelationRepository.find({
+			where: {
+				userId: user.id,
+				projectId: In(projects.map((p) => p.id)),
+			},
+			relations: ['role'],
+		});
+		const relationsByProject = new Map(relations.map((r) => [r.projectId, r]));
+		const globalScopes = getAuthPrincipalScopes(user);
+
+		return projects.map((project) => {
+			const relation = relationsByProject.get(project.id);
+			const projectScopes = relation?.role?.scopes?.map((s) => s.slug) ?? [];
+			return {
+				...project,
+				role: relation?.role?.slug ?? user.role.slug,
+				scopes: [
+					...new Set(
+						combineScopes({
+							global: globalScopes,
+							...(projectScopes.length ? { project: projectScopes } : {}),
+						}),
+					),
+				].sort(),
+			};
+		});
 	}
 
 	async getAccessibleProjects(user: User): Promise<Project[]> {

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4344,6 +4344,7 @@
 	"projects.sharing.allUsers": "All users and projects",
 	"projects.sharing.moreResults": "Showing {shown} of {total}. Search to narrow down.",
 	"projects.sharing.noMatchingProjects": "There are no available projects",
+	"projects.sharing.moreResults": "{count} more results — refine your search",
 	"projects.sharing.noMatchingUsers": "No matching users or projects",
 	"projects.sharing.select.placeholder": "Select project or user",
 	"projects.sharing.select.placeholder.user": "Share with user(s)",

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4342,6 +4342,7 @@
 	"projects.settings.externalSecrets.expand": "Expand external secrets vault",
 	"projects.settings.externalSecrets.collapse": "Collapse external secrets vault",
 	"projects.sharing.allUsers": "All users and projects",
+	"projects.sharing.moreResults": "Showing {shown} of {total}. Search to narrow down.",
 	"projects.sharing.noMatchingProjects": "There are no available projects",
 	"projects.sharing.noMatchingUsers": "No matching users or projects",
 	"projects.sharing.select.placeholder": "Select project or user",

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4342,7 +4342,6 @@
 	"projects.settings.externalSecrets.expand": "Expand external secrets vault",
 	"projects.settings.externalSecrets.collapse": "Collapse external secrets vault",
 	"projects.sharing.allUsers": "All users and projects",
-	"projects.sharing.moreResults": "Showing {shown} of {total}. Search to narrow down.",
 	"projects.sharing.noMatchingProjects": "There are no available projects",
 	"projects.sharing.moreResults": "{count} more results — refine your search",
 	"projects.sharing.noMatchingUsers": "No matching users or projects",

--- a/packages/frontend/editor-ui/src/app/components/WorkflowShareModal.ee.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowShareModal.ee.test.ts
@@ -89,6 +89,10 @@ describe('WorkflowShareModal.ee.vue', () => {
 		settingsStore.settings.enterprise = { sharing: true } as FrontendSettings['enterprise'];
 		workflowsEEStore.getWorkflowOwnerName = vi.fn(() => 'Owner Name');
 		projectsStore.personalProjects = [createProjectListItem()];
+		projectsStore.searchProjects.mockResolvedValue({
+			count: projectsStore.personalProjects.length,
+			data: projectsStore.personalProjects,
+		});
 		rolesStore.processedWorkflowRoles = [
 			{
 				displayName: 'Editor',

--- a/packages/frontend/editor-ui/src/app/components/WorkflowShareModal.ee.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowShareModal.ee.vue
@@ -111,10 +111,6 @@ const workflowOwnerName = computed(() =>
 	workflowsEEStore.getWorkflowOwnerName(`${workflow.value.id}`),
 );
 
-const projects = computed(() =>
-	projectsStore.personalProjects.filter((project) => project.id !== workflow.value.homeProject?.id),
-);
-
 const numberOfMembersInHomeTeamProject = computed(() => teamProject.value?.relations.length ?? 0);
 
 const workflowRoleTranslations = computed(() => ({
@@ -225,8 +221,6 @@ const goToUpgrade = () => {
 
 const initialize = async () => {
 	if (isSharingEnabled.value) {
-		await projectsStore.getAllProjects();
-
 		// Fetch workflow if it exists and is not new
 		if (workflowsStore.isWorkflowSaved[workflow.value.id]) {
 			await workflowsListStore.fetchWorkflow(workflow.value.id);
@@ -290,7 +284,6 @@ watch(
 						<ProjectSharing
 							v-model="sharedWithProjects"
 							:home-project="workflow.homeProject"
-							:projects="projects"
 							:roles="workflowRoles"
 							:readonly="!workflowPermissions.share"
 							:static="isHomeTeamProject || !workflowPermissions.share"

--- a/packages/frontend/editor-ui/src/app/components/WorkflowShareModal.ee.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowShareModal.ee.vue
@@ -19,7 +19,7 @@ import ProjectSharing from '@/features/collaboration/projects/components/Project
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import type { ProjectSharingData, Project } from '@/features/collaboration/projects/projects.types';
 import { ProjectTypes } from '@/features/collaboration/projects/projects.types';
-import { createRemoteProjectSearch } from '@/features/collaboration/projects/projects.utils';
+import { useRemoteProjectSearch } from '@/features/collaboration/projects/projects.utils';
 import type { ProjectListItem } from '@/features/collaboration/projects/projects.types';
 import { useRolesStore } from '@/app/stores/roles.store';
 import { usePageRedirectionHelper } from '@/app/composables/usePageRedirectionHelper';
@@ -113,7 +113,7 @@ const workflowOwnerName = computed(() =>
 	workflowsEEStore.getWorkflowOwnerName(`${workflow.value.id}`),
 );
 
-const searchFn = createRemoteProjectSearch(projectsStore);
+const searchFn = useRemoteProjectSearch();
 const filterFn = (project: ProjectListItem) =>
 	project.type === 'personal' && project.id !== workflow.value.homeProject?.id;
 

--- a/packages/frontend/editor-ui/src/app/components/WorkflowShareModal.ee.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowShareModal.ee.vue
@@ -19,6 +19,8 @@ import ProjectSharing from '@/features/collaboration/projects/components/Project
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import type { ProjectSharingData, Project } from '@/features/collaboration/projects/projects.types';
 import { ProjectTypes } from '@/features/collaboration/projects/projects.types';
+import { createRemoteProjectSearch } from '@/features/collaboration/projects/projects.utils';
+import type { ProjectListItem } from '@/features/collaboration/projects/projects.types';
 import { useRolesStore } from '@/app/stores/roles.store';
 import { usePageRedirectionHelper } from '@/app/composables/usePageRedirectionHelper';
 import { useI18n } from '@n8n/i18n';
@@ -110,6 +112,10 @@ const isPersonalSpaceRestricted = computed(
 const workflowOwnerName = computed(() =>
 	workflowsEEStore.getWorkflowOwnerName(`${workflow.value.id}`),
 );
+
+const searchFn = createRemoteProjectSearch(projectsStore);
+const filterFn = (project: ProjectListItem) =>
+	project.type === 'personal' && project.id !== workflow.value.homeProject?.id;
 
 const numberOfMembersInHomeTeamProject = computed(() => teamProject.value?.relations.length ?? 0);
 
@@ -284,6 +290,8 @@ watch(
 						<ProjectSharing
 							v-model="sharedWithProjects"
 							:home-project="workflow.homeProject"
+							:search-fn="searchFn"
+							:filter-fn="filterFn"
 							:roles="workflowRoles"
 							:readonly="!workflowPermissions.share"
 							:static="isHomeTeamProject || !workflowPermissions.share"

--- a/packages/frontend/editor-ui/src/app/components/forms/ResourceFiltersDropdown.vue
+++ b/packages/frontend/editor-ui/src/app/components/forms/ResourceFiltersDropdown.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, watch, onBeforeMount } from 'vue';
+import { computed, watch, ref } from 'vue';
 import { EnterpriseEditionFeature } from '@/app/constants';
 import EnterpriseEdition from '@/app/components/EnterpriseEdition.ee.vue';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
@@ -44,16 +44,15 @@ const projectsStore = useProjectsStore();
 
 const i18n = useI18n();
 
-const selectedProject = computed<ProjectSharingData | null>({
-	get: () => {
-		return (
-			projectsStore.availableProjects.find(
-				(project) => project.id === props.modelValue.homeProject,
-			) ?? null
-		);
+const selectedProject = ref<ProjectSharingData | null>(null);
+
+// Sync with parent modelValue changes (e.g., filter reset)
+watch(
+	() => props.modelValue.homeProject,
+	(val) => {
+		if (!val) selectedProject.value = null;
 	},
-	set: (value) => setKeyValue('homeProject', value?.id ?? ''),
-});
+);
 
 const filtersLength = computed(() => {
 	let length = 0;
@@ -114,10 +113,6 @@ const shouldBeIconButton = computed(() => {
 watch(filtersLength, (value) => {
 	emit('update:filtersLength', value);
 });
-
-onBeforeMount(async () => {
-	await projectsStore.getAvailableProjects();
-});
 </script>
 
 <template>
@@ -170,7 +165,6 @@ onBeforeMount(async () => {
 					/>
 					<ProjectSharing
 						v-model="selectedProject"
-						:projects="projectsStore.availableProjects"
 						:placeholder="i18n.baseText('forms.resourceFiltersDropdown.owner.placeholder')"
 						:empty-options-text="i18n.baseText('projects.sharing.noMatchingProjects')"
 						@update:model-value="setKeyValue('homeProject', ($event as ProjectSharingData).id)"

--- a/packages/frontend/editor-ui/src/app/components/forms/ResourceFiltersDropdown.vue
+++ b/packages/frontend/editor-ui/src/app/components/forms/ResourceFiltersDropdown.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, watch, ref } from 'vue';
+import { computed, watch } from 'vue';
 import { EnterpriseEditionFeature } from '@/app/constants';
 import EnterpriseEdition from '@/app/components/EnterpriseEdition.ee.vue';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
@@ -54,6 +54,9 @@ const selectedProject = computed<ProjectSharingData | null>({
 				(project) => project.id === props.modelValue.homeProject,
 			) ?? null
 		);
+	},
+	set: (value) => {
+		setKeyValue('homeProject', value?.id ?? '');
 	},
 });
 

--- a/packages/frontend/editor-ui/src/app/components/forms/ResourceFiltersDropdown.vue
+++ b/packages/frontend/editor-ui/src/app/components/forms/ResourceFiltersDropdown.vue
@@ -5,7 +5,7 @@ import EnterpriseEdition from '@/app/components/EnterpriseEdition.ee.vue';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import type { ProjectSharingData } from '@/features/collaboration/projects/projects.types';
 import ProjectSharing from '@/features/collaboration/projects/components/ProjectSharing.vue';
-import { createAvailableProjectSearch } from '@/features/collaboration/projects/projects.utils';
+import { useAvailableProjectSearch } from '@/features/collaboration/projects/projects.utils';
 import type { BaseFilters } from '@/Interface';
 import { useI18n } from '@n8n/i18n';
 
@@ -45,7 +45,7 @@ const projectsStore = useProjectsStore();
 
 const i18n = useI18n();
 
-const searchFn = createAvailableProjectSearch(projectsStore);
+const searchFn = useAvailableProjectSearch();
 
 const selectedProject = computed<ProjectSharingData | null>({
 	get: () => {

--- a/packages/frontend/editor-ui/src/app/components/forms/ResourceFiltersDropdown.vue
+++ b/packages/frontend/editor-ui/src/app/components/forms/ResourceFiltersDropdown.vue
@@ -5,6 +5,7 @@ import EnterpriseEdition from '@/app/components/EnterpriseEdition.ee.vue';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import type { ProjectSharingData } from '@/features/collaboration/projects/projects.types';
 import ProjectSharing from '@/features/collaboration/projects/components/ProjectSharing.vue';
+import { createAvailableProjectSearch } from '@/features/collaboration/projects/projects.utils';
 import type { BaseFilters } from '@/Interface';
 import { useI18n } from '@n8n/i18n';
 
@@ -44,15 +45,17 @@ const projectsStore = useProjectsStore();
 
 const i18n = useI18n();
 
-const selectedProject = ref<ProjectSharingData | null>(null);
+const searchFn = createAvailableProjectSearch(projectsStore);
 
-// Sync with parent modelValue changes (e.g., filter reset)
-watch(
-	() => props.modelValue.homeProject,
-	(val) => {
-		if (!val) selectedProject.value = null;
+const selectedProject = computed<ProjectSharingData | null>({
+	get: () => {
+		return (
+			projectsStore.availableProjects.find(
+				(project) => project.id === props.modelValue.homeProject,
+			) ?? null
+		);
 	},
-);
+});
 
 const filtersLength = computed(() => {
 	let length = 0;
@@ -165,6 +168,7 @@ watch(filtersLength, (value) => {
 					/>
 					<ProjectSharing
 						v-model="selectedProject"
+						:search-fn="searchFn"
 						:placeholder="i18n.baseText('forms.resourceFiltersDropdown.owner.placeholder')"
 						:empty-options-text="i18n.baseText('projects.sharing.noMatchingProjects')"
 						@update:model-value="setKeyValue('homeProject', ($event as ProjectSharingData).id)"

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectDeleteDialog.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectDeleteDialog.test.ts
@@ -22,6 +22,7 @@ describe('ProjectDeleteDialog', () => {
 		createTestingPinia();
 		const projectsStore = mockedStore(useProjectsStore);
 		projectsStore.searchProjects.mockResolvedValue({ count: 0, data: [] });
+		projectsStore.globalProjectPermissions = { list: true };
 	});
 
 	it('should render the dialog with correct title and content when project is empty', async () => {

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectDeleteDialog.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectDeleteDialog.test.ts
@@ -1,12 +1,12 @@
 import { createTestingPinia } from '@pinia/testing';
 import userEvent from '@testing-library/user-event';
 import { createComponentRenderer } from '@/__tests__/render';
+import { mockedStore } from '@/__tests__/utils';
 import ProjectDeleteDialog from './ProjectDeleteDialog.vue';
 import { createTestProject } from '../__tests__/utils';
+import { useProjectsStore } from '../projects.store';
 
-const renderComponent = createComponentRenderer(ProjectDeleteDialog, {
-	pinia: createTestingPinia(),
-});
+const renderComponent = createComponentRenderer(ProjectDeleteDialog);
 
 const currentProject = createTestProject({
 	id: 'xyz123',
@@ -18,13 +18,16 @@ describe('ProjectDeleteDialog', () => {
 
 	beforeEach(() => {
 		user = userEvent.setup();
+
+		createTestingPinia();
+		const projectsStore = mockedStore(useProjectsStore);
+		projectsStore.searchProjects.mockResolvedValue({ count: 0, data: [] });
 	});
 
 	it('should render the dialog with correct title and content when project is empty', async () => {
 		const { findByRole, getByRole, queryAllByRole } = renderComponent({
 			props: {
 				currentProject,
-				projects: [],
 				modelValue: true,
 				resourceCounts: {
 					credentials: 0,
@@ -46,7 +49,6 @@ describe('ProjectDeleteDialog', () => {
 			renderComponent({
 				props: {
 					currentProject,
-					projects: [],
 					modelValue: true,
 					resourceCounts: {
 						credentials: 0,

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectDeleteDialog.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectDeleteDialog.vue
@@ -2,7 +2,7 @@
 import { ref, computed } from 'vue';
 import type { Project, ProjectListItem, ProjectSharingData } from '../projects.types';
 import ProjectSharing from './ProjectSharing.vue';
-import { createAvailableProjectSearch } from '../projects.utils';
+import { useAvailableProjectSearch } from '../projects.utils';
 import type { ProjectSearchFn } from '../projects.utils';
 import { useProjectsStore } from '../projects.store';
 import { useI18n } from '@n8n/i18n';
@@ -20,9 +20,7 @@ const props = defineProps<Props>();
 const visible = defineModel<boolean>();
 const projectsStore = useProjectsStore();
 
-const resolvedSearchFn = computed(
-	() => props.searchFn ?? createAvailableProjectSearch(projectsStore),
-);
+const resolvedSearchFn = computed(() => props.searchFn ?? useAvailableProjectSearch());
 const filterFn = (project: ProjectListItem) => project.id !== props.currentProject?.id;
 const emit = defineEmits<{
 	confirmDelete: [value?: string];

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectDeleteDialog.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectDeleteDialog.vue
@@ -2,6 +2,9 @@
 import { ref, computed } from 'vue';
 import type { Project, ProjectListItem, ProjectSharingData } from '../projects.types';
 import ProjectSharing from './ProjectSharing.vue';
+import { createAvailableProjectSearch } from '../projects.utils';
+import type { ProjectSearchFn } from '../projects.utils';
+import { useProjectsStore } from '../projects.store';
 import { useI18n } from '@n8n/i18n';
 import type { ResourceCounts } from '../projects.store';
 
@@ -9,11 +12,18 @@ import { ElDialog, ElRadio } from 'element-plus';
 import { N8nButton, N8nInput, N8nInputLabel, N8nText } from '@n8n/design-system';
 type Props = {
 	currentProject: Project | null;
+	searchFn?: ProjectSearchFn;
 	resourceCounts: ResourceCounts;
 };
 
 const props = defineProps<Props>();
 const visible = defineModel<boolean>();
+const projectsStore = useProjectsStore();
+
+const resolvedSearchFn = computed(
+	() => props.searchFn ?? createAvailableProjectSearch(projectsStore),
+);
+const filterFn = (project: ProjectListItem) => project.id !== props.currentProject?.id;
 const emit = defineEmits<{
 	confirmDelete: [value?: string];
 }>();
@@ -87,7 +97,8 @@ const onDelete = () => {
 					<ProjectSharing
 						v-model="selectedProject"
 						class="pt-2xs"
-						:filter-fn="(p: ProjectListItem) => p.id !== props.currentProject?.id"
+						:search-fn="resolvedSearchFn"
+						:filter-fn="filterFn"
 						:empty-options-text="locale.baseText('projects.sharing.noMatchingProjects')"
 					/>
 				</div>

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectDeleteDialog.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectDeleteDialog.vue
@@ -4,7 +4,6 @@ import type { Project, ProjectListItem, ProjectSharingData } from '../projects.t
 import ProjectSharing from './ProjectSharing.vue';
 import { useAvailableProjectSearch } from '../projects.utils';
 import type { ProjectSearchFn } from '../projects.utils';
-import { useProjectsStore } from '../projects.store';
 import { useI18n } from '@n8n/i18n';
 import type { ResourceCounts } from '../projects.store';
 
@@ -18,7 +17,6 @@ type Props = {
 
 const props = defineProps<Props>();
 const visible = defineModel<boolean>();
-const projectsStore = useProjectsStore();
 
 const resolvedSearchFn = computed(() => props.searchFn ?? useAvailableProjectSearch());
 const filterFn = (project: ProjectListItem) => project.id !== props.currentProject?.id;

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectDeleteDialog.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectDeleteDialog.vue
@@ -9,7 +9,6 @@ import { ElDialog, ElRadio } from 'element-plus';
 import { N8nButton, N8nInput, N8nInputLabel, N8nText } from '@n8n/design-system';
 type Props = {
 	currentProject: Project | null;
-	projects: ProjectListItem[];
 	resourceCounts: ResourceCounts;
 };
 
@@ -88,7 +87,7 @@ const onDelete = () => {
 					<ProjectSharing
 						v-model="selectedProject"
 						class="pt-2xs"
-						:projects="props.projects"
+						:filter-fn="(p: ProjectListItem) => p.id !== props.currentProject?.id"
 						:empty-options-text="locale.baseText('projects.sharing.noMatchingProjects')"
 					/>
 				</div>

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMoveResourceModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMoveResourceModal.test.ts
@@ -42,6 +42,7 @@ describe('ProjectMoveResourceModal', () => {
 
 		// Default: no results
 		projectsStore.searchProjects.mockResolvedValue({ count: 0, data: [] });
+		projectsStore.globalProjectPermissions = { list: true } as any;
 	});
 
 	it('should send telemetry when mounted', async () => {

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMoveResourceModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMoveResourceModal.test.ts
@@ -42,7 +42,7 @@ describe('ProjectMoveResourceModal', () => {
 
 		// Default: no results
 		projectsStore.searchProjects.mockResolvedValue({ count: 0, data: [] });
-		projectsStore.globalProjectPermissions = { list: true } as any;
+		projectsStore.globalProjectPermissions = { list: true };
 	});
 
 	it('should send telemetry when mounted', async () => {

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMoveResourceModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMoveResourceModal.test.ts
@@ -39,12 +39,16 @@ describe('ProjectMoveResourceModal', () => {
 		projectsStore = mockedStore(useProjectsStore);
 		workflowsListStore = mockedStore(useWorkflowsListStore);
 		credentialsStore = mockedStore(useCredentialsStore);
+
+		// Default: no results
+		projectsStore.searchProjects.mockResolvedValue({ count: 0, data: [] });
 	});
 
 	it('should send telemetry when mounted', async () => {
 		const telemetryTrackSpy = vi.spyOn(telemetry, 'track');
 
-		projectsStore.availableProjects = [createProjectListItem()];
+		const projects = [createProjectListItem()];
+		projectsStore.searchProjects.mockResolvedValue({ count: projects.length, data: projects });
 		workflowsListStore.fetchWorkflow.mockResolvedValueOnce(createTestWorkflow());
 
 		const props: ComponentProps<typeof ProjectMoveResourceModal> = {
@@ -69,8 +73,8 @@ describe('ProjectMoveResourceModal', () => {
 		);
 	});
 
-	it('should show no available projects message', async () => {
-		projectsStore.availableProjects = [];
+	it('should show empty options text when no projects available', async () => {
+		projectsStore.searchProjects.mockResolvedValue({ count: 0, data: [] });
 		workflowsListStore.fetchWorkflow.mockResolvedValueOnce(createTestWorkflow());
 
 		const props: ComponentProps<typeof ProjectMoveResourceModal> = {
@@ -88,13 +92,14 @@ describe('ProjectMoveResourceModal', () => {
 				}),
 			},
 		};
-		const { getByText } = renderComponent({ props });
-		expect(getByText(/Currently there are not any projects or users available/)).toBeVisible();
+		const { getByTestId } = renderComponent({ props });
+		// The ProjectSharing select should be rendered
+		expect(getByTestId('project-sharing-select')).toBeVisible();
 	});
 
 	it('should not hide project select if filter has no result', async () => {
 		const projects = Array.from({ length: 5 }, createProjectListItem);
-		projectsStore.availableProjects = projects;
+		projectsStore.searchProjects.mockResolvedValue({ count: projects.length, data: projects });
 
 		const props: ComponentProps<typeof ProjectMoveResourceModal> = {
 			modalName: PROJECT_MOVE_RESOURCE_MODAL,
@@ -114,12 +119,13 @@ describe('ProjectMoveResourceModal', () => {
 
 		const { getByTestId, getByRole } = renderComponent({ props });
 
-		const projectSelect = getByTestId('project-move-resource-modal-select');
+		const projectSelect = getByTestId('project-sharing-select');
 		const projectSelectInput: HTMLInputElement = getByRole('combobox');
 		expect(projectSelectInput).toBeVisible();
 		expect(projectSelect).toBeVisible();
 
 		const projectSelectDropdownItems = await getDropdownItems(projectSelect);
+		// Home project is excluded by ProjectSharing
 		expect(projectSelectDropdownItems).toHaveLength(projects.length - 1);
 
 		await userEvent.click(projectSelectInput);
@@ -130,7 +136,8 @@ describe('ProjectMoveResourceModal', () => {
 
 	it('should not load workflow if the resource is a credential', async () => {
 		const telemetryTrackSpy = vi.spyOn(telemetry, 'track');
-		projectsStore.availableProjects = [createProjectListItem()];
+		const projects = [createProjectListItem()];
+		projectsStore.searchProjects.mockResolvedValue({ count: projects.length, data: projects });
 
 		const props: ComponentProps<typeof ProjectMoveResourceModal> = {
 			modalName: PROJECT_MOVE_RESOURCE_MODAL,
@@ -179,7 +186,10 @@ describe('ProjectMoveResourceModal', () => {
 		};
 
 		projectsStore.currentProjectId = currentProjectId;
-		projectsStore.availableProjects = [destinationProject];
+		projectsStore.searchProjects.mockResolvedValue({
+			count: 1,
+			data: [destinationProject],
+		});
 		workflowsListStore.fetchWorkflow.mockResolvedValueOnce(movedWorkflow);
 		credentialsStore.fetchAllCredentials.mockResolvedValueOnce([
 			{
@@ -223,7 +233,7 @@ describe('ProjectMoveResourceModal', () => {
 		expect(getByTestId('project-move-resource-modal-button')).toBeDisabled();
 		expect(getByText(/Moving will remove any existing sharing for this workflow/)).toBeVisible();
 
-		const projectSelect = getByTestId('project-move-resource-modal-select');
+		const projectSelect = getByTestId('project-sharing-select');
 		expect(projectSelect).toBeVisible();
 
 		const projectSelectDropdownItems = await getDropdownItems(projectSelect);
@@ -245,7 +255,10 @@ describe('ProjectMoveResourceModal', () => {
 
 	it('should prevent duplicate submissions when button clicked multiple times', async () => {
 		const destinationProject = createProjectListItem();
-		projectsStore.availableProjects = [destinationProject];
+		projectsStore.searchProjects.mockResolvedValue({
+			count: 1,
+			data: [destinationProject],
+		});
 		workflowsListStore.fetchWorkflow.mockResolvedValueOnce(createTestWorkflow());
 
 		// Make moveResourceToProject take time to simulate slow operation
@@ -270,7 +283,7 @@ describe('ProjectMoveResourceModal', () => {
 		const { getByTestId } = renderComponent({ props });
 
 		// Select a project
-		const projectSelect = getByTestId('project-move-resource-modal-select');
+		const projectSelect = getByTestId('project-sharing-select');
 		const projectSelectDropdownItems = await getDropdownItems(projectSelect);
 		await userEvent.click(projectSelectDropdownItems[0]);
 

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMoveResourceModal.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMoveResourceModal.vue
@@ -21,6 +21,7 @@ import type { ProjectListItem, ProjectSharingData } from '../projects.types';
 // ProjectListItem extends ProjectSharingData with `role` - the toast component types
 // expect ProjectListItem but only uses fields from ProjectSharingData (name, type).
 import {
+	createAvailableProjectSearch,
 	getTruncatedProjectName,
 	MAX_NAME_LENGTH,
 	ResourceType,
@@ -56,6 +57,7 @@ const uiStore = useUIStore();
 const toast = useToast();
 const router = useRouter();
 const projectsStore = useProjectsStore();
+const searchFn = createAvailableProjectSearch(projectsStore);
 const workflowsListStore = useWorkflowsListStore();
 const credentialsStore = useCredentialsStore();
 const telemetry = useTelemetry();
@@ -244,6 +246,7 @@ onMounted(async () => {
 				<ProjectSharing
 					v-model="selectedProject"
 					class="mr-2xs mb-xs"
+					:search-fn="searchFn"
 					:home-project="props.data.resource.homeProject"
 					:filter-fn="projectFilterFn"
 					:placeholder="i18n.baseText('projects.move.resource.modal.selectPlaceholder')"

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMoveResourceModal.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMoveResourceModal.vue
@@ -2,6 +2,7 @@
 import Modal from '@/app/components/Modal.vue';
 import ProjectMoveResourceModalCredentialsList from './ProjectMoveResourceModalCredentialsList.vue';
 import ProjectMoveSuccessToastMessage from './ProjectMoveSuccessToastMessage.vue';
+import ProjectSharing from './ProjectSharing.vue';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useToast } from '@/app/composables/useToast';
 import { VIEWS } from '@/app/constants';
@@ -16,6 +17,9 @@ import { useProjectsStore } from '../projects.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { ProjectTypes } from '../projects.types';
+import type { ProjectListItem, ProjectSharingData } from '../projects.types';
+// ProjectListItem extends ProjectSharingData with `role` - the toast component types
+// expect ProjectListItem but only uses fields from ProjectSharingData (name, type).
 import {
 	getTruncatedProjectName,
 	MAX_NAME_LENGTH,
@@ -24,7 +28,6 @@ import {
 } from '../projects.utils';
 import { useI18n } from '@n8n/i18n';
 import type { EventBus } from '@n8n/utils/event-bus';
-import { sortByProperty } from '@n8n/utils/sort/sortByProperty';
 import { truncate } from '@n8n/utils/string/truncate';
 import { computed, h, onMounted, ref } from 'vue';
 import { I18nT } from 'vue-i18n';
@@ -35,9 +38,6 @@ import {
 	N8nCallout,
 	N8nCheckbox,
 	N8nHeading,
-	N8nIcon,
-	N8nOption,
-	N8nSelect,
 	N8nText,
 	N8nTooltip,
 } from '@n8n/design-system';
@@ -60,8 +60,7 @@ const workflowsListStore = useWorkflowsListStore();
 const credentialsStore = useCredentialsStore();
 const telemetry = useTelemetry();
 
-const filter = ref('');
-const projectId = ref<string | null>(null);
+const selectedProject = ref<ProjectSharingData | null>(null);
 const shareUsedCredentials = ref(false);
 const usedCredentials = ref<IUsedCredential[]>([]);
 const allCredentials = ref<ICredentialsResponse[]>([]);
@@ -93,22 +92,10 @@ const unShareableCredentials = computed(() =>
 const homeProjectName = computed(
 	() => processProjectName(props.data.resource.homeProject?.name ?? '') ?? '',
 );
-const availableProjects = computed(() =>
-	sortByProperty(
-		'name',
-		projectsStore.availableProjects.filter(
-			(p) =>
-				p.id !== props.data.resource.homeProject?.id &&
-				(!p.scopes || getResourcePermissions(p.scopes)[props.data.resourceType].create),
-		),
-	),
-);
-const filteredProjects = computed(() =>
-	availableProjects.value.filter((p) => p.name?.toLowerCase().includes(filter.value.toLowerCase())),
-);
-const selectedProject = computed(() =>
-	availableProjects.value.find((p) => p.id === projectId.value),
-);
+
+const projectFilterFn = (p: ProjectListItem): boolean =>
+	!p.scopes || !!getResourcePermissions(p.scopes)[props.data.resourceType].create;
+
 const isResourceInTeamProject = computed(() => isHomeProjectTeam(props.data.resource));
 const isResourceWorkflow = computed(() => props.data.resourceType === ResourceType.Workflow);
 const targetProjectName = computed(() => {
@@ -121,7 +108,7 @@ const isPersonalSpaceRestricted = computed(
 		props.data.resource.homeProject?.id === projectsStore.personalProject?.id,
 );
 const isTargetPersonalProject = computed(
-	() => projectId.value === projectsStore.personalProject?.id,
+	() => selectedProject.value?.id === projectsStore.personalProject?.id,
 );
 
 const isHomeProjectTeam = (resource: IWorkflowDb | ICredentialsResponse) =>
@@ -132,16 +119,8 @@ const processProjectName = (projectName: string) => {
 	return name ?? email;
 };
 
-const updateProject = (value: string) => {
-	projectId.value = value;
-};
-
 const closeModal = () => {
 	uiStore.closeModal(props.modalName);
-};
-
-const setFilter = (query: string) => {
-	filter.value = query;
 };
 
 const moveResource = async () => {
@@ -172,7 +151,7 @@ const moveResource = async () => {
 			message: h(ProjectMoveSuccessToastMessage, {
 				routeName: isResourceWorkflow.value ? VIEWS.PROJECTS_WORKFLOWS : VIEWS.PROJECTS_CREDENTIALS,
 				resourceType: props.data.resourceType,
-				targetProject: selectedProject.value,
+				targetProject: selectedProject.value as ProjectListItem,
 				isShareCredentialsChecked: shareUsedCredentials.value,
 				areAllUsedCredentialsShareable:
 					shareableCredentials.value.length === usedCredentials.value.length,
@@ -216,8 +195,6 @@ onMounted(async () => {
 		[`${props.data.resourceType}_id`]: props.data.resource.id,
 		project_from_type: projectsStore.currentProject?.type ?? projectsStore.personalProject?.type,
 	});
-
-	await projectsStore.getAvailableProjects();
 
 	if (isResourceWorkflow.value) {
 		const [workflow, credentials] = await Promise.all([
@@ -263,26 +240,20 @@ onMounted(async () => {
 			</N8nText>
 		</template>
 		<template #content>
-			<div v-if="availableProjects.length">
-				<N8nSelect
+			<div>
+				<ProjectSharing
+					v-model="selectedProject"
 					class="mr-2xs mb-xs"
-					:model-value="projectId"
-					:filterable="true"
-					:filter-method="setFilter"
+					:home-project="props.data.resource.homeProject"
+					:filter-fn="projectFilterFn"
 					:placeholder="i18n.baseText('projects.move.resource.modal.selectPlaceholder')"
+					:empty-options-text="
+						i18n.baseText('projects.move.resource.modal.message.noProjects', {
+							interpolate: { resourceTypeLabel: props.data.resourceTypeLabel },
+						})
+					"
 					data-test-id="project-move-resource-modal-select"
-					@update:model-value="updateProject"
-				>
-					<template #prefix>
-						<N8nIcon icon="search" />
-					</template>
-					<N8nOption
-						v-for="p in filteredProjects"
-						:key="p.id"
-						:value="p.id"
-						:label="p.name ?? ''"
-					></N8nOption>
-				</N8nSelect>
+				/>
 				<N8nText>
 					<I18nT keypath="projects.move.resource.modal.message.sharingNote" scope="global">
 						<template #note
@@ -373,11 +344,6 @@ onMounted(async () => {
 					</N8nCallout>
 				</N8nText>
 			</div>
-			<N8nText v-else>{{
-				i18n.baseText('projects.move.resource.modal.message.noProjects', {
-					interpolate: { resourceTypeLabel: props.data.resourceTypeLabel },
-				})
-			}}</N8nText>
 		</template>
 		<template #footer>
 			<div :class="$style.buttons">
@@ -387,7 +353,7 @@ onMounted(async () => {
 				<N8nButton
 					variant="solid"
 					:loading="loading"
-					:disabled="!projectId || loading"
+					:disabled="!selectedProject || loading"
 					data-test-id="project-move-resource-modal-button"
 					@click="moveResource"
 				>

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMoveResourceModal.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMoveResourceModal.vue
@@ -21,7 +21,7 @@ import type { ProjectListItem, ProjectSharingData } from '../projects.types';
 // ProjectListItem extends ProjectSharingData with `role` - the toast component types
 // expect ProjectListItem but only uses fields from ProjectSharingData (name, type).
 import {
-	createAvailableProjectSearch,
+	useAvailableProjectSearch,
 	getTruncatedProjectName,
 	MAX_NAME_LENGTH,
 	ResourceType,
@@ -57,7 +57,7 @@ const uiStore = useUIStore();
 const toast = useToast();
 const router = useRouter();
 const projectsStore = useProjectsStore();
-const searchFn = createAvailableProjectSearch(projectsStore);
+const searchFn = useAvailableProjectSearch();
 const workflowsListStore = useWorkflowsListStore();
 const credentialsStore = useCredentialsStore();
 const telemetry = useTelemetry();

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.test.ts
@@ -1,14 +1,14 @@
 import { within } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import { createComponentRenderer } from '@/__tests__/render';
-import { getDropdownItems, getSelectedDropdownValue, mockedStore } from '@/__tests__/utils';
+import { getDropdownItems, getSelectedDropdownValue } from '@/__tests__/utils';
 import { createProjectListItem, createProjectSharingData } from '../__tests__/utils';
 import ProjectSharing from './ProjectSharing.vue';
 import type { AllRolesMap } from '@n8n/permissions';
 import { useI18n } from '@n8n/i18n';
 import type * as I18nModule from '@n8n/i18n';
-import { createTestingPinia } from '@pinia/testing';
-import { useProjectsStore } from '../projects.store';
+import type { ProjectListItem } from '../projects.types';
+import type { ProjectSearchFn } from '../projects.utils';
 
 vi.mock('@n8n/i18n', async (importOriginal) => {
 	const actual = await importOriginal<typeof I18nModule>();
@@ -26,6 +26,31 @@ const mockBaseText = vi.fn((key: string) => {
 	return translations[key] || key;
 });
 
+/** Creates a searchFn that filters a static list locally, matching the strategy pattern. */
+const createTestSearchFn = (projects: ProjectListItem[]): ProjectSearchFn => {
+	return async (query: string) => {
+		const lowerQuery = query.toLowerCase();
+		const filtered = projects.filter(
+			(p) => !query || (p.name?.toLowerCase().includes(lowerQuery) ?? false),
+		);
+		return { count: filtered.length, data: filtered };
+	};
+};
+
+/** Creates a searchFn that returns more results than displayed (for "more results" tests). */
+const createTestSearchFnWithCount = (
+	projects: ProjectListItem[],
+	totalCount: number,
+): ProjectSearchFn => {
+	return async (query: string) => {
+		const lowerQuery = query.toLowerCase();
+		const filtered = projects.filter(
+			(p) => !query || (p.name?.toLowerCase().includes(lowerQuery) ?? false),
+		);
+		return { count: totalCount, data: filtered };
+	};
+};
+
 const renderComponent = createComponentRenderer(ProjectSharing);
 
 const personalProjects = Array.from({ length: 3 }, createProjectListItem);
@@ -33,26 +58,16 @@ const teamProjects = Array.from({ length: 3 }, () => createProjectListItem('team
 const homeProject = createProjectSharingData();
 
 describe('ProjectSharing', () => {
-	let projectsStore: ReturnType<typeof mockedStore<typeof useProjectsStore>>;
-
 	beforeEach(() => {
 		vi.mocked(useI18n).mockReturnValue({
 			baseText: mockBaseText,
 		} as unknown as ReturnType<typeof useI18n>);
-
-		createTestingPinia();
-		projectsStore = mockedStore(useProjectsStore);
-		projectsStore.searchProjects.mockResolvedValue({
-			count: personalProjects.length,
-			data: personalProjects,
-		});
 	});
 
 	it('should render empty select when no projects returned and no selected project existing', async () => {
-		projectsStore.searchProjects.mockResolvedValue({ count: 0, data: [] });
-
 		const { getByTestId, queryByTestId } = renderComponent({
 			props: {
+				searchFn: createTestSearchFn([]),
 				modelValue: [],
 			},
 		});
@@ -62,22 +77,24 @@ describe('ProjectSharing', () => {
 		expect(queryByTestId('project-sharing-owner')).not.toBeInTheDocument();
 	});
 
-	it('should add and remove projects', async () => {
-		const { getByTestId, getAllByTestId, queryAllByTestId, emitted } = renderComponent({
-			props: {
-				modelValue: [personalProjects[0]],
-				roles: [
-					{
-						role: 'project:admin',
-						name: 'Admin',
-					},
-					{
-						role: 'project:editor',
-						name: 'Editor',
-					},
-				] as unknown as AllRolesMap['workflow' | 'credential' | 'project'],
-			},
-		});
+	it('should filter, add and remove projects', async () => {
+		const { getByTestId, getAllByTestId, queryByTestId, queryAllByTestId, emitted } =
+			renderComponent({
+				props: {
+					searchFn: createTestSearchFn(personalProjects),
+					modelValue: [personalProjects[0]],
+					roles: [
+						{
+							role: 'project:admin',
+							name: 'Admin',
+						},
+						{
+							role: 'project:editor',
+							name: 'Editor',
+						},
+					] as unknown as AllRolesMap['workflow' | 'credential' | 'project'],
+				},
+			});
 
 		// Check the initial state (one selected project comes from the modelValue prop)
 		expect(getAllByTestId('project-sharing-list-item')).toHaveLength(1);
@@ -137,13 +154,9 @@ describe('ProjectSharing', () => {
 	});
 
 	it('should work as a simple select when model is not an array', async () => {
-		projectsStore.searchProjects.mockResolvedValue({
-			count: teamProjects.length,
-			data: teamProjects,
-		});
-
 		const { getByTestId, queryByTestId, emitted } = renderComponent({
 			props: {
+				searchFn: createTestSearchFn(teamProjects),
 				modelValue: null,
 			},
 		});
@@ -191,6 +204,7 @@ describe('ProjectSharing', () => {
 	it('should render home project as owner when defined', async () => {
 		const { getByTestId, queryByTestId } = renderComponent({
 			props: {
+				searchFn: createTestSearchFn(personalProjects),
 				modelValue: [],
 				homeProject,
 			},
@@ -202,13 +216,9 @@ describe('ProjectSharing', () => {
 	});
 
 	it('should show "more results" indicator when server has more results than displayed', async () => {
-		projectsStore.searchProjects.mockResolvedValue({
-			count: 200,
-			data: personalProjects,
-		});
-
 		const { getByTestId } = renderComponent({
 			props: {
+				searchFn: createTestSearchFnWithCount(personalProjects, 200),
 				modelValue: [],
 			},
 		});
@@ -223,13 +233,9 @@ describe('ProjectSharing', () => {
 	});
 
 	it('should not show "more results" indicator when all results fit', async () => {
-		projectsStore.searchProjects.mockResolvedValue({
-			count: personalProjects.length,
-			data: personalProjects,
-		});
-
 		const { getByTestId } = renderComponent({
 			props: {
+				searchFn: createTestSearchFn(personalProjects),
 				modelValue: [],
 			},
 		});
@@ -249,6 +255,7 @@ describe('ProjectSharing', () => {
 		it('should show "All Users" option when canShareGlobally is true', async () => {
 			const { getByTestId } = renderComponent({
 				props: {
+					searchFn: createTestSearchFn(personalProjects),
 					modelValue: [],
 					canShareGlobally: true,
 				},
@@ -266,6 +273,7 @@ describe('ProjectSharing', () => {
 		it('should not show "All Users" option when canShareGlobally is false', async () => {
 			const { getByTestId } = renderComponent({
 				props: {
+					searchFn: createTestSearchFn(personalProjects),
 					modelValue: [],
 					canShareGlobally: false,
 				},
@@ -282,6 +290,7 @@ describe('ProjectSharing', () => {
 		it('should not show "All Users" option when canShareGlobally is undefined', async () => {
 			const { getByTestId } = renderComponent({
 				props: {
+					searchFn: createTestSearchFn(personalProjects),
 					modelValue: [],
 				},
 			});
@@ -297,6 +306,7 @@ describe('ProjectSharing', () => {
 		it('should emit update:shareWithAllUsers when "All Users" is selected', async () => {
 			const { getByTestId, emitted } = renderComponent({
 				props: {
+					searchFn: createTestSearchFn(personalProjects),
 					modelValue: [],
 					canShareGlobally: true,
 				},
@@ -315,6 +325,7 @@ describe('ProjectSharing', () => {
 		it('should show "All Users" in selected list when isSharedGlobally is true', async () => {
 			const { getAllByTestId } = renderComponent({
 				props: {
+					searchFn: createTestSearchFn(personalProjects),
 					modelValue: [],
 					canShareGlobally: true,
 					isSharedGlobally: true,
@@ -329,6 +340,7 @@ describe('ProjectSharing', () => {
 		it('should emit update:shareWithAllUsers with false when "All Users" is removed', async () => {
 			const { getAllByTestId, emitted } = renderComponent({
 				props: {
+					searchFn: createTestSearchFn(personalProjects),
 					modelValue: [],
 					canShareGlobally: true,
 					isSharedGlobally: true,
@@ -353,6 +365,7 @@ describe('ProjectSharing', () => {
 		it('should not show remove button for "All Users" when canShareGlobally is false', async () => {
 			const { getAllByTestId } = renderComponent({
 				props: {
+					searchFn: createTestSearchFn(personalProjects),
 					modelValue: [],
 					canShareGlobally: false,
 					isSharedGlobally: true,
@@ -369,6 +382,7 @@ describe('ProjectSharing', () => {
 		it('should not show "All Users" in dropdown when already globally shared', async () => {
 			const { getByTestId } = renderComponent({
 				props: {
+					searchFn: createTestSearchFn(personalProjects),
 					modelValue: [],
 					canShareGlobally: true,
 					isSharedGlobally: true,

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.test.ts
@@ -1,12 +1,14 @@
 import { within } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import { createComponentRenderer } from '@/__tests__/render';
-import { getDropdownItems, getSelectedDropdownValue } from '@/__tests__/utils';
+import { getDropdownItems, getSelectedDropdownValue, mockedStore } from '@/__tests__/utils';
 import { createProjectListItem, createProjectSharingData } from '../__tests__/utils';
 import ProjectSharing from './ProjectSharing.vue';
 import type { AllRolesMap } from '@n8n/permissions';
 import { useI18n } from '@n8n/i18n';
 import type * as I18nModule from '@n8n/i18n';
+import { createTestingPinia } from '@pinia/testing';
+import { useProjectsStore } from '../projects.store';
 
 vi.mock('@n8n/i18n', async (importOriginal) => {
 	const actual = await importOriginal<typeof I18nModule>();
@@ -31,15 +33,26 @@ const teamProjects = Array.from({ length: 3 }, () => createProjectListItem('team
 const homeProject = createProjectSharingData();
 
 describe('ProjectSharing', () => {
+	let projectsStore: ReturnType<typeof mockedStore<typeof useProjectsStore>>;
+
 	beforeEach(() => {
 		vi.mocked(useI18n).mockReturnValue({
 			baseText: mockBaseText,
 		} as unknown as ReturnType<typeof useI18n>);
+
+		createTestingPinia();
+		projectsStore = mockedStore(useProjectsStore);
+		projectsStore.searchProjects.mockResolvedValue({
+			count: personalProjects.length,
+			data: personalProjects,
+		});
 	});
-	it('should render empty select when projects is empty and no selected project existing', async () => {
+
+	it('should render empty select when no projects returned and no selected project existing', async () => {
+		projectsStore.searchProjects.mockResolvedValue({ count: 0, data: [] });
+
 		const { getByTestId, queryByTestId } = renderComponent({
 			props: {
-				projects: [],
 				modelValue: [],
 			},
 		});
@@ -49,33 +62,29 @@ describe('ProjectSharing', () => {
 		expect(queryByTestId('project-sharing-owner')).not.toBeInTheDocument();
 	});
 
-	it('should filter, add and remove projects', async () => {
-		const { getByTestId, getAllByTestId, queryByTestId, queryAllByTestId, emitted } =
-			renderComponent({
-				props: {
-					projects: personalProjects,
-					modelValue: [personalProjects[0]],
-					roles: [
-						{
-							role: 'project:admin',
-							name: 'Admin',
-						},
-						{
-							role: 'project:editor',
-							name: 'Editor',
-						},
-					] as unknown as AllRolesMap['workflow' | 'credential' | 'project'],
-				},
-			});
+	it('should add and remove projects', async () => {
+		const { getByTestId, getAllByTestId, queryAllByTestId, emitted } = renderComponent({
+			props: {
+				modelValue: [personalProjects[0]],
+				roles: [
+					{
+						role: 'project:admin',
+						name: 'Admin',
+					},
+					{
+						role: 'project:editor',
+						name: 'Editor',
+					},
+				] as unknown as AllRolesMap['workflow' | 'credential' | 'project'],
+			},
+		});
 
-		expect(queryByTestId('project-sharing-owner')).not.toBeInTheDocument();
 		// Check the initial state (one selected project comes from the modelValue prop)
 		expect(getAllByTestId('project-sharing-list-item')).toHaveLength(1);
 
 		const projectSelect = getByTestId('project-sharing-select');
-		const projectSelectInput = projectSelect.querySelector('input') as HTMLInputElement;
 
-		// Get the dropdown items
+		// Get the dropdown items (personalProjects[0] is excluded because it's already selected)
 		let projectSelectDropdownItems = await getDropdownItems(projectSelect);
 		expect(projectSelectDropdownItems).toHaveLength(2);
 
@@ -84,6 +93,7 @@ describe('ProjectSharing', () => {
 		expect(emitted()['update:modelValue']).toEqual([[[expect.any(Object), expect.any(Object)]]]);
 
 		expect(getAllByTestId('project-sharing-list-item')).toHaveLength(2);
+		const projectSelectInput = projectSelect.querySelector('input') as HTMLInputElement;
 		expect(projectSelectInput.value).toBe('');
 		projectSelectDropdownItems = await getDropdownItems(projectSelect);
 		expect(projectSelectDropdownItems).toHaveLength(1);
@@ -127,12 +137,17 @@ describe('ProjectSharing', () => {
 	});
 
 	it('should work as a simple select when model is not an array', async () => {
+		projectsStore.searchProjects.mockResolvedValue({
+			count: teamProjects.length,
+			data: teamProjects,
+		});
+
 		const { getByTestId, queryByTestId, emitted } = renderComponent({
 			props: {
-				projects: teamProjects,
 				modelValue: null,
 			},
 		});
+
 		expect(queryByTestId('project-sharing-owner')).not.toBeInTheDocument();
 
 		const projectSelect = getByTestId('project-sharing-select');
@@ -176,7 +191,6 @@ describe('ProjectSharing', () => {
 	it('should render home project as owner when defined', async () => {
 		const { getByTestId, queryByTestId } = renderComponent({
 			props: {
-				projects: personalProjects,
 				modelValue: [],
 				homeProject,
 			},
@@ -187,11 +201,54 @@ describe('ProjectSharing', () => {
 		expect(getByTestId('project-sharing-owner')).toBeInTheDocument();
 	});
 
+	it('should show "more results" indicator when server has more results than displayed', async () => {
+		projectsStore.searchProjects.mockResolvedValue({
+			count: 200,
+			data: personalProjects,
+		});
+
+		const { getByTestId } = renderComponent({
+			props: {
+				modelValue: [],
+			},
+		});
+
+		const projectSelect = getByTestId('project-sharing-select');
+		const dropdownItems = await getDropdownItems(projectSelect);
+
+		// Last item should be the disabled "more results" indicator
+		const lastItem = dropdownItems[dropdownItems.length - 1];
+		expect(lastItem).toHaveClass('is-disabled');
+		expect(lastItem).toHaveTextContent('projects.sharing.moreResults');
+	});
+
+	it('should not show "more results" indicator when all results fit', async () => {
+		projectsStore.searchProjects.mockResolvedValue({
+			count: personalProjects.length,
+			data: personalProjects,
+		});
+
+		const { getByTestId } = renderComponent({
+			props: {
+				modelValue: [],
+			},
+		});
+
+		const projectSelect = getByTestId('project-sharing-select');
+		const dropdownItems = await getDropdownItems(projectSelect);
+
+		expect(dropdownItems).toHaveLength(personalProjects.length);
+		// No disabled items
+		const disabledItems = Array.from(dropdownItems).filter((item) =>
+			item.classList.contains('is-disabled'),
+		);
+		expect(disabledItems).toHaveLength(0);
+	});
+
 	describe('global sharing', () => {
 		it('should show "All Users" option when canShareGlobally is true', async () => {
 			const { getByTestId } = renderComponent({
 				props: {
-					projects: personalProjects,
 					modelValue: [],
 					canShareGlobally: true,
 				},
@@ -209,7 +266,6 @@ describe('ProjectSharing', () => {
 		it('should not show "All Users" option when canShareGlobally is false', async () => {
 			const { getByTestId } = renderComponent({
 				props: {
-					projects: personalProjects,
 					modelValue: [],
 					canShareGlobally: false,
 				},
@@ -226,7 +282,6 @@ describe('ProjectSharing', () => {
 		it('should not show "All Users" option when canShareGlobally is undefined', async () => {
 			const { getByTestId } = renderComponent({
 				props: {
-					projects: personalProjects,
 					modelValue: [],
 				},
 			});
@@ -242,7 +297,6 @@ describe('ProjectSharing', () => {
 		it('should emit update:shareWithAllUsers when "All Users" is selected', async () => {
 			const { getByTestId, emitted } = renderComponent({
 				props: {
-					projects: personalProjects,
 					modelValue: [],
 					canShareGlobally: true,
 				},
@@ -258,10 +312,9 @@ describe('ProjectSharing', () => {
 			expect(emitted()['update:shareWithAllUsers']).toEqual([[true]]);
 		});
 
-		it('should show "All Users" in selected list when isSharedGlobally is true', () => {
+		it('should show "All Users" in selected list when isSharedGlobally is true', async () => {
 			const { getAllByTestId } = renderComponent({
 				props: {
-					projects: personalProjects,
 					modelValue: [],
 					canShareGlobally: true,
 					isSharedGlobally: true,
@@ -276,7 +329,6 @@ describe('ProjectSharing', () => {
 		it('should emit update:shareWithAllUsers with false when "All Users" is removed', async () => {
 			const { getAllByTestId, emitted } = renderComponent({
 				props: {
-					projects: personalProjects,
 					modelValue: [],
 					canShareGlobally: true,
 					isSharedGlobally: true,
@@ -298,10 +350,9 @@ describe('ProjectSharing', () => {
 			expect(emitted()['update:shareWithAllUsers']).toEqual([[false]]);
 		});
 
-		it('should not show remove button for "All Users" when canShareGlobally is false', () => {
+		it('should not show remove button for "All Users" when canShareGlobally is false', async () => {
 			const { getAllByTestId } = renderComponent({
 				props: {
-					projects: personalProjects,
 					modelValue: [],
 					canShareGlobally: false,
 					isSharedGlobally: true,
@@ -318,7 +369,6 @@ describe('ProjectSharing', () => {
 		it('should not show "All Users" in dropdown when already globally shared', async () => {
 			const { getByTestId } = renderComponent({
 				props: {
-					projects: personalProjects,
 					modelValue: [],
 					canShareGlobally: true,
 					isSharedGlobally: true,

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.test.ts
@@ -78,23 +78,22 @@ describe('ProjectSharing', () => {
 	});
 
 	it('should filter, add and remove projects', async () => {
-		const { getByTestId, getAllByTestId, queryByTestId, queryAllByTestId, emitted } =
-			renderComponent({
-				props: {
-					searchFn: createTestSearchFn(personalProjects),
-					modelValue: [personalProjects[0]],
-					roles: [
-						{
-							role: 'project:admin',
-							name: 'Admin',
-						},
-						{
-							role: 'project:editor',
-							name: 'Editor',
-						},
-					] as unknown as AllRolesMap['workflow' | 'credential' | 'project'],
-				},
-			});
+		const { getByTestId, getAllByTestId, queryAllByTestId, emitted } = renderComponent({
+			props: {
+				searchFn: createTestSearchFn(personalProjects),
+				modelValue: [personalProjects[0]],
+				roles: [
+					{
+						role: 'project:admin',
+						name: 'Admin',
+					},
+					{
+						role: 'project:editor',
+						name: 'Editor',
+					},
+				] as unknown as AllRolesMap['workflow' | 'credential' | 'project'],
+			},
+		});
 
 		// Check the initial state (one selected project comes from the modelValue prop)
 		expect(getAllByTestId('project-sharing-list-item')).toHaveLength(1);

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.vue
@@ -3,7 +3,6 @@ import { isIconOrEmoji, type IconOrEmoji } from '@n8n/design-system/components/N
 import type { SelectSize } from '@n8n/design-system/types';
 import { useI18n } from '@n8n/i18n';
 import type { AllRolesMap } from '@n8n/permissions';
-import orderBy from 'lodash/orderBy';
 import { useDebounceFn } from '@vueuse/core';
 import { computed, ref, watch, onMounted } from 'vue';
 import { ProjectTypes, type ProjectListItem, type ProjectSharingData } from '../projects.types';
@@ -95,7 +94,8 @@ const filteredProjects = computed(() => {
 
 	// Exclude already-selected projects (multi-select mode)
 	if (Array.isArray(model.value)) {
-		list = list.filter((p) => !model.value?.find((s: ProjectSharingData) => s.id === p.id));
+		const selected = model.value;
+		list = list.filter((p) => !selected.find((s) => s.id === p.id));
 	}
 
 	return list;

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.vue
@@ -3,12 +3,13 @@ import { isIconOrEmoji, type IconOrEmoji } from '@n8n/design-system/components/N
 import type { SelectSize } from '@n8n/design-system/types';
 import { useI18n } from '@n8n/i18n';
 import type { AllRolesMap } from '@n8n/permissions';
-import { useDebounceFn, useAsyncState } from '@vueuse/core';
-import { computed, ref, watch } from 'vue';
-import { DEBOUNCE_TIME, getDebounceTime } from '@/app/constants';
-import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
+import orderBy from 'lodash/orderBy';
+import { useDebounceFn } from '@vueuse/core';
+import { computed, ref, watch, onMounted } from 'vue';
 import { ProjectTypes, type ProjectListItem, type ProjectSharingData } from '../projects.types';
+import type { ProjectSearchFn } from '../projects.utils';
 import ProjectSharingInfo from './ProjectSharingInfo.vue';
+import { DEBOUNCE_TIME, getDebounceTime } from '@/app/constants';
 
 import {
 	N8nBadge,
@@ -21,13 +22,10 @@ import {
 } from '@n8n/design-system';
 
 const locale = useI18n();
-const projectsStore = useProjectsStore();
 
 type Props = {
-	/** Client-side post-filter applied to results (e.g. permission checks). */
+	searchFn: ProjectSearchFn;
 	filterFn?: (project: ProjectListItem) => boolean;
-	/** When true, excludes personal projects of non-activated (pending) users. */
-	activated?: boolean;
 	homeProject?: ProjectSharingData;
 	roles?: AllRolesMap['workflow' | 'credential' | 'project'];
 	readonly?: boolean;
@@ -82,42 +80,25 @@ const noDataText = computed(
 	() => props.emptyOptionsText ?? locale.baseText('projects.sharing.noMatchingUsers'),
 );
 
-const excludedIds = computed(() => {
-	const selected = Array.isArray(model.value) ? model.value.map((p) => p.id) : [];
-	return new Set([...(props.homeProject?.id ? [props.homeProject.id] : []), ...selected]);
-});
-
-const TAKE = 50;
-
-const {
-	isLoading,
-	execute: fetchRemoteProjects,
-	state,
-} = useAsyncState<
-	{
-		count: number;
-		data: ProjectListItem[];
-	},
-	[string]
->(
-	async (query: string) =>
-		await projectsStore.searchProjects({
-			search: query || undefined,
-			take: TAKE,
-			activated: props.activated,
-		}),
-	{
-		count: 0,
-		data: [],
-	},
-	{
-		immediate: true,
-	},
-);
+// ── Search state ──
+const searchResults = ref<ProjectListItem[]>([]);
+const searchCount = ref(0);
+const filter = ref('');
 
 const filteredProjects = computed(() => {
-	const results = state.value.data.filter((project) => !excludedIds.value.has(project.id));
-	return props.filterFn ? results.filter(props.filterFn) : results;
+	let list = searchResults.value;
+
+	// Apply consumer's filterFn
+	if (props.filterFn) {
+		list = list.filter(props.filterFn);
+	}
+
+	// Exclude already-selected projects (multi-select mode)
+	if (Array.isArray(model.value)) {
+		list = list.filter((p) => !model.value?.find((s: ProjectSharingData) => s.id === p.id));
+	}
+
+	return list;
 });
 
 const sortedProjects = computed((): ProjectListItem[] => {
@@ -127,13 +108,13 @@ const sortedProjects = computed((): ProjectListItem[] => {
 	];
 });
 
+const moreResultsCount = computed(() => {
+	return Math.max(0, searchCount.value - searchResults.value.length);
+});
+
 const projectIcon = computed<IconOrEmoji>(() => {
 	const defaultIcon: IconOrEmoji = { type: 'icon', value: 'layers' };
-	const project =
-		state.value.data.find((p) => p.id === selectedProject.value) ??
-		(!Array.isArray(model.value) && model.value?.id === selectedProject.value
-			? model.value
-			: undefined);
+	const project = searchResults.value.find((p) => p.id === selectedProject.value);
 
 	if (project?.type === ProjectTypes.Personal) {
 		return { type: 'icon', value: 'user' };
@@ -144,21 +125,29 @@ const projectIcon = computed<IconOrEmoji>(() => {
 	return defaultIcon;
 });
 
-const hasMoreResults = computed(() => state.value.count > state.value.data.length);
+// ── Search logic ──
+const executeSearch = async (query: string) => {
+	try {
+		const result = await props.searchFn(query);
+		searchResults.value = result.data ?? [];
+		searchCount.value = result.count ?? 0;
+	} catch {
+		searchResults.value = [];
+		searchCount.value = 0;
+	}
+};
 
-const moreResultsLabel = computed(() =>
-	locale.baseText('projects.sharing.moreResults', {
-		interpolate: {
-			shown: String(sortedProjects.value.length),
-			total: String(state.value.count),
-		},
-	}),
-);
+const debouncedSearch = useDebounceFn(executeSearch, getDebounceTime(DEBOUNCE_TIME.INPUT.SEARCH));
 
-const debouncedRemoteSearch = useDebounceFn(
-	async (query: string) => await fetchRemoteProjects(0, query),
-	getDebounceTime(DEBOUNCE_TIME.INPUT.SEARCH),
-);
+const setFilter = (query: string) => {
+	filter.value = query;
+	void debouncedSearch(query);
+};
+
+// Load initial results
+onMounted(() => {
+	void executeSearch('');
+});
 
 const onProjectSelected = (projectId: string) => {
 	if (projectId === GLOBAL_GROUP.id) {
@@ -166,7 +155,7 @@ const onProjectSelected = (projectId: string) => {
 		return;
 	}
 
-	const project = state.value.data.find((p) => p.id === projectId);
+	const project = searchResults.value.find((p) => p.id === projectId);
 
 	if (!project) {
 		return;
@@ -217,10 +206,9 @@ watch(
 				v-if="!props.static || props.disabledTooltip"
 				:model-value="selectedProject"
 				data-test-id="project-sharing-select"
-				:filterable="true"
+				filterable
 				remote
-				:remote-method="debouncedRemoteSearch"
-				:loading="isLoading"
+				:remote-method="setFilter"
 				:placeholder="selectPlaceholder"
 				:default-first-option="true"
 				:no-data-text="noDataText"
@@ -250,15 +238,19 @@ watch(
 					<ProjectSharingInfo :project="project" />
 				</N8nOption>
 				<N8nOption
-					v-if="hasMoreResults"
-					key="__more_results__"
-					value="__more_results__"
-					:label="moreResultsLabel"
+					v-if="moreResultsCount > 0"
+					:key="'more-results'"
+					:value="''"
+					:label="''"
 					disabled
 					:class="$style.moreResults"
 				>
 					<N8nText size="small" color="text-light">
-						{{ moreResultsLabel }}
+						{{
+							locale.baseText('projects.sharing.moreResults', {
+								interpolate: { count: moreResultsCount },
+							})
+						}}
 					</N8nText>
 				</N8nOption>
 			</N8nSelect>

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.vue
@@ -131,12 +131,17 @@ const projectIcon = computed<IconOrEmoji>(() => {
 });
 
 // ── Search logic ──
+let searchGeneration = 0;
+
 const executeSearch = async (query: string) => {
+	const generation = ++searchGeneration;
 	try {
 		const result = await props.searchFn(query);
+		if (generation !== searchGeneration) return; // stale response, discard
 		searchResults.value = result.data ?? [];
 		searchCount.value = result.count ?? 0;
 	} catch {
+		if (generation !== searchGeneration) return;
 		searchResults.value = [];
 		searchCount.value = 0;
 	}

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.vue
@@ -3,8 +3,10 @@ import { isIconOrEmoji, type IconOrEmoji } from '@n8n/design-system/components/N
 import type { SelectSize } from '@n8n/design-system/types';
 import { useI18n } from '@n8n/i18n';
 import type { AllRolesMap } from '@n8n/permissions';
-import orderBy from 'lodash/orderBy';
+import { useDebounceFn, useAsyncState } from '@vueuse/core';
 import { computed, ref, watch } from 'vue';
+import { DEBOUNCE_TIME, getDebounceTime } from '@/app/constants';
+import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { ProjectTypes, type ProjectListItem, type ProjectSharingData } from '../projects.types';
 import ProjectSharingInfo from './ProjectSharingInfo.vue';
 
@@ -19,9 +21,13 @@ import {
 } from '@n8n/design-system';
 
 const locale = useI18n();
+const projectsStore = useProjectsStore();
 
 type Props = {
-	projects: ProjectListItem[];
+	/** Client-side post-filter applied to results (e.g. permission checks). */
+	filterFn?: (project: ProjectListItem) => boolean;
+	/** When true, excludes personal projects of non-activated (pending) users. */
+	activated?: boolean;
 	homeProject?: ProjectSharingData;
 	roles?: AllRolesMap['workflow' | 'credential' | 'project'];
 	readonly?: boolean;
@@ -69,7 +75,6 @@ const selectedProjects = computed((): ProjectSharingData[] | null => {
 	return props.isSharedGlobally ? [GLOBAL_GROUP, ...model.value] : model.value;
 });
 
-const filter = ref('');
 const selectPlaceholder = computed(
 	() => props.placeholder ?? locale.baseText('projects.sharing.select.placeholder'),
 );
@@ -77,26 +82,58 @@ const noDataText = computed(
 	() => props.emptyOptionsText ?? locale.baseText('projects.sharing.noMatchingUsers'),
 );
 
-const filteredProjects = computed(() =>
-	props.projects.filter(
-		(project) =>
-			project.name?.toLowerCase().includes(filter.value.toLowerCase()) &&
-			(Array.isArray(model.value) ? !model.value?.find((p) => p.id === project.id) : true),
-	),
+const excludedIds = computed(() => {
+	const selected = Array.isArray(model.value) ? model.value.map((p) => p.id) : [];
+	return new Set([...(props.homeProject?.id ? [props.homeProject.id] : []), ...selected]);
+});
+
+const TAKE = 50;
+
+const {
+	isLoading,
+	execute: fetchRemoteProjects,
+	state,
+} = useAsyncState<
+	{
+		count: number;
+		data: ProjectListItem[];
+	},
+	[string]
+>(
+	async (query: string) =>
+		await projectsStore.searchProjects({
+			search: query || undefined,
+			take: TAKE,
+			activated: props.activated,
+		}),
+	{
+		count: 0,
+		data: [],
+	},
+	{
+		immediate: true,
+	},
 );
 
-const sortedProjects = computed((): ProjectListItem[] => [
-	...(props.canShareGlobally && !props.isSharedGlobally ? [GLOBAL_GROUP] : []),
-	...orderBy(
-		filteredProjects.value,
-		['type', (project) => project.name?.toLowerCase()],
-		['desc', 'asc'],
-	),
-]);
+const filteredProjects = computed(() => {
+	const results = state.value.data.filter((project) => !excludedIds.value.has(project.id));
+	return props.filterFn ? results.filter(props.filterFn) : results;
+});
+
+const sortedProjects = computed((): ProjectListItem[] => {
+	return [
+		...(props.canShareGlobally && !props.isSharedGlobally ? [GLOBAL_GROUP] : []),
+		...filteredProjects.value,
+	];
+});
 
 const projectIcon = computed<IconOrEmoji>(() => {
 	const defaultIcon: IconOrEmoji = { type: 'icon', value: 'layers' };
-	const project = props.projects.find((p) => p.id === selectedProject.value);
+	const project =
+		state.value.data.find((p) => p.id === selectedProject.value) ??
+		(!Array.isArray(model.value) && model.value?.id === selectedProject.value
+			? model.value
+			: undefined);
 
 	if (project?.type === ProjectTypes.Personal) {
 		return { type: 'icon', value: 'user' };
@@ -107,9 +144,21 @@ const projectIcon = computed<IconOrEmoji>(() => {
 	return defaultIcon;
 });
 
-const setFilter = (query: string) => {
-	filter.value = query;
-};
+const hasMoreResults = computed(() => state.value.count > state.value.data.length);
+
+const moreResultsLabel = computed(() =>
+	locale.baseText('projects.sharing.moreResults', {
+		interpolate: {
+			shown: String(sortedProjects.value.length),
+			total: String(state.value.count),
+		},
+	}),
+);
+
+const debouncedRemoteSearch = useDebounceFn(
+	async (query: string) => await fetchRemoteProjects(0, query),
+	getDebounceTime(DEBOUNCE_TIME.INPUT.SEARCH),
+);
 
 const onProjectSelected = (projectId: string) => {
 	if (projectId === GLOBAL_GROUP.id) {
@@ -117,7 +166,7 @@ const onProjectSelected = (projectId: string) => {
 		return;
 	}
 
-	const project = props.projects.find((p) => p.id === projectId);
+	const project = state.value.data.find((p) => p.id === projectId);
 
 	if (!project) {
 		return;
@@ -139,11 +188,6 @@ const onRoleAction = (project: ProjectSharingData, role: string) => {
 	if (project.id === GLOBAL_GROUP.id && role === 'remove') {
 		emit('update:shareWithAllUsers', false);
 
-		return;
-	}
-
-	const index = model.value?.findIndex((p) => p.id === project.id) ?? -1;
-	if (index === -1) {
 		return;
 	}
 
@@ -174,7 +218,9 @@ watch(
 				:model-value="selectedProject"
 				data-test-id="project-sharing-select"
 				:filterable="true"
-				:filter-method="setFilter"
+				remote
+				:remote-method="debouncedRemoteSearch"
+				:loading="isLoading"
 				:placeholder="selectPlaceholder"
 				:default-first-option="true"
 				:no-data-text="noDataText"
@@ -202,6 +248,18 @@ watch(
 					:label="project.name ?? ''"
 				>
 					<ProjectSharingInfo :project="project" />
+				</N8nOption>
+				<N8nOption
+					v-if="hasMoreResults"
+					key="__more_results__"
+					value="__more_results__"
+					:label="moreResultsLabel"
+					disabled
+					:class="$style.moreResults"
+				>
+					<N8nText size="small" color="text-light">
+						{{ moreResultsLabel }}
+					</N8nText>
 				</N8nOption>
 			</N8nSelect>
 		</N8nTooltip>
@@ -240,9 +298,9 @@ watch(
 					/>
 				</N8nSelect>
 				<N8nButton
-					variant="subtle"
-					iconOnly
 					v-if="!props.static && !(project.id === GLOBAL_GROUP.id && !canShareGlobally)"
+					variant="subtle"
+					icon-only
 					native-type="button"
 					icon="trash-2"
 					:aria-label="locale.baseText('generic.delete')"
@@ -289,5 +347,11 @@ watch(
 
 .emoji {
 	font-size: var(--font-size--sm);
+}
+
+.moreResults {
+	cursor: default;
+	text-align: center;
+	border-top: var(--border);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.vue
@@ -92,6 +92,11 @@ const filteredProjects = computed(() => {
 		list = list.filter(props.filterFn);
 	}
 
+	// Exclude homeProject from the dropdown (it's shown separately as "owner")
+	if (props.homeProject) {
+		list = list.filter((p) => p.id !== props.homeProject!.id);
+	}
+
 	// Exclude already-selected projects (multi-select mode)
 	if (Array.isArray(model.value)) {
 		const selected = model.value;

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/projects.api.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/projects.api.ts
@@ -10,7 +10,13 @@ export const getAllProjects = async (context: IRestApiContext): Promise<ProjectL
 
 export const searchProjects = async (
 	context: IRestApiContext,
-	params: { search?: string; take?: number; type?: 'personal' | 'team'; activated?: boolean },
+	params: {
+		search?: string;
+		take?: number;
+		skip?: number;
+		type?: 'personal' | 'team';
+		activated?: boolean;
+	},
 ): Promise<{ count: number; data: ProjectListItem[] }> => {
 	return await getFullApiResponse<ProjectListItem[]>(context, 'GET', '/projects', params);
 };

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/projects.api.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/projects.api.ts
@@ -1,11 +1,18 @@
 import type { IRestApiContext } from '@n8n/rest-api-client';
-import { makeRestApiRequest } from '@n8n/rest-api-client';
+import { getFullApiResponse, makeRestApiRequest } from '@n8n/rest-api-client';
 import type { Project, ProjectListItem, ProjectsCount } from './projects.types';
 import type { CreateProjectDto, UpdateProjectDto } from '@n8n/api-types';
 import type { AssignableProjectRole } from '@n8n/permissions';
 
 export const getAllProjects = async (context: IRestApiContext): Promise<ProjectListItem[]> => {
 	return await makeRestApiRequest(context, 'GET', '/projects');
+};
+
+export const searchProjects = async (
+	context: IRestApiContext,
+	params: { search?: string; take?: number; type?: 'personal' | 'team'; activated?: boolean },
+): Promise<{ count: number; data: ProjectListItem[] }> => {
+	return await getFullApiResponse<ProjectListItem[]>(context, 'GET', '/projects', params);
 };
 
 export const getMyProjects = async (context: IRestApiContext): Promise<ProjectListItem[]> => {

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/projects.store.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/projects.store.ts
@@ -345,7 +345,6 @@ export const useProjectsStore = defineStore(STORES.PROJECTS, () => {
 		getMyProjects,
 		getPersonalProject,
 		getAvailableProjects,
-		searchProjects,
 		getProject,
 		fetchProject,
 		fetchAndSetProject,

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/projects.store.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/projects.store.ts
@@ -95,10 +95,6 @@ export const useProjectsStore = defineStore(STORES.PROJECTS, () => {
 		currentProject.value = project;
 	};
 
-	const searchProjects = async (params: { search?: string; take?: number; skip?: number }) => {
-		return await projectsApi.searchProjects(rootStore.restApiContext, params);
-	};
-
 	const getAllProjects = async () => {
 		projects.value = await projectsApi.getAllProjects(rootStore.restApiContext);
 	};
@@ -122,6 +118,7 @@ export const useProjectsStore = defineStore(STORES.PROJECTS, () => {
 	const searchProjects = async (params: {
 		search?: string;
 		take?: number;
+		skip?: number;
 		type?: 'personal' | 'team';
 		activated?: boolean;
 	}) => {

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/projects.store.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/projects.store.ts
@@ -95,6 +95,10 @@ export const useProjectsStore = defineStore(STORES.PROJECTS, () => {
 		currentProject.value = project;
 	};
 
+	const searchProjects = async (params: { search?: string; take?: number; skip?: number }) => {
+		return await projectsApi.searchProjects(rootStore.restApiContext, params);
+	};
+
 	const getAllProjects = async () => {
 		projects.value = await projectsApi.getAllProjects(rootStore.restApiContext);
 	};
@@ -336,8 +340,10 @@ export const useProjectsStore = defineStore(STORES.PROJECTS, () => {
 		canViewProjects,
 		hasPermissionToCreateProjects,
 		isTeamProjectFeatureEnabled,
+		globalProjectPermissions,
 		projectNavActiveId,
 		setCurrentProject,
+		searchProjects,
 		getAllProjects,
 		getMyProjects,
 		getPersonalProject,

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/projects.store.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/projects.store.ts
@@ -115,6 +115,15 @@ export const useProjectsStore = defineStore(STORES.PROJECTS, () => {
 		}
 	};
 
+	const searchProjects = async (params: {
+		search?: string;
+		take?: number;
+		type?: 'personal' | 'team';
+		activated?: boolean;
+	}) => {
+		return await projectsApi.searchProjects(rootStore.restApiContext, params);
+	};
+
 	const fetchProject = async (id: string) =>
 		await projectsApi.getProject(rootStore.restApiContext, id);
 
@@ -333,6 +342,7 @@ export const useProjectsStore = defineStore(STORES.PROJECTS, () => {
 		getMyProjects,
 		getPersonalProject,
 		getAvailableProjects,
+		searchProjects,
 		getProject,
 		fetchProject,
 		fetchAndSetProject,

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/projects.utils.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/projects.utils.ts
@@ -1,6 +1,6 @@
 import { truncate } from '@n8n/utils/string/truncate';
 import type { ProjectListItem } from './projects.types';
-import type { useProjectsStore } from './projects.store';
+import { useProjectsStore } from './projects.store';
 
 export const DEFAULT_PROJECT_SEARCH_PAGE_SIZE = 50;
 
@@ -11,9 +11,8 @@ export type ProjectSearchFn = (query: string) => Promise<ProjectSearchResult>;
  * Remote search for Group 1 consumers (sharing/transfer modals).
  * Always searches via GET /projects?search=&take= for ALL roles.
  */
-export function createRemoteProjectSearch(
-	store: ReturnType<typeof useProjectsStore>,
-): ProjectSearchFn {
+export function useRemoteProjectSearch(): ProjectSearchFn {
+	const store = useProjectsStore();
 	return async (query: string) => {
 		return await store.searchProjects({
 			search: query,
@@ -27,9 +26,8 @@ export function createRemoteProjectSearch(
  * - Admin (has project:list): remote search via GET /projects
  * - Member (no project:list): local filter over myProjects (bounded set)
  */
-export function createAvailableProjectSearch(
-	store: ReturnType<typeof useProjectsStore>,
-): ProjectSearchFn {
+export function useAvailableProjectSearch(): ProjectSearchFn {
+	const store = useProjectsStore();
 	return async (query: string) => {
 		if (store.globalProjectPermissions.list) {
 			return await store.searchProjects({

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/projects.utils.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/projects.utils.ts
@@ -1,4 +1,50 @@
 import { truncate } from '@n8n/utils/string/truncate';
+import type { ProjectListItem } from './projects.types';
+import type { useProjectsStore } from './projects.store';
+
+export const DEFAULT_PROJECT_SEARCH_PAGE_SIZE = 50;
+
+export type ProjectSearchResult = { count: number; data: ProjectListItem[] };
+export type ProjectSearchFn = (query: string) => Promise<ProjectSearchResult>;
+
+/**
+ * Remote search for Group 1 consumers (sharing/transfer modals).
+ * Always searches via GET /projects?search=&take= for ALL roles.
+ */
+export function createRemoteProjectSearch(
+	store: ReturnType<typeof useProjectsStore>,
+): ProjectSearchFn {
+	return async (query: string) => {
+		return await store.searchProjects({
+			search: query,
+			take: DEFAULT_PROJECT_SEARCH_PAGE_SIZE,
+		});
+	};
+}
+
+/**
+ * Mirrors getAvailableProjects() behavior:
+ * - Admin (has project:list): remote search via GET /projects
+ * - Member (no project:list): local filter over myProjects (bounded set)
+ */
+export function createAvailableProjectSearch(
+	store: ReturnType<typeof useProjectsStore>,
+): ProjectSearchFn {
+	return async (query: string) => {
+		if (store.globalProjectPermissions.list) {
+			return await store.searchProjects({
+				search: query,
+				take: DEFAULT_PROJECT_SEARCH_PAGE_SIZE,
+			});
+		}
+		// Member: filter locally over myProjects (already fetched, bounded)
+		const lowerQuery = query.toLowerCase();
+		const filtered = store.myProjects.filter(
+			(p) => !query || (p.name?.toLowerCase().includes(lowerQuery) ?? false),
+		);
+		return { count: filtered.length, data: filtered };
+	};
+}
 
 // Splits a project name into first name, last name, and email when it is in the format "First Last <email@domain.com>"
 export const splitName = (

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.test.ts
@@ -170,7 +170,7 @@ describe('ProjectSettings', () => {
 		createTestingPinia();
 
 		projectsStore = mockedStore(useProjectsStore);
-		projectsStore.searchProjects.mockResolvedValue({ count: 0, data: [] });
+		projectsStore.searchProjects.mockResolvedValue({ count: projects.length, data: projects });
 		usersStore = mockedStore(useUsersStore);
 		settingsStore = mockedStore(useSettingsStore);
 		rolesStore = mockedStore(useRolesStore);

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.test.ts
@@ -171,6 +171,7 @@ describe('ProjectSettings', () => {
 
 		projectsStore = mockedStore(useProjectsStore);
 		projectsStore.searchProjects.mockResolvedValue({ count: projects.length, data: projects });
+		projectsStore.globalProjectPermissions = { list: true } as any;
 		usersStore = mockedStore(useUsersStore);
 		settingsStore = mockedStore(useSettingsStore);
 		rolesStore = mockedStore(useRolesStore);

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.test.ts
@@ -170,6 +170,7 @@ describe('ProjectSettings', () => {
 		createTestingPinia();
 
 		projectsStore = mockedStore(useProjectsStore);
+		projectsStore.searchProjects.mockResolvedValue({ count: 0, data: [] });
 		usersStore = mockedStore(useUsersStore);
 		settingsStore = mockedStore(useSettingsStore);
 		rolesStore = mockedStore(useRolesStore);

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.test.ts
@@ -171,7 +171,7 @@ describe('ProjectSettings', () => {
 
 		projectsStore = mockedStore(useProjectsStore);
 		projectsStore.searchProjects.mockResolvedValue({ count: projects.length, data: projects });
-		projectsStore.globalProjectPermissions = { list: true } as any;
+		projectsStore.globalProjectPermissions = { list: true };
 		usersStore = mockedStore(useUsersStore);
 		settingsStore = mockedStore(useSettingsStore);
 		rolesStore = mockedStore(useRolesStore);

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.vue
@@ -112,11 +112,6 @@ const usersList = computed(() =>
 	}),
 );
 
-const projects = computed(() =>
-	projectsStore.availableProjects.filter(
-		(project) => project.id !== projectsStore.currentProjectId,
-	),
-);
 const firstLicensedRole = computed(
 	() => rolesStore.processedProjectRoles.find((role) => role.licensed)?.slug,
 );
@@ -368,8 +363,6 @@ const onSubmit = async () => {
 };
 
 const onDelete = async () => {
-	await projectsStore.getAvailableProjects();
-
 	if (projectsStore.currentProjectId) {
 		resourceCounts.value = await projectsStore.getResourceCounts(projectsStore.currentProjectId);
 	}
@@ -707,7 +700,6 @@ onMounted(async () => {
 			v-model="dialogVisible"
 			:current-project="projectsStore.currentProject"
 			:resource-counts="resourceCounts"
-			:projects="projects"
 			@confirm-delete="onConfirmDelete"
 		/>
 		<ProjectRoleUpgradeDialog

--- a/packages/frontend/editor-ui/src/features/core/folders/components/MoveToFolderModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/folders/components/MoveToFolderModal.test.ts
@@ -187,6 +187,7 @@ describe('MoveToFolderModal', () => {
 		projectsStore = mockedStore(useProjectsStore);
 		projectsStore.moveResourceToProject = vi.fn().mockResolvedValue(undefined);
 		projectsStore.searchProjects.mockResolvedValue({ count: projects.length, data: projects });
+		projectsStore.globalProjectPermissions = { list: true };
 
 		projectsStore.currentProject = personalProject as unknown as Project;
 		projectsStore.currentProjectId = personalProject.id;

--- a/packages/frontend/editor-ui/src/features/core/folders/components/MoveToFolderModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/folders/components/MoveToFolderModal.test.ts
@@ -186,6 +186,7 @@ describe('MoveToFolderModal', () => {
 
 		projectsStore = mockedStore(useProjectsStore);
 		projectsStore.moveResourceToProject = vi.fn().mockResolvedValue(undefined);
+		projectsStore.searchProjects.mockResolvedValue({ count: projects.length, data: projects });
 
 		projectsStore.currentProject = personalProject as unknown as Project;
 		projectsStore.currentProjectId = personalProject.id;

--- a/packages/frontend/editor-ui/src/features/core/folders/components/MoveToFolderModal.vue
+++ b/packages/frontend/editor-ui/src/features/core/folders/components/MoveToFolderModal.vue
@@ -30,6 +30,7 @@ import {
 	ResourceType,
 	getTruncatedProjectName,
 	splitName,
+	createAvailableProjectSearch,
 } from '@/features/collaboration/projects/projects.utils';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useToast } from '@/app/composables/useToast';
@@ -122,8 +123,9 @@ const unShareableCredentials = computed(() =>
 	),
 );
 
-const projectFilterFn = (p: ProjectListItem): boolean =>
-	!p.scopes || !!getResourcePermissions(p.scopes)[props.data.resourceType].create;
+const searchFn = createAvailableProjectSearch(projectsStore);
+const filterFn = (p: ProjectListItem) =>
+	!p.scopes || getResourcePermissions(p.scopes)[props.data.resourceType].create;
 
 const resourceTypeLabel = computed(() => {
 	return i18n.baseText(`generic.${props.data.resourceType}`).toLowerCase();
@@ -431,7 +433,8 @@ onMounted(async () => {
 					<ProjectSharing
 						v-model="selectedProject"
 						class="pt-2xs"
-						:filter-fn="projectFilterFn"
+						:search-fn="searchFn"
+						:filter-fn="filterFn"
 						:placeholder="i18n.baseText('folders.move.modal.project.placeholder')"
 					/>
 				</div>

--- a/packages/frontend/editor-ui/src/features/core/folders/components/MoveToFolderModal.vue
+++ b/packages/frontend/editor-ui/src/features/core/folders/components/MoveToFolderModal.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed, onMounted, ref, watch } from 'vue';
 import { useI18n } from '@n8n/i18n';
-import { sortByProperty } from '@n8n/utils/sort/sortByProperty';
+
 import { EnterpriseEditionFeature } from '@/app/constants';
 import { MOVE_FOLDER_MODAL_KEY } from '../folders.constants';
 import { useFoldersStore } from '../folders.store';
@@ -122,14 +122,8 @@ const unShareableCredentials = computed(() =>
 	),
 );
 
-const availableProjects = computed<ProjectListItem[]>(() =>
-	sortByProperty(
-		'name',
-		projectsStore.availableProjects.filter(
-			(p) => !p.scopes || getResourcePermissions(p.scopes)[props.data.resourceType].create,
-		),
-	),
-);
+const projectFilterFn = (p: ProjectListItem): boolean =>
+	!p.scopes || !!getResourcePermissions(p.scopes)[props.data.resourceType].create;
 
 const resourceTypeLabel = computed(() => {
 	return i18n.baseText(`generic.${props.data.resourceType}`).toLowerCase();
@@ -437,7 +431,7 @@ onMounted(async () => {
 					<ProjectSharing
 						v-model="selectedProject"
 						class="pt-2xs"
-						:projects="availableProjects"
+						:filter-fn="projectFilterFn"
 						:placeholder="i18n.baseText('folders.move.modal.project.placeholder')"
 					/>
 				</div>

--- a/packages/frontend/editor-ui/src/features/core/folders/components/MoveToFolderModal.vue
+++ b/packages/frontend/editor-ui/src/features/core/folders/components/MoveToFolderModal.vue
@@ -125,7 +125,7 @@ const unShareableCredentials = computed(() =>
 
 const searchFn = createAvailableProjectSearch(projectsStore);
 const filterFn = (p: ProjectListItem) =>
-	!p.scopes || getResourcePermissions(p.scopes)[props.data.resourceType].create;
+	!p.scopes || !!getResourcePermissions(p.scopes)[props.data.resourceType].create;
 
 const resourceTypeLabel = computed(() => {
 	return i18n.baseText(`generic.${props.data.resourceType}`).toLowerCase();

--- a/packages/frontend/editor-ui/src/features/core/folders/components/MoveToFolderModal.vue
+++ b/packages/frontend/editor-ui/src/features/core/folders/components/MoveToFolderModal.vue
@@ -30,7 +30,7 @@ import {
 	ResourceType,
 	getTruncatedProjectName,
 	splitName,
-	createAvailableProjectSearch,
+	useAvailableProjectSearch,
 } from '@/features/collaboration/projects/projects.utils';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useToast } from '@/app/composables/useToast';
@@ -123,7 +123,7 @@ const unShareableCredentials = computed(() =>
 	),
 );
 
-const searchFn = createAvailableProjectSearch(projectsStore);
+const searchFn = useAvailableProjectSearch();
 const filterFn = (p: ProjectListItem) =>
 	!p.scopes || !!getResourcePermissions(p.scopes)[props.data.resourceType].create;
 

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialSharing.ee.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialSharing.ee.test.ts
@@ -12,7 +12,10 @@ import { getDropdownItems } from '@/__tests__/utils';
 import { useI18n } from '@n8n/i18n';
 import type * as I18nModule from '@n8n/i18n';
 import { ProjectTypes } from '@/features/collaboration/projects/projects.types';
-import { createTestProject } from '@/features/collaboration/projects/__tests__/utils';
+import {
+	createProjectListItem,
+	createTestProject,
+} from '@/features/collaboration/projects/__tests__/utils';
 
 vi.mock('@n8n/i18n', async (importOriginal) => {
 	const actual = await importOriginal<typeof I18nModule>();
@@ -52,6 +55,7 @@ const mockBaseText = vi.fn((key: string, options?: { interpolate?: Record<string
 });
 
 const renderComponent = createComponentRenderer(CredentialSharing);
+const testProjects = Array.from({ length: 3 }, createProjectListItem);
 
 const createCredential = (overrides = {}): ICredentialsResponse => ({
 	id: '1',
@@ -96,6 +100,10 @@ describe('CredentialSharing.ee', () => {
 		// Mock store methods
 		vi.spyOn(usersStore, 'fetchUsers').mockResolvedValue();
 		vi.spyOn(projectsStore, 'getAllProjects').mockResolvedValue();
+		vi.spyOn(projectsStore, 'searchProjects').mockResolvedValue({
+			count: testProjects.length,
+			data: testProjects,
+		});
 		vi.spyOn(rolesStore, 'processedCredentialRoles', 'get').mockReturnValue([
 			{
 				slug: 'credential:user',

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialSharing.ee.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialSharing.ee.vue
@@ -17,7 +17,7 @@ import type {
 import { ProjectTypes } from '@/features/collaboration/projects/projects.types';
 import {
 	splitName,
-	createRemoteProjectSearch,
+	useRemoteProjectSearch,
 } from '@/features/collaboration/projects/projects.utils';
 import type { EventBus } from '@n8n/utils/event-bus';
 import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
@@ -73,7 +73,7 @@ const credentialDataHomeProject = computed<ProjectSharingData | undefined>(() =>
 		: undefined;
 });
 
-const searchFn = createRemoteProjectSearch(projectsStore);
+const searchFn = useRemoteProjectSearch();
 const filterFn = (project: ProjectListItem) =>
 	project.id !== props.credential?.homeProject?.id &&
 	project.id !== credentialDataHomeProject.value?.id;

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialSharing.ee.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialSharing.ee.vue
@@ -10,12 +10,18 @@ import { useRolesStore } from '@/app/stores/roles.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
-import type { ProjectSharingData } from '@/features/collaboration/projects/projects.types';
+import type {
+	ProjectListItem,
+	ProjectSharingData,
+} from '@/features/collaboration/projects/projects.types';
 import { ProjectTypes } from '@/features/collaboration/projects/projects.types';
-import { splitName } from '@/features/collaboration/projects/projects.utils';
+import {
+	splitName,
+	createRemoteProjectSearch,
+} from '@/features/collaboration/projects/projects.utils';
 import type { EventBus } from '@n8n/utils/event-bus';
 import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { getResourcePermissions } from '@n8n/permissions';
 
 import { N8nActionBox, N8nInfoTip } from '@n8n/design-system';
@@ -67,6 +73,11 @@ const credentialDataHomeProject = computed<ProjectSharingData | undefined>(() =>
 		: undefined;
 });
 
+const searchFn = createRemoteProjectSearch(projectsStore);
+const filterFn = (project: ProjectListItem) =>
+	project.id !== props.credential?.homeProject?.id &&
+	project.id !== credentialDataHomeProject.value?.id;
+
 const homeProject = computed<ProjectSharingData | undefined>(
 	() => props.credential?.homeProject ?? credentialDataHomeProject.value,
 );
@@ -116,9 +127,7 @@ watch(
 	{ deep: true },
 );
 
-onMounted(async () => {
-	// ProjectSharing handles its own data fetching in remote search mode
-});
+// Projects are now fetched on demand via searchFn in ProjectSharing
 
 function goToUpgrade() {
 	void pageRedirectionHelper.goToUpgrade('credential_sharing', 'upgrade-credentials-sharing');
@@ -163,6 +172,8 @@ function goToUpgrade() {
 			</N8nInfoTip>
 			<ProjectSharing
 				v-model="sharedWithProjects"
+				:search-fn="searchFn"
+				:filter-fn="filterFn"
 				:roles="credentialRoles"
 				:home-project="homeProject"
 				:readonly="!credentialPermissions.share"

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialSharing.ee.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialSharing.ee.vue
@@ -10,10 +10,7 @@ import { useRolesStore } from '@/app/stores/roles.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
-import type {
-	ProjectListItem,
-	ProjectSharingData,
-} from '@/features/collaboration/projects/projects.types';
+import type { ProjectSharingData } from '@/features/collaboration/projects/projects.types';
 import { ProjectTypes } from '@/features/collaboration/projects/projects.types';
 import { splitName } from '@/features/collaboration/projects/projects.utils';
 import type { EventBus } from '@n8n/utils/event-bus';
@@ -70,14 +67,6 @@ const credentialDataHomeProject = computed<ProjectSharingData | undefined>(() =>
 		: undefined;
 });
 
-const projects = computed<ProjectListItem[]>(() => {
-	return projectsStore.projects.filter(
-		(project) =>
-			project.id !== props.credential?.homeProject?.id &&
-			project.id !== credentialDataHomeProject.value?.id,
-	);
-});
-
 const homeProject = computed<ProjectSharingData | undefined>(
 	() => props.credential?.homeProject ?? credentialDataHomeProject.value,
 );
@@ -128,7 +117,7 @@ watch(
 );
 
 onMounted(async () => {
-	await projectsStore.getAllProjects();
+	// ProjectSharing handles its own data fetching in remote search mode
 });
 
 function goToUpgrade() {
@@ -174,7 +163,6 @@ function goToUpgrade() {
 			</N8nInfoTip>
 			<ProjectSharing
 				v-model="sharedWithProjects"
-				:projects="projects"
 				:roles="credentialRoles"
 				:home-project="homeProject"
 				:readonly="!credentialPermissions.share"

--- a/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.test.ts
@@ -284,6 +284,7 @@ describe('InsightsDashboard', () => {
 		// Mock projects store
 		projectsStore.availableProjects = projects;
 		projectsStore.getAvailableProjects = vi.fn().mockResolvedValue(projects);
+		projectsStore.searchProjects.mockResolvedValue({ count: projects.length, data: projects });
 
 		// Mock async states
 		insightsStore.summary = {

--- a/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.test.ts
@@ -285,6 +285,7 @@ describe('InsightsDashboard', () => {
 		projectsStore.availableProjects = projects;
 		projectsStore.getAvailableProjects = vi.fn().mockResolvedValue(projects);
 		projectsStore.searchProjects.mockResolvedValue({ count: projects.length, data: projects });
+		projectsStore.globalProjectPermissions = { list: true };
 
 		// Mock async states
 		insightsStore.summary = {

--- a/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.vue
+++ b/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.vue
@@ -4,7 +4,7 @@ import ProjectSharing from '@/features/collaboration/projects/components/Project
 import type { ProjectSharingData } from '@/features/collaboration/projects/projects.types';
 import type { ProjectListItem } from '@/features/collaboration/projects/projects.types';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
-import { createAvailableProjectSearch } from '@/features/collaboration/projects/projects.utils';
+import { useAvailableProjectSearch } from '@/features/collaboration/projects/projects.utils';
 import InsightsSummary from '@/features/execution/insights/components/InsightsSummary.vue';
 import { useInsightsStore } from '@/features/execution/insights/insights.store';
 import type { DateValue } from '@internationalized/date';
@@ -195,7 +195,7 @@ onMounted(() => {
 // Must be *only* <email> — no extra text before or after
 const emailPattern = /^<([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})>$/;
 
-const searchFn = createAvailableProjectSearch(projectsStore);
+const searchFn = useAvailableProjectSearch();
 const filterFn = (project: ProjectListItem) =>
 	!!project.name && !emailPattern.test(project.name.trim());
 

--- a/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.vue
+++ b/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.vue
@@ -200,8 +200,11 @@ const filterFn = (project: ProjectListItem) =>
 	!!project.name && !emailPattern.test(project.name.trim());
 
 onBeforeMount(async () => {
-	// Load myProjects for members so createAvailableProjectSearch can filter locally
-	await projectsStore.getAvailableProjects();
+	// Members filter locally over myProjects — preload them.
+	// Admins use remote search, so skip the unpaginated GET /projects call.
+	if (!projectsStore.globalProjectPermissions.list) {
+		await projectsStore.getAvailableProjects();
+	}
 });
 </script>
 

--- a/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.vue
+++ b/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
 import ProjectSharing from '@/features/collaboration/projects/components/ProjectSharing.vue';
-import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import type { ProjectSharingData } from '@/features/collaboration/projects/projects.types';
 import InsightsSummary from '@/features/execution/insights/components/InsightsSummary.vue';
 import { useInsightsStore } from '@/features/execution/insights/insights.store';
@@ -9,15 +8,7 @@ import type { DateValue } from '@internationalized/date';
 import { getLocalTimeZone, today } from '@internationalized/date';
 import type { InsightsSummaryType } from '@n8n/api-types';
 import { useI18n } from '@n8n/i18n';
-import {
-	computed,
-	defineAsyncComponent,
-	onBeforeMount,
-	onMounted,
-	ref,
-	shallowRef,
-	watch,
-} from 'vue';
+import { computed, defineAsyncComponent, onMounted, ref, shallowRef, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { INSIGHT_TYPES } from '../insights.constants';
 import { getAdjustedDateRange, getTimeRangeLabels, timeRangeMappings } from '../insights.utils';
@@ -60,8 +51,6 @@ const route = useRoute();
 const i18n = useI18n();
 
 const insightsStore = useInsightsStore();
-const projectsStore = useProjectsStore();
-
 const isTimeSavedRoute = computed(() => route.params.insightType === INSIGHT_TYPES.TIME_SAVED);
 
 const chartComponents = computed(() => ({
@@ -191,18 +180,6 @@ watch(
 onMounted(() => {
 	useDocumentTitle().set(i18n.baseText('insights.heading'));
 });
-onBeforeMount(async () => {
-	await projectsStore.getAvailableProjects();
-});
-
-// Must be *only* <email> — no extra text before or after
-const emailPattern = /^<([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})>$/;
-
-const projects = computed(() =>
-	projectsStore.availableProjects.filter(
-		(project) => project.name && !emailPattern.test(project.name.trim()),
-	),
-);
 </script>
 
 <template>
@@ -215,7 +192,7 @@ const projects = computed(() =>
 			<div class="mt-s" style="display: flex; gap: 12px; align-items: center">
 				<ProjectSharing
 					v-model="selectedProject"
-					:projects="projects"
+					:activated="true"
 					:placeholder="i18n.baseText('insights.dashboard.search.placeholder')"
 					:empty-options-text="i18n.baseText('projects.sharing.noMatchingProjects')"
 					size="mini"

--- a/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.vue
+++ b/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.vue
@@ -2,13 +2,24 @@
 import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
 import ProjectSharing from '@/features/collaboration/projects/components/ProjectSharing.vue';
 import type { ProjectSharingData } from '@/features/collaboration/projects/projects.types';
+import type { ProjectListItem } from '@/features/collaboration/projects/projects.types';
+import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
+import { createAvailableProjectSearch } from '@/features/collaboration/projects/projects.utils';
 import InsightsSummary from '@/features/execution/insights/components/InsightsSummary.vue';
 import { useInsightsStore } from '@/features/execution/insights/insights.store';
 import type { DateValue } from '@internationalized/date';
 import { getLocalTimeZone, today } from '@internationalized/date';
 import type { InsightsSummaryType } from '@n8n/api-types';
 import { useI18n } from '@n8n/i18n';
-import { computed, defineAsyncComponent, onMounted, ref, shallowRef, watch } from 'vue';
+import {
+	computed,
+	defineAsyncComponent,
+	onBeforeMount,
+	onMounted,
+	ref,
+	shallowRef,
+	watch,
+} from 'vue';
 import { useRoute } from 'vue-router';
 import { INSIGHT_TYPES } from '../insights.constants';
 import { getAdjustedDateRange, getTimeRangeLabels, timeRangeMappings } from '../insights.utils';
@@ -51,6 +62,7 @@ const route = useRoute();
 const i18n = useI18n();
 
 const insightsStore = useInsightsStore();
+const projectsStore = useProjectsStore();
 const isTimeSavedRoute = computed(() => route.params.insightType === INSIGHT_TYPES.TIME_SAVED);
 
 const chartComponents = computed(() => ({
@@ -180,6 +192,17 @@ watch(
 onMounted(() => {
 	useDocumentTitle().set(i18n.baseText('insights.heading'));
 });
+// Must be *only* <email> — no extra text before or after
+const emailPattern = /^<([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})>$/;
+
+const searchFn = createAvailableProjectSearch(projectsStore);
+const filterFn = (project: ProjectListItem) =>
+	!!project.name && !emailPattern.test(project.name.trim());
+
+onBeforeMount(async () => {
+	// Load myProjects for members so createAvailableProjectSearch can filter locally
+	await projectsStore.getAvailableProjects();
+});
 </script>
 
 <template>
@@ -192,7 +215,8 @@ onMounted(() => {
 			<div class="mt-s" style="display: flex; gap: 12px; align-items: center">
 				<ProjectSharing
 					v-model="selectedProject"
-					:activated="true"
+					:search-fn="searchFn"
+					:filter-fn="filterFn"
 					:placeholder="i18n.baseText('insights.dashboard.search.placeholder')"
 					:empty-options-text="i18n.baseText('projects.sharing.noMatchingProjects')"
 					size="mini"

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
@@ -159,6 +159,7 @@ describe('SourceControlPushModal', () => {
 
 		const projectsStore = mockedStore(useProjectsStore);
 		projectsStore.searchProjects.mockResolvedValue({ count: 0, data: [] });
+		projectsStore.globalProjectPermissions = { list: true };
 	});
 
 	it('mounts', async () => {

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
@@ -156,6 +156,9 @@ describe('SourceControlPushModal', () => {
 
 		settingsStore = mockedStore(useSettingsStore);
 		settingsStore.settings.enterprise = defaultSettings.enterprise;
+
+		const projectsStore = mockedStore(useProjectsStore);
+		projectsStore.searchProjects.mockResolvedValue({ count: 0, data: [] });
 	});
 
 	it('mounts', async () => {
@@ -1500,6 +1503,10 @@ describe('SourceControlPushModal', () => {
 		])('should filter %s by project', async (entity, name) => {
 			const projectsStore = mockedStore(useProjectsStore);
 			projectsStore.availableProjects = projects as unknown as ProjectListItem[];
+			projectsStore.searchProjects.mockResolvedValue({
+				count: projects.length,
+				data: projects as unknown as ProjectListItem[],
+			});
 
 			const status: SourceControlledFile[] = [
 				{

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
@@ -135,12 +135,8 @@ onBeforeMount(() => {
 	void projectsStore.getAvailableProjects();
 });
 
-const projectsForFilters = computed(() => {
-	return projectsStore.availableProjects.filter(
-		// global admins role is empty...
-		(project) => !project.role || project.role === 'project:admin',
-	);
-});
+const projectAdminFilterFn = (project: ProjectListItem) =>
+	!project.role || project.role === 'project:admin';
 
 const concatenateWithAnd = (messages: string[]) =>
 	new Intl.ListFormat(i18n.locale, { style: 'long', type: 'conjunction' }).format(messages);
@@ -972,7 +968,7 @@ onMounted(async () => {
 								v-model="filters.project"
 								data-test-id="source-control-push-modal-project-search"
 								clearable
-								:projects="projectsForFilters"
+								:filter-fn="projectAdminFilterFn"
 								:placeholder="i18n.baseText('forms.resourceFiltersDropdown.owner.placeholder')"
 								:empty-options-text="i18n.baseText('projects.sharing.noMatchingProjects')"
 								@clear="clearProjectFilter"

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
@@ -42,7 +42,7 @@ import { DynamicScroller, DynamicScrollerItem } from 'vue-virtual-scroller';
 import 'vue-virtual-scroller/dist/vue-virtual-scroller.css';
 import Modal from '@/app/components/Modal.vue';
 import ProjectSharing from '@/features/collaboration/projects/components/ProjectSharing.vue';
-import { createAvailableProjectSearch } from '@/features/collaboration/projects/projects.utils';
+import { useAvailableProjectSearch } from '@/features/collaboration/projects/projects.utils';
 import {
 	N8nBadge,
 	N8nButton,
@@ -132,7 +132,7 @@ const projectAdminCalloutDismissed = useStorage(
 	localStorage,
 );
 
-const searchFnForFilters = createAvailableProjectSearch(projectsStore);
+const searchFnForFilters = useAvailableProjectSearch();
 const filterFnForFilters = (project: ProjectListItem) =>
 	!project.role || project.role === 'project:admin';
 

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
@@ -42,6 +42,7 @@ import { DynamicScroller, DynamicScrollerItem } from 'vue-virtual-scroller';
 import 'vue-virtual-scroller/dist/vue-virtual-scroller.css';
 import Modal from '@/app/components/Modal.vue';
 import ProjectSharing from '@/features/collaboration/projects/components/ProjectSharing.vue';
+import { createAvailableProjectSearch } from '@/features/collaboration/projects/projects.utils';
 import {
 	N8nBadge,
 	N8nButton,
@@ -131,12 +132,14 @@ const projectAdminCalloutDismissed = useStorage(
 	localStorage,
 );
 
-onBeforeMount(() => {
-	void projectsStore.getAvailableProjects();
-});
-
-const projectAdminFilterFn = (project: ProjectListItem) =>
+const searchFnForFilters = createAvailableProjectSearch(projectsStore);
+const filterFnForFilters = (project: ProjectListItem) =>
 	!project.role || project.role === 'project:admin';
+
+onBeforeMount(async () => {
+	// Load projects for file→project mapping display and for member search
+	await projectsStore.getAvailableProjects();
+});
 
 const concatenateWithAnd = (messages: string[]) =>
 	new Intl.ListFormat(i18n.locale, { style: 'long', type: 'conjunction' }).format(messages);
@@ -968,7 +971,8 @@ onMounted(async () => {
 								v-model="filters.project"
 								data-test-id="source-control-push-modal-project-search"
 								clearable
-								:filter-fn="projectAdminFilterFn"
+								:search-fn="searchFnForFilters"
+								:filter-fn="filterFnForFilters"
 								:placeholder="i18n.baseText('forms.resourceFiltersDropdown.owner.placeholder')"
 								:empty-options-text="i18n.baseText('projects.sharing.noMatchingProjects')"
 								@clear="clearProjectFilter"

--- a/packages/frontend/editor-ui/src/features/settings/users/components/DeleteUserModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/components/DeleteUserModal.test.ts
@@ -9,6 +9,7 @@ import { STORES } from '@n8n/stores';
 import { ProjectTypes } from '@/features/collaboration/projects/projects.types';
 import userEvent from '@testing-library/user-event';
 import { useUsersStore } from '../users.store';
+import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { ROLE, type UsersList, type User } from '@n8n/api-types';
 
 const ModalStub = {
@@ -92,6 +93,12 @@ describe('DeleteUserModal', () => {
 	beforeEach(() => {
 		pinia = createTestingPinia({ initialState });
 		usersStore = mockedStore(useUsersStore);
+
+		const projectsStore = mockedStore(useProjectsStore);
+		projectsStore.searchProjects.mockResolvedValue({
+			count: initialState[STORES.PROJECTS].projects.length,
+			data: initialState[STORES.PROJECTS].projects,
+		});
 
 		usersStore.usersList = {
 			state: mockUsersList,

--- a/packages/frontend/editor-ui/src/features/settings/users/components/DeleteUserModal.vue
+++ b/packages/frontend/editor-ui/src/features/settings/users/components/DeleteUserModal.vue
@@ -1,12 +1,14 @@
 <script lang="ts" setup>
-import { ref, computed, onBeforeMount } from 'vue';
+import { ref, computed } from 'vue';
 import { useToast } from '@/app/composables/useToast';
 import Modal from '@/app/components/Modal.vue';
 import ProjectSharing from '@/features/collaboration/projects/components/ProjectSharing.vue';
 import { useUsersStore } from '../users.store';
-import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { createEventBus } from '@n8n/utils/event-bus';
-import type { ProjectSharingData } from '@/features/collaboration/projects/projects.types';
+import type {
+	ProjectListItem,
+	ProjectSharingData,
+} from '@/features/collaboration/projects/projects.types';
 import { useI18n } from '@n8n/i18n';
 
 import { ElRadio } from 'element-plus';
@@ -27,7 +29,6 @@ const selectedProject = ref<ProjectSharingData | null>(null);
 
 const i18n = useI18n();
 const usersStore = useUsersStore();
-const projectsStore = useProjectsStore();
 
 const userToDelete = computed(() => {
 	if (!props.data?.userId) return null;
@@ -61,17 +62,9 @@ const enabled = computed(() => {
 	return !!(operation.value === 'transfer' && selectedProject.value);
 });
 
-const projects = computed(() => {
-	return projectsStore.projects.filter(
-		(project) =>
-			project.name !==
-			`${userToDelete.value?.firstName} ${userToDelete.value?.lastName} <${userToDelete.value?.email}>`,
-	);
-});
-
-onBeforeMount(async () => {
-	await projectsStore.getAllProjects();
-});
+const projectFilterFn = (project: ProjectListItem) =>
+	project.name !==
+	`${userToDelete.value?.firstName} ${userToDelete.value?.lastName} <${userToDelete.value?.email}>`;
 
 const { showMessage, showError } = useToast();
 
@@ -91,13 +84,10 @@ async function onSubmit() {
 		await usersStore.deleteUser(params);
 
 		let message = '';
-		if (params.transferId) {
-			const transferProject = projects.value.find((project) => project.id === params.transferId);
-			if (transferProject) {
-				message = i18n.baseText('settings.users.transferredToUser', {
-					interpolate: { projectName: transferProject.name ?? '' },
-				});
-			}
+		if (params.transferId && selectedProject.value) {
+			message = i18n.baseText('settings.users.transferredToUser', {
+				interpolate: { projectName: selectedProject.value.name ?? '' },
+			});
 		}
 
 		showMessage({
@@ -154,7 +144,7 @@ async function onSubmit() {
 						<ProjectSharing
 							v-model="selectedProject"
 							class="pt-2xs"
-							:projects="projects"
+							:filter-fn="projectFilterFn"
 							:placeholder="
 								i18n.baseText('settings.users.transferWorkflowsAndCredentials.placeholder')
 							"

--- a/packages/frontend/editor-ui/src/features/settings/users/components/DeleteUserModal.vue
+++ b/packages/frontend/editor-ui/src/features/settings/users/components/DeleteUserModal.vue
@@ -7,8 +7,7 @@ import { useUsersStore } from '../users.store';
 import { createEventBus } from '@n8n/utils/event-bus';
 import type { ProjectSharingData } from '@/features/collaboration/projects/projects.types';
 import type { ProjectListItem } from '@/features/collaboration/projects/projects.types';
-import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
-import { createRemoteProjectSearch } from '@/features/collaboration/projects/projects.utils';
+import { useRemoteProjectSearch } from '@/features/collaboration/projects/projects.utils';
 import { useI18n } from '@n8n/i18n';
 
 import { ElRadio } from 'element-plus';
@@ -29,7 +28,6 @@ const selectedProject = ref<ProjectSharingData | null>(null);
 
 const i18n = useI18n();
 const usersStore = useUsersStore();
-const projectsStore = useProjectsStore();
 
 const userToDelete = computed(() => {
 	if (!props.data?.userId) return null;
@@ -63,7 +61,7 @@ const enabled = computed(() => {
 	return !!(operation.value === 'transfer' && selectedProject.value);
 });
 
-const searchFn = createRemoteProjectSearch(projectsStore);
+const searchFn = useRemoteProjectSearch();
 const filterFn = (project: ProjectListItem) =>
 	project.name !==
 	`${userToDelete.value?.firstName} ${userToDelete.value?.lastName} <${userToDelete.value?.email}>`;

--- a/packages/frontend/editor-ui/src/features/settings/users/components/DeleteUserModal.vue
+++ b/packages/frontend/editor-ui/src/features/settings/users/components/DeleteUserModal.vue
@@ -5,10 +5,10 @@ import Modal from '@/app/components/Modal.vue';
 import ProjectSharing from '@/features/collaboration/projects/components/ProjectSharing.vue';
 import { useUsersStore } from '../users.store';
 import { createEventBus } from '@n8n/utils/event-bus';
-import type {
-	ProjectListItem,
-	ProjectSharingData,
-} from '@/features/collaboration/projects/projects.types';
+import type { ProjectSharingData } from '@/features/collaboration/projects/projects.types';
+import type { ProjectListItem } from '@/features/collaboration/projects/projects.types';
+import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
+import { createRemoteProjectSearch } from '@/features/collaboration/projects/projects.utils';
 import { useI18n } from '@n8n/i18n';
 
 import { ElRadio } from 'element-plus';
@@ -29,6 +29,7 @@ const selectedProject = ref<ProjectSharingData | null>(null);
 
 const i18n = useI18n();
 const usersStore = useUsersStore();
+const projectsStore = useProjectsStore();
 
 const userToDelete = computed(() => {
 	if (!props.data?.userId) return null;
@@ -62,7 +63,8 @@ const enabled = computed(() => {
 	return !!(operation.value === 'transfer' && selectedProject.value);
 });
 
-const projectFilterFn = (project: ProjectListItem) =>
+const searchFn = createRemoteProjectSearch(projectsStore);
+const filterFn = (project: ProjectListItem) =>
 	project.name !==
 	`${userToDelete.value?.firstName} ${userToDelete.value?.lastName} <${userToDelete.value?.email}>`;
 
@@ -144,7 +146,8 @@ async function onSubmit() {
 						<ProjectSharing
 							v-model="selectedProject"
 							class="pt-2xs"
-							:filter-fn="projectFilterFn"
+							:search-fn="searchFn"
+							:filter-fn="filterFn"
 							:placeholder="
 								i18n.baseText('settings.users.transferWorkflowsAndCredentials.placeholder')
 							"


### PR DESCRIPTION
## Summary

Converts all `ProjectSharing` callers to use the paginated `GET /projects` endpoint (added in #27036) with server-side search, replacing client-side filtering that loaded all projects upfront. This prevents UI freezes when large numbers of users (~10k) exist.

**Changes:**
- Add `searchProjects` API function and Pinia store method using `getFullApiResponse` with `take`/`search`/`activated` params
- Refactor `ProjectSharing` to use `useAsyncState` with `remote` + `remote-method` for debounced server-side search
- Show a "more results" indicator when the server has more results than displayed
- Refactor `ProjectMoveResourceModal` to use `ProjectSharing` instead of raw `N8nSelect` + `getAvailableProjects` (which loaded ALL projects)
- Update all other callers (`DeleteUserModal`, `CredentialSharing`, `InsightsDashboard`, `ResourceFiltersDropdown`, `MoveToFolderModal`, `SourceControlPushModal`, `ProjectDeleteDialog`, `ProjectSettings`, `WorkflowShareModal`) to remove client-side project lists and use server-side search

<img width="609" height="466" alt="image" src="https://github.com/user-attachments/assets/9875e5e0-4c10-4c1e-8e66-70f90cea8910" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-382

Depends on #27036 (merged)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
