### PR TITLE
fix(Anthropic Node): Update credential test to use available model

### DIFF
--- a/packages/@n8n/nodes-langchain/credentials/AnthropicApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/AnthropicApi.credentials.ts
@@ -71,7 +71,7 @@ export class AnthropicApi implements ICredentialType {
 				'anthropic-version': '2023-06-01',
 			},
 			body: {
-				model: 'claude-3-haiku-20240307',
+				model: 'claude-haiku-4-5-20251001',
 				messages: [{ role: 'user', content: 'Hey' }],
 				max_tokens: 1,
 			},


### PR DESCRIPTION
## Summary

The Anthropic credential test was using the deprecated model `claude-3-haiku-20240307`, which is no longer available on newer Anthropic accounts. This caused credential verification to fail with a 404 error when users tried to add their Anthropic API credentials.

This fix updates the test to use `claude-haiku-4-5-20251001`, the current smallest/cheapest model available, which is ideal for a lightweight credential test.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2227

Closes #26637

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included (existing unit tests pass).
- [ ] Docs updated or follow-up ticket created.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` if needed