### PR TITLE
feat(core): Support workflow history on instance AI tools

### DIFF
--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -579,6 +579,7 @@ export interface InstanceAiPermissions {
 	cleanupTestExecutions: InstanceAiPermissionMode;
 	readFilesystem: InstanceAiPermissionMode;
 	fetchUrl: InstanceAiPermissionMode;
+	restoreWorkflowVersion: InstanceAiPermissionMode;
 }
 
 export const DEFAULT_INSTANCE_AI_PERMISSIONS: InstanceAiPermissions = {
@@ -598,6 +599,7 @@ export const DEFAULT_INSTANCE_AI_PERMISSIONS: InstanceAiPermissions = {
 	cleanupTestExecutions: 'require_approval',
 	readFilesystem: 'require_approval',
 	fetchUrl: 'require_approval',
+	restoreWorkflowVersion: 'require_approval',
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/@n8n/instance-ai/docs/tools.md
+++ b/packages/@n8n/instance-ai/docs/tools.md
@@ -172,7 +172,7 @@ Only available when `N8N_INSTANCE_AI_BROWSER_MCP=true`.
 
 ---
 
-## Workflow Tools (10)
+## Workflow Tools (11)
 
 ### `list-workflows`
 
@@ -295,6 +295,25 @@ version — publish separately after restoring.
 
 **HITL**: Requires user approval (severity: `warning`) since it overwrites the
 current draft. Controlled by `restoreWorkflowVersion` permission.
+
+### `update-workflow-version`
+
+Update the name or description of a workflow version. Use to label versions
+with meaningful names (e.g. "v1 – initial release") or add descriptions
+explaining what changed.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `workflowId` | string | yes | Workflow ID |
+| `versionId` | string | yes | Version ID to update |
+| `name` | string \| null | no | New name for the version (null to clear) |
+| `description` | string \| null | no | New description for the version (null to clear) |
+
+**Returns**: `{ success: boolean, error?: string }`
+
+**Conditional**: Only registered when the `feat:namedVersions` license feature
+is active. The adapter checks the license at context creation time and omits
+the `updateVersion` method when unlicensed.
 
 ---
 

--- a/packages/@n8n/instance-ai/docs/tools.md
+++ b/packages/@n8n/instance-ai/docs/tools.md
@@ -172,7 +172,7 @@ Only available when `N8N_INSTANCE_AI_BROWSER_MCP=true`.
 
 ---
 
-## Workflow Tools (7)
+## Workflow Tools (10)
 
 ### `list-workflows`
 
@@ -252,6 +252,49 @@ Unpublish a workflow — stops it from running in production. The draft is prese
 | `workflowId` | string | yes | Workflow ID to unpublish |
 
 **Returns**: `{ success: boolean }`
+
+### `list-workflow-versions`
+
+List version history for a workflow (metadata only, no nodes/connections). Each
+version includes flags indicating whether it is the currently active (published)
+version or the current draft.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `workflowId` | string | yes | — | Workflow ID |
+| `limit` | number | no | 20 | Max results (1–100) |
+| `skip` | number | no | 0 | Number of results to skip |
+
+**Returns**: `{ versions: [{ versionId, name, description, authors, createdAt, autosaved, isActive, isCurrentDraft }] }`
+
+### `get-workflow-version`
+
+Get full details of a specific workflow version including nodes and connections.
+Use to inspect what a version looked like, diff against the current draft, or
+answer "when did node X change".
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `workflowId` | string | yes | Workflow ID |
+| `versionId` | string | yes | Version ID to retrieve |
+
+**Returns**: `{ versionId, name, description, authors, createdAt, autosaved, isActive, isCurrentDraft, nodes: [{ name, type, parameters, position }], connections }`
+
+### `restore-workflow-version`
+
+Restore a workflow to a previous version by overwriting the current draft with
+that version's nodes and connections. Does NOT affect the published/active
+version — publish separately after restoring.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `workflowId` | string | yes | Workflow ID |
+| `versionId` | string | yes | Version ID to restore |
+
+**Returns**: `{ success: boolean }`
+
+**HITL**: Requires user approval (severity: `warning`) since it overwrites the
+current draft. Controlled by `restoreWorkflowVersion` permission.
 
 ---
 

--- a/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.test.ts
@@ -1,0 +1,39 @@
+import { getSystemPrompt } from '../system-prompt';
+
+describe('getSystemPrompt', () => {
+	describe('license hints', () => {
+		it('includes License Limitations section when hints are provided', () => {
+			const prompt = getSystemPrompt({
+				licenseHints: ['**Feature A** — requires Pro plan.'],
+			});
+
+			expect(prompt).toContain('## License Limitations');
+			expect(prompt).toContain('**Feature A** — requires Pro plan.');
+			expect(prompt).toContain('require a license upgrade');
+		});
+
+		it('renders multiple hints as a list', () => {
+			const prompt = getSystemPrompt({
+				licenseHints: [
+					'**Feature A** — requires Pro plan.',
+					'**Feature B** — requires Enterprise plan.',
+				],
+			});
+
+			expect(prompt).toContain('- **Feature A** — requires Pro plan.');
+			expect(prompt).toContain('- **Feature B** — requires Enterprise plan.');
+		});
+
+		it('omits License Limitations section when hints array is empty', () => {
+			const prompt = getSystemPrompt({ licenseHints: [] });
+
+			expect(prompt).not.toContain('License Limitations');
+		});
+
+		it('omits License Limitations section when hints are not provided', () => {
+			const prompt = getSystemPrompt({});
+
+			expect(prompt).not.toContain('License Limitations');
+		});
+	});
+});

--- a/packages/@n8n/instance-ai/src/agent/instance-agent.ts
+++ b/packages/@n8n/instance-ai/src/agent/instance-agent.ts
@@ -266,6 +266,7 @@ export async function createInstanceAgent(options: CreateInstanceAgentOptions): 
 				webhookBaseUrl: orchestrationContext?.webhookBaseUrl,
 				filesystemAccess: !!(context.localMcpServer ?? context.filesystemService),
 				toolSearchEnabled: hasDeferrableTools,
+				licenseHints: context.licenseHints,
 			}),
 			providerOptions: {
 				anthropic: { cacheControl: { type: 'ephemeral' } },

--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -3,10 +3,13 @@ interface SystemPromptOptions {
 	webhookBaseUrl?: string;
 	filesystemAccess?: boolean;
 	toolSearchEnabled?: boolean;
+	/** Human-readable hints about licensed features that are NOT available on this instance. */
+	licenseHints?: string[];
 }
 
 export function getSystemPrompt(options: SystemPromptOptions = {}): string {
-	const { researchMode, webhookBaseUrl, filesystemAccess, toolSearchEnabled } = options;
+	const { researchMode, webhookBaseUrl, filesystemAccess, toolSearchEnabled, licenseHints } =
+		options;
 	return `You are the n8n Instance Agent — an AI assistant embedded in an n8n instance. You help users build, run, debug, and manage workflows through natural language.
 ${webhookBaseUrl ? `\n## Instance Info\n\nWebhook base URL: ${webhookBaseUrl}\nWhen a workflow has webhook triggers, its live URL is: ${webhookBaseUrl}/{path} (where {path} is the webhook path parameter). Always share the full webhook URL with the user after a workflow with webhooks is created.\n\n**This URL is for sharing with the user only.** Do NOT include it in \`build-workflow-with-agent\` task descriptions — the builder cannot reach the n8n instance via HTTP and will fail if it tries to curl/fetch this URL.\n` : ''}
 
@@ -86,7 +89,17 @@ Keep exploration shallow — start at depth 1-2, prefer \`search-files\` over br
 You do NOT have access to the user's project files. The filesystem tools (list-files, read-file, search-files, get-file-tree) are not available. Do not attempt to use them or claim you can browse the user's codebase.`
 }
 
-## Conversation Summary
+${
+	licenseHints && licenseHints.length > 0
+		? `## License Limitations
+
+The following features require a license that is not active on this instance. If the user asks for these capabilities, explain that they require a license upgrade.
+
+${licenseHints.map((h) => `- ${h}`).join('\n')}
+
+`
+		: ''
+}## Conversation Summary
 
 When \`<conversation-summary>\` is present in your input, treat it as compressed prior context from earlier turns. Use the recent raw messages for exact wording and details; use the summary for long-range continuity (user goals, past decisions, workflow state). Do not repeat the summary back to the user.
 

--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -63,6 +63,8 @@ export type {
 	WorkflowSummary,
 	WorkflowDetail,
 	WorkflowNode,
+	WorkflowVersionSummary,
+	WorkflowVersionDetail,
 	ExecutionResult,
 	ExecutionDebugInfo,
 	NodeOutputResult,

--- a/packages/@n8n/instance-ai/src/tools/index.ts
+++ b/packages/@n8n/instance-ai/src/tools/index.ts
@@ -50,10 +50,13 @@ import { createWebSearchTool } from './web-research/web-search.tool';
 import { createBuildWorkflowTool } from './workflows/build-workflow.tool';
 import { createDeleteWorkflowTool } from './workflows/delete-workflow.tool';
 import { createGetWorkflowAsCodeTool } from './workflows/get-workflow-as-code.tool';
+import { createGetWorkflowVersionTool } from './workflows/get-workflow-version.tool';
 import { createGetWorkflowTool } from './workflows/get-workflow.tool';
+import { createListWorkflowVersionsTool } from './workflows/list-workflow-versions.tool';
 import { createListWorkflowsTool } from './workflows/list-workflows.tool';
 import { createPatchWorkflowTool } from './workflows/patch-workflow.tool';
 import { createPublishWorkflowTool } from './workflows/publish-workflow.tool';
+import { createRestoreWorkflowVersionTool } from './workflows/restore-workflow-version.tool';
 import { createUnpublishWorkflowTool } from './workflows/unpublish-workflow.tool';
 import { createCleanupTestExecutionsTool } from './workspace/cleanup-test-executions.tool';
 import { createCreateFolderTool } from './workspace/create-folder.tool';
@@ -113,6 +116,13 @@ export function createAllTools(context: InstanceAiContext) {
 		...(context.webResearchService?.search ? { 'web-search': createWebSearchTool(context) } : {}),
 		...(context.workflowService.patchNode
 			? { 'patch-workflow': createPatchWorkflowTool(context) }
+			: {}),
+		...(context.workflowService.listVersions
+			? {
+					'list-workflow-versions': createListWorkflowVersionsTool(context),
+					'get-workflow-version': createGetWorkflowVersionTool(context),
+					'restore-workflow-version': createRestoreWorkflowVersionTool(context),
+				}
 			: {}),
 		...(context.workspaceService
 			? {

--- a/packages/@n8n/instance-ai/src/tools/index.ts
+++ b/packages/@n8n/instance-ai/src/tools/index.ts
@@ -58,6 +58,7 @@ import { createPatchWorkflowTool } from './workflows/patch-workflow.tool';
 import { createPublishWorkflowTool } from './workflows/publish-workflow.tool';
 import { createRestoreWorkflowVersionTool } from './workflows/restore-workflow-version.tool';
 import { createUnpublishWorkflowTool } from './workflows/unpublish-workflow.tool';
+import { createUpdateWorkflowVersionTool } from './workflows/update-workflow-version.tool';
 import { createCleanupTestExecutionsTool } from './workspace/cleanup-test-executions.tool';
 import { createCreateFolderTool } from './workspace/create-folder.tool';
 import { createDeleteFolderTool } from './workspace/delete-folder.tool';
@@ -123,6 +124,9 @@ export function createAllTools(context: InstanceAiContext) {
 					'get-workflow-version': createGetWorkflowVersionTool(context),
 					'restore-workflow-version': createRestoreWorkflowVersionTool(context),
 				}
+			: {}),
+		...(context.workflowService.updateVersion
+			? { 'update-workflow-version': createUpdateWorkflowVersionTool(context) }
 			: {}),
 		...(context.workspaceService
 			? {

--- a/packages/@n8n/instance-ai/src/tools/index.ts
+++ b/packages/@n8n/instance-ai/src/tools/index.ts
@@ -131,13 +131,17 @@ export function createAllTools(context: InstanceAiContext) {
 		...(context.workspaceService
 			? {
 					'list-projects': createListProjectsTool(context),
-					'list-folders': createListFoldersTool(context),
-					'create-folder': createCreateFolderTool(context),
-					'delete-folder': createDeleteFolderTool(context),
-					'move-workflow-to-folder': createMoveWorkflowToFolderTool(context),
 					'tag-workflow': createTagWorkflowTool(context),
 					'list-tags': createListTagsTool(context),
 					'cleanup-test-executions': createCleanupTestExecutionsTool(context),
+					...(context.workspaceService.listFolders
+						? {
+								'list-folders': createListFoldersTool(context),
+								'create-folder': createCreateFolderTool(context),
+								'delete-folder': createDeleteFolderTool(context),
+								'move-workflow-to-folder': createMoveWorkflowToFolderTool(context),
+							}
+						: {}),
 				}
 			: {}),
 		...(context.localMcpServer

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/list-workflow-versions.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/list-workflow-versions.tool.test.ts
@@ -1,0 +1,129 @@
+import type { InstanceAiContext } from '../../../types';
+import { createListWorkflowVersionsTool } from '../list-workflow-versions.tool';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mockVersions = [
+	{
+		versionId: 'v-1',
+		name: 'Initial',
+		description: 'First version',
+		authors: 'user@example.com',
+		createdAt: '2025-06-01T12:00:00.000Z',
+		autosaved: false,
+		isActive: true,
+		isCurrentDraft: false,
+	},
+	{
+		versionId: 'v-2',
+		name: null,
+		description: null,
+		authors: 'user@example.com',
+		createdAt: '2025-06-02T12:00:00.000Z',
+		autosaved: true,
+		isActive: false,
+		isCurrentDraft: true,
+	},
+];
+
+function createMockContext(overrides?: Partial<InstanceAiContext>): InstanceAiContext {
+	return {
+		userId: 'test-user',
+		workflowService: {
+			list: jest.fn(),
+			get: jest.fn(),
+			getAsWorkflowJSON: jest.fn(),
+			createFromWorkflowJSON: jest.fn(),
+			updateFromWorkflowJSON: jest.fn(),
+			archive: jest.fn(),
+			delete: jest.fn(),
+			publish: jest.fn().mockResolvedValue({ activeVersionId: 'v-active-1' }),
+			unpublish: jest.fn(),
+			listVersions: jest.fn().mockResolvedValue(mockVersions),
+		},
+		executionService: {
+			list: jest.fn(),
+			run: jest.fn(),
+			getStatus: jest.fn(),
+			getResult: jest.fn(),
+			stop: jest.fn(),
+			getDebugInfo: jest.fn(),
+			getNodeOutput: jest.fn(),
+		},
+		credentialService: {
+			list: jest.fn(),
+			get: jest.fn(),
+			delete: jest.fn(),
+			test: jest.fn(),
+		},
+		nodeService: {
+			listAvailable: jest.fn(),
+			getDescription: jest.fn(),
+			listSearchable: jest.fn(),
+		},
+		dataTableService: {
+			list: jest.fn(),
+			create: jest.fn(),
+			delete: jest.fn(),
+			getSchema: jest.fn(),
+			addColumn: jest.fn(),
+			deleteColumn: jest.fn(),
+			renameColumn: jest.fn(),
+			queryRows: jest.fn(),
+			insertRows: jest.fn(),
+			updateRows: jest.fn(),
+			deleteRows: jest.fn(),
+		},
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createListWorkflowVersionsTool', () => {
+	let context: InstanceAiContext;
+
+	beforeEach(() => {
+		context = createMockContext();
+	});
+
+	it('has the expected tool id', () => {
+		const tool = createListWorkflowVersionsTool(context);
+
+		expect(tool.id).toBe('list-workflow-versions');
+	});
+
+	it('returns versions from the service', async () => {
+		const tool = createListWorkflowVersionsTool(context);
+
+		const result = await tool.execute!({ workflowId: 'wf-123' }, {} as never);
+
+		expect(context.workflowService.listVersions).toHaveBeenCalledWith('wf-123', {
+			limit: undefined,
+			skip: undefined,
+		});
+		expect(result).toEqual({ versions: mockVersions });
+	});
+
+	it('passes limit and skip to the service', async () => {
+		const tool = createListWorkflowVersionsTool(context);
+
+		await tool.execute!({ workflowId: 'wf-123', limit: 5, skip: 10 }, {} as never);
+
+		expect(context.workflowService.listVersions).toHaveBeenCalledWith('wf-123', {
+			limit: 5,
+			skip: 10,
+		});
+	});
+
+	it('propagates service errors', async () => {
+		(context.workflowService.listVersions as jest.Mock).mockRejectedValue(new Error('Not found'));
+		const tool = createListWorkflowVersionsTool(context);
+
+		await expect(tool.execute!({ workflowId: 'wf-123' }, {} as never)).rejects.toThrow('Not found');
+	});
+});

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/publish-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/publish-workflow.tool.test.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_INSTANCE_AI_PERMISSIONS } from '@n8n/api-types';
+import type { z } from 'zod';
 
 import type { InstanceAiContext } from '../../../types';
 import { createPublishWorkflowTool } from '../publish-workflow.tool';
@@ -184,6 +185,74 @@ describe('createPublishWorkflowTool', () => {
 				versionId: undefined,
 			});
 			expect(result).toEqual({ success: true, activeVersionId: 'v-active-1' });
+		});
+	});
+
+	describe('when named versions license is available', () => {
+		beforeEach(() => {
+			context = createMockContext({
+				workflowService: {
+					...createMockContext().workflowService,
+					updateVersion: jest.fn(),
+				},
+				permissions: {
+					...DEFAULT_INSTANCE_AI_PERMISSIONS,
+					publishWorkflow: 'always_allow',
+				},
+			});
+		});
+
+		it('includes name and description in the input schema', () => {
+			const tool = createPublishWorkflowTool(context);
+			const shape = (tool.inputSchema as unknown as z.ZodObject<z.ZodRawShape>).shape;
+
+			expect(shape).toHaveProperty('name');
+			expect(shape).toHaveProperty('description');
+		});
+
+		it('passes name and description to the service', async () => {
+			const tool = createPublishWorkflowTool(context);
+
+			await tool.execute!(
+				{ workflowId: 'wf-123', name: 'v1.0', description: 'Initial release' } as never,
+				{
+					agent: { suspend: jest.fn(), resumeData: undefined },
+				} as never,
+			);
+
+			expect(context.workflowService.publish).toHaveBeenCalledWith('wf-123', {
+				versionId: undefined,
+				name: 'v1.0',
+				description: 'Initial release',
+			});
+		});
+	});
+
+	describe('when named versions license is not available', () => {
+		it('does not include name and description in the input schema', () => {
+			const tool = createPublishWorkflowTool(context);
+			const shape = (tool.inputSchema as unknown as z.ZodObject<z.ZodRawShape>).shape;
+
+			expect(shape).not.toHaveProperty('name');
+			expect(shape).not.toHaveProperty('description');
+		});
+
+		it('does not pass name and description to the service', async () => {
+			context = createMockContext({
+				permissions: {
+					...DEFAULT_INSTANCE_AI_PERMISSIONS,
+					publishWorkflow: 'always_allow',
+				},
+			});
+			const tool = createPublishWorkflowTool(context);
+
+			await tool.execute!({ workflowId: 'wf-123' }, {
+				agent: { suspend: jest.fn(), resumeData: undefined },
+			} as never);
+
+			expect(context.workflowService.publish).toHaveBeenCalledWith('wf-123', {
+				versionId: undefined,
+			});
 		});
 	});
 

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/restore-workflow-version.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/restore-workflow-version.tool.test.ts
@@ -1,0 +1,197 @@
+import { DEFAULT_INSTANCE_AI_PERMISSIONS } from '@n8n/api-types';
+
+import type { InstanceAiContext } from '../../../types';
+import { createRestoreWorkflowVersionTool } from '../restore-workflow-version.tool';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockContext(overrides?: Partial<InstanceAiContext>): InstanceAiContext {
+	return {
+		userId: 'test-user',
+		workflowService: {
+			list: jest.fn(),
+			get: jest.fn(),
+			getAsWorkflowJSON: jest.fn(),
+			createFromWorkflowJSON: jest.fn(),
+			updateFromWorkflowJSON: jest.fn(),
+			archive: jest.fn(),
+			delete: jest.fn(),
+			publish: jest.fn().mockResolvedValue({ activeVersionId: 'v-active-1' }),
+			unpublish: jest.fn(),
+			getVersion: jest.fn().mockResolvedValue({
+				id: 'v-42',
+				name: 'Initial version',
+				createdAt: '2025-06-01T12:00:00.000Z',
+			}),
+			restoreVersion: jest.fn().mockResolvedValue(undefined),
+		},
+		executionService: {
+			list: jest.fn(),
+			run: jest.fn(),
+			getStatus: jest.fn(),
+			getResult: jest.fn(),
+			stop: jest.fn(),
+			getDebugInfo: jest.fn(),
+			getNodeOutput: jest.fn(),
+		},
+		credentialService: {
+			list: jest.fn(),
+			get: jest.fn(),
+			delete: jest.fn(),
+			test: jest.fn(),
+		},
+		nodeService: {
+			listAvailable: jest.fn(),
+			getDescription: jest.fn(),
+			listSearchable: jest.fn(),
+		},
+		dataTableService: {
+			list: jest.fn(),
+			create: jest.fn(),
+			delete: jest.fn(),
+			getSchema: jest.fn(),
+			addColumn: jest.fn(),
+			deleteColumn: jest.fn(),
+			renameColumn: jest.fn(),
+			queryRows: jest.fn(),
+			insertRows: jest.fn(),
+			updateRows: jest.fn(),
+			deleteRows: jest.fn(),
+		},
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createRestoreWorkflowVersionTool', () => {
+	let context: InstanceAiContext;
+
+	beforeEach(() => {
+		context = createMockContext();
+	});
+
+	it('has the expected tool id', () => {
+		const tool = createRestoreWorkflowVersionTool(context);
+
+		expect(tool.id).toBe('restore-workflow-version');
+	});
+
+	describe('when permissions require approval (default)', () => {
+		it('suspends for user confirmation on first call', async () => {
+			const tool = createRestoreWorkflowVersionTool(context);
+			const suspend = jest.fn();
+
+			await tool.execute!({ workflowId: 'wf-123', versionId: 'v-42' }, {
+				agent: { suspend, resumeData: undefined },
+			} as never);
+
+			expect(suspend).toHaveBeenCalledTimes(1);
+			const suspendPayload = (suspend.mock.calls as unknown[][])[0][0] as Record<string, unknown>;
+			expect(suspendPayload).toEqual(
+				expect.objectContaining({
+					message: expect.stringContaining('overwrite the current draft'),
+					severity: 'warning',
+				}),
+			);
+		});
+
+		it('includes version name and timestamp in confirmation when available', async () => {
+			const tool = createRestoreWorkflowVersionTool(context);
+			const suspend = jest.fn();
+
+			await tool.execute!({ workflowId: 'wf-123', versionId: 'v-42' }, {
+				agent: { suspend, resumeData: undefined },
+			} as never);
+
+			const suspendPayload = (suspend.mock.calls as unknown[][])[0][0] as Record<string, unknown>;
+			expect(suspendPayload.message).toContain('Initial version');
+		});
+
+		it('falls back to versionId when getVersion fails', async () => {
+			(context.workflowService.getVersion as jest.Mock).mockRejectedValue(new Error('Not found'));
+			const tool = createRestoreWorkflowVersionTool(context);
+			const suspend = jest.fn();
+
+			await tool.execute!({ workflowId: 'wf-123', versionId: 'v-42' }, {
+				agent: { suspend, resumeData: undefined },
+			} as never);
+
+			const suspendPayload = (suspend.mock.calls as unknown[][])[0][0] as Record<string, unknown>;
+			expect(suspendPayload.message).toContain('v-42');
+			expect(suspendPayload.message).toContain('unknown date');
+		});
+
+		it('restores the version when resumed with approved: true', async () => {
+			const tool = createRestoreWorkflowVersionTool(context);
+
+			const result = await tool.execute!({ workflowId: 'wf-123', versionId: 'v-42' }, {
+				agent: { suspend: jest.fn(), resumeData: { approved: true } },
+			} as never);
+
+			expect(context.workflowService.restoreVersion).toHaveBeenCalledWith('wf-123', 'v-42');
+			expect(result).toEqual({ success: true });
+		});
+
+		it('returns denied when resumed with approved: false', async () => {
+			const tool = createRestoreWorkflowVersionTool(context);
+
+			const result = await tool.execute!({ workflowId: 'wf-123', versionId: 'v-42' }, {
+				agent: { suspend: jest.fn(), resumeData: { approved: false } },
+			} as never);
+
+			expect(context.workflowService.restoreVersion).not.toHaveBeenCalled();
+			expect(result).toEqual({
+				success: false,
+				denied: true,
+				reason: 'User denied the action',
+			});
+		});
+	});
+
+	describe('when permissions.restoreWorkflowVersion is always_allow', () => {
+		beforeEach(() => {
+			context = createMockContext({
+				permissions: {
+					...DEFAULT_INSTANCE_AI_PERMISSIONS,
+					restoreWorkflowVersion: 'always_allow',
+				},
+			});
+		});
+
+		it('skips confirmation and restores immediately', async () => {
+			const tool = createRestoreWorkflowVersionTool(context);
+			const suspend = jest.fn();
+
+			const result = await tool.execute!({ workflowId: 'wf-123', versionId: 'v-42' }, {
+				agent: { suspend, resumeData: undefined },
+			} as never);
+
+			expect(suspend).not.toHaveBeenCalled();
+			expect(context.workflowService.restoreVersion).toHaveBeenCalledWith('wf-123', 'v-42');
+			expect(result).toEqual({ success: true });
+		});
+	});
+
+	describe('error handling', () => {
+		it('returns error when restore fails', async () => {
+			(context.workflowService.restoreVersion as jest.Mock).mockRejectedValue(
+				new Error('Version not found'),
+			);
+			const tool = createRestoreWorkflowVersionTool(context);
+
+			const result = await tool.execute!({ workflowId: 'wf-123', versionId: 'v-42' }, {
+				agent: { suspend: jest.fn(), resumeData: { approved: true } },
+			} as never);
+
+			expect(result).toEqual({
+				success: false,
+				error: 'Version not found',
+			});
+		});
+	});
+});

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/restore-workflow-version.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/restore-workflow-version.tool.test.ts
@@ -94,6 +94,7 @@ describe('createRestoreWorkflowVersionTool', () => {
 			const suspendPayload = (suspend.mock.calls as unknown[][])[0][0] as Record<string, unknown>;
 			expect(suspendPayload).toEqual(
 				expect.objectContaining({
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 					message: expect.stringContaining('overwrite the current draft'),
 					severity: 'warning',
 				}),

--- a/packages/@n8n/instance-ai/src/tools/workflows/get-workflow-version.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/get-workflow-version.tool.ts
@@ -1,0 +1,40 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import type { InstanceAiContext } from '../../types';
+
+export function createGetWorkflowVersionTool(context: InstanceAiContext) {
+	return createTool({
+		id: 'get-workflow-version',
+		description:
+			'Get full details of a specific workflow version including nodes and connections. ' +
+			'Use to inspect what a version looked like, diff against the current draft, or ' +
+			'answer questions like "when did node X change".',
+		inputSchema: z.object({
+			workflowId: z.string().describe('ID of the workflow'),
+			versionId: z.string().describe('ID of the version to retrieve'),
+		}),
+		outputSchema: z.object({
+			versionId: z.string(),
+			name: z.string().nullable(),
+			description: z.string().nullable(),
+			authors: z.string(),
+			createdAt: z.string(),
+			autosaved: z.boolean(),
+			isActive: z.boolean(),
+			isCurrentDraft: z.boolean(),
+			nodes: z.array(
+				z.object({
+					name: z.string(),
+					type: z.string(),
+					parameters: z.record(z.unknown()).optional(),
+					position: z.array(z.number()),
+				}),
+			),
+			connections: z.record(z.unknown()),
+		}),
+		execute: async (input) => {
+			return await context.workflowService.getVersion!(input.workflowId, input.versionId);
+		},
+	});
+}

--- a/packages/@n8n/instance-ai/src/tools/workflows/list-workflow-versions.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/list-workflow-versions.tool.ts
@@ -1,0 +1,49 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import type { InstanceAiContext } from '../../types';
+
+export function createListWorkflowVersionsTool(context: InstanceAiContext) {
+	return createTool({
+		id: 'list-workflow-versions',
+		description:
+			'List version history for a workflow (metadata only). Use to discover past versions, ' +
+			'see who made changes, and find the active/current draft versions.',
+		inputSchema: z.object({
+			workflowId: z.string().describe('ID of the workflow'),
+			limit: z
+				.number()
+				.int()
+				.positive()
+				.max(100)
+				.optional()
+				.describe('Max results to return (default 20)'),
+			skip: z.number().int().min(0).optional().describe('Number of results to skip (default 0)'),
+		}),
+		outputSchema: z.object({
+			versions: z.array(
+				z.object({
+					versionId: z.string(),
+					name: z.string().nullable(),
+					description: z.string().nullable(),
+					authors: z.string(),
+					createdAt: z.string(),
+					autosaved: z.boolean(),
+					isActive: z
+						.boolean()
+						.describe('True when this version is the currently published/active version'),
+					isCurrentDraft: z
+						.boolean()
+						.describe('True when this version is the current draft (latest saved version)'),
+				}),
+			),
+		}),
+		execute: async (input) => {
+			const versions = await context.workflowService.listVersions!(input.workflowId, {
+				limit: input.limit,
+				skip: input.skip,
+			});
+			return { versions };
+		},
+	});
+}

--- a/packages/@n8n/instance-ai/src/tools/workflows/publish-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/publish-workflow.tool.ts
@@ -6,19 +6,36 @@ import { z } from 'zod';
 import type { InstanceAiContext } from '../../types';
 
 export function createPublishWorkflowTool(context: InstanceAiContext) {
+	const hasNamedVersions = !!context.workflowService.updateVersion;
+
+	const baseSchema = z.object({
+		workflowId: z.string().describe('ID of the workflow'),
+		versionId: z
+			.string()
+			.optional()
+			.describe('Specific version to publish (omit to publish the latest draft)'),
+	});
+
+	const inputSchema = hasNamedVersions
+		? baseSchema.extend({
+				name: z
+					.string()
+					.optional()
+					.describe('Name for this published version (e.g. "v1.2 — added retry logic")'),
+				description: z
+					.string()
+					.optional()
+					.describe('Description of what this version does or what changed'),
+			})
+		: baseSchema;
+
 	return createTool({
 		id: 'publish-workflow',
 		description:
 			'Publish a workflow version to production. Publishing makes the specified version active — ' +
 			'it will run on its triggers. If the workflow has been edited since last publish, you must ' +
 			're-publish for changes to take effect. Omit versionId to publish the latest draft.',
-		inputSchema: z.object({
-			workflowId: z.string().describe('ID of the workflow'),
-			versionId: z
-				.string()
-				.optional()
-				.describe('Specific version to publish (omit to publish the latest draft)'),
-		}),
+		inputSchema,
 		outputSchema: z.object({
 			success: z.boolean(),
 			activeVersionId: z
@@ -60,6 +77,12 @@ export function createPublishWorkflowTool(context: InstanceAiContext) {
 			try {
 				const result = await context.workflowService.publish(input.workflowId, {
 					versionId: input.versionId,
+					...(hasNamedVersions
+						? {
+								name: (input as { name?: string }).name,
+								description: (input as { description?: string }).description,
+							}
+						: {}),
 				});
 				return { success: true, activeVersionId: result.activeVersionId };
 			} catch (error) {

--- a/packages/@n8n/instance-ai/src/tools/workflows/restore-workflow-version.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/restore-workflow-version.tool.ts
@@ -1,0 +1,72 @@
+import { createTool } from '@mastra/core/tools';
+import { instanceAiConfirmationSeveritySchema } from '@n8n/api-types';
+import { nanoid } from 'nanoid';
+import { z } from 'zod';
+
+import type { InstanceAiContext } from '../../types';
+import { formatTimestamp } from '../../utils/format-timestamp';
+
+export function createRestoreWorkflowVersionTool(context: InstanceAiContext) {
+	return createTool({
+		id: 'restore-workflow-version',
+		description:
+			'Restore a workflow to a previous version by overwriting the current draft with that ' +
+			"version's nodes and connections. This does NOT affect the published/active version — " +
+			'you must publish separately after restoring.',
+		inputSchema: z.object({
+			workflowId: z.string().describe('ID of the workflow'),
+			versionId: z.string().describe('ID of the version to restore'),
+		}),
+		outputSchema: z.object({
+			success: z.boolean(),
+			error: z.string().optional(),
+			denied: z.boolean().optional(),
+			reason: z.string().optional(),
+		}),
+		suspendSchema: z.object({
+			requestId: z.string(),
+			message: z.string(),
+			severity: instanceAiConfirmationSeveritySchema,
+		}),
+		resumeSchema: z.object({
+			approved: z.boolean(),
+		}),
+		execute: async (input, ctx) => {
+			const { resumeData, suspend } = ctx?.agent ?? {};
+
+			const needsApproval = context.permissions?.restoreWorkflowVersion !== 'always_allow';
+
+			if (needsApproval && (resumeData === undefined || resumeData === null)) {
+				const version = await context.workflowService.getVersion!(
+					input.workflowId,
+					input.versionId,
+				).catch(() => undefined);
+				const timestamp = version?.createdAt ? formatTimestamp(version.createdAt) : undefined;
+				const versionLabel = version?.name
+					? `"${version.name}" (${timestamp})`
+					: `"${input.versionId}" (${timestamp ?? 'unknown date'})`;
+
+				await suspend?.({
+					requestId: nanoid(),
+					message: `Restore workflow to version ${versionLabel}? This will overwrite the current draft.`,
+					severity: 'warning' as const,
+				});
+				return { success: false };
+			}
+
+			if (resumeData !== undefined && resumeData !== null && !resumeData.approved) {
+				return { success: false, denied: true, reason: 'User denied the action' };
+			}
+
+			try {
+				await context.workflowService.restoreVersion!(input.workflowId, input.versionId);
+				return { success: true };
+			} catch (error) {
+				return {
+					success: false,
+					error: error instanceof Error ? error.message : 'Restore failed',
+				};
+			}
+		},
+	});
+}

--- a/packages/@n8n/instance-ai/src/tools/workflows/update-workflow-version.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/update-workflow-version.tool.ts
@@ -1,0 +1,35 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import type { InstanceAiContext } from '../../types';
+
+export function createUpdateWorkflowVersionTool(context: InstanceAiContext) {
+	return createTool({
+		id: 'update-workflow-version',
+		description:
+			'Update the name or description of a workflow version. Use to label versions ' +
+			'with meaningful names (e.g. "v1 – initial release") or add descriptions ' +
+			'explaining what changed. Only available when the named-versions license feature is active.',
+		inputSchema: z.object({
+			workflowId: z.string().describe('ID of the workflow'),
+			versionId: z.string().describe('ID of the version to update'),
+			name: z.string().nullable().optional().describe('New name for the version (null to clear)'),
+			description: z
+				.string()
+				.nullable()
+				.optional()
+				.describe('New description for the version (null to clear)'),
+		}),
+		outputSchema: z.object({
+			success: z.boolean(),
+			error: z.string().optional(),
+		}),
+		execute: async (input) => {
+			await context.workflowService.updateVersion!(input.workflowId, input.versionId, {
+				name: input.name,
+				description: input.description,
+			});
+			return { success: true };
+		},
+	});
+}

--- a/packages/@n8n/instance-ai/src/tools/workspace/create-folder.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workspace/create-folder.tool.ts
@@ -60,7 +60,7 @@ export function createCreateFolderTool(context: InstanceAiContext) {
 			}
 
 			// State 3: Approved or always_allow — execute
-			return await context.workspaceService!.createFolder(
+			return await context.workspaceService!.createFolder!(
 				input.name,
 				input.projectId,
 				input.parentFolderId,

--- a/packages/@n8n/instance-ai/src/tools/workspace/delete-folder.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workspace/delete-folder.tool.ts
@@ -58,7 +58,7 @@ export function createDeleteFolderTool(context: InstanceAiContext) {
 			}
 
 			// State 3: Approved or always_allow — execute
-			await context.workspaceService!.deleteFolder(
+			await context.workspaceService!.deleteFolder!(
 				input.folderId,
 				input.projectId,
 				input.transferToFolderId,

--- a/packages/@n8n/instance-ai/src/tools/workspace/list-folders.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workspace/list-folders.tool.ts
@@ -21,7 +21,7 @@ export function createListFoldersTool(context: InstanceAiContext) {
 			),
 		}),
 		execute: async (input) => {
-			const folders = await context.workspaceService!.listFolders(input.projectId);
+			const folders = await context.workspaceService!.listFolders!(input.projectId);
 			return { folders };
 		},
 	});

--- a/packages/@n8n/instance-ai/src/tools/workspace/move-workflow-to-folder.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workspace/move-workflow-to-folder.tool.ts
@@ -48,7 +48,7 @@ export function createMoveWorkflowToFolderTool(context: InstanceAiContext) {
 			}
 
 			// State 3: Approved or always_allow — execute
-			await context.workspaceService!.moveWorkflowToFolder(input.workflowId, input.folderId);
+			await context.workspaceService!.moveWorkflowToFolder!(input.workflowId, input.folderId);
 			return { success: true };
 		},
 	});

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -173,6 +173,12 @@ export interface InstanceAiWorkflowService {
 	getVersion?(workflowId: string, versionId: string): Promise<WorkflowVersionDetail>;
 	/** Restore a workflow to a previous version by overwriting the current draft. */
 	restoreVersion?(workflowId: string, versionId: string): Promise<void>;
+	/** Update name/description of a workflow version (licensed: namedVersions). */
+	updateVersion?(
+		workflowId: string,
+		versionId: string,
+		data: { name?: string | null; description?: string | null },
+	): Promise<void>;
 }
 
 export interface ExecutionSummary {

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -536,6 +536,9 @@ export interface InstanceAiContext {
 	localMcpServer?: LocalMcpServer;
 	/** Per-action HITL permission overrides. When absent, tools default to requiring approval. */
 	permissions?: InstanceAiPermissions;
+	/** Human-readable hints about licensed features that are NOT available on this instance.
+	 *  Injected into the system prompt so the agent can explain why certain capabilities are missing. */
+	licenseHints?: string[];
 	/** Domain access tracker for HITL gating of fetch-url and similar tools. */
 	domainAccessTracker?: DomainAccessTracker;
 	/** Current run ID — used for transient (allow_once) domain approvals. */

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -115,6 +115,22 @@ export interface NodeDescription extends NodeSummary {
 
 // ── Service interfaces ───────────────────────────────────────────────────────
 
+export interface WorkflowVersionSummary {
+	versionId: string;
+	name: string | null;
+	description: string | null;
+	authors: string;
+	createdAt: string;
+	autosaved: boolean;
+	isActive: boolean;
+	isCurrentDraft: boolean;
+}
+
+export interface WorkflowVersionDetail extends WorkflowVersionSummary {
+	nodes: WorkflowNode[];
+	connections: Record<string, unknown>;
+}
+
 export interface InstanceAiWorkflowService {
 	list(options?: { query?: string; limit?: number }): Promise<WorkflowSummary[]>;
 	get(workflowId: string): Promise<WorkflowDetail>;
@@ -148,6 +164,15 @@ export interface InstanceAiWorkflowService {
 			disabled?: boolean;
 		},
 	): Promise<WorkflowDetail>;
+	/** List version history for a workflow (metadata only, no nodes/connections). */
+	listVersions?(
+		workflowId: string,
+		options?: { limit?: number; skip?: number },
+	): Promise<WorkflowVersionSummary[]>;
+	/** Get full details of a specific version (including nodes and connections). */
+	getVersion?(workflowId: string, versionId: string): Promise<WorkflowVersionDetail>;
+	/** Restore a workflow to a previous version by overwriting the current draft. */
+	restoreVersion?(workflowId: string, versionId: string): Promise<void>;
 }
 
 export interface ExecutionSummary {

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -151,7 +151,7 @@ export interface InstanceAiWorkflowService {
 	delete(workflowId: string): Promise<void>;
 	publish(
 		workflowId: string,
-		options?: { versionId?: string },
+		options?: { versionId?: string; name?: string; description?: string },
 	): Promise<{ activeVersionId: string }>;
 	unpublish(workflowId: string): Promise<void>;
 	/** Patch a single node's parameters, credentials, or disabled state in-place. */

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -498,13 +498,13 @@ export interface InstanceAiWorkspaceService {
 	getProject?(projectId: string): Promise<ProjectSummary | null>;
 	listProjects(): Promise<ProjectSummary[]>;
 
-	// Folders
-	listFolders(projectId: string): Promise<FolderSummary[]>;
-	createFolder(name: string, projectId: string, parentFolderId?: string): Promise<FolderSummary>;
-	deleteFolder(folderId: string, projectId: string, transferToFolderId?: string): Promise<void>;
+	// Folders (licensed: feat:folders)
+	listFolders?(projectId: string): Promise<FolderSummary[]>;
+	createFolder?(name: string, projectId: string, parentFolderId?: string): Promise<FolderSummary>;
+	deleteFolder?(folderId: string, projectId: string, transferToFolderId?: string): Promise<void>;
 
-	// Workflow organization
-	moveWorkflowToFolder(workflowId: string, folderId: string): Promise<void>;
+	// Workflow organization (moveWorkflowToFolder requires feat:folders)
+	moveWorkflowToFolder?(workflowId: string, folderId: string): Promise<void>;
 	tagWorkflow(workflowId: string, tagNames: string[]): Promise<string[]>;
 
 	// Tags

--- a/packages/@n8n/instance-ai/src/utils/format-timestamp.ts
+++ b/packages/@n8n/instance-ai/src/utils/format-timestamp.ts
@@ -1,0 +1,16 @@
+/** Format an ISO timestamp to match the app's display style (e.g. "Mar 19, 2026 14:30:00"). */
+export function formatTimestamp(iso: string): string {
+	const date = new Date(iso);
+	const datePart = date.toLocaleDateString('en-US', {
+		month: 'short',
+		day: 'numeric',
+		...(date.getFullYear() !== new Date().getFullYear() ? { year: 'numeric' } : {}),
+	});
+	const timePart = date.toLocaleTimeString('en-GB', {
+		hour: '2-digit',
+		minute: '2-digit',
+		second: '2-digit',
+		hour12: false,
+	});
+	return `${datePart} ${timePart}`;
+}

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -858,7 +858,10 @@ describe('createDataTableAdapter', () => {
 // createWorkflowAdapter – project scoping
 // ---------------------------------------------------------------------------
 
-function createWorkflowAdapterForTests(overrides?: { namedVersionsLicensed?: boolean }) {
+function createWorkflowAdapterForTests(overrides?: {
+	namedVersionsLicensed?: boolean;
+	foldersLicensed?: boolean;
+}) {
 	const mockProjectRepository = {
 		getPersonalProjectForUserOrFail: jest.fn().mockResolvedValue({ id: 'personal-project-id' }),
 	};
@@ -917,12 +920,11 @@ function createWorkflowAdapterForTests(overrides?: { namedVersionsLicensed?: boo
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[20],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[21],
 		{
-			isLicensed: jest
-				.fn()
-				.mockImplementation(
-					(feat: string) =>
-						feat === 'feat:namedVersions' && (overrides?.namedVersionsLicensed ?? false),
-				),
+			isLicensed: jest.fn().mockImplementation((feat: string) => {
+				if (feat === 'feat:namedVersions') return overrides?.namedVersionsLicensed ?? false;
+				if (feat === 'feat:folders') return overrides?.foldersLicensed ?? false;
+				return false;
+			}),
 		} as unknown as License,
 	);
 
@@ -1000,35 +1002,75 @@ describe('license-gated features', () => {
 		mockedUserHasScopes.mockResolvedValue(true);
 	});
 
-	describe('updateVersion', () => {
-		it('is present on workflowService when namedVersions is licensed', () => {
+	describe('updateVersion (feat:namedVersions)', () => {
+		it('is present on workflowService when licensed', () => {
 			const { adapter } = createWorkflowAdapterForTests({ namedVersionsLicensed: true });
 
 			expect(adapter.updateVersion).toBeDefined();
 			expect(typeof adapter.updateVersion).toBe('function');
 		});
 
-		it('is absent on workflowService when namedVersions is not licensed', () => {
+		it('is absent on workflowService when not licensed', () => {
 			const { adapter } = createWorkflowAdapterForTests({ namedVersionsLicensed: false });
 
 			expect(adapter.updateVersion).toBeUndefined();
 		});
 	});
 
-	describe('licenseHints', () => {
-		it('includes named versions hint when feature is not licensed', () => {
-			const { context } = createWorkflowAdapterForTests({ namedVersionsLicensed: false });
+	describe('folders (feat:folders)', () => {
+		it('includes folder methods on workspaceService when licensed', () => {
+			const { context } = createWorkflowAdapterForTests({ foldersLicensed: true });
 
-			expect(context.licenseHints).toBeDefined();
+			expect(context.workspaceService!.listFolders).toBeDefined();
+			expect(context.workspaceService!.createFolder).toBeDefined();
+			expect(context.workspaceService!.deleteFolder).toBeDefined();
+			expect(context.workspaceService!.moveWorkflowToFolder).toBeDefined();
+		});
+
+		it('omits folder methods on workspaceService when not licensed', () => {
+			const { context } = createWorkflowAdapterForTests({ foldersLicensed: false });
+
+			expect(context.workspaceService!.listFolders).toBeUndefined();
+			expect(context.workspaceService!.createFolder).toBeUndefined();
+			expect(context.workspaceService!.deleteFolder).toBeUndefined();
+			expect(context.workspaceService!.moveWorkflowToFolder).toBeUndefined();
+		});
+	});
+
+	describe('licenseHints', () => {
+		it('includes hints for unlicensed features', () => {
+			const { context } = createWorkflowAdapterForTests({
+				namedVersionsLicensed: false,
+				foldersLicensed: false,
+			});
+
 			expect(context.licenseHints).toEqual(
-				expect.arrayContaining([expect.stringContaining('Named workflow versions')]),
+				expect.arrayContaining([
+					expect.stringContaining('Named workflow versions'),
+					expect.stringContaining('Folders'),
+				]),
 			);
 		});
 
-		it('does not include named versions hint when feature is licensed', () => {
-			const { context } = createWorkflowAdapterForTests({ namedVersionsLicensed: true });
+		it('omits hints for licensed features', () => {
+			const { context } = createWorkflowAdapterForTests({
+				namedVersionsLicensed: true,
+				foldersLicensed: true,
+			});
 
 			expect(context.licenseHints).toEqual([]);
+		});
+
+		it('only includes hints for unlicensed features', () => {
+			const { context } = createWorkflowAdapterForTests({
+				namedVersionsLicensed: true,
+				foldersLicensed: false,
+			});
+
+			expect(context.licenseHints).toEqual([expect.stringContaining('Folders')]);
+			expect(context.licenseHints).not.toEqual(
+				expect.arrayContaining([expect.stringContaining('Named workflow versions')]),
+			);
 		});
 	});
 });

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -745,6 +745,7 @@ function createDataTableAdapterForTests(overrides?: {
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[18],
 		mockSourceControlPreferencesService as unknown as SourceControlPreferencesService,
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[20],
+		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[21],
 	);
 
 	const adapter = service.createContext(mockUser).dataTableService;
@@ -912,6 +913,7 @@ function createWorkflowAdapterForTests() {
 			getPreferences: jest.fn().mockReturnValue({ branchReadOnly: false }),
 		} as unknown as SourceControlPreferencesService,
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[20],
+		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[21],
 	);
 
 	const adapter = service.createContext(mockUser).workflowService;

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -682,6 +682,7 @@ import type { DataTableService } from '@/modules/data-table/data-table.service';
 import type { SourceControlPreferencesService } from '@/modules/source-control.ee/source-control-preferences.service.ee';
 import type { WorkflowJSON } from '@n8n/workflow-sdk';
 import type { WorkflowService } from '@/workflows/workflow.service';
+import type { License } from '@/license';
 
 import { InstanceAiAdapterService } from '../instance-ai.adapter.service';
 import { userHasScopes } from '@/permissions.ee/check-access';
@@ -746,6 +747,7 @@ function createDataTableAdapterForTests(overrides?: {
 		mockSourceControlPreferencesService as unknown as SourceControlPreferencesService,
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[20],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[21],
+		{ isLicensed: jest.fn().mockReturnValue(false) } as unknown as License,
 	);
 
 	const adapter = service.createContext(mockUser).dataTableService;
@@ -914,6 +916,7 @@ function createWorkflowAdapterForTests() {
 		} as unknown as SourceControlPreferencesService,
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[20],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[21],
+		{ isLicensed: jest.fn().mockReturnValue(false) } as unknown as License,
 	);
 
 	const adapter = service.createContext(mockUser).workflowService;

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -858,7 +858,7 @@ describe('createDataTableAdapter', () => {
 // createWorkflowAdapter – project scoping
 // ---------------------------------------------------------------------------
 
-function createWorkflowAdapterForTests() {
+function createWorkflowAdapterForTests(overrides?: { namedVersionsLicensed?: boolean }) {
 	const mockProjectRepository = {
 		getPersonalProjectForUserOrFail: jest.fn().mockResolvedValue({ id: 'personal-project-id' }),
 	};
@@ -916,13 +916,22 @@ function createWorkflowAdapterForTests() {
 		} as unknown as SourceControlPreferencesService,
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[20],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[21],
-		{ isLicensed: jest.fn().mockReturnValue(false) } as unknown as License,
+		{
+			isLicensed: jest
+				.fn()
+				.mockImplementation(
+					(feat: string) =>
+						feat === 'feat:namedVersions' && (overrides?.namedVersionsLicensed ?? false),
+				),
+		} as unknown as License,
 	);
 
-	const adapter = service.createContext(mockUser).workflowService;
+	const context = service.createContext(mockUser);
+	const adapter = context.workflowService;
 
 	return {
 		adapter,
+		context,
 		mockProjectRepository,
 		mockWorkflowRepository,
 		mockSharedWorkflowRepository,
@@ -978,5 +987,48 @@ describe('createWorkflowAdapter', () => {
 				projectId: 'restricted-project-id',
 			}),
 		).rejects.toThrow('User does not have the required permissions in this project');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// License-gated features
+// ---------------------------------------------------------------------------
+
+describe('license-gated features', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockedUserHasScopes.mockResolvedValue(true);
+	});
+
+	describe('updateVersion', () => {
+		it('is present on workflowService when namedVersions is licensed', () => {
+			const { adapter } = createWorkflowAdapterForTests({ namedVersionsLicensed: true });
+
+			expect(adapter.updateVersion).toBeDefined();
+			expect(typeof adapter.updateVersion).toBe('function');
+		});
+
+		it('is absent on workflowService when namedVersions is not licensed', () => {
+			const { adapter } = createWorkflowAdapterForTests({ namedVersionsLicensed: false });
+
+			expect(adapter.updateVersion).toBeUndefined();
+		});
+	});
+
+	describe('licenseHints', () => {
+		it('includes named versions hint when feature is not licensed', () => {
+			const { context } = createWorkflowAdapterForTests({ namedVersionsLicensed: false });
+
+			expect(context.licenseHints).toBeDefined();
+			expect(context.licenseHints).toEqual(
+				expect.arrayContaining([expect.stringContaining('Named workflow versions')]),
+			);
+		});
+
+		it('does not include named versions hint when feature is licensed', () => {
+			const { context } = createWorkflowAdapterForTests({ namedVersionsLicensed: true });
+
+			expect(context.licenseHints).toEqual([]);
+		});
 	});
 });

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -143,8 +143,19 @@ export class InstanceAiAdapterService {
 			dataTableService: this.createDataTableAdapter(user),
 			webResearchService: this.createWebResearchAdapter(user),
 			workspaceService: this.createWorkspaceAdapter(user),
+			licenseHints: this.buildLicenseHints(),
 			...(filesystemService ? { filesystemService } : {}),
 		};
+	}
+
+	private buildLicenseHints(): string[] {
+		const hints: string[] = [];
+		if (!this.license.isLicensed('feat:namedVersions')) {
+			hints.push(
+				'**Named workflow versions** — naming and describing workflow versions (update-workflow-version) is available on the Pro plan and above.',
+			);
+		}
+		return hints;
 	}
 
 	private createProjectScopeHelpers(user: User) {

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -244,9 +244,14 @@ export class InstanceAiAdapterService {
 				await workflowService.delete(user, workflowId);
 			},
 
-			async publish(workflowId: string, options?: { versionId?: string }) {
+			async publish(
+				workflowId: string,
+				options?: { versionId?: string; name?: string; description?: string },
+			) {
 				const wf = await workflowService.activateWorkflow(user, workflowId, {
 					versionId: options?.versionId,
+					name: options?.name,
+					description: options?.description,
 				});
 				if (!wf.activeVersionId) {
 					throw new Error(`Workflow ${workflowId} was not activated — no active version set`);

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -15,6 +15,8 @@ import type {
 	WorkflowSummary,
 	WorkflowDetail,
 	WorkflowNode,
+	WorkflowVersionSummary,
+	WorkflowVersionDetail,
 	ExecutionResult,
 	ExecutionDebugInfo,
 	NodeOutputResult,
@@ -93,6 +95,7 @@ import { ProjectService } from '@/services/project.service.ee';
 import { TagService } from '@/services/tag.service';
 import { WorkflowSharingService } from '@/workflows/workflow-sharing.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
 import { WorkflowService } from '@/workflows/workflow.service';
 import { WorkflowRunner } from '@/workflow-runner';
 import { getBase } from '@/workflow-execute-additional-data';
@@ -123,6 +126,7 @@ export class InstanceAiAdapterService {
 		private readonly tagService: TagService,
 		private readonly sourceControlPreferencesService: SourceControlPreferencesService,
 		private readonly settingsService: InstanceAiSettingsService,
+		private readonly workflowHistoryService: WorkflowHistoryService,
 	) {
 		this.allowSendingParameterValues = globalConfig.ai.allowSendingParameterValues;
 	}
@@ -169,8 +173,13 @@ export class InstanceAiAdapterService {
 	}
 
 	private createWorkflowAdapter(user: User): InstanceAiWorkflowService {
-		const { workflowService, workflowFinderService, workflowRepository, sharedWorkflowRepository } =
-			this;
+		const {
+			workflowService,
+			workflowFinderService,
+			workflowRepository,
+			sharedWorkflowRepository,
+			workflowHistoryService,
+		} = this;
 		const { resolveProjectId } = this.createProjectScopeHelpers(user);
 
 		return {
@@ -336,6 +345,74 @@ export class InstanceAiAdapterService {
 
 				const updated = await workflowService.update(user, updateData, workflowId);
 				return toWorkflowDetail(updated);
+			},
+
+			async listVersions(workflowId, options) {
+				const take = options?.limit ?? 20;
+				const skip = options?.skip ?? 0;
+				const versions = await workflowHistoryService.getList(user, workflowId, take, skip);
+
+				// Fetch the workflow to determine active/draft version IDs
+				const workflow = await workflowFinderService.findWorkflowForUser(workflowId, user, [
+					'workflow:read',
+				]);
+				const activeVersionId = workflow?.activeVersionId ?? null;
+				const currentDraftVersionId = workflow?.versionId ?? null;
+
+				return versions.map(
+					(v): WorkflowVersionSummary => ({
+						versionId: v.versionId,
+						name: v.name ?? null,
+						description: v.description ?? null,
+						authors: v.authors,
+						createdAt: v.createdAt.toISOString(),
+						autosaved: v.autosaved ?? false,
+						isActive: v.versionId === activeVersionId,
+						isCurrentDraft: v.versionId === currentDraftVersionId,
+					}),
+				);
+			},
+
+			async getVersion(workflowId, versionId) {
+				const version = await workflowHistoryService.getVersion(user, workflowId, versionId);
+
+				// Fetch the workflow to determine active/draft version IDs
+				const workflow = await workflowFinderService.findWorkflowForUser(workflowId, user, [
+					'workflow:read',
+				]);
+				const activeVersionId = workflow?.activeVersionId ?? null;
+				const currentDraftVersionId = workflow?.versionId ?? null;
+
+				return {
+					versionId: version.versionId,
+					name: version.name ?? null,
+					description: version.description ?? null,
+					authors: version.authors,
+					createdAt: version.createdAt.toISOString(),
+					autosaved: version.autosaved ?? false,
+					isActive: version.versionId === activeVersionId,
+					isCurrentDraft: version.versionId === currentDraftVersionId,
+					nodes: (version.nodes ?? []).map(
+						(n): WorkflowNode => ({
+							name: n.name,
+							type: n.type,
+							parameters: n.parameters as Record<string, unknown>,
+							position: n.position,
+						}),
+					),
+					connections: version.connections as Record<string, unknown>,
+				} satisfies WorkflowVersionDetail;
+			},
+
+			async restoreVersion(workflowId, versionId) {
+				const version = await workflowHistoryService.getVersion(user, workflowId, versionId);
+
+				const updateData = workflowRepository.create({
+					nodes: version.nodes,
+					connections: version.connections,
+				} as Partial<WorkflowEntity>);
+
+				await workflowService.update(user, updateData, workflowId);
 			},
 		};
 	}

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -155,6 +155,11 @@ export class InstanceAiAdapterService {
 				'**Named workflow versions** — naming and describing workflow versions (update-workflow-version) is available on the Pro plan and above.',
 			);
 		}
+		if (!this.license.isLicensed('feat:folders')) {
+			hints.push(
+				'**Folders** — organizing workflows into folders (list-folders, create-folder, delete-folder, move-workflow-to-folder) is available on registered Community Edition or paid plans.',
+			);
+		}
 		return hints;
 	}
 
@@ -1376,54 +1381,58 @@ export class InstanceAiAdapterService {
 				}));
 			},
 
-			async listFolders(projectId: string): Promise<FolderSummary[]> {
-				const [folders] = await folderService.getManyAndCount(projectId, { take: 100 });
-				return (folders as Array<{ id: string; name: string; parentFolderId: string | null }>).map(
-					(f) => ({
-						id: f.id,
-						name: f.name,
-						parentFolderId: f.parentFolderId,
-					}),
-				);
-			},
+			...(this.license.isLicensed('feat:folders')
+				? {
+						async listFolders(projectId: string): Promise<FolderSummary[]> {
+							const [folders] = await folderService.getManyAndCount(projectId, { take: 100 });
+							return (
+								folders as Array<{ id: string; name: string; parentFolderId: string | null }>
+							).map((f) => ({
+								id: f.id,
+								name: f.name,
+								parentFolderId: f.parentFolderId,
+							}));
+						},
 
-			async createFolder(
-				name: string,
-				projectId: string,
-				parentFolderId?: string,
-			): Promise<FolderSummary> {
-				const folder = await folderService.createFolder(
-					{ name, parentFolderId: parentFolderId ?? undefined },
-					projectId,
-				);
-				return {
-					id: folder.id,
-					name: folder.name,
-					parentFolderId: folder.parentFolderId ?? null,
-				};
-			},
+						async createFolder(
+							name: string,
+							projectId: string,
+							parentFolderId?: string,
+						): Promise<FolderSummary> {
+							const folder = await folderService.createFolder(
+								{ name, parentFolderId: parentFolderId ?? undefined },
+								projectId,
+							);
+							return {
+								id: folder.id,
+								name: folder.name,
+								parentFolderId: folder.parentFolderId ?? null,
+							};
+						},
 
-			async deleteFolder(
-				folderId: string,
-				projectId: string,
-				transferToFolderId?: string,
-			): Promise<void> {
-				await folderService.deleteFolder(user, folderId, projectId, {
-					transferToFolderId: transferToFolderId ?? undefined,
-				});
-			},
+						async deleteFolder(
+							folderId: string,
+							projectId: string,
+							transferToFolderId?: string,
+						): Promise<void> {
+							await folderService.deleteFolder(user, folderId, projectId, {
+								transferToFolderId: transferToFolderId ?? undefined,
+							});
+						},
 
-			async moveWorkflowToFolder(workflowId: string, folderId: string): Promise<void> {
-				const workflow = await workflowFinderService.findWorkflowForUser(workflowId, user, [
-					'workflow:update',
-				]);
-				if (!workflow) {
-					throw new Error(`Workflow ${workflowId} not found or not accessible`);
-				}
-				await workflowService.update(user, workflow, workflowId, {
-					parentFolderId: folderId,
-				});
-			},
+						async moveWorkflowToFolder(workflowId: string, folderId: string): Promise<void> {
+							const workflow = await workflowFinderService.findWorkflowForUser(workflowId, user, [
+								'workflow:update',
+							]);
+							if (!workflow) {
+								throw new Error(`Workflow ${workflowId} not found or not accessible`);
+							}
+							await workflowService.update(user, workflow, workflowId, {
+								parentFolderId: folderId,
+							});
+						},
+					}
+				: {}),
 
 			async tagWorkflow(workflowId: string, tagNames: string[]): Promise<string[]> {
 				const workflow = await workflowFinderService.findWorkflowForUser(workflowId, user, [

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -84,6 +84,7 @@ import {
 import { ActiveExecutions } from '@/active-executions';
 import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
 import { CredentialsService } from '@/credentials/credentials.service';
+import { License } from '@/license';
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import { DataTableRepository } from '@/modules/data-table/data-table.repository';
 import { DataTableService } from '@/modules/data-table/data-table.service';
@@ -127,6 +128,7 @@ export class InstanceAiAdapterService {
 		private readonly sourceControlPreferencesService: SourceControlPreferencesService,
 		private readonly settingsService: InstanceAiSettingsService,
 		private readonly workflowHistoryService: WorkflowHistoryService,
+		private readonly license: License,
 	) {
 		this.allowSendingParameterValues = globalConfig.ai.allowSendingParameterValues;
 	}
@@ -414,6 +416,18 @@ export class InstanceAiAdapterService {
 
 				await workflowService.update(user, updateData, workflowId);
 			},
+
+			...(this.license.isLicensed('feat:namedVersions')
+				? {
+						async updateVersion(
+							workflowId: string,
+							versionId: string,
+							data: { name?: string | null; description?: string | null },
+						) {
+							await workflowHistoryService.updateVersionForUser(user, workflowId, versionId, data);
+						},
+					}
+				: {}),
 		};
 	}
 

--- a/packages/cli/src/workflows/workflow-history/workflow-history.service.ts
+++ b/packages/cli/src/workflows/workflow-history/workflow-history.service.ts
@@ -53,6 +53,7 @@ export class WorkflowHistoryService {
 				'updatedAt',
 				'name',
 				'description',
+				'autosaved',
 			],
 			relations: ['workflowPublishHistory'],
 			order: { createdAt: 'DESC' },

--- a/packages/cli/test/integration/workflow-history.api.test.ts
+++ b/packages/cli/test/integration/workflow-history.api.test.ts
@@ -78,6 +78,7 @@ describe('GET /workflow-history/:workflowId', () => {
 			description: last.description,
 			createdAt: last.createdAt.toISOString(),
 			updatedAt: last.updatedAt.toISOString(),
+			autosaved: last.autosaved,
 			workflowPublishHistory: last.workflowPublishHistory,
 		};
 
@@ -113,6 +114,7 @@ describe('GET /workflow-history/:workflowId', () => {
 			description: last.description,
 			createdAt: last.createdAt.toISOString(),
 			updatedAt: last.updatedAt.toISOString(),
+			autosaved: last.autosaved,
 			workflowPublishHistory: last.workflowPublishHistory,
 		};
 
@@ -143,6 +145,7 @@ describe('GET /workflow-history/:workflowId', () => {
 			description: last.description,
 			createdAt: last.createdAt.toISOString(),
 			updatedAt: last.updatedAt.toISOString(),
+			autosaved: last.autosaved,
 			workflowPublishHistory: last.workflowPublishHistory,
 		};
 
@@ -173,6 +176,7 @@ describe('GET /workflow-history/:workflowId', () => {
 			description: last.description,
 			createdAt: last.createdAt.toISOString(),
 			updatedAt: last.updatedAt.toISOString(),
+			autosaved: last.autosaved,
 			workflowPublishHistory: last.workflowPublishHistory,
 		};
 


### PR DESCRIPTION
## Summary

Followup to https://github.com/n8n-io/n8n/pull/27282, making it possible to manage workflow versions.
Since naming versions is a licensed feature added a mechanism to gate tools behind license, and added this on folder operations which are also licensed. AI gets information about licensed tools via `licenseHints` to its system prompt.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
