### PR TITLE
fix(core): Move OIDC SSO provisioning outside user creation transaction

### DIFF
--- a/packages/cli/src/modules/sso-oidc/oidc.service.ee.ts
+++ b/packages/cli/src/modules/sso-oidc/oidc.service.ee.ts
@@ -306,8 +306,8 @@ export class OidcService {
 			return foundUser;
 		}
 
-		return await this.userRepository.manager.transaction(async (trx) => {
-			const { user } = await this.userRepository.createUserWithProject(
+		const user = await this.userRepository.manager.transaction(async (trx) => {
+			const { user: newUser } = await this.userRepository.createUserWithProject(
 				{
 					firstName: userInfo.given_name,
 					lastName: userInfo.family_name,
@@ -323,14 +323,16 @@ export class OidcService {
 				trx.create(AuthIdentity, {
 					providerId: claims.sub,
 					providerType: 'oidc',
-					userId: user.id,
+					userId: newUser.id,
 				}),
 			);
 
-			await this.applySsoProvisioning(user, claims);
-
-			return user;
+			return newUser;
 		});
+
+		await this.applySsoProvisioning(user, claims);
+
+		return user;
 	}
 
 	private async applySsoProvisioning(user: User, claims: any) {

--- a/packages/cli/test/integration/oidc/oidc.service.ee.test.ts
+++ b/packages/cli/test/integration/oidc/oidc.service.ee.test.ts
@@ -9,8 +9,8 @@ jest.mock('openid-client', () => ({
 	fetchUserInfo: fetchUserInfoMock,
 }));
 
-import type { OidcConfigDto } from '@n8n/api-types';
-import { testDb } from '@n8n/backend-test-utils';
+import type { OidcConfigDto, ProvisioningConfigDto } from '@n8n/api-types';
+import { createTeamProject, getProjectRoleForUser, testDb } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
 import { type User, UserRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
@@ -763,6 +763,166 @@ describe('OIDC service', () => {
 
 			expect(error).toBeInstanceOf(BadRequestError);
 			expect(error.message).toBe('Invalid token');
+		});
+
+		describe('new user login with SSO provisioning', () => {
+			const createProvisioningMockTokens = (
+				sub: string,
+				extraClaims: Record<string, unknown>,
+			): mocked_oidc_client.TokenEndpointResponse &
+				mocked_oidc_client.TokenEndpointResponseHelpers =>
+				({
+					access_token: `mock-access-token-${sub}`,
+					id_token: `mock-id-token-${sub}`,
+					token_type: 'bearer',
+					claims: () => {
+						return {
+							sub,
+							iss: 'https://example.com/auth/realms/n8n',
+							aud: 'test-client-id',
+							iat: Math.floor(Date.now() / 1000) - 1000,
+							exp: Math.floor(Date.now() / 1000) + 3600,
+							...extraClaims,
+						} as mocked_oidc_client.IDToken;
+					},
+					expiresIn: () => 3600,
+				}) as mocked_oidc_client.TokenEndpointResponse &
+					mocked_oidc_client.TokenEndpointResponseHelpers;
+
+			let savedProvisioningConfig: ProvisioningConfigDto;
+
+			beforeAll(async () => {
+				await Container.get(ProvisioningService).init();
+			});
+
+			beforeEach(() => {
+				authorizationCodeGrantMock.mockReset();
+				fetchUserInfoMock.mockReset();
+
+				const provisioningService = Container.get(ProvisioningService);
+				// @ts-expect-error - provisioningConfig is private
+				savedProvisioningConfig = { ...provisioningService.provisioningConfig };
+			});
+
+			afterEach(() => {
+				const provisioningService = Container.get(ProvisioningService);
+				// @ts-expect-error - provisioningConfig is private
+				provisioningService.provisioningConfig = { ...savedProvisioningConfig };
+			});
+
+			it('should provision instance role for a new user', async () => {
+				const provisioningService = Container.get(ProvisioningService);
+				// @ts-expect-error - provisioningConfig is private
+				provisioningService.provisioningConfig.scopesProvisionInstanceRole = true;
+				// @ts-expect-error - provisioningConfig is private
+				provisioningService.provisioningConfig.scopesProvisionProjectRoles = false;
+				// @ts-expect-error - provisioningConfig is private
+				provisioningService.provisioningConfig.scopesInstanceRoleClaimName = 'n8n_instance_role';
+
+				const state = oidcService.generateState();
+				const nonce = oidcService.generateNonce();
+				const callbackUrl = new URL(
+					`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state.plaintext}`,
+				);
+
+				const mockTokens = createProvisioningMockTokens('new-instance-role-sub', {
+					n8n_instance_role: 'global:admin',
+				});
+				authorizationCodeGrantMock.mockResolvedValueOnce(mockTokens);
+				fetchUserInfoMock.mockResolvedValueOnce({
+					email_verified: true,
+					email: 'new-instance-role-user@example.com',
+				});
+
+				const user = await oidcService.loginUser(callbackUrl, state.signed, nonce.signed);
+				expect(user).toBeDefined();
+				expect(user.email).toEqual('new-instance-role-user@example.com');
+
+				const userFromDB = await userRepository.findOne({
+					where: { id: user.id },
+					relations: ['role'],
+				});
+				expect(userFromDB).toBeDefined();
+				expect(userFromDB!.role.slug).toEqual('global:admin');
+			});
+
+			it('should provision project roles for a new user', async () => {
+				const project = await createTeamProject('oidc-provisioning-test-project');
+
+				const provisioningService = Container.get(ProvisioningService);
+				// @ts-expect-error - provisioningConfig is private
+				provisioningService.provisioningConfig.scopesProvisionInstanceRole = false;
+				// @ts-expect-error - provisioningConfig is private
+				provisioningService.provisioningConfig.scopesProvisionProjectRoles = true;
+				// @ts-expect-error - provisioningConfig is private
+				provisioningService.provisioningConfig.scopesProjectsRolesClaimName = 'n8n_projects';
+
+				const state = oidcService.generateState();
+				const nonce = oidcService.generateNonce();
+				const callbackUrl = new URL(
+					`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state.plaintext}`,
+				);
+
+				const mockTokens = createProvisioningMockTokens('new-project-role-sub', {
+					n8n_projects: [`${project.id}:editor`],
+				});
+				authorizationCodeGrantMock.mockResolvedValueOnce(mockTokens);
+				fetchUserInfoMock.mockResolvedValueOnce({
+					email_verified: true,
+					email: 'new-project-role-user@example.com',
+				});
+
+				const user = await oidcService.loginUser(callbackUrl, state.signed, nonce.signed);
+				expect(user).toBeDefined();
+				expect(user.email).toEqual('new-project-role-user@example.com');
+
+				const projectRole = await getProjectRoleForUser(project.id, user.id);
+				expect(projectRole).toEqual('project:editor');
+			});
+
+			it('should provision both instance role and project roles for a new user', async () => {
+				const project = await createTeamProject('oidc-provisioning-both-test-project');
+
+				const provisioningService = Container.get(ProvisioningService);
+				// @ts-expect-error - provisioningConfig is private
+				provisioningService.provisioningConfig.scopesProvisionInstanceRole = true;
+				// @ts-expect-error - provisioningConfig is private
+				provisioningService.provisioningConfig.scopesProvisionProjectRoles = true;
+				// @ts-expect-error - provisioningConfig is private
+				provisioningService.provisioningConfig.scopesInstanceRoleClaimName = 'n8n_instance_role';
+				// @ts-expect-error - provisioningConfig is private
+				provisioningService.provisioningConfig.scopesProjectsRolesClaimName = 'n8n_projects';
+
+				const state = oidcService.generateState();
+				const nonce = oidcService.generateNonce();
+				const callbackUrl = new URL(
+					`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state.plaintext}`,
+				);
+
+				const mockTokens = createProvisioningMockTokens('new-both-provisioning-sub', {
+					n8n_instance_role: 'global:admin',
+					n8n_projects: [`${project.id}:editor`],
+				});
+				authorizationCodeGrantMock.mockResolvedValueOnce(mockTokens);
+				fetchUserInfoMock.mockResolvedValueOnce({
+					email_verified: true,
+					email: 'new-both-provisioning-user@example.com',
+				});
+
+				const user = await oidcService.loginUser(callbackUrl, state.signed, nonce.signed);
+				expect(user).toBeDefined();
+				expect(user.email).toEqual('new-both-provisioning-user@example.com');
+
+				const userFromDB = await userRepository.findOne({
+					where: { id: user.id },
+					relations: ['role'],
+				});
+				expect(userFromDB).toBeDefined();
+				expect(userFromDB!.role.slug).toEqual('global:admin');
+
+				const projectRole = await getProjectRoleForUser(project.id, user.id);
+				expect(projectRole).toEqual('project:editor');
+			});
 		});
 
 		it('should throw `BadRequestError` with "Invalid token" when fetchUserInfo fails', async () => {


### PR DESCRIPTION
## Summary

- Fix OIDC login failure for new users when SSO provisioning ("Instance and project roles") is enabled
- The root cause was `applySsoProvisioning` being called inside the user creation transaction, while the provisioning methods open their own separate transactions — causing nested transaction deadlocks (SQLite) or FK violations (PostgreSQL) because the user row isn't committed yet
- Move `applySsoProvisioning` after the transaction commits so the user exists in the DB when provisioning runs

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/IAM-409/community-issue-oidc-issue-new-users-unable-to-login-after-switching
- Fixes https://github.com/n8n-io/n8n/issues/25984

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
