### PR TITLE
fix(Jira Node): Add continueOnFail support for all operations

### DIFF
--- a/packages/nodes-base/nodes/Jira/Jira.node.ts
+++ b/packages/nodes-base/nodes/Jira/Jira.node.ts
@@ -469,595 +469,699 @@ export class Jira implements INodeType {
 			//https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issue-post
 			if (operation === 'create') {
 				for (let i = 0; i < length; i++) {
-					const summary = this.getNodeParameter('summary', i) as string;
-					const projectId = this.getNodeParameter('project', i, '', {
-						extractValue: true,
-					}) as string;
-					const issueTypeId = this.getNodeParameter('issueType', i, '', {
-						extractValue: true,
-					}) as string;
-					const additionalFields = this.getNodeParameter('additionalFields', i);
+					try {
+						const summary = this.getNodeParameter('summary', i) as string;
+						const projectId = this.getNodeParameter('project', i, '', {
+							extractValue: true,
+						}) as string;
+						const issueTypeId = this.getNodeParameter('issueType', i, '', {
+							extractValue: true,
+						}) as string;
+						const additionalFields = this.getNodeParameter('additionalFields', i);
 
-					const assignee = this.getNodeParameter('additionalFields.assignee', i, '', {
-						extractValue: true,
-					});
-					if (assignee) additionalFields.assignee = assignee;
+						const assignee = this.getNodeParameter('additionalFields.assignee', i, '', {
+							extractValue: true,
+						});
+						if (assignee) additionalFields.assignee = assignee;
 
-					const reporter = this.getNodeParameter('additionalFields.reporter', i, '', {
-						extractValue: true,
-					});
-					if (reporter) additionalFields.reporter = reporter;
+						const reporter = this.getNodeParameter('additionalFields.reporter', i, '', {
+							extractValue: true,
+						});
+						if (reporter) additionalFields.reporter = reporter;
 
-					const priority = this.getNodeParameter('additionalFields.priority', i, '', {
-						extractValue: true,
-					});
-					if (priority) additionalFields.priority = priority;
+						const priority = this.getNodeParameter('additionalFields.priority', i, '', {
+							extractValue: true,
+						});
+						if (priority) additionalFields.priority = priority;
 
-					const body: IIssue = {};
-					const fields: IFields = {
-						summary,
-						project: {
-							id: projectId,
-						},
-						issuetype: {
-							id: issueTypeId,
-						},
-					};
-					if (additionalFields.labels) {
-						fields.labels = additionalFields.labels as string[];
-					}
-					if (additionalFields.serverLabels) {
-						fields.labels = additionalFields.serverLabels as string[];
-					}
-					if (additionalFields.priority) {
-						fields.priority = {
-							id: additionalFields.priority as string,
+						const body: IIssue = {};
+						const fields: IFields = {
+							summary,
+							project: {
+								id: projectId,
+							},
+							issuetype: {
+								id: issueTypeId,
+							},
 						};
-					}
-					if (additionalFields.assignee) {
-						if (jiraVersion === 'server' || jiraVersion === 'serverPat') {
-							fields.assignee = {
-								name: additionalFields.assignee as string,
-							};
-						} else {
-							fields.assignee = {
-								id: additionalFields.assignee as string,
-							};
+						if (additionalFields.labels) {
+							fields.labels = additionalFields.labels as string[];
 						}
-					}
-					if (additionalFields.reporter) {
-						if (jiraVersion === 'server' || jiraVersion === 'serverPat') {
-							fields.reporter = {
-								name: additionalFields.reporter as string,
-							};
-						} else {
-							fields.reporter = {
-								id: additionalFields.reporter as string,
+						if (additionalFields.serverLabels) {
+							fields.labels = additionalFields.serverLabels as string[];
+						}
+						if (additionalFields.priority) {
+							fields.priority = {
+								id: additionalFields.priority as string,
 							};
 						}
-					}
-					if (additionalFields.description) {
-						fields.description = additionalFields.description as string;
-					}
-					if (additionalFields.updateHistory) {
-						qs.updateHistory = additionalFields.updateHistory as boolean;
-					}
-					if (additionalFields.componentIds) {
-						fields.components = (additionalFields.componentIds as string[]).map((id) => ({ id }));
-					}
-					if (additionalFields.customFieldsUi) {
-						const customFields = (additionalFields.customFieldsUi as IDataObject)
-							.customFieldsValues as IDataObject[];
-						if (customFields) {
-							// resolve resource locator fieldId value
-							customFields.forEach((cf) => {
-								if (typeof cf.fieldId !== 'string') {
-									cf.fieldId = ((cf.fieldId as IDataObject).value as string).trim();
-								}
-							});
-							const data = customFields.reduce(
-								(obj, value) => Object.assign(obj, { [`${value.fieldId}`]: value.fieldValue }),
-								{},
-							);
-							Object.assign(fields, data);
+						if (additionalFields.assignee) {
+							if (jiraVersion === 'server' || jiraVersion === 'serverPat') {
+								fields.assignee = {
+									name: additionalFields.assignee as string,
+								};
+							} else {
+								fields.assignee = {
+									id: additionalFields.assignee as string,
+								};
+							}
 						}
-					}
-					const issueTypes = await jiraSoftwareCloudApiRequest.call(
-						this,
-						'/api/2/issuetype',
-						'GET',
-						{},
-						qs,
-					);
-					const subtaskIssues = [];
-					for (const issueType of issueTypes) {
-						if (issueType.subtask) {
-							subtaskIssues.push(issueType.id);
+						if (additionalFields.reporter) {
+							if (jiraVersion === 'server' || jiraVersion === 'serverPat') {
+								fields.reporter = {
+									name: additionalFields.reporter as string,
+								};
+							} else {
+								fields.reporter = {
+									id: additionalFields.reporter as string,
+								};
+							}
 						}
-					}
-					if (!additionalFields.parentIssueKey && subtaskIssues.includes(issueTypeId)) {
-						throw new NodeOperationError(
-							this.getNode(),
-							'You must define a Parent Issue Key when Issue type is sub-task',
-							{ itemIndex: i },
+						if (additionalFields.description) {
+							fields.description = additionalFields.description as string;
+						}
+						if (additionalFields.updateHistory) {
+							qs.updateHistory = additionalFields.updateHistory as boolean;
+						}
+						if (additionalFields.componentIds) {
+							fields.components = (additionalFields.componentIds as string[]).map((id) => ({ id }));
+						}
+						if (additionalFields.customFieldsUi) {
+							const customFields = (additionalFields.customFieldsUi as IDataObject)
+								.customFieldsValues as IDataObject[];
+							if (customFields) {
+								// resolve resource locator fieldId value
+								customFields.forEach((cf) => {
+									if (typeof cf.fieldId !== 'string') {
+										cf.fieldId = ((cf.fieldId as IDataObject).value as string).trim();
+									}
+								});
+								const data = customFields.reduce(
+									(obj, value) => Object.assign(obj, { [`${value.fieldId}`]: value.fieldValue }),
+									{},
+								);
+								Object.assign(fields, data);
+							}
+						}
+						const issueTypes = await jiraSoftwareCloudApiRequest.call(
+							this,
+							'/api/2/issuetype',
+							'GET',
+							{},
+							qs,
 						);
-					} else if (additionalFields.parentIssueKey && subtaskIssues.includes(issueTypeId)) {
-						fields.parent = {
-							key: (additionalFields.parentIssueKey as string).toUpperCase(),
-						};
-					}
-					body.fields = fields;
-					responseData = await jiraSoftwareCloudApiRequest.call(this, '/api/2/issue', 'POST', body);
-
-					const executionData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray(responseData as IDataObject[]),
-						{ itemData: { item: i } },
-					);
-
-					returnData.push(...executionData);
-				}
-			}
-			//https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issue-issueIdOrKey-put
-			if (operation === 'update') {
-				for (let i = 0; i < length; i++) {
-					const issueKey = this.getNodeParameter('issueKey', i) as string;
-					const updateFields = this.getNodeParameter('updateFields', i);
-
-					const assignee = this.getNodeParameter('updateFields.assignee', i, '', {
-						extractValue: true,
-					});
-					if (assignee) updateFields.assignee = assignee;
-
-					const reporter = this.getNodeParameter('updateFields.reporter', i, '', {
-						extractValue: true,
-					});
-					if (reporter) updateFields.reporter = reporter;
-
-					const priority = this.getNodeParameter('updateFields.priority', i, '', {
-						extractValue: true,
-					});
-					if (priority) updateFields.priority = priority;
-
-					const statusId = this.getNodeParameter('updateFields.statusId', i, '', {
-						extractValue: true,
-					});
-					if (statusId) updateFields.statusId = statusId;
-
-					const body: IIssue = {};
-					const fields: IFields = {};
-					if (updateFields.summary) {
-						fields.summary = updateFields.summary as string;
-					}
-					if (updateFields.issueType) {
-						fields.issuetype = {
-							id: updateFields.issueType as string,
-						};
-					}
-					if (updateFields.labels) {
-						fields.labels = updateFields.labels as string[];
-					}
-					if (updateFields.serverLabels) {
-						fields.labels = updateFields.serverLabels as string[];
-					}
-					if (updateFields.priority) {
-						fields.priority = {
-							id: updateFields.priority as string,
-						};
-					}
-					if (updateFields.assignee) {
-						if (jiraVersion === 'server' || jiraVersion === 'serverPat') {
-							fields.assignee = {
-								name: updateFields.assignee as string,
-							};
-						} else {
-							fields.assignee = {
-								id: updateFields.assignee as string,
-							};
+						const subtaskIssues = [];
+						for (const issueType of issueTypes) {
+							if (issueType.subtask) {
+								subtaskIssues.push(issueType.id);
+							}
 						}
-					}
-					if (updateFields.reporter) {
-						if (jiraVersion === 'server' || jiraVersion === 'serverPat') {
-							fields.reporter = {
-								name: updateFields.reporter as string,
-							};
-						} else {
-							fields.reporter = {
-								id: updateFields.reporter as string,
-							};
-						}
-					}
-					if (updateFields.description) {
-						fields.description = updateFields.description as string;
-					}
-					if (updateFields.customFieldsUi) {
-						const customFields = (updateFields.customFieldsUi as IDataObject)
-							.customFieldsValues as IDataObject[];
-						if (customFields) {
-							// resolve resource locator fieldId value
-							customFields.forEach((cf) => {
-								if (typeof cf.fieldId !== 'string') {
-									cf.fieldId = ((cf.fieldId as IDataObject).value as string).trim();
-								}
-							});
-							const data = customFields.reduce(
-								(obj, value) => Object.assign(obj, { [`${value.fieldId}`]: value.fieldValue }),
-								{},
+						if (!additionalFields.parentIssueKey && subtaskIssues.includes(issueTypeId)) {
+							throw new NodeOperationError(
+								this.getNode(),
+								'You must define a Parent Issue Key when Issue type is sub-task',
+								{ itemIndex: i },
 							);
-							Object.assign(fields, data);
+						} else if (additionalFields.parentIssueKey && subtaskIssues.includes(issueTypeId)) {
+							fields.parent = {
+								key: (additionalFields.parentIssueKey as string).toUpperCase(),
+							};
 						}
-					}
-					const issueTypes = await jiraSoftwareCloudApiRequest.call(
-						this,
-						'/api/2/issuetype',
-						'GET',
-					);
-					const subtaskIssues = [];
-					for (const issueType of issueTypes) {
-						if (issueType.subtask) {
-							subtaskIssues.push(issueType.id);
-						}
-					}
-					if (!updateFields.parentIssueKey && subtaskIssues.includes(updateFields.issueType)) {
-						throw new NodeOperationError(
-							this.getNode(),
-							'You must define a Parent Issue Key when Issue type is sub-task',
-							{ itemIndex: i },
-						);
-					} else if (
-						updateFields.parentIssueKey &&
-						subtaskIssues.includes(updateFields.issueType)
-					) {
-						fields.parent = {
-							key: (updateFields.parentIssueKey as string).toUpperCase(),
-						};
-					}
-					body.fields = fields;
-
-					if (updateFields.statusId) {
+						body.fields = fields;
 						responseData = await jiraSoftwareCloudApiRequest.call(
 							this,
-							`/api/2/issue/${issueKey}/transitions`,
+							'/api/2/issue',
 							'POST',
-							{ transition: { id: updateFields.statusId } },
-						);
-					}
-
-					responseData = await jiraSoftwareCloudApiRequest.call(
-						this,
-						`/api/2/issue/${issueKey}`,
-						'PUT',
-						body,
-					);
-					const executionData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray({ success: true }),
-						{ itemData: { item: i } },
-					);
-
-					returnData.push(...executionData);
-				}
-			}
-			//https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issue-issueIdOrKey-get
-			if (operation === 'get') {
-				for (let i = 0; i < length; i++) {
-					const issueKey = this.getNodeParameter('issueKey', i) as string;
-					const simplifyOutput = this.getNodeParameter('simplifyOutput', i) as boolean;
-					const additionalFields = this.getNodeParameter('additionalFields', i);
-					if (additionalFields.fields) {
-						qs.fields = additionalFields.fields as string;
-					}
-					if (additionalFields.fieldsByKey) {
-						qs.fieldsByKey = additionalFields.fieldsByKey as boolean;
-					}
-					if (additionalFields.expand) {
-						qs.expand = additionalFields.expand as string;
-					}
-					if (simplifyOutput) {
-						qs.expand = `${qs.expand || ''},names`;
-					}
-					if (additionalFields.properties) {
-						qs.properties = additionalFields.properties as string;
-					}
-					if (additionalFields.updateHistory) {
-						qs.updateHistory = additionalFields.updateHistory as string;
-					}
-					responseData = await jiraSoftwareCloudApiRequest.call(
-						this,
-						`/api/2/issue/${issueKey}`,
-						'GET',
-						{},
-						qs,
-					);
-
-					if (simplifyOutput) {
-						// Use rendered fields if requested and available
-						qs.expand = qs.expand || '';
-						if (
-							(qs.expand as string).toLowerCase().indexOf('renderedfields') !== -1 &&
-							responseData.renderedFields &&
-							Object.keys(responseData.renderedFields as IDataObject[]).length
-						) {
-							responseData.fields = mergeWith(
-								responseData.fields,
-								responseData.renderedFields,
-								(a, b) => (b === null ? a : b),
-							);
-						}
-						const executionData = this.helpers.constructExecutionMetaData(
-							this.helpers.returnJsonArray(simplifyIssueOutput(responseData)),
-							{ itemData: { item: i } },
+							body,
 						);
 
-						returnData.push(...executionData);
-					} else {
 						const executionData = this.helpers.constructExecutionMetaData(
 							this.helpers.returnJsonArray(responseData as IDataObject[]),
 							{ itemData: { item: i } },
 						);
 
 						returnData.push(...executionData);
+					} catch (error) {
+						if (this.continueOnFail()) {
+							const executionData = this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray({ error: error.message }),
+								{ itemData: { item: i } },
+							);
+							returnData.push(...executionData);
+							continue;
+						}
+						throw error;
+					}
+				}
+			}
+			//https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issue-issueIdOrKey-put
+			if (operation === 'update') {
+				for (let i = 0; i < length; i++) {
+					try {
+						const issueKey = this.getNodeParameter('issueKey', i) as string;
+						const updateFields = this.getNodeParameter('updateFields', i);
+
+						const assignee = this.getNodeParameter('updateFields.assignee', i, '', {
+							extractValue: true,
+						});
+						if (assignee) updateFields.assignee = assignee;
+
+						const reporter = this.getNodeParameter('updateFields.reporter', i, '', {
+							extractValue: true,
+						});
+						if (reporter) updateFields.reporter = reporter;
+
+						const priority = this.getNodeParameter('updateFields.priority', i, '', {
+							extractValue: true,
+						});
+						if (priority) updateFields.priority = priority;
+
+						const statusId = this.getNodeParameter('updateFields.statusId', i, '', {
+							extractValue: true,
+						});
+						if (statusId) updateFields.statusId = statusId;
+
+						const body: IIssue = {};
+						const fields: IFields = {};
+						if (updateFields.summary) {
+							fields.summary = updateFields.summary as string;
+						}
+						if (updateFields.issueType) {
+							fields.issuetype = {
+								id: updateFields.issueType as string,
+							};
+						}
+						if (updateFields.labels) {
+							fields.labels = updateFields.labels as string[];
+						}
+						if (updateFields.serverLabels) {
+							fields.labels = updateFields.serverLabels as string[];
+						}
+						if (updateFields.priority) {
+							fields.priority = {
+								id: updateFields.priority as string,
+							};
+						}
+						if (updateFields.assignee) {
+							if (jiraVersion === 'server' || jiraVersion === 'serverPat') {
+								fields.assignee = {
+									name: updateFields.assignee as string,
+								};
+							} else {
+								fields.assignee = {
+									id: updateFields.assignee as string,
+								};
+							}
+						}
+						if (updateFields.reporter) {
+							if (jiraVersion === 'server' || jiraVersion === 'serverPat') {
+								fields.reporter = {
+									name: updateFields.reporter as string,
+								};
+							} else {
+								fields.reporter = {
+									id: updateFields.reporter as string,
+								};
+							}
+						}
+						if (updateFields.description) {
+							fields.description = updateFields.description as string;
+						}
+						if (updateFields.customFieldsUi) {
+							const customFields = (updateFields.customFieldsUi as IDataObject)
+								.customFieldsValues as IDataObject[];
+							if (customFields) {
+								// resolve resource locator fieldId value
+								customFields.forEach((cf) => {
+									if (typeof cf.fieldId !== 'string') {
+										cf.fieldId = ((cf.fieldId as IDataObject).value as string).trim();
+									}
+								});
+								const data = customFields.reduce(
+									(obj, value) => Object.assign(obj, { [`${value.fieldId}`]: value.fieldValue }),
+									{},
+								);
+								Object.assign(fields, data);
+							}
+						}
+						const issueTypes = await jiraSoftwareCloudApiRequest.call(
+							this,
+							'/api/2/issuetype',
+							'GET',
+						);
+						const subtaskIssues = [];
+						for (const issueType of issueTypes) {
+							if (issueType.subtask) {
+								subtaskIssues.push(issueType.id);
+							}
+						}
+						if (!updateFields.parentIssueKey && subtaskIssues.includes(updateFields.issueType)) {
+							throw new NodeOperationError(
+								this.getNode(),
+								'You must define a Parent Issue Key when Issue type is sub-task',
+								{ itemIndex: i },
+							);
+						} else if (
+							updateFields.parentIssueKey &&
+							subtaskIssues.includes(updateFields.issueType)
+						) {
+							fields.parent = {
+								key: (updateFields.parentIssueKey as string).toUpperCase(),
+							};
+						}
+						body.fields = fields;
+
+						if (updateFields.statusId) {
+							responseData = await jiraSoftwareCloudApiRequest.call(
+								this,
+								`/api/2/issue/${issueKey}/transitions`,
+								'POST',
+								{ transition: { id: updateFields.statusId } },
+							);
+						}
+
+						responseData = await jiraSoftwareCloudApiRequest.call(
+							this,
+							`/api/2/issue/${issueKey}`,
+							'PUT',
+							body,
+						);
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray({ success: true }),
+							{ itemData: { item: i } },
+						);
+
+						returnData.push(...executionData);
+					} catch (error) {
+						if (this.continueOnFail()) {
+							const executionData = this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray({ error: error.message }),
+								{ itemData: { item: i } },
+							);
+							returnData.push(...executionData);
+							continue;
+						}
+						throw error;
+					}
+				}
+			}
+			//https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issue-issueIdOrKey-get
+			if (operation === 'get') {
+				for (let i = 0; i < length; i++) {
+					try {
+						const issueKey = this.getNodeParameter('issueKey', i) as string;
+						const simplifyOutput = this.getNodeParameter('simplifyOutput', i) as boolean;
+						const additionalFields = this.getNodeParameter('additionalFields', i);
+						if (additionalFields.fields) {
+							qs.fields = additionalFields.fields as string;
+						}
+						if (additionalFields.fieldsByKey) {
+							qs.fieldsByKey = additionalFields.fieldsByKey as boolean;
+						}
+						if (additionalFields.expand) {
+							qs.expand = additionalFields.expand as string;
+						}
+						if (simplifyOutput) {
+							qs.expand = `${qs.expand || ''},names`;
+						}
+						if (additionalFields.properties) {
+							qs.properties = additionalFields.properties as string;
+						}
+						if (additionalFields.updateHistory) {
+							qs.updateHistory = additionalFields.updateHistory as string;
+						}
+						responseData = await jiraSoftwareCloudApiRequest.call(
+							this,
+							`/api/2/issue/${issueKey}`,
+							'GET',
+							{},
+							qs,
+						);
+
+						if (simplifyOutput) {
+							// Use rendered fields if requested and available
+							qs.expand = qs.expand || '';
+							if (
+								(qs.expand as string).toLowerCase().indexOf('renderedfields') !== -1 &&
+								responseData.renderedFields &&
+								Object.keys(responseData.renderedFields as IDataObject[]).length
+							) {
+								responseData.fields = mergeWith(
+									responseData.fields,
+									responseData.renderedFields,
+									(a, b) => (b === null ? a : b),
+								);
+							}
+							const executionData = this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray(simplifyIssueOutput(responseData)),
+								{ itemData: { item: i } },
+							);
+
+							returnData.push(...executionData);
+						} else {
+							const executionData = this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray(responseData as IDataObject[]),
+								{ itemData: { item: i } },
+							);
+
+							returnData.push(...executionData);
+						}
+					} catch (error) {
+						if (this.continueOnFail()) {
+							const executionData = this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray({ error: error.message }),
+								{ itemData: { item: i } },
+							);
+							returnData.push(...executionData);
+							continue;
+						}
+						throw error;
 					}
 				}
 			}
 			//https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-search-post
 			if (operation === 'getAll') {
 				for (let i = 0; i < length; i++) {
-					const returnAll = this.getNodeParameter('returnAll', i);
-					const options = this.getNodeParameter('options', i);
-					const body: IDataObject = {};
-					if (!options.fields) {
-						// By default, the new endpoint returns only the ids, before it used to return `*navigable` fields
-						options.fields = '*navigable';
-					}
-					body.fields = (options.fields as string).split(',');
-					if (!options.jql) {
-						// Jira API returns an error if the JQL query is unbounded (i.e. does not include any filters)
-						options.jql = 'created >= "1970-01-01"';
-					}
-					body.jql = options.jql as string;
-					if (options.expand) {
-						if (typeof options.expand === 'string') {
-							body.expand = options.expand.split(',');
-						} else {
-							body.expand = options.expand;
+					try {
+						const returnAll = this.getNodeParameter('returnAll', i);
+						const options = this.getNodeParameter('options', i);
+						const body: IDataObject = {};
+						if (!options.fields) {
+							// By default, the new endpoint returns only the ids, before it used to return `*navigable` fields
+							options.fields = '*navigable';
 						}
-					}
-					if (returnAll) {
-						if (jiraVersion === 'server' || jiraVersion === 'serverPat') {
-							responseData = await jiraSoftwareCloudApiRequestAllItems.call(
-								this,
-								'issues',
-								'/api/2/search',
-								'POST',
-								body,
-							);
-						} else {
-							responseData = await jiraSoftwareCloudApiRequestAllItems.call(
-								this,
-								'issues',
-								'/api/2/search/jql',
-								'POST',
-								body,
-								{},
-								'token',
-							);
+						body.fields = (options.fields as string).split(',');
+						if (!options.jql) {
+							// Jira API returns an error if the JQL query is unbounded (i.e. does not include any filters)
+							options.jql = 'created >= "1970-01-01"';
 						}
-					} else {
-						const limit = this.getNodeParameter('limit', i);
-						body.maxResults = limit;
-						if (jiraVersion === 'server' || jiraVersion === 'serverPat') {
-							responseData = await jiraSoftwareCloudApiRequest.call(
-								this,
-								'/api/2/search',
-								'POST',
-								body,
-							);
-						} else {
-							responseData = await jiraSoftwareCloudApiRequest.call(
-								this,
-								'/api/2/search/jql',
-								'POST',
-								body,
-							);
+						body.jql = options.jql as string;
+						if (options.expand) {
+							if (typeof options.expand === 'string') {
+								body.expand = options.expand.split(',');
+							} else {
+								body.expand = options.expand;
+							}
 						}
-						responseData = responseData.issues;
-					}
+						if (returnAll) {
+							if (jiraVersion === 'server' || jiraVersion === 'serverPat') {
+								responseData = await jiraSoftwareCloudApiRequestAllItems.call(
+									this,
+									'issues',
+									'/api/2/search',
+									'POST',
+									body,
+								);
+							} else {
+								responseData = await jiraSoftwareCloudApiRequestAllItems.call(
+									this,
+									'issues',
+									'/api/2/search/jql',
+									'POST',
+									body,
+									{},
+									'token',
+								);
+							}
+						} else {
+							const limit = this.getNodeParameter('limit', i);
+							body.maxResults = limit;
+							if (jiraVersion === 'server' || jiraVersion === 'serverPat') {
+								responseData = await jiraSoftwareCloudApiRequest.call(
+									this,
+									'/api/2/search',
+									'POST',
+									body,
+								);
+							} else {
+								responseData = await jiraSoftwareCloudApiRequest.call(
+									this,
+									'/api/2/search/jql',
+									'POST',
+									body,
+								);
+							}
+							responseData = responseData.issues;
+						}
 
-					const executionData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray(responseData as IDataObject[]),
-						{ itemData: { item: i } },
-					);
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray(responseData as IDataObject[]),
+							{ itemData: { item: i } },
+						);
 
-					returnData.push(...executionData);
+						returnData.push(...executionData);
+					} catch (error) {
+						if (this.continueOnFail()) {
+							const executionData = this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray({ error: error.message }),
+								{ itemData: { item: i } },
+							);
+							returnData.push(...executionData);
+							continue;
+						}
+						throw error;
+					}
 				}
 			}
 			//https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issue-issueIdOrKey-changelog-get
 			if (operation === 'changelog') {
 				for (let i = 0; i < length; i++) {
-					const issueKey = this.getNodeParameter('issueKey', i) as string;
-					const returnAll = this.getNodeParameter('returnAll', i);
-					if (returnAll) {
-						responseData = await jiraSoftwareCloudApiRequestAllItems.call(
-							this,
-							'values',
-							`/api/2/issue/${issueKey}/changelog`,
-							'GET',
+					try {
+						const issueKey = this.getNodeParameter('issueKey', i) as string;
+						const returnAll = this.getNodeParameter('returnAll', i);
+						if (returnAll) {
+							responseData = await jiraSoftwareCloudApiRequestAllItems.call(
+								this,
+								'values',
+								`/api/2/issue/${issueKey}/changelog`,
+								'GET',
+							);
+						} else {
+							qs.maxResults = this.getNodeParameter('limit', i);
+							responseData = await jiraSoftwareCloudApiRequest.call(
+								this,
+								`/api/2/issue/${issueKey}/changelog`,
+								'GET',
+								{},
+								qs,
+							);
+							responseData = responseData.values;
+						}
+
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray(responseData as IDataObject[]),
+							{ itemData: { item: i } },
 						);
-					} else {
-						qs.maxResults = this.getNodeParameter('limit', i);
-						responseData = await jiraSoftwareCloudApiRequest.call(
-							this,
-							`/api/2/issue/${issueKey}/changelog`,
-							'GET',
-							{},
-							qs,
-						);
-						responseData = responseData.values;
+
+						returnData.push(...executionData);
+					} catch (error) {
+						if (this.continueOnFail()) {
+							const executionData = this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray({ error: error.message }),
+								{ itemData: { item: i } },
+							);
+							returnData.push(...executionData);
+							continue;
+						}
+						throw error;
 					}
-
-					const executionData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray(responseData as IDataObject[]),
-						{ itemData: { item: i } },
-					);
-
-					returnData.push(...executionData);
 				}
 			}
 			//https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issue-issueIdOrKey-notify-post
 			if (operation === 'notify') {
 				for (let i = 0; i < length; i++) {
-					const issueKey = this.getNodeParameter('issueKey', i) as string;
-					const additionalFields = this.getNodeParameter('additionalFields', i);
-					const jsonActive = this.getNodeParameter('jsonParameters', 0);
-					const body: INotify = {};
-					if (additionalFields.textBody) {
-						body.textBody = additionalFields.textBody as string;
-					}
-					if (additionalFields.htmlBody) {
-						body.htmlBody = additionalFields.htmlBody as string;
-					}
-					if (!jsonActive) {
-						const notificationRecipientsValues = (
-							this.getNodeParameter('notificationRecipientsUi', i) as IDataObject
-						).notificationRecipientsValues as IDataObject;
-						const notificationRecipients: INotificationRecipients = {};
-						if (notificationRecipientsValues) {
-							if (notificationRecipientsValues.reporter) {
-								notificationRecipients.reporter = notificationRecipientsValues.reporter as boolean;
-							}
+					try {
+						const issueKey = this.getNodeParameter('issueKey', i) as string;
+						const additionalFields = this.getNodeParameter('additionalFields', i);
+						const jsonActive = this.getNodeParameter('jsonParameters', 0);
+						const body: INotify = {};
+						if (additionalFields.textBody) {
+							body.textBody = additionalFields.textBody as string;
+						}
+						if (additionalFields.htmlBody) {
+							body.htmlBody = additionalFields.htmlBody as string;
+						}
+						if (!jsonActive) {
+							const notificationRecipientsValues = (
+								this.getNodeParameter('notificationRecipientsUi', i) as IDataObject
+							).notificationRecipientsValues as IDataObject;
+							const notificationRecipients: INotificationRecipients = {};
+							if (notificationRecipientsValues) {
+								if (notificationRecipientsValues.reporter) {
+									notificationRecipients.reporter =
+										notificationRecipientsValues.reporter as boolean;
+								}
 
-							if (notificationRecipientsValues.assignee) {
-								notificationRecipients.assignee = notificationRecipientsValues.assignee as boolean;
-							}
+								if (notificationRecipientsValues.assignee) {
+									notificationRecipients.assignee =
+										notificationRecipientsValues.assignee as boolean;
+								}
 
-							if (notificationRecipientsValues.assignee) {
-								notificationRecipients.watchers = notificationRecipientsValues.watchers as boolean;
-							}
+								if (notificationRecipientsValues.assignee) {
+									notificationRecipients.watchers =
+										notificationRecipientsValues.watchers as boolean;
+								}
 
-							if (notificationRecipientsValues.voters) {
-								notificationRecipients.watchers = notificationRecipientsValues.voters as boolean;
-							}
+								if (notificationRecipientsValues.voters) {
+									notificationRecipients.watchers = notificationRecipientsValues.voters as boolean;
+								}
 
-							if (((notificationRecipientsValues.users as IDataObject[]) || []).length > 0) {
-								notificationRecipients.users = (
-									notificationRecipientsValues.users as IDataObject[]
-								).map((user) => {
-									return {
-										accountId: user,
-									};
-								});
-							}
+								if (((notificationRecipientsValues.users as IDataObject[]) || []).length > 0) {
+									notificationRecipients.users = (
+										notificationRecipientsValues.users as IDataObject[]
+									).map((user) => {
+										return {
+											accountId: user,
+										};
+									});
+								}
 
-							if (((notificationRecipientsValues.groups as IDataObject[]) || []).length > 0) {
-								notificationRecipients.groups = (
-									notificationRecipientsValues.groups as IDataObject[]
-								).map((group) => {
-									return {
-										name: group,
-									};
-								});
+								if (((notificationRecipientsValues.groups as IDataObject[]) || []).length > 0) {
+									notificationRecipients.groups = (
+										notificationRecipientsValues.groups as IDataObject[]
+									).map((group) => {
+										return {
+											name: group,
+										};
+									});
+								}
+							}
+							body.to = notificationRecipients;
+							const notificationRecipientsRestrictionsValues = (
+								this.getNodeParameter('notificationRecipientsRestrictionsUi', i) as IDataObject
+							).notificationRecipientsRestrictionsValues as IDataObject;
+							const notificationRecipientsRestrictions: NotificationRecipientsRestrictions = {};
+							if (notificationRecipientsRestrictionsValues) {
+								if (
+									((notificationRecipientsRestrictionsValues.groups as IDataObject[]) || [])
+										.length > 0
+								) {
+									notificationRecipientsRestrictions.groups = (
+										notificationRecipientsRestrictionsValues.groups as IDataObject[]
+									).map((group) => {
+										return {
+											name: group,
+										};
+									});
+								}
+							}
+							body.restrict = notificationRecipientsRestrictions;
+						} else {
+							const notificationRecipientsJson = validateJSON(
+								this.getNodeParameter('notificationRecipientsJson', i) as string,
+							);
+							if (notificationRecipientsJson) {
+								body.to = notificationRecipientsJson;
+							}
+							const notificationRecipientsRestrictionsJson = validateJSON(
+								this.getNodeParameter('notificationRecipientsRestrictionsJson', i) as string,
+							);
+							if (notificationRecipientsRestrictionsJson) {
+								body.restrict = notificationRecipientsRestrictionsJson;
 							}
 						}
-						body.to = notificationRecipients;
-						const notificationRecipientsRestrictionsValues = (
-							this.getNodeParameter('notificationRecipientsRestrictionsUi', i) as IDataObject
-						).notificationRecipientsRestrictionsValues as IDataObject;
-						const notificationRecipientsRestrictions: NotificationRecipientsRestrictions = {};
-						if (notificationRecipientsRestrictionsValues) {
-							if (
-								((notificationRecipientsRestrictionsValues.groups as IDataObject[]) || []).length >
-								0
-							) {
-								notificationRecipientsRestrictions.groups = (
-									notificationRecipientsRestrictionsValues.groups as IDataObject[]
-								).map((group) => {
-									return {
-										name: group,
-									};
-								});
-							}
-						}
-						body.restrict = notificationRecipientsRestrictions;
-					} else {
-						const notificationRecipientsJson = validateJSON(
-							this.getNodeParameter('notificationRecipientsJson', i) as string,
+						responseData = await jiraSoftwareCloudApiRequest.call(
+							this,
+							`/api/2/issue/${issueKey}/notify`,
+							'POST',
+							body,
+							qs,
 						);
-						if (notificationRecipientsJson) {
-							body.to = notificationRecipientsJson;
-						}
-						const notificationRecipientsRestrictionsJson = validateJSON(
-							this.getNodeParameter('notificationRecipientsRestrictionsJson', i) as string,
+
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray({ success: true }),
+							{ itemData: { item: i } },
 						);
-						if (notificationRecipientsRestrictionsJson) {
-							body.restrict = notificationRecipientsRestrictionsJson;
+
+						returnData.push(...executionData);
+					} catch (error) {
+						if (this.continueOnFail()) {
+							const executionData = this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray({ error: error.message }),
+								{ itemData: { item: i } },
+							);
+							returnData.push(...executionData);
+							continue;
 						}
+						throw error;
 					}
-					responseData = await jiraSoftwareCloudApiRequest.call(
-						this,
-						`/api/2/issue/${issueKey}/notify`,
-						'POST',
-						body,
-						qs,
-					);
-
-					const executionData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray({ success: true }), //endpoint returns no content
-						{ itemData: { item: i } },
-					);
-
-					returnData.push(...executionData);
 				}
 			}
 			//https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issue-issueIdOrKey-transitions-get
 			if (operation === 'transitions') {
 				for (let i = 0; i < length; i++) {
-					const issueKey = this.getNodeParameter('issueKey', i) as string;
-					const additionalFields = this.getNodeParameter('additionalFields', i);
-					if (additionalFields.transitionId) {
-						qs.transitionId = additionalFields.transitionId as string;
-					}
-					if (additionalFields.expand) {
-						qs.expand = additionalFields.expand as string;
-					}
-					if (additionalFields.skipRemoteOnlyCondition) {
-						qs.skipRemoteOnlyCondition = additionalFields.skipRemoteOnlyCondition as boolean;
-					}
-					responseData = await jiraSoftwareCloudApiRequest.call(
-						this,
-						`/api/2/issue/${issueKey}/transitions`,
-						'GET',
-						{},
-						qs,
-					);
-					responseData = responseData.transitions;
+					try {
+						const issueKey = this.getNodeParameter('issueKey', i) as string;
+						const additionalFields = this.getNodeParameter('additionalFields', i);
+						if (additionalFields.transitionId) {
+							qs.transitionId = additionalFields.transitionId as string;
+						}
+						if (additionalFields.expand) {
+							qs.expand = additionalFields.expand as string;
+						}
+						if (additionalFields.skipRemoteOnlyCondition) {
+							qs.skipRemoteOnlyCondition = additionalFields.skipRemoteOnlyCondition as boolean;
+						}
+						responseData = await jiraSoftwareCloudApiRequest.call(
+							this,
+							`/api/2/issue/${issueKey}/transitions`,
+							'GET',
+							{},
+							qs,
+						);
+						responseData = responseData.transitions;
 
-					const executionData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray(responseData as IDataObject[]),
-						{ itemData: { item: i } },
-					);
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray(responseData as IDataObject[]),
+							{ itemData: { item: i } },
+						);
 
-					returnData.push(...executionData);
+						returnData.push(...executionData);
+					} catch (error) {
+						if (this.continueOnFail()) {
+							const executionData = this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray({ error: error.message }),
+								{ itemData: { item: i } },
+							);
+							returnData.push(...executionData);
+							continue;
+						}
+						throw error;
+					}
 				}
 			}
 			//https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issue-issueIdOrKey-delete
 			if (operation === 'delete') {
 				for (let i = 0; i < length; i++) {
-					const issueKey = this.getNodeParameter('issueKey', i) as string;
-					const deleteSubtasks = this.getNodeParameter('deleteSubtasks', i) as boolean;
-					qs.deleteSubtasks = deleteSubtasks;
-					responseData = await jiraSoftwareCloudApiRequest.call(
-						this,
-						`/api/2/issue/${issueKey}`,
-						'DELETE',
-						{},
-						qs,
-					);
+					try {
+						const issueKey = this.getNodeParameter('issueKey', i) as string;
+						const deleteSubtasks = this.getNodeParameter('deleteSubtasks', i) as boolean;
+						qs.deleteSubtasks = deleteSubtasks;
+						responseData = await jiraSoftwareCloudApiRequest.call(
+							this,
+							`/api/2/issue/${issueKey}`,
+							'DELETE',
+							{},
+							qs,
+						);
 
-					const executionData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray({ success: true }),
-						{ itemData: { item: i } },
-					);
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray({ success: true }),
+							{ itemData: { item: i } },
+						);
 
-					returnData.push(...executionData);
+						returnData.push(...executionData);
+					} catch (error) {
+						if (this.continueOnFail()) {
+							const executionData = this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray({ error: error.message }),
+								{ itemData: { item: i } },
+							);
+							returnData.push(...executionData);
+							continue;
+						}
+						throw error;
+					}
 				}
 			}
 		}
