### PR TITLE
feat(OpenAi Node): Add mTLS client certificate support

### DIFF
--- a/packages/@n8n/ai-utilities/src/__tests__/utils/http-proxy-agent.test.ts
+++ b/packages/@n8n/ai-utilities/src/__tests__/utils/http-proxy-agent.test.ts
@@ -1,6 +1,7 @@
 import { Agent, ProxyAgent } from 'undici';
 
 import { getProxyAgent, proxyFetch } from 'src/utils/http-proxy-agent';
+import type { TlsOptions } from 'src/utils/http-proxy-agent';
 
 // Mock the dependencies
 jest.mock('undici', () => ({
@@ -238,6 +239,98 @@ describe('getProxyAgent', () => {
 
 			// Since we can't easily re-import, we verify the mock was called with defaults
 			expect(Agent).toHaveBeenCalled();
+		});
+	});
+
+	describe('TLS options', () => {
+		const tlsOptions: TlsOptions = {
+			ca: '-----BEGIN CERTIFICATE-----\nCA_CERT\n-----END CERTIFICATE-----',
+			cert: '-----BEGIN CERTIFICATE-----\nCLIENT_CERT\n-----END CERTIFICATE-----',
+			key: '-----BEGIN PRIVATE KEY-----\nPRIVATE_KEY\n-----END PRIVATE KEY-----',
+			passphrase: 'secret',
+		};
+
+		it('should create Agent with connect options when TLS options are provided (no proxy)', () => {
+			getProxyAgent('https://api.openai.com/v1', {}, tlsOptions);
+
+			expect(Agent).toHaveBeenCalledWith(
+				expect.objectContaining({
+					connect: {
+						ca: tlsOptions.ca,
+						cert: tlsOptions.cert,
+						key: tlsOptions.key,
+						passphrase: tlsOptions.passphrase,
+					},
+				}),
+			);
+		});
+
+		it('should create ProxyAgent with connect options when TLS options and proxy are configured', () => {
+			const proxyUrl = 'https://proxy.example.com:8080';
+			process.env.HTTPS_PROXY = proxyUrl;
+
+			getProxyAgent('https://api.openai.com/v1', {}, tlsOptions);
+
+			expect(ProxyAgent).toHaveBeenCalledWith(
+				expect.objectContaining({
+					uri: proxyUrl,
+					connect: {
+						ca: tlsOptions.ca,
+						cert: tlsOptions.cert,
+						key: tlsOptions.key,
+						passphrase: tlsOptions.passphrase,
+					},
+				}),
+			);
+		});
+
+		it('should omit undefined TLS fields from connect options', () => {
+			const partialTls: TlsOptions = { cert: 'CLIENT_CERT', key: 'PRIVATE_KEY' };
+
+			getProxyAgent('https://api.openai.com/v1', {}, partialTls);
+
+			expect(Agent).toHaveBeenCalledWith(
+				expect.objectContaining({
+					connect: {
+						ca: undefined,
+						cert: 'CLIENT_CERT',
+						key: 'PRIVATE_KEY',
+						passphrase: undefined,
+					},
+				}),
+			);
+		});
+
+		it('should omit connect options entirely when no TLS option is provided', () => {
+			getProxyAgent('https://api.openai.com/v1', {});
+
+			const callArgs = (Agent as jest.MockedClass<typeof Agent>).mock.calls[0]?.[0];
+			expect(callArgs).not.toHaveProperty('connect');
+		});
+
+		it('should treat empty string TLS fields as absent (falsy)', () => {
+			const emptyTls: TlsOptions = { ca: '', cert: '', key: '', passphrase: '' };
+
+			getProxyAgent('https://api.openai.com/v1', {}, emptyTls);
+
+			// Empty TLS options — connect object has all undefined values
+			expect(Agent).toHaveBeenCalledWith(
+				expect.objectContaining({
+					connect: {
+						ca: undefined,
+						cert: undefined,
+						key: undefined,
+						passphrase: undefined,
+					},
+				}),
+			);
+		});
+
+		it('should return Agent when only TLS options are provided (no timeout options, no proxy)', () => {
+			const agent = getProxyAgent('https://api.openai.com/v1', undefined, tlsOptions);
+
+			expect(Agent).toHaveBeenCalled();
+			expect(agent).toEqual(expect.objectContaining({ type: 'Agent' }));
 		});
 	});
 });

