### PR TITLE
feat(editor): Add canvas-only mode

### DIFF
--- a/packages/@n8n/api-types/src/frontend-settings.ts
+++ b/packages/@n8n/api-types/src/frontend-settings.ts
@@ -233,6 +233,7 @@ export interface FrontendSettings {
 
 	/** Backend modules that were initialized during startup. */
 	activeModules: string[];
+	canvasOnly: boolean;
 	envFeatureFlags: N8nEnvFeatFlags;
 }
 

--- a/packages/@n8n/config/src/index.ts
+++ b/packages/@n8n/config/src/index.ts
@@ -215,6 +215,10 @@ export class GlobalConfig {
 	@Env('N8N_SSL_CERT')
 	ssl_cert: string = '';
 
+	/** Whether to enable canvas-only mode, hiding the chrome UI. */
+	@Env('N8N_CANVAS_ONLY')
+	canvasOnly: boolean = false;
+
 	/** Public URL where the editor is accessible. Also used for emails sent from n8n. */
 	@Env('N8N_EDITOR_BASE_URL')
 	editorBaseUrl: string = '';

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -68,6 +68,7 @@ describe('GlobalConfig', () => {
 		proxy_hops: 0,
 		ssl_key: '',
 		ssl_cert: '',
+		canvasOnly: false,
 		editorBaseUrl: '',
 		dataTable: {
 			maxSize: 50 * 1024 * 1024,

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -381,6 +381,7 @@ export class FrontendService {
 				quota: this.licenseState.getMaxWorkflowsWithEvaluations(),
 			},
 			activeModules: this.moduleRegistry.getActiveModules(),
+			canvasOnly: process.env.N8N_CANVAS_ONLY === 'true',
 			envFeatureFlags: this.collectEnvFeatureFlags(),
 		};
 	}

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -381,7 +381,7 @@ export class FrontendService {
 				quota: this.licenseState.getMaxWorkflowsWithEvaluations(),
 			},
 			activeModules: this.moduleRegistry.getActiveModules(),
-			canvasOnly: process.env.N8N_CANVAS_ONLY === 'true',
+			canvasOnly: this.globalConfig.canvasOnly,
 			envFeatureFlags: this.collectEnvFeatureFlags(),
 		};
 	}

--- a/packages/frontend/editor-ui/src/__tests__/defaults.ts
+++ b/packages/frontend/editor-ui/src/__tests__/defaults.ts
@@ -169,6 +169,7 @@ export const defaultSettings: FrontendSettings = {
 		quota: 0,
 	},
 	activeModules: [],
