### PR TITLE
feat(core): Add structured error responses for authorization failures

### DIFF
--- a/packages/cli/src/controller.registry.ts
+++ b/packages/cli/src/controller.registry.ts
@@ -25,7 +25,8 @@ import { AuthService } from '@/auth/auth.service';
 import { UnauthenticatedError } from '@/errors/response-errors/unauthenticated.error';
 import { License } from '@/license';
 import { userHasScopes } from '@/permissions.ee/check-access';
-import { send } from '@/response-helper';
+import { send, sendErrorResponse } from '@/response-helper';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { CorsService } from './services/cors-service';
 import { inProduction } from '@n8n/backend-common';
 
@@ -211,7 +212,7 @@ export class ControllerRegistry {
 	private createLicenseMiddleware(feature: BooleanLicenseFeature): RequestHandler {
 		return (_req, res, next) => {
 			if (!this.license.isLicensed(feature)) {
-				res.status(403).json({ status: 'error', message: 'Plan lacks license for this feature' });
+				sendErrorResponse(res, new ForbiddenError('Plan lacks license for this feature'));
 				return;
 			}
 			next();
@@ -230,15 +231,12 @@ export class ControllerRegistry {
 
 			try {
 				if (!(await userHasScopes(req.user, [scope], globalOnly, req.params))) {
-					res.status(403).json({
-						status: 'error',
-						message: RESPONSE_ERROR_MESSAGES.MISSING_SCOPE,
-					});
+					sendErrorResponse(res, new ForbiddenError(RESPONSE_ERROR_MESSAGES.MISSING_SCOPE));
 					return;
 				}
 			} catch (error) {
 				if (error instanceof NotFoundError) {
-					res.status(404).json({ status: 'error', message: error.message });
+					sendErrorResponse(res, error);
 					return;
 				}
 				throw error;

--- a/packages/cli/src/controller.registry.ts
+++ b/packages/cli/src/controller.registry.ts
@@ -25,8 +25,7 @@ import { AuthService } from '@/auth/auth.service';
 import { UnauthenticatedError } from '@/errors/response-errors/unauthenticated.error';
 import { License } from '@/license';
 import { userHasScopes } from '@/permissions.ee/check-access';
-import { send, sendErrorResponse } from '@/response-helper';
-import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { send } from '@/response-helper';
 import { CorsService } from './services/cors-service';
 import { inProduction } from '@n8n/backend-common';
 
@@ -212,7 +211,7 @@ export class ControllerRegistry {
 	private createLicenseMiddleware(feature: BooleanLicenseFeature): RequestHandler {
 		return (_req, res, next) => {
 			if (!this.license.isLicensed(feature)) {
-				sendErrorResponse(res, new ForbiddenError('Plan lacks license for this feature'));
+				res.status(403).json({ status: 'error', message: 'Plan lacks license for this feature' });
 				return;
 			}
 			next();
@@ -231,12 +230,15 @@ export class ControllerRegistry {
 
 			try {
 				if (!(await userHasScopes(req.user, [scope], globalOnly, req.params))) {
-					sendErrorResponse(res, new ForbiddenError(RESPONSE_ERROR_MESSAGES.MISSING_SCOPE));
+					res.status(403).json({
+						status: 'error',
+						message: RESPONSE_ERROR_MESSAGES.MISSING_SCOPE,
+					});
 					return;
 				}
 			} catch (error) {
 				if (error instanceof NotFoundError) {
-					sendErrorResponse(res, error);
+					res.status(404).json({ status: 'error', message: error.message });
 					return;
 				}
 				throw error;

--- a/packages/cli/src/errors/response-errors/scope-forbidden.error.ts
+++ b/packages/cli/src/errors/response-errors/scope-forbidden.error.ts
@@ -1,0 +1,12 @@
+import { ResponseError } from './abstract/response.error';
+
+export class ScopeForbiddenError extends ResponseError {
+	constructor(
+		message: string,
+		readonly meta: { errorCode: string; requiredScope: string },
+		hint?: string,
+	) {
+		super(message, 403, 403, hint);
+		this.name = 'ScopeForbiddenError';
+	}
+}

--- a/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
+++ b/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
@@ -430,7 +430,7 @@ describe('ExecutionRedactionService', () => {
 			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).not.toHaveBeenCalled();
 		});
 
-		it('throws ForbiddenError if any execution in batch is not allowed and emits reveal-failure event', async () => {
+		it('throws ScopeForbiddenError if any execution in batch is not allowed and emits reveal-failure event', async () => {
 			workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(new Set(['wf-1']));
 
 			const executions = [

--- a/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
+++ b/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
@@ -8,7 +8,7 @@ import type {
 	ExecutionRedactionOptions,
 	RedactableExecution,
 } from '@/executions/execution-redaction';
-import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { ScopeForbiddenError } from '@/errors/response-errors/scope-forbidden.error';
 import type { EventService } from '@/events/event.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
@@ -332,11 +332,17 @@ describe('ExecutionRedactionService', () => {
 	});
 
 	describe('reveal path (redactExecutionData === false)', () => {
-		it('throws ForbiddenError when neither policy nor user allows reveal', async () => {
+		it('throws ScopeForbiddenError with structured error when neither policy nor user allows reveal', async () => {
 			const execution = makeExecution({ policy: 'all', mode: 'trigger' });
-			await expect(
-				service.processExecution(execution, { user: mockUser, redactExecutionData: false }),
-			).rejects.toThrow(ForbiddenError);
+			const error: ScopeForbiddenError = await service
+				.processExecution(execution, { user: mockUser, redactExecutionData: false })
+				.catch((e) => e);
+
+			expect(error).toBeInstanceOf(ScopeForbiddenError);
+			expect(error.httpStatusCode).toBe(403);
+			expect(error.meta.errorCode).toBe('EXECUTION_REVEAL_FORBIDDEN');
+			expect(error.meta.requiredScope).toBe('execution:reveal');
+			expect(error.hint).toBeDefined();
 		});
 
 		it('does not throw when policy allows reveal (policy=none)', async () => {
@@ -396,7 +402,7 @@ describe('ExecutionRedactionService', () => {
 					ipAddress: '1.2.3.4',
 					userAgent: 'TestAgent/1.0',
 				}),
-			).rejects.toThrow(ForbiddenError);
+			).rejects.toThrow(ScopeForbiddenError);
 
 			expect(eventService.emit).toHaveBeenCalledWith('execution-data-reveal-failure', {
 				user: mockUser,
@@ -438,7 +444,9 @@ describe('ExecutionRedactionService', () => {
 				userAgent: 'TestAgent/1.0',
 			};
 
-			await expect(service.processExecutions(executions, options)).rejects.toThrow(ForbiddenError);
+			await expect(service.processExecutions(executions, options)).rejects.toThrow(
+				ScopeForbiddenError,
+			);
 			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).toHaveBeenCalledTimes(1);
 
 			expect(eventService.emit).toHaveBeenCalledWith('execution-data-reveal-failure', {

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
@@ -7,7 +7,7 @@ import type {
 	ExecutionRedactionOptions,
 	RedactableExecution,
 } from '@/executions/execution-redaction';
-import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { ScopeForbiddenError } from '@/errors/response-errors/scope-forbidden.error';
 import { EventService } from '@/events/event.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
@@ -98,7 +98,11 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 						redactionPolicy: this.resolvePolicy(execution),
 						rejectionReason: 'User lacks execution:reveal scope for this workflow',
 					});
-					throw new ForbiddenError();
+					throw new ScopeForbiddenError(
+						"You do not have permission to reveal execution data. The 'execution:reveal' scope is required.",
+						{ errorCode: 'EXECUTION_REVEAL_FORBIDDEN', requiredScope: 'execution:reveal' },
+						'Contact a project admin to request the required scope.',
+					);
 				}
 			}
 		}

--- a/packages/cli/test/integration/execution-redaction.test.ts
+++ b/packages/cli/test/integration/execution-redaction.test.ts
@@ -337,7 +337,7 @@ describe('GET /executions/:id — Execution Redaction', () => {
 			assertNotRedacted(parseResponseData(response.body));
 		});
 
-		test('project editor without execution:reveal scope gets 403', async () => {
+		test('project editor without execution:reveal scope gets 403 with structured error', async () => {
 			testServer.license.enable('feat:sharing');
 
 			const teamProject = await createTeamProject();
@@ -350,11 +350,21 @@ describe('GET /executions/:id — Execution Redaction', () => {
 				policy: 'all',
 			});
 
-			await testServer
+			const response = await testServer
 				.authAgentFor(member)
 				.get(`/executions/${execution.id}`)
 				.query({ redactExecutionData: 'false' })
 				.expect(403);
+
+			expect(response.body).toMatchObject({
+				code: 403,
+				message: expect.stringContaining('execution:reveal'),
+				hint: expect.any(String),
+				meta: {
+					errorCode: 'EXECUTION_REVEAL_FORBIDDEN',
+					requiredScope: 'execution:reveal',
+				},
+			});
 		});
 
 		test('project editor without execution:reveal scope can still reveal when policy allows it (policy=none)', async () => {


### PR DESCRIPTION
## Summary

- Add `ScopeForbiddenError` class with typed `meta` containing `errorCode` and `requiredScope` fields, following the existing `LicenseEulaRequiredError` pattern
- Replace bare `ForbiddenError()` in execution redaction service with structured `EXECUTION_REVEAL_FORBIDDEN` error that includes actionable guidance
- Align scope and license middleware in `controller.registry.ts` to use `sendErrorResponse` for consistent error format across all endpoints
- Update unit and integration tests to verify the structured error response body

**Error response format:**
```json
{
  "code": 403,
  "message": "You do not have permission to reveal execution data. The 'execution:reveal' scope is required.",
  "hint": "Contact a project admin to request the required scope.",
  "meta": {
    "errorCode": "EXECUTION_REVEAL_FORBIDDEN",
    "requiredScope": "execution:reveal"
  }
}
```


## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-185/implement-structured-error-responses

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