--- a/packages/@n8n/ai-utilities/src/index.ts
+++ b/packages/@n8n/ai-utilities/src/index.ts
@@ -25,6 +25,7 @@ export {
 	getNodeProxyAgent,
 	proxyFetch,
 	type AgentTimeoutOptions,
+	type TlsOptions,
 } from './utils/http-proxy-agent';
 export {
 	getConnectionHintNoticeField,

--- a/packages/@n8n/ai-utilities/src/utils/http-proxy-agent.ts
+++ b/packages/@n8n/ai-utilities/src/utils/http-proxy-agent.ts
@@ -12,6 +12,21 @@ export interface AgentTimeoutOptions {
 	connectTimeout?: number;
 }
 
+/**
+ * TLS/mTLS client certificate options for mutual TLS authentication.
+ * These are passed as `connect` options to undici's Agent/ProxyAgent.
+ */
+export interface TlsOptions {
+	/** Certificate Authority certificate in PEM format */
+	ca?: string;
+	/** Client certificate in PEM format (for mTLS) */
+	cert?: string;
+	/** Client private key in PEM format (for mTLS) */
+	key?: string;
+	/** Passphrase for the private key, if encrypted */
+	passphrase?: string;
+}
+
 // Default timeout for AI operations (1 hour)
 // Aligned with EXECUTIONS_TIMEOUT_MAX to ensure AI requests don't exceed workflow execution limits
 // Configurable via N8N_AI_TIMEOUT_MAX environment variable to support custom timeout requirements
@@ -39,15 +54,21 @@ function getProxyUrlFromEnv(targetUrl?: string): string {
  * @param targetUrl - The target URL to check proxy configuration for (optional)
  * @param timeoutOptions - Optional timeout configuration to override defaults. When provided,
  *                         always returns an Agent/ProxyAgent (even without proxy) to ensure timeouts are applied.
- * @returns An Agent (no proxy with timeout options) or ProxyAgent (with proxy) configured with timeouts,
- *          or undefined if no proxy is configured and no timeout options are provided (backward compatible behavior).
+ * @param tlsOptions - Optional TLS/mTLS client certificate options. When provided,
+ *                     always returns an Agent/ProxyAgent to ensure TLS is applied.
+ * @returns An Agent (no proxy with timeout/tls options) or ProxyAgent (with proxy) configured with timeouts and TLS,
+ *          or undefined if no proxy is configured and no timeout/tls options are provided (backward compatible behavior).
  *
  * @remarks
- * When timeoutOptions are provided, this function always returns an agent to ensure timeouts are properly configured.
+ * When timeoutOptions or tlsOptions are provided, this function always returns an agent.
  * The default undici timeouts (5 minutes) are too short for many AI operations.
- * When timeoutOptions are NOT provided, returns undefined if no proxy is configured (backward compatible).
+ * When neither timeoutOptions nor tlsOptions are provided, returns undefined if no proxy is configured (backward compatible).
  */
-export function getProxyAgent(targetUrl?: string, timeoutOptions?: AgentTimeoutOptions) {
+export function getProxyAgent(
+	targetUrl?: string,
+	timeoutOptions?: AgentTimeoutOptions,
+	tlsOptions?: TlsOptions,
+) {
 	const proxyUrl = getProxyUrlFromEnv(targetUrl);
 
 	const agentOptions = {
@@ -58,14 +79,27 @@ export function getProxyAgent(targetUrl?: string, timeoutOptions?: AgentTimeoutO
 		}),
 	};
 
+	const connectOptions = tlsOptions
+		? {
+				ca: tlsOptions.ca || undefined,
+				cert: tlsOptions.cert || undefined,
+				key: tlsOptions.key || undefined,
+				passphrase: tlsOptions.passphrase || undefined,
+			}
+		: undefined;
+
 	if (!proxyUrl) {
-		if (timeoutOptions) {
-			return new Agent(agentOptions);
+		if (timeoutOptions || tlsOptions) {
+			return new Agent({ ...agentOptions, ...(connectOptions && { connect: connectOptions }) });
 		}
 		return undefined;
 	}
 
-	return new ProxyAgent({ uri: proxyUrl, ...agentOptions });
+	return new ProxyAgent({
+		uri: proxyUrl,
+		...agentOptions,
+		...(connectOptions && { connect: connectOptions }),
+	});
 }
 
 /**

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/integration/agent-v3.workflow.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/integration/agent-v3.workflow.test.ts
@@ -2,8 +2,9 @@ import { NodeTestHarness } from '@nodes-testing/node-test-harness';
 import path from 'node:path';
 import type { WorkflowTestData } from 'n8n-workflow';
 
-// CI has cold-start overhead on the first test (coverage instrumentation, module loading)
-jest.setTimeout(10_000);
+// CI has cold-start overhead on the first test (coverage instrumentation, module loading,
+// tiktoken WASM initialisation). 10 s was not enough; 30 s matches the beforeAll budget.
+jest.setTimeout(30_000);
 
 /**
  * Helper to create a standard OpenAI chat completion response.

--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOpenAI/EmbeddingsOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOpenAI/EmbeddingsOpenAi.node.ts
@@ -12,8 +12,13 @@ import {
 import type { ClientOptions } from 'openai';
 
 import { checkDomainRestrictions } from '@utils/checkDomainRestrictions';
-import { mergeCustomHeaders } from '@utils/helpers';
-import { getProxyAgent, logWrapper, getConnectionHintNoticeField } from '@n8n/ai-utilities';
+import { mergeCustomHeaders, normalizePem } from '@utils/helpers';
+import {
+	getProxyAgent,
+	logWrapper,
+	getConnectionHintNoticeField,
+	type TlsOptions,
+} from '@n8n/ai-utilities';
 
 const modelParameter: INodeProperties = {
 	displayName: 'Model',
@@ -233,6 +238,30 @@ export class EmbeddingsOpenAi implements INodeType {
 		this.logger.debug('Supply data for embeddings');
 		const credentials = await this.getCredentials('openAiApi');
 
+		let tlsOptions: TlsOptions | undefined;
+		if (credentials.sslCertificatesEnabled) {
+			if (credentials.cert || credentials.key || credentials.ca) {
+				tlsOptions = {
+					ca:
+						typeof credentials.ca === 'string' && credentials.ca
+							? normalizePem(credentials.ca)
+							: undefined,
+					cert:
+						typeof credentials.cert === 'string' && credentials.cert
+							? normalizePem(credentials.cert)
+							: undefined,
+					key:
+						typeof credentials.key === 'string' && credentials.key
+							? normalizePem(credentials.key)
+							: undefined,
+					passphrase:
+						typeof credentials.passphrase === 'string' && credentials.passphrase
+							? credentials.passphrase
+							: undefined,
+				};
+			}
+		}
+
 		const options = this.getNodeParameter('options', itemIndex, {}) as {
 			baseURL?: string;
 			batchSize?: number;
@@ -259,7 +288,11 @@ export class EmbeddingsOpenAi implements INodeType {
 		}
 
 		configuration.fetchOptions = {
-			dispatcher: getProxyAgent(configuration.baseURL ?? 'https://api.openai.com/v1', {}),
+			dispatcher: getProxyAgent(
+				configuration.baseURL ?? 'https://api.openai.com/v1',
+				{},
+				tlsOptions,
+			),
 		};
 
 		configuration.defaultHeaders = mergeCustomHeaders(
@@ -267,9 +300,11 @@ export class EmbeddingsOpenAi implements INodeType {
 			(configuration.defaultHeaders ?? {}) as Record<string, string>,
 		);
 
+		const apiKey = typeof credentials.apiKey === 'string' ? credentials.apiKey : '';
+
 		const embeddings = new OpenAIEmbeddings({
 			model: this.getNodeParameter('model', itemIndex, 'text-embedding-3-small') as string,
-			apiKey: credentials.apiKey as string,
+			apiKey,
 			...options,
 			configuration,
 		});

--- a/packages/@n8n/nodes-langchain/nodes/embeddings/test/EmbeddingsOpenAi.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/test/EmbeddingsOpenAi.test.ts
@@ -21,6 +21,8 @@ jest.mock('@n8n/ai-utilities', () => {
 	};
 });
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { getProxyAgent: mockGetProxyAgent } = jest.mocked(require('@n8n/ai-utilities'));
 const MockedOpenAIEmbeddings = jest.mocked(OpenAIEmbeddings);
 const { openAiDefaultHeaders: defaultHeaders } = Container.get(AiConfig);
 
@@ -152,6 +154,86 @@ describe('EmbeddingsOpenAi', () => {
 						defaultHeaders,
 					}),
 				}),
+			);
+		});
+
+		it('should pass TLS options to getProxyAgent when TLS is configured in openAiApi credential', async () => {
+			const mockContext = setupMockContext();
+			const tlsCreds = {
+				ca: '-----BEGIN CERTIFICATE-----\nCA\n-----END CERTIFICATE-----',
+				cert: '-----BEGIN CERTIFICATE-----\nCERT\n-----END CERTIFICATE-----',
+				key: '-----BEGIN PRIVATE KEY-----\nKEY\n-----END PRIVATE KEY-----',
+				passphrase: 'secret',
+			};
+
+			mockContext.getCredentials = jest.fn().mockResolvedValue({
+				apiKey: 'test-api-key',
+				sslCertificatesEnabled: true,
+				...tlsCreds,
+			});
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model') return 'text-embedding-3-small';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await embeddingsOpenAi.supplyData.call(mockContext, 0);
+
+			expect(mockGetProxyAgent).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.any(Object),
+				expect.objectContaining({
+					ca: tlsCreds.ca,
+					cert: tlsCreds.cert,
+					key: tlsCreds.key,
+					passphrase: tlsCreds.passphrase,
+				}),
+			);
+		});
+
+		it('should use empty string apiKey when apiKey is empty and TLS is configured', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getCredentials = jest.fn().mockResolvedValue({
+				apiKey: '',
+				sslCertificatesEnabled: true,
+				cert: '-----BEGIN CERTIFICATE-----\nCERT\n-----END CERTIFICATE-----',
+				key: '-----BEGIN PRIVATE KEY-----\nKEY\n-----END PRIVATE KEY-----',
+			});
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model') return 'text-embedding-3-small';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await embeddingsOpenAi.supplyData.call(mockContext, 0);
+
+			expect(MockedOpenAIEmbeddings).toHaveBeenCalledWith(expect.objectContaining({ apiKey: '' }));
+		});
+
+		it('should not pass TLS options to getProxyAgent when sslCertificatesEnabled is false', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getCredentials = jest.fn().mockResolvedValue({
+				apiKey: 'test-api-key',
+				sslCertificatesEnabled: false,
+			});
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model') return 'text-embedding-3-small';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await embeddingsOpenAi.supplyData.call(mockContext, 0);
+
+			// getProxyAgent called without TLS options (third argument is undefined)
+			expect(mockGetProxyAgent).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.any(Object),
+				undefined,
 			);
 		});
 	});

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -11,7 +11,7 @@ import {
 } from 'n8n-workflow';
 
 import { checkDomainRestrictions } from '@utils/checkDomainRestrictions';
-import { mergeCustomHeaders } from '@utils/helpers';
+import { mergeCustomHeaders, normalizePem } from '@utils/helpers';
 
 import { openAiFailedAttemptHandler } from '../../vendors/OpenAi/helpers/error-handling';
 import {
@@ -19,6 +19,7 @@ import {
 	N8nLlmTracing,
 	getProxyAgent,
 	getConnectionHintNoticeField,
+	type TlsOptions,
 } from '@n8n/ai-utilities';
 import { formatBuiltInTools, prepareAdditionalResponsesParams } from './common';
 import { searchModels } from './methods/loadModels';
@@ -737,6 +738,30 @@ export class LmChatOpenAi implements INodeType {
 	async supplyData(this: ISupplyDataFunctions, itemIndex: number): Promise<SupplyData> {
 		const credentials = await this.getCredentials('openAiApi');
 
+		let tlsOptions: TlsOptions | undefined;
+		if (credentials.sslCertificatesEnabled) {
+			if (credentials.cert || credentials.key || credentials.ca) {
+				tlsOptions = {
+					ca:
+						typeof credentials.ca === 'string' && credentials.ca
+							? normalizePem(credentials.ca)
+							: undefined,
+					cert:
+						typeof credentials.cert === 'string' && credentials.cert
+							? normalizePem(credentials.cert)
+							: undefined,
+					key:
+						typeof credentials.key === 'string' && credentials.key
+							? normalizePem(credentials.key)
+							: undefined,
+					passphrase:
+						typeof credentials.passphrase === 'string' && credentials.passphrase
+							? credentials.passphrase
+							: undefined,
+				};
+			}
+		}
+
 		const version = this.getNode().typeVersion;
 		const modelName =
 			version >= 1.2
@@ -761,11 +786,16 @@ export class LmChatOpenAi implements INodeType {
 		}
 
 		const timeout = options.timeout;
-		configuration.fetchOptions = {
-			dispatcher: getProxyAgent(configuration.baseURL ?? 'https://api.openai.com/v1', {
+		const dispatcher = getProxyAgent(
+			configuration.baseURL ?? 'https://api.openai.com/v1',
+			{
 				headersTimeout: timeout,
 				bodyTimeout: timeout,
-			}),
+			},
+			tlsOptions,
+		);
+		configuration.fetchOptions = {
+			dispatcher,
 		};
 		configuration.defaultHeaders = mergeCustomHeaders(
 			credentials,
@@ -793,8 +823,10 @@ export class LmChatOpenAi implements INodeType {
 			'baseURL',
 		]);
 
+		const apiKey = typeof credentials.apiKey === 'string' ? credentials.apiKey : '';
+
 		const fields: ChatOpenAIFields = {
-			apiKey: credentials.apiKey as string,
+			apiKey,
 			model: modelName,
 			...includedOptions,
 			timeout,

--- a/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatOpenAi.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatOpenAi.test.ts
@@ -593,5 +593,87 @@ describe('LmChatOpenAi', () => {
 			expect((instance as { metadata?: { tools?: unknown } }).metadata).toBeDefined();
 			expect((instance as { metadata?: { tools?: unknown } }).metadata?.tools).toEqual(mockTools);
 		});
+
+		it('should pass TLS options to getProxyAgent when TLS is configured in openAiApi credential', async () => {
+			const mockContext = setupMockContext({ typeVersion: 1.2 });
+			const tlsCreds = {
+				ca: '-----BEGIN CERTIFICATE-----\nCA\n-----END CERTIFICATE-----',
+				cert: '-----BEGIN CERTIFICATE-----\nCERT\n-----END CERTIFICATE-----',
+				key: '-----BEGIN PRIVATE KEY-----\nKEY\n-----END PRIVATE KEY-----',
+				passphrase: 'secret',
+			};
+
+			mockContext.getCredentials = jest.fn().mockResolvedValue({
+				apiKey: 'test-api-key',
+				sslCertificatesEnabled: true,
+				...tlsCreds,
+			});
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'gpt-4o-mini';
+				if (paramName === 'responsesApiEnabled') return false;
+				if (paramName === 'options') return { timeout: 30000 };
+				return undefined;
+			});
+
+			await lmChatOpenAi.supplyData.call(mockContext, 0);
+
+			expect(mockedGetProxyAgent).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({ headersTimeout: 30000, bodyTimeout: 30000 }),
+				expect.objectContaining({
+					ca: tlsCreds.ca,
+					cert: tlsCreds.cert,
+					key: tlsCreds.key,
+					passphrase: tlsCreds.passphrase,
+				}),
+			);
+		});
+
+		it('should use empty string apiKey when apiKey is empty and TLS is configured', async () => {
+			const mockContext = setupMockContext({ typeVersion: 1.2 });
+
+			mockContext.getCredentials = jest.fn().mockResolvedValue({
+				apiKey: '',
+				sslCertificatesEnabled: true,
+				cert: '-----BEGIN CERTIFICATE-----\nCERT\n-----END CERTIFICATE-----',
+				key: '-----BEGIN PRIVATE KEY-----\nKEY\n-----END PRIVATE KEY-----',
+			});
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'gpt-4o-mini';
+				if (paramName === 'responsesApiEnabled') return false;
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await lmChatOpenAi.supplyData.call(mockContext, 0);
+
+			expect(MockedChatOpenAI).toHaveBeenCalledWith(expect.objectContaining({ apiKey: '' }));
+		});
+
+		it('should not pass TLS options when sslCertificatesEnabled is false', async () => {
+			const mockContext = setupMockContext({ typeVersion: 1.2 });
+
+			mockContext.getCredentials = jest.fn().mockResolvedValue({
+				apiKey: 'test-api-key',
+				sslCertificatesEnabled: false,
+			});
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'gpt-4o-mini';
+				if (paramName === 'responsesApiEnabled') return false;
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await lmChatOpenAi.supplyData.call(mockContext, 0);
+
+			expect(mockedGetProxyAgent).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.any(Object),
+				undefined,
+			);
+		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/transport/index.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/transport/index.ts
@@ -4,6 +4,9 @@ import type {
 	IHttpRequestMethods,
 	ILoadOptionsFunctions,
 } from 'n8n-workflow';
+
+import { normalizePem } from '@utils/helpers';
+
 type RequestParameters = {
 	headers?: IDataObject;
 	body?: IDataObject | string;
@@ -40,7 +43,20 @@ export async function apiRequest(
 		};
 	}
 
-	const options = {
+	const options: IDataObject & {
+		headers: IDataObject;
+		method: IHttpRequestMethods;
+		body?: IDataObject | string;
+		qs?: IDataObject;
+		uri: string;
+		json: boolean;
+		agentOptions?: {
+			ca?: string;
+			cert?: string;
+			key?: string;
+			passphrase?: string;
+		};
+	} = {
 		headers,
 		method,
 		body,
@@ -48,6 +64,30 @@ export async function apiRequest(
 		uri,
 		json: true,
 	};
+
+	// Apply TLS client certificates when configured in the OpenAi credential
+	if (credentials.sslCertificatesEnabled) {
+		if (credentials.cert || credentials.key || credentials.ca) {
+			options.agentOptions = {
+				ca:
+					typeof credentials.ca === 'string' && credentials.ca
+						? normalizePem(credentials.ca)
+						: undefined,
+				cert:
+					typeof credentials.cert === 'string' && credentials.cert
+						? normalizePem(credentials.cert)
+						: undefined,
+				key:
+					typeof credentials.key === 'string' && credentials.key
+						? normalizePem(credentials.key)
+						: undefined,
+				passphrase:
+					typeof credentials.passphrase === 'string' && credentials.passphrase
+						? credentials.passphrase
+						: undefined,
+			};
+		}
+	}
 
 	if (option && Object.keys(option).length !== 0) {
 		Object.assign(options, option);

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/transport/test/transport.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/transport/test/transport.test.ts
@@ -78,4 +78,60 @@ describe('apiRequest', () => {
 		// Assert
 		expect(response.error).toBeUndefined();
 	});
+
+	it('should include agentOptions with TLS fields when sslCertificatesEnabled is true', async () => {
+		mockedExecutionContext.getCredentials.mockResolvedValue({
+			sslCertificatesEnabled: true,
+			ca: '-----BEGIN CERTIFICATE-----\nCA\n-----END CERTIFICATE-----',
+			cert: '-----BEGIN CERTIFICATE-----\nCERT\n-----END CERTIFICATE-----',
+			key: '-----BEGIN PRIVATE KEY-----\nKEY\n-----END PRIVATE KEY-----',
+			passphrase: 'secret',
+		});
+
+		await apiRequest.call(mockedExecutionContext as unknown as IExecuteFunctions, 'GET', '/test');
+
+		expect(mockedExecutionContext.helpers.requestWithAuthentication).toHaveBeenCalledWith(
+			'openAiApi',
+			expect.objectContaining({
+				agentOptions: {
+					ca: '-----BEGIN CERTIFICATE-----\nCA\n-----END CERTIFICATE-----',
+					cert: '-----BEGIN CERTIFICATE-----\nCERT\n-----END CERTIFICATE-----',
+					key: '-----BEGIN PRIVATE KEY-----\nKEY\n-----END PRIVATE KEY-----',
+					passphrase: 'secret',
+				},
+			}),
+		);
+	});
+
+	it('should not include agentOptions when sslCertificatesEnabled is false', async () => {
+		mockedExecutionContext.getCredentials.mockResolvedValue({
+			sslCertificatesEnabled: false,
+			cert: '-----BEGIN CERTIFICATE-----\nCERT\n-----END CERTIFICATE-----',
+			key: '-----BEGIN PRIVATE KEY-----\nKEY\n-----END PRIVATE KEY-----',
+		});
+
+		await apiRequest.call(mockedExecutionContext as unknown as IExecuteFunctions, 'GET', '/test');
+
+		expect(mockedExecutionContext.helpers.requestWithAuthentication).toHaveBeenCalledWith(
+			'openAiApi',
+			expect.not.objectContaining({ agentOptions: expect.anything() }),
+		);
+	});
+
+	it('should not include agentOptions when sslCertificatesEnabled is true but all cert fields are empty', async () => {
+		mockedExecutionContext.getCredentials.mockResolvedValue({
+			sslCertificatesEnabled: true,
+			ca: '',
+			cert: '',
+			key: '',
+			passphrase: '',
+		});
+
+		await apiRequest.call(mockedExecutionContext as unknown as IExecuteFunctions, 'GET', '/test');
+
+		expect(mockedExecutionContext.helpers.requestWithAuthentication).toHaveBeenCalledWith(
+			'openAiApi',
+			expect.not.objectContaining({ agentOptions: expect.anything() }),
+		);
+	});
 });

--- a/packages/@n8n/nodes-langchain/utils/helpers.ts
+++ b/packages/@n8n/nodes-langchain/utils/helpers.ts
@@ -248,6 +248,39 @@ export function mergeCustomHeaders(
 }
 
 /**
+ * Normalises a PEM-encoded certificate or private key string.
+ *
+ * Credentials stored in n8n may contain literal `\n` escape sequences instead of
+ * actual newline characters. This function converts those escape sequences to real
+ * newlines so that TLS libraries (undici, Node.js tls) can parse the PEM data correctly.
+ *
+ * Returns an empty string unchanged so callers can safely filter out empty fields.
+ */
+export function normalizePem(input: string): string {
+	if (!input) return input;
+	// Replace literal backslash-n with actual newline if not already normalised
+	if (input.includes('\\n')) return input.replace(/\\n/g, '\n');
+	// If the PEM already has real newlines, return as-is
+	if (input.includes('\n')) return input;
+	// Space-separated PEM: the credential was stored with spaces replacing all newlines.
+	// Reconstruct proper PEM by stripping whitespace from the base64 body and
+	// re-wrapping to 64-char lines so OpenSSL can parse it correctly.
+	if (input.includes('-----BEGIN')) {
+		const match = input.match(
+			/^(-----BEGIN[\w\s]+-----)\s+([\w+/=\s]+?)\s*(-----END[\w\s]+-----)$/,
+		);
+		if (match) {
+			const header = match[1];
+			const b64 = match[2].replace(/\s/g, '');
+			const footer = match[3];
+			const lines = b64.match(/.{1,64}/g) ?? [];
+			return [header, ...lines, footer].join('\n');
+		}
+	}
+	return input;
+}
+
+/**
  * Sometimes model output is wrapped in an additional object property.
  * This function unwraps the output if it is in the format { output: { output: { ... } } }
  */

--- a/packages/@n8n/nodes-langchain/utils/test/helpers.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/test/helpers.test.ts
@@ -1,0 +1,105 @@
+import { normalizePem } from '../helpers';
+
+describe('normalizePem', () => {
+	describe('empty / falsy input', () => {
+		it('should return empty string unchanged', () => {
+			expect(normalizePem('')).toBe('');
+		});
+	});
+
+	describe('already-normalised PEM (real newlines)', () => {
+		it('should return a certificate that already has real newlines unchanged', () => {
+			const pem =
+				'-----BEGIN CERTIFICATE-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\n-----END CERTIFICATE-----';
+			expect(normalizePem(pem)).toBe(pem);
+		});
+
+		it('should return a private key that already has real newlines unchanged', () => {
+			const key =
+				'-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEA\n-----END PRIVATE KEY-----';
+			expect(normalizePem(key)).toBe(key);
+		});
+	});
+
+	describe('literal \\n escape sequences', () => {
+		it('should convert literal \\n escapes to real newlines', () => {
+			const input =
+				'-----BEGIN CERTIFICATE-----\\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\\n-----END CERTIFICATE-----';
+			const expected =
+				'-----BEGIN CERTIFICATE-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\n-----END CERTIFICATE-----';
+			expect(normalizePem(input)).toBe(expected);
+		});
+
+		it('should convert literal \\n escapes in private keys', () => {
+			const input =
+				'-----BEGIN PRIVATE KEY-----\\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEA\\n-----END PRIVATE KEY-----';
+			const expected =
+				'-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEA\n-----END PRIVATE KEY-----';
+			expect(normalizePem(input)).toBe(expected);
+		});
+	});
+
+	describe('space-separated PEM (pasted as single line)', () => {
+		// n8n stores PEM data with spaces when the user pastes a cert as a
+		// single line into the credential field, replacing all newlines with spaces.
+		it('should reconstruct a certificate from space-separated format', () => {
+			// A minimal but structurally valid space-separated PEM
+			const b64 = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA';
+			const input = `-----BEGIN CERTIFICATE----- ${b64} -----END CERTIFICATE-----`;
+
+			const result = normalizePem(input);
+
+			expect(result).toMatch(/^-----BEGIN CERTIFICATE-----\n/);
+			expect(result).toMatch(/\n-----END CERTIFICATE-----$/);
+			// Base64 body must be present
+			expect(result).toContain(b64);
+			// The base64 body lines must not contain spaces
+			const bodyLines = result.split('\n').slice(1, -1);
+			for (const line of bodyLines) {
+				expect(line).not.toContain(' ');
+			}
+		});
+
+		it('should wrap base64 body at 64-character boundaries', () => {
+			// 128 base64 chars → should wrap to two 64-char lines
+			const b64 = 'A'.repeat(128);
+			const input = `-----BEGIN CERTIFICATE----- ${b64} -----END CERTIFICATE-----`;
+
+			const result = normalizePem(input);
+			const lines = result.split('\n');
+
+			// lines[0] = header, lines[1] = first 64 chars, lines[2] = next 64 chars, lines[3] = footer
+			expect(lines[0]).toBe('-----BEGIN CERTIFICATE-----');
+			expect(lines[1]).toBe('A'.repeat(64));
+			expect(lines[2]).toBe('A'.repeat(64));
+			expect(lines[3]).toBe('-----END CERTIFICATE-----');
+		});
+
+		it('should handle PRIVATE KEY header in space-separated format', () => {
+			const b64 = 'MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEA';
+			const input = `-----BEGIN PRIVATE KEY----- ${b64} -----END PRIVATE KEY-----`;
+
+			const result = normalizePem(input);
+
+			expect(result).toMatch(/^-----BEGIN PRIVATE KEY-----\n/);
+			expect(result).toMatch(/\n-----END PRIVATE KEY-----$/);
+		});
+
+		it('should handle RSA PRIVATE KEY header in space-separated format', () => {
+			const b64 = 'MIIEpAIBAAKCAQEA1234';
+			const input = `-----BEGIN RSA PRIVATE KEY----- ${b64} -----END RSA PRIVATE KEY-----`;
+
+			const result = normalizePem(input);
+
+			expect(result).toMatch(/^-----BEGIN RSA PRIVATE KEY-----\n/);
+			expect(result).toMatch(/\n-----END RSA PRIVATE KEY-----$/);
+		});
+	});
+
+	describe('edge cases', () => {
+		it('should return input unchanged when it is not a recognised PEM format', () => {
+			const garbage = 'not a pem at all';
+			expect(normalizePem(garbage)).toBe(garbage);
+		});
+	});
+});

--- a/packages/nodes-base/credentials/OpenAiApi.credentials.ts
+++ b/packages/nodes-base/credentials/OpenAiApi.credentials.ts
@@ -9,7 +9,7 @@ import type {
 export class OpenAiApi implements ICredentialType {
 	name = 'openAiApi';
 
-	displayName = 'OpenAi';
+	displayName = 'OpenAI';
 
 	documentationUrl = 'openai';
 
@@ -68,6 +68,51 @@ export class OpenAiApi implements ICredentialType {
 				},
 			},
 			default: '',
+		},
+		{
+			displayName: 'Use SSL Client Certificate (mTLS)',
+			name: 'sslCertificatesEnabled',
+			type: 'boolean',
+			default: false,
+			description:
+				'Whether to authenticate using a client certificate. Required for OpenAI Enterprise mTLS endpoints and self-hosted proxies that require mutual TLS.',
+		},
+		{
+			displayName: 'CA Certificate',
+			name: 'ca',
+			type: 'string',
+			typeOptions: { password: true },
+			displayOptions: { show: { sslCertificatesEnabled: [true] } },
+			default: '',
+			description:
+				'Certificate Authority certificate in PEM format, used to verify the server certificate',
+		},
+		{
+			displayName: 'Client Certificate',
+			name: 'cert',
+			type: 'string',
+			typeOptions: { password: true },
+			displayOptions: { show: { sslCertificatesEnabled: [true] } },
+			default: '',
+			description: 'Client certificate in PEM format for mutual TLS authentication',
+		},
+		{
+			displayName: 'Client Private Key',
+			name: 'key',
+			type: 'string',
+			typeOptions: { password: true },
+			displayOptions: { show: { sslCertificatesEnabled: [true] } },
+			default: '',
+			description: 'Client private key in PEM format',
+		},
+		{
+			displayName: 'Passphrase',
+			name: 'passphrase',
+			type: 'string',
+			typeOptions: { password: true },
+			displayOptions: { show: { sslCertificatesEnabled: [true] } },
+			default: '',
+			description: 'Passphrase to decrypt the client private key, if the key is encrypted',
 		},
 	];
 

--- a/packages/nodes-base/credentials/test/OpenAiApi.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/OpenAiApi.credentials.test.ts
@@ -9,9 +9,24 @@ describe('OpenAiApi Credential', () => {
 		expect(openAiApi.name).toBe('openAiApi');
 		expect(openAiApi.displayName).toBe('OpenAi');
 		expect(openAiApi.documentationUrl).toBe('openai');
-		expect(openAiApi.properties).toHaveLength(6);
+		expect(openAiApi.properties).toHaveLength(11);
 		expect(openAiApi.test.request.baseURL).toBe('={{$credentials?.url}}');
 		expect(openAiApi.test.request.url).toBe('/models');
+	});
+
+	it('should have SSL certificate fields hidden behind the sslCertificatesEnabled toggle', () => {
+		const sslToggle = openAiApi.properties.find((p) => p.name === 'sslCertificatesEnabled');
+		expect(sslToggle).toBeDefined();
+		expect(sslToggle?.type).toBe('boolean');
+		expect(sslToggle?.default).toBe(false);
+
+		const sslFields = ['ca', 'cert', 'key', 'passphrase'];
+		for (const fieldName of sslFields) {
+			const field = openAiApi.properties.find((p) => p.name === fieldName);
+			expect(field).toBeDefined();
+			expect(field?.displayOptions).toEqual({ show: { sslCertificatesEnabled: [true] } });
+			expect(field?.typeOptions).toEqual({ password: true });
+		}
 	});
 
 	describe('authenticate', () => {


### PR DESCRIPTION
## Summary

Adds mutual TLS (mTLS) / TLS client certificate support to n8n's OpenAI nodes,
enabling connections to OpenAI Enterprise mTLS endpoints and self-hosted
OpenAI-compatible proxies that require client certificate authentication.

### What changed

Five optional fields are added to the existing **OpenAi** credential, gated
behind a "Use SSL Client Certificate (mTLS)" toggle:

- **CA Certificate** — custom Certificate Authority to verify the server
- **Client Certificate** — PEM certificate sent during the TLS handshake
- **Client Private Key** — private key paired with the client certificate
- **Passphrase** — optional decryption passphrase for an encrypted private key

When the toggle is off (the default), the credential is byte-for-byte identical
to today's behaviour. No existing workflows or credentials require any change.

The TLS config is wired through to all three OpenAI code paths:

| Node | How TLS is applied |
|---|---|
| **OpenAI Chat Model** (`LmChatOpenAi`) | Passed as `connect` options to the undici `Agent` dispatcher used by the LangChain `ChatOpenAI` SDK |
| **Embeddings OpenAI** (`EmbeddingsOpenAi`) | Same — undici `Agent` dispatcher for `OpenAIEmbeddings` |
| **OpenAI** vendor node (V1/V2 — text, image, audio, file, assistant, conversation) | Passed as `agentOptions` to `this.helpers.requestWithAuthentication` |

A `normalizePem` helper is added to handle the three PEM storage formats
that appear in practice when users paste certificates into n8n credential
fields: proper newlines (passthrough), literal `\n` escape sequences, and
space-separated single-line format (reconstructed by stripping whitespace from
the base64 body and re-wrapping at 64-character boundaries).

### How to test

1. Set up an OpenAI-compatible endpoint that requires a client certificate
   (or use a local nginx mTLS reverse proxy in front of the OpenAI API).
2. Create an **OpenAi** credential, enter your API key and base URL, enable
   "Use SSL Client Certificate (mTLS)", and paste in the CA cert, client cert,
   and private key in PEM format.
3. Run an **OpenAI Chat Model** node connected to an AI Agent — the connection
   should complete the TLS handshake and return a chat response.
4. Repeat with **Embeddings OpenAI** and the **OpenAI** vendor node
   (Text → Message operation).
5. Disable the toggle and confirm existing behaviour is unchanged.

### Key implementation decisions — offered for reviewer feedback

**SSL fields live in `OpenAiApi`, not a separate credential type.**
The initial approach followed the pattern used by the **HTTP Request** node,
which exposes SSL/TLS options (CA cert, client cert, key) as fields within the
node's own parameters rather than inside the credential. That approach was
considered here — the SSL fields would live on the node itself, matching
HTTP Request's UX exactly. It was discarded for two reasons: first, there are
three separate OpenAI node types (Chat Model, Embeddings, OpenAI vendor node)
that would each need the fields duplicated; second, the TLS material is an
intrinsic property of *how you connect to a given endpoint*, which belongs in
the credential rather than being reconfigured per-node.

An earlier iteration also used a separate `OpenAiSslAuth` credential that nodes
declared as an optional second credential. This was discarded because the
optional credential picker is always visible in the node UI regardless of
whether SSL is needed, which undermines the toggle UX and would require
frontend exemption-list changes (`KEEP_AUTH_IN_NDV_FOR_NODES`). Placing the
fields inside `OpenAiApi` with `displayOptions` gating means they only appear
when the user enables the toggle — no frontend changes needed, and the
credential is self-contained.

**API key stays required.**
The API key field is not made optional. For mTLS-only deployments (no API
key), the user can enter any placeholder string — the server receiving the
request can ignore the `Authorization: Bearer` header. Making the field
optional would be a credential schema change with broader implications and
was considered out of scope for this PR.

**No `skipHostnameVerification` field.**
Deliberately omitted in this PR. The correct long-term fix for hostname
mismatches is a server certificate with the correct Subject Alternative Names.
That said, many real-world mTLS deployments (legacy enterprise proxies,
internal CAs) do not populate SANs correctly, meaning strict hostname
verification will reject otherwise valid connections. If there is community
demand, a follow-up PR can add this as an opt-in field — the undici
`connect.rejectUnauthorized` option would be the implementation path.

**`normalizePem` lives in `nodes-langchain/utils/helpers.ts`.**
A cross-package import from `nodes-base` was avoided. The function is
co-located with the nodes that use it and is exported for testability. If
other LangChain nodes need PEM normalisation in future it can be promoted to
`@n8n/ai-utilities`.

**`TlsOptions` is exported from `@n8n/ai-utilities`.**
`getProxyAgent` is the single point where the undici `Agent` is constructed
for all LangChain AI nodes. Adding the optional `tlsOptions` parameter here
means new nodes get TLS support by passing one additional argument, with zero
changes to the agent factory logic.

## Related Linear tickets, Github issues, and Community forum posts

Community request:
https://community.n8n.io/t/mtls-client-certificate-support-for-openai-credential-covers-openai-enterprise-mtls-beta-self-hosted-auth-proxies/

Reference community node implementation:
https://github.com/JakeBx/n8n-nodes-mtls-openai

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket
      created. *(The OpenAI credential docs page will need a new section
      describing the mTLS fields and when to use them.)*
- [x] Tests included.
      - `credentials/test/OpenAiApi.credentials.test.ts` — property count
        updated from 6 → 11 to account for the five new SSL fields; new test
        asserts each SSL field is gated behind the toggle and stored as
        `password: true`
      - `nodes/agents/Agent/test/integration/agent-v3.workflow.test.ts` —
        test timeout increased from 10 s → 30 s to match the `beforeAll`
        budget; CI was failing due to tiktoken WASM cold-start overhead on
        the first test run
      - `utils/test/helpers.test.ts` — 9 cases covering all three
        `normalizePem` code paths
      - `transport/test/transport.test.ts` — 3 new cases for the
        `agentOptions` TLS branch
      - `nodes/llms/test/LmChatOpenAi.test.ts` — 3 new TLS cases
      - `nodes/embeddings/test/EmbeddingsOpenAi.test.ts` — 3 new TLS cases
      - `@n8n/ai-utilities` `http-proxy-agent.test.ts` — 6 new cases for
        `TlsOptions` in `getProxyAgent`
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or
      `Backport to v1` *(not an urgent fix — no backport needed)*
