### PR TITLE
refactor(editor): Migrate integrations, evaluation, and experiments to `workflowDocumentStore` (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/evaluation.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/evaluation.store.ts
@@ -5,6 +5,10 @@ import * as evaluationsApi from './evaluation.api';
 import type { TestCaseExecutionRecord, TestRunRecord } from './evaluation.api';
 import { STORES } from '@n8n/stores';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { EVALUATION_NODE_TYPE, EVALUATION_TRIGGER_NODE_TYPE, NodeHelpers } from 'n8n-workflow';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
@@ -21,6 +25,11 @@ export const useEvaluationStore = defineStore(
 		// Store instances
 		const rootStore = useRootStore();
 		const workflowsStore = useWorkflowsStore();
+		const workflowDocumentStore = computed(() =>
+			workflowsStore.workflowId
+				? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+				: undefined,
+		);
 		const nodeTypesStore = useNodeTypesStore();
 		const settingsStore = useSettingsStore();
 
@@ -44,13 +53,13 @@ export const useEvaluationStore = defineStore(
 		});
 
 		const evaluationTriggerExists = computed(() => {
-			return workflowsStore.workflow.nodes.some(
+			return (workflowDocumentStore.value?.allNodes ?? []).some(
 				(node) => node.type === EVALUATION_TRIGGER_NODE_TYPE,
 			);
 		});
 
 		function evaluationNodeExist(operation: string) {
-			return workflowsStore.workflow.nodes.some((node) => {
+			return (workflowDocumentStore.value?.allNodes ?? []).some((node) => {
 				if (node.type !== EVALUATION_NODE_TYPE) {
 					return false;
 				}

--- a/packages/frontend/editor-ui/src/features/integrations/logStreaming.ee/components/EventDestinationSettingsModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/logStreaming.ee/components/EventDestinationSettingsModal.vue
@@ -198,9 +198,11 @@ const destinationNode = computed(
 watch(
 	() => destinationNode.value?.credentials,
 	(newCredentials) => {
+		unchanged.value = false;
 		if (newCredentials) {
-			unchanged.value = false;
 			nodeParameters.value.credentials = newCredentials as unknown as NodeParameterValueType;
+		} else {
+			nodeParameters.value.credentials = {};
 		}
 	},
 );

--- a/packages/frontend/editor-ui/src/features/integrations/logStreaming.ee/components/EventDestinationSettingsModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/logStreaming.ee/components/EventDestinationSettingsModal.vue
@@ -29,7 +29,11 @@ import { createEventBus } from '@n8n/utils/event-bus';
 
 import { useLogStreamingStore } from '../logStreaming.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
-import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import ParameterInputList from '@/features/ndv/parameters/components/ParameterInputList.vue';
 import type { IMenuItem, IUpdateInformation, ModalKey } from '@/Interface';
 import { LOG_STREAM_MODAL_KEY, MODAL_CONFIRM } from '@/app/constants';
@@ -84,7 +88,12 @@ const { confirm } = useMessage();
 const telemetry = useTelemetry();
 const logStreamingStore = useLogStreamingStore();
 const ndvStore = useNDVStore();
-const workflowDocumentStore = injectWorkflowDocumentStore();
+const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = computed(() =>
+	workflowsStore.workflowId
+		? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: undefined,
+);
 const uiStore = useUIStore();
 
 const unchanged = ref(!isNew);

--- a/packages/frontend/editor-ui/src/features/integrations/logStreaming.ee/components/EventDestinationSettingsModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/logStreaming.ee/components/EventDestinationSettingsModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, useTemplateRef } from 'vue';
+import { computed, onMounted, ref, useTemplateRef, watch } from 'vue';
 import get from 'lodash/get';
 import set from 'lodash/set';
 import unset from 'lodash/unset';
@@ -29,7 +29,7 @@ import { createEventBus } from '@n8n/utils/event-bus';
 
 import { useLogStreamingStore } from '../logStreaming.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import ParameterInputList from '@/features/ndv/parameters/components/ParameterInputList.vue';
 import type { IMenuItem, IUpdateInformation, ModalKey } from '@/Interface';
 import { LOG_STREAM_MODAL_KEY, MODAL_CONFIRM } from '@/app/constants';
@@ -62,11 +62,6 @@ import {
 	N8nSelect,
 	N8nText,
 } from '@n8n/design-system';
-import {
-	injectWorkflowState,
-	type WorkflowStateBusEvents,
-	workflowStateEventBus,
-} from '@/app/composables/useWorkflowState';
 
 defineOptions({ name: 'EventDestinationSettingsModal' });
 
@@ -89,8 +84,7 @@ const { confirm } = useMessage();
 const telemetry = useTelemetry();
 const logStreamingStore = useLogStreamingStore();
 const ndvStore = useNDVStore();
-const workflowsStore = useWorkflowsStore();
-const workflowState = injectWorkflowState();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const uiStore = useUIStore();
 
 const unchanged = ref(!isNew);
@@ -188,23 +182,23 @@ const isFormValid = computed(() => {
 	return issues === null;
 });
 
-function onUpdateNodeProperties(event: WorkflowStateBusEvents['updateNodeProperties']) {
-	const updateInformation = event[1];
-	if (updateInformation.name === destination.id) {
-		if ('credentials' in updateInformation.properties) {
+const destinationNode = computed(
+	() => workflowDocumentStore?.value?.getNodeByName(destination.id ?? '') ?? null,
+);
+
+watch(
+	() => destinationNode.value?.credentials,
+	(newCredentials) => {
+		if (newCredentials) {
 			unchanged.value = false;
-			nodeParameters.value.credentials = updateInformation.properties
-				.credentials as NodeParameterValueType;
+			nodeParameters.value.credentials = newCredentials as unknown as NodeParameterValueType;
 		}
-	}
-}
+	},
+);
 
 onMounted(() => {
 	setupNode(Object.assign(deepCopy(defaultMessageEventBusDestinationOptions), destination));
-	workflowStateEventBus.on('updateNodeProperties', onUpdateNodeProperties);
 });
-
-onUnmounted(() => workflowStateEventBus.off('updateNodeProperties', onUpdateNodeProperties));
 
 function onInput() {
 	unchanged.value = false;
@@ -222,9 +216,9 @@ function onLabelChange(value: string) {
 }
 
 function setupNode(options: MessageEventBusDestinationOptions) {
-	workflowsStore.removeNode(node.value);
+	workflowDocumentStore?.value?.removeNode(node.value);
 	ndvStore.setActiveNodeName(options.id ?? 'thisshouldnothappen', 'other');
-	workflowsStore.addNode(destinationToFakeINodeUi(options));
+	workflowDocumentStore?.value?.addNode(destinationToFakeINodeUi(options));
 	nodeParameters.value = options as INodeParameters;
 	logStreamingStore.items[destination.id!].destination = options;
 }
@@ -289,7 +283,7 @@ function valueChanged(parameterData: IUpdateInformation) {
 	}
 
 	nodeParameters.value = deepCopy(nodeParametersCopy);
-	workflowState.updateNodeProperties({
+	workflowDocumentStore?.value?.updateNodeProperties({
 		name: node.value.name,
 		properties: { parameters: nodeParameters.value, position: [0, 0] },
 	});
@@ -329,7 +323,7 @@ async function removeThis() {
 
 function onModalClose() {
 	if (!hasOnceBeenSaved.value) {
-		workflowsStore.removeNode(node.value);
+		workflowDocumentStore?.value?.removeNode(node.value);
 		if (nodeParameters.value.id && typeof nodeParameters.value.id !== 'object') {
 			logStreamingStore.removeDestination(nodeParameters.value.id.toString());
 		}

--- a/packages/frontend/editor-ui/src/features/integrations/logStreaming.ee/views/SettingsLogStreamingView.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/logStreaming.ee/views/SettingsLogStreamingView.vue
@@ -14,7 +14,11 @@ import { createEventBus } from '@n8n/utils/event-bus';
 import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
 import { useI18n } from '@n8n/i18n';
 import { usePageRedirectionHelper } from '@/app/composables/usePageRedirectionHelper';
-import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 import { ElCol, ElRow, ElSwitch } from 'element-plus';
 import { N8nActionBox, N8nButton, N8nHeading, N8nInfoTip } from '@n8n/design-system';
@@ -22,7 +26,12 @@ const environment = process.env.NODE_ENV;
 
 const settingsStore = useSettingsStore();
 const logStreamingStore = useLogStreamingStore();
-const workflowDocumentStore = injectWorkflowDocumentStore();
+const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = computed(() =>
+	workflowsStore.workflowId
+		? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: undefined,
+);
 const uiStore = useUIStore();
 const credentialsStore = useCredentialsStore();
 const documentTitle = useDocumentTitle();

--- a/packages/frontend/editor-ui/src/features/integrations/logStreaming.ee/views/SettingsLogStreamingView.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/logStreaming.ee/views/SettingsLogStreamingView.vue
@@ -1,7 +1,6 @@
 <script lang="ts" setup>
 import { computed, nextTick, onBeforeMount, onMounted, ref, getCurrentInstance } from 'vue';
 import { v4 as uuid } from 'uuid';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { hasPermission } from '@/app/utils/rbac/permissions';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { useLogStreamingStore } from '../logStreaming.store';
@@ -15,7 +14,7 @@ import { createEventBus } from '@n8n/utils/event-bus';
 import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
 import { useI18n } from '@n8n/i18n';
 import { usePageRedirectionHelper } from '@/app/composables/usePageRedirectionHelper';
-import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 import { ElCol, ElRow, ElSwitch } from 'element-plus';
 import { N8nActionBox, N8nButton, N8nHeading, N8nInfoTip } from '@n8n/design-system';
@@ -23,8 +22,7 @@ const environment = process.env.NODE_ENV;
 
 const settingsStore = useSettingsStore();
 const logStreamingStore = useLogStreamingStore();
-const workflowsStore = useWorkflowsStore();
-const workflowState = injectWorkflowState();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const uiStore = useUIStore();
 const credentialsStore = useCredentialsStore();
 const documentTitle = useDocumentTitle();
@@ -97,7 +95,7 @@ function forceUpdateInstance() {
 }
 
 function onBusClosing() {
-	workflowState.removeAllNodes({ setStateDirty: false, removePinData: true });
+	workflowDocumentStore?.value?.removeAllNodes();
 	uiStore.markStateClean();
 }
 
@@ -148,9 +146,9 @@ async function addDestination() {
 async function onRemove(destinationId?: string) {
 	if (!destinationId) return;
 	await logStreamingStore.deleteDestination(destinationId);
-	const foundNode = workflowsStore.getNodeByName(destinationId);
+	const foundNode = workflowDocumentStore?.value?.getNodeByName(destinationId);
 	if (foundNode) {
-		workflowsStore.removeNode(foundNode);
+		workflowDocumentStore?.value?.removeNode(foundNode);
 	}
 }
 

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstallNode.ts
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstallNode.ts
@@ -2,10 +2,14 @@ import { useCommunityNodesStore } from '../communityNodes.store';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
-import { nextTick, ref } from 'vue';
+import { computed, nextTick, ref } from 'vue';
 import { i18n } from '@n8n/i18n';
 import { useToast } from '@/app/composables/useToast';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 import { removePreviewToken } from '@/features/shared/nodeCreator/nodeCreator.utils';
 import { useTelemetry } from '@/app/composables/useTelemetry';
@@ -39,6 +43,11 @@ export function useInstallNode() {
 	const nodeTypesStore = useNodeTypesStore();
 	const credentialsStore = useCredentialsStore();
 	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 	const userStore = useUsersStore();
 	const loading = ref(false);
 	const toast = useToast();
@@ -93,10 +102,9 @@ export function useInstallNode() {
 			// update parameters and webhooks for freshly installed nodes
 			// rename types from preview version to the actual version
 			const nodeType = props.nodeType;
-			if (nodeType && workflowsStore.workflow.nodes?.length) {
-				const nodesToUpdate = workflowsStore.workflow.nodes.filter(
-					(node) => node.type === removePreviewToken(nodeType),
-				);
+			const allNodes = workflowDocumentStore.value?.allNodes ?? [];
+			if (nodeType && allNodes.length) {
+				const nodesToUpdate = allNodes.filter((node) => node.type === removePreviewToken(nodeType));
 				canvasOperations.initializeUnknownNodes(nodesToUpdate);
 			}
 			toast.showMessage({

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalCanvasNodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalCanvasNodeSettings.vue
@@ -6,6 +6,7 @@ import { type IUpdateInformation } from '@/Interface';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { computed } from 'vue';
 
 const { nodeId, isReadOnly, subTitle, isEmbeddedInCanvas } = defineProps<{
@@ -22,12 +23,13 @@ const emit = defineEmits<{
 }>();
 
 const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const uiStore = useUIStore();
 const { renameNode } = useCanvasOperations();
 const nodeHelpers = useNodeHelpers();
 const ndvStore = useNDVStore();
 
-const activeNode = computed(() => workflowsStore.getNodeById(nodeId));
+const activeNode = computed(() => workflowDocumentStore?.value?.getNodeById(nodeId));
 const foreignCredentials = computed(() =>
 	nodeHelpers.getForeignCredentialsIfSharingEnabled(activeNode.value?.credentials),
 );

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalEmbeddedNodeDetails.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalEmbeddedNodeDetails.vue
@@ -2,7 +2,6 @@
 import { ExpressionLocalResolveContextSymbol } from '@/app/constants';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useVueFlow } from '@vue-flow/core';
 import { watchOnce } from '@vueuse/core';
 import { computed, provide, ref } from 'vue';
@@ -15,6 +14,7 @@ import ExperimentalEmbeddedNdvActions from '@/features/workflows/canvas/experime
 import { useCanvas } from '@/features/workflows/canvas/composables/useCanvas';
 import { useExpressionResolveCtx } from '@/features/workflows/canvas/experimental/composables/useExpressionResolveCtx';
 import { useTelemetryContext } from '@/app/composables/useTelemetryContext';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 import { N8nText } from '@n8n/design-system';
 const { nodeId, isReadOnly } = defineProps<{
@@ -27,11 +27,11 @@ const ndvStore = useNDVStore();
 const experimentalNdvStore = useExperimentalNdvStore();
 const isExpanded = computed(() => !experimentalNdvStore.collapsedNodes[nodeId]);
 const nodeTypesStore = useNodeTypesStore();
-const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 
 useTelemetryContext({ view_shown: 'zoomed_view' });
 
-const node = computed(() => workflowsStore.getNodeById(nodeId) ?? null);
+const node = computed(() => workflowDocumentStore?.value?.getNodeById(nodeId) ?? null);
 const nodeType = computed(() => {
 	if (node.value) {
 		return nodeTypesStore.getNodeType(node.value.type, node.value.typeVersion);


### PR DESCRIPTION
## Summary

Migrate 6 source files from legacy workflowsStore/workflowState node access to the new workflowDocumentStore facade:
- ExperimentalCanvasNodeSettings.vue, ExperimentalEmbeddedNodeDetails.vue: use inject pattern (inside WorkflowLayout)
- evaluation.store.ts, useInstallNode.ts: use computed pattern with workflowDocumentStore
- SettingsLogStreamingView.vue: replace workflowState.removeAllNodes with workflowDocumentStore.removeAllNodes
- EventDestinationSettingsModal.vue: replace workflowStateEventBus listener with watch on node.credentials

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2524

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
