### PR TITLE
fix(instance-ai): persist thread delete and rename to backend

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -10,6 +10,8 @@ export { AiUsageSettingsRequestDto } from './ai/ai-usage-settings-request.dto';
 export { AiTruncateMessagesRequestDto } from './ai/ai-truncate-messages-request.dto';
 export { AiClearSessionRequestDto } from './ai/ai-clear-session-request.dto';
 
+export { InstanceAiRenameThreadRequestDto } from './instance-ai/instance-ai-rename-thread-request.dto';
+
 export { BinaryDataQueryDto } from './binary-data/binary-data-query.dto';
 export { BinaryDataSignedQueryDto } from './binary-data/binary-data-signed-query.dto';
 

--- a/packages/@n8n/api-types/src/dto/instance-ai/instance-ai-rename-thread-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/instance-ai/instance-ai-rename-thread-request.dto.ts
@@ -3,5 +3,5 @@ import { z } from 'zod';
 import { Z } from '../../zod-class';
 
 export class InstanceAiRenameThreadRequestDto extends Z.class({
-	title: z.string().trim().min(1),
+	title: z.string().trim().min(1).max(255),
 }) {}

--- a/packages/@n8n/api-types/src/dto/instance-ai/instance-ai-rename-thread-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/instance-ai/instance-ai-rename-thread-request.dto.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+
+export class InstanceAiRenameThreadRequestDto extends Z.class({
+	title: z.string().trim().min(1),
+}) {}

--- a/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
@@ -223,6 +223,33 @@ export class InstanceAiMemoryService {
 		return thread.resourceId === userId ? 'owned' : 'other_user';
 	}
 
