### PR TITLE
refactor(editor): Migrate NDV stores and views to `workflowDocumentStore` (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/InputNodeSelect.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/InputNodeSelect.vue
@@ -2,7 +2,6 @@
 import { useI18n } from '@n8n/i18n';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { isPresent } from '@/app/utils/typesUtils';
 import type { IConnectedNode, Workflow } from 'n8n-workflow';
@@ -24,7 +23,6 @@ const emit = defineEmits<{
 }>();
 
 const i18n = useI18n();
-const workflowsStore = useWorkflowsStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const nodeTypesStore = useNodeTypesStore();
 const ndvStore = useNDVStore();
@@ -89,7 +87,7 @@ function getMultipleNodesText(nodeName: string): string {
 		return '';
 
 	const activeNodeConnections =
-		workflowsStore.connectionsByDestinationNode[activeNode.value.name].main || [];
+		workflowDocumentStore?.value?.connectionsByDestinationNode[activeNode.value.name]?.main ?? [];
 	// Collect indexes of connected nodes
 	const connectedInputIndexes = activeNodeConnections.reduce((acc: number[], node, index) => {
 		if (node?.[0] && node[0].node === nodeName) return [...acc, index];

--- a/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.ts
@@ -160,7 +160,7 @@ export const useNDVStore = defineStore(STORES.NDV, () => {
 	const ndvNodeInputNumber = computed(() => {
 		const returnData: { [nodeName: string]: number[] } = {};
 		const activeNodeConections = (
-			workflowsStore.connectionsByDestinationNode[activeNode.value?.name || ''] ?? {}
+			workflowDocumentStore.value?.connectionsByDestinationNode[activeNode.value?.name || ''] ?? {}
 		).main;
 
 		if (!activeNodeConections || activeNodeConections.length < 2) return returnData;

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.vue
@@ -614,7 +614,7 @@ watch(
 
 			setTimeout(() => {
 				if (activeNode.value) {
-					const outgoingConnections = workflowsStore.outgoingConnectionsByNodeName(
+					const outgoingConnections = workflowDocumentStore?.value?.outgoingConnectionsByNodeName(
 						activeNode.value?.name,
 					);
 

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.vue
@@ -606,7 +606,7 @@ watch(
 
 			setTimeout(() => {
 				if (activeNode.value) {
-					const outgoingConnections = workflowsStore.outgoingConnectionsByNodeName(
+					const outgoingConnections = workflowDocumentStore?.value?.outgoingConnectionsByNodeName(
 						activeNode.value?.name,
 					);
 


### PR DESCRIPTION
## Summary

Migrates NDV connection reads from deprecated `workflowsStore` facade methods to `workflowDocumentStore`, continuing the ongoing store migration.

**Changes:**
- `ndv.store.ts` — `workflowsStore.connectionsByDestinationNode` → `workflowDocumentStore.value?.connectionsByDestinationNode`
- `InputNodeSelect.vue` — same migration + removed now-unused `useWorkflowsStore` import
- `NodeDetailsView.vue` — `workflowsStore.outgoingConnectionsByNodeName()` → `workflowDocumentStore?.value?.outgoingConnectionsByNodeName()`
- `NodeDetailsViewV2.vue` — same as above

All files already had `workflowDocumentStore` set up, so no new imports were needed.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2640

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.