### PR TITLE
fix(core): VM test Group G — RCE prevention & expression fixture fixes

### DIFF
--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -316,9 +316,20 @@ export class IsolatedVmBridge implements RuntimeBridge {
 		// Used by createDeepLazyProxy when accessing properties
 		const getValueAtPath = new (getIvm().Reference)((path: string[]) => {
 			// Navigate to value
+			// Special-case: paths starting with ['$item', index] call data.$item(index)
+			// to get the sub-proxy for that item, then continue navigating the rest.
 			let value: unknown = data;
-			for (const key of path) {
-				value = (value as Record<string, unknown>)?.[key];
+			let startIndex = 0;
+			const itemFn = (data as Record<string, unknown>).$item;
+			if (path.length >= 2 && path[0] === '$item' && typeof itemFn === 'function') {
+				const itemIndex = parseInt(path[1], 10);
+				if (!isNaN(itemIndex)) {
+					value = (itemFn as (i: number) => unknown)(itemIndex);
+					startIndex = 2;
+				}
+			}
+			for (let i = startIndex; i < path.length; i++) {
+				value = (value as Record<string, unknown>)?.[path[i]];
 				if (value === undefined || value === null) {
 					return value;
 				}
@@ -359,9 +370,19 @@ export class IsolatedVmBridge implements RuntimeBridge {
 		// Used by array proxy when accessing numeric indices
 		const getArrayElement = new (getIvm().Reference)((path: string[], index: number) => {
 			// Navigate to array
+			// Special-case: paths starting with ['$item', index] call data.$item(index)
 			let arr: unknown = data;
-			for (const key of path) {
-				arr = (arr as Record<string, unknown>)?.[key];
+			let startIndex = 0;
+			const itemFn = (data as Record<string, unknown>).$item;
+			if (path.length >= 2 && path[0] === '$item' && typeof itemFn === 'function') {
+				const itemIndex = parseInt(path[1], 10);
+				if (!isNaN(itemIndex)) {
+					arr = (itemFn as (i: number) => unknown)(itemIndex);
+					startIndex = 2;
+				}
+			}
+			for (let i = startIndex; i < path.length; i++) {
+				arr = (arr as Record<string, unknown>)?.[path[i]];
 				if (arr === undefined || arr === null) {
 					return undefined;
 				}

--- a/packages/@n8n/expression-runtime/src/extensions/extend.ts
+++ b/packages/@n8n/expression-runtime/src/extensions/extend.ts
@@ -50,7 +50,40 @@ interface FoundFunction {
 	function: Function;
 }
 
+/**
+ * Property names that must never be accessed via expression extensions.
+ * Matches the host-side blocklist in packages/workflow/src/utils.ts.
+ */
+const UNSAFE_PROPERTY_NAMES = new Set([
+	'__proto__',
+	'prototype',
+	'constructor',
+	'getPrototypeOf',
+	'mainModule',
+	'binding',
+	'_linkedBinding',
+	'_load',
+	'prepareStackTrace',
+	'__lookupGetter__',
+	'__lookupSetter__',
+	'__defineGetter__',
+	'__defineSetter__',
+	'caller',
+	'arguments',
+	'getBuiltinModule',
+	'dlopen',
+	'execve',
+	'loadEnvFile',
+]);
+
 function findExtendedFunction(input: unknown, functionName: string): FoundFunction | undefined {
+	const name = typeof functionName === 'string' ? functionName : String(functionName);
+	if (UNSAFE_PROPERTY_NAMES.has(name)) {
+		throw new ExpressionExtensionError(
+			`Cannot access "${name}" via expression extension due to security concerns`,
+		);
+	}
+
 	// eslint-disable-next-line @typescript-eslint/no-restricted-types
 	let foundFunction: Function | undefined;
 	if (Array.isArray(input)) {

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -95,6 +95,14 @@ export function createDeepLazyProxy(basePath: string[] = []): any {
 			// Handle arrays - metadata: { __isArray: true, __length: number }
 			if (value && typeof value === 'object' && value.__isArray) {
 				const arrayProxy = new Proxy([] as any[], {
+					has(arrTarget: any, arrProp: string | symbol): boolean {
+						if (typeof arrProp === 'symbol') return arrProp in arrTarget;
+						const index = Number(arrProp);
+						if (!isNaN(index) && index >= 0 && index < value.__length) {
+							return true;
+						}
+						return arrProp in arrTarget;
+					},
 					get(arrTarget: any, arrProp: string | symbol): unknown {
 						// Symbols can't be transferred via isolated-vm; return undefined
 						if (typeof arrProp === 'symbol') {

--- a/packages/@n8n/expression-runtime/src/runtime/reset.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/reset.ts
@@ -3,7 +3,7 @@ import { DateTime, IANAZone, Settings } from 'luxon';
 import { extend, extendOptional } from '../extensions/extend';
 import { extendedFunctions } from '../extensions/function-extensions';
 
-import { __sanitize, createSafeErrorSubclass } from './safe-globals';
+import { __sanitize, createSafeErrorSubclass, ExpressionError } from './safe-globals';
 import { createDeepLazyProxy } from './lazy-proxy';
 
 // Pre-create safe error subclass wrappers (reused across evaluations)
@@ -43,7 +43,15 @@ export function resetDataProxies(timezone?: string): void {
 
 	// __sanitize must be on __data because PrototypeSanitizer generates:
 	// obj[this.__sanitize(expr)] where 'this' is __data (via .call(__data) wrapping)
-	globalThis.__data.__sanitize = __sanitize;
+	// Use a non-writable property descriptor so override attempts throw instead of silently succeeding.
+	Object.defineProperty(globalThis.__data, '__sanitize', {
+		get: () => __sanitize,
+		set: () => {
+			throw new ExpressionError('Cannot override "__sanitize" due to security concerns');
+		},
+		enumerable: false,
+		configurable: false,
+	});
 
 	// Verify callbacks are available
 	// Note: ivm.Reference may not be typeof 'function', check for existence

--- a/packages/@n8n/expression-runtime/src/runtime/reset.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/reset.ts
@@ -178,7 +178,14 @@ export function resetDataProxies(timezone?: string): void {
 	// Wire builtins so tournament's VariablePolyfill resolves them from __data
 	initializeBuiltins(globalThis.__data as Record<string, unknown>);
 
-	// TODO: Add other function properties as needed ($item, $vars, etc.)
+	// $item(itemIndex) returns a sub-proxy for the specified item (legacy syntax)
+	globalThis.__data.$item = function (itemIndex: number) {
+		const indexStr = String(itemIndex);
+		return {
+			$json: createDeepLazyProxy(['$item', indexStr, '$json']),
+			$binary: createDeepLazyProxy(['$item', indexStr, '$binary']),
+		};
+	};
 }
 
 // Matches initializeGlobalContext() lines 262-318 in packages/workflow/src/expression.ts


### PR DESCRIPTION
## Summary

Fixes failing VM expression engine tests (Group G) by addressing security and compatibility gaps in the isolated-vm bridge.

- **Unsafe property guard in extend()**: Added `UNSAFE_PROPERTY_NAMES` blocklist to VM-side `findExtendedFunction()` — blocks access to `__proto__`, `constructor`, `prototype`, etc. via expression extensions (20 tests)
- **`__sanitize` override protection**: Replaced direct property assignment with `Object.defineProperty` getter/setter that throws on override attempts (1 test)
- **`$item()` legacy syntax**: Implemented `$item(itemIndex)` in the VM by creating lazy proxies rooted at `['$item', index, '$json']` and special-casing `$item` paths in the bridge's `getValueAtPath`/`getArrayElement` callbacks (1 test)
- **Array proxy `has` trap**: Added `has` trap returning true for numeric indices within bounds, fixing `[].concat(proxyArray)` which uses `in` to check element existence (1 test)

**Test results**: 25 failing → 2 remaining (both deferred — Int8Array cross-isolate transfer and ExpressionError propagation)

## Related

https://linear.app/n8n/issue/CAT-2543

## Review / Merge checklist

- [ ] Tests pass with `N8N_EXPRESSION_ENGINE=vm pnpm test test/expression.test.ts` in `packages/workflow`
- [ ] No changes to host-side expression evaluation (current engine unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)