### PR TITLE
build: Pin `uuid` in `n8n-workflow` to catalog version

### DIFF
--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -67,6 +67,7 @@
     "recast": "0.22.0",
     "title-case": "3.0.3",
     "transliteration": "2.3.5",
+    "uuid": "catalog:",
     "xml2js": "catalog:",
     "zod": "catalog:",
     "jsonrepair": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3990,6 +3990,9 @@ importers:
       transliteration:
         specifier: 2.3.5
         version: 2.3.5
+      uuid:
+        specifier: 'catalog:'
+        version: 10.0.0
       xml2js:
         specifier: 'catalog:'
         version: 0.6.2


### PR DESCRIPTION
`packages/workflow` imports `uuid` but doesn't declare it as a dependency. After the langchain packages upgrade at #26892, `@langchain/langgraph-*` brought in `uuid@13.0.0` (ESM-only) as a transitive dependency. When running `pnpm install` locally, pnpm can resolve `uuid` to v13 instead of the catalog-pinned v10, which breaks all  Jest tests in the `cli` package locally with:

```
SyntaxError: Unexpected token 'export'
```

I _think_ CI is unaffected because it uses `--frozen-lockfile` against the committed lockfile which doesn't contain `uuid@13`.

This fix adds `uuid: "catalog:"` to `packages/workflow/package.json` so it explicitly pins to v10.