### PR TITLE
feat(editor): Auto-redirect to SSO on sign-in page

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4476,6 +4476,7 @@
 	"settings.mfa.toast.noRecoveryCodeLeft.message": "You have used all of your recovery codes. Disable then re-enable two-factor authentication to generate new codes. <a href='/settings/personal' target='_blank' >Open settings</a>",
 	"sso.login.divider": "or",
 	"sso.login.button": "Continue with SSO",
+	"sso.login.redirecting": "Redirecting to single sign-on…",
 	"executionUsage.currentUsage": "{text} {count}",
 	"executionUsage.currentUsage.text": "You are in a free trial with limited executions. You have",
 	"executionUsage.currentUsage.count": "{n} day left. | {n} days left.",

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SigninView.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SigninView.test.ts
@@ -2,10 +2,12 @@ import { createComponentRenderer } from '@/__tests__/render';
 import { mockedStore } from '@/__tests__/utils';
 import { createTestingPinia } from '@pinia/testing';
 import userEvent from '@testing-library/user-event';
+import { waitFor } from '@testing-library/vue';
 import { useRouter, useRoute } from 'vue-router';
 import SigninView from './SigninView.vue';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
+import { useSSOStore } from '@/features/settings/sso/sso.store';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { VIEWS } from '@/app/constants';
 
@@ -39,6 +41,7 @@ const renderComponent = createComponentRenderer(SigninView);
 
 let usersStore: ReturnType<typeof mockedStore<typeof useUsersStore>>;
 let settingsStore: ReturnType<typeof mockedStore<typeof useSettingsStore>>;
+let ssoStore: ReturnType<typeof mockedStore<typeof useSSOStore>>;
 
 let router: ReturnType<typeof useRouter>;
 let telemetry: ReturnType<typeof useTelemetry>;