@@ -1068,87 +1172,124 @@ export class Jira implements INodeType {
 			//https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-attachments/#api-rest-api-3-issue-issueidorkey-attachments-post
 			if (operation === 'add') {
 				for (let i = 0; i < length; i++) {
-					const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
-					const issueKey = this.getNodeParameter('issueKey', i) as string;
-					const binaryData = this.helpers.assertBinaryData(i, binaryPropertyName);
+					try {
+						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
+						const issueKey = this.getNodeParameter('issueKey', i) as string;
+						const binaryData = this.helpers.assertBinaryData(i, binaryPropertyName);
 
-					let uploadData: Buffer | Readable;
-					if (binaryData.id) {
-						uploadData = await this.helpers.getBinaryStream(binaryData.id);
-					} else {
-						uploadData = Buffer.from(binaryData.data, BINARY_ENCODING);
-					}
+						let uploadData: Buffer | Readable;
+						if (binaryData.id) {
+							uploadData = await this.helpers.getBinaryStream(binaryData.id);
+						} else {
+							uploadData = Buffer.from(binaryData.data, BINARY_ENCODING);
+						}
 
-					responseData = await jiraSoftwareCloudApiRequest.call(
-						this,
-						`/api/${apiVersion}/issue/${issueKey}/attachments`,
-						'POST',
-						{},
-						{},
-						undefined,
-						{
-							formData: {
-								file: {
-									value: uploadData,
-									options: {
-										filename: binaryData.fileName,
+						responseData = await jiraSoftwareCloudApiRequest.call(
+							this,
+							`/api/${apiVersion}/issue/${issueKey}/attachments`,
+							'POST',
+							{},
+							{},
+							undefined,
+							{
+								formData: {
+									file: {
+										value: uploadData,
+										options: {
+											filename: binaryData.fileName,
+										},
 									},
 								},
 							},
-						},
-					);
+						);
 
-					const executionData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray(responseData as IDataObject[]),
-						{ itemData: { item: i } },
-					);
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray(responseData as IDataObject[]),
+							{ itemData: { item: i } },
+						);
 
-					returnData.push(...executionData);
+						returnData.push(...executionData);
+					} catch (error) {
+						if (this.continueOnFail()) {
+							const executionData = this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray({ error: error.message }),
+								{ itemData: { item: i } },
+							);
+							returnData.push(...executionData);
+							continue;
+						}
+						throw error;
+					}
 				}
 			}
 			//https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-attachments/#api-rest-api-3-attachment-id-delete
 			if (operation === 'remove') {
 				for (let i = 0; i < length; i++) {
-					const attachmentId = this.getNodeParameter('attachmentId', i) as string;
-					responseData = await jiraSoftwareCloudApiRequest.call(
-						this,
-						`/api/${apiVersion}/attachment/${attachmentId}`,
-						'DELETE',
-						{},
-						qs,
-					);
+					try {
+						const attachmentId = this.getNodeParameter('attachmentId', i) as string;
+						responseData = await jiraSoftwareCloudApiRequest.call(
+							this,
+							`/api/${apiVersion}/attachment/${attachmentId}`,
+							'DELETE',
+							{},
+							qs,
+						);
 
-					const executionData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray({ success: true }),
-						{ itemData: { item: i } },
-					);
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray({ success: true }),
+							{ itemData: { item: i } },
+						);
 
-					returnData.push(...executionData);
+						returnData.push(...executionData);
+					} catch (error) {
+						if (this.continueOnFail()) {
+							const executionData = this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray({ error: error.message }),
+								{ itemData: { item: i } },
+							);
+							returnData.push(...executionData);
+							continue;
+						}
+						throw error;
+					}
 				}
 			}
 			//https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-attachments/#api-rest-api-3-attachment-id-get
 			if (operation === 'get') {
 				const download = this.getNodeParameter('download', 0);
 				for (let i = 0; i < length; i++) {
-					const attachmentId = this.getNodeParameter('attachmentId', i) as string;
-					responseData = await jiraSoftwareCloudApiRequest.call(
-						this,
-						`/api/${apiVersion}/attachment/${attachmentId}`,
-						'GET',
-						{},
-						qs,
-					);
+					try {
+						const attachmentId = this.getNodeParameter('attachmentId', i) as string;
+						responseData = await jiraSoftwareCloudApiRequest.call(
+							this,
+							`/api/${apiVersion}/attachment/${attachmentId}`,
+							'GET',
+							{},
+							qs,
+						);
 
-					const executionData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray(responseData as IDataObject[]),
-						{ itemData: { item: i } },
-					);
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray(responseData as IDataObject[]),
+							{ itemData: { item: i } },
+						);
 
-					returnData.push(...executionData);
+						returnData.push(...executionData);
+					} catch (error) {
+						if (this.continueOnFail()) {
+							const executionData = this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray({ error: error.message }),
+								{ itemData: { item: i } },
+							);
+							returnData.push(...executionData);
+							continue;
+						}
+						throw error;
+					}
 				}
 				if (download) {
 					const binaryPropertyName = this.getNodeParameter('binaryProperty', 0);
 					for (const [index, attachment] of returnData.entries()) {
+						if (attachment.json.error) continue;
 						returnData[index].binary = {};
 
 						const buffer = await jiraSoftwareCloudApiRequest.call(
@@ -1172,34 +1313,47 @@ export class Jira implements INodeType {
 			if (operation === 'getAll') {
 				const download = this.getNodeParameter('download', 0);
 				for (let i = 0; i < length; i++) {
-					const issueKey = this.getNodeParameter('issueKey', i) as string;
-					const returnAll = this.getNodeParameter('returnAll', i);
-					const {
-						fields: { attachment },
-					} = await jiraSoftwareCloudApiRequest.call(
-						this,
-						`/api/2/issue/${issueKey}`,
-						'GET',
-						{},
-						qs,
-					);
-					responseData = attachment;
-					if (!returnAll) {
-						const limit = this.getNodeParameter('limit', i);
-						responseData = responseData.slice(0, limit);
+					try {
+						const issueKey = this.getNodeParameter('issueKey', i) as string;
+						const returnAll = this.getNodeParameter('returnAll', i);
+						const {
+							fields: { attachment },
+						} = await jiraSoftwareCloudApiRequest.call(
+							this,
+							`/api/2/issue/${issueKey}`,
+							'GET',
+							{},
+							qs,
+						);
+						responseData = attachment;
+						if (!returnAll) {
+							const limit = this.getNodeParameter('limit', i);
+							responseData = responseData.slice(0, limit);
+						}
+						responseData = responseData.map((data: IDataObject) => ({ json: data }));
+
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray(responseData as IDataObject[]),
+							{ itemData: { item: i } },
+						);
+
+						returnData.push(...executionData);
+					} catch (error) {
+						if (this.continueOnFail()) {
+							const executionData = this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray({ error: error.message }),
+								{ itemData: { item: i } },
+							);
+							returnData.push(...executionData);
+							continue;
+						}
+						throw error;
 					}
-					responseData = responseData.map((data: IDataObject) => ({ json: data }));
-
-					const executionData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray(responseData as IDataObject[]),
-						{ itemData: { item: i } },
-					);
-
-					returnData.push(...executionData);
 				}
 				if (download) {
 					const binaryPropertyName = this.getNodeParameter('binaryProperty', 0);
 					for (const [index, attachment] of returnData.entries()) {
+						if (attachment.json.error) continue;
 						returnData[index].binary = {};
 						const buffer = await jiraSoftwareCloudApiRequest.call(
 							this,
@@ -1227,219 +1381,287 @@ export class Jira implements INodeType {
 			//https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-post
 			if (operation === 'add') {
 				for (let i = 0; i < length; i++) {
-					const jsonParameters = this.getNodeParameter('jsonParameters', 0);
-					const issueKey = this.getNodeParameter('issueKey', i) as string;
-					const options = this.getNodeParameter('options', i);
+					try {
+						const jsonParameters = this.getNodeParameter('jsonParameters', 0);
+						const issueKey = this.getNodeParameter('issueKey', i) as string;
+						const options = this.getNodeParameter('options', i);
 
-					if (options.wikiMarkup) {
-						apiVersion = '2';
-					}
+						if (options.wikiMarkup) {
+							apiVersion = '2';
+						}
 
-					const body: IDataObject = {};
-					if (options.expand) {
-						qs.expand = options.expand as string;
-						delete options.expand;
-					}
+						const body: IDataObject = {};
+						if (options.expand) {
+							qs.expand = options.expand as string;
+							delete options.expand;
+						}
 
-					Object.assign(body, options);
-					if (!jsonParameters) {
-						const comment = this.getNodeParameter('comment', i) as string;
-						if (jiraVersion === 'server' || jiraVersion === 'serverPat' || options.wikiMarkup) {
-							Object.assign(body, { body: comment });
+						Object.assign(body, options);
+						if (!jsonParameters) {
+							const comment = this.getNodeParameter('comment', i) as string;
+							if (jiraVersion === 'server' || jiraVersion === 'serverPat' || options.wikiMarkup) {
+								Object.assign(body, { body: comment });
+							} else {
+								Object.assign(body, {
+									body: {
+										type: 'doc',
+										version: 1,
+										content: [
+											{
+												type: 'paragraph',
+												content: [
+													{
+														type: 'text',
+														text: comment,
+													},
+												],
+											},
+										],
+									},
+								});
+							}
 						} else {
-							Object.assign(body, {
-								body: {
-									type: 'doc',
-									version: 1,
-									content: [
-										{
-											type: 'paragraph',
-											content: [
-												{
-													type: 'text',
-													text: comment,
-												},
-											],
-										},
-									],
-								},
-							});
-						}
-					} else {
-						const commentJson = this.getNodeParameter('commentJson', i) as string;
-						const json = validateJSON(commentJson);
-						if (json === '') {
-							throw new NodeOperationError(this.getNode(), 'Document Format must be a valid JSON', {
-								itemIndex: i,
-							});
+							const commentJson = this.getNodeParameter('commentJson', i) as string;
+							const json = validateJSON(commentJson);
+							if (json === '') {
+								throw new NodeOperationError(
+									this.getNode(),
+									'Document Format must be a valid JSON',
+									{
+										itemIndex: i,
+									},
+								);
+							}
+
+							Object.assign(body, { body: json });
 						}
 
-						Object.assign(body, { body: json });
+						responseData = await jiraSoftwareCloudApiRequest.call(
+							this,
+							`/api/${apiVersion}/issue/${issueKey}/comment`,
+							'POST',
+							body,
+							qs,
+						);
+
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray(responseData as IDataObject[]),
+							{ itemData: { item: i } },
+						);
+
+						returnData.push(...executionData);
+					} catch (error) {
+						if (this.continueOnFail()) {
+							const executionData = this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray({ error: error.message }),
+								{ itemData: { item: i } },
+							);
+							returnData.push(...executionData);
+							continue;
+						}
+						throw error;
 					}
-
-					responseData = await jiraSoftwareCloudApiRequest.call(
-						this,
-						`/api/${apiVersion}/issue/${issueKey}/comment`,
-						'POST',
-						body,
-						qs,
-					);
-
-					const executionData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray(responseData as IDataObject[]),
-						{ itemData: { item: i } },
-					);
-
-					returnData.push(...executionData);
 				}
 			}
 			//https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issue-issueIdOrKey-get
 			if (operation === 'get') {
 				for (let i = 0; i < length; i++) {
-					const issueKey = this.getNodeParameter('issueKey', i) as string;
-					const commentId = this.getNodeParameter('commentId', i) as string;
-					const options = this.getNodeParameter('options', i);
-					Object.assign(qs, options);
-					responseData = await jiraSoftwareCloudApiRequest.call(
-						this,
-						`/api/${apiVersion}/issue/${issueKey}/comment/${commentId}`,
-						'GET',
-						{},
-						qs,
-					);
+					try {
+						const issueKey = this.getNodeParameter('issueKey', i) as string;
+						const commentId = this.getNodeParameter('commentId', i) as string;
+						const options = this.getNodeParameter('options', i);
+						Object.assign(qs, options);
+						responseData = await jiraSoftwareCloudApiRequest.call(
+							this,
+							`/api/${apiVersion}/issue/${issueKey}/comment/${commentId}`,
+							'GET',
+							{},
+							qs,
+						);
 
-					const executionData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray(responseData as IDataObject[]),
-						{ itemData: { item: i } },
-					);
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray(responseData as IDataObject[]),
+							{ itemData: { item: i } },
+						);
 
-					returnData.push(...executionData);
+						returnData.push(...executionData);
+					} catch (error) {
+						if (this.continueOnFail()) {
+							const executionData = this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray({ error: error.message }),
+								{ itemData: { item: i } },
+							);
+							returnData.push(...executionData);
+							continue;
+						}
+						throw error;
+					}
 				}
 			}
 			//https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-get
 			if (operation === 'getAll') {
 				for (let i = 0; i < length; i++) {
-					const issueKey = this.getNodeParameter('issueKey', i) as string;
-					const returnAll = this.getNodeParameter('returnAll', i);
-					const options = this.getNodeParameter('options', i);
-					Object.assign(qs, options);
-					if (returnAll) {
-						responseData = await jiraSoftwareCloudApiRequestAllItems.call(
-							this,
-							'comments',
-							`/api/${apiVersion}/issue/${issueKey}/comment`,
-							'GET',
-							{},
-							qs,
+					try {
+						const issueKey = this.getNodeParameter('issueKey', i) as string;
+						const returnAll = this.getNodeParameter('returnAll', i);
+						const options = this.getNodeParameter('options', i);
+						Object.assign(qs, options);
+						if (returnAll) {
+							responseData = await jiraSoftwareCloudApiRequestAllItems.call(
+								this,
+								'comments',
+								`/api/${apiVersion}/issue/${issueKey}/comment`,
+								'GET',
+								{},
+								qs,
+							);
+						} else {
+							const limit = this.getNodeParameter('limit', i);
+							qs.maxResults = limit;
+							responseData = await jiraSoftwareCloudApiRequest.call(
+								this,
+								`/api/${apiVersion}/issue/${issueKey}/comment`,
+								'GET',
+								{},
+								qs,
+							);
+							responseData = responseData.comments;
+						}
+
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray(responseData as IDataObject[]),
+							{ itemData: { item: i } },
 						);
-					} else {
-						const limit = this.getNodeParameter('limit', i);
-						qs.maxResults = limit;
-						responseData = await jiraSoftwareCloudApiRequest.call(
-							this,
-							`/api/${apiVersion}/issue/${issueKey}/comment`,
-							'GET',
-							{},
-							qs,
-						);
-						responseData = responseData.comments;
+
+						returnData.push(...executionData);
+					} catch (error) {
+						if (this.continueOnFail()) {
+							const executionData = this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray({ error: error.message }),
+								{ itemData: { item: i } },
+							);
+							returnData.push(...executionData);
+							continue;
+						}
+						throw error;
 					}
-
-					const executionData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray(responseData as IDataObject[]),
-						{ itemData: { item: i } },
-					);
-
-					returnData.push(...executionData);
 				}
 			}
 			//https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-id-delete
 			if (operation === 'remove') {
 				for (let i = 0; i < length; i++) {
-					const issueKey = this.getNodeParameter('issueKey', i) as string;
-					const commentId = this.getNodeParameter('commentId', i) as string;
-					responseData = await jiraSoftwareCloudApiRequest.call(
-						this,
-						`/api/${apiVersion}/issue/${issueKey}/comment/${commentId}`,
-						'DELETE',
-						{},
-						qs,
-					);
+					try {
+						const issueKey = this.getNodeParameter('issueKey', i) as string;
+						const commentId = this.getNodeParameter('commentId', i) as string;
+						responseData = await jiraSoftwareCloudApiRequest.call(
+							this,
+							`/api/${apiVersion}/issue/${issueKey}/comment/${commentId}`,
+							'DELETE',
+							{},
+							qs,
+						);
 
-					const executionData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray({ success: true }),
-						{ itemData: { item: i } },
-					);
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray({ success: true }),
+							{ itemData: { item: i } },
+						);
 
-					returnData.push(...executionData);
+						returnData.push(...executionData);
+					} catch (error) {
+						if (this.continueOnFail()) {
+							const executionData = this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray({ error: error.message }),
+								{ itemData: { item: i } },
+							);
+							returnData.push(...executionData);
+							continue;
+						}
+						throw error;
+					}
 				}
 			}
 			//https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-id-put
 			if (operation === 'update') {
 				for (let i = 0; i < length; i++) {
-					const issueKey = this.getNodeParameter('issueKey', i) as string;
-					const commentId = this.getNodeParameter('commentId', i) as string;
-					const options = this.getNodeParameter('options', i);
-					const jsonParameters = this.getNodeParameter('jsonParameters', 0);
-					const body: IDataObject = {};
-					if (options.expand) {
-						qs.expand = options.expand as string;
-						delete options.expand;
-					}
+					try {
+						const issueKey = this.getNodeParameter('issueKey', i) as string;
+						const commentId = this.getNodeParameter('commentId', i) as string;
+						const options = this.getNodeParameter('options', i);
+						const jsonParameters = this.getNodeParameter('jsonParameters', 0);
+						const body: IDataObject = {};
+						if (options.expand) {
+							qs.expand = options.expand as string;
+							delete options.expand;
+						}
 
-					if (options.wikiMarkup) {
-						apiVersion = '2';
-					}
+						if (options.wikiMarkup) {
+							apiVersion = '2';
+						}
 
-					Object.assign(qs, options);
-					if (!jsonParameters) {
-						const comment = this.getNodeParameter('comment', i) as string;
-						if (jiraVersion === 'server' || jiraVersion === 'serverPat' || options.wikiMarkup) {
-							Object.assign(body, { body: comment });
+						Object.assign(qs, options);
+						if (!jsonParameters) {
+							const comment = this.getNodeParameter('comment', i) as string;
+							if (jiraVersion === 'server' || jiraVersion === 'serverPat' || options.wikiMarkup) {
+								Object.assign(body, { body: comment });
+							} else {
+								Object.assign(body, {
+									body: {
+										type: 'doc',
+										version: 1,
+										content: [
+											{
+												type: 'paragraph',
+												content: [
+													{
+														type: 'text',
+														text: comment,
+													},
+												],
+											},
+										],
+									},
+								});
+							}
 						} else {
-							Object.assign(body, {
-								body: {
-									type: 'doc',
-									version: 1,
-									content: [
-										{
-											type: 'paragraph',
-											content: [
-												{
-													type: 'text',
-													text: comment,
-												},
-											],
-										},
-									],
-								},
-							});
-						}
-					} else {
-						const commentJson = this.getNodeParameter('commentJson', i) as string;
-						const json = validateJSON(commentJson);
-						if (json === '') {
-							throw new NodeOperationError(this.getNode(), 'Document Format must be a valid JSON', {
-								itemIndex: i,
-							});
-						}
+							const commentJson = this.getNodeParameter('commentJson', i) as string;
+							const json = validateJSON(commentJson);
+							if (json === '') {
+								throw new NodeOperationError(
+									this.getNode(),
+									'Document Format must be a valid JSON',
+									{
+										itemIndex: i,
+									},
+								);
+							}
 
-						Object.assign(body, { body: json });
+							Object.assign(body, { body: json });
+						}
+						responseData = await jiraSoftwareCloudApiRequest.call(
+							this,
+							`/api/${apiVersion}/issue/${issueKey}/comment/${commentId}`,
+							'PUT',
+							body,
+							qs,
+						);
+
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray(responseData as IDataObject[]),
+							{ itemData: { item: i } },
+						);
+
+						returnData.push(...executionData);
+					} catch (error) {
+						if (this.continueOnFail()) {
+							const executionData = this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray({ error: error.message }),
+								{ itemData: { item: i } },
+							);
+							returnData.push(...executionData);
+							continue;
+						}
+						throw error;
 					}
-					responseData = await jiraSoftwareCloudApiRequest.call(
-						this,
-						`/api/${apiVersion}/issue/${issueKey}/comment/${commentId}`,
-						'PUT',
-						body,
-						qs,
-					);
-
-					const executionData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray(responseData as IDataObject[]),
-						{ itemData: { item: i } },
-					);
-
-					returnData.push(...executionData);
 				}
 			}
 		}
