### PR TITLE
chore: Update PR template with new backport labels

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,4 +26,4 @@ https://linear.app/n8n/issue/
    A bug is not considered fixed, unless a test is added to prevent it from happening again.
    A feature is not complete without tests.
 -->
-- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
+- [ ] PR Labeled with `Backport to Beta/Stable/v1` (if the PR is an urgent fix that needs to be backported)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,4 +26,4 @@ https://linear.app/n8n/issue/
    A bug is not considered fixed, unless a test is added to prevent it from happening again.
    A feature is not complete without tests.
 -->
-- [ ] PR Labeled with `Backport to Beta/Stable/v1` (if the PR is an urgent fix that needs to be backported)
+- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


### PR DESCRIPTION
## Summary

Update PR template to reflect new backport branches.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
