### PR TITLE
chore: Add 1.x branch compatibility to workflow scripts

### DIFF
--- a/.github/scripts/determine-version-info.mjs
+++ b/.github/scripts/determine-version-info.mjs
@@ -1,6 +1,10 @@
 import { readFileSync } from 'node:fs';
-import { RELEASE_TRACKS, resolveReleaseTagForTrack, writeGithubOutput } from './github-helpers.mjs';
-import { tagVersionInfoToReleaseCandidateBranchName } from './ensure-release-candidate-branches.mjs';
+import {
+	RELEASE_TRACKS,
+	resolveReleaseTagForTrack,
+	tagVersionInfoToReleaseCandidateBranchName,
+	writeGithubOutput,
+} from './github-helpers.mjs';
 import semver from 'semver';
 
 /**

--- a/.github/scripts/determine-version-info.test.mjs
+++ b/.github/scripts/determine-version-info.test.mjs
@@ -1,5 +1,6 @@
 import { describe, it, mock, before } from 'node:test';
 import assert from 'node:assert/strict';
+import { tagVersionInfoToReleaseCandidateBranchName } from './github-helpers.mjs';
 
 /**
  * Run these tests by running
@@ -18,6 +19,7 @@ mock.module('./github-helpers.mjs', {
 			if (track === 'beta') return { version: '2.10.1', tag: 'n8n@2.10.1' };
 			return { version: '1.123.33', tag: 'n8n@1.123.33' };
 		},
+		tagVersionInfoToReleaseCandidateBranchName,
 		writeGithubOutput: () => {}, // no-op in tests
 		getCommitForRef: () => {}, // no-op
 		localRefExists: () => {}, // no-op

--- a/.github/scripts/ensure-release-candidate-branches.mjs
+++ b/.github/scripts/ensure-release-candidate-branches.mjs
@@ -2,13 +2,13 @@ import semver from 'semver';
 import {
 	getCommitForRef,
 	localRefExists,
+	RELEASE_CANDIDATE_BRANCH_PREFIX,
 	remoteBranchExists,
 	resolveReleaseTagForTrack,
 	sh,
+	tagVersionInfoToReleaseCandidateBranchName,
 	writeGithubOutput,
 } from './github-helpers.mjs';
-
-const RELEASE_CANDIDATE_BRANCH_PREFIX = 'release-candidate/';
 
 /**
  * @typedef BranchChanges
@@ -49,20 +49,6 @@ export function determineBranchChanges() {
 		branchesToEnsure,
 		branchesToDeprecate,
 	};
-}
-
-/**
- * Takes a TagVersionInfo object and returns a rc-branch name.
- *
- * e.g. release-candidate/2.8.x
- *
- * @param {import('./github-helpers.mjs').TagVersionInfo} tagVersionInfo
- *
- * @returns { `${RELEASE_CANDIDATE_BRANCH_PREFIX}${number}.${number}.x` }
- * */
-export function tagVersionInfoToReleaseCandidateBranchName(tagVersionInfo) {
-	const version = tagVersionInfo.version;
-	return `${RELEASE_CANDIDATE_BRANCH_PREFIX}${semver.major(version)}.${semver.minor(version)}.x`;
 }
 
 /**

--- a/.github/scripts/ensure-release-candidate-branches.test.mjs
+++ b/.github/scripts/ensure-release-candidate-branches.test.mjs
@@ -1,5 +1,6 @@
 import { describe, it, mock, before } from 'node:test';
 import assert from 'node:assert/strict';
+import { RELEASE_CANDIDATE_BRANCH_PREFIX } from './github-helpers.mjs';
 
 /**
  * Run these tests by running
@@ -7,12 +8,18 @@ import assert from 'node:assert/strict';
  * node --test --experimental-test-module-mocks ./.github/scripts/ensure-release-candidate-branches.test.mjs
  * */
 
