### PR TITLE
fix(core): Add plain text body to password reset and notification emails

### DIFF
--- a/packages/cli/src/user-management/email/__tests__/node-mailer.test.ts
+++ b/packages/cli/src/user-management/email/__tests__/node-mailer.test.ts
@@ -83,7 +83,6 @@ describe('NodeMailer', () => {
 			});
 
 			const sentText = mockTransport.sendMail.mock.calls[0][0].text as string;
-			console.log('\n--- user-invited ---\n' + sentText + '\n--- end ---');
 			expect(sentText).toContain('Welcome to n8n!');
 			expect(sentText).toContain('example.com');
 			expect(sentText).toContain('Set up your n8n account (https://n8n.example.com/invite/abc123)');
@@ -104,7 +103,6 @@ describe('NodeMailer', () => {
 			});
 
 			const sentText = mockTransport.sendMail.mock.calls[0][0].text as string;
-			console.log('\n--- password-reset-requested ---\n' + sentText + '\n--- end ---');
 			expect(sentText).toContain('Reset your n8n password');
 			expect(sentText).toContain('Hi John,');
 			expect(sentText).toContain('example.com');
@@ -127,7 +125,6 @@ describe('NodeMailer', () => {
 			});
 
 			const sentText = mockTransport.sendMail.mock.calls[0][0].text as string;
-			console.log('\n--- workflow-shared ---\n' + sentText + '\n--- end ---');
 			expect(sentText).toContain('A workflow has been shared with you');
 			expect(sentText).toContain('"My Workflow"');
 			expect(sentText).toContain('Open Workflow (https://n8n.example.com/workflow/123)');
@@ -148,7 +145,6 @@ describe('NodeMailer', () => {
 			});
 
 			const sentText = mockTransport.sendMail.mock.calls[0][0].text as string;
-			console.log('\n--- credentials-shared ---\n' + sentText + '\n--- end ---');
 			expect(sentText).toContain('A credential has been shared with you');
 			expect(sentText).toContain('"My API Key"');
 			expect(sentText).toContain('Open credential (https://n8n.example.com/home/credentials)');
@@ -170,7 +166,6 @@ describe('NodeMailer', () => {
 			});
 
 			const sentText = mockTransport.sendMail.mock.calls[0][0].text as string;
-			console.log('\n--- project-shared ---\n' + sentText + '\n--- end ---');
 			expect(sentText).toContain('My Project');
 			expect(sentText).toContain('editor');
 			expect(sentText).toContain('View project (https://n8n.example.com/projects/123)');
@@ -191,7 +186,6 @@ describe('NodeMailer', () => {
 			});
 
 			const sentText = mockTransport.sendMail.mock.calls[0][0].text as string;
-			console.log('\n--- workflow-deactivated ---\n' + sentText + '\n--- end ---');
 			expect(sentText).toContain('Workflow automatically deactivated');
 			expect(sentText).toContain('"My Workflow"');
 			expect(sentText).toContain('View Workflow (https://n8n.example.com/workflow/123)');
@@ -215,7 +209,6 @@ describe('NodeMailer', () => {
 			});
 
 			const sentText = mockTransport.sendMail.mock.calls[0][0].text as string;
