### PR TITLE
fix(core): Fix IDOR in test-runs endpoint by consolidating access checks

### DIFF
--- a/packages/cli/src/evaluation.ee/__tests__/test-runs.controller.ee.test.ts
+++ b/packages/cli/src/evaluation.ee/__tests__/test-runs.controller.ee.test.ts
@@ -3,12 +3,10 @@ import type { TestCaseExecutionRepository, TestRun, TestRunRepository, User } fr
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import type { TestRunnerService } from '@/evaluation.ee/test-runner/test-runner.service.ee';
 import { TestRunsController } from '@/evaluation.ee/test-runs.controller.ee';
-import { getSharedWorkflowIds } from '@/public-api/v1/handlers/workflows/workflows.service';
+import type { TestRunsRequest } from '@/evaluation.ee/test-runs.types.ee';
 import type { Telemetry } from '@/telemetry';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
-// Mock dependencies
-jest.mock('@/public-api/v1/handlers/workflows/workflows.service');
 jest.mock('@/evaluation.ee/test-runner/test-runner.service.ee');
 
 describe('TestRunsController', () => {
@@ -18,13 +16,11 @@ describe('TestRunsController', () => {
 	let mockTestCaseExecutionRepository: jest.Mocked<TestCaseExecutionRepository>;
 	let mockTestRunnerService: jest.Mocked<TestRunnerService>;
 	let mockTelemetry: jest.Mocked<Telemetry>;
-	let mockGetSharedWorkflowIds: jest.MockedFunction<typeof getSharedWorkflowIds>;
 	let mockUser: User;
 	let mockWorkflowId: string;
 	let mockTestRunId: string;
 
 	beforeEach(() => {
-		// Setup mocks
 		mockTestRunRepository = {
 			findOne: jest.fn(),
 			getMany: jest.fn(),
@@ -51,11 +47,6 @@ describe('TestRunsController', () => {
 			track: jest.fn(),
 		} as unknown as jest.Mocked<Telemetry>;
 
-		mockGetSharedWorkflowIds = getSharedWorkflowIds as jest.MockedFunction<
-			typeof getSharedWorkflowIds
-		>;
-
-		// Create test instance
 		testRunsController = new TestRunsController(
 			mockTestRunRepository,
 			mockWorkflowFinderService,
@@ -64,13 +55,12 @@ describe('TestRunsController', () => {
 			mockTelemetry,
 		);
 
-		// Common test data
 		mockUser = { id: 'user123' } as User;
 		mockWorkflowId = 'workflow123';
 		mockTestRunId = 'testrun123';
 
-		// Default mock behavior
-		mockGetSharedWorkflowIds.mockResolvedValue([mockWorkflowId]);
+		// Default: user has access to the workflow
+		mockWorkflowFinderService.findWorkflowForUser.mockResolvedValue({ id: mockWorkflowId } as any);
 		mockTestRunRepository.findOne.mockResolvedValue({
 			id: mockTestRunId,
 			status: 'running',
@@ -81,25 +71,61 @@ describe('TestRunsController', () => {
 		jest.clearAllMocks();
 	});
 
+	describe('getMany', () => {
+		it('should return test runs when user has access to the workflow', async () => {
+			const mockResult = [{ id: 'run1' }];
+			mockTestRunRepository.getMany.mockResolvedValue(mockResult as any);
+
+			const req = {
+				params: { workflowId: mockWorkflowId },
+				user: mockUser,
+				listQueryOptions: {},
+			} as unknown as TestRunsRequest.GetMany;
+
+			const result = await testRunsController.getMany(req);
+
+			expect(mockWorkflowFinderService.findWorkflowForUser).toHaveBeenCalledWith(
+				mockWorkflowId,
+				mockUser,
+				['workflow:read'],
+			);
+			expect(mockTestRunRepository.getMany).toHaveBeenCalledWith(mockWorkflowId, {});
+			expect(result).toEqual(mockResult);
+		});
+
+		it('should throw NotFoundError when user has no access to workflow', async () => {
+			mockWorkflowFinderService.findWorkflowForUser.mockResolvedValue(null);
+
+			const req = {
+				params: { workflowId: mockWorkflowId },
+				user: mockUser,
+				listQueryOptions: {},
+			} as unknown as TestRunsRequest.GetMany;
+
+			await expect(testRunsController.getMany(req)).rejects.toThrow(NotFoundError);
+			expect(mockTestRunRepository.getMany).not.toHaveBeenCalled();
+		});
+	});
+
 	describe('getTestRun', () => {
 		it('should return test run when it exists and user has access', async () => {
-			// Arrange
 			const mockTestRun = {
 				id: mockTestRunId,
 				status: 'running',
 			} as TestRun;
-			mockGetSharedWorkflowIds.mockResolvedValue([mockWorkflowId]);
 			mockTestRunRepository.findOne.mockResolvedValue(mockTestRun);
 
-			// Act
 			const result = await (testRunsController as any).getTestRun(
 				mockTestRunId,
 				mockWorkflowId,
 				mockUser,
 			);
 
-			// Assert
-			expect(mockGetSharedWorkflowIds).toHaveBeenCalledWith(mockUser, ['workflow:read']);
+			expect(mockWorkflowFinderService.findWorkflowForUser).toHaveBeenCalledWith(
+				mockWorkflowId,
+				mockUser,
+				['workflow:read'],
+			);
 			expect(mockTestRunRepository.findOne).toHaveBeenCalledWith({
 				where: { id: mockTestRunId },
 			});
@@ -107,39 +133,25 @@ describe('TestRunsController', () => {
 		});
 
 		it('should throw NotFoundError when user has no access to workflow', async () => {
-			// Arrange
-			mockGetSharedWorkflowIds.mockResolvedValue([]); // No access to any workflow
+			mockWorkflowFinderService.findWorkflowForUser.mockResolvedValue(null);
 
-			// Act & Assert
 			await expect(
 				(testRunsController as any).getTestRun(mockTestRunId, mockWorkflowId, mockUser),
 			).rejects.toThrow(NotFoundError);
-			expect(mockGetSharedWorkflowIds).toHaveBeenCalledWith(mockUser, ['workflow:read']);
-			expect(mockTestRunRepository.findOne).not.toHaveBeenCalled();
-		});
-
-		it('should throw NotFoundError when workflowId does not match any shared workflows', async () => {
-			// Arrange
-			mockGetSharedWorkflowIds.mockResolvedValue(['different-workflow-id']);
-
-			// Act & Assert
-			await expect(
-				(testRunsController as any).getTestRun(mockTestRunId, mockWorkflowId, mockUser),
-			).rejects.toThrow(NotFoundError);
-			expect(mockGetSharedWorkflowIds).toHaveBeenCalledWith(mockUser, ['workflow:read']);
 			expect(mockTestRunRepository.findOne).not.toHaveBeenCalled();
 		});
 
 		it('should throw NotFoundError when test run does not exist', async () => {
-			// Arrange
-			mockGetSharedWorkflowIds.mockResolvedValue([mockWorkflowId]);
-			mockTestRunRepository.findOne.mockResolvedValue(null); // Test run not found
+			mockTestRunRepository.findOne.mockResolvedValue(null);
 
-			// Act & Assert
 			await expect(
 				(testRunsController as any).getTestRun(mockTestRunId, mockWorkflowId, mockUser),
 			).rejects.toThrow(NotFoundError);
-			expect(mockGetSharedWorkflowIds).toHaveBeenCalledWith(mockUser, ['workflow:read']);
+			expect(mockWorkflowFinderService.findWorkflowForUser).toHaveBeenCalledWith(
+				mockWorkflowId,
+				mockUser,
+				['workflow:read'],
+			);
 			expect(mockTestRunRepository.findOne).toHaveBeenCalledWith({
 				where: { id: mockTestRunId },
 			});

--- a/packages/cli/src/evaluation.ee/test-runs.controller.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runs.controller.ee.ts
@@ -9,7 +9,6 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { TestRunnerService } from '@/evaluation.ee/test-runner/test-runner.service.ee';
 import { TestRunsRequest } from '@/evaluation.ee/test-runs.types.ee';
 import { listQueryMiddleware } from '@/middlewares';
-import { getSharedWorkflowIds } from '@/public-api/v1/handlers/workflows/workflows.service';
 import { Telemetry } from '@/telemetry';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
@@ -23,15 +22,21 @@ export class TestRunsController {
 		private readonly telemetry: Telemetry,
 	) {}
 
+	private async assertUserHasAccessToWorkflow(workflowId: string, user: User) {
+		const workflow = await this.workflowFinderService.findWorkflowForUser(workflowId, user, [
+			'workflow:read',
+		]);
+
+		if (!workflow) {
+			throw new NotFoundError('Workflow not found');
+		}
+	}
+
 	/**
 	 * Get the test run (or just check that it exists and the user has access to it)
 	 */
 	private async getTestRun(testRunId: string, workflowId: string, user: User) {
-		const sharedWorkflowsIds = await getSharedWorkflowIds(user, ['workflow:read']);
-
-		if (!sharedWorkflowsIds.includes(workflowId)) {
-			throw new NotFoundError('Test run not found');
-		}
+		await this.assertUserHasAccessToWorkflow(workflowId, user);
 
 		const testRun = await this.testRunRepository.findOne({
 			where: { id: testRunId },
@@ -45,6 +50,8 @@ export class TestRunsController {
 	@Get('/:workflowId/test-runs', { middlewares: listQueryMiddleware })
 	async getMany(req: TestRunsRequest.GetMany) {
 		const { workflowId } = req.params;
+
+		await this.assertUserHasAccessToWorkflow(workflowId, req.user);
 
 		return await this.testRunRepository.getMany(workflowId, req.listQueryOptions);
 	}
@@ -106,20 +113,11 @@ export class TestRunsController {
 	async create(req: TestRunsRequest.Create, res: express.Response) {
 		const { workflowId } = req.params;
 
-		const workflow = await this.workflowFinderService.findWorkflowForUser(workflowId, req.user, [
-			'workflow:read',
-		]);
-
-		if (!workflow) {
-			// user trying to access a workflow they do not own
-			// and was not shared to them
-			// Or does not exist.
-			return res.status(404).json({ message: 'Not Found' });
-		}
+		await this.assertUserHasAccessToWorkflow(workflowId, req.user);
 
 		// We do not await for the test run to complete
-		void this.testRunnerService.runTest(req.user, workflow.id);
+		void this.testRunnerService.runTest(req.user, workflowId);
 
-		return res.status(202).json({ success: true });
+		res.status(202).json({ success: true });
 	}
 }

--- a/packages/cli/test/integration/evaluation/test-runs.api.test.ts
+++ b/packages/cli/test/integration/evaluation/test-runs.api.test.ts
@@ -51,17 +51,10 @@ describe('GET /workflows/:workflowId/test-runs', () => {
 		expect(resp.body.data).toEqual([]);
 	});
 
-	// TODO: replace with non existent workflow
-	// test('should return 404 if test definition does not exist', async () => {
-	// 	const resp = await authOwnerAgent.get('/evaluation/test-definitions/123/runs');
-	//
-	// 	expect(resp.statusCode).toBe(404);
-	// });
-
 	test('should return 404 if user does not have access to workflow', async () => {
-		const testRun = await testRunRepository.createTestRun(otherWorkflow.id);
+		await testRunRepository.createTestRun(otherWorkflow.id);
 
-		const resp = await authOwnerAgent.get(`/workflows/${otherWorkflow.id}/test-runs/${testRun.id}`);
+		const resp = await authOwnerAgent.get(`/workflows/${otherWorkflow.id}/test-runs`);
 
 		expect(resp.statusCode).toBe(404);
 	});
@@ -275,6 +268,31 @@ describe('POST /workflows/:workflowId/test-runs/:id/cancel', () => {
 		const resp = await authOwnerAgent.post(
 			`/workflows/${otherWorkflow.id}/test-runs/${testRun.id}/cancel`,
 		);
+
+		expect(resp.statusCode).toBe(404);
+	});
+});
+
+describe('POST /workflows/:workflowId/test-runs/new', () => {
+	test('should create a test run for a workflow the user owns', async () => {
+		const resp = await authOwnerAgent.post(`/workflows/${workflowUnderTest.id}/test-runs/new`);
+
+		expect(resp.statusCode).toBe(202);
+		expect(resp.body).toEqual({ success: true });
+		expect(testRunner.runTest).toHaveBeenCalledWith(
+			expect.objectContaining({ id: ownerShell.id }),
+			workflowUnderTest.id,
+		);
+	});
+
+	test('should return 404 if user does not have access to workflow', async () => {
+		const resp = await authOwnerAgent.post(`/workflows/${otherWorkflow.id}/test-runs/new`);
+
+		expect(resp.statusCode).toBe(404);
+	});
+
+	test('should return 404 if workflow does not exist', async () => {
+		const resp = await authOwnerAgent.post('/workflows/non-existent-id/test-runs/new');
 
 		expect(resp.statusCode).toBe(404);
 	});


### PR DESCRIPTION
## Summary

Fixed an IDOR (Insecure Direct Object Reference) vulnerability in the test-runs endpoint by consolidating workflow access checks using `WorkflowFinderService.findWorkflowForUser`. Previously, different endpoint handlers used inconsistent authorization logic (`getSharedWorkflowIds` vs direct checks), allowing attackers to potentially access test runs for workflows they don't have permission to view.

**Changes:**
- Introduced `assertUserHasAccessToWorkflow` helper method to ensure consistent access control across all endpoints
- Replaced `getSharedWorkflowIds` usage with `WorkflowFinderService.findWorkflowForUser` in all handlers (getMany, getTestRun, create)
- Removed duplicate authorization logic in the `create` endpoint

**Tests:**
- Added unit tests for `getMany` endpoint access control
- Added integration tests for `POST /test-runs/new` endpoint, including IDOR prevention test
- All 24 integration tests and 5 unit tests pass

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-421

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included (IDOR regression tests added)
- [x] Code is using `(no-changelog)` since this is a security fix