### PR TITLE
fix(Execute Workflow Node): Fallback to latest draft if there no active sub-workflow version

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/__tests__/local-load-options-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/local-load-options-context.test.ts
@@ -61,28 +61,39 @@ describe('LocalLoadOptionsContext', () => {
 			);
 		});
 
-		it('should throw ApplicationError when useActiveVersion is true but no activeVersion exists', async () => {
+		it('should fall back to draft nodes when useActiveVersion is true but no activeVersion exists', async () => {
 			const workflowId = 'workflow-123';
+			const nodeParameters = { inputSource: 'passthrough' };
 			additionalData.currentNodeParameters = {
 				workflowId: { value: workflowId },
 			};
 
+			const draftNode = mock<INode>({
+				type: targetNodeType,
+				name: 'Draft Trigger',
+				parameters: nodeParameters,
+			});
 			const dbWorkflow = mock<IWorkflowBase>({
 				id: workflowId,
 				name: 'Test Workflow',
-				nodes: [],
+				nodes: [draftNode],
 				activeVersion: null,
 			});
 			workflowLoader.get.mockResolvedValue(dbWorkflow);
 
 			const context = new LocalLoadOptionsContext(nodeTypes, additionalData, path, workflowLoader);
 
-			await expect(context.getWorkflowNodeContext(targetNodeType, true)).rejects.toThrow(
-				ApplicationError,
-			);
-			await expect(context.getWorkflowNodeContext(targetNodeType, true)).rejects.toThrow(
-				`No active version found for workflow "${workflowId}"!`,
-			);
+			const result = await context.getWorkflowNodeContext(targetNodeType, true);
+
+			expect(result).toBeInstanceOf(LoadWorkflowNodeContext);
+			expect(Workflow).toHaveBeenCalledWith({
+				id: workflowId,
+				name: 'Test Workflow',
+				nodes: [draftNode],
+				connections: {},
+				active: false,
+				nodeTypes,
+			});
 		});
 
 		it('should return null when no node of the specified type exists in the workflow', async () => {

--- a/packages/core/src/execution-engine/node-execution-context/local-load-options-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/local-load-options-context.ts
@@ -34,12 +34,10 @@ export class LocalLoadOptionsContext implements ILocalLoadOptionsFunctions {
 
 		const dbWorkflow = await this.workflowLoader.get(workflowId);
 
-		if (useActiveVersion && !dbWorkflow.activeVersion) {
-			throw new ApplicationError(`No active version found for workflow "${workflowId}"!`);
-		}
-
 		const selectedWorkflowNode = (
-			useActiveVersion ? dbWorkflow.activeVersion!.nodes : dbWorkflow.nodes
+			useActiveVersion && dbWorkflow.activeVersion
+				? dbWorkflow.activeVersion.nodes
+				: dbWorkflow.nodes
 		).find((node) => node.type === nodeType);
 
 		if (selectedWorkflowNode) {

--- a/packages/core/src/execution-engine/node-execution-context/local-load-options-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/local-load-options-context.ts
@@ -22,7 +22,7 @@ export class LocalLoadOptionsContext implements ILocalLoadOptionsFunctions {
 
 	async getWorkflowNodeContext(
 		nodeType: string,
-		useActiveVersion: boolean = false,
+		preferActiveVersion: boolean = false,
 	): Promise<IWorkflowNodeContext | null> {
 		const { value: workflowId } = this.getCurrentNodeParameter(
 			'workflowId',
@@ -35,7 +35,7 @@ export class LocalLoadOptionsContext implements ILocalLoadOptionsFunctions {
 		const dbWorkflow = await this.workflowLoader.get(workflowId);
 
 		const selectedWorkflowNode = (
-			useActiveVersion && dbWorkflow.activeVersion
+			preferActiveVersion && dbWorkflow.activeVersion
 				? dbWorkflow.activeVersion.nodes
 				: dbWorkflow.nodes
 		).find((node) => node.type === nodeType);


### PR DESCRIPTION
## Summary

Change the code used in https://github.com/n8n-io/n8n/blob/a2373d846e968a8523b32df5d924e5848c9e153d/packages/nodes-base/utils/workflowInputsResourceMapping/GenericFunctions.ts#L171. 

This makes parameters show up correctly.

## Related Linear tickets, Github issues, and Community forum posts


https://linear.app/n8n/issue/ADO-4958


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
