### PR TITLE
fix(editor): Adjust external secrets input styling

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
@@ -518,7 +518,7 @@ defineExpose({ focus, blur, select });
 }
 
 .input::placeholder {
-	color: var(--color--text--tint-2);
+	color: var(--color--text--tint-1);
 }
 
 .input:read-only {
@@ -527,7 +527,7 @@ defineExpose({ focus, blur, select });
 
 .input:disabled {
 	cursor: not-allowed;
-	color: var(--color--text--tint-2);
+	color: var(--color--text--tint-1);
 }
 
 .textarea {
@@ -544,7 +544,7 @@ defineExpose({ focus, blur, select });
 }
 
 .textarea::placeholder {
-	color: var(--color--text--tint-2);
+	color: var(--color--text--tint-1);
 }
 
 .textarea:read-only {
@@ -553,7 +553,7 @@ defineExpose({ focus, blur, select });
 
 .textarea:disabled {
 	cursor: not-allowed;
-	color: var(--color--text--tint-2);
+	color: var(--color--text--tint-1);
 }
 
 .prefix,

--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
@@ -518,7 +518,7 @@ defineExpose({ focus, blur, select });
 }
 
 .input::placeholder {
-	color: var(--color--text--subtler);
+	color: var(--color--text--tint-2);
 }
 
 .input:read-only {
@@ -527,7 +527,7 @@ defineExpose({ focus, blur, select });
 
 .input:disabled {
 	cursor: not-allowed;
-	color: var(--color--text--subtler);
+	color: var(--color--text--tint-2);
 }
 
 .textarea {
@@ -544,7 +544,7 @@ defineExpose({ focus, blur, select });
 }
 
 .textarea::placeholder {
-	color: var(--color--text--subtler);
+	color: var(--color--text--tint-2);
 }
 
 .textarea:read-only {
@@ -553,7 +553,7 @@ defineExpose({ focus, blur, select });
 
 .textarea:disabled {
 	cursor: not-allowed;
-	color: var(--color--text--subtler);
+	color: var(--color--text--tint-2);
 }
 
 .prefix,

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionModal.ee.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionModal.ee.vue
@@ -549,8 +549,8 @@ onMounted(async () => {
 
 .mainContent {
 	flex: 1;
-	overflow: auto;
 	padding-bottom: 60px;
+	padding-inline: var(--spacing--xs);
 }
 
 .icon {


### PR DESCRIPTION
## Summary
- Align external secrets input placeholder and disabled text styling with design tokens.
- Add horizontal padding to the external secrets connection modal content to prevent input borders from clipping.

| Before | After |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/4baf88a5-ae84-47b3-bec3-b9b533672ffc" width="960px" alt="before image" /> | <img src="https://github.com/user-attachments/assets/eabd4b1f-ebb8-49d9-9fcd-9b18e733b471" width="960px" alt="after image" /> |

## Related Linear tickets, Github issues, and Community forum posts
- https://linear.app/n8n/issue/PD-877

## Review / Merge checklist
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)