@@ -1451,75 +1673,113 @@ export class Jira implements INodeType {
 			if (operation === 'create') {
 				// https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-users/#api-rest-api-3-user-post
 				for (let i = 0; i < length; i++) {
-					const body = {
-						name: this.getNodeParameter('username', i),
-						emailAddress: this.getNodeParameter('emailAddress', i),
-						displayName: this.getNodeParameter('displayName', i),
-					};
+					try {
+						const body = {
+							name: this.getNodeParameter('username', i),
+							emailAddress: this.getNodeParameter('emailAddress', i),
+							displayName: this.getNodeParameter('displayName', i),
+						};
 
-					const additionalFields = this.getNodeParameter('additionalFields', i);
+						const additionalFields = this.getNodeParameter('additionalFields', i);
 
-					Object.assign(body, additionalFields);
+						Object.assign(body, additionalFields);
 
-					responseData = await jiraSoftwareCloudApiRequest.call(
-						this,
-						`/api/${apiVersion}/user`,
-						'POST',
-						body,
-						{},
-					);
+						responseData = await jiraSoftwareCloudApiRequest.call(
+							this,
+							`/api/${apiVersion}/user`,
+							'POST',
+							body,
+							{},
+						);
 
-					const executionData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray(responseData as IDataObject[]),
-						{ itemData: { item: i } },
-					);
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray(responseData as IDataObject[]),
+							{ itemData: { item: i } },
+						);
 
-					returnData.push(...executionData);
+						returnData.push(...executionData);
+					} catch (error) {
+						if (this.continueOnFail()) {
+							const executionData = this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray({ error: error.message }),
+								{ itemData: { item: i } },
+							);
+							returnData.push(...executionData);
+							continue;
+						}
+						throw error;
+					}
 				}
 			} else if (operation === 'delete') {
 				// https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-users/#api-rest-api-3-user-delete
 				for (let i = 0; i < length; i++) {
-					qs.accountId = this.getNodeParameter('accountId', i);
-					responseData = await jiraSoftwareCloudApiRequest.call(
-						this,
-						`/api/${apiVersion}/user`,
-						'DELETE',
-						{},
-						qs,
-					);
+					try {
+						qs.accountId = this.getNodeParameter('accountId', i);
+						responseData = await jiraSoftwareCloudApiRequest.call(
+							this,
+							`/api/${apiVersion}/user`,
+							'DELETE',
+							{},
+							qs,
+						);
 
-					const executionData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray({ success: true }),
-						{ itemData: { item: i } },
-					);
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray({ success: true }),
+							{ itemData: { item: i } },
+						);
 
-					returnData.push(...executionData);
+						returnData.push(...executionData);
+					} catch (error) {
+						if (this.continueOnFail()) {
+							const executionData = this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray({ error: error.message }),
+								{ itemData: { item: i } },
+							);
+							returnData.push(...executionData);
+							continue;
+						}
+						throw error;
+					}
 				}
 			} else if (operation === 'get') {
 				// https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-users/#api-rest-api-3-user-get
 				for (let i = 0; i < length; i++) {
-					qs.accountId = this.getNodeParameter('accountId', i);
+					try {
+						qs.accountId = this.getNodeParameter('accountId', i);
 
-					const { expand } = this.getNodeParameter('additionalFields', i) as { expand: string[] };
+						const { expand } = this.getNodeParameter('additionalFields', i) as {
+							expand: string[];
+						};
 
-					if (expand) {
-						qs.expand = expand.join(',');
+						if (expand) {
+							qs.expand = expand.join(',');
+						}
+
+						responseData = await jiraSoftwareCloudApiRequest.call(
+							this,
+							`/api/${apiVersion}/user`,
+							'GET',
+							{},
+							qs,
+						);
+
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray(responseData as IDataObject[]),
+							{ itemData: { item: i } },
+						);
+
+						returnData.push(...executionData);
+					} catch (error) {
+						if (this.continueOnFail()) {
+							const executionData = this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray({ error: error.message }),
+								{ itemData: { item: i } },
+							);
+							returnData.push(...executionData);
+							continue;
+						}
+						throw error;
 					}
-
-					responseData = await jiraSoftwareCloudApiRequest.call(
-						this,
-						`/api/${apiVersion}/user`,
-						'GET',
-						{},
-						qs,
-					);
-
-					const executionData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray(responseData as IDataObject[]),
-						{ itemData: { item: i } },
-					);
-
-					returnData.push(...executionData);
 				}
 			}
 		}

