### PR TITLE
feat(core): Make workflow tools aware of active version and add tools for publish/unpublish

### DIFF
--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -564,7 +564,7 @@ export type InstanceAiPermissionMode = 'require_approval' | 'always_allow';
 
 export interface InstanceAiPermissions {
 	runWorkflow: InstanceAiPermissionMode;
-	activateWorkflow: InstanceAiPermissionMode;
+	publishWorkflow: InstanceAiPermissionMode;
 	deleteWorkflow: InstanceAiPermissionMode;
 	buildWorkflow: InstanceAiPermissionMode;
 	patchWorkflow: InstanceAiPermissionMode;
@@ -583,7 +583,7 @@ export interface InstanceAiPermissions {
 
 export const DEFAULT_INSTANCE_AI_PERMISSIONS: InstanceAiPermissions = {
 	runWorkflow: 'require_approval',
-	activateWorkflow: 'require_approval',
+	publishWorkflow: 'require_approval',
 	deleteWorkflow: 'require_approval',
 	buildWorkflow: 'require_approval',
 	patchWorkflow: 'require_approval',

--- a/packages/@n8n/instance-ai/docs/tools.md
+++ b/packages/@n8n/instance-ai/docs/tools.md
@@ -172,7 +172,7 @@ Only available when `N8N_INSTANCE_AI_BROWSER_MCP=true`.
 
 ---
 
-## Workflow Tools (6)
+## Workflow Tools (7)
 
 ### `list-workflows`
 
@@ -232,14 +232,24 @@ Archive a workflow. This is a soft delete that deactivates it if needed and can 
 
 **Returns**: `{ success: boolean }`
 
-### `activate-workflow`
+### `publish-workflow`
 
-Activate or deactivate a workflow.
+Publish a workflow version to production. Makes the specified version active — it will run on its triggers.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `workflowId` | string | yes | Workflow ID |
-| `active` | boolean | yes | `true` to activate, `false` to deactivate |
+| `versionId` | string | no | Specific version to publish (omit to publish the latest draft) |
+
+**Returns**: `{ success: boolean, activeVersionId?: string }`
+
+### `unpublish-workflow`
+
+Unpublish a workflow — stops it from running in production. The draft is preserved.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `workflowId` | string | yes | Workflow ID to unpublish |
 
 **Returns**: `{ success: boolean }`
 

--- a/packages/@n8n/instance-ai/src/tools/index.ts
+++ b/packages/@n8n/instance-ai/src/tools/index.ts
@@ -47,13 +47,14 @@ import { createSearchTemplateParametersTool } from './templates/search-template-
 import { createSearchTemplateStructuresTool } from './templates/search-template-structures.tool';
 import { createFetchUrlTool } from './web-research/fetch-url.tool';
 import { createWebSearchTool } from './web-research/web-search.tool';
-import { createActivateWorkflowTool } from './workflows/activate-workflow.tool';
 import { createBuildWorkflowTool } from './workflows/build-workflow.tool';
 import { createDeleteWorkflowTool } from './workflows/delete-workflow.tool';
 import { createGetWorkflowAsCodeTool } from './workflows/get-workflow-as-code.tool';
 import { createGetWorkflowTool } from './workflows/get-workflow.tool';
 import { createListWorkflowsTool } from './workflows/list-workflows.tool';
 import { createPatchWorkflowTool } from './workflows/patch-workflow.tool';
+import { createPublishWorkflowTool } from './workflows/publish-workflow.tool';
+import { createUnpublishWorkflowTool } from './workflows/unpublish-workflow.tool';
 import { createCleanupTestExecutionsTool } from './workspace/cleanup-test-executions.tool';
 import { createCreateFolderTool } from './workspace/create-folder.tool';
 import { createDeleteFolderTool } from './workspace/delete-folder.tool';
@@ -74,7 +75,8 @@ export function createAllTools(context: InstanceAiContext) {
 		'get-workflow-as-code': createGetWorkflowAsCodeTool(context),
 		'build-workflow': createBuildWorkflowTool(context),
 		'delete-workflow': createDeleteWorkflowTool(context),
-		'activate-workflow': createActivateWorkflowTool(context),
+		'publish-workflow': createPublishWorkflowTool(context),
+		'unpublish-workflow': createUnpublishWorkflowTool(context),
 		'list-executions': createListExecutionsTool(context),
 		'run-workflow': createRunWorkflowTool(context),
 		'get-execution': createGetExecutionTool(context),

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.prompt.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.prompt.ts
@@ -629,7 +629,7 @@ Supported input types: \`string\`, \`number\`, \`boolean\`, \`array\`, \`object\
 ### Step 2: Submit and test the chunk
 
 1. Write the chunk file, then submit it: \`submit-workflow\` with the chunk file path.
-   - Sub-workflows with \`executeWorkflowTrigger\` are **auto-activated** on submission. The response will include \`activated: true\`.
+   - Sub-workflows with \`executeWorkflowTrigger\` can be tested immediately via \`run-workflow\` without publishing. However, they must be **published** via \`publish-workflow\` before the parent workflow can call them in production (trigger-based) executions.
 2. Run the chunk: \`run-workflow\` with \`inputData\` matching the trigger schema.
 3. If it fails, use \`debug-execution\` to investigate, fix, and re-submit.
 
@@ -703,7 +703,7 @@ When \`explore-node-resources\` returns no results for a required resource:
 - You CANNOT find or use n8n API keys — they do not exist in the sandbox environment
 - Do NOT spend time searching for API keys, config files, environment variables, or process info — none of it is accessible
 
-**All interaction with n8n is through the provided tools:** \`submit-workflow\`, \`run-workflow\`, \`debug-execution\`, \`get-execution\`, \`list-credentials\`, \`test-credential\`, \`explore-node-resources\`, \`activate-workflow\`, \`list-data-tables\`, \`create-data-table\`, \`get-data-table-schema\`, etc. These tools communicate with n8n internally — no HTTP required.
+**All interaction with n8n is through the provided tools:** \`submit-workflow\`, \`run-workflow\`, \`debug-execution\`, \`get-execution\`, \`list-credentials\`, \`test-credential\`, \`explore-node-resources\`, \`publish-workflow\`, \`unpublish-workflow\`, \`list-data-tables\`, \`create-data-table\`, \`get-data-table-schema\`, etc. These tools communicate with n8n internally — no HTTP required.
 
 ## Sandbox-Specific Rules
 
@@ -784,11 +784,12 @@ Follow the **Compositional Workflow Pattern** above. The process becomes:
 5. **For each chunk**:
    a. Write the chunk to \`/home/daytona/workspace/chunks/<name>.ts\` with an \`executeWorkflowTrigger\` and explicit input schema.
    b. Run tsc.
-   c. Submit the chunk: \`submit-workflow\` with \`filePath\` pointing to the chunk file. Sub-workflows are auto-activated.
+   c. Submit the chunk: \`submit-workflow\` with \`filePath\` pointing to the chunk file. Test via \`run-workflow\` (no publish needed for manual runs).
    d. Fix if needed (max 2 submission fix attempts per chunk).
 6. **Write the main workflow** in \`/home/daytona/workspace/src/workflow.ts\` that composes chunks via \`executeWorkflow\` nodes, referencing each chunk's workflow ID.
 7. **Submit** the main workflow.
-8. **Done**: Output ONE sentence summarizing what was built, including the workflow ID and any known issues.
+8. **Publish** all sub-workflows and the main workflow via \`publish-workflow\` so they run on triggers in production.
+9. **Done**: Output ONE sentence summarizing what was built, including the workflow ID and any known issues.
 
 Do NOT produce visible output until the final step. All reasoning happens internally.
 

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
@@ -154,7 +154,8 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 					'get-execution',
 					'debug-execution',
 					// Workflow lifecycle
-					'activate-workflow',
+					'publish-workflow',
+					'unpublish-workflow',
 					// Data table management (create/inspect tables used by workflows)
 					'list-data-tables',
 					'create-data-table',

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/delete-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/delete-workflow.tool.test.ts
@@ -18,8 +18,8 @@ function createMockContext(overrides?: Partial<InstanceAiContext>): InstanceAiCo
 			updateFromWorkflowJSON: jest.fn(),
 			archive: jest.fn(),
 			delete: jest.fn(),
-			activate: jest.fn(),
-			deactivate: jest.fn(),
+			publish: jest.fn(),
+			unpublish: jest.fn(),
 		},
 		executionService: {
 			list: jest.fn(),

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/get-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/get-workflow.tool.test.ts
@@ -16,8 +16,8 @@ function createMockContext(overrides?: Partial<InstanceAiContext>): InstanceAiCo
 			updateFromWorkflowJSON: jest.fn(),
 			archive: jest.fn(),
 			delete: jest.fn(),
-			activate: jest.fn(),
-			deactivate: jest.fn(),
+			publish: jest.fn(),
+			unpublish: jest.fn(),
 		},
 		executionService: {
 			list: jest.fn(),
@@ -60,7 +60,8 @@ function makeWorkflowDetail(): WorkflowDetail {
 	return {
 		id: 'wf-123',
 		name: 'Test Workflow',
-		active: true,
+		versionId: 'v-abc-123',
+		activeVersionId: 'v-abc-123',
 		createdAt: '2025-01-01T00:00:00.000Z',
 		updatedAt: '2025-01-02T00:00:00.000Z',
 		nodes: [
@@ -83,7 +84,8 @@ function expectedOutputFromDetail(detail: WorkflowDetail) {
 	return {
 		id: detail.id,
 		name: detail.name,
-		active: detail.active,
+		versionId: detail.versionId,
+		activeVersionId: detail.activeVersionId,
 		nodes: detail.nodes,
 		connections: detail.connections,
 		settings: detail.settings,

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/publish-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/publish-workflow.tool.test.ts
@@ -1,0 +1,207 @@
+import { DEFAULT_INSTANCE_AI_PERMISSIONS } from '@n8n/api-types';
+
+import type { InstanceAiContext } from '../../../types';
+import { createPublishWorkflowTool } from '../publish-workflow.tool';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockContext(overrides?: Partial<InstanceAiContext>): InstanceAiContext {
+	return {
+		userId: 'test-user',
+		workflowService: {
+			list: jest.fn(),
+			get: jest.fn(),
+			getAsWorkflowJSON: jest.fn(),
+			createFromWorkflowJSON: jest.fn(),
+			updateFromWorkflowJSON: jest.fn(),
+			archive: jest.fn(),
+			delete: jest.fn(),
+			publish: jest.fn().mockResolvedValue({ activeVersionId: 'v-active-1' }),
+			unpublish: jest.fn(),
+		},
+		executionService: {
+			list: jest.fn(),
+			run: jest.fn(),
+			getStatus: jest.fn(),
+			getResult: jest.fn(),
+			stop: jest.fn(),
+			getDebugInfo: jest.fn(),
+			getNodeOutput: jest.fn(),
+		},
+		credentialService: {
+			list: jest.fn(),
+			get: jest.fn(),
+			delete: jest.fn(),
+			test: jest.fn(),
+		},
+		nodeService: {
+			listAvailable: jest.fn(),
+			getDescription: jest.fn(),
+			listSearchable: jest.fn(),
+		},
+		dataTableService: {
+			list: jest.fn(),
+			create: jest.fn(),
+			delete: jest.fn(),
+			getSchema: jest.fn(),
+			addColumn: jest.fn(),
+			deleteColumn: jest.fn(),
+			renameColumn: jest.fn(),
+			queryRows: jest.fn(),
+			insertRows: jest.fn(),
+			updateRows: jest.fn(),
+			deleteRows: jest.fn(),
+		},
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createPublishWorkflowTool', () => {
+	let context: InstanceAiContext;
+
+	beforeEach(() => {
+		context = createMockContext();
+	});
+
+	it('has the expected tool id', () => {
+		const tool = createPublishWorkflowTool(context);
+
+		expect(tool.id).toBe('publish-workflow');
+	});
+
+	describe('when permissions require approval (default)', () => {
+		it('suspends for user confirmation on first call', async () => {
+			const tool = createPublishWorkflowTool(context);
+			const suspend = jest.fn();
+
+			await tool.execute!({ workflowId: 'wf-123' }, {
+				agent: { suspend, resumeData: undefined },
+			} as never);
+
+			expect(suspend).toHaveBeenCalledTimes(1);
+			const suspendPayload = (suspend.mock.calls as unknown[][])[0][0] as Record<string, unknown>;
+			expect(suspendPayload).toEqual(
+				expect.objectContaining({
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+					message: expect.stringContaining('wf-123'),
+					severity: 'warning',
+				}),
+			);
+		});
+
+		it('includes versionId in the confirmation message when provided', async () => {
+			const tool = createPublishWorkflowTool(context);
+			const suspend = jest.fn();
+
+			await tool.execute!({ workflowId: 'wf-123', versionId: 'v-42' }, {
+				agent: { suspend, resumeData: undefined },
+			} as never);
+
+			const suspendPayload = (suspend.mock.calls as unknown[][])[0][0] as Record<string, unknown>;
+			expect(suspendPayload.message).toContain('v-42');
+			expect(suspendPayload.message).toContain('wf-123');
+		});
+
+		it('does not include versionId in message when omitted', async () => {
+			const tool = createPublishWorkflowTool(context);
+			const suspend = jest.fn();
+
+			await tool.execute!({ workflowId: 'wf-123' }, {
+				agent: { suspend, resumeData: undefined },
+			} as never);
+
+			const suspendPayload = (suspend.mock.calls as unknown[][])[0][0] as Record<string, unknown>;
+			expect(suspendPayload.message).toBe('Publish workflow "wf-123"?');
+		});
+
+		it('publishes the workflow when resumed with approved: true', async () => {
+			const tool = createPublishWorkflowTool(context);
+
+			const result = await tool.execute!({ workflowId: 'wf-123' }, {
+				agent: { suspend: jest.fn(), resumeData: { approved: true } },
+			} as never);
+
+			expect(context.workflowService.publish).toHaveBeenCalledWith('wf-123', {
+				versionId: undefined,
+			});
+			expect(result).toEqual({ success: true, activeVersionId: 'v-active-1' });
+		});
+
+		it('passes versionId to the service when provided', async () => {
+			const tool = createPublishWorkflowTool(context);
+
+			await tool.execute!({ workflowId: 'wf-123', versionId: 'v-42' }, {
+				agent: { suspend: jest.fn(), resumeData: { approved: true } },
+			} as never);
+
+			expect(context.workflowService.publish).toHaveBeenCalledWith('wf-123', {
+				versionId: 'v-42',
+			});
+		});
+
+		it('returns denied when resumed with approved: false', async () => {
+			const tool = createPublishWorkflowTool(context);
+
+			const result = await tool.execute!({ workflowId: 'wf-123' }, {
+				agent: { suspend: jest.fn(), resumeData: { approved: false } },
+			} as never);
+
+			expect(context.workflowService.publish).not.toHaveBeenCalled();
+			expect(result).toEqual({
+				success: false,
+				denied: true,
+				reason: 'User denied the action',
+			});
+		});
+	});
+
+	describe('when permissions.publishWorkflow is always_allow', () => {
+		beforeEach(() => {
+			context = createMockContext({
+				permissions: {
+					...DEFAULT_INSTANCE_AI_PERMISSIONS,
+					publishWorkflow: 'always_allow',
+				},
+			});
+		});
+
+		it('skips confirmation and publishes immediately', async () => {
+			const tool = createPublishWorkflowTool(context);
+			const suspend = jest.fn();
+
+			const result = await tool.execute!({ workflowId: 'wf-123' }, {
+				agent: { suspend, resumeData: undefined },
+			} as never);
+
+			expect(suspend).not.toHaveBeenCalled();
+			expect(context.workflowService.publish).toHaveBeenCalledWith('wf-123', {
+				versionId: undefined,
+			});
+			expect(result).toEqual({ success: true, activeVersionId: 'v-active-1' });
+		});
+	});
+
+	describe('error handling', () => {
+		it('returns error when publish fails', async () => {
+			(context.workflowService.publish as jest.Mock).mockRejectedValue(
+				new Error('Activation failed'),
+			);
+			const tool = createPublishWorkflowTool(context);
+
+			const result = await tool.execute!({ workflowId: 'wf-123' }, {
+				agent: { suspend: jest.fn(), resumeData: { approved: true } },
+			} as never);
+
+			expect(result).toEqual({
+				success: false,
+				error: 'Activation failed',
+			});
+		});
+	});
+});

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/unpublish-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/unpublish-workflow.tool.test.ts
@@ -1,0 +1,168 @@
+import { DEFAULT_INSTANCE_AI_PERMISSIONS } from '@n8n/api-types';
+
+import type { InstanceAiContext } from '../../../types';
+import { createUnpublishWorkflowTool } from '../unpublish-workflow.tool';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockContext(overrides?: Partial<InstanceAiContext>): InstanceAiContext {
+	return {
+		userId: 'test-user',
+		workflowService: {
+			list: jest.fn(),
+			get: jest.fn(),
+			getAsWorkflowJSON: jest.fn(),
+			createFromWorkflowJSON: jest.fn(),
+			updateFromWorkflowJSON: jest.fn(),
+			archive: jest.fn(),
+			delete: jest.fn(),
+			publish: jest.fn(),
+			unpublish: jest.fn(),
+		},
+		executionService: {
+			list: jest.fn(),
+			run: jest.fn(),
+			getStatus: jest.fn(),
+			getResult: jest.fn(),
+			stop: jest.fn(),
+			getDebugInfo: jest.fn(),
+			getNodeOutput: jest.fn(),
+		},
+		credentialService: {
+			list: jest.fn(),
+			get: jest.fn(),
+			delete: jest.fn(),
+			test: jest.fn(),
+		},
+		nodeService: {
+			listAvailable: jest.fn(),
+			getDescription: jest.fn(),
+			listSearchable: jest.fn(),
+		},
+		dataTableService: {
+			list: jest.fn(),
+			create: jest.fn(),
+			delete: jest.fn(),
+			getSchema: jest.fn(),
+			addColumn: jest.fn(),
+			deleteColumn: jest.fn(),
+			renameColumn: jest.fn(),
+			queryRows: jest.fn(),
+			insertRows: jest.fn(),
+			updateRows: jest.fn(),
+			deleteRows: jest.fn(),
+		},
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createUnpublishWorkflowTool', () => {
+	let context: InstanceAiContext;
+
+	beforeEach(() => {
+		context = createMockContext();
+	});
+
+	it('has the expected tool id', () => {
+		const tool = createUnpublishWorkflowTool(context);
+
+		expect(tool.id).toBe('unpublish-workflow');
+	});
+
+	describe('when permissions require approval (default)', () => {
+		it('suspends for user confirmation on first call', async () => {
+			const tool = createUnpublishWorkflowTool(context);
+			const suspend = jest.fn();
+
+			await tool.execute!({ workflowId: 'wf-123' }, {
+				agent: { suspend, resumeData: undefined },
+			} as never);
+
+			expect(suspend).toHaveBeenCalledTimes(1);
+			const suspendPayload = (suspend.mock.calls as unknown[][])[0][0] as Record<string, unknown>;
+			expect(suspendPayload).toEqual(
+				expect.objectContaining({
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+					message: expect.stringContaining('wf-123'),
+					severity: 'warning',
+				}),
+			);
+		});
+
+		it('unpublishes the workflow when resumed with approved: true', async () => {
+			(context.workflowService.unpublish as jest.Mock).mockResolvedValue(undefined);
+			const tool = createUnpublishWorkflowTool(context);
+
+			const result = await tool.execute!({ workflowId: 'wf-123' }, {
+				agent: { suspend: jest.fn(), resumeData: { approved: true } },
+			} as never);
+
+			expect(context.workflowService.unpublish).toHaveBeenCalledWith('wf-123');
+			expect(result).toEqual({ success: true });
+		});
+
+		it('returns denied when resumed with approved: false', async () => {
+			const tool = createUnpublishWorkflowTool(context);
+
+			const result = await tool.execute!({ workflowId: 'wf-123' }, {
+				agent: { suspend: jest.fn(), resumeData: { approved: false } },
+			} as never);
+
+			expect(context.workflowService.unpublish).not.toHaveBeenCalled();
+			expect(result).toEqual({
+				success: false,
+				denied: true,
+				reason: 'User denied the action',
+			});
+		});
+	});
+
+	describe('when permissions.publishWorkflow is always_allow', () => {
+		beforeEach(() => {
+			context = createMockContext({
+				permissions: {
+					...DEFAULT_INSTANCE_AI_PERMISSIONS,
+					publishWorkflow: 'always_allow',
+				},
+			});
+		});
+
+		it('skips confirmation and unpublishes immediately', async () => {
+			(context.workflowService.unpublish as jest.Mock).mockResolvedValue(undefined);
+			const tool = createUnpublishWorkflowTool(context);
+			const suspend = jest.fn();
+
+			const result = await tool.execute!({ workflowId: 'wf-123' }, {
+				agent: { suspend, resumeData: undefined },
+			} as never);
+
+			expect(suspend).not.toHaveBeenCalled();
+			expect(context.workflowService.unpublish).toHaveBeenCalledWith('wf-123');
+			expect(result).toEqual({ success: true });
+		});
+	});
+
+	describe('error handling', () => {
+		it('returns error when unpublish fails', async () => {
+			(context.workflowService.unpublish as jest.Mock).mockRejectedValue(
+				new Error('Deactivation failed'),
+			);
+			const tool = createUnpublishWorkflowTool(context);
+
+			const result = await tool.execute!({ workflowId: 'wf-123' }, {
+				agent: { suspend: jest.fn(), resumeData: { approved: true } },
+			} as never);
+
+			expect(result).toEqual({
+				success: false,
+				error: 'Deactivation failed',
+			});
+		});
+	});
+});

--- a/packages/@n8n/instance-ai/src/tools/workflows/delete-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/delete-workflow.tool.ts
@@ -9,7 +9,7 @@ export function createDeleteWorkflowTool(context: InstanceAiContext) {
 	return createTool({
 		id: 'delete-workflow',
 		description:
-			'Archive a workflow by ID. This is a soft delete that deactivates the workflow if needed and can be undone later.',
+			'Archive a workflow by ID. This is a soft delete that unpublishes the workflow if needed and can be undone later.',
 		inputSchema: z.object({
 			workflowId: z.string().describe('ID of the workflow to archive'),
 		}),

--- a/packages/@n8n/instance-ai/src/tools/workflows/get-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/get-workflow.tool.ts
@@ -7,14 +7,20 @@ export function createGetWorkflowTool(context: InstanceAiContext) {
 	return createTool({
 		id: 'get-workflow',
 		description:
-			'Get full details of a specific workflow including nodes, connections, and settings.',
+			'Get full details of a specific workflow including nodes, connections, settings, and publish state. A workflow is published (running in production) when activeVersionId is not null.',
 		inputSchema: z.object({
 			workflowId: z.string().describe('The ID of the workflow to retrieve'),
 		}),
 		outputSchema: z.object({
 			id: z.string(),
 			name: z.string(),
-			active: z.boolean(),
+			versionId: z.string(),
+			activeVersionId: z
+				.string()
+				.nullable()
+				.describe(
+					'The published version ID. Non-null means the workflow is published and running on its triggers; null means unpublished.',
+				),
 			nodes: z.array(
 				z.object({
 					name: z.string(),

--- a/packages/@n8n/instance-ai/src/tools/workflows/list-workflows.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/list-workflows.tool.ts
@@ -23,7 +23,11 @@ export function createListWorkflowsTool(context: InstanceAiContext) {
 				z.object({
 					id: z.string(),
 					name: z.string(),
-					active: z.boolean(),
+					versionId: z.string(),
+					activeVersionId: z
+						.string()
+						.nullable()
+						.describe('Non-null when the workflow is published and running in production.'),
 					createdAt: z.string(),
 					updatedAt: z.string(),
 				}),

--- a/packages/@n8n/instance-ai/src/tools/workflows/publish-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/publish-workflow.tool.ts
@@ -45,7 +45,9 @@ export function createPublishWorkflowTool(context: InstanceAiContext) {
 			if (needsApproval && (resumeData === undefined || resumeData === null)) {
 				await suspend?.({
 					requestId: nanoid(),
-					message: `Publish workflow "${input.workflowId}"?`,
+					message: input.versionId
+						? `Publish version "${input.versionId}" of workflow "${input.workflowId}"?`
+						: `Publish workflow "${input.workflowId}"?`,
 					severity: 'warning' as const,
 				});
 				return { success: false };

--- a/packages/@n8n/instance-ai/src/tools/workflows/publish-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/publish-workflow.tool.ts
@@ -1,0 +1,71 @@
+import { createTool } from '@mastra/core/tools';
+import { instanceAiConfirmationSeveritySchema } from '@n8n/api-types';
+import { nanoid } from 'nanoid';
+import { z } from 'zod';
+
+import type { InstanceAiContext } from '../../types';
+
+export function createPublishWorkflowTool(context: InstanceAiContext) {
+	return createTool({
+		id: 'publish-workflow',
+		description:
+			'Publish a workflow version to production. Publishing makes the specified version active — ' +
+			'it will run on its triggers. If the workflow has been edited since last publish, you must ' +
+			're-publish for changes to take effect. Omit versionId to publish the latest draft.',
+		inputSchema: z.object({
+			workflowId: z.string().describe('ID of the workflow'),
+			versionId: z
+				.string()
+				.optional()
+				.describe('Specific version to publish (omit to publish the latest draft)'),
+		}),
+		outputSchema: z.object({
+			success: z.boolean(),
+			activeVersionId: z
+				.string()
+				.optional()
+				.describe('The now-active version ID. Confirms the workflow is published.'),
+			error: z.string().optional(),
+			denied: z.boolean().optional(),
+			reason: z.string().optional(),
+		}),
+		suspendSchema: z.object({
+			requestId: z.string(),
+			message: z.string(),
+			severity: instanceAiConfirmationSeveritySchema,
+		}),
+		resumeSchema: z.object({
+			approved: z.boolean(),
+		}),
+		execute: async (input, ctx) => {
+			const { resumeData, suspend } = ctx?.agent ?? {};
+
+			const needsApproval = context.permissions?.publishWorkflow !== 'always_allow';
+
+			if (needsApproval && (resumeData === undefined || resumeData === null)) {
+				await suspend?.({
+					requestId: nanoid(),
+					message: `Publish workflow "${input.workflowId}"?`,
+					severity: 'warning' as const,
+				});
+				return { success: false };
+			}
+
+			if (resumeData !== undefined && resumeData !== null && !resumeData.approved) {
+				return { success: false, denied: true, reason: 'User denied the action' };
+			}
+
+			try {
+				const result = await context.workflowService.publish(input.workflowId, {
+					versionId: input.versionId,
+				});
+				return { success: true, activeVersionId: result.activeVersionId };
+			} catch (error) {
+				return {
+					success: false,
+					error: error instanceof Error ? error.message : 'Publish failed',
+				};
+			}
+		},
+	});
+}

--- a/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow.tool.ts
@@ -252,8 +252,8 @@ export function createSubmitWorkflowTool(
 		id: 'submit-workflow',
 		description:
 			'Submit a workflow from a TypeScript file in the sandbox. Reads the file, validates it, ' +
-			'and saves it to n8n. Sub-workflows (those with only an executeWorkflowTrigger) are ' +
-			'automatically activated so they can be called by executeWorkflow nodes.',
+			'and saves it to n8n as a draft. The workflow must be explicitly published via ' +
+			'publish-workflow before it will run on its triggers in production.',
 		inputSchema: z.object({
 			filePath: z
 				.string()
@@ -272,7 +272,6 @@ export function createSubmitWorkflowTool(
 		outputSchema: z.object({
 			success: z.boolean(),
 			workflowId: z.string().optional(),
-			activated: z.boolean().optional(),
 			/** Node names whose credentials were mocked via pinned data. */
 			mockedNodeNames: z.array(z.string()).optional(),
 			/** Credential types that were mocked (not resolved to real credentials). */
@@ -434,58 +433,17 @@ export function createSubmitWorkflowTool(
 
 			const hasMockedCredentials = mockResult.mockedNodeNames.length > 0;
 
-			// Auto-activate sub-workflows: if the only trigger is executeWorkflowTrigger,
-			// this is a sub-workflow meant to be called by executeWorkflow nodes.
-			// It must be active for composition to work.
-			// However, skip activation if credentials were mocked — the workflow is
-			// testable but not production-ready.
-			const EXECUTE_WORKFLOW_TRIGGER = 'n8n-nodes-base.executeWorkflowTrigger';
-			let activated = false;
-			const triggers = (json.nodes ?? []).filter(
-				(n) =>
-					n.type === EXECUTE_WORKFLOW_TRIGGER ||
-					n.type?.endsWith?.('Trigger') ||
-					n.type?.endsWith?.('trigger'),
-			);
-			const isSubWorkflow =
-				triggers.length > 0 && triggers.every((t) => t.type === EXECUTE_WORKFLOW_TRIGGER);
-
-			if (isSubWorkflow && !hasMockedCredentials) {
-				// For newly created workflows, activation may fail if the version history
-				// hasn't been committed yet. Retry once after a short delay.
-				let activationError: string | undefined;
-				for (let attempt = 0; attempt < 2 && !activated; attempt++) {
-					try {
-						if (attempt > 0) {
-							await new Promise((resolve) => setTimeout(resolve, 500));
-						}
-						await context.workflowService.activate(savedId);
-						activated = true;
-					} catch (error) {
-						activationError = error instanceof Error ? error.message : 'Unknown activation error';
-					}
-				}
-				if (!activated && activationError) {
-					informational.push({
-						code: 'ACTIVATION_FAILED',
-						message: `Sub-workflow auto-activation failed: ${activationError}. Call activate-workflow explicitly after verifying the workflow.`,
-					});
-				}
-			} else if (isSubWorkflow && hasMockedCredentials) {
-				informational.push({
-					code: 'ACTIVATION_SKIPPED_MOCKED',
-					message: `Sub-workflow auto-activation skipped because credentials were mocked (${mockResult.mockedCredentialTypes.join(', ')}). Add real credentials before activating.`,
-				});
-			}
-
 			// Add mock summary warning when credentials were mocked
 			if (hasMockedCredentials) {
 				informational.push({
 					code: 'CREDENTIALS_MOCKED',
-					message: `Mocked ${mockResult.mockedCredentialTypes.join(', ')} via pinned data on nodes: ${mockResult.mockedNodeNames.join(', ')}. Add real credentials before activating.`,
+					message: `Mocked ${mockResult.mockedCredentialTypes.join(', ')} via pinned data on nodes: ${mockResult.mockedNodeNames.join(', ')}. Add real credentials before publishing.`,
 				});
 			}
 
+			const triggers = (json.nodes ?? []).filter(
+				(n) => n.type?.endsWith?.('Trigger') || n.type?.endsWith?.('trigger'),
+			);
 			const triggerNodeTypes = triggers.map((t) => t.type).filter(Boolean);
 			reportAttempt({
 				success: true,
@@ -498,7 +456,6 @@ export function createSubmitWorkflowTool(
 				success: true,
 				workflowId: savedId,
 				workflowName: json.name || undefined,
-				activated: activated || undefined,
 				mockedNodeNames: hasMockedCredentials ? mockResult.mockedNodeNames : undefined,
 				mockedCredentialTypes: hasMockedCredentials ? mockResult.mockedCredentialTypes : undefined,
 				warnings:

--- a/packages/@n8n/instance-ai/src/tools/workflows/unpublish-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/unpublish-workflow.tool.ts
@@ -5,13 +5,14 @@ import { z } from 'zod';
 
 import type { InstanceAiContext } from '../../types';
 
-export function createActivateWorkflowTool(context: InstanceAiContext) {
+export function createUnpublishWorkflowTool(context: InstanceAiContext) {
 	return createTool({
-		id: 'activate-workflow',
-		description: 'Activate or deactivate a workflow. Active workflows run on their triggers.',
+		id: 'unpublish-workflow',
+		description:
+			'Unpublish a workflow — stops it from running in production. ' +
+			'The draft is preserved and can be re-published later.',
 		inputSchema: z.object({
-			workflowId: z.string().describe('ID of the workflow'),
-			active: z.boolean().describe('true to activate, false to deactivate'),
+			workflowId: z.string().describe('ID of the workflow to unpublish'),
 		}),
 		outputSchema: z.object({
 			success: z.boolean(),
@@ -30,36 +31,28 @@ export function createActivateWorkflowTool(context: InstanceAiContext) {
 		execute: async (input, ctx) => {
 			const { resumeData, suspend } = ctx?.agent ?? {};
 
-			const needsApproval = context.permissions?.activateWorkflow !== 'always_allow';
+			const needsApproval = context.permissions?.publishWorkflow !== 'always_allow';
 
-			// If approval is required and this is the first call, suspend for confirmation
 			if (needsApproval && (resumeData === undefined || resumeData === null)) {
-				const action = input.active ? 'Activate' : 'Deactivate';
 				await suspend?.({
 					requestId: nanoid(),
-					message: `${action} workflow "${input.workflowId}"?`,
+					message: `Unpublish workflow "${input.workflowId}"?`,
 					severity: 'warning' as const,
 				});
 				return { success: false };
 			}
 
-			// If resumed with denial
 			if (resumeData !== undefined && resumeData !== null && !resumeData.approved) {
 				return { success: false, denied: true, reason: 'User denied the action' };
 			}
 
-			// Approved or always_allow — execute
 			try {
-				if (input.active) {
-					await context.workflowService.activate(input.workflowId);
-				} else {
-					await context.workflowService.deactivate(input.workflowId);
-				}
+				await context.workflowService.unpublish(input.workflowId);
 				return { success: true };
 			} catch (error) {
 				return {
 					success: false,
-					error: error instanceof Error ? error.message : 'Activation failed',
+					error: error instanceof Error ? error.message : 'Unpublish failed',
 				};
 			}
 		},

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -25,7 +25,8 @@ import type { BuilderSandboxFactory } from './workspace/builder-sandbox-factory'
 export interface WorkflowSummary {
 	id: string;
 	name: string;
-	active: boolean;
+	versionId: string;
+	activeVersionId: string | null;
 	createdAt: string;
 	updatedAt: string;
 	tags?: string[];
@@ -132,8 +133,11 @@ export interface InstanceAiWorkflowService {
 	): Promise<WorkflowDetail>;
 	archive(workflowId: string): Promise<void>;
 	delete(workflowId: string): Promise<void>;
-	activate(workflowId: string): Promise<void>;
-	deactivate(workflowId: string): Promise<void>;
+	publish(
+		workflowId: string,
+		options?: { versionId?: string },
+	): Promise<{ activeVersionId: string }>;
+	unpublish(workflowId: string): Promise<void>;
 	/** Patch a single node's parameters, credentials, or disabled state in-place. */
 	patchNode?(
 		workflowId: string,

--- a/packages/cli/src/modules/instance-ai/instance-ai-settings.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-settings.service.ts
@@ -401,7 +401,16 @@ export class InstanceAiSettingsService {
 		if (persisted.subAgentMaxSteps !== undefined) c.subAgentMaxSteps = persisted.subAgentMaxSteps;
 		if (persisted.browserMcp !== undefined) c.browserMcp = persisted.browserMcp;
 		if (persisted.permissions) {
-			this.permissions = { ...DEFAULT_INSTANCE_AI_PERMISSIONS, ...persisted.permissions };
+			// Migrate legacy "activateWorkflow" → "publishWorkflow"
+			const perms = { ...persisted.permissions } as Record<string, unknown>;
+			if ('activateWorkflow' in perms && !('publishWorkflow' in perms)) {
+				perms.publishWorkflow = perms.activateWorkflow;
+				delete perms.activateWorkflow;
+			}
+			this.permissions = {
+				...DEFAULT_INSTANCE_AI_PERMISSIONS,
+				...perms,
+			} as typeof this.permissions;
 		}
 		if (persisted.mcpServers !== undefined) c.mcpServers = persisted.mcpServers;
 		if (persisted.sandboxEnabled !== undefined) c.sandboxEnabled = persisted.sandboxEnabled;

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -184,12 +184,13 @@ export class InstanceAiAdapterService {
 				});
 
 				return workflows
-					.filter((wf): wf is WorkflowEntity => 'active' in wf)
+					.filter((wf): wf is WorkflowEntity => 'versionId' in wf)
 					.map(
 						(wf): WorkflowSummary => ({
 							id: wf.id,
 							name: wf.name,
-							active: wf.active,
+							versionId: wf.versionId,
+							activeVersionId: wf.activeVersionId ?? null,
 							createdAt: wf.createdAt.toISOString(),
 							updatedAt: wf.updatedAt.toISOString(),
 						}),
@@ -216,11 +217,14 @@ export class InstanceAiAdapterService {
 				await workflowService.delete(user, workflowId);
 			},
 
-			async activate(workflowId: string) {
-				await workflowService.activateWorkflow(user, workflowId);
+			async publish(workflowId: string, options?: { versionId?: string }) {
+				const wf = await workflowService.activateWorkflow(user, workflowId, {
+					versionId: options?.versionId,
+				});
+				return { activeVersionId: wf.activeVersionId ?? options?.versionId ?? workflowId };
 			},
 
-			async deactivate(workflowId: string) {
+			async unpublish(workflowId: string) {
 				await workflowService.deactivateWorkflow(user, workflowId);
 			},
 
@@ -1820,7 +1824,8 @@ function toWorkflowDetail(workflow: WorkflowEntity): WorkflowDetail {
 	return {
 		id: workflow.id,
 		name: workflow.name,
-		active: workflow.active,
+		versionId: workflow.versionId,
+		activeVersionId: workflow.activeVersionId ?? null,
 		createdAt: workflow.createdAt.toISOString(),
 		updatedAt: workflow.updatedAt.toISOString(),
 		nodes: (workflow.nodes ?? []).map(

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -221,7 +221,10 @@ export class InstanceAiAdapterService {
 				const wf = await workflowService.activateWorkflow(user, workflowId, {
 					versionId: options?.versionId,
 				});
-				return { activeVersionId: wf.activeVersionId ?? options?.versionId ?? workflowId };
+				if (!wf.activeVersionId) {
+					throw new Error(`Workflow ${workflowId} was not activated — no active version set`);
+				}
+				return { activeVersionId: wf.activeVersionId };
 			},
 
 			async unpublish(workflowId: string) {

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -5023,7 +5023,7 @@
 	"instanceAi.settings.section.permissions": "Permissions",
 	"instanceAi.settings.permissions.description": "Toggle which actions require your approval before the agent executes them.",
 	"instanceAi.settings.permissions.runWorkflow.label": "Run workflow without approval",
-	"instanceAi.settings.permissions.publishWorkflow.label": "Publish workflow without approval",
+	"instanceAi.settings.permissions.publishWorkflow.label": "Publish/unpublish workflow without approval",
 	"instanceAi.settings.permissions.deleteWorkflow.label": "Delete workflow without approval",
 	"instanceAi.settings.permissions.deleteCredential.label": "Delete credential without approval",
 	"instanceAi.builderCard.title": "Building workflow",

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -5023,7 +5023,7 @@
 	"instanceAi.settings.section.permissions": "Permissions",
 	"instanceAi.settings.permissions.description": "Toggle which actions require your approval before the agent executes them.",
 	"instanceAi.settings.permissions.runWorkflow.label": "Run workflow without approval",
-	"instanceAi.settings.permissions.activateWorkflow.label": "Activate workflow without approval",
+	"instanceAi.settings.permissions.publishWorkflow.label": "Publish workflow without approval",
 	"instanceAi.settings.permissions.deleteWorkflow.label": "Delete workflow without approval",
 	"instanceAi.settings.permissions.deleteCredential.label": "Delete credential without approval",
 	"instanceAi.builderCard.title": "Building workflow",

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiMessage.vue
@@ -300,7 +300,7 @@ function formatJson(value: unknown): string {
 	width: 6px;
 	height: 6px;
 	border-radius: 50%;
-	background: var(--background--brand);
+	background: var(--color--primary);
 	animation: pulse 1.5s ease-in-out infinite;
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/settings/PermissionsSection.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/settings/PermissionsSection.vue
@@ -33,12 +33,12 @@ const store = useInstanceAiSettingsStore();
 
 		<div :class="$style.switchRow">
 			<span :class="$style.switchLabel">{{
-				i18n.baseText('instanceAi.settings.permissions.activateWorkflow.label')
+				i18n.baseText('instanceAi.settings.permissions.publishWorkflow.label')
 			}}</span>
 			<ElSwitch
-				:model-value="store.getPermission('activateWorkflow') === 'always_allow'"
+				:model-value="store.getPermission('publishWorkflow') === 'always_allow'"
 				@update:model-value="
-					store.setPermission('activateWorkflow', $event ? 'always_allow' : 'require_approval')
+					store.setPermission('publishWorkflow', $event ? 'always_allow' : 'require_approval')
 				"
 			/>
 		</div>


### PR DESCRIPTION
## Summary

We were just using the old activation paradigm, make the WF tools more aware of the new publish/unpublish paradigm.

This led to AI thinking that "okay, active flag was already on, I just edited the WF but I don't need to publish anything" while in fact they had to publish the changes.

I'll follow this with another PR with workflow history tools.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
