### PR TITLE
refactor(editor): Extract workflow document connections facade composable (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
@@ -72,6 +72,7 @@ export function useWorkflowState() {
 		}
 	}
 
+	/** @deprecated Use `workflowDocumentStore.removeAllConnections()` instead. */
 	function removeAllConnections(data: { setStateDirty: boolean }): void {
 		if (data?.setStateDirty) {
 			uiStore.markStateDirty();

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.test.ts
@@ -7,6 +7,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
+import { NodeConnectionTypes } from 'n8n-workflow';
 import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
@@ -18,6 +19,7 @@ import type { INodeUi } from '@/Interface';
 vi.mock('@/app/stores/nodeTypes.store', () => ({
 	useNodeTypesStore: vi.fn(() => ({
 		getNodeType: vi.fn().mockReturnValue(null),
+		communityNodeType: vi.fn().mockReturnValue(null),
 	})),
 }));
 
@@ -30,21 +32,26 @@ describe('workflowDocument.store orchestration', () => {
 		setActivePinia(createPinia());
 	});
 
-	it('removeAllNodes clears both nodes and pin data', () => {
+	it('removeAllNodes clears nodes, connections, and pin data', () => {
 		const store = useWorkflowDocumentStore(createWorkflowDocumentId('test-wf'));
 
-		// Set up nodes and pin data
+		// Set up nodes, connections, and pin data
 		store.setNodes([createNode({ name: 'A' }), createNode({ name: 'B' })]);
+		store.setConnections({
+			A: { main: [[{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]] },
+		});
 		store.setPinData({ A: [{ json: { value: 1 } }] });
 
-		// Verify both are populated
+		// Verify all are populated
 		expect(store.allNodes).toHaveLength(2);
+		expect(store.connectionsBySourceNode).toHaveProperty('A');
 		expect(store.pinData).toHaveProperty('A');
 
-		// removeAllNodes should clear both
+		// removeAllNodes should clear all three
 		store.removeAllNodes();
 
 		expect(store.allNodes).toHaveLength(0);
+		expect(store.connectionsBySourceNode).toEqual({});
 		expect(store.pinData).toEqual({});
 	});
 
@@ -58,6 +65,27 @@ describe('workflowDocument.store orchestration', () => {
 
 		// addNode fires onStateDirty, which the store wires to markStateDirty
 		store.addNode(createNode({ name: 'A' }));
+
+		expect(uiStore.stateIsDirty).toBe(true);
+	});
+
+	it('connection mutation triggers markStateDirty on UI store', () => {
+		const store = useWorkflowDocumentStore(createWorkflowDocumentId('test-wf'));
+		const uiStore = useUIStore();
+
+		store.setNodes([createNode({ name: 'A' }), createNode({ name: 'B' })]);
+
+		// Start clean
+		uiStore.markStateClean();
+		expect(uiStore.stateIsDirty).toBe(false);
+
+		// addConnection fires onStateDirty, which the store wires to markStateDirty
+		store.addConnection({
+			connection: [
+				{ node: 'A', type: NodeConnectionTypes.Main, index: 0 },
+				{ node: 'B', type: NodeConnectionTypes.Main, index: 0 },
+			],
+		});
 
 		expect(uiStore.stateIsDirty).toBe(true);
 	});

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -16,6 +16,7 @@ import { useWorkflowDocumentParentFolder } from './workflowDocument/useWorkflowD
 import { useWorkflowDocumentUsedCredentials } from './workflowDocument/useWorkflowDocumentUsedCredentials';
 import { useWorkflowDocumentNodes } from './workflowDocument/useWorkflowDocumentNodes';
 import { useWorkflowDocumentViewport } from './workflowDocument/useWorkflowDocumentViewport';
+import { useWorkflowDocumentConnections } from './workflowDocument/useWorkflowDocumentConnections';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 
@@ -73,22 +74,27 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 		const workflowDocumentUsedCredentials = useWorkflowDocumentUsedCredentials();
 		const workflowDocumentViewport = useWorkflowDocumentViewport();
 		const nodeTypesStore = useNodeTypesStore();
-		const { onStateDirty, ...workflowDocumentNodes } = useWorkflowDocumentNodes({
+		const { onStateDirty: onNodesStateDirty, ...workflowDocumentNodes } = useWorkflowDocumentNodes({
 			getNodeType: (typeName, version) => nodeTypesStore.getNodeType(typeName, version),
 		});
+		const { onStateDirty: onConnectionsStateDirty, ...workflowDocumentConnections } =
+			useWorkflowDocumentConnections({
+				getNodeById: (id) => workflowDocumentNodes.getNodeById(id),
+			});
 
 		// --- Cross-cut orchestration ---
 		// Each composable is self-contained and unaware of its siblings. This
 		// store is where cross-concern side effects are wired. When adding new
-		// composables (e.g. connections), check workflowsStore for hidden
-		// cross-cuts that need to surface here. Known future ones:
+		// composables, check workflowsStore for hidden cross-cuts that need to
+		// surface here. Known future ones:
 		//   - removeNode → unpinNodeData (currently in workflowsStore.removeNode)
-		//   - removeAllNodes → removeAllConnections (when connections composable exists)
 
-		onStateDirty(() => useUIStore().markStateDirty());
+		onNodesStateDirty(() => useUIStore().markStateDirty());
+		onConnectionsStateDirty(() => useUIStore().markStateDirty());
 
 		function removeAllNodes() {
 			workflowDocumentNodes.removeAllNodes();
+			workflowDocumentConnections.removeAllConnections();
 			workflowDocumentPinData.setPinData({});
 		}
 
@@ -109,6 +115,7 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 			...workflowDocumentUsedCredentials,
 			...workflowDocumentViewport,
 			...workflowDocumentNodes,
+			...workflowDocumentConnections,
 			removeAllNodes,
 		};
 	})();

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentConnections.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentConnections.test.ts
@@ -1,0 +1,504 @@
+/**
+ * Integration tests for useWorkflowDocumentConnections.
+ *
+ * These tests use a real Pinia store (createPinia, not createTestingPinia) so
+ * that every write goes through the actual workflowsStore and every read comes
+ * back through the public API. This "round-trip" pattern (write → read back →
+ * assert) is intentional:
+ *
+ *  - It catches regressions when consumers migrate from workflowsStore to
+ *    workflowDocumentStore — the round-trip proves both paths produce the same
+ *    result.
+ *  - It survives internal refactors. When the internals change (e.g. owning
+ *    its own refs instead of delegating), these tests stay unchanged because
+ *    they only exercise the public contract.
+ *  - Delegation-style tests (expect(store.method).toHaveBeenCalled()) would
+ *    need to be rewritten every time internals change; round-trips do not.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import type { IConnection, NodeConnectionType } from 'n8n-workflow';
+import { NodeConnectionTypes } from 'n8n-workflow';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { createTestNode } from '@/__tests__/mocks';
+import type { INodeUi } from '@/Interface';
+import {
+	useWorkflowDocumentConnections,
+	type WorkflowDocumentConnectionsDeps,
+} from './useWorkflowDocumentConnections';
+
+function createNode(overrides: Partial<INodeUi> = {}): INodeUi {
+	return createTestNode({ name: 'Test Node', ...overrides }) as INodeUi;
+}
+
+function createDeps(
+	overrides: Partial<WorkflowDocumentConnectionsDeps> = {},
+): WorkflowDocumentConnectionsDeps {
+	return {
+		getNodeById: vi.fn().mockReturnValue(undefined),
+		...overrides,
+	};
+}
+
+/**
+ * Helper to create the connection data format expected by addConnection/removeConnection.
+ * Returns { connection: [sourceConnection, destinationConnection] }.
+ */
+function createConnectionData(
+	sourceNode: string,
+	destNode: string,
+	opts: { sourceIndex?: number; destIndex?: number; type?: NodeConnectionType } = {},
+): { connection: IConnection[] } {
+	const type = opts.type ?? NodeConnectionTypes.Main;
+	return {
+		connection: [
+			{ node: sourceNode, type, index: opts.sourceIndex ?? 0 },
+			{ node: destNode, type, index: opts.destIndex ?? 0 },
+		],
+	};
+}
+
+describe('useWorkflowDocumentConnections', () => {
+	let workflowsStore: ReturnType<typeof useWorkflowsStore>;
+	let deps: WorkflowDocumentConnectionsDeps;
+
+	beforeEach(() => {
+		setActivePinia(createPinia());
+		workflowsStore = useWorkflowsStore();
+		deps = createDeps();
+
+		// Ensure connections are clean — workflowObject may retain state
+		// from a previous test if the Workflow class caches internally.
+		workflowsStore.setConnections({});
+	});
+
+	describe('round-trip: setConnections → read', () => {
+		it('connections set via setConnections are readable via connectionsBySourceNode', () => {
+			const connections = {
+				A: { main: [[{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]] },
+			};
+
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.setConnections(connections);
+
+			expect(composable.connectionsBySourceNode.value).toEqual(connections);
+		});
+
+		it('connections set via setConnections are readable via connectionsByDestinationNode', () => {
+			const connections = {
+				A: { main: [[{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]] },
+			};
+
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.setConnections(connections);
+
+			// connectionsByDestinationNode inverts: keyed by destination node
+			expect(composable.connectionsByDestinationNode.value).toHaveProperty('B');
+		});
+
+		it('outgoingConnectionsByNodeName returns connections for existing node', () => {
+			const connections = {
+				A: { main: [[{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]] },
+			};
+
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.setConnections(connections);
+
+			const outgoing = composable.outgoingConnectionsByNodeName('A');
+			expect(outgoing.main).toBeDefined();
+			expect(outgoing.main[0]).toEqual([{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]);
+		});
+
+		it('outgoingConnectionsByNodeName returns empty object for unknown node', () => {
+			const composable = useWorkflowDocumentConnections(deps);
+
+			expect(composable.outgoingConnectionsByNodeName('NonExistent')).toEqual({});
+		});
+
+		it('incomingConnectionsByNodeName returns connections for existing node', () => {
+			const connections = {
+				A: { main: [[{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]] },
+			};
+
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.setConnections(connections);
+
+			const incoming = composable.incomingConnectionsByNodeName('B');
+			expect(incoming.main).toBeDefined();
+		});
+
+		it('incomingConnectionsByNodeName returns empty object for unknown node', () => {
+			const composable = useWorkflowDocumentConnections(deps);
+
+			expect(composable.incomingConnectionsByNodeName('NonExistent')).toEqual({});
+		});
+
+		it('nodeHasOutputConnection returns true when node has outgoing connections', () => {
+			const connections = {
+				A: { main: [[{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]] },
+			};
+
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.setConnections(connections);
+
+			expect(composable.nodeHasOutputConnection('A')).toBe(true);
+		});
+
+		it('nodeHasOutputConnection returns false when node has no outgoing connections', () => {
+			const composable = useWorkflowDocumentConnections(deps);
+
+			expect(composable.nodeHasOutputConnection('A')).toBe(false);
+		});
+	});
+
+	describe('round-trip: addConnection → read', () => {
+		it('connection added via addConnection is readable via connectionsBySourceNode', () => {
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.addConnection(createConnectionData('A', 'B'));
+
+			const connections = composable.connectionsBySourceNode.value;
+			expect(connections.A).toBeDefined();
+			expect(connections.A.main[0]).toEqual(
+				expect.arrayContaining([{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]),
+			);
+		});
+
+		it('addConnection skips duplicate connections', () => {
+			const composable = useWorkflowDocumentConnections(deps);
+
+			composable.addConnection(createConnectionData('A', 'B'));
+			composable.addConnection(createConnectionData('A', 'B'));
+
+			const connections = composable.connectionsBySourceNode.value;
+			expect(connections.A.main[0]).toHaveLength(1);
+		});
+
+		it('addConnection with multiple connections to same source creates correct structure', () => {
+			const composable = useWorkflowDocumentConnections(deps);
+
+			composable.addConnection(createConnectionData('A', 'B'));
+			composable.addConnection(createConnectionData('A', 'C'));
+
+			const connections = composable.connectionsBySourceNode.value;
+			expect(connections.A.main[0]).toHaveLength(2);
+			expect(connections.A.main[0]).toEqual(
+				expect.arrayContaining([
+					{ node: 'B', type: NodeConnectionTypes.Main, index: 0 },
+					{ node: 'C', type: NodeConnectionTypes.Main, index: 0 },
+				]),
+			);
+		});
+	});
+
+	describe('round-trip: removeConnection → read', () => {
+		it('removeConnection removes a connection from connectionsBySourceNode', () => {
+			const composable = useWorkflowDocumentConnections(deps);
+
+			// Verify clean state
+			expect(composable.connectionsBySourceNode.value).toEqual({});
+
+			composable.addConnection(createConnectionData('A', 'B'));
+
+			const conns = composable.connectionsBySourceNode.value.A.main[0];
+			expect(conns).toHaveLength(1);
+
+			composable.removeConnection(createConnectionData('A', 'B'));
+			expect(composable.connectionsBySourceNode.value.A.main[0]).toHaveLength(0);
+		});
+
+		it('removeConnection is a no-op when source node does not exist', () => {
+			const composable = useWorkflowDocumentConnections(deps);
+
+			// Should not throw — workflowsStore.removeConnection silently returns
+			composable.removeConnection(createConnectionData('NonExistent', 'B'));
+
+			// No connection for NonExistent was created
+			expect(composable.nodeHasOutputConnection('NonExistent')).toBe(false);
+		});
+	});
+
+	describe('round-trip: removeAllNodeConnection → read', () => {
+		it('removeAllNodeConnection removes all connections for a node', () => {
+			const nodeA = createNode({ name: 'A' });
+
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.addConnection(createConnectionData('A', 'B'));
+			composable.addConnection(createConnectionData('C', 'A'));
+
+			composable.removeAllNodeConnection(nodeA);
+
+			// Outgoing from A should be gone
+			expect(composable.nodeHasOutputConnection('A')).toBe(false);
+			// Incoming to A (from C) should also be gone
+			const cConnections = composable.connectionsBySourceNode.value.C?.main?.[0] ?? [];
+			const connectionsToA = cConnections.filter((c) => c.node === 'A');
+			expect(connectionsToA).toHaveLength(0);
+		});
+
+		it('removeAllNodeConnection with preserveInputConnections keeps incoming', () => {
+			const nodeA = createNode({ name: 'A' });
+
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.addConnection(createConnectionData('A', 'B'));
+			composable.addConnection(createConnectionData('C', 'A'));
+
+			composable.removeAllNodeConnection(nodeA, { preserveInputConnections: true });
+
+			// Outgoing from A should be gone
+			expect(composable.nodeHasOutputConnection('A')).toBe(false);
+			// Incoming to A (from C) should still exist
+			const cConnections = composable.connectionsBySourceNode.value.C?.main?.[0] ?? [];
+			const connectionsToA = cConnections.filter((c) => c.node === 'A');
+			expect(connectionsToA).toHaveLength(1);
+		});
+
+		it('removeAllNodeConnection with preserveOutputConnections keeps outgoing', () => {
+			const nodeA = createNode({ name: 'A' });
+
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.addConnection(createConnectionData('A', 'B'));
+			composable.addConnection(createConnectionData('C', 'A'));
+
+			composable.removeAllNodeConnection(nodeA, { preserveOutputConnections: true });
+
+			// Outgoing from A should still exist
+			expect(composable.nodeHasOutputConnection('A')).toBe(true);
+			// Incoming to A (from C) should be gone
+			const cConnections = composable.connectionsBySourceNode.value.C?.main?.[0] ?? [];
+			const connectionsToA = cConnections.filter((c) => c.node === 'A');
+			expect(connectionsToA).toHaveLength(0);
+		});
+	});
+
+	describe('round-trip: removeNodeConnectionsById → read', () => {
+		it('removeNodeConnectionsById removes connections by resolving node ID via deps', () => {
+			const nodeA = createNode({ name: 'A' });
+			const customDeps = createDeps({
+				getNodeById: vi.fn().mockReturnValue(nodeA),
+			});
+
+			const composable = useWorkflowDocumentConnections(customDeps);
+			composable.addConnection(createConnectionData('A', 'B'));
+
+			composable.removeNodeConnectionsById(nodeA.id);
+
+			expect(composable.nodeHasOutputConnection('A')).toBe(false);
+		});
+
+		it('removeNodeConnectionsById is a no-op when node ID not found', () => {
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.addConnection(createConnectionData('A', 'B'));
+
+			// deps.getNodeById returns undefined by default
+			composable.removeNodeConnectionsById('nonexistent');
+
+			// Connection should still exist
+			expect(composable.nodeHasOutputConnection('A')).toBe(true);
+		});
+	});
+
+	describe('round-trip: removeAllConnections → read', () => {
+		it('removeAllConnections clears all connections', () => {
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.addConnection(createConnectionData('A', 'B'));
+			composable.addConnection(createConnectionData('B', 'C'));
+
+			composable.removeAllConnections();
+
+			expect(composable.connectionsBySourceNode.value).toEqual({});
+		});
+	});
+
+	describe('isNodeInOutgoingNodeConnections', () => {
+		it('returns true when search node is a direct successor', () => {
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.addConnection(createConnectionData('A', 'B'));
+
+			expect(composable.isNodeInOutgoingNodeConnections('A', 'B')).toBe(true);
+		});
+
+		it('returns true when search node is a transitive successor', () => {
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.addConnection(createConnectionData('A', 'B'));
+			composable.addConnection(createConnectionData('B', 'C'));
+
+			expect(composable.isNodeInOutgoingNodeConnections('A', 'C')).toBe(true);
+		});
+
+		it('returns false when search node is not connected', () => {
+			const composable = useWorkflowDocumentConnections(deps);
+
+			// Only A → B exists, D is completely disconnected
+			composable.setConnections({
+				A: { main: [[{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]] },
+			});
+
+			expect(composable.isNodeInOutgoingNodeConnections('A', 'D')).toBe(false);
+		});
+
+		it('respects depth limit', () => {
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.addConnection(createConnectionData('A', 'B'));
+			composable.addConnection(createConnectionData('B', 'C'));
+
+			// Depth 1: only check direct successors — C is 2 hops away
+			expect(composable.isNodeInOutgoingNodeConnections('A', 'C', 1)).toBe(false);
+			// Depth 2: check 2 hops — C is reachable
+			expect(composable.isNodeInOutgoingNodeConnections('A', 'C', 2)).toBe(true);
+		});
+	});
+
+	describe('events', () => {
+		it('setConnections does not fire onConnectionsChange (initialization path)', () => {
+			const hookSpy = vi.fn();
+
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.onConnectionsChange(hookSpy);
+			composable.setConnections({
+				A: { main: [[{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]] },
+			});
+
+			expect(hookSpy).not.toHaveBeenCalled();
+		});
+
+		it('setConnections does not fire onStateDirty (initialization path)', () => {
+			const dirtySpy = vi.fn();
+
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.onStateDirty(dirtySpy);
+			composable.setConnections({
+				A: { main: [[{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]] },
+			});
+
+			expect(dirtySpy).not.toHaveBeenCalled();
+		});
+
+		it('addConnection fires onConnectionsChange with ADD action', () => {
+			const hookSpy = vi.fn();
+			const connectionData = createConnectionData('A', 'B');
+
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.onConnectionsChange(hookSpy);
+			composable.addConnection(connectionData);
+
+			expect(hookSpy).toHaveBeenCalledWith({
+				action: 'add',
+				payload: { connection: connectionData.connection },
+			});
+		});
+
+		it('addConnection fires onStateDirty', () => {
+			const dirtySpy = vi.fn();
+
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.onStateDirty(dirtySpy);
+			composable.addConnection(createConnectionData('A', 'B'));
+
+			expect(dirtySpy).toHaveBeenCalledOnce();
+		});
+
+		it('removeConnection fires onConnectionsChange with DELETE action', () => {
+			const hookSpy = vi.fn();
+			const connectionData = createConnectionData('A', 'B');
+
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.addConnection(connectionData);
+			composable.onConnectionsChange(hookSpy);
+			composable.removeConnection(connectionData);
+
+			expect(hookSpy).toHaveBeenCalledWith({
+				action: 'delete',
+				payload: { connection: connectionData.connection },
+			});
+		});
+
+		it('removeConnection fires onStateDirty', () => {
+			const dirtySpy = vi.fn();
+
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.addConnection(createConnectionData('A', 'B'));
+			composable.onStateDirty(dirtySpy);
+			composable.removeConnection(createConnectionData('A', 'B'));
+
+			expect(dirtySpy).toHaveBeenCalledOnce();
+		});
+
+		it('removeAllNodeConnection fires onConnectionsChange with DELETE action', () => {
+			const hookSpy = vi.fn();
+			const nodeA = createNode({ name: 'A' });
+
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.addConnection(createConnectionData('A', 'B'));
+			composable.onConnectionsChange(hookSpy);
+			composable.removeAllNodeConnection(nodeA);
+
+			expect(hookSpy).toHaveBeenCalledWith({
+				action: 'delete',
+				payload: { nodeName: 'A' },
+			});
+		});
+
+		it('removeAllNodeConnection fires onStateDirty', () => {
+			const dirtySpy = vi.fn();
+			const nodeA = createNode({ name: 'A' });
+
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.addConnection(createConnectionData('A', 'B'));
+			composable.onStateDirty(dirtySpy);
+			composable.removeAllNodeConnection(nodeA);
+
+			expect(dirtySpy).toHaveBeenCalledOnce();
+		});
+
+		it('removeNodeConnectionsById fires onStateDirty when node is found', () => {
+			const dirtySpy = vi.fn();
+			const nodeA = createNode({ name: 'A' });
+			const customDeps = createDeps({
+				getNodeById: vi.fn().mockReturnValue(nodeA),
+			});
+
+			const composable = useWorkflowDocumentConnections(customDeps);
+			composable.addConnection(createConnectionData('A', 'B'));
+			composable.onStateDirty(dirtySpy);
+			composable.removeNodeConnectionsById(nodeA.id);
+
+			expect(dirtySpy).toHaveBeenCalledOnce();
+		});
+
+		it('removeNodeConnectionsById does not fire events when node not found', () => {
+			const hookSpy = vi.fn();
+			const dirtySpy = vi.fn();
+
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.addConnection(createConnectionData('A', 'B'));
+			composable.onConnectionsChange(hookSpy);
+			composable.onStateDirty(dirtySpy);
+			composable.removeNodeConnectionsById('nonexistent');
+
+			expect(hookSpy).not.toHaveBeenCalled();
+			expect(dirtySpy).not.toHaveBeenCalled();
+		});
+
+		it('removeAllConnections does not fire onConnectionsChange (reset path)', () => {
+			const hookSpy = vi.fn();
+
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.addConnection(createConnectionData('A', 'B'));
+			composable.onConnectionsChange(hookSpy);
+			composable.removeAllConnections();
+
+			expect(hookSpy).not.toHaveBeenCalled();
+		});
+
+		it('removeAllConnections does not fire onStateDirty (reset path)', () => {
+			const dirtySpy = vi.fn();
+
+			const composable = useWorkflowDocumentConnections(deps);
+			composable.addConnection(createConnectionData('A', 'B'));
+			composable.onStateDirty(dirtySpy);
+			composable.removeAllConnections();
+
+			expect(dirtySpy).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentConnections.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentConnections.ts
@@ -1,0 +1,167 @@
+import { computed } from 'vue';
+import { createEventHook } from '@vueuse/core';
+import type { IConnection, IConnections, INodeConnections } from 'n8n-workflow';
+import type { INodeUi } from '@/Interface';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { CHANGE_ACTION } from './types';
+import type { ChangeEvent } from './types';
+
+// --- Event types ---
+
+export type ConnectionAddedPayload = { connection: IConnection[] };
+export type ConnectionRemovedPayload = { connection: IConnection[] };
+export type AllNodeConnectionsRemovedPayload = { nodeName: string };
+
+export type ConnectionsChangeEvent =
+	| ChangeEvent<ConnectionAddedPayload>
+	| ChangeEvent<ConnectionRemovedPayload>
+	| ChangeEvent<AllNodeConnectionsRemovedPayload>;
+
+// --- Deps ---
+
+export interface WorkflowDocumentConnectionsDeps {
+	getNodeById: (id: string) => INodeUi | undefined;
+}
+
+// --- Composable ---
+
+// TODO: This composable currently delegates to workflowsStore for reads and writes.
+// The long-term goal is to remove workflowsStore entirely — connections will become
+// private state owned by workflowDocumentStore. Once that happens, the direct import
+// (and the import-cycle warning it causes) will go away.
+export function useWorkflowDocumentConnections(deps: WorkflowDocumentConnectionsDeps) {
+	const workflowsStore = useWorkflowsStore();
+
+	const onConnectionsChange = createEventHook<ConnectionsChangeEvent>();
+	// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+	const onStateDirty = createEventHook<void>();
+
+	// -----------------------------------------------------------------------
+	// Apply methods (private) — the only functions that mutate state
+	// -----------------------------------------------------------------------
+
+	function applySetConnections(value: IConnections) {
+		workflowsStore.setConnections(value);
+	}
+
+	function applyAddConnection(data: { connection: IConnection[] }) {
+		workflowsStore.addConnection(data);
+		void onConnectionsChange.trigger({
+			action: CHANGE_ACTION.ADD,
+			payload: { connection: data.connection },
+		});
+		void onStateDirty.trigger();
+	}
+
+	function applyRemoveConnection(data: { connection: IConnection[] }) {
+		workflowsStore.removeConnection(data);
+		void onConnectionsChange.trigger({
+			action: CHANGE_ACTION.DELETE,
+			payload: { connection: data.connection },
+		});
+		void onStateDirty.trigger();
+	}
+
+	function applyRemoveAllNodeConnection(
+		node: INodeUi,
+		opts?: { preserveInputConnections?: boolean; preserveOutputConnections?: boolean },
+	) {
+		workflowsStore.removeAllNodeConnection(node, opts);
+		void onConnectionsChange.trigger({
+			action: CHANGE_ACTION.DELETE,
+			payload: { nodeName: node.name },
+		});
+		void onStateDirty.trigger();
+	}
+
+	function applyRemoveAllConnections() {
+		workflowsStore.setConnections({});
+	}
+
+	// -----------------------------------------------------------------------
+	// Read API
+	// -----------------------------------------------------------------------
+
+	const connectionsBySourceNode = computed<IConnections>(
+		() => workflowsStore.connectionsBySourceNode,
+	);
+
+	const connectionsByDestinationNode = computed<IConnections>(
+		() => workflowsStore.connectionsByDestinationNode,
+	);
+
+	function outgoingConnectionsByNodeName(nodeName: string): INodeConnections {
+		return workflowsStore.outgoingConnectionsByNodeName(nodeName);
+	}
+
+	function incomingConnectionsByNodeName(nodeName: string): INodeConnections {
+		return workflowsStore.incomingConnectionsByNodeName(nodeName);
+	}
+
+	function nodeHasOutputConnection(nodeName: string): boolean {
+		return workflowsStore.nodeHasOutputConnection(nodeName);
+	}
+
+	function isNodeInOutgoingNodeConnections(
+		rootNodeName: string,
+		searchNodeName: string,
+		depth = -1,
+	): boolean {
+		return workflowsStore.isNodeInOutgoingNodeConnections(rootNodeName, searchNodeName, depth);
+	}
+
+	// -----------------------------------------------------------------------
+	// Write API
+	// -----------------------------------------------------------------------
+
+	function setConnections(value: IConnections): void {
+		applySetConnections(value);
+	}
+
+	function addConnection(data: { connection: IConnection[] }): void {
+		applyAddConnection(data);
+	}
+
+	function removeConnection(data: { connection: IConnection[] }): void {
+		applyRemoveConnection(data);
+	}
+
+	function removeAllNodeConnection(
+		node: INodeUi,
+		opts?: { preserveInputConnections?: boolean; preserveOutputConnections?: boolean },
+	): void {
+		applyRemoveAllNodeConnection(node, opts);
+	}
+
+	function removeNodeConnectionsById(nodeId: string): void {
+		const node = deps.getNodeById(nodeId);
+		if (!node) return;
+		applyRemoveAllNodeConnection(node);
+	}
+
+	function removeAllConnections(): void {
+		applyRemoveAllConnections();
+	}
+
+	return {
+		// Read
+		connectionsBySourceNode,
+		connectionsByDestinationNode,
+		outgoingConnectionsByNodeName,
+		incomingConnectionsByNodeName,
+		nodeHasOutputConnection,
+		isNodeInOutgoingNodeConnections,
+
+		// Write
+		setConnections,
+		addConnection,
+		removeConnection,
+		removeAllNodeConnection,
+		removeNodeConnectionsById,
+		removeAllConnections,
+
+		// Events
+		onConnectionsChange: onConnectionsChange.on,
+		onStateDirty: onStateDirty.on,
+	};
+}

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -195,6 +195,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		return workflowExecutionData.value.data.resultData.runData;
 	});
 
+	/** @deprecated Use `workflowDocumentStore.allConnections` instead. */
 	const allConnections = computed(() => workflow.value.connections);
 
 	/** @deprecated Use `workflowDocumentStore.allNodes` instead. */
@@ -340,7 +341,9 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	 * This section contains functions migrated from the workflow class
 	 */
 
+	/** @deprecated Use `workflowDocumentStore.connectionsBySourceNode` instead. */
 	const connectionsBySourceNode = computed(() => workflow.value.connections);
+	/** @deprecated Use `workflowDocumentStore.connectionsByDestinationNode` instead. */
 	const connectionsByDestinationNode = computed(() =>
 		workflowUtils.mapConnectionsByDestination(workflow.value.connections),
 	);
@@ -397,6 +400,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		return getWorkflowRunData.value[nodeName];
 	}
 
+	/** @deprecated Use `workflowDocumentStore.outgoingConnectionsByNodeName()` instead. */
 	function outgoingConnectionsByNodeName(nodeName: string): INodeConnections {
 		if (workflow.value.connections.hasOwnProperty(nodeName)) {
 			return workflow.value.connections[nodeName] as unknown as INodeConnections;
@@ -404,6 +408,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		return {};
 	}
 
+	/** @deprecated Use `workflowDocumentStore.incomingConnectionsByNodeName()` instead. */
 	function incomingConnectionsByNodeName(nodeName: string): INodeConnections {
 		if (connectionsByDestinationNode.value.hasOwnProperty(nodeName)) {
 			return connectionsByDestinationNode.value[nodeName] as unknown as INodeConnections;
@@ -411,10 +416,12 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		return {};
 	}
 
+	/** @deprecated Use `workflowDocumentStore.nodeHasOutputConnection()` instead. */
 	function nodeHasOutputConnection(nodeName: string): boolean {
 		return workflow.value.connections.hasOwnProperty(nodeName);
 	}
 
+	/** @deprecated Use `workflowDocumentStore.isNodeInOutgoingNodeConnections()` instead. */
 	function isNodeInOutgoingNodeConnections(
 		rootNodeName: string,
 		searchNodeName: string,
@@ -845,6 +852,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		);
 	}
 
+	/** @deprecated Use `workflowDocumentStore.addConnection()` instead. */
 	function addConnection(data: { connection: IConnection[] }): void {
 		if (data.connection.length !== 2) {
 			// All connections need two entries
@@ -912,6 +920,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		workflowObject.value.setConnections(workflow.value.connections);
 	}
 
+	/** @deprecated Use `workflowDocumentStore.removeConnection()` instead. */
 	function removeConnection(data: { connection: IConnection[] }): void {
 		const sourceData = data.connection[0];
 		const destinationData = data.connection[1];
@@ -953,6 +962,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		workflowObject.value.setConnections(workflow.value.connections);
 	}
 
+	/** @deprecated Use `workflowDocumentStore.removeAllNodeConnection()` instead. */
 	function removeAllNodeConnection(
 		node: INodeUi,
 		{ preserveInputConnections = false, preserveOutputConnections = false } = {},
@@ -1080,6 +1090,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		workflowObject.value.setNodes(nodes);
 	}
 
+	/** @deprecated Use `workflowDocumentStore.setConnections()` instead. */
 	function setConnections(value: IConnections): void {
 		workflow.value.connections = value;
 		workflowObject.value.setConnections(value);


### PR DESCRIPTION
## Summary

Extract connection management into a dedicated composable following the apply/public pattern used by other workflowDocument composables. This prepares the codebase for eventually removing the workflowsStore dependency.

Wire cross-cutting concerns (dirty state tracking, removeAllNodes cleanup) in the orchestration store. Add comprehensive integration tests covering all public methods, events, and edge cases.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2633/create-useworkflowdocumentconnections-facade-and-eslint-migration

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
