### PR TITLE
fix(core): Emit `leader-takeover` on leadership mismatch in `checkLeader`

### DIFF
--- a/packages/cli/src/scaling/__tests__/multi-main-setup.ee.test.ts
+++ b/packages/cli/src/scaling/__tests__/multi-main-setup.ee.test.ts
@@ -1,0 +1,110 @@
+import { mockLogger } from '@n8n/backend-test-utils';
+import type { GlobalConfig } from '@n8n/config';
+import { MultiMainMetadata } from '@n8n/decorators';
+import { mock } from 'jest-mock-extended';
+import type { ErrorReporter, InstanceSettings } from 'n8n-core';
+
+import type { Publisher } from '@/scaling/pubsub/publisher.service';
+import type { RedisClientService } from '@/services/redis-client.service';
+
+import { MultiMainSetup } from '../multi-main-setup.ee';
+
+describe('MultiMainSetup', () => {
+	const hostId = 'main-n8n-main-0';
+
+	const logger = mockLogger();
+	const publisher = mock<Publisher>();
+	const redisClientService = mock<RedisClientService>();
+	const errorReporter = mock<ErrorReporter>();
+	const metadata = new MultiMainMetadata();
+
+	const globalConfig = mock<GlobalConfig>({
+		redis: { prefix: 'n8n' },
+		multiMainSetup: { ttl: 10, interval: 3, enabled: true },
+	});
+
+	redisClientService.toValidPrefix.mockReturnValue('n8n');
+
+	let instanceSettings: InstanceSettings;
+	let multiMainSetup: MultiMainSetup;
+
+	beforeEach(() => {
+		instanceSettings = mock<InstanceSettings>({ hostId, isLeader: false });
+		multiMainSetup = new MultiMainSetup(
+			logger,
+			instanceSettings,
+			publisher,
+			redisClientService,
+			globalConfig,
+			metadata,
+			errorReporter,
+		);
+		jest.clearAllMocks();
+	});
+
+	describe('checkLeader', () => {
+		beforeEach(async () => {
+			await multiMainSetup.init();
+		});
+
+		it('should emit `leader-takeover` when Redis has own `hostId` but instance thinks it is follower', async () => {
+			publisher.get.mockResolvedValue(hostId);
+			const emit = jest.spyOn(multiMainSetup, 'emit');
+
+			// @ts-expect-error - private method
+			await multiMainSetup.checkLeader();
+
+			expect(instanceSettings.markAsLeader).toHaveBeenCalled();
+			expect(emit).toHaveBeenCalledWith('leader-takeover');
+		});
+
+		it('should not emit leader-takeover when already leader', async () => {
+			publisher.get.mockResolvedValue(hostId);
+			Object.defineProperty(instanceSettings, 'isLeader', { get: () => true });
+			const emit = jest.spyOn(multiMainSetup, 'emit');
+
+			// @ts-expect-error - private method
+			await multiMainSetup.checkLeader();
+
+			expect(instanceSettings.markAsLeader).not.toHaveBeenCalled();
+			expect(emit).not.toHaveBeenCalledWith('leader-takeover');
+			expect(publisher.setExpiration).toHaveBeenCalled();
+		});
+
+		it('should emit leader-stepdown when another instance is leader', async () => {
+			publisher.get.mockResolvedValue('main-n8n-main-1');
+			Object.defineProperty(instanceSettings, 'isLeader', { get: () => true });
+			const emit = jest.spyOn(multiMainSetup, 'emit');
+
+			// @ts-expect-error - private method
+			await multiMainSetup.checkLeader();
+
+			expect(instanceSettings.markAsFollower).toHaveBeenCalled();
+			expect(emit).toHaveBeenCalledWith('leader-stepdown');
+		});
+
+		it('should not emit `leader-stepdown` when already a follower', async () => {
+			publisher.get.mockResolvedValue('main-n8n-main-1');
+			const emit = jest.spyOn(multiMainSetup, 'emit');
+
+			// @ts-expect-error - private method
+			await multiMainSetup.checkLeader();
+
+			expect(emit).not.toHaveBeenCalledWith('leader-stepdown');
+		});
+
+		it('should attempt to become leader when leadership is vacant', async () => {
+			publisher.get.mockResolvedValue(null);
+			publisher.setIfNotExists.mockResolvedValue(true);
+			const emit = jest.spyOn(multiMainSetup, 'emit');
+
+			// @ts-expect-error - private method
+			await multiMainSetup.checkLeader();
+
+			expect(instanceSettings.markAsFollower).toHaveBeenCalled();
+			expect(emit).toHaveBeenCalledWith('leader-stepdown');
+			expect(emit).toHaveBeenCalledWith('leader-takeover');
+			expect(instanceSettings.markAsLeader).toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/scaling/__tests__/multi-main-setup.ee.test.ts
+++ b/packages/cli/src/scaling/__tests__/multi-main-setup.ee.test.ts
@@ -58,7 +58,7 @@ describe('MultiMainSetup', () => {
 			expect(emit).toHaveBeenCalledWith('leader-takeover');
 		});
 
-		it('should not emit leader-takeover when already leader', async () => {
+		it('should not emit `leader-takeover` when already leader', async () => {
 			publisher.get.mockResolvedValue(hostId);
 			Object.defineProperty(instanceSettings, 'isLeader', { get: () => true });
 			const emit = jest.spyOn(multiMainSetup, 'emit');
@@ -71,7 +71,7 @@ describe('MultiMainSetup', () => {
 			expect(publisher.setExpiration).toHaveBeenCalled();
 		});
 
-		it('should emit leader-stepdown when another instance is leader', async () => {
+		it('should emit `leader-stepdown` when another instance is leader', async () => {
 			publisher.get.mockResolvedValue('main-n8n-main-1');
 			Object.defineProperty(instanceSettings, 'isLeader', { get: () => true });
 			const emit = jest.spyOn(multiMainSetup, 'emit');

--- a/packages/cli/src/scaling/multi-main-setup.ee.ts
+++ b/packages/cli/src/scaling/multi-main-setup.ee.ts
@@ -84,8 +84,11 @@ export class MultiMainSetup extends TypedEmitter<MultiMainEvents> {
 						shouldReport: true,
 					},
 				);
+
+				this.instanceSettings.markAsLeader();
+
+				this.emit('leader-takeover');
 			}
-			this.instanceSettings.markAsLeader();
 
 			this.logger.debug(`[Instance ID ${hostId}] Leader is this instance`);
 


### PR DESCRIPTION


## Summary

Scenario:

1. A main is the leader, has `WaitTracker` running
2. This main terminates, and the key still has this main's name, with a few seconds of TTL left
3. This main restarts and tries to claim leadership via `MultiMainSetup.init` during startup. This fails (as expected) because the key is still set, left over from before the restart. This main marks itself as follower
4. `WaitTracker.init` runs during startup. This main is a follower so `WaitTracker` does not start (as expected)
5. The first `MultiMainSetup.checkLeader` runs. This main reads the key and finds its own name left over from before the restart, and marks itself as leader. But importantly, this main does not fire the `leader-takeover` event, because we're assuming that when a main finds its own name in Redis, this is just a routine leadership check
6. Main is now the leader with no `WaitTracker` so waiting executions do not resume

Likely a `StatefulSet` rolling restart on cloud is faster than a restart in the old docker compose setup on internal, and also the hostname is fixed in k8s vs. dynamic in docker compose, where the hostname defaults to the container ID which changes on restart. 

This fix moves `markAsLeader()` and adds `emit('leader-takeover')` inside the existing guard, so the event fires exactly once on the follower-to-leader transition.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2622

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)