### PR TITLE
fix: Fix credential displayNames with missing spaces

### DIFF
--- a/packages/@n8n/nodes-langchain/credentials/CohereApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/CohereApi.credentials.ts
@@ -8,7 +8,7 @@ import type {
 export class CohereApi implements ICredentialType {
 	name = 'cohereApi';
 
-	displayName = 'CohereApi';
+	displayName = 'Cohere API';
 
 	documentationUrl = 'cohere';
 

--- a/packages/@n8n/nodes-langchain/credentials/HuggingFaceApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/HuggingFaceApi.credentials.ts
@@ -8,7 +8,7 @@ import type {
 export class HuggingFaceApi implements ICredentialType {
 	name = 'huggingFaceApi';
 
-	displayName = 'HuggingFaceApi';
+	displayName = 'Hugging Face API';
 
 	documentationUrl = 'huggingface';
 

--- a/packages/@n8n/nodes-langchain/credentials/MotorheadApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/MotorheadApi.credentials.ts
@@ -8,7 +8,7 @@ import type {
 export class MotorheadApi implements ICredentialType {
 	name = 'motorheadApi';
 
-	displayName = 'MotorheadApi';
+	displayName = 'Motorhead API';
 
 	documentationUrl = 'motorhead';
 

--- a/packages/@n8n/nodes-langchain/credentials/PineconeApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/PineconeApi.credentials.ts
@@ -8,7 +8,7 @@ import type {
 export class PineconeApi implements ICredentialType {
 	name = 'pineconeApi';
 
-	displayName = 'PineconeApi';
+	displayName = 'Pinecone API';
 
 	documentationUrl = 'pinecone';
 

--- a/packages/@n8n/nodes-langchain/credentials/QdrantApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/QdrantApi.credentials.ts
@@ -8,7 +8,7 @@ import type {
 export class QdrantApi implements ICredentialType {
 	name = 'qdrantApi';
 
-	displayName = 'QdrantApi';
+	displayName = 'Qdrant API';
 
 	documentationUrl = 'https://docs.n8n.io/integrations/builtin/credentials/qdrant/';
 

--- a/packages/@n8n/nodes-langchain/credentials/WolframAlphaApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/WolframAlphaApi.credentials.ts
@@ -8,7 +8,7 @@ import type {
 export class WolframAlphaApi implements ICredentialType {
 	name = 'wolframAlphaApi';
 
-	displayName = 'WolframAlphaApi';
+	displayName = 'Wolfram Alpha API';
 
 	documentationUrl = 'wolframalpha';
 

--- a/packages/nodes-base/credentials/DynatraceApi.credentials.ts
+++ b/packages/nodes-base/credentials/DynatraceApi.credentials.ts
@@ -3,7 +3,7 @@ import type { IAuthenticateGeneric, ICredentialType, INodeProperties } from 'n8n
 export class DynatraceApi implements ICredentialType {
 	name = 'dynatraceApi';
 
-	displayName = 'DynatraceAPI';
+	displayName = 'Dynatrace API';
 
 	documentationUrl = 'dynatrace';
 

--- a/packages/nodes-base/credentials/MalcoreApi.credentials.ts
+++ b/packages/nodes-base/credentials/MalcoreApi.credentials.ts
@@ -8,7 +8,7 @@ import type {
 export class MalcoreApi implements ICredentialType {
 	name = 'malcoreApi';
 
-	displayName = 'MalcoreAPI';
+	displayName = 'Malcore API';
 
 	documentationUrl = 'malcore';
 

--- a/packages/nodes-base/credentials/OpenAiApi.credentials.ts
+++ b/packages/nodes-base/credentials/OpenAiApi.credentials.ts
@@ -9,7 +9,7 @@ import type {
 export class OpenAiApi implements ICredentialType {
 	name = 'openAiApi';
 
-	displayName = 'OpenAi';
+	displayName = 'OpenAI';
 
 	documentationUrl = 'openai';
 

--- a/packages/nodes-base/credentials/test/OpenAiApi.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/OpenAiApi.credentials.test.ts
@@ -7,7 +7,7 @@ describe('OpenAiApi Credential', () => {
 
 	it('should have correct properties', () => {
 		expect(openAiApi.name).toBe('openAiApi');
-		expect(openAiApi.displayName).toBe('OpenAi');
+		expect(openAiApi.displayName).toBe('OpenAI');
 		expect(openAiApi.documentationUrl).toBe('openai');
 		expect(openAiApi.properties).toHaveLength(6);
 		expect(openAiApi.test.request.baseURL).toBe('={{$credentials?.url}}');


### PR DESCRIPTION
## Summary

Several credential types had malformed `displayName` values (e.g. `'PineconeApi'` instead of `'Pinecone API'`), causing the quick connect button and other UI elements to show raw camelCase names instead of properly formatted service names.

Fixed 9 credential displayNames:
- **nodes-langchain**: `PineconeApi` → `Pinecone API`, `QdrantApi` → `Qdrant API`, `HuggingFaceApi` → `Hugging Face API`, `WolframAlphaApi` → `Wolfram Alpha API`, `CohereApi` → `Cohere API`, `MotorheadApi` → `Motorhead API`
- **nodes-base**: `DynatraceAPI` → `Dynatrace API`, `MalcoreAPI` → `Malcore API`, `OpenAi` → `OpenAI`

Skipped `SerpAPI` and `ConvertAPI` as those are the actual product names.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4621

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)