### PR TITLE
feat: Add publish workflow to node-cli

### DIFF
--- a/packages/@n8n/node-cli/src/template/templates/shared/default/.github/workflows/ci.yml
+++ b/packages/@n8n/node-cli/src/template/templates/shared/default/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
     branches:
       - main
 
+# Cancel in-progress runs for the same branch/PR to avoid wasting CI minutes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,10 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: 'lts/*'
+          cache: '{{packageManager.name}}'
 
       - name: Install dependencies
         run: '{{packageManager.name}} {{packageManager.installCommand}}'

--- a/packages/@n8n/node-cli/src/template/templates/shared/default/.github/workflows/publish.yml
+++ b/packages/@n8n/node-cli/src/template/templates/shared/default/.github/workflows/publish.yml
@@ -1,0 +1,101 @@
+# Publishes this n8n community node package to npm on every version tag push.
+#
+# Starting May 1 2026, n8n requires all community nodes to be published via
+# GitHub Actions with npm provenance statements. This workflow satisfies that
+# requirement. Provenance lets anyone cryptographically verify that a package
+# was built by this exact workflow, from this exact repository and commit.
+#
+# ─── PREREQUISITES ─────────────────────────────────────────────────────────────
+#
+# @n8n/node-cli ≥ 0.23.0 is required. Earlier versions do not support the
+# provenance flag passed by `npm run release` in CI, and the publish step will
+# fail. Check the version installed in this project with:
+#
+#   {{packageManager.name}} list @n8n/node-cli
+#
+# To upgrade, add @n8n/node-cli@latest as a dev dependency using your package manager.
+#
+# ─── ONE-TIME SETUP ────────────────────────────────────────────────────────────
+#
+# Option A — OIDC Trusted Publishing (recommended, no long-lived secrets):
+#   1. Log in to npmjs.com and open your package's settings.
+#   2. Under "Publish access" → "Trusted Publishers", click "Add a publisher".
+#   3. Select GitHub Actions and fill in:
+#        Repository owner: <your-github-username-or-org>
+#        Repository name:  <your-repo-name>
+#        Workflow name:    publish.yml
+#        Environment:      (leave blank unless you use GitHub Environments)
+#   4. Leave the NPM_TOKEN secret unset in this repository. GitHub's OIDC
+#      token is used instead — no secret ever touches your repo settings.
+#
+# Option B — npm Automation Token (fallback):
+#   1. On npmjs.com: Access Tokens → Generate New Token → Granular Access Token.
+#      Scope it to this package with "Read and write" publish permission.
+#   2. In GitHub: Settings → Secrets and variables → Actions → New secret.
+#      Name it NPM_TOKEN and paste the token value.
+#
+# Both options work with --provenance. Provenance is signed by GitHub's OIDC
+# infrastructure regardless of how npm authentication is handled.
+#
+# ─── TAG CONVENTION ────────────────────────────────────────────────────────────
+#
+# This workflow triggers on tags matching "*.*.*" (e.g. 0.2.0).
+# If you prefer tags with a "v" prefix (e.g. v0.2.0), change the filter to:
+#   tags: ['v*.*.*']
+#
+# ─── RELEASE PROCESS ───────────────────────────────────────────────────────────
+#
+# Run the following command locally to start an interactive release:
+#
+#   {{packageManager.name}} run release
+#
+# This will lint, build, prompt for a version bump, update the changelog,
+# commit, tag, and push — which triggers this workflow to publish to npm.
+
+name: Publish
+
+on:
+  push:
+    tags:
+      # Matches 0.1.0, 1.2.3, 2.0.0-rc.1, etc.
+      # See "TAG CONVENTION" above if you prefer tags with a "v" prefix.
+      - '*.*.*'
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Required to mint an OIDC token for npm provenance attestation.
+      id-token: write
+      # Scoped down from the default (write) for least-privilege publishing.
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          # registry-url is required for the NODE_AUTH_TOKEN / OIDC exchange.
+          registry-url: 'https://registry.npmjs.org/'
+          cache: '{{packageManager.name}}'
+
+      - name: Install dependencies
+        run: '{{packageManager.name}} {{packageManager.installCommand}}'
+
+      - name: Release
+        # `npm run release` detects the GitHub Actions environment and publishes
+        # to npm with a provenance attestation (requires id-token: write above).
+        # Lint and build run automatically as part of the release process.
+        #
+        # NODE_AUTH_TOKEN   Works for both auth options:
+        #   Option A (OIDC): Leave NPM_TOKEN secret unset. setup-node writes
+        #                    an .npmrc using this variable; when it is empty,
+        #                    npm falls through to the OIDC exchange automatically.
+        #   Option B (token): Set NPM_TOKEN in repo secrets and it is used here.
+        run: '{{packageManager.name}} run release'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/@n8n/node-cli/src/template/templates/shared/default/.github/workflows/publish.yml
+++ b/packages/@n8n/node-cli/src/template/templates/shared/default/.github/workflows/publish.yml
@@ -79,23 +79,21 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
-          # registry-url is required for the NODE_AUTH_TOKEN / OIDC exchange.
-          registry-url: 'https://registry.npmjs.org/'
           cache: '{{packageManager.name}}'
 
       - name: Install dependencies
         run: '{{packageManager.name}} {{packageManager.installCommand}}'
 
       - name: Release
-        # `npm run release` detects the GitHub Actions environment and publishes
-        # to npm with a provenance attestation (requires id-token: write above).
+        # Publishes to npm with a provenance attestation (requires id-token: write above).
         # Lint and build run automatically as part of the release process.
         #
-        # NODE_AUTH_TOKEN   Works for both auth options:
-        #   Option A (OIDC): Leave NPM_TOKEN secret unset. setup-node writes
-        #                    an .npmrc using this variable; when it is empty,
-        #                    npm falls through to the OIDC exchange automatically.
-        #   Option B (token): Set NPM_TOKEN in repo secrets and it is used here.
-        run: '{{packageManager.name}} run release'
+        # Option A (OIDC): leave NPM_TOKEN unset — the token step is skipped and
+        #   npm uses the OIDC exchange instead.
+        # Option B (token): set NPM_TOKEN in repo secrets — it is written to
+        #   .npmrc here before publishing.
+        run: |
+          [ -n "$NPM_TOKEN" ] && npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
+          {{packageManager.name}} run release
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a `publish.yml` GitHub Actions workflow to the `node-cli` scaffolded template, and improves the existing `ci.yml`.

Starting **May 1 2026**, n8n requires all community nodes to be published via GitHub Actions with npm provenance statements. This workflow is included automatically when users scaffold a new node package via `npm create @n8n/node`.

**`publish.yml`** — triggers on version tags (`*.*.*`), publishes to npm with a provenance attestation. Supports two auth strategies:
- **Option A (recommended):** OIDC Trusted Publishing — no long-lived secrets, configured once on npmjs.com
- **Option B:** `NPM_TOKEN` repo secret

The token is written to `.npmrc` only when `NPM_TOKEN` is non-empty, so the OIDC path isn't shadowed by an empty `_authToken`.

**`ci.yml`** — switches to `lts/*`, adds `cache: npm`, and adds a `concurrency` group to cancel redundant runs on new pushes.

Test workflow: scaffold a new node package with `npm create @n8n/node` and verify both workflow files are present and correct.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CE-578

Sibling PR: https://github.com/n8n-io/n8n-nodes-starter/pull/112

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
