### PR TITLE
fix(editor): Support per-corner border radius in N8nInput

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
@@ -448,6 +448,7 @@ defineExpose({ focus, blur, select });
 	min-width: 0;
 	gap: var(--input--padding);
 	padding: 0 var(--input--padding);
+	height: var(--input--height);
 	border-radius: var(--input--radius--top-left, var(--input--radius))
 		var(--input--radius--top-right, var(--input--radius))
 		var(--input--radius--bottom-right, var(--input--radius))

--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
@@ -448,7 +448,7 @@ defineExpose({ focus, blur, select });
 	min-width: 0;
 	gap: var(--input--padding);
 	padding: 0 var(--input--padding);
-	height: var(--input--height);
+	min-height: var(--input--height);
 	border-radius: var(--input--radius--top-left, var(--input--radius))
 		var(--input--radius--top-right, var(--input--radius))
 		var(--input--radius--bottom-right, var(--input--radius))

--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
@@ -448,7 +448,10 @@ defineExpose({ focus, blur, select });
 	min-width: 0;
 	gap: var(--input--padding);
 	padding: 0 var(--input--padding);
-	border-radius: var(--input--radius);
+	border-radius: var(--input--radius--top-left, var(--input--radius))
+		var(--input--radius--top-right, var(--input--radius))
+		var(--input--radius--bottom-right, var(--input--radius))
+		var(--input--radius--bottom-left, var(--input--radius));
 	background-color: var(--input--color--background);
 	box-shadow:
 		var(--input--shadow),

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/resourceLocator.scss
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/resourceLocator.scss
@@ -104,6 +104,11 @@ $--mode-selector-width: 92px;
 	}
 }
 
+/** NOTE (@heymynameisrob): Manual override to match legacy size of Select. Will need removing when sizes are unified **/
+.selectInput {
+	--input--height: 30px !important;
+}
+
 .selectInput input {
 	overflow: hidden;
 	text-overflow: ellipsis;


### PR DESCRIPTION
## Summary

- Update `N8nInput` to allow per-corner `border-radius` CSS variables on `.inputWrapper`.
- Keep full backward compatibility by falling back each corner to `--input--radius`.
- This addresses DS-505 by enabling precise corner control for composed inputs (e.g. resource locator segments) so adjacent controls can align without visual gaps or mismatched corner rounding.

| Before | After |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/b2f381b4-6a0d-415b-99fb-23288b1cc02f" width="960px" alt="before image" /> | <img src="https://github.com/user-attachments/assets/da935230-4752-42d6-90ce-e45d69a1261b" width="960px" alt="after image" /> |


## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/DS-505/bug-resource-locator-component-visual-alignment-issues

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
