### PR TITLE
fix(editor): Clear resource locator cache after URL redirect creation

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.test.ts
@@ -493,7 +493,7 @@ describe('ResourceLocator', () => {
 			.mockResolvedValueOnce({ results: TEST_ITEMS, paginationToken: null })
 			.mockResolvedValueOnce({ results: TEST_ITEMS_UPDATED, paginationToken: null });
 
-		const { getByTestId, getByText, queryByText } = renderComponent({
+		const { getByTestId, getByText } = renderComponent({
 			props: {
 				modelValue: { __rl: true, value: '', mode: 'list' },
 				parameter: TEST_PARAMETER_URL_REDIRECT,

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.test.ts
@@ -482,6 +482,46 @@ describe('ResourceLocator', () => {
 		expect(nodeTypesStore.getNodeParameterActionResult).not.toHaveBeenCalled();
 	});
 
+	it('clears cached resources after URL redirect so fresh data is fetched on re-open', async () => {
+		const TEST_ITEMS = [{ name: 'Old Table', value: 'old-table' }];
+		const TEST_ITEMS_UPDATED = [
+			{ name: 'Old Table', value: 'old-table' },
+			{ name: 'New Table', value: 'new-table' },
+		];
+
+		nodeTypesStore.getResourceLocatorResults
+			.mockResolvedValueOnce({ results: TEST_ITEMS, paginationToken: null })
+			.mockResolvedValueOnce({ results: TEST_ITEMS_UPDATED, paginationToken: null });
+
+		const { getByTestId, getByText, queryByText } = renderComponent({
+			props: {
+				modelValue: { __rl: true, value: '', mode: 'list' },
+				parameter: TEST_PARAMETER_URL_REDIRECT,
+				path: `parameters.${TEST_PARAMETER_URL_REDIRECT.name}`,
+				node: TEST_NODE_URL_REDIRECT,
+				displayTitle: 'Test Resource Locator',
+				expressionComputedValue: '',
+			},
+		});
+
+		// Open dropdown — first fetch returns old data
+		await fireEvent.focus(getByTestId('rlc-input'));
+		await waitFor(() => {
+			expect(nodeTypesStore.getResourceLocatorResults).toHaveBeenCalledTimes(1);
+		});
+		expect(getByText('Old Table')).toBeInTheDocument();
+
+		// Click "Create new" — opens URL and clears cache
+		await userEvent.click(getByTestId('rlc-item-add-resource'));
+
+		// Re-open dropdown — should fetch fresh data since cache was cleared
+		await fireEvent.focus(getByTestId('rlc-input'));
+		await waitFor(() => {
+			expect(nodeTypesStore.getResourceLocatorResults).toHaveBeenCalledTimes(2);
+		});
+		expect(getByText('New Table')).toBeInTheDocument();
+	});
+
 	describe('slow load notice', () => {
 		it('should pass slowLoadNotice configuration to dropdown component', async () => {
 			vi.useFakeTimers();

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
@@ -419,6 +419,7 @@ const handleAddResourceClick = async () => {
 		}
 
 		hideResourceDropdown();
+		refreshList();
 		openResource(resolvedUrl);
 		return;
 	}


### PR DESCRIPTION
## Summary
Previously in order to see the new resource the user has to reopen the NDV

After the fix:

https://github.com/user-attachments/assets/d7ef1337-f457-47fd-82d8-2b941724e89d
