### PR TITLE
fix(editor): Unify input component background surfaces

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nColorPicker/ColorPicker.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nColorPicker/ColorPicker.vue
@@ -90,7 +90,7 @@ const onColorSelect = (value: string | null) => {
 
 .input {
 	margin-left: var(--spacing--3xs);
-	--input--color--background: light-dark(var(--color--neutral-100), var(--color--neutral-950));
+	--input--color--background: light-dark(var(--color--neutral-white), var(--color--neutral-950));
 }
 </style>
 

--- a/packages/frontend/@n8n/design-system/src/components/N8nColorPicker/ColorPicker.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nColorPicker/ColorPicker.vue
@@ -90,6 +90,7 @@ const onColorSelect = (value: string | null) => {
 
 .input {
 	margin-left: var(--spacing--3xs);
+	--input--color--background: light-dark(var(--color--neutral-100), var(--color--neutral-950));
 }
 </style>
 

--- a/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/InlineTextEdit.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/InlineTextEdit.vue
@@ -147,7 +147,7 @@ defineExpose({ forceFocus, forceCancel });
 		width: calc(100% + var(--spacing--xs));
 		height: calc(100% + var(--spacing--2xs));
 		border-radius: var(--radius);
-		background-color: light-dark(var(--color--neutral-100), var(--color--neutral-950));
+		background-color: light-dark(var(--color--neutral-white), var(--color--neutral-950));
 		opacity: 0;
 		z-index: 0;
 		transition: all 0.1s ease-in-out;

--- a/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/InlineTextEdit.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/InlineTextEdit.vue
@@ -147,7 +147,7 @@ defineExpose({ forceFocus, forceCancel });
 		width: calc(100% + var(--spacing--xs));
 		height: calc(100% + var(--spacing--2xs));
 		border-radius: var(--radius);
-		background-color: var(--color--foreground--tint-2);
+		background-color: light-dark(var(--color--neutral-100), var(--color--neutral-950));
 		opacity: 0;
 		z-index: 0;
 		transition: all 0.1s ease-in-out;

--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
@@ -534,7 +534,7 @@ defineExpose({ focus, blur, select });
 	flex: 1;
 	min-width: 0;
 	resize: vertical;
-	padding: var(--spacing--xs);
+	padding: var(--input--padding);
 	line-height: var(--line-height--md);
 	border: none;
 	background: transparent;

--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
@@ -391,7 +391,7 @@ defineExpose({ focus, blur, select });
 	--input--font-size: var(--font-size--sm);
 	--input--padding: var(--spacing--xs);
 
-	--input--color--background: light-dark(var(--color--neutral-white), transparent);
+	--input--color--background: light-dark(var(--color--neutral-100), var(--color--neutral-950));
 	--input--shadow: 0 0 0 0 transparent;
 	--input--shadow--hover: 0 0 0 0 transparent;
 	--input--shadow--focus: 0 0 0 0 transparent;

--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
@@ -391,7 +391,7 @@ defineExpose({ focus, blur, select });
 	--input--font-size: var(--font-size--sm);
 	--input--padding: var(--spacing--xs);
 
-	--input--color--background: light-dark(var(--color--neutral-100), var(--color--neutral-950));
+	--input--color--background: light-dark(var(--color--neutral-white), var(--color--neutral-950));
 	--input--shadow: 0 0 0 0 transparent;
 	--input--shadow--hover: 0 0 0 0 transparent;
 	--input--shadow--focus: 0 0 0 0 transparent;

--- a/packages/frontend/@n8n/design-system/src/components/N8nInputNumber/InputNumber.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInputNumber/InputNumber.vue
@@ -38,6 +38,13 @@ const resolvedSize = computed(() => (props.size ? sizeMap[props.size] : undefine
 		:max="max"
 		:step="step"
 		:precision="precision"
+		:class="$style.inputNumber"
 		v-bind="$attrs"
 	/>
 </template>
+
+<style lang="scss" module>
+.inputNumber {
+	--input--color--background: light-dark(var(--color--neutral-100), var(--color--neutral-950));
+}
+</style>

--- a/packages/frontend/@n8n/design-system/src/components/N8nInputNumber/InputNumber.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInputNumber/InputNumber.vue
@@ -45,6 +45,6 @@ const resolvedSize = computed(() => (props.size ? sizeMap[props.size] : undefine
 
 <style lang="scss" module>
 .inputNumber {
-	--input--color--background: light-dark(var(--color--neutral-100), var(--color--neutral-950));
+	--input--color--background: light-dark(var(--color--neutral-white), var(--color--neutral-950));
 }
 </style>

--- a/packages/frontend/@n8n/design-system/src/components/N8nSelect/Select.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nSelect/Select.vue
@@ -160,6 +160,7 @@ defineExpose({
 .container {
 	display: inline-flex;
 	width: 100%;
+	--input--color--background: light-dark(var(--color--neutral-100), var(--color--neutral-950));
 }
 
 .withPrepend {
@@ -179,7 +180,7 @@ defineExpose({
 	display: flex;
 	align-items: center;
 	padding: 0 var(--spacing--3xs);
-	background-color: var(--color--background--light-2);
+	background-color: var(--input--color--background);
 	border-bottom-left-radius: var(--input--radius, var(--radius));
 	border-top-left-radius: var(--input--radius, var(--radius));
 	color: var(--color--text);

--- a/packages/frontend/@n8n/design-system/src/components/N8nSelect/Select.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nSelect/Select.vue
@@ -160,7 +160,7 @@ defineExpose({
 .container {
 	display: inline-flex;
 	width: 100%;
-	--input--color--background: light-dark(var(--color--neutral-100), var(--color--neutral-950));
+	--input--color--background: light-dark(var(--color--neutral-white), var(--color--neutral-950));
 }
 
 .withPrepend {

--- a/packages/frontend/@n8n/design-system/src/v2/components/InputNumber/InputNumber.vue
+++ b/packages/frontend/@n8n/design-system/src/v2/components/InputNumber/InputNumber.vue
@@ -116,7 +116,7 @@ const sizeClass = computed(() => sizes[props.size ?? 'medium']);
 	width: 100%;
 	border-radius: var(--radius);
 	border: var(--border);
-	background-color: var(--color--background--light-2);
+	background-color: light-dark(var(--color--neutral-100), var(--color--neutral-950));
 	transition:
 		border-color 0.2s,
 		box-shadow 0.2s;

--- a/packages/frontend/@n8n/design-system/src/v2/components/InputNumber/InputNumber.vue
+++ b/packages/frontend/@n8n/design-system/src/v2/components/InputNumber/InputNumber.vue
@@ -116,7 +116,7 @@ const sizeClass = computed(() => sizes[props.size ?? 'medium']);
 	width: 100%;
 	border-radius: var(--radius);
 	border: var(--border);
-	background-color: light-dark(var(--color--neutral-100), var(--color--neutral-950));
+	background-color: light-dark(var(--color--neutral-white), var(--color--neutral-950));
 	transition:
 		border-color 0.2s,
 		box-shadow 0.2s;

--- a/packages/frontend/@n8n/design-system/src/v2/components/Select/Select.vue
+++ b/packages/frontend/@n8n/design-system/src/v2/components/Select/Select.vue
@@ -216,7 +216,7 @@ const groups = computed<SelectItemProps[]>(() => {
 	font-weight: var(--font-weight--regular);
 	line-height: var(--line-height--md);
 	border: 1px solid transparent;
-	background-color: light-dark(var(--color--neutral-100), var(--color--neutral-950));
+	background-color: light-dark(var(--color--neutral-white), var(--color--neutral-950));
 	height: var(--spacing--lg);
 	position: relative;
 	gap: var(--spacing--3xs);

--- a/packages/frontend/@n8n/design-system/src/v2/components/Select/Select.vue
+++ b/packages/frontend/@n8n/design-system/src/v2/components/Select/Select.vue
@@ -216,7 +216,7 @@ const groups = computed<SelectItemProps[]>(() => {
 	font-weight: var(--font-weight--regular);
 	line-height: var(--line-height--md);
 	border: 1px solid transparent;
-	background-color: var(--color--background--light-2);
+	background-color: light-dark(var(--color--neutral-100), var(--color--neutral-950));
 	height: var(--spacing--lg);
 	position: relative;
 	gap: var(--spacing--3xs);


### PR DESCRIPTION
## Summary

- Unify input-type surface backgrounds across legacy and v2 design-system components, particularly in dark mode.
- Co-locate background value ownership in each component `.vue` style block (`N8nInput`, `N8nSelect`, `N8nInputNumber`, `N8nInlineTextEdit`, `N8nColorPicker`, `N8nSelect2`, `N8nInputNumber2`).
- Keep shared SCSS structural rules intact and avoid public API/prop/event changes.

| Before | After |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/4266fc4b-4ee1-4720-918d-5db31c41ccb9" width="960px" alt="Before image" /> | <img src="https://github.com/user-attachments/assets/ecad911e-e145-423b-aee2-cd7d6aaa0d8f" width="960px" alt="After image" /> |

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/DS-507

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
