### PR TITLE
fix(editor): Fix tooltip on credits counter info icon

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/CreditsSettingsDropdown.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/CreditsSettingsDropdown.vue
@@ -18,9 +18,13 @@ const i18n = useI18n();
 const isOpen = ref(false);
 const dropdownRef = ref<HTMLElement>();
 
-onClickOutside(dropdownRef, () => {
-	isOpen.value = false;
-});
+onClickOutside(
+	dropdownRef,
+	() => {
+		isOpen.value = false;
+	},
+	{ ignore: ['.n8n-tooltip'] },
+);
 
 const hasCredits = computed(() => {
 	return props.creditsQuota !== undefined && props.creditsRemaining !== undefined;


### PR DESCRIPTION
## Summary

The credits settings dropdown was closing when clicking on the info icon tooltip because the `onClickOutside` handler was triggered by interactions with the teleported tooltip content. Fixed by adding `.n8n-tooltip` to the `ignore` list.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2234

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)