### PR TITLE
fix(core): Fix unhandled rejection in task broker on runner disconnect

### DIFF
--- a/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
+++ b/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
@@ -714,6 +714,28 @@ describe('TaskBroker', () => {
 				nodeTypes,
 			});
 		});
+
+		it('should discard `requester:rpcresponse` for an already-cleaned-up task', async () => {
+			await expect(
+				taskBroker.handleRequesterRpcResponse('nonexistent', 'call1', 'success', {}),
+			).resolves.toBeUndefined();
+		});
+
+		it('should discard `requester:taskdataresponse` for an already-cleaned-up task', async () => {
+			await expect(
+				taskBroker.handleRequesterDataResponse('nonexistent', 'req1', {}),
+			).resolves.toBeUndefined();
+		});
+
+		it('should discard `requester:nodetypesresponse` for an already-cleaned-up task', async () => {
+			await expect(
+				taskBroker.handleRequesterNodeTypesResponse('nonexistent', 'req1', []),
+			).resolves.toBeUndefined();
+		});
+
+		it('should discard `sendTaskSettings` for an already-cleaned-up task', async () => {
+			await expect(taskBroker.sendTaskSettings('nonexistent', {})).resolves.toBeUndefined();
+		});
 	});
 
 	describe('task execution timeouts', () => {

--- a/packages/cli/src/task-runners/task-broker/task-broker.service.ts
+++ b/packages/cli/src/task-runners/task-broker/task-broker.service.ts
@@ -363,6 +363,7 @@ export class TaskBroker {
 		status: RequesterMessage.ToBroker.RPCResponse['status'],
 		data: unknown,
 	) {
+		if (!this.tasks.has(taskId)) return;
 		const runner = await this.getRunnerOrFailTask(taskId);
 		await this.messageRunner(runner.id, {
 			type: 'broker:rpcresponse',
@@ -374,6 +375,7 @@ export class TaskBroker {
 	}
 
 	async handleRequesterDataResponse(taskId: Task['id'], requestId: string, data: unknown) {
+		if (!this.tasks.has(taskId)) return;
 		const runner = await this.getRunnerOrFailTask(taskId);
 
 		await this.messageRunner(runner.id, {
@@ -389,6 +391,7 @@ export class TaskBroker {
 		requestId: RequesterMessage.ToBroker.NodeTypesResponse['requestId'],
 		nodeTypes: RequesterMessage.ToBroker.NodeTypesResponse['nodeTypes'],
 	) {
+		if (!this.tasks.has(taskId)) return;
 		const runner = await this.getRunnerOrFailTask(taskId);
 
 		await this.messageRunner(runner.id, {
@@ -463,6 +466,7 @@ export class TaskBroker {
 	}
 
 	async sendTaskSettings(taskId: Task['id'], settings: unknown) {
+		if (!this.tasks.has(taskId)) return;
 		const runner = await this.getRunnerOrFailTask(taskId);
 
 		const task = this.tasks.get(taskId);

--- a/packages/cli/src/task-runners/task-managers/local-task-requester.ts
+++ b/packages/cli/src/task-runners/task-managers/local-task-requester.ts
@@ -37,6 +37,8 @@ export class LocalTaskRequester extends TaskRequester {
 	}
 
 	sendMessage(message: RequesterMessage.ToBroker.All) {
-		void this.taskBroker.onRequesterMessage(this.id, message);
+		void this.taskBroker.onRequesterMessage(this.id, message).catch((error) => {
+			this.errorReporter.error(error);
+		});
 	}
 }

--- a/packages/cli/src/task-runners/task-managers/task-requester.ts
+++ b/packages/cli/src/task-runners/task-managers/task-requester.ts
@@ -72,7 +72,7 @@ export abstract class TaskRequester {
 		private readonly eventService: EventService,
 		private readonly taskRunnersConfig: TaskRunnersConfig,
 		private readonly globalConfig: GlobalConfig,
-		private readonly errorReporter: ErrorReporter,
+		protected readonly errorReporter: ErrorReporter,
 	) {}
 
 	setRunnerUnavailable(taskType: string, reason: string) {


### PR DESCRIPTION
## Summary

When a runner disconnects mid-task for any reason, `TaskBroker.deregisterRunner` runs and deletes both the runner and its tasks from the broker's maps. But the requester may still be processing an in-flight RPC call from that runner that was disconnected and deregistered. So when the requester finishes and sends back the response, `TaskBroker.handleRequesterRpcResponse` calls `TaskBroker.getRunnerOrFailTask` for a task that no longer exists, so it throws an error that becomes an unhandled promise rejection.

This fix skips the `getRunnerOrFailTask` call when we already know the task is gone so we know there will be no runner for it, and `TaskRequester.sendMessage` catches any remaining unexpected errors. Every path that removes a task from the map notifies the requester first, so the requester already knows the runner is gone and the RPC response has nowhere to go.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2555

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)