### PR TITLE
fix(editor): Show warning toast when executed node was not reached

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2341,6 +2341,8 @@
 	"personalizationModal.registerEmailForTrial.success.button": "Start using n8n",
 	"personalizationModal.registerEmailForTrial.error": "Error while registering for enterprise trial",
 	"pushConnection.nodeExecutedSuccessfully": "Node executed successfully",
+	"pushConnection.nodeNotExecuted": "Node was not executed",
+	"pushConnection.nodeNotExecuted.message": "The execution took a different path and didn't reach this node. This typically happens with conditional nodes like If or Switch.",
 	"pushConnection.workflowExecutedSuccessfully": "Workflow executed successfully",
 	"pushConnection.error.message": "Connection lost",
 	"pushConnection.error.tooltip": "You have a connection issue or the server is down. <br />n8n should reconnect automatically once the issue is resolved.",

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.test.ts
@@ -10,6 +10,7 @@ import {
 } from './executionFinished';
 import type { IRunExecutionData, ITaskData, INodeTypeDescription } from 'n8n-workflow';
 import { EVALUATION_TRIGGER_NODE_TYPE } from 'n8n-workflow';
+import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
 import type { INodeUi, IWorkflowDb } from '@/Interface';
 import type { Router } from 'vue-router';
 import type { WorkflowState } from '@/app/composables/useWorkflowState';
@@ -614,7 +615,7 @@ describe('manual execution stats tracking', () => {
 						},
 					},
 				},
