### PR TITLE
fix(core): Apply Postgres statement_timeout via SET, not startup param

### DIFF
--- a/packages/@n8n/db/src/connection/__tests__/db-connection-options.test.ts
+++ b/packages/@n8n/db/src/connection/__tests__/db-connection-options.test.ts
@@ -112,7 +112,6 @@ describe('DbConnectionOptions', () => {
 					poolSize: 2,
 					migrations: postgresMigrations,
 					connectTimeoutMS: 20000,
-					statementTimeout: 300_000,
 					ssl: false,
 					extra: {
 						idleTimeoutMillis: 30000,

--- a/packages/@n8n/db/src/connection/db-connection-options.ts
+++ b/packages/@n8n/db/src/connection/db-connection-options.ts
@@ -108,7 +108,6 @@ export class DbConnectionOptions {
 			poolSize: postgresConfig.poolSize,
 			migrations: postgresMigrations,
 			connectTimeoutMS: postgresConfig.connectionTimeoutMs,
-			statementTimeout: postgresConfig.statementTimeoutMs,
 			ssl,
 			extra: {
 				idleTimeoutMillis: postgresConfig.idleTimeoutMs,

--- a/packages/@n8n/db/src/connection/db-connection.ts
+++ b/packages/@n8n/db/src/connection/db-connection.ts
@@ -4,6 +4,7 @@ import { Time } from '@n8n/constants';
 import { Memoized } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
 import { DataSource } from '@n8n/typeorm';
+import { PostgresDriver } from '@n8n/typeorm/driver/postgres/PostgresDriver';
 import { ErrorReporter } from 'n8n-core';
 import { DbConnectionTimeoutError, ensureError, OperationalError } from 'n8n-workflow';
 import { setTimeout as setTimeoutP } from 'timers/promises';
@@ -66,8 +67,30 @@ export class DbConnection {
 			throw error;
 		}
 
+		this.setPostgresStatementTimeout();
+
 		connectionState.connected = true;
 		if (!inTest) this.scheduleNextPing();
+	}
+
+	/**
+	 * Sets `statement_timeout` on each new pool connection via `SET`.
+	 * Some PostgreSQL providers (e.g. AWS RDS Proxy) reject some
+	 * startup params, so we apply this after the conn is established.
+	 */
+	private setPostgresStatementTimeout() {
+		const { driver } = this.dataSource;
+		if (!(driver instanceof PostgresDriver)) return;
+
+		const timeoutMs = this.databaseConfig.postgresdb.statementTimeoutMs;
+		if (timeoutMs === 0) return;
+
+		const { master: pool } = driver;
+		if (!pool) return;
+
+		pool.on('connect', (client: { query: (sql: string) => void }) => {
+			client.query(`SET statement_timeout = ${timeoutMs}`);
+		});
 	}
 
 	async migrate() {


### PR DESCRIPTION
## Summary

Fixes Postgres `statement_timeout` breaking startup on AWS RDS Proxy and other providers that reject startup parameters The previous fix #25813 moved from `-c statement_timeout=n` to typeorm's native `statementTimeout` property, but both paths still end up in being passed via the `pg` driver.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/CAT-2645
- Closes #25705

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
