### PR TITLE
feat(local-gateway): Implement file write tools

### DIFF
--- a/packages/@n8n/fs-proxy/spec/local-gateway.md
+++ b/packages/@n8n/fs-proxy/spec/local-gateway.md
@@ -27,11 +27,68 @@ The AI can read files and navigate the directory structure within a
 user-specified root directory. Access is strictly scoped — the AI cannot access
 files outside the configured root.
 
-Supported operations:
-- Read file contents
-- List files in a directory
-- Get a directory tree
-- Search file contents
+#### Read operations (always available when filesystem is enabled)
+
+- **Read file** — read the text content of a file. Files larger than 512 KB or
+  binary files are rejected. Supports paginated access via a start line and
+  line count (default: 200 lines).
+- **List files** — list the immediate children of a directory. Results can be
+  filtered by type (file, directory, or all) and capped at a maximum count
+  (default: 200).
+- **Get file tree** — get an indented directory tree starting from a given
+  path. Traversal depth is configurable (default: 2 levels). Common
+  generated directories (`node_modules`, `dist`, `.git`, etc.) are excluded
+  automatically.
+- **Search files** — search for a regex pattern across all files under a
+  directory. Supports an optional glob filter (e.g. `**/*.ts`),
+  case-insensitive mode, and a result cap (default: 50 matches). Files
+  larger than 512 KB are skipped.
+
+#### Write operations (requires `writeAccess` to be enabled)
+
+Write operations are disabled by default. They must be explicitly enabled via
+the `writeAccess` configuration property on the filesystem capability. This
+gives the user clear, deliberate control over whether the AI is permitted to
+modify the local filesystem.
+
+When `writeAccess` is enabled, the following additional operations become
+available:
+
+- **Write file** — create a new file with the given content. Overwrites if the
+  file already exists. Parent directories are created automatically.
+  Content must not exceed the maximum file size\*.
+- **Edit file** — apply a targeted search-and-replace to an existing file.
+  Finds the first occurrence of an exact string and replaces it with the
+  provided replacement. Fails if the string is not found. File must not exceed
+  the maximum file size\*.
+- **Create directory** — create a new directory. Idempotent: does nothing if
+  the directory already exists. Parent directories are created automatically.
+- **Delete** — delete a file or directory. Deleting a directory removes it and
+  all of its contents recursively.
+- **Move** — move or rename a file or directory to a new path. Overwrites the
+  destination if it already exists. Parent directories at the destination are
+  created automatically.
+- **Copy file** — copy a file to a new path. Overwrites the destination if it
+  already exists. Parent directories at the destination are created
+  automatically.
+
+All write operations are subject to the same path-scoping rules as read
+operations — paths outside the configured root are rejected.
+
+\* Maximum file size: 512 KB.
+
+#### Configuration
+
+The filesystem capability is configured with two properties:
+
+```
+dir         — the root directory the AI can access (required)
+writeAccess — enables write operations (default: false)
+```
+
+Exposed as CLI flags `--filesystem-dir <path>` and `--filesystem-write-access`,
+and as env vars `N8N_GATEWAY_FILESYSTEM_DIR` and
+`N8N_GATEWAY_FILESYSTEM_WRITE_ACCESS`.
 
 ### 2. Shell Execution
 
@@ -114,7 +171,11 @@ it. Only one active connection is allowed per user at a time.
 
 When connecting, the user specifies a root directory. The AI can only access
 files within that directory and its subdirectories. Access to any path outside
-the root is denied.
+the root is denied — this applies equally to read and write operations.
+
+Write access is an opt-in: even within the root, the AI cannot modify the
+filesystem unless `writeAccess` is explicitly enabled. Read and write access
+are independent — read-only mode remains the default.
 
 ---
 

--- a/packages/@n8n/fs-proxy/spec/technical-spec.md
+++ b/packages/@n8n/fs-proxy/spec/technical-spec.md
@@ -180,10 +180,10 @@ sequenceDiagram
     Note over D: uploadCapabilities() — resolves tool definitions,<br/>then POSTs rootPath + McpTool[]
     Note over SRV: consumePairingToken(userId, token)<br/>Issues session key sess_...
     SRV-->>D: { ok: true, sessionKey: "sess_..." }
-    Note over D: Stores session key; uses it for all<br/>subsequent requests instead of the pairing token
+    Note over D: Stores session key, uses it for all<br/>subsequent requests instead of the pairing token
 
     D->>SRV: GET /gateway/events?apiKey=sess_... (SSE, persistent)
