### PR TITLE
ci: Strip backport information from commit labels on changelog

### DIFF
--- a/.github/scripts/update-changelog.mjs
+++ b/.github/scripts/update-changelog.mjs
@@ -30,7 +30,15 @@ const changelogStream = new ConventionalChangelog()
 			const isBenchmarkScope = commit.scope === 'benchmark';
 
 			// Ignore commits that have 'benchmark' scope or '(no-changelog)' in the header
-			return hasNoChangelogInHeader || isBenchmarkScope ? null : commit;
+			if (hasNoChangelogInHeader || isBenchmarkScope) return null;
+
+			// Strip backport information from commit subject, e.g.:
+			// "Fix something (backport to release-candidate/2.12.x) (#123)" → "Fix something (#123)"
+			if (commit.subject) {
+				commit.subject = commit.subject.replace(/\s*\(backport to [^)]+\)/g, '');
+			}
+
+			return commit;
 		},
 	})
 	.writeStream()


### PR DESCRIPTION
## Summary

Current backporting behavior adds `(backport to release-candidate/2.yy.x)` to commit messages. This looks noisy on changelogs and should be stripped to reduce noise.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
