### PR TITLE
refactor(editor): Migrate workflow composables to workflowDocumentStore (connections) (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.ts
@@ -48,7 +48,9 @@ export function useWorkflowExtraction() {
 	const i18n = useI18n();
 	const telemetry = useTelemetry();
 
-	const adjacencyList = computed(() => buildAdjacencyList(workflowsStore.workflow.connections));
+	const adjacencyList = computed(() =>
+		buildAdjacencyList(workflowDocumentStore?.value?.connectionsBySourceNode ?? {}),
+	);
 
 	const workflowObject = computed(() => workflowsStore.workflowObject as Workflow);
 
@@ -496,7 +498,7 @@ export function useWorkflowExtraction() {
 			newWorkflowName,
 			selection,
 			nodes,
-			workflowsStore.workflow.connections,
+			workflowDocumentStore?.value?.connectionsBySourceNode ?? {},
 			variables,
 			afterVariables,
 			startNodeName,

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
@@ -324,11 +324,14 @@ describe('useWorkflowHelpers', () => {
 			workflowsStore.workflowId = workflowId;
 			workflowsStore.workflowName = 'Test Workflow';
 			workflowsStore.allNodes = [];
-			workflowsStore.allConnections = initialConnections;
 			workflowsStore.workflow.versionId = 'v1';
 
 			const documentId = createWorkflowDocumentId(workflowId);
 			const workflowDocumentStore = useWorkflowDocumentStore(documentId);
+			Object.defineProperty(workflowDocumentStore, 'connectionsBySourceNode', {
+				value: initialConnections,
+				configurable: true,
+			});
 			vi.mocked(workflowDocumentStore.getSettingsSnapshot).mockReturnValue({
 				executionOrder: 'v1',
 			});
@@ -353,7 +356,6 @@ describe('useWorkflowHelpers', () => {
 			workflowsStore.workflowId = workflowId;
 			workflowsStore.workflowName = 'Test Workflow';
 			workflowsStore.allNodes = [];
-			workflowsStore.allConnections = {};
 			workflowsStore.isWorkflowActive = false;
 			workflowsStore.workflow.settings = { executionOrder: 'v1' };
 			workflowsStore.workflow.versionId = 'v1';
@@ -361,6 +363,10 @@ describe('useWorkflowHelpers', () => {
 
 			const documentId = createWorkflowDocumentId(workflowId);
 			const workflowDocumentStore = useWorkflowDocumentStore(documentId);
+			Object.defineProperty(workflowDocumentStore, 'connectionsBySourceNode', {
+				value: {},
+				configurable: true,
+			});
 
 			// Note: createTestingPinia() stubs actions by default, so setTags()/setSettings() won't work
 			Object.defineProperty(workflowDocumentStore, 'tags', {

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -104,7 +104,7 @@ export async function resolveParameter<T = IDataObject>(
 	return await resolveParameterImpl(
 		parameter,
 		workflowsStore.workflowObject as Workflow,
-		workflowsStore.connectionsBySourceNode,
+		workflowDocumentStore?.connectionsBySourceNode ?? {},
 		useEnvironmentsStore().variablesAsObject,
 		useNDVStore().activeNode,
 		workflowsStore.workflowExecutionData,
@@ -580,8 +580,12 @@ export function useWorkflowHelpers() {
 	}
 
 	async function getWorkflowDataToSave() {
+		const workflowDocumentStore = useWorkflowDocumentStore(
+			createWorkflowDocumentId(workflowsStore.workflowId),
+		);
+
 		const workflowNodes = workflowsStore.allNodes;
-		const workflowConnections = workflowsStore.allConnections;
+		const workflowConnections = workflowDocumentStore.connectionsBySourceNode;
 
 		let nodeData;
 
@@ -597,10 +601,6 @@ export function useWorkflowHelpers() {
 		// mutations between now and request serialization can include connections to
 		// nodes not present in the nodes snapshot, violating a BE invariant.
 		const connections = deepCopy(workflowConnections);
-
-		const workflowDocumentStore = useWorkflowDocumentStore(
-			createWorkflowDocumentId(workflowsStore.workflowId),
-		);
 
 		const data: WorkflowData = {
 			name: workflowsStore.workflowName,

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -584,7 +584,7 @@ export function useWorkflowHelpers() {
 			createWorkflowDocumentId(workflowsStore.workflowId),
 		);
 
-		const workflowNodes = workflowsStore.allNodes;
+		const workflowNodes = workflowDocumentStore.allNodes;
 		const workflowConnections = workflowDocumentStore.connectionsBySourceNode;
 
 		let nodeData;

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.test.ts
@@ -3,6 +3,10 @@ import { setActivePinia } from 'pinia';
 import { createTestingPinia } from '@pinia/testing';
 import { useWorkflowUpdate } from './useWorkflowUpdate';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
@@ -54,6 +58,7 @@ vi.mock('@/app/utils/nodeTypesUtils', () => ({
 
 describe('useWorkflowUpdate', () => {
 	let workflowsStore: ReturnType<typeof mockedStore<typeof useWorkflowsStore>>;
+	let workflowDocumentStore: ReturnType<typeof useWorkflowDocumentStore>;
 	let builderStore: ReturnType<typeof mockedStore<typeof useBuilderStore>>;
 	let credentialsStore: ReturnType<typeof mockedStore<typeof useCredentialsStore>>;
 	let nodeTypesStore: ReturnType<typeof mockedStore<typeof useNodeTypesStore>>;
@@ -79,14 +84,16 @@ describe('useWorkflowUpdate', () => {
 			nodes: [],
 			connections: {},
 		} as unknown as ReturnType<typeof useWorkflowsStore>['workflow'];
+		workflowsStore.workflowId = 'test-workflow';
 		workflowsStore.cloneWorkflowObject = vi.fn().mockReturnValue({
 			nodes: {},
 			connectionsBySourceNode: {},
 			renameNode: vi.fn(),
 		});
 		workflowsStore.setNodes = vi.fn();
-		workflowsStore.setConnections = vi.fn();
 		workflowsStore.nodesByName = {};
+
+		workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId('test-workflow'));
 
 		builderStore.setBuilderMadeEdits = vi.fn();
 
@@ -348,7 +355,7 @@ describe('useWorkflowUpdate', () => {
 
 				// Should sync state back to store
 				expect(workflowsStore.setNodes).toHaveBeenCalled();
-				expect(workflowsStore.setConnections).toHaveBeenCalled();
+				expect(workflowDocumentStore.setConnections).toHaveBeenCalled();
 			});
 
 			it('should apply executeOnce when updated node has it set', async () => {

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
@@ -15,6 +15,7 @@ import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import { computed } from 'vue';
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
@@ -50,6 +51,12 @@ export function useWorkflowUpdate() {
 	const uiStore = useUIStore();
 	const canvasOperations = useCanvasOperations();
 	const nodeHelpers = useNodeHelpers();
+
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 
 	/**
 	 * Categorize nodes into those to update, add, or remove.
@@ -173,7 +180,7 @@ export function useWorkflowUpdate() {
 
 		// Sync state back to store
 		workflowsStore.setNodes(Object.values(workflow.nodes));
-		workflowsStore.setConnections(workflow.connectionsBySourceNode);
+		workflowDocumentStore.value?.setConnections(workflow.connectionsBySourceNode);
 		// Revalidate updated nodes to refresh error indicators on canvas
 		for (const { existing } of nodesToUpdate) {
 			const nodeName = renamedNodes.get(existing.id) ?? existing.name;
@@ -240,7 +247,7 @@ export function useWorkflowUpdate() {
 	 * Update connections - remove old, add new
 	 */
 	async function updateConnections(newConnections: IConnections): Promise<void> {
-		const existingConnections = workflowsStore.workflow.connections;
+		const existingConnections = workflowDocumentStore.value?.connectionsBySourceNode ?? {};
 
 		// Convert to canvas format for comparison
 		const existingCanvasConnections = mapLegacyConnectionsToCanvasConnections(
@@ -373,12 +380,9 @@ export function useWorkflowUpdate() {
 			updateWorkflowNameIfNeeded(workflowData.name, options?.isInitialGeneration);
 
 			// Merge pin data from workflow data with existing pin data
-			if (workflowData.pinData && workflowsStore.workflowId) {
-				const workflowDocumentStore = useWorkflowDocumentStore(
-					createWorkflowDocumentId(workflowsStore.workflowId),
-				);
-				workflowDocumentStore.setPinData({
-					...workflowDocumentStore.getPinDataSnapshot(),
+			if (workflowData.pinData && workflowDocumentStore.value) {
+				workflowDocumentStore.value.setPinData({
+					...workflowDocumentStore.value.getPinDataSnapshot(),
 					...workflowData.pinData,
 				});
 			}


### PR DESCRIPTION
## Summary

Migrates connection reads/writes from `workflowsStore` to `workflowDocumentStore` in three composable files, as part of the ongoing `workflowDocumentStore` migration.

**Source files:**
- `useWorkflowHelpers.ts` — `connectionsBySourceNode` replaces `allConnections` and `connectionsBySourceNode` reads from `workflowsStore`
- `useWorkflowUpdate.ts` — `setConnections` and `connectionsBySourceNode` via computed accessor; consolidates inline `useWorkflowDocumentStore()` calls
- `useWorkflowExtraction.ts` — `connectionsBySourceNode` via injected store replaces `workflow.connections` reads

**Test files:**
- `useWorkflowHelpers.test.ts` — migrates `allConnections` assignments to `Object.defineProperty` on document store
- `useWorkflowUpdate.test.ts` — asserts on `workflowDocumentStore.setConnections` instead of `workflowsStore.setConnections`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2635

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.