--- a/packages/nodes-base/nodes/Jira/Jira.node.ts
+++ b/packages/nodes-base/nodes/Jira/Jira.node.ts
@@ -1310,9 +1310,7 @@ export class Jira implements INodeType {
 							);
 						} catch (error) {
 							if (this.continueOnFail()) {
-								returnData[index] = {
-									json: { error: error.message },
-								};
+								returnData[index].json = { error: error.message };
 								continue;
 							}
 							throw error;
@@ -1382,9 +1380,7 @@ export class Jira implements INodeType {
 							);
 						} catch (error) {
 							if (this.continueOnFail()) {
-								returnData[index] = {
-									json: { error: error.message },
-								};
+								returnData[index].json = { error: error.message };
 								continue;
 							}
 							throw error;

--- a/packages/nodes-base/nodes/Jira/Jira.node.ts
+++ b/packages/nodes-base/nodes/Jira/Jira.node.ts
@@ -1290,23 +1290,33 @@ export class Jira implements INodeType {
 					const binaryPropertyName = this.getNodeParameter('binaryProperty', 0);
 					for (const [index, attachment] of returnData.entries()) {
 						if (attachment.json.error) continue;
-						returnData[index].binary = {};
+						try {
+							returnData[index].binary = {};
 
-						const buffer = await jiraSoftwareCloudApiRequest.call(
-							this,
-							'',
-							'GET',
-							{},
-							{},
-							attachment?.json.content as string,
-							{ json: false, encoding: null, useStream: true },
-						);
+							const buffer = await jiraSoftwareCloudApiRequest.call(
+								this,
+								'',
+								'GET',
+								{},
+								{},
+								attachment?.json.content as string,
+								{ json: false, encoding: null, useStream: true },
+							);
 
-						returnData[index].binary[binaryPropertyName] = await this.helpers.prepareBinaryData(
-							buffer as Buffer,
-							attachment.json.filename as string,
-							attachment.json.mimeType as string,
-						);
+							returnData[index].binary[binaryPropertyName] = await this.helpers.prepareBinaryData(
+								buffer as Buffer,
+								attachment.json.filename as string,
+								attachment.json.mimeType as string,
+							);
+						} catch (error) {
+							if (this.continueOnFail()) {
+								returnData[index] = {
+									json: { error: error.message },
+								};
+								continue;
+							}
+							throw error;
+						}
 					}
 				}
 			}
