### PR TITLE
refactor(editor): Migrate workflow composables to use `WorkflowDocumentStore` (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.ts
@@ -327,7 +327,7 @@ export function useWorkflowExtraction() {
 				...x: Parameters<typeof NodeHelpers.getNodeInputs>
 			) => ReturnType<typeof NodeHelpers.getNodeInputs>,
 		) => {
-			const node = workflowsStore.getNodeByName(nodeName);
+			const node = workflowDocumentStore?.value?.getNodeByName(nodeName) ?? null;
 			if (!node) return true; // invariant broken -> abort onto error path
 			const nodeType = useNodeTypesStore().getNodeType(node.type, node.typeVersion);
 			if (!nodeType) return true; // invariant broken -> abort onto error path
@@ -398,7 +398,7 @@ export function useWorkflowExtraction() {
 		);
 
 		for (const node of selectionChildNodes) {
-			const currentNode = workflowsStore.workflow.nodes.find((x) => x.id === node.id);
+			const currentNode = workflowDocumentStore?.value?.getNodeById(node.id);
 
 			if (isEqual(node, currentNode)) continue;
 
@@ -415,7 +415,9 @@ export function useWorkflowExtraction() {
 	}
 
 	function tryExtractNodesIntoSubworkflow(nodeIds: string[]): boolean {
-		const subGraph = nodeIds.map(workflowsStore.getNodeById).filter((x) => x !== undefined);
+		const subGraph = nodeIds
+			.map((id) => workflowDocumentStore?.value?.getNodeById(id))
+			.filter((x) => x !== undefined);
 
 		const triggers = subGraph.filter((x) =>
 			useNodeTypesStore().getNodeType(x.type, x.typeVersion)?.group.includes('trigger'),
@@ -450,7 +452,7 @@ export function useWorkflowExtraction() {
 	) {
 		const { start, end } = selection;
 
-		const allNodeNames = workflowsStore.workflow.nodes.map((x) => x.name);
+		const allNodeNames = (workflowDocumentStore?.value?.allNodes ?? []).map((x) => x.name);
 
 		let startNodeName = 'Start';
 		const subGraphNames = subGraph.map((x) => x.name);

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.ts
@@ -327,7 +327,7 @@ export function useWorkflowExtraction() {
 				...x: Parameters<typeof NodeHelpers.getNodeInputs>
 			) => ReturnType<typeof NodeHelpers.getNodeInputs>,
 		) => {
-			const node = workflowDocumentStore?.value?.getNodeByName(nodeName) ?? null;
+			const node = workflowsStore.getNodeByName(nodeName);
 			if (!node) return true; // invariant broken -> abort onto error path
 			const nodeType = useNodeTypesStore().getNodeType(node.type, node.typeVersion);
 			if (!nodeType) return true; // invariant broken -> abort onto error path
@@ -398,7 +398,7 @@ export function useWorkflowExtraction() {
 		);
 
 		for (const node of selectionChildNodes) {
-			const currentNode = workflowDocumentStore?.value?.getNodeById(node.id);
+			const currentNode = workflowsStore.workflow.nodes.find((x) => x.id === node.id);
 
 			if (isEqual(node, currentNode)) continue;
 
@@ -415,9 +415,7 @@ export function useWorkflowExtraction() {
 	}
 
 	function tryExtractNodesIntoSubworkflow(nodeIds: string[]): boolean {
-		const subGraph = nodeIds
-			.map((id) => workflowDocumentStore?.value?.getNodeById(id))
-			.filter((x) => x !== undefined);
+		const subGraph = nodeIds.map(workflowsStore.getNodeById).filter((x) => x !== undefined);
 
 		const triggers = subGraph.filter((x) =>
 			useNodeTypesStore().getNodeType(x.type, x.typeVersion)?.group.includes('trigger'),
@@ -452,7 +450,7 @@ export function useWorkflowExtraction() {
 	) {
 		const { start, end } = selection;
 
-		const allNodeNames = (workflowDocumentStore?.value?.allNodes ?? []).map((x) => x.name);
+		const allNodeNames = workflowsStore.workflow.nodes.map((x) => x.name);
 
 		let startNodeName = 'Start';
 		const subGraphNames = subGraph.map((x) => x.name);

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -62,6 +62,7 @@ import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
+import { computed } from 'vue';
 
 export type ResolveParameterOptions = {
 	targetItem?: TargetItem;
@@ -539,8 +540,14 @@ export function useWorkflowHelpers() {
 
 	const i18n = useI18n();
 
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
+
 	function getNodeTypesMaxCount() {
-		const nodes = workflowsStore.allNodes;
+		const nodes = workflowDocumentStore.value?.allNodes ?? [];
 
 		const returnData: INodeTypesMaxCount = {};
 
@@ -566,7 +573,7 @@ export function useWorkflowHelpers() {
 	}
 
 	function getNodeTypeCount(nodeType: string) {
-		const nodes = workflowsStore.allNodes;
+		const nodes = workflowDocumentStore.value?.allNodes ?? [];
 
 		let count = 0;
 
@@ -580,7 +587,7 @@ export function useWorkflowHelpers() {
 	}
 
 	async function getWorkflowDataToSave() {
-		const workflowNodes = workflowsStore.allNodes;
+		const workflowNodes = workflowDocumentStore.value?.allNodes ?? [];
 		const workflowConnections = workflowsStore.allConnections;
 
 		let nodeData;
@@ -598,20 +605,16 @@ export function useWorkflowHelpers() {
 		// nodes not present in the nodes snapshot, violating a BE invariant.
 		const connections = deepCopy(workflowConnections);
 
-		const workflowDocumentStore = useWorkflowDocumentStore(
-			createWorkflowDocumentId(workflowsStore.workflowId),
-		);
-
 		const data: WorkflowData = {
 			name: workflowsStore.workflowName,
 			nodes,
-			pinData: workflowDocumentStore.getPinDataSnapshot(),
+			pinData: workflowDocumentStore.value?.getPinDataSnapshot(),
 			connections,
-			active: workflowDocumentStore.active,
-			settings: workflowDocumentStore.settings,
-			tags: [...workflowDocumentStore.tags],
+			active: workflowDocumentStore.value?.active,
+			settings: workflowDocumentStore.value?.settings,
+			tags: [...(workflowDocumentStore.value?.tags ?? [])],
 			versionId: workflowsStore.workflow.versionId,
-			meta: workflowDocumentStore.meta,
+			meta: workflowDocumentStore.value?.meta,
 		};
 
 		const workflowId = workflowsStore.workflowId;
@@ -882,17 +885,17 @@ export function useWorkflowHelpers() {
 			uiStore.markStateClean();
 		}
 
-		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+		const wfDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
 
 		if (workflow.activeVersion) {
 			workflowsStore.setWorkflowActive(workflowId, workflow.activeVersion, isCurrentWorkflow);
-			workflowDocumentStore.setActiveState({
+			wfDocumentStore.setActiveState({
 				activeVersionId: workflow.activeVersion.versionId,
 				activeVersion: workflow.activeVersion,
 			});
 		} else {
 			workflowsStore.setWorkflowInactive(workflowId);
-			workflowDocumentStore.setActiveState({
+			wfDocumentStore.setActiveState({
 				activeVersionId: null,
 				activeVersion: null,
 			});
@@ -1021,36 +1024,34 @@ export function useWorkflowHelpers() {
 		const tags = (workflowData.tags ?? []) as ITag[];
 		const tagIds = convertWorkflowTagsToIds(tags);
 
-		const workflowDocumentStore = useWorkflowDocumentStore(
-			createWorkflowDocumentId(workflowData.id),
-		);
+		const wfDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowData.id));
 
 		// Sync document store settings → workflowObject (runtime Workflow instance)
-		workflowDocumentStore.onSettingsChange(({ payload }) => {
+		wfDocumentStore.onSettingsChange(({ payload }) => {
 			workflowsStore.workflowObject.setSettings(payload.settings);
 		});
 
-		workflowDocumentStore.setTags(tagIds);
-		workflowDocumentStore.setActiveState({
+		wfDocumentStore.setTags(tagIds);
+		wfDocumentStore.setActiveState({
 			activeVersionId: workflowData.activeVersionId,
 			activeVersion: workflowData.activeVersion ?? null,
 		});
-		workflowDocumentStore.setSettings(workflowData.settings ?? {});
-		workflowDocumentStore.setPinData(workflowData.pinData ?? {});
-		workflowDocumentStore.setCreatedAt(workflowData.createdAt);
-		workflowDocumentStore.setUpdatedAt(workflowData.updatedAt);
-		workflowDocumentStore.setHomeProject(workflowData.homeProject ?? null);
+		wfDocumentStore.setSettings(workflowData.settings ?? {});
+		wfDocumentStore.setPinData(workflowData.pinData ?? {});
+		wfDocumentStore.setCreatedAt(workflowData.createdAt);
+		wfDocumentStore.setUpdatedAt(workflowData.updatedAt);
+		wfDocumentStore.setHomeProject(workflowData.homeProject ?? null);
 		if (workflowData.checksum) {
-			workflowDocumentStore.setChecksum(workflowData.checksum);
+			wfDocumentStore.setChecksum(workflowData.checksum);
 		}
-		workflowDocumentStore.setIsArchived(workflowData.isArchived);
-		workflowDocumentStore.setUsedCredentials(workflowData.usedCredentials ?? []);
-		workflowDocumentStore.setMeta(workflowData.meta);
-		workflowDocumentStore.setParentFolder(workflowData.parentFolder ?? null);
-		workflowDocumentStore.setScopes(workflowData.scopes ?? []);
+		wfDocumentStore.setIsArchived(workflowData.isArchived);
+		wfDocumentStore.setUsedCredentials(workflowData.usedCredentials ?? []);
+		wfDocumentStore.setMeta(workflowData.meta);
+		wfDocumentStore.setParentFolder(workflowData.parentFolder ?? null);
+		wfDocumentStore.setScopes(workflowData.scopes ?? []);
 		tagsStore.upsertTags(tags);
 
-		return { workflowDocumentStore };
+		return { workflowDocumentStore: wfDocumentStore };
 	}
 
 	/**

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -540,14 +540,14 @@ export function useWorkflowHelpers() {
 
 	const i18n = useI18n();
 
-	const workflowDocumentStore = computed(() =>
+	const currentWorkflowDocumentStore = computed(() =>
 		workflowsStore.workflowId
 			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
 			: undefined,
 	);
 
 	function getNodeTypesMaxCount() {
-		const nodes = workflowDocumentStore.value?.allNodes ?? [];
+		const nodes = currentWorkflowDocumentStore.value?.allNodes ?? [];
 
 		const returnData: INodeTypesMaxCount = {};
 
@@ -573,7 +573,7 @@ export function useWorkflowHelpers() {
 	}
 
 	function getNodeTypeCount(nodeType: string) {
-		const nodes = workflowDocumentStore.value?.allNodes ?? [];
+		const nodes = currentWorkflowDocumentStore.value?.allNodes ?? [];
 
 		let count = 0;
 
@@ -587,7 +587,7 @@ export function useWorkflowHelpers() {
 	}
 
 	async function getWorkflowDataToSave() {
-		const workflowNodes = workflowDocumentStore.value?.allNodes ?? [];
+		const workflowNodes = currentWorkflowDocumentStore.value?.allNodes ?? [];
 		const workflowConnections = workflowsStore.allConnections;
 
 		let nodeData;
@@ -608,13 +608,13 @@ export function useWorkflowHelpers() {
 		const data: WorkflowData = {
 			name: workflowsStore.workflowName,
 			nodes,
-			pinData: workflowDocumentStore.value?.getPinDataSnapshot(),
+			pinData: currentWorkflowDocumentStore.value?.getPinDataSnapshot(),
 			connections,
-			active: workflowDocumentStore.value?.active,
-			settings: workflowDocumentStore.value?.settings,
-			tags: [...(workflowDocumentStore.value?.tags ?? [])],
+			active: currentWorkflowDocumentStore.value?.active,
+			settings: currentWorkflowDocumentStore.value?.settings,
+			tags: [...(currentWorkflowDocumentStore.value?.tags ?? [])],
 			versionId: workflowsStore.workflow.versionId,
-			meta: workflowDocumentStore.value?.meta,
+			meta: currentWorkflowDocumentStore.value?.meta,
 		};
 
 		const workflowId = workflowsStore.workflowId;
@@ -885,17 +885,17 @@ export function useWorkflowHelpers() {
 			uiStore.markStateClean();
 		}
 
-		const wfDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
 
 		if (workflow.activeVersion) {
 			workflowsStore.setWorkflowActive(workflowId, workflow.activeVersion, isCurrentWorkflow);
-			wfDocumentStore.setActiveState({
+			workflowDocumentStore.setActiveState({
 				activeVersionId: workflow.activeVersion.versionId,
 				activeVersion: workflow.activeVersion,
 			});
 		} else {
 			workflowsStore.setWorkflowInactive(workflowId);
-			wfDocumentStore.setActiveState({
+			workflowDocumentStore.setActiveState({
 				activeVersionId: null,
 				activeVersion: null,
 			});
@@ -1024,34 +1024,36 @@ export function useWorkflowHelpers() {
 		const tags = (workflowData.tags ?? []) as ITag[];
 		const tagIds = convertWorkflowTagsToIds(tags);
 
-		const wfDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowData.id));
+		const workflowDocumentStore = useWorkflowDocumentStore(
+			createWorkflowDocumentId(workflowData.id),
+		);
 
 		// Sync document store settings → workflowObject (runtime Workflow instance)
-		wfDocumentStore.onSettingsChange(({ payload }) => {
+		workflowDocumentStore.onSettingsChange(({ payload }) => {
 			workflowsStore.workflowObject.setSettings(payload.settings);
 		});
 
-		wfDocumentStore.setTags(tagIds);
-		wfDocumentStore.setActiveState({
+		workflowDocumentStore.setTags(tagIds);
+		workflowDocumentStore.setActiveState({
 			activeVersionId: workflowData.activeVersionId,
 			activeVersion: workflowData.activeVersion ?? null,
 		});
-		wfDocumentStore.setSettings(workflowData.settings ?? {});
-		wfDocumentStore.setPinData(workflowData.pinData ?? {});
-		wfDocumentStore.setCreatedAt(workflowData.createdAt);
-		wfDocumentStore.setUpdatedAt(workflowData.updatedAt);
-		wfDocumentStore.setHomeProject(workflowData.homeProject ?? null);
+		workflowDocumentStore.setSettings(workflowData.settings ?? {});
+		workflowDocumentStore.setPinData(workflowData.pinData ?? {});
+		workflowDocumentStore.setCreatedAt(workflowData.createdAt);
+		workflowDocumentStore.setUpdatedAt(workflowData.updatedAt);
+		workflowDocumentStore.setHomeProject(workflowData.homeProject ?? null);
 		if (workflowData.checksum) {
-			wfDocumentStore.setChecksum(workflowData.checksum);
+			workflowDocumentStore.setChecksum(workflowData.checksum);
 		}
-		wfDocumentStore.setIsArchived(workflowData.isArchived);
-		wfDocumentStore.setUsedCredentials(workflowData.usedCredentials ?? []);
-		wfDocumentStore.setMeta(workflowData.meta);
-		wfDocumentStore.setParentFolder(workflowData.parentFolder ?? null);
-		wfDocumentStore.setScopes(workflowData.scopes ?? []);
+		workflowDocumentStore.setIsArchived(workflowData.isArchived);
+		workflowDocumentStore.setUsedCredentials(workflowData.usedCredentials ?? []);
+		workflowDocumentStore.setMeta(workflowData.meta);
+		workflowDocumentStore.setParentFolder(workflowData.parentFolder ?? null);
+		workflowDocumentStore.setScopes(workflowData.scopes ?? []);
 		tagsStore.upsertTags(tags);
 
-		return { workflowDocumentStore: wfDocumentStore };
+		return { workflowDocumentStore };
 	}
 
 	/**

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -497,7 +497,7 @@ export function useWorkflowSaving({
 						value: changedNodes[nodeName],
 						name: nodeName,
 					} as IUpdateInformation;
-					workflowState.setNodeValue(changes);
+					workflowDocumentStore?.setNodeValue(changes);
 				});
 			}
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.test.ts
@@ -10,6 +10,7 @@ import { mockedStore } from '@/__tests__/utils';
 import { createTestNode } from '@/__tests__/mocks';
 import type { INodeUi } from '@/Interface';
 import { DEFAULT_NEW_WORKFLOW_NAME } from '@/app/constants';
+import type { useWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 // Mock canvas event bus - using hoisted to ensure proper initialization order
 const canvasEventBusEmitMock = vi.hoisted(() => vi.fn());
@@ -25,9 +26,22 @@ vi.mock('@/features/workflows/canvas/canvas.utils', () => ({
 	mapLegacyConnectionsToCanvasConnections: mockMapLegacyConnectionsToCanvasConnections,
 }));
 
+// Mock workflowDocumentStore - using hoisted for proper initialization
+const mockDocumentStore = vi.hoisted(() => ({
+	allNodes: [] as INodeUi[],
+	setNodes: vi.fn(),
+	resetParametersLastUpdatedAt: vi.fn(),
+	setPinData: vi.fn(),
+	getPinDataSnapshot: vi.fn().mockReturnValue({}),
+})) as unknown as ReturnType<typeof useWorkflowDocumentStore>;
+
+vi.mock('@/app/stores/workflowDocument.store', () => ({
+	useWorkflowDocumentStore: vi.fn().mockReturnValue(mockDocumentStore),
+	createWorkflowDocumentId: vi.fn().mockReturnValue('test-id'),
+}));
+
 // Mock useWorkflowState - using hoisted for proper initialization
 const mockWorkflowState = vi.hoisted(() => ({
-	resetParametersLastUpdatedAt: vi.fn(),
 	setWorkflowName: vi.fn(),
 }));
 vi.mock('@/app/composables/useWorkflowState', () => ({
@@ -72,7 +86,12 @@ describe('useWorkflowUpdate', () => {
 		mockMapLegacyConnectionsToCanvasConnections.mockReturnValue([]);
 
 		// Setup default mocks
-		workflowsStore.allNodes = [];
+		(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [];
+		vi.mocked(mockDocumentStore.setNodes).mockClear();
+		vi.mocked(mockDocumentStore.resetParametersLastUpdatedAt).mockClear();
+		vi.mocked(mockDocumentStore.setPinData).mockClear();
+		vi.mocked(mockDocumentStore.getPinDataSnapshot).mockReturnValue({});
+		workflowsStore.workflowId = 'test-workflow';
 		workflowsStore.workflow = {
 			id: 'test-workflow',
 			name: DEFAULT_NEW_WORKFLOW_NAME,
@@ -84,7 +103,6 @@ describe('useWorkflowUpdate', () => {
 			connectionsBySourceNode: {},
 			renameNode: vi.fn(),
 		});
-		workflowsStore.setNodes = vi.fn();
 		workflowsStore.setConnections = vi.fn();
 		workflowsStore.nodesByName = {};
 
@@ -155,7 +173,7 @@ describe('useWorkflowUpdate', () => {
 					name: 'Existing Node',
 				}) as INodeUi;
 
-				workflowsStore.allNodes = [existingNode];
+				(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [existingNode];
 
 				const { updateWorkflow } = useWorkflowUpdate();
 
@@ -180,7 +198,7 @@ describe('useWorkflowUpdate', () => {
 					position: [100, 200],
 				}) as INodeUi;
 
-				workflowsStore.allNodes = [existingNode];
+				(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [existingNode];
 
 				const mockWorkflowObject = {
 					nodes: { 'Chat Trigger': { ...existingNode } },
@@ -210,7 +228,7 @@ describe('useWorkflowUpdate', () => {
 				// Should NOT remove the existing node
 				expect(mockCanvasOperations.deleteNode).not.toHaveBeenCalled();
 				// Should sync state back to store (update in place)
-				expect(workflowsStore.setNodes).toHaveBeenCalled();
+				expect(mockDocumentStore.setNodes).toHaveBeenCalled();
 			});
 
 			it('should preserve existing ID when reconciling by name+type', async () => {
@@ -222,7 +240,7 @@ describe('useWorkflowUpdate', () => {
 					parameters: { url: 'http://old.com' },
 				}) as INodeUi;
 
-				workflowsStore.allNodes = [existingNode];
+				(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [existingNode];
 
 				const mockWorkflowObject = {
 					nodes: { 'HTTP Request': { ...existingNode } },
@@ -248,8 +266,8 @@ describe('useWorkflowUpdate', () => {
 				});
 
 				// Should update the node with the existing ID preserved
-				expect(workflowsStore.setNodes).toHaveBeenCalled();
-				const setNodesCall = workflowsStore.setNodes.mock.calls[0][0];
+				expect(mockDocumentStore.setNodes).toHaveBeenCalled();
+				const setNodesCall = vi.mocked(mockDocumentStore.setNodes).mock.calls[0][0];
 				expect(setNodesCall[0].id).toBe('existing-id');
 				expect(setNodesCall[0].parameters.url).toBe('http://new.com');
 			});
@@ -261,7 +279,7 @@ describe('useWorkflowUpdate', () => {
 					type: 'n8n-nodes-base.httpRequest',
 				}) as INodeUi;
 
-				workflowsStore.allNodes = [existingNode];
+				(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [existingNode];
 
 				const mockWorkflowObject = {
 					nodes: { 'HTTP Request': { ...existingNode } },
@@ -317,7 +335,7 @@ describe('useWorkflowUpdate', () => {
 					position: [100, 200],
 				}) as INodeUi;
 
-				workflowsStore.allNodes = [existingNode];
+				(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [existingNode];
 
 				const mockWorkflowObject = {
 					nodes: { 'Old Name': { ...existingNode } },
@@ -347,7 +365,7 @@ describe('useWorkflowUpdate', () => {
 				expect(mockCanvasOperations.deleteNode).not.toHaveBeenCalled();
 
 				// Should sync state back to store
-				expect(workflowsStore.setNodes).toHaveBeenCalled();
+				expect(mockDocumentStore.setNodes).toHaveBeenCalled();
 				expect(workflowsStore.setConnections).toHaveBeenCalled();
 			});
 
@@ -360,7 +378,7 @@ describe('useWorkflowUpdate', () => {
 					parameters: { url: 'http://example.com' },
 				}) as INodeUi;
 
-				workflowsStore.allNodes = [existingNode];
+				(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [existingNode];
 
 				const mockWorkflowObject = {
 					nodes: { 'HTTP Request': { ...existingNode } },
@@ -386,8 +404,8 @@ describe('useWorkflowUpdate', () => {
 					connections: {},
 				});
 
-				expect(workflowsStore.setNodes).toHaveBeenCalled();
-				const setNodesCall = workflowsStore.setNodes.mock.calls[0][0];
+				expect(mockDocumentStore.setNodes).toHaveBeenCalled();
+				const setNodesCall = vi.mocked(mockDocumentStore.setNodes).mock.calls[0][0];
 				expect(setNodesCall[0].executeOnce).toBe(true);
 			});
 
@@ -428,7 +446,7 @@ describe('useWorkflowUpdate', () => {
 					name: 'Old Name',
 				}) as INodeUi;
 
-				workflowsStore.allNodes = [existingNode];
+				(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [existingNode];
 
 				// After rename, cloneWorkflowObject returns node with new name
 				const mockWorkflowObject = {
@@ -467,7 +485,7 @@ describe('useWorkflowUpdate', () => {
 					name: 'Same Name',
 				}) as INodeUi;
 
-				workflowsStore.allNodes = [existingNode];
+				(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [existingNode];
 
 				const mockWorkflowObject = {
 					nodes: { 'Same Name': { ...existingNode } },
@@ -502,7 +520,7 @@ describe('useWorkflowUpdate', () => {
 					parameters: { url: 'http://example.com' },
 				}) as INodeUi;
 
-				workflowsStore.allNodes = [existingNode];
+				(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [existingNode];
 
 				// Rename fails
 				mockCanvasOperations.renameNode.mockResolvedValueOnce(false);
@@ -532,8 +550,8 @@ describe('useWorkflowUpdate', () => {
 				});
 
 				// Should still update node properties under old name
-				expect(workflowsStore.setNodes).toHaveBeenCalled();
-				const setNodesCall = workflowsStore.setNodes.mock.calls[0][0];
+				expect(mockDocumentStore.setNodes).toHaveBeenCalled();
+				const setNodesCall = vi.mocked(mockDocumentStore.setNodes).mock.calls[0][0];
 				expect(setNodesCall[0].name).toBe('Old Name');
 				expect(setNodesCall[0].parameters.url).toBe('http://updated.com');
 			});
@@ -547,7 +565,7 @@ describe('useWorkflowUpdate', () => {
 					parameters: { url: 'http://old.com' },
 				}) as INodeUi;
 
-				workflowsStore.allNodes = [existingNode];
+				(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [existingNode];
 
 				const mockWorkflowObject = {
 					nodes: { 'HTTP Request': { ...existingNode } },
@@ -572,7 +590,7 @@ describe('useWorkflowUpdate', () => {
 					connections: {},
 				});
 
-				expect(mockWorkflowState.resetParametersLastUpdatedAt).toHaveBeenCalledWith('HTTP Request');
+				expect(mockDocumentStore.resetParametersLastUpdatedAt).toHaveBeenCalledWith('HTTP Request');
 			});
 
 			it('should not mark node as dirty when parameters are unchanged', async () => {
@@ -582,7 +600,7 @@ describe('useWorkflowUpdate', () => {
 					parameters: { url: 'http://same.com' },
 				}) as INodeUi;
 
-				workflowsStore.allNodes = [existingNode];
+				(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [existingNode];
 
 				const mockWorkflowObject = {
 					nodes: { 'HTTP Request': { ...existingNode } },
@@ -607,7 +625,7 @@ describe('useWorkflowUpdate', () => {
 					connections: {},
 				});
 
-				expect(mockWorkflowState.resetParametersLastUpdatedAt).not.toHaveBeenCalled();
+				expect(mockDocumentStore.resetParametersLastUpdatedAt).not.toHaveBeenCalled();
 			});
 		});
 
@@ -698,7 +716,7 @@ describe('useWorkflowUpdate', () => {
 					name: 'Existing Node',
 				}) as INodeUi;
 
-				workflowsStore.allNodes = [existingNode];
+				(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [existingNode];
 
 				const { updateWorkflow } = useWorkflowUpdate();
 
@@ -724,7 +742,7 @@ describe('useWorkflowUpdate', () => {
 					parameters: { url: 'http://example.com' },
 				}) as INodeUi;
 
-				workflowsStore.allNodes = [existingNode];
+				(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [existingNode];
 
 				const mockWorkflowObject = {
 					nodes: { 'HTTP Request': { ...existingNode } },
@@ -888,7 +906,7 @@ describe('useWorkflowUpdate', () => {
 					name: 'Existing Node',
 				}) as INodeUi;
 
-				workflowsStore.allNodes = [existingNode];
+				(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [existingNode];
 
 				const testError = new Error('Failed to clone workflow');
 				workflowsStore.cloneWorkflowObject = vi.fn().mockImplementation(() => {

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
@@ -23,6 +23,7 @@ import { getAuthTypeForNodeCredential, getMainAuthField } from '@/app/utils/node
 import type { WorkflowDataUpdate } from '@n8n/rest-api-client/api/workflows';
 import { NodeHelpers, type IConnections, type INode } from 'n8n-workflow';
 import isEqual from 'lodash/isEqual';
+import { computed } from 'vue';
 
 export interface UpdateWorkflowOptions {
 	isInitialGeneration?: boolean;
@@ -51,6 +52,12 @@ export function useWorkflowUpdate() {
 	const canvasOperations = useCanvasOperations();
 	const nodeHelpers = useNodeHelpers();
 
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
+
 	/**
 	 * Categorize nodes into those to update, add, or remove.
 	 *
@@ -61,12 +68,11 @@ export function useWorkflowUpdate() {
 	 * triggering maxNodes validation errors for nodes like ChatTrigger.
 	 */
 	function categorizeNodes(workflowData: WorkflowDataUpdate) {
-		const existingNodesById = new Map(workflowsStore.allNodes.map((n) => [n.id, n]));
+		const allNodes = workflowDocumentStore.value?.allNodes ?? [];
+		const existingNodesById = new Map(allNodes.map((n) => [n.id, n]));
 
 		// Add name+type index for fallback matching when IDs differ
-		const existingNodesByNameType = new Map(
-			workflowsStore.allNodes.map((n) => [`${n.type}::${n.name}`, n]),
-		);
+		const existingNodesByNameType = new Map(allNodes.map((n) => [`${n.type}::${n.name}`, n]));
 
 		const nodesToUpdate: Array<{ existing: INodeUi; updated: INode }> = [];
 		const nodesToAdd: INode[] = [];
@@ -166,13 +172,13 @@ export function useWorkflowUpdate() {
 
 			// Mark node as dirty if parameters changed
 			if (!isEqual(existing.parameters, updated.parameters)) {
-				workflowState.resetParametersLastUpdatedAt(nodeName);
+				workflowDocumentStore.value?.resetParametersLastUpdatedAt(nodeName);
 				hasChanges = true;
 			}
 		}
 
 		// Sync state back to store
-		workflowsStore.setNodes(Object.values(workflow.nodes));
+		workflowDocumentStore.value?.setNodes(Object.values(workflow.nodes));
 		workflowsStore.setConnections(workflow.connectionsBySourceNode);
 		// Revalidate updated nodes to refresh error indicators on canvas
 		for (const { existing } of nodesToUpdate) {
@@ -243,14 +249,12 @@ export function useWorkflowUpdate() {
 		const existingConnections = workflowsStore.workflow.connections;
 
 		// Convert to canvas format for comparison
+		const allNodes = workflowDocumentStore.value?.allNodes ?? [];
 		const existingCanvasConnections = mapLegacyConnectionsToCanvasConnections(
 			existingConnections,
-			workflowsStore.allNodes,
+			allNodes,
 		);
-		const newCanvasConnections = mapLegacyConnectionsToCanvasConnections(
-			newConnections,
-			workflowsStore.allNodes,
-		);
+		const newCanvasConnections = mapLegacyConnectionsToCanvasConnections(newConnections, allNodes);
 
 		// Find connections to remove (exist in current but not in new)
 		const connectionsToRemove = existingCanvasConnections.filter(
@@ -373,12 +377,9 @@ export function useWorkflowUpdate() {
 			updateWorkflowNameIfNeeded(workflowData.name, options?.isInitialGeneration);
 
 			// Merge pin data from workflow data with existing pin data
-			if (workflowData.pinData && workflowsStore.workflowId) {
-				const workflowDocumentStore = useWorkflowDocumentStore(
-					createWorkflowDocumentId(workflowsStore.workflowId),
-				);
-				workflowDocumentStore.setPinData({
-					...workflowDocumentStore.getPinDataSnapshot(),
+			if (workflowData.pinData && workflowDocumentStore.value) {
+				workflowDocumentStore.value.setPinData({
+					...workflowDocumentStore.value.getPinDataSnapshot(),
 					...workflowData.pinData,
 				});
 			}

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
@@ -1184,6 +1184,7 @@ describe('useWorkflowsStore', () => {
 		});
 
 		it('should add node error event and track errored executions', async () => {
+			workflowsStore.workflow.id = 'test-workflow';
 			workflowsStore.workflow.pinData = {};
 			useWorkflowState().setWorkflowExecutionData(executionResponse);
 			workflowsStore.addNode({


### PR DESCRIPTION
## Summary

Replace workflowsStore node access patterns with WorkflowDocumentStore throughout useWorkflowExtraction, useWorkflowHelpers, useWorkflowSaving, and useWorkflowUpdate composables. Update tests to mock the document store instead of the workflows store.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2511

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
