### PR TITLE
feat(API): Add public API endpoint for pushing to git

### DIFF
--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -315,6 +315,27 @@ describe('TelemetryEventRelay', () => {
 			});
 		});
 
+		it('should track on `source-control-user-pushed-api` event', () => {
+			const event: RelayEventMap['source-control-user-pushed-api'] = {
+				userId: 'user1',
+				workflowsPushed: 3,
+				workflowsEligible: 5,
+				credsPushed: 2,
+				variablesPushed: 1,
+				forced: true,
+			};
+
+			eventService.emit('source-control-user-pushed-api', event);
+
+			expect(telemetry.track).toHaveBeenCalledWith('User pushed via API', {
+				workflows_pushed: 3,
+				workflows_eligible: 5,
+				creds_pushed: 2,
+				variables_pushed: 1,
+				forced: true,
+			});
+		});
+
 		it('should track on `source-control-user-started-push-ui` event', () => {
 			const event: RelayEventMap['source-control-user-started-push-ui'] = {
 				userId: 'userId',

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -536,6 +536,15 @@ export type RelayEventMap = {
 		forced: boolean;
 	};
 
+	'source-control-user-pushed-api': {
+		userId: string;
+		workflowsPushed: number;
+		workflowsEligible: number;
+		credsPushed: number;
+		variablesPushed: number;
+		forced: boolean;
+	};
+
 	'source-control-user-started-push-ui': {
 		userId?: string;
 		workflowsEligible: number;

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -81,6 +81,7 @@ export class TelemetryEventRelay extends EventRelay {
 			'source-control-user-finished-pull-ui': (event) =>
 				this.sourceControlUserFinishedPullUi(event),
 			'source-control-user-pulled-api': (event) => this.sourceControlUserPulledApi(event),
+			'source-control-user-pushed-api': (event) => this.sourceControlUserPushedApi(event),
 			'source-control-user-started-push-ui': (event) => this.sourceControlUserStartedPushUi(event),
 			'source-control-user-finished-push-ui': (event) =>
 				this.sourceControlUserFinishedPushUi(event),
@@ -246,6 +247,22 @@ export class TelemetryEventRelay extends EventRelay {
 	}: RelayEventMap['source-control-user-pulled-api']) {
 		this.telemetry.track('User pulled via API', {
 			workflow_updates: workflowUpdates,
+			forced,
+		});
+	}
+
+	private sourceControlUserPushedApi({
+		workflowsPushed,
+		workflowsEligible,
+		credsPushed,
+		variablesPushed,
+		forced,
+	}: RelayEventMap['source-control-user-pushed-api']) {
+		this.telemetry.track('User pushed via API', {
+			workflows_pushed: workflowsPushed,
+			workflows_eligible: workflowsEligible,
+			creds_pushed: credsPushed,
+			variables_pushed: variablesPushed,
 			forced,
 		});
 	}

--- a/packages/cli/src/public-api/v1/handlers/source-control/__tests__/source-control.handler.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/source-control/__tests__/source-control.handler.test.ts
@@ -1,0 +1,233 @@
+import { Container } from '@n8n/di';
+import type { Response } from 'express';
+
+import type { EventService } from '@/events/event.service';
+import * as sourceControlHelper from '@/modules/source-control.ee/source-control-helper.ee';
+import type { SourceControlPreferencesService } from '@/modules/source-control.ee/source-control-preferences.service.ee';
+import type { SourceControlService } from '@/modules/source-control.ee/source-control.service.ee';
+import * as middlewares from '@/public-api/v1/shared/middlewares/global.middleware';
+
+// Mock middleware before requiring handler
+const mockMiddleware = jest.fn(async (_req: unknown, _res: unknown, next: () => void) =>
+	next(),
+) as unknown as ReturnType<typeof middlewares.apiKeyHasScopeWithGlobalScopeFallback>;
+jest.spyOn(middlewares, 'apiKeyHasScopeWithGlobalScopeFallback').mockReturnValue(mockMiddleware);
+
+const handler = require('../source-control.handler');
+
+describe('source-control handler', () => {
+	let mockSourceControlService: jest.Mocked<SourceControlService>;
+	let mockSourceControlPreferencesService: jest.Mocked<SourceControlPreferencesService>;
+	let mockEventService: jest.Mocked<EventService>;
+	let mockResponse: Partial<Response>;
+
+	beforeEach(() => {
+		mockSourceControlService = {
+			pullWorkfolder: jest.fn(),
+			pushWorkfolder: jest.fn(),
+		} as unknown as jest.Mocked<SourceControlService>;
+
+		mockSourceControlPreferencesService = {
+			isSourceControlConnected: jest.fn().mockReturnValue(true),
+		} as unknown as jest.Mocked<SourceControlPreferencesService>;
+
+		mockEventService = {
+			emit: jest.fn(),
+		} as unknown as jest.Mocked<EventService>;
+
+		jest.spyOn(Container, 'get').mockImplementation((serviceClass) => {
+			if (serviceClass.name === 'SourceControlService') return mockSourceControlService;
+			if (serviceClass.name === 'SourceControlPreferencesService')
+				return mockSourceControlPreferencesService;
+			if (serviceClass.name === 'EventService') return mockEventService;
+			return {} as unknown;
+		});
+
+		jest.spyOn(sourceControlHelper, 'isSourceControlLicensed').mockReturnValue(true);
+
+		mockResponse = {
+			status: jest.fn().mockReturnThis(),
+			json: jest.fn().mockReturnThis(),
+			send: jest.fn().mockReturnThis(),
+		};
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	describe('pull', () => {
+		it('should return 401 when source control is not licensed', async () => {
+			jest.spyOn(sourceControlHelper, 'isSourceControlLicensed').mockReturnValue(false);
+
+			const req = { user: { id: 'user1' }, body: { force: false } };
+
+			await handler.pull[1](req, mockResponse);
+
+			expect(mockResponse.status).toHaveBeenCalledWith(401);
+			expect(mockResponse.json).toHaveBeenCalledWith({
+				status: 'Error',
+				message: 'Source Control feature is not licensed',
+			});
+		});
+
+		it('should return 400 when source control is not connected', async () => {
+			mockSourceControlPreferencesService.isSourceControlConnected.mockReturnValue(false);
+
+			const req = { user: { id: 'user1' }, body: { force: false } };
+
+			await handler.pull[1](req, mockResponse);
+
+			expect(mockResponse.status).toHaveBeenCalledWith(400);
+			expect(mockResponse.json).toHaveBeenCalledWith({
+				status: 'Error',
+				message: 'Source Control is not connected to a repository',
+			});
+		});
+
+		it('should return 200 with status result on successful pull', async () => {
+			const statusResult = [{ file: 'workflow.json', id: 'wf1', name: 'My Workflow' }];
+			mockSourceControlService.pullWorkfolder.mockResolvedValue({
+				statusCode: 200,
+				statusResult,
+			} as unknown as ReturnType<SourceControlService['pullWorkfolder']>);
+
+			const req = { user: { id: 'user1' }, body: { force: false } };
+
+			await handler.pull[1](req, mockResponse);
+
+			expect(mockResponse.status).toHaveBeenCalledWith(200);
+			expect(mockResponse.send).toHaveBeenCalledWith(statusResult);
+			expect(mockEventService.emit).toHaveBeenCalledWith(
+				'source-control-user-pulled-api',
+				expect.objectContaining({ forced: false }),
+			);
+		});
+
+		it('should return 409 when pull detects conflicts', async () => {
+			const statusResult = [{ file: 'workflow.json', conflict: true }];
+			mockSourceControlService.pullWorkfolder.mockResolvedValue({
+				statusCode: 409,
+				statusResult,
+			} as unknown as ReturnType<SourceControlService['pullWorkfolder']>);
+
+			const req = { user: { id: 'user1' }, body: { force: false } };
+
+			await handler.pull[1](req, mockResponse);
+
+			expect(mockResponse.status).toHaveBeenCalledWith(409);
+			expect(mockResponse.send).toHaveBeenCalledWith(statusResult);
+		});
+
+		it('should return 400 on unexpected error', async () => {
+			mockSourceControlService.pullWorkfolder.mockRejectedValue(new Error('Git error'));
+
+			const req = { user: { id: 'user1' }, body: { force: false } };
+
+			await handler.pull[1](req, mockResponse);
+
+			expect(mockResponse.status).toHaveBeenCalledWith(400);
+			expect(mockResponse.send).toHaveBeenCalledWith('Git error');
+		});
+	});
+
+	describe('push', () => {
+		const validBody = { force: false, commitMessage: 'Test commit', fileNames: [] };
+
+		it('should return 401 when source control is not licensed', async () => {
+			jest.spyOn(sourceControlHelper, 'isSourceControlLicensed').mockReturnValue(false);
+
+			const req = { user: { id: 'user1' }, body: validBody };
+
+			await handler.push[1](req, mockResponse);
+
+			expect(mockResponse.status).toHaveBeenCalledWith(401);
+			expect(mockResponse.json).toHaveBeenCalledWith({
+				status: 'Error',
+				message: 'Source Control feature is not licensed',
+			});
+		});
+
+		it('should return 400 when source control is not connected', async () => {
+			mockSourceControlPreferencesService.isSourceControlConnected.mockReturnValue(false);
+
+			const req = { user: { id: 'user1' }, body: validBody };
+
+			await handler.push[1](req, mockResponse);
+
+			expect(mockResponse.status).toHaveBeenCalledWith(400);
+			expect(mockResponse.json).toHaveBeenCalledWith({
+				status: 'Error',
+				message: 'Source Control is not connected to a repository',
+			});
+		});
+
+		it('should return 200 with status result on successful push', async () => {
+			const statusResult = [{ file: 'workflow.json', id: 'wf1', name: 'My Workflow', pushed: true }];
+			mockSourceControlService.pushWorkfolder.mockResolvedValue({
+				statusCode: 200,
+				statusResult,
+				pushResult: undefined,
+			});
+
+			const req = { user: { id: 'user1' }, body: validBody };
+
+			await handler.push[1](req, mockResponse);
+
+			expect(mockSourceControlService.pushWorkfolder).toHaveBeenCalledWith(
+				req.user,
+				expect.objectContaining({ force: false, commitMessage: 'Test commit' }),
+			);
+			expect(mockResponse.status).toHaveBeenCalledWith(200);
+			expect(mockResponse.send).toHaveBeenCalledWith(statusResult);
+			expect(mockEventService.emit).toHaveBeenCalledWith(
+				'source-control-user-pushed-api',
+				expect.objectContaining({ forced: false }),
+			);
+		});
+
+		it('should return 409 when push detects conflicts', async () => {
+			const statusResult = [{ file: 'workflow.json', conflict: true }];
+			mockSourceControlService.pushWorkfolder.mockResolvedValue({
+				statusCode: 409,
+				statusResult,
+				pushResult: undefined,
+			});
+
+			const req = { user: { id: 'user1' }, body: validBody };
+
+			await handler.push[1](req, mockResponse);
+
+			expect(mockResponse.status).toHaveBeenCalledWith(409);
+			expect(mockResponse.send).toHaveBeenCalledWith(statusResult);
+			expect(mockEventService.emit).not.toHaveBeenCalled();
+		});
+
+		it('should return 400 on unexpected error', async () => {
+			mockSourceControlService.pushWorkfolder.mockRejectedValue(
+				new Error('Cannot push onto read-only branch.'),
+			);
+
+			const req = { user: { id: 'user1' }, body: validBody };
+
+			await handler.push[1](req, mockResponse);
+
+			expect(mockResponse.status).toHaveBeenCalledWith(400);
+			expect(mockResponse.send).toHaveBeenCalledWith('Cannot push onto read-only branch.');
+		});
+
+		it('should not emit telemetry event when push returns 409', async () => {
+			mockSourceControlService.pushWorkfolder.mockResolvedValue({
+				statusCode: 409,
+				statusResult: [],
+				pushResult: undefined,
+			});
+
+			const req = { user: { id: 'user1' }, body: { ...validBody, force: true } };
+
+			await handler.push[1](req, mockResponse);
+
+			expect(mockEventService.emit).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/public-api/v1/handlers/source-control/source-control.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/source-control/source-control.handler.ts
@@ -1,10 +1,11 @@
-import { PullWorkFolderRequestDto } from '@n8n/api-types';
+import { PullWorkFolderRequestDto, PushWorkFolderRequestDto } from '@n8n/api-types';
 import type { AuthenticatedRequest } from '@n8n/db';
 import { Container } from '@n8n/di';
 import type express from 'express';
 import type { StatusResult } from 'simple-git';
 
 import {
+	getTrackingInformationFromPostPushResult,
 	getTrackingInformationFromPullResult,
 	isSourceControlLicensed,
 } from '@/modules/source-control.ee/source-control-helper.ee';
@@ -41,6 +42,42 @@ export = {
 				if (result.statusCode === 200) {
 					Container.get(EventService).emit('source-control-user-pulled-api', {
 						...getTrackingInformationFromPullResult(req.user.id, result.statusResult),
+						forced: payload.force ?? false,
+					});
+					return res.status(200).send(result.statusResult);
+				} else {
+					return res.status(409).send(result.statusResult);
+				}
+			} catch (error) {
+				return res.status(400).send((error as { message: string }).message);
+			}
+		},
+	],
+	push: [
+		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'sourceControl:push' }),
+		async (
+			req: AuthenticatedRequest,
+			res: express.Response,
+		): Promise<express.Response> => {
+			const sourceControlPreferencesService = Container.get(SourceControlPreferencesService);
+			if (!isSourceControlLicensed()) {
+				return res
+					.status(401)
+					.json({ status: 'Error', message: 'Source Control feature is not licensed' });
+			}
+			if (!sourceControlPreferencesService.isSourceControlConnected()) {
+				return res
+					.status(400)
+					.json({ status: 'Error', message: 'Source Control is not connected to a repository' });
+			}
+			try {
+				const payload = PushWorkFolderRequestDto.parse(req.body);
+				const sourceControlService = Container.get(SourceControlService);
+				const result = await sourceControlService.pushWorkfolder(req.user, payload);
+
+				if (result.statusCode === 200) {
+					Container.get(EventService).emit('source-control-user-pushed-api', {
+						...getTrackingInformationFromPostPushResult(req.user.id, result.statusResult),
 						forced: payload.force ?? false,
 					});
 					return res.status(200).send(result.statusResult);

--- a/packages/cli/src/public-api/v1/handlers/source-control/spec/paths/sourceControlPush.yml
+++ b/packages/cli/src/public-api/v1/handlers/source-control/spec/paths/sourceControlPush.yml
@@ -1,0 +1,25 @@
+post:
+  x-eov-operation-id: push
+  x-eov-operation-handler: v1/handlers/source-control/source-control.handler
+  tags:
+    - SourceControl
+  summary: Push changes to the remote repository
+  description: Requires the Source Control feature to be licensed and connected to a repository.
+  requestBody:
+    description: Push options
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/push.yml'
+  responses:
+    '200':
+      description: Push result
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/pushResult.yml'
+    '400':
+      $ref: '../../../../shared/spec/responses/badRequest.yml'
+    '409':
+      $ref: '../../../../shared/spec/responses/conflict.yml'

--- a/packages/cli/src/public-api/v1/handlers/source-control/spec/paths/sourceControlPush.yml
+++ b/packages/cli/src/public-api/v1/handlers/source-control/spec/paths/sourceControlPush.yml
@@ -21,5 +21,7 @@ post:
             $ref: '../schemas/pushResult.yml'
     '400':
       $ref: '../../../../shared/spec/responses/badRequest.yml'
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
     '409':
       $ref: '../../../../shared/spec/responses/conflict.yml'

--- a/packages/cli/src/public-api/v1/handlers/source-control/spec/schemas/push.yml
+++ b/packages/cli/src/public-api/v1/handlers/source-control/spec/schemas/push.yml
@@ -1,0 +1,45 @@
+type: object
+required:
+  - fileNames
+properties:
+  force:
+    type: boolean
+    example: true
+  commitMessage:
+    type: string
+    example: Updated workflows
+  fileNames:
+    type: array
+    items:
+      type: object
+      required:
+        - file
+        - id
+        - name
+        - type
+        - status
+        - location
+        - conflict
+        - updatedAt
+      properties:
+        file:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        type:
+          type: string
+          enum: [credential, workflow, tags, variables, file, folders, project, datatable]
+        status:
+          type: string
+          enum: [new, modified, deleted, created, renamed, conflicted, ignored, staged, unknown]
+        location:
+          type: string
+          enum: [local, remote]
+        conflict:
+          type: boolean
+        updatedAt:
+          type: string
+        pushed:
+          type: boolean

--- a/packages/cli/src/public-api/v1/handlers/source-control/spec/schemas/pushResult.yml
+++ b/packages/cli/src/public-api/v1/handlers/source-control/spec/schemas/pushResult.yml
@@ -1,0 +1,38 @@
+type: object
+properties:
+  files:
+    type: array
+    items:
+      type: object
+      properties:
+        file:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        type:
+          type: string
+          enum: [credential, workflow, tags, variables, file, folders, project, datatable]
+        status:
+          type: string
+          enum: [new, modified, deleted, created, renamed, conflicted, ignored, staged, unknown]
+        location:
+          type: string
+          enum: [local, remote]
+        conflict:
+          type: boolean
+        updatedAt:
+          type: string
+        pushed:
+          type: boolean
+  commit:
+    type: object
+    nullable: true
+    properties:
+      hash:
+        type: string
+      message:
+        type: string
+      branch:
+        type: string

--- a/packages/cli/src/public-api/v1/openapi.yml
+++ b/packages/cli/src/public-api/v1/openapi.yml
@@ -86,6 +86,8 @@ paths:
     $ref: './handlers/users/spec/paths/users.id.role.yml'
   /source-control/pull:
     $ref: './handlers/source-control/spec/paths/sourceControl.yml'
+  /source-control/push:
+    $ref: './handlers/source-control/spec/paths/sourceControlPush.yml'
   /variables:
     $ref: './handlers/variables/spec/paths/variables.yml'
   /variables/{id}:


### PR DESCRIPTION
## Summary

Adds a `POST /source-control/push` endpoint to the public API, mirroring the existing `pull` endpoint. This allows external tools and CI/CD pipelines to trigger git pushes programmatically without using the n8n UI.

- Adds `POST /source-control/push` handler with license + connection guard checks
- Emits `source-control-user-pushed-api` telemetry event on successful push (tracking workflows/creds/variables pushed and whether forced)
- Adds OpenAPI spec for the new endpoint (`sourceControlPush.yml`, `push.yml`, `pushResult.yml` schemas)
- Returns `200` with pushed file list, `409` on conflicts, `400` on error

## Related Linear tickets, Github issues, and Community forum posts

<https://community.n8n.io/t/feat-source-control-add-push-endpoint-to-public-api-v1/277063>

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](<https://github.com/n8n-io/n8n-docs>) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