@@ -1354,21 +1364,31 @@ export class Jira implements INodeType {
 					const binaryPropertyName = this.getNodeParameter('binaryProperty', 0);
 					for (const [index, attachment] of returnData.entries()) {
 						if (attachment.json.error) continue;
-						returnData[index].binary = {};
-						const buffer = await jiraSoftwareCloudApiRequest.call(
-							this,
-							'',
-							'GET',
-							{},
-							{},
-							attachment.json.content as string,
-							{ json: false, encoding: null, useStream: true },
-						);
-						returnData[index].binary[binaryPropertyName] = await this.helpers.prepareBinaryData(
-							buffer as Buffer,
-							attachment.json.filename as string,
-							attachment.json.mimeType as string,
-						);
+						try {
+							returnData[index].binary = {};
+							const buffer = await jiraSoftwareCloudApiRequest.call(
+								this,
+								'',
+								'GET',
+								{},
+								{},
+								attachment.json.content as string,
+								{ json: false, encoding: null, useStream: true },
+							);
+							returnData[index].binary[binaryPropertyName] = await this.helpers.prepareBinaryData(
+								buffer as Buffer,
+								attachment.json.filename as string,
+								attachment.json.mimeType as string,
+							);
+						} catch (error) {
+							if (this.continueOnFail()) {
+								returnData[index] = {
+									json: { error: error.message },
+								};
+								continue;
+							}
+							throw error;
+						}
 					}
 				}
 			}