+	canvasOnly: false,
 	envFeatureFlags: {},
 	dynamicBanners: {
 		endpoint: 'https://api.n8n.io/api/banners',

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
@@ -321,6 +321,7 @@ async function onWorkflowDeactivated() {
 				v-if="onWorkflowPage"
 				:items="tabBarItems"
 				:model-value="activeHeaderTab"
+				:floating="settingsStore.isCanvasOnly"
 				@update:model-value="onTabSelected"
 			/>
 		</div>

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
@@ -280,9 +280,13 @@ async function onWorkflowDeactivated() {
 <template>
 	<div :class="$style.container">
 		<div
-			:class="{ [$style['main-header']]: true, [$style.expanded]: !uiStore.sidebarMenuCollapsed }"
+			:class="{
+				[$style['main-header']]: true,
+				[$style.expanded]: !uiStore.sidebarMenuCollapsed,
+				[$style['canvas-only']]: settingsStore.isCanvasOnly,
+			}"
 		>
-			<div v-show="!hideMenuBar" :class="$style['top-menu']">
+			<div v-show="!hideMenuBar && !settingsStore.isCanvasOnly" :class="$style['top-menu']">
 				<WorkflowDetails
 					v-if="workflow?.name"
 					:id="workflow.id"
@@ -337,6 +341,12 @@ async function onWorkflowDeactivated() {
 	width: 100%;
 	box-sizing: border-box;
 	border-bottom: var(--border-width) var(--border-style) var(--color--foreground);
+}
+
+.canvas-only {
+	min-height: 0;
+	border-bottom: none;
+	background-color: transparent;
 }
 
 .top-menu {

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/TabBar.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/TabBar.vue
@@ -7,9 +7,11 @@ withDefaults(
 	defineProps<{
 		items: ITabBarItem[];
 		modelValue?: string;
+		floating?: boolean;
 	}>(),
 	{
 		modelValue: MAIN_HEADER_TABS.WORKFLOW,
+		floating: false,
 	},
 );
 
@@ -27,6 +29,7 @@ function onUpdateModelValue(tab: string, event: MouseEvent): void {
 		v-if="items"
 		:class="{
 			[$style.container]: true,
+			[$style.floating]: floating,
 			['tab-bar-container']: true,
 		}"
 	>
@@ -43,7 +46,7 @@ function onUpdateModelValue(tab: string, event: MouseEvent): void {
 	position: absolute;
 	bottom: 0;
 	left: 50%;
-	transform: translateX(-50%) translateY(150%);
+	transform: translateX(-50%) translateY(50%);
 	min-height: 30px;
 	display: flex;
 	padding: var(--spacing--5xs);
@@ -51,6 +54,10 @@ function onUpdateModelValue(tab: string, event: MouseEvent): void {
 	border-radius: var(--radius);
 	transition: all 150ms ease-in-out;
 	z-index: 100; // Should float above other layout components in any page
+}
+
+.floating {
+	transform: translateX(-50%) translateY(150%);
 }
 
 @media screen and (max-width: 430px) {

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/TabBar.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/TabBar.vue
@@ -43,7 +43,7 @@ function onUpdateModelValue(tab: string, event: MouseEvent): void {
 	position: absolute;
 	bottom: 0;
 	left: 50%;
-	transform: translateX(-50%) translateY(50%);
+	transform: translateX(-50%) translateY(150%);
 	min-height: 30px;
 	display: flex;
 	padding: var(--spacing--5xs);

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/TabBar.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/TabBar.vue
@@ -54,10 +54,11 @@ function onUpdateModelValue(tab: string, event: MouseEvent): void {
 	border-radius: var(--radius);
 	transition: all 150ms ease-in-out;
 	z-index: 100; // Should float above other layout components in any page
+	align-items: center;
 }
 
 .floating {
-	transform: translateX(-50%) translateY(150%);
+	top: var(--spacing--4xs);
 }
 
 @media screen and (max-width: 430px) {

--- a/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
@@ -16,11 +16,14 @@ import LogsPanel from '@/features/execution/logs/components/LogsPanel.vue';
 import LoadingView from '@/app/views/LoadingView.vue';
 import { WorkflowStateKey, WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
 import { useProvideWorkflowId } from '@/app/composables/useProvideWorkflowId';
+import { useSettingsStore } from '@/app/stores/settings.store';
 
 const { layoutProps } = useLayoutProps();
 const assistantStore = useAssistantStore();
 const chatHubPanelStore = useChatHubPanelStore();
 const pushConnectionStore = usePushConnectionStore();
+const settingsStore = useSettingsStore();
+const isCanvasOnly = settingsStore.isCanvasOnly;
 
 const workflowState = useWorkflowState();
 provide(WorkflowStateKey, workflowState);
@@ -83,10 +86,10 @@ onBeforeUnmount(() => {
 
 <template>
 	<BaseLayout>
-		<template #header>
+		<template v-if="!isCanvasOnly" #header>
 			<AppHeader />
 		</template>
-		<template #sidebar>
+		<template v-if="!isCanvasOnly" #sidebar>
 			<AppSidebar />
 		</template>
 		<LoadingView v-if="isLoading" />
@@ -94,7 +97,7 @@ onBeforeUnmount(() => {
 		<template v-if="layoutProps.logs" #footer>
 			<LogsPanel />
 		</template>
-		<template #overlays>
+		<template v-if="!isCanvasOnly" #overlays>
 			<AskAssistantFloatingButton v-if="assistantStore.isFloatingButtonShown" />
 			<CanvasChatOverlay v-if="chatHubPanelStore.isFloatingChatEnabled" />
 		</template>

--- a/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
@@ -86,7 +86,7 @@ onBeforeUnmount(() => {
 
 <template>
 	<BaseLayout>
-		<template v-if="!isCanvasOnly" #header>
+		<template #header>
 			<AppHeader />
 		</template>
 		<template v-if="!isCanvasOnly" #sidebar>

--- a/packages/frontend/editor-ui/src/app/stores/settings.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/settings.store.ts
@@ -80,6 +80,8 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 
 	const isPreviewMode = computed(() => settings.value.previewMode);
 
+	const isCanvasOnly = computed(() => settings.value.canvasOnly);
+
 	const publicApiLatestVersion = computed(() => api.value.latestVersion);
 
 	const publicApiPath = computed(() => api.value.path);
@@ -368,6 +370,7 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 		isPublicApiEnabled,
 		isSwaggerUIEnabled,
 		isPreviewMode,
+		isCanvasOnly,
 		publicApiLatestVersion,
 		publicApiPath,
 		showSetupPage,

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/NodeCreator.vue
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/NodeCreator.vue
@@ -14,6 +14,7 @@ import { useBannersStore } from '@/features/shared/banners/banners.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { DRAG_EVENT_DATA_KEY } from '@/app/constants';
 import { useChatPanelStore } from '@/features/ai/assistant/chatPanel.store';
+import { useSettingsStore } from '@/app/stores/settings.store';
 import type { NodeTypeSelectedPayload } from '@/Interface';
 import { onClickOutside } from '@vueuse/core';
 
@@ -39,6 +40,7 @@ const emit = defineEmits<{
 const uiStore = useUIStore();
 const bannersStore = useBannersStore();
 const chatPanelStore = useChatPanelStore();
+const settingsStore = useSettingsStore();
 
 const { setActions, setMergeNodes } = useNodeCreatorStore();
 const { generateMergedNodesAndActions } = useActionsGenerator();
@@ -53,7 +55,7 @@ const viewStacksLength = computed(() => useViewStacks().viewStacks.length);
 const nodeCreatorInlineStyle = computed(() => {
 	const rightPosition = getRightOffset();
 	return {
-		top: `${bannersStore.bannersHeight + uiStore.headerHeight}px`,
+		top: `${settingsStore.isCanvasOnly ? 0 : bannersStore.bannersHeight + uiStore.headerHeight}px`,
 		right: `${rightPosition}px`,
 	};
 });


### PR DESCRIPTION
## Summary
- Introduce `N8N_CANVAS_ONLY` environment variable that enables a canvas-only mode
- When enabled, hides the header, sidebar, and overlay elements (assistant button, chat overlay) in the workflow layout
- Adds `canvasOnly` setting to `FrontendSettings` and exposes it via `useSettingsStore`

## Test plan
- [ ] Set `N8N_CANVAS_ONLY=true` and verify header, sidebar, and overlays are hidden
- [ ] Verify default behavior (env var unset) remains unchanged
- [ ] Verify canvas and workflow functionality works correctly in canvas-only mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)