### PR TITLE
fix(core): Assign webhook ID to API-created webhook nodes

### DIFF
--- a/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
@@ -1,5 +1,4 @@
 import { type User, type ProjectRepository, WorkflowEntity } from '@n8n/db';
-import { resolveNodeWebhookId } from 'n8n-workflow';
 import z from 'zod';
 
 import { MCP_CREATE_WORKFLOW_FROM_CODE_TOOL, CODE_BUILDER_VALIDATE_TOOL } from './constants';
@@ -11,6 +10,7 @@ import type { CredentialsService } from '@/credentials/credentials.service';
 import type { NodeTypes } from '@/node-types';
 import type { UrlService } from '@/services/url.service';
 import type { Telemetry } from '@/telemetry';
+import { resolveNodeWebhookIds } from '@/workflow-helpers';
 import type { WorkflowCreationService } from '@/workflows/workflow-creation.service';
 
 const inputSchema = {
@@ -124,14 +124,7 @@ export const createCreateWorkflowFromCodeTool = (
 				meta: { ...workflowJson.meta, aiBuilderAssisted: true },
 			});
 
-			for (const node of newWorkflow.nodes) {
-				try {
-					const desc = nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
-					resolveNodeWebhookId(node, desc.description);
-				} catch {
-					// Node type not found, skip
-				}
-			}
+			resolveNodeWebhookIds(newWorkflow, nodeTypes);
 
 			// Resolve the effective project ID — default to the user's personal project
 			let effectiveProjectId = projectId;

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -1,5 +1,4 @@
 import { type User, type SharedWorkflowRepository, WorkflowEntity } from '@n8n/db';
-import { resolveNodeWebhookId } from 'n8n-workflow';
 import z from 'zod';
 
 import { USER_CALLED_MCP_TOOL_EVENT } from '../../mcp.constants';
@@ -11,6 +10,7 @@ import type { CredentialsService } from '@/credentials/credentials.service';
 import type { NodeTypes } from '@/node-types';
 import type { UrlService } from '@/services/url.service';
 import type { Telemetry } from '@/telemetry';
+import { resolveNodeWebhookIds } from '@/workflow-helpers';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import type { WorkflowService } from '@/workflows/workflow.service';
 
@@ -126,14 +126,7 @@ export const createUpdateWorkflowTool = (
 				meta: { ...workflowJson.meta, aiBuilderAssisted: true },
 			});
 
