### PR TITLE
fix(core): Fix OIDC/SAML new user provisioning with project and instance roles

### DIFF
--- a/packages/@n8n/db/src/repositories/role.repository.ts
+++ b/packages/@n8n/db/src/repositories/role.repository.ts
@@ -162,8 +162,13 @@ export class RoleRepository extends Repository<Role> {
 		});
 	}
 
-	async findBySlugs(slugs: string[], roleType: 'global' | 'project' | 'workflow' | 'credential') {
-		return await this.find({
+	async findBySlugs(
+		slugs: string[],
+		roleType: 'global' | 'project' | 'workflow' | 'credential',
+		em?: EntityManager,
+	) {
+		const manager = em ?? this.manager;
+		return await manager.find(Role, {
 			where: { slug: In(slugs), roleType },
 			relations: ['scopes'],
 		});

--- a/packages/cli/src/modules/provisioning.ee/__tests__/provisioning.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/provisioning.service.ee.test.ts
@@ -4,12 +4,9 @@ import { mock } from 'jest-mock-extended';
 import { ProvisioningService } from '@/modules/provisioning.ee/provisioning.service.ee';
 import {
 	type User,
-	type UserRepository,
 	type SettingsRepository,
-	type RoleRepository,
 	type Role,
 	type Project,
-	type ProjectRepository,
 	ProjectRelation,
 } from '@n8n/db';
 import { type GlobalConfig } from '@n8n/config';
@@ -24,26 +21,20 @@ import { type UserService } from '@/services/user.service';
 
 const globalConfig = mock<GlobalConfig>();
 const settingsRepository = mock<SettingsRepository>();
-const userRepository = mock<UserRepository>();
 const userService = mock<UserService>();
 const entityManager = mock<EntityManager>();
-const projectRepository = mock<ProjectRepository>({ manager: entityManager });
 const projectService = mock<ProjectService>();
 const eventService = mock<EventService>();
 
 const logger = mock<Logger>();
 const publisher = mock<Publisher>();
-const roleRepository = mock<RoleRepository>();
 const instanceSettings = mock<InstanceSettings>();
 
 const provisioningService = new ProvisioningService(
 	eventService,
 	globalConfig,
 	settingsRepository,
-	projectRepository,
 	projectService,
-	roleRepository,
-	userRepository,
 	userService,
 	logger,
 	publisher,
@@ -179,8 +170,8 @@ describe('ProvisioningService', () => {
 
 			provisioningService['isInstanceRoleProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
-			await provisioningService.provisionInstanceRoleForUser(user, roleSlug);
-			expect(userRepository.update).not.toHaveBeenCalled();
+			await provisioningService.provisionInstanceRoleForUser(user, roleSlug, entityManager);
+			expect(userService.changeUserRole).not.toHaveBeenCalled();
 			expect(logger.warn).toHaveBeenCalledTimes(1);
 			expect(logger.warn).toHaveBeenCalledWith(
 				'skipping instance role provisioning. Invalid role type: expected string, received number',
@@ -193,12 +184,12 @@ describe('ProvisioningService', () => {
 			const roleSlug = 'global:invalid';
 			const thrownError = new Error('Role not found');
 
-			roleRepository.findOneOrFail.mockRejectedValue(thrownError);
+			entityManager.findOneOrFail.mockRejectedValue(thrownError);
 
 			provisioningService['isInstanceRoleProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
-			await provisioningService.provisionInstanceRoleForUser(user, roleSlug);
-			expect(userRepository.update).not.toHaveBeenCalled();
+			await provisioningService.provisionInstanceRoleForUser(user, roleSlug, entityManager);
+			expect(userService.changeUserRole).not.toHaveBeenCalled();
 			expect(logger.warn).toHaveBeenCalledTimes(1);
 			expect(logger.warn).toHaveBeenCalledWith(
 				`Skipping instance role provisioning, a role matching the slug ${roleSlug} was not found`,
@@ -210,15 +201,15 @@ describe('ProvisioningService', () => {
 			const user = mock<User>({ role: { slug: 'global:owner' } });
 			const roleSlug = 'global:member';
 
-			userRepository.count.mockResolvedValue(0);
-			roleRepository.findOneOrFail.mockResolvedValue(
+			entityManager.count.mockResolvedValue(0);
+			entityManager.findOneOrFail.mockResolvedValue(
 				mock<Role>({ slug: 'global:member', roleType: 'global' }),
 			);
 
 			provisioningService['isInstanceRoleProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
-			await provisioningService.provisionInstanceRoleForUser(user, roleSlug);
-			expect(userRepository.update).not.toHaveBeenCalled();
+			await provisioningService.provisionInstanceRoleForUser(user, roleSlug, entityManager);
+			expect(userService.changeUserRole).not.toHaveBeenCalled();
 			expect(logger.warn).toHaveBeenCalledTimes(1);
 			expect(logger.warn).toHaveBeenCalledWith(
 				`Skipping instance role provisioning. Cannot remove last owner role: global:owner from user: ${user.id}`,
@@ -229,40 +220,48 @@ describe('ProvisioningService', () => {
 		it('should allow a user to change from an owner role to a non-owner role, if there are other owners', async () => {
 			const user = mock<User>({ role: { slug: 'global:owner' } });
 			const roleSlug = 'global:member';
-			userRepository.count.mockResolvedValue(1);
-			roleRepository.findOneOrFail.mockResolvedValue(
+			entityManager.count.mockResolvedValue(1);
+			entityManager.findOneOrFail.mockResolvedValue(
 				mock<Role>({ slug: 'global:member', roleType: 'global' }),
 			);
 			provisioningService['isInstanceRoleProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
-			await provisioningService.provisionInstanceRoleForUser(user, roleSlug);
+			await provisioningService.provisionInstanceRoleForUser(user, roleSlug, entityManager);
 
-			expect(userService.changeUserRole).toHaveBeenCalledWith(user, { newRoleName: roleSlug });
+			expect(userService.changeUserRole).toHaveBeenCalledWith(
+				user,
+				{ newRoleName: roleSlug },
+				entityManager,
+			);
 			expect(logger.warn).not.toHaveBeenCalled();
 		});
 
 		it('should provision the instance role for the user', async () => {
 			const user = mock<User>({ role: { slug: 'global:member' } });
 			const roleSlug = 'global:owner';
-			roleRepository.findOneOrFail.mockResolvedValue(
+			entityManager.findOneOrFail.mockResolvedValue(
 				mock<Role>({ slug: 'global:owner', roleType: 'global' }),
 			);
 			provisioningService['isInstanceRoleProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
-			await provisioningService.provisionInstanceRoleForUser(user, roleSlug);
+			await provisioningService.provisionInstanceRoleForUser(user, roleSlug, entityManager);
 
-			expect(userService.changeUserRole).toHaveBeenCalledWith(user, { newRoleName: roleSlug });
+			expect(userService.changeUserRole).toHaveBeenCalledWith(
+				user,
+				{ newRoleName: roleSlug },
+				entityManager,
+			);
 		});
 
 		it('should do nothing if the role has not changed', async () => {
 			const user = mock<User>({ role: { slug: 'global:owner' } });
 			const roleSlug = 'global:owner';
-			roleRepository.findOneOrFail.mockResolvedValue(
+			entityManager.findOneOrFail.mockResolvedValue(
 				mock<Role>({ slug: 'global:owner', roleType: 'global' }),
 			);
 			provisioningService['isInstanceRoleProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
-			await provisioningService.provisionInstanceRoleForUser(user, roleSlug);
+			await provisioningService.provisionInstanceRoleForUser(user, roleSlug, entityManager);
 
 			expect(userService.changeUserRole).not.toHaveBeenCalled();
 			expect(logger.warn).not.toHaveBeenCalled();
@@ -271,12 +270,12 @@ describe('ProvisioningService', () => {
 		it('should do nothing if the role is not a global role', async () => {
 			const user = mock<User>({ role: { slug: 'global:member' } });
 			const roleSlug = 'global:owner';
-			roleRepository.findOneOrFail.mockResolvedValue(
+			entityManager.findOneOrFail.mockResolvedValue(
 				mock<Role>({ slug: 'global:owner', roleType: 'project' }),
 			);
 			provisioningService['isInstanceRoleProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
-			await provisioningService.provisionInstanceRoleForUser(user, roleSlug);
+			await provisioningService.provisionInstanceRoleForUser(user, roleSlug, entityManager);
 
 			expect(userService.changeUserRole).not.toHaveBeenCalled();
 			expect(logger.warn).toHaveBeenCalledTimes(1);
@@ -290,13 +289,13 @@ describe('ProvisioningService', () => {
 			const user = mock<User>({ id: 'user-123', role: { slug: 'global:member' } });
 			const roleSlug = 'global:owner';
 
-			roleRepository.findOneOrFail.mockResolvedValue(
+			entityManager.findOneOrFail.mockResolvedValue(
 				mock<Role>({ slug: 'global:owner', roleType: 'global' }),
 			);
 
 			provisioningService['isInstanceRoleProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
-			await provisioningService.provisionInstanceRoleForUser(user, roleSlug);
+			await provisioningService.provisionInstanceRoleForUser(user, roleSlug, entityManager);
 
 			expect(eventService.emit).toHaveBeenCalledTimes(1);
 			expect(eventService.emit).toHaveBeenCalledWith('sso-user-instance-role-updated', {
@@ -313,7 +312,11 @@ describe('ProvisioningService', () => {
 
 			provisioningService['isProjectRolesProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
-			await provisioningService.provisionProjectRolesForUser(userId, projectIdToRole);
+			await provisioningService.provisionProjectRolesForUser(
+				userId,
+				projectIdToRole,
+				entityManager,
+			);
 
 			expect(projectService.addUser).not.toHaveBeenCalled();
 			expect(logger.warn).toHaveBeenCalledTimes(1);
@@ -329,7 +332,11 @@ describe('ProvisioningService', () => {
 
 			provisioningService['isProjectRolesProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
-			await provisioningService.provisionProjectRolesForUser(userId, projectIdToRole);
+			await provisioningService.provisionProjectRolesForUser(
+				userId,
+				projectIdToRole,
+				entityManager,
+			);
 
 			expect(projectService.addUser).not.toHaveBeenCalled();
 			expect(logger.warn).toHaveBeenCalledTimes(1);
@@ -345,7 +352,11 @@ describe('ProvisioningService', () => {
 
 			provisioningService['isProjectRolesProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
-			await provisioningService.provisionProjectRolesForUser(userId, projectIdToRole);
+			await provisioningService.provisionProjectRolesForUser(
+				userId,
+				projectIdToRole,
+				entityManager,
+			);
 
 			expect(projectService.addUser).not.toHaveBeenCalled();
 			expect(logger.warn).toHaveBeenCalledTimes(1);
@@ -358,12 +369,16 @@ describe('ProvisioningService', () => {
 		it('should do nothing if the project does not exist', async () => {
 			const userId = 'user-id-123';
 			const projectIdToRole = ['non-existent-project:viewer'];
-			projectRepository.find.mockResolvedValue([]);
-			roleRepository.find.mockResolvedValue([mock<Role>({ slug: 'project:viewer' })]);
+			entityManager.find.mockResolvedValueOnce([]); // projects
+			entityManager.find.mockResolvedValueOnce([mock<Role>({ slug: 'project:viewer' })]); // roles
 
 			provisioningService['isProjectRolesProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
-			await provisioningService.provisionProjectRolesForUser(userId, projectIdToRole);
+			await provisioningService.provisionProjectRolesForUser(
+				userId,
+				projectIdToRole,
+				entityManager,
+			);
 
 			expect(projectService.addUser).not.toHaveBeenCalled();
 		});
@@ -371,12 +386,16 @@ describe('ProvisioningService', () => {
 		it('should do nothing if the provided role does not exist', async () => {
 			const userId = 'user-id-123';
 			const projectIdToRole = ['project-1:non-existent-role'];
-			projectRepository.find.mockResolvedValue([mock<Project>({ id: 'project-1' })]);
-			roleRepository.find.mockResolvedValue([]);
+			entityManager.find.mockResolvedValueOnce([mock<Project>({ id: 'project-1' })]); // projects
+			entityManager.find.mockResolvedValueOnce([]); // roles
 
 			provisioningService['isProjectRolesProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
-			await provisioningService.provisionProjectRolesForUser(userId, projectIdToRole);
+			await provisioningService.provisionProjectRolesForUser(
+				userId,
+				projectIdToRole,
+				entityManager,
+			);
 
 			expect(projectService.addUser).not.toHaveBeenCalled();
 		});
@@ -387,16 +406,18 @@ describe('ProvisioningService', () => {
 				'nonExistentProject:non-existent-role',
 				'anotherNonExistentProject:viewer',
 			];
-			// Mock that no projects exist
-			projectRepository.find.mockResolvedValueOnce([]);
-			// Mock that roles exist but projects don't
-			roleRepository.find.mockResolvedValue([
+			entityManager.find.mockResolvedValueOnce([]); // projects — none exist
+			entityManager.find.mockResolvedValueOnce([
 				mock<Role>({ displayName: 'viewer', slug: 'project:viewer' }),
-			]);
+			]); // roles
 
 			provisioningService['isProjectRolesProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
-			await provisioningService.provisionProjectRolesForUser(userId, projectIdToRole);
+			await provisioningService.provisionProjectRolesForUser(
+				userId,
+				projectIdToRole,
+				entityManager,
+			);
 
 			expect(projectService.addUser).not.toHaveBeenCalled();
 			expect(logger.warn).toHaveBeenCalledWith(
@@ -412,18 +433,20 @@ describe('ProvisioningService', () => {
 		it('should skip projectIds that reference a personal project', async () => {
 			const userId = 'user-id-123';
 			const projectIdToRole = ['personalProject1:viewer', 'teamProject1:editor'];
-			// Mocks query to find existing projects
-			projectRepository.find.mockResolvedValueOnce([mock<Project>({ id: 'teamProject1' })]);
-			// Mocks query to find currently accessible projects
-			projectRepository.find.mockResolvedValueOnce([]);
-			roleRepository.find.mockResolvedValue([
+			entityManager.find.mockResolvedValueOnce([mock<Project>({ id: 'teamProject1' })]); // existing projects
+			entityManager.find.mockResolvedValueOnce([
 				mock<Role>({ displayName: 'viewer', slug: 'project:viewer' }),
 				mock<Role>({ displayName: 'editor', slug: 'project:editor' }),
-			]);
+			]); // roles
+			entityManager.find.mockResolvedValueOnce([]); // currently accessible projects
 
 			provisioningService['isProjectRolesProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
-			await provisioningService.provisionProjectRolesForUser(userId, projectIdToRole);
+			await provisioningService.provisionProjectRolesForUser(
+				userId,
+				projectIdToRole,
+				entityManager,
+			);
 
 			expect(projectService.addUser).toHaveBeenCalledTimes(1);
 			expect(projectService.addUser).toHaveBeenCalledWith(
@@ -440,21 +463,23 @@ describe('ProvisioningService', () => {
 		it('should provision project roles for the user', async () => {
 			const userId = 'user-id-123';
 			const projectIdToRole = ['project-1:viewer', 'project-2:editor'];
-			// Mocks query to find existing projects
-			projectRepository.find.mockResolvedValueOnce([
+			entityManager.find.mockResolvedValueOnce([
 				mock<Project>({ id: 'project-1' }),
 				mock<Project>({ id: 'project-2' }),
-			]);
-			// Mocks query to find currently accessible projects
-			projectRepository.find.mockResolvedValueOnce([]);
-			roleRepository.find.mockResolvedValue([
+			]); // existing projects
+			entityManager.find.mockResolvedValueOnce([
 				mock<Role>({ displayName: 'viewer', slug: 'project:viewer' }),
 				mock<Role>({ displayName: 'editor', slug: 'project:editor' }),
-			]);
+			]); // roles
+			entityManager.find.mockResolvedValueOnce([]); // currently accessible projects
 
 			provisioningService['isProjectRolesProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
-			await provisioningService.provisionProjectRolesForUser(userId, projectIdToRole);
+			await provisioningService.provisionProjectRolesForUser(
+				userId,
+				projectIdToRole,
+				entityManager,
+			);
 
 			expect(projectService.addUser).toHaveBeenCalledTimes(2);
 			expect(projectService.addUser).toHaveBeenCalledWith(
@@ -471,12 +496,16 @@ describe('ProvisioningService', () => {
 		it('should filter out non-project roles', async () => {
 			const userId = 'user-id-123';
 			const projectIdToRole = ['project1:admin'];
-			projectRepository.find.mockResolvedValue([mock<Project>({ id: 'project1' })]);
-			roleRepository.find.mockResolvedValue([]);
+			entityManager.find.mockResolvedValueOnce([mock<Project>({ id: 'project1' })]); // projects
+			entityManager.find.mockResolvedValueOnce([]); // roles — none match
 
 			provisioningService['isProjectRolesProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
-			await provisioningService.provisionProjectRolesForUser(userId, projectIdToRole);
+			await provisioningService.provisionProjectRolesForUser(
+				userId,
+				projectIdToRole,
+				entityManager,
+			);
 
 			expect(projectService.addUser).not.toHaveBeenCalled();
 			expect(logger.warn).toHaveBeenCalledWith(
@@ -488,22 +517,23 @@ describe('ProvisioningService', () => {
 		it('removes existing access to non-personal projects that are no longer present in the provided mapping', async () => {
 			const userId = 'user-id-123';
 			const projectIdToRole = ['project-1:viewer'];
-			// Mocks query to find existing projects
-			projectRepository.find.mockResolvedValueOnce([mock<Project>({ id: 'project-1' })]);
-			// Mocks query to find currently accessible projects
-			projectRepository.find.mockResolvedValueOnce([
+			entityManager.find.mockResolvedValueOnce([mock<Project>({ id: 'project-1' })]); // existing projects
+			entityManager.find.mockResolvedValueOnce([
+				mock<Role>({ displayName: 'viewer', slug: 'project:viewer' }),
+			]); // roles
+			entityManager.find.mockResolvedValueOnce([
 				mock<Project>({ id: 'project-1', type: 'team' }),
 				mock<Project>({ id: 'project-2', type: 'team' }),
-			]);
-			roleRepository.find.mockResolvedValue([
-				mock<Role>({ displayName: 'viewer', slug: 'project:viewer' }),
-			]);
+			]); // currently accessible projects
 
 			provisioningService['isProjectRolesProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
-			await provisioningService.provisionProjectRolesForUser(userId, projectIdToRole);
+			await provisioningService.provisionProjectRolesForUser(
+				userId,
+				projectIdToRole,
+				entityManager,
+			);
 
-			expect(entityManager.transaction).toHaveBeenCalledTimes(1);
 			expect(entityManager.delete).toHaveBeenCalledWith(ProjectRelation, {
 				projectId: 'project-2',
 				userId,
@@ -518,21 +548,23 @@ describe('ProvisioningService', () => {
 		it('sends telemetry event', async () => {
 			const userId = 'user-id-123';
 			const projectIdToRole = ['project-1:viewer', 'project-2:editor'];
-			projectRepository.find.mockResolvedValueOnce([
+			entityManager.find.mockResolvedValueOnce([
 				mock<Project>({ id: 'project-1' }),
 				mock<Project>({ id: 'project-2' }),
-			]);
-			projectRepository.find.mockResolvedValueOnce([
-				mock<Project>({ id: 'project-3', type: 'team' }),
-			]);
-			roleRepository.find.mockResolvedValue([
+			]); // existing projects
+			entityManager.find.mockResolvedValueOnce([
 				mock<Role>({ displayName: 'viewer', slug: 'project:viewer' }),
 				mock<Role>({ displayName: 'editor', slug: 'project:editor' }),
-			]);
+			]); // roles
+			entityManager.find.mockResolvedValueOnce([mock<Project>({ id: 'project-3', type: 'team' })]); // currently accessible projects
 
 			provisioningService['isProjectRolesProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
-			await provisioningService.provisionProjectRolesForUser(userId, projectIdToRole);
+			await provisioningService.provisionProjectRolesForUser(
+				userId,
+				projectIdToRole,
+				entityManager,
+			);
 
 			expect(eventService.emit).toHaveBeenCalledTimes(1);
 			expect(eventService.emit).toHaveBeenCalledWith('sso-user-project-access-updated', {

--- a/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
@@ -1,15 +1,8 @@
 import { ProvisioningConfigDto, ProvisioningConfigPatchDto } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
-import {
-	RoleRepository,
-	SettingsRepository,
-	User,
-	UserRepository,
-	Role,
-	ProjectRepository,
-	ProjectRelation,
-} from '@n8n/db';
+import { SettingsRepository, User, Role, Project, ProjectRelation } from '@n8n/db';
+import type { EntityManager } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { jsonParse } from 'n8n-workflow';
 import { PROVISIONING_PREFERENCES_DB_KEY } from './constants';
@@ -31,10 +24,7 @@ export class ProvisioningService {
 		private readonly eventService: EventService,
 		private readonly globalConfig: GlobalConfig,
 		private readonly settingsRepository: SettingsRepository,
-		private readonly projectRepository: ProjectRepository,
 		private readonly projectService: ProjectService,
-		private readonly roleRepository: RoleRepository,
-		private readonly userRepository: UserRepository,
 		private readonly userService: UserService,
 		private readonly logger: Logger,
 		private readonly publisher: Publisher,
@@ -53,7 +43,7 @@ export class ProvisioningService {
 		return this.provisioningConfig;
 	}
 
-	async provisionInstanceRoleForUser(user: User, roleSlug: unknown) {
+	async provisionInstanceRoleForUser(user: User, roleSlug: unknown, trx: EntityManager) {
 		if (!(await this.isInstanceRoleProvisioningEnabled())) {
 			return;
 		}
@@ -71,10 +61,10 @@ export class ProvisioningService {
 			return;
 		}
 
-		let dbRole: Role;
+		let dbRole: Role | null;
 
 		try {
-			dbRole = await this.roleRepository.findOneOrFail({ where: { slug: roleSlug } });
+			dbRole = await trx.findOneOrFail(Role, { where: { slug: roleSlug } });
 		} catch (error) {
 			this.logger.warn(
 				`Skipping instance role provisioning, a role matching the slug ${roleSlug} was not found`,
@@ -96,7 +86,7 @@ export class ProvisioningService {
 		 * we need to check if they are the last owner to avoid an instance losing its only owner
 		 */
 		if (user.role.slug === globalOwnerRoleSlug && dbRole.slug !== globalOwnerRoleSlug) {
-			const otherOwners = await this.userRepository.count({
+			const otherOwners = await trx.count(User, {
 				where: { role: { slug: globalOwnerRoleSlug }, id: Not(user.id) },
 			});
 
@@ -111,7 +101,7 @@ export class ProvisioningService {
 
 		// No need to update record if the role hasn't changed
 		if (user.role.slug !== dbRole.slug) {
-			await this.userService.changeUserRole(user, { newRoleName: dbRole.slug });
+			await this.userService.changeUserRole(user, { newRoleName: dbRole.slug }, trx);
 
 			this.eventService.emit('sso-user-instance-role-updated', {
 				userId: user.id,
@@ -128,7 +118,11 @@ export class ProvisioningService {
 	 *   ...
 	 * ]
 	 */
-	async provisionProjectRolesForUser(userId: string, projectIdToRoles: unknown): Promise<void> {
+	async provisionProjectRolesForUser(
+		userId: string,
+		projectIdToRoles: unknown,
+		trx: EntityManager,
+	): Promise<void> {
 		if (!(await this.isProjectRolesProvisioningEnabled())) {
 			return;
 		}
@@ -182,11 +176,11 @@ export class ProvisioningService {
 		}
 
 		const [existingProjects, existingRoles] = await Promise.all([
-			this.projectRepository.find({
+			trx.find(Project, {
 				where: { id: In(projectIds), type: Not('personal') },
 				select: ['id'],
 			}),
-			this.roleRepository.find({
+			trx.find(Role, {
 				where: {
 					slug: In(roleSlugs),
 					roleType: 'project',
@@ -227,7 +221,7 @@ export class ProvisioningService {
 			return;
 		}
 
-		const currentlyAccessibleProjects = await this.projectRepository.find({
+		const currentlyAccessibleProjects = await trx.find(Project, {
 			where: {
 				type: Not('personal'),
 				projectRelations: {
@@ -242,15 +236,13 @@ export class ProvisioningService {
 			(project) => !validProjectIds.has(project.id),
 		);
 
-		await this.projectRepository.manager.transaction(async (tx) => {
-			for (const project of projectsToRemoveAccessFrom) {
-				await tx.delete(ProjectRelation, { projectId: project.id, userId });
-			}
+		for (const project of projectsToRemoveAccessFrom) {
+			await trx.delete(ProjectRelation, { projectId: project.id, userId });
+		}
 
-			for (const { projectId, roleSlug } of validProjectToRoleMappings) {
-				await this.projectService.addUser(projectId, { userId, role: roleSlug }, tx);
-			}
-		});
+		for (const { projectId, roleSlug } of validProjectToRoleMappings) {
+			await this.projectService.addUser(projectId, { userId, role: roleSlug }, trx);
+		}
 
 		this.eventService.emit('sso-user-project-access-updated', {
 			projectsAdded: validProjectIds.size,

--- a/packages/cli/src/modules/sso-oidc/__tests__/oidc.service.ee.test.ts
+++ b/packages/cli/src/modules/sso-oidc/__tests__/oidc.service.ee.test.ts
@@ -478,6 +478,7 @@ describe('OidcService', () => {
 			oidcService.getOidcConfiguration = jest.fn().mockResolvedValue({} as client.Configuration);
 			// @ts-expect-error - applySsoProvisioning is private and only accessible within class 'OidcService'
 			oidcService.applySsoProvisioning = jest.fn().mockResolvedValue(undefined);
+			userRepository.manager.transaction = jest.fn().mockImplementation(async (cb) => cb({}));
 			authIdentityRepository.findOne = jest
 				.fn()
 				.mockResolvedValue({ user: { email: 'john.doe@test.com' } as any });
@@ -500,7 +501,11 @@ describe('OidcService', () => {
 			expect(user).toBeDefined();
 			expect(user.email).toEqual('john.doe@test.com');
 			// @ts-expect-error - applySsoProvisioning is private and only accessible within class 'OidcService'
-			expect(oidcService.applySsoProvisioning).toHaveBeenCalledWith(user, { sub: 'valid-subject' });
+			expect(oidcService.applySsoProvisioning).toHaveBeenCalledWith(
+				user,
+				{ sub: 'valid-subject' },
+				expect.objectContaining({}),
+			);
 		});
 
 		it('should return a user if the user exists but the auth identity does not', async () => {
@@ -510,6 +515,11 @@ describe('OidcService', () => {
 			oidcService.getOidcConfiguration = jest.fn().mockResolvedValue({} as client.Configuration);
 			// @ts-expect-error - applySsoProvisioning is private and only accessible within class 'OidcService'
 			oidcService.applySsoProvisioning = jest.fn().mockResolvedValue(undefined);
+			userRepository.manager.transaction = jest
+				.fn()
+				.mockImplementation(async (cb) =>
+					cb({ create: jest.fn().mockReturnValue({}), save: jest.fn().mockResolvedValue({}) }),
+				);
 			userRepository.findOne = jest.fn().mockResolvedValue({ email: 'john.doe@test.com' } as any);
 
 			jest.spyOn(client, 'authorizationCodeGrant').mockResolvedValue({
@@ -530,7 +540,11 @@ describe('OidcService', () => {
 			expect(user).toBeDefined();
 			expect(user.email).toEqual('john.doe@test.com');
 			// @ts-expect-error - applySsoProvisioning is private and only accessible within class 'OidcService'
-			expect(oidcService.applySsoProvisioning).toHaveBeenCalledWith(user, { sub: 'valid-subject' });
+			expect(oidcService.applySsoProvisioning).toHaveBeenCalledWith(
+				user,
+				{ sub: 'valid-subject' },
+				expect.objectContaining({}),
+			);
 		});
 
 		it('should create a new user if the user does not exist', async () => {

--- a/packages/cli/src/modules/sso-oidc/oidc.service.ee.ts
+++ b/packages/cli/src/modules/sso-oidc/oidc.service.ee.ts
@@ -270,6 +270,10 @@ export class OidcService {
 			throw new BadRequestError('Invalid email format');
 		}
 
+		// Pre-warm provisioning config cache before entering any transaction,
+		// to avoid a DB query inside the transaction exhausting the connection pool.
+		await this.provisioningService.getConfig();
+
 		const openidUser = await this.authIdentityRepository.findOne({
 			where: { providerId: claims.sub, providerType: 'oidc' },
 			relations: {

--- a/packages/cli/src/modules/sso-oidc/oidc.service.ee.ts
+++ b/packages/cli/src/modules/sso-oidc/oidc.service.ee.ts
@@ -7,6 +7,7 @@ import {
 	isValidEmail,
 	GLOBAL_MEMBER_ROLE,
 	SettingsRepository,
+	type EntityManager,
 	type User,
 	UserRepository,
 } from '@n8n/db';
@@ -279,7 +280,9 @@ export class OidcService {
 		});
 
 		if (openidUser) {
-			await this.applySsoProvisioning(openidUser.user, claims);
+			await this.userRepository.manager.transaction(async (trx) => {
+				await this.applySsoProvisioning(openidUser.user, claims, trx);
+			});
 
 			return openidUser.user;
 		}
@@ -293,15 +296,17 @@ export class OidcService {
 			this.logger.debug(
 				`OIDC login: User with email ${userInfo.email} already exists, linking OIDC identity.`,
 			);
-			// If the user already exists, we just add the OIDC identity to the user
-			const id = this.authIdentityRepository.create({
-				providerId: claims.sub,
-				providerType: 'oidc',
-				userId: foundUser.id,
-			});
 
-			await this.authIdentityRepository.save(id);
-			await this.applySsoProvisioning(foundUser, claims);
+			await this.userRepository.manager.transaction(async (trx) => {
+				await trx.save(
+					trx.create(AuthIdentity, {
+						providerId: claims.sub,
+						providerType: 'oidc',
+						userId: foundUser.id,
+					}),
+				);
+				await this.applySsoProvisioning(foundUser, claims, trx);
+			});
 
 			return foundUser;
 		}
@@ -327,21 +332,25 @@ export class OidcService {
 				}),
 			);
 
-			await this.applySsoProvisioning(user, claims);
+			await this.applySsoProvisioning(user, claims, trx);
 
 			return user;
 		});
 	}
 
-	private async applySsoProvisioning(user: User, claims: any) {
+	private async applySsoProvisioning(
+		user: User,
+		claims: Record<string, unknown>,
+		trx: EntityManager,
+	) {
 		const provisioningConfig = await this.provisioningService.getConfig();
-		const projectRoleMapping = claims[provisioningConfig.scopesProjectsRolesClaimName];
 		const instanceRole = claims[provisioningConfig.scopesInstanceRoleClaimName];
 		if (instanceRole) {
-			await this.provisioningService.provisionInstanceRoleForUser(user, instanceRole);
+			await this.provisioningService.provisionInstanceRoleForUser(user, instanceRole, trx);
 		}
+		const projectRoleMapping = claims[provisioningConfig.scopesProjectsRolesClaimName];
 		if (projectRoleMapping) {
-			await this.provisioningService.provisionProjectRolesForUser(user.id, projectRoleMapping);
+			await this.provisioningService.provisionProjectRolesForUser(user.id, projectRoleMapping, trx);
 		}
 	}
 

--- a/packages/cli/src/modules/sso-saml/__tests__/saml-helpers.test.ts
+++ b/packages/cli/src/modules/sso-saml/__tests__/saml-helpers.test.ts
@@ -1,11 +1,12 @@
 import { mockInstance } from '@n8n/backend-test-utils';
-import type { AuthIdentity } from '@n8n/db';
+import type { AuthIdentity, EntityManager } from '@n8n/db';
 import { generateNanoId, User, AuthIdentityRepository, UserRepository } from '@n8n/db';
+import { mock } from 'jest-mock-extended';
 
 import * as helpers from '../saml-helpers';
 import type { SamlUserAttributes } from '../types';
 
-const userRepository = mockInstance(UserRepository);
+mockInstance(UserRepository);
 mockInstance(AuthIdentityRepository);
 
 describe('sso/saml/samlHelpers', () => {
@@ -30,26 +31,20 @@ describe('sso/saml/samlHelpers', () => {
 				n8nInstanceRole: 'n8n_instance_role',
 			};
 
-			userRepository.findOne.mockImplementationOnce(async (_) => user);
-			userRepository.save.mockImplementationOnce(async (_) => user);
+			const trx = mock<EntityManager>();
+			trx.save.mockImplementation(async (_entity: unknown, data: unknown) => data as any);
+			trx.findOne.mockResolvedValue(user as any);
 
 			//
 			// ACT
 			//
-			await helpers.updateUserFromSamlAttributes(user, samlUserAttributes);
+			await helpers.updateUserFromSamlAttributes(user, samlUserAttributes, trx);
 
 			//
 			// ASSERT
 			//
-			expect(userRepository.save).toHaveBeenCalledWith(
-				{
-					...user,
-					firstName: samlUserAttributes.firstName,
-					lastName: samlUserAttributes.lastName,
-				},
-				{ transaction: false },
-			);
-			expect(userRepository.update).not.toHaveBeenCalled();
+			expect(trx.save).toHaveBeenCalledTimes(2); // AuthIdentity + User
+			expect(trx.findOne).toHaveBeenCalledTimes(1); // reload user with role
 		});
 	});
 

--- a/packages/cli/src/modules/sso-saml/__tests__/saml.service.ee.test.ts
+++ b/packages/cli/src/modules/sso-saml/__tests__/saml.service.ee.test.ts
@@ -4,6 +4,7 @@ import type { GlobalConfig } from '@n8n/config';
 import { SettingsRepository } from '@n8n/db';
 import type { UserRepository, Settings, User } from '@n8n/db';
 import { Container } from '@n8n/di';
+import type { EntityManager } from '@n8n/typeorm';
 import axios from 'axios';
 import type express from 'express';
 import type { HttpProxyAgent } from 'http-proxy-agent';
@@ -195,7 +196,12 @@ describe('SamlService', () => {
 			isMultiMain: true,
 		});
 		provisioningService = mock<ProvisioningService>();
-		userRepository = mock<UserRepository>();
+		const entityManager = mock<EntityManager>();
+		userRepository = mock<UserRepository>({ manager: entityManager });
+		entityManager.transaction.mockImplementation(async (cb) => {
+			// @ts-expect-error Mock
+			return await cb(entityManager);
+		});
 		globalConfig = mock<GlobalConfig>({
 			sso: { saml: { loginEnabled: false } },
 		});
@@ -551,13 +557,17 @@ describe('SamlService', () => {
 
 			await samlService.handleSamlLogin(mock<express.Request>(), 'post');
 
+			const entityManager = userRepository.manager;
+			expect(entityManager.transaction).toHaveBeenCalledTimes(1);
 			expect(provisioningService.provisionInstanceRoleForUser).toHaveBeenCalledWith(
 				mockUser,
 				samlAttributes.n8nInstanceRole,
+				entityManager,
 			);
 			expect(provisioningService.provisionProjectRolesForUser).toHaveBeenCalledWith(
 				mockUser.id,
 				samlAttributes.n8nProjectRoles,
+				entityManager,
 			);
 		});
 	});

--- a/packages/cli/src/modules/sso-saml/saml-helpers.ts
+++ b/packages/cli/src/modules/sso-saml/saml-helpers.ts
@@ -1,8 +1,8 @@
 import type { SamlAcsDto, SamlPreferences } from '@n8n/api-types';
 import { GlobalConfig } from '@n8n/config';
-import type { User } from '@n8n/db';
-import { AuthIdentity, AuthIdentityRepository, UserRepository } from '@n8n/db';
+import { AuthIdentity, AuthIdentityRepository, User, UserRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
+import type { EntityManager } from '@n8n/db';
 import { randomString } from 'n8n-workflow';
 import type { FlowResult } from 'samlify/types/src/flow';
 
@@ -50,7 +50,10 @@ export const isSamlPreferences = (candidate: unknown): candidate is SamlPreferen
 	);
 };
 
-export async function createUserFromSamlAttributes(attributes: SamlUserAttributes): Promise<User> {
+export async function createUserFromSamlAttributes(
+	attributes: SamlUserAttributes,
+	afterCreate?: (user: User, trx: EntityManager) => Promise<void>,
+): Promise<User> {
 	const randomPassword = randomString(18);
 	const userRepository = Container.get(UserRepository);
 	return await userRepository.manager.transaction(async (trx) => {
@@ -74,6 +77,8 @@ export async function createUserFromSamlAttributes(attributes: SamlUserAttribute
 			}),
 		);
 
+		if (afterCreate) await afterCreate(user, trx);
+
 		return user;
 	});
 }
@@ -81,6 +86,7 @@ export async function createUserFromSamlAttributes(attributes: SamlUserAttribute
 export async function updateUserFromSamlAttributes(
 	user: User,
 	attributes: SamlUserAttributes,
+	trx?: EntityManager,
 ): Promise<User> {
 	if (!attributes.email) throw new AuthError('Email is required to update user');
 	if (!user) throw new AuthError('User not found');
@@ -94,15 +100,15 @@ export async function updateUserFromSamlAttributes(
 	} else {
 		samlAuthIdentity.providerId = attributes.userPrincipalName;
 	}
-	await Container.get(AuthIdentityRepository).save(samlAuthIdentity, { transaction: false });
+	const em = trx ?? Container.get(AuthIdentityRepository).manager;
+	await em.save(AuthIdentity, samlAuthIdentity);
 	user.firstName = attributes.firstName;
 	user.lastName = attributes.lastName;
-	const resultUser = await Container.get(UserRepository).save(user, { transaction: false });
+	const resultUser = await em.save(User, user);
 	if (!resultUser) throw new AuthError('Could not update User');
-	const userWithRole = await Container.get(UserRepository).findOne({
+	const userWithRole = await em.findOne(User, {
 		where: { id: resultUser.id },
 		relations: ['role'],
-		transaction: false,
 	});
 	if (!userWithRole) throw new AuthError('Failed to fetch user!');
 	return userWithRole;

--- a/packages/cli/src/modules/sso-saml/saml.service.ee.ts
+++ b/packages/cli/src/modules/sso-saml/saml.service.ee.ts
@@ -219,6 +219,10 @@ export class SamlService {
 	}> {
 		const attributes = await this.getAttributesFromLoginResponse(req, binding);
 
+		// Pre-warm provisioning config cache before entering any transaction,
+		// to avoid a DB query inside the transaction exhausting the connection pool.
+		await this.provisioningService.getConfig();
+
 		if (attributes.email) {
 			const lowerCasedEmail = attributes.email.toLowerCase();
 

--- a/packages/cli/src/modules/sso-saml/saml.service.ee.ts
+++ b/packages/cli/src/modules/sso-saml/saml.service.ee.ts
@@ -1,7 +1,7 @@
 import type { SamlPreferences, SamlPreferencesAttributeMapping } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
-import type { Settings, User } from '@n8n/db';
+import type { EntityManager, Settings, User } from '@n8n/db';
 import { isValidEmail, SettingsRepository, UserRepository } from '@n8n/db';
 import { OnPubSubEvent } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
@@ -237,7 +237,9 @@ export class SamlService {
 						(e) => e.providerType === 'saml' && e.providerId === attributes.userPrincipalName,
 					)
 				) {
-					await this.applySsoProvisioning(user, attributes);
+					await this.userRepository.manager.transaction(async (trx) => {
+						await this.applySsoProvisioning(user, attributes, trx);
+					});
 					return {
 						authenticatedUser: user,
 						attributes,
@@ -245,20 +247,24 @@ export class SamlService {
 					};
 				} else {
 					// Login path for existing users that are NOT fully set up for SAML
-					const updatedUser = await updateUserFromSamlAttributes(user, attributes);
-					const onboardingRequired = !updatedUser.firstName || !updatedUser.lastName;
-					await this.applySsoProvisioning(updatedUser, attributes);
-					return {
-						authenticatedUser: updatedUser,
-						attributes,
-						onboardingRequired,
-					};
+					return await this.userRepository.manager.transaction(async (trx) => {
+						const updatedUser = await updateUserFromSamlAttributes(user, attributes, trx);
+						const onboardingRequired = !updatedUser.firstName || !updatedUser.lastName;
+						await this.applySsoProvisioning(updatedUser, attributes, trx);
+						return {
+							authenticatedUser: updatedUser,
+							attributes,
+							onboardingRequired,
+						};
+					});
 				}
 			} else {
 				// New users to be created JIT based on SAML attributes
 				if (isSsoJustInTimeProvisioningEnabled()) {
-					const newUser = await createUserFromSamlAttributes(attributes);
-					await this.applySsoProvisioning(newUser, attributes);
+					const newUser = await createUserFromSamlAttributes(
+						attributes,
+						async (user, trx) => await this.applySsoProvisioning(user, attributes, trx),
+					);
 					return {
 						authenticatedUser: newUser,
 						attributes,
@@ -275,14 +281,23 @@ export class SamlService {
 		};
 	}
 
-	private async applySsoProvisioning(user: User, attributes: SamlPreferencesAttributeMapping) {
+	private async applySsoProvisioning(
+		user: User,
+		attributes: SamlPreferencesAttributeMapping,
+		trx: EntityManager,
+	) {
 		if (attributes?.n8nInstanceRole) {
-			await this.provisioningService.provisionInstanceRoleForUser(user, attributes.n8nInstanceRole);
+			await this.provisioningService.provisionInstanceRoleForUser(
+				user,
+				attributes.n8nInstanceRole,
+				trx,
+			);
 		}
 		if (attributes?.n8nProjectRoles) {
 			await this.provisioningService.provisionProjectRolesForUser(
 				user.id,
 				attributes.n8nProjectRoles,
+				trx,
 			);
 		}
 	}

--- a/packages/cli/src/services/__tests__/ownership.service.test.ts
+++ b/packages/cli/src/services/__tests__/ownership.service.test.ts
@@ -244,7 +244,10 @@ describe('OwnershipService', () => {
 
 			await ownershipService.invalidateProjectOwnerCacheByUserId('some-user-id');
 
-			expect(projectRepository.getPersonalProjectForUser).toHaveBeenCalledWith('some-user-id');
+			expect(projectRepository.getPersonalProjectForUser).toHaveBeenCalledWith(
+				'some-user-id',
+				undefined,
+			);
 			expect(cacheService.deleteFromHash).toHaveBeenCalledWith('project-owner', project.id);
 		});
 
@@ -253,7 +256,10 @@ describe('OwnershipService', () => {
 
 			await ownershipService.invalidateProjectOwnerCacheByUserId('some-user-id');
 
-			expect(projectRepository.getPersonalProjectForUser).toHaveBeenCalledWith('some-user-id');
+			expect(projectRepository.getPersonalProjectForUser).toHaveBeenCalledWith(
+				'some-user-id',
+				undefined,
+			);
 			expect(cacheService.deleteFromHash).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/cli/src/services/__tests__/user.service.test.ts
+++ b/packages/cli/src/services/__tests__/user.service.test.ts
@@ -337,7 +337,9 @@ describe('UserService', () => {
 
 			await userService.changeUserRole(user, { newRoleName: 'global:admin' });
 
-			expect(ownershipService.invalidateProjectOwnerCacheByUserId).toHaveBeenCalledWith(user.id);
+			const calls = ownershipService.invalidateProjectOwnerCacheByUserId.mock.calls;
+			expect(calls).toHaveLength(1);
+			expect(calls[0][0]).toBe(user.id);
 		});
 
 		it('removes higher privilege scopes from API tokens of user who is demoted from admin', async () => {

--- a/packages/cli/src/services/ownership.service.ts
+++ b/packages/cli/src/services/ownership.service.ts
@@ -1,3 +1,4 @@
+import type { EntityManager } from '@n8n/typeorm';
 import type { ListQueryDb } from '@n8n/db';
 import {
 	GLOBAL_OWNER_ROLE,
@@ -140,8 +141,11 @@ export class OwnershipService {
 		return owner;
 	}
 
-	async invalidateProjectOwnerCacheByUserId(userId: string) {
-		const personalProject = await this.projectRepository.getPersonalProjectForUser(userId);
+	async invalidateProjectOwnerCacheByUserId(userId: string, entityManager?: EntityManager) {
+		const personalProject = await this.projectRepository.getPersonalProjectForUser(
+			userId,
+			entityManager,
+		);
 		if (personalProject) {
 			await this.cacheService.deleteFromHash('project-owner', personalProject.id);
 		}

--- a/packages/cli/src/services/ownership.service.ts
+++ b/packages/cli/src/services/ownership.service.ts
@@ -1,5 +1,4 @@
-import type { EntityManager } from '@n8n/typeorm';
-import type { ListQueryDb } from '@n8n/db';
+import type { EntityManager, ListQueryDb } from '@n8n/db';
 import {
 	GLOBAL_OWNER_ROLE,
 	Project,

--- a/packages/cli/src/services/role.service.ts
+++ b/packages/cli/src/services/role.service.ts
@@ -226,9 +226,10 @@ export class RoleService {
 	async checkRolesExist(
 		roleSlugs: string[],
 		roleType: 'global' | 'project' | 'workflow' | 'credential',
+		trx?: EntityManager,
 	) {
 		const uniqueRoleSlugs = new Set(roleSlugs);
-		const roles = await this.roleRepository.findBySlugs(Array.from(uniqueRoleSlugs), roleType);
+		const roles = await this.roleRepository.findBySlugs(Array.from(uniqueRoleSlugs), roleType, trx);
 
 		if (roles.length < uniqueRoleSlugs.size) {
 			const nonExistentRoles = Array.from(uniqueRoleSlugs).filter(

--- a/packages/cli/src/services/user.service.ts
+++ b/packages/cli/src/services/user.service.ts
@@ -1,7 +1,7 @@
 import type { RoleChangeRequestDto } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
-import type { AuthIdentity, PublicUser } from '@n8n/db';
+import type { AuthIdentity, EntityManager, PublicUser } from '@n8n/db';
 import {
 	ProjectRelation,
 	User,
@@ -293,11 +293,11 @@ export class UserService {
 		return { usersInvited, usersCreated: toCreateUsers.map(({ email }) => email) };
 	}
 
-	async changeUserRole(user: User, newRole: RoleChangeRequestDto) {
+	async changeUserRole(user: User, newRole: RoleChangeRequestDto, outerTrx?: EntityManager) {
 		// Check that new role exists
 		await this.roleService.checkRolesExist([newRole.newRoleName], 'global');
 
-		await this.userRepository.manager.transaction(async (trx) => {
+		const runInTransaction = async (trx: EntityManager) => {
 			await trx.update(User, { id: user.id }, { role: { slug: newRole.newRoleName } });
 
 			const isAdminRole = (roleName: string) => {
@@ -378,7 +378,13 @@ export class UserService {
 					{ role: { slug: PROJECT_OWNER_ROLE_SLUG } },
 				);
 			}
-		});
+		};
+
+		if (outerTrx) {
+			await runInTransaction(outerTrx);
+		} else {
+			await this.userRepository.manager.transaction(runInTransaction);
+		}
 
 		// Invalidate ownership cache for the user to ensure their new permissions are reflected in subsequent requests
 		await this.ownershipService.invalidateProjectOwnerCacheByUserId(user.id);

--- a/packages/cli/src/services/user.service.ts
+++ b/packages/cli/src/services/user.service.ts
@@ -294,10 +294,9 @@ export class UserService {
 	}
 
 	async changeUserRole(user: User, newRole: RoleChangeRequestDto, outerTrx?: EntityManager) {
-		// Check that new role exists
-		await this.roleService.checkRolesExist([newRole.newRoleName], 'global');
-
 		const runInTransaction = async (trx: EntityManager) => {
+			// Check that new role exists (using trx to avoid acquiring a second connection)
+			await this.roleService.checkRolesExist([newRole.newRoleName], 'global', trx);
 			await trx.update(User, { id: user.id }, { role: { slug: newRole.newRoleName } });
 
 			const isAdminRole = (roleName: string) => {

--- a/packages/cli/src/services/user.service.ts
+++ b/packages/cli/src/services/user.service.ts
@@ -379,14 +379,17 @@ export class UserService {
 			}
 		};
 
-		if (outerTrx) {
-			await runInTransaction(outerTrx);
-		} else {
-			await this.userRepository.manager.transaction(runInTransaction);
-		}
+		const runInTransactionAndInvalidateCache = async (trx: EntityManager) => {
+			await runInTransaction(trx);
+			// Invalidate ownership cache for the user to ensure their new permissions are reflected in subsequent requests
+			await this.ownershipService.invalidateProjectOwnerCacheByUserId(user.id, trx);
+		};
 
-		// Invalidate ownership cache for the user to ensure their new permissions are reflected in subsequent requests
-		await this.ownershipService.invalidateProjectOwnerCacheByUserId(user.id);
+		if (outerTrx) {
+			await runInTransactionAndInvalidateCache(outerTrx);
+		} else {
+			await this.userRepository.manager.transaction(runInTransactionAndInvalidateCache);
+		}
 	}
 
 	/**

--- a/packages/cli/test/integration/modules/provisioning/sso-provisioning-atomicity.integration.test.ts
+++ b/packages/cli/test/integration/modules/provisioning/sso-provisioning-atomicity.integration.test.ts
@@ -1,0 +1,314 @@
+const discoveryMock = jest.fn();
+const authorizationCodeGrantMock = jest.fn();
+const fetchUserInfoMock = jest.fn();
+
+jest.mock('openid-client', () => ({
+	...jest.requireActual('openid-client'),
+	discovery: discoveryMock,
+	authorizationCodeGrant: authorizationCodeGrantMock,
+	fetchUserInfo: fetchUserInfoMock,
+}));
+
+import type { OidcConfigDto } from '@n8n/api-types';
+import { createTeamProject, testDb } from '@n8n/backend-test-utils';
+import { ProjectRelationRepository, UserRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+import type * as mocked_oidc_client from 'openid-client';
+const real_oidc_client = jest.requireActual('openid-client');
+
+import { ProvisioningService } from '@/modules/provisioning.ee/provisioning.service.ee';
+import { OidcService } from '@/modules/sso-oidc/oidc.service.ee';
+import { ProjectService } from '@/services/project.service.ee';
+import { UserService } from '@/services/user.service';
+import { createOwner } from '@test-integration/db/users';
+
+let mockConfiguration: mocked_oidc_client.Configuration;
+
+beforeAll(async () => {
+	await testDb.init();
+
+	mockConfiguration = new real_oidc_client.Configuration(
+		{
+			issuer: 'https://example.com/auth/realms/n8n',
+			client_id: 'test-client-id',
+			redirect_uris: ['http://n8n.io/sso/oidc/callback'],
+			response_types: ['code'],
+			scopes: ['openid', 'profile', 'email'],
+			authorization_endpoint: 'https://example.com/auth',
+		},
+		'test-client-id',
+	);
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+/**
+ * Helper: create OIDC mock tokens with given claims
+ */
+function createMockTokens(
+	claims: Record<string, unknown>,
+): mocked_oidc_client.TokenEndpointResponse & mocked_oidc_client.TokenEndpointResponseHelpers {
+	return {
+		access_token: `mock-access-token-${Math.random()}`,
+		id_token: `mock-id-token-${Math.random()}`,
+		token_type: 'bearer',
+		claims: () =>
+			({
+				sub: claims.sub as string,
+				iss: 'https://example.com/auth/realms/n8n',
+				aud: 'test-client-id',
+				iat: Math.floor(Date.now() / 1000) - 1000,
+				exp: Math.floor(Date.now() / 1000) + 3600,
+				...claims,
+			}) as mocked_oidc_client.IDToken,
+		expiresIn: () => 3600,
+	} as mocked_oidc_client.TokenEndpointResponse & mocked_oidc_client.TokenEndpointResponseHelpers;
+}
+
+// On SQLite, nested transactions cause deadlocks (the bug manifests as a hang).
+// On PostgreSQL, they cause FK constraint violations.
+// Either way, these tests should fail before the fix and pass after.
+jest.setTimeout(60_000);
+
+describe('SSO Provisioning Atomicity', () => {
+	let oidcService: OidcService;
+	let userRepository: UserRepository;
+	let projectRelationRepository: ProjectRelationRepository;
+	let provisioningService: ProvisioningService;
+	let owner: Awaited<ReturnType<typeof createOwner>>;
+
+	beforeAll(async () => {
+		oidcService = Container.get(OidcService);
+		userRepository = Container.get(UserRepository);
+		projectRelationRepository = Container.get(ProjectRelationRepository);
+		provisioningService = Container.get(ProvisioningService);
+
+		await oidcService.init();
+		await provisioningService.init();
+
+		discoveryMock.mockResolvedValue(mockConfiguration);
+
+		const oidcConfig: OidcConfigDto = {
+			clientId: 'test-client-id',
+			clientSecret: 'test-client-secret',
+			discoveryEndpoint: 'https://example.com/.well-known/openid-configuration',
+			loginEnabled: true,
+			prompt: 'consent',
+			authenticationContextClassReference: [],
+		};
+		await oidcService.updateConfig(oidcConfig);
+
+		// Create owner (needed for team projects)
+		owner = await createOwner();
+
+		// Enable provisioning
+		// @ts-expect-error - provisioningConfig is private
+		provisioningService.provisioningConfig = {
+			scopesProvisionInstanceRole: true,
+			scopesProvisionProjectRoles: true,
+			scopesName: 'n8n',
+			scopesInstanceRoleClaimName: 'n8n_instance_role',
+			scopesProjectsRolesClaimName: 'n8n_projects',
+		};
+	});
+
+	beforeEach(() => {
+		discoveryMock.mockResolvedValue(mockConfiguration);
+	});
+
+	/**
+	 * Helper: perform OIDC login for a new user with given claims
+	 */
+	async function oidcLoginNewUser(email: string, extraClaims: Record<string, unknown>) {
+		const state = oidcService.generateState();
+		const nonce = oidcService.generateNonce();
+		const callbackUrl = new URL(
+			`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state.plaintext}`,
+		);
+
+		const claims = { sub: `oidc-sub-${Math.random()}`, ...extraClaims };
+		authorizationCodeGrantMock.mockResolvedValueOnce(createMockTokens(claims));
+		fetchUserInfoMock.mockResolvedValueOnce({ email_verified: true, email });
+
+		return await oidcService.loginUser(callbackUrl, state.signed, nonce.signed);
+	}
+
+	describe('OIDC new user provisioning', () => {
+		it('should create user with project role when provisioning project roles', async () => {
+			const project = await createTeamProject('OIDC Project Test', owner);
+
+			const user = await oidcLoginNewUser('oidc-project@test.com', {
+				n8n_projects: [`${project.id}:editor`],
+			});
+
+			expect(user).toBeDefined();
+			expect(user.email).toEqual('oidc-project@test.com');
+
+			// Verify user was assigned to the project
+			const relation = await projectRelationRepository.findOne({
+				where: { userId: user.id, projectId: project.id },
+				relations: ['role'],
+			});
+			expect(relation).toBeDefined();
+			expect(relation!.role.slug).toEqual('project:editor');
+		});
+
+		it('should create user with correct instance role when provisioning instance roles', async () => {
+			const user = await oidcLoginNewUser('oidc-instance@test.com', {
+				n8n_instance_role: 'global:admin',
+			});
+
+			expect(user).toBeDefined();
+			expect(user.email).toEqual('oidc-instance@test.com');
+
+			// Verify user has the correct instance role
+			const userFromDb = await userRepository.findOneOrFail({
+				where: { id: user.id },
+				relations: ['role'],
+			});
+			expect(userFromDb.role.slug).toEqual('global:admin');
+		});
+
+		it('should create user with both instance role and project role', async () => {
+			const project = await createTeamProject('OIDC Both Test', owner);
+
+			const user = await oidcLoginNewUser('oidc-both@test.com', {
+				n8n_instance_role: 'global:admin',
+				n8n_projects: [`${project.id}:editor`],
+			});
+
+			expect(user).toBeDefined();
+			expect(user.email).toEqual('oidc-both@test.com');
+
+			// Verify instance role
+			const userFromDb = await userRepository.findOneOrFail({
+				where: { id: user.id },
+				relations: ['role'],
+			});
+			expect(userFromDb.role.slug).toEqual('global:admin');
+
+			// Verify project role
+			const relation = await projectRelationRepository.findOne({
+				where: { userId: user.id, projectId: project.id },
+				relations: ['role'],
+			});
+			expect(relation).toBeDefined();
+			expect(relation!.role.slug).toEqual('project:editor');
+		});
+	});
+
+	describe('SAML new user provisioning (atomicity)', () => {
+		it('should roll back user creation when project role provisioning fails', async () => {
+			const project = await createTeamProject('SAML Project Fail Test', owner);
+
+			// Make addUser throw to simulate provisioning failure
+			const projectService = Container.get(ProjectService);
+			jest.spyOn(projectService, 'addUser').mockRejectedValueOnce(new Error('Provisioning failed'));
+
+			const { createUserFromSamlAttributes } = await import('@/modules/sso-saml/saml-helpers');
+
+			const samlAttributes = {
+				email: 'saml-project-fail@test.com',
+				firstName: 'Test',
+				lastName: 'User',
+				userPrincipalName: 'saml-project-fail@test.com',
+				n8nProjectRoles: [`${project.id}:editor`],
+			};
+
+			// Attempt to create user with provisioning that will fail
+			await expect(
+				createUserFromSamlAttributes(samlAttributes, async (user, trx) => {
+					await provisioningService.provisionProjectRolesForUser(
+						user.id,
+						samlAttributes.n8nProjectRoles,
+						trx,
+					);
+				}),
+			).rejects.toThrow();
+
+			// User should NOT exist — the entire transaction should have rolled back
+			const userInDb = await userRepository.findOne({
+				where: { email: 'saml-project-fail@test.com' },
+			});
+			expect(userInDb).toBeNull();
+		});
+
+		it('should roll back user creation when instance role provisioning fails', async () => {
+			// Make changeUserRole throw to simulate provisioning failure
+			const userService = Container.get(UserService);
+			jest
+				.spyOn(userService, 'changeUserRole')
+				.mockRejectedValueOnce(new Error('Role change failed'));
+
+			const { createUserFromSamlAttributes } = await import('@/modules/sso-saml/saml-helpers');
+
+			const samlAttributes = {
+				email: 'saml-instance-fail@test.com',
+				firstName: 'Test',
+				lastName: 'User',
+				userPrincipalName: 'saml-instance-fail@test.com',
+				n8nInstanceRole: 'global:admin',
+			};
+
+			await expect(
+				createUserFromSamlAttributes(samlAttributes, async (user, trx) => {
+					await provisioningService.provisionInstanceRoleForUser(
+						user,
+						samlAttributes.n8nInstanceRole,
+						trx,
+					);
+				}),
+			).rejects.toThrow();
+
+			// User should NOT exist — the entire transaction should have rolled back
+			const userInDb = await userRepository.findOne({
+				where: { email: 'saml-instance-fail@test.com' },
+			});
+			expect(userInDb).toBeNull();
+		});
+
+		it('should roll back everything when project provisioning fails after instance role succeeds', async () => {
+			const project = await createTeamProject('SAML Both Fail Test', owner);
+
+			// Make addUser throw ONLY (instance role provisioning succeeds, project role fails)
+			const projectService = Container.get(ProjectService);
+			jest.spyOn(projectService, 'addUser').mockRejectedValueOnce(new Error('Provisioning failed'));
+
+			const { createUserFromSamlAttributes } = await import('@/modules/sso-saml/saml-helpers');
+
+			const samlAttributes = {
+				email: 'saml-both-fail@test.com',
+				firstName: 'Test',
+				lastName: 'User',
+				userPrincipalName: 'saml-both-fail@test.com',
+				n8nInstanceRole: 'global:admin',
+				n8nProjectRoles: [`${project.id}:editor`],
+			};
+
+			await expect(
+				createUserFromSamlAttributes(samlAttributes, async (user, trx) => {
+					// Instance role provisioning succeeds
+					await provisioningService.provisionInstanceRoleForUser(
+						user,
+						samlAttributes.n8nInstanceRole,
+						trx,
+					);
+					// Project role provisioning fails
+					await provisioningService.provisionProjectRolesForUser(
+						user.id,
+						samlAttributes.n8nProjectRoles,
+						trx,
+					);
+				}),
+			).rejects.toThrow();
+
+			// User should NOT exist — entire transaction including instance role change should be rolled back
+			const userInDb = await userRepository.findOne({
+				where: { email: 'saml-both-fail@test.com' },
+			});
+			expect(userInDb).toBeNull();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Fixes a transaction boundary issue where new users logging in via OIDC with "Instance and project roles" provisioning enabled would get a foreign key constraint violation (PostgreSQL) or transaction deadlock (SQLite). The root cause was that user creation and role provisioning ran in separate database transactions — the provisioning transaction couldn't see the uncommitted user row.

- Thread a single `EntityManager` transaction through the entire SSO login flow (user creation + auth identity + provisioning) for both OIDC and SAML
- Make `trx` mandatory on `provisionInstanceRoleForUser` and `provisionProjectRolesForUser` to prevent future transaction boundary bugs
- Add optional `trx` to `changeUserRole` so it can participate in an outer transaction
- Restructure SAML `handleSamlLogin` so all three paths (existing user with identity, existing user first setup, new JIT user) are fully atomic — if provisioning fails, user creation is rolled back
- Add 6 integration tests covering OIDC provisioning (project roles, instance roles, combined) and SAML atomicity (rollback on project role failure, instance role failure, combined failure)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-409
Fixes https://github.com/n8n-io/n8n/issues/25984

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)