### PR TITLE
Add business dashboard and agent template selector to chat hub

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/chatHub/BusinessDashboardView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/BusinessDashboardView.vue
@@ -1,0 +1,610 @@
+<script setup lang="ts">
+import { computed, watch } from 'vue';
+import { useRouter } from 'vue-router';
+import { useChatStore } from '@/features/ai/chatHub/chat.store';
+import { useChatCredentials } from '@/features/ai/chatHub/composables/useChatCredentials';
+import { useUsersStore } from '@/features/settings/users/users.store';
+import { useUIStore } from '@/app/stores/ui.store';
+import { useChatHubSidebarState } from '@/features/ai/chatHub/composables/useChatHubSidebarState';
+import { useMediaQuery } from '@vueuse/core';
+import { N8nButton, N8nIcon, N8nIconButton, N8nText } from '@n8n/design-system';
+import { CHAT_VIEW, CHAT_AGENTS_VIEW, MOBILE_MEDIA_QUERY } from '@/features/ai/chatHub/constants';
+import { BUSINESS_AGENT_TEMPLATES } from '@/features/ai/chatHub/business-templates';
+
+const router = useRouter();
+const chatStore = useChatStore();
+const usersStore = useUsersStore();
+const uiStore = useUIStore();
+const sidebar = useChatHubSidebarState();
+const isMobileDevice = useMediaQuery(MOBILE_MEDIA_QUERY);
+
+const { credentialsByProvider } = useChatCredentials(usersStore.currentUserId ?? 'anonymous');
+
+// Load agents and sessions data
+watch(
+	credentialsByProvider,
+	(credentials) => {
+		if (credentials) {
+			void chatStore.fetchAgents(credentials);
+		}
+	},
+	{ immediate: true },
+);
+
+watch(
+	() => chatStore.sessionsReady,
+	(ready) => {
+		if (!ready) {
+			void chatStore.fetchSessions();
+		}
+	},
+	{ immediate: true },
+);
+
+const totalAgents = computed(() => {
+	const customAgents = chatStore.agents['custom-agent'].models.length;
+	const n8nAgents = chatStore.agents.n8n.models.length;
+	return customAgents + n8nAgents;
+});
+
+const totalConversations = computed(() => chatStore.sessions.length);
+
+const recentSessions = computed(() =>
+	[...chatStore.sessions]
+		.sort((a, b) => {
+			const aTime = a.lastMessageAt ?? a.createdAt;
+			const bTime = b.lastMessageAt ?? b.createdAt;
+			return bTime.localeCompare(aTime);
+		})
+		.slice(0, 5),
+);
+
+const featuredTemplates = computed(() => BUSINESS_AGENT_TEMPLATES.slice(0, 3));
+
+const integrationCards = [
+	{
+		id: 'crm',
+		title: 'Connect your CRM',
+		description: 'Link agents to HubSpot, Salesforce, or Pipedrive to manage leads automatically.',
+		icon: 'database' as const,
+		action: 'Set up CRM workflow',
+		color: 'crm',
+	},
+	{
+		id: 'documents',
+		title: 'Add a knowledge base',
+		description: 'Connect documents, PDFs, or Notion pages so agents can answer questions.',
+		icon: 'file-text' as const,
+		action: 'Connect documents',
+		color: 'docs',
+	},
+	{
+		id: 'embed',
+		title: 'Embed on your website',
+		description: 'Deploy a chat widget on your website for customer-facing interactions.',
+		icon: 'code' as const,
+		action: 'Get embed code',
+		color: 'embed',
+	},
+];
+
+function navigateToChat() {
+	void router.push({ name: CHAT_VIEW });
+}
+
+function navigateToAgents() {
+	void router.push({ name: CHAT_AGENTS_VIEW });
+}
+
+function openNewAgentModal() {
+	chatStore.currentEditingAgent = null;
+	uiStore.openModal('agentEditor');
+}
+
+function openConversation(sessionId: string) {
+	void router.push({ name: 'chat-conversation', params: { id: sessionId } });
+}
+
+function formatRelativeTime(dateStr: string): string {
+	const date = new Date(dateStr);
+	const now = new Date();
+	const diffMs = now.getTime() - date.getTime();
+	const diffMins = Math.floor(diffMs / 60000);
+	const diffHours = Math.floor(diffMs / 3600000);
+	const diffDays = Math.floor(diffMs / 86400000);
+
+	if (diffMins < 1) return 'Just now';
+	if (diffMins < 60) return `${diffMins}m ago`;
+	if (diffHours < 24) return `${diffHours}h ago`;
+	if (diffDays < 7) return `${diffDays}d ago`;
+	return date.toLocaleDateString();
+}
+</script>
+
+<template>
+	<div :class="[$style.container, { [$style.isMobileDevice]: isMobileDevice }]">
+		<!-- Page header -->
+		<div :class="$style.pageHeader">
+			<div>
+				<N8nText tag="h1" size="xlarge" bold>AI Agent Hub</N8nText>
+				<N8nText color="text-light">
+					Manage your business AI agents, conversations, and integrations.
+				</N8nText>
+			</div>
+			<div :class="$style.headerActions">
+				<N8nButton type="secondary" size="large" @click="navigateToChat">
+					Open Chat
+				</N8nButton>
+				<N8nButton type="primary" size="large" icon="plus" @click="openNewAgentModal">
+					New Agent
+				</N8nButton>
+			</div>
+		</div>
+
+		<!-- Stats row -->
+		<div :class="$style.statsRow">
+			<div :class="$style.statCard" data-test-id="stat-agents">
+				<div :class="$style.statIcon">
+					<N8nIcon icon="bot" size="large" />
+				</div>
+				<div :class="$style.statContent">
+					<N8nText tag="p" size="2xlarge" bold :class="$style.statNumber">
+						{{ totalAgents }}
+					</N8nText>
+					<N8nText color="text-light" size="small">Active agents</N8nText>
+				</div>
+			</div>
+
+			<div :class="$style.statCard" data-test-id="stat-conversations">
+				<div :class="$style.statIcon">
+					<N8nIcon icon="message-circle" size="large" />
+				</div>
+				<div :class="$style.statContent">
+					<N8nText tag="p" size="2xlarge" bold :class="$style.statNumber">
+						{{ totalConversations }}
+					</N8nText>
+					<N8nText color="text-light" size="small">Conversations</N8nText>
+				</div>
+			</div>
+
+			<div :class="$style.statCard" data-test-id="stat-integrations">
+				<div :class="$style.statIcon">
+					<N8nIcon icon="layers" size="large" />
+				</div>
+				<div :class="$style.statContent">
+					<N8nText tag="p" size="2xlarge" bold :class="$style.statNumber">3</N8nText>
+					<N8nText color="text-light" size="small">Integrations available</N8nText>
+				</div>
+			</div>
+		</div>
+
+		<!-- Main content grid -->
+		<div :class="$style.mainGrid">
+			<!-- Left column -->
+			<div :class="$style.leftColumn">
+				<!-- Quick start with templates -->
+				<div :class="$style.section">
+					<div :class="$style.sectionHeader">
+						<N8nText tag="h2" size="large" bold>Quick start</N8nText>
+						<N8nButton type="tertiary" size="small" @click="navigateToAgents">
+							View all agents
+						</N8nButton>
+					</div>
+					<div :class="$style.templateGrid">
+						<button
+							v-for="template in featuredTemplates"
+							:key="template.id"
+							:class="[$style.templateCard, $style[template.category]]"
+							data-test-id="dashboard-template-card"
+							@click="openNewAgentModal"
+						>
+							<div :class="$style.templateCardIcon">
+								<N8nIcon :icon="template.icon" size="medium" />
+							</div>
+							<N8nText bold size="small" :class="$style.templateName">
+								{{ template.name }}
+							</N8nText>
+							<N8nText color="text-light" size="xsmall" :class="$style.templateDesc">
+								{{ template.description.slice(0, 80) }}...
+							</N8nText>
+						</button>
+					</div>
+				</div>
+
+				<!-- Integration cards -->
+				<div :class="$style.section">
+					<div :class="$style.sectionHeader">
+						<N8nText tag="h2" size="large" bold>Integrations</N8nText>
+					</div>
+					<div :class="$style.integrationList">
+						<div
+							v-for="card in integrationCards"
+							:key="card.id"
+							:class="$style.integrationCard"
+							:data-test-id="`integration-card-${card.id}`"
+						>
+							<div :class="[$style.integrationIcon, $style[`icon-${card.color}`]]">
+								<N8nIcon :icon="card.icon" size="medium" />
+							</div>
+							<div :class="$style.integrationContent">
+								<N8nText bold size="small">{{ card.title }}</N8nText>
+								<N8nText color="text-light" size="xsmall">{{ card.description }}</N8nText>
+							</div>
+							<N8nButton type="tertiary" size="small" :class="$style.integrationAction">
+								{{ card.action }}
+							</N8nButton>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<!-- Right column: Recent conversations -->
+			<div :class="$style.rightColumn">
+				<div :class="$style.section">
+					<div :class="$style.sectionHeader">
+						<N8nText tag="h2" size="large" bold>Recent conversations</N8nText>
+						<N8nButton type="tertiary" size="small" @click="navigateToChat">
+							View all
+						</N8nButton>
+					</div>
+
+					<div v-if="recentSessions.length === 0" :class="$style.emptyState">
+						<N8nIcon icon="message-circle" size="xlarge" color="text-light" />
+						<N8nText color="text-light" size="small">No conversations yet.</N8nText>
+						<N8nButton type="secondary" size="small" @click="navigateToChat">
+							Start a chat
+						</N8nButton>
+					</div>
+
+					<div v-else :class="$style.sessionList">
+						<button
+							v-for="session in recentSessions"
+							:key="session.id"
+							:class="$style.sessionItem"
+							:data-test-id="`session-item-${session.id}`"
+							@click="openConversation(session.id)"
+						>
+							<div :class="$style.sessionAvatar">
+								<N8nIcon icon="message-circle" size="small" />
+							</div>
+							<div :class="$style.sessionContent">
+								<N8nText bold size="small" :class="$style.sessionTitle">
+									{{ session.title }}
+								</N8nText>
+								<N8nText color="text-light" size="xsmall">
+									{{ session.agentName ?? session.provider ?? 'Chat' }}
+								</N8nText>
+							</div>
+							<N8nText color="text-light" size="xsmall" :class="$style.sessionTime">
+								{{ formatRelativeTime(session.lastMessageAt ?? session.createdAt) }}
+							</N8nText>
+						</button>
+					</div>
+				</div>
+			</div>
+		</div>
+
+		<!-- Sidebar toggle on mobile -->
+		<N8nIconButton
+			v-if="!sidebar.isStatic.value"
+			:class="$style.menuButton"
+			type="secondary"
+			icon="panel-left"
+			text
+			icon-size="large"
+			@click="sidebar.toggleOpen(true)"
+		/>
+	</div>
+</template>
+
+<style lang="scss" module>
+.container {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	width: 100%;
+	max-width: var(--content-container--width);
+	padding: var(--spacing--xl);
+	gap: var(--spacing--xl);
+	overflow-y: auto;
+	position: relative;
+}
+
+.menuButton {
+	position: fixed;
+	top: 0;
+	left: 0;
+	margin: var(--spacing--sm);
+
+	.isMobileDevice & {
+		margin: var(--spacing--2xs);
+	}
+}
+
+.pageHeader {
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-start;
+	gap: var(--spacing--lg);
+	flex-wrap: wrap;
+}
+
+.headerActions {
+	display: flex;
+	gap: var(--spacing--2xs);
+	align-items: center;
+}
+
+/* Stats */
+.statsRow {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: var(--spacing--sm);
+
+	.isMobileDevice & {
+		grid-template-columns: 1fr;
+	}
+}
+
+.statCard {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing--sm);
+	padding: var(--spacing--md);
+	background: var(--color--background);
+	border: var(--border-width) var(--border-style) var(--color--foreground);
+	border-radius: var(--radius--lg);
+}
+
+.statIcon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 48px;
+	height: 48px;
+	background: var(--color--primary--tint-3);
+	color: var(--color--primary);
+	border-radius: var(--radius--lg);
+	flex-shrink: 0;
+}
+
+.statContent {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--5xs);
+}
+
+.statNumber {
+	margin: 0;
+	line-height: 1;
+}
+
+/* Main grid */
+.mainGrid {
+	display: grid;
+	grid-template-columns: 1fr 360px;
+	gap: var(--spacing--lg);
+
+	.isMobileDevice & {
+		grid-template-columns: 1fr;
+	}
+}
+
+.leftColumn,
+.rightColumn {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--lg);
+}
+
+/* Sections */
+.section {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--sm);
+}
+
+.sectionHeader {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
+
+/* Template cards */
+.templateGrid {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: var(--spacing--2xs);
+
+	.isMobileDevice & {
+		grid-template-columns: 1fr;
+	}
+}
+
+.templateCard {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--3xs);
+	padding: var(--spacing--sm);
+	border: var(--border-width) var(--border-style) var(--color--foreground);
+	border-radius: var(--radius--lg);
+	background: var(--color--background);
+	cursor: pointer;
+	text-align: left;
+	transition: all 0.15s ease;
+
+	&:hover {
+		border-color: var(--color--primary);
+		background: var(--color--primary--tint-3);
+	}
+
+	&.sales .templateCardIcon {
+		background: var(--color--success--tint-4);
+		color: var(--color--success--shade-1);
+	}
+
+	&.support .templateCardIcon {
+		background: var(--color--primary--tint-3);
+		color: var(--color--primary--shade-1);
+	}
+
+	&.operations .templateCardIcon {
+		background: var(--color--warning--tint-2);
+		color: var(--color--warning--shade-1);
+	}
+
+	&.crm .templateCardIcon {
+		background: var(--color--secondary--tint-2);
+		color: var(--color--secondary--shade-1);
+	}
+}
+
+.templateCardIcon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 36px;
+	height: 36px;
+	border-radius: var(--radius);
+	margin-bottom: var(--spacing--4xs);
+}
+
+.templateName {
+	display: block;
+}
+
+.templateDesc {
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+	line-height: var(--line-height--xl);
+}
+
+/* Integration cards */
+.integrationList {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--2xs);
+}
+
+.integrationCard {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing--sm);
+	padding: var(--spacing--sm);
+	border: var(--border-width) var(--border-style) var(--color--foreground);
+	border-radius: var(--radius--lg);
+	background: var(--color--background);
+}
+
+.integrationIcon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 40px;
+	height: 40px;
+	border-radius: var(--radius);
+	flex-shrink: 0;
+
+	&.icon-crm {
+		background: var(--color--secondary--tint-2);
+		color: var(--color--secondary--shade-1);
+	}
+
+	&.icon-docs {
+		background: var(--color--warning--tint-2);
+		color: var(--color--warning--shade-1);
+	}
+
+	&.icon-embed {
+		background: var(--color--primary--tint-3);
+		color: var(--color--primary--shade-1);
+	}
+}
+
+.integrationContent {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--5xs);
+	min-width: 0;
+}
+
+.integrationAction {
+	flex-shrink: 0;
+}
+
+/* Recent sessions */
+.emptyState {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: var(--spacing--sm);
+	padding: var(--spacing--xl);
+	border: var(--border-width) var(--border-style) var(--color--foreground);
+	border-radius: var(--radius--lg);
+	min-height: 160px;
+}
+
+.sessionList {
+	display: flex;
+	flex-direction: column;
+	border: var(--border-width) var(--border-style) var(--color--foreground);
+	border-radius: var(--radius--lg);
+	overflow: hidden;
+}
+
+.sessionItem {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing--sm);
+	padding: var(--spacing--sm) var(--spacing--md);
+	background: var(--color--background);
+	cursor: pointer;
+	text-align: left;
+	border: none;
+	width: 100%;
+	transition: background 0.1s ease;
+
+	&:not(:last-child) {
+		border-bottom: var(--border-width) var(--border-style) var(--color--foreground--tint-1);
+	}
+
+	&:hover {
+		background: var(--color--foreground--tint-2);
+	}
+}
+
+.sessionAvatar {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 32px;
+	height: 32px;
+	background: var(--color--primary--tint-3);
+	color: var(--color--primary);
+	border-radius: 50%;
+	flex-shrink: 0;
+}
+
+.sessionContent {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--5xs);
+}
+
+.sessionTitle {
+	display: block;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.sessionTime {
+	flex-shrink: 0;
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/business-templates.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/business-templates.ts
@@ -1,0 +1,170 @@
+/**
+ * Business agent templates for common enterprise use cases.
+ * These pre-configured templates help businesses quickly set up
+ * AI agents for sales, customer support, and internal operations.
+ */
+
+export interface BusinessAgentTemplate {
+	id: string;
+	name: string;
+	description: string;
+	category: 'sales' | 'support' | 'operations' | 'crm';
+	icon: string;
+	systemPrompt: string;
+	suggestedModel: string;
+	integrations: string[];
+}
+
+export const BUSINESS_AGENT_TEMPLATES: BusinessAgentTemplate[] = [
+	{
+		id: 'sales-lead-qualifier',
+		name: 'Sales Lead Qualifier',
+		description:
+			'Qualifies inbound leads, captures key information, and schedules follow-ups. Integrates with your CRM to create and update contacts automatically.',
+		category: 'sales',
+		icon: 'zap',
+		systemPrompt: `You are a professional sales representative assistant for [Company Name].
+
+Your role is to:
+1. Greet potential customers warmly and learn about their needs
+2. Qualify leads by asking about their company size, budget, timeline, and specific requirements
+3. Highlight relevant product/service benefits based on their needs
+4. Capture contact information: name, email, phone, company name, and role
+5. Schedule a follow-up call or demo when appropriate
+6. Log all information accurately for the sales team
+
+Key qualification questions to ask:
+- What is the main challenge you are trying to solve?
+- How many people in your team would use this solution?
+- What is your timeline for implementing a solution?
+- Do you have a budget allocated for this?
+
+Always be professional, helpful, and never pushy. If the prospect is not ready, offer helpful resources and let them know you will follow up.`,
+		suggestedModel: 'gpt-4o',
+		integrations: ['HubSpot', 'Salesforce', 'Pipedrive'],
+	},
+	{
+		id: 'customer-support',
+		name: 'Customer Support Agent',
+		description:
+			'Handles customer inquiries, resolves common issues, and escalates complex cases. Connects to your knowledge base and ticketing system.',
+		category: 'support',
+		icon: 'message-circle',
+		systemPrompt: `You are a helpful customer support agent for [Company Name].
+
+Your responsibilities:
+1. Greet customers and identify the issue they are experiencing
+2. Resolve common issues using the knowledge base available to you
+3. Provide step-by-step instructions clearly and patiently
+4. If you cannot resolve an issue, collect all relevant details and escalate to a human agent
+5. Always confirm the customer's issue is resolved before ending the conversation
+6. Offer additional help or resources when appropriate
+
+Guidelines:
+- Always be empathetic and patient
+- Use clear, simple language - avoid technical jargon unless the customer uses it first
+- If a customer is frustrated, acknowledge their feelings before diving into solutions
+- For billing or account issues, always verify identity before sharing sensitive information
+- Log the resolution for future reference
+
+Escalation triggers:
+- Legal or compliance matters
+- Refund requests over [threshold]
+- Repeated unresolved issues
+- Angry or threatening customers`,
+		suggestedModel: 'gpt-4o-mini',
+		integrations: ['Zendesk', 'Freshdesk', 'Intercom'],
+	},
+	{
+		id: 'internal-hr-assistant',
+		name: 'HR & Internal Operations',
+		description:
+			'Answers employee questions about policies, benefits, and procedures. Helps with onboarding and connects to internal documentation.',
+		category: 'operations',
+		icon: 'users',
+		systemPrompt: `You are an internal HR and operations assistant for [Company Name] employees.
+
+You help employees with:
+1. HR policies and procedures (vacation, sick leave, benefits, etc.)
+2. Onboarding information for new employees
+3. IT and facilities requests routing
+4. Company announcements and updates
+5. Finding the right department or person to contact
+
+Important guidelines:
+- Only share information that is appropriate for all employees
+- For sensitive HR matters (disciplinary, personal issues), direct employees to HR directly
+- Keep responses clear and concise
+- Always provide the correct department contact when you cannot fully answer
+- Maintain employee confidentiality at all times
+
+You have access to the company knowledge base. Always check it before saying you do not know something.
+If information is not available, direct the employee to the appropriate team.`,
+		suggestedModel: 'gpt-4o-mini',
+		integrations: ['Notion', 'Confluence', 'Google Drive'],
+	},
+	{
+		id: 'crm-data-assistant',
+		name: 'CRM Data Assistant',
+		description:
+			'Helps sales teams quickly access and update CRM data, generate reports, and get insights about their pipeline.',
+		category: 'crm',
+		icon: 'database',
+		systemPrompt: `You are a CRM data assistant for the sales team at [Company Name].
+
+You help sales representatives:
+1. Look up customer and prospect information quickly
+2. Update contact records and opportunity details
+3. Generate pipeline reports and summaries
+4. Track follow-up tasks and remind about pending actions
+5. Provide insights on deals at risk or opportunities to prioritize
+
+When accessing CRM data:
+- Always confirm you are looking at the correct record before making updates
+- Summarize key information clearly (last contact, deal stage, value, next steps)
+- Flag any data quality issues (missing fields, outdated information)
+- Suggest next best actions based on deal stage and history
+
+Data privacy: Only share customer information with authorized team members. Do not share competitor-sensitive deal information across teams.`,
+		suggestedModel: 'gpt-4o',
+		integrations: ['Salesforce', 'HubSpot', 'Pipedrive', 'Zoho CRM'],
+	},
+	{
+		id: 'document-qa',
+		name: 'Document Q&A Agent',
+		description:
+			'Answers questions based on your company documents, manuals, and knowledge bases. Powered by vector search for accurate retrieval.',
+		category: 'operations',
+		icon: 'file-text',
+		systemPrompt: `You are a knowledgeable assistant that helps users find information from [Company Name]'s documents and knowledge base.
+
+Your capabilities:
+1. Search and retrieve relevant information from connected documents
+2. Answer questions accurately based on the document content
+3. Cite the source document when providing answers
+4. Summarize lengthy documents on request
+5. Compare information across multiple documents
+
+Important rules:
+- Only answer based on information found in the provided documents
+- If information is not in the knowledge base, clearly state that and suggest where to find it
+- Always cite the source document and section when possible
+- If a question is ambiguous, ask for clarification before answering
+- Do not make up or infer information not explicitly stated in documents
+
+When you cannot find an answer:
+- Tell the user the information is not available in the current knowledge base
+- Suggest who they can contact for that information
+- Offer to search for related topics that might help`,
+		suggestedModel: 'gpt-4o',
+		integrations: ['Google Drive', 'Notion', 'Confluence', 'SharePoint'],
+	},
+];
+
+export const TEMPLATE_CATEGORIES = [
+	{ id: 'all', label: 'All templates', icon: 'grid-2x2' },
+	{ id: 'sales', label: 'Sales', icon: 'zap' },
+	{ id: 'support', label: 'Support', icon: 'message-circle' },
+	{ id: 'operations', label: 'Operations', icon: 'settings' },
+	{ id: 'crm', label: 'CRM', icon: 'database' },
+] as const;

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/AgentEditorModal.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/AgentEditorModal.vue
@@ -4,6 +4,7 @@ import { useMessage } from '@/app/composables/useMessage';
 import { useToast } from '@/app/composables/useToast';
 import { useChatStore } from '@/features/ai/chatHub/chat.store';
 import ModelSelector from '@/features/ai/chatHub/components/ModelSelector.vue';
+import AgentTemplateSelector from '@/features/ai/chatHub/components/AgentTemplateSelector.vue';
 import { useUIStore } from '@/app/stores/ui.store';
 import type { ChatHubProvider, ChatModelDto } from '@n8n/api-types';
 import { N8nButton, N8nHeading, N8nInput, N8nInputLabel } from '@n8n/design-system';
@@ -12,6 +13,7 @@ import { assert } from '@n8n/utils/assert';
 import { createEventBus } from '@n8n/utils/event-bus';
 import { computed, ref, watch } from 'vue';
 import type { CredentialsMap } from '../chat.types';
+import type { BusinessAgentTemplate } from '@/features/ai/chatHub/business-templates';
 
 const props = defineProps<{
 	credentials: CredentialsMap;
@@ -36,6 +38,7 @@ const systemPrompt = ref('');
 const selectedModel = ref<ChatModelDto | null>(null);
 const isSaving = ref(false);
 const isDeleting = ref(false);
+const showTemplateSelector = ref(false);
 
 const agentSelectedCredentials = ref<CredentialsMap>({});
 
@@ -87,6 +90,18 @@ function resetForm() {
 	systemPrompt.value = '';
 	selectedModel.value = null;
 	agentSelectedCredentials.value = {};
+	showTemplateSelector.value = false;
+}
+
+function applyTemplate(template: BusinessAgentTemplate) {
+	name.value = template.name;
+	description.value = template.description;
+	systemPrompt.value = template.systemPrompt;
+	showTemplateSelector.value = false;
+}
+
+function onSkipTemplate() {
+	showTemplateSelector.value = false;
 }
 
 // Watch for modal opening
@@ -98,6 +113,7 @@ watch(
 				loadAgent();
 			} else {
 				resetForm();
+				showTemplateSelector.value = true;
 			}
 		}
 	},
@@ -200,16 +216,30 @@ async function onDelete() {
 	<Modal
 		name="agentEditor"
 		:event-bus="modalBus"
-		width="600px"
+		:width="showTemplateSelector ? '760px' : '600px'"
 		:center="true"
-		max-width="90%"
+		max-width="95%"
 		min-height="400px"
 	>
 		<template #header>
 			<N8nHeading tag="h2" size="large">{{ title }}</N8nHeading>
 		</template>
 		<template #content>
-			<div :class="$style.content">
+			<div v-if="showTemplateSelector" :class="$style.content">
+				<AgentTemplateSelector @select="applyTemplate" @skip="onSkipTemplate" />
+			</div>
+			<div v-else :class="$style.content">
+				<div v-if="!isEditMode" :class="$style.templateLink">
+					<N8nButton
+						type="tertiary"
+						size="small"
+						icon="layers"
+						@click="showTemplateSelector = true"
+					>
+						Use a template
+					</N8nButton>
+				</div>
+
 				<N8nInputLabel
 					input-name="agent-name"
 					:label="i18n.baseText('chatHub.agent.editor.name.label')"
@@ -269,7 +299,7 @@ async function onDelete() {
 				</N8nInputLabel>
 			</div>
 		</template>
-		<template #footer>
+		<template v-if="!showTemplateSelector" #footer>
 			<div :class="$style.footer">
 				<div :class="$style.footerRight">
 					<N8nButton
@@ -295,6 +325,11 @@ async function onDelete() {
 	flex-direction: column;
 	gap: var(--spacing--md);
 	padding: var(--spacing--sm) 0;
+}
+
+.templateLink {
+	display: flex;
+	justify-content: flex-end;
 }
 
 .input {

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/AgentTemplateSelector.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/AgentTemplateSelector.vue
@@ -1,0 +1,297 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { N8nButton, N8nIcon, N8nText, N8nInput } from '@n8n/design-system';
+import {
+	BUSINESS_AGENT_TEMPLATES,
+	TEMPLATE_CATEGORIES,
+	type BusinessAgentTemplate,
+} from '@/features/ai/chatHub/business-templates';
+
+const emit = defineEmits<{
+	select: [template: BusinessAgentTemplate];
+	skip: [];
+}>();
+
+const searchQuery = ref('');
+const selectedCategory = ref<string>('all');
+
+const filteredTemplates = computed(() => {
+	return BUSINESS_AGENT_TEMPLATES.filter((template) => {
+		const matchesCategory =
+			selectedCategory.value === 'all' || template.category === selectedCategory.value;
+		const matchesSearch =
+			searchQuery.value.trim() === '' ||
+			template.name.toLowerCase().includes(searchQuery.value.toLowerCase()) ||
+			template.description.toLowerCase().includes(searchQuery.value.toLowerCase());
+		return matchesCategory && matchesSearch;
+	});
+});
+
+function onSelectTemplate(template: BusinessAgentTemplate) {
+	emit('select', template);
+}
+
+function onSkip() {
+	emit('skip');
+}
+</script>
+
+<template>
+	<div :class="$style.container">
+		<div :class="$style.header">
+			<N8nText tag="h3" size="large" bold>Start from a template</N8nText>
+			<N8nText color="text-light" size="small">
+				Choose a pre-configured business agent template or start from scratch.
+			</N8nText>
+		</div>
+
+		<div :class="$style.filters">
+			<N8nInput
+				v-model="searchQuery"
+				placeholder="Search templates..."
+				:class="$style.search"
+				clearable
+				size="small"
+			>
+				<template #prefix>
+					<N8nIcon icon="search" size="xsmall" />
+				</template>
+			</N8nInput>
+
+			<div :class="$style.categories">
+				<button
+					v-for="category in TEMPLATE_CATEGORIES"
+					:key="category.id"
+					:class="[$style.categoryBtn, { [$style.active]: selectedCategory === category.id }]"
+					@click="selectedCategory = category.id"
+				>
+					{{ category.label }}
+				</button>
+			</div>
+		</div>
+
+		<div :class="$style.grid">
+			<button
+				v-for="template in filteredTemplates"
+				:key="template.id"
+				:class="$style.templateCard"
+				data-test-id="agent-template-card"
+				@click="onSelectTemplate(template)"
+			>
+				<div :class="$style.cardHeader">
+					<div :class="[$style.iconWrapper, $style[template.category]]">
+						<N8nIcon :icon="template.icon" size="medium" />
+					</div>
+					<div :class="$style.cardCategory">
+						{{ template.category }}
+					</div>
+				</div>
+
+				<N8nText tag="p" bold size="medium" :class="$style.cardTitle">
+					{{ template.name }}
+				</N8nText>
+
+				<N8nText color="text-light" size="small" :class="$style.cardDescription">
+					{{ template.description }}
+				</N8nText>
+
+				<div v-if="template.integrations.length > 0" :class="$style.integrations">
+					<N8nText size="xsmall" color="text-light">Works with:</N8nText>
+					<div :class="$style.integrationTags">
+						<span
+							v-for="integration in template.integrations.slice(0, 3)"
+							:key="integration"
+							:class="$style.tag"
+						>
+							{{ integration }}
+						</span>
+						<span v-if="template.integrations.length > 3" :class="$style.tag">
+							+{{ template.integrations.length - 3 }}
+						</span>
+					</div>
+				</div>
+			</button>
+
+			<div v-if="filteredTemplates.length === 0" :class="$style.empty">
+				<N8nText color="text-light">No templates match your search.</N8nText>
+			</div>
+		</div>
+
+		<div :class="$style.footer">
+			<N8nButton type="tertiary" size="small" @click="onSkip">
+				Start from scratch
+			</N8nButton>
+		</div>
+	</div>
+</template>
+
+<style lang="scss" module>
+.container {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--md);
+}
+
+.header {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--4xs);
+}
+
+.filters {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--2xs);
+}
+
+.search {
+	width: 100%;
+}
+
+.categories {
+	display: flex;
+	gap: var(--spacing--4xs);
+	flex-wrap: wrap;
+}
+
+.categoryBtn {
+	padding: var(--spacing--5xs) var(--spacing--2xs);
+	border: var(--border-width) var(--border-style) var(--color--foreground);
+	border-radius: var(--radius);
+	background: var(--color--background);
+	color: var(--color--text--tint-1);
+	font-size: var(--font-size--2xs);
+	cursor: pointer;
+	transition: all 0.15s ease;
+
+	&:hover {
+		border-color: var(--color--primary);
+		color: var(--color--primary);
+	}
+
+	&.active {
+		background: var(--color--primary--tint-3);
+		border-color: var(--color--primary);
+		color: var(--color--primary);
+		font-weight: var(--font-weight--bold);
+	}
+}
+
+.grid {
+	display: grid;
+	grid-template-columns: repeat(2, 1fr);
+	gap: var(--spacing--2xs);
+	max-height: 380px;
+	overflow-y: auto;
+}
+
+.templateCard {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--3xs);
+	padding: var(--spacing--sm);
+	border: var(--border-width) var(--border-style) var(--color--foreground);
+	border-radius: var(--radius--lg);
+	background: var(--color--background);
+	cursor: pointer;
+	text-align: left;
+	transition: all 0.15s ease;
+
+	&:hover {
+		border-color: var(--color--primary);
+		background: var(--color--primary--tint-3);
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+	}
+}
+
+.cardHeader {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+}
+
+.iconWrapper {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 32px;
+	height: 32px;
+	border-radius: var(--radius);
+
+	&.sales {
+		background: var(--color--success--tint-4);
+		color: var(--color--success--shade-1);
+	}
+
+	&.support {
+		background: var(--color--primary--tint-3);
+		color: var(--color--primary--shade-1);
+	}
+
+	&.operations {
+		background: var(--color--warning--tint-2);
+		color: var(--color--warning--shade-1);
+	}
+
+	&.crm {
+		background: var(--color--secondary--tint-2);
+		color: var(--color--secondary--shade-1);
+	}
+}
+
+.cardCategory {
+	font-size: var(--font-size--3xs);
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: var(--color--text--tint-2);
+	font-weight: var(--font-weight--bold);
+}
+
+.cardTitle {
+	margin: 0;
+}
+
+.cardDescription {
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+	line-height: var(--line-height--xl);
+}
+
+.integrations {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--5xs);
+	margin-top: auto;
+}
+
+.integrationTags {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--spacing--5xs);
+}
+
+.tag {
+	font-size: var(--font-size--3xs);
+	padding: 2px var(--spacing--4xs);
+	background: var(--color--foreground--tint-2);
+	border-radius: var(--radius--sm);
+	color: var(--color--text--tint-1);
+}
+
+.empty {
+	grid-column: 1 / -1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: var(--spacing--xl);
+}
+
+.footer {
+	display: flex;
+	justify-content: center;
+	padding-top: var(--spacing--3xs);
+	border-top: var(--border-width) var(--border-style) var(--color--foreground--tint-1);
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatSidebarContent.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatSidebarContent.vue
@@ -7,7 +7,11 @@ import { useChatStore } from '@/features/ai/chatHub/chat.store';
 import { groupConversationsByDate } from '@/features/ai/chatHub/chat.utils';
 import ChatSidebarLink from '@/features/ai/chatHub/components/ChatSidebarLink.vue';
 import { useChatHubSidebarState } from '@/features/ai/chatHub/composables/useChatHubSidebarState';
-import { CHAT_VIEW, CHAT_AGENTS_VIEW } from '@/features/ai/chatHub/constants';
+import {
+	CHAT_VIEW,
+	CHAT_AGENTS_VIEW,
+	CHAT_BUSINESS_DASHBOARD_VIEW,
+} from '@/features/ai/chatHub/constants';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { N8nIconButton, N8nScrollArea, N8nText } from '@n8n/design-system';
 import Logo from '@n8n/design-system/components/N8nLogo';
@@ -127,6 +131,13 @@ onMounted(() => {
 				label="Custom Agents"
 				icon="robot"
 				:active="route.name === CHAT_AGENTS_VIEW"
+				@click="sidebar.toggleOpen(false)"
+			/>
+			<ChatSidebarLink
+				:to="{ name: CHAT_BUSINESS_DASHBOARD_VIEW }"
+				label="Business Hub"
+				icon="home"
+				:active="route.name === CHAT_BUSINESS_DASHBOARD_VIEW"
 				@click="sidebar.toggleOpen(false)"
 			/>
 		</div>

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/constants.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/constants.ts
@@ -4,6 +4,7 @@ import type { ChatHubProvider } from '@n8n/api-types';
 export const CHAT_VIEW = 'chat';
 export const CHAT_CONVERSATION_VIEW = 'chat-conversation';
 export const CHAT_AGENTS_VIEW = 'chat-agents';
+export const CHAT_BUSINESS_DASHBOARD_VIEW = 'chat-business-dashboard';
 
 export const CHAT_STORE = 'chatStore';
 

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/module.descriptor.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/module.descriptor.ts
@@ -1,9 +1,16 @@
 import { type FrontendModuleDescription } from '@/app/moduleInitializer/module.types';
-import { CHAT_VIEW, CHAT_CONVERSATION_VIEW, CHAT_AGENTS_VIEW } from './constants';
+import {
+	CHAT_VIEW,
+	CHAT_CONVERSATION_VIEW,
+	CHAT_AGENTS_VIEW,
+	CHAT_BUSINESS_DASHBOARD_VIEW,
+} from './constants';
 
 const ChatSidebar = async () => await import('@/features/ai/chatHub/components/ChatSidebar.vue');
 const ChatView = async () => await import('@/features/ai/chatHub/ChatView.vue');
 const ChatAgentsView = async () => await import('@/features/ai/chatHub/ChatAgentsView.vue');
+const BusinessDashboardView = async () =>
+	await import('@/features/ai/chatHub/BusinessDashboardView.vue');
 
 export const ChatModule: FrontendModuleDescription = {
 	id: 'chat-hub',
@@ -39,6 +46,17 @@ export const ChatModule: FrontendModuleDescription = {
 			path: '/home/chat/agents',
 			components: {
 				default: ChatAgentsView,
+				sidebar: ChatSidebar,
+			},
+			meta: {
+				middleware: ['authenticated', 'custom'],
+			},
+		},
+		{
+			name: CHAT_BUSINESS_DASHBOARD_VIEW,
+			path: '/home/chat/business',
+			components: {
+				default: BusinessDashboardView,
 				sidebar: ChatSidebar,
 			},
 			meta: {


### PR DESCRIPTION
## Summary

This PR adds a new business dashboard view and agent template selector to the chat hub, enabling users to quickly create AI agents from pre-configured templates for common enterprise use cases.

### Key Changes

1. **New BusinessDashboardView component** (`BusinessDashboardView.vue`)
   - Displays key metrics: active agents, conversations, and available integrations
   - Shows featured agent templates for quick access
   - Lists integration options (CRM, documents, website embedding)
   - Displays recent conversations with relative timestamps
   - Responsive design with mobile support

2. **New AgentTemplateSelector component** (`AgentTemplateSelector.vue`)
   - Searchable template browser with category filtering
   - Pre-configured templates for sales, support, operations, and CRM use cases
   - Shows integration compatibility for each template
   - Option to start from scratch or select a template

3. **Business agent templates** (`business-templates.ts`)
   - 5 pre-configured templates with detailed system prompts:
     - Sales Lead Qualifier
     - Customer Support Agent
     - HR & Internal Operations
     - CRM Data Assistant
     - Document Q&A Agent
   - Each template includes suggested model, integrations, and category metadata

4. **AgentEditorModal integration**
   - Template selector shown when creating new agents
   - Apply template functionality to pre-populate agent configuration
   - Skip option to start from scratch

5. **Module and routing updates**
   - Added `CHAT_BUSINESS_DASHBOARD_VIEW` constant
   - Registered BusinessDashboardView in module descriptor
   - Updated sidebar navigation to include dashboard link

### Testing

- Existing tests pass
- New components follow established patterns and use existing composables
- Template data is static and well-structured
- Responsive design tested with mobile media query

https://claude.ai/code/session_01ETVCcKw4zkKfXBp4ZPVGdL