-			console.log('\n--- workflow-failure ---\n' + sentText + '\n--- end ---');
 			expect(sentText).toContain('Hi John,');
 			expect(sentText).toContain('"My Workflow"');
 			expect(sentText).toContain(
@@ -274,6 +267,18 @@ describe('NodeMailer', () => {
 			expect(sentText).not.toMatch(/\n{3,}/);
 			expect(sentText).toContain('First');
 			expect(sentText).toContain('Second');
+		});
+
+		it('should strip head, script, and style content', async () => {
+			await nodeMailer.sendMail({
+				emailRecipients: 'user@test.com',
+				subject: 'Test',
+				body: '<head><style>body{color:red}</style></head><body><p>Visible content</p></body>',
+			});
+
+			const sentText = mockTransport.sendMail.mock.calls[0][0].text as string;
+			expect(sentText).toBe('Visible content');
+			expect(sentText).not.toContain('color:red');
 		});
 
 		it('should convert br tags to newlines', async () => {

--- a/packages/cli/src/user-management/email/__tests__/node-mailer.test.ts
+++ b/packages/cli/src/user-management/email/__tests__/node-mailer.test.ts
@@ -1,0 +1,290 @@
+import { mockInstance } from '@n8n/backend-test-utils';
+import { GlobalConfig } from '@n8n/config';
+import { readFile } from 'fs/promises';
+import Handlebars from 'handlebars';
+import { mock } from 'jest-mock-extended';
+import { join as pathJoin } from 'path';
+import type { Transporter } from 'nodemailer';
+
+import { NodeMailer } from '@/user-management/email/node-mailer';
+
+const templatesDir = pathJoin(__dirname, '../templates');
+
+async function resolveMjmlIncludes(markup: string): Promise<string> {
+	const includePattern = /<mj-include\s+path="\.\/([^"]+)"\s*\/>/g;
+	let result = markup;
+	let match;
+	while ((match = includePattern.exec(result)) !== null) {
+		const includedContent = await readFile(pathJoin(templatesDir, match[1]), 'utf-8');
+		result = result.replace(match[0], includedContent);
+		// Reset regex since the string changed
+		includePattern.lastIndex = 0;
+	}
+	return result;
+}
+
+async function renderTemplate(
+	templateName: string,
+	data: Record<string, unknown>,
+): Promise<string> {
+	const rawMarkup = await readFile(pathJoin(templatesDir, `${templateName}.mjml`), 'utf-8');
+	const markup = await resolveMjmlIncludes(rawMarkup);
+	const template = Handlebars.compile(markup);
+	return template(data);
+}
+
+const basePayload = {
+	baseUrl: 'https://n8n.example.com',
+	domain: 'example.com',
+	currentYear: 2026,
+};
+
+describe('NodeMailer', () => {
+	let nodeMailer: NodeMailer;
+	let mockTransport: jest.Mocked<Transporter>;
+
+	beforeEach(() => {
+		nodeMailer = new NodeMailer(
+			mockInstance(GlobalConfig, {
+				userManagement: {
+					emails: {
+						smtp: {
+							host: 'smtp.test.com',
+							port: 587,
+							secure: false,
+							startTLS: true,
+							sender: 'noreply@test.com',
+							auth: { user: '', pass: '', serviceClient: '', privateKey: '' },
+						},
+					},
+				},
+			}),
+			mock(),
+			mock(),
+		);
+
+		mockTransport = mock<Transporter>();
+		mockTransport.sendMail.mockResolvedValue({});
+		// Replace the private transport with our mock
+		Object.defineProperty(nodeMailer, 'transport', { value: mockTransport });
+	});
+
+	describe('plain text generation from templates', () => {
+		it('should generate plain text from user-invited template', async () => {
+			const body = await renderTemplate('user-invited', {
+				...basePayload,
+				inviteAcceptUrl: 'https://n8n.example.com/invite/abc123',
+			});
+
+			await nodeMailer.sendMail({
+				emailRecipients: 'user@test.com',
+				subject: 'You have been invited to n8n',
+				body,
+			});
+
+			const sentText = mockTransport.sendMail.mock.calls[0][0].text as string;
+			console.log('\n--- user-invited ---\n' + sentText + '\n--- end ---');
+			expect(sentText).toContain('Welcome to n8n!');
+			expect(sentText).toContain('example.com');
+			expect(sentText).toContain('Set up your n8n account (https://n8n.example.com/invite/abc123)');
+			expect(sentText).not.toMatch(/<[^>]+>/);
+		});
+
+		it('should generate plain text from password-reset-requested template', async () => {
+			const body = await renderTemplate('password-reset-requested', {
+				...basePayload,
+				firstName: 'John',
+				passwordResetUrl: 'https://n8n.example.com/reset/abc123',
+			});
+
+			await nodeMailer.sendMail({
+				emailRecipients: 'user@test.com',
+				subject: 'n8n password reset',
+				body,
+			});
+
+			const sentText = mockTransport.sendMail.mock.calls[0][0].text as string;
+			console.log('\n--- password-reset-requested ---\n' + sentText + '\n--- end ---');
+			expect(sentText).toContain('Reset your n8n password');
+			expect(sentText).toContain('Hi John,');
+			expect(sentText).toContain('example.com');
+			expect(sentText).toContain('Set a new password (https://n8n.example.com/reset/abc123)');
+			expect(sentText).toContain('only valid for 20 minutes');
+			expect(sentText).not.toMatch(/<[^>]+>/);
+		});
+
+		it('should generate plain text from workflow-shared template', async () => {
+			const body = await renderTemplate('workflow-shared', {
+				...basePayload,
+				workflowName: 'My Workflow',
+				workflowUrl: 'https://n8n.example.com/workflow/123',
+			});
+
+			await nodeMailer.sendMail({
+				emailRecipients: 'user@test.com',
+				subject: 'Sharer has shared an n8n workflow with you',
+				body,
+			});
+
+			const sentText = mockTransport.sendMail.mock.calls[0][0].text as string;
+			console.log('\n--- workflow-shared ---\n' + sentText + '\n--- end ---');
+			expect(sentText).toContain('A workflow has been shared with you');
+			expect(sentText).toContain('"My Workflow"');
+			expect(sentText).toContain('Open Workflow (https://n8n.example.com/workflow/123)');
+			expect(sentText).not.toMatch(/<[^>]+>/);
+		});
+
+		it('should generate plain text from credentials-shared template', async () => {
+			const body = await renderTemplate('credentials-shared', {
+				...basePayload,
+				credentialsName: 'My API Key',
+				credentialsListUrl: 'https://n8n.example.com/home/credentials',
+			});
+
+			await nodeMailer.sendMail({
+				emailRecipients: 'user@test.com',
+				subject: 'Sharer has shared an n8n credential with you',
+				body,
+			});
+
+			const sentText = mockTransport.sendMail.mock.calls[0][0].text as string;
+			console.log('\n--- credentials-shared ---\n' + sentText + '\n--- end ---');
+			expect(sentText).toContain('A credential has been shared with you');
+			expect(sentText).toContain('"My API Key"');
+			expect(sentText).toContain('Open credential (https://n8n.example.com/home/credentials)');
+			expect(sentText).not.toMatch(/<[^>]+>/);
+		});
+
+		it('should generate plain text from project-shared template', async () => {
+			const body = await renderTemplate('project-shared', {
+				...basePayload,
+				projectName: 'My Project',
+				role: 'editor',
+				projectUrl: 'https://n8n.example.com/projects/123',
+			});
+
+			await nodeMailer.sendMail({
+				emailRecipients: 'user@test.com',
+				subject: 'Sharer has invited you to a project',
+				body,
+			});
+
+			const sentText = mockTransport.sendMail.mock.calls[0][0].text as string;
+			console.log('\n--- project-shared ---\n' + sentText + '\n--- end ---');
+			expect(sentText).toContain('My Project');
+			expect(sentText).toContain('editor');
+			expect(sentText).toContain('View project (https://n8n.example.com/projects/123)');
+			expect(sentText).not.toMatch(/<[^>]+>/);
+		});
+
+		it('should generate plain text from workflow-deactivated template', async () => {
+			const body = await renderTemplate('workflow-deactivated', {
+				...basePayload,
+				workflowName: 'My Workflow',
+				workflowUrl: 'https://n8n.example.com/workflow/123',
+			});
+
+			await nodeMailer.sendMail({
+				emailRecipients: 'user@test.com',
+				subject: 'n8n has automatically autodeactivated a workflow',
+				body,
+			});
+
+			const sentText = mockTransport.sendMail.mock.calls[0][0].text as string;
+			console.log('\n--- workflow-deactivated ---\n' + sentText + '\n--- end ---');
+			expect(sentText).toContain('Workflow automatically deactivated');
+			expect(sentText).toContain('"My Workflow"');
+			expect(sentText).toContain('View Workflow (https://n8n.example.com/workflow/123)');
+			expect(sentText).not.toMatch(/<[^>]+>/);
+		});
+
+		it('should generate plain text from workflow-failure template', async () => {
+			const body = await renderTemplate('workflow-failure', {
+				...basePayload,
+				firstName: 'John',
+				workflowName: 'My Workflow',
+				workflowId: '123',
+				workflowUrl: 'https://n8n.example.com/workflow/123',
+				instanceURL: 'https://n8n.example.com',
+			});
+
+			await nodeMailer.sendMail({
+				emailRecipients: 'user@test.com',
+				subject: '⚠️ Your workflow failed. Get alerts next time',
+				body,
+			});
+
+			const sentText = mockTransport.sendMail.mock.calls[0][0].text as string;
+			console.log('\n--- workflow-failure ---\n' + sentText + '\n--- end ---');
+			expect(sentText).toContain('Hi John,');
+			expect(sentText).toContain('"My Workflow"');
+			expect(sentText).toContain(
+				'Set up my Error Workflow (https://n8n.example.com/templates/2159)',
+			);
+			expect(sentText).toContain('Tutorial (https://www.youtube.com/watch?v=bTF3tACqPRU)');
+			expect(sentText).toContain('Docs (https://docs.n8n.io/flow-logic/error-handling/)');
+			expect(sentText).toContain('Happy automating');
+			expect(sentText).toContain('The n8n team');
+			expect(sentText).not.toMatch(/<[^>]+>/);
+		});
+	});
+
+	describe('plain text edge cases', () => {
+		it('should use textOnly when provided instead of generating plain text', async () => {
+			await nodeMailer.sendMail({
+				emailRecipients: 'user@test.com',
+				subject: 'Test',
+				body: '<p>HTML body</p>',
+				textOnly: 'Custom plain text',
+			});
+
+			const sentText = mockTransport.sendMail.mock.calls[0][0].text as string;
+			expect(sentText).toBe('Custom plain text');
+		});
+
+		it('should not generate plain text when body is a Buffer', async () => {
+			await nodeMailer.sendMail({
+				emailRecipients: 'user@test.com',
+				subject: 'Test',
+				body: Buffer.from('binary content') as unknown as string,
+			});
+
+			expect(mockTransport.sendMail.mock.calls[0][0].text).toBeUndefined();
+		});
+
+		it('should decode HTML entities', async () => {
+			await nodeMailer.sendMail({
+				emailRecipients: 'user@test.com',
+				subject: 'Test',
+				body: '<p>Tom &amp; Jerry &lt;3 &gt; &quot;friends&quot; &#039;forever&#039;</p>',
+			});
+
+			const sentText = mockTransport.sendMail.mock.calls[0][0].text as string;
+			expect(sentText).toBe('Tom & Jerry <3 > "friends" \'forever\'');
+		});
+
+		it('should collapse multiple blank lines', async () => {
+			await nodeMailer.sendMail({
+				emailRecipients: 'user@test.com',
+				subject: 'Test',
+				body: '<p>First</p><p></p><p></p><p></p><p>Second</p>',
+			});
+
+			const sentText = mockTransport.sendMail.mock.calls[0][0].text as string;
+			expect(sentText).not.toMatch(/\n{3,}/);
+			expect(sentText).toContain('First');
+			expect(sentText).toContain('Second');
+		});
+
+		it('should convert br tags to newlines', async () => {
+			await nodeMailer.sendMail({
+				emailRecipients: 'user@test.com',
+				subject: 'Test',
+				body: 'Happy automating,<br />The n8n team',
+			});
+
+			const sentText = mockTransport.sendMail.mock.calls[0][0].text as string;
+			expect(sentText).toContain('Happy automating,\nThe n8n team');
+		});
+	});
+});

--- a/packages/cli/src/user-management/email/__tests__/node-mailer.test.ts
+++ b/packages/cli/src/user-management/email/__tests__/node-mailer.test.ts
@@ -273,12 +273,13 @@ describe('NodeMailer', () => {
 			await nodeMailer.sendMail({
 				emailRecipients: 'user@test.com',
 				subject: 'Test',
-				body: '<head><style>body{color:red}</style></head><body><p>Visible content</p></body>',
+				body: '<head><style>body{color:red}</style></head><script>alert("x")</script><body><p>Visible content</p></body>',
 			});
 
 			const sentText = mockTransport.sendMail.mock.calls[0][0].text as string;
 			expect(sentText).toBe('Visible content');
 			expect(sentText).not.toContain('color:red');
+			expect(sentText).not.toContain('alert');
 		});
 
 		it('should convert br tags to newlines', async () => {

--- a/packages/cli/src/user-management/email/node-mailer.ts
+++ b/packages/cli/src/user-management/email/node-mailer.ts
@@ -84,6 +84,10 @@ export class NodeMailer {
 	private htmlToPlainText(html: string): string {
 		return (
 			html
+				// Remove non-visible content
+				.replace(/<head[\s\S]*?<\/head>/gi, '')
+				.replace(/<script[\s\S]*?<\/script>/gi, '')
+				.replace(/<style[\s\S]*?<\/style>/gi, '')
 				// Convert links and buttons to "text (url)" format
 				.replace(/<a\s[^>]*href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/gi, '$2 ($1)')
 				.replace(/<mj-button\s[^>]*href="([^"]*)"[^>]*>([\s\S]*?)<\/mj-button>/gi, '$2 ($1)')

--- a/packages/cli/src/user-management/email/node-mailer.ts
+++ b/packages/cli/src/user-management/email/node-mailer.ts
@@ -47,11 +47,15 @@ export class NodeMailer {
 
 	async sendMail(mailData: MailData): Promise<SendEmailResult> {
 		try {
+			const plainText =
+				mailData.textOnly ??
+				(typeof mailData.body === 'string' ? this.htmlToPlainText(mailData.body) : undefined);
+
 			await this.transport.sendMail({
 				from: this.sender,
 				to: mailData.emailRecipients,
 				subject: mailData.subject,
-				text: mailData.textOnly,
+				text: plainText,
 				html: mailData.body,
 				attachments: [
 					{
@@ -75,5 +79,31 @@ export class NodeMailer {
 		}
 
 		return { emailSent: true };
+	}
+
+	private htmlToPlainText(html: string): string {
+		return (
+			html
+				// Convert links and buttons to "text (url)" format
+				.replace(/<a\s[^>]*href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/gi, '$2 ($1)')
+				.replace(/<mj-button\s[^>]*href="([^"]*)"[^>]*>([\s\S]*?)<\/mj-button>/gi, '$2 ($1)')
+				// Replace <br> and block-level closing tags with newlines
+				.replace(/<br\s*\/?>/gi, '\n')
+				.replace(/<\/(p|div|h[1-6]|li|tr)>/gi, '\n')
+				// Strip remaining HTML tags
+				.replace(/<[^>]+>/g, '')
+				// Decode common HTML entities
+				.replace(/&amp;/g, '&')
+				.replace(/&lt;/g, '<')
+				.replace(/&gt;/g, '>')
+				.replace(/&quot;/g, '"')
+				.replace(/&#039;/g, "'")
+				.replace(/&nbsp;/g, ' ')
+				// Trim leading whitespace from each line
+				.replace(/^[\t ]+/gm, '')
+				// Collapse multiple blank lines
+				.replace(/\n{3,}/g, '\n\n')
+				.trim()
+		);
 	}
 }


### PR DESCRIPTION
## Summary

Implements automatic conversion of HTML email bodies to plain text format, ensuring all email recipients receive both HTML and plain text versions. Converts links and buttons to 'text (url)' format for readability and properly handles MJML template structures. Includes comprehensive tests for all email templates (user-invited, password-reset-requested, workflow-shared, credentials-shared, project-shared, workflow-deactivated, and workflow-failure).

Here are the plain text templates:

```
    --- user-invited ---
    Welcome to n8n! 🎉
    You have been invited to join n8n at example.com.
    To accept, please click the button below.
    Set up your n8n account (https://n8n.example.com/invite/abc123)
    
    n8n GmbH, Novalisstraße 10, 10115 Berlin, Germany
    
    ©2026 n8n GmbH, all rights reserved
    --- end ---
    
    --- password-reset-requested ---
    Reset your n8n password
    Hi John,
    Somebody asked to reset your password on n8n at example.com.
    Click the following link to choose a new password.
    Set a new password (https://n8n.example.com/reset/abc123)
    
    The link is only valid for 20 minutes since this email was sent. If you did not request this email, you can safely ignore this. Your password will not be changed.
    
    n8n GmbH, Novalisstraße 10, 10115 Berlin, Germany
    
    ©2026 n8n GmbH, all rights reserved
    --- end ---
    
    --- workflow-shared ---
    A workflow has been shared with you
    "My Workflow" workflow has been shared with you.
    To access it, please click the button below.
    Open Workflow (https://n8n.example.com/workflow/123)
    
    n8n GmbH, Novalisstraße 10, 10115 Berlin, Germany
    
    ©2026 n8n GmbH, all rights reserved
    --- end ---
    
    --- credentials-shared ---
    A credential has been shared with you
    "My API Key" credential has been shared with you.
    To access it, please click the button below.
    Open credential (https://n8n.example.com/home/credentials)
    
    n8n GmbH, Novalisstraße 10, 10115 Berlin, Germany
    
    ©2026 n8n GmbH, all rights reserved
    --- end ---
    
    --- project-shared ---
    You have been added to the My Project project as editor
    
    This gives you access to all the workflows and credentials in that project.
    View project (https://n8n.example.com/projects/123)
    
    n8n GmbH, Novalisstraße 10, 10115 Berlin, Germany
    
    ©2026 n8n GmbH, all rights reserved
    --- end ---
    
    --- workflow-deactivated ---
    Workflow automatically deactivated
    n8n has automatically deactivated "My Workflow" due to repeated
    crashes.
    Please review its recent executions and resolve any issues before reactivating
    it.
    View Workflow (https://n8n.example.com/workflow/123)
    
    n8n GmbH, Novalisstraße 10, 10115 Berlin, Germany
    
    ©2026 n8n GmbH, all rights reserved
    --- end ---
    
    --- workflow-failure ---
    Hi John,
    ⚠️ Your workflow "My Workflow" ran into an error.
    Set up an error workflow now to get instant alerts on Gmail, Slack or any tool of your choice.
    Set up my Error Workflow (https://n8n.example.com/templates/2159)
    
    Tutorial (https://www.youtube.com/watch?v=bTF3tACqPRU)
    
    Docs (https://docs.n8n.io/flow-logic/error-handling/)
    
    Happy automating,
    The n8n team
    
    n8n GmbH, Novalisstraße 10, 10115 Berlin, Germany
    
    ©2026 n8n GmbH, all rights reserved
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-376

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included (12 comprehensive unit tests covering all templates and edge cases)
- [ ] Docs updated or follow-up ticket created

🤖 Generated with [Claude Code](https://claude.com/claude-code)