### PR TITLE
chore(editor): Differentiate canvas and chat hub events

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
@@ -645,6 +645,7 @@ function handleSelectPrompt(prompt: string) {
 	if (selectedModel.value) {
 		telemetry.track('User clicked chat hub suggested prompt', {
 			...flattenModel(selectedModel.value.model),
+			source: 'chat_hub',
 		});
 	}
 

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
@@ -607,10 +607,16 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 			agent,
 		};
 
+		const useManualMode = isCanvasManualExecution(agent.model);
+		const mode = useManualMode ? 'manual' : 'production';
+		const source = useManualMode ? 'canvas' : 'chat_hub';
+
 		telemetry.track('User sent chat hub message', {
 			...flattenModel(agent.model),
 			is_custom: agent.model.provider === 'custom-agent',
 			chat_session_id: sessionId,
+			mode,
+			source,
 		});
 
 		const payload = {
@@ -624,11 +630,6 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 			agentName: agent.name,
 			timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 		};
-
-		// Detect if this is a manual execution from the canvas.
-		// When the user is on a canvas with the same workflow as the selected n8n agent,
-		// use the manual endpoint to execute the draft version with canvas events.
-		const useManualMode = isCanvasManualExecution(agent.model);
 
 		try {
 			// Create session entry if new
@@ -726,14 +727,18 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 			attachments: [...keptExistingAttachments, ...binaryData],
 		};
 
+		const useManualMode = isCanvasManualExecution(agent.model);
+		const mode = useManualMode ? 'manual' : 'production';
+		const source = useManualMode ? 'canvas' : 'chat_hub';
+
 		telemetry.track('User edited chat hub message', {
 			...flattenModel(agent.model),
 			is_custom: agent.model.provider === 'custom-agent',
 			chat_session_id: sessionId,
 			chat_message_id: editId,
+			mode,
+			source,
 		});
-
-		const useManualMode = isCanvasManualExecution(agent.model);
 
 		try {
 			if (useManualMode) {
@@ -795,14 +800,18 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 			attachments: [],
 		};
 
+		const useManualMode = isCanvasManualExecution(agent.model);
+		const mode = useManualMode ? 'manual' : 'production';
+		const source = useManualMode ? 'canvas' : 'chat_hub';
+
 		telemetry.track('User regenerated chat hub message', {
 			...flattenModel(agent.model),
 			is_custom: agent.model.provider === 'custom-agent',
 			chat_session_id: sessionId,
 			chat_message_id: retryId,
+			mode,
+			source,
 		});
-
-		const useManualMode = isCanvasManualExecution(agent.model);
 
 		try {
 			if (useManualMode) {

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chatHubPanel.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chatHubPanel.store.ts
@@ -5,6 +5,7 @@ import { useRoute } from 'vue-router';
 import { FLOATING_CHAT_HUB_PANEL_EXPERIMENT } from '@/app/constants';
 import { usePostHog } from '@/app/stores/posthog.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
+import { useTelemetry } from '@/app/composables/useTelemetry';
 import { EDITABLE_CANVAS_VIEWS } from '@/app/constants';
 import type { VIEWS } from '@/app/constants';
 
@@ -19,6 +20,7 @@ export const useChatHubPanelStore = defineStore(STORES.CHAT_HUB_PANEL, () => {
 	const route = useRoute();
 	const posthogStore = usePostHog();
 	const settingsStore = useSettingsStore();
+	const telemetry = useTelemetry();
 
 	// State
 	const isOpen = ref(false);
@@ -37,6 +39,7 @@ export const useChatHubPanelStore = defineStore(STORES.CHAT_HUB_PANEL, () => {
 	function open() {
 		if (!isEnabledView(route?.name, EDITABLE_CANVAS_VIEWS)) return;
 		isOpen.value = true;
+		telemetry.track('User opened floating chat panel', { source: 'canvas' });
 	}
 
 	function close() {
@@ -56,6 +59,7 @@ export const useChatHubPanelStore = defineStore(STORES.CHAT_HUB_PANEL, () => {
 
 	function popOut() {
 		isPoppedOut.value = true;
+		telemetry.track('User popped out floating chat panel', { source: 'canvas' });
 	}
 
 	// Close when navigating away from enabled views

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/CanvasChatHubPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/CanvasChatHubPanel.vue
@@ -13,6 +13,8 @@ import type {
 	ChatSessionId,
 } from '@n8n/api-types';
 import { CHAT_TRIGGER_NODE_TYPE } from '@/app/constants';
+import { useTelemetry } from '@/app/composables/useTelemetry';
+import { flattenModel } from '@/features/ai/chatHub/chat.utils';
 import { useChatStore } from '../chat.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
@@ -43,6 +45,7 @@ const chatStore = useChatStore();
 const workflowsStore = useWorkflowsStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const chatHubPanelStore = useChatHubPanelStore();
+const telemetry = useTelemetry();
 const clipboard = useClipboard();
 const toast = useToast();
 
@@ -156,6 +159,7 @@ async function copySessionId() {
 }
 
 function handleNewSession() {
+	telemetry.track('User clicked new chat button', { source: 'canvas' });
 	sessionId.value = uuidv4();
 }
 
@@ -236,6 +240,12 @@ async function handleEditMessage(
 }
 
 function handleSelectPrompt(prompt: string) {
+	if (workflowAgent.value) {
+		telemetry.track('User clicked chat hub suggested prompt', {
+			...flattenModel(workflowAgent.value.model),
+			source: 'canvas',
+		});
+	}
 	inputRef.value?.setText(prompt);
 	inputRef.value?.focus();
 }

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatSidebarContent.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatSidebarContent.vue
@@ -132,7 +132,7 @@ async function handleDeleteSession(sessionId: string) {
 }
 
 function handleNewChatClick() {
-	telemetry.track('User clicked new chat button', {});
+	telemetry.track('User clicked new chat button', { source: 'chat_hub' });
 }
 
 onMounted(() => {


### PR DESCRIPTION
## Summary

Adjust telemetry to be able to tell canvas and chat hub events apart.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-147/spike-manual-chat-hub-executions

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
