### PR TITLE
chore(core): Switch PostHog environment variables to EU region

### DIFF
--- a/packages/@n8n/config/src/configs/diagnostics.config.ts
+++ b/packages/@n8n/config/src/configs/diagnostics.config.ts
@@ -2,10 +2,11 @@ import { Config, Env, Nested } from '../decorators';
 
 @Config
 class PostHogConfig {
-	// Note : On cloud staging, the staging PostHog key is injected via the environment variable through middleware.
+	/** PostHog project API key for product analytics. */
 	@Env('N8N_DIAGNOSTICS_POSTHOG_API_KEY')
 	apiKey: string = 'phc_kMstNfAgBcBkWSh6KdsgN09heqqNe5VNmalHP1Ni9Q4';
 
+	/** PostHog API host URL. */
 	@Env('N8N_DIAGNOSTICS_POSTHOG_API_HOST')
 	apiHost: string = 'https://ph.n8n.io';
 }

--- a/packages/@n8n/config/src/configs/diagnostics.config.ts
+++ b/packages/@n8n/config/src/configs/diagnostics.config.ts
@@ -2,13 +2,12 @@ import { Config, Env, Nested } from '../decorators';
 
 @Config
 class PostHogConfig {
-	/** PostHog project API key for product analytics. */
+	// Note : On cloud staging, the staging PostHog key is injected via the environment variable through middleware.
 	@Env('N8N_DIAGNOSTICS_POSTHOG_API_KEY')
-	apiKey: string = 'phc_4URIAm1uYfJO7j8kWSe0J8lc8IqnstRLS7Jx8NcakHo';
+	apiKey: string = 'phc_kMstNfAgBcBkWSh6KdsgN09heqqNe5VNmalHP1Ni9Q4';
 
-	/** PostHog API host URL. */
 	@Env('N8N_DIAGNOSTICS_POSTHOG_API_HOST')
-	apiHost: string = 'https://us.i.posthog.com';
+	apiHost: string = 'https://ph.n8n.io';
 }
 
 @Config

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -390,7 +390,7 @@ describe('GlobalConfig', () => {
 			frontendConfig: '1zPn9bgWPzlQc0p8Gj1uiK6DOTn;https://telemetry.n8n.io',
 			backendConfig: '1zPn7YoGC3ZXE9zLeTKLuQCB4F6;https://telemetry.n8n.io',
 			posthogConfig: {
-				apiKey: 'phc_A1F0pkCo7km1rPwWPNyEW4MfRMDe2XijLYR50fs9DZm', // Staging key
+				apiKey: 'phc_kMstNfAgBcBkWSh6KdsgN09heqqNe5VNmalHP1Ni9Q4',
 				apiHost: 'https://ph.n8n.io',
 			},
 		},

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -390,8 +390,8 @@ describe('GlobalConfig', () => {
 			frontendConfig: '1zPn9bgWPzlQc0p8Gj1uiK6DOTn;https://telemetry.n8n.io',
 			backendConfig: '1zPn7YoGC3ZXE9zLeTKLuQCB4F6;https://telemetry.n8n.io',
 			posthogConfig: {
-				apiKey: 'phc_4URIAm1uYfJO7j8kWSe0J8lc8IqnstRLS7Jx8NcakHo',
-				apiHost: 'https://us.i.posthog.com',
+				apiKey: 'phc_A1F0pkCo7km1rPwWPNyEW4MfRMDe2XijLYR50fs9DZm', // Staging key
+				apiHost: 'https://ph.n8n.io',
 			},
 		},
 		aiAssistant: {


### PR DESCRIPTION
## Summary
Switches PostHog environment variables to those of new EU region instance

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/GRO-276/telemetry-migrate-posthog-from-us-to-eu-cloud

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
