### PR TITLE
fix(ai-builder): Show feedback buttons in variant (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.test.ts
@@ -1399,6 +1399,64 @@ describe('AskAssistantChat', () => {
 			expect(wrapper.queryByTestId('footer-rating')).toBeFalsy();
 		});
 
+		it('should show footer rating for code builder when workflow-updated is last message (no text response)', () => {
+			const messages: ChatUI.AssistantMessage[] = [
+				{
+					id: '1',
+					role: 'user',
+					type: 'text',
+					content: 'Build me a workflow',
+				},
+				{
+					id: '2',
+					role: 'assistant',
+					type: 'tool',
+					toolName: 'build_workflow',
+					toolCallId: 'tc-1',
+					displayTitle: 'Building workflow',
+					status: 'completed',
+					updates: [],
+				},
+				{
+					id: '3',
+					role: 'assistant',
+					type: 'workflow-updated',
+					codeSnippet: '{}',
+				},
+			];
+
+			const wrapper = renderWithFooterRating(messages, false);
+
+			expect(wrapper.queryByTestId('footer-rating')).toBeTruthy();
+		});
+
+		it('should NOT show footer rating for code builder when user has responded after workflow-updated', () => {
+			const messages: ChatUI.AssistantMessage[] = [
+				{
+					id: '1',
+					role: 'user',
+					type: 'text',
+					content: 'Build me a workflow',
+				},
+				{
+					id: '2',
+					role: 'assistant',
+					type: 'workflow-updated',
+					codeSnippet: '{}',
+				},
+				{
+					id: '3',
+					role: 'user',
+					type: 'text',
+					content: 'Can you modify this?',
+				},
+			];
+
+			const wrapper = renderWithFooterRating(messages, false);
+
+			expect(wrapper.queryByTestId('footer-rating')).toBeFalsy();
+		});
+
 		it('should emit feedback event when rating is submitted', async () => {
 			const messages: ChatUI.AssistantMessage[] = [
 				{

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
@@ -6,7 +6,12 @@ import MessageWrapper from './messages/MessageWrapper.vue';
 import ThinkingMessage from './messages/ThinkingMessage.vue';
 import { useI18n } from '../../composables/useI18n';
 import type { ChatUI, RatingFeedback, WorkflowSuggestion } from '../../types/assistant';
-import { isTaskAbortedMessage, isToolMessage, isThinkingGroupMessage } from '../../types/assistant';
+import {
+	isTaskAbortedMessage,
+	isToolMessage,
+	isThinkingGroupMessage,
+	isWorkflowUpdatedMessage,
+} from '../../types/assistant';
 import AssistantIcon from '../AskAssistantIcon/AssistantIcon.vue';
 import AssistantText from '../AskAssistantText/AssistantText.vue';
 import InlineAskAssistantButton from '../InlineAskAssistantButton/InlineAskAssistantButton.vue';
@@ -336,17 +341,15 @@ const showFooterRating = computed(() => {
 
 	// Find the last workflow-updated message index.
 	// (workflow-updated is filtered out of normalizedMessages since it's not rendered visually)
-	const lastWorkflowUpdateIdx = props.messages.findLastIndex(
-		(msg) => msg.type === 'workflow-updated',
-	);
+	const lastWorkflowUpdateIdx = props.messages.findLastIndex(isWorkflowUpdatedMessage);
 	if (lastWorkflowUpdateIdx === -1 || !normalizedMessages.value.length) {
 		return false;
 	}
 
 	// Don't show rating if the user has responded since the last workflow update
-	const hasUserAfterWorkflowUpdate = props.messages
-		.slice(lastWorkflowUpdateIdx + 1)
-		.some((msg) => msg.role === 'user');
+	const hasUserAfterWorkflowUpdate = props.messages.some(
+		(msg, i) => i > lastWorkflowUpdateIdx && msg.role === 'user',
+	);
 	if (hasUserAfterWorkflowUpdate) {
 		return false;
 	}

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
@@ -334,16 +334,29 @@ const showFooterRating = computed(() => {
 		return false;
 	}
 
-	// Check if there's a workflow-updated message in the original messages
+	// Find the last workflow-updated message index.
 	// (workflow-updated is filtered out of normalizedMessages since it's not rendered visually)
-	// and check the last visible message (from normalizedMessages)
-	const hasWorkflowUpdate = props.messages.some((msg) => msg.type === 'workflow-updated');
-	if (!hasWorkflowUpdate || !normalizedMessages.value.length) {
+	const lastWorkflowUpdateIdx = props.messages.findLastIndex(
+		(msg) => msg.type === 'workflow-updated',
+	);
+	if (lastWorkflowUpdateIdx === -1 || !normalizedMessages.value.length) {
 		return false;
 	}
 
+	// Don't show rating if the user has responded since the last workflow update
+	const hasUserAfterWorkflowUpdate = props.messages
+		.slice(lastWorkflowUpdateIdx + 1)
+		.some((msg) => msg.role === 'user');
+	if (hasUserAfterWorkflowUpdate) {
+		return false;
+	}
+
+	// Show rating when the last visible message is from the assistant.
+	// This handles both the multi-agent builder (last visible message is a text response after
+	// workflow-updated) and the code builder (workflow-updated is the last real message and gets
+	// filtered from normalizedMessages, leaving a thinking-group with role 'assistant' as last).
 	const lastMsg = normalizedMessages.value[normalizedMessages.value.length - 1];
-	return lastMsg.role !== 'user' && lastMsg.type !== 'thinking-group';
+	return lastMsg.role !== 'user';
 });
 
 function isEndOfSessionEvent(event?: ChatUI.AssistantMessage) {


### PR DESCRIPTION
## Summary
The code builder variant of the AI assistant wasn't showing the feedback rating buttons after completing a workflow build. This happened because the showFooterRating logic only checked whether any workflow-updated message existed, without distinguishing between the multi-agent builder (which ends with a visible text response) and the code builder (which ends with a workflow-updated message that is filtered out of the visible message list, leaving a thinking-group as the last normalized message).


**To test**:
  1. Open the AI assistant code builder and generate a workflow — rating buttons should appear in the footer
  2. Respond to the assistant after generation — rating buttons should disappear
  3. Verify the multi-agent builder still shows rating buttons after the text response following a workflow-updated message

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-2225

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
