### PR TITLE
feat(core): Introduce expression-based role resolver for SSO claim mapping (no-changelog)

### DIFF
--- a/packages/cli/src/modules/provisioning.ee/__tests__/claims-context.builder.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/claims-context.builder.test.ts
@@ -1,0 +1,157 @@
+import {
+	buildOidcClaimsContext,
+	buildSamlClaimsContext,
+	withProjectContext,
+} from '../claims-context.builder';
+import type { ProjectInfo, RoleResolverContext } from '../role-resolver-types';
+
+describe('claims-context.builder', () => {
+	describe('buildOidcClaimsContext', () => {
+		it('should merge idToken and userInfo into $claims with userInfo taking precedence', () => {
+			const idToken = { sub: 'user-123', role: 'admin', email: 'old@example.com' };
+			const userInfo = { email: 'new@example.com', name: 'Test User' };
+
+			const context = buildOidcClaimsContext(idToken, userInfo);
+
+			expect(context.$claims).toEqual({
+				sub: 'user-123',
+				role: 'admin',
+				email: 'new@example.com',
+				name: 'Test User',
+			});
+		});
+
+		it('should populate $oidc.idToken and $oidc.userInfo', () => {
+			const idToken = { sub: 'user-123' };
+			const userInfo = { email: 'test@example.com' };
+
+			const context = buildOidcClaimsContext(idToken, userInfo);
+
+			expect(context.$oidc).toEqual({
+				idToken: { sub: 'user-123' },
+				userInfo: { email: 'test@example.com' },
+			});
+		});
+
+		it('should set $provider to oidc', () => {
+			const context = buildOidcClaimsContext({}, {});
+
+			expect(context.$provider).toBe('oidc');
+		});
+
+		it('should not have $saml set', () => {
+			const context = buildOidcClaimsContext({}, {});
+
+			expect(context.$saml).toBeUndefined();
+		});
+
+		it('should deep-clone input data so mutations do not affect the context', () => {
+			const idToken = { sub: 'user-123', nested: { groups: ['a'] } };
+			const userInfo = { email: 'test@example.com' };
+
+			const context = buildOidcClaimsContext(idToken, userInfo);
+
+			idToken.nested.groups.push('b');
+			userInfo.email = 'changed@example.com';
+
+			expect(context.$claims).toEqual({
+				sub: 'user-123',
+				nested: { groups: ['a'] },
+				email: 'test@example.com',
+			});
+			expect(context.$oidc!.idToken).toEqual({ sub: 'user-123', nested: { groups: ['a'] } });
+			expect(context.$oidc!.userInfo).toEqual({ email: 'test@example.com' });
+		});
+	});
+
+	describe('buildSamlClaimsContext', () => {
+		it('should populate $claims from raw attributes', () => {
+			const attributes = { email: 'test@example.com', role: 'admin' };
+
+			const context = buildSamlClaimsContext(attributes);
+
+			expect(context.$claims).toEqual({ email: 'test@example.com', role: 'admin' });
+		});
+
+		it('should populate $saml.attributes', () => {
+			const attributes = { email: 'test@example.com' };
+
+			const context = buildSamlClaimsContext(attributes);
+
+			expect(context.$saml).toEqual({
+				attributes: { email: 'test@example.com' },
+			});
+		});
+
+		it('should set $provider to saml', () => {
+			const context = buildSamlClaimsContext({});
+
+			expect(context.$provider).toBe('saml');
+		});
+
+		it('should not have $oidc set', () => {
+			const context = buildSamlClaimsContext({});
+
+			expect(context.$oidc).toBeUndefined();
+		});
+
+		it('should deep-clone input data so mutations do not affect the context', () => {
+			const attributes = { groups: ['engineering', 'devops'] };
+
+			const context = buildSamlClaimsContext(attributes);
+
+			attributes.groups.push('sales');
+
+			expect(context.$claims).toEqual({ groups: ['engineering', 'devops'] });
+			expect(context.$saml!.attributes).toEqual({ groups: ['engineering', 'devops'] });
+		});
+	});
+
+	describe('withProjectContext', () => {
+		const baseContext: RoleResolverContext = {
+			$claims: { role: 'admin' },
+			$provider: 'oidc',
+		};
+
+		const project: ProjectInfo = {
+			id: 'proj-1',
+			name: 'Engineering',
+			type: 'team',
+			description: 'Engineering team project',
+		};
+
+		it('should add $project to context', () => {
+			const enriched = withProjectContext(baseContext, project);
+
+			expect(enriched.$project).toEqual({
+				id: 'proj-1',
+				name: 'Engineering',
+				type: 'team',
+				description: 'Engineering team project',
+			});
+		});
+
+		it('should preserve existing context properties', () => {
+			const enriched = withProjectContext(baseContext, project);
+
+			expect(enriched.$claims).toEqual({ role: 'admin' });
+			expect(enriched.$provider).toBe('oidc');
+		});
+
+		it('should not mutate the original context', () => {
+			const enriched = withProjectContext(baseContext, project);
+
+			expect(baseContext.$project).toBeUndefined();
+			expect(enriched.$project).toBeDefined();
+		});
+
+		it('should not be affected by mutations to the project input', () => {
+			const mutableProject = { ...project };
+			const enriched = withProjectContext(baseContext, mutableProject);
+
+			mutableProject.name = 'Changed';
+
+			expect(enriched.$project!.name).toBe('Engineering');
+		});
+	});
+});

