### PR TITLE
fix(editor): preserve stored filter options when resolving typeOptions

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FilterConditions/FilterConditions.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FilterConditions/FilterConditions.vue
@@ -115,6 +115,7 @@ watchEffect(async () => {
 		newOptions = {
 			...DEFAULT_FILTER_OPTIONS,
 			...(await resolveParameter(typeOptions as unknown as NodeParameterValue)),
+			...(props.value?.options ?? {}),
 		};
 	} catch {
 		// Keep default options


### PR DESCRIPTION
## Summary

Fixes #27131

The `watchEffect` in `FilterConditions.vue` merges `DEFAULT_FILTER_OPTIONS` with the resolved `typeOptions` from the node definition but never includes the stored options from the workflow data (`props.value?.options`). This causes user-set values like `typeValidation: "loose"` to be silently overwritten with the resolved defaults whenever an IF or Switch node is opened in the editor.

## Root Cause

In the `watchEffect` block (line ~115), the options merge was:
```typescript
newOptions = {
  ...DEFAULT_FILTER_OPTIONS,
  ...(await resolveParameter(typeOptions)),
};
```

This always produces the node definition defaults. User-persisted options (stored in the workflow JSON) were never included in the merge.

## Fix

Spread `props.value?.options` as the last entry in the merge so stored values take precedence:
```typescript
newOptions = {
  ...DEFAULT_FILTER_OPTIONS,
  ...(await resolveParameter(typeOptions)),
  ...(props.value?.options ?? {}),
};
```

## Test Plan

1. Create a workflow with an IF node
2. Set `typeValidation` to `"loose"` in the node settings
3. Save the workflow
4. Close and reopen the IF node — `typeValidation` should remain `"loose"`
5. Previously it would silently revert to `"strict"`

Made with [Cursor](https://cursor.com)