### PR TITLE
refactor(editor): Migrate execution and logs composables to `workflowDocumentStore` (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionDebugging.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionDebugging.test.ts
@@ -1,11 +1,9 @@
-import { shallowRef } from 'vue';
 import { createTestingPinia } from '@pinia/testing';
 import { mockedStore } from '@/__tests__/utils';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
-	injectWorkflowDocumentStore,
 } from '@/app/stores/workflowDocument.store';
 import {
 	injectWorkflowState,
@@ -35,14 +33,6 @@ vi.mock('@/app/composables/useWorkflowState', async () => {
 	};
 });
 
-vi.mock('@/app/stores/workflowDocument.store', async () => {
-	const actual = await vi.importActual('@/app/stores/workflowDocument.store');
-	return {
-		...actual,
-		injectWorkflowDocumentStore: vi.fn(),
-	};
-});
-
 let workflowState: WorkflowState;
 let executionDebugging: ReturnType<typeof useExecutionDebugging>;
 let toast: ReturnType<typeof useToast>;
@@ -59,7 +49,6 @@ describe('useExecutionDebugging()', () => {
 		workflowDocumentStore = useWorkflowDocumentStore(
 			createWorkflowDocumentId(workflowStore.workflowId),
 		);
-		vi.mocked(injectWorkflowDocumentStore).mockReturnValue(shallowRef(workflowDocumentStore));
 
 		toast = useToast();
 

--- a/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionDebugging.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionDebugging.test.ts
@@ -1,9 +1,11 @@
+import { shallowRef } from 'vue';
 import { createTestingPinia } from '@pinia/testing';
 import { mockedStore } from '@/__tests__/utils';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
+	injectWorkflowDocumentStore,
 } from '@/app/stores/workflowDocument.store';
 import {
 	injectWorkflowState,
@@ -33,9 +35,18 @@ vi.mock('@/app/composables/useWorkflowState', async () => {
 	};
 });
 
+vi.mock('@/app/stores/workflowDocument.store', async () => {
+	const actual = await vi.importActual('@/app/stores/workflowDocument.store');
+	return {
+		...actual,
+		injectWorkflowDocumentStore: vi.fn(),
+	};
+});
+
 let workflowState: WorkflowState;
 let executionDebugging: ReturnType<typeof useExecutionDebugging>;
 let toast: ReturnType<typeof useToast>;
+let workflowDocumentStore: ReturnType<typeof useWorkflowDocumentStore>;
 
 describe('useExecutionDebugging()', () => {
 	beforeEach(() => {
@@ -44,6 +55,11 @@ describe('useExecutionDebugging()', () => {
 
 		const workflowStore = mockedStore(useWorkflowsStore);
 		workflowStore.workflow.id = 'test-workflow';
+
+		workflowDocumentStore = useWorkflowDocumentStore(
+			createWorkflowDocumentId(workflowStore.workflowId),
+		);
+		vi.mocked(injectWorkflowDocumentStore).mockReturnValue(shallowRef(workflowDocumentStore));
 
 		toast = useToast();
 
@@ -65,7 +81,7 @@ describe('useExecutionDebugging()', () => {
 		} as unknown as IExecutionResponse;
 
 		const workflowStore = mockedStore(useWorkflowsStore);
-		workflowStore.getNodes.mockReturnValue([{ name: 'testNode' }] as INodeUi[]);
+		vi.mocked(workflowDocumentStore.getNodes).mockReturnValue([{ name: 'testNode' }] as INodeUi[]);
 		workflowStore.getExecution.mockResolvedValueOnce(mockExecution);
 		workflowStore.workflowObject = {
 			pinData: {},
@@ -106,7 +122,9 @@ describe('useExecutionDebugging()', () => {
 		} as unknown as IExecutionResponse;
 
 		const workflowStore = mockedStore(useWorkflowsStore);
-		workflowStore.getNodes.mockReturnValue([{ name: 'TriggerNode' }] as INodeUi[]);
+		vi.mocked(workflowDocumentStore.getNodes).mockReturnValue([
+			{ name: 'TriggerNode' },
+		] as INodeUi[]);
 		workflowStore.getExecution.mockResolvedValueOnce(mockExecution);
 		workflowStore.workflowObject = {
 			pinData: {},
@@ -115,9 +133,6 @@ describe('useExecutionDebugging()', () => {
 
 		await executionDebugging.applyExecutionData('1');
 
-		const workflowDocumentStore = useWorkflowDocumentStore(
-			createWorkflowDocumentId(workflowStore.workflow.id),
-		);
 		expect(workflowDocumentStore.pinNodeData).toHaveBeenCalledWith('TriggerNode', [
 			{
 				json: { test: 'data' },
@@ -153,7 +168,9 @@ describe('useExecutionDebugging()', () => {
 		} as unknown as IExecutionResponse;
 
 		const workflowStore = mockedStore(useWorkflowsStore);
-		workflowStore.getNodes.mockReturnValue([{ name: 'TriggerNode' }] as INodeUi[]);
+		vi.mocked(workflowDocumentStore.getNodes).mockReturnValue([
+			{ name: 'TriggerNode' },
+		] as INodeUi[]);
 		workflowStore.getExecution.mockResolvedValueOnce(mockExecution);
 		workflowStore.workflowObject = {
 			pinData: {},
@@ -162,9 +179,6 @@ describe('useExecutionDebugging()', () => {
 
 		await executionDebugging.applyExecutionData('1');
 
-		const workflowDocumentStore = useWorkflowDocumentStore(
-			createWorkflowDocumentId(workflowStore.workflow.id),
-		);
 		expect(workflowDocumentStore.pinNodeData).toHaveBeenCalledWith('TriggerNode', [
 			{ json: { test: 'data' } },
 		]);
@@ -186,7 +200,7 @@ describe('useExecutionDebugging()', () => {
 		} as unknown as IExecutionResponse;
 
 		const workflowStore = mockedStore(useWorkflowsStore);
-		workflowStore.getNodes.mockReturnValue([{ name: 'testNode2' }] as INodeUi[]);
+		vi.mocked(workflowDocumentStore.getNodes).mockReturnValue([{ name: 'testNode2' }] as INodeUi[]);
 		workflowStore.getExecution.mockResolvedValueOnce(mockExecution);
 		workflowStore.workflowObject = {
 			pinData: {},
@@ -217,7 +231,7 @@ describe('useExecutionDebugging()', () => {
 		} as unknown as IExecutionResponse;
 
 		const workflowStore = mockedStore(useWorkflowsStore);
-		workflowStore.getNodes.mockReturnValue([{ name: 'testNode' }] as INodeUi[]);
+		vi.mocked(workflowDocumentStore.getNodes).mockReturnValue([{ name: 'testNode' }] as INodeUi[]);
 		workflowStore.getExecution.mockResolvedValueOnce(mockExecution);
 		workflowStore.workflowObject = {
 			pinData: {},

--- a/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionDebugging.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionDebugging.ts
@@ -8,10 +8,7 @@ import { EnterpriseEditionFeature, MODAL_CONFIRM, VIEWS } from '@/app/constants'
 import { DEBUG_PAYWALL_MODAL_KEY } from '../executions.constants';
 import type { INodeUi } from '@/Interface';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import {
-	useWorkflowDocumentStore,
-	createWorkflowDocumentId,
-} from '@/app/stores/workflowDocument.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useTelemetry } from '@/app/composables/useTelemetry';
@@ -33,6 +30,7 @@ export const useExecutionDebugging = (providedWorkflowState?: WorkflowState) => 
 	const message = useMessage();
 	const toast = useToast();
 	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = injectWorkflowDocumentStore();
 	const workflowState = providedWorkflowState ?? injectWorkflowState();
 	const settingsStore = useSettingsStore();
 	const uiStore = useUIStore();
@@ -46,7 +44,7 @@ export const useExecutionDebugging = (providedWorkflowState?: WorkflowState) => 
 	const applyExecutionData = async (executionId: string): Promise<void> => {
 		const execution = await workflowsStore.getExecution(executionId);
 		const workflowObject = workflowsStore.workflowObject;
-		const workflowNodes = workflowsStore.getNodes();
+		const workflowNodes = workflowDocumentStore?.value?.getNodes() ?? [];
 
 		if (!execution?.data?.resultData) {
 			return;
@@ -61,10 +59,7 @@ export const useExecutionDebugging = (providedWorkflowState?: WorkflowState) => 
 
 		// Using the pinned data of the workflow to check if the node is pinned
 		// because workflowsStore.getCurrentWorkflow() returns a cached workflow without the updated pinned data
-		const workflowDocumentStore = workflowsStore.workflowId
-			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
-			: undefined;
-		const workflowPinnedNodeNames = Object.keys(workflowDocumentStore?.pinData ?? {});
+		const workflowPinnedNodeNames = Object.keys(workflowDocumentStore?.value?.pinData ?? {});
 		const matchingPinnedNodeNames = executionNodeNames.filter((name) =>
 			workflowPinnedNodeNames.includes(name),
 		);
@@ -93,7 +88,7 @@ export const useExecutionDebugging = (providedWorkflowState?: WorkflowState) => 
 
 			if (overWritePinnedDataConfirm === MODAL_CONFIRM) {
 				matchingPinnedNodeNames.forEach((name) => {
-					workflowDocumentStore?.unpinNodeData(name);
+					workflowDocumentStore?.value?.unpinNodeData(name);
 				});
 			} else {
 				await router.push({
@@ -105,7 +100,7 @@ export const useExecutionDebugging = (providedWorkflowState?: WorkflowState) => 
 		}
 
 		// Set execution data
-		workflowState.resetAllNodesIssues();
+		workflowDocumentStore?.value?.resetAllNodesIssues();
 		workflowState.setWorkflowExecutionData(execution);
 
 		// Pin data of all nodes which do not have a parent node
@@ -122,7 +117,7 @@ export const useExecutionDebugging = (providedWorkflowState?: WorkflowState) => 
 				const nodeData = taskData.data.main.find((output) => output && output.length > 0);
 				if (nodeData) {
 					pinnings++;
-					workflowDocumentStore?.pinNodeData(node.name, nodeData);
+					workflowDocumentStore?.value?.pinNodeData(node.name, nodeData);
 
 					// Clear dirtiness timestamps so nodes don't appear dirty after restoration.
 					// The old pinData({ isRestoration: true }) handled this internally.

--- a/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionDebugging.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionDebugging.ts
@@ -8,7 +8,10 @@ import { EnterpriseEditionFeature, MODAL_CONFIRM, VIEWS } from '@/app/constants'
 import { DEBUG_PAYWALL_MODAL_KEY } from '../executions.constants';
 import type { INodeUi } from '@/Interface';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useTelemetry } from '@/app/composables/useTelemetry';
@@ -30,7 +33,11 @@ export const useExecutionDebugging = (providedWorkflowState?: WorkflowState) => 
 	const message = useMessage();
 	const toast = useToast();
 	const workflowsStore = useWorkflowsStore();
-	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 	const workflowState = providedWorkflowState ?? injectWorkflowState();
 	const settingsStore = useSettingsStore();
 	const uiStore = useUIStore();
@@ -44,7 +51,7 @@ export const useExecutionDebugging = (providedWorkflowState?: WorkflowState) => 
 	const applyExecutionData = async (executionId: string): Promise<void> => {
 		const execution = await workflowsStore.getExecution(executionId);
 		const workflowObject = workflowsStore.workflowObject;
-		const workflowNodes = workflowDocumentStore?.value?.getNodes() ?? [];
+		const workflowNodes = workflowDocumentStore.value?.getNodes() ?? [];
 
 		if (!execution?.data?.resultData) {
 			return;
@@ -59,7 +66,7 @@ export const useExecutionDebugging = (providedWorkflowState?: WorkflowState) => 
 
 		// Using the pinned data of the workflow to check if the node is pinned
 		// because workflowsStore.getCurrentWorkflow() returns a cached workflow without the updated pinned data
-		const workflowPinnedNodeNames = Object.keys(workflowDocumentStore?.value?.pinData ?? {});
+		const workflowPinnedNodeNames = Object.keys(workflowDocumentStore.value?.pinData ?? {});
 		const matchingPinnedNodeNames = executionNodeNames.filter((name) =>
 			workflowPinnedNodeNames.includes(name),
 		);
@@ -88,7 +95,7 @@ export const useExecutionDebugging = (providedWorkflowState?: WorkflowState) => 
 
 			if (overWritePinnedDataConfirm === MODAL_CONFIRM) {
 				matchingPinnedNodeNames.forEach((name) => {
-					workflowDocumentStore?.value?.unpinNodeData(name);
+					workflowDocumentStore.value?.unpinNodeData(name);
 				});
 			} else {
 				await router.push({
@@ -100,7 +107,7 @@ export const useExecutionDebugging = (providedWorkflowState?: WorkflowState) => 
 		}
 
 		// Set execution data
-		workflowDocumentStore?.value?.resetAllNodesIssues();
+		workflowDocumentStore.value?.resetAllNodesIssues();
 		workflowState.setWorkflowExecutionData(execution);
 
 		// Pin data of all nodes which do not have a parent node
@@ -117,7 +124,7 @@ export const useExecutionDebugging = (providedWorkflowState?: WorkflowState) => 
 				const nodeData = taskData.data.main.find((output) => output && output.length > 0);
 				if (nodeData) {
 					pinnings++;
-					workflowDocumentStore?.value?.pinNodeData(node.name, nodeData);
+					workflowDocumentStore.value?.pinNodeData(node.name, nodeData);
 
 					// Clear dirtiness timestamps so nodes don't appear dirty after restoration.
 					// The old pinData({ isRestoration: true }) handled this internally.

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.test.ts
@@ -7,7 +7,11 @@ import { createTestingPinia, type TestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
 import { createRouter, createWebHistory } from 'vue-router';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import { computed, h, nextTick, ref } from 'vue';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
+import { computed, h, nextTick, ref, shallowRef } from 'vue';
 import {
 	aiAgentNode,
 	aiChatExecutionResponse as aiChatExecutionResponseTemplate,
@@ -18,7 +22,7 @@ import {
 } from '../__test__/data';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { IN_PROGRESS_EXECUTION_ID, WorkflowStateKey } from '@/app/constants';
-import { WorkflowIdKey } from '@/app/constants/injectionKeys';
+import { WorkflowDocumentStoreKey, WorkflowIdKey } from '@/app/constants/injectionKeys';
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { createRunExecutionData, deepCopy } from 'n8n-workflow';
@@ -100,6 +104,9 @@ describe('LogsPanel', () => {
 					[ChatOptionsSymbol as symbol]: {},
 					[WorkflowStateKey as symbol]: workflowState,
 					[WorkflowIdKey as unknown as string]: computed(() => 'test-workflow-id'),
+					[WorkflowDocumentStoreKey as symbol]: shallowRef(
+						useWorkflowDocumentStore(createWorkflowDocumentId('test-workflow-id')),
+					),
 				},
 				plugins: [
 					createRouter({

--- a/packages/frontend/editor-ui/src/features/execution/logs/composables/useChatState.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/composables/useChatState.test.ts
@@ -1,14 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { nextTick, shallowRef } from 'vue';
+import { nextTick } from 'vue';
 import { setActivePinia } from 'pinia';
 import { createTestingPinia } from '@pinia/testing';
 import { useChatState } from './useChatState';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import {
-	useWorkflowDocumentStore,
-	createWorkflowDocumentId,
-	injectWorkflowDocumentStore,
-} from '@/app/stores/workflowDocument.store';
 import { useLogsStore } from '@/app/stores/logs.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
@@ -16,13 +11,6 @@ import type { INode } from 'n8n-workflow';
 import * as useRunWorkflowModule from '@/app/composables/useRunWorkflow';
 
 vi.mock('@/app/composables/useRunWorkflow');
-vi.mock('@/app/stores/workflowDocument.store', async () => {
-	const actual = await vi.importActual('@/app/stores/workflowDocument.store');
-	return {
-		...actual,
-		injectWorkflowDocumentStore: vi.fn(),
-	};
-});
 vi.mock('@/app/composables/useWorkflowHelpers', async (importOriginal) => {
 	const actual: Record<string, unknown> = await importOriginal();
 	return {
@@ -171,9 +159,6 @@ describe('useChatState', () => {
 		});
 		setActivePinia(pinia);
 		workflowsStore = useWorkflowsStore();
-		vi.mocked(injectWorkflowDocumentStore).mockReturnValue(
-			shallowRef(useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))),
-		);
 		logsStore = useLogsStore();
 		const rootStore = useRootStore();
 		nodeTypesStore = useNodeTypesStore();

--- a/packages/frontend/editor-ui/src/features/execution/logs/composables/useChatState.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/composables/useChatState.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { nextTick } from 'vue';
+import { nextTick, shallowRef } from 'vue';
 import { setActivePinia } from 'pinia';
 import { createTestingPinia } from '@pinia/testing';
 import { useChatState } from './useChatState';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+	injectWorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
 import { useLogsStore } from '@/app/stores/logs.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
@@ -11,6 +16,13 @@ import type { INode } from 'n8n-workflow';
 import * as useRunWorkflowModule from '@/app/composables/useRunWorkflow';
 
 vi.mock('@/app/composables/useRunWorkflow');
+vi.mock('@/app/stores/workflowDocument.store', async () => {
+	const actual = await vi.importActual('@/app/stores/workflowDocument.store');
+	return {
+		...actual,
+		injectWorkflowDocumentStore: vi.fn(),
+	};
+});
 vi.mock('@/app/composables/useWorkflowHelpers', async (importOriginal) => {
 	const actual: Record<string, unknown> = await importOriginal();
 	return {
@@ -159,6 +171,9 @@ describe('useChatState', () => {
 		});
 		setActivePinia(pinia);
 		workflowsStore = useWorkflowsStore();
+		vi.mocked(injectWorkflowDocumentStore).mockReturnValue(
+			shallowRef(useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))),
+		);
 		logsStore = useLogsStore();
 		const rootStore = useRootStore();
 		nodeTypesStore = useNodeTypesStore();

--- a/packages/frontend/editor-ui/src/features/execution/logs/composables/useChatState.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/composables/useChatState.ts
@@ -3,6 +3,7 @@ import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { useRunWorkflow } from '@/app/composables/useRunWorkflow';
 import { VIEWS } from '@/app/constants';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import MessageWithButtons from '@n8n/chat/components/MessageWithButtons.vue';
 import { chatEventBus } from '@n8n/chat/event-buses';
@@ -43,6 +44,7 @@ export function useChatState(
 ): ChatState {
 	const locale = useI18n();
 	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = injectWorkflowDocumentStore();
 	const workflowState = injectWorkflowState();
 	const rootStore = useRootStore();
 	const logsStore = useLogsStore();
@@ -60,7 +62,9 @@ export function useChatState(
 	const effectiveSessionId = computed(() => toValue(sessionId) ?? currentSessionId.value);
 
 	const previousChatMessages = computed(() => workflowsStore.getPastChatMessages);
-	const chatTriggerNode = computed(() => workflowsStore.allNodes.find(isChatNode) ?? null);
+	const chatTriggerNode = computed(
+		() => (workflowDocumentStore?.value?.allNodes ?? []).find(isChatNode) ?? null,
+	);
 
 	// Resolve the effective value for an options sub-parameter: returns the
 	// user-set value if present, otherwise the default from the node type

--- a/packages/frontend/editor-ui/src/features/execution/logs/composables/useChatState.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/composables/useChatState.ts
@@ -3,7 +3,10 @@ import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { useRunWorkflow } from '@/app/composables/useRunWorkflow';
 import { VIEWS } from '@/app/constants';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import MessageWithButtons from '@n8n/chat/components/MessageWithButtons.vue';
 import { chatEventBus } from '@n8n/chat/event-buses';
@@ -44,7 +47,11 @@ export function useChatState(
 ): ChatState {
 	const locale = useI18n();
 	const workflowsStore = useWorkflowsStore();
-	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 	const workflowState = injectWorkflowState();
 	const rootStore = useRootStore();
 	const logsStore = useLogsStore();
@@ -63,7 +70,7 @@ export function useChatState(
 
 	const previousChatMessages = computed(() => workflowsStore.getPastChatMessages);
 	const chatTriggerNode = computed(
-		() => (workflowDocumentStore?.value?.allNodes ?? []).find(isChatNode) ?? null,
+		() => (workflowDocumentStore.value?.allNodes ?? []).find(isChatNode) ?? null,
 	);
 
 	// Resolve the effective value for an options sub-parameter: returns the

--- a/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsExecutionData.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsExecutionData.ts
@@ -2,7 +2,10 @@ import { watch, computed, ref, type ComputedRef } from 'vue';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
 import { Workflow, type IRunExecutionData, type ITaskStartedData } from 'n8n-workflow';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import {
 	copyExecutionData,
@@ -31,7 +34,11 @@ interface UseLogsExecutionDataOptions {
 export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionDataOptions = {}) {
 	const nodeHelpers = useNodeHelpers();
 	const workflowsStore = useWorkflowsStore();
-	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 	const workflowState = injectWorkflowState();
 	const toast = useToast();
 
@@ -55,7 +62,7 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 	const latestNodeNameById = computed(() =>
 		Object.values(workflow.value?.nodes ?? {}).reduce<Record<string, LatestNodeInfo>>(
 			(acc, node) => {
-				const nodeInStore = workflowDocumentStore?.value?.getNodeById(node.id) ?? null;
+				const nodeInStore = workflowDocumentStore.value?.getNodeById(node.id) ?? null;
 
 				acc[node.id] = {
 					deleted: !nodeInStore,
@@ -72,7 +79,7 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 		// When the floating chat panel experiment is enabled and the ChatTrigger has
 		// availableInChat enabled, the floating chat hub handles chat instead of the bottom panel
 		if (chatHubPanelStore.isFloatingChatEnabled) {
-			const isChatHubActive = (workflowDocumentStore?.value?.allNodes ?? []).some(
+			const isChatHubActive = (workflowDocumentStore.value?.allNodes ?? []).some(
 				(node) => node.type === CHAT_TRIGGER_NODE_TYPE && node.parameters?.availableInChat === true,
 			);
 			if (isChatHubActive) return false;
@@ -80,7 +87,7 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 
 		return [
 			Object.values(workflow.value?.nodes ?? {}),
-			workflowDocumentStore?.value?.allNodes ?? [],
+			workflowDocumentStore.value?.allNodes ?? [],
 		].some((nodes) => nodes.some(isChatNode));
 	});
 

--- a/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsExecutionData.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsExecutionData.ts
@@ -2,6 +2,7 @@ import { watch, computed, ref, type ComputedRef } from 'vue';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
 import { Workflow, type IRunExecutionData, type ITaskStartedData } from 'n8n-workflow';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import {
 	copyExecutionData,
@@ -30,6 +31,7 @@ interface UseLogsExecutionDataOptions {
 export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionDataOptions = {}) {
 	const nodeHelpers = useNodeHelpers();
 	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = injectWorkflowDocumentStore();
 	const workflowState = injectWorkflowState();
 	const toast = useToast();
 
@@ -53,7 +55,7 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 	const latestNodeNameById = computed(() =>
 		Object.values(workflow.value?.nodes ?? {}).reduce<Record<string, LatestNodeInfo>>(
 			(acc, node) => {
-				const nodeInStore = workflowsStore.getNodeById(node.id);
+				const nodeInStore = workflowDocumentStore?.value?.getNodeById(node.id) ?? null;
 
 				acc[node.id] = {
 					deleted: !nodeInStore,
@@ -70,15 +72,16 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 		// When the floating chat panel experiment is enabled and the ChatTrigger has
 		// availableInChat enabled, the floating chat hub handles chat instead of the bottom panel
 		if (chatHubPanelStore.isFloatingChatEnabled) {
-			const isChatHubActive = workflowsStore.workflow.nodes.some(
+			const isChatHubActive = (workflowDocumentStore?.value?.allNodes ?? []).some(
 				(node) => node.type === CHAT_TRIGGER_NODE_TYPE && node.parameters?.availableInChat === true,
 			);
 			if (isChatHubActive) return false;
 		}
 
-		return [Object.values(workflow.value?.nodes ?? {}), workflowsStore.workflow.nodes].some(
-			(nodes) => nodes.some(isChatNode),
-		);
+		return [
+			Object.values(workflow.value?.nodes ?? {}),
+			workflowDocumentStore?.value?.allNodes ?? [],
+		].some((nodes) => nodes.some(isChatNode));
 	});
 
 	const entries = computed<LogEntry[]>(() => {

--- a/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsSelection.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsSelection.ts
@@ -15,7 +15,7 @@ import { useUIStore } from '@/app/stores/ui.store';
 import { shallowRef, watch } from 'vue';
 import { computed } from 'vue';
 import type { Ref, ComputedRef } from 'vue';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 export function useLogsSelection(
 	execution: ComputedRef<IExecutionResponse | undefined>,
@@ -33,7 +33,7 @@ export function useLogsSelection(
 	const logsStore = useLogsStore();
 	const uiStore = useUIStore();
 	const canvasStore = useCanvasStore();
-	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = injectWorkflowDocumentStore();
 
 	function syncSelectionToCanvasIfEnabled(value: LogEntry) {
 		if (!logsStore.isLogSelectionSyncedWithCanvas) {
@@ -105,7 +105,7 @@ export function useLogsSelection(
 		[() => uiStore.lastSelectedNode, () => logsStore.isLogSelectionSyncedWithCanvas],
 		([selectedOnCanvas, shouldSync]) => {
 			const selectedNodeId = selectedOnCanvas
-				? workflowsStore.nodesByName[selectedOnCanvas]?.id
+				? (workflowDocumentStore?.value?.nodesByName ?? {})[selectedOnCanvas]?.id
 				: undefined;
 
 			nodeIdToSelect.value =

--- a/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsSelection.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsSelection.ts
@@ -15,7 +15,11 @@ import { useUIStore } from '@/app/stores/ui.store';
 import { shallowRef, watch } from 'vue';
 import { computed } from 'vue';
 import type { Ref, ComputedRef } from 'vue';
-import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 export function useLogsSelection(
 	execution: ComputedRef<IExecutionResponse | undefined>,
@@ -33,7 +37,12 @@ export function useLogsSelection(
 	const logsStore = useLogsStore();
 	const uiStore = useUIStore();
 	const canvasStore = useCanvasStore();
-	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 
 	function syncSelectionToCanvasIfEnabled(value: LogEntry) {
 		if (!logsStore.isLogSelectionSyncedWithCanvas) {
@@ -105,7 +114,7 @@ export function useLogsSelection(
 		[() => uiStore.lastSelectedNode, () => logsStore.isLogSelectionSyncedWithCanvas],
 		([selectedOnCanvas, shouldSync]) => {
 			const selectedNodeId = selectedOnCanvas
-				? (workflowDocumentStore?.value?.nodesByName ?? {})[selectedOnCanvas]?.id
+				? (workflowDocumentStore.value?.nodesByName ?? {})[selectedOnCanvas]?.id
 				: undefined;
 
 			nodeIdToSelect.value =


### PR DESCRIPTION

## Summary

Migrate 4 composables from workflowsStore/workflowState to the new workflowDocumentStore: useExecutionDebugging, useLogsExecutionData, useLogsSelection, and useChatState. All composables use the inject pattern since they're called from within the WorkflowLayout component tree. Update 3 test files to mock the injected store and wire it in test fixtures.


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2519

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
