### PR TITLE
refactor(editor): Migrate shared editors and context menu to injectWorkflowDocumentStore (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenuItems.ts
+++ b/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenuItems.ts
@@ -82,7 +82,7 @@ export function useContextMenuItems(targetNodeIds: ComputedRef<string[]>): Compu
 
 	const targetNodes = computed(() =>
 		targetNodeIds.value
-			.map((nodeId) => workflowDocumentStore?.value?.getNodeById(nodeId) ?? null)
+			.map((nodeId) => workflowDocumentStore?.value?.getNodeById(nodeId))
 			.filter(isPresent),
 	);
 

--- a/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/completions/base.completions.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/completions/base.completions.ts
@@ -3,14 +3,9 @@ import { addInfoRenderer } from '../utils';
 import { addVarType } from '@/features/settings/environments.ee/completions/variables.completions';
 import type { Completion, CompletionContext, CompletionResult } from '@codemirror/autocomplete';
 import type { INodeUi } from '@/Interface';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import {
-	useWorkflowDocumentStore,
-	createWorkflowDocumentId,
-} from '@/app/stores/workflowDocument.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { escapeMappingString } from '@/app/utils/mappingUtils';
 import { useI18n } from '@n8n/i18n';
-import { computed } from 'vue';
 
 function getAutoCompletableNodeNames(nodes: INodeUi[]) {
 	return nodes
@@ -23,12 +18,7 @@ export function useBaseCompletions(
 	language: string,
 ) {
 	const i18n = useI18n();
-	const workflowsStore = useWorkflowsStore();
-	const workflowDocumentStore = computed(() =>
-		workflowsStore.workflowId
-			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
-			: undefined,
-	);
+	const workflowDocumentStore = injectWorkflowDocumentStore();
 
 	const itemCompletions = (context: CompletionContext): CompletionResult | null => {
 		const preCursor = context.matchBefore(/i\w*/);
@@ -113,7 +103,7 @@ export function useBaseCompletions(
 		const options: Completion[] = TOP_LEVEL_COMPLETIONS_IN_BOTH_MODES.map(addVarType);
 
 		options.push(
-			...getAutoCompletableNodeNames(workflowDocumentStore.value?.allNodes ?? []).map(
+			...getAutoCompletableNodeNames(workflowDocumentStore?.value?.allNodes ?? []).map(
 				(nodeName) => {
 					return {
 						label: `${prefix}('${escapeMappingString(nodeName)}')`,
@@ -155,7 +145,7 @@ export function useBaseCompletions(
 		if (!preCursor || (preCursor.from === preCursor.to && !context.explicit)) return null;
 
 		const options: Completion[] = getAutoCompletableNodeNames(
-			workflowDocumentStore.value?.allNodes ?? [],
+			workflowDocumentStore?.value?.allNodes ?? [],
 		).map((nodeName) => {
 			return {
 				label: `${prefix}('${escapeMappingString(nodeName)}')`,

--- a/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/completions/jsonField.completions.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/completions/jsonField.completions.ts
@@ -5,15 +5,13 @@ import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { isAllowedInDotNotation } from '@/features/shared/editors/plugins/codemirror/completions/utils';
 import { useI18n } from '@n8n/i18n';
 import type { IRunData, IDataObject } from 'n8n-workflow';
-import {
-	useWorkflowDocumentStore,
-	createWorkflowDocumentId,
-} from '@/app/stores/workflowDocument.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 function useJsonFieldCompletions() {
 	const i18n = useI18n();
 	const ndvStore = useNDVStore();
 	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = injectWorkflowDocumentStore();
 
 	/**
 	 * - Complete `x.first().json.` to `.field`.
@@ -256,11 +254,7 @@ function useJsonFieldCompletions() {
 			nodeName = quotedNodeName.replace(/^"/, '').replace(/"$/, '');
 		}
 
-		const wfStore = useWorkflowsStore();
-		const workflowDocumentStore = wfStore.workflowId
-			? useWorkflowDocumentStore(createWorkflowDocumentId(wfStore.workflowId))
-			: undefined;
-		const pinData = workflowDocumentStore?.getPinDataSnapshot();
+		const pinData = workflowDocumentStore?.value?.getPinDataSnapshot();
 
 		const nodePinData = pinData?.[nodeName];
 
@@ -276,7 +270,7 @@ function useJsonFieldCompletions() {
 			} catch {}
 		}
 
-		const runData: IRunData | null = useWorkflowsStore().getWorkflowRunData;
+		const runData: IRunData | null = workflowsStore.getWorkflowRunData;
 
 		const nodeRunData = runData?.[nodeName];
 


### PR DESCRIPTION
## Summary

Migrates shared editors and context menu composables from manual `useWorkflowDocumentStore(createWorkflowDocumentId(...))` pattern to `injectWorkflowDocumentStore()`, aligning with the ongoing workflowDocumentStore migration.

**Files changed:**
- `useContextMenuItems.ts` — Simplified `getNodeById` call (removed redundant `?? null` since `isPresent` filter handles it)
- `base.completions.ts` — Replaced `useWorkflowsStore` + manual document store creation with `injectWorkflowDocumentStore()`, removed unused `computed` import
- `jsonField.completions.ts` — Replaced manual store creation with `injectWorkflowDocumentStore()` for pin data access, reused existing `workflowsStore` variable instead of redundant `useWorkflowsStore()` call

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2523

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.