### PR TITLE
build: Add `import-x/no-extraneous-dependencies` lint rule to `n8n-workflow`

### DIFF
--- a/packages/workflow/eslint.config.mjs
+++ b/packages/workflow/eslint.config.mjs
@@ -5,6 +5,7 @@ export default defineConfig(
 	baseConfig,
 	{
 		rules: {
+			'import-x/no-extraneous-dependencies': 'error',
 			'unicorn/filename-case': ['error', { case: 'kebabCase' }],
 			complexity: ['error', 23],
 


### PR DESCRIPTION
## Summary

Enables the `import-x/no-extraneous-dependencies` ESLint rule for `packages/workflow`.

This ensures every import has a corresponding entry in `package.json`, catching dependencies that only work by accident via hoisting. Would have prevented the issue fixed in #27129. (Enabling this rule for _all_ packages is out of scope.)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.