### PR TITLE
fix(core): Stop auto applying credentials for updated MCP workflows

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
@@ -90,6 +90,7 @@ describe('update-workflow MCP tool', () => {
 	const mockExistingWorkflow = Object.assign(new WorkflowEntity(), {
 		id: 'wf-1',
 		name: 'Existing Workflow',
+		nodes: [] as INode[],
 		settings: { availableInMCP: true },
 	});
 
@@ -120,7 +121,9 @@ describe('update-workflow MCP tool', () => {
 		});
 		nodeTypes = mockInstance(NodeTypes);
 
-		mockParseAndValidate.mockResolvedValue({ workflow: mockWorkflowJson });
+		mockParseAndValidate.mockImplementation(async () => ({
+			workflow: { ...mockWorkflowJson, nodes: mockNodes.map((n) => ({ ...n })) },
+		}));
 		mockStripImportStatements.mockImplementation((code: string) => code);
 		mockAutoPopulateNodeCredentials.mockResolvedValue({ assignments: [], skippedHttpNodes: [] });
 	});
@@ -367,6 +370,108 @@ describe('update-workflow MCP tool', () => {
 			expect(response.note).toBe(
 				'HTTP Request nodes (HTTP Request, HTTP Request1) were skipped during credential auto-assignment. Their credentials must be configured manually.',
 			);
+		});
+
+		describe('credential preservation from existing workflow', () => {
+			test('copies credentials from existing node when name and type match and updated node has none', async () => {
+				findWorkflowMock.mockResolvedValue(
+					Object.assign(new WorkflowEntity(), {
+						id: 'wf-1',
+						name: 'Existing Workflow',
+						settings: { availableInMCP: true },
+						nodes: [
+							{
+								id: 'node-2',
+								name: 'Set',
+								type: 'n8n-nodes-base.set',
+								typeVersion: 1,
+								position: [200, 0] as [number, number],
+								parameters: {},
+								credentials: { setApi: { id: 'cred-1', name: 'My Set Cred' } },
+							},
+						] as INode[],
+					}),
+				);
+
+				await callHandler({ workflowId: 'wf-1', code: 'const wf = ...' });
+
+				const savedWorkflow = updateMock.mock.calls[0][1] as WorkflowEntity;
+				const setNode = savedWorkflow.nodes.find((n: INode) => n.name === 'Set');
+				expect(setNode!.credentials).toEqual({ setApi: { id: 'cred-1', name: 'My Set Cred' } });
+			});
+
+			test('does not copy credentials when node type differs', async () => {
+				findWorkflowMock.mockResolvedValue(
+					Object.assign(new WorkflowEntity(), {
+						id: 'wf-1',
+						name: 'Existing Workflow',
+						settings: { availableInMCP: true },
+						nodes: [
+							{
+								id: 'node-2',
+								name: 'Set',
+								type: 'n8n-nodes-base.differentType',
+								typeVersion: 1,
+								position: [200, 0] as [number, number],
+								parameters: {},
+								credentials: { setApi: { id: 'cred-1', name: 'My Set Cred' } },
+							},
+						] as INode[],
+					}),
+				);
+
+				await callHandler({ workflowId: 'wf-1', code: 'const wf = ...' });
+
+				const savedWorkflow = updateMock.mock.calls[0][1] as WorkflowEntity;
+				const setNode = savedWorkflow.nodes.find((n: INode) => n.name === 'Set');
+				expect(setNode!.credentials).toBeUndefined();
+			});
+
+			test('does not overwrite credentials already set on the updated node', async () => {
+				const newNodeCredentials = { setApi: { id: 'cred-new', name: 'New Cred' } };
+				mockParseAndValidate.mockResolvedValue({
+					workflow: {
+						...mockWorkflowJson,
+						nodes: mockNodes.map((n) =>
+							n.name === 'Set' ? { ...n, credentials: newNodeCredentials } : n,
+						),
+					},
+				});
+				findWorkflowMock.mockResolvedValue(
+					Object.assign(new WorkflowEntity(), {
+						id: 'wf-1',
+						name: 'Existing Workflow',
+						settings: { availableInMCP: true },
+						nodes: [
+							{
+								id: 'node-2',
+								name: 'Set',
+								type: 'n8n-nodes-base.set',
+								typeVersion: 1,
+								position: [200, 0] as [number, number],
+								parameters: {},
+								credentials: { setApi: { id: 'cred-old', name: 'Old Cred' } },
+							},
+						] as INode[],
+					}),
+				);
+
+				await callHandler({ workflowId: 'wf-1', code: 'const wf = ...' });
+
+				const savedWorkflow = updateMock.mock.calls[0][1] as WorkflowEntity;
+				const setNode = savedWorkflow.nodes.find((n: INode) => n.name === 'Set');
+				expect(setNode!.credentials).toEqual(newNodeCredentials);
+			});
+
+			test('handles existing workflow with no nodes without error', async () => {
+				// mockExistingWorkflow already has nodes: [] — verify no crash and no credentials copied
+				await callHandler({ workflowId: 'wf-1', code: 'const wf = ...' });
+
+				const savedWorkflow = updateMock.mock.calls[0][1] as WorkflowEntity;
+				for (const node of savedWorkflow.nodes) {
+					expect(node.credentials).toBeUndefined();
+				}
+			});
 		});
 	});
 });

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -105,7 +105,12 @@ export const createUpdateWorkflowTool = (
 
 		try {
 			// Fetch the workflow to check if it's available in MCP
-			await getMcpWorkflow(workflowId, user, ['workflow:update'], workflowFinderService);
+			const existingWorkflow = await getMcpWorkflow(
+				workflowId,
+				user,
+				['workflow:update'],
+				workflowFinderService,
+			);
 
 			const { ParseValidateHandler, stripImportStatements } = await import(
 				'@n8n/ai-workflow-builder'
@@ -132,6 +137,20 @@ export const createUpdateWorkflowTool = (
 					resolveNodeWebhookId(node, desc.description);
 				} catch {
 					// Node type not found, skip
+				}
+			}
+
+			// Preserve user-configured credentials from the existing workflow.
+			// Match nodes by name + type so that auto-assign skips them.
+			const existingCredsByNode = new Map(
+				existingWorkflow.nodes.map((n) => [n.name, { type: n.type, credentials: n.credentials }]),
+			);
+			for (const node of workflowUpdateData.nodes) {
+				if (!node.credentials) {
+					const existing = existingCredsByNode.get(node.name);
+					if (existing?.type === node.type && existing.credentials) {
+						node.credentials = { ...existing.credentials };
+					}
 				}
 			}
 


### PR DESCRIPTION
## Summary
Preventing the `update-workflow` mcp tool from auto-assigning credentials to nodes that already have credentials set.

## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-4974

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
