### PR TITLE
feat(core): Batch public API telemetry events on pulse cycle

### DIFF
--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -655,6 +655,7 @@ describe('TelemetryEventRelay', () => {
 				path: '/api/v1/workflows',
 				method: 'GET',
 				apiVersion: 'v1',
+				userAgent: 'n8n-cli',
 			};
 
 			eventService.emit('public-api-invoked', event);
@@ -664,6 +665,7 @@ describe('TelemetryEventRelay', () => {
 				path: '/api/v1/workflows',
 				method: 'GET',
 				api_version: 'v1',
+				user_agent: 'n8n-cli',
 			});
 		});
 

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -649,7 +649,7 @@ describe('TelemetryEventRelay', () => {
 	});
 
 	describe('public API events', () => {
-		it('should track on `public-api-invoked` event', () => {
+		it('should buffer on `public-api-invoked` event', () => {
 			const event: RelayEventMap['public-api-invoked'] = {
 				userId: 'user123',
 				path: '/api/v1/workflows',
@@ -660,7 +660,7 @@ describe('TelemetryEventRelay', () => {
 
 			eventService.emit('public-api-invoked', event);
 
-			expect(telemetry.track).toHaveBeenCalledWith('User invoked API', {
+			expect(telemetry.trackApiInvocation).toHaveBeenCalledWith({
 				user_id: 'user123',
 				path: '/api/v1/workflows',
 				method: 'GET',

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -345,6 +345,7 @@ export type RelayEventMap = {
 		path: string;
 		method: string;
 		apiVersion: string;
+		userAgent?: string;
 	};
 
 	// #endregion

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -409,7 +409,7 @@ export class TelemetryEventRelay extends EventRelay {
 		apiVersion,
 		userAgent,
 	}: RelayEventMap['public-api-invoked']) {
-		this.telemetry.track('User invoked API', {
+		this.telemetry.trackApiInvocation({
 			user_id: userId,
 			path,
 			method,

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -407,12 +407,14 @@ export class TelemetryEventRelay extends EventRelay {
 		path,
 		method,
 		apiVersion,
+		userAgent,
 	}: RelayEventMap['public-api-invoked']) {
 		this.telemetry.track('User invoked API', {
 			user_id: userId,
 			path,
 			method,
 			api_version: apiVersion,
+			user_agent: userAgent,
 		});
 	}
 

--- a/packages/cli/src/services/public-api-key.service.ts
+++ b/packages/cli/src/services/public-api-key.service.ts
@@ -156,6 +156,7 @@ export class PublicApiKeyService {
 				path: req.path,
 				method: req.method,
 				apiVersion: version,
+				userAgent: req.headers['user-agent'],
 			});
 
 			req.user = user;

--- a/packages/cli/src/telemetry/__tests__/telemetry.test.ts
+++ b/packages/cli/src/telemetry/__tests__/telemetry.test.ts
@@ -348,6 +348,103 @@ describe('Telemetry', () => {
 		});
 	});
 
+	describe('trackApiInvocation', () => {
+		beforeEach(() => {
+			jest.setSystemTime(testDateTime);
+		});
+
+		test('should count calls per user and endpoint', () => {
+			const execTime1 = fakeJestSystemTime('2022-01-01 12:00:00');
+
+			telemetry.trackApiInvocation({
+				user_id: 'user1',
+				path: '/workflows',
+				method: 'GET',
+				api_version: 'v1',
+				user_agent: 'n8n-cli/1.0',
+			});
+
+			telemetry.trackApiInvocation({
+				user_id: 'user1',
+				path: '/workflows',
+				method: 'GET',
+				api_version: 'v1',
+				user_agent: 'n8n-cli/1.0',
+			});
+
+			telemetry.trackApiInvocation({
+				user_id: 'user1',
+				path: '/executions',
+				method: 'POST',
+				api_version: 'v1',
+				user_agent: 'custom-app/2.0',
+			});
+
+			const buffer = telemetry.getApiInvocationsBuffer();
+
+			expect(buffer['user1'].total_calls).toBe(3);
+			expect(buffer['user1'].first).toEqual(execTime1);
+			expect(buffer['user1'].endpoints['GET /workflows']).toBe(2);
+			expect(buffer['user1'].endpoints['POST /executions']).toBe(1);
+			expect(buffer['user1'].user_agents['n8n-cli/1.0']).toBe(2);
+			expect(buffer['user1'].user_agents['custom-app/2.0']).toBe(1);
+		});
+
+		test('should handle missing user_agent', () => {
+			telemetry.trackApiInvocation({
+				user_id: 'user1',
+				path: '/workflows',
+				method: 'GET',
+				api_version: 'v1',
+			});
+
+			const buffer = telemetry.getApiInvocationsBuffer();
+
+			expect(buffer['user1'].total_calls).toBe(1);
+			expect(buffer['user1'].user_agents).toEqual({});
+		});
+
+		test('should track multiple users independently', () => {
+			telemetry.trackApiInvocation({
+				user_id: 'user1',
+				path: '/workflows',
+				method: 'GET',
+				api_version: 'v1',
+				user_agent: 'n8n-cli/1.0',
+			});
+
+			telemetry.trackApiInvocation({
+				user_id: 'user2',
+				path: '/executions',
+				method: 'POST',
+				api_version: 'v1',
+				user_agent: 'custom-app/2.0',
+			});
+
+			const buffer = telemetry.getApiInvocationsBuffer();
+
+			expect(buffer['user1'].total_calls).toBe(1);
+			expect(buffer['user1'].endpoints['GET /workflows']).toBe(1);
+			expect(buffer['user2'].total_calls).toBe(1);
+			expect(buffer['user2'].endpoints['POST /executions']).toBe(1);
+		});
+
+		test('should not buffer when rudderStack is not initialized', () => {
+			// @ts-expect-error Assigning to private property
+			telemetry.rudderStack = undefined;
+
+			telemetry.trackApiInvocation({
+				user_id: 'user1',
+				path: '/workflows',
+				method: 'GET',
+				api_version: 'v1',
+			});
+
+			const buffer = telemetry.getApiInvocationsBuffer();
+			expect(Object.keys(buffer)).toHaveLength(0);
+		});
+	});
+
 	describe('Rudderstack', () => {
 		test("should call rudderStack.identify() with a fake IP address to instruct Rudderstack to not use the user's IP address", () => {
 			const traits = {

--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -45,6 +45,25 @@ interface IExecutionsBuffer {
 	};
 }
 
+interface IApiInvocationProperties {
+	user_id: string;
+	path: string;
+	method: string;
+	api_version: string;
+	user_agent?: string;
+}
+
+interface IApiInvocationsBufferEntry {
+	total_calls: number;
+	first: Date;
+	endpoints: Record<string, number>;
+	user_agents: Record<string, number>;
+}
+
+interface IApiInvocationsBuffer {
+	[userId: string]: IApiInvocationsBufferEntry;
+}
+
 @Service()
 export class Telemetry {
 	private rudderStack?: RudderStack;
@@ -52,6 +71,8 @@ export class Telemetry {
 	private pulseIntervalReference: NodeJS.Timeout;
 
 	private executionCountsBuffer: IExecutionsBuffer = {};
+
+	private apiInvocationsBuffer: IApiInvocationsBuffer = {};
 
 	constructor(
 		private readonly logger: Logger,
@@ -178,6 +199,21 @@ export class Telemetry {
 
 		this.executionCountsBuffer = {};
 
+		// Flush API invocation counts
+		for (const userId of Object.keys(this.apiInvocationsBuffer)) {
+			const entry = this.apiInvocationsBuffer[userId];
+			if (entry.total_calls > 0) {
+				this.track('Public API usage', {
+					user_id: userId,
+					total_calls: entry.total_calls,
+					first: entry.first,
+					endpoints: JSON.stringify(entry.endpoints),
+					user_agents: JSON.stringify(entry.user_agents),
+				});
+			}
+		}
+		this.apiInvocationsBuffer = {};
+
 		const sourceControlPreferences = Container.get(
 			SourceControlPreferencesService,
 		).getPreferences();
@@ -238,6 +274,29 @@ export class Telemetry {
 			) {
 				this.track('Workflow execution errored', properties);
 			}
+		}
+	}
+
+	trackApiInvocation(properties: IApiInvocationProperties) {
+		if (!this.rudderStack) return;
+
+		const { user_id, path, method, user_agent } = properties;
+
+		this.apiInvocationsBuffer[user_id] = this.apiInvocationsBuffer[user_id] ?? {
+			total_calls: 0,
+			first: new Date(),
+			endpoints: {},
+			user_agents: {},
+		};
+
+		const entry = this.apiInvocationsBuffer[user_id];
+		entry.total_calls++;
+
+		const endpointKey = `${method} ${path}`;
+		entry.endpoints[endpointKey] = (entry.endpoints[endpointKey] ?? 0) + 1;
+
+		if (user_agent) {
+			entry.user_agents[user_agent] = (entry.user_agents[user_agent] ?? 0) + 1;
 		}
 	}
 
@@ -349,5 +408,9 @@ export class Telemetry {
 	// test helpers
 	getCountsBuffer(): IExecutionsBuffer {
 		return this.executionCountsBuffer;
+	}
+
+	getApiInvocationsBuffer(): IApiInvocationsBuffer {
+		return this.apiInvocationsBuffer;
 	}
 }


### PR DESCRIPTION
## Summary

- Aggregate individual "User invoked API" Rudderstack events into batched "Public API usage" events flushed on the existing 6-hour pulse cycle
- Tracks endpoint breakdown (`GET /workflows` -> count) and user-agent breakdown per user
- Reduces Rudderstack event volume and cost while preserving visibility into API usage patterns

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4965

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)