### PR TITLE
refactor(editor): Migrate node composables to workflowDocumentStore (connections) (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useNodeDirtiness.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeDirtiness.ts
@@ -131,8 +131,16 @@ export function useNodeDirtiness() {
 			: undefined,
 	);
 
+	function getIncomingConnections(nodeName: string): INodeConnections {
+		return workflowDocumentStore.value?.incomingConnectionsByNodeName(nodeName) ?? {};
+	}
+
+	function getOutgoingConnections(nodeName: string): INodeConnections {
+		return workflowDocumentStore.value?.outgoingConnectionsByNodeName(nodeName) ?? {};
+	}
+
 	function getParentSubNodes(nodeName: string) {
-		return Object.entries(workflowsStore.incomingConnectionsByNodeName(nodeName))
+		return Object.entries(getIncomingConnections(nodeName))
 			.filter(([type]) => (type as NodeConnectionType) !== NodeConnectionTypes.Main)
 			.flatMap(([, typeConnections]) => typeConnections.flat().filter((conn) => conn !== null));
 	}
@@ -170,8 +178,8 @@ export function useNodeDirtiness() {
 					command,
 					nodeName,
 					[],
-					workflowsStore.incomingConnectionsByNodeName,
-					workflowsStore.outgoingConnectionsByNodeName,
+					getIncomingConnections,
+					getOutgoingConnections,
 				)
 			) {
 				return CanvasNodeDirtiness.INCOMING_CONNECTIONS_UPDATED;
@@ -202,9 +210,7 @@ export function useNodeDirtiness() {
 
 			myVisited.add(nodeName);
 
-			for (const [type, typeConnections] of Object.entries(
-				workflowsStore.outgoingConnectionsByNodeName(nodeName),
-			)) {
+			for (const [type, typeConnections] of Object.entries(getOutgoingConnections(nodeName))) {
 				if ((type as NodeConnectionType) !== NodeConnectionTypes.Main) {
 					continue;
 				}
@@ -222,8 +228,7 @@ export function useNodeDirtiness() {
 		}
 
 		for (const startNode of workflowDocumentStore.value?.allNodes ?? []) {
-			const hasIncomingNode =
-				Object.keys(workflowsStore.incomingConnectionsByNodeName(startNode.name)).length > 0;
+			const hasIncomingNode = Object.keys(getIncomingConnections(startNode.name)).length > 0;
 
 			if (hasIncomingNode) {
 				continue;
@@ -243,7 +248,7 @@ export function useNodeDirtiness() {
 		function setDirtiness(nodeName: string, value: CanvasNodeDirtinessType) {
 			dirtiness[nodeName] = dirtiness[nodeName] ?? value;
 
-			const loop = findLoop(nodeName, [], workflowsStore.incomingConnectionsByNodeName);
+			const loop = findLoop(nodeName, [], getIncomingConnections);
 
 			if (!loop) {
 				return;
@@ -283,9 +288,7 @@ export function useNodeDirtiness() {
 				continue;
 			}
 
-			const hasInputPinnedDataChanged = Object.values(
-				workflowsStore.incomingConnectionsByNodeName(nodeName),
-			)
+			const hasInputPinnedDataChanged = Object.values(getIncomingConnections(nodeName))
 				.flat()
 				.flat()
 				.filter((connection) => connection !== null)

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/composables/useExpressionResolveCtx.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/composables/useExpressionResolveCtx.ts
@@ -1,6 +1,10 @@
 import type { INodeUi } from '@/Interface';
 import useEnvironmentsStore from '@/features/settings/environments.ee/environments.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import type { ExpressionLocalResolveContext } from '@/app/types/expressions';
 import type { Workflow } from 'n8n-workflow';
 import { computed, type ComputedRef } from 'vue';
@@ -9,6 +13,12 @@ export function useExpressionResolveCtx(node: ComputedRef<INodeUi | null | undef
 	const environmentsStore = useEnvironmentsStore();
 	const workflowsStore = useWorkflowsStore();
 	const workflowObject = computed(() => workflowsStore.workflowObject as Workflow);
+
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 
 	return computed<ExpressionLocalResolveContext | undefined>(() => {
 		if (!node.value) {
@@ -52,7 +62,7 @@ export function useExpressionResolveCtx(node: ComputedRef<INodeUi | null | undef
 			nodeName,
 			additionalKeys: {},
 			inputNode: findInputNode(),
-			connections: workflowsStore.connectionsBySourceNode,
+			connections: workflowDocumentStore.value?.connectionsBySourceNode ?? {},
 		};
 	});
 }


### PR DESCRIPTION
## Summary

Migrate connection read accessors in `useNodeDirtiness` and `useExpressionResolveCtx` from deprecated `workflowsStore` methods to `workflowDocumentStore`:

- `useNodeDirtiness.ts` — replaced 5× `workflowsStore.incomingConnectionsByNodeName` and 2× `workflowsStore.outgoingConnectionsByNodeName` with `workflowDocumentStore` equivalents
- `useExpressionResolveCtx.ts` — replaced 1× `workflowsStore.connectionsBySourceNode` with `workflowDocumentStore` equivalent

No test changes needed — the document store delegates to `workflowsStore` under the hood, so existing mocks continue to work transparently.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2641/migrate-node-composables-to-workflowdocumentstore-connections

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.