### PR TITLE
fix(core): Add 'restart-event-bus' to immediate commands

### DIFF
--- a/packages/cli/src/scaling/constants.ts
+++ b/packages/cli/src/scaling/constants.ts
@@ -31,4 +31,5 @@ export const IMMEDIATE_COMMANDS = new Set<PubSub.Command['command']>([
 	'relay-execution-lifecycle-event',
 	'relay-chat-stream-event',
 	'cancel-test-run',
+	'restart-event-bus',
 ]);

--- a/packages/cli/src/scaling/pubsub/__tests__/publisher.service.test.ts
+++ b/packages/cli/src/scaling/pubsub/__tests__/publisher.service.test.ts
@@ -118,6 +118,30 @@ describe('Publisher', () => {
 			);
 		});
 
+		it('should not debounce `restart-event-bus`', async () => {
+			const publisher = new Publisher(
+				logger,
+				redisClientService,
+				instanceSettings,
+				executionsConfig,
+				globalConfig,
+			);
+			const msg = mock<PubSub.Command>({ command: 'restart-event-bus' });
+
+			await publisher.publishCommand(msg);
+
+			expect(client.publish).toHaveBeenCalledWith(
+				'n8n:n8n.commands',
+				JSON.stringify({
+					...msg,
+					_isMockObject: true,
+					senderId: hostId,
+					selfSend: false,
+					debounce: false,
+				}),
+			);
+		});
+
 		it('should not debounce `remove-triggers-and-pollers`', async () => {
 			const publisher = new Publisher(
 				logger,


### PR DESCRIPTION
## Summary

When running n8n in multi-main queue mode, disabling a log streaming destination on one instance didn't reliably propagate to the others. The disable action sends a restart-event-bus command over Redis pubsub, but that command was being debounced, which means it could get silently dropped if another pubsub message arrived within the same time window.
This adds restart-event-bus to the immediate commands list so it's processed immediately, without debouncing.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-260

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)