+	async deleteThread(userId: string, threadId: string): Promise<void> {
+		const memory = this.createMemoryInstance();
+		const thread = await memory.getThreadById({ threadId });
+		if (!thread || thread.resourceId !== userId) {
+			throw new Error(`Thread ${threadId} not found or not owned by user ${userId}`);
+		}
+		await memory.deleteThread(threadId);
+	}
+
+	async renameThread(
+		userId: string,
+		threadId: string,
+		title: string,
+	): Promise<InstanceAiThreadInfo> {
+		const memory = this.createMemoryInstance();
+		const thread = await memory.getThreadById({ threadId });
+		if (!thread || thread.resourceId !== userId) {
+			throw new Error(`Thread ${threadId} not found or not owned by user ${userId}`);
+		}
+		const updated = await memory.updateThread({
+			id: threadId,
+			title,
+			metadata: thread.metadata ?? {},
+		});
+		return this.toThreadInfo(updated);
+	}
+
 	async getThreadMetadata(
 		userId: string,
 		threadId: string,

--- a/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
@@ -223,24 +223,20 @@ export class InstanceAiMemoryService {
 		return thread.resourceId === userId ? 'owned' : 'other_user';
 	}
 
-	async deleteThread(userId: string, threadId: string): Promise<void> {
+	async deleteThread(_userId: string, threadId: string): Promise<void> {
 		const memory = this.createMemoryInstance();
-		const thread = await memory.getThreadById({ threadId });
-		if (!thread || thread.resourceId !== userId) {
-			throw new Error(`Thread ${threadId} not found or not owned by user ${userId}`);
-		}
 		await memory.deleteThread(threadId);
 	}
 
 	async renameThread(
-		userId: string,
+		_userId: string,
 		threadId: string,
 		title: string,
 	): Promise<InstanceAiThreadInfo> {
 		const memory = this.createMemoryInstance();
 		const thread = await memory.getThreadById({ threadId });
-		if (!thread || thread.resourceId !== userId) {
-			throw new Error(`Thread ${threadId} not found or not owned by user ${userId}`);
+		if (!thread) {
+			throw new Error(`Thread ${threadId} not found`);
 		}
 		const updated = await memory.updateThread({
 			id: threadId,

--- a/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
@@ -12,6 +12,8 @@ import type {
 	InstanceAiThreadInfo,
 } from '@n8n/api-types';
 
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+
 import { AgentTreeSnapshotStorage } from './agent-tree-snapshot';
 import { parseStoredMessages } from './message-parser';
 import type { MastraDBMessage } from './message-parser';
@@ -236,7 +238,7 @@ export class InstanceAiMemoryService {
 		const memory = this.createMemoryInstance();
 		const thread = await memory.getThreadById({ threadId });
 		if (!thread) {
-			throw new Error(`Thread ${threadId} not found`);
+			throw new NotFoundError(`Thread ${threadId} not found`);
 		}
 		const updated = await memory.updateThread({
 			id: threadId,

--- a/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
@@ -10,7 +10,7 @@ import {
 import { ModuleRegistry } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { AuthenticatedRequest } from '@n8n/db';
-import { RestController, Get, Post, Put, Param } from '@n8n/decorators';
+import { RestController, Get, Post, Put, Patch, Delete, Param } from '@n8n/decorators';
 import type { StoredEvent } from '@n8n/instance-ai';
 import type { Request, Response } from 'express';
 import { randomUUID, timingSafeEqual } from 'node:crypto';
@@ -337,6 +337,31 @@ export class InstanceAiController {
 
 		await this.assertThreadAccess(req.user.id, requestedThreadId, { allowNew: true });
 		return await this.memoryService.ensureThread(req.user.id, requestedThreadId);
+	}
+
+	@Delete('/threads/:threadId')
+	async deleteThread(
+		req: AuthenticatedRequest,
+		_res: Response,
+		@Param('threadId') threadId: string,
+	) {
+		await this.assertThreadAccess(req.user.id, threadId);
+		await this.memoryService.deleteThread(req.user.id, threadId);
+		return { ok: true };
+	}
+
+	@Patch('/threads/:threadId')
+	async renameThread(
+		req: AuthenticatedRequest,
+		_res: Response,
+		@Param('threadId') threadId: string,
+	) {
+		const { title } = req.body as { title?: string };
+		if (typeof title !== 'string' || !title.trim()) {
+			throw new BadRequestError('Title is required');
+		}
+		const thread = await this.memoryService.renameThread(req.user.id, threadId, title.trim());
+		return { thread };
 	}
 
 	@Get('/threads/:threadId/messages')

--- a/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
@@ -6,11 +6,12 @@ import type {
 import {
 	instanceAiGatewayCapabilitiesSchema,
 	instanceAiFilesystemResponseSchema,
+	InstanceAiRenameThreadRequestDto,
 } from '@n8n/api-types';
 import { ModuleRegistry } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { AuthenticatedRequest } from '@n8n/db';
-import { RestController, Get, Post, Put, Patch, Delete, Param } from '@n8n/decorators';
+import { RestController, Get, Post, Put, Patch, Delete, Param, Body } from '@n8n/decorators';
 import type { StoredEvent } from '@n8n/instance-ai';
 import type { Request, Response } from 'express';
 import { randomUUID, timingSafeEqual } from 'node:crypto';
@@ -355,12 +356,10 @@ export class InstanceAiController {
 		req: AuthenticatedRequest,
 		_res: Response,
 		@Param('threadId') threadId: string,
+		@Body payload: InstanceAiRenameThreadRequestDto,
 	) {
-		const { title } = req.body as { title?: string };
-		if (typeof title !== 'string' || !title.trim()) {
-			throw new BadRequestError('Title is required');
-		}
-		const thread = await this.memoryService.renameThread(req.user.id, threadId, title.trim());
+		await this.assertThreadAccess(req.user.id, threadId);
+		const thread = await this.memoryService.renameThread(req.user.id, threadId, payload.title);
 		return { thread };
 	}
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAi.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAi.store.test.ts
@@ -58,6 +58,8 @@ vi.mock('../instanceAi.memory.api', () => ({
 	fetchThreadStatus: vi
 		.fn()
 		.mockResolvedValue({ hasActiveRun: false, isSuspended: false, backgroundTasks: [] }),
+	deleteThread: vi.fn().mockResolvedValue(undefined),
+	renameThread: vi.fn().mockResolvedValue({ thread: {} }),
 }));
 
 // Mock EventSource globally
@@ -307,7 +309,7 @@ describe('useInstanceAiStore - onSSEMessage', () => {
 			}),
 		);
 
-		store.deleteThread(deletedThreadId);
+		await store.deleteThread(deletedThreadId);
 
 		await vi.waitFor(() => {
 			expect(capturedInstance).not.toBe(previousEventSource);

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiThreadList.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiThreadList.vue
@@ -77,10 +77,13 @@ function startRename(threadId: string, currentTitle: string) {
 
 async function confirmRename(threadId: string) {
 	const title = editingTitle.value.trim();
-	if (title && title !== store.threads.find((t) => t.id === threadId)?.title) {
-		await store.renameThread(threadId, title);
+	try {
+		if (title && title !== store.threads.find((t) => t.id === threadId)?.title) {
+			await store.renameThread(threadId, title);
+		}
+	} finally {
+		editingThreadId.value = null;
 	}
-	editingThreadId.value = null;
 }
 
 function cancelRename() {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiThreadList.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiThreadList.vue
@@ -60,8 +60,8 @@ function handleNewThread() {
 	void router.push({ name: INSTANCE_AI_THREAD_VIEW, params: { threadId } });
 }
 
-function handleDeleteThread(threadId: string) {
-	const { wasActive } = store.deleteThread(threadId);
+async function handleDeleteThread(threadId: string) {
+	const { wasActive } = await store.deleteThread(threadId);
 	if (wasActive) {
 		void router.push({
 			name: INSTANCE_AI_THREAD_VIEW,
@@ -75,10 +75,10 @@ function startRename(threadId: string, currentTitle: string) {
 	editingTitle.value = currentTitle;
 }
 
-function confirmRename(threadId: string) {
+async function confirmRename(threadId: string) {
 	const title = editingTitle.value.trim();
 	if (title && title !== store.threads.find((t) => t.id === threadId)?.title) {
-		store.renameThread(threadId, title);
+		await store.renameThread(threadId, title);
 	}
 	editingThreadId.value = null;
 }
@@ -89,7 +89,7 @@ function cancelRename() {
 
 function handleThreadAction(action: string, threadId: string) {
 	if (action === 'delete') {
-		handleDeleteThread(threadId);
+		void handleDeleteThread(threadId);
 	} else if (action === 'rename') {
 		const thread = store.threads.find((t) => t.id === threadId);
 		if (thread) {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.memory.api.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.memory.api.ts
@@ -1,6 +1,7 @@
 import { makeRestApiRequest } from '@n8n/rest-api-client';
 import type { IRestApiContext } from '@n8n/rest-api-client';
 import type {
+	InstanceAiThreadInfo,
 	InstanceAiThreadListResponse,
 	InstanceAiThreadContextResponse,
 	InstanceAiRichMessagesResponse,
@@ -26,6 +27,20 @@ export async function fetchThreads(
 	context: IRestApiContext,
 ): Promise<InstanceAiThreadListResponse> {
 	return await makeRestApiRequest(context, 'GET', '/instance-ai/threads');
+}
+
+export async function deleteThread(context: IRestApiContext, threadId: string): Promise<void> {
+	await makeRestApiRequest(context, 'DELETE', `/instance-ai/threads/${threadId}`);
+}
+
+export async function renameThread(
+	context: IRestApiContext,
+	threadId: string,
+	title: string,
+): Promise<{ thread: InstanceAiThreadInfo }> {
+	return await makeRestApiRequest(context, 'PATCH', `/instance-ai/threads/${threadId}`, {
+		title,
+	});
 }
 
 export async function fetchThreadMessages(

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.store.ts
@@ -351,8 +351,13 @@ export const useInstanceAiStore = defineStore('instanceAi', () => {
 
 		// Only call API for threads that have been persisted to the backend
 		if (persistedThreadIds.has(threadId)) {
-			await deleteThreadApi(rootStore.restApiContext, threadId);
-			persistedThreadIds.delete(threadId);
+			try {
+				await deleteThreadApi(rootStore.restApiContext, threadId);
+				persistedThreadIds.delete(threadId);
+			} catch {
+				toast.showError(new Error('Failed to delete thread. Try again.'), 'Delete failed');
+				return { currentThreadId: currentThreadId.value, wasActive };
+			}
 		}
 
 		// Remove thread from list

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.store.ts
@@ -19,6 +19,8 @@ import {
 	fetchThreads as fetchThreadsApi,
 	fetchThreadMessages as fetchThreadMessagesApi,
 	fetchThreadStatus as fetchThreadStatusApi,
+	deleteThread as deleteThreadApi,
+	renameThread as renameThreadApi,
 } from './instanceAi.memory.api';
 import { handleEvent as reduceEvent, rebuildRunStateFromTree } from './instanceAi.reducer';
 import { useResourceRegistry } from './useResourceRegistry';
@@ -342,8 +344,16 @@ export const useInstanceAiStore = defineStore('instanceAi', () => {
 		return newThreadId;
 	}
 
-	function deleteThread(threadId: string): { currentThreadId: string; wasActive: boolean } {
+	async function deleteThread(
+		threadId: string,
+	): Promise<{ currentThreadId: string; wasActive: boolean }> {
 		const wasActive = threadId === currentThreadId.value;
+
+		// Only call API for threads that have been persisted to the backend
+		if (persistedThreadIds.has(threadId)) {
+			await deleteThreadApi(rootStore.restApiContext, threadId);
+			persistedThreadIds.delete(threadId);
+		}
 
 		// Remove thread from list
 		threads.value = threads.value.filter((t) => t.id !== threadId);
@@ -685,10 +695,15 @@ export const useInstanceAiStore = defineStore('instanceAi', () => {
 		);
 	}
 
-	function renameThread(threadId: string, title: string): void {
+	async function renameThread(threadId: string, title: string): Promise<void> {
 		const thread = threads.value.find((t) => t.id === threadId);
 		if (thread) {
 			thread.title = title;
+		}
+
+		// Only call API for threads that have been persisted to the backend
+		if (persistedThreadIds.has(threadId)) {
+			await renameThreadApi(rootStore.restApiContext, threadId, title);
 		}
 	}
 


### PR DESCRIPTION
## Summary
![Kapture 2026-03-19 at 18 07 46](https://github.com/user-attachments/assets/86041cda-301c-4d5a-85bc-63d620ff4bd6)

- Thread deletion and renaming in Instance AI were purely client-side (in-memory Pinia state only), so changes were lost on page refresh
- Added `DELETE` and `PATCH /instance-ai/threads/:threadId` backend endpoints
- Wired frontend store actions to call the API before updating local state

## Linear ticket
https://linear.app/n8n/issue/AI-2240/instance-ai-thread-delete-and-rename-not-persisted-to-backend

## Test plan
- [ ] Delete a thread → refresh page → thread should stay deleted
- [ ] Rename a thread → refresh page → new title should persist
- [ ] Delete the last/active thread → a new empty thread should be created
- [ ] Deleting a thread that hasn't been persisted yet (no messages sent) should not call the API