### PR TITLE
refactor(editor): Migrate NDV settings and runData to `workflowDocumentStore` (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -113,7 +113,7 @@ import {
 	N8nSwitch2,
 } from '@n8n/design-system';
 import { useCollectionOverhaul } from '@/app/composables/useCollectionOverhaul';
-import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { isPlaceholderValue } from '@/features/ai/assistant/composables/useBuilderTodos';
 
 type Picker = { $emit: (arg0: string, arg1: Date) => void };
@@ -176,7 +176,7 @@ const credentialsStore = useCredentialsStore();
 const ndvStore = useNDVStore();
 const workflowsStore = useWorkflowsStore();
 const workflowsListStore = useWorkflowsListStore();
-const workflowState = injectWorkflowState();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const settingsStore = useSettingsStore();
 const nodeTypesStore = useNodeTypesStore();
 const uiStore = useUIStore();
@@ -726,9 +726,9 @@ function isRemoteParameterOption(option: INodePropertyOptions) {
 
 function credentialSelected(updateInformation: INodeUpdatePropertiesInformation) {
 	// Update the values on the node
-	workflowState.updateNodeProperties(updateInformation);
+	workflowDocumentStore?.value?.updateNodeProperties(updateInformation);
 
-	const updateNode = workflowsStore.getNodeByName(updateInformation.name);
+	const updateNode = workflowDocumentStore?.value?.getNodeByName(updateInformation.name) ?? null;
 
 	if (updateNode) {
 		// Update the issues

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
@@ -94,7 +94,6 @@ import {
 	N8nText,
 	N8nTooltip,
 } from '@n8n/design-system';
-import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 const LazyRunDataTable = defineAsyncComponent(async () => await import('./RunDataTable.vue'));
@@ -228,7 +227,6 @@ const workflowId = useInjectWorkflowId();
 const nodeTypesStore = useNodeTypesStore();
 const ndvStore = useNDVStore();
 const workflowsStore = useWorkflowsStore();
-const workflowState = injectWorkflowState();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const sourceControlStore = useSourceControlStore();
 const collaborationStore = useCollaborationStore();
@@ -645,7 +643,7 @@ const hasPreviewSchema = asyncComputed(async () => {
 	if (!isSchemaPreviewEnabled.value || props.nodes.length === 0) return false;
 	const nodes = props.nodes
 		.filter((n) => n.depth === 1)
-		.map((n) => workflowsStore.getNodeByName(n.name))
+		.map((n) => workflowDocumentStore?.value?.getNodeByName(n.name) ?? null)
 		.filter(isPresent);
 
 	for (const connectedNode of nodes) {
@@ -1395,7 +1393,7 @@ function enableNode() {
 			},
 		};
 
-		workflowState.updateNodeProperties(updateInformation);
+		workflowDocumentStore?.value?.updateNodeProperties(updateInformation);
 	}
 }
 

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.vue
@@ -321,7 +321,7 @@ const nodesSchemas = asyncComputed<SchemaNode[]>(async () => {
 	const search = props.search;
 
 	for (const node of props.nodes) {
-		const fullNode = workflowsStore.getNodeByName(node.name);
+		const fullNode = workflowDocumentStore?.value?.getNodeByName(node.name) ?? null;
 		if (!fullNode) continue;
 
 		const nodeType = nodeTypesStore.getNodeType(fullNode.type, fullNode.typeVersion);

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
@@ -67,11 +67,7 @@ import { useQuickConnect } from '@/features/credentials/quickConnect/composables
 import { N8nBlockUi, N8nIcon, N8nNotice, N8nText } from '@n8n/design-system';
 import { useRoute } from 'vue-router';
 import { useSettingsStore } from '@/app/stores/settings.store';
-import { injectWorkflowState } from '@/app/composables/useWorkflowState';
-import {
-	useWorkflowDocumentStore,
-	createWorkflowDocumentId,
-} from '@/app/stores/workflowDocument.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { ProjectTypes } from '@/features/collaboration/projects/projects.types';
 
 const props = withDefaults(
@@ -129,12 +125,7 @@ const nodeTypesStore = useNodeTypesStore();
 const ndvStore = useNDVStore();
 const workflowsStore = useWorkflowsStore();
 const workflowsListStore = useWorkflowsListStore();
-const workflowState = injectWorkflowState();
-const workflowDocumentStore = computed(() =>
-	workflowsStore.workflowId
-		? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
-		: undefined,
-);
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const credentialsStore = useCredentialsStore();
 const historyStore = useHistoryStore();
 
@@ -339,7 +330,7 @@ const valueChanged = (parameterData: IUpdateInformation) => {
 		return;
 	}
 
-	const _node = workflowsStore.getNodeByName(nodeNameBefore);
+	const _node = workflowDocumentStore?.value?.getNodeByName(nodeNameBefore) ?? null;
 
 	if (_node === null) {
 		return;
@@ -425,7 +416,7 @@ const valueChanged = (parameterData: IUpdateInformation) => {
 				value: nodeParameters,
 			};
 
-			workflowState.setNodeParameters(updateInformation);
+			workflowDocumentStore?.value?.setNodeParameters(updateInformation);
 
 			nodeHelpers.updateNodeParameterIssuesByName(_node.name);
 			nodeHelpers.updateNodeCredentialIssuesByName(_node.name);
@@ -455,7 +446,7 @@ const valueChanged = (parameterData: IUpdateInformation) => {
 			value: newValue,
 		};
 
-		workflowState.setNodeValue(updateInformation);
+		workflowDocumentStore?.value?.setNodeValue(updateInformation);
 	}
 };
 
@@ -515,9 +506,9 @@ const onNodeExecute = () => {
 
 const credentialSelected = (updateInformation: INodeUpdatePropertiesInformation) => {
 	// Update the values on the node
-	workflowState.updateNodeProperties(updateInformation);
+	workflowDocumentStore?.value?.updateNodeProperties(updateInformation);
 
-	const node = workflowsStore.getNodeByName(updateInformation.name);
+	const node = workflowDocumentStore?.value?.getNodeByName(updateInformation.name) ?? null;
 
 	if (node) {
 		// Update the issues

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
@@ -280,7 +280,7 @@ const isCommunityNode = computed(() => !!node.value && isCommunityPackageName(no
 const packageName = computed(() => node.value?.type.split('.')[0] ?? '');
 
 const usedCredentials = computed(() =>
-	Object.values(workflowDocumentStore.value?.usedCredentials ?? {}).filter((credential) =>
+	Object.values(workflowDocumentStore?.value?.usedCredentials ?? {}).filter((credential) =>
 		Object.values(node.value?.credentials || []).find(
 			(nodeCredential) => nodeCredential.id === credential.id,
 		),

--- a/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.ts
@@ -1,6 +1,6 @@
 import get from 'lodash/get';
 import set from 'lodash/set';
-import type { Ref } from 'vue';
+import { computed, type Ref } from 'vue';
 import {
 	type INode,
 	type INodeParameters,
@@ -31,12 +31,19 @@ import {
 	getNodeAuthFields,
 	isAuthRelatedParameter,
 } from '@/app/utils/nodeTypesUtils';
-import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 
 export function useNodeSettingsParameters() {
 	const workflowsStore = useWorkflowsStore();
-	const workflowState = injectWorkflowState();
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 	const nodeTypesStore = useNodeTypesStore();
 	const settingsStore = useSettingsStore();
 	const telemetry = useTelemetry();
@@ -133,7 +140,7 @@ export function useNodeSettingsParameters() {
 			workflowsStore.setConnections(updatedConnections);
 		}
 
-		workflowState.setNodeParameters(updateInformation);
+		workflowDocumentStore.value?.setNodeParameters(updateInformation);
 
 		void externalHooks.run('nodeSettings.valueChanged', {
 			parameterPath,

--- a/packages/frontend/editor-ui/src/features/shared/editors/components/SqlEditor/SQLEditor.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/SqlEditor/SQLEditor.test.ts
@@ -8,8 +8,19 @@ import { renderComponent, type RenderOptions } from '@/__tests__/render';
 import { waitFor } from '@testing-library/vue';
 import { userEvent } from '@testing-library/user-event';
 import { setActivePinia } from 'pinia';
+import { shallowRef } from 'vue';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	injectWorkflowDocumentStore,
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import type { INodeUi } from '@/Interface';
+
+vi.mock('@/app/stores/workflowDocument.store', async () => {
+	const actual = await vi.importActual('@/app/stores/workflowDocument.store');
+	return { ...actual, injectWorkflowDocumentStore: vi.fn() };
+});
 
 const EXPRESSION_OUTPUT_TEST_ID = 'inline-expression-editor-output';
 
@@ -75,7 +86,11 @@ describe('SqlEditor.vue', () => {
 		setActivePinia(pinia);
 
 		const workflowsStore = useWorkflowsStore();
+		workflowsStore.workflow.id = 'test-workflow';
 		vi.mocked(workflowsStore).getNodeByName.mockReturnValue(nodes[0]);
+		vi.mocked(injectWorkflowDocumentStore).mockReturnValue(
+			shallowRef(useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))),
+		);
 	});
 
 	afterAll(() => {


### PR DESCRIPTION
## Summary

This pull request refactors several NDV (Node Details View) frontend components to use the new `workflowDocumentStore` instead of the older `workflowState` and direct access to `workflowsStore` for node and workflow state management. This change improves consistency and prepares the codebase for collaborative and multi-document editing features. The update touches parameter input, run data, node settings, and related composables, as well as updates relevant tests.

**Migration to `workflowDocumentStore` for Workflow State Management:**

* Replaced all uses of `injectWorkflowState` and direct node lookups via `workflowsStore.getNodeByName` with `injectWorkflowDocumentStore` and its methods (e.g., `getNodeByName`, `updateNodeProperties`, `setNodeParameters`, `setNodeValue`) in `ParameterInput.vue`, `RunData.vue`, and `NodeSettings.vue`. [[1]](diffhunk://#diff-f3b689111fd8485348b4b2ca48fd989606b2d64576efbe9fc34292da343a726aL116-R116) [[2]](diffhunk://#diff-f3b689111fd8485348b4b2ca48fd989606b2d64576efbe9fc34292da343a726aL179-R179) [[3]](diffhunk://#diff-f3b689111fd8485348b4b2ca48fd989606b2d64576efbe9fc34292da343a726aL729-R731) [[4]](diffhunk://#diff-67fea899fd80dbaa3a37f4a46baf44a4e465bb59de6aad3e5bf975b3b20955b5L97) [[5]](diffhunk://#diff-67fea899fd80dbaa3a37f4a46baf44a4e465bb59de6aad3e5bf975b3b20955b5L231) [[6]](diffhunk://#diff-67fea899fd80dbaa3a37f4a46baf44a4e465bb59de6aad3e5bf975b3b20955b5L648-R646) [[7]](diffhunk://#diff-67fea899fd80dbaa3a37f4a46baf44a4e465bb59de6aad3e5bf975b3b20955b5L1398-R1396) [[8]](diffhunk://#diff-a6eca62dcdb6f79f70df9de619deb44f3bc49202eb85d85526137ecbe6809d32L324-R324) [[9]](diffhunk://#diff-7973c6486bc2ec26a1a5b388e0936d473e51761d91d0abbe817d188ca7b9c58fL70-R70) [[10]](diffhunk://#diff-7973c6486bc2ec26a1a5b388e0936d473e51761d91d0abbe817d188ca7b9c58fL132-R128) [[11]](diffhunk://#diff-7973c6486bc2ec26a1a5b388e0936d473e51761d91d0abbe817d188ca7b9c58fL342-R333) [[12]](diffhunk://#diff-7973c6486bc2ec26a1a5b388e0936d473e51761d91d0abbe817d188ca7b9c58fL428-R419) [[13]](diffhunk://#diff-7973c6486bc2ec26a1a5b388e0936d473e51761d91d0abbe817d188ca7b9c58fL458-R449) [[14]](diffhunk://#diff-7973c6486bc2ec26a1a5b388e0936d473e51761d91d0abbe817d188ca7b9c58fL518-R511)

* Updated the `useNodeSettingsParameters` composable to use a computed `workflowDocumentStore` instead of `injectWorkflowState`, and refactored parameter update logic accordingly. [[1]](diffhunk://#diff-8232004239447a8fbe4031a9a17afd99b4745d61955d5e171fa500da6b96f1cfL3-R3) [[2]](diffhunk://#diff-8232004239447a8fbe4031a9a17afd99b4745d61955d5e171fa500da6b96f1cfL34-R46) [[3]](diffhunk://#diff-8232004239447a8fbe4031a9a17afd99b4745d61955d5e171fa500da6b96f1cfL136-R143)

**Test Adaptation:**

* Modified the `SqlEditor` component test to mock and use the new `workflowDocumentStore` injection, ensuring tests remain valid after the refactor. [[1]](diffhunk://#diff-f9f43dfb3b828e9e1b58bf3a0d4c67044b6a89a60b4a763816229bdcb6c5adc4R11-R24) [[2]](diffhunk://#diff-f9f43dfb3b828e9e1b58bf3a0d4c67044b6a89a60b4a763816229bdcb6c5adc4R89-R93)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2518


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
