### PR TITLE
feat(instance-ai): add rolling compaction with centralized model registry

### DIFF
--- a/packages/@n8n/api-types/src/schemas/agent-run-reducer.ts
+++ b/packages/@n8n/api-types/src/schemas/agent-run-reducer.ts
@@ -33,6 +33,8 @@ export interface AgentNode {
 	subtitle?: string;
 	goal?: string;
 	targetResource?: InstanceAiTargetResource;
+	/** Transient status message (e.g. "Recalling conversation..."). Cleared when empty. */
+	statusMessage?: string;
 	status: InstanceAiAgentStatus;
 	textContent: string;
 	reasoning: string;
@@ -316,6 +318,14 @@ export function reduceEvent(state: AgentRunState, event: InstanceAiEvent): Agent
 			break;
 		}
 
+		case 'status': {
+			const agent = ensureAgent(state, event.agentId);
+			if (agent) {
+				agent.statusMessage = event.payload.message || undefined;
+			}
+			break;
+		}
+
 		case 'error': {
 			const errorText = '\n\n*Error: ' + event.payload.content + '*';
 			const agent = ensureAgent(state, event.agentId);
@@ -410,6 +420,7 @@ function buildNodeRecursive(state: AgentRunState, agentId: string): InstanceAiAg
 		subtitle: agent?.subtitle,
 		goal: agent?.goal,
 		targetResource: agent?.targetResource,
+		statusMessage: agent?.statusMessage,
 		status: agent?.status ?? 'active',
 		textContent: agent?.textContent ?? '',
 		reasoning: agent?.reasoning ?? '',

--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -26,6 +26,7 @@ export const instanceAiEventTypeSchema = z.enum([
 	'confirmation-request',
 	'tasks-update',
 	'filesystem-request',
+	'status',
 	'error',
 ]);
 export type InstanceAiEventType = z.infer<typeof instanceAiEventTypeSchema>;
@@ -178,6 +179,10 @@ export const confirmationRequestPayloadSchema = z.object({
 		.describe('When present, renders domain-access approval UI instead of generic confirm'),
 });
 
+export const statusPayloadSchema = z.object({
+	message: z.string().describe('Transient status message. Empty string clears the indicator.'),
+});
+
 export const errorPayloadSchema = z.object({
 	content: z.string(),
 	statusCode: z.number().optional(),
@@ -302,6 +307,7 @@ export const instanceAiEventSchema = z.discriminatedUnion('type', [
 		payload: confirmationRequestPayloadSchema,
 	}),
 	z.object({ type: z.literal('tasks-update'), ...eventBase, payload: tasksUpdatePayloadSchema }),
+	z.object({ type: z.literal('status'), ...eventBase, payload: statusPayloadSchema }),
 	z.object({ type: z.literal('error'), ...eventBase, payload: errorPayloadSchema }),
 	z.object({
 		type: z.literal('filesystem-request'),
@@ -331,6 +337,7 @@ export type InstanceAiConfirmationRequestEvent = Extract<
 	{ type: 'confirmation-request' }
 >;
 export type InstanceAiTasksUpdateEvent = Extract<InstanceAiEvent, { type: 'tasks-update' }>;
+export type InstanceAiStatusEvent = Extract<InstanceAiEvent, { type: 'status' }>;
 export type InstanceAiErrorEvent = Extract<InstanceAiEvent, { type: 'error' }>;
 export type InstanceAiFilesystemRequestEvent = Extract<
 	InstanceAiEvent,
@@ -416,6 +423,8 @@ export interface InstanceAiAgentNode {
 	goal?: string;
 	/** Resource this agent works on. */
 	targetResource?: InstanceAiTargetResource;
+	/** Transient status message (e.g. "Recalling conversation..."). Cleared when empty. */
+	statusMessage?: string;
 	status: InstanceAiAgentStatus;
 	textContent: string;
 	reasoning: string;

--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -86,6 +86,10 @@ Keep exploration shallow — start at depth 1-2, prefer \`search-files\` over br
 You do NOT have access to the user's project files. The filesystem tools (list-files, read-file, search-files, get-file-tree) are not available. Do not attempt to use them or claim you can browse the user's codebase.`
 }
 
+## Conversation Summary
+
+When \`<conversation-summary>\` is present in your input, treat it as compressed prior context from earlier turns. Use the recent raw messages for exact wording and details; use the summary for long-range continuity (user goals, past decisions, workflow state). Do not repeat the summary back to the user.
+
 ## Background Tasks
 
 Workflow builds and data table operations run in the background. Acknowledge briefly ("Building your Gmail → Slack workflow.") and move on. When \`<background-tasks>\` context reports a completed task, confirm the result. If a task failed, explain concisely and offer to retry.

--- a/packages/@n8n/instance-ai/src/compaction/compaction-helper.ts
+++ b/packages/@n8n/instance-ai/src/compaction/compaction-helper.ts
@@ -1,0 +1,75 @@
+import { Agent } from '@mastra/core/agent';
+
+import type { ModelConfig } from '../types';
+
+const COMPACTION_SYSTEM_PROMPT = `You are a conversation summarizer for an AI assistant embedded in n8n (a workflow automation platform).
+
+Given a previous summary (if any) and a batch of new conversation turns, produce an updated rolling summary.
+
+## Output format
+
+Return exactly five sections with these headers, no other text:
+
+### Goal
+The user's primary objective in this conversation.
+
+### Important facts and decisions
+Key facts, user preferences, credential names, workflow IDs, and decisions made. Bullet list.
+
+### Current workflow/build state
+What workflows exist, their status (draft/active/tested), last build outcome, any verification results. If no workflow work has happened, write "No workflow activity yet."
+
+### Open issues or blockers
+Unresolved errors, missing credentials, failed verifications, or pending user decisions. If none, write "None."
+
+### Likely next step
+What the assistant should do next based on the conversation so far.
+
+## Rules
+
+- Be concise. Each section should be 1-5 bullet points maximum.
+- Preserve all workflow IDs, credential names, node names, and error messages exactly.
+- Drop verbose tool payloads, binary data references, and raw execution outputs — keep only the outcome.
+- When merging with a previous summary, update sections rather than appending duplicates.
+- If a decision was reversed or an issue was resolved, reflect the current state, not the history.`;
+
+export interface CompactionInput {
+	previousSummary: string | null;
+	messageBatch: Array<{ role: string; text: string }>;
+}
+
+/**
+ * Generate a compacted summary from a previous summary and a batch of messages.
+ * Uses a lightweight Mastra Agent with no tools and no memory.
+ */
+export async function generateCompactionSummary(
+	modelId: ModelConfig,
+	input: CompactionInput,
+): Promise<string> {
+	const agent = new Agent({
+		id: 'compaction-summarizer',
+		name: 'Compaction Summarizer',
+		instructions: {
+			role: 'system' as const,
+			content: COMPACTION_SYSTEM_PROMPT,
+		},
+		model: modelId,
+	});
+
+	const parts: string[] = [];
+
+	if (input.previousSummary) {
+		parts.push(`<previous-summary>\n${input.previousSummary}\n</previous-summary>`);
+	}
+
+	parts.push('<new-turns>');
+	for (const msg of input.messageBatch) {
+		parts.push(`[${msg.role}]: ${msg.text}`);
+	}
+	parts.push('</new-turns>');
+
+	parts.push('Produce the updated summary now. Return only the five sections, nothing else.');
+
+	const result = await agent.generate(parts.join('\n\n'), { maxSteps: 1 });
+	return result.text;
+}

--- a/packages/@n8n/instance-ai/src/compaction/index.ts
+++ b/packages/@n8n/instance-ai/src/compaction/index.ts
@@ -1,0 +1,2 @@
+export { generateCompactionSummary } from './compaction-helper';
+export type { CompactionInput } from './compaction-helper';

--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -1,3 +1,5 @@
+export { generateCompactionSummary } from './compaction';
+export type { CompactionInput } from './compaction';
 export { createDomainAccessTracker } from './domain-access';
 export type { DomainAccessTracker } from './domain-access';
 export { createInstanceAgent } from './agent/instance-agent';

--- a/packages/cli/src/modules/instance-ai/__tests__/compaction.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/compaction.service.test.ts
@@ -1,0 +1,287 @@
+// Manual mock — must be declared before any imports that touch the mocked module.
+// We mock @n8n/instance-ai (which compaction.service.ts imports from) so Jest
+// doesn't try to resolve the workspace package's dist/ (which may not be built).
+const mockGenerateCompactionSummary = jest.fn();
+jest.mock('@n8n/instance-ai', () => ({
+	generateCompactionSummary: (...args: unknown[]) => mockGenerateCompactionSummary(...args),
+}));
+
+// Mock Mastra imports that compaction.service.ts and its transitive deps use.
+// TypeORMMemoryStorage extends MemoryStorage, so we must provide a real class.
+jest.mock('@mastra/core/agent', () => ({}));
+jest.mock('@mastra/core/storage', () => ({
+	MemoryStorage: class MemoryStorage {},
+	MastraCompositeStore: class MastraCompositeStore {},
+}));
+jest.mock('@mastra/memory', () => ({}));
+
+// Now safe to import — all external deps are mocked
+import { InstanceAiCompactionService } from '../compaction.service';
+
+interface MockMessage {
+	id: string;
+	role: string;
+	content: unknown;
+	createdAt: Date;
+	threadId: string;
+}
+
+function createMessage(id: string, role: 'user' | 'assistant', text: string): MockMessage {
+	return {
+		id,
+		role,
+		content: { content: [{ type: 'text', text }] },
+		createdAt: new Date(),
+		threadId: 'thread-1',
+	};
+}
+
+function createToolMessage(id: string): MockMessage {
+	return {
+		id,
+		role: 'tool',
+		content: { content: [{ type: 'tool-result', toolCallId: 'tc-1', result: '{}' }] },
+		createdAt: new Date(),
+		threadId: 'thread-1',
+	};
+}
+
+function createMockMemory(metadata?: Record<string, unknown>) {
+	return {
+		getThreadById: jest.fn().mockResolvedValue({
+			id: 'thread-1',
+			title: 'Test Thread',
+			metadata: metadata ?? {},
+		}),
+		updateThread: jest.fn().mockResolvedValue({}),
+	};
+}
+
+function createService(messages: MockMessage[]): InstanceAiCompactionService {
+	const mockLogger = {
+		info: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+		debug: jest.fn(),
+	};
+	const mockStorage = {
+		listMessages: jest.fn().mockResolvedValue({
+			messages,
+			total: messages.length,
+			page: 0,
+			perPage: false,
+			hasMore: false,
+		}),
+	};
+	return new InstanceAiCompactionService(mockLogger as never, mockStorage as never);
+}
+
+describe('InstanceAiCompactionService', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('thread below threshold', () => {
+		it('should not create or update summary when thread has fewer messages than lastMessages', async () => {
+			const messages = Array.from({ length: 10 }, (_, i) =>
+				createMessage(`msg-${i}`, i % 2 === 0 ? 'user' : 'assistant', `Message ${i}`),
+			);
+			const service = createService(messages);
+			const memory = createMockMemory();
+
+			const result = await service.prepareCompactedContext(
+				'thread-1',
+				memory as never,
+				'anthropic/claude-sonnet-4-5',
+				20,
+			);
+
+			expect(result).toBeNull();
+			expect(mockGenerateCompactionSummary).not.toHaveBeenCalled();
+			expect(memory.updateThread).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('first compaction', () => {
+		it('should create a summary, advance upToMessageId, and leave raw messages untouched', async () => {
+			const messages = Array.from({ length: 40 }, (_, i) =>
+				createMessage(`msg-${i}`, i % 2 === 0 ? 'user' : 'assistant', `Message ${i}`),
+			);
+			const service = createService(messages);
+			const memory = createMockMemory();
+
+			mockGenerateCompactionSummary.mockResolvedValue('### Goal\nTest goal');
+
+			const result = await service.prepareCompactedContext(
+				'thread-1',
+				memory as never,
+				'anthropic/claude-sonnet-4-5',
+				20,
+			);
+
+			// Should return formatted summary block
+			expect(result).toContain('<conversation-summary>');
+			expect(result).toContain('### Goal');
+			expect(result).toContain('</conversation-summary>');
+
+			// Should call the compaction helper with no previous summary
+			expect(mockGenerateCompactionSummary).toHaveBeenCalledTimes(1);
+			const [modelId, input] = mockGenerateCompactionSummary.mock.calls[0];
+			expect(modelId).toBe('anthropic/claude-sonnet-4-5');
+			expect(input.previousSummary).toBeNull();
+			expect(input.messageBatch.length).toBeGreaterThan(0);
+
+			// Should persist metadata with upToMessageId = last message in prefix
+			expect(memory.updateThread).toHaveBeenCalledTimes(1);
+			const updateCall = memory.updateThread.mock.calls[0][0];
+			const savedMetadata = updateCall.metadata.instanceAiConversationSummary;
+			expect(savedMetadata.version).toBe(1);
+			expect(savedMetadata.upToMessageId).toBe('msg-19'); // prefix end = 40 - 20 = index 19
+			expect(savedMetadata.summary).toBe('### Goal\nTest goal');
+		});
+	});
+
+	describe('incremental compaction', () => {
+		it('should only summarize the delta after the stored upToMessageId', async () => {
+			const messages = Array.from({ length: 50 }, (_, i) =>
+				createMessage(`msg-${i}`, i % 2 === 0 ? 'user' : 'assistant', `Message ${i}`),
+			);
+			const service = createService(messages);
+			const memory = createMockMemory({
+				instanceAiConversationSummary: {
+					version: 1,
+					upToMessageId: 'msg-14',
+					summary: 'Previous summary content',
+					updatedAt: '2025-01-01T00:00:00Z',
+				},
+			});
+
+			mockGenerateCompactionSummary.mockResolvedValue('### Goal\nUpdated goal');
+
+			await service.prepareCompactedContext(
+				'thread-1',
+				memory as never,
+				'anthropic/claude-sonnet-4-5',
+				20,
+			);
+
+			// Should pass previous summary for merging
+			const [, input] = mockGenerateCompactionSummary.mock.calls[0];
+			expect(input.previousSummary).toBe('Previous summary content');
+
+			// Should advance upToMessageId to end of new prefix
+			const updateCall = memory.updateThread.mock.calls[0][0];
+			const savedMetadata = updateCall.metadata.instanceAiConversationSummary;
+			expect(savedMetadata.version).toBe(2);
+			expect(savedMetadata.upToMessageId).toBe('msg-29'); // prefix end = 50 - 20 = index 29
+		});
+	});
+
+	describe('tool-heavy conversations', () => {
+		it('should ignore tool payloads and preserve user/assistant content', async () => {
+			const messages: MockMessage[] = [];
+			for (let i = 0; i < 40; i++) {
+				if (i % 3 === 0) {
+					messages.push(createMessage(`msg-${i}`, 'user', `User question ${i}`));
+				} else if (i % 3 === 1) {
+					messages.push(createToolMessage(`msg-${i}`));
+				} else {
+					messages.push(createMessage(`msg-${i}`, 'assistant', `Assistant answer ${i}`));
+				}
+			}
+			const service = createService(messages);
+			const memory = createMockMemory();
+
+			mockGenerateCompactionSummary.mockResolvedValue('### Goal\nGoal with tools');
+
+			await service.prepareCompactedContext(
+				'thread-1',
+				memory as never,
+				'anthropic/claude-sonnet-4-5',
+				20,
+			);
+
+			// The message batch should only contain user and assistant messages
+			const [, input] = mockGenerateCompactionSummary.mock.calls[0];
+			for (const msg of input.messageBatch) {
+				expect(msg.role).toMatch(/^(user|assistant)$/);
+			}
+		});
+	});
+
+	describe('cached summary', () => {
+		it('should return cached summary when unsummarized delta is below threshold', async () => {
+			const messages = Array.from({ length: 25 }, (_, i) =>
+				createMessage(`msg-${i}`, i % 2 === 0 ? 'user' : 'assistant', `Message ${i}`),
+			);
+			const service = createService(messages);
+			const memory = createMockMemory({
+				instanceAiConversationSummary: {
+					version: 1,
+					upToMessageId: 'msg-3',
+					summary: 'Cached summary content',
+					updatedAt: '2025-01-01T00:00:00Z',
+				},
+			});
+
+			const result = await service.prepareCompactedContext(
+				'thread-1',
+				memory as never,
+				'anthropic/claude-sonnet-4-5',
+				20,
+			);
+
+			// Should return the cached summary without regenerating
+			expect(result).toContain('<conversation-summary>');
+			expect(result).toContain('Cached summary content');
+			expect(mockGenerateCompactionSummary).not.toHaveBeenCalled();
+			expect(memory.updateThread).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('failure handling', () => {
+		it('should log a warning and return null when compaction generation fails', async () => {
+			const messages = Array.from({ length: 40 }, (_, i) =>
+				createMessage(`msg-${i}`, i % 2 === 0 ? 'user' : 'assistant', `Message ${i}`),
+			);
+			const service = createService(messages);
+			const memory = createMockMemory();
+
+			mockGenerateCompactionSummary.mockRejectedValue(new Error('LLM timeout'));
+
+			const result = await service.prepareCompactedContext(
+				'thread-1',
+				memory as never,
+				'anthropic/claude-sonnet-4-5',
+				20,
+			);
+
+			expect(result).toBeNull();
+		});
+	});
+
+	describe('message input composition', () => {
+		it('should format the summary block with conversation-summary tags', async () => {
+			const messages = Array.from({ length: 40 }, (_, i) =>
+				createMessage(`msg-${i}`, i % 2 === 0 ? 'user' : 'assistant', `Message ${i}`),
+			);
+			const service = createService(messages);
+			const memory = createMockMemory();
+
+			mockGenerateCompactionSummary.mockResolvedValue(
+				'### Goal\nBuild a workflow\n\n### Important facts and decisions\n- Using Gmail',
+			);
+
+			const result = await service.prepareCompactedContext(
+				'thread-1',
+				memory as never,
+				'anthropic/claude-sonnet-4-5',
+				20,
+			);
+
+			expect(result).toBe(
+				'<conversation-summary>\n### Goal\nBuild a workflow\n\n### Important facts and decisions\n- Using Gmail\n</conversation-summary>',
+			);
+		});
+	});
+});

--- a/packages/cli/src/modules/instance-ai/__tests__/compaction.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/compaction.service.test.ts
@@ -1,13 +1,9 @@
 // Manual mock — must be declared before any imports that touch the mocked module.
-// We mock @n8n/instance-ai (which compaction.service.ts imports from) so Jest
-// doesn't try to resolve the workspace package's dist/ (which may not be built).
 const mockGenerateCompactionSummary = jest.fn();
 jest.mock('@n8n/instance-ai', () => ({
 	generateCompactionSummary: (...args: unknown[]) => mockGenerateCompactionSummary(...args),
 }));
 
-// Mock Mastra imports that compaction.service.ts and its transitive deps use.
-// TypeORMMemoryStorage extends MemoryStorage, so we must provide a real class.
 jest.mock('@mastra/core/agent', () => ({}));
 jest.mock('@mastra/core/storage', () => ({
 	MemoryStorage: class MemoryStorage {},
@@ -15,7 +11,6 @@ jest.mock('@mastra/core/storage', () => ({
 }));
 jest.mock('@mastra/memory', () => ({}));
 
-// Now safe to import — all external deps are mocked
 import { InstanceAiCompactionService } from '../compaction.service';
 
 interface MockMessage {
@@ -26,11 +21,22 @@ interface MockMessage {
 	threadId: string;
 }
 
-function createMessage(id: string, role: 'user' | 'assistant', text: string): MockMessage {
+/**
+ * Create a message with controllable size.
+ * ~4 chars per token, so `tokenCount` tokens ≈ `tokenCount * 4` chars.
+ */
+function createMessage(
+	id: string,
+	role: 'user' | 'assistant',
+	text: string,
+	tokenCount?: number,
+): MockMessage {
+	// If a specific token count is requested, pad the text to that size
+	const content = tokenCount ? text + 'x'.repeat(Math.max(0, tokenCount * 4 - text.length)) : text;
 	return {
 		id,
 		role,
-		content: { content: [{ type: 'text', text }] },
+		content: { content: [{ type: 'text', text: content }] },
 		createdAt: new Date(),
 		threadId: 'thread-1',
 	};
@@ -76,15 +82,20 @@ function createService(messages: MockMessage[]): InstanceAiCompactionService {
 	return new InstanceAiCompactionService(mockLogger as never, mockStorage as never);
 }
 
+// Claude context window = 200k tokens. At 80% threshold = 160k tokens trigger.
+// With 8k overhead, messages need ~152k tokens to trigger.
+// For test convenience, we use a low threshold (0.1 = 10%) so smaller messages trigger.
+
 describe('InstanceAiCompactionService', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 	});
 
-	describe('thread below threshold', () => {
-		it('should not create or update summary when thread has fewer messages than lastMessages', async () => {
-			const messages = Array.from({ length: 10 }, (_, i) =>
-				createMessage(`msg-${i}`, i % 2 === 0 ? 'user' : 'assistant', `Message ${i}`),
+	describe('thread below token threshold', () => {
+		it('should not compact when total tokens are below the threshold', async () => {
+			// Small messages, well below any threshold
+			const messages = Array.from({ length: 30 }, (_, i) =>
+				createMessage(`msg-${i}`, i % 2 === 0 ? 'user' : 'assistant', `Short msg ${i}`),
 			);
 			const service = createService(messages);
 			const memory = createMockMemory();
@@ -94,18 +105,20 @@ describe('InstanceAiCompactionService', () => {
 				memory as never,
 				'anthropic/claude-sonnet-4-5',
 				20,
+				0.8, // 80% of 200k = 160k tokens — tiny messages won't reach this
 			);
 
 			expect(result).toBeNull();
 			expect(mockGenerateCompactionSummary).not.toHaveBeenCalled();
-			expect(memory.updateThread).not.toHaveBeenCalled();
 		});
 	});
 
-	describe('first compaction', () => {
-		it('should create a summary, advance upToMessageId, and leave raw messages untouched', async () => {
+	describe('thread above token threshold', () => {
+		it('should compact when total tokens exceed the threshold', async () => {
+			// Create messages with ~5000 tokens each = 40 * 5000 = 200k tokens
+			// With overhead (8k), total = ~208k. At 80% of 200k (160k), this triggers.
 			const messages = Array.from({ length: 40 }, (_, i) =>
-				createMessage(`msg-${i}`, i % 2 === 0 ? 'user' : 'assistant', `Message ${i}`),
+				createMessage(`msg-${i}`, i % 2 === 0 ? 'user' : 'assistant', `Message ${i}`, 5000),
 			);
 			const service = createService(messages);
 			const memory = createMockMemory();
@@ -117,34 +130,24 @@ describe('InstanceAiCompactionService', () => {
 				memory as never,
 				'anthropic/claude-sonnet-4-5',
 				20,
+				0.8,
 			);
 
-			// Should return formatted summary block
 			expect(result).toContain('<conversation-summary>');
-			expect(result).toContain('### Goal');
-			expect(result).toContain('</conversation-summary>');
-
-			// Should call the compaction helper with no previous summary
 			expect(mockGenerateCompactionSummary).toHaveBeenCalledTimes(1);
-			const [modelId, input] = mockGenerateCompactionSummary.mock.calls[0];
-			expect(modelId).toBe('anthropic/claude-sonnet-4-5');
-			expect(input.previousSummary).toBeNull();
-			expect(input.messageBatch.length).toBeGreaterThan(0);
 
-			// Should persist metadata with upToMessageId = last message in prefix
-			expect(memory.updateThread).toHaveBeenCalledTimes(1);
+			// Should persist with upToMessageId at the end of the prefix
 			const updateCall = memory.updateThread.mock.calls[0][0];
 			const savedMetadata = updateCall.metadata.instanceAiConversationSummary;
 			expect(savedMetadata.version).toBe(1);
-			expect(savedMetadata.upToMessageId).toBe('msg-19'); // prefix end = 40 - 20 = index 19
-			expect(savedMetadata.summary).toBe('### Goal\nTest goal');
+			expect(savedMetadata.upToMessageId).toBe('msg-19'); // 40 - 20 = index 19
 		});
 	});
 
 	describe('incremental compaction', () => {
 		it('should only summarize the delta after the stored upToMessageId', async () => {
 			const messages = Array.from({ length: 50 }, (_, i) =>
-				createMessage(`msg-${i}`, i % 2 === 0 ? 'user' : 'assistant', `Message ${i}`),
+				createMessage(`msg-${i}`, i % 2 === 0 ? 'user' : 'assistant', `Message ${i}`, 4000),
 			);
 			const service = createService(messages);
 			const memory = createMockMemory({
@@ -163,17 +166,18 @@ describe('InstanceAiCompactionService', () => {
 				memory as never,
 				'anthropic/claude-sonnet-4-5',
 				20,
+				0.8,
 			);
 
 			// Should pass previous summary for merging
 			const [, input] = mockGenerateCompactionSummary.mock.calls[0];
 			expect(input.previousSummary).toBe('Previous summary content');
 
-			// Should advance upToMessageId to end of new prefix
+			// Should advance upToMessageId
 			const updateCall = memory.updateThread.mock.calls[0][0];
 			const savedMetadata = updateCall.metadata.instanceAiConversationSummary;
 			expect(savedMetadata.version).toBe(2);
-			expect(savedMetadata.upToMessageId).toBe('msg-29'); // prefix end = 50 - 20 = index 29
+			expect(savedMetadata.upToMessageId).toBe('msg-29');
 		});
 	});
 
@@ -182,11 +186,11 @@ describe('InstanceAiCompactionService', () => {
 			const messages: MockMessage[] = [];
 			for (let i = 0; i < 40; i++) {
 				if (i % 3 === 0) {
-					messages.push(createMessage(`msg-${i}`, 'user', `User question ${i}`));
+					messages.push(createMessage(`msg-${i}`, 'user', `User question ${i}`, 5000));
 				} else if (i % 3 === 1) {
 					messages.push(createToolMessage(`msg-${i}`));
 				} else {
-					messages.push(createMessage(`msg-${i}`, 'assistant', `Assistant answer ${i}`));
+					messages.push(createMessage(`msg-${i}`, 'assistant', `Assistant answer ${i}`, 5000));
 				}
 			}
 			const service = createService(messages);
@@ -199,9 +203,9 @@ describe('InstanceAiCompactionService', () => {
 				memory as never,
 				'anthropic/claude-sonnet-4-5',
 				20,
+				0.5, // lower threshold since tool messages are small
 			);
 
-			// The message batch should only contain user and assistant messages
 			const [, input] = mockGenerateCompactionSummary.mock.calls[0];
 			for (const msg of input.messageBatch) {
 				expect(msg.role).toMatch(/^(user|assistant)$/);
@@ -210,9 +214,10 @@ describe('InstanceAiCompactionService', () => {
 	});
 
 	describe('cached summary', () => {
-		it('should return cached summary when unsummarized delta is below threshold', async () => {
+		it('should return cached summary when below token threshold', async () => {
+			// Small messages — below threshold, but existing summary should be returned
 			const messages = Array.from({ length: 25 }, (_, i) =>
-				createMessage(`msg-${i}`, i % 2 === 0 ? 'user' : 'assistant', `Message ${i}`),
+				createMessage(`msg-${i}`, i % 2 === 0 ? 'user' : 'assistant', `Short ${i}`),
 			);
 			const service = createService(messages);
 			const memory = createMockMemory({
@@ -229,20 +234,18 @@ describe('InstanceAiCompactionService', () => {
 				memory as never,
 				'anthropic/claude-sonnet-4-5',
 				20,
+				0.8,
 			);
 
-			// Should return the cached summary without regenerating
-			expect(result).toContain('<conversation-summary>');
 			expect(result).toContain('Cached summary content');
 			expect(mockGenerateCompactionSummary).not.toHaveBeenCalled();
-			expect(memory.updateThread).not.toHaveBeenCalled();
 		});
 	});
 
 	describe('failure handling', () => {
 		it('should log a warning and return null when compaction generation fails', async () => {
 			const messages = Array.from({ length: 40 }, (_, i) =>
-				createMessage(`msg-${i}`, i % 2 === 0 ? 'user' : 'assistant', `Message ${i}`),
+				createMessage(`msg-${i}`, i % 2 === 0 ? 'user' : 'assistant', `Msg ${i}`, 5000),
 			);
 			const service = createService(messages);
 			const memory = createMockMemory();
@@ -254,34 +257,36 @@ describe('InstanceAiCompactionService', () => {
 				memory as never,
 				'anthropic/claude-sonnet-4-5',
 				20,
+				0.8,
 			);
 
 			expect(result).toBeNull();
 		});
 	});
 
-	describe('message input composition', () => {
-		it('should format the summary block with conversation-summary tags', async () => {
+	describe('context window scaling', () => {
+		it('should use different context windows for different models', async () => {
+			// GPT-3.5 has 16k context. 40 messages * 500 tokens = 20k + 8k overhead = 28k
+			// 80% of 16k = 12.8k → 28k > 12.8k → should compact
 			const messages = Array.from({ length: 40 }, (_, i) =>
-				createMessage(`msg-${i}`, i % 2 === 0 ? 'user' : 'assistant', `Message ${i}`),
+				createMessage(`msg-${i}`, i % 2 === 0 ? 'user' : 'assistant', `Msg ${i}`, 500),
 			);
 			const service = createService(messages);
 			const memory = createMockMemory();
 
-			mockGenerateCompactionSummary.mockResolvedValue(
-				'### Goal\nBuild a workflow\n\n### Important facts and decisions\n- Using Gmail',
-			);
+			mockGenerateCompactionSummary.mockResolvedValue('### Goal\nCompacted');
 
 			const result = await service.prepareCompactedContext(
 				'thread-1',
 				memory as never,
-				'anthropic/claude-sonnet-4-5',
+				'openai/gpt-3.5-turbo',
 				20,
+				0.8,
 			);
 
-			expect(result).toBe(
-				'<conversation-summary>\n### Goal\nBuild a workflow\n\n### Important facts and decisions\n- Using Gmail\n</conversation-summary>',
-			);
+			// Should compact because 28k > 12.8k (80% of 16k)
+			expect(result).toContain('<conversation-summary>');
+			expect(mockGenerateCompactionSummary).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/packages/cli/src/modules/instance-ai/compaction.service.ts
+++ b/packages/cli/src/modules/instance-ai/compaction.service.ts
@@ -1,0 +1,229 @@
+import { Logger } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+import { generateCompactionSummary } from '@n8n/instance-ai';
+import type { ModelConfig } from '@n8n/instance-ai';
+import type { Memory } from '@mastra/memory';
+import type { MastraMessageContentV2 } from '@mastra/core/agent';
+import type { MastraDBMessage } from '@mastra/core/storage';
+
+import { TypeORMMemoryStorage } from './storage/typeorm-memory-storage';
+
+const METADATA_KEY = 'instanceAiConversationSummary';
+
+interface ConversationSummaryMetadata {
+	version: number;
+	upToMessageId: string;
+	summary: string;
+	updatedAt: string;
+}
+
+/**
+ * Manages rolling compaction of older thread messages into a summary.
+ * Stores compaction state in thread metadata — no DB migration needed.
+ *
+ * Design:
+ *   - recent tail (lastMessages) is never compacted
+ *   - only the older prefix before the tail gets summarized
+ *   - raw messages stay in storage for debugging/UI — only model input is compacted
+ *   - compaction is best-effort: failures log a warning and return null
+ */
+@Service()
+export class InstanceAiCompactionService {
+	constructor(
+		private readonly logger: Logger,
+		private readonly memoryStorage: TypeORMMemoryStorage,
+	) {}
+
+	/**
+	 * If compaction is needed, generate a summary and return a formatted
+	 * `<conversation-summary>` block for prompt injection. Returns null if
+	 * compaction is not needed or if a cached summary is still valid.
+	 */
+	async prepareCompactedContext(
+		threadId: string,
+		memory: Memory,
+		modelId: ModelConfig,
+		lastMessages: number,
+	): Promise<string | null> {
+		try {
+			const recentTail = lastMessages;
+			const compactBatch = Math.max(6, Math.floor(recentTail / 2));
+
+			// Load all messages for the thread, ordered chronologically
+			const { messages: allMessages } = await this.memoryStorage.listMessages({
+				threadId,
+				perPage: false,
+				orderBy: { field: 'createdAt', direction: 'ASC' },
+			});
+
+			if (allMessages.length <= recentTail) {
+				// Thread is short enough — no compaction needed
+				return this.getCachedSummaryBlock(threadId, memory);
+			}
+
+			// Split into prefix (older messages) and tail (recent)
+			const prefixEnd = allMessages.length - recentTail;
+			const prefix = allMessages.slice(0, prefixEnd);
+
+			// Load existing compaction state
+			const thread = await memory.getThreadById({ threadId });
+			const existing = this.parseMetadata(thread?.metadata?.[METADATA_KEY]);
+
+			// Find where the previous summary left off
+			let unsummarizedStart = 0;
+			if (existing?.upToMessageId) {
+				const idx = prefix.findIndex((m) => m.id === existing.upToMessageId);
+				if (idx >= 0) {
+					unsummarizedStart = idx + 1;
+				}
+			}
+
+			const unsummarizedSlice = prefix.slice(unsummarizedStart);
+
+			// Only compact when there are enough unsummarized messages
+			if (unsummarizedSlice.length < compactBatch) {
+				return this.getCachedSummaryBlock(threadId, memory);
+			}
+
+			// Extract high-signal content from the unsummarized slice
+			const messageBatch = this.extractHighSignalContent(unsummarizedSlice);
+
+			if (messageBatch.length === 0) {
+				return this.getCachedSummaryBlock(threadId, memory);
+			}
+
+			// Generate the updated summary
+			const summary = await generateCompactionSummary(modelId, {
+				previousSummary: existing?.summary ?? null,
+				messageBatch,
+			});
+
+			// Persist the updated compaction state
+			const lastCompactedMessage = unsummarizedSlice[unsummarizedSlice.length - 1];
+			const newMetadata: ConversationSummaryMetadata = {
+				version: (existing?.version ?? 0) + 1,
+				upToMessageId: lastCompactedMessage.id,
+				summary,
+				updatedAt: new Date().toISOString(),
+			};
+
+			await this.saveMetadata(threadId, memory, newMetadata);
+
+			return this.formatSummaryBlock(summary);
+		} catch (error) {
+			this.logger.warn('Conversation compaction failed, continuing without summary', {
+				threadId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return null;
+		}
+	}
+
+	/**
+	 * Return the cached summary block if one exists, without re-generating.
+	 */
+	private async getCachedSummaryBlock(threadId: string, memory: Memory): Promise<string | null> {
+		const thread = await memory.getThreadById({ threadId });
+		const existing = this.parseMetadata(thread?.metadata?.[METADATA_KEY]);
+		if (existing?.summary) {
+			return this.formatSummaryBlock(existing.summary);
+		}
+		return null;
+	}
+
+	/**
+	 * Extract user/assistant text content from messages, skipping tool calls,
+	 * tool results, and system messages.
+	 */
+	private extractHighSignalContent(
+		messages: MastraDBMessage[],
+	): Array<{ role: string; text: string }> {
+		const result: Array<{ role: string; text: string }> = [];
+
+		for (const msg of messages) {
+			if (msg.role !== 'user' && msg.role !== 'assistant') continue;
+
+			const text = this.extractTextFromContent(msg.content);
+			if (!text) continue;
+
+			result.push({ role: msg.role, text });
+		}
+
+		return result;
+	}
+
+	/**
+	 * Extract plain text from a Mastra message content structure.
+	 * Handles both string content and structured content arrays.
+	 */
+	private extractTextFromContent(content: MastraMessageContentV2): string {
+		// Direct string content
+		if (typeof content === 'string') return content;
+
+		// Mastra wraps content in { content: [...parts] }
+		const inner = (content as Record<string, unknown>)?.content;
+		if (typeof inner === 'string') return inner;
+
+		if (Array.isArray(inner)) {
+			const textParts: string[] = [];
+			for (const part of inner) {
+				if (typeof part === 'string') {
+					textParts.push(part);
+				} else if (isTextPart(part)) {
+					textParts.push(part.text);
+				}
+				// Skip tool-call, tool-result, image, and file parts
+			}
+			return textParts.join('\n');
+		}
+
+		return '';
+	}
+
+	private formatSummaryBlock(summary: string): string {
+		return `<conversation-summary>\n${summary}\n</conversation-summary>`;
+	}
+
+	private parseMetadata(raw: unknown): ConversationSummaryMetadata | null {
+		if (!raw || typeof raw !== 'object') return null;
+		const obj = raw as Record<string, unknown>;
+		if (
+			typeof obj.version === 'number' &&
+			typeof obj.upToMessageId === 'string' &&
+			typeof obj.summary === 'string' &&
+			typeof obj.updatedAt === 'string'
+		) {
+			return obj as unknown as ConversationSummaryMetadata;
+		}
+		return null;
+	}
+
+	private async saveMetadata(
+		threadId: string,
+		memory: Memory,
+		metadata: ConversationSummaryMetadata,
+	): Promise<void> {
+		const thread = await memory.getThreadById({ threadId });
+		if (!thread) return;
+
+		await memory.updateThread({
+			id: threadId,
+			title: thread.title ?? threadId,
+			metadata: {
+				...thread.metadata,
+				[METADATA_KEY]: metadata,
+			},
+		});
+	}
+}
+
+function isTextPart(part: unknown): part is { type: 'text'; text: string } {
+	return (
+		typeof part === 'object' &&
+		part !== null &&
+		'type' in part &&
+		(part as { type: string }).type === 'text' &&
+		'text' in part &&
+		typeof (part as { text: unknown }).text === 'string'
+	);
+}

--- a/packages/cli/src/modules/instance-ai/compaction.service.ts
+++ b/packages/cli/src/modules/instance-ai/compaction.service.ts
@@ -4,7 +4,7 @@ import { generateCompactionSummary } from '@n8n/instance-ai';
 import type { ModelConfig } from '@n8n/instance-ai';
 import type { Memory } from '@mastra/memory';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
-import type { MastraDBMessage } from '@mastra/core/storage';
+import type { MastraDBMessage } from '@mastra/core/memory';
 
 import { TypeORMMemoryStorage } from './storage/typeorm-memory-storage';
 
@@ -85,7 +85,7 @@ export class InstanceAiCompactionService {
 			});
 
 			if (allMessages.length <= recentTail) {
-				return this.getCachedSummaryBlock(threadId, memory);
+				return await this.getCachedSummaryBlock(threadId, memory);
 			}
 
 			// Estimate total token usage across all messages
@@ -98,7 +98,7 @@ export class InstanceAiCompactionService {
 
 			// Only compact when context usage exceeds the threshold
 			if (totalTokens < threshold) {
-				return this.getCachedSummaryBlock(threadId, memory);
+				return await this.getCachedSummaryBlock(threadId, memory);
 			}
 
 			// Split into prefix (older messages) and tail (recent)
@@ -126,14 +126,14 @@ export class InstanceAiCompactionService {
 				0,
 			);
 			if (unsummarizedTokens < 500) {
-				return this.getCachedSummaryBlock(threadId, memory);
+				return await this.getCachedSummaryBlock(threadId, memory);
 			}
 
 			// Extract high-signal content from the unsummarized slice
 			const messageBatch = this.extractHighSignalContent(unsummarizedSlice);
 
 			if (messageBatch.length === 0) {
-				return this.getCachedSummaryBlock(threadId, memory);
+				return await this.getCachedSummaryBlock(threadId, memory);
 			}
 
 			// Generate the updated summary
@@ -177,8 +177,9 @@ export class InstanceAiCompactionService {
 
 	/** Get the full serialized text of a message (for token estimation). */
 	private extractRawText(msg: MastraDBMessage): string {
-		if (typeof msg.content === 'string') return msg.content;
-		return JSON.stringify(msg.content);
+		const content: unknown = msg.content;
+		if (typeof content === 'string') return content;
+		return JSON.stringify(content);
 	}
 
 	/**

--- a/packages/cli/src/modules/instance-ai/compaction.service.ts
+++ b/packages/cli/src/modules/instance-ai/compaction.service.ts
@@ -31,7 +31,15 @@ function estimateTokens(text: string): number {
 function getContextWindowForModel(modelId: ModelConfig): number {
 	const raw = typeof modelId === 'string' ? modelId : modelId.id;
 	const slashIndex = raw.indexOf('/');
-	if (slashIndex < 0) return DEFAULT_CONTEXT_WINDOW;
+	if (slashIndex < 0) {
+		for (const providerModels of Object.values(maxContextWindowTokens)) {
+			if (providerModels[raw]) return providerModels[raw];
+			for (const [registryModel, tokens] of Object.entries(providerModels)) {
+				if (tokens > 0 && registryModel.startsWith(raw)) return tokens;
+			}
+		}
+		return DEFAULT_CONTEXT_WINDOW;
+	}
 
 	const provider = raw.slice(0, slashIndex) as ChatHubLLMProvider;
 	const model = raw.slice(slashIndex + 1);

--- a/packages/cli/src/modules/instance-ai/compaction.service.ts
+++ b/packages/cli/src/modules/instance-ai/compaction.service.ts
@@ -10,6 +10,28 @@ import { TypeORMMemoryStorage } from './storage/typeorm-memory-storage';
 
 const METADATA_KEY = 'instanceAiConversationSummary';
 
+/**
+ * Rough token estimate: ~4 chars per token for English text.
+ * Good enough for triggering decisions — not used for billing.
+ */
+function estimateTokens(text: string): number {
+	return Math.ceil(text.length / 4);
+}
+
+/** Look up context window size (in tokens) for known model families. */
+function getContextWindowForModel(modelId: ModelConfig): number {
+	const id = typeof modelId === 'string' ? modelId : modelId.id;
+	if (id.includes('claude')) return 200_000;
+	if (id.includes('gpt-4o')) return 128_000;
+	if (id.includes('gpt-4')) return 128_000;
+	if (id.includes('gpt-3.5')) return 16_000;
+	// Conservative default for unknown models
+	return 128_000;
+}
+
+/** Estimate tokens consumed by system prompt, tools, and working memory overhead. */
+const FIXED_CONTEXT_OVERHEAD_TOKENS = 8_000;
+
 interface ConversationSummaryMetadata {
 	version: number;
 	upToMessageId: string;
@@ -20,6 +42,10 @@ interface ConversationSummaryMetadata {
 /**
  * Manages rolling compaction of older thread messages into a summary.
  * Stores compaction state in thread metadata — no DB migration needed.
+ *
+ * Trigger: compacts when estimated total thread tokens exceed a percentage
+ * of the model's context window (default 80%), matching the pattern used
+ * by Claude Code and OpenAI's auto-compaction.
  *
  * Design:
  *   - recent tail (lastMessages) is never compacted
@@ -38,16 +64,18 @@ export class InstanceAiCompactionService {
 	 * If compaction is needed, generate a summary and return a formatted
 	 * `<conversation-summary>` block for prompt injection. Returns null if
 	 * compaction is not needed or if a cached summary is still valid.
+	 *
+	 * @param compactionThreshold — fraction of context window that triggers compaction (0-1, default 0.8)
 	 */
 	async prepareCompactedContext(
 		threadId: string,
 		memory: Memory,
 		modelId: ModelConfig,
 		lastMessages: number,
+		compactionThreshold = 0.8,
 	): Promise<string | null> {
 		try {
 			const recentTail = lastMessages;
-			const compactBatch = Math.max(6, Math.floor(recentTail / 2));
 
 			// Load all messages for the thread, ordered chronologically
 			const { messages: allMessages } = await this.memoryStorage.listMessages({
@@ -57,7 +85,19 @@ export class InstanceAiCompactionService {
 			});
 
 			if (allMessages.length <= recentTail) {
-				// Thread is short enough — no compaction needed
+				return this.getCachedSummaryBlock(threadId, memory);
+			}
+
+			// Estimate total token usage across all messages
+			const totalTokens =
+				FIXED_CONTEXT_OVERHEAD_TOKENS +
+				allMessages.reduce((sum, m) => sum + estimateTokens(this.extractRawText(m)), 0);
+
+			const contextWindow = getContextWindowForModel(modelId);
+			const threshold = contextWindow * compactionThreshold;
+
+			// Only compact when context usage exceeds the threshold
+			if (totalTokens < threshold) {
 				return this.getCachedSummaryBlock(threadId, memory);
 			}
 
@@ -80,8 +120,12 @@ export class InstanceAiCompactionService {
 
 			const unsummarizedSlice = prefix.slice(unsummarizedStart);
 
-			// Only compact when there are enough unsummarized messages
-			if (unsummarizedSlice.length < compactBatch) {
+			// Need at least some unsummarized content to justify a compaction call
+			const unsummarizedTokens = unsummarizedSlice.reduce(
+				(sum, m) => sum + estimateTokens(this.extractRawText(m)),
+				0,
+			);
+			if (unsummarizedTokens < 500) {
 				return this.getCachedSummaryBlock(threadId, memory);
 			}
 
@@ -131,6 +175,12 @@ export class InstanceAiCompactionService {
 		return null;
 	}
 
+	/** Get the full serialized text of a message (for token estimation). */
+	private extractRawText(msg: MastraDBMessage): string {
+		if (typeof msg.content === 'string') return msg.content;
+		return JSON.stringify(msg.content);
+	}
+
 	/**
 	 * Extract user/assistant text content from messages, skipping tool calls,
 	 * tool results, and system messages.
@@ -157,10 +207,8 @@ export class InstanceAiCompactionService {
 	 * Handles both string content and structured content arrays.
 	 */
 	private extractTextFromContent(content: MastraMessageContentV2): string {
-		// Direct string content
 		if (typeof content === 'string') return content;
 
-		// Mastra wraps content in { content: [...parts] }
 		const inner = (content as Record<string, unknown>)?.content;
 		if (typeof inner === 'string') return inner;
 
@@ -172,7 +220,6 @@ export class InstanceAiCompactionService {
 				} else if (isTextPart(part)) {
 					textParts.push(part.text);
 				}
-				// Skip tool-call, tool-result, image, and file parts
 			}
 			return textParts.join('\n');
 		}

--- a/packages/cli/src/modules/instance-ai/compaction.service.ts
+++ b/packages/cli/src/modules/instance-ai/compaction.service.ts
@@ -1,3 +1,4 @@
+import type { ChatHubLLMProvider } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
 import { generateCompactionSummary } from '@n8n/instance-ai';
@@ -6,9 +7,13 @@ import type { Memory } from '@mastra/memory';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import type { MastraDBMessage } from '@mastra/core/memory';
 
+import { maxContextWindowTokens } from '@/modules/chat-hub/context-limits';
+
 import { TypeORMMemoryStorage } from './storage/typeorm-memory-storage';
 
 const METADATA_KEY = 'instanceAiConversationSummary';
+
+const DEFAULT_CONTEXT_WINDOW = 128_000;
 
 /**
  * Rough token estimate: ~4 chars per token for English text.
@@ -18,15 +23,32 @@ function estimateTokens(text: string): number {
 	return Math.ceil(text.length / 4);
 }
 
-/** Look up context window size (in tokens) for known model families. */
+/**
+ * Look up context window size (in tokens) using the Chat Hub model registry.
+ * Tries exact match first, then prefix match (e.g. "claude-sonnet-4-5" matches
+ * "claude-sonnet-4-5-20250929"), falling back to a conservative default.
+ */
 function getContextWindowForModel(modelId: ModelConfig): number {
-	const id = typeof modelId === 'string' ? modelId : modelId.id;
-	if (id.includes('claude')) return 200_000;
-	if (id.includes('gpt-4o')) return 128_000;
-	if (id.includes('gpt-4')) return 128_000;
-	if (id.includes('gpt-3.5')) return 16_000;
-	// Conservative default for unknown models
-	return 128_000;
+	const raw = typeof modelId === 'string' ? modelId : modelId.id;
+	const slashIndex = raw.indexOf('/');
+	if (slashIndex < 0) return DEFAULT_CONTEXT_WINDOW;
+
+	const provider = raw.slice(0, slashIndex) as ChatHubLLMProvider;
+	const model = raw.slice(slashIndex + 1);
+
+	const providerModels = maxContextWindowTokens[provider];
+	if (!providerModels) return DEFAULT_CONTEXT_WINDOW;
+
+	// Exact match
+	if (providerModels[model]) return providerModels[model];
+
+	// Prefix match: instance-ai may use short aliases (e.g. "claude-sonnet-4-5")
+	// while the registry stores full API IDs (e.g. "claude-sonnet-4-5-20250929")
+	for (const [registryModel, tokens] of Object.entries(providerModels)) {
+		if (tokens > 0 && registryModel.startsWith(model)) return tokens;
+	}
+
+	return DEFAULT_CONTEXT_WINDOW;
 }
 
 /** Estimate tokens consumed by system prompt, tools, and working memory overhead. */

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -784,12 +784,24 @@ export class InstanceAiService {
 			});
 
 			// Compact older conversation history into a summary (best-effort, non-blocking on failure)
+			this.eventBus.publish(threadId, {
+				type: 'status',
+				runId,
+				agentId: ORCHESTRATOR_AGENT_ID,
+				payload: { message: 'Recalling conversation...' },
+			});
 			const conversationSummary = await this.compactionService.prepareCompactedContext(
 				threadId,
 				memory,
 				modelId,
 				this.instanceAiConfig.lastMessages ?? 20,
 			);
+			this.eventBus.publish(threadId, {
+				type: 'status',
+				runId,
+				agentId: ORCHESTRATOR_AGENT_ID,
+				payload: { message: '' },
+			});
 
 			// Inject completed/running background task context into the message
 			const enrichedMessage = await this.enrichMessageWithBackgroundTasks(

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -53,6 +53,7 @@ import { InstanceAiSettingsService } from './instance-ai-settings.service';
 import { MastraIterationLogStorage } from './iteration-log-storage';
 import { MastraTaskStorage } from './task-storage';
 import { TypeORMCompositeStore } from './storage/typeorm-composite-store';
+import { InstanceAiCompactionService } from './compaction.service';
 import { WorkflowLoopStorage } from './workflow-loop-storage';
 
 interface ActiveRun {
@@ -203,6 +204,7 @@ export class InstanceAiService {
 		private readonly eventBus: InProcessEventBus,
 		private readonly settingsService: InstanceAiSettingsService,
 		private readonly compositeStore: TypeORMCompositeStore,
+		private readonly compactionService: InstanceAiCompactionService,
 	) {
 		this.instanceAiConfig = globalConfig.instanceAi;
 		const editorBaseUrl = globalConfig.editorBaseUrl || `http://localhost:${globalConfig.port}`;
@@ -781,12 +783,25 @@ export class InstanceAiService {
 				disableDeferredTools: true,
 			});
 
+			// Compact older conversation history into a summary (best-effort, non-blocking on failure)
+			const conversationSummary = await this.compactionService.prepareCompactedContext(
+				threadId,
+				memory,
+				modelId,
+				this.instanceAiConfig.lastMessages ?? 20,
+			);
+
 			// Inject completed/running background task context into the message
 			const enrichedMessage = await this.enrichMessageWithBackgroundTasks(
 				threadId,
 				message,
 				workflowLoopStorage,
 			);
+
+			// Compose runtime input: conversation summary → background tasks → user message
+			const fullMessage = conversationSummary
+				? `${conversationSummary}\n\n${enrichedMessage}`
+				: enrichedMessage;
 
 			// Build multimodal message when attachments are present
 			const streamInput =
@@ -795,7 +810,7 @@ export class InstanceAiService {
 							{
 								role: 'user' as const,
 								content: [
-									{ type: 'text' as const, text: enrichedMessage },
+									{ type: 'text' as const, text: fullMessage },
 									...attachments.map((a) => ({
 										type: 'file' as const,
 										data: a.data,
@@ -804,7 +819,7 @@ export class InstanceAiService {
 								],
 							},
 						]
-					: enrichedMessage;
+					: fullMessage;
 
 			const result = await agent.stream(streamInput, {
 				abortSignal: signal,

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiMessage.vue
@@ -260,7 +260,7 @@ function formatJson(value: unknown): string {
 	width: 6px;
 	height: 6px;
 	border-radius: 50%;
-	background: var(--color--primary);
+	background: var(--background--brand);
 	animation: pulse 1.5s ease-in-out infinite;
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiMessage.vue
@@ -53,6 +53,12 @@ const formattedTechnicalDetails = computed(() => {
 
 const attachments = computed(() => props.message.attachments ?? []);
 
+/** Transient status message from the backend (e.g. "Recalling conversation..."). */
+const statusMessage = computed(() => {
+	if (!isStreaming.value || !props.message.agentTree) return '';
+	return props.message.agentTree.statusMessage ?? '';
+});
+
 /**
  * Background task indicator: shows when the orchestrator run has finished
  * but child agents (e.g., workflow builder) are still working in the background.
@@ -124,9 +130,15 @@ function formatJson(value: unknown): string {
 						<InstanceAiMarkdown v-if="props.message.content" :content="props.message.content" />
 					</div>
 
+					<!-- Status indicator while preparing context -->
+					<div v-if="statusMessage && !props.message.content" :class="$style.statusIndicator">
+						<span :class="$style.statusDot" />
+						<span>{{ statusMessage }}</span>
+					</div>
+
 					<!-- Blinking cursor while waiting for response -->
 					<span
-						v-if="isStreaming && !props.message.content && !props.message.agentTree"
+						v-else-if="isStreaming && !props.message.content && !props.message.agentTree"
 						:class="$style.blinkingCursor"
 					/>
 
@@ -232,6 +244,43 @@ function formatJson(value: unknown): string {
 	margin-top: var(--spacing--4xs);
 	font-size: var(--font-size--2xs);
 	color: var(--color--text);
+}
+
+.statusIndicator {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing--3xs);
+	font-size: var(--font-size--2xs);
+	color: var(--color--text--tint-1);
+	padding: var(--spacing--4xs) 0;
+	animation: status-fade-in 0.2s ease;
+}
+
+.statusDot {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: var(--color--primary);
+	animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes status-fade-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+@keyframes pulse {
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.3;
+	}
 }
 
 .blinkingCursor {


### PR DESCRIPTION
## Summary

Closes https://linear.app/n8n/issue/AI-2233

- Adds automatic rolling compaction of older thread messages into a structured summary to maintain long-range context in Instance AI conversations
- New `InstanceAiCompactionService` (CLI) + `generateCompactionSummary` helper (`@n8n/instance-ai`) handle the full lifecycle
- Compaction state stored in thread metadata (`instanceAiConversationSummary`) — no DB migration needed
- Best-effort, non-blocking: failures log a warning and proceed without summary
- Subtle "Recalling conversation..." status indicator via new `status` streaming event
- Context window lookup uses the **Chat Hub model registry** (`context-limits.ts`) — single source of truth covering 100+ models across all providers

## How it works

1. Before each agent stream, `prepareCompactedContext()` estimates the total token usage across all thread messages
2. If total tokens exceed **80% of the model's context window**, compaction triggers on the older message prefix (before the `lastMessages` tail)
3. A lightweight Mastra Agent (no tools, no memory) generates a rolling summary with five fixed sections: Goal, Important facts, Workflow state, Open issues, Likely next step
4. The summary is prepended to the user message as a `<conversation-summary>` XML block
5. System prompt instructs the agent to use the summary for long-range continuity and recent raw messages for exact wording

## Compaction trigger

The trigger is **token-based**, matching the pattern used by Claude Code and OpenAI's auto-compaction:

- **Token estimation**: `ceil(chars / 4)` across all thread messages + 8k fixed overhead (system prompt, tools, working memory)
- **Context window**: looked up from the **Chat Hub model registry** (`maxContextWindowTokens` in `context-limits.ts`), which covers all supported providers (OpenAI, Anthropic, Google, Groq, Mistral, xAI, DeepSeek, etc.). Uses exact match first, then prefix match for short aliases (e.g. `claude-sonnet-4-5` → `claude-sonnet-4-5-20250929`), with a conservative 128k fallback for unknown models.
- **Threshold**: compacts when total estimated tokens exceed **80%** of the model's context window (configurable via `compactionThreshold` parameter, 0–1)
- **Minimum delta**: at least 500 unsummarized tokens required to avoid trivial compaction calls
- **Incremental**: each compaction only processes the delta since the last `upToMessageId`

Example: with Claude Sonnet (200k window), compaction triggers when thread messages total ~160k+ estimated tokens.

## Key design decisions

- **Non-destructive**: raw messages stay in storage/UI — only model input is compacted
- **Token-based trigger**: context percentage, not message count — a few large tool-result messages trigger earlier than many short ones
- **Centralized model registry**: context window sizes are looked up from the Chat Hub's `maxContextWindowTokens` map rather than hardcoded per model family — new models are picked up automatically when the registry is updated
- **High-signal only**: user/assistant text is preserved; tool payloads, binary data, and execution outputs are dropped from the summary input
- **Thread-scoped**: summary is per-thread, not user-global
- **Input order**: `<conversation-summary>` → `<background-tasks>` → user message
- **Status UX**: pulsing dot + "Recalling conversation..." label appears before first token, via new `status` streaming event type