-    Note over SRV: SSE connection held open;<br/>tool call requests streamed as events
+    Note over SRV: SSE connection held open,<br/>tool call requests streamed as events
     SRV-->>FE: push: instanceAiGatewayStateChanged { connected: true, directory }
 ```
 

--- a/packages/@n8n/fs-proxy/src/config.ts
+++ b/packages/@n8n/fs-proxy/src/config.ts
@@ -41,6 +41,7 @@ export type LogLevel = z.infer<typeof logLevelSchema>;
 
 const filesystemConfigSchema = z.object({
 	dir: z.string().default('.'),
+	writeAccess: z.boolean().default(false),
 });
 
 const shellConfigSchema = z.object({
@@ -105,10 +106,14 @@ function buildEnvConfig(): Partial<GatewayConfig> {
 	// Filesystem
 	const fsEnabled = envBoolean('FILESYSTEM_ENABLED');
 	const fsDir = envString('FILESYSTEM_DIR');
+	const fsWriteAccess = envBoolean('FILESYSTEM_WRITE_ACCESS');
 	if (fsEnabled === false) {
 		config.filesystem = false;
-	} else if (fsDir) {
-		config.filesystem = { dir: fsDir };
+	} else {
+		const fsConfig: Record<string, unknown> = {};
+		if (fsDir) fsConfig.dir = fsDir;
+		if (fsWriteAccess !== undefined) fsConfig.writeAccess = fsWriteAccess;
+		if (Object.keys(fsConfig).length > 0) config.filesystem = fsConfig;
 	}
 
 	// Computer — shell
@@ -176,8 +181,11 @@ function buildCliConfig(args: yargsParser.Arguments): Partial<GatewayConfig> {
 	if (args['no-filesystem'] === true) {
 		config.filesystem = false;
 	} else {
+		const fsConfig: Record<string, unknown> = {};
 		const dir = args['filesystem-dir'] as string;
-		if (dir) config.filesystem = { dir };
+		if (dir) fsConfig.dir = dir;
+		if (args['filesystem-write-access'] === true) fsConfig.writeAccess = true;
+		if (Object.keys(fsConfig).length > 0) config.filesystem = fsConfig;
 	}
 
 	// Computer — shell
@@ -279,6 +287,7 @@ export function parseConfig(argv = process.argv.slice(2)): ParsedArgs {
 		string: ['log-level', 'filesystem-dir', 'browser-default', 'browser-viewport', 'allow-origin'],
 		boolean: [
 			'no-filesystem',
+			'filesystem-write-access',
 			'no-computer-shell',
 			'no-computer-screenshot',
 			'no-computer-mouse-keyboard',

--- a/packages/@n8n/fs-proxy/src/config.ts
+++ b/packages/@n8n/fs-proxy/src/config.ts
@@ -184,7 +184,8 @@ function buildCliConfig(args: yargsParser.Arguments): Partial<GatewayConfig> {
 		const fsConfig: Record<string, unknown> = {};
 		const dir = args['filesystem-dir'] as string;
 		if (dir) fsConfig.dir = dir;
-		if (args['filesystem-write-access'] === true) fsConfig.writeAccess = true;
+		if (args['filesystem-write-access'] !== undefined)
+			fsConfig.writeAccess = args['filesystem-write-access'] as boolean;
 		if (Object.keys(fsConfig).length > 0) config.filesystem = fsConfig;
 	}
 

--- a/packages/@n8n/fs-proxy/src/gateway-client.ts
+++ b/packages/@n8n/fs-proxy/src/gateway-client.ts
@@ -13,7 +13,7 @@ import {
 	printToolResult,
 } from './logger';
 import type { BrowserModule } from './tools/browser';
-import { filesystemTools } from './tools/filesystem';
+import { filesystemReadTools, filesystemWriteTools } from './tools/filesystem';
 import { MouseKeyboardModule } from './tools/mouse-keyboard';
 import { ScreenshotModule } from './tools/screenshot';
 import { ShellModule } from './tools/shell';
@@ -138,7 +138,10 @@ export class GatewayClient {
 
 		// Filesystem
 		if (config.filesystem !== false) {
-			defs.push(...filesystemTools);
+			defs.push(...filesystemReadTools);
+			if (config.filesystem.writeAccess) {
+				defs.push(...filesystemWriteTools);
+			}
 		}
 
 		// Computer use modules — check both config and platform support

--- a/packages/@n8n/fs-proxy/src/logger.ts
+++ b/packages/@n8n/fs-proxy/src/logger.ts
@@ -135,7 +135,17 @@ export function printModuleStatus(config: ResolvedGatewayConfig): void {
 	// Filesystem
 	if (config.filesystem !== false) {
 		const dir = formatPath(config.filesystem.dir);
-		logger.info(`  ${pc.green('✓')} Filesystem    ${pc.dim(dir)}`, { module: 'Filesystem', dir });
+		const writeAccess = config.filesystem.writeAccess ? ', write access' : '';
+		logger.info(`  ${pc.green('✓')} Filesystem    ${pc.dim(dir + writeAccess)}`, {
+			module: 'Filesystem',
+			dir,
+			writeAccess: config.filesystem.writeAccess,
+		});
+		if (writeAccess) {
+			logger.info(`  ${pc.green('✓')} Filesystem write access`);
+		} else {
+			logger.info(pc.dim('  ✗ Filesystem write access'));
+		}
 	} else {
 		logger.info(pc.dim('  ✗ Filesystem'), { module: 'Filesystem', enabled: false });
 	}
@@ -310,7 +320,18 @@ function groupTools(tools: ToolDefinition[]): Array<[string, string[]]> {
 	return sorted;
 }
 
-const FILESYSTEM_TOOLS = new Set(['read_file', 'list_files', 'get_file_tree', 'search_files']);
+const FILESYSTEM_TOOLS = new Set([
+	'read_file',
+	'list_files',
+	'get_file_tree',
+	'search_files',
+	'write_file',
+	'edit_file',
+	'create_directory',
+	'delete',
+	'move',
+	'copy_file',
+]);
 
 function categorize(toolName: string): string {
 	if (FILESYSTEM_TOOLS.has(toolName)) return 'Filesystem';

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/constants.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_FILE_SIZE = 512 * 1024; // 512 KB

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/copy-file.test.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/copy-file.test.ts
@@ -18,6 +18,10 @@ function mockCopyFile(): void {
 describe('copyFileTool', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
+		(fs.realpath as jest.Mock).mockImplementation(async (p: string) => {
+			if (p === '/base') return await Promise.resolve('/base');
+			throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+		});
 	});
 
 	describe('metadata', () => {

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/copy-file.test.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/copy-file.test.ts
@@ -1,0 +1,118 @@
+import * as fs from 'node:fs/promises';
+
+import { textOf } from '../test-utils';
+import { copyFileTool } from './copy-file';
+
+jest.mock('node:fs/promises');
+
+const CONTEXT = { dir: '/base' };
+
+function mockMkdir(): void {
+	(fs.mkdir as jest.Mock).mockResolvedValue(undefined);
+}
+
+function mockCopyFile(): void {
+	jest.mocked(fs.copyFile).mockResolvedValue(undefined);
+}
+
+describe('copyFileTool', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	describe('metadata', () => {
+		it('has the correct name', () => {
+			expect(copyFileTool.name).toBe('copy_file');
+		});
+
+		it('has a non-empty description', () => {
+			expect(copyFileTool.description).not.toBe('');
+		});
+	});
+
+	describe('inputSchema validation', () => {
+		it('accepts valid input', () => {
+			expect(() =>
+				copyFileTool.inputSchema.parse({
+					sourcePath: 'src/file.ts',
+					destinationPath: 'dst/file.ts',
+				}),
+			).not.toThrow();
+		});
+
+		it('throws when sourcePath is missing', () => {
+			expect(() => copyFileTool.inputSchema.parse({ destinationPath: 'dst/file.ts' })).toThrow();
+		});
+
+		it('throws when destinationPath is missing', () => {
+			expect(() => copyFileTool.inputSchema.parse({ sourcePath: 'src/file.ts' })).toThrow();
+		});
+	});
+
+	describe('execute', () => {
+		it('creates parent directories and copies the file', async () => {
+			mockMkdir();
+			mockCopyFile();
+
+			const result = await copyFileTool.execute(
+				{ sourcePath: 'src/file.ts', destinationPath: 'dst/sub/file.ts' },
+				CONTEXT,
+			);
+
+			// eslint-disable-next-line n8n-local-rules/no-uncaught-json-parse
+			const data = JSON.parse(textOf(result)) as {
+				sourcePath: string;
+				destinationPath: string;
+			};
+			expect(data.sourcePath).toBe('src/file.ts');
+			expect(data.destinationPath).toBe('dst/sub/file.ts');
+			expect(fs.mkdir).toHaveBeenCalledWith('/base/dst/sub', { recursive: true });
+			expect(fs.copyFile).toHaveBeenCalledWith('/base/src/file.ts', '/base/dst/sub/file.ts');
+		});
+
+		it('overwrites the destination if it already exists', async () => {
+			mockMkdir();
+			mockCopyFile();
+
+			await expect(
+				copyFileTool.execute(
+					{ sourcePath: 'src/file.ts', destinationPath: 'existing.ts' },
+					CONTEXT,
+				),
+			).resolves.not.toThrow();
+		});
+
+		it('returns a single text content block', async () => {
+			mockMkdir();
+			mockCopyFile();
+
+			const result = await copyFileTool.execute(
+				{ sourcePath: 'a.ts', destinationPath: 'b.ts' },
+				CONTEXT,
+			);
+
+			expect(result.content).toHaveLength(1);
+			expect(result.content[0].type).toBe('text');
+		});
+
+		it('rejects path traversal on source', async () => {
+			await expect(
+				copyFileTool.execute(
+					{ sourcePath: '../../../etc/passwd', destinationPath: 'dst.txt' },
+					CONTEXT,
+				),
+			).rejects.toThrow('escapes');
+		});
+
+		it('rejects path traversal on destination', async () => {
+			mockMkdir();
+
+			await expect(
+				copyFileTool.execute(
+					{ sourcePath: 'src/file.ts', destinationPath: '../../../etc/passwd' },
+					CONTEXT,
+				),
+			).rejects.toThrow('escapes');
+		});
+	});
+});

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/copy-file.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/copy-file.ts
@@ -18,8 +18,8 @@ export const copyFileTool: ToolDefinition<typeof inputSchema> = {
 	inputSchema,
 	annotations: { defaultPermission: 'confirm' },
 	async execute({ sourcePath, destinationPath }, { dir }) {
-		const resolvedSrc = resolveSafePath(dir, sourcePath);
-		const resolvedDest = resolveSafePath(dir, destinationPath);
+		const resolvedSrc = await resolveSafePath(dir, sourcePath);
+		const resolvedDest = await resolveSafePath(dir, destinationPath);
 
 		await fs.mkdir(path.dirname(resolvedDest), { recursive: true });
 		await fs.copyFile(resolvedSrc, resolvedDest);

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/copy-file.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/copy-file.ts
@@ -1,0 +1,29 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { z } from 'zod';
+
+import type { ToolDefinition } from '../types';
+import { formatCallToolResult } from '../utils';
+import { resolveSafePath } from './fs-utils';
+
+const inputSchema = z.object({
+	sourcePath: z.string().describe('Source file path relative to root'),
+	destinationPath: z.string().describe('Destination file path relative to root'),
+});
+
+export const copyFileTool: ToolDefinition<typeof inputSchema> = {
+	name: 'copy_file',
+	description:
+		'Copy a file to a new path. Overwrites the destination if it already exists. Parent directories at the destination are created automatically.',
+	inputSchema,
+	annotations: { defaultPermission: 'confirm' },
+	async execute({ sourcePath, destinationPath }, { dir }) {
+		const resolvedSrc = resolveSafePath(dir, sourcePath);
+		const resolvedDest = resolveSafePath(dir, destinationPath);
+
+		await fs.mkdir(path.dirname(resolvedDest), { recursive: true });
+		await fs.copyFile(resolvedSrc, resolvedDest);
+
+		return formatCallToolResult({ sourcePath, destinationPath });
+	},
+};

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/create-directory.test.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/create-directory.test.ts
@@ -14,6 +14,10 @@ function mockMkdir(): void {
 describe('createDirectoryTool', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
+		(fs.realpath as jest.Mock).mockImplementation(async (p: string) => {
+			if (p === '/base') return await Promise.resolve('/base');
+			throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+		});
 	});
 
 	describe('metadata', () => {
@@ -55,11 +59,15 @@ describe('createDirectoryTool', () => {
 		});
 
 		it('is idempotent when the directory already exists', async () => {
-			mockMkdir();
+			// fs.mkdir with { recursive: true } resolves without error when the dir already exists
+			(fs.mkdir as jest.Mock).mockResolvedValue(undefined);
 
-			await expect(
-				createDirectoryTool.execute({ dirPath: 'existing' }, CONTEXT),
-			).resolves.not.toThrow();
+			const result = await createDirectoryTool.execute({ dirPath: 'existing' }, CONTEXT);
+
+			// eslint-disable-next-line n8n-local-rules/no-uncaught-json-parse
+			const data = JSON.parse(textOf(result)) as { path: string };
+			expect(data.path).toBe('existing');
+			expect(fs.mkdir).toHaveBeenCalledWith('/base/existing', { recursive: true });
 		});
 
 		it('returns a single text content block', async () => {

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/create-directory.test.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/create-directory.test.ts
@@ -1,0 +1,80 @@
+import * as fs from 'node:fs/promises';
+
+import { textOf } from '../test-utils';
+import { createDirectoryTool } from './create-directory';
+
+jest.mock('node:fs/promises');
+
+const CONTEXT = { dir: '/base' };
+
+function mockMkdir(): void {
+	(fs.mkdir as jest.Mock).mockResolvedValue(undefined);
+}
+
+describe('createDirectoryTool', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	describe('metadata', () => {
+		it('has the correct name', () => {
+			expect(createDirectoryTool.name).toBe('create_directory');
+		});
+
+		it('has a non-empty description', () => {
+			expect(createDirectoryTool.description).not.toBe('');
+		});
+	});
+
+	describe('inputSchema validation', () => {
+		it('accepts a valid input', () => {
+			expect(() =>
+				createDirectoryTool.inputSchema.parse({ dirPath: 'src/components' }),
+			).not.toThrow();
+		});
+
+		it('throws when dirPath is missing', () => {
+			expect(() => createDirectoryTool.inputSchema.parse({})).toThrow();
+		});
+
+		it('throws when dirPath is not a string', () => {
+			expect(() => createDirectoryTool.inputSchema.parse({ dirPath: 42 })).toThrow();
+		});
+	});
+
+	describe('execute', () => {
+		it('creates directory including parent directories', async () => {
+			mockMkdir();
+
+			const result = await createDirectoryTool.execute({ dirPath: 'a/b/c' }, CONTEXT);
+
+			// eslint-disable-next-line n8n-local-rules/no-uncaught-json-parse
+			const data = JSON.parse(textOf(result)) as { path: string };
+			expect(data.path).toBe('a/b/c');
+			expect(fs.mkdir).toHaveBeenCalledWith('/base/a/b/c', { recursive: true });
+		});
+
+		it('is idempotent when the directory already exists', async () => {
+			mockMkdir();
+
+			await expect(
+				createDirectoryTool.execute({ dirPath: 'existing' }, CONTEXT),
+			).resolves.not.toThrow();
+		});
+
+		it('returns a single text content block', async () => {
+			mockMkdir();
+
+			const result = await createDirectoryTool.execute({ dirPath: 'newdir' }, CONTEXT);
+
+			expect(result.content).toHaveLength(1);
+			expect(result.content[0].type).toBe('text');
+		});
+
+		it('rejects path traversal', async () => {
+			await expect(
+				createDirectoryTool.execute({ dirPath: '../../../etc' }, CONTEXT),
+			).rejects.toThrow('escapes');
+		});
+	});
+});

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/create-directory.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/create-directory.ts
@@ -1,0 +1,25 @@
+import * as fs from 'node:fs/promises';
+import { z } from 'zod';
+
+import type { ToolDefinition } from '../types';
+import { formatCallToolResult } from '../utils';
+import { resolveSafePath } from './fs-utils';
+
+const inputSchema = z.object({
+	dirPath: z.string().describe('Directory path relative to root'),
+});
+
+export const createDirectoryTool: ToolDefinition<typeof inputSchema> = {
+	name: 'create_directory',
+	description:
+		'Create a new directory. Idempotent: does nothing if the directory already exists. Parent directories are created automatically.',
+	inputSchema,
+	annotations: { defaultPermission: 'confirm' },
+	async execute({ dirPath }, { dir }) {
+		const resolvedPath = resolveSafePath(dir, dirPath);
+
+		await fs.mkdir(resolvedPath, { recursive: true });
+
+		return formatCallToolResult({ path: dirPath });
+	},
+};

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/create-directory.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/create-directory.ts
@@ -16,7 +16,7 @@ export const createDirectoryTool: ToolDefinition<typeof inputSchema> = {
 	inputSchema,
 	annotations: { defaultPermission: 'confirm' },
 	async execute({ dirPath }, { dir }) {
-		const resolvedPath = resolveSafePath(dir, dirPath);
+		const resolvedPath = await resolveSafePath(dir, dirPath);
 
 		await fs.mkdir(resolvedPath, { recursive: true });
 

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/delete.test.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/delete.test.ts
@@ -24,6 +24,10 @@ function mockStatNotFound(): void {
 describe('deleteTool', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
+		(fs.realpath as jest.Mock).mockImplementation(async (p: string) => {
+			if (p === '/base') return await Promise.resolve('/base');
+			throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+		});
 	});
 
 	describe('metadata', () => {

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/delete.test.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/delete.test.ts
@@ -1,0 +1,102 @@
+import type { Stats } from 'node:fs';
+import * as fs from 'node:fs/promises';
+
+import { textOf } from '../test-utils';
+import { deleteTool } from './delete';
+
+jest.mock('node:fs/promises');
+
+const CONTEXT = { dir: '/base' };
+
+function mockStatFile(): void {
+	jest.mocked(fs.stat).mockResolvedValue({ isDirectory: () => false } as unknown as Stats);
+}
+
+function mockStatDirectory(): void {
+	jest.mocked(fs.stat).mockResolvedValue({ isDirectory: () => true } as unknown as Stats);
+}
+
+function mockStatNotFound(): void {
+	const error = Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' });
+	jest.mocked(fs.stat).mockRejectedValue(error);
+}
+
+describe('deleteTool', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	describe('metadata', () => {
+		it('has the correct name', () => {
+			expect(deleteTool.name).toBe('delete');
+		});
+
+		it('has a non-empty description', () => {
+			expect(deleteTool.description).not.toBe('');
+		});
+	});
+
+	describe('inputSchema validation', () => {
+		it('accepts a valid input', () => {
+			expect(() => deleteTool.inputSchema.parse({ path: 'src/old-file.ts' })).not.toThrow();
+		});
+
+		it('throws when path is missing', () => {
+			expect(() => deleteTool.inputSchema.parse({})).toThrow();
+		});
+
+		it('throws when path is not a string', () => {
+			expect(() => deleteTool.inputSchema.parse({ path: 123 })).toThrow();
+		});
+	});
+
+	describe('execute', () => {
+		it('deletes a file using unlink', async () => {
+			mockStatFile();
+			jest.mocked(fs.unlink).mockResolvedValue(undefined);
+
+			const result = await deleteTool.execute({ path: 'src/old.ts' }, CONTEXT);
+
+			// eslint-disable-next-line n8n-local-rules/no-uncaught-json-parse
+			const data = JSON.parse(textOf(result)) as { path: string };
+			expect(data.path).toBe('src/old.ts');
+			expect(fs.unlink).toHaveBeenCalledWith('/base/src/old.ts');
+			expect(fs.rm).not.toHaveBeenCalled();
+		});
+
+		it('deletes a directory recursively using rm', async () => {
+			mockStatDirectory();
+			(fs.rm as jest.Mock).mockResolvedValue(undefined);
+
+			const result = await deleteTool.execute({ path: 'old-dir' }, CONTEXT);
+
+			// eslint-disable-next-line n8n-local-rules/no-uncaught-json-parse
+			const data = JSON.parse(textOf(result)) as { path: string };
+			expect(data.path).toBe('old-dir');
+			expect(fs.rm).toHaveBeenCalledWith('/base/old-dir', { recursive: true, force: false });
+			expect(fs.unlink).not.toHaveBeenCalled();
+		});
+
+		it('returns a single text content block', async () => {
+			mockStatFile();
+			jest.mocked(fs.unlink).mockResolvedValue(undefined);
+
+			const result = await deleteTool.execute({ path: 'file.ts' }, CONTEXT);
+
+			expect(result.content).toHaveLength(1);
+			expect(result.content[0].type).toBe('text');
+		});
+
+		it('propagates error when path does not exist', async () => {
+			mockStatNotFound();
+
+			await expect(deleteTool.execute({ path: 'missing.ts' }, CONTEXT)).rejects.toThrow('ENOENT');
+		});
+
+		it('rejects path traversal', async () => {
+			await expect(deleteTool.execute({ path: '../../../etc/passwd' }, CONTEXT)).rejects.toThrow(
+				'escapes',
+			);
+		});
+	});
+});

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/delete.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/delete.ts
@@ -1,0 +1,31 @@
+import * as fs from 'node:fs/promises';
+import { z } from 'zod';
+
+import type { ToolDefinition } from '../types';
+import { formatCallToolResult } from '../utils';
+import { resolveSafePath } from './fs-utils';
+
+const inputSchema = z.object({
+	path: z.string().describe('Path relative to root (file or directory)'),
+});
+
+export const deleteTool: ToolDefinition<typeof inputSchema> = {
+	name: 'delete',
+	description:
+		'Delete a file or directory. Deleting a directory removes it and all of its contents recursively.',
+	inputSchema,
+	annotations: { defaultPermission: 'confirm', destructiveHint: true },
+	async execute({ path: relPath }, { dir }) {
+		const resolvedPath = resolveSafePath(dir, relPath);
+
+		const stat = await fs.stat(resolvedPath);
+
+		if (stat.isDirectory()) {
+			await fs.rm(resolvedPath, { recursive: true, force: false });
+		} else {
+			await fs.unlink(resolvedPath);
+		}
+
+		return formatCallToolResult({ path: relPath });
+	},
+};

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/delete.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/delete.ts
@@ -16,7 +16,7 @@ export const deleteTool: ToolDefinition<typeof inputSchema> = {
 	inputSchema,
 	annotations: { defaultPermission: 'confirm', destructiveHint: true },
 	async execute({ path: relPath }, { dir }) {
-		const resolvedPath = resolveSafePath(dir, relPath);
+		const resolvedPath = await resolveSafePath(dir, relPath);
 
 		const stat = await fs.stat(resolvedPath);
 

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/edit-file.test.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/edit-file.test.ts
@@ -23,6 +23,10 @@ function mockWriteFile(): void {
 describe('editFileTool', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
+		(fs.realpath as jest.Mock).mockImplementation(async (p: string) => {
+			if (p === '/base') return await Promise.resolve('/base');
+			throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+		});
 	});
 
 	describe('metadata', () => {
@@ -55,6 +59,16 @@ describe('editFileTool', () => {
 		it('throws when oldString is missing', () => {
 			expect(() =>
 				editFileTool.inputSchema.parse({ filePath: 'src/index.ts', newString: 'bar' }),
+			).toThrow();
+		});
+
+		it('throws when oldString is empty', () => {
+			expect(() =>
+				editFileTool.inputSchema.parse({
+					filePath: 'src/index.ts',
+					oldString: '',
+					newString: 'bar',
+				}),
 			).toThrow();
 		});
 

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/edit-file.test.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/edit-file.test.ts
@@ -1,0 +1,148 @@
+import type { Stats } from 'node:fs';
+import * as fs from 'node:fs/promises';
+
+import { textOf } from '../test-utils';
+import { editFileTool } from './edit-file';
+
+jest.mock('node:fs/promises');
+
+const CONTEXT = { dir: '/base' };
+
+function mockStat(size: number): void {
+	jest.mocked(fs.stat).mockResolvedValue({ size } as unknown as Stats);
+}
+
+function mockReadFile(content: string): void {
+	(fs.readFile as jest.Mock).mockResolvedValue(content);
+}
+
+function mockWriteFile(): void {
+	(fs.writeFile as jest.Mock).mockResolvedValue(undefined);
+}
+
+describe('editFileTool', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	describe('metadata', () => {
+		it('has the correct name', () => {
+			expect(editFileTool.name).toBe('edit_file');
+		});
+
+		it('has a non-empty description', () => {
+			expect(editFileTool.description).not.toBe('');
+		});
+	});
+
+	describe('inputSchema validation', () => {
+		it('accepts valid input', () => {
+			expect(() =>
+				editFileTool.inputSchema.parse({
+					filePath: 'src/index.ts',
+					oldString: 'foo',
+					newString: 'bar',
+				}),
+			).not.toThrow();
+		});
+
+		it('throws when filePath is missing', () => {
+			expect(() =>
+				editFileTool.inputSchema.parse({ oldString: 'foo', newString: 'bar' }),
+			).toThrow();
+		});
+
+		it('throws when oldString is missing', () => {
+			expect(() =>
+				editFileTool.inputSchema.parse({ filePath: 'src/index.ts', newString: 'bar' }),
+			).toThrow();
+		});
+
+		it('throws when newString is missing', () => {
+			expect(() =>
+				editFileTool.inputSchema.parse({ filePath: 'src/index.ts', oldString: 'foo' }),
+			).toThrow();
+		});
+	});
+
+	describe('execute', () => {
+		it('replaces the first occurrence of oldString with newString', async () => {
+			mockStat(100);
+			mockReadFile('const foo = 1;\nconst foo2 = 2;');
+			mockWriteFile();
+
+			const result = await editFileTool.execute(
+				{ filePath: 'src/index.ts', oldString: 'const foo = 1;', newString: 'const foo = 99;' },
+				CONTEXT,
+			);
+
+			// eslint-disable-next-line n8n-local-rules/no-uncaught-json-parse
+			const data = JSON.parse(textOf(result)) as { path: string };
+			expect(data.path).toBe('src/index.ts');
+			expect(fs.writeFile).toHaveBeenCalledWith(
+				'/base/src/index.ts',
+				'const foo = 99;\nconst foo2 = 2;',
+				'utf-8',
+			);
+		});
+
+		it('only replaces the first occurrence when multiple exist', async () => {
+			mockStat(100);
+			mockReadFile('foo foo foo');
+			mockWriteFile();
+
+			await editFileTool.execute(
+				{ filePath: 'file.txt', oldString: 'foo', newString: 'bar' },
+				CONTEXT,
+			);
+
+			expect(fs.writeFile).toHaveBeenCalledWith('/base/file.txt', 'bar foo foo', 'utf-8');
+		});
+
+		it('returns a single text content block', async () => {
+			mockStat(100);
+			mockReadFile('hello world');
+			mockWriteFile();
+
+			const result = await editFileTool.execute(
+				{ filePath: 'file.txt', oldString: 'hello', newString: 'hi' },
+				CONTEXT,
+			);
+
+			expect(result.content).toHaveLength(1);
+			expect(result.content[0].type).toBe('text');
+		});
+
+		it('throws when oldString is not found', async () => {
+			mockStat(100);
+			mockReadFile('hello world');
+
+			await expect(
+				editFileTool.execute(
+					{ filePath: 'file.txt', oldString: 'missing', newString: 'replacement' },
+					CONTEXT,
+				),
+			).rejects.toThrow('oldString not found');
+		});
+
+		it('rejects files larger than 512 KB', async () => {
+			mockStat(600 * 1024);
+
+			await expect(
+				editFileTool.execute(
+					{ filePath: 'large.txt', oldString: 'foo', newString: 'bar' },
+					CONTEXT,
+				),
+			).rejects.toThrow('too large');
+		});
+
+		it('rejects path traversal', async () => {
+			await expect(
+				editFileTool.execute(
+					{ filePath: '../../../etc/passwd', oldString: 'root', newString: 'evil' },
+					CONTEXT,
+				),
+			).rejects.toThrow('escapes');
+		});
+	});
+});

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/edit-file.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/edit-file.ts
@@ -1,0 +1,41 @@
+import * as fs from 'node:fs/promises';
+import { z } from 'zod';
+
+import type { ToolDefinition } from '../types';
+import { formatCallToolResult } from '../utils';
+import { MAX_FILE_SIZE } from './constants';
+import { resolveSafePath } from './fs-utils';
+
+const inputSchema = z.object({
+	filePath: z.string().describe('File path relative to root'),
+	oldString: z.string().describe('Exact string to find and replace (first occurrence)'),
+	newString: z.string().describe('Replacement string'),
+});
+
+export const editFileTool: ToolDefinition<typeof inputSchema> = {
+	name: 'edit_file',
+	description:
+		'Apply a targeted search-and-replace to a file. Replaces the first occurrence of oldString with newString. Fails if oldString is not found.',
+	inputSchema,
+	annotations: { defaultPermission: 'confirm' },
+	async execute({ filePath, oldString, newString }, { dir }) {
+		const resolvedPath = resolveSafePath(dir, filePath);
+
+		const stat = await fs.stat(resolvedPath);
+		if (stat.size > MAX_FILE_SIZE) {
+			throw new Error(
+				`File too large: ${stat.size} bytes (max ${MAX_FILE_SIZE} bytes). Use write_file to replace the entire content.`,
+			);
+		}
+
+		const content = await fs.readFile(resolvedPath, 'utf-8');
+
+		if (!content.includes(oldString)) {
+			throw new Error(`oldString not found in file: ${filePath}`);
+		}
+
+		await fs.writeFile(resolvedPath, content.replace(oldString, newString), 'utf-8');
+
+		return formatCallToolResult({ path: filePath });
+	},
+};

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/edit-file.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/edit-file.ts
@@ -8,7 +8,7 @@ import { resolveSafePath } from './fs-utils';
 
 const inputSchema = z.object({
 	filePath: z.string().describe('File path relative to root'),
-	oldString: z.string().describe('Exact string to find and replace (first occurrence)'),
+	oldString: z.string().min(1).describe('Exact string to find and replace (first occurrence)'),
 	newString: z.string().describe('Replacement string'),
 });
 
@@ -19,7 +19,7 @@ export const editFileTool: ToolDefinition<typeof inputSchema> = {
 	inputSchema,
 	annotations: { defaultPermission: 'confirm' },
 	async execute({ filePath, oldString, newString }, { dir }) {
-		const resolvedPath = resolveSafePath(dir, filePath);
+		const resolvedPath = await resolveSafePath(dir, filePath);
 
 		const stat = await fs.stat(resolvedPath);
 		if (stat.size > MAX_FILE_SIZE) {

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/fs-utils.test.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/fs-utils.test.ts
@@ -1,0 +1,134 @@
+import type { Stats } from 'node:fs';
+import * as fs from 'node:fs/promises';
+
+import { resolveSafePath } from './fs-utils';
+
+jest.mock('node:fs/promises');
+
+const BASE = '/base';
+const enoent = (): Error => Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+
+function mockRealpath(entries: Array<[string, string]>): void {
+	const map = new Map(entries);
+	(fs.realpath as jest.Mock).mockImplementation(async (p: string) => {
+		if (map.has(p)) return await Promise.resolve(map.get(p)!);
+		throw enoent();
+	});
+}
+
+function mockLstat(entries: Array<[string, Partial<Stats>]>): void {
+	const map = new Map(entries);
+	jest.mocked(fs.lstat).mockImplementation(async (p) => {
+		const entry = map.get(p as string);
+		if (entry) return await Promise.resolve(entry as Stats);
+		throw enoent();
+	});
+}
+
+function mockReadlink(entries: Array<[string, string]>): void {
+	const map = new Map(entries);
+	(fs.readlink as jest.Mock).mockImplementation(async (p: string) => {
+		if (map.has(p)) return await Promise.resolve(map.get(p)!);
+		throw enoent();
+	});
+}
+
+describe('resolveSafePath', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+		// Default: only base exists; everything else is ENOENT
+		mockRealpath([[BASE, BASE]]);
+		jest.mocked(fs.lstat).mockRejectedValue(enoent());
+	});
+
+	it('resolves a simple path within the base directory', async () => {
+		const result = await resolveSafePath(BASE, 'src/index.ts');
+		expect(result).toBe('/base/src/index.ts');
+	});
+
+	it('resolves "." to the base directory', async () => {
+		const result = await resolveSafePath(BASE, '.');
+		expect(result).toBe(BASE);
+	});
+
+	it('throws when path traversal escapes the base directory', async () => {
+		await expect(resolveSafePath(BASE, '../../../etc/passwd')).rejects.toThrow('escapes');
+	});
+
+	it('throws when path traversal reaches exactly the parent of base', async () => {
+		await expect(resolveSafePath(BASE, '..')).rejects.toThrow('escapes');
+	});
+
+	it('resolves a path through a symlink that stays within the base', async () => {
+		// /base/link → /base/inner (resolved target inside base)
+		const baseLink = `${BASE}/link`;
+		const baseInner = `${BASE}/inner`;
+		mockRealpath([
+			[BASE, BASE],
+			[baseLink, baseInner],
+		]);
+
+		const result = await resolveSafePath(BASE, 'link/file.ts');
+		expect(result).toBe('/base/inner/file.ts');
+	});
+
+	it('throws when a symlink redirects outside the base directory', async () => {
+		// /base/link → /outside (resolved target outside base)
+		const baseLink = `${BASE}/link`;
+		mockRealpath([
+			[BASE, BASE],
+			[baseLink, '/outside'],
+		]);
+
+		await expect(resolveSafePath(BASE, 'link/file.ts')).rejects.toThrow('escapes');
+	});
+
+	it('throws when a dangling symlink points outside the base directory', async () => {
+		// /base/link is a dangling symlink → /outside/newfile
+		const baseLink = `${BASE}/link`;
+		mockLstat([[baseLink, { isSymbolicLink: () => true } as unknown as Stats]]);
+		mockReadlink([[baseLink, '/outside/newfile']]);
+
+		await expect(resolveSafePath(BASE, 'link/sub')).rejects.toThrow('escapes');
+	});
+
+	it('resolves a dangling symlink that points within the base directory', async () => {
+		// /base/link is a dangling symlink → /base/newfile (target does not exist yet)
+		const baseLink = `${BASE}/link`;
+		const baseNewfile = `${BASE}/newfile`;
+		mockLstat([[baseLink, { isSymbolicLink: () => true } as unknown as Stats]]);
+		mockReadlink([[baseLink, baseNewfile]]);
+
+		const result = await resolveSafePath(BASE, 'link/sub');
+		expect(result).toBe('/base/newfile/sub');
+	});
+
+	it('resolves a symlink chain that loops back inside the base', async () => {
+		// Simulates the user's scenario:
+		//   base = /base
+		//   /base/test → /outside   (first hop exits base)
+		//   /outside/hello → /base  (second hop re-enters base)
+		// resolveSafePath('/base', 'test/hello/bam/bum') must succeed → /base/bam/bum
+		const baseTest = `${BASE}/test`;
+		const outsideHello = '/outside/hello';
+		mockRealpath([
+			[BASE, BASE],
+			[baseTest, '/outside'],
+			[outsideHello, BASE],
+		]);
+
+		const result = await resolveSafePath(BASE, 'test/hello/bam/bum');
+		expect(result).toBe('/base/bam/bum');
+	});
+
+	it('throws when a symlink chain exits the base without returning', async () => {
+		// /base/test → /outside; no symlink back; /outside/bam stays outside
+		const baseTest = `${BASE}/test`;
+		mockRealpath([
+			[BASE, BASE],
+			[baseTest, '/outside'],
+		]);
+
+		await expect(resolveSafePath(BASE, 'test/bam/bum')).rejects.toThrow('escapes');
+	});
+});

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/fs-utils.test.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/fs-utils.test.ts
@@ -69,7 +69,8 @@ describe('resolveSafePath', () => {
 		]);
 
 		const result = await resolveSafePath(BASE, 'link/file.ts');
-		expect(result).toBe('/base/inner/file.ts');
+		// Returns the logical path without following symlinks
+		expect(result).toBe('/base/link/file.ts');
 	});
 
 	it('throws when a symlink redirects outside the base directory', async () => {
@@ -100,7 +101,8 @@ describe('resolveSafePath', () => {
 		mockReadlink([[baseLink, baseNewfile]]);
 
 		const result = await resolveSafePath(BASE, 'link/sub');
-		expect(result).toBe('/base/newfile/sub');
+		// Returns the logical path without following symlinks
+		expect(result).toBe('/base/link/sub');
 	});
 
 	it('resolves a symlink chain that loops back inside the base', async () => {
@@ -118,7 +120,8 @@ describe('resolveSafePath', () => {
 		]);
 
 		const result = await resolveSafePath(BASE, 'test/hello/bam/bum');
-		expect(result).toBe('/base/bam/bum');
+		// Returns the logical path without following symlinks
+		expect(result).toBe('/base/test/hello/bam/bum');
 	});
 
 	it('throws when a symlink chain exits the base without returning', async () => {

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/fs-utils.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/fs-utils.ts
@@ -128,11 +128,62 @@ function isAllowedDotFile(name: string): boolean {
 	return allowed.has(name);
 }
 
-/** Resolve a file path safely within the base directory. */
-export function resolveSafePath(basePath: string, relativePath: string): string {
-	const resolved = path.resolve(basePath, relativePath);
-	if (!resolved.startsWith(basePath + path.sep) && resolved !== basePath) {
+/**
+ * Resolve a path safely within the base directory, following symlinks.
+ *
+ * Walks each component of the path individually using `fs.realpath` so that
+ * symlinks are resolved at every level. This prevents a symlink inside the
+ * root from redirecting reads or writes to a location outside the root.
+ *
+ * For path components that do not yet exist (e.g. the target of a write
+ * operation), the remaining components are appended as plain strings once the
+ * deepest existing ancestor has been resolved.
+ *
+ * Dangling symlinks (a symlink whose target does not exist) are followed
+ * manually via `fs.lstat` + `fs.readlink` so that they are subject to the
+ * same bounds check as regular symlinks.
+ */
+export async function resolveSafePath(basePath: string, relativePath: string): Promise<string> {
+	const realBase = await fs.realpath(basePath);
+	const absolute = path.resolve(basePath, relativePath);
+
+	// Walk from the filesystem root, resolving each component in turn.
+	const root = path.parse(absolute).root;
+	const parts = path.relative(root, absolute).split(path.sep).filter(Boolean);
+
+	let current = root;
+
+	for (let i = 0; i < parts.length; i++) {
+		const next = path.join(current, parts[i]);
+
+		try {
+			// Happy path: follows all existing symlinks and returns the real path.
+			current = await fs.realpath(next);
+		} catch (realpathError) {
+			if ((realpathError as NodeJS.ErrnoException).code !== 'ENOENT') throw realpathError;
+
+			// ENOENT can mean the path is absent OR it is a dangling symlink whose
+			// target does not exist. Check with lstat (which does not follow symlinks).
+			try {
+				const lstat = await fs.lstat(next);
+				if (lstat.isSymbolicLink()) {
+					// Dangling symlink — follow it manually and continue the walk.
+					const target = await fs.readlink(next);
+					current = path.resolve(current, target);
+					continue;
+				}
+			} catch {
+				// lstat also failed — the path truly does not exist.
+			}
+
+			// Path does not exist and is not a symlink; append remaining parts as-is.
+			current = path.join(current, ...parts.slice(i));
+			break;
+		}
+	}
+
+	if (!current.startsWith(realBase + path.sep) && current !== realBase) {
 		throw new Error(`Path "${relativePath}" escapes the base directory`);
 	}
-	return resolved;
+	return current;
 }

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/fs-utils.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/fs-utils.ts
@@ -129,11 +129,12 @@ function isAllowedDotFile(name: string): boolean {
 }
 
 /**
- * Resolve a path safely within the base directory, following symlinks.
+ * Resolve a path safely within the base directory.
  *
  * Walks each component of the path individually using `fs.realpath` so that
- * symlinks are resolved at every level. This prevents a symlink inside the
- * root from redirecting reads or writes to a location outside the root.
+ * symlinks are resolved at every level during the *security check*. This
+ * prevents a symlink inside the root from redirecting reads or writes to a
+ * location outside the root.
  *
  * For path components that do not yet exist (e.g. the target of a write
  * operation), the remaining components are appended as plain strings once the
@@ -142,6 +143,9 @@ function isAllowedDotFile(name: string): boolean {
  * Dangling symlinks (a symlink whose target does not exist) are followed
  * manually via `fs.lstat` + `fs.readlink` so that they are subject to the
  * same bounds check as regular symlinks.
+ *
+ * Returns the logical absolute path (without resolving symlinks), so the
+ * caller never needs to know that a symlink is involved.
  */
 export async function resolveSafePath(basePath: string, relativePath: string): Promise<string> {
 	const realBase = await fs.realpath(basePath);
@@ -185,5 +189,5 @@ export async function resolveSafePath(basePath: string, relativePath: string): P
 	if (!current.startsWith(realBase + path.sep) && current !== realBase) {
 		throw new Error(`Path "${relativePath}" escapes the base directory`);
 	}
-	return current;
+	return absolute;
 }

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/get-file-tree.test.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/get-file-tree.test.ts
@@ -37,6 +37,10 @@ function mockReaddir(...batches: Dirent[][]): void {
 describe('getFileTreeTool', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
+		(fs.realpath as jest.Mock).mockImplementation(async (p: string) => {
+			if (p === '/base') return await Promise.resolve('/base');
+			throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+		});
 	});
 
 	describe('metadata', () => {

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/get-file-tree.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/get-file-tree.ts
@@ -14,7 +14,7 @@ export const getFileTreeTool: ToolDefinition<typeof inputSchema> = {
 	inputSchema,
 	annotations: { defaultPermission: 'allow', readOnlyHint: true },
 	async execute({ dirPath, maxDepth }, { dir }) {
-		const resolvedDir = resolveSafePath(dir, dirPath || '.');
+		const resolvedDir = await resolveSafePath(dir, dirPath || '.');
 		const depth = maxDepth ?? 2;
 		const { rootPath, tree, truncated } = await scanDirectory(resolvedDir, depth);
 

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/index.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/index.ts
@@ -1,12 +1,27 @@
 import type { ToolDefinition } from '../types';
+import { copyFileTool } from './copy-file';
+import { createDirectoryTool } from './create-directory';
+import { deleteTool } from './delete';
+import { editFileTool } from './edit-file';
 import { getFileTreeTool } from './get-file-tree';
 import { listFilesTool } from './list-files';
+import { moveFileTool } from './move';
 import { readFileTool } from './read-file';
 import { searchFilesTool } from './search-files';
+import { writeFileTool } from './write-file';
 
-export const filesystemTools: ToolDefinition[] = [
+export const filesystemReadTools: ToolDefinition[] = [
 	getFileTreeTool,
 	listFilesTool,
 	readFileTool,
 	searchFilesTool,
+];
+
+export const filesystemWriteTools: ToolDefinition[] = [
+	writeFileTool,
+	editFileTool,
+	createDirectoryTool,
+	deleteTool,
+	moveFileTool,
+	copyFileTool,
 ];

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/list-files.test.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/list-files.test.ts
@@ -34,6 +34,10 @@ function mockStat(size = 100): void {
 describe('listFilesTool', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
+		(fs.realpath as jest.Mock).mockImplementation(async (p: string) => {
+			if (p === '/base') return await Promise.resolve('/base');
+			throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+		});
 	});
 
 	describe('metadata', () => {

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/list-files.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/list-files.ts
@@ -19,7 +19,7 @@ export const listFilesTool: ToolDefinition<typeof inputSchema> = {
 	inputSchema,
 	annotations: { defaultPermission: 'allow', readOnlyHint: true },
 	async execute({ dirPath, type, maxResults }, { dir }) {
-		const resolvedDir = resolveSafePath(dir, dirPath || '.');
+		const resolvedDir = await resolveSafePath(dir, dirPath || '.');
 		// maxDepth=0 → immediate children only, no recursion
 		const { tree } = await scanDirectory(resolvedDir, 0);
 

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/move.test.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/move.test.ts
@@ -18,6 +18,10 @@ function mockRename(): void {
 describe('moveFileTool', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
+		(fs.realpath as jest.Mock).mockImplementation(async (p: string) => {
+			if (p === '/base') return await Promise.resolve('/base');
+			throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+		});
 	});
 
 	describe('metadata', () => {

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/move.test.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/move.test.ts
@@ -1,0 +1,129 @@
+import * as fs from 'node:fs/promises';
+
+import { textOf } from '../test-utils';
+import { moveFileTool } from './move';
+
+jest.mock('node:fs/promises');
+
+const CONTEXT = { dir: '/base' };
+
+function mockMkdir(): void {
+	(fs.mkdir as jest.Mock).mockResolvedValue(undefined);
+}
+
+function mockRename(): void {
+	jest.mocked(fs.rename).mockResolvedValue(undefined);
+}
+
+describe('moveFileTool', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	describe('metadata', () => {
+		it('has the correct name', () => {
+			expect(moveFileTool.name).toBe('move');
+		});
+
+		it('has a non-empty description', () => {
+			expect(moveFileTool.description).not.toBe('');
+		});
+	});
+
+	describe('inputSchema validation', () => {
+		it('accepts valid input', () => {
+			expect(() =>
+				moveFileTool.inputSchema.parse({
+					sourcePath: 'src/old.ts',
+					destinationPath: 'src/new.ts',
+				}),
+			).not.toThrow();
+		});
+
+		it('throws when sourcePath is missing', () => {
+			expect(() => moveFileTool.inputSchema.parse({ destinationPath: 'src/new.ts' })).toThrow();
+		});
+
+		it('throws when destinationPath is missing', () => {
+			expect(() => moveFileTool.inputSchema.parse({ sourcePath: 'src/old.ts' })).toThrow();
+		});
+	});
+
+	describe('execute', () => {
+		it('moves a file to the destination', async () => {
+			mockMkdir();
+			mockRename();
+
+			const result = await moveFileTool.execute(
+				{ sourcePath: 'src/old.ts', destinationPath: 'src/new.ts' },
+				CONTEXT,
+			);
+
+			// eslint-disable-next-line n8n-local-rules/no-uncaught-json-parse
+			const data = JSON.parse(textOf(result)) as {
+				sourcePath: string;
+				destinationPath: string;
+			};
+			expect(data.sourcePath).toBe('src/old.ts');
+			expect(data.destinationPath).toBe('src/new.ts');
+			expect(fs.rename).toHaveBeenCalledWith('/base/src/old.ts', '/base/src/new.ts');
+		});
+
+		it('overwrites the destination if it already exists', async () => {
+			mockMkdir();
+			mockRename();
+
+			await expect(
+				moveFileTool.execute(
+					{ sourcePath: 'src/old.ts', destinationPath: 'src/existing.ts' },
+					CONTEXT,
+				),
+			).resolves.not.toThrow();
+		});
+
+		it('creates parent directories at the destination', async () => {
+			mockMkdir();
+			mockRename();
+
+			await moveFileTool.execute(
+				{ sourcePath: 'file.ts', destinationPath: 'new/nested/dir/file.ts' },
+				CONTEXT,
+			);
+
+			expect(fs.mkdir).toHaveBeenCalledWith('/base/new/nested/dir', { recursive: true });
+		});
+
+		it('returns a single text content block', async () => {
+			mockMkdir();
+			mockRename();
+
+			const result = await moveFileTool.execute(
+				{ sourcePath: 'a.ts', destinationPath: 'b.ts' },
+				CONTEXT,
+			);
+
+			expect(result.content).toHaveLength(1);
+			expect(result.content[0].type).toBe('text');
+		});
+
+		it('rejects path traversal on source', async () => {
+			await expect(
+				moveFileTool.execute(
+					{ sourcePath: '../../../etc/passwd', destinationPath: 'dest.txt' },
+					CONTEXT,
+				),
+			).rejects.toThrow('escapes');
+		});
+
+		it('rejects path traversal on destination', async () => {
+			mockMkdir();
+
+			await expect(
+				moveFileTool.execute(
+					{ sourcePath: 'src/file.ts', destinationPath: '../../../etc/passwd' },
+					CONTEXT,
+				),
+			).rejects.toThrow('escapes');
+		});
+	});
+});

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/move.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/move.ts
@@ -1,0 +1,29 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { z } from 'zod';
+
+import type { ToolDefinition } from '../types';
+import { formatCallToolResult } from '../utils';
+import { resolveSafePath } from './fs-utils';
+
+const inputSchema = z.object({
+	sourcePath: z.string().describe('Source path relative to root (file or directory)'),
+	destinationPath: z.string().describe('Destination path relative to root'),
+});
+
+export const moveFileTool: ToolDefinition<typeof inputSchema> = {
+	name: 'move',
+	description:
+		'Move or rename a file or directory. Overwrites the destination if it already exists. Parent directories at the destination are created automatically.',
+	inputSchema,
+	annotations: { defaultPermission: 'confirm', destructiveHint: true },
+	async execute({ sourcePath, destinationPath }, { dir }) {
+		const resolvedSrc = resolveSafePath(dir, sourcePath);
+		const resolvedDest = resolveSafePath(dir, destinationPath);
+
+		await fs.mkdir(path.dirname(resolvedDest), { recursive: true });
+		await fs.rename(resolvedSrc, resolvedDest);
+
+		return formatCallToolResult({ sourcePath, destinationPath });
+	},
+};

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/move.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/move.ts
@@ -18,8 +18,8 @@ export const moveFileTool: ToolDefinition<typeof inputSchema> = {
 	inputSchema,
 	annotations: { defaultPermission: 'confirm', destructiveHint: true },
 	async execute({ sourcePath, destinationPath }, { dir }) {
-		const resolvedSrc = resolveSafePath(dir, sourcePath);
-		const resolvedDest = resolveSafePath(dir, destinationPath);
+		const resolvedSrc = await resolveSafePath(dir, sourcePath);
+		const resolvedDest = await resolveSafePath(dir, destinationPath);
 
 		await fs.mkdir(path.dirname(resolvedDest), { recursive: true });
 		await fs.rename(resolvedSrc, resolvedDest);

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/read-file.test.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/read-file.test.ts
@@ -19,6 +19,10 @@ function mockReadFile(content: Buffer | string): void {
 describe('readFileTool', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
+		(fs.realpath as jest.Mock).mockImplementation(async (p: string) => {
+			if (p === '/base') return await Promise.resolve('/base');
+			throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+		});
 	});
 
 	describe('metadata', () => {

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/read-file.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/read-file.ts
@@ -20,7 +20,7 @@ export const readFileTool: ToolDefinition<typeof inputSchema> = {
 	inputSchema,
 	annotations: { defaultPermission: 'allow', readOnlyHint: true },
 	async execute({ filePath, startLine, maxLines }, { dir }) {
-		const resolvedPath = resolveSafePath(dir, filePath);
+		const resolvedPath = await resolveSafePath(dir, filePath);
 
 		const stat = await fs.stat(resolvedPath);
 		if (stat.size > MAX_FILE_SIZE) {

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/read-file.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/read-file.ts
@@ -3,9 +3,8 @@ import { z } from 'zod';
 
 import type { ToolDefinition } from '../types';
 import { formatCallToolResult } from '../utils';
+import { MAX_FILE_SIZE } from './constants';
 import { resolveSafePath } from './fs-utils';
-
-const MAX_FILE_SIZE = 512 * 1024; // 512 KB
 const DEFAULT_MAX_LINES = 200;
 const BINARY_CHECK_SIZE = 8192;
 

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/search-files.test.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/search-files.test.ts
@@ -30,6 +30,10 @@ function mockStat(size = 100): void {
 describe('searchFilesTool', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
+		(fs.realpath as jest.Mock).mockImplementation(async (p: string) => {
+			if (p === '/base') return await Promise.resolve('/base');
+			throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+		});
 	});
 
 	describe('metadata', () => {

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/search-files.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/search-files.ts
@@ -4,9 +4,8 @@ import { z } from 'zod';
 
 import type { ToolDefinition } from '../types';
 import { formatCallToolResult } from '../utils';
+import { MAX_FILE_SIZE } from './constants';
 import { EXCLUDED_DIRS, resolveSafePath } from './fs-utils';
-
-const MAX_FILE_SIZE = 512 * 1024; // 512 KB
 
 const inputSchema = z.object({
 	dirPath: z.string().describe('Directory to search in'),

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/search-files.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/search-files.ts
@@ -21,7 +21,7 @@ export const searchFilesTool: ToolDefinition<typeof inputSchema> = {
 	inputSchema,
 	annotations: { defaultPermission: 'allow', readOnlyHint: true },
 	async execute({ dirPath, query, filePattern, ignoreCase, maxResults }, { dir }) {
-		const resolvedDir = resolveSafePath(dir, dirPath);
+		const resolvedDir = await resolveSafePath(dir, dirPath);
 		const limit = maxResults ?? 50;
 		const flags = ignoreCase ? 'gi' : 'g';
 		const regex = new RegExp(escapeRegex(query), flags);

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/write-file.test.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/write-file.test.ts
@@ -18,6 +18,10 @@ function mockWriteFile(): void {
 describe('writeFileTool', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
+		(fs.realpath as jest.Mock).mockImplementation(async (p: string) => {
+			if (p === '/base') return await Promise.resolve('/base');
+			throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+		});
 	});
 
 	describe('metadata', () => {

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/write-file.test.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/write-file.test.ts
@@ -1,0 +1,105 @@
+import * as fs from 'node:fs/promises';
+
+import { textOf } from '../test-utils';
+import { writeFileTool } from './write-file';
+
+jest.mock('node:fs/promises');
+
+const CONTEXT = { dir: '/base' };
+
+function mockMkdir(): void {
+	(fs.mkdir as jest.Mock).mockResolvedValue(undefined);
+}
+
+function mockWriteFile(): void {
+	(fs.writeFile as jest.Mock).mockResolvedValue(undefined);
+}
+
+describe('writeFileTool', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	describe('metadata', () => {
+		it('has the correct name', () => {
+			expect(writeFileTool.name).toBe('write_file');
+		});
+
+		it('has a non-empty description', () => {
+			expect(writeFileTool.description).not.toBe('');
+		});
+	});
+
+	describe('inputSchema validation', () => {
+		it('accepts valid input', () => {
+			expect(() =>
+				writeFileTool.inputSchema.parse({ filePath: 'src/index.ts', content: 'hello' }),
+			).not.toThrow();
+		});
+
+		it('throws when filePath is missing', () => {
+			expect(() => writeFileTool.inputSchema.parse({ content: 'hello' })).toThrow();
+		});
+
+		it('throws when content is missing', () => {
+			expect(() => writeFileTool.inputSchema.parse({ filePath: 'src/index.ts' })).toThrow();
+		});
+
+		it('throws when filePath is not a string', () => {
+			expect(() => writeFileTool.inputSchema.parse({ filePath: 99, content: 'hello' })).toThrow();
+		});
+	});
+
+	describe('execute', () => {
+		it('creates parent directories and writes the file', async () => {
+			mockMkdir();
+			mockWriteFile();
+
+			const result = await writeFileTool.execute(
+				{ filePath: 'subdir/hello.txt', content: 'hello world' },
+				CONTEXT,
+			);
+
+			// eslint-disable-next-line n8n-local-rules/no-uncaught-json-parse
+			const data = JSON.parse(textOf(result)) as { path: string };
+			expect(data.path).toBe('subdir/hello.txt');
+			expect(fs.mkdir).toHaveBeenCalledWith('/base/subdir', { recursive: true });
+			expect(fs.writeFile).toHaveBeenCalledWith('/base/subdir/hello.txt', 'hello world', 'utf-8');
+		});
+
+		it('returns a single text content block', async () => {
+			mockMkdir();
+			mockWriteFile();
+
+			const result = await writeFileTool.execute({ filePath: 'hello.txt', content: 'hi' }, CONTEXT);
+
+			expect(result.content).toHaveLength(1);
+			expect(result.content[0].type).toBe('text');
+		});
+
+		it('overwrites a file that already exists', async () => {
+			mockMkdir();
+			mockWriteFile();
+
+			await expect(
+				writeFileTool.execute({ filePath: 'existing.txt', content: 'new data' }, CONTEXT),
+			).resolves.not.toThrow();
+
+			expect(fs.writeFile).toHaveBeenCalledWith('/base/existing.txt', 'new data', 'utf-8');
+		});
+
+		it('rejects content larger than 512 KB', async () => {
+			const largeContent = 'x'.repeat(600 * 1024);
+
+			await expect(
+				writeFileTool.execute({ filePath: 'large.txt', content: largeContent }, CONTEXT),
+			).rejects.toThrow('too large');
+		});
+
+		it('rejects path traversal', async () => {
+			await expect(
+				writeFileTool.execute({ filePath: '../../../etc/passwd', content: 'bad' }, CONTEXT),
+			).rejects.toThrow('escapes');
+		});
+	});
+});

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/write-file.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/write-file.ts
@@ -1,0 +1,34 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { z } from 'zod';
+
+import type { ToolDefinition } from '../types';
+import { formatCallToolResult } from '../utils';
+import { MAX_FILE_SIZE } from './constants';
+import { resolveSafePath } from './fs-utils';
+
+const inputSchema = z.object({
+	filePath: z.string().describe('File path relative to root'),
+	content: z.string().describe('Text content to write'),
+});
+
+export const writeFileTool: ToolDefinition<typeof inputSchema> = {
+	name: 'write_file',
+	description:
+		'Create a new file with the given content. Overwrites if the file already exists. Content must not exceed 512 KB.',
+	inputSchema,
+	annotations: { defaultPermission: 'confirm' },
+	async execute({ filePath, content }, { dir }) {
+		const resolvedPath = resolveSafePath(dir, filePath);
+
+		const byteSize = Buffer.byteLength(content, 'utf-8');
+		if (byteSize > MAX_FILE_SIZE) {
+			throw new Error(`Content too large: ${byteSize} bytes (max ${MAX_FILE_SIZE} bytes).`);
+		}
+
+		await fs.mkdir(path.dirname(resolvedPath), { recursive: true });
+		await fs.writeFile(resolvedPath, content, 'utf-8');
+
+		return formatCallToolResult({ path: filePath });
+	},
+};

--- a/packages/@n8n/fs-proxy/src/tools/filesystem/write-file.ts
+++ b/packages/@n8n/fs-proxy/src/tools/filesystem/write-file.ts
@@ -19,7 +19,7 @@ export const writeFileTool: ToolDefinition<typeof inputSchema> = {
 	inputSchema,
 	annotations: { defaultPermission: 'confirm' },
 	async execute({ filePath, content }, { dir }) {
-		const resolvedPath = resolveSafePath(dir, filePath);
+		const resolvedPath = await resolveSafePath(dir, filePath);
 
 		const byteSize = Buffer.byteLength(content, 'utf-8');
 		if (byteSize > MAX_FILE_SIZE) {


### PR DESCRIPTION
## Summary

Implements file write tools/operation for the local gateway ([Spec](https://github.com/n8n-io/n8n/blob/feature/instance-ai-fs-write/packages/%40n8n/fs-proxy/spec/local-gateway.md)).

Write access can be enabled in the `fs-proxy` package by running

```
N8N_GATEWAY_FILESYSTEM_WRITE_ACCESS=true pnpm start
```

or

```
pnpm start --filesystem-write-access true
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4622/implement-write-for-fs-operations


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
