### PR TITLE
fix(core): Fix race condition when stopping jobs in queue mode

### DIFF
--- a/packages/cli/src/scaling/__tests__/scaling.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/scaling.service.test.ts
@@ -5,7 +5,7 @@ import { Container } from '@n8n/di';
 import * as BullModule from 'bull';
 import { mock } from 'jest-mock-extended';
 import { InstanceSettings } from 'n8n-core';
-import { ApplicationError, ManualExecutionCancelledError } from 'n8n-workflow';
+import { ApplicationError } from 'n8n-workflow';
 
 import type { ActiveExecutions } from '@/active-executions';
 
@@ -288,15 +288,15 @@ describe('ScalingService', () => {
 	});
 
 	describe('stopJob', () => {
-		it('should stop an active job', async () => {
+		it('should stop an active job by sending abort signal only', async () => {
 			await scalingService.setupQueue();
 			const job = mock<Job>({ isActive: jest.fn().mockResolvedValue(true) });
 
 			const result = await scalingService.stopJob(job);
 
 			expect(job.progress).toHaveBeenCalledWith({ kind: 'abort-job' });
-			expect(job.discard).toHaveBeenCalled();
-			expect(job.moveToFailed).toHaveBeenCalledWith(new ManualExecutionCancelledError('123'), true);
+			expect(job.discard).not.toHaveBeenCalled();
+			expect(job.moveToFailed).not.toHaveBeenCalled();
 			expect(result).toBe(true);
 		});
 

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -23,6 +23,7 @@ import type {
 } from 'n8n-workflow';
 import {
 	BINARY_ENCODING,
+	ManualExecutionCancelledError,
 	NodeConnectionTypes,
 	Workflow,
 	UnexpectedError,
@@ -285,6 +286,10 @@ export class JobProcessor {
 		const run = await workflowRun;
 
 		delete this.runningJobs[job.id];
+
+		if (run?.status === 'canceled') {
+			throw new ManualExecutionCancelledError(executionId);
+		}
 
 		const props = process.env.N8N_MINIMIZE_EXECUTION_DATA_FETCHING
 			? this.deriveJobFinishedProps(run, startedAt)

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -5,14 +5,7 @@ import { ExecutionRepository } from '@n8n/db';
 import { OnLeaderStepdown, OnLeaderTakeover, OnShutdown } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
 import { ErrorReporter, InstanceSettings } from 'n8n-core';
-import {
-	BINARY_ENCODING,
-	sleep,
-	jsonStringify,
-	ensureError,
-	UnexpectedError,
-	ManualExecutionCancelledError,
-} from 'n8n-workflow';
+import { BINARY_ENCODING, sleep, jsonStringify, ensureError, UnexpectedError } from 'n8n-workflow';
 import type { IExecuteResponsePromiseData, IRun } from 'n8n-workflow';
 import assert, { strict } from 'node:assert';
 
@@ -264,8 +257,7 @@ export class ScalingService {
 		try {
 			if (await job.isActive()) {
 				await job.progress({ kind: 'abort-job' }); // being processed by worker
-				await job.discard(); // prevent retries
-				await job.moveToFailed(new ManualExecutionCancelledError(job.data.executionId), true); // remove from queue
+				this.logger.debug('Sent abort signal to worker', props);
 				return true;
 			}
 


### PR DESCRIPTION
## Summary

Fix the race condition on stopping an execution in queue mode where the main process calls `job.moveToFailed()` (which deletes the job key from Redis) while the worker's Bull processor is still running, causing `Missing key for job updateProgress` errors.

To reproduce:

1. Start main and worker in queue mode with `OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS=true`
2. Create a workflow: Webhook → Code node with `await new Promise(r => setTimeout(r, 120_000))`
3. Publish the workflow and trigger the webhook
4. In the UI, go to Executions → find the running execution → click Stop
5. **Before fix**: Worker logs `Missing key for job <id> updateProgress` and `Missing key for job <id> failed`, execution appears stuck in UI
6. **After fix**: Worker throws `ManualExecutionCancelledError`, Bull moves the job to failed cleanly, no missing key errors

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2616

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