@@ -78,6 +81,7 @@ describe('SigninView', () => {
 		createTestingPinia();
 		usersStore = mockedStore(useUsersStore);
 		settingsStore = mockedStore(useSettingsStore);
+		ssoStore = mockedStore(useSSOStore);
 
 		router = useRouter();
 		telemetry = useTelemetry();
@@ -190,6 +194,99 @@ describe('SigninView', () => {
 
 			expect(hrefSpy).not.toHaveBeenCalled();
 			expect(router.push).toHaveBeenCalledWith({ name: VIEWS.HOMEPAGE });
+		});
+	});
+
+	describe('SSO auto-redirect', () => {
+		let route: ReturnType<typeof useRoute>;
+
+		beforeEach(() => {
+			route = useRoute();
+			global.window = Object.create(window);
+			Object.defineProperty(window, 'location', {
+				value: { href: '', origin: 'https://n8n.local' },
+				writable: true,
+			});
+		});
+
+		it('should auto-redirect to SAML IdP when SAML is default auth', async () => {
+			vi.spyOn(route, 'query', 'get').mockReturnValue({});
+			ssoStore.showSsoLoginButton = true;
+			ssoStore.isDefaultAuthenticationSaml = true;
+			ssoStore.getSSORedirectUrl.mockResolvedValue('https://idp.example.com/saml');
+
+			const hrefSpy = vi.spyOn(window.location, 'href', 'set');
+			const { getByTestId } = renderComponent();
+
+			await vi.waitFor(() => {
+				expect(hrefSpy).toHaveBeenCalledWith('https://idp.example.com/saml');
+			});
+
+			expect(getByTestId('sso-redirecting')).toBeInTheDocument();
+		});
+
+		it('should auto-redirect to OIDC when OIDC is default auth', async () => {
+			vi.spyOn(route, 'query', 'get').mockReturnValue({});
+			ssoStore.showSsoLoginButton = true;
+			ssoStore.isDefaultAuthenticationSaml = false;
+			ssoStore.oidc = { loginEnabled: true, loginUrl: 'https://idp.example.com/oidc' };
+
+			const hrefSpy = vi.spyOn(window.location, 'href', 'set');
+			const { getByTestId } = renderComponent();
+
+			await vi.waitFor(() => {
+				expect(hrefSpy).toHaveBeenCalledWith('https://idp.example.com/oidc');
+			});
+
+			expect(getByTestId('sso-redirecting')).toBeInTheDocument();
+		});
+
+		it('should NOT auto-redirect when noSsoRedirect query param is present', async () => {
+			vi.spyOn(route, 'query', 'get').mockReturnValue({ noSsoRedirect: '' });
+			ssoStore.showSsoLoginButton = true;
+			ssoStore.isDefaultAuthenticationSaml = true;
+
+			const hrefSpy = vi.spyOn(window.location, 'href', 'set');
+			const { queryByTestId, getByTestId } = renderComponent();
+
+			await vi.dynamicImportSettled();
+
+			expect(hrefSpy).not.toHaveBeenCalled();
+			expect(queryByTestId('sso-redirecting')).not.toBeInTheDocument();
+			expect(getByTestId('signin-form')).toBeInTheDocument();
+		});
+
+		it('should fall back to login form on redirect failure', async () => {
+			vi.spyOn(route, 'query', 'get').mockReturnValue({});
+			settingsStore.isCloudDeployment = false;
+			settingsStore.activeModules = [];
+			ssoStore.showSsoLoginButton = true;
+			ssoStore.isDefaultAuthenticationSaml = true;
+			ssoStore.getSSORedirectUrl.mockRejectedValue(new Error('SSO unavailable'));
+
+			const hrefSpy = vi.spyOn(window.location, 'href', 'set');
+			const { getByTestId, queryByTestId } = renderComponent();
+
+			await waitFor(() => {
+				expect(queryByTestId('sso-redirecting')).not.toBeInTheDocument();
+				expect(getByTestId('signin-form')).toBeInTheDocument();
+			});
+
+			expect(hrefSpy).not.toHaveBeenCalled();
+		});
+
+		it('should NOT auto-redirect when SSO is not default auth', async () => {
+			vi.spyOn(route, 'query', 'get').mockReturnValue({});
+			ssoStore.showSsoLoginButton = false;
+
+			const hrefSpy = vi.spyOn(window.location, 'href', 'set');
+			const { queryByTestId, getByTestId } = renderComponent();
+
+			await vi.dynamicImportSettled();
+
+			expect(hrefSpy).not.toHaveBeenCalled();
+			expect(queryByTestId('sso-redirecting')).not.toBeInTheDocument();
+			expect(getByTestId('signin-form')).toBeInTheDocument();
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SigninView.vue
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SigninView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, reactive, ref } from 'vue';
+import { computed, onMounted, reactive, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 
 import AuthView from './AuthView.vue';
@@ -12,6 +12,7 @@ import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useSSOStore } from '@/features/settings/sso/sso.store';
+import { N8nSpinner } from '@n8n/design-system';
 
 import type { IFormBoxConfig } from '@/Interface';
 import { MFA_AUTHENTICATION_REQUIRED_ERROR_CODE, VIEWS, MFA_FORM } from '@/app/constants';
@@ -37,6 +38,7 @@ const telemetry = useTelemetry();
 
 const loading = ref(false);
 const showMfaView = ref(false);
+const ssoRedirecting = ref(false);
 const emailOrLdapLoginId = ref('');
 const password = ref('');
 const reportError = ref(false);
@@ -196,24 +198,63 @@ const cacheCredentials = (form: EmailOrLdapLoginIdAndPassword) => {
 	emailOrLdapLoginId.value = form.emailOrLdapLoginId;
 	password.value = form.password;
 };
+
+onMounted(async () => {
+	if ('noSsoRedirect' in (route.query ?? {})) return;
+	if (!ssoStore.showSsoLoginButton) return;
+
+	ssoRedirecting.value = true;
+	try {
+		const redirectUrl = ssoStore.isDefaultAuthenticationSaml
+			? await ssoStore.getSSORedirectUrl(
+					typeof route.query?.redirect === 'string' ? route.query.redirect : '',
+				)
+			: ssoStore.oidc.loginUrl;
+		window.location.href = redirectUrl ?? '';
+	} catch {
+		ssoRedirecting.value = false;
+	}
+});
 </script>
 
 <template>
 	<div>
-		<AuthView
-			v-if="!showMfaView"
-			:form="formConfig"
-			:form-loading="loading"
-			:with-sso="true"
-			data-test-id="signin-form"
-			@submit="onEmailPasswordSubmitted"
-		/>
-		<MfaView
-			v-if="showMfaView"
-			:report-error="reportError"
-			@submit="onMFASubmitted"
-			@on-back-click="onBackClick"
-			@on-form-changed="onFormChanged"
-		/>
+		<div v-if="ssoRedirecting" :class="$style.ssoRedirecting" data-test-id="sso-redirecting">
+			<N8nSpinner type="dots" />
+			<span :class="$style.ssoRedirectingText">{{ locale.baseText('sso.login.redirecting') }}</span>
+		</div>
+		<template v-else>
+			<AuthView
+				v-if="!showMfaView"
+				:form="formConfig"
+				:form-loading="loading"
+				:with-sso="true"
+				data-test-id="signin-form"
+				@submit="onEmailPasswordSubmitted"
+			/>
+			<MfaView
+				v-if="showMfaView"
+				:report-error="reportError"
+				@submit="onMFASubmitted"
+				@on-back-click="onBackClick"
+				@on-form-changed="onFormChanged"
+			/>
+		</template>
 	</div>
 </template>
+
+<style lang="scss" module>
+.ssoRedirecting {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	min-height: 300px;
+	gap: var(--spacing--sm);
+}
+
+.ssoRedirectingText {
+	font-size: var(--font-size--sm);
+	color: var(--color--text--tint-1);
+}
+</style>


### PR DESCRIPTION
## Summary

- When SSO is configured as the default auth method, automatically redirect users to the IdP on the sign-in page instead of showing the email/password form
- Adds `?noSsoRedirect` query parameter as escape hatch to bypass auto-redirect and show the normal login form
- Falls back to the normal login form if the SSO redirect fails

## How it works

- `onMounted` in `SigninView.vue` checks if SSO is the default auth method
- If so, shows a spinner with "Redirecting to single sign-on..." and sets `window.location.href` to the IdP URL (SAML or OIDC)
- If the redirect fails (network error, misconfiguration), the spinner is removed and the normal login form is shown
- If `?noSsoRedirect` is in the URL, the auto-redirect is skipped entirely

## No redirect loop risk

- Backend ACS handler renders error pages on failure (does NOT redirect to `/signin`)
- Frontend only triggers on `onMounted` — if it fails, `ssoRedirecting = false` and form renders (no retry)
- If user is already authenticated, the route's `guest` middleware redirects away before `SigninView` mounts

## Test plan

- [x] Unit tests for SAML auto-redirect
- [x] Unit tests for OIDC auto-redirect
- [x] Unit tests for `?noSsoRedirect` escape hatch
- [x] Unit tests for fallback on redirect failure
- [x] Unit tests for no redirect when SSO is not default

