### PR TITLE
fix(core): Use published version for error workflow execution

### DIFF
--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -788,6 +788,105 @@ describe('WorkflowExecutionService', () => {
 				projectId: 'project-id',
 			});
 		});
+
+		test('should use published (activeVersion) nodes, not draft nodes', async () => {
+			const workflowErrorData: IWorkflowErrorData = {
+				workflow: { id: 'workflow-id', name: 'Test Workflow' },
+				execution: {
+					id: 'execution-id',
+					mode: 'manual',
+					error: new Error('Test error') as ExecutionError,
+					lastNodeExecuted: 'Node with error',
+				},
+			};
+
+			const workflowRunnerMock = mock<WorkflowRunner>();
+			workflowRunnerMock.run.mockResolvedValue('fake-execution-id');
+
+			const errorTriggerType = 'n8n-nodes-base.errorTrigger';
+			const globalConfig = mock<GlobalConfig>({
+				nodes: { errorTriggerType },
+			});
+
+			const errorTriggerNode: INode = {
+				id: 'error-trigger-node-id',
+				name: 'Error Trigger',
+				type: errorTriggerType,
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			};
+
+			const unpublishedNode: INode = {
+				id: 'unpublished-node-id',
+				name: 'Unpublished Node',
+				type: 'n8n-nodes-base.set',
+				typeVersion: 3,
+				position: [200, 0],
+				parameters: {},
+			};
+
+			const publishedNodes = [errorTriggerNode];
+			const publishedConnections: IConnections = {};
+
+			const draftNodes = [errorTriggerNode, unpublishedNode];
+			const draftConnections: IConnections = {
+				'Error Trigger': {
+					[NodeConnectionTypes.Main]: [[{ node: 'Unpublished Node', type: 'main', index: 0 }]],
+				},
+			};
+
+			const errorWorkflow = mock<WorkflowEntity>({
+				id: 'error-workflow-id',
+				name: 'Error Workflow',
+				active: false,
+				activeVersionId: 'active-version-id',
+				isArchived: false,
+				pinData: {},
+				nodes: draftNodes,
+				connections: draftConnections,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+				activeVersion: {
+					nodes: publishedNodes,
+					connections: publishedConnections,
+				},
+			});
+
+			const workflowRepositoryMock = mock<WorkflowRepository>();
+			workflowRepositoryMock.get.mockResolvedValue(errorWorkflow);
+
+			const service = new WorkflowExecutionService(
+				mock(),
+				mock(),
+				mock(),
+				workflowRepositoryMock,
+				nodeTypes,
+				mock(),
+				workflowRunnerMock,
+				globalConfig,
+				mock(),
+				mock(),
+				mock(),
+			);
+
+			await service.executeErrorWorkflow(
+				'error-workflow-id',
+				workflowErrorData,
+				mock<Project>({ id: 'project-id' }),
+			);
+
+			expect(workflowRunnerMock.run).toHaveBeenCalledTimes(1);
+			const runCall = workflowRunnerMock.run.mock.calls[0][0];
+
+			// The workflowData passed to the runner should use published nodes,
+			// not the draft nodes that include the unpublished node
+			expect(runCall.workflowData.nodes).toEqual(publishedNodes);
+			expect(runCall.workflowData.connections).toEqual(publishedConnections);
+			expect(runCall.workflowData.nodes).not.toContainEqual(
+				expect.objectContaining({ name: 'Unpublished Node' }),
+			);
+		});
 	});
 });
 

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -318,12 +318,20 @@ export class WorkflowExecutionService {
 			}
 
 			const executionMode = 'error';
+
+			// Use published nodes/connections for execution, not the draft.
+			// The workflowData entity contains draft nodes, but the activeVersion
+			// relation holds the published state. We must override the entity's
+			// nodes/connections so the WorkflowRunner uses the published version.
+			workflowData.nodes = workflowData.activeVersion.nodes;
+			workflowData.connections = workflowData.activeVersion.connections;
+
 			const workflowInstance = new Workflow({
 				id: workflowId,
 				name: workflowData.name,
 				nodeTypes: this.nodeTypes,
-				nodes: workflowData.activeVersion.nodes,
-				connections: workflowData.activeVersion.connections,
+				nodes: workflowData.nodes,
+				connections: workflowData.connections,
 				active: true,
 				staticData: workflowData.staticData,
 				settings: workflowData.settings,

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -320,9 +320,6 @@ export class WorkflowExecutionService {
 			const executionMode = 'error';
 
 			// Use published nodes/connections for execution, not the draft.
-			// The workflowData entity contains draft nodes, but the activeVersion
-			// relation holds the published state. We must override the entity's
-			// nodes/connections so the WorkflowRunner uses the published version.
 			workflowData.nodes = workflowData.activeVersion.nodes;
 			workflowData.connections = workflowData.activeVersion.connections;
 


### PR DESCRIPTION
## Summary

Error workflows were incorrectly executing with **draft (unpublished) nodes** instead of the published version. When a workflow failed and triggered its configured error workflow, the `executeErrorWorkflow` method loaded the `activeVersion` relation but passed the raw `workflowData` entity (containing draft nodes/connections) to `WorkflowRunner.run()`. The runner then rebuilt the `Workflow` from the draft data, ignoring the published version entirely.

**Root cause:** In `WorkflowExecutionService.executeErrorWorkflow()`, the `workflowInstance` was correctly built from `activeVersion.nodes`, but `workflowData` (with draft nodes) was passed to the runner at line 433. The runner creates a new `Workflow` from `data.workflowData.nodes` (draft), not from the already-validated `workflowInstance`.

**Fix:** Override `workflowData.nodes` and `workflowData.connections` with the `activeVersion` values before passing to the runner, ensuring the published version is used throughout.

### How to reproduce

1. Create an error workflow with an Error Trigger node and publish it
2. Create a main workflow that intentionally fails, set the error workflow in settings, and publish it
3. Add a new node to the error workflow **without publishing**
4. Trigger the main workflow in production mode
5. **Before fix:** The error workflow execution includes the unpublished node
6. **After fix:** The error workflow execution only includes the published nodes

## Related Linear tickets, Github issues, and Community forum posts

Fixes https://github.com/n8n-io/n8n/issues/26692

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
