### PR TITLE
feat(editor): Migrate node composables to use `workflowDocumentStore` directly (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.test.ts
@@ -396,7 +396,7 @@ describe('NodeExecuteButton', () => {
 				name: 'test',
 				value: 'Test',
 			}));
-		const updateNodePropertiesSpy = vi.spyOn(workflowState, 'updateNodeProperties');
+		const updateNodePropertiesSpy = vi.spyOn(workflowDocumentStore, 'updateNodeProperties');
 		const node = mockNode({
 			name: 'test-node',
 			type: AI_TRANSFORM_NODE_TYPE,

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -1804,7 +1804,8 @@ describe('useCanvasOperations', () => {
 				createTestNode({ id: '2', name: 'B' }),
 			];
 			workflowsStore.getNodesByIds.mockReturnValue(nodes);
-			const updateNodePropertiesSpy = vi.spyOn(workflowState, 'updateNodeProperties');
+			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+			const updateNodePropertiesSpy = vi.spyOn(workflowDocumentStore, 'updateNodeProperties');
 
 			const { toggleNodesDisabled } = useCanvasOperations();
 			toggleNodesDisabled([nodes[0].id, nodes[1].id], {
@@ -1827,7 +1828,8 @@ describe('useCanvasOperations', () => {
 			const nodeName = 'testNode';
 			const node = createTestNode({ name: nodeName });
 			workflowsStore.getNodeByName.mockReturnValue(node);
-			const updateNodePropertiesSpy = vi.spyOn(workflowState, 'updateNodeProperties');
+			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+			const updateNodePropertiesSpy = vi.spyOn(workflowDocumentStore, 'updateNodeProperties');
 
 			const { revertToggleNodeDisabled } = useCanvasOperations();
 			revertToggleNodeDisabled(nodeName);

--- a/packages/frontend/editor-ui/src/app/composables/useNodeDirtiness.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeDirtiness.ts
@@ -10,6 +10,10 @@ import {
 import { useHistoryStore } from '@/app/stores/history.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
+import {
 	CanvasNodeDirtiness,
 	type CanvasNodeDirtinessType,
 } from '@/features/workflows/canvas/canvas.types';
@@ -121,6 +125,12 @@ export function useNodeDirtiness() {
 	const historyStore = useHistoryStore();
 	const workflowsStore = useWorkflowsStore();
 
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
+
 	function getParentSubNodes(nodeName: string) {
 		return Object.entries(workflowsStore.incomingConnectionsByNodeName(nodeName))
 			.filter(([type]) => (type as NodeConnectionType) !== NodeConnectionTypes.Main)
@@ -211,7 +221,7 @@ export function useNodeDirtiness() {
 			}
 		}
 
-		for (const startNode of workflowsStore.allNodes) {
+		for (const startNode of workflowDocumentStore.value?.allNodes ?? []) {
 			const hasIncomingNode =
 				Object.keys(workflowsStore.incomingConnectionsByNodeName(startNode.name)).length > 0;
 

--- a/packages/frontend/editor-ui/src/app/composables/useNodeExecution.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeExecution.test.ts
@@ -36,6 +36,7 @@ const {
 	mockRunWorkflow,
 	mockPinnedData,
 	mockMessage,
+	mockWorkflowDocumentStore,
 } = vi.hoisted(() => ({
 	mockWorkflowsStore: {
 		isWorkflowRunning: false,
@@ -68,6 +69,14 @@ const {
 	mockMessage: {
 		confirm: vi.fn(),
 	},
+	mockWorkflowDocumentStore: {
+		updateNodeProperties: vi.fn(),
+	},
+}));
+
+vi.mock('@/app/stores/workflowDocument.store', () => ({
+	useWorkflowDocumentStore: vi.fn().mockReturnValue(mockWorkflowDocumentStore),
+	createWorkflowDocumentId: vi.fn().mockReturnValue('test-id'),
 }));
 
 vi.mock('vue-router', async (importOriginal) => {
@@ -755,7 +764,7 @@ describe('useNodeExecution', () => {
 				name: `parameters.${AI_TRANSFORM_JS_CODE}`,
 				value: 'return items;',
 			});
-			vi.spyOn(workflowState, 'updateNodeProperties').mockImplementation(() => {});
+			mockWorkflowDocumentStore.updateNodeProperties.mockClear();
 			const node = ref(
 				createTestNode({
 					name: 'AI Transform',
@@ -768,7 +777,7 @@ describe('useNodeExecution', () => {
 			const result = await execute();
 
 			expect(generateCodeForAiTransform).toHaveBeenCalled();
-			expect(workflowState.updateNodeProperties).toHaveBeenCalled();
+			expect(mockWorkflowDocumentStore.updateNodeProperties).toHaveBeenCalled();
 			expect(result).toBe('executed');
 		});
 
@@ -777,7 +786,7 @@ describe('useNodeExecution', () => {
 				name: `parameters.${AI_TRANSFORM_JS_CODE}`,
 				value: 'return items;',
 			});
-			vi.spyOn(workflowState, 'updateNodeProperties').mockImplementation(() => {});
+			mockWorkflowDocumentStore.updateNodeProperties.mockClear();
 			const onCodeGenerated = vi.fn();
 			const node = ref(
 				createTestNode({

--- a/packages/frontend/editor-ui/src/app/composables/useNodeExecution.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeExecution.ts
@@ -23,6 +23,10 @@ import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useToast } from '@/app/composables/useToast';
 import { useExternalHooks } from '@/app/composables/useExternalHooks';
 import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 import { needsAgentInput } from '@/app/utils/nodes/nodeTransforms';
 import { generateCodeForAiTransform } from '@/features/ndv/parameters/utils/buttonParameter.utils';
@@ -99,6 +103,12 @@ export function useNodeExecution(
 	const ndvStore = useNDVStore();
 	const uiStore = useUIStore();
 	const workflowState = injectWorkflowState();
+
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 
 	const { runWorkflow, stopCurrentExecution } = useRunWorkflow({ router });
 
@@ -289,7 +299,7 @@ export function useNodeExecution(
 			}
 
 			// Update node with generated code
-			workflowState.updateNodeProperties({
+			workflowDocumentStore.value?.updateNodeProperties({
 				name: nodeRef.value.name,
 				properties: {
 					parameters: {

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
@@ -19,7 +19,6 @@ import { faker } from '@faker-js/faker';
 import type { INodeUi } from '@/Interface';
 import type { IUsedCredential } from '@/features/credentials/credentials.types';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
-import { injectWorkflowState, useWorkflowState } from './useWorkflowState';
 
 const mockDocumentStoreUsedCredentials: Record<string, IUsedCredential> = {};
 
@@ -29,15 +28,11 @@ vi.mock('@/app/stores/workflowDocument.store', async () => {
 		...actual,
 		useWorkflowDocumentStore: vi.fn(() => ({
 			usedCredentials: mockDocumentStoreUsedCredentials,
+			allNodes: [],
+			getNodeByName: vi.fn(),
+			setNodeIssue: vi.fn(),
+			updateNodeProperties: vi.fn(),
 		})),
-	};
-});
-
-vi.mock('@/app/composables/useWorkflowState', async () => {
-	const actual = await vi.importActual('@/app/composables/useWorkflowState');
-	return {
-		...actual,
-		injectWorkflowState: vi.fn(),
 	};
 });
 
@@ -52,23 +47,6 @@ describe('useNodeHelpers()', () => {
 		for (const key of Object.keys(mockDocumentStoreUsedCredentials)) {
 			delete mockDocumentStoreUsedCredentials[key];
 		}
-	});
-
-	describe('initialization', () => {
-		it('should use provided workflowState and not inject', () => {
-			const workflowState = useWorkflowState();
-			vi.clearAllMocks();
-
-			useNodeHelpers({ workflowState });
-
-			expect(injectWorkflowState).not.toBeCalled();
-		});
-
-		it('should create workflowState if not provided', () => {
-			useNodeHelpers();
-
-			expect(injectWorkflowState).toBeCalled();
-		});
 	});
 
 	describe('isNodeExecutable()', () => {
@@ -763,8 +741,7 @@ describe('useNodeHelpers()', () => {
 			mockedStore(useNodeTypesStore).getNodeType = vi.fn().mockReturnValue(nodeTypeWithFeatures);
 			const getNodeParametersIssuesSpy = vi.spyOn(NodeHelpers, 'getNodeParametersIssues');
 
-			const workflowState = useWorkflowState();
-			const { updateNodeParameterIssues } = useNodeHelpers({ workflowState });
+			const { updateNodeParameterIssues } = useNodeHelpers();
 
 			updateNodeParameterIssues(node);
 

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
@@ -47,7 +47,6 @@ import { useTelemetry } from './useTelemetry';
 import { hasPermission } from '@/app/utils/rbac/permissions';
 import { useCanvasStore } from '@/app/stores/canvas.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
-import { injectWorkflowState, type WorkflowState } from './useWorkflowState';
 import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
@@ -63,15 +62,20 @@ declare namespace HttpRequestNode {
 	}
 }
 
-export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
+export function useNodeHelpers() {
 	const credentialsStore = useCredentialsStore();
 	const historyStore = useHistoryStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const workflowsStore = useWorkflowsStore();
-	const workflowState = opts.workflowState ?? injectWorkflowState();
 	const settingsStore = useSettingsStore();
 	const i18n = useI18n();
 	const canvasStore = useCanvasStore();
+
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 
 	const isInsertingNodes = ref(false);
 	const credentialsUpdated = ref(false);
@@ -290,7 +294,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 
 		const nodeInputIssues = getNodeInputIssues(workflowObject.value, node, nodeType);
 
-		workflowState.setNodeIssue({
+		workflowDocumentStore.value?.setNodeIssue({
 			node: node.name,
 			type: 'input',
 			value: nodeInputIssues?.input ? nodeInputIssues.input : null,
@@ -298,7 +302,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 	}
 
 	function updateNodesInputIssues() {
-		const nodes = workflowsStore.allNodes;
+		const nodes = workflowDocumentStore.value?.allNodes ?? [];
 
 		for (const node of nodes) {
 			updateNodeInputIssues(node);
@@ -306,10 +310,10 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 	}
 
 	function updateNodesExecutionIssues() {
-		const nodes = workflowsStore.allNodes;
+		const nodes = workflowDocumentStore.value?.allNodes ?? [];
 
 		for (const node of nodes) {
-			workflowState.setNodeIssue({
+			workflowDocumentStore.value?.setNodeIssue({
 				node: node.name,
 				type: 'execution',
 				value: hasNodeExecutionIssues(node) ? true : null,
@@ -318,7 +322,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 	}
 
 	function updateNodesParameterIssues() {
-		const nodes = workflowsStore.allNodes;
+		const nodes = workflowDocumentStore.value?.allNodes ?? [];
 
 		for (const node of nodes) {
 			updateNodeParameterIssues(node);
@@ -326,7 +330,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 	}
 
 	function updateNodeCredentialIssuesByName(name: string): void {
-		const node = workflowsStore.getNodeByName(name);
+		const node = workflowDocumentStore.value?.getNodeByName(name) ?? null;
 
 		if (node) {
 			updateNodeCredentialIssues(node);
@@ -341,7 +345,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 			newIssues = fullNodeIssues.credentials!;
 		}
 
-		workflowState.setNodeIssue({
+		workflowDocumentStore.value?.setNodeIssue({
 			node: node.name,
 			type: 'credentials',
 			value: newIssues,
@@ -349,7 +353,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 	}
 
 	function updateNodeParameterIssuesByName(name: string): void {
-		const node = workflowsStore.getNodeByName(name);
+		const node = workflowDocumentStore.value?.getNodeByName(name) ?? null;
 
 		if (node) {
 			updateNodeParameterIssues(node);
@@ -376,7 +380,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 			newIssues = fullNodeIssues.parameters!;
 		}
 
-		workflowState.setNodeIssue({
+		workflowDocumentStore.value?.setNodeIssue({
 			node: node.name,
 			type: 'parameters',
 			value: newIssues,
@@ -606,13 +610,13 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 	}
 
 	function updateNodesCredentialsIssues() {
-		const nodes = workflowsStore.allNodes;
+		const nodes = workflowDocumentStore.value?.allNodes ?? [];
 		let issues: INodeIssues | null;
 
 		for (const node of nodes) {
 			issues = getNodeCredentialIssues(node);
 
-			workflowState.setNodeIssue({
+			workflowDocumentStore.value?.setNodeIssue({
 				node: node.name,
 				type: 'credentials',
 				value: issues?.credentials ?? null,
@@ -744,7 +748,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 				workflow_id: workflowsStore.workflowId,
 			});
 
-			workflowState.updateNodeProperties(updateInformation);
+			workflowDocumentStore.value?.updateNodeProperties(updateInformation);
 			workflowsStore.clearNodeExecutionData(node.name);
 			updateNodeParameterIssues(node);
 			updateNodeCredentialIssues(node);

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -416,11 +416,15 @@ export function handleExecutionFinishedWithSuccessOrOther(
 	const workflowObject = workflowsStore.workflowObject;
 	const workflowName = workflowObject.name ?? '';
 
+	const workflowDocumentStore = workflowsStore.workflowId
+		? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: undefined;
+
 	useDocumentTitle().setDocumentTitle(workflowName, 'IDLE');
 
 	const workflowExecution = workflowsStore.getWorkflowExecution;
 	if (workflowExecution?.executedNode) {
-		const node = workflowsStore.getNodeByName(workflowExecution.executedNode);
+		const node = workflowDocumentStore?.getNodeByName(workflowExecution.executedNode) ?? null;
 		const nodeType = node && nodeTypesStore.getNodeType(node.type, node.typeVersion);
 		const nodeOutput =
 			workflowExecution.data?.resultData?.runData?.[workflowExecution.executedNode];
@@ -473,7 +477,7 @@ export function setRunExecutionData(
 	workflowState: WorkflowState,
 ) {
 	const workflowsStore = useWorkflowsStore();
-	const nodeHelpers = useNodeHelpers({ workflowState });
+	const nodeHelpers = useNodeHelpers();
 	const runDataExecutedErrorMessage = getRunDataExecutedErrorMessage(execution);
 	const workflowExecution = workflowsStore.getWorkflowExecution;
 

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
@@ -38,6 +38,10 @@ import {
 
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { displayForm } from '@/features/execution/executions/executions.utils';
 import { useExternalHooks } from '@/app/composables/useExternalHooks';
 import { useWorkflowHelpers } from '@/app/composables/useWorkflowHelpers';
@@ -77,7 +81,14 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 	const pushConnectionStore = usePushConnectionStore();
 	const workflowsStore = useWorkflowsStore();
 	const workflowState = useRunWorkflowOpts.workflowState ?? injectWorkflowState();
-	const nodeHelpers = useNodeHelpers({ workflowState });
+
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
+
+	const nodeHelpers = useNodeHelpers();
 	const workflowSaving = useWorkflowSaving({
 		router: useRunWorkflowOpts.router,
 		workflowState,
@@ -91,8 +102,8 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 
 	function sortNodesByYPosition(nodes: string[]) {
 		return [...nodes].sort((a, b) => {
-			const nodeA = workflowsStore.getNodeByName(a)?.position ?? [0, 0];
-			const nodeB = workflowsStore.getNodeByName(b)?.position ?? [0, 0];
+			const nodeA = workflowDocumentStore.value?.getNodeByName(a)?.position ?? [0, 0];
+			const nodeB = workflowDocumentStore.value?.getNodeByName(b)?.position ?? [0, 0];
 
 			const nodeAYPosition = nodeA[1];
 			const nodeBYPosition = nodeB[1];
@@ -189,7 +200,7 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 
 			const { startNodeNames } = consolidatedData;
 			const destinationNodeType = options.destinationNode
-				? workflowsStore.getNodeByName(options.destinationNode.nodeName)?.type
+				? (workflowDocumentStore.value?.getNodeByName(options.destinationNode.nodeName)?.type ?? '')
 				: '';
 
 			let executedNode: string | undefined;
@@ -338,7 +349,9 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 
 			if ('destinationNode' in options) {
 				startRunData.destinationNode = options.destinationNode;
-				const nodeId = workflowsStore.getNodeByName(options.destinationNode?.nodeName ?? '')?.id;
+				const nodeId = workflowDocumentStore.value?.getNodeByName(
+					options.destinationNode?.nodeName ?? '',
+				)?.id;
 				if (workflowObject.value.id && nodeId) {
 					const agentRequest = agentRequestStore.getAgentRequest(workflowObject.value.id, nodeId);
 

--- a/packages/frontend/editor-ui/src/app/composables/useToolParameters.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useToolParameters.test.ts
@@ -14,6 +14,17 @@ import type { INode, INodeTypeDescription, Workflow } from 'n8n-workflow';
 import { AI_MCP_TOOL_NODE_TYPE } from '../constants';
 import { mock } from 'vitest-mock-extended';
 
+const { mockWorkflowDocumentStore } = vi.hoisted(() => ({
+	mockWorkflowDocumentStore: {
+		getNodeByName: vi.fn(),
+	},
+}));
+
+vi.mock('@/app/stores/workflowDocument.store', () => ({
+	useWorkflowDocumentStore: vi.fn().mockReturnValue(mockWorkflowDocumentStore),
+	createWorkflowDocumentId: vi.fn().mockReturnValue('test-id'),
+}));
+
 describe('useToolParameters', () => {
 	let workflowsStore: MockedStore<typeof useWorkflowsStore>;
 	let projectsStore: MockedStore<typeof useProjectsStore>;
@@ -28,6 +39,7 @@ describe('useToolParameters', () => {
 		agentRequestStore = useAgentRequestStore();
 
 		// Setup default mocks
+		mockWorkflowDocumentStore.getNodeByName.mockReset();
 		projectsStore.currentProjectId = 'test-project';
 		workflowsStore.workflowId = 'test-workflow';
 		workflowsStore.getWorkflowExecution = null;
@@ -377,7 +389,7 @@ describe('useToolParameters', () => {
 			});
 
 			workflowsStore.workflowObject = mockWorkflow;
-			workflowsStore.getNodeByName = vi.fn().mockImplementation((name: string) => {
+			mockWorkflowDocumentStore.getNodeByName.mockImplementation((name: string) => {
 				if (name === 'Connected Tool') return connectedTool;
 				return null;
 			});
@@ -430,7 +442,7 @@ describe('useToolParameters', () => {
 			});
 
 			workflowsStore.workflowObject = mockWorkflow;
-			workflowsStore.getNodeByName = vi.fn().mockImplementation((name: string) => {
+			mockWorkflowDocumentStore.getNodeByName.mockImplementation((name: string) => {
 				if (name === 'Connected Tool') return connectedTool;
 				return null;
 			});

--- a/packages/frontend/editor-ui/src/app/composables/useToolParameters.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useToolParameters.ts
@@ -8,6 +8,10 @@ import {
 } from 'n8n-workflow';
 import { computed, reactive, ref, watch, type Ref } from 'vue';
 import { useWorkflowsStore } from '../stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { useNodeTypesStore } from '../stores/nodeTypes.store';
 import { useAgentRequestStore } from '@n8n/stores/useAgentRequestStore';
@@ -30,6 +34,12 @@ export function useToolParameters({ node }: GetToolParametersProps) {
 	const projectsStore = useProjectsStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const agentRequestStore = useAgentRequestStore();
+
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 
 	const selectedToolMap = reactive<Record<string, string | undefined>>({});
 	const error = ref<Error | undefined>(undefined);
@@ -197,7 +207,7 @@ export function useToolParameters({ node }: GetToolParametersProps) {
 			1,
 		);
 		const connectedTools = connectedToolNodeNames
-			.map((nodeName) => workflowsStore.getNodeByName(nodeName))
+			.map((nodeName) => workflowDocumentStore.value?.getNodeByName(nodeName) ?? null)
 			.filter((tool): tool is INode => !!tool);
 
 		const ignoredFields = ['tool', 'toolParameters'];

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.test.ts
@@ -32,7 +32,6 @@ import type { ChatMessage } from '@n8n/chat/types';
 import * as useChatMessaging from '@/features/execution/logs/composables/useChatMessaging';
 import { useToast } from '@/app/composables/useToast';
 import { useWorkflowState, type WorkflowState } from '@/app/composables/useWorkflowState';
-import type * as useNodeHelpersModule from '@/app/composables/useNodeHelpers';
 
 vi.mock('@/app/composables/useToast', () => {
 	const showMessage = vi.fn();
@@ -66,18 +65,6 @@ vi.mock('@/stores/pushConnection.store', () => ({
 		isConnected: true,
 	}),
 }));
-
-// Use a mutable reference so the mock always returns the current workflowState
-const workflowStateRef: { current: WorkflowState | undefined } = { current: undefined };
-
-vi.mock('@/app/composables/useNodeHelpers', async (importOriginal) => {
-	const actual = await importOriginal<typeof useNodeHelpersModule>();
-	return {
-		...actual,
-		useNodeHelpers: (opts = {}) =>
-			actual.useNodeHelpers({ ...opts, workflowState: workflowStateRef.current }),
-	};
-});
 
 describe('LogsPanel', () => {
 	const VIEWPORT_HEIGHT = 800;
@@ -125,7 +112,6 @@ describe('LogsPanel', () => {
 
 		workflowsStore = mockedStore(useWorkflowsStore);
 		workflowState = useWorkflowState();
-		workflowStateRef.current = workflowState;
 		workflowState.setWorkflowExecutionData(null);
 
 		logsStore = mockedStore(useLogsStore);


### PR DESCRIPTION
## Summary

This pull request refactors several composables and tests in the frontend editor UI to consistently use the `workflowDocumentStore` for accessing and updating workflow node data, instead of relying on the `workflowsStore` or injected workflow state. This change centralizes workflow document management and simplifies the API surface of helper composables. The update also removes now-unnecessary dependency injection patterns and adapts related tests accordingly.

**Refactoring to use workflowDocumentStore:**

* Updated `useNodeHelpers`, `useNodeExecution`, `useNodeDirtiness`, and `useRunWorkflow` composables to use `workflowDocumentStore` (via `useWorkflowDocumentStore(createWorkflowDocumentId(...))`) for all node access, updates, and issue management, replacing direct access to `workflowsStore.allNodes`, `workflowsStore.getNodeByName`, and injected workflow state. [[1]](diffhunk://#diff-10d3bee4649d947b5e06c369c77a3be95fbd5180dd32c546b53eafad2e019d19L66-R79) [[2]](diffhunk://#diff-10d3bee4649d947b5e06c369c77a3be95fbd5180dd32c546b53eafad2e019d19L293-R316) [[3]](diffhunk://#diff-10d3bee4649d947b5e06c369c77a3be95fbd5180dd32c546b53eafad2e019d19L321-R333) [[4]](diffhunk://#diff-10d3bee4649d947b5e06c369c77a3be95fbd5180dd32c546b53eafad2e019d19L344-R356) [[5]](diffhunk://#diff-10d3bee4649d947b5e06c369c77a3be95fbd5180dd32c546b53eafad2e019d19L379-R383) [[6]](diffhunk://#diff-10d3bee4649d947b5e06c369c77a3be95fbd5180dd32c546b53eafad2e019d19L609-R619) [[7]](diffhunk://#diff-10d3bee4649d947b5e06c369c77a3be95fbd5180dd32c546b53eafad2e019d19L747-R751) [[8]](diffhunk://#diff-f81fa61aa1be731e8608a711971ed477843d047d2ba105c66089a94f5b18def2R12-R15) [[9]](diffhunk://#diff-f81fa61aa1be731e8608a711971ed477843d047d2ba105c66089a94f5b18def2R128-R133) [[10]](diffhunk://#diff-f81fa61aa1be731e8608a711971ed477843d047d2ba105c66089a94f5b18def2L214-R224) [[11]](diffhunk://#diff-203fd3c442038e6a9d38043dcbe385e90e72e10e11126a457a3e175623b9ae0bR26-R29) [[12]](diffhunk://#diff-203fd3c442038e6a9d38043dcbe385e90e72e10e11126a457a3e175623b9ae0bR107-R112) [[13]](diffhunk://#diff-203fd3c442038e6a9d38043dcbe385e90e72e10e11126a457a3e175623b9ae0bL292-R302) [[14]](diffhunk://#diff-9905f05046694e89ebd6d16ae9e2ce7c41a1a20d6bde4f998a8d231d02d6d212R41-R44) [[15]](diffhunk://#diff-9905f05046694e89ebd6d16ae9e2ce7c41a1a20d6bde4f998a8d231d02d6d212L80-R91) [[16]](diffhunk://#diff-9905f05046694e89ebd6d16ae9e2ce7c41a1a20d6bde4f998a8d231d02d6d212L94-R106) [[17]](diffhunk://#diff-9905f05046694e89ebd6d16ae9e2ce7c41a1a20d6bde4f998a8d231d02d6d212L192-R203) [[18]](diffhunk://#diff-35e46b8718c4989453ee5336424d9a1a6436890ae69c057a13fca57c0c427378R419-R427)

* Removed the optional `workflowState` parameter and related dependency injection from `useNodeHelpers`, and updated its consumers and tests accordingly. [[1]](diffhunk://#diff-10d3bee4649d947b5e06c369c77a3be95fbd5180dd32c546b53eafad2e019d19L66-R79) [[2]](diffhunk://#diff-210f38baf564692c0b304b5619711de0692af43ca8e5782de28817f2e232d513L22) [[3]](diffhunk://#diff-210f38baf564692c0b304b5619711de0692af43ca8e5782de28817f2e232d513R31-L43) [[4]](diffhunk://#diff-210f38baf564692c0b304b5619711de0692af43ca8e5782de28817f2e232d513L57-L73) [[5]](diffhunk://#diff-210f38baf564692c0b304b5619711de0692af43ca8e5782de28817f2e232d513L766-R744) [[6]](diffhunk://#diff-35e46b8718c4989453ee5336424d9a1a6436890ae69c057a13fca57c0c427378L476-R480)

**Test updates:**

* Refactored tests for `useNodeExecution` and `useNodeHelpers` to mock and assert against `workflowDocumentStore` methods instead of the previous workflow state or store methods, ensuring test coverage aligns with the new architecture. [[1]](diffhunk://#diff-71d2ceaac3203a5a9a7872252d5a3729c156dd5568cb11efe68f62e0c4747074R39) [[2]](diffhunk://#diff-71d2ceaac3203a5a9a7872252d5a3729c156dd5568cb11efe68f62e0c4747074R72-R79) [[3]](diffhunk://#diff-71d2ceaac3203a5a9a7872252d5a3729c156dd5568cb11efe68f62e0c4747074L758-R767) [[4]](diffhunk://#diff-71d2ceaac3203a5a9a7872252d5a3729c156dd5568cb11efe68f62e0c4747074L771-R780) [[5]](diffhunk://#diff-71d2ceaac3203a5a9a7872252d5a3729c156dd5568cb11efe68f62e0c4747074L780-R789) [[6]](diffhunk://#diff-210f38baf564692c0b304b5619711de0692af43ca8e5782de28817f2e232d513L22) [[7]](diffhunk://#diff-210f38baf564692c0b304b5619711de0692af43ca8e5782de28817f2e232d513R31-L43) [[8]](diffhunk://#diff-210f38baf564692c0b304b5619711de0692af43ca8e5782de28817f2e232d513L57-L73) [[9]](diffhunk://#diff-210f38baf564692c0b304b5619711de0692af43ca8e5782de28817f2e232d513L766-R744)

**Workflow execution and push connection handlers:**

* Updated execution and push connection handlers to use `workflowDocumentStore` for node lookups and issue updates, ensuring that runtime node state is always sourced from the document store. [[1]](diffhunk://#diff-35e46b8718c4989453ee5336424d9a1a6436890ae69c057a13fca57c0c427378R419-R427) [[2]](diffhunk://#diff-35e46b8718c4989453ee5336424d9a1a6436890ae69c057a13fca57c0c427378L476-R480)

These changes collectively improve consistency, maintainability, and future extensibility of workflow node state management in the application.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2512

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
