### PR TITLE
refactor(editor): Migrate NDV panel components to `workflowDocumentStore` (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/InputNodeSelect.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/InputNodeSelect.vue
@@ -3,6 +3,7 @@ import { useI18n } from '@n8n/i18n';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { isPresent } from '@/app/utils/typesUtils';
 import type { IConnectedNode, Workflow } from 'n8n-workflow';
 import { computed } from 'vue';
@@ -24,10 +25,13 @@ const emit = defineEmits<{
 
 const i18n = useI18n();
 const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const nodeTypesStore = useNodeTypesStore();
 const ndvStore = useNDVStore();
 
-const selectedInputNode = computed(() => workflowsStore.getNodeByName(props.modelValue ?? ''));
+const selectedInputNode = computed(
+	() => workflowDocumentStore?.value?.getNodeByName(props.modelValue ?? '') ?? null,
+);
 
 const selectedInputNodeType = computed(() => {
 	const node = selectedInputNode.value;
@@ -40,7 +44,7 @@ const inputNodes = computed(
 	() =>
 		props.nodes
 			?.map((node) => {
-				const fullNode = workflowsStore.getNodeByName(node.name);
+				const fullNode = workflowDocumentStore?.value?.getNodeByName(node.name) ?? null;
 				if (!fullNode) return null;
 
 				return {

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/InputPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/InputPanel.test.ts
@@ -12,10 +12,20 @@ import {
 	type IRunData,
 } from 'n8n-workflow';
 import { setActivePinia } from 'pinia';
-import { computed } from 'vue';
+import { computed, shallowRef } from 'vue';
 import { WorkflowIdKey } from '@/app/constants/injectionKeys';
 
 import { useWorkflowState } from '@/app/composables/useWorkflowState';
+import {
+	injectWorkflowDocumentStore,
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
+
+vi.mock('@/app/stores/workflowDocument.store', async () => {
+	const actual = await vi.importActual('@/app/stores/workflowDocument.store');
+	return { ...actual, injectWorkflowDocumentStore: vi.fn() };
+});
 
 vi.mock('vue-router', () => {
 	return {
@@ -61,6 +71,10 @@ const render = (props: Partial<Props> = {}, pinData?: INodeExecutionData[], runD
 	const workflowState = useWorkflowState();
 
 	workflowStore.setWorkflow(workflow);
+
+	vi.mocked(injectWorkflowDocumentStore).mockReturnValue(
+		shallowRef(useWorkflowDocumentStore(createWorkflowDocumentId(workflowStore.workflowId))),
+	);
 
 	if (pinData) {
 		workflowStore.workflow.pinData = Object.fromEntries(nodes.map((n) => [n.name, pinData]));

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/InputPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/InputPanel.vue
@@ -5,6 +5,7 @@ import { useTelemetry } from '@/app/composables/useTelemetry';
 import { CRON_NODE_TYPE, INTERVAL_NODE_TYPE, MANUAL_TRIGGER_NODE_TYPE } from '@/app/constants';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { waitingNodeTooltip } from '@/features/execution/executions/executions.utils';
 import uniqBy from 'lodash/uniqBy';
 import {
@@ -99,11 +100,14 @@ const inputModes = [
 const workflowId = useInjectWorkflowId();
 const nodeTypesStore = useNodeTypesStore();
 const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const workflowState = injectWorkflowState();
 const router = useRouter();
 const { runWorkflow } = useRunWorkflow({ router });
 
-const activeNode = computed(() => workflowsStore.getNodeByName(props.activeNodeName));
+const activeNode = computed(
+	() => workflowDocumentStore?.value?.getNodeByName(props.activeNodeName) ?? null,
+);
 
 const rootNode = computed(() => {
 	if (!activeNode.value) return null;
@@ -205,7 +209,7 @@ const currentNode = computed(() => {
 	if (isActiveNodeConfig.value) {
 		// if we're mapping node we want to show the output of the mapped node
 		if (mappedNode.value) {
-			return workflowsStore.getNodeByName(mappedNode.value);
+			return workflowDocumentStore?.value?.getNodeByName(mappedNode.value) ?? null;
 		}
 
 		// in debugging mode data does get set manually and is only for debugging
@@ -213,7 +217,7 @@ const currentNode = computed(() => {
 		return activeNode.value;
 	}
 
-	return workflowsStore.getNodeByName(props.currentNodeName ?? '');
+	return workflowDocumentStore?.value?.getNodeByName(props.currentNodeName ?? '') ?? null;
 });
 
 const connectedCurrentNodeOutputs = computed(() => {
@@ -247,7 +251,10 @@ const waitingMessage = computed(() => {
 	const parentNode = parentNodes.value[0];
 	return (
 		parentNode &&
-		waitingNodeTooltip(workflowsStore.getNodeByName(parentNode.name), props.workflowObject)
+		waitingNodeTooltip(
+			workflowDocumentStore?.value?.getNodeByName(parentNode.name) ?? null,
+			props.workflowObject,
+		)
 	);
 });
 

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/NDVFloatingNodes.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/NDVFloatingNodes.vue
@@ -2,6 +2,7 @@
 import type { INodeUi } from '@/Interface';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { computed, onMounted, onBeforeUnmount } from 'vue';
 import NodeIcon from '@/app/components/NodeIcon.vue';
 import { NodeConnectionTypes, type INodeTypeDescription } from 'n8n-workflow';
@@ -17,6 +18,7 @@ const enum FloatingNodePosition {
 }
 const props = defineProps<Props>();
 const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const nodeTypesStore = useNodeTypesStore();
 const emit = defineEmits<{
 	switchSelectedNode: [nodeName: string];
@@ -53,7 +55,7 @@ function onKeyDown(e: KeyboardEvent) {
 function getINodesFromNames(names: string[]): NodeConfig[] {
 	return names
 		.map((name) => {
-			const node = workflowsStore.getNodeByName(name);
+			const node = workflowDocumentStore?.value?.getNodeByName(name) ?? null;
 			if (node) {
 				const nodeType = nodeTypesStore.getNodeType(node.type);
 				if (nodeType) {

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/NDVSubConnections.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/NDVSubConnections.vue
@@ -2,6 +2,7 @@
 import type { INodeUi } from '@/Interface';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { computed, ref, watch } from 'vue';
 import { NodeHelpers } from 'n8n-workflow';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
@@ -25,6 +26,7 @@ interface Props {
 
 const props = defineProps<Props>();
 const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const nodeTypesStore = useNodeTypesStore();
 const nodeHelpers = useNodeHelpers();
 const i18n = useI18n();
@@ -59,7 +61,9 @@ const nodeType = computed(() =>
 	nodeTypesStore.getNodeType(props.rootNode.type, props.rootNode.typeVersion),
 );
 
-const nodeData = computed(() => workflowsStore.getNodeByName(props.rootNode.name));
+const nodeData = computed(
+	() => workflowDocumentStore?.value?.getNodeByName(props.rootNode.name) ?? null,
+);
 const ndvStore = useNDVStore();
 
 const workflowObject = computed(() => workflowsStore.workflowObject as Workflow);
@@ -159,7 +163,7 @@ function expandConnectionGroup(connectionContext: ConnectionContext, isExpanded:
 function getINodesFromNames(names: string[]): NodeConfig[] {
 	return names
 		.map((name) => {
-			const node = workflowsStore.getNodeByName(name);
+			const node = workflowDocumentStore?.value?.getNodeByName(name) ?? null;
 			if (node) {
 				const matchedNodeType = nodeTypesStore.getNodeType(node.type);
 				if (matchedNodeType) {

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/TriggerPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/TriggerPanel.test.ts
@@ -6,20 +6,35 @@ import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { createTestNode, mockNodeTypeDescription } from '@/__tests__/mocks';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { setActivePinia } from 'pinia';
-import { computed } from 'vue';
+import { computed, shallowRef } from 'vue';
 import { WorkflowIdKey } from '@/app/constants/injectionKeys';
+import {
+	injectWorkflowDocumentStore,
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
+
+vi.mock('@/app/stores/workflowDocument.store', async () => {
+	const actual = await vi.importActual('@/app/stores/workflowDocument.store');
+	return { ...actual, injectWorkflowDocumentStore: vi.fn() };
+});
 
 let workflowsStore: MockedStore<typeof useWorkflowsStore>;
 let nodeTypesStore: MockedStore<typeof useNodeTypesStore>;
 
 describe('TriggerPanel.vue', () => {
 	beforeEach(async () => {
-		setActivePinia(createTestingPinia());
+		setActivePinia(createTestingPinia({ stubActions: false }));
 		workflowsStore = mockedStore(useWorkflowsStore);
 		workflowsStore.workflowName = 'Test Workflow';
 		workflowsStore.workflowId = '1';
 		const node = createTestNode({ id: '0', name: 'Webhook', type: 'n8n-nodes-base.webhook' });
-		workflowsStore.getNodeByName.mockReturnValue(node);
+		workflowsStore.workflow.nodes = [node];
+
+		vi.mocked(injectWorkflowDocumentStore).mockReturnValue(
+			shallowRef(useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))),
+		);
+
 		nodeTypesStore = mockedStore(useNodeTypesStore);
 		const nodeTypeDescription = mockNodeTypeDescription({
 			name: 'n8n-nodes-base.webhook',

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/TriggerPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/TriggerPanel.vue
@@ -67,7 +67,9 @@ const executionsHelpEventBus = createEventBus();
 
 const help = ref<HTMLElement | null>(null);
 
-const node = computed<INodeUi | null>(() => workflowsStore.getNodeByName(props.nodeName));
+const node = computed<INodeUi | null>(
+	() => workflowDocumentStore?.value?.getNodeByName(props.nodeName) ?? null,
+);
 
 const nodeType = computed<INodeTypeDescription | null>(() => {
 	if (node.value) {


### PR DESCRIPTION
## Summary

Replace workflowsStore.getNodeByName() calls with workflowDocumentStore to align with the WorkflowDocumentStore pattern.

Updates InputNodeSelect, InputPanel, NDVFloatingNodes, NDVSubConnections, and TriggerPanel components and their tests.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2517

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
