### PR TITLE
feat(core): Apply execution redaction to real-time push events (no-changelog)

### DIFF
--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
-import type { Project } from '@n8n/db';
+import type { Project, User } from '@n8n/db';
 import { ExecutionRepository, UserRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 import {
@@ -10,6 +10,7 @@ import {
 	ExecutionLifecycleHooks,
 	BinaryDataConfig,
 } from 'n8n-core';
+import { stringify } from 'flatted';
 import { createRunExecutionData, ExpressionError } from 'n8n-workflow';
 import type {
 	IRunExecutionData,
@@ -56,8 +57,8 @@ describe('Execution Lifecycle Hooks', () => {
 	const binaryDataService = mockInstance(BinaryDataService);
 	const ownershipService = mockInstance(OwnershipService);
 	const workflowExecutionService = mockInstance(WorkflowExecutionService);
-	mockInstance(UserRepository);
-	mockInstance(ExecutionRedactionServiceProxy);
+	const userRepository = mockInstance(UserRepository);
+	const redactionProxy = mockInstance(ExecutionRedactionServiceProxy);
 
 	const nodeName = 'Test Node';
 	const nodeType = 'n8n-nodes-base.testNode';
@@ -142,6 +143,8 @@ describe('Execution Lifecycle Hooks', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
+		userRepository.findOne.mockResolvedValue(mock<User>());
+		redactionProxy.processExecution.mockImplementation(async (execution) => execution);
 		workflowData.settings = {};
 		successfulRun.data = createRunExecutionData({
 			resultData: {
@@ -440,6 +443,119 @@ describe('Execution Lifecycle Hooks', () => {
 
 				expect(executionRepository.findSingleExecution).not.toHaveBeenCalled();
 			});
+
+			it('should send redacted data in nodeExecuteAfterData when redaction modifies it', async () => {
+				const mockTaskData: ITaskData = {
+					startTime: 1,
+					executionTime: 1,
+					executionIndex: 0,
+					source: [],
+					data: {
+						main: [[{ json: { secret: 'original-value' } }]],
+					},
+				};
+
+				const redactedTaskData: ITaskData = {
+					...mockTaskData,
+					data: { main: [[{ json: { secret: 'REDACTED' } }]] },
+				};
+
+				redactionProxy.processExecution.mockImplementation(async (execution) => ({
+					...execution,
+					data: {
+						...execution.data,
+						resultData: { runData: { [nodeName]: [redactedTaskData] } },
+					},
+				}));
+
+				await lifecycleHooks.runHook('nodeExecuteAfter', [
+					nodeName,
+					mockTaskData,
+					runExecutionData,
+				]);
+
+				expect(redactionProxy.processExecution).toHaveBeenCalledTimes(1);
+				const [redactableExec, options] = redactionProxy.processExecution.mock.calls[0];
+				expect(redactableExec).toHaveProperty('workflowId', workflowId);
+				expect(options.copyOnWrite).toBe(true);
+				expect(options.user).toBeDefined();
+
+				// nodeExecuteAfter (metadata-only) is unaffected
+				expect(push.send).toHaveBeenNthCalledWith(
+					1,
+					expect.objectContaining({ type: 'nodeExecuteAfter' }),
+					pushRef,
+				);
+
+				// nodeExecuteAfterData contains redacted data
+				expect(push.send).toHaveBeenNthCalledWith(
+					2,
+					{
+						type: 'nodeExecuteAfterData',
+						data: {
+							executionId,
+							nodeName,
+							itemCountByConnectionType: { main: [1] },
+							data: redactedTaskData,
+						},
+					},
+					pushRef,
+					true,
+				);
+			});
+
+			it('should invoke processExecution for nodeExecuteAfterData', async () => {
+				const mockTaskData: ITaskData = {
+					startTime: 1,
+					executionTime: 1,
+					executionIndex: 0,
+					source: [],
+					data: { main: [[{ json: { key: 'value' } }]] },
+				};
+
+				await lifecycleHooks.runHook('nodeExecuteAfter', [
+					nodeName,
+					mockTaskData,
+					runExecutionData,
+				]);
+
+				expect(userRepository.findOne).toHaveBeenCalled();
+				expect(redactionProxy.processExecution).toHaveBeenCalledTimes(1);
+			});
+
+			it('should skip nodeExecuteAfterData push when user cannot be resolved (fail-closed)', async () => {
+				userRepository.findOne.mockResolvedValue(null);
+				lifecycleHooks = createHooks();
+
+				const mockTaskData: ITaskData = {
+					startTime: 1,
+					executionTime: 1,
+					executionIndex: 0,
+					source: [],
+					data: { main: [[{ json: { key: 'value' } }]] },
+				};
+
+				await lifecycleHooks.runHook('nodeExecuteAfter', [
+					nodeName,
+					mockTaskData,
+					runExecutionData,
+				]);
+
+				// nodeExecuteAfter (metadata-only) is still sent
+				expect(push.send).toHaveBeenCalledWith(
+					expect.objectContaining({ type: 'nodeExecuteAfter' }),
+					pushRef,
+				);
+
+				// nodeExecuteAfterData is NOT sent
+				expect(push.send).not.toHaveBeenCalledWith(
+					expect.objectContaining({ type: 'nodeExecuteAfterData' }),
+					pushRef,
+					true,
+				);
+
+				expect(redactionProxy.processExecution).not.toHaveBeenCalled();
+			});
 		});
 
 		describe('workflowExecuteBefore', () => {
@@ -467,6 +583,89 @@ describe('Execution Lifecycle Hooks', () => {
 				await lifecycleHooks.runHook('workflowExecuteBefore', [workflow, runExecutionData]);
 
 				expect(externalHooks.run).toHaveBeenCalledWith('workflow.preExecute', [workflow, 'manual']);
+			});
+
+			it('should send redacted flattedRunData when redaction modifies it', async () => {
+				const originalRunData = {
+					[nodeName]: [
+						{
+							startTime: 1,
+							executionTime: 1,
+							executionIndex: 0,
+							source: [],
+							data: { main: [[{ json: { secret: 'original' } }]] },
+						} as ITaskData,
+					],
+				};
+				const redactedRunData = {
+					[nodeName]: [
+						{
+							startTime: 1,
+							executionTime: 1,
+							executionIndex: 0,
+							source: [],
+							data: { main: [[{ json: { secret: 'REDACTED' } }]] },
+						} as ITaskData,
+					],
+				};
+
+				const execData = createRunExecutionData({
+					resultData: { runData: originalRunData },
+				});
+
+				redactionProxy.processExecution.mockImplementation(async (execution) => ({
+					...execution,
+					data: {
+						...execution.data,
+						resultData: { runData: redactedRunData },
+					},
+				}));
+
+				await lifecycleHooks.runHook('workflowExecuteBefore', [workflow, execData]);
+
+				expect(redactionProxy.processExecution).toHaveBeenCalledTimes(1);
+				const [redactableExec, options] = redactionProxy.processExecution.mock.calls[0];
+				expect(redactableExec).toHaveProperty('workflowId', workflowId);
+				expect(options.copyOnWrite).toBe(true);
+				expect(options.user).toBeDefined();
+
+				expect(push.send).toHaveBeenCalledWith(
+					expect.objectContaining({
+						type: 'executionStarted',
+						data: expect.objectContaining({
+							flattedRunData: stringify(redactedRunData),
+						}),
+					}),
+					pushRef,
+				);
+			});
+
+			it('should skip executionStarted push when user cannot be resolved (fail-closed)', async () => {
+				userRepository.findOne.mockResolvedValue(null);
+				lifecycleHooks = createHooks();
+
+				await lifecycleHooks.runHook('workflowExecuteBefore', [workflow, runExecutionData]);
+
+				expect(push.send).not.toHaveBeenCalledWith(
+					expect.objectContaining({ type: 'executionStarted' }),
+					pushRef,
+				);
+				expect(redactionProxy.processExecution).not.toHaveBeenCalled();
+			});
+
+			it('should not call processExecution when runData is empty', async () => {
+				await lifecycleHooks.runHook('workflowExecuteBefore', [workflow, runExecutionData]);
+
+				expect(redactionProxy.processExecution).not.toHaveBeenCalled();
+				expect(push.send).toHaveBeenCalledWith(
+					expect.objectContaining({
+						type: 'executionStarted',
+						data: expect.objectContaining({
+							flattedRunData: '[{}]',
+						}),
+					}),
+					pushRef,
+				);
 			});
 		});
 

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -640,14 +640,19 @@ describe('Execution Lifecycle Hooks', () => {
 				);
 			});
 
-			it('should skip executionStarted push when user cannot be resolved (fail-closed)', async () => {
+			it('should send executionStarted with empty runData when user cannot be resolved (fail-closed)', async () => {
 				userRepository.findOne.mockResolvedValue(null);
 				lifecycleHooks = createHooks();
 
 				await lifecycleHooks.runHook('workflowExecuteBefore', [workflow, runExecutionData]);
 
-				expect(push.send).not.toHaveBeenCalledWith(
-					expect.objectContaining({ type: 'executionStarted' }),
+				expect(push.send).toHaveBeenCalledWith(
+					expect.objectContaining({
+						type: 'executionStarted',
+						data: expect.objectContaining({
+							flattedRunData: '[{}]',
+						}),
+					}),
 					pushRef,
 				);
 				expect(redactionProxy.processExecution).not.toHaveBeenCalled();

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -477,7 +477,7 @@ describe('Execution Lifecycle Hooks', () => {
 				expect(redactionProxy.processExecution).toHaveBeenCalledTimes(1);
 				const [redactableExec, options] = redactionProxy.processExecution.mock.calls[0];
 				expect(redactableExec).toHaveProperty('workflowId', workflowId);
-				expect(options.copyOnWrite).toBe(true);
+				expect(options.keepOriginal).toBe(true);
 				expect(options.user).toBeDefined();
 
 				// nodeExecuteAfter (metadata-only) is unaffected
@@ -626,7 +626,7 @@ describe('Execution Lifecycle Hooks', () => {
 				expect(redactionProxy.processExecution).toHaveBeenCalledTimes(1);
 				const [redactableExec, options] = redactionProxy.processExecution.mock.calls[0];
 				expect(redactableExec).toHaveProperty('workflowId', workflowId);
-				expect(options.copyOnWrite).toBe(true);
+				expect(options.keepOriginal).toBe(true);
 				expect(options.user).toBeDefined();
 
 				expect(push.send).toHaveBeenCalledWith(

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
 import type { Project } from '@n8n/db';
-import { ExecutionRepository } from '@n8n/db';
+import { ExecutionRepository, UserRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 import {
 	BinaryDataService,
@@ -24,6 +24,7 @@ import type {
 } from 'n8n-workflow';
 
 import { EventService } from '@/events/event.service';
+import { ExecutionRedactionServiceProxy } from '@/executions/execution-redaction-proxy.service';
 import { ExecutionPersistence } from '@/executions/execution-persistence';
 import { ExternalHooks } from '@/external-hooks';
 import { Push } from '@/push';
@@ -55,6 +56,8 @@ describe('Execution Lifecycle Hooks', () => {
 	const binaryDataService = mockInstance(BinaryDataService);
 	const ownershipService = mockInstance(OwnershipService);
 	const workflowExecutionService = mockInstance(WorkflowExecutionService);
+	mockInstance(UserRepository);
+	mockInstance(ExecutionRedactionServiceProxy);
 
 	const nodeName = 'Test Node';
 	const nodeType = 'n8n-nodes-base.testNode';

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -1,5 +1,6 @@
 import { Logger } from '@n8n/backend-common';
-import { ExecutionRepository } from '@n8n/db';
+import { ExecutionRepository, UserRepository } from '@n8n/db';
+import type { User } from '@n8n/db';
 import { LifecycleMetadata } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
 import { stringify } from 'flatted';
@@ -14,6 +15,8 @@ import {
 import { ExecutionPersistence } from '@/executions/execution-persistence';
 import type {
 	IRun,
+	IRunData,
+	IRunExecutionData,
 	IWorkflowBase,
 	RelatedExecution,
 	WorkflowExecuteMode,
@@ -21,6 +24,8 @@ import type {
 } from 'n8n-workflow';
 
 import { EventService } from '@/events/event.service';
+import type { RedactableExecution } from '@/executions/execution-redaction';
+import { ExecutionRedactionServiceProxy } from '@/executions/execution-redaction-proxy.service';
 import { ExternalHooks } from '@/external-hooks';
 import { Push } from '@/push';
 import { WorkflowStatisticsService } from '@/services/workflow-statistics.service';
@@ -182,15 +187,53 @@ function hookFunctionsNodeEvents(hooks: ExecutionLifecycleHooks) {
 }
 
 /**
+ * Constructs a minimal RedactableExecution from push event data so the existing
+ * redaction pipeline can be reused for real-time push events.
+ */
+function buildRedactableExecution(
+	hooks: ExecutionLifecycleHooks,
+	runData: IRunData,
+	executionData?: IRunExecutionData,
+): RedactableExecution {
+	return {
+		id: hooks.executionId,
+		mode: hooks.mode,
+		workflowId: hooks.workflowData.id,
+		data: {
+			resultData: { runData },
+			executionData: executionData?.executionData,
+		} as IRunExecutionData,
+		workflowData: {
+			settings: hooks.workflowData.settings,
+			nodes: hooks.workflowData.nodes,
+		},
+	};
+}
+
+/**
  * Returns hook functions to push data to Editor-UI
  */
 function hookFunctionsPush(
 	hooks: ExecutionLifecycleHooks,
 	{ pushRef, retryOf }: HooksSetupParameters,
+	userId?: string,
 ) {
 	if (!pushRef) return;
 	const logger = Container.get(Logger);
 	const pushInstance = Container.get(Push);
+	const redactionProxy = Container.get(ExecutionRedactionServiceProxy);
+	const userRepository = Container.get(UserRepository);
+
+	// Lazy user resolution — resolved once, reused across all node events in this execution
+	let resolvedUser: User | null | undefined; // undefined = not yet resolved
+	async function getUser(): Promise<User | null> {
+		if (resolvedUser !== undefined) return resolvedUser;
+		resolvedUser = userId
+			? await userRepository.findOne({ where: { id: userId }, relations: ['role'] })
+			: null;
+		return resolvedUser;
+	}
+
 	hooks.addHandler('nodeExecuteBefore', function (nodeName, data) {
 		const { executionId } = this;
 		// Push data to session which started workflow before each
@@ -206,7 +249,7 @@ function hookFunctionsPush(
 			pushRef,
 		);
 	});
-	hooks.addHandler('nodeExecuteAfter', function (nodeName, data) {
+	hooks.addHandler('nodeExecuteAfter', async function (nodeName, data, executionData) {
 		const { executionId } = this;
 		// Push data to session which started workflow after each rendered node
 		logger.debug(`Executing hook on node "${nodeName}" (hookFunctionsPush)`, {
@@ -226,6 +269,22 @@ function hookFunctionsPush(
 			pushRef,
 		);
 
+		// Apply copy-on-write redaction before sending binary data.
+		// Returns the original data if no redaction is needed (zero-copy),
+		// or a structuredClone with redaction applied.
+		let dataToSend = data;
+		const user = await getUser();
+		if (user) {
+			const dummy = buildRedactableExecution(this, { [nodeName]: [data] }, executionData);
+			const result = await redactionProxy.processExecution(dummy, {
+				user,
+				copyOnWrite: true,
+			});
+			if (result !== dummy) {
+				dataToSend = result.data.resultData.runData[nodeName][0];
+			}
+		}
+
 		// We send the node execution data as a WS binary message to the FE. Not
 		// because it's more efficient on the wire: the content is a JSON string
 		// so both text and binary would end the same on the wire. The reason
@@ -236,13 +295,13 @@ function hookFunctionsPush(
 		pushInstance.send(
 			{
 				type: 'nodeExecuteAfterData',
-				data: { executionId, nodeName, itemCountByConnectionType, data },
+				data: { executionId, nodeName, itemCountByConnectionType, data: dataToSend },
 			},
 			pushRef,
 			asBinary,
 		);
 	});
-	hooks.addHandler('workflowExecuteBefore', function (_workflow, data) {
+	hooks.addHandler('workflowExecuteBefore', async function (_workflow, data) {
 		const { executionId } = this;
 		const { id: workflowId, name: workflowName } = this.workflowData;
 		logger.debug('Executing hook (hookFunctionsPush)', {
@@ -250,6 +309,21 @@ function hookFunctionsPush(
 			pushRef,
 			workflowId,
 		});
+
+		// Apply copy-on-write redaction to flattedRunData when retrying/resuming
+		let runDataToStringify = data?.resultData.runData ?? {};
+		const user = await getUser();
+		if (user && data?.resultData.runData && Object.keys(data.resultData.runData).length > 0) {
+			const dummy = buildRedactableExecution(this, data.resultData.runData, data);
+			const result = await redactionProxy.processExecution(dummy, {
+				user,
+				copyOnWrite: true,
+			});
+			if (result !== dummy) {
+				runDataToStringify = result.data.resultData.runData;
+			}
+		}
+
 		// Push data to session which started the workflow
 		pushInstance.send(
 			{
@@ -261,9 +335,7 @@ function hookFunctionsPush(
 					retryOf,
 					workflowId,
 					workflowName,
-					flattedRunData: data?.resultData.runData
-						? stringify(data.resultData.runData)
-						: stringify({}),
+					flattedRunData: stringify(runDataToStringify),
 				},
 			},
 			pushRef,
@@ -582,7 +654,7 @@ export function getLifecycleHooksForScalingWorker(
 	hookFunctionsExternalHooks(hooks);
 
 	if (executionMode === 'manual' && Container.get(InstanceSettings).isWorker) {
-		hookFunctionsPush(hooks, optionalParameters);
+		hookFunctionsPush(hooks, optionalParameters, data.userId);
 	}
 
 	Container.get(ModulesHooksRegistry).addHooks(hooks);
@@ -675,7 +747,7 @@ export function getLifecycleHooksForRegularMain(
 	hookFunctionsNodeEvents(hooks);
 	hookFunctionsFinalizeExecutionStatus(hooks);
 	hookFunctionsSave(hooks, optionalParameters);
-	hookFunctionsPush(hooks, optionalParameters);
+	hookFunctionsPush(hooks, optionalParameters, userId);
 	hookFunctionsSaveProgress(hooks, optionalParameters);
 	hookFunctionsStatistics(hooks);
 	hookFunctionsExternalHooks(hooks);

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -284,14 +284,25 @@ function hookFunctionsPush(
 		// Apply copy-on-write redaction before sending binary data.
 		// Returns the original data if no redaction is needed (zero-copy),
 		// or a structuredClone with redaction applied.
+		// Fail-closed: if redaction throws, skip the data push rather than
+		// sending unredacted data. The metadata-only push above already fired.
 		let dataToSend = data;
-		const dummy = buildRedactableExecution(this, { [nodeName]: [data] }, executionData);
-		const result = await redactionProxy.processExecution(dummy, {
-			user,
-			copyOnWrite: true,
-		});
-		if (result !== dummy) {
-			dataToSend = result.data.resultData.runData[nodeName][0];
+		try {
+			const dummy = buildRedactableExecution(this, { [nodeName]: [data] }, executionData);
+			const result = await redactionProxy.processExecution(dummy, {
+				user,
+				copyOnWrite: true,
+			});
+			if (result !== dummy) {
+				dataToSend = result.data.resultData.runData[nodeName][0];
+			}
+		} catch (error) {
+			logger.error('Failed to redact push data, skipping nodeExecuteAfterData', {
+				executionId,
+				nodeName,
+				error,
+			});
+			return;
 		}
 
 		// We send the node execution data as a WS binary message to the FE. Not
@@ -319,32 +330,40 @@ function hookFunctionsPush(
 			workflowId,
 		});
 
-		// Fail-closed redaction: if user cannot be resolved, skip the push
-		// entirely rather than sending unredacted run data to the client.
+		// Apply copy-on-write redaction to flattedRunData when retrying/resuming.
+		// Fail-closed: if user cannot be resolved or redaction throws, send
+		// empty runData rather than skipping the push or leaking unredacted data.
 		const user = await getUser();
-		if (!user) {
-			logger.warn('Skipping execution start push: unable to resolve user for redaction', {
+		let runDataToStringify: IRunData = {};
+		const hasRunData = data?.resultData.runData && Object.keys(data.resultData.runData).length > 0;
+
+		if (hasRunData && user) {
+			try {
+				const dummy = buildRedactableExecution(this, data.resultData.runData, data);
+				const result = await redactionProxy.processExecution(dummy, {
+					user,
+					copyOnWrite: true,
+				});
+				runDataToStringify =
+					result !== dummy ? result.data.resultData.runData : data.resultData.runData;
+			} catch (error) {
+				logger.error('Failed to redact execution start data, sending empty runData', {
+					executionId,
+					workflowId,
+					error,
+				});
+				// runDataToStringify stays {} — fail closed
+			}
+		} else if (hasRunData && !user) {
+			logger.warn('Cannot redact execution start data: unable to resolve user', {
 				executionId,
 				workflowId,
 				userId,
 			});
-			return;
+			// runDataToStringify stays {} — fail closed
 		}
 
-		// Apply copy-on-write redaction to flattedRunData when retrying/resuming
-		let runDataToStringify = data?.resultData.runData ?? {};
-		if (data?.resultData.runData && Object.keys(data.resultData.runData).length > 0) {
-			const dummy = buildRedactableExecution(this, data.resultData.runData, data);
-			const result = await redactionProxy.processExecution(dummy, {
-				user,
-				copyOnWrite: true,
-			});
-			if (result !== dummy) {
-				runDataToStringify = result.data.resultData.runData;
-			}
-		}
-
-		// Push data to session which started the workflow
+		// Always send executionStarted so the editor can initialise the execution UI
 		pushInstance.send(
 			{
 				type: 'executionStarted',

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -202,7 +202,7 @@ function buildRedactableExecution(
 		data: {
 			resultData: { runData },
 			executionData: executionData?.executionData,
-		} as IRunExecutionData,
+		},
 		workflowData: {
 			settings: hooks.workflowData.settings,
 			nodes: hooks.workflowData.nodes,
@@ -269,20 +269,29 @@ function hookFunctionsPush(
 			pushRef,
 		);
 
+		// Fail-closed redaction: if user cannot be resolved, skip the data push
+		// entirely rather than sending unredacted data to the client.
+		const user = await getUser();
+		if (!user) {
+			logger.warn('Skipping execution data push: unable to resolve user for redaction', {
+				executionId,
+				nodeName,
+				userId,
+			});
+			return;
+		}
+
 		// Apply copy-on-write redaction before sending binary data.
 		// Returns the original data if no redaction is needed (zero-copy),
 		// or a structuredClone with redaction applied.
 		let dataToSend = data;
-		const user = await getUser();
-		if (user) {
-			const dummy = buildRedactableExecution(this, { [nodeName]: [data] }, executionData);
-			const result = await redactionProxy.processExecution(dummy, {
-				user,
-				copyOnWrite: true,
-			});
-			if (result !== dummy) {
-				dataToSend = result.data.resultData.runData[nodeName][0];
-			}
+		const dummy = buildRedactableExecution(this, { [nodeName]: [data] }, executionData);
+		const result = await redactionProxy.processExecution(dummy, {
+			user,
+			copyOnWrite: true,
+		});
+		if (result !== dummy) {
+			dataToSend = result.data.resultData.runData[nodeName][0];
 		}
 
 		// We send the node execution data as a WS binary message to the FE. Not
@@ -310,10 +319,21 @@ function hookFunctionsPush(
 			workflowId,
 		});
 
+		// Fail-closed redaction: if user cannot be resolved, skip the push
+		// entirely rather than sending unredacted run data to the client.
+		const user = await getUser();
+		if (!user) {
+			logger.warn('Skipping execution start push: unable to resolve user for redaction', {
+				executionId,
+				workflowId,
+				userId,
+			});
+			return;
+		}
+
 		// Apply copy-on-write redaction to flattedRunData when retrying/resuming
 		let runDataToStringify = data?.resultData.runData ?? {};
-		const user = await getUser();
-		if (user && data?.resultData.runData && Object.keys(data.resultData.runData).length > 0) {
+		if (data?.resultData.runData && Object.keys(data.resultData.runData).length > 0) {
 			const dummy = buildRedactableExecution(this, data.resultData.runData, data);
 			const result = await redactionProxy.processExecution(dummy, {
 				user,

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -291,7 +291,7 @@ function hookFunctionsPush(
 			const dummy = buildRedactableExecution(this, { [nodeName]: [data] }, executionData);
 			const result = await redactionProxy.processExecution(dummy, {
 				user,
-				copyOnWrite: true,
+				keepOriginal: true,
 			});
 			if (result !== dummy) {
 				dataToSend = result.data.resultData.runData[nodeName][0];
@@ -342,7 +342,7 @@ function hookFunctionsPush(
 				const dummy = buildRedactableExecution(this, data.resultData.runData, data);
 				const result = await redactionProxy.processExecution(dummy, {
 					user,
-					copyOnWrite: true,
+					keepOriginal: true,
 				});
 				runDataToStringify =
 					result !== dummy ? result.data.resultData.runData : data.resultData.runData;

--- a/packages/cli/src/executions/execution-redaction.ts
+++ b/packages/cli/src/executions/execution-redaction.ts
@@ -9,7 +9,7 @@ export type ExecutionRedactionOptions = {
 	/** When true, the original execution is never mutated. If redaction is needed,
 	 *  a structuredClone is created and returned. If no redaction is needed, the
 	 *  original is returned as-is (caller can check referential equality). */
-	copyOnWrite?: boolean;
+	keepOriginal?: boolean;
 } & Pick<ExecutionRedactionQueryDto, 'redactExecutionData'>;
 
 export interface ExecutionRedaction {

--- a/packages/cli/src/executions/execution-redaction.ts
+++ b/packages/cli/src/executions/execution-redaction.ts
@@ -36,6 +36,6 @@ export type RedactableExecution = {
 	id?: string;
 	mode: WorkflowExecuteMode;
 	workflowId: string;
-	data: IRunExecutionData;
+	data: Pick<IRunExecutionData, 'resultData' | 'executionData' | 'redactionInfo'>;
 	workflowData: Pick<IWorkflowBase, 'settings' | 'nodes'>;
 };

--- a/packages/cli/src/executions/execution-redaction.ts
+++ b/packages/cli/src/executions/execution-redaction.ts
@@ -6,6 +6,10 @@ export type ExecutionRedactionOptions = {
 	user: User;
 	ipAddress?: string;
 	userAgent?: string;
+	/** When true, the original execution is never mutated. If redaction is needed,
+	 *  a structuredClone is created and returned. If no redaction is needed, the
+	 *  original is returned as-is (caller can check referential equality). */
+	copyOnWrite?: boolean;
 } & Pick<ExecutionRedactionQueryDto, 'redactExecutionData'>;
 
 export interface ExecutionRedaction {

--- a/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
+++ b/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
@@ -193,6 +193,45 @@ describe('ExecutionRedactionService', () => {
 		});
 	});
 
+	describe('copyOnWrite mode', () => {
+		it('clones only executions that need redaction, preserving original references for others', async () => {
+			const noneExecution = makeExecution({
+				policy: 'none',
+				mode: 'trigger',
+				workflowId: 'wf-none',
+			});
+			const allExecution = makeExecution({
+				policy: 'all',
+				mode: 'trigger',
+				workflowId: 'wf-all',
+			});
+			const nonManualManual = makeExecution({
+				policy: 'non-manual',
+				mode: 'manual',
+				workflowId: 'wf-nm',
+			});
+
+			// FullItemRedactionStrategy.wouldModify always returns true when in the pipeline
+			fullItemRedactionStrategy.wouldModify.mockReturnValue(true);
+			// NodeDefinedFieldRedactionStrategy.wouldModify returns false (no sensitive fields)
+			nodeDefinedFieldRedactionStrategy.wouldModify.mockReturnValue(false);
+
+			const executions = [noneExecution, allExecution, nonManualManual];
+			const options: ExecutionRedactionOptions = { user: mockUser, copyOnWrite: true };
+
+			await service.processExecutions(executions, options);
+
+			// policy=none → FullItemRedaction not in pipeline → no wouldModify=true → same reference
+			expect(executions[0]).toBe(noneExecution);
+
+			// policy=all → FullItemRedaction in pipeline → wouldModify=true → cloned
+			expect(executions[1]).not.toBe(allExecution);
+
+			// policy=non-manual + mode=manual → FullItemRedaction not in pipeline → same reference
+			expect(executions[2]).toBe(nonManualManual);
+		});
+	});
+
 	describe('FullItemRedactionStrategy inclusion', () => {
 		it('is included when redactExecutionData === true (regardless of policy)', async () => {
 			const execution = makeExecution({ policy: 'none', mode: 'trigger' });

--- a/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
+++ b/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
@@ -211,20 +211,20 @@ describe('ExecutionRedactionService', () => {
 				workflowId: 'wf-nm',
 			});
 
-			// FullItemRedactionStrategy.wouldModify always returns true when in the pipeline
-			fullItemRedactionStrategy.wouldModify.mockReturnValue(true);
-			// NodeDefinedFieldRedactionStrategy.wouldModify returns false (no sensitive fields)
-			nodeDefinedFieldRedactionStrategy.wouldModify.mockReturnValue(false);
+			// FullItemRedactionStrategy.requiresRedaction always returns true when in the pipeline
+			fullItemRedactionStrategy.requiresRedaction.mockReturnValue(true);
+			// NodeDefinedFieldRedactionStrategy.requiresRedaction returns false (no sensitive fields)
+			nodeDefinedFieldRedactionStrategy.requiresRedaction.mockReturnValue(false);
 
 			const executions = [noneExecution, allExecution, nonManualManual];
 			const options: ExecutionRedactionOptions = { user: mockUser, keepOriginal: true };
 
 			await service.processExecutions(executions, options);
 
-			// policy=none → FullItemRedaction not in pipeline → no wouldModify=true → same reference
+			// policy=none → FullItemRedaction not in pipeline → no requiresRedaction=true → same reference
 			expect(executions[0]).toBe(noneExecution);
 
-			// policy=all → FullItemRedaction in pipeline → wouldModify=true → cloned
+			// policy=all → FullItemRedaction in pipeline → requiresRedaction=true → cloned
 			expect(executions[1]).not.toBe(allExecution);
 
 			// policy=non-manual + mode=manual → FullItemRedaction not in pipeline → same reference

--- a/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
+++ b/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
@@ -193,7 +193,7 @@ describe('ExecutionRedactionService', () => {
 		});
 	});
 
-	describe('copyOnWrite mode', () => {
+	describe('keepOriginal mode', () => {
 		it('clones only executions that need redaction, preserving original references for others', async () => {
 			const noneExecution = makeExecution({
 				policy: 'none',
@@ -217,7 +217,7 @@ describe('ExecutionRedactionService', () => {
 			nodeDefinedFieldRedactionStrategy.wouldModify.mockReturnValue(false);
 
 			const executions = [noneExecution, allExecution, nonManualManual];
-			const options: ExecutionRedactionOptions = { user: mockUser, copyOnWrite: true };
+			const options: ExecutionRedactionOptions = { user: mockUser, keepOriginal: true };
 
 			await service.processExecutions(executions, options);
 

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.interfaces.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.interfaces.ts
@@ -13,7 +13,7 @@ export interface RedactionContext {
 	/** Pre-resolved by the orchestrator — true if the user can see unredacted data. */
 	readonly userCanReveal: boolean;
 	/** Generic memo store — strategies may cache intermediate results here
-	 *  to avoid redundant computation across wouldModify/apply calls.
+	 *  to avoid redundant computation across requiresRedaction/apply calls.
 	 *  Keyed by strategy name. */
 	readonly memo: Map<string, unknown>;
 }
@@ -31,5 +31,5 @@ export interface IExecutionRedactionStrategy {
 	apply(execution: RedactableExecution, context: RedactionContext): Promise<void>;
 	/** Returns true if apply() would mutate the execution data. Used by the
 	 *  copy-on-write path to avoid unnecessary cloning. */
-	wouldModify(execution: RedactableExecution, context: RedactionContext): boolean;
+	requiresRedaction(execution: RedactableExecution, context: RedactionContext): boolean;
 }

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.interfaces.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.interfaces.ts
@@ -25,4 +25,7 @@ export interface RedactionContext {
 export interface IExecutionRedactionStrategy {
 	readonly name: string;
 	apply(execution: RedactableExecution, context: RedactionContext): Promise<void>;
+	/** Returns true if apply() would mutate the execution data. Used by the
+	 *  copy-on-write path to avoid unnecessary cloning. */
+	wouldModify(execution: RedactableExecution, context: RedactionContext): boolean;
 }

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.interfaces.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.interfaces.ts
@@ -12,6 +12,10 @@ export interface RedactionContext {
 	readonly redactExecutionData: boolean | undefined;
 	/** Pre-resolved by the orchestrator — true if the user can see unredacted data. */
 	readonly userCanReveal: boolean;
+	/** Generic memo store — strategies may cache intermediate results here
+	 *  to avoid redundant computation across wouldModify/apply calls.
+	 *  Keyed by strategy name. */
+	readonly memo: Map<string, unknown>;
 }
 
 /**

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
@@ -121,6 +121,7 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 				user: options.user,
 				redactExecutionData: options.redactExecutionData,
 				userCanReveal,
+				memo: new Map(),
 			};
 			const pipeline = this.buildPipeline(execution, context, policyAllowsReveal);
 

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
@@ -49,7 +49,7 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 	/**
 	 * Thin wrapper around `processExecutions` for single-execution callers.
 	 *
-	 * With `copyOnWrite: true`, the original execution is never mutated. Returns
+	 * With `keepOriginal: true`, the original execution is never mutated. Returns
 	 * either the original (if no redaction needed) or a structuredClone with
 	 * redaction applied. Callers can check referential equality to determine
 	 * whether redaction occurred.
@@ -126,7 +126,7 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 			const pipeline = this.buildPipeline(execution, context, policyAllowsReveal);
 
 			let target = execution;
-			if (options.copyOnWrite) {
+			if (options.keepOriginal) {
 				const needsClone = pipeline.some((s) => s.wouldModify(execution, context));
 				if (!needsClone) continue;
 				target = structuredClone(execution);

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
@@ -127,7 +127,7 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 
 			let target = execution;
 			if (options.keepOriginal) {
-				const needsClone = pipeline.some((s) => s.wouldModify(execution, context));
+				const needsClone = pipeline.some((s) => s.requiresRedaction(execution, context));
 				if (!needsClone) continue;
 				target = structuredClone(execution);
 				executions[i] = target;

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
@@ -48,13 +48,19 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 
 	/**
 	 * Thin wrapper around `processExecutions` for single-execution callers.
+	 *
+	 * With `copyOnWrite: true`, the original execution is never mutated. Returns
+	 * either the original (if no redaction needed) or a structuredClone with
+	 * redaction applied. Callers can check referential equality to determine
+	 * whether redaction occurred.
 	 */
 	async processExecution(
 		execution: RedactableExecution,
 		options: ExecutionRedactionOptions,
 	): Promise<RedactableExecution> {
-		await this.processExecutions([execution], options);
-		return execution;
+		const executions = [execution];
+		await this.processExecutions(executions, options);
+		return executions[0];
 	}
 
 	/**
@@ -106,7 +112,9 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 		// Unified pipeline execution. buildPipeline excludes FullItemRedactionStrategy on the
 		// reveal path (redactExecutionData === false). NodeDefinedFieldRedactionStrategy
 		// always runs — node-declared sensitive fields are never revealable.
-		for (const execution of executions) {
+
+		for (let i = 0; i < executions.length; i++) {
+			const execution = executions[i];
 			const policyAllowsReveal = this.policyAllowsReveal(execution);
 			const userCanReveal = policyAllowsReveal || revealableIds.has(execution.workflowId);
 			const context: RedactionContext = {
@@ -115,8 +123,17 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 				userCanReveal,
 			};
 			const pipeline = this.buildPipeline(execution, context, policyAllowsReveal);
+
+			let target = execution;
+			if (options.copyOnWrite) {
+				const needsClone = pipeline.some((s) => s.wouldModify(execution, context));
+				if (!needsClone) continue;
+				target = structuredClone(execution);
+				executions[i] = target;
+			}
+
 			for (const strategy of pipeline) {
-				await strategy.apply(execution, context);
+				await strategy.apply(target, context);
 			}
 		}
 

--- a/packages/cli/src/modules/redaction/executions/strategies/__tests__/full-item-redaction.strategy.test.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/__tests__/full-item-redaction.strategy.test.ts
@@ -9,6 +9,7 @@ const makeContext = (overrides: Partial<RedactionContext> = {}): RedactionContex
 	user: { id: 'user-1' } as RedactionContext['user'],
 	redactExecutionData: undefined,
 	userCanReveal: false,
+	memo: new Map(),
 	...overrides,
 });
 

--- a/packages/cli/src/modules/redaction/executions/strategies/__tests__/node-defined-field-redaction.strategy.test.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/__tests__/node-defined-field-redaction.strategy.test.ts
@@ -12,6 +12,7 @@ const makeContext = (overrides: Partial<RedactionContext> = {}): RedactionContex
 	user: { id: 'user-1' } as RedactionContext['user'],
 	redactExecutionData: undefined,
 	userCanReveal: false,
+	memo: new Map(),
 	...overrides,
 });
 

--- a/packages/cli/src/modules/redaction/executions/strategies/full-item-redaction.strategy.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/full-item-redaction.strategy.ts
@@ -17,6 +17,11 @@ import type {
 export class FullItemRedactionStrategy implements IExecutionRedactionStrategy {
 	readonly name = 'full-item-redaction';
 
+	wouldModify(_execution: RedactableExecution, _context: RedactionContext): boolean {
+		// If this strategy is in the pipeline, it always modifies (clears all items).
+		return true;
+	}
+
 	async apply(execution: RedactableExecution, context: RedactionContext): Promise<void> {
 		const runData = execution.data.resultData.runData;
 		if (!runData) return;

--- a/packages/cli/src/modules/redaction/executions/strategies/full-item-redaction.strategy.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/full-item-redaction.strategy.ts
@@ -17,7 +17,7 @@ import type {
 export class FullItemRedactionStrategy implements IExecutionRedactionStrategy {
 	readonly name = 'full-item-redaction';
 
-	wouldModify(_execution: RedactableExecution, _context: RedactionContext): boolean {
+	requiresRedaction(_execution: RedactableExecution, _context: RedactionContext): boolean {
 		// If this strategy is in the pipeline, it always modifies (clears all items).
 		return true;
 	}

--- a/packages/cli/src/modules/redaction/executions/strategies/node-defined-field-redaction.strategy.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/node-defined-field-redaction.strategy.ts
@@ -19,6 +19,11 @@ export class NodeDefinedFieldRedactionStrategy implements IExecutionRedactionStr
 		private readonly nodeTypes: NodeTypes,
 	) {}
 
+	wouldModify(execution: RedactableExecution, _context: RedactionContext): boolean {
+		const { sensitiveFields, unknownNodes } = this.buildSensitiveFieldsMap(execution);
+		return sensitiveFields.size > 0 || unknownNodes.size > 0;
+	}
+
 	async apply(execution: RedactableExecution, _context: RedactionContext): Promise<void> {
 		const { sensitiveFields, unknownNodes } = this.buildSensitiveFieldsMap(execution);
 		if (sensitiveFields.size === 0 && unknownNodes.size === 0) return;

--- a/packages/cli/src/modules/redaction/executions/strategies/node-defined-field-redaction.strategy.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/node-defined-field-redaction.strategy.ts
@@ -10,6 +10,22 @@ import type {
 	RedactionContext,
 } from '../execution-redaction.interfaces';
 
+interface SensitiveFieldsResult {
+	sensitiveFields: Map<string, string[]>;
+	unknownNodes: Set<string>;
+}
+
+function isSensitiveFieldsResult(value: unknown): value is SensitiveFieldsResult {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		'sensitiveFields' in value &&
+		'unknownNodes' in value &&
+		value.sensitiveFields instanceof Map &&
+		value.unknownNodes instanceof Set
+	);
+}
+
 @Service()
 export class NodeDefinedFieldRedactionStrategy implements IExecutionRedactionStrategy {
 	readonly name = 'node-defined-field-redaction';
@@ -19,13 +35,14 @@ export class NodeDefinedFieldRedactionStrategy implements IExecutionRedactionStr
 		private readonly nodeTypes: NodeTypes,
 	) {}
 
-	wouldModify(execution: RedactableExecution, _context: RedactionContext): boolean {
-		const { sensitiveFields, unknownNodes } = this.buildSensitiveFieldsMap(execution);
+	wouldModify(execution: RedactableExecution, context: RedactionContext): boolean {
+		if (!execution.data.resultData.runData) return false;
+		const { sensitiveFields, unknownNodes } = this.getSensitiveFieldsMap(execution, context);
 		return sensitiveFields.size > 0 || unknownNodes.size > 0;
 	}
 
-	async apply(execution: RedactableExecution, _context: RedactionContext): Promise<void> {
-		const { sensitiveFields, unknownNodes } = this.buildSensitiveFieldsMap(execution);
+	async apply(execution: RedactableExecution, context: RedactionContext): Promise<void> {
+		const { sensitiveFields, unknownNodes } = this.getSensitiveFieldsMap(execution, context);
 		if (sensitiveFields.size === 0 && unknownNodes.size === 0) return;
 
 		const runData = execution.data.resultData.runData;
@@ -63,6 +80,18 @@ export class NodeDefinedFieldRedactionStrategy implements IExecutionRedactionStr
 				}
 			}
 		}
+	}
+
+	private getSensitiveFieldsMap(
+		execution: RedactableExecution,
+		context: RedactionContext,
+	): SensitiveFieldsResult {
+		const cached = context.memo.get(this.name);
+		if (isSensitiveFieldsResult(cached)) return cached;
+
+		const result = this.buildSensitiveFieldsMap(execution);
+		context.memo.set(this.name, result);
+		return result;
 	}
 
 	/**

--- a/packages/cli/src/modules/redaction/executions/strategies/node-defined-field-redaction.strategy.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/node-defined-field-redaction.strategy.ts
@@ -35,7 +35,7 @@ export class NodeDefinedFieldRedactionStrategy implements IExecutionRedactionStr
 		private readonly nodeTypes: NodeTypes,
 	) {}
 
-	wouldModify(execution: RedactableExecution, context: RedactionContext): boolean {
+	requiresRedaction(execution: RedactableExecution, context: RedactionContext): boolean {
 		if (!execution.data.resultData.runData) return false;
 		const { sensitiveFields, unknownNodes } = this.getSensitiveFieldsMap(execution, context);
 		return sensitiveFields.size > 0 || unknownNodes.size > 0;

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -155,6 +155,7 @@ export class JobProcessor {
 				workflowData: execution.workflowData,
 				retryOf: execution.retryOf,
 				pushRef,
+				userId: execution.data.manualData?.userId,
 			},
 			executionId,
 		);


### PR DESCRIPTION
## Summary

Applies the existing `ExecutionRedactionService` pipeline to WebSocket/SSE push events
(`nodeExecuteAfterData`, `executionStarted`) so that redaction policies are enforced in
real-time, not just on `GET /executions/:id`.

**Key design decisions:**

- **Copy-on-write redaction** — Adds a `copyOnWrite` option to `ExecutionRedactionOptions`.
  The service checks each strategy's new `wouldModify()` method *before* cloning. For the
  common case (`policy=none`, no sensitive output fields), zero copies are made.
- **Reuses existing pipeline** — Constructs a lightweight `RedactableExecution` from hook
  context and feeds it through the same `ExecutionRedactionService` strategies. No separate
  redaction logic for push events.
- **`wouldModify()` on strategy interface** — New required method on
  `IExecutionRedactionStrategy`. `FullItemRedactionStrategy` always returns `true` (if in
  pipeline, it mutates). `NodeDefinedFieldRedactionStrategy` checks `buildSensitiveFieldsMap`
  and returns `true` only when there are sensitive fields or unresolvable node types.
- **Lazy user resolution** — The `User` (with `role` relation) is resolved once per execution
  and cached across all node hooks in that execution.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-364

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)