### PR TITLE
fix(editor): Remove toast bottom offset when AI chat panel is open

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useFloatingUiOffsets.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useFloatingUiOffsets.test.ts
@@ -7,6 +7,7 @@ import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
+import { useChatPanelStateStore } from '@/features/ai/assistant/chatPanelState.store';
 import { setActivePinia } from 'pinia';
 import { useFloatingUiOffsets } from './useFloatingUiOffsets';
 import { reactive } from 'vue';
@@ -52,6 +53,18 @@ describe(useFloatingUiOffsets, () => {
 			useNDVStore().unsetActiveNodeName(); // close NDV
 
 			expect(toastBottomOffset.value).toBe('3px');
+		});
+
+		it('should not account for the height of log view when chat panel is open', () => {
+			useLogsStore().setHeight(300);
+
+			const { toastBottomOffset } = useFloatingUiOffsets();
+
+			expect(toastBottomOffset.value).toBe('300px');
+
+			useChatPanelStateStore().isOpen = true;
+
+			expect(toastBottomOffset.value).toBe('0px');
 		});
 
 		it.each(EDITABLE_CANVAS_VIEWS)(

--- a/packages/frontend/editor-ui/src/app/composables/useFloatingUiOffsets.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useFloatingUiOffsets.ts
@@ -18,7 +18,7 @@ export function useFloatingUiOffsets() {
 	return {
 		askAiFloatingButtonBottomOffset: computed(() => `${askAiOffset.value}px`),
 		toastBottomOffset: computed(() => {
-			const logsPanelOffset = ndvStore.isNDVOpen ? 0 : logsStore.height;
+			const logsPanelOffset = ndvStore.isNDVOpen || chatPanelStore.isOpen ? 0 : logsStore.height;
 			const assistantOffset = assistantStore.isFloatingButtonShown
 				? ASSISTANT_FLOATING_BUTTON_SIZE + askAiOffset.value
 				: 0;


### PR DESCRIPTION
## Summary

When both the logs panel and the AI builder chat panel are open on the canvas, toast notifications were rendered with an unnecessary bottom offset. 

**Before** (AI builder + logs panel open — toast has unnecessary bottom offset):
<img width="1112" height="704" alt="image" src="https://github.com/user-attachments/assets/c03817a3-658f-4264-8455-a68500879982" />


**After** (toast positioned correctly):

<img width="1109" height="550" alt="image" src="https://github.com/user-attachments/assets/627ce3e1-9df4-4197-bc77-3ebc1abfcf77" />
<img width="1096" height="777" alt="image" src="https://github.com/user-attachments/assets/de8484fa-90e8-4433-a4b6-07a8ef0db228" />

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)