### PR TITLE
refactor(editor): Migrate NDV settings to workflowDocumentStore connections (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
@@ -306,7 +306,8 @@ const featureRequestUrl = computed(() => {
 
 const hasOutputConnection = computed(() => {
 	if (!node.value) return false;
-	const outgoingConnections = workflowsStore.outgoingConnectionsByNodeName(node.value.name);
+	const outgoingConnections =
+		workflowDocumentStore?.value?.outgoingConnectionsByNodeName(node.value.name) ?? {};
 
 	// Check if there's at-least one output connection
 	return (Object.values(outgoingConnections)?.[0]?.[0] ?? []).length > 0;

--- a/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.ts
@@ -132,12 +132,12 @@ export function useNodeSettingsParameters() {
 			value: nodeParameters,
 		};
 
-		const connections = workflowsStore.allConnections;
+		const connections = workflowDocumentStore.value?.connectionsBySourceNode ?? {};
 
 		const updatedConnections = updateDynamicConnections(node, connections, parameterData);
 
 		if (updatedConnections) {
-			workflowsStore.setConnections(updatedConnections);
+			workflowDocumentStore.value?.setConnections(updatedConnections);
 		}
 
 		workflowDocumentStore.value?.setNodeParameters(updateInformation);


### PR DESCRIPTION
## Summary

Migrate connection reads and writes in NDV settings from `workflowsStore` to `workflowDocumentStore`, continuing the facade migration.

- `NodeSettings.vue`: `workflowsStore.outgoingConnectionsByNodeName()` → `workflowDocumentStore.outgoingConnectionsByNodeName()`
- `useNodeSettingsParameters.ts`: `workflowsStore.allConnections` → `workflowDocumentStore.connectionsBySourceNode`
- `useNodeSettingsParameters.ts`: `workflowsStore.setConnections()` → `workflowDocumentStore.setConnections()`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2637

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.