-			for (const node of workflowUpdateData.nodes) {
-				try {
-					const desc = nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
-					resolveNodeWebhookId(node, desc.description);
-				} catch {
-					// Node type not found, skip
-				}
-			}
+			resolveNodeWebhookIds(workflowUpdateData, nodeTypes);
 
 			// Resolve the project ID from the workflow's owner relationship
 			const sharedWorkflow = await sharedWorkflowRepository.findOneOrFail({

--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
@@ -12,7 +12,8 @@ import { z } from 'zod';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { EventService } from '@/events/event.service';
 import { ExternalHooks } from '@/external-hooks';
-import { addNodeIds, replaceInvalidCredentials } from '@/workflow-helpers';
+import { NodeTypes } from '@/node-types';
+import { addNodeIds, replaceInvalidCredentials, resolveNodeWebhookIds } from '@/workflow-helpers';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
 import { WorkflowService } from '@/workflows/workflow.service';
@@ -39,6 +40,7 @@ export = {
 			await replaceInvalidCredentials(workflow);
 
 			addNodeIds(workflow);
+			resolveNodeWebhookIds(workflow, Container.get(NodeTypes));
 
 			const project = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(
 				req.user.id,

--- a/packages/cli/src/workflow-helpers.ts
+++ b/packages/cli/src/workflow-helpers.ts
@@ -4,12 +4,14 @@ import { Container } from '@n8n/di';
 import type {
 	IDataObject,
 	INodeCredentialsDetails,
+	INodeTypes,
 	IRun,
 	ITaskData,
 	IWorkflowBase,
 	IWorkflowSettings,
 	RelatedExecution,
 } from 'n8n-workflow';
+import { resolveNodeWebhookId } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
 
 import { VariablesService } from '@/environments.ee/variables/variables.service.ee';
@@ -66,6 +68,25 @@ export function addNodeIds(workflow: IWorkflowBase) {
 			node.id = uuid();
 		}
 	});
+}
+
+/**
+ * Assign webhookId to any webhook node that is missing one.
+ * The UI does this on the frontend when adding nodes to the canvas,
+ * but workflows created via the API skip that step.
+ */
+export function resolveNodeWebhookIds(workflow: IWorkflowBase, nodeTypes: INodeTypes) {
+	const { nodes } = workflow;
+	if (!nodes) return;
+
+	for (const node of nodes) {
+		try {
+			const nodeType = nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
+			resolveNodeWebhookId(node, nodeType.description);
+		} catch {
+			// node type not found, skip
+		}
+	}
 }
 
 /**

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -363,6 +363,7 @@ export class WorkflowService {
 		await WorkflowHelpers.replaceInvalidCredentials(workflowUpdateData);
 
 		WorkflowHelpers.addNodeIds(workflowUpdateData);
+		WorkflowHelpers.resolveNodeWebhookIds(workflowUpdateData, this.nodeTypes);
 
 		// Strip redactionPolicy if user lacks scope and value is changing
 		if (

--- a/packages/cli/test/integration/public-api/workflows.test.ts
+++ b/packages/cli/test/integration/public-api/workflows.test.ts
@@ -1294,6 +1294,32 @@ describe('POST /workflows', () => {
 		expect(sharedWorkflow?.role).toEqual('workflow:owner');
 	});
 
+	test('should assign webhookId to webhook nodes created via public API', async () => {
+		const payload = {
+			name: 'webhook-test',
+			nodes: [
+				{
+					id: 'uuid-1234',
+					parameters: { path: 'test-hook', httpMethod: 'POST' },
+					name: 'Webhook',
+					type: 'n8n-nodes-base.webhook',
+					typeVersion: 2,
+					position: [250, 300],
+				},
+			],
+			connections: {},
+			settings: {
+				executionOrder: 'v1',
+			},
+		};
+
+		const response = await authOwnerAgent.post('/workflows').send(payload);
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body.nodes[0].webhookId).toBeDefined();
+		expect(typeof response.body.nodes[0].webhookId).toBe('string');
+	});
+
 	test('should always create workflow history version', async () => {
 		const payload = {
 			name: 'testing',

--- a/packages/cli/test/integration/shared/utils/index.ts
+++ b/packages/cli/test/integration/shared/utils/index.ts
@@ -21,7 +21,8 @@ import { FormTrigger } from 'n8n-nodes-base/nodes/Form/FormTrigger.node';
 import { ManualTrigger } from 'n8n-nodes-base/nodes/ManualTrigger/ManualTrigger.node';
 import { ScheduleTrigger } from 'n8n-nodes-base/nodes/Schedule/ScheduleTrigger.node';
 import { Set } from 'n8n-nodes-base/nodes/Set/Set.node';
-import type { INodeTypeData, INode } from 'n8n-workflow';
+import { Webhook as WebhookNode } from 'n8n-nodes-base/nodes/Webhook/Webhook.node';
+import type { INodeType, INodeTypeData, INode } from 'n8n-workflow';
 import type request from 'supertest';
 import { v4 as uuid } from 'uuid';
 
@@ -105,6 +106,10 @@ export async function initNodeTypes(customNodes?: INodeTypeData) {
 		},
 		'n8n-nodes-base.formTrigger': {
 			type: new FormTrigger(),
+			sourcePath: '',
+		},
+		'n8n-nodes-base.webhook': {
+			type: mock<INodeType>({ description: new WebhookNode().description }),
 			sourcePath: '',
 		},
 	};


### PR DESCRIPTION
## Summary

When a workflow with a webhook node is created via the public API, we never assign a `webhookId` to those nodes. Without `webhookId`, `getNodeWebhookPath()` constructs the wrong path format, so the registered webhook path can't match incoming requests.

PR #22790 adds `'activate'` to `shouldAddWebhooks()`, but webhooks are already registered during activation on single-instance setups (`isLeader` being `true`). The problem is not that registration is skipped, but rather that registration uses the wrong path because `webhookId` is missing from the node.

Four spots:

- **Public API create** -> Only entry point for API-created workflows.
- **`WorkflowService.update`** -> Assigns `webhookId` to any webhook node still missing one (e.g. workflows created before this fix). Existing IDs are never overwritten.
- **MCP create tool** -> MCP-generated workflows skip the UI. Refactored to use the shared helper.
- **MCP update tool** -> Technically redundant since `WorkflowService.update` now also calls it, but harmless (idempotent). Refactored to use the shared helper.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2624
#21614

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