+let tagVersionInfoToReleaseCandidateBranchName;
+before(async () => {
+	({ tagVersionInfoToReleaseCandidateBranchName } = await import('./github-helpers.mjs'));
+});
+
 // mock.module must be called before the module under test is imported,
 // because static imports are hoisted and resolve before any code runs.
 mock.module('./github-helpers.mjs', {
 	namedExports: {
 		RELEASE_TRACKS: ['stable', 'beta', 'v1'],
 		RELEASE_PREFIX: 'n8n@',
+		RELEASE_CANDIDATE_BRANCH_PREFIX: RELEASE_CANDIDATE_BRANCH_PREFIX,
 		resolveReleaseTagForTrack: (track) => {
 			// Always return deterministic data
 			if (track === 'stable') return { version: '2.9.2', tag: 'n8n@2.9.2' };
@@ -27,11 +34,9 @@ mock.module('./github-helpers.mjs', {
 	},
 });
 
-let determineBranchChanges, tagVersionInfoToReleaseCandidateBranchName;
+let determineBranchChanges;
 before(async () => {
-	({ determineBranchChanges, tagVersionInfoToReleaseCandidateBranchName } = await import(
-		'./ensure-release-candidate-branches.mjs'
-	));
+	({ determineBranchChanges } = await import('./ensure-release-candidate-branches.mjs'));
 });
 
 describe('Determine branch changes', () => {

--- a/.github/scripts/ensure-release-candidate-branches.test.mjs
+++ b/.github/scripts/ensure-release-candidate-branches.test.mjs
@@ -20,6 +20,7 @@ mock.module('./github-helpers.mjs', {
 		RELEASE_TRACKS: ['stable', 'beta', 'v1'],
 		RELEASE_PREFIX: 'n8n@',
 		RELEASE_CANDIDATE_BRANCH_PREFIX: RELEASE_CANDIDATE_BRANCH_PREFIX,
+		tagVersionInfoToReleaseCandidateBranchName,
 		resolveReleaseTagForTrack: (track) => {
 			// Always return deterministic data
 			if (track === 'stable') return { version: '2.9.2', tag: 'n8n@2.9.2' };

--- a/.github/scripts/github-helpers.mjs
+++ b/.github/scripts/github-helpers.mjs
@@ -4,6 +4,9 @@ import fs from 'node:fs';
 import path from 'node:path';
 import semver from 'semver';
 
+export const CURRENT_MAJOR_VERSION = 2;
+export const RELEASE_CANDIDATE_BRANCH_PREFIX = 'release-candidate/';
+
 export const RELEASE_TRACKS = /** @type { const } */ ([
 	//
 	'stable',
@@ -24,7 +27,7 @@ export const RELEASE_TRACKS = /** @type { const } */ ([
  * */
 
 /**
- * @typedef {{ tag: ReleaseVersion, version: SemVer}} TagVersionInfo
+ * @typedef {{ tag: ReleaseVersion, version: SemVer }} TagVersionInfo
  * */
 
 export const RELEASE_PREFIX = 'n8n@';
@@ -113,6 +116,25 @@ export function resolveRcBranchForTrack(track) {
 }
 
 /**
+ * Takes a TagVersionInfo object and returns a rc-branch name.
+ *
+ * e.g. release-candidate/2.8.x or 1.x
+ *
+ * @param {import('./github-helpers.mjs').TagVersionInfo} tagVersionInfo
+ *
+ * @returns { `${RELEASE_CANDIDATE_BRANCH_PREFIX}${number}.${number}.x` | `${number}.x` }
+ * */
+export function tagVersionInfoToReleaseCandidateBranchName(tagVersionInfo) {
+	const version = tagVersionInfo.version;
+	const majorVersion = semver.major(version);
+	if (majorVersion < CURRENT_MAJOR_VERSION) {
+		return `${majorVersion}.x`;
+	}
+
+	return `${RELEASE_CANDIDATE_BRANCH_PREFIX}${majorVersion}.${semver.minor(version)}.x`;
+}
+
+/**
  * @param {string} tag
  *
  * @returns { SemVer }
@@ -150,8 +172,9 @@ export function readPrLabels(pullRequest) {
 /**
  * Ensures git tag exists.
  *
- * @throws { Error } if no tag was found
- * */
+ * @param {string} tag
+ * @throws {Error} if no tag was found
+ */
 export function ensureTagExists(tag) {
 	sh('git', ['fetch', '--force', '--no-tags', 'origin', `refs/tags/${tag}:refs/tags/${tag}`]);
 }


### PR DESCRIPTION
## Summary

Add final steps of compatibility for workflow scripts to be able to run on 1.x branch. After this PR, the workflows will be backported to 1.x. 

PR modifies multiple files due to some QoL refactoring.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