-			} as unknown as ReturnType<typeof workflowsStore.getWorkflowExecution>);
+			} as unknown as IExecutionResponse);
 
 			vi.spyOn(workflowsStore, 'getNodeByName').mockReturnValue(
 				mock<INodeUi>({ type: 'n8n-nodes-base.telegram', typeVersion: 1 }),
@@ -642,7 +643,7 @@ describe('manual execution stats tracking', () => {
 						runData: {},
 					},
 				},
-			} as unknown as ReturnType<typeof workflowsStore.getWorkflowExecution>);
+			} as unknown as IExecutionResponse);
 
 			vi.spyOn(workflowsStore, 'getNodeByName').mockReturnValue(
 				mock<INodeUi>({ type: 'n8n-nodes-base.vonage', typeVersion: 1 }),
@@ -670,7 +671,7 @@ describe('manual execution stats tracking', () => {
 						runData: {},
 					},
 				},
-			} as unknown as ReturnType<typeof workflowsStore.getWorkflowExecution>);
+			} as unknown as IExecutionResponse);
 
 			vi.spyOn(workflowsStore, 'getNodeByName').mockReturnValue(
 				mock<INodeUi>({ type: 'n8n-nodes-base.vonage', typeVersion: 1 }),

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.test.ts
@@ -8,7 +8,7 @@ import {
 	handleExecutionFinishedWithErrorOrCanceled,
 	type SimplifiedExecution,
 } from './executionFinished';
-import type { IRunExecutionData, ITaskData } from 'n8n-workflow';
+import type { IRunExecutionData, ITaskData, INodeTypeDescription } from 'n8n-workflow';
 import { EVALUATION_TRIGGER_NODE_TYPE } from 'n8n-workflow';
 import type { INodeUi, IWorkflowDb } from '@/Interface';
 import type { Router } from 'vue-router';
@@ -21,11 +21,25 @@ import { useUIStore } from '@/app/stores/ui.store';
 import { mockedStore } from '@/__tests__/utils';
 import { useReadyToRunStore } from '@/features/workflows/readyToRun/stores/readyToRun.store';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
+import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 
 const opts = {
 	workflowState: mock<WorkflowState>(),
 	router: mock<Router>(),
 };
+
+const mockShowMessage = vi.fn();
+vi.mock('@/app/composables/useToast', () => ({
+	useToast: () => ({
+		showMessage: mockShowMessage,
+	}),
+}));
+
+vi.mock('@/app/composables/useDocumentTitle', () => ({
+	useDocumentTitle: () => ({
+		setDocumentTitle: vi.fn(),
+	}),
+}));
 
 const runWorkflow = vi.fn();
 
@@ -575,6 +589,98 @@ describe('manual execution stats tracking', () => {
 			handleExecutionFinishedWithSuccessOrOther(mock<WorkflowState>(), 'error', false);
 
 			expect(incrementSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('toast messages', () => {
+		beforeEach(() => {
+			mockShowMessage.mockClear();
+		});
+
+		it('shows success toast when executed node has run data', () => {
+			const pinia = createTestingPinia();
+			setActivePinia(pinia);
+
+			const workflowsStore = mockedStore(useWorkflowsStore);
+			const nodeTypesStore = mockedStore(useNodeTypesStore);
+
+			const nodeName = 'Send Telegram';
+			vi.spyOn(workflowsStore, 'getWorkflowExecution', 'get').mockReturnValue({
+				executedNode: nodeName,
+				data: {
+					resultData: {
+						runData: {
+							[nodeName]: [mock<ITaskData>()],
+						},
+					},
+				},
+			} as unknown as ReturnType<typeof workflowsStore.getWorkflowExecution>);
+
+			vi.spyOn(workflowsStore, 'getNodeByName').mockReturnValue(
+				mock<INodeUi>({ type: 'n8n-nodes-base.telegram', typeVersion: 1 }),
+			);
+
+			nodeTypesStore.getNodeType = () => mock<INodeTypeDescription>({ polling: undefined });
+
+			handleExecutionFinishedWithSuccessOrOther(mock<WorkflowState>(), 'success', false);
+
+			expect(mockShowMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+		});
+
+		it('shows warning toast when executed node was not reached', () => {
+			const pinia = createTestingPinia();
+			setActivePinia(pinia);
+
+			const workflowsStore = mockedStore(useWorkflowsStore);
+			const nodeTypesStore = mockedStore(useNodeTypesStore);
+
+			const nodeName = 'Send a text message';
+			vi.spyOn(workflowsStore, 'getWorkflowExecution', 'get').mockReturnValue({
+				executedNode: nodeName,
+				data: {
+					resultData: {
+						runData: {},
+					},
+				},
+			} as unknown as ReturnType<typeof workflowsStore.getWorkflowExecution>);
+
+			vi.spyOn(workflowsStore, 'getNodeByName').mockReturnValue(
+				mock<INodeUi>({ type: 'n8n-nodes-base.vonage', typeVersion: 1 }),
+			);
+
+			nodeTypesStore.getNodeType = () => mock<INodeTypeDescription>({ polling: undefined });
+
+			handleExecutionFinishedWithSuccessOrOther(mock<WorkflowState>(), 'success', false);
+
+			expect(mockShowMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' }));
+		});
+
+		it('does not show warning toast when successToastAlreadyShown is true', () => {
+			const pinia = createTestingPinia();
+			setActivePinia(pinia);
+
+			const workflowsStore = mockedStore(useWorkflowsStore);
+			const nodeTypesStore = mockedStore(useNodeTypesStore);
+
+			const nodeName = 'Send a text message';
+			vi.spyOn(workflowsStore, 'getWorkflowExecution', 'get').mockReturnValue({
+				executedNode: nodeName,
+				data: {
+					resultData: {
+						runData: {},
+					},
+				},
+			} as unknown as ReturnType<typeof workflowsStore.getWorkflowExecution>);
+
+			vi.spyOn(workflowsStore, 'getNodeByName').mockReturnValue(
+				mock<INodeUi>({ type: 'n8n-nodes-base.vonage', typeVersion: 1 }),
+			);
+
+			nodeTypesStore.getNodeType = () => mock<INodeTypeDescription>({ polling: undefined });
+
+			handleExecutionFinishedWithSuccessOrOther(mock<WorkflowState>(), 'success', true);
+
+			expect(mockShowMessage).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -439,6 +439,12 @@ export function handleExecutionFinishedWithSuccessOrOther(
 				}),
 				type: 'success',
 			});
+		} else if (!nodeOutput && !successToastAlreadyShown) {
+			toast.showMessage({
+				title: i18n.baseText('pushConnection.nodeNotExecuted'),
+				message: i18n.baseText('pushConnection.nodeNotExecuted.message'),
+				type: 'warning',
+			});
 		} else if (!successToastAlreadyShown) {
 			handleExecutionFinishedSuccessfully(
 				workflowName,


### PR DESCRIPTION
## Summary
- When executing to a specific node on a conditional branch (e.g. after an If or Switch node), the node may not be reached if the condition routes data down a different path
- Previously the toast incorrectly showed "Node executed successfully"
- Now shows a warning toast explaining the execution took a different path and didn't reach the node

before:

https://github.com/user-attachments/assets/78e37ef3-0eeb-4f75-b3eb-a69593f00a4d

after:


https://github.com/user-attachments/assets/11dde167-513b-447a-99e3-c26881a0e0fc

## Related tickets and issues

## Review / Merge checklist
- [ ] PR title and target branch are correct

## Test plan
- [ ] Create a workflow with an If node and nodes on both branches
- [ ] Execute to a node on the branch that is NOT taken by the condition
- [ ] Verify a warning toast appears saying "Node was not executed" instead of "Node executed successfully"
- [ ] Execute to a node on the branch that IS taken
- [ ] Verify the success toast still appears as before


🤖 Generated with [Claude Code](https://claude.com/claude-code)