--- a/packages/nodes-base/nodes/Jira/__test__/Jira.node.test.ts
+++ b/packages/nodes-base/nodes/Jira/__test__/Jira.node.test.ts
@@ -315,7 +315,7 @@ describe('Jira Node', () => {
 			);
 		});
 
-		it('should return error item when attachment download fails and continueOnFail is true', async () => {
+		it('should return error item with preserved paired-item metadata when attachment download fails', async () => {
 			const attachmentMeta = {
 				id: '10001',
 				filename: 'file.txt',
@@ -332,8 +332,11 @@ describe('Jira Node', () => {
 					[{ json: data as IDataObject }] as INodeExecutionData[],
 			);
 			executeFunctionsMock.helpers.constructExecutionMetaData.mockImplementation(
-				(items) =>
-					items as unknown as ReturnType<
+				(items, { itemData }) =>
+					items.map((item) => ({
+						...item,
+						pairedItem: itemData,
+					})) as unknown as ReturnType<
 						typeof executeFunctionsMock.helpers.constructExecutionMetaData
 					>,
 			);
@@ -365,7 +368,7 @@ describe('Jira Node', () => {
 
 			expect(result[0]).toHaveLength(1);
 			expect(result[0][0].json).toEqual({ error: 'Download failed' });
-			expect(result[0][0].binary).toBeUndefined();
+			expect(result[0][0].pairedItem).toEqual({ item: 0 });
 		});
 
 		it('should return error items for failed items and success items for passing items', async () => {

--- a/packages/nodes-base/nodes/Jira/__test__/Jira.node.test.ts
+++ b/packages/nodes-base/nodes/Jira/__test__/Jira.node.test.ts
@@ -315,6 +315,59 @@ describe('Jira Node', () => {
 			);
 		});
 
+		it('should return error item when attachment download fails and continueOnFail is true', async () => {
+			const attachmentMeta = {
+				id: '10001',
+				filename: 'file.txt',
+				mimeType: 'text/plain',
+				content: 'https://jira.example.com/attachments/10001',
+			};
+			jiraSoftwareCloudApiRequestMock
+				.mockResolvedValueOnce(attachmentMeta)
+				.mockRejectedValueOnce(new Error('Download failed'));
+
+			executeFunctionsMock.continueOnFail.mockReturnValue(true);
+			executeFunctionsMock.helpers.returnJsonArray.mockImplementation(
+				(data: IDataObject | IDataObject[]) =>
+					[{ json: data as IDataObject }] as INodeExecutionData[],
+			);
+			executeFunctionsMock.helpers.constructExecutionMetaData.mockImplementation(
+				(items) =>
+					items as unknown as ReturnType<
+						typeof executeFunctionsMock.helpers.constructExecutionMetaData
+					>,
+			);
+
+			executeFunctionsMock.getNodeParameter.mockImplementation((parameterName: string) => {
+				switch (parameterName) {
+					case 'resource':
+						return 'issueAttachment';
+					case 'operation':
+						return 'get';
+					case 'jiraVersion':
+						return 'cloud';
+					case 'attachmentId':
+						return '10001';
+					case 'download':
+						return true;
+					case 'binaryProperty':
+						return 'data';
+					default:
+						return null;
+				}
+			});
+			executeFunctionsMock.helpers.assertBinaryData.mockReturnValue({
+				mimeType: 'text/plain',
+				data: '',
+			});
+
+			const result = await jiraNode.execute.call(executeFunctionsMock);
+
+			expect(result[0]).toHaveLength(1);
+			expect(result[0][0].json).toEqual({ error: 'Download failed' });
+			expect(result[0][0].binary).toBeUndefined();
+		});
+
 		it('should return error items for failed items and success items for passing items', async () => {
 			const errorMessage = 'Issue does not exist';
 			jiraSoftwareCloudApiRequestMock

--- a/packages/nodes-base/nodes/Jira/__test__/Jira.node.test.ts
+++ b/packages/nodes-base/nodes/Jira/__test__/Jira.node.test.ts
@@ -1,6 +1,6 @@
 import type { DeepMockProxy } from 'jest-mock-extended';
 import { mockDeep } from 'jest-mock-extended';
-import type { IExecuteFunctions } from 'n8n-workflow';
+import type { IDataObject, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 
 import * as GenericFunctions from '../GenericFunctions';
 import { Jira } from '../Jira.node';
@@ -244,5 +244,123 @@ describe('Jira Node', () => {
 				);
 			},
 		);
+	});
+
+	describe('continueOnFail', () => {
+		it('should return error item when API request fails and continueOnFail is true', async () => {
+			const errorMessage = 'Issue does not exist';
+			jiraSoftwareCloudApiRequestMock.mockRejectedValueOnce(new Error(errorMessage));
+			executeFunctionsMock.continueOnFail.mockReturnValue(true);
+			executeFunctionsMock.helpers.returnJsonArray.mockImplementation(
+				(data: IDataObject | IDataObject[]) =>
+					[{ json: data as IDataObject }] as INodeExecutionData[],
+			);
+			executeFunctionsMock.helpers.constructExecutionMetaData.mockImplementation(
+				(items) =>
+					items as unknown as ReturnType<
+						typeof executeFunctionsMock.helpers.constructExecutionMetaData
+					>,
+			);
+
+			executeFunctionsMock.getNodeParameter.mockImplementation((parameterName: string) => {
+				switch (parameterName) {
+					case 'resource':
+						return 'issue';
+					case 'operation':
+						return 'get';
+					case 'jiraVersion':
+						return 'cloud';
+					case 'issueKey':
+						return 'TEST-123';
+					case 'simplifyOutput':
+						return false;
+					case 'additionalFields':
+						return {};
+					default:
+						return null;
+				}
+			});
+
+			const result = await jiraNode.execute.call(executeFunctionsMock);
+
+			expect(result).toEqual([[{ json: { error: errorMessage } }]]);
+		});
+
+		it('should throw when API request fails and continueOnFail is false', async () => {
+			const error = new Error('Issue does not exist');
+			jiraSoftwareCloudApiRequestMock.mockRejectedValueOnce(error);
+			executeFunctionsMock.continueOnFail.mockReturnValue(false);
+
+			executeFunctionsMock.getNodeParameter.mockImplementation((parameterName: string) => {
+				switch (parameterName) {
+					case 'resource':
+						return 'issue';
+					case 'operation':
+						return 'get';
+					case 'jiraVersion':
+						return 'cloud';
+					case 'issueKey':
+						return 'TEST-123';
+					case 'simplifyOutput':
+						return false;
+					case 'additionalFields':
+						return {};
+					default:
+						return null;
+				}
+			});
+
+			await expect(jiraNode.execute.call(executeFunctionsMock)).rejects.toThrow(
+				'Issue does not exist',
+			);
+		});
+
+		it('should return error items for failed items and success items for passing items', async () => {
+			const errorMessage = 'Issue does not exist';
+			jiraSoftwareCloudApiRequestMock
+				.mockResolvedValueOnce({ id: '1', key: 'TEST-1' })
+				.mockRejectedValueOnce(new Error(errorMessage))
+				.mockResolvedValueOnce({ id: '3', key: 'TEST-3' });
+
+			executeFunctionsMock.continueOnFail.mockReturnValue(true);
+			executeFunctionsMock.getInputData.mockReturnValue([{ json: {} }, { json: {} }, { json: {} }]);
+
+			executeFunctionsMock.helpers.returnJsonArray.mockImplementation(
+				(data: IDataObject | IDataObject[]) =>
+					[{ json: data as IDataObject }] as INodeExecutionData[],
+			);
+			executeFunctionsMock.helpers.constructExecutionMetaData.mockImplementation(
+				(items) =>
+					items as unknown as ReturnType<
+						typeof executeFunctionsMock.helpers.constructExecutionMetaData
+					>,
+			);
+
+			executeFunctionsMock.getNodeParameter.mockImplementation((parameterName: string) => {
+				switch (parameterName) {
+					case 'resource':
+						return 'issue';
+					case 'operation':
+						return 'get';
+					case 'jiraVersion':
+						return 'cloud';
+					case 'issueKey':
+						return 'TEST-123';
+					case 'simplifyOutput':
+						return false;
+					case 'additionalFields':
+						return {};
+					default:
+						return null;
+				}
+			});
+
+			const result = await jiraNode.execute.call(executeFunctionsMock);
+
+			expect(result[0]).toHaveLength(3);
+			expect(result[0][0].json).toEqual({ id: '1', key: 'TEST-1' });
+			expect(result[0][1].json).toEqual({ error: errorMessage });
+			expect(result[0][2].json).toEqual({ id: '3', key: 'TEST-3' });
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Adds `continueOnFail` support to all operations in the Jira node. Previously, when a single item failed (e.g., an issue didn't exist), the entire node execution would stop. Now, when "Continue On Fail" is enabled, failed items return `{ error: <message> }` and execution continues with remaining items.

Operations covered: Issue (create, update, get, getAll, changelog, notify, transitions, delete), Issue Attachment (add, remove, get, getAll), Issue Comment (add, get, getAll, remove, update), and User (create, delete, get).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3645

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

Made with [Cursor](https://cursor.com)