### PR TITLE
refactor(instance-ai): Simplify builder working memory template (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/docs/memory.md
+++ b/packages/@n8n/instance-ai/docs/memory.md
@@ -164,7 +164,7 @@ Memory-enabled sub-agent roles get their own Mastra working memory:
 
 | Role | Resource ID | Template Focus |
 |------|-------------|---------------|
-| `workflow-builder` | `{userId}:workflow-builder` | Credential mappings, node gotchas, error patterns, conventions |
+| `workflow-builder` | `{userId}:workflow-builder` | User preferences, instance-specific credential disambiguation and quirks |
 | `execution-debugger` | `{userId}:execution-debugger` | Failure patterns, auth issues, environment quirks |
 | `data-table-manager` | `{userId}:data-table-manager` | Table inventory, schema patterns, query patterns |
 

--- a/packages/@n8n/instance-ai/src/memory/__tests__/sub-agent-memory-templates.test.ts
+++ b/packages/@n8n/instance-ai/src/memory/__tests__/sub-agent-memory-templates.test.ts
@@ -43,12 +43,17 @@ describe('MEMORY_ENABLED_ROLES', () => {
 
 describe('template content', () => {
 	it('builder template has key sections', () => {
-		expect(BUILDER_MEMORY_TEMPLATE).toContain('# Credential Map');
-		expect(BUILDER_MEMORY_TEMPLATE).toContain('# Node Gotchas');
-		expect(BUILDER_MEMORY_TEMPLATE).toContain('# Workflow Topology');
-		expect(BUILDER_MEMORY_TEMPLATE).toContain('# Recurring Errors & Fixes');
-		expect(BUILDER_MEMORY_TEMPLATE).toContain('# User Conventions');
-		expect(BUILDER_MEMORY_TEMPLATE).toContain('# SDK & Build Patterns');
+		expect(BUILDER_MEMORY_TEMPLATE).toContain('# User Preferences');
+		expect(BUILDER_MEMORY_TEMPLATE).toContain('# Instance Knowledge');
+	});
+
+	it('builder template does not contain removed sections', () => {
+		expect(BUILDER_MEMORY_TEMPLATE).not.toContain('# Credential Map');
+		expect(BUILDER_MEMORY_TEMPLATE).not.toContain('# Node Gotchas');
+		expect(BUILDER_MEMORY_TEMPLATE).not.toContain('# Workflow Topology');
+		expect(BUILDER_MEMORY_TEMPLATE).not.toContain('# SDK & Build Patterns');
+		expect(BUILDER_MEMORY_TEMPLATE).not.toContain('# Recurring Errors & Fixes');
+		expect(BUILDER_MEMORY_TEMPLATE).not.toContain('# User Conventions');
 	});
 
 	it('debugger template has key sections', () => {

--- a/packages/@n8n/instance-ai/src/memory/sub-agent-memory-templates.ts
+++ b/packages/@n8n/instance-ai/src/memory/sub-agent-memory-templates.ts
@@ -15,31 +15,18 @@
 // ── Builder ──────────────────────────────────────────────────────────────────
 
 export const BUILDER_MEMORY_TEMPLATE = `
-# Credential Map
-Track every credential the user has and what it unlocks.
-- **credential name → type, services, quirks**:
+# User Preferences
+Style and convention choices that affect how workflows are built.
+- **naming**:
+- **default trigger**:
+- **structure**:
+- **other**:
 
-# Node Gotchas
-Hard-won lessons about specific node configurations.
-- **node type → pitfall / required setting / version quirk**:
-
-# Workflow Topology
-Key workflows and how they relate to each other.
-- **workflow name (ID) → purpose, triggers, dependencies**:
-
-# Recurring Errors & Fixes
-Patterns that keep coming up — record the fix once, apply forever.
-- **error signature → root cause → fix**:
-
-# User Conventions
-Naming patterns, preferred structures, team standards.
-- **naming**: (e.g. kebab-case, prefix with team name)
-- **structure**: (e.g. always Error Trigger → Slack alert)
-- **preferred nodes**: (e.g. HTTP Request over vendor nodes)
-
-# SDK & Build Patterns
-Reusable code patterns discovered during builds.
-- **pattern → code snippet or approach**:
+# Instance Knowledge
+Facts specific to this user's environment, not derivable from tools or schemas.
+- **credential disambiguation**: (when multiple credentials of same type exist, which to prefer)
+- **node runtime quirks**: (issues unique to this instance's data/setup, not in schema)
+- **recurring failures**: (stable instance-specific failures worth remembering)
 `;
 
 // ── Debugger ─────────────────────────────────────────────────────────────────

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.prompt.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.prompt.ts
@@ -514,6 +514,23 @@ Do NOT produce visible output until step 4. All reasoning happens internally.
 - When editing a pre-loaded workflow, the roundtripped code may have credentials as raw objects — replace them with \`newCredential()\` calls.
 - Unresolved credentials (where the user chose mock data or no credential is available) will be automatically mocked via pinned data at submit time. Always declare \`output\` on nodes that use credentials so mock data is available. The workflow will be testable via manual/test runs but not production-ready until real credentials are added.
 
+## Working Memory
+Your working memory persists across conversations. Update it ONLY for:
+- User style preferences (naming conventions, preferred triggers, structure patterns)
+- Credential disambiguation (when multiple credentials of the same type exist, which one the user prefers)
+- Node runtime quirks unique to this instance (NOT generic node docs — those are in get-node-type-definition)
+- Recurring instance-specific failures worth remembering
+
+Do NOT store:
+- Credential inventories (use list-credentials tool)
+- Workflow catalogs or IDs (use list-workflows or get-workflow-as-code tools)
+- SDK patterns or code snippets (already in your prompt)
+- Node schema details or parameter docs (use get-node-type-definition)
+- Generic best practices or build recipes
+
+Keep entries short (one bullet each). Remove stale entries when updating.
+If your memory contains sections not in the current template, discard them and retain only matching facts.
+
 ${SDK_RULES_AND_PATTERNS}
 `;
 
@@ -799,6 +816,23 @@ When modifying an existing workflow, the current code is **already pre-loaded** 
 - Edit using \`edit_file\` for targeted changes or \`write_file\` for full rewrites (always use absolute paths)
 - Run tsc → submit-workflow with the \`workflowId\`
 - Do NOT call \`get-workflow-as-code\` — the file is already populated
+
+## Working Memory
+Your working memory persists across conversations. Update it ONLY for:
+- User style preferences (naming conventions, preferred triggers, structure patterns)
+- Credential disambiguation (when multiple credentials of the same type exist, which one the user prefers)
+- Node runtime quirks unique to this instance (NOT generic node docs — those are in get-node-type-definition)
+- Recurring instance-specific failures worth remembering
+
+Do NOT store:
+- Credential inventories (use list-credentials tool)
+- Workflow catalogs or IDs (use list-workflows or get-workflow-as-code tools)
+- SDK patterns or code snippets (already in your prompt)
+- Node schema details or parameter docs (use get-node-type-definition)
+- Generic best practices or build recipes
+
+Keep entries short (one bullet each). Remove stale entries when updating.
+If your memory contains sections not in the current template, discard them and retain only matching facts.
 
 ${SDK_RULES_AND_PATTERNS}
 `;

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
@@ -140,6 +140,8 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 					'get-workflow-as-code',
 					'get-node-type-definition',
 					'explore-node-resources',
+					// Workflow discovery
+					'list-workflows',
 					// Credential awareness
 					'list-credentials',
 					'test-credential',
@@ -173,6 +175,7 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 					'build-workflow',
 					'get-node-type-definition',
 					'get-workflow-as-code',
+					'list-workflows',
 					'search-nodes',
 					'get-suggested-nodes',
 					// Data table management


### PR DESCRIPTION
## Summary

Replace the 6-section builder working memory template with a compact 2-section preference-oriented template, add admission rules to builder prompts, and give the builder a `list-workflows` tool for runtime workflow discovery.

### Problem

A live audit of an active user's builder memory showed **15,324 chars across 81 lines**, with **8,894 chars (58%)** from `Workflow Topology` and `SDK & Build Patterns` — both fully redundant with runtime tools and prompt injections. This bloated memory:
- Adds **~4-5K redundant tokens** to every builder invocation (injected via Mastra working memory)
- Causes **~50s latency** on `updateWorkingMemory` calls as the LLM reads, reasons about, and regenerates 15K chars of content
- Reduces prompt cache hit rate (bloated memory changes more often, invalidating Anthropic's ephemeral cache)
- Stores stale data (workflow IDs, credential inventories become outdated between invocations)

### Why each section is redundant

| Removed Section | Already covered by | Why memory is the wrong place |
|---|---|---|
| **Credential Map** | `buildCredentialMap()` builds a fresh map at the start of every builder invocation. `list-credentials` tool queries on demand. | Memory stores a stale snapshot — credentials can be added/removed/renamed between invocations, making the cached map misleading. |
| **Node Gotchas** | `@builderHint` annotations in `search-nodes` and `get-node-type-definition` deliver context-specific guidance inline with the node schema. Validation error enhancers catch misconfigurations at build time. | Generic node docs in memory duplicate what's already in the schema. The agent was storing code snippets and parameter docs that are always available via tools. |
| **Workflow Topology** | `get-workflow-as-code` fetches any workflow's current code on demand. In sandbox mode, existing workflows are pre-loaded as JSON files. | Memory was acting as a historical workflow catalog (names, IDs, purposes). Goes stale the moment a workflow is renamed, deleted, or modified. Adding `list-workflows` to the builder's tool set covers runtime discovery. |
| **SDK & Build Patterns** | `SDK_RULES_AND_PATTERNS` — a 469-line block with all SDK rules, code patterns, expression reference, and critical patterns — is injected into the builder's system prompt on every single invocation. | The agent was duplicating SDK snippets from its own prompt into memory. Pure waste — the patterns are literally already in the same context window. |
| **Recurring Errors & Fixes** | Generic build mistakes are covered by prompt rules, `@builderHint` annotations, and validation error enhancers. | Most entries were generic ("always use `newCredential()` not raw objects") rather than instance-specific. These belong in prompts, not per-user long-term memory. |
| **User Conventions** | Nothing — this is the one section that stores genuinely non-discoverable, user-specific facts. | Renamed to **User Preferences** with clearer sub-slots (naming, default trigger, structure, other). |

### Changes

- **Template**: 6 sections → 2 sections (`User Preferences` + `Instance Knowledge`). Only stores what can't be discovered at runtime.
- **Prompts**: Added `## Working Memory` admission rules to both `BUILDER_AGENT_PROMPT` and `SANDBOX_BUILDER_AGENT_PROMPT` — explicit DO/DO NOT store guidance
- **Tools**: Added `list-workflows` to both sandbox and tool mode builder tool sets (replaces persisted workflow catalog)
- **Migration**: Last line of admission rules handles existing users: "If your memory contains sections not in the current template, discard them and retain only matching facts"
- **Tests**: Updated assertions + regression guards for removed sections

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2241
