### PR TITLE
fix: move @eslint/js from devDependencies to dependencies in node-cli

### DIFF
--- a/packages/@n8n/node-cli/package.json
+++ b/packages/@n8n/node-cli/package.json
@@ -60,10 +60,10 @@
     "prompts": "^2.4.2",
     "rimraf": "catalog:",
     "ts-morph": "catalog:",
-    "typescript-eslint": "^8.35.0"
+    "typescript-eslint": "^8.35.0",
+    "@eslint/js": "^9.29.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.29.0",
     "@n8n/typescript-config": "workspace:*",
     "@n8n/vitest-config": "workspace:*",
     "@oclif/test": "^4.1.13",


### PR DESCRIPTION
## Summary
Fixes #26544.

**Root cause:** `@eslint/js` is imported at runtime in `packages/@n8n/node-cli/src/configs/eslint.ts` (line 1: `import eslint from '@eslint/js'`) but is listed as a `devDependency`. When users install `@n8n/node-cli` as a package, `devDependencies` are not installed, causing `Error: Cannot find module '@eslint/js'` when running `n8n-node lint` with ESLint v10+.

**Fix:** Moved `@eslint/js` from `devDependencies` to `dependencies` in `package.json`.

## Changes
- `packages/@n8n/node-cli/package.json`: Moved `"@eslint/js": "^9.29.0"` from `devDependencies` to `dependencies`.

## Testing
- Verified that `@eslint/js` is now available as a runtime dependency
- No version change — same `^9.29.0` constraint
- Change is minimal and backward-compatible

Made with [Cursor](https://cursor.com)