--- a/packages/cli/src/modules/provisioning.ee/__tests__/role-resolver.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/role-resolver.service.ee.test.ts
@@ -1,0 +1,532 @@
+import type { Logger } from '@n8n/backend-common';
+import type { ProjectRepository } from '@n8n/db';
+import { mock } from 'jest-mock-extended';
+
+import { RoleResolverService } from '../role-resolver.service.ee';
+import type {
+	ProjectInfo,
+	RoleMappingConfig,
+	RoleMappingRule,
+	RoleResolverContext,
+} from '../role-resolver-types';
+
+const logger = mock<Logger>();
+const projectRepository = mock<ProjectRepository>();
+
+const service = new RoleResolverService(logger, projectRepository);
+
+function makeRule(overrides: Partial<RoleMappingRule> = {}): RoleMappingRule {
+	return {
+		id: 'rule-1',
+		expression: '{{ true }}',
+		role: 'global:admin',
+		enabled: true,
+		...overrides,
+	};
+}
+
+function makeConfig(overrides: Partial<RoleMappingConfig> = {}): RoleMappingConfig {
+	return {
+		instanceRoleRules: [],
+		projectRoleRules: [],
+		fallbackInstanceRole: 'global:member',
+		...overrides,
+	};
+}
+
+function makeContext(overrides: Partial<RoleResolverContext> = {}): RoleResolverContext {
+	return {
+		$claims: {},
+		$provider: 'oidc',
+		...overrides,
+	};
+}
+
+function makeProject(overrides: Partial<ProjectInfo> = {}): ProjectInfo {
+	return {
+		id: 'proj-1',
+		name: 'Engineering',
+		type: 'team',
+		description: null,
+		...overrides,
+	};
+}
+
+describe('RoleResolverService', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		projectRepository.find.mockResolvedValue([]);
+	});
+
+	describe('resolveRoles - instance role rules', () => {
+		it('should return the role of the first matching rule', async () => {
+			const config = makeConfig({
+				instanceRoleRules: [
+					makeRule({ id: 'r1', expression: '{{ false }}', role: 'global:owner' }),
+					makeRule({ id: 'r2', expression: '{{ true }}', role: 'global:admin' }),
+					makeRule({ id: 'r3', expression: '{{ true }}', role: 'global:member' }),
+				],
+			});
+
+			const result = await service.resolveRoles(config, makeContext());
+
+			expect(result.instanceRole).toBe('global:admin');
+		});
+
+		it('should fallback to fallbackInstanceRole when no rule matches', async () => {
+			const config = makeConfig({
+				instanceRoleRules: [
+					makeRule({ id: 'r1', expression: '{{ false }}', role: 'global:admin' }),
+				],
+				fallbackInstanceRole: 'global:member',
+			});
+
+			const result = await service.resolveRoles(config, makeContext());
+
+			expect(result.instanceRole).toBe('global:member');
+		});
+
+		it('should fallback when there are no rules', async () => {
+			const config = makeConfig({ instanceRoleRules: [] });
+
+			const result = await service.resolveRoles(config, makeContext());
+
+			expect(result.instanceRole).toBe('global:member');
+		});
+
+		it('should skip disabled rules', async () => {
+			const config = makeConfig({
+				instanceRoleRules: [
+					makeRule({ id: 'r1', expression: '{{ true }}', role: 'global:admin', enabled: false }),
+					makeRule({ id: 'r2', expression: '{{ true }}', role: 'global:member' }),
+				],
+			});
+
+			const result = await service.resolveRoles(config, makeContext());
+
+			expect(result.instanceRole).toBe('global:member');
+		});
+
+		it('should evaluate expressions against $claims context', async () => {
+			const config = makeConfig({
+				instanceRoleRules: [
+					makeRule({
+						id: 'r1',
+						expression: '{{ $claims.role === "admin" }}',
+						role: 'global:admin',
+					}),
+				],
+			});
+			const context = makeContext({ $claims: { role: 'admin' } });
+
+			const result = await service.resolveRoles(config, context);
+
+			expect(result.instanceRole).toBe('global:admin');
+		});
+
+		it('should evaluate expressions against $oidc context', async () => {
+			const config = makeConfig({
+				instanceRoleRules: [
+					makeRule({
+						id: 'r1',
+						expression: '{{ $oidc.userInfo.groups.includes("admins") }}',
+						role: 'global:admin',
+					}),
+				],
+			});
+			const context = makeContext({
+				$claims: {},
+				$oidc: {
+					idToken: {},
+					userInfo: { groups: ['admins', 'users'] },
+				},
+			});
+
+			const result = await service.resolveRoles(config, context);
+
+			expect(result.instanceRole).toBe('global:admin');
+		});
+
+		it('should evaluate expressions against $saml context', async () => {
+			const config = makeConfig({
+				instanceRoleRules: [
+					makeRule({
+						id: 'r1',
+						expression: '{{ $saml.attributes.role === "admin" }}',
+						role: 'global:admin',
+					}),
+				],
+			});
+			const context = makeContext({
+				$claims: {},
+				$provider: 'saml',
+				$saml: { attributes: { role: 'admin' } },
+			});
+
+			const result = await service.resolveRoles(config, context);
+
+			expect(result.instanceRole).toBe('global:admin');
+		});
+
+		it('should treat expressions that access non-existent paths as false', async () => {
+			const config = makeConfig({
+				instanceRoleRules: [
+					makeRule({
+						id: 'r1',
+						expression: '{{ $claims.nonExistent.deep.path }}',
+						role: 'global:admin',
+					}),
+				],
+			});
+
+			const result = await service.resolveRoles(config, makeContext());
+
+			expect(result.instanceRole).toBe('global:member');
+		});
+
+		it('should treat throwing expressions as false and log a warning', async () => {
+			const config = makeConfig({
+				instanceRoleRules: [
+					makeRule({
+						id: 'r1',
+						expression: '{{ throw new Error("bad") }}',
+						role: 'global:admin',
+					}),
+				],
+			});
+
+			const result = await service.resolveRoles(config, makeContext());
+
+			expect(result.instanceRole).toBe('global:member');
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Role resolver expression evaluation failed, treating as false',
+				expect.objectContaining({ expression: '{{ throw new Error("bad") }}' }),
+			);
+		});
+
+		it('should not match truthy non-boolean values', async () => {
+			const config = makeConfig({
+				instanceRoleRules: [
+					makeRule({ id: 'r1', expression: '{{ 1 }}', role: 'global:admin' }),
+					makeRule({ id: 'r2', expression: '{{ "yes" }}', role: 'global:admin' }),
+					makeRule({ id: 'r3', expression: '{{ [] }}', role: 'global:admin' }),
+				],
+			});
+
+			const result = await service.resolveRoles(config, makeContext());
+
+			expect(result.instanceRole).toBe('global:member');
+		});
+
+		it('should match string "true"', async () => {
+			const config = makeConfig({
+				instanceRoleRules: [
+					makeRule({ id: 'r1', expression: '{{ "true" }}', role: 'global:admin' }),
+				],
+			});
+
+			const result = await service.resolveRoles(config, makeContext());
+
+			expect(result.instanceRole).toBe('global:admin');
+		});
+	});
+
+	describe('resolveRoles - project role rules', () => {
+		it('should assign roles per project with first-match-wins', async () => {
+			const projects = [
+				makeProject({ id: 'proj-1', name: 'Engineering' }),
+				makeProject({ id: 'proj-2', name: 'Marketing' }),
+			];
+			projectRepository.find.mockResolvedValue(projects as never);
+
+			const config = makeConfig({
+				projectRoleRules: [
+					makeRule({
+						id: 'r1',
+						expression: '{{ true }}',
+						role: 'project:admin',
+						projectId: 'proj-1',
+					}),
+					makeRule({
+						id: 'r2',
+						expression: '{{ true }}',
+						role: 'project:viewer',
+						projectId: 'proj-1',
+					}),
+					makeRule({
+						id: 'r3',
+						expression: '{{ true }}',
+						role: 'project:editor',
+						projectId: 'proj-2',
+					}),
+				],
+			});
+
+			const result = await service.resolveRoles(config, makeContext());
+
+			expect(result.projectRoles.get('proj-1')).toBe('project:admin');
+			expect(result.projectRoles.get('proj-2')).toBe('project:editor');
+		});
+
+		it('should return empty map when no project rules match', async () => {
+			const projects = [makeProject({ id: 'proj-1' })];
+			projectRepository.find.mockResolvedValue(projects as never);
+
+			const config = makeConfig({
+				projectRoleRules: [
+					makeRule({
+						id: 'r1',
+						expression: '{{ false }}',
+						role: 'project:admin',
+						projectId: 'proj-1',
+					}),
+				],
+			});
+
+			const result = await service.resolveRoles(config, makeContext());
+
+			expect(result.projectRoles.size).toBe(0);
+		});
+
+		it('should skip rules for non-existent projects with a warning', async () => {
+			projectRepository.find.mockResolvedValue([]);
+
+			const config = makeConfig({
+				projectRoleRules: [
+					makeRule({
+						id: 'r1',
+						expression: '{{ true }}',
+						role: 'project:admin',
+						projectId: 'proj-deleted',
+					}),
+				],
+			});
+
+			const result = await service.resolveRoles(config, makeContext());
+
+			expect(result.projectRoles.size).toBe(0);
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Skipping role mapping rule "r1": project "proj-deleted" not found',
+			);
+		});
+
+		it('should make $project available in project role expressions', async () => {
+			const projects = [makeProject({ id: 'proj-1', name: 'Engineering' })];
+			projectRepository.find.mockResolvedValue(projects as never);
+
+			const config = makeConfig({
+				projectRoleRules: [
+					makeRule({
+						id: 'r1',
+						expression: '{{ $project.name === "Engineering" }}',
+						role: 'project:admin',
+						projectId: 'proj-1',
+					}),
+				],
+			});
+
+			const result = await service.resolveRoles(config, makeContext());
+
+			expect(result.projectRoles.get('proj-1')).toBe('project:admin');
+		});
+
+		it('should allow expressions using both $claims and $project', async () => {
+			const projects = [makeProject({ id: 'proj-1', name: 'engineering' })];
+			projectRepository.find.mockResolvedValue(projects as never);
+
+			const config = makeConfig({
+				projectRoleRules: [
+					makeRule({
+						id: 'r1',
+						expression: '{{ $claims.groups.includes($project.name) }}',
+						role: 'project:editor',
+						projectId: 'proj-1',
+					}),
+				],
+			});
+			const context = makeContext({
+				$claims: { groups: ['engineering', 'devops'] },
+			});
+
+			const result = await service.resolveRoles(config, context);
+
+			expect(result.projectRoles.get('proj-1')).toBe('project:editor');
+		});
+
+		it('should allow expressions using $project.type', async () => {
+			const projects = [makeProject({ id: 'proj-1', type: 'team' })];
+			projectRepository.find.mockResolvedValue(projects as never);
+
+			const config = makeConfig({
+				projectRoleRules: [
+					makeRule({
+						id: 'r1',
+						expression: '{{ $project.type === "team" }}',
+						role: 'project:viewer',
+						projectId: 'proj-1',
+					}),
+				],
+			});
+
+			const result = await service.resolveRoles(config, makeContext());
+
+			expect(result.projectRoles.get('proj-1')).toBe('project:viewer');
+		});
+
+		it('should skip disabled project rules', async () => {
+			const projects = [makeProject({ id: 'proj-1' })];
+			projectRepository.find.mockResolvedValue(projects as never);
+
+			const config = makeConfig({
+				projectRoleRules: [
+					makeRule({
+						id: 'r1',
+						expression: '{{ true }}',
+						role: 'project:admin',
+						projectId: 'proj-1',
+						enabled: false,
+					}),
+				],
+			});
+
+			const result = await service.resolveRoles(config, makeContext());
+
+			expect(result.projectRoles.size).toBe(0);
+		});
+
+		it('should skip project rules without projectId', async () => {
+			const config = makeConfig({
+				projectRoleRules: [
+					makeRule({
+						id: 'r1',
+						expression: '{{ true }}',
+						role: 'project:admin',
+						projectId: undefined,
+					}),
+				],
+			});
+
+			const result = await service.resolveRoles(config, makeContext());
+
+			expect(result.projectRoles.size).toBe(0);
+		});
+	});
+
+	describe('collectProjectInfoForRules', () => {
+		it('should not query DB when there are no project rules', async () => {
+			const config = makeConfig({ projectRoleRules: [] });
+
+			await service.resolveRoles(config, makeContext());
+
+			expect(projectRepository.find).not.toHaveBeenCalled();
+		});
+
+		it('should not query DB when all project rules are disabled', async () => {
+			const config = makeConfig({
+				projectRoleRules: [
+					makeRule({
+						id: 'r1',
+						expression: '{{ true }}',
+						role: 'project:admin',
+						projectId: 'proj-1',
+						enabled: false,
+					}),
+				],
+			});
+
+			await service.resolveRoles(config, makeContext());
+
+			expect(projectRepository.find).not.toHaveBeenCalled();
+		});
+
+		it('should fetch only projects referenced by enabled rules', async () => {
+			projectRepository.find.mockResolvedValue([]);
+
+			const config = makeConfig({
+				projectRoleRules: [
+					makeRule({
+						id: 'r1',
+						expression: '{{ true }}',
+						role: 'project:admin',
+						projectId: 'proj-1',
+					}),
+					makeRule({
+						id: 'r2',
+						expression: '{{ true }}',
+						role: 'project:editor',
+						projectId: 'proj-2',
+						enabled: false,
+					}),
+					makeRule({
+						id: 'r3',
+						expression: '{{ true }}',
+						role: 'project:viewer',
+						projectId: 'proj-3',
+					}),
+				],
+			});
+
+			await service.resolveRoles(config, makeContext());
+
+			expect(projectRepository.find).toHaveBeenCalledTimes(1);
+			const callArgs = projectRepository.find.mock.calls[0][0]!;
+			expect(callArgs.select).toEqual(['id', 'name', 'type', 'description']);
+		});
+
+		it('should deduplicate project IDs', async () => {
+			projectRepository.find.mockResolvedValue([]);
+
+			const config = makeConfig({
+				projectRoleRules: [
+					makeRule({
+						id: 'r1',
+						expression: '{{ true }}',
+						role: 'project:admin',
+						projectId: 'proj-1',
+					}),
+					makeRule({
+						id: 'r2',
+						expression: '{{ false }}',
+						role: 'project:viewer',
+						projectId: 'proj-1',
+					}),
+				],
+			});
+
+			await service.resolveRoles(config, makeContext());
+
+			expect(projectRepository.find).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('resolveRoles - combined instance and project rules', () => {
+		it('should resolve both instance and project roles together', async () => {
+			const projects = [makeProject({ id: 'proj-1' })];
+			projectRepository.find.mockResolvedValue(projects as never);
+
+			const config = makeConfig({
+				instanceRoleRules: [
+					makeRule({
+						id: 'ir1',
+						expression: '{{ $claims.role === "admin" }}',
+						role: 'global:admin',
+					}),
+				],
+				projectRoleRules: [
+					makeRule({
+						id: 'pr1',
+						expression: '{{ true }}',
+						role: 'project:editor',
+						projectId: 'proj-1',
+					}),
+				],
+			});
+			const context = makeContext({ $claims: { role: 'admin' } });
+
+			const result = await service.resolveRoles(config, context);
+
+			expect(result.instanceRole).toBe('global:admin');
+			expect(result.projectRoles.get('proj-1')).toBe('project:editor');
+		});
+	});
+});

--- a/packages/cli/src/modules/provisioning.ee/claims-context.builder.ts
+++ b/packages/cli/src/modules/provisioning.ee/claims-context.builder.ts
@@ -1,0 +1,37 @@
+import type { ProjectInfo, RoleResolverContext } from './role-resolver-types';
+
+export function buildOidcClaimsContext(
+	idTokenClaims: Record<string, unknown>,
+	userInfo: Record<string, unknown>,
+): RoleResolverContext {
+	return {
+		$claims: structuredClone({ ...idTokenClaims, ...userInfo }),
+		$oidc: {
+			idToken: structuredClone(idTokenClaims),
+			userInfo: structuredClone(userInfo),
+		},
+		$provider: 'oidc',
+	};
+}
+
+export function buildSamlClaimsContext(
+	rawAttributes: Record<string, unknown>,
+): RoleResolverContext {
+	return {
+		$claims: structuredClone(rawAttributes),
+		$saml: {
+			attributes: structuredClone(rawAttributes),
+		},
+		$provider: 'saml',
+	};
+}
+
+export function withProjectContext(
+	context: RoleResolverContext,
+	project: ProjectInfo,
+): RoleResolverContext {
+	return {
+		...context,
+		$project: { ...project },
+	};
+}

--- a/packages/cli/src/modules/provisioning.ee/role-resolver-types.ts
+++ b/packages/cli/src/modules/provisioning.ee/role-resolver-types.ts
@@ -1,0 +1,50 @@
+export interface RoleResolverContext {
+	/** Protocol-agnostic merged claims */
+	$claims: Record<string, unknown>;
+
+	/** OIDC-specific data */
+	$oidc?: {
+		idToken: Record<string, unknown>;
+		userInfo: Record<string, unknown>;
+	};
+
+	/** SAML-specific data */
+	$saml?: {
+		attributes: Record<string, unknown>;
+	};
+
+	// Future: $ldap?: { attributes: Record<string, unknown> }
+
+	$provider: 'oidc' | 'saml' | 'ldap';
+
+	/** Populated per-rule during project role evaluation */
+	$project?: ProjectInfo;
+}
+
+export interface RoleMappingRule {
+	id: string;
+	expression: string;
+	role: string;
+	/** undefined = instance role rule; set = project role rule */
+	projectId?: string;
+	enabled: boolean;
+	description?: string;
+}
+
+export interface RoleMappingConfig {
+	instanceRoleRules: RoleMappingRule[];
+	projectRoleRules: RoleMappingRule[];
+	fallbackInstanceRole: string;
+}
+
+export interface ResolvedRoles {
+	instanceRole: string;
+	projectRoles: Map<string, string>;
+}
+
+export interface ProjectInfo {
+	id: string;
+	name: string;
+	type: 'personal' | 'team';
+	description: string | null;
+}

--- a/packages/cli/src/modules/provisioning.ee/role-resolver.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/role-resolver.service.ee.ts
@@ -1,0 +1,126 @@
+import { Logger } from '@n8n/backend-common';
+import { ProjectRepository } from '@n8n/db';
+import { Service } from '@n8n/di';
+import { In } from '@n8n/typeorm';
+import { Expression, type IDataObject } from 'n8n-workflow';
+
+import { withProjectContext } from './claims-context.builder';
+import type {
+	ProjectInfo,
+	ResolvedRoles,
+	RoleMappingConfig,
+	RoleMappingRule,
+	RoleResolverContext,
+} from './role-resolver-types';
+
+@Service()
+export class RoleResolverService {
+	constructor(
+		private readonly logger: Logger,
+		private readonly projectRepository: ProjectRepository,
+	) {}
+
+	async resolveRoles(
+		config: RoleMappingConfig,
+		context: RoleResolverContext,
+	): Promise<ResolvedRoles> {
+		const projects = await this.collectProjectInfoForRules(config.projectRoleRules);
+
+		const instanceRole = this.resolveInstanceRole(
+			config.instanceRoleRules,
+			context,
+			config.fallbackInstanceRole,
+		);
+
+		const projectRoles = this.resolveProjectRoles(config.projectRoleRules, context, projects);
+
+		return { instanceRole, projectRoles };
+	}
+
+	private async collectProjectInfoForRules(
+		rules: RoleMappingRule[],
+	): Promise<Map<string, ProjectInfo>> {
+		const projectIds = [
+			...new Set(rules.filter((r) => r.enabled && r.projectId).map((r) => r.projectId as string)),
+		];
+
+		if (projectIds.length === 0) {
+			return new Map();
+		}
+
+		const projects = await this.projectRepository.find({
+			where: { id: In(projectIds) },
+			select: ['id', 'name', 'type', 'description'],
+		});
+
+		const map = new Map<string, ProjectInfo>();
+		for (const project of projects) {
+			map.set(project.id, {
+				id: project.id,
+				name: project.name,
+				type: project.type,
+				description: project.description,
+			});
+		}
+		return map;
+	}
+
+	private resolveInstanceRole(
+		rules: RoleMappingRule[],
+		context: RoleResolverContext,
+		fallback: string,
+	): string {
+		for (const rule of rules) {
+			if (!rule.enabled) continue;
+			if (this.evaluateExpression(rule.expression, context)) {
+				return rule.role;
+			}
+		}
+		return fallback;
+	}
+
+	private resolveProjectRoles(
+		rules: RoleMappingRule[],
+		context: RoleResolverContext,
+		projects: Map<string, ProjectInfo>,
+	): Map<string, string> {
+		const result = new Map<string, string>();
+
+		for (const rule of rules) {
+			if (!rule.enabled) continue;
+			if (!rule.projectId) continue;
+			if (result.has(rule.projectId)) continue;
+
+			const project = projects.get(rule.projectId);
+			if (!project) {
+				this.logger.warn(
+					`Skipping role mapping rule "${rule.id}": project "${rule.projectId}" not found`,
+				);
+				continue;
+			}
+
+			const enrichedContext = withProjectContext(context, project);
+			if (this.evaluateExpression(rule.expression, enrichedContext)) {
+				result.set(rule.projectId, rule.role);
+			}
+		}
+
+		return result;
+	}
+
+	private evaluateExpression(expression: string, context: RoleResolverContext): boolean {
+		try {
+			const result = Expression.resolveWithoutWorkflow(
+				expression,
+				context as unknown as IDataObject,
+			);
+			return String(result) === 'true';
+		} catch (error) {
+			this.logger.warn('Role resolver expression evaluation failed, treating as false', {
+				expression,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds the foundational role resolver service for expression-based SSO role mapping (IAM feature, behind feature flag — not yet wired).

- **`RoleResolverService`** — evaluates admin-defined mapping rules against SSO claims using n8n's sandboxed expression engine (`Expression.resolveWithoutWorkflow`). Instance role rules use first-match-wins; project role rules use first-match-wins per project. Failing expressions are safely treated as `false`.
- **`ClaimsContextBuilder`** — builds the `$claims`, `$oidc`, `$saml`, and `$project` context objects that expressions can reference. OIDC merges ID token + userInfo; SAML uses raw attributes. `$project` context (id, name, type, description) is injected per-rule during project role evaluation.
- **Types** — `RoleMappingRule`, `RoleMappingConfig`, `ResolvedRoles`, `RoleResolverContext`, `ProjectInfo`
- Project info is fetched in a single batch query before expression evaluation, keeping DB transactions short and isolated from potentially slow expressions.
- 74 unit tests covering both protocols, ordering, fallback, disabled rules, missing projects, and error handling.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-394/role-resolver-expression-engine

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
