### PR TITLE
fix(editor): Fix broken link to documentation from multiple places in the UI

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -290,7 +290,7 @@ export class McpClientTool implements INodeType {
 				type: 'multiOptions',
 				default: [],
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getTools',
 					loadOptionsDependsOn: ['sseEndpoint'],
@@ -307,7 +307,7 @@ export class McpClientTool implements INodeType {
 				type: 'multiOptions',
 				default: [],
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getTools',
 				},

--- a/packages/nodes-base/nodes/ActionNetwork/descriptions/PersonTagDescription.ts
+++ b/packages/nodes-base/nodes/ActionNetwork/descriptions/PersonTagDescription.ts
@@ -35,7 +35,7 @@ export const personTagFields: INodeProperties[] = [
 		displayName: 'Tag Name or ID',
 		name: 'tagId',
 		description:
-			'ID of the tag to add. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the tag to add. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		typeOptions: {
 			loadOptionsMethod: 'getTags',
@@ -71,7 +71,7 @@ export const personTagFields: INodeProperties[] = [
 		displayName: 'Tag Name or ID',
 		name: 'tagId',
 		description:
-			'ID of the tag whose tagging to delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the tag whose tagging to delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		typeOptions: {
 			loadOptionsMethod: 'getTags',
@@ -89,7 +89,7 @@ export const personTagFields: INodeProperties[] = [
 		displayName: 'Tagging Name or ID',
 		name: 'taggingId',
 		description:
-			'ID of the tagging to remove. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the tagging to remove. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		typeOptions: {
 			loadOptionsDependsOn: ['tagId'],

--- a/packages/nodes-base/nodes/ActiveCampaign/AccountDescription.ts
+++ b/packages/nodes-base/nodes/ActiveCampaign/AccountDescription.ts
@@ -111,7 +111,7 @@ export const accountFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Field Value',
@@ -196,7 +196,7 @@ export const accountFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Field Value',

--- a/packages/nodes-base/nodes/ActiveCampaign/ActiveCampaignTrigger.node.ts
+++ b/packages/nodes-base/nodes/ActiveCampaign/ActiveCampaignTrigger.node.ts
@@ -45,7 +45,7 @@ export class ActiveCampaignTrigger implements INodeType {
 				name: 'events',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getEvents',
 				},

--- a/packages/nodes-base/nodes/ActiveCampaign/ContactDescription.ts
+++ b/packages/nodes-base/nodes/ActiveCampaign/ContactDescription.ts
@@ -119,7 +119,7 @@ export const contactFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Field Value',
@@ -211,7 +211,7 @@ export const contactFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Field Value',

--- a/packages/nodes-base/nodes/ActiveCampaign/ContactTagDescription.ts
+++ b/packages/nodes-base/nodes/ActiveCampaign/ContactTagDescription.ts
@@ -38,7 +38,7 @@ export const contactTagFields: INodeProperties[] = [
 		name: 'tagId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTags',
 		},

--- a/packages/nodes-base/nodes/Affinity/ListEntryDescription.ts
+++ b/packages/nodes-base/nodes/Affinity/ListEntryDescription.ts
@@ -61,7 +61,7 @@ export const listEntryFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The unique ID of the list whose list entries are to be retrieved. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The unique ID of the list whose list entries are to be retrieved. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Entity ID',
@@ -120,7 +120,7 @@ export const listEntryFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The unique ID of the list that contains the specified list_entry_id. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The unique ID of the list that contains the specified list_entry_id. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'List Entry ID',
@@ -154,7 +154,7 @@ export const listEntryFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The unique ID of the list whose list entries are to be retrieved. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The unique ID of the list whose list entries are to be retrieved. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',
@@ -206,7 +206,7 @@ export const listEntryFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The unique ID of the list that contains the specified list_entry_id. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The unique ID of the list that contains the specified list_entry_id. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'List Entry ID',

--- a/packages/nodes-base/nodes/Affinity/OrganizationDescription.ts
+++ b/packages/nodes-base/nodes/Affinity/OrganizationDescription.ts
@@ -101,7 +101,7 @@ export const organizationFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Persons that the new organization will be associated with. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Persons that the new organization will be associated with. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -158,7 +158,7 @@ export const organizationFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Persons that the new organization will be associated with. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Persons that the new organization will be associated with. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Affinity/PersonDescription.ts
+++ b/packages/nodes-base/nodes/Affinity/PersonDescription.ts
@@ -101,7 +101,7 @@ export const personFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Organizations that the person is associated with. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Organizations that the person is associated with. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -176,7 +176,7 @@ export const personFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Organizations that the person is associated with. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Organizations that the person is associated with. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/search.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/search.operation.ts
@@ -108,7 +108,7 @@ const properties: INodeProperties[] = [
 						},
 						default: '',
 						description:
-							'Name of the field to sort on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Name of the field to sort on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Direction',

--- a/packages/nodes-base/nodes/ApiTemplateIo/ApiTemplateIo.node.ts
+++ b/packages/nodes-base/nodes/ApiTemplateIo/ApiTemplateIo.node.ts
@@ -126,7 +126,7 @@ export class ApiTemplateIo implements INodeType {
 				required: true,
 				default: '',
 				description:
-					'ID of the image template to use. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the image template to use. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getImageTemplates',
 				},
@@ -144,7 +144,7 @@ export class ApiTemplateIo implements INodeType {
 				required: true,
 				default: '',
 				description:
-					'ID of the PDF template to use. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the PDF template to use. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getPdfTemplates',
 				},

--- a/packages/nodes-base/nodes/Asana/Asana.node.ts
+++ b/packages/nodes-base/nodes/Asana/Asana.node.ts
@@ -202,7 +202,7 @@ export class Asana implements INodeType {
 						},
 						default: '',
 						description:
-							'Set Assignee on the subtask. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Set Assignee on the subtask. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Assignee Status',
@@ -269,7 +269,7 @@ export class Asana implements INodeType {
 						},
 						default: '',
 						description:
-							'The workspace to create the subtask in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The workspace to create the subtask in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 				],
 			},
@@ -343,7 +343,7 @@ export class Asana implements INodeType {
 						},
 						default: ['gid', 'name', 'resource_type'],
 						description:
-							'Defines fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Defines fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Pretty',
@@ -434,7 +434,7 @@ export class Asana implements INodeType {
 					},
 				},
 				description:
-					'The workspace to create the task in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The workspace to create the task in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Name',
@@ -543,7 +543,7 @@ export class Asana implements INodeType {
 						},
 						default: '',
 						description:
-							'The assignee to filter tasks on. Note: If you specify assignee, you must also specify the workspace to filter on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The assignee to filter tasks on. Note: If you specify assignee, you must also specify the workspace to filter on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Field Names or IDs',
@@ -554,7 +554,7 @@ export class Asana implements INodeType {
 						},
 						default: ['gid', 'name', 'resource_type'],
 						description:
-							'Defines fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Defines fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Pretty',
@@ -572,7 +572,7 @@ export class Asana implements INodeType {
 						},
 						default: '',
 						description:
-							'The project to filter tasks on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The project to filter tasks on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Section Name or ID',
@@ -583,7 +583,7 @@ export class Asana implements INodeType {
 						},
 						default: '',
 						description:
-							'The section to filter tasks on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The section to filter tasks on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Workspace Name or ID',
@@ -594,7 +594,7 @@ export class Asana implements INodeType {
 						},
 						default: '',
 						description:
-							'The workspace to filter tasks on. Note: If you specify workspace, you must also specify the assignee to filter on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The workspace to filter tasks on. Note: If you specify workspace, you must also specify the assignee to filter on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Completed Since',
@@ -649,7 +649,7 @@ export class Asana implements INodeType {
 					},
 				},
 				description:
-					'Project to show the sections of. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Project to show the sections of. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Section Name or ID',
@@ -669,7 +669,7 @@ export class Asana implements INodeType {
 					},
 				},
 				description:
-					'The Section to move the task to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The Section to move the task to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 
 			// ----------------------------------
@@ -710,7 +710,7 @@ export class Asana implements INodeType {
 					},
 				},
 				description:
-					'The workspace in which the task is searched. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The workspace in which the task is searched. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Filters',
@@ -771,7 +771,7 @@ export class Asana implements INodeType {
 						},
 						default: '',
 						description:
-							'Set Assignee on the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Set Assignee on the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Assignee Status',
@@ -850,7 +850,7 @@ export class Asana implements INodeType {
 						},
 						default: [],
 						description:
-							'The project to filter tasks on. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The project to filter tasks on. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 				],
 			},
@@ -1052,7 +1052,7 @@ export class Asana implements INodeType {
 					},
 				},
 				description:
-					'The project where the task will be added. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The project where the task will be added. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Additional Fields',
@@ -1128,7 +1128,7 @@ export class Asana implements INodeType {
 					},
 				},
 				description:
-					'The project where the task will be removed from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The project where the task will be removed from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			// ----------------------------------
 			//         taskTag
@@ -1196,7 +1196,7 @@ export class Asana implements INodeType {
 					},
 				},
 				description:
-					'The tag that should be added. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The tag that should be added. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 
 			// ----------------------------------
@@ -1234,7 +1234,7 @@ export class Asana implements INodeType {
 					},
 				},
 				description:
-					'The tag that should be added. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The tag that should be added. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 
 			// ----------------------------------
@@ -1306,7 +1306,7 @@ export class Asana implements INodeType {
 					},
 				},
 				description:
-					'The workspace in which to get users. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The workspace in which to get users. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 
 			// ----------------------------------
@@ -1391,7 +1391,7 @@ export class Asana implements INodeType {
 					},
 				},
 				description:
-					'The workspace to create the project in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The workspace to create the project in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Team Name or ID',
@@ -1409,7 +1409,7 @@ export class Asana implements INodeType {
 				},
 				default: '',
 				description:
-					'The team this project will be assigned to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The team this project will be assigned to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Additional Fields',
@@ -1524,7 +1524,7 @@ export class Asana implements INodeType {
 					},
 				},
 				description:
-					'The workspace in which to get users. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The workspace in which to get users. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Return All',
@@ -1589,7 +1589,7 @@ export class Asana implements INodeType {
 						},
 						default: '',
 						description:
-							'The new name of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The new name of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 				],
 			},
@@ -1613,7 +1613,7 @@ export class Asana implements INodeType {
 					},
 				},
 				description:
-					'The workspace in which to get users. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The workspace in which to get users. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Project ID',
@@ -1711,7 +1711,7 @@ export class Asana implements INodeType {
 						},
 						default: '',
 						description:
-							'The team this project will be assigned to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The team this project will be assigned to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 				],
 			},

--- a/packages/nodes-base/nodes/Asana/AsanaTrigger.node.ts
+++ b/packages/nodes-base/nodes/Asana/AsanaTrigger.node.ts
@@ -92,7 +92,7 @@ export class AsanaTrigger implements INodeType {
 				options: [],
 				default: '',
 				description:
-					'The workspace ID the resource is registered under. This is only required if you want to allow overriding existing webhooks. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The workspace ID the resource is registered under. This is only required if you want to allow overriding existing webhooks. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	};

--- a/packages/nodes-base/nodes/Autopilot/ContactDescription.ts
+++ b/packages/nodes-base/nodes/Autopilot/ContactDescription.ts
@@ -103,7 +103,7 @@ export const contactFields: INodeProperties[] = [
 									loadOptionsMethod: 'getCustomFields',
 								},
 								description:
-									'User-specified key of user-defined data. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'User-specified key of user-defined data. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 								default: '',
 							},
 							{
@@ -162,7 +162,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'List to which this contact will be added on creation. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'List to which this contact will be added on creation. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Mailing Country',

--- a/packages/nodes-base/nodes/Autopilot/ContactJourneyDescription.ts
+++ b/packages/nodes-base/nodes/Autopilot/ContactJourneyDescription.ts
@@ -43,7 +43,7 @@ export const contactJourneyFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'List ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'List ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Contact ID',

--- a/packages/nodes-base/nodes/Autopilot/ContactListDescription.ts
+++ b/packages/nodes-base/nodes/Autopilot/ContactListDescription.ts
@@ -61,7 +61,7 @@ export const contactListFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'ID of the list to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the list to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Contact ID',

--- a/packages/nodes-base/nodes/Aws/AwsLambda.node.ts
+++ b/packages/nodes-base/nodes/Aws/AwsLambda.node.ts
@@ -62,7 +62,7 @@ export class AwsLambda implements INodeType {
 				default: '',
 				required: true,
 				description:
-					'The function you want to invoke. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The function you want to invoke. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Qualifier',

--- a/packages/nodes-base/nodes/Aws/DynamoDB/ItemDescription.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/ItemDescription.ts
@@ -49,7 +49,7 @@ export const itemFields: INodeProperties[] = [
 		displayName: 'Table Name or ID',
 		name: 'tableName',
 		description:
-			'Table to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Table to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		required: true,
 		displayOptions: {

--- a/packages/nodes-base/nodes/Aws/ELB/ListenerCertificateDescription.ts
+++ b/packages/nodes-base/nodes/Aws/ELB/ListenerCertificateDescription.ts
@@ -57,7 +57,7 @@ export const listenerCertificateFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'Unique identifier for a particular loadBalancer. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Unique identifier for a particular loadBalancer. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Listener ARN Name or ID',
@@ -76,7 +76,7 @@ export const listenerCertificateFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'Unique identifier for a particular loadBalancer. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Unique identifier for a particular loadBalancer. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Certificate ARN',
@@ -113,7 +113,7 @@ export const listenerCertificateFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'Unique identifier for a particular loadBalancer. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Unique identifier for a particular loadBalancer. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Listener ARN Name or ID',
@@ -132,7 +132,7 @@ export const listenerCertificateFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'Unique identifier for a particular loadBalancer. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Unique identifier for a particular loadBalancer. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',
@@ -185,7 +185,7 @@ export const listenerCertificateFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'Unique identifier for a particular loadBalancer. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Unique identifier for a particular loadBalancer. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Listener ARN Name or ID',
@@ -204,7 +204,7 @@ export const listenerCertificateFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'Unique identifier for a particular loadBalancer. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Unique identifier for a particular loadBalancer. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Certificate ARN',

--- a/packages/nodes-base/nodes/Aws/ELB/LoadBalancerDescription.ts
+++ b/packages/nodes-base/nodes/Aws/ELB/LoadBalancerDescription.ts
@@ -135,7 +135,7 @@ export const loadBalancerFields: INodeProperties[] = [
 		name: 'subnets',
 		type: 'multiOptions',
 		description:
-			'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		displayOptions: {
 			show: {
 				resource: ['loadBalancer'],
@@ -166,7 +166,7 @@ export const loadBalancerFields: INodeProperties[] = [
 				name: 'securityGroups',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getSecurityGroups',
 				},

--- a/packages/nodes-base/nodes/Aws/SES/AwsSes.node.ts
+++ b/packages/nodes-base/nodes/Aws/SES/AwsSes.node.ts
@@ -458,7 +458,7 @@ export class AwsSes implements INodeType {
 				},
 				default: '',
 				description:
-					'The ARN of the template to use when sending this email. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The ARN of the template to use when sending this email. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'From Email',

--- a/packages/nodes-base/nodes/Aws/SQS/AwsSqs.node.ts
+++ b/packages/nodes-base/nodes/Aws/SQS/AwsSqs.node.ts
@@ -64,7 +64,7 @@ export class AwsSqs implements INodeType {
 				default: '',
 				required: true,
 				description:
-					'Queue to send a message to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Queue to send a message to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Queue Type',

--- a/packages/nodes-base/nodes/BambooHr/v1/actions/employee/create/shareDescription.ts
+++ b/packages/nodes-base/nodes/BambooHr/v1/actions/employee/create/shareDescription.ts
@@ -65,7 +65,7 @@ export const createEmployeeSharedDescription = (sync = false): INodeProperties[]
 			name: 'department',
 			type: 'options',
 			description:
-				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			typeOptions: {
 				loadOptionsMethod: 'getDepartments',
 			},
@@ -76,7 +76,7 @@ export const createEmployeeSharedDescription = (sync = false): INodeProperties[]
 			name: 'division',
 			type: 'options',
 			description:
-				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			typeOptions: {
 				loadOptionsMethod: 'getDivisions',
 			},
@@ -131,7 +131,7 @@ export const createEmployeeSharedDescription = (sync = false): INodeProperties[]
 			name: 'location',
 			type: 'options',
 			description:
-				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			typeOptions: {
 				loadOptionsMethod: 'getEmployeeLocations',
 			},

--- a/packages/nodes-base/nodes/BambooHr/v1/actions/employee/get/description.ts
+++ b/packages/nodes-base/nodes/BambooHr/v1/actions/employee/get/description.ts
@@ -36,7 +36,7 @@ export const employeeGetDescription: EmployeeProperties = [
 				},
 				default: ['all'],
 				description:
-					'Set of fields to get from employee data. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Set of fields to get from employee data. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/BambooHr/v1/actions/employee/update/sharedDescription.ts
+++ b/packages/nodes-base/nodes/BambooHr/v1/actions/employee/update/sharedDescription.ts
@@ -65,7 +65,7 @@ export const updateEmployeeSharedDescription = (sync = false): INodeProperties[]
 			name: 'department',
 			type: 'options',
 			description:
-				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			typeOptions: {
 				loadOptionsMethod: 'getDepartments',
 			},
@@ -76,7 +76,7 @@ export const updateEmployeeSharedDescription = (sync = false): INodeProperties[]
 			name: 'division',
 			type: 'options',
 			description:
-				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			typeOptions: {
 				loadOptionsMethod: 'getDivisions',
 			},
@@ -153,7 +153,7 @@ export const updateEmployeeSharedDescription = (sync = false): INodeProperties[]
 			name: 'location',
 			type: 'options',
 			description:
-				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			typeOptions: {
 				loadOptionsMethod: 'getEmployeeLocations',
 			},

--- a/packages/nodes-base/nodes/BambooHr/v1/actions/employeeDocument/update/description.ts
+++ b/packages/nodes-base/nodes/BambooHr/v1/actions/employeeDocument/update/description.ts
@@ -50,7 +50,7 @@ export const employeeDocumentUpdateDescription: EmployeeDocumentProperties = [
 				},
 				default: '',
 				description:
-					'ID of the new category of the file. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the new category of the file. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Name',

--- a/packages/nodes-base/nodes/BambooHr/v1/actions/file/update/description.ts
+++ b/packages/nodes-base/nodes/BambooHr/v1/actions/file/update/description.ts
@@ -37,7 +37,7 @@ export const fileUpdateDescription: FileProperties = [
 				},
 				default: '',
 				description:
-					'Move the file to a different category. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Move the file to a different category. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Name',

--- a/packages/nodes-base/nodes/BambooHr/v1/actions/file/upload/description.ts
+++ b/packages/nodes-base/nodes/BambooHr/v1/actions/file/upload/description.ts
@@ -21,7 +21,7 @@ export const fileUploadDescription: INodeProperties[] = [
 		name: 'categoryId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getCompanyFileCategories',
 		},

--- a/packages/nodes-base/nodes/Bannerbear/ImageDescription.ts
+++ b/packages/nodes-base/nodes/Bannerbear/ImageDescription.ts
@@ -49,7 +49,7 @@ export const imageFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The template ID you want to use. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The template ID you want to use. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Additional Fields',
@@ -134,7 +134,7 @@ export const imageFields: INodeProperties[] = [
 						},
 						default: '',
 						description:
-							'The name of the item you want to change. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The name of the item you want to change. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Text',

--- a/packages/nodes-base/nodes/Baserow/OperationDescription.ts
+++ b/packages/nodes-base/nodes/Baserow/OperationDescription.ts
@@ -11,7 +11,7 @@ export const operationFields: INodeProperties[] = [
 		default: '0',
 		required: true,
 		description:
-			'Database to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Database to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		typeOptions: {
 			loadOptionsMethod: 'getDatabaseIds',
 		},
@@ -28,7 +28,7 @@ export const operationFields: INodeProperties[] = [
 		default: '',
 		required: true,
 		description:
-			'Table to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Table to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		typeOptions: {
 			loadOptionsDependsOn: ['databaseId'],
 			loadOptionsMethod: 'getTableIds',
@@ -137,7 +137,7 @@ export const operationFields: INodeProperties[] = [
 						name: 'fieldId',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsDependsOn: ['tableId'],
 							loadOptionsMethod: 'getTableFields',
@@ -206,7 +206,7 @@ export const operationFields: INodeProperties[] = [
 										name: 'fieldId',
 										type: 'options',
 										description:
-											'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+											'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 										typeOptions: {
 											loadOptionsDependsOn: ['tableId'],
 											loadOptionsMethod: 'getTableFields',
@@ -364,7 +364,7 @@ export const operationFields: INodeProperties[] = [
 								type: 'options',
 								default: '',
 								description:
-									'Field to compare. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Field to compare. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 								typeOptions: {
 									loadOptionsDependsOn: ['tableId'],
 									loadOptionsMethod: 'getTableFields',
@@ -757,7 +757,7 @@ export const operationFields: INodeProperties[] = [
 								type: 'options',
 								default: '',
 								description:
-									'Field name to sort by. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Field name to sort by. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 								typeOptions: {
 									loadOptionsDependsOn: ['tableId'],
 									loadOptionsMethod: 'getTableFields',

--- a/packages/nodes-base/nodes/Beeminder/Beeminder.node.ts
+++ b/packages/nodes-base/nodes/Beeminder/Beeminder.node.ts
@@ -300,7 +300,7 @@ export class Beeminder implements INodeType {
 				},
 				default: '',
 				description:
-					'The name of the goal. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The name of the goal. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				required: true,
 			},
 			{
@@ -318,7 +318,7 @@ export class Beeminder implements INodeType {
 				},
 				default: '',
 				description:
-					'The name of the goal to derail. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The name of the goal to derail. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				required: true,
 			},
 			{
@@ -336,7 +336,7 @@ export class Beeminder implements INodeType {
 				},
 				default: '',
 				description:
-					'The name of the goal. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The name of the goal. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				required: true,
 			},
 			{

--- a/packages/nodes-base/nodes/Bitbucket/BitbucketTrigger.node.ts
+++ b/packages/nodes-base/nodes/Bitbucket/BitbucketTrigger.node.ts
@@ -135,7 +135,7 @@ export class BitbucketTrigger implements INodeType {
 				required: true,
 				default: '',
 				description:
-					'The repository of which to listen to the events. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The repository of which to listen to the events. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Event Names or IDs',
@@ -153,7 +153,7 @@ export class BitbucketTrigger implements INodeType {
 				required: true,
 				default: [],
 				description:
-					'The events to listen to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The events to listen to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Repository Name or ID',
@@ -171,7 +171,7 @@ export class BitbucketTrigger implements INodeType {
 				required: true,
 				default: '',
 				description:
-					'The repository of which to listen to the events. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The repository of which to listen to the events. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Event Names or IDs',
@@ -189,7 +189,7 @@ export class BitbucketTrigger implements INodeType {
 				required: true,
 				default: [],
 				description:
-					'The events to listen to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The events to listen to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	};

--- a/packages/nodes-base/nodes/Bitly/LinkDescription.ts
+++ b/packages/nodes-base/nodes/Bitly/LinkDescription.ts
@@ -77,7 +77,7 @@ export const linkFields: INodeProperties[] = [
 				name: 'group',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getGroups',
@@ -88,7 +88,7 @@ export const linkFields: INodeProperties[] = [
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getTags',
@@ -192,7 +192,7 @@ export const linkFields: INodeProperties[] = [
 				name: 'group',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getGroups',
@@ -209,7 +209,7 @@ export const linkFields: INodeProperties[] = [
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getTags',

--- a/packages/nodes-base/nodes/Bitwarden/descriptions/CollectionDescription.ts
+++ b/packages/nodes-base/nodes/Bitwarden/descriptions/CollectionDescription.ts
@@ -107,7 +107,7 @@ export const collectionFields: INodeProperties[] = [
 				name: 'groups',
 				type: 'multiOptions',
 				description:
-					'The group to assign this collection to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The group to assign this collection to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getGroups',

--- a/packages/nodes-base/nodes/Bitwarden/descriptions/GroupDescription.ts
+++ b/packages/nodes-base/nodes/Bitwarden/descriptions/GroupDescription.ts
@@ -149,7 +149,7 @@ export const groupFields: INodeProperties[] = [
 				name: 'collections',
 				type: 'multiOptions',
 				description:
-					'The collections to assign to this group. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The collections to assign to this group. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getCollections',
@@ -194,7 +194,7 @@ export const groupFields: INodeProperties[] = [
 				name: 'collections',
 				type: 'multiOptions',
 				description:
-					'The collections to assign to this group. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The collections to assign to this group. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getCollections',

--- a/packages/nodes-base/nodes/Bitwarden/descriptions/MemberDescription.ts
+++ b/packages/nodes-base/nodes/Bitwarden/descriptions/MemberDescription.ts
@@ -176,7 +176,7 @@ export const memberFields: INodeProperties[] = [
 				name: 'collections',
 				type: 'multiOptions',
 				description:
-					'The collections to assign to this member. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The collections to assign to this member. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getCollections',
@@ -236,7 +236,7 @@ export const memberFields: INodeProperties[] = [
 				name: 'collections',
 				type: 'multiOptions',
 				description:
-					'The collections to assign to this member. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The collections to assign to this member. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getCollections',

--- a/packages/nodes-base/nodes/Cal/CalTrigger.node.ts
+++ b/packages/nodes-base/nodes/Cal/CalTrigger.node.ts
@@ -136,7 +136,7 @@ export class CalTrigger implements INodeType {
 							loadOptionsMethod: 'getEventTypes',
 						},
 						description:
-							'The EventType to monitor. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The EventType to monitor. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 						default: '',
 					},
 					{

--- a/packages/nodes-base/nodes/Cisco/Webex/descriptions/MeetingDescription.ts
+++ b/packages/nodes-base/nodes/Cisco/Webex/descriptions/MeetingDescription.ts
@@ -356,7 +356,7 @@ export const meetingFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'URL of the Webex site which the meeting is created on. If not specified, the meeting is created on user\'s preferred site. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'URL of the Webex site which the meeting is created on. If not specified, the meeting is created on user\'s preferred site. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -591,7 +591,7 @@ export const meetingFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'URL of the Webex site which the API lists meetings from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'URL of the Webex site which the API lists meetings from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'State',
@@ -939,7 +939,7 @@ export const meetingFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'URL of the Webex site which the meeting is created on. If not specified, the meeting is created on user\'s preferred site. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'URL of the Webex site which the meeting is created on. If not specified, the meeting is created on user\'s preferred site. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Start',

--- a/packages/nodes-base/nodes/Cisco/Webex/descriptions/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Cisco/Webex/descriptions/MessageDescription.ts
@@ -80,7 +80,7 @@ export const messageFields: INodeProperties[] = [
 		name: 'roomId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getRooms',
 		},
@@ -416,7 +416,7 @@ export const messageFields: INodeProperties[] = [
 		displayName: 'Room Name or ID',
 		name: 'roomId',
 		description:
-			'List messages in a room, by ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'List messages in a room, by ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		typeOptions: {
 			loadOptionsMethod: 'getRooms',

--- a/packages/nodes-base/nodes/ClickUp/ClickUpTrigger.node.ts
+++ b/packages/nodes-base/nodes/ClickUp/ClickUpTrigger.node.ts
@@ -76,7 +76,7 @@ export class ClickUpTrigger implements INodeType {
 				name: 'team',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getTeams',
 				},

--- a/packages/nodes-base/nodes/ClickUp/FolderDescription.ts
+++ b/packages/nodes-base/nodes/ClickUp/FolderDescription.ts
@@ -56,7 +56,7 @@ export const folderFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -74,7 +74,7 @@ export const folderFields: INodeProperties[] = [
 		name: 'space',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -110,7 +110,7 @@ export const folderFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -128,7 +128,7 @@ export const folderFields: INodeProperties[] = [
 		name: 'space',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -147,7 +147,7 @@ export const folderFields: INodeProperties[] = [
 		name: 'folder',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -170,7 +170,7 @@ export const folderFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -188,7 +188,7 @@ export const folderFields: INodeProperties[] = [
 		name: 'space',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -207,7 +207,7 @@ export const folderFields: INodeProperties[] = [
 		name: 'folder',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -230,7 +230,7 @@ export const folderFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -248,7 +248,7 @@ export const folderFields: INodeProperties[] = [
 		name: 'space',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -309,7 +309,7 @@ export const folderFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -327,7 +327,7 @@ export const folderFields: INodeProperties[] = [
 		name: 'space',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -346,7 +346,7 @@ export const folderFields: INodeProperties[] = [
 		name: 'folder',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {

--- a/packages/nodes-base/nodes/ClickUp/GoalDescription.ts
+++ b/packages/nodes-base/nodes/ClickUp/GoalDescription.ts
@@ -56,7 +56,7 @@ export const goalFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -170,7 +170,7 @@ export const goalFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {

--- a/packages/nodes-base/nodes/ClickUp/GuestDescription.ts
+++ b/packages/nodes-base/nodes/ClickUp/GuestDescription.ts
@@ -50,7 +50,7 @@ export const guestFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -118,7 +118,7 @@ export const guestFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -153,7 +153,7 @@ export const guestFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -188,7 +188,7 @@ export const guestFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {

--- a/packages/nodes-base/nodes/ClickUp/ListDescription.ts
+++ b/packages/nodes-base/nodes/ClickUp/ListDescription.ts
@@ -68,7 +68,7 @@ export const listFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -86,7 +86,7 @@ export const listFields: INodeProperties[] = [
 		name: 'space',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -118,7 +118,7 @@ export const listFields: INodeProperties[] = [
 		name: 'folder',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -199,7 +199,7 @@ export const listFields: INodeProperties[] = [
 				name: 'status',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getStatuses',
 					loadOptionsDependsOn: ['list'],
@@ -265,7 +265,7 @@ export const listFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -283,7 +283,7 @@ export const listFields: INodeProperties[] = [
 		name: 'space',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -315,7 +315,7 @@ export const listFields: INodeProperties[] = [
 		name: 'folder',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -335,7 +335,7 @@ export const listFields: INodeProperties[] = [
 		name: 'list',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -355,7 +355,7 @@ export const listFields: INodeProperties[] = [
 		name: 'list',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -379,7 +379,7 @@ export const listFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -397,7 +397,7 @@ export const listFields: INodeProperties[] = [
 		name: 'space',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -429,7 +429,7 @@ export const listFields: INodeProperties[] = [
 		name: 'folder',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -466,7 +466,7 @@ export const listFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -484,7 +484,7 @@ export const listFields: INodeProperties[] = [
 		name: 'space',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -516,7 +516,7 @@ export const listFields: INodeProperties[] = [
 		name: 'folder',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -553,7 +553,7 @@ export const listFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -571,7 +571,7 @@ export const listFields: INodeProperties[] = [
 		name: 'space',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -603,7 +603,7 @@ export const listFields: INodeProperties[] = [
 		name: 'folder',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -665,7 +665,7 @@ export const listFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -683,7 +683,7 @@ export const listFields: INodeProperties[] = [
 		name: 'space',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -715,7 +715,7 @@ export const listFields: INodeProperties[] = [
 		name: 'folder',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -761,7 +761,7 @@ export const listFields: INodeProperties[] = [
 				name: 'assignee',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getAssignees',
 					loadOptionsDependsOn: ['list'],

--- a/packages/nodes-base/nodes/ClickUp/SpaceTagDescription.ts
+++ b/packages/nodes-base/nodes/ClickUp/SpaceTagDescription.ts
@@ -76,7 +76,7 @@ export const spaceTagFields: INodeProperties[] = [
 		name: 'name',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsDependsOn: ['space'],
 			loadOptionsMethod: 'getTags',

--- a/packages/nodes-base/nodes/ClickUp/TaskDescription.ts
+++ b/packages/nodes-base/nodes/ClickUp/TaskDescription.ts
@@ -68,7 +68,7 @@ export const taskFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -86,7 +86,7 @@ export const taskFields: INodeProperties[] = [
 		name: 'space',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -118,7 +118,7 @@ export const taskFields: INodeProperties[] = [
 		name: 'folder',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -138,7 +138,7 @@ export const taskFields: INodeProperties[] = [
 		name: 'list',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -158,7 +158,7 @@ export const taskFields: INodeProperties[] = [
 		name: 'list',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -205,7 +205,7 @@ export const taskFields: INodeProperties[] = [
 				name: 'assignees',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getAssignees',
 					loadOptionsDependsOn: ['list'],
@@ -288,7 +288,7 @@ export const taskFields: INodeProperties[] = [
 				name: 'status',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getStatuses',
 					loadOptionsDependsOn: ['list'],
@@ -305,7 +305,7 @@ export const taskFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The array of tags applied to this task. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The array of tags applied to this task. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Time Estimate',
@@ -493,7 +493,7 @@ export const taskFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -511,7 +511,7 @@ export const taskFields: INodeProperties[] = [
 		name: 'space',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -543,7 +543,7 @@ export const taskFields: INodeProperties[] = [
 		name: 'folder',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -563,7 +563,7 @@ export const taskFields: INodeProperties[] = [
 		name: 'list',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -583,7 +583,7 @@ export const taskFields: INodeProperties[] = [
 		name: 'list',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -653,7 +653,7 @@ export const taskFields: INodeProperties[] = [
 				name: 'assignees',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getAssignees',
 					loadOptionsDependsOn: ['list'],
@@ -685,7 +685,7 @@ export const taskFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Operator',
@@ -824,7 +824,7 @@ export const taskFields: INodeProperties[] = [
 				name: 'statuses',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getStatuses',
 					loadOptionsDependsOn: ['list'],
@@ -848,7 +848,7 @@ export const taskFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The array of tags applied to this task. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The array of tags applied to this task. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/ClickUp/TaskTagDescription.ts
+++ b/packages/nodes-base/nodes/ClickUp/TaskTagDescription.ts
@@ -88,7 +88,7 @@ export const taskTagFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Only used when the parameter is set to custom_task_ids=true. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Only used when the parameter is set to custom_task_ids=true. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/ClickUp/TimeEntryDescription.ts
+++ b/packages/nodes-base/nodes/ClickUp/TimeEntryDescription.ts
@@ -68,7 +68,7 @@ export const timeEntryFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -148,7 +148,7 @@ export const timeEntryFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -197,7 +197,7 @@ export const timeEntryFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -215,7 +215,7 @@ export const timeEntryFields: INodeProperties[] = [
 		name: 'space',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -247,7 +247,7 @@ export const timeEntryFields: INodeProperties[] = [
 		name: 'folder',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -267,7 +267,7 @@ export const timeEntryFields: INodeProperties[] = [
 		name: 'list',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -287,7 +287,7 @@ export const timeEntryFields: INodeProperties[] = [
 		name: 'list',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -334,7 +334,7 @@ export const timeEntryFields: INodeProperties[] = [
 		name: 'task',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		displayOptions: {
 			show: {
 				resource: ['timeEntry'],
@@ -365,7 +365,7 @@ export const timeEntryFields: INodeProperties[] = [
 				name: 'assignee',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getAssignees',
 					loadOptionsDependsOn: ['list'],
@@ -390,7 +390,7 @@ export const timeEntryFields: INodeProperties[] = [
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['team'],
 					loadOptionsMethod: 'getTimeEntryTags',
@@ -408,7 +408,7 @@ export const timeEntryFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -471,7 +471,7 @@ export const timeEntryFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -493,7 +493,7 @@ export const timeEntryFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -528,7 +528,7 @@ export const timeEntryFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -546,7 +546,7 @@ export const timeEntryFields: INodeProperties[] = [
 		name: 'space',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -578,7 +578,7 @@ export const timeEntryFields: INodeProperties[] = [
 		name: 'folder',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -598,7 +598,7 @@ export const timeEntryFields: INodeProperties[] = [
 		name: 'list',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -618,7 +618,7 @@ export const timeEntryFields: INodeProperties[] = [
 		name: 'list',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -677,7 +677,7 @@ export const timeEntryFields: INodeProperties[] = [
 				name: 'assignee',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getAssignees',
 					loadOptionsDependsOn: ['list'],
@@ -715,7 +715,7 @@ export const timeEntryFields: INodeProperties[] = [
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['spaceId'],
 					loadOptionsMethod: 'getTags',
@@ -727,7 +727,7 @@ export const timeEntryFields: INodeProperties[] = [
 				name: 'task',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getTasks',
 					loadOptionsDependsOn: ['archived', 'list'],

--- a/packages/nodes-base/nodes/ClickUp/TimeEntryTagDescription.ts
+++ b/packages/nodes-base/nodes/ClickUp/TimeEntryTagDescription.ts
@@ -44,7 +44,7 @@ export const timeEntryTagFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -97,7 +97,7 @@ export const timeEntryTagFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -174,7 +174,7 @@ export const timeEntryTagFields: INodeProperties[] = [
 		name: 'team',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		displayOptions: {
 			show: {
@@ -205,7 +205,7 @@ export const timeEntryTagFields: INodeProperties[] = [
 		name: 'tagNames',
 		type: 'multiOptions',
 		description:
-			'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTimeEntryTags',
 			loadOptionsDependsOn: ['teamId'],

--- a/packages/nodes-base/nodes/Clockify/Clockify.node.ts
+++ b/packages/nodes-base/nodes/Clockify/Clockify.node.ts
@@ -94,7 +94,7 @@ export class Clockify implements INodeType {
 				name: 'workspaceId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'listWorkspaces',
 				},

--- a/packages/nodes-base/nodes/Clockify/ClockifyTrigger.node.ts
+++ b/packages/nodes-base/nodes/Clockify/ClockifyTrigger.node.ts
@@ -42,7 +42,7 @@ export class ClockifyTrigger implements INodeType {
 				name: 'workspaceId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'listWorkspaces',
 				},

--- a/packages/nodes-base/nodes/Clockify/ProjectDescription.ts
+++ b/packages/nodes-base/nodes/Clockify/ProjectDescription.ts
@@ -95,7 +95,7 @@ export const projectFields: INodeProperties[] = [
 				name: 'clientId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['workspaceId'],
 					loadOptionsMethod: 'loadClientsForWorkspace',
@@ -253,7 +253,7 @@ export const projectFields: INodeProperties[] = [
 				name: 'clients',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['workspaceId'],
 					loadOptionsMethod: 'loadClientsForWorkspace',
@@ -345,7 +345,7 @@ export const projectFields: INodeProperties[] = [
 				name: 'users',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['workspaceId'],
 					loadOptionsMethod: 'loadUsersForWorkspace',
@@ -418,7 +418,7 @@ export const projectFields: INodeProperties[] = [
 				name: 'clientId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['workspaceId'],
 					loadOptionsMethod: 'loadClientsForWorkspace',

--- a/packages/nodes-base/nodes/Clockify/TaskDescription.ts
+++ b/packages/nodes-base/nodes/Clockify/TaskDescription.ts
@@ -53,7 +53,7 @@ export const taskFields: INodeProperties[] = [
 		name: 'projectId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsDependsOn: ['workspaceId'],
 			loadOptionsMethod: 'loadProjectsForWorkspace',
@@ -101,7 +101,7 @@ export const taskFields: INodeProperties[] = [
 				name: 'assigneeIds',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'loadUsersForWorkspace',
@@ -280,7 +280,7 @@ export const taskFields: INodeProperties[] = [
 				name: 'assigneeIds',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'loadUsersForWorkspace',

--- a/packages/nodes-base/nodes/Clockify/TimeEntryDescription.ts
+++ b/packages/nodes-base/nodes/Clockify/TimeEntryDescription.ts
@@ -102,7 +102,7 @@ export const timeEntryFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -132,7 +132,7 @@ export const timeEntryFields: INodeProperties[] = [
 				name: 'projectId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['workspaceId'],
 					loadOptionsMethod: 'loadProjectsForWorkspace',
@@ -144,7 +144,7 @@ export const timeEntryFields: INodeProperties[] = [
 				name: 'tagIds',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['workspaceId'],
 					loadOptionsMethod: 'loadTagsForWorkspace',
@@ -283,7 +283,7 @@ export const timeEntryFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -313,7 +313,7 @@ export const timeEntryFields: INodeProperties[] = [
 				name: 'projectId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['workspaceId'],
 					loadOptionsMethod: 'loadProjectsForWorkspace',
@@ -331,7 +331,7 @@ export const timeEntryFields: INodeProperties[] = [
 				name: 'tagIds',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['workspaceId'],
 					loadOptionsMethod: 'loadTagsForWorkspace',

--- a/packages/nodes-base/nodes/Cloudflare/ZoneCertificateDescription.ts
+++ b/packages/nodes-base/nodes/Cloudflare/ZoneCertificateDescription.ts
@@ -50,7 +50,7 @@ export const zoneCertificateFields: INodeProperties[] = [
 		name: 'zoneId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getZones',
 		},

--- a/packages/nodes-base/nodes/Cockpit/CollectionDescription.ts
+++ b/packages/nodes-base/nodes/Cockpit/CollectionDescription.ts
@@ -52,7 +52,7 @@ export const collectionFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'Name of the collection to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Name of the collection to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 
 	// Collection:entry:getAll

--- a/packages/nodes-base/nodes/Cockpit/SingletonDescription.ts
+++ b/packages/nodes-base/nodes/Cockpit/SingletonDescription.ts
@@ -39,6 +39,6 @@ export const singletonFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'Name of the singleton to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Name of the singleton to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 ];

--- a/packages/nodes-base/nodes/Coda/ControlDescription.ts
+++ b/packages/nodes-base/nodes/Coda/ControlDescription.ts
@@ -49,7 +49,7 @@ export const controlFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Control ID',
@@ -84,7 +84,7 @@ export const controlFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',

--- a/packages/nodes-base/nodes/Coda/FormulaDescription.ts
+++ b/packages/nodes-base/nodes/Coda/FormulaDescription.ts
@@ -49,7 +49,7 @@ export const formulaFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Formula ID',
@@ -84,7 +84,7 @@ export const formulaFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',

--- a/packages/nodes-base/nodes/Coda/TableDescription.ts
+++ b/packages/nodes-base/nodes/Coda/TableDescription.ts
@@ -79,7 +79,7 @@ export const tableFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Table Name or ID',
@@ -98,7 +98,7 @@ export const tableFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The table to create the row in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The table to create the row in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Options',
@@ -149,7 +149,7 @@ export const tableFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Table Name or ID',
@@ -168,7 +168,7 @@ export const tableFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The table to get the row from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The table to get the row from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Row ID',
@@ -255,7 +255,7 @@ export const tableFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Table Name or ID',
@@ -274,7 +274,7 @@ export const tableFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The table to get the rows from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The table to get the rows from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',
@@ -410,7 +410,7 @@ export const tableFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Table Name or ID',
@@ -429,7 +429,7 @@ export const tableFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The table to delete the row in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The table to delete the row in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Row ID',
@@ -464,7 +464,7 @@ export const tableFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Table Name or ID',
@@ -483,7 +483,7 @@ export const tableFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The table to get the row from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The table to get the row from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Row ID',
@@ -505,7 +505,7 @@ export const tableFields: INodeProperties[] = [
 		name: 'columnId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		typeOptions: {
 			loadOptionsMethod: 'getColumns',
@@ -538,7 +538,7 @@ export const tableFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Table Name or ID',
@@ -557,7 +557,7 @@ export const tableFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The table to get the row from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The table to get the row from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Column ID',
@@ -592,7 +592,7 @@ export const tableFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Table Name or ID',
@@ -611,7 +611,7 @@ export const tableFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The table to get the row from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The table to get the row from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',

--- a/packages/nodes-base/nodes/Coda/ViewDescription.ts
+++ b/packages/nodes-base/nodes/Coda/ViewDescription.ts
@@ -78,7 +78,7 @@ export const viewFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'View ID',
@@ -113,7 +113,7 @@ export const viewFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',
@@ -165,7 +165,7 @@ export const viewFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'View Name or ID',
@@ -184,7 +184,7 @@ export const viewFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The table to get the rows from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The table to get the rows from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',
@@ -313,7 +313,7 @@ export const viewFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'View Name or ID',
@@ -332,7 +332,7 @@ export const viewFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The table to get the rows from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The table to get the rows from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',
@@ -384,7 +384,7 @@ export const viewFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'View Name or ID',
@@ -403,7 +403,7 @@ export const viewFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The view to get the row from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The view to get the row from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Row Name or ID',
@@ -422,7 +422,7 @@ export const viewFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The view to get the row from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The view to get the row from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	/* -------------------------------------------------------------------------- */
 	/*                                   view:pushViewButton                      */
@@ -443,7 +443,7 @@ export const viewFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'View Name or ID',
@@ -462,7 +462,7 @@ export const viewFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The view to get the row from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The view to get the row from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Row Name or ID',
@@ -481,14 +481,14 @@ export const viewFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The view to get the row from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The view to get the row from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Column Name or ID',
 		name: 'columnId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		typeOptions: {
 			loadOptionsMethod: 'getViewColumns',
@@ -521,7 +521,7 @@ export const viewFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the doc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'View Name or ID',
@@ -540,7 +540,7 @@ export const viewFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The view to get the row from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The view to get the row from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Row Name or ID',
@@ -559,7 +559,7 @@ export const viewFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The view to get the row from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The view to get the row from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Key Name',

--- a/packages/nodes-base/nodes/CoinGecko/CoinDescription.ts
+++ b/packages/nodes-base/nodes/CoinGecko/CoinDescription.ts
@@ -99,7 +99,7 @@ export const coinFields: INodeProperties[] = [
 		required: true,
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getCoins',
 		},
@@ -128,7 +128,7 @@ export const coinFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The first currency in the pair. For BTC:ETH this is BTC. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The first currency in the pair. For BTC:ETH this is BTC. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Base Currency Name or ID',
@@ -146,7 +146,7 @@ export const coinFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The first currency in the pair. For BTC:ETH this is BTC. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The first currency in the pair. For BTC:ETH this is BTC. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Coin Name or ID',
@@ -154,7 +154,7 @@ export const coinFields: INodeProperties[] = [
 		required: true,
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getCoins',
 		},
@@ -185,7 +185,7 @@ export const coinFields: INodeProperties[] = [
 		default: [],
 		placeholder: 'bitcoin',
 		description:
-			'The first currency in the pair. For BTC:ETH this is BTC. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The first currency in the pair. For BTC:ETH this is BTC. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Platform ID',
@@ -258,7 +258,7 @@ export const coinFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The first currency in the pair. For BTC:ETH this is BTC. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The first currency in the pair. For BTC:ETH this is BTC. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Quote Currency Name or ID',
@@ -276,7 +276,7 @@ export const coinFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The second currency in the pair. For BTC:ETH this is ETH. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The second currency in the pair. For BTC:ETH this is ETH. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Quote Currency Names or IDs',
@@ -294,7 +294,7 @@ export const coinFields: INodeProperties[] = [
 		},
 		default: [],
 		description:
-			'The second currency in the pair. For BTC:ETH this is ETH. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The second currency in the pair. For BTC:ETH this is ETH. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Range (Days)',
@@ -573,7 +573,7 @@ export const coinFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Filter results by exchange IDs. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Filter results by exchange IDs. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Include Exchange Logo',

--- a/packages/nodes-base/nodes/CoinGecko/EventDescription.ts
+++ b/packages/nodes-base/nodes/CoinGecko/EventDescription.ts
@@ -78,7 +78,7 @@ export const eventFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Country code of event. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Country code of event. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'From Date',
@@ -103,7 +103,7 @@ export const eventFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Type of event. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Type of event. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Upcoming Events Only',

--- a/packages/nodes-base/nodes/ConvertKit/ConvertKitTrigger.node.ts
+++ b/packages/nodes-base/nodes/ConvertKit/ConvertKitTrigger.node.ts
@@ -97,7 +97,7 @@ export class ConvertKitTrigger implements INodeType {
 				name: 'formId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getForms',
 				},
@@ -114,7 +114,7 @@ export class ConvertKitTrigger implements INodeType {
 				name: 'courseId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getSequences',
 				},
@@ -156,7 +156,7 @@ export class ConvertKitTrigger implements INodeType {
 				name: 'tagId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getTags',
 				},

--- a/packages/nodes-base/nodes/ConvertKit/FormDescription.ts
+++ b/packages/nodes-base/nodes/ConvertKit/FormDescription.ts
@@ -42,7 +42,7 @@ export const formFields: INodeProperties[] = [
 		name: 'id',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getForms',
 		},

--- a/packages/nodes-base/nodes/ConvertKit/SequenceDescription.ts
+++ b/packages/nodes-base/nodes/ConvertKit/SequenceDescription.ts
@@ -42,7 +42,7 @@ export const sequenceFields: INodeProperties[] = [
 		name: 'id',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getSequences',
 		},
@@ -166,7 +166,7 @@ export const sequenceFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Tags. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Tags. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/ConvertKit/TagSubscriberDescription.ts
+++ b/packages/nodes-base/nodes/ConvertKit/TagSubscriberDescription.ts
@@ -41,7 +41,7 @@ export const tagSubscriberFields: INodeProperties[] = [
 		name: 'tagId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTags',
 		},

--- a/packages/nodes-base/nodes/Cortex/AnalyzerDescriptions.ts
+++ b/packages/nodes-base/nodes/Cortex/AnalyzerDescriptions.ts
@@ -43,7 +43,7 @@ export const analyzerFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Choose the analyzer. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Choose the analyzer. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		default: '',
 	},
 	{
@@ -66,7 +66,7 @@ export const analyzerFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'Choose the observable type. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Choose the observable type. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 
 	// Observable type != file

--- a/packages/nodes-base/nodes/Cortex/ResponderDescription.ts
+++ b/packages/nodes-base/nodes/Cortex/ResponderDescription.ts
@@ -43,7 +43,7 @@ export const responderFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Choose the responder. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Choose the responder. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Entity Type Name or ID',
@@ -61,7 +61,7 @@ export const responderFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'Choose the Data type. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Choose the Data type. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'JSON Parameters',

--- a/packages/nodes-base/nodes/Crypto/v1/CryptoV1.node.ts
+++ b/packages/nodes-base/nodes/Crypto/v1/CryptoV1.node.ts
@@ -336,7 +336,7 @@ const versionDescription: INodeTypeDescription = {
 			},
 			type: 'options',
 			description:
-				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			options: supportedAlgorithms,
 			default: '',
 			required: true,

--- a/packages/nodes-base/nodes/Crypto/v2/CryptoV2.node.ts
+++ b/packages/nodes-base/nodes/Crypto/v2/CryptoV2.node.ts
@@ -336,7 +336,7 @@ const versionDescription: INodeTypeDescription = {
 			},
 			type: 'options',
 			description:
-				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			options: supportedAlgorithms,
 			default: '',
 			required: true,

--- a/packages/nodes-base/nodes/DataTable/actions/row/get.operation.ts
+++ b/packages/nodes-base/nodes/DataTable/actions/row/get.operation.ts
@@ -60,7 +60,7 @@ export const description: INodeProperties[] = [
 		type: 'options',
 		// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 		description:
-			'Choose from the list, or specify using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsDependsOn: ['dataTableId.value'],
 			loadOptionsMethod: 'getDataTableColumns',

--- a/packages/nodes-base/nodes/DataTable/common/selectMany.ts
+++ b/packages/nodes-base/nodes/DataTable/common/selectMany.ts
@@ -87,7 +87,7 @@ export function getSelectFields(
 							type: 'options',
 							// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 							description:
-								'Choose from the list, or specify using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+								'Choose from the list, or specify using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 							typeOptions: {
 								loadOptionsDependsOn: [`${DATA_TABLE_ID_FIELD}.value`],
 								loadOptionsMethod: 'getDataTableColumns',

--- a/packages/nodes-base/nodes/DateTime/V1/DateTimeV1.node.ts
+++ b/packages/nodes-base/nodes/DateTime/V1/DateTimeV1.node.ts
@@ -217,7 +217,7 @@ const versionDescription: INodeTypeDescription = {
 					},
 					default: 'UTC',
 					description:
-						'The timezone to convert from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						'The timezone to convert from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				},
 				{
 					displayName: 'To Timezone Name or ID',
@@ -228,7 +228,7 @@ const versionDescription: INodeTypeDescription = {
 					},
 					default: 'UTC',
 					description:
-						'The timezone to convert to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						'The timezone to convert to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				},
 			],
 		},

--- a/packages/nodes-base/nodes/DeepL/TextDescription.ts
+++ b/packages/nodes-base/nodes/DeepL/TextDescription.ts
@@ -23,7 +23,7 @@ export const textOperations: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'Language to translate to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Language to translate to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		required: true,
 		displayOptions: {
 			show: {
@@ -44,7 +44,7 @@ export const textOperations: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Language to translate from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Language to translate from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getLanguages',
 				},

--- a/packages/nodes-base/nodes/Demio/EventDescription.ts
+++ b/packages/nodes-base/nodes/Demio/EventDescription.ts
@@ -160,7 +160,7 @@ export const eventFields: INodeProperties[] = [
 		name: 'eventId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getEvents',
 		},
@@ -293,7 +293,7 @@ export const eventFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Event Session ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Event Session ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Website',

--- a/packages/nodes-base/nodes/Demio/ReportDescription.ts
+++ b/packages/nodes-base/nodes/Demio/ReportDescription.ts
@@ -32,7 +32,7 @@ export const reportFields: INodeProperties[] = [
 		name: 'eventId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getEvents',
 		},
@@ -55,7 +55,7 @@ export const reportFields: INodeProperties[] = [
 		default: '',
 		required: true,
 		description:
-			'ID of the session. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the session. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['report'],

--- a/packages/nodes-base/nodes/Discourse/PostDescription.ts
+++ b/packages/nodes-base/nodes/Discourse/PostDescription.ts
@@ -96,7 +96,7 @@ export const postFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the category. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the category. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Reply To Post Number',

--- a/packages/nodes-base/nodes/E2eTest/E2eTest.node.ts
+++ b/packages/nodes-base/nodes/E2eTest/E2eTest.node.ts
@@ -59,7 +59,7 @@ export class E2eTest implements INodeType {
 				displayName: 'Remote Options Name or ID',
 				name: 'remoteOptions',
 				description:
-					'Remote options to load. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Remote options to load. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				type: 'options',
 				typeOptions: {
 					loadOptionsDependsOn: ['fieldId'],

--- a/packages/nodes-base/nodes/ERPNext/DocumentDescription.ts
+++ b/packages/nodes-base/nodes/ERPNext/DocumentDescription.ts
@@ -60,7 +60,7 @@ export const documentFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'DocType whose documents to retrieve. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'DocType whose documents to retrieve. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		placeholder: 'Customer',
 		displayOptions: {
 			show: {
@@ -122,7 +122,7 @@ export const documentFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Comma-separated list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Comma-separated list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				placeholder: 'name,country',
 			},
 			{
@@ -145,7 +145,7 @@ export const documentFields: INodeProperties[] = [
 								name: 'field',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								typeOptions: {
 									loadOptionsMethod: 'getDocFields',
 									loadOptionsDependsOn: ['docType'],
@@ -211,7 +211,7 @@ export const documentFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'DocType you would like to create. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'DocType you would like to create. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		placeholder: 'Customer',
 		displayOptions: {
 			show: {
@@ -247,7 +247,7 @@ export const documentFields: INodeProperties[] = [
 						name: 'field',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getDocFields',
 							loadOptionsDependsOn: ['docType'],
@@ -277,7 +277,7 @@ export const documentFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The type of document you would like to get. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The type of document you would like to get. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['document'],
@@ -313,7 +313,7 @@ export const documentFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The type of document you would like to delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The type of document you would like to delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['document'],
@@ -349,7 +349,7 @@ export const documentFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The type of document you would like to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The type of document you would like to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['document'],
@@ -398,7 +398,7 @@ export const documentFields: INodeProperties[] = [
 						name: 'field',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getDocFields',
 							loadOptionsDependsOn: ['docType'],

--- a/packages/nodes-base/nodes/EditImage/EditImage.node.ts
+++ b/packages/nodes-base/nodes/EditImage/EditImage.node.ts
@@ -860,7 +860,7 @@ export class EditImage implements INodeType {
 								},
 								default: '',
 								description:
-									'The font to use. Defaults to Arial. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The font to use. Defaults to Arial. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 						],
 					},
@@ -909,7 +909,7 @@ export class EditImage implements INodeType {
 						},
 						default: '',
 						description:
-							'The font to use. Defaults to Arial. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The font to use. Defaults to Arial. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Format',

--- a/packages/nodes-base/nodes/Egoi/Egoi.node.ts
+++ b/packages/nodes-base/nodes/Egoi/Egoi.node.ts
@@ -98,7 +98,7 @@ export class Egoi implements INodeType {
 				},
 				default: '',
 				description:
-					'ID of list to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of list to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Email',
@@ -189,7 +189,7 @@ export class Egoi implements INodeType {
 										name: 'field_id',
 										type: 'options',
 										description:
-											'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+											'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 										typeOptions: {
 											loadOptionsMethod: 'getExtraFields',
 											loadOptionsDependsOn: ['list'],
@@ -254,7 +254,7 @@ export class Egoi implements INodeType {
 						},
 						default: [],
 						description:
-							'List of tag IDs to be added. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'List of tag IDs to be added. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 				],
 			},
@@ -317,7 +317,7 @@ export class Egoi implements INodeType {
 										name: 'field_id',
 										type: 'options',
 										description:
-											'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+											'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 										typeOptions: {
 											loadOptionsMethod: 'getExtraFields',
 											loadOptionsDependsOn: ['list'],
@@ -382,7 +382,7 @@ export class Egoi implements INodeType {
 						},
 						default: [],
 						description:
-							'List of tag IDs to be added. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'List of tag IDs to be added. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 				],
 			},

--- a/packages/nodes-base/nodes/Elastic/ElasticSecurity/descriptions/CaseDescription.ts
+++ b/packages/nodes-base/nodes/Elastic/ElasticSecurity/descriptions/CaseDescription.ts
@@ -74,7 +74,7 @@ export const caseFields: INodeProperties[] = [
 		displayName: 'Connector Name or ID',
 		name: 'connectorId',
 		description:
-			'Connectors allow you to send Elastic Security cases into other systems (only ServiceNow, Jira, or IBM Resilient). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Connectors allow you to send Elastic Security cases into other systems (only ServiceNow, Jira, or IBM Resilient). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		required: true,
 		default: '',
@@ -427,7 +427,7 @@ export const caseFields: INodeProperties[] = [
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getTags',

--- a/packages/nodes-base/nodes/Elastic/ElasticSecurity/descriptions/CaseTagDescription.ts
+++ b/packages/nodes-base/nodes/Elastic/ElasticSecurity/descriptions/CaseTagDescription.ts
@@ -51,7 +51,7 @@ export const caseTagFields: INodeProperties[] = [
 		name: 'tag',
 		type: 'options',
 		description:
-			'Tag to attach to the case. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Tag to attach to the case. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		required: true,
 		default: '',
 		typeOptions: {
@@ -86,7 +86,7 @@ export const caseTagFields: INodeProperties[] = [
 		name: 'tag',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		default: '',
 		typeOptions: {

--- a/packages/nodes-base/nodes/Emelia/CampaignDescription.ts
+++ b/packages/nodes-base/nodes/Emelia/CampaignDescription.ts
@@ -66,7 +66,7 @@ export const campaignFields: INodeProperties[] = [
 		default: [],
 		required: true,
 		description:
-			'The ID of the campaign to add the contact to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the campaign to add the contact to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['campaign'],
@@ -303,7 +303,7 @@ export const campaignFields: INodeProperties[] = [
 		default: '',
 		required: true,
 		description:
-			'The ID of the campaign to duplicate. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the campaign to duplicate. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		typeOptions: {
 			loadOptionsMethod: 'getCampaigns',
 		},

--- a/packages/nodes-base/nodes/Emelia/ContactListDescription.ts
+++ b/packages/nodes-base/nodes/Emelia/ContactListDescription.ts
@@ -41,7 +41,7 @@ export const contactListFields: INodeProperties[] = [
 		default: [],
 		required: true,
 		description:
-			'The ID of the contact list to add the contact to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the contact list to add the contact to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['contactList'],

--- a/packages/nodes-base/nodes/Emelia/EmeliaTrigger.node.ts
+++ b/packages/nodes-base/nodes/Emelia/EmeliaTrigger.node.ts
@@ -52,7 +52,7 @@ export class EmeliaTrigger implements INodeType {
 				name: 'campaignId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getCampaigns',
 				},

--- a/packages/nodes-base/nodes/Eventbrite/EventbriteTrigger.node.ts
+++ b/packages/nodes-base/nodes/Eventbrite/EventbriteTrigger.node.ts
@@ -87,7 +87,7 @@ export class EventbriteTrigger implements INodeType {
 				},
 				default: '',
 				description:
-					'The Eventbrite Organization to work on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The Eventbrite Organization to work on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Event Name or ID',
@@ -100,7 +100,7 @@ export class EventbriteTrigger implements INodeType {
 				},
 				default: '',
 				description:
-					'Limit the triggers to this event. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Limit the triggers to this event. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Actions',

--- a/packages/nodes-base/nodes/Facebook/FacebookTrigger.node.ts
+++ b/packages/nodes-base/nodes/Facebook/FacebookTrigger.node.ts
@@ -147,7 +147,7 @@ export class FacebookTrigger implements INodeType {
 				},
 				default: [],
 				description:
-					'The set of fields in this object that are subscribed to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The set of fields in this object that are subscribed to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Options',

--- a/packages/nodes-base/nodes/FileMaker/FileMaker.node.ts
+++ b/packages/nodes-base/nodes/FileMaker/FileMaker.node.ts
@@ -112,7 +112,7 @@ export class FileMaker implements INodeType {
 				displayOptions: {},
 				placeholder: 'Layout Name',
 				description:
-					'FileMaker Layout Name. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'FileMaker Layout Name. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Record ID',
@@ -188,7 +188,7 @@ export class FileMaker implements INodeType {
 				},
 				placeholder: 'Portals',
 				description:
-					'The portal result set to return. Use the portal object name or portal table name. If this parameter is omitted, the API will return all portal objects and records in the layout. For best performance, pass the portal object name or portal table name. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The portal result set to return. Use the portal object name or portal table name. If this parameter is omitted, the API will return all portal objects and records in the layout. For best performance, pass the portal object name or portal table name. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			// ----------------------------------
 			//         find/records
@@ -198,7 +198,7 @@ export class FileMaker implements INodeType {
 				name: 'responseLayout',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getResponseLayouts',
 				},
@@ -253,7 +253,7 @@ export class FileMaker implements INodeType {
 												},
 												options: [],
 												description:
-													'Search Field. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+													'Search Field. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 											},
 											{
 												displayName: 'Value',
@@ -320,7 +320,7 @@ export class FileMaker implements INodeType {
 								},
 								options: [],
 								description:
-									'Field Name. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Field Name. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Order',
@@ -374,7 +374,7 @@ export class FileMaker implements INodeType {
 				},
 				placeholder: 'Script Name',
 				description:
-					'The name of the FileMaker script to be run after the action specified by the API call and after the subsequent sort. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The name of the FileMaker script to be run after the action specified by the API call and after the subsequent sort. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Script Parameter',
@@ -421,7 +421,7 @@ export class FileMaker implements INodeType {
 				},
 				placeholder: 'Script Name',
 				description:
-					'The name of the FileMaker script to be run after the action specified by the API call but before the subsequent sort. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The name of the FileMaker script to be run after the action specified by the API call but before the subsequent sort. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Script Parameter',
@@ -468,7 +468,7 @@ export class FileMaker implements INodeType {
 				},
 				placeholder: 'Script Name',
 				description:
-					'The name of the FileMaker script to be run after the action specified by the API call and after the subsequent sort. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The name of the FileMaker script to be run after the action specified by the API call and after the subsequent sort. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Script Parameter',
@@ -546,7 +546,7 @@ export class FileMaker implements INodeType {
 								},
 								options: [],
 								description:
-									'Field Name. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Field Name. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -578,7 +578,7 @@ export class FileMaker implements INodeType {
 				},
 				placeholder: 'Script Name',
 				description:
-					'The name of the FileMaker script to be run. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The name of the FileMaker script to be run. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Script Parameter',

--- a/packages/nodes-base/nodes/FormIo/FormIoTrigger.node.ts
+++ b/packages/nodes-base/nodes/FormIo/FormIoTrigger.node.ts
@@ -51,7 +51,7 @@ export class FormIoTrigger implements INodeType {
 				required: true,
 				default: '',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			},
 			{
 				displayName: 'Form Name or ID',
@@ -64,7 +64,7 @@ export class FormIoTrigger implements INodeType {
 				required: true,
 				default: '',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			},
 			{
 				displayName: 'Trigger Events',

--- a/packages/nodes-base/nodes/Formstack/FormstackTrigger.node.ts
+++ b/packages/nodes-base/nodes/Formstack/FormstackTrigger.node.ts
@@ -80,7 +80,7 @@ export class FormstackTrigger implements INodeType {
 				default: '',
 				required: true,
 				description:
-					'The Formstack form to monitor for new submissions. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The Formstack form to monitor for new submissions. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Simplify',

--- a/packages/nodes-base/nodes/Freshdesk/Freshdesk.node.ts
+++ b/packages/nodes-base/nodes/Freshdesk/Freshdesk.node.ts
@@ -372,7 +372,7 @@ export class Freshdesk implements INodeType {
 							loadOptionsMethod: 'getAgents',
 						},
 						description:
-							'ID of the agent to whom the ticket has been assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the agent to whom the ticket has been assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'CC Emails',
@@ -391,7 +391,7 @@ export class Freshdesk implements INodeType {
 							loadOptionsMethod: 'getCompanies',
 						},
 						description:
-							'Company ID of the requester. This attribute can only be set if the Multiple Companies feature is enabled (Estate plan and above). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Company ID of the requester. This attribute can only be set if the Multiple Companies feature is enabled (Estate plan and above). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Description',
@@ -434,7 +434,7 @@ export class Freshdesk implements INodeType {
 							loadOptionsMethod: 'getGroups',
 						},
 						description:
-							'ID of the group to which the ticket has been assigned. The default value is the ID of the group that is associated with the given email_config_id. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the group to which the ticket has been assigned. The default value is the ID of the group that is associated with the given email_config_id. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Name',
@@ -453,7 +453,7 @@ export class Freshdesk implements INodeType {
 							loadOptionsMethod: 'getProducts',
 						},
 						description:
-							'ID of the product to which the ticket is associated. It will be ignored if the email_config_id attribute is set in the request. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the product to which the ticket is associated. It will be ignored if the email_config_id attribute is set in the request. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Subject',
@@ -611,7 +611,7 @@ export class Freshdesk implements INodeType {
 							loadOptionsMethod: 'getAgents',
 						},
 						description:
-							'ID of the agent to whom the ticket has been assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the agent to whom the ticket has been assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'CC Emails',
@@ -630,7 +630,7 @@ export class Freshdesk implements INodeType {
 							loadOptionsMethod: 'getCompanies',
 						},
 						description:
-							'Company ID of the requester. This attribute can only be set if the Multiple Companies feature is enabled (Estate plan and above). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Company ID of the requester. This attribute can only be set if the Multiple Companies feature is enabled (Estate plan and above). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Due By',
@@ -663,7 +663,7 @@ export class Freshdesk implements INodeType {
 							loadOptionsMethod: 'getGroups',
 						},
 						description:
-							'ID of the group to which the ticket has been assigned. The default value is the ID of the group that is associated with the given email_config_id. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the group to which the ticket has been assigned. The default value is the ID of the group that is associated with the given email_config_id. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Name',
@@ -682,7 +682,7 @@ export class Freshdesk implements INodeType {
 							loadOptionsMethod: 'getProducts',
 						},
 						description:
-							'ID of the product to which the ticket is associated. It will be ignored if the email_config_id attribute is set in the request. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the product to which the ticket is associated. It will be ignored if the email_config_id attribute is set in the request. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Priority',

--- a/packages/nodes-base/nodes/Freshservice/descriptions/AgentDescription.ts
+++ b/packages/nodes-base/nodes/Freshservice/descriptions/AgentDescription.ts
@@ -106,7 +106,7 @@ export const agentFields: INodeProperties[] = [
 						displayName: 'Role Name or ID',
 						name: 'role',
 						description:
-							'Name of the role to assign to the agent. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Name of the role to assign to the agent. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 						type: 'options',
 						typeOptions: {
 							loadOptionsMethod: 'getAgentRoles',
@@ -144,7 +144,7 @@ export const agentFields: INodeProperties[] = [
 						displayName: 'Group Names or IDs',
 						name: 'groups',
 						description:
-							'Groups in which the permissions granted by the role apply. Required only when Scope is Specified Groups - ignored otherwise. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Groups in which the permissions granted by the role apply. Required only when Scope is Specified Groups - ignored otherwise. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 						type: 'multiOptions',
 						typeOptions: {
 							loadOptionsMethod: 'getAgentGroups',
@@ -186,7 +186,7 @@ export const agentFields: INodeProperties[] = [
 				type: 'multiOptions',
 				default: [],
 				description:
-					'IDs of the departments to which the agent belongs. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'IDs of the departments to which the agent belongs. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getDepartments',
 				},
@@ -216,7 +216,7 @@ export const agentFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getLocations',
 				},
@@ -227,7 +227,7 @@ export const agentFields: INodeProperties[] = [
 				type: 'multiOptions',
 				default: [],
 				description:
-					'Comma-separated IDs of the groups that the agent is a member of. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Comma-separated IDs of the groups that the agent is a member of. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgentGroups',
 				},
@@ -244,7 +244,7 @@ export const agentFields: INodeProperties[] = [
 				type: 'multiOptions',
 				default: [],
 				description:
-					'Comma-separated IDs of the groups that the agent is an observer of. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Comma-separated IDs of the groups that the agent is an observer of. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgentGroups',
 				},
@@ -396,7 +396,7 @@ export const agentFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the department to which the agent belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the department to which the agent belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getDepartments',
 				},
@@ -439,7 +439,7 @@ export const agentFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Choose from the list or specify an ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Choose from the list or specify an ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getLocations',
 				},
@@ -507,7 +507,7 @@ export const agentFields: INodeProperties[] = [
 				type: 'multiOptions',
 				default: [],
 				description:
-					'IDs of the departments to which the agent belongs. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'IDs of the departments to which the agent belongs. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getDepartments',
 				},
@@ -550,7 +550,7 @@ export const agentFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Choose from the list or specify an ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Choose from the list or specify an ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getLocations',
 				},
@@ -561,7 +561,7 @@ export const agentFields: INodeProperties[] = [
 				type: 'multiOptions',
 				default: [],
 				description:
-					'Comma-separated IDs of the groups that the agent is a member of. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Comma-separated IDs of the groups that the agent is a member of. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgentGroups',
 				},
@@ -578,7 +578,7 @@ export const agentFields: INodeProperties[] = [
 				type: 'multiOptions',
 				default: [],
 				description:
-					'Comma-separated IDs of the groups that the agent is an observer of. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Comma-separated IDs of the groups that the agent is an observer of. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgentGroups',
 				},

--- a/packages/nodes-base/nodes/Freshservice/descriptions/AgentGroupDescription.ts
+++ b/packages/nodes-base/nodes/Freshservice/descriptions/AgentGroupDescription.ts
@@ -92,7 +92,7 @@ export const agentGroupFields: INodeProperties[] = [
 					loadOptionsMethod: 'getAgents',
 				},
 				description:
-					'ID of the user to whom an escalation email is sent if a ticket in this group is unassigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user to whom an escalation email is sent if a ticket in this group is unassigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Member Names or IDs',
@@ -100,7 +100,7 @@ export const agentGroupFields: INodeProperties[] = [
 				type: 'multiOptions',
 				default: [],
 				description:
-					'Comma-separated IDs of agents who are members of this group. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Comma-separated IDs of agents who are members of this group. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgents',
 				},
@@ -111,7 +111,7 @@ export const agentGroupFields: INodeProperties[] = [
 				type: 'multiOptions',
 				default: [],
 				description:
-					'Comma-separated agent IDs who are observers of this group. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Comma-separated agent IDs who are observers of this group. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgents',
 				},
@@ -273,7 +273,7 @@ export const agentGroupFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the agent to whom an escalation email is sent if a ticket in this group is unassigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the agent to whom an escalation email is sent if a ticket in this group is unassigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgents',
 				},
@@ -284,7 +284,7 @@ export const agentGroupFields: INodeProperties[] = [
 				type: 'multiOptions',
 				default: [],
 				description:
-					'Comma-separated IDs of agents who are members of this group. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Comma-separated IDs of agents who are members of this group. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgents',
 				},
@@ -301,7 +301,7 @@ export const agentGroupFields: INodeProperties[] = [
 				type: 'multiOptions',
 				default: [],
 				description:
-					'Comma-separated agent user IDs who are observers of this group. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Comma-separated agent user IDs who are observers of this group. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgents',
 				},

--- a/packages/nodes-base/nodes/Freshservice/descriptions/AnnouncementDescription.ts
+++ b/packages/nodes-base/nodes/Freshservice/descriptions/AnnouncementDescription.ts
@@ -146,7 +146,7 @@ export const announcementFields: INodeProperties[] = [
 				type: 'multiOptions',
 				default: [],
 				description:
-					'Comma-separated IDs of departments that may view this announcement. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Comma-separated IDs of departments that may view this announcement. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getDepartments',
 				},
@@ -289,7 +289,7 @@ export const announcementFields: INodeProperties[] = [
 				type: 'multiOptions',
 				default: [],
 				description:
-					'Comma-separated IDs of departments that may view this announcement. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Comma-separated IDs of departments that may view this announcement. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getDepartments',
 				},

--- a/packages/nodes-base/nodes/Freshservice/descriptions/AssetDescription.ts
+++ b/packages/nodes-base/nodes/Freshservice/descriptions/AssetDescription.ts
@@ -69,7 +69,7 @@ export const assetFields: INodeProperties[] = [
 		name: 'assetTypeId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		default: '',
 		typeOptions: {
@@ -112,7 +112,7 @@ export const assetFields: INodeProperties[] = [
 						},
 						default: '',
 						description:
-							'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Value',
@@ -213,7 +213,7 @@ export const assetFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the agent by whom the asset is managed. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the agent by whom the asset is managed. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgents',
 				},
@@ -231,7 +231,7 @@ export const assetFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the asset type to filter by. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the asset type to filter by. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAssetTypes',
 				},
@@ -242,7 +242,7 @@ export const assetFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the department to which the asset belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the department to which the asset belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getDepartments',
 				},
@@ -253,7 +253,7 @@ export const assetFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the location to filter by. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the location to filter by. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getLocations',
 				},
@@ -315,7 +315,7 @@ export const assetFields: INodeProperties[] = [
 						},
 						default: '',
 						description:
-							'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Value',

--- a/packages/nodes-base/nodes/Freshservice/descriptions/AssetTypeDescription.ts
+++ b/packages/nodes-base/nodes/Freshservice/descriptions/AssetTypeDescription.ts
@@ -87,7 +87,7 @@ export const assetTypeFields: INodeProperties[] = [
 				displayName: 'Parent Asset Type Name or ID',
 				name: 'parent_asset_type_id',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				type: 'options',
 				default: '',
 				typeOptions: {

--- a/packages/nodes-base/nodes/Freshservice/descriptions/ChangeDescription.ts
+++ b/packages/nodes-base/nodes/Freshservice/descriptions/ChangeDescription.ts
@@ -56,7 +56,7 @@ export const changeFields: INodeProperties[] = [
 		name: 'requesterId',
 		// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 		description:
-			'ID of the requester of the change. Choose from the list or specify an ID. You can also specify the ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the requester of the change. Choose from the list or specify an ID. You can also specify the ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		required: true,
 		default: '',
@@ -128,7 +128,7 @@ export const changeFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the agent to whom the change is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the agent to whom the change is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgents',
 				},
@@ -163,7 +163,7 @@ export const changeFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the department requesting the change. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the department requesting the change. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getDepartments',
 				},
@@ -181,7 +181,7 @@ export const changeFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the agent group to which the change is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the agent group to which the change is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgentGroups',
 				},
@@ -467,7 +467,7 @@ export const changeFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the agent to whom the change is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the agent to whom the change is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgents',
 				},
@@ -502,7 +502,7 @@ export const changeFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the department requesting the change. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the department requesting the change. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getDepartments',
 				},
@@ -520,7 +520,7 @@ export const changeFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the agent group to which the change is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the agent group to which the change is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgentGroups',
 				},
@@ -576,7 +576,7 @@ export const changeFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the requester of the change. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the requester of the change. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getRequesters',
 				},

--- a/packages/nodes-base/nodes/Freshservice/descriptions/ProblemDescription.ts
+++ b/packages/nodes-base/nodes/Freshservice/descriptions/ProblemDescription.ts
@@ -68,7 +68,7 @@ export const problemFields: INodeProperties[] = [
 		displayName: 'Requester Name or ID',
 		name: 'requesterId',
 		description:
-			'ID of the initiator of the problem. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the initiator of the problem. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		required: true,
 		default: '',
@@ -114,7 +114,7 @@ export const problemFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the agent to whom the problem is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the agent to whom the problem is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgents',
 				},
@@ -125,7 +125,7 @@ export const problemFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the department initiating the problem. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the department initiating the problem. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getDepartments',
 				},
@@ -143,7 +143,7 @@ export const problemFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the agent group to which the problem is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the agent group to which the problem is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgentGroups',
 				},
@@ -321,7 +321,7 @@ export const problemFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the agent to whom the problem is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the agent to whom the problem is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgents',
 				},
@@ -332,7 +332,7 @@ export const problemFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the department initiating the problem. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the department initiating the problem. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getDepartments',
 				},
@@ -357,7 +357,7 @@ export const problemFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the agent group to which the problem is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the agent group to which the problem is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgentGroups',
 				},
@@ -412,7 +412,7 @@ export const problemFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the initiator of the problem. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the initiator of the problem. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getRequesters',
 				},

--- a/packages/nodes-base/nodes/Freshservice/descriptions/ProductDescription.ts
+++ b/packages/nodes-base/nodes/Freshservice/descriptions/ProductDescription.ts
@@ -56,7 +56,7 @@ export const productFields: INodeProperties[] = [
 		name: 'assetTypeId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		default: '',
 		typeOptions: {
@@ -256,7 +256,7 @@ export const productFields: INodeProperties[] = [
 				name: 'asset_type_id',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getAssetTypes',

--- a/packages/nodes-base/nodes/Freshservice/descriptions/ReleaseDescription.ts
+++ b/packages/nodes-base/nodes/Freshservice/descriptions/ReleaseDescription.ts
@@ -204,7 +204,7 @@ export const releaseFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the department initiating the release. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the department initiating the release. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getDepartments',
 				},
@@ -222,7 +222,7 @@ export const releaseFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the agent group to which the release is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the agent group to which the release is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgentGroups',
 				},
@@ -336,7 +336,7 @@ export const releaseFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the department initiating the release. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the department initiating the release. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getDepartments',
 				},
@@ -354,7 +354,7 @@ export const releaseFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the agent group to which the release is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the agent group to which the release is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgentGroups',
 				},

--- a/packages/nodes-base/nodes/Freshservice/descriptions/RequesterDescription.ts
+++ b/packages/nodes-base/nodes/Freshservice/descriptions/RequesterDescription.ts
@@ -109,7 +109,7 @@ export const requesterFields: INodeProperties[] = [
 				type: 'multiOptions',
 				default: [],
 				description:
-					'Comma-separated IDs of the departments associated with the requester. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Comma-separated IDs of the departments associated with the requester. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getDepartments',
 				},
@@ -137,7 +137,7 @@ export const requesterFields: INodeProperties[] = [
 				displayName: 'Location Name or ID',
 				name: 'location_id',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				type: 'options',
 				default: '',
 				typeOptions: {
@@ -268,7 +268,7 @@ export const requesterFields: INodeProperties[] = [
 				displayName: 'Department Name or ID',
 				name: 'department_id',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				type: 'options',
 				default: '',
 				typeOptions: {
@@ -305,7 +305,7 @@ export const requesterFields: INodeProperties[] = [
 				name: 'location_id',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getLocations',
@@ -380,7 +380,7 @@ export const requesterFields: INodeProperties[] = [
 				type: 'multiOptions',
 				default: [],
 				description:
-					'Comma-separated IDs of the departments associated with the requester. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Comma-separated IDs of the departments associated with the requester. Choose from the list or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getDepartments',
 				},
@@ -416,7 +416,7 @@ export const requesterFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getLocations',
 				},

--- a/packages/nodes-base/nodes/Freshservice/descriptions/TicketDescription.ts
+++ b/packages/nodes-base/nodes/Freshservice/descriptions/TicketDescription.ts
@@ -177,7 +177,7 @@ export const ticketFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the department to which this ticket belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the department to which this ticket belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getDepartments',
 				},
@@ -188,7 +188,7 @@ export const ticketFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the group to which the ticket has been assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the group to which the ticket has been assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgentGroups',
 				},
@@ -225,7 +225,7 @@ export const ticketFields: INodeProperties[] = [
 				name: 'requester_id',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getRequesters',
@@ -322,7 +322,7 @@ export const ticketFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the agent to whom the tickets have been assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the agent to whom the tickets have been assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgents',
 				},
@@ -333,7 +333,7 @@ export const ticketFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the group to which the tickets have been assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the group to which the tickets have been assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgentGroups',
 				},
@@ -459,7 +459,7 @@ export const ticketFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the department to which this ticket has been assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the department to which this ticket has been assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getDepartments',
 				},
@@ -485,7 +485,7 @@ export const ticketFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the group to which the ticket has been assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the group to which the ticket has been assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getAgentGroups',
 				},

--- a/packages/nodes-base/nodes/FreshworksCrm/descriptions/AccountDescription.ts
+++ b/packages/nodes-base/nodes/FreshworksCrm/descriptions/AccountDescription.ts
@@ -101,7 +101,7 @@ export const accountFields: INodeProperties[] = [
 					loadOptionsMethod: 'getBusinessTypes',
 				},
 				description:
-					'ID of the business that the account belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the business that the account belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'City',
@@ -133,7 +133,7 @@ export const accountFields: INodeProperties[] = [
 					loadOptionsMethod: 'getIndustryTypes',
 				},
 				description:
-					'ID of the industry that the account belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the industry that the account belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'LinkedIn',
@@ -158,7 +158,7 @@ export const accountFields: INodeProperties[] = [
 					loadOptionsMethod: 'getUsers',
 				},
 				description:
-					'ID of the user to whom the account is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user to whom the account is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Parent Sales Account ID',
@@ -190,7 +190,7 @@ export const accountFields: INodeProperties[] = [
 					loadOptionsMethod: 'getTerritories',
 				},
 				description:
-					'ID of the territory that the account belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the territory that the account belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Twitter',
@@ -260,7 +260,7 @@ export const accountFields: INodeProperties[] = [
 		name: 'view',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		typeOptions: {
 			loadOptionsMethod: 'getAccountViews',
@@ -357,7 +357,7 @@ export const accountFields: INodeProperties[] = [
 					loadOptionsMethod: 'getBusinessTypes',
 				},
 				description:
-					'ID of the business that the account belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the business that the account belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'City',
@@ -389,7 +389,7 @@ export const accountFields: INodeProperties[] = [
 					loadOptionsMethod: 'getIndustryTypes',
 				},
 				description:
-					'ID of the industry that the account belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the industry that the account belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'LinkedIn',
@@ -421,7 +421,7 @@ export const accountFields: INodeProperties[] = [
 					loadOptionsMethod: 'getUsers',
 				},
 				description:
-					'ID of the user to whom the account is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user to whom the account is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Parent Sales Account ID',
@@ -453,7 +453,7 @@ export const accountFields: INodeProperties[] = [
 					loadOptionsMethod: 'getTerritories',
 				},
 				description:
-					'ID of the territory that the account belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the territory that the account belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Twitter',

--- a/packages/nodes-base/nodes/FreshworksCrm/descriptions/AppointmentDescription.ts
+++ b/packages/nodes-base/nodes/FreshworksCrm/descriptions/AppointmentDescription.ts
@@ -137,7 +137,7 @@ export const appointmentFields: INodeProperties[] = [
 						name: 'userId',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						displayOptions: {
 							show: {
 								type: ['user'],
@@ -185,7 +185,7 @@ export const appointmentFields: INodeProperties[] = [
 					loadOptionsMethod: 'getUsers',
 				},
 				description:
-					'ID of the user who created the appointment. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user who created the appointment. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Is All-Day',
@@ -224,7 +224,7 @@ export const appointmentFields: INodeProperties[] = [
 					loadOptionsMethod: 'getOutcomes',
 				},
 				description:
-					'ID of outcome of Appointment sales activity type. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of outcome of Appointment sales activity type. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Target ID',
@@ -450,7 +450,7 @@ export const appointmentFields: INodeProperties[] = [
 								name: 'userId',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								displayOptions: {
 									show: {
 										type: ['user'],
@@ -485,7 +485,7 @@ export const appointmentFields: INodeProperties[] = [
 					loadOptionsMethod: 'getUsers',
 				},
 				description:
-					'ID of the user who created the appointment. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user who created the appointment. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'End Date',
@@ -532,7 +532,7 @@ export const appointmentFields: INodeProperties[] = [
 					loadOptionsMethod: 'getOutcomes',
 				},
 				description:
-					'ID of outcome of Appointment sales activity type. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of outcome of Appointment sales activity type. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Start Date',

--- a/packages/nodes-base/nodes/FreshworksCrm/descriptions/ContactDescription.ts
+++ b/packages/nodes-base/nodes/FreshworksCrm/descriptions/ContactDescription.ts
@@ -122,7 +122,7 @@ export const contactFields: INodeProperties[] = [
 					loadOptionsMethod: 'getCampaigns',
 				},
 				description:
-					'ID of the campaign that led your contact to your webapp. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the campaign that led your contact to your webapp. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'City',
@@ -140,7 +140,7 @@ export const contactFields: INodeProperties[] = [
 					loadOptionsMethod: 'getContactStatuses',
 				},
 				description:
-					'ID of the contact status that the contact belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the contact status that the contact belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Country',
@@ -193,7 +193,7 @@ export const contactFields: INodeProperties[] = [
 					loadOptionsMethod: 'getLifecycleStages',
 				},
 				description:
-					'ID of the lifecycle stage that the contact belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the lifecycle stage that the contact belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'LinkedIn',
@@ -225,7 +225,7 @@ export const contactFields: INodeProperties[] = [
 					loadOptionsMethod: 'getUsers',
 				},
 				description:
-					'ID of the user to whom the contact is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user to whom the contact is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Sales Account Names or IDs',
@@ -236,7 +236,7 @@ export const contactFields: INodeProperties[] = [
 					loadOptionsMethod: 'getAccounts',
 				},
 				description:
-					'Accounts which contact belongs to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Accounts which contact belongs to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'State',
@@ -268,7 +268,7 @@ export const contactFields: INodeProperties[] = [
 					loadOptionsMethod: 'getTerritories',
 				},
 				description:
-					'ID of the territory that the contact belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the territory that the contact belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Time Zone',
@@ -345,7 +345,7 @@ export const contactFields: INodeProperties[] = [
 		name: 'view',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		displayOptions: {
 			show: {
 				resource: ['contact'],
@@ -434,7 +434,7 @@ export const contactFields: INodeProperties[] = [
 					loadOptionsMethod: 'getCampaigns',
 				},
 				description:
-					'ID of the campaign that led your contact to your webapp. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the campaign that led your contact to your webapp. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'City',
@@ -452,7 +452,7 @@ export const contactFields: INodeProperties[] = [
 					loadOptionsMethod: 'getContactStatuses',
 				},
 				description:
-					'ID of the contact status that the contact belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the contact status that the contact belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Country',
@@ -509,7 +509,7 @@ export const contactFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'ID of the source where contact came from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the source where contact came from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Lifecycle Stage Name or ID',
@@ -520,7 +520,7 @@ export const contactFields: INodeProperties[] = [
 					loadOptionsMethod: 'getLifecycleStages',
 				},
 				description:
-					'ID of the lifecycle stage that the contact belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the lifecycle stage that the contact belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'LinkedIn',
@@ -552,7 +552,7 @@ export const contactFields: INodeProperties[] = [
 					loadOptionsMethod: 'getUsers',
 				},
 				description:
-					'ID of the user to whom the contact is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user to whom the contact is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Sales Account Names or IDs',
@@ -563,7 +563,7 @@ export const contactFields: INodeProperties[] = [
 					loadOptionsMethod: 'getAccounts',
 				},
 				description:
-					'Accounts which contact belongs to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Accounts which contact belongs to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'State',
@@ -578,7 +578,7 @@ export const contactFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Status of subscription that the contact is in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Status of subscription that the contact is in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Subscription Types Name or ID',
@@ -586,7 +586,7 @@ export const contactFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Type of subscription that the contact is in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Type of subscription that the contact is in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Territory Name or ID',
@@ -597,7 +597,7 @@ export const contactFields: INodeProperties[] = [
 					loadOptionsMethod: 'getTerritories',
 				},
 				description:
-					'ID of the territory that the contact belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the territory that the contact belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Time Zone',

--- a/packages/nodes-base/nodes/FreshworksCrm/descriptions/DealDescription.ts
+++ b/packages/nodes-base/nodes/FreshworksCrm/descriptions/DealDescription.ts
@@ -108,7 +108,7 @@ export const dealFields: INodeProperties[] = [
 					loadOptionsMethod: 'getCampaigns',
 				},
 				description:
-					'ID of the campaign that landed this deal. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the campaign that landed this deal. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Currency Name or ID',
@@ -119,7 +119,7 @@ export const dealFields: INodeProperties[] = [
 					loadOptionsMethod: 'getCurrencies',
 				},
 				description:
-					'ID of the currency that the deal belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the currency that the deal belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Deal Payment Status Name or ID',
@@ -130,7 +130,7 @@ export const dealFields: INodeProperties[] = [
 					loadOptionsMethod: 'getDealPaymentStatuses',
 				},
 				description:
-					'ID of the mode of payment for the deal. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the mode of payment for the deal. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Deal Pipeline Name or ID',
@@ -141,7 +141,7 @@ export const dealFields: INodeProperties[] = [
 					loadOptionsMethod: 'getDealPipelines',
 				},
 				description:
-					'ID of the deal pipeline that it belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the deal pipeline that it belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Deal Product Name or ID',
@@ -152,7 +152,7 @@ export const dealFields: INodeProperties[] = [
 					loadOptionsMethod: 'getDealProducts',
 				},
 				description:
-					'ID of the product that the deal belongs to (in a multi-product company). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the product that the deal belongs to (in a multi-product company). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Deal Reason Name or ID',
@@ -163,7 +163,7 @@ export const dealFields: INodeProperties[] = [
 					loadOptionsMethod: 'getDealReasons',
 				},
 				description:
-					'ID of the reason for losing the deal. Can only be set if the deal is in \'Lost\' stage. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the reason for losing the deal. Can only be set if the deal is in \'Lost\' stage. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Deal Stage Name or ID',
@@ -174,7 +174,7 @@ export const dealFields: INodeProperties[] = [
 					loadOptionsMethod: 'getDealStages',
 				},
 				description:
-					'ID of the deal stage that the deal belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the deal stage that the deal belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Deal Type Name or ID',
@@ -185,7 +185,7 @@ export const dealFields: INodeProperties[] = [
 					loadOptionsMethod: 'getDealTypes',
 				},
 				description:
-					'ID of the deal type that the deal belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the deal type that the deal belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Lead Source ID',
@@ -203,7 +203,7 @@ export const dealFields: INodeProperties[] = [
 					loadOptionsMethod: 'getUsers',
 				},
 				description:
-					'ID of the user to whom the deal is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user to whom the deal is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Probability',
@@ -225,7 +225,7 @@ export const dealFields: INodeProperties[] = [
 					loadOptionsMethod: 'getAccounts',
 				},
 				description:
-					'ID of the account that the deal belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the account that the deal belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Territory Name or ID',
@@ -236,7 +236,7 @@ export const dealFields: INodeProperties[] = [
 					loadOptionsMethod: 'getTerritories',
 				},
 				description:
-					'ID of the territory that the deal belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the territory that the deal belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -285,7 +285,7 @@ export const dealFields: INodeProperties[] = [
 		name: 'view',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		displayOptions: {
 			show: {
 				resource: ['deal'],
@@ -387,7 +387,7 @@ export const dealFields: INodeProperties[] = [
 					loadOptionsMethod: 'getCampaigns',
 				},
 				description:
-					'ID of the campaign that landed this deal. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the campaign that landed this deal. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Currency Name or ID',
@@ -398,7 +398,7 @@ export const dealFields: INodeProperties[] = [
 					loadOptionsMethod: 'getCurrencies',
 				},
 				description:
-					'ID of the currency that the deal belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the currency that the deal belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Deal Payment Status Name or ID',
@@ -409,7 +409,7 @@ export const dealFields: INodeProperties[] = [
 					loadOptionsMethod: 'getDealPaymentStatuses',
 				},
 				description:
-					'ID of the mode of payment for the deal. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the mode of payment for the deal. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Deal Pipeline Name or ID',
@@ -420,7 +420,7 @@ export const dealFields: INodeProperties[] = [
 					loadOptionsMethod: 'getDealPipelines',
 				},
 				description:
-					'ID of the deal pipeline that it belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the deal pipeline that it belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Deal Product Name or ID',
@@ -431,7 +431,7 @@ export const dealFields: INodeProperties[] = [
 					loadOptionsMethod: 'getDealProducts',
 				},
 				description:
-					'ID of the product that the deal belongs to (in a multi-product company). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the product that the deal belongs to (in a multi-product company). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Deal Reason Name or ID',
@@ -442,7 +442,7 @@ export const dealFields: INodeProperties[] = [
 					loadOptionsMethod: 'getDealReasons',
 				},
 				description:
-					'ID of the reason for losing the deal. Can only be set if the deal is in \'Lost\' stage. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the reason for losing the deal. Can only be set if the deal is in \'Lost\' stage. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Deal Stage Name or ID',
@@ -453,7 +453,7 @@ export const dealFields: INodeProperties[] = [
 					loadOptionsMethod: 'getDealStages',
 				},
 				description:
-					'ID of the deal stage that the deal belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the deal stage that the deal belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Deal Type Name or ID',
@@ -464,7 +464,7 @@ export const dealFields: INodeProperties[] = [
 					loadOptionsMethod: 'getDealTypes',
 				},
 				description:
-					'ID of the deal type that the deal belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the deal type that the deal belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Lead Source ID',
@@ -489,7 +489,7 @@ export const dealFields: INodeProperties[] = [
 					loadOptionsMethod: 'getUsers',
 				},
 				description:
-					'ID of the user to whom the deal is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user to whom the deal is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Probability',
@@ -511,7 +511,7 @@ export const dealFields: INodeProperties[] = [
 					loadOptionsMethod: 'getAccounts',
 				},
 				description:
-					'ID of the account that the deal belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the account that the deal belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Territory Name or ID',
@@ -522,7 +522,7 @@ export const dealFields: INodeProperties[] = [
 					loadOptionsMethod: 'getTerritories',
 				},
 				description:
-					'ID of the territory that the deal belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the territory that the deal belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/FreshworksCrm/descriptions/SalesActivityDescription.ts
+++ b/packages/nodes-base/nodes/FreshworksCrm/descriptions/SalesActivityDescription.ts
@@ -57,7 +57,7 @@ export const salesActivityFields: INodeProperties[] = [
 			loadOptionsMethod: 'getSalesActivityTypes',
 		},
 		description:
-			'ID of a sales activity type for which the sales activity is created. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of a sales activity type for which the sales activity is created. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['salesActivity'],
@@ -83,7 +83,7 @@ export const salesActivityFields: INodeProperties[] = [
 		displayName: 'Owner Name or ID',
 		name: 'ownerId',
 		description:
-			'ID of the user who owns the sales activity. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the user who owns the sales activity. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		default: '',
 		typeOptions: {
@@ -190,7 +190,7 @@ export const salesActivityFields: INodeProperties[] = [
 					loadOptionsMethod: 'getUsers',
 				},
 				description:
-					'ID of the user who created the sales activity. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user who created the sales activity. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Latitude',
@@ -229,7 +229,7 @@ export const salesActivityFields: INodeProperties[] = [
 					loadOptionsMethod: 'getOutcomes',
 				},
 				description:
-					'ID of a sales activity\'s outcome. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of a sales activity\'s outcome. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -343,7 +343,7 @@ export const salesActivityFields: INodeProperties[] = [
 					loadOptionsMethod: 'getUsers',
 				},
 				description:
-					'ID of the user who created the sales activity. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user who created the sales activity. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Start Date',
@@ -389,7 +389,7 @@ export const salesActivityFields: INodeProperties[] = [
 					loadOptionsMethod: 'getUsers',
 				},
 				description:
-					'ID of the user who owns the sales activity. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user who owns the sales activity. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Sales Activity Outcome Name or ID',
@@ -400,7 +400,7 @@ export const salesActivityFields: INodeProperties[] = [
 					loadOptionsMethod: 'getOutcomes',
 				},
 				description:
-					'ID of a sales activity\'s outcome. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of a sales activity\'s outcome. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Sales Activity Type Name or ID',
@@ -411,7 +411,7 @@ export const salesActivityFields: INodeProperties[] = [
 					loadOptionsMethod: 'getSalesActivityTypes',
 				},
 				description:
-					'ID of a sales activity type for which the sales activity is updated. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of a sales activity type for which the sales activity is updated. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Start Date',

--- a/packages/nodes-base/nodes/FreshworksCrm/descriptions/TaskDescription.ts
+++ b/packages/nodes-base/nodes/FreshworksCrm/descriptions/TaskDescription.ts
@@ -83,7 +83,7 @@ export const taskFields: INodeProperties[] = [
 		displayName: 'Owner Name or ID',
 		name: 'ownerId',
 		description:
-			'ID of the user to whom the task is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the user to whom the task is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		default: '',
 		typeOptions: {
@@ -162,7 +162,7 @@ export const taskFields: INodeProperties[] = [
 					loadOptionsMethod: 'getUsers',
 				},
 				description:
-					'ID of the user who created the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user who created the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Outcome Name or ID',
@@ -173,7 +173,7 @@ export const taskFields: INodeProperties[] = [
 					loadOptionsMethod: 'getOutcomes',
 				},
 				description:
-					'ID of the outcome of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the outcome of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Task Type ID',
@@ -357,7 +357,7 @@ export const taskFields: INodeProperties[] = [
 					loadOptionsMethod: 'getUsers',
 				},
 				description:
-					'ID of the user who created the sales activity. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user who created the sales activity. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Due Date',
@@ -375,7 +375,7 @@ export const taskFields: INodeProperties[] = [
 					loadOptionsMethod: 'getOutcomes',
 				},
 				description:
-					'ID of the outcome of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the outcome of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Owner Name or ID',
@@ -386,7 +386,7 @@ export const taskFields: INodeProperties[] = [
 					loadOptionsMethod: 'getUsers',
 				},
 				description:
-					'ID of the user to whom the task is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user to whom the task is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Target ID',

--- a/packages/nodes-base/nodes/GetResponse/ContactDescription.ts
+++ b/packages/nodes-base/nodes/GetResponse/ContactDescription.ts
@@ -79,7 +79,7 @@ export const contactFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 	},
 	{
 		displayName: 'Additional Fields',
@@ -116,7 +116,7 @@ export const contactFields: INodeProperties[] = [
 									loadOptionsMethod: 'getCustomFields',
 								},
 								description:
-									'The end user specified key of the user defined data. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The end user specified key of the user defined data. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 								default: '',
 							},
 							{
@@ -172,7 +172,7 @@ export const contactFields: INodeProperties[] = [
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getTags',
 				},
@@ -514,7 +514,7 @@ export const contactFields: INodeProperties[] = [
 				name: 'campaignId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getCampaigns',
 				},
@@ -542,7 +542,7 @@ export const contactFields: INodeProperties[] = [
 									loadOptionsMethod: 'getCustomFields',
 								},
 								description:
-									'The end user specified key of the user defined data. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The end user specified key of the user defined data. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 								default: '',
 							},
 							{
@@ -605,7 +605,7 @@ export const contactFields: INodeProperties[] = [
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getTags',
 				},

--- a/packages/nodes-base/nodes/GetResponse/GetResponseTrigger.node.ts
+++ b/packages/nodes-base/nodes/GetResponse/GetResponseTrigger.node.ts
@@ -111,7 +111,7 @@ export class GetResponseTrigger implements INodeType {
 				name: 'listIds',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getLists',
 				},

--- a/packages/nodes-base/nodes/Ghost/PostDescription.ts
+++ b/packages/nodes-base/nodes/Ghost/PostDescription.ts
@@ -189,7 +189,7 @@ export const postFields: INodeProperties[] = [
 				name: 'authors',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getAuthors',
 				},
@@ -289,7 +289,7 @@ export const postFields: INodeProperties[] = [
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getTags',
 				},
@@ -695,7 +695,7 @@ export const postFields: INodeProperties[] = [
 				name: 'authors',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getAuthors',
 				},
@@ -829,7 +829,7 @@ export const postFields: INodeProperties[] = [
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getTags',
 				},

--- a/packages/nodes-base/nodes/GoToWebinar/descriptions/AttendeeDescription.ts
+++ b/packages/nodes-base/nodes/GoToWebinar/descriptions/AttendeeDescription.ts
@@ -46,7 +46,7 @@ export const attendeeFields: INodeProperties[] = [
 		required: true,
 		default: '',
 		description:
-			'Key of the webinar that the attendee attended. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Key of the webinar that the attendee attended. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['attendee'],
@@ -64,7 +64,7 @@ export const attendeeFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'Key of the session that the attendee attended. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Key of the session that the attendee attended. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['attendee'],

--- a/packages/nodes-base/nodes/GoToWebinar/descriptions/CoorganizerDescription.ts
+++ b/packages/nodes-base/nodes/GoToWebinar/descriptions/CoorganizerDescription.ts
@@ -51,7 +51,7 @@ export const coorganizerFields: INodeProperties[] = [
 		required: true,
 		default: [],
 		description:
-			'Key of the webinar that the co-organizer is hosting. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Key of the webinar that the co-organizer is hosting. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['coorganizer'],
@@ -130,7 +130,7 @@ export const coorganizerFields: INodeProperties[] = [
 		required: true,
 		default: [],
 		description:
-			'Key of the webinar to delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Key of the webinar to delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['coorganizer'],
@@ -181,7 +181,7 @@ export const coorganizerFields: INodeProperties[] = [
 		required: true,
 		default: [],
 		description:
-			'Key of the webinar to retrieve all co-organizers from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Key of the webinar to retrieve all co-organizers from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['coorganizer'],

--- a/packages/nodes-base/nodes/GoToWebinar/descriptions/PanelistDescription.ts
+++ b/packages/nodes-base/nodes/GoToWebinar/descriptions/PanelistDescription.ts
@@ -80,7 +80,7 @@ export const panelistFields: INodeProperties[] = [
 		required: true,
 		default: [],
 		description:
-			'Key of the webinar that the panelist will present at. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Key of the webinar that the panelist will present at. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['panelist'],
@@ -102,7 +102,7 @@ export const panelistFields: INodeProperties[] = [
 		required: true,
 		default: [],
 		description:
-			'Key of the webinar to retrieve all panelists from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Key of the webinar to retrieve all panelists from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['panelist'],
@@ -155,7 +155,7 @@ export const panelistFields: INodeProperties[] = [
 		required: true,
 		default: [],
 		description:
-			'Key of the webinar to delete the panelist from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Key of the webinar to delete the panelist from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['panelist'],
@@ -191,7 +191,7 @@ export const panelistFields: INodeProperties[] = [
 		required: true,
 		default: [],
 		description:
-			'Key of the webinar to reinvite the panelist to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Key of the webinar to reinvite the panelist to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['panelist'],

--- a/packages/nodes-base/nodes/GoToWebinar/descriptions/RegistrantDescription.ts
+++ b/packages/nodes-base/nodes/GoToWebinar/descriptions/RegistrantDescription.ts
@@ -51,7 +51,7 @@ export const registrantFields: INodeProperties[] = [
 		required: true,
 		default: [],
 		description:
-			'Key of the webinar of the registrant to create. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Key of the webinar of the registrant to create. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['registrant'],
@@ -191,7 +191,7 @@ export const registrantFields: INodeProperties[] = [
 								name: 'questionKey',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								typeOptions: {
 									loadOptionsMethod: 'getRegistranMultiChoiceQuestions',
 									loadOptionsDependsOn: ['webinarKey'],
@@ -275,7 +275,7 @@ export const registrantFields: INodeProperties[] = [
 								name: 'questionKey',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								typeOptions: {
 									loadOptionsMethod: 'getRegistranSimpleQuestions',
 									loadOptionsDependsOn: ['webinarKey'],
@@ -316,7 +316,7 @@ export const registrantFields: INodeProperties[] = [
 		required: true,
 		default: [],
 		description:
-			'The key of the webinar to retrieve registrants from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The key of the webinar to retrieve registrants from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['registrant'],
@@ -369,7 +369,7 @@ export const registrantFields: INodeProperties[] = [
 		required: true,
 		default: [],
 		description:
-			'Key of the webinar of the registrant to delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Key of the webinar of the registrant to delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['registrant'],
@@ -405,7 +405,7 @@ export const registrantFields: INodeProperties[] = [
 		required: true,
 		default: [],
 		description:
-			'Key of the webinar of the registrant to retrieve. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Key of the webinar of the registrant to retrieve. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['registrant'],

--- a/packages/nodes-base/nodes/GoToWebinar/descriptions/SessionDescription.ts
+++ b/packages/nodes-base/nodes/GoToWebinar/descriptions/SessionDescription.ts
@@ -119,7 +119,7 @@ export const sessionFields: INodeProperties[] = [
 				},
 				default: {},
 				description:
-					'Webinar by which to filter the sessions to retrieve. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Webinar by which to filter the sessions to retrieve. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -137,7 +137,7 @@ export const sessionFields: INodeProperties[] = [
 		required: true,
 		default: [],
 		description:
-			'Key of the webinar to which the session belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Key of the webinar to which the session belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['session'],

--- a/packages/nodes-base/nodes/GoToWebinar/descriptions/WebinarDescription.ts
+++ b/packages/nodes-base/nodes/GoToWebinar/descriptions/WebinarDescription.ts
@@ -154,7 +154,7 @@ export const webinarFields: INodeProperties[] = [
 				name: 'timezone',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: '',
 				placeholder: '2020-12-11T09:00:00Z',
 				typeOptions: {
@@ -456,7 +456,7 @@ export const webinarFields: INodeProperties[] = [
 				default: '',
 				placeholder: '2020-12-11T09:00:00Z',
 				description:
-					'Timezone where the webinar is to take place. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Timezone where the webinar is to take place. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					alwaysOpenEditWindow: true,
 					loadOptionsMethod: 'getTimezones',

--- a/packages/nodes-base/nodes/Google/Analytics/v1/ReportDescription.ts
+++ b/packages/nodes-base/nodes/Google/Analytics/v1/ReportDescription.ts
@@ -41,7 +41,7 @@ export const reportFields: INodeProperties[] = [
 		},
 		placeholder: '123456',
 		description:
-			'The View ID of Google Analytics. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The View ID of Google Analytics. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',
@@ -153,7 +153,7 @@ export const reportFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Name of the dimension to fetch, for example ga:browser. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Name of the dimension to fetch, for example ga:browser. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 						],
 					},
@@ -183,7 +183,7 @@ export const reportFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Name of the dimension to filter by. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Name of the dimension to filter by. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							// https://developers.google.com/analytics/devguides/reporting/core/v4/rest/v4/reports/batchGet#Operator
 							{

--- a/packages/nodes-base/nodes/Google/Analytics/v1/UserActivityDescription.ts
+++ b/packages/nodes-base/nodes/Google/Analytics/v1/UserActivityDescription.ts
@@ -41,7 +41,7 @@ export const userActivityFields: INodeProperties[] = [
 		},
 		placeholder: '123456',
 		description:
-			'The View ID of Google Analytics. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The View ID of Google Analytics. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'User ID',

--- a/packages/nodes-base/nodes/Google/Analytics/v2/actions/report/FiltersDescription.ts
+++ b/packages/nodes-base/nodes/Google/Analytics/v2/actions/report/FiltersDescription.ts
@@ -65,7 +65,7 @@ export const dimensionDropdown: INodeProperties[] = [
 		},
 		default: 'date',
 		description:
-			'The name of the dimension. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The name of the dimension. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				listName: ['other'],
@@ -145,7 +145,7 @@ export const metricDropdown: INodeProperties[] = [
 		default: 'totalUsers',
 		hint: 'If expression is specified, name can be any string that you would like',
 		description:
-			'The name of the metric. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The name of the metric. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				listName: ['other'],

--- a/packages/nodes-base/nodes/Google/Analytics/v2/actions/report/get.ga4.operation.ts
+++ b/packages/nodes-base/nodes/Google/Analytics/v2/actions/report/get.ga4.operation.ts
@@ -382,7 +382,7 @@ export const description: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Sorts by metric values. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Sorts by metric values. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 						],
 					},
@@ -407,7 +407,7 @@ export const description: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Sorts by metric values. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Sorts by metric values. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Order Type',

--- a/packages/nodes-base/nodes/Google/Analytics/v2/actions/report/get.universal.operation.ts
+++ b/packages/nodes-base/nodes/Google/Analytics/v2/actions/report/get.universal.operation.ts
@@ -81,7 +81,7 @@ const dimensionDropdown: INodeProperties[] = [
 		},
 		default: 'ga:date',
 		description:
-			'Name of the dimension to fetch, for example ga:browser. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Name of the dimension to fetch, for example ga:browser. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				listName: ['other'],
@@ -302,7 +302,7 @@ export const description: INodeProperties[] = [
 						default: 'ga:users',
 						hint: 'If expression is specified, name can be any string that you would like',
 						description:
-							'The name of the metric. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The name of the metric. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 						displayOptions: {
 							show: {
 								listName: ['other'],

--- a/packages/nodes-base/nodes/Google/Analytics/v2/actions/userActivity/search.operation.ts
+++ b/packages/nodes-base/nodes/Google/Analytics/v2/actions/userActivity/search.operation.ts
@@ -25,7 +25,7 @@ export const description: INodeProperties[] = [
 		},
 		placeholder: '123456',
 		description:
-			'The view from Google Analytics. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The view from Google Analytics. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		hint: "If there's nothing here, try changing the 'Property type' field above",
 	},
 	{

--- a/packages/nodes-base/nodes/Google/BigQuery/v1/RecordDescription.ts
+++ b/packages/nodes-base/nodes/Google/BigQuery/v1/RecordDescription.ts
@@ -49,7 +49,7 @@ export const recordFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'ID of the project to create the record in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the project to create the record in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Dataset Name or ID',
@@ -68,7 +68,7 @@ export const recordFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'ID of the dataset to create the record in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the dataset to create the record in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Table Name or ID',
@@ -87,7 +87,7 @@ export const recordFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'ID of the table to create the record in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the table to create the record in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Columns',
@@ -169,7 +169,7 @@ export const recordFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'ID of the project to retrieve all rows from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the project to retrieve all rows from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Dataset Name or ID',
@@ -188,7 +188,7 @@ export const recordFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'ID of the dataset to retrieve all rows from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the dataset to retrieve all rows from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Table Name or ID',
@@ -207,7 +207,7 @@ export const recordFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'ID of the table to retrieve all rows from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the table to retrieve all rows from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',

--- a/packages/nodes-base/nodes/Google/BigQuery/v2/actions/database/executeQuery.operation.ts
+++ b/packages/nodes-base/nodes/Google/BigQuery/v2/actions/database/executeQuery.operation.ts
@@ -74,7 +74,7 @@ const properties: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'If not set, all table names in the query string must be qualified in the format \'datasetId.tableId\'. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'If not set, all table names in the query string must be qualified in the format \'datasetId.tableId\'. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Dry Run',

--- a/packages/nodes-base/nodes/Google/BigQuery/v2/actions/database/insert.operation.ts
+++ b/packages/nodes-base/nodes/Google/BigQuery/v2/actions/database/insert.operation.ts
@@ -65,7 +65,7 @@ const properties: INodeProperties[] = [
 						name: 'fieldId',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsDependsOn: ['projectId.value', 'datasetId.value', 'tableId.value'],
 							loadOptionsMethod: 'getSchema',

--- a/packages/nodes-base/nodes/Google/Calendar/EventDescription.ts
+++ b/packages/nodes-base/nodes/Google/Calendar/EventDescription.ts
@@ -227,7 +227,7 @@ export const eventFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The color of the event. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The color of the event. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Conference Data',
@@ -248,7 +248,7 @@ export const eventFields: INodeProperties[] = [
 								name: 'conferenceSolution',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								typeOptions: {
 									loadOptionsMethod: 'getConferenceSolutions',
 									loadOptionsDependsOn: ['calendar'],
@@ -1064,7 +1064,7 @@ export const eventFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The color of the event. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The color of the event. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Description',

--- a/packages/nodes-base/nodes/Google/Chat/descriptions/MemberDescription.ts
+++ b/packages/nodes-base/nodes/Google/Chat/descriptions/MemberDescription.ts
@@ -69,7 +69,7 @@ export const memberFields: INodeProperties[] = [
 		},
 		default: [],
 		description:
-			'The name of the space for which to retrieve members, in the form "spaces/*". Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The name of the space for which to retrieve members, in the form "spaces/*". Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 
 	...getPagingParameters('member'),

--- a/packages/nodes-base/nodes/Google/Chat/descriptions/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Google/Chat/descriptions/MessageDescription.ts
@@ -57,7 +57,7 @@ export const spaceIdProperty: INodeProperties = {
 	},
 	default: '',
 	description:
-		'Space resource name, in the form "spaces/*". Example: spaces/AAAAMpdlehY. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+		'Space resource name, in the form "spaces/*". Example: spaces/AAAAMpdlehY. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 };
 
 export const messageFields: INodeProperties[] = [

--- a/packages/nodes-base/nodes/Google/Contacts/ContactDescription.ts
+++ b/packages/nodes-base/nodes/Google/Contacts/ContactDescription.ts
@@ -336,7 +336,7 @@ export const contactFields: INodeProperties[] = [
 				name: 'group',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getGroups',
 				},
@@ -1346,7 +1346,7 @@ export const contactFields: INodeProperties[] = [
 				name: 'group',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getGroups',
 				},

--- a/packages/nodes-base/nodes/Google/Docs/DocumentDescription.ts
+++ b/packages/nodes-base/nodes/Google/Docs/DocumentDescription.ts
@@ -41,7 +41,7 @@ export const documentFields: INodeProperties[] = [
 		name: 'driveId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getDrives',
 		},
@@ -59,7 +59,7 @@ export const documentFields: INodeProperties[] = [
 		name: 'folderId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsDependsOn: ['driveId'],
 			loadOptionsMethod: 'getFolders',

--- a/packages/nodes-base/nodes/Google/Drive/GoogleDriveTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Drive/GoogleDriveTrigger.node.ts
@@ -294,7 +294,7 @@ export class GoogleDriveTrigger implements INodeType {
 				default: 'root',
 				required: true,
 				description:
-					'The drive to monitor. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The drive to monitor. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Watch For',

--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/CollectionDescription.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/CollectionDescription.ts
@@ -42,7 +42,7 @@ export const collectionFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'As displayed in firebase console URL. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'As displayed in firebase console URL. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		required: true,
 	},
 	{

--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/DocumentDescription.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/DocumentDescription.ts
@@ -78,7 +78,7 @@ export const documentFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'As displayed in firebase console URL. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'As displayed in firebase console URL. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		required: true,
 	},
 	{
@@ -168,7 +168,7 @@ export const documentFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'As displayed in firebase console URL. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'As displayed in firebase console URL. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		required: true,
 	},
 	{
@@ -244,7 +244,7 @@ export const documentFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'As displayed in firebase console URL. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'As displayed in firebase console URL. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		required: true,
 	},
 	{
@@ -339,7 +339,7 @@ export const documentFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'As displayed in firebase console URL. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'As displayed in firebase console URL. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		required: true,
 	},
 	{
@@ -516,7 +516,7 @@ export const documentFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'As displayed in firebase console URL. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'As displayed in firebase console URL. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		required: true,
 	},
 	{
@@ -595,7 +595,7 @@ export const documentFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'As displayed in firebase console URL. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'As displayed in firebase console URL. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		required: true,
 	},
 	{

--- a/packages/nodes-base/nodes/Google/Firebase/RealtimeDatabase/GoogleFirebaseRealtimeDatabase.node.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/RealtimeDatabase/GoogleFirebaseRealtimeDatabase.node.ts
@@ -43,7 +43,7 @@ export class GoogleFirebaseRealtimeDatabase implements INodeType {
 					loadOptionsMethod: 'getProjects',
 				},
 				description:
-					'As displayed in firebase console URL. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'As displayed in firebase console URL. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				required: true,
 			},
 			{

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/DeviceDescription.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/DeviceDescription.ts
@@ -180,7 +180,7 @@ export const deviceFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Specify the organizational unit name or ID. Choose from the list or use an expression. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Specify the organizational unit name or ID. Choose from the list or use an expression. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Query',
@@ -290,7 +290,7 @@ export const deviceFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The full path to the organizational unit. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The full path to the organizational unit. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Annotated User',

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/UserDescription.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/UserDescription.ts
@@ -278,7 +278,7 @@ export const userFields: INodeProperties[] = [
 		name: 'domain',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getDomains',
 		},
@@ -512,7 +512,7 @@ export const userFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Select the schema to use for custom fields. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Select the schema to use for custom fields. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Field Name or ID',
@@ -663,7 +663,7 @@ export const userFields: INodeProperties[] = [
 		},
 		default: [],
 		description:
-			'A comma-separated list of schema names. All fields from these schemas are fetched. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'A comma-separated list of schema names. All fields from these schemas are fetched. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 
 	/* -------------------------------------------------------------------------- */
@@ -823,7 +823,7 @@ export const userFields: INodeProperties[] = [
 		},
 		default: [],
 		description:
-			'A comma-separated list of schema names. All fields from these schemas are fetched. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'A comma-separated list of schema names. All fields from these schemas are fetched. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Filter',
@@ -1206,7 +1206,7 @@ export const userFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Select the schema to use for custom fields. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Select the schema to use for custom fields. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Field Name or ID',

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -144,7 +144,7 @@ export class GmailTrigger implements INodeType {
 						},
 						default: [],
 						description:
-							'Only return messages with labels that match all of the specified label IDs. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Only return messages with labels that match all of the specified label IDs. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Search',

--- a/packages/nodes-base/nodes/Google/Gmail/v1/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v1/MessageDescription.ts
@@ -421,7 +421,7 @@ export const messageFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Only return messages with labels that match all of the specified label IDs. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Only return messages with labels that match all of the specified label IDs. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Query',

--- a/packages/nodes-base/nodes/Google/Gmail/v1/MessageLabelDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v1/MessageLabelDescription.ts
@@ -58,6 +58,6 @@ export const messageLabelFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the label. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the label. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 ];

--- a/packages/nodes-base/nodes/Google/Gmail/v2/DraftDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/DraftDescription.ts
@@ -174,7 +174,7 @@ export const draftFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Select the alias to send the email from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Select the alias to send the email from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getGmailAliases',
 				},

--- a/packages/nodes-base/nodes/Google/Gmail/v2/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/MessageDescription.ts
@@ -425,7 +425,7 @@ export const messageFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Only return messages with labels that match all of the specified label IDs. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Only return messages with labels that match all of the specified label IDs. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Search',
@@ -554,6 +554,6 @@ export const messageFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 	},
 ];

--- a/packages/nodes-base/nodes/Google/Gmail/v2/ThreadDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/ThreadDescription.ts
@@ -87,7 +87,7 @@ export const threadFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		displayOptions: {
 			show: {
 				resource: ['thread'],
@@ -341,7 +341,7 @@ export const threadFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Only return threads with labels that match all of the specified label IDs. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Only return threads with labels that match all of the specified label IDs. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Search',
@@ -427,6 +427,6 @@ export const threadFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 	},
 ];

--- a/packages/nodes-base/nodes/Google/Perspective/GooglePerspective.node.ts
+++ b/packages/nodes-base/nodes/Google/Perspective/GooglePerspective.node.ts
@@ -165,7 +165,7 @@ export class GooglePerspective implements INodeType {
 						},
 						default: '',
 						description:
-							'Languages of the text input. If unspecified, the API will auto-detect the comment language. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Languages of the text input. If unspecified, the API will auto-detect the comment language. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 				],
 			},

--- a/packages/nodes-base/nodes/Google/Sheet/GoogleSheetsTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/GoogleSheetsTrigger.node.ts
@@ -233,7 +233,7 @@ export class GoogleSheetsTrigger implements INodeType {
 						name: 'columnsToWatch',
 						type: 'multiOptions',
 						description:
-							'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsDependsOn: ['sheetName.value'],
 							loadOptionsMethod: 'getSheetHeaderRowAndSkipEmpty',

--- a/packages/nodes-base/nodes/Google/Sheet/v1/versionDescription.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v1/versionDescription.ts
@@ -239,7 +239,7 @@ export const versionDescription: INodeTypeDescription = {
 							default: '',
 							required: true,
 							description:
-								'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+								'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						},
 						{
 							displayName: 'Start Index',
@@ -278,7 +278,7 @@ export const versionDescription: INodeTypeDescription = {
 							default: '',
 							required: true,
 							description:
-								'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+								'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						},
 						{
 							displayName: 'Start Index',

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/append.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/append.operation.ts
@@ -100,7 +100,7 @@ export const description: SheetProperties = [
 						name: 'fieldId',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsDependsOn: ['sheetName.value'],
 							loadOptionsMethod: 'getSheetHeaderRowAndSkipEmpty',

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/appendOrUpdate.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/appendOrUpdate.operation.ts
@@ -67,7 +67,7 @@ export const description: SheetProperties = [
 		name: 'columnToMatchOn',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsDependsOn: ['sheetName.value'],
 			loadOptionsMethod: 'getSheetHeaderRowAndSkipEmpty',
@@ -133,7 +133,7 @@ export const description: SheetProperties = [
 						name: 'column',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsDependsOn: ['sheetName.value', 'columnToMatchOn'],
 							loadOptionsMethod: 'getSheetHeaderRowAndAddColumn',

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/read.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/read.operation.ts
@@ -53,7 +53,7 @@ export const readFilter: INodeProperties = {
 					},
 					default: '',
 					description:
-						'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+						'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				},
 				{
 					displayName: 'Value',

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/update.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/update.operation.ts
@@ -53,7 +53,7 @@ export const description: SheetProperties = [
 		name: 'columnToMatchOn',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsDependsOn: ['sheetName.value'],
 			loadOptionsMethod: 'getSheetHeaderRowAndSkipEmpty',
@@ -119,7 +119,7 @@ export const description: SheetProperties = [
 						name: 'column',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsDependsOn: ['sheetName.value', 'columnToMatchOn'],
 							loadOptionsMethod: 'getSheetHeaderRowAndAddColumn',

--- a/packages/nodes-base/nodes/Google/Slides/GoogleSlides.node.ts
+++ b/packages/nodes-base/nodes/Google/Slides/GoogleSlides.node.ts
@@ -285,7 +285,7 @@ export class GoogleSlides implements INodeType {
 									loadOptionsDependsOn: ['presentationId'],
 								},
 								description:
-									'If non-empty, limits the matches to slide elements only on the given slides. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'If non-empty, limits the matches to slide elements only on the given slides. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Search For',

--- a/packages/nodes-base/nodes/Google/Task/TaskDescription.ts
+++ b/packages/nodes-base/nodes/Google/Task/TaskDescription.ts
@@ -56,7 +56,7 @@ export const taskFields: INodeProperties[] = [
 		name: 'task',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTasks',
 		},
@@ -167,7 +167,7 @@ export const taskFields: INodeProperties[] = [
 		name: 'task',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTasks',
 		},
@@ -201,7 +201,7 @@ export const taskFields: INodeProperties[] = [
 		name: 'task',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTasks',
 		},
@@ -235,7 +235,7 @@ export const taskFields: INodeProperties[] = [
 		name: 'task',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTasks',
 		},
@@ -363,7 +363,7 @@ export const taskFields: INodeProperties[] = [
 		name: 'task',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTasks',
 		},

--- a/packages/nodes-base/nodes/Google/Translate/GoogleTranslate.node.ts
+++ b/packages/nodes-base/nodes/Google/Translate/GoogleTranslate.node.ts
@@ -156,7 +156,7 @@ export class GoogleTranslate implements INodeType {
 				},
 				default: '',
 				description:
-					'The language to use for translation of the input text, set to one of the language codes listed in <a href="https://cloud.google.com/translate/docs/languages">Language Support</a>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The language to use for translation of the input text, set to one of the language codes listed in <a href="https://cloud.google.com/translate/docs/languages">Language Support</a>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				required: true,
 				displayOptions: {
 					show: {

--- a/packages/nodes-base/nodes/Google/YouTube/ChannelDescription.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/ChannelDescription.ts
@@ -203,7 +203,7 @@ export const channelFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The hl parameter instructs the API to retrieve localized resource metadata for a specific application language that the YouTube website supports. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The hl parameter instructs the API to retrieve localized resource metadata for a specific application language that the YouTube website supports. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'On Behalf Of Content Owner',

--- a/packages/nodes-base/nodes/Google/YouTube/PlaylistDescription.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/PlaylistDescription.ts
@@ -123,7 +123,7 @@ export const playlistFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The language of the text in the playlist resource\'s title and description properties. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The language of the text in the playlist resource\'s title and description properties. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'On Behalf Of Content Owner Channel',
@@ -468,7 +468,7 @@ export const playlistFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The language of the text in the playlist resource\'s title and description properties. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The language of the text in the playlist resource\'s title and description properties. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Description',

--- a/packages/nodes-base/nodes/Google/YouTube/PlaylistItemDescription.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/PlaylistItemDescription.ts
@@ -50,7 +50,7 @@ export const playlistItemFields: INodeProperties[] = [
 		name: 'playlistId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getPlaylists',
 		},
@@ -257,7 +257,7 @@ export const playlistItemFields: INodeProperties[] = [
 		name: 'playlistId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getPlaylists',
 		},

--- a/packages/nodes-base/nodes/Google/YouTube/VideoCategoryDescription.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/VideoCategoryDescription.ts
@@ -33,7 +33,7 @@ export const videoCategoryFields: INodeProperties[] = [
 		name: 'regionCode',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		displayOptions: {
 			show: {

--- a/packages/nodes-base/nodes/Google/YouTube/VideoDescription.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/VideoDescription.ts
@@ -76,7 +76,7 @@ export const videoFields: INodeProperties[] = [
 		name: 'regionCode',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getCountriesCodes',
 		},
@@ -93,7 +93,7 @@ export const videoFields: INodeProperties[] = [
 		name: 'categoryId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getVideoCategories',
 			loadOptionsDependsOn: ['regionCode'],
@@ -142,7 +142,7 @@ export const videoFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The language of the text in the playlist resource\'s title and description properties. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The language of the text in the playlist resource\'s title and description properties. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Description',
@@ -481,7 +481,7 @@ export const videoFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The regionCode parameter instructs the API to select a video chart available in the specified region. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The regionCode parameter instructs the API to select a video chart available in the specified region. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Related To Video ID',
@@ -668,7 +668,7 @@ export const videoFields: INodeProperties[] = [
 		name: 'regionCode',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getCountriesCodes',
 		},
@@ -685,7 +685,7 @@ export const videoFields: INodeProperties[] = [
 		name: 'categoryId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getVideoCategories',
 			loadOptionsDependsOn: ['regionCode'],
@@ -720,7 +720,7 @@ export const videoFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The language of the text in the playlist resource\'s title and description properties. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The language of the text in the playlist resource\'s title and description properties. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Description',

--- a/packages/nodes-base/nodes/Grafana/descriptions/DashboardDescription.ts
+++ b/packages/nodes-base/nodes/Grafana/descriptions/DashboardDescription.ts
@@ -81,7 +81,7 @@ export const dashboardFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Folder to create the dashboard in - if the folder is unspecified, the dashboard will be saved to the General folder. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Folder to create the dashboard in - if the folder is unspecified, the dashboard will be saved to the General folder. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getFolders',
 				},
@@ -219,7 +219,7 @@ export const dashboardFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Folder to move the dashboard into - if the folder is unspecified, the dashboard will be saved to the General folder. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Folder to move the dashboard into - if the folder is unspecified, the dashboard will be saved to the General folder. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getFolders',
 				},

--- a/packages/nodes-base/nodes/Grafana/descriptions/TeamMemberDescription.ts
+++ b/packages/nodes-base/nodes/Grafana/descriptions/TeamMemberDescription.ts
@@ -43,7 +43,7 @@ export const teamMemberFields: INodeProperties[] = [
 		displayName: 'User Name or ID',
 		name: 'userId',
 		description:
-			'User to add to a team. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'User to add to a team. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		required: true,
 		default: '',
@@ -61,7 +61,7 @@ export const teamMemberFields: INodeProperties[] = [
 		displayName: 'Team Name or ID',
 		name: 'teamId',
 		description:
-			'Team to add the user to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Team to add the user to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		required: true,
 		default: '',
@@ -83,7 +83,7 @@ export const teamMemberFields: INodeProperties[] = [
 		displayName: 'User Name or ID',
 		name: 'memberId',
 		description:
-			'User to remove from the team. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'User to remove from the team. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		required: true,
 		default: '',
@@ -101,7 +101,7 @@ export const teamMemberFields: INodeProperties[] = [
 		displayName: 'Team Name or ID',
 		name: 'teamId',
 		description:
-			'Team to remove the user from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Team to remove the user from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		required: true,
 		default: '',
@@ -123,7 +123,7 @@ export const teamMemberFields: INodeProperties[] = [
 		displayName: 'Team Name or ID',
 		name: 'teamId',
 		description:
-			'Team to retrieve all members from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Team to retrieve all members from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		typeOptions: {
 			loadOptionsMethod: 'getTeams',
 		},

--- a/packages/nodes-base/nodes/Grist/OperationDescription.ts
+++ b/packages/nodes-base/nodes/Grist/OperationDescription.ts
@@ -143,7 +143,7 @@ export const operationFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Column to apply the filter in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Column to apply the filter in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 								required: true,
 							},
 							{
@@ -182,7 +182,7 @@ export const operationFields: INodeProperties[] = [
 								default: '',
 								required: true,
 								description:
-									'Column to sort on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Column to sort on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Direction',
@@ -292,7 +292,7 @@ export const operationFields: INodeProperties[] = [
 						displayName: 'Column Name or ID',
 						name: 'fieldId',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						type: 'options',
 						typeOptions: {
 							loadOptionsDependsOn: ['tableId'],

--- a/packages/nodes-base/nodes/HaloPSA/descriptions/SiteDescription.ts
+++ b/packages/nodes-base/nodes/HaloPSA/descriptions/SiteDescription.ts
@@ -97,7 +97,7 @@ export const siteFields: INodeProperties[] = [
 		name: 'clientId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		required: true,
 		typeOptions: {

--- a/packages/nodes-base/nodes/HaloPSA/descriptions/TicketDescription.ts
+++ b/packages/nodes-base/nodes/HaloPSA/descriptions/TicketDescription.ts
@@ -56,7 +56,7 @@ export const ticketFields: INodeProperties[] = [
 		name: 'ticketType',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		required: true,
 		typeOptions: {
@@ -115,7 +115,7 @@ export const ticketFields: INodeProperties[] = [
 				name: 'agent_id',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getHaloPSAAgents',
@@ -277,7 +277,7 @@ export const ticketFields: INodeProperties[] = [
 				name: 'agent_id',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getHaloPSAAgents',

--- a/packages/nodes-base/nodes/HaloPSA/descriptions/UserDescription.ts
+++ b/packages/nodes-base/nodes/HaloPSA/descriptions/UserDescription.ts
@@ -70,7 +70,7 @@ export const userFields: INodeProperties[] = [
 		name: 'siteId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		required: true,
 		typeOptions: {
@@ -302,7 +302,7 @@ export const userFields: INodeProperties[] = [
 				name: 'site_id',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getHaloPSASites',

--- a/packages/nodes-base/nodes/Harvest/Harvest.node.ts
+++ b/packages/nodes-base/nodes/Harvest/Harvest.node.ts
@@ -143,7 +143,7 @@ export class Harvest implements INodeType {
 				name: 'accountId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				required: true,
 				typeOptions: {
 					loadOptionsMethod: 'getAccounts',

--- a/packages/nodes-base/nodes/HelpScout/ConversationDescription.ts
+++ b/packages/nodes-base/nodes/HelpScout/ConversationDescription.ts
@@ -61,7 +61,7 @@ export const conversationFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'ID of a mailbox where the conversation is being created. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of a mailbox where the conversation is being created. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Status',
@@ -218,7 +218,7 @@ export const conversationFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'List of tags to be added to the conversation. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'List of tags to be added to the conversation. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'User ID',
@@ -572,7 +572,7 @@ export const conversationFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Filter conversation by tags. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Filter conversation by tags. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/HelpScout/CustomerDescription.ts
+++ b/packages/nodes-base/nodes/HelpScout/CustomerDescription.ts
@@ -206,7 +206,7 @@ export const customerFields: INodeProperties[] = [
 						name: 'country',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getCountriesCodes',
 						},

--- a/packages/nodes-base/nodes/HighLevel/v1/description/ContactDescription.ts
+++ b/packages/nodes-base/nodes/HighLevel/v1/description/ContactDescription.ts
@@ -181,7 +181,7 @@ const customFields: INodeProperties = {
 					required: true,
 					default: '',
 					description:
-						'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+						'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 					typeOptions: {
 						loadOptions: {
 							routing: {
@@ -423,7 +423,7 @@ const createProperties: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getTimezones',
 				},
@@ -626,7 +626,7 @@ const updateProperties: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getTimezones',
 				},

--- a/packages/nodes-base/nodes/HighLevel/v1/description/OpportunityDescription.ts
+++ b/packages/nodes-base/nodes/HighLevel/v1/description/OpportunityDescription.ts
@@ -109,7 +109,7 @@ const pipelineId: INodeProperties = {
 		},
 	},
 	description:
-		'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+		'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 	typeOptions: {
 		loadOptions: {
 			routing: {
@@ -153,7 +153,7 @@ const createProperties: INodeProperties[] = [
 		type: 'options',
 		required: true,
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		displayOptions: {
 			show: {
 				resource: ['opportunity'],
@@ -269,7 +269,7 @@ const createProperties: INodeProperties[] = [
 				default: '',
 				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 				description:
-					'Choose staff member from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose staff member from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getUsers',
 				},
@@ -427,7 +427,7 @@ const getAllProperties: INodeProperties[] = [
 				default: '',
 				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 				description:
-					'Choose staff member from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose staff member from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getUsers',
 				},
@@ -482,7 +482,7 @@ const getAllProperties: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['pipelineId'],
 					loadOptionsMethod: 'getPipelineStages',
@@ -591,7 +591,7 @@ const updateProperties: INodeProperties[] = [
 				default: '',
 				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 				description:
-					'Choose staff member from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose staff member from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getUsers',
 				},
@@ -659,7 +659,7 @@ const updateProperties: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['pipelineId'],
 					loadOptionsMethod: 'getPipelineStages',

--- a/packages/nodes-base/nodes/HighLevel/v1/description/TaskDescription.ts
+++ b/packages/nodes-base/nodes/HighLevel/v1/description/TaskDescription.ts
@@ -185,7 +185,7 @@ const createProperties: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getUsers',
 				},
@@ -396,7 +396,7 @@ const updateProperties: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getUsers',
 				},

--- a/packages/nodes-base/nodes/HighLevel/v2/description/OpportunityDescription.ts
+++ b/packages/nodes-base/nodes/HighLevel/v2/description/OpportunityDescription.ts
@@ -106,7 +106,7 @@ const pipelineId: INodeProperties = {
 		},
 	},
 	description:
-		'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+		'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 	typeOptions: {
 		loadOptionsMethod: 'getPipelines',
 	},
@@ -127,7 +127,7 @@ const createProperties: INodeProperties[] = [
 		required: true,
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		hint: 'There can only be one opportunity for each contact',
 		displayOptions: {
 			show: {
@@ -222,7 +222,7 @@ const createProperties: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getUsers',
 				},
@@ -276,7 +276,7 @@ const createProperties: INodeProperties[] = [
 				name: 'stageId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 
 				default: '',
 				typeOptions: {
@@ -384,7 +384,7 @@ const getAllProperties: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getUsers',
 				},
@@ -425,7 +425,7 @@ const getAllProperties: INodeProperties[] = [
 				name: 'pipelineId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getPipelines',
 				},
@@ -443,7 +443,7 @@ const getAllProperties: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				hint: "Select 'Pipeline Name or ID' first to see stages",
 				typeOptions: {
 					loadOptionsDependsOn: ['pipelineId'],
@@ -552,7 +552,7 @@ const updateProperties: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getUsers',
 				},
@@ -594,7 +594,7 @@ const updateProperties: INodeProperties[] = [
 				name: 'pipelineId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getPipelines',
 				},
@@ -612,7 +612,7 @@ const updateProperties: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				hint: "Select 'Pipeline Name or ID' first to see stages",
 				typeOptions: {
 					loadOptionsDependsOn: ['pipelineId'],

--- a/packages/nodes-base/nodes/HighLevel/v2/description/TaskDescription.ts
+++ b/packages/nodes-base/nodes/HighLevel/v2/description/TaskDescription.ts
@@ -129,7 +129,7 @@ const createProperties: INodeProperties[] = [
 		default: '',
 		required: true,
 		description:
-			'Contact the task belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Contact the task belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Title',
@@ -209,7 +209,7 @@ const createProperties: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getUsers',
 				},
@@ -254,7 +254,7 @@ const deleteProperties: INodeProperties[] = [
 		default: '',
 		required: true,
 		description:
-			'Contact the task belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Contact the task belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Task ID',
@@ -289,7 +289,7 @@ const getProperties: INodeProperties[] = [
 		default: '',
 		required: true,
 		description:
-			'Contact the task belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Contact the task belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Task ID',
@@ -324,7 +324,7 @@ const getAllProperties: INodeProperties[] = [
 		default: '',
 		required: true,
 		description:
-			'Contact the task belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Contact the task belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',
@@ -383,7 +383,7 @@ const updateProperties: INodeProperties[] = [
 		default: '',
 		required: true,
 		description:
-			'Contact the task belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Contact the task belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Task ID',
@@ -418,7 +418,7 @@ const updateProperties: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getUsers',
 				},

--- a/packages/nodes-base/nodes/HomeAssistant/CameraProxyDescription.ts
+++ b/packages/nodes-base/nodes/HomeAssistant/CameraProxyDescription.ts
@@ -32,7 +32,7 @@ export const cameraProxyFields: INodeProperties[] = [
 		name: 'cameraEntityId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getCameraEntities',
 		},

--- a/packages/nodes-base/nodes/HomeAssistant/ServiceDescription.ts
+++ b/packages/nodes-base/nodes/HomeAssistant/ServiceDescription.ts
@@ -73,7 +73,7 @@ export const serviceFields: INodeProperties[] = [
 		name: 'domain',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getDomains',
 		},
@@ -91,7 +91,7 @@ export const serviceFields: INodeProperties[] = [
 		name: 'service',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsDependsOn: ['domain'],
 			loadOptionsMethod: 'getDomainServices',

--- a/packages/nodes-base/nodes/HomeAssistant/StateDescription.ts
+++ b/packages/nodes-base/nodes/HomeAssistant/StateDescription.ts
@@ -44,7 +44,7 @@ export const stateFields: INodeProperties[] = [
 		name: 'entityId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getAllEntities',
 		},
@@ -112,7 +112,7 @@ export const stateFields: INodeProperties[] = [
 		required: true,
 		default: '',
 		description:
-			'The entity ID for which a state will be created. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The entity ID for which a state will be created. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'State',

--- a/packages/nodes-base/nodes/HttpRequest/V3/Description.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/Description.ts
@@ -439,7 +439,7 @@ export const mainProperties: INodeProperties[] = [
 						type: 'string',
 						default: '',
 						description:
-							'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Value',
@@ -522,7 +522,7 @@ export const mainProperties: INodeProperties[] = [
 						type: 'string',
 						default: '',
 						description:
-							'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Value',
@@ -612,7 +612,7 @@ export const mainProperties: INodeProperties[] = [
 						type: 'string',
 						default: '',
 						description:
-							'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Value',

--- a/packages/nodes-base/nodes/Hubspot/HubspotTrigger.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/HubspotTrigger.node.ts
@@ -175,7 +175,7 @@ export class HubspotTrigger implements INodeType {
 								name: 'property',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								typeOptions: {
 									loadOptionsDependsOn: ['contact.propertyChange'],
 									loadOptionsMethod: 'getContactProperties',
@@ -193,7 +193,7 @@ export class HubspotTrigger implements INodeType {
 								name: 'property',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								typeOptions: {
 									loadOptionsDependsOn: ['company.propertyChange'],
 									loadOptionsMethod: 'getCompanyProperties',
@@ -211,7 +211,7 @@ export class HubspotTrigger implements INodeType {
 								name: 'property',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								typeOptions: {
 									loadOptionsDependsOn: ['deal.propertyChange'],
 									loadOptionsMethod: 'getDealProperties',

--- a/packages/nodes-base/nodes/Hubspot/V1/CompanyDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/V1/CompanyDescription.ts
@@ -141,7 +141,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The owner of the company. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The owner of the company. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Country/Region',
@@ -173,7 +173,7 @@ export const companyFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Name of the property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Name of the property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -219,7 +219,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The type of business the company performs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The type of business the company performs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Is Public',
@@ -237,7 +237,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The company\'s sales, prospecting or outreach status. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The company\'s sales, prospecting or outreach status. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Lifecycle Stage Name or ID',
@@ -248,7 +248,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The most advanced lifecycle stage across all contacts associated with this company or organization. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The most advanced lifecycle stage across all contacts associated with this company or organization. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'LinkedIn Bio',
@@ -283,7 +283,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Original source for the contact with the earliest activity for this company or organization. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Original source for the contact with the earliest activity for this company or organization. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Phone Number',
@@ -334,7 +334,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The Target Account property is a means to flag high priority companies if you are following an account based strategy. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The Target Account property is a means to flag high priority companies if you are following an account based strategy. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Timezone',
@@ -388,7 +388,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The optional classification of this company record - prospect, partner, etc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The optional classification of this company record - prospect, partner, etc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Web Technologies Name or ID',
@@ -399,7 +399,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The web technologies used by the company or organization. Powered by HubSpot Insights. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The web technologies used by the company or organization. Powered by HubSpot Insights. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Website URL',
@@ -495,7 +495,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The owner of the company. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The owner of the company. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Country/Region',
@@ -527,7 +527,7 @@ export const companyFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Name of the property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Name of the property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -573,7 +573,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The type of business the company performs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The type of business the company performs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Is Public',
@@ -591,7 +591,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The company\'s sales, prospecting or outreach status. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The company\'s sales, prospecting or outreach status. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Lifecycle Stage Name or ID',
@@ -602,7 +602,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The most advanced lifecycle stage across all contacts associated with this company or organization. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The most advanced lifecycle stage across all contacts associated with this company or organization. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Linkedin Bio',
@@ -643,7 +643,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Original source for the contact with the earliest activity for this company or organization. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Original source for the contact with the earliest activity for this company or organization. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Phone Number',
@@ -694,7 +694,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The Target Account property is a means to flag high priority companies if you are following an account based strategy. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The Target Account property is a means to flag high priority companies if you are following an account based strategy. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Timezone',
@@ -748,7 +748,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The optional classification of this company record - prospect, partner, etc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The optional classification of this company record - prospect, partner, etc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Web Technologies Name or ID',
@@ -759,7 +759,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The web technologies used by the company or organization. Powered by HubSpot Insights. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The web technologies used by the company or organization. Powered by HubSpot Insights. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Website URL',
@@ -884,7 +884,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'<p>Used to include specific company properties in the results. By default, the results will only include company ID and will not include the values for any properties for your companies.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'<p>Used to include specific company properties in the results. By default, the results will only include company ID and will not include the values for any properties for your companies.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Properties With History',
@@ -1051,7 +1051,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'<p>Used to include specific company properties in the results. By default, the results will only include company ID and will not include the values for any properties for your company.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'<p>Used to include specific company properties in the results. By default, the results will only include company ID and will not include the values for any properties for your company.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Hubspot/V1/ContactDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/V1/ContactDescription.ts
@@ -118,7 +118,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Companies associated with the ticket. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Companies associated with the ticket. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'City',
@@ -155,7 +155,7 @@ export const contactFields: INodeProperties[] = [
 				name: 'contactOwner',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getOwners',
 				},
@@ -190,7 +190,7 @@ export const contactFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Name of the property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Name of the property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -300,7 +300,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The contact\'s sales, prospecting or outreach status. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The contact\'s sales, prospecting or outreach status. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Legal Basic For Processing Contact Data Name or ID',
@@ -311,7 +311,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					"Legal basis for processing contact's data; 'Not applicable' will exempt the contact from GDPR protections. Choose from the list, or specify an ID using an <a href=\"https://docs.n8n.io/code/expressions/\">expression</a>.",
+					"Legal basis for processing contact's data; 'Not applicable' will exempt the contact from GDPR protections. Choose from the list, or specify an ID using an <a href=\"https://docs.n8n.io/data/expressions/\">expression</a>.",
 			},
 			{
 				displayName: 'Lifecycle Stage Name or ID',
@@ -322,7 +322,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The qualification of contacts to sales readiness. It can be set through imports, forms, workflows, and manually on a per contact basis. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The qualification of contacts to sales readiness. It can be set through imports, forms, workflows, and manually on a per contact basis. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Marital Status',
@@ -364,7 +364,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The number of company employees. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The number of company employees. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Original Source Name or ID',
@@ -375,7 +375,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The first known source through which a contact found your website. Source is automatically set by HubSpot, but may be updated manually. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The first known source through which a contact found your website. Source is automatically set by HubSpot, but may be updated manually. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Phone Number',
@@ -398,7 +398,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'<p>Used to include specific company properties in the results. By default, the results will only include company ID and will not include the values for any properties for your company.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'<p>Used to include specific company properties in the results. By default, the results will only include company ID and will not include the values for any properties for your company.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Postal Code',
@@ -416,7 +416,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Set your contact\'s preferred language for communications. This property can be changed from an import, form, or integration. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Set your contact\'s preferred language for communications. This property can be changed from an import, form, or integration. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Relationship Status',
@@ -474,7 +474,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The status of the contact\'s content membership. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The status of the contact\'s content membership. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Street Address',
@@ -580,7 +580,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'<p>Used to include specific company properties in the results. By default, the results will only include company ID and will not include the values for any properties for your company.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'<p>Used to include specific company properties in the results. By default, the results will only include company ID and will not include the values for any properties for your company.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Property Mode',
@@ -691,7 +691,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'<p>Used to include specific company properties in the results. By default, the results will only include company ID and will not include the values for any properties for your company.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'<p>Used to include specific company properties in the results. By default, the results will only include company ID and will not include the values for any properties for your company.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Property Mode',
@@ -820,7 +820,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'<p>Used to include specific company properties in the results. By default, the results will only include company ID and will not include the values for any properties for your company.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'<p>Used to include specific company properties in the results. By default, the results will only include company ID and will not include the values for any properties for your company.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Property Mode',
@@ -916,7 +916,7 @@ export const contactFields: INodeProperties[] = [
 										name: 'propertyName',
 										type: 'options',
 										description:
-											'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+											'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 										typeOptions: {
 											loadOptionsMethod: 'getContactProperties',
 										},
@@ -1029,7 +1029,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: ['firstname', 'lastname', 'email'],
 				description:
-					'<p>Used to include specific company properties in the results. By default, the results will only include company ID and will not include the values for any properties for your company.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'<p>Used to include specific company properties in the results. By default, the results will only include company ID and will not include the values for any properties for your company.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Query',
@@ -1044,7 +1044,7 @@ export const contactFields: INodeProperties[] = [
 				name: 'sortBy',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getContactProperties',
 				},

--- a/packages/nodes-base/nodes/Hubspot/V1/DealDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/V1/DealDescription.ts
@@ -86,7 +86,7 @@ export const dealFields: INodeProperties[] = [
 		default: '',
 		options: [],
 		description:
-			'The dealstage is required when creating a deal. See the CRM Pipelines API for details on managing pipelines and stages. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The dealstage is required when creating a deal. See the CRM Pipelines API for details on managing pipelines and stages. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Additional Fields',
@@ -112,7 +112,7 @@ export const dealFields: INodeProperties[] = [
 				name: 'associatedCompany',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getCompanies',
 				},
@@ -123,7 +123,7 @@ export const dealFields: INodeProperties[] = [
 				name: 'associatedVids',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getContacts',
 				},
@@ -158,7 +158,7 @@ export const dealFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Name of the property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Name of the property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -188,7 +188,7 @@ export const dealFields: INodeProperties[] = [
 				name: 'dealType',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getDealTypes',
 				},
@@ -268,7 +268,7 @@ export const dealFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Name of the property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Name of the property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -302,14 +302,14 @@ export const dealFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The dealstage is required when creating a deal. See the CRM Pipelines API for details on managing pipelines and stages. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The dealstage is required when creating a deal. See the CRM Pipelines API for details on managing pipelines and stages. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Deal Type Name or ID',
 				name: 'dealType',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getDealTypes',
 				},
@@ -430,7 +430,7 @@ export const dealFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'<p>Used to include specific deal properties in the results. By default, the results will only include Deal ID and will not include the values for any properties for your Deals.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'<p>Used to include specific deal properties in the results. By default, the results will only include Deal ID and will not include the values for any properties for your Deals.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Properties with History',
@@ -441,7 +441,7 @@ export const dealFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Works similarly to properties=, but this parameter will include the history for the specified property, instead of just including the current value. Use this parameter when you need the full history of changes to a property\'s value. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Works similarly to properties=, but this parameter will include the history for the specified property, instead of just including the current value. Use this parameter when you need the full history of changes to a property\'s value. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -603,7 +603,7 @@ export const dealFields: INodeProperties[] = [
 										name: 'propertyName',
 										type: 'options',
 										description:
-											'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+											'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 										typeOptions: {
 											loadOptionsMethod: 'getDealProperties',
 										},
@@ -716,7 +716,7 @@ export const dealFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'<p>Used to include specific deal properties in the results. By default, the results will only include Deal ID and will not include the values for any properties for your company.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'<p>Used to include specific deal properties in the results. By default, the results will only include Deal ID and will not include the values for any properties for your company.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Query',
@@ -731,7 +731,7 @@ export const dealFields: INodeProperties[] = [
 				name: 'sortBy',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getDealProperties',
 				},

--- a/packages/nodes-base/nodes/Hubspot/V1/FormDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/V1/FormDescription.ts
@@ -49,7 +49,7 @@ export const formFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The ID of the form you\'re sending data to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the form you\'re sending data to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Additional Fields',
@@ -213,7 +213,7 @@ export const formFields: INodeProperties[] = [
 										},
 										default: '',
 										description:
-											'The ID of the specific subscription type. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+											'The ID of the specific subscription type. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 									},
 									{
 										displayName: 'Value',
@@ -250,7 +250,7 @@ export const formFields: INodeProperties[] = [
 						},
 						default: '',
 						description:
-							'The ID of the specific subscription type that this forms indicates interest to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The ID of the specific subscription type that this forms indicates interest to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Value',
@@ -309,6 +309,6 @@ export const formFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The ID of the form. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the form. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 ];

--- a/packages/nodes-base/nodes/Hubspot/V1/TicketDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/V1/TicketDescription.ts
@@ -67,7 +67,7 @@ export const ticketFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The ID of the pipeline the ticket is in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the pipeline the ticket is in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Stage Name or ID',
@@ -86,7 +86,7 @@ export const ticketFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The ID of the pipeline the ticket is in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the pipeline the ticket is in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Ticket Name',
@@ -124,7 +124,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Companies associated with the ticket. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Companies associated with the ticket. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Contact Names or IDs',
@@ -135,7 +135,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Contacts associated with the ticket. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Contacts associated with the ticket. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Category Name or ID',
@@ -146,7 +146,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Main reason customer reached out for help. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Main reason customer reached out for help. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Close Date',
@@ -178,7 +178,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The level of attention needed on the ticket. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The level of attention needed on the ticket. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Resolution Name or ID',
@@ -189,7 +189,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The action taken to resolve the ticket. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The action taken to resolve the ticket. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Source Name or ID',
@@ -200,7 +200,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Channel where ticket was originally submitted. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Channel where ticket was originally submitted. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Ticket Owner Name or ID',
@@ -211,7 +211,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The user from your team that the ticket is assigned to. You can assign additional users to a ticket record by creating a custom HubSpot user property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The user from your team that the ticket is assigned to. You can assign additional users to a ticket record by creating a custom HubSpot user property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -254,7 +254,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Companies associated with the ticket. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Companies associated with the ticket. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Contact Names or IDs',
@@ -265,7 +265,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Contact associated with the ticket. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Contact associated with the ticket. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Category Name or ID',
@@ -276,7 +276,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Main reason customer reached out for help. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Main reason customer reached out for help. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Close Date',
@@ -308,7 +308,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The ID of the pipeline the ticket is in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The ID of the pipeline the ticket is in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Priority Name or ID',
@@ -319,7 +319,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The level of attention needed on the ticket. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The level of attention needed on the ticket. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Resolution Name or ID',
@@ -330,7 +330,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The action taken to resolve the ticket. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The action taken to resolve the ticket. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Source Name or ID',
@@ -341,7 +341,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Channel where ticket was originally submitted. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Channel where ticket was originally submitted. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Stage Name or ID',
@@ -353,7 +353,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The stage ID of the pipeline the ticket is in; depends on Pipeline ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The stage ID of the pipeline the ticket is in; depends on Pipeline ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Ticket Name',
@@ -371,7 +371,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The user from your team that the ticket is assigned to. You can assign additional users to a ticket record by creating a custom HubSpot user property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The user from your team that the ticket is assigned to. You can assign additional users to a ticket record by creating a custom HubSpot user property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -421,7 +421,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'<p>Used to include specific ticket properties in the results. By default, the results will only include ticket ID and will not include the values for any properties for your tickets.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'<p>Used to include specific ticket properties in the results. By default, the results will only include ticket ID and will not include the values for any properties for your tickets.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Properties With History',
@@ -490,7 +490,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'<p>Used to include specific ticket properties in the results. By default, the results will only include ticket ID and will not include the values for any properties for your company.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'<p>Used to include specific ticket properties in the results. By default, the results will only include ticket ID and will not include the values for any properties for your company.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Properties With History',

--- a/packages/nodes-base/nodes/Hubspot/V2/CompanyDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/V2/CompanyDescription.ts
@@ -139,7 +139,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The owner of the company. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The owner of the company. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Country/Region',
@@ -171,7 +171,7 @@ export const companyFields: INodeProperties[] = [
 								},
 								default: {},
 								description:
-									'Name of the property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Name of the property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -218,7 +218,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The type of business the company performs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The type of business the company performs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Is Public',
@@ -236,7 +236,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The company\'s sales, prospecting or outreach status. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The company\'s sales, prospecting or outreach status. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Lifecycle Stage Name or ID',
@@ -247,7 +247,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The most advanced lifecycle stage across all contacts associated with this company or organization. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The most advanced lifecycle stage across all contacts associated with this company or organization. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'LinkedIn Bio',
@@ -282,7 +282,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Original source for the contact with the earliest activity for this company or organization. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Original source for the contact with the earliest activity for this company or organization. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Phone Number',
@@ -333,7 +333,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The Target Account property is a means to flag high priority companies if you are following an account based strategy. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The Target Account property is a means to flag high priority companies if you are following an account based strategy. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Timezone',
@@ -390,7 +390,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The optional classification of this company record - prospect, partner, etc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The optional classification of this company record - prospect, partner, etc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Web Technologies Name or ID',
@@ -401,7 +401,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The web technologies used by the company or organization. Powered by HubSpot Insights. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The web technologies used by the company or organization. Powered by HubSpot Insights. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Website URL',
@@ -526,7 +526,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The owner of the company. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The owner of the company. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Country/Region',
@@ -558,7 +558,7 @@ export const companyFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Name of the property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Name of the property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -605,7 +605,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The type of business the company performs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The type of business the company performs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Is Public',
@@ -623,7 +623,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The company\'s sales, prospecting or outreach status. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The company\'s sales, prospecting or outreach status. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Lifecycle Stage Name or ID',
@@ -634,7 +634,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The most advanced lifecycle stage across all contacts associated with this company or organization. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The most advanced lifecycle stage across all contacts associated with this company or organization. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Linkedin Bio',
@@ -675,7 +675,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Original source for the contact with the earliest activity for this company or organization. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Original source for the contact with the earliest activity for this company or organization. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Phone Number',
@@ -726,7 +726,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The Target Account property is a means to flag high priority companies if you are following an account based strategy. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The Target Account property is a means to flag high priority companies if you are following an account based strategy. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Timezone',
@@ -783,7 +783,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The optional classification of this company record - prospect, partner, etc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The optional classification of this company record - prospect, partner, etc. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Web Technologies Name or ID',
@@ -794,7 +794,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The web technologies used by the company or organization. Powered by HubSpot Insights. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The web technologies used by the company or organization. Powered by HubSpot Insights. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Website URL',
@@ -954,7 +954,7 @@ export const companyFields: INodeProperties[] = [
 								},
 								default: [],
 								description:
-									'Whether to include specific Company properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Whether to include specific Company properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Include',
@@ -978,7 +978,7 @@ export const companyFields: INodeProperties[] = [
 					},
 				],
 				description:
-					'Whether to include specific Company properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Whether to include specific Company properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -1100,7 +1100,7 @@ export const companyFields: INodeProperties[] = [
 								},
 								default: [],
 								description:
-									'Whether to include specific Company properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Whether to include specific Company properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Include',
@@ -1124,7 +1124,7 @@ export const companyFields: INodeProperties[] = [
 					},
 				],
 				description:
-					'Whether to include specific Company properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Whether to include specific Company properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -1199,7 +1199,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Whether to include specific Company properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Whether to include specific Company properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Hubspot/V2/ContactDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/V2/ContactDescription.ts
@@ -103,7 +103,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Companies associated with the ticket. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Companies associated with the ticket. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Buying Role',
@@ -188,7 +188,7 @@ export const contactFields: INodeProperties[] = [
 				name: 'contactOwner',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getOwners',
 				},
@@ -208,7 +208,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Whether to include specific Contact properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Whether to include specific Contact properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Country/Region',
@@ -246,7 +246,7 @@ export const contactFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Name of the property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Name of the property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -1862,7 +1862,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The contact\'s sales, prospecting or outreach status. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The contact\'s sales, prospecting or outreach status. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Legal Basic For Processing Contact Data Name or ID',
@@ -1873,7 +1873,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					"Legal basis for processing contact's data; 'Not applicable' will exempt the contact from GDPR protections. Choose from the list, or specify an ID using an <a href=\"https://docs.n8n.io/code/expressions/\">expression</a>.",
+					"Legal basis for processing contact's data; 'Not applicable' will exempt the contact from GDPR protections. Choose from the list, or specify an ID using an <a href=\"https://docs.n8n.io/data/expressions/\">expression</a>.",
 			},
 			{
 				displayName: 'Lifecycle Stage Name or ID',
@@ -1884,7 +1884,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The qualification of contacts to sales readiness. It can be set through imports, forms, workflows, and manually on a per contact basis. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The qualification of contacts to sales readiness. It can be set through imports, forms, workflows, and manually on a per contact basis. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'LinkedIn URL',
@@ -1954,7 +1954,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The number of company employees. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The number of company employees. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Original Source Name or ID',
@@ -1965,7 +1965,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The first known source through which a contact found your website. Source is automatically set by HubSpot, but may be updated manually. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The first known source through which a contact found your website. Source is automatically set by HubSpot, but may be updated manually. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Persona',
@@ -1997,7 +1997,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Set your contact\'s preferred language for communications. This property can be changed from an import, form, or integration. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Set your contact\'s preferred language for communications. This property can be changed from an import, form, or integration. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Prospecting Agent Last Enrolled',
@@ -2075,7 +2075,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The status of the contact\'s content membership. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The status of the contact\'s content membership. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Street Address',
@@ -4361,7 +4361,7 @@ export const contactFields: INodeProperties[] = [
 								},
 								default: [],
 								description:
-									'Whether to include specific Contact properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Whether to include specific Contact properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Include',
@@ -4385,7 +4385,7 @@ export const contactFields: INodeProperties[] = [
 					},
 				],
 				description:
-					'<p>Used to include specific contact properties in the results. By default, the results will only include Contact ID and will not include the values for any properties for your Contact.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'<p>Used to include specific contact properties in the results. By default, the results will only include Contact ID and will not include the values for any properties for your Contact.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -4488,7 +4488,7 @@ export const contactFields: INodeProperties[] = [
 								},
 								default: [],
 								description:
-									'Whether to include specific Contact properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Whether to include specific Contact properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Include',
@@ -4512,7 +4512,7 @@ export const contactFields: INodeProperties[] = [
 					},
 				],
 				description:
-					'<p>Used to include specific contact properties in the results. By default, the results will only include Contact ID and will not include the values for any properties for your Contact.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'<p>Used to include specific contact properties in the results. By default, the results will only include Contact ID and will not include the values for any properties for your Contact.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -4661,7 +4661,7 @@ export const contactFields: INodeProperties[] = [
 								},
 								default: [],
 								description:
-									'Whether to include specific Contact properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Whether to include specific Contact properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Include',
@@ -4685,7 +4685,7 @@ export const contactFields: INodeProperties[] = [
 					},
 				],
 				description:
-					'<p>Used to include specific contact properties in the results. By default, the results will only include Contact ID and will not include the values for any properties for your Contact.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'<p>Used to include specific contact properties in the results. By default, the results will only include Contact ID and will not include the values for any properties for your Contact.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -4763,7 +4763,7 @@ export const contactFields: INodeProperties[] = [
 										name: 'propertyName',
 										type: 'options',
 										description:
-											'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+											'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 										typeOptions: {
 											loadOptionsMethod: 'getContactPropertiesWithType',
 										},
@@ -4921,7 +4921,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: ['firstname', 'lastname', 'email'],
 				description:
-					'Whether to include specific Contact properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Whether to include specific Contact properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Query',
@@ -4936,7 +4936,7 @@ export const contactFields: INodeProperties[] = [
 				name: 'sortBy',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getContactProperties',
 				},

--- a/packages/nodes-base/nodes/Hubspot/V2/DealDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/V2/DealDescription.ts
@@ -80,7 +80,7 @@ export const dealFields: INodeProperties[] = [
 		default: '',
 		options: [],
 		description:
-			'The deal stage is required when creating a deal. See the CRM Pipelines API for details on managing pipelines and stages. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The deal stage is required when creating a deal. See the CRM Pipelines API for details on managing pipelines and stages. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Deal Properties',
@@ -106,7 +106,7 @@ export const dealFields: INodeProperties[] = [
 				name: 'associatedCompany',
 				type: 'multiOptions',
 				description:
-					'Whether to include specific Associated Company properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Whether to include specific Associated Company properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getCompanies',
 				},
@@ -117,7 +117,7 @@ export const dealFields: INodeProperties[] = [
 				name: 'associatedVids',
 				type: 'multiOptions',
 				description:
-					'Whether to include specific Associated Vid in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Whether to include specific Associated Vid in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getContacts',
 				},
@@ -154,7 +154,7 @@ export const dealFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Name of the property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Name of the property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -218,7 +218,7 @@ export const dealFields: INodeProperties[] = [
 				name: 'dealType',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getDealTypes',
 				},
@@ -229,7 +229,7 @@ export const dealFields: INodeProperties[] = [
 				name: 'pipeline',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getDealPipelines',
 				},
@@ -331,7 +331,7 @@ export const dealFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Name of the property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Name of the property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -399,14 +399,14 @@ export const dealFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The deal stage is required when creating a deal. See the CRM Pipelines API for details on managing pipelines and stages. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The deal stage is required when creating a deal. See the CRM Pipelines API for details on managing pipelines and stages. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Deal Type Name or ID',
 				name: 'dealType',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getDealTypes',
 				},
@@ -505,7 +505,7 @@ export const dealFields: INodeProperties[] = [
 								},
 								default: [],
 								description:
-									'Whether to include specific Deal properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Whether to include specific Deal properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Include',
@@ -529,7 +529,7 @@ export const dealFields: INodeProperties[] = [
 					},
 				],
 				description:
-					'<p>Used to include specific deal properties in the results. By default, the results will only include Deal ID and will not include the values for any properties for your Deals.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'<p>Used to include specific deal properties in the results. By default, the results will only include Deal ID and will not include the values for any properties for your Deals.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -641,7 +641,7 @@ export const dealFields: INodeProperties[] = [
 								},
 								default: [],
 								description:
-									'Whether to include specific Deal properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Whether to include specific Deal properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Include',
@@ -665,7 +665,7 @@ export const dealFields: INodeProperties[] = [
 					},
 				],
 				description:
-					'<p>Used to include specific deal properties in the results. By default, the results will only include Deal ID and will not include the values for any properties for your Deals.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'<p>Used to include specific deal properties in the results. By default, the results will only include Deal ID and will not include the values for any properties for your Deals.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				displayOptions: {
 					show: {
 						'@version': [2],
@@ -859,7 +859,7 @@ export const dealFields: INodeProperties[] = [
 										name: 'propertyName',
 										type: 'options',
 										description:
-											'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+											'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 										typeOptions: {
 											loadOptionsMethod: 'getDealProperties',
 										},
@@ -1017,7 +1017,7 @@ export const dealFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Whether to include specific Deal properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Whether to include specific Deal properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Query',
@@ -1032,7 +1032,7 @@ export const dealFields: INodeProperties[] = [
 				name: 'sortBy',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getDealProperties',
 				},

--- a/packages/nodes-base/nodes/Hubspot/V2/FormDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/V2/FormDescription.ts
@@ -49,7 +49,7 @@ export const formFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The ID of the form you\'re sending data to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the form you\'re sending data to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Options',
@@ -214,7 +214,7 @@ export const formFields: INodeProperties[] = [
 										},
 										default: '',
 										description:
-											'The ID of the specific subscription type. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+											'The ID of the specific subscription type. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 									},
 									{
 										displayName: 'Value',
@@ -251,7 +251,7 @@ export const formFields: INodeProperties[] = [
 						},
 						default: '',
 						description:
-							'The ID of the specific subscription type that this forms indicates interest to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The ID of the specific subscription type that this forms indicates interest to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Value',
@@ -310,6 +310,6 @@ export const formFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The ID of the form. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the form. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 ];

--- a/packages/nodes-base/nodes/Hubspot/V2/TicketDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/V2/TicketDescription.ts
@@ -67,7 +67,7 @@ export const ticketFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The ID of the pipeline the ticket is in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the pipeline the ticket is in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Stage Name or ID',
@@ -86,7 +86,7 @@ export const ticketFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The stage ID of the pipeline the ticket is in; depends on Pipeline ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The stage ID of the pipeline the ticket is in; depends on Pipeline ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Ticket Name',
@@ -123,7 +123,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Whether to include specific Company properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Whether to include specific Company properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Contact Names or IDs',
@@ -134,7 +134,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Whether to include specific Contact properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Whether to include specific Contact properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Category Name or ID',
@@ -145,7 +145,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Main reason customer reached out for help. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Main reason customer reached out for help. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Close Date',
@@ -182,7 +182,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The level of attention needed on the ticket. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The level of attention needed on the ticket. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Resolution Name or ID',
@@ -193,7 +193,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The action taken to resolve the ticket. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The action taken to resolve the ticket. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Source Name or ID',
@@ -204,7 +204,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Channel where ticket was originally submitted. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Channel where ticket was originally submitted. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Ticket Owner Name or ID',
@@ -215,7 +215,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The user from your team that the ticket is assigned to. You can assign additional users to a ticket record by creating a custom HubSpot user property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The user from your team that the ticket is assigned to. You can assign additional users to a ticket record by creating a custom HubSpot user property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -283,7 +283,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Whether to include specific Company properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Whether to include specific Company properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Contact Names or IDs',
@@ -294,7 +294,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Whether to include specific Contact properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Whether to include specific Contact properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Category Name or ID',
@@ -305,7 +305,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Main reason customer reached out for help. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Main reason customer reached out for help. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Close Date',
@@ -342,7 +342,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The ID of the pipeline the ticket is in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The ID of the pipeline the ticket is in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Priority Name or ID',
@@ -353,7 +353,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The level of attention needed on the ticket. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The level of attention needed on the ticket. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Resolution Name or ID',
@@ -364,7 +364,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The action taken to resolve the ticket. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The action taken to resolve the ticket. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Source Name or ID',
@@ -375,7 +375,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Channel where ticket was originally submitted. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Channel where ticket was originally submitted. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Stage Name or ID',
@@ -387,7 +387,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The stage ID of the pipeline the ticket is in; depends on Pipeline ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The stage ID of the pipeline the ticket is in; depends on Pipeline ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Ticket Name',
@@ -404,7 +404,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The user from your team that the ticket is assigned to. You can assign additional users to a ticket record by creating a custom HubSpot user property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The user from your team that the ticket is assigned to. You can assign additional users to a ticket record by creating a custom HubSpot user property. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -479,7 +479,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Whether to include specific Ticket properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Whether to include specific Ticket properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Properties With History',
@@ -548,7 +548,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Whether to include specific Ticket properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Whether to include specific Ticket properties in the returned results. Choose from a list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Properties With History',

--- a/packages/nodes-base/nodes/Intercom/LeadDescription.ts
+++ b/packages/nodes-base/nodes/Intercom/LeadDescription.ts
@@ -310,7 +310,7 @@ export const leadFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Identifies the companies this user belongs to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Identifies the companies this user belongs to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Email',

--- a/packages/nodes-base/nodes/Intercom/UserDescription.ts
+++ b/packages/nodes-base/nodes/Intercom/UserDescription.ts
@@ -323,7 +323,7 @@ export const userFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Identifies the companies this user belongs to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Identifies the companies this user belongs to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Email',

--- a/packages/nodes-base/nodes/InvoiceNinja/BankTransactionDescription.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/BankTransactionDescription.ts
@@ -75,7 +75,7 @@ export const bankTransactionFields: INodeProperties[] = [
 				name: 'bankIntegrationId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getBankIntegrations',
 				},
@@ -102,7 +102,7 @@ export const bankTransactionFields: INodeProperties[] = [
 				name: 'currencyId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getCurrencies',
 				},
@@ -209,7 +209,7 @@ export const bankTransactionFields: INodeProperties[] = [
 		name: 'paymentId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getPayments',
 		},

--- a/packages/nodes-base/nodes/InvoiceNinja/ClientDescription.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/ClientDescription.ts
@@ -151,7 +151,7 @@ export const clientFields: INodeProperties[] = [
 						name: 'countryCode',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getCountryCodes',
 						},
@@ -266,7 +266,7 @@ export const clientFields: INodeProperties[] = [
 						name: 'countryCode',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getCountryCodes',
 						},

--- a/packages/nodes-base/nodes/InvoiceNinja/ExpenseDescription.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/ExpenseDescription.ts
@@ -76,7 +76,7 @@ export const expenseFields: INodeProperties[] = [
 				name: 'client',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getClients',
 				},
@@ -99,7 +99,7 @@ export const expenseFields: INodeProperties[] = [
 				name: 'category',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getExpenseCategories',
 				},
@@ -300,7 +300,7 @@ export const expenseFields: INodeProperties[] = [
 				name: 'vendor',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getVendors',
 				},
@@ -339,7 +339,7 @@ export const expenseFields: INodeProperties[] = [
 				name: 'client',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getClients',
 				},
@@ -362,7 +362,7 @@ export const expenseFields: INodeProperties[] = [
 				name: 'category',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getExpenseCategories',
 				},
@@ -623,7 +623,7 @@ export const expenseFields: INodeProperties[] = [
 				name: 'vendor',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getVendors',
 				},

--- a/packages/nodes-base/nodes/InvoiceNinja/InvoiceDescription.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/InvoiceDescription.ts
@@ -69,7 +69,7 @@ export const invoiceFields: INodeProperties[] = [
 				name: 'client',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getClients',
 				},

--- a/packages/nodes-base/nodes/InvoiceNinja/PaymentDescription.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/PaymentDescription.ts
@@ -50,7 +50,7 @@ export const paymentFields: INodeProperties[] = [
 		name: 'invoice',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getInvoices',
 		},

--- a/packages/nodes-base/nodes/InvoiceNinja/QuoteDescription.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/QuoteDescription.ts
@@ -69,7 +69,7 @@ export const quoteFields: INodeProperties[] = [
 				name: 'client',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getClients',
 				},

--- a/packages/nodes-base/nodes/InvoiceNinja/TaskDescription.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/TaskDescription.ts
@@ -63,7 +63,7 @@ export const taskFields: INodeProperties[] = [
 				name: 'client',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getClients',
 				},
@@ -92,7 +92,7 @@ export const taskFields: INodeProperties[] = [
 				name: 'project',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getProjects',
 				},

--- a/packages/nodes-base/nodes/Iterable/UserListDescription.ts
+++ b/packages/nodes-base/nodes/Iterable/UserListDescription.ts
@@ -49,7 +49,7 @@ export const userListFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'Identifier to be used. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Identifier to be used. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Identifier',
@@ -108,7 +108,7 @@ export const userListFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'Identifier to be used. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Identifier to be used. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Identifier',

--- a/packages/nodes-base/nodes/Jenkins/Jenkins.node.ts
+++ b/packages/nodes-base/nodes/Jenkins/Jenkins.node.ts
@@ -137,7 +137,7 @@ export class Jenkins implements INodeType {
 				required: true,
 				default: '',
 				description:
-					'Name of the job. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Name of the job. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 
 			// --------------------------------------------------------------------------------------------------------
@@ -169,7 +169,7 @@ export class Jenkins implements INodeType {
 								name: 'name',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								typeOptions: {
 									loadOptionsMethod: 'getJobParameters',
 									loadOptionsDependsOn: ['job'],
@@ -354,7 +354,7 @@ export class Jenkins implements INodeType {
 				required: true,
 				default: '',
 				description:
-					'Name of the job. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Name of the job. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Return All',

--- a/packages/nodes-base/nodes/Jira/IssueDescription.ts
+++ b/packages/nodes-base/nodes/Jira/IssueDescription.ts
@@ -233,7 +233,7 @@ export const issueFields: INodeProperties[] = [
 				name: 'componentIds',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getProjectComponents',
 					loadOptionsDependsOn: ['project'],
@@ -307,7 +307,7 @@ export const issueFields: INodeProperties[] = [
 				name: 'labels',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getLabels',
 				},
@@ -568,7 +568,7 @@ export const issueFields: INodeProperties[] = [
 				name: 'labels',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getLabels',
 				},
@@ -1134,7 +1134,7 @@ export const issueFields: INodeProperties[] = [
 						},
 						default: [],
 						description:
-							'List of users to receive the notification. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'List of users to receive the notification. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Group Names or IDs',
@@ -1145,7 +1145,7 @@ export const issueFields: INodeProperties[] = [
 						},
 						default: [],
 						description:
-							'List of groups to receive the notification. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'List of groups to receive the notification. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 				],
 			},
@@ -1199,7 +1199,7 @@ export const issueFields: INodeProperties[] = [
 						},
 						default: [],
 						description:
-							'List of users to receive the notification. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'List of users to receive the notification. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Group Names or IDs',
@@ -1210,7 +1210,7 @@ export const issueFields: INodeProperties[] = [
 						},
 						default: [],
 						description:
-							'List of groups to receive the notification. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'List of groups to receive the notification. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 				],
 			},

--- a/packages/nodes-base/nodes/JotForm/JotFormTrigger.node.ts
+++ b/packages/nodes-base/nodes/JotForm/JotFormTrigger.node.ts
@@ -56,7 +56,7 @@ export class JotFormTrigger implements INodeType {
 				},
 				default: '',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			},
 			{
 				displayName: 'Resolve Data',

--- a/packages/nodes-base/nodes/Keap/ContactDescription.ts
+++ b/packages/nodes-base/nodes/Keap/ContactDescription.ts
@@ -104,7 +104,7 @@ export const contactFields: INodeProperties[] = [
 				name: 'contactType',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getContactTypes',
 				},
@@ -157,7 +157,7 @@ export const contactFields: INodeProperties[] = [
 				name: 'ownerId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getUsers',
 				},
@@ -219,7 +219,7 @@ export const contactFields: INodeProperties[] = [
 				name: 'timezone',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getTimezones',
 				},
@@ -278,7 +278,7 @@ export const contactFields: INodeProperties[] = [
 						name: 'countryCode',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getCountries',
 						},

--- a/packages/nodes-base/nodes/Keap/ContactNoteDescription.ts
+++ b/packages/nodes-base/nodes/Keap/ContactNoteDescription.ts
@@ -66,7 +66,7 @@ export const contactNoteFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The infusionsoft user to create the note on behalf of. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The infusionsoft user to create the note on behalf of. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Contact ID',
@@ -232,7 +232,7 @@ export const contactNoteFields: INodeProperties[] = [
 				name: 'userId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getUsers',
 				},
@@ -331,7 +331,7 @@ export const contactNoteFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The infusionsoft user to create the note on behalf of. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The infusionsoft user to create the note on behalf of. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Keap/ContactTagDescription.ts
+++ b/packages/nodes-base/nodes/Keap/ContactTagDescription.ts
@@ -57,7 +57,7 @@ export const contactTagFields: INodeProperties[] = [
 		name: 'tagIds',
 		type: 'multiOptions',
 		description:
-			'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTags',
 		},

--- a/packages/nodes-base/nodes/Keap/EcommerceOrderDescripion.ts
+++ b/packages/nodes-base/nodes/Keap/EcommerceOrderDescripion.ts
@@ -179,7 +179,7 @@ export const ecommerceOrderFields: INodeProperties[] = [
 						name: 'countryCode',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getCountries',
 						},

--- a/packages/nodes-base/nodes/Keap/EmailDescription.ts
+++ b/packages/nodes-base/nodes/Keap/EmailDescription.ts
@@ -295,7 +295,7 @@ export const emailFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The infusionsoft user to send the email on behalf of. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The infusionsoft user to send the email on behalf of. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Contact IDs',

--- a/packages/nodes-base/nodes/Keap/KeapTrigger.node.ts
+++ b/packages/nodes-base/nodes/Keap/KeapTrigger.node.ts
@@ -48,7 +48,7 @@ export class KeapTrigger implements INodeType {
 				name: 'eventId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getEvents',
 				},

--- a/packages/nodes-base/nodes/KoBoToolbox/FileDescription.ts
+++ b/packages/nodes-base/nodes/KoBoToolbox/FileDescription.ts
@@ -60,7 +60,7 @@ export const fileFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Form ID (e.g. aSAvYreNzVEkrWg5Gdcvg). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Form ID (e.g. aSAvYreNzVEkrWg5Gdcvg). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	/* -------------------------------------------------------------------------- */
 	/*                                file:delete                                 */

--- a/packages/nodes-base/nodes/KoBoToolbox/FormDescription.ts
+++ b/packages/nodes-base/nodes/KoBoToolbox/FormDescription.ts
@@ -55,7 +55,7 @@ export const formFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Form ID (e.g. aSAvYreNzVEkrWg5Gdcvg). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Form ID (e.g. aSAvYreNzVEkrWg5Gdcvg). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	/* -------------------------------------------------------------------------- */
 	/*                                form:getAll                                 */

--- a/packages/nodes-base/nodes/KoBoToolbox/HookDescription.ts
+++ b/packages/nodes-base/nodes/KoBoToolbox/HookDescription.ts
@@ -67,7 +67,7 @@ export const hookFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Form ID (e.g. aSAvYreNzVEkrWg5Gdcvg). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Form ID (e.g. aSAvYreNzVEkrWg5Gdcvg). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Hook ID',

--- a/packages/nodes-base/nodes/KoBoToolbox/KoBoToolboxTrigger.node.ts
+++ b/packages/nodes-base/nodes/KoBoToolbox/KoBoToolboxTrigger.node.ts
@@ -55,7 +55,7 @@ export class KoBoToolboxTrigger implements INodeType {
 				required: true,
 				default: '',
 				description:
-					'Form ID (e.g. aSAvYreNzVEkrWg5Gdcvg). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Form ID (e.g. aSAvYreNzVEkrWg5Gdcvg). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Trigger On',

--- a/packages/nodes-base/nodes/KoBoToolbox/SubmissionDescription.ts
+++ b/packages/nodes-base/nodes/KoBoToolbox/SubmissionDescription.ts
@@ -67,7 +67,7 @@ export const submissionFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Form ID (e.g. aSAvYreNzVEkrWg5Gdcvg). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Form ID (e.g. aSAvYreNzVEkrWg5Gdcvg). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Submission ID',

--- a/packages/nodes-base/nodes/Ldap/LdapDescription.ts
+++ b/packages/nodes-base/nodes/Ldap/LdapDescription.ts
@@ -416,7 +416,7 @@ export const ldapFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Comma-separated list of attributes to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Comma-separated list of attributes to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Page Size',

--- a/packages/nodes-base/nodes/Lemlist/LemlistTrigger.node.ts
+++ b/packages/nodes-base/nodes/Lemlist/LemlistTrigger.node.ts
@@ -64,7 +64,7 @@ export class LemlistTrigger implements INodeType {
 						},
 						default: '',
 						description:
-							'We\'ll call this hook only for this campaignId. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'We\'ll call this hook only for this campaignId. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Is First',

--- a/packages/nodes-base/nodes/Lemlist/v1/descriptions/ActivityDescription.ts
+++ b/packages/nodes-base/nodes/Lemlist/v1/descriptions/ActivityDescription.ts
@@ -79,7 +79,7 @@ export const activityFields: INodeProperties[] = [
 					loadOptionsMethod: 'getCampaigns',
 				},
 				description:
-					'ID of the campaign to retrieve activity for. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the campaign to retrieve activity for. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Type',

--- a/packages/nodes-base/nodes/Lemlist/v1/descriptions/LeadDescription.ts
+++ b/packages/nodes-base/nodes/Lemlist/v1/descriptions/LeadDescription.ts
@@ -51,7 +51,7 @@ export const leadFields: INodeProperties[] = [
 			loadOptionsMethod: 'getCampaigns',
 		},
 		description:
-			'ID of the campaign to create the lead under. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the campaign to create the lead under. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['lead'],
@@ -159,7 +159,7 @@ export const leadFields: INodeProperties[] = [
 			loadOptionsMethod: 'getCampaigns',
 		},
 		description:
-			'ID of the campaign to remove the lead from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the campaign to remove the lead from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['lead'],
@@ -213,7 +213,7 @@ export const leadFields: INodeProperties[] = [
 			loadOptionsMethod: 'getCampaigns',
 		},
 		description:
-			'ID of the campaign to unsubscribe the lead from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the campaign to unsubscribe the lead from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['lead'],

--- a/packages/nodes-base/nodes/Lemlist/v2/descriptions/ActivityDescription.ts
+++ b/packages/nodes-base/nodes/Lemlist/v2/descriptions/ActivityDescription.ts
@@ -79,7 +79,7 @@ export const activityFields: INodeProperties[] = [
 					loadOptionsMethod: 'getCampaigns',
 				},
 				description:
-					'ID of the campaign to retrieve activity for. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the campaign to retrieve activity for. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Is First',

--- a/packages/nodes-base/nodes/Lemlist/v2/descriptions/CampaignDescription.ts
+++ b/packages/nodes-base/nodes/Lemlist/v2/descriptions/CampaignDescription.ts
@@ -96,7 +96,7 @@ export const campaignFields: INodeProperties[] = [
 			loadOptionsMethod: 'getCampaigns',
 		},
 		description:
-			'ID of the campaign to get stats for. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the campaign to get stats for. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['campaign'],

--- a/packages/nodes-base/nodes/Lemlist/v2/descriptions/LeadDescription.ts
+++ b/packages/nodes-base/nodes/Lemlist/v2/descriptions/LeadDescription.ts
@@ -51,7 +51,7 @@ export const leadFields: INodeProperties[] = [
 			loadOptionsMethod: 'getCampaigns',
 		},
 		description:
-			'ID of the campaign to create the lead under. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the campaign to create the lead under. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['lead'],
@@ -202,7 +202,7 @@ export const leadFields: INodeProperties[] = [
 			loadOptionsMethod: 'getCampaigns',
 		},
 		description:
-			'ID of the campaign to remove the lead from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the campaign to remove the lead from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['lead'],
@@ -256,7 +256,7 @@ export const leadFields: INodeProperties[] = [
 			loadOptionsMethod: 'getCampaigns',
 		},
 		description:
-			'ID of the campaign to unsubscribe the lead from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the campaign to unsubscribe the lead from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['lead'],

--- a/packages/nodes-base/nodes/Linear/IssueDescription.ts
+++ b/packages/nodes-base/nodes/Linear/IssueDescription.ts
@@ -62,7 +62,7 @@ export const issueFields: INodeProperties[] = [
 		name: 'teamId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		displayOptions: {
 			show: {
@@ -106,7 +106,7 @@ export const issueFields: INodeProperties[] = [
 				name: 'assigneeId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getUsers',
 				},
@@ -151,7 +151,7 @@ export const issueFields: INodeProperties[] = [
 				name: 'stateId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getStates',
 				},
@@ -243,7 +243,7 @@ export const issueFields: INodeProperties[] = [
 				name: 'assigneeId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getUsers',
 				},
@@ -288,7 +288,7 @@ export const issueFields: INodeProperties[] = [
 				name: 'stateId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getStates',
 				},
@@ -299,7 +299,7 @@ export const issueFields: INodeProperties[] = [
 				name: 'teamId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getTeams',
 				},
@@ -334,7 +334,7 @@ export const issueFields: INodeProperties[] = [
 				name: 'assigneeId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getUsers',
 				},
@@ -379,7 +379,7 @@ export const issueFields: INodeProperties[] = [
 				name: 'stateId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getStates',
 				},
@@ -390,7 +390,7 @@ export const issueFields: INodeProperties[] = [
 				name: 'teamId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getTeams',
 				},

--- a/packages/nodes-base/nodes/Linear/LinearTrigger.node.ts
+++ b/packages/nodes-base/nodes/Linear/LinearTrigger.node.ts
@@ -82,7 +82,7 @@ export class LinearTrigger implements INodeType {
 				name: 'teamId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getTeams',
 				},

--- a/packages/nodes-base/nodes/LingvaNex/ActivityDescription.ts
+++ b/packages/nodes-base/nodes/LingvaNex/ActivityDescription.ts
@@ -38,7 +38,7 @@ export const activityFields: INodeProperties[] = [
 		name: 'workspaceId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getWorkspaces',
 		},
@@ -99,7 +99,7 @@ export const activityFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'A user-defined way to group activities of the same nature. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'A user-defined way to group activities of the same nature. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Description',
@@ -147,7 +147,7 @@ export const activityFields: INodeProperties[] = [
 		name: 'workspaceId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getWorkspaces',
 		},

--- a/packages/nodes-base/nodes/LingvaNex/LingvaNex.node.ts
+++ b/packages/nodes-base/nodes/LingvaNex/LingvaNex.node.ts
@@ -75,7 +75,7 @@ export class LingvaNex implements INodeType {
 				},
 				default: '',
 				description:
-					'The language to use for translation of the input text, set to one of the language codes listed in <a href="https://cloud.google.com/translate/docs/languages">Language Support</a>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The language to use for translation of the input text, set to one of the language codes listed in <a href="https://cloud.google.com/translate/docs/languages">Language Support</a>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				required: true,
 				displayOptions: {
 					show: {
@@ -105,7 +105,7 @@ export class LingvaNex implements INodeType {
 						},
 						default: '',
 						description:
-							'The language code in the format “language code_code of the country”. If this parameter is not present, the auto-detect language mode is enabled. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The language code in the format “language code_code of the country”. If this parameter is not present, the auto-detect language mode is enabled. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Platform',

--- a/packages/nodes-base/nodes/LinkedIn/PostDescription.ts
+++ b/packages/nodes-base/nodes/LinkedIn/PostDescription.ts
@@ -54,7 +54,7 @@ export const postFields: INodeProperties[] = [
 		default: '',
 		required: true,
 		description:
-			'Person as which the post should be posted as. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Person as which the post should be posted as. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				operation: ['create'],

--- a/packages/nodes-base/nodes/LoneScale/LoneScale.node.ts
+++ b/packages/nodes-base/nodes/LoneScale/LoneScale.node.ts
@@ -135,7 +135,7 @@ export class LoneScale implements INodeType {
 				},
 				default: '',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				required: true,
 			},
 			{

--- a/packages/nodes-base/nodes/Magento/CustomerDescription.ts
+++ b/packages/nodes-base/nodes/Magento/CustomerDescription.ts
@@ -169,7 +169,7 @@ export const customerFields: INodeProperties[] = [
 		name: 'website_id',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		displayOptions: {
 			show: {
 				resource: ['customer'],

--- a/packages/nodes-base/nodes/Magento/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Magento/GenericFunctions.ts
@@ -115,7 +115,7 @@ export function getAddressesUi(): INodeProperties {
 						name: 'country_id',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getCountries',
 						},
@@ -557,7 +557,7 @@ export function getCustomerOptionalFields(): INodeProperties[] {
 							name: 'attribute_code',
 							type: 'options',
 							description:
-								'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+								'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 							typeOptions: {
 								loadOptionsMethod: 'getCustomAttributes',
 							},
@@ -616,7 +616,7 @@ export function getCustomerOptionalFields(): INodeProperties[] {
 			name: 'group_id',
 			type: 'options',
 			description:
-				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			typeOptions: {
 				loadOptionsMethod: 'getGroups',
 			},
@@ -652,7 +652,7 @@ export function getCustomerOptionalFields(): INodeProperties[] {
 			name: 'store_id',
 			type: 'options',
 			description:
-				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			typeOptions: {
 				loadOptionsMethod: 'getStores',
 			},
@@ -681,7 +681,7 @@ export function getCustomerOptionalFields(): INodeProperties[] {
 			name: 'website_id',
 			type: 'options',
 			description:
-				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			displayOptions: {
 				show: {
 					'/operation': ['create'],
@@ -702,7 +702,7 @@ export function getProductOptionalFields(): INodeProperties[] {
 			name: 'attribute_set_id',
 			type: 'options',
 			description:
-				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			displayOptions: {
 				show: {
 					'/operation': ['update'],
@@ -798,7 +798,7 @@ export function getProductOptionalFields(): INodeProperties[] {
 			name: 'type_id',
 			type: 'options',
 			description:
-				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			typeOptions: {
 				loadOptionsMethod: 'getProductTypes',
 			},

--- a/packages/nodes-base/nodes/Magento/ProductDescription.ts
+++ b/packages/nodes-base/nodes/Magento/ProductDescription.ts
@@ -85,7 +85,7 @@ export const productFields: INodeProperties[] = [
 		name: 'attributeSetId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		displayOptions: {
 			show: {
 				resource: ['product'],

--- a/packages/nodes-base/nodes/Mailchimp/Mailchimp.node.ts
+++ b/packages/nodes-base/nodes/Mailchimp/Mailchimp.node.ts
@@ -291,7 +291,7 @@ export class Mailchimp implements INodeType {
 				options: [],
 				required: true,
 				description:
-					'List of lists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'List of lists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Email',
@@ -514,7 +514,7 @@ export class Mailchimp implements INodeType {
 								},
 								required: true,
 								description:
-									'Merge Field name. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Merge Field name. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 								default: '',
 							},
 							{
@@ -590,7 +590,7 @@ export class Mailchimp implements INodeType {
 								name: 'categoryId',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								typeOptions: {
 									loadOptionsMethod: 'getGroupCategories',
 									loadOptionsDependsOn: ['list'],
@@ -649,7 +649,7 @@ export class Mailchimp implements INodeType {
 				options: [],
 				required: true,
 				description:
-					'List of lists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'List of lists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Email',
@@ -686,7 +686,7 @@ export class Mailchimp implements INodeType {
 				options: [],
 				required: true,
 				description:
-					'List of lists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'List of lists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Email',
@@ -752,7 +752,7 @@ export class Mailchimp implements INodeType {
 				options: [],
 				required: true,
 				description:
-					'List of lists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'List of lists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Return All',
@@ -903,7 +903,7 @@ export class Mailchimp implements INodeType {
 				options: [],
 				required: true,
 				description:
-					'List of lists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'List of lists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Email',
@@ -991,7 +991,7 @@ export class Mailchimp implements INodeType {
 										name: 'categoryId',
 										type: 'options',
 										description:
-											'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+											'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 										typeOptions: {
 											loadOptionsMethod: 'getGroupCategories',
 											loadOptionsDependsOn: ['list'],
@@ -1056,7 +1056,7 @@ export class Mailchimp implements INodeType {
 										},
 										required: true,
 										description:
-											'Merge Field name. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+											'Merge Field name. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 										default: '',
 									},
 									{
@@ -1255,7 +1255,7 @@ export class Mailchimp implements INodeType {
 				options: [],
 				required: true,
 				description:
-					'List of lists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'List of lists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Email',
@@ -1330,14 +1330,14 @@ export class Mailchimp implements INodeType {
 				options: [],
 				required: true,
 				description:
-					'List of lists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'List of lists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Group Category Name or ID',
 				name: 'groupCategory',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getGroupCategories',
 					loadOptionsDependsOn: ['list'],
@@ -1453,7 +1453,7 @@ export class Mailchimp implements INodeType {
 						},
 						default: [],
 						description:
-							'A comma-separated list of fields to exclude. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'A comma-separated list of fields to exclude. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Field Names or IDs',
@@ -1471,7 +1471,7 @@ export class Mailchimp implements INodeType {
 							'campaigns.settings.title',
 						],
 						description:
-							'A comma-separated list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'A comma-separated list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'List Name or ID',
@@ -1482,7 +1482,7 @@ export class Mailchimp implements INodeType {
 						},
 						default: '',
 						description:
-							'List of lists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'List of lists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Since Create Time',

--- a/packages/nodes-base/nodes/Mailchimp/MailchimpTrigger.node.ts
+++ b/packages/nodes-base/nodes/Mailchimp/MailchimpTrigger.node.ts
@@ -84,7 +84,7 @@ export class MailchimpTrigger implements INodeType {
 				required: true,
 				default: '',
 				description:
-					'The list that is gonna fire the event. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The list that is gonna fire the event. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getLists',
 				},

--- a/packages/nodes-base/nodes/MailerLite/v1/SubscriberDescription.ts
+++ b/packages/nodes-base/nodes/MailerLite/v1/SubscriberDescription.ts
@@ -109,7 +109,7 @@ export const subscriberFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -224,7 +224,7 @@ export const subscriberFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',

--- a/packages/nodes-base/nodes/MailerLite/v2/SubscriberDescription.ts
+++ b/packages/nodes-base/nodes/MailerLite/v2/SubscriberDescription.ts
@@ -115,7 +115,7 @@ export const subscriberFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',

--- a/packages/nodes-base/nodes/Mailjet/EmailDescription.ts
+++ b/packages/nodes-base/nodes/Mailjet/EmailDescription.ts
@@ -312,7 +312,7 @@ export const emailFields: INodeProperties[] = [
 		name: 'templateId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTemplates',
 		},

--- a/packages/nodes-base/nodes/Mandrill/Mandrill.node.ts
+++ b/packages/nodes-base/nodes/Mandrill/Mandrill.node.ts
@@ -171,7 +171,7 @@ export class Mandrill implements INodeType {
 				options: [],
 				required: true,
 				description:
-					'The template you want to send. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The template you want to send. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'From Email',

--- a/packages/nodes-base/nodes/Matrix/MediaDescription.ts
+++ b/packages/nodes-base/nodes/Matrix/MediaDescription.ts
@@ -42,7 +42,7 @@ export const mediaFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Room ID to post. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Room ID to post. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		required: true,
 	},
 	{

--- a/packages/nodes-base/nodes/Matrix/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Matrix/MessageDescription.ts
@@ -50,7 +50,7 @@ export const messageFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The channel to send the message to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The channel to send the message to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Text',
@@ -155,7 +155,7 @@ export const messageFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The token to start returning events from. This token can be obtained from a prev_batch token returned for each room by the sync API. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The token to start returning events from. This token can be obtained from a prev_batch token returned for each room by the sync API. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		required: true,
 	},
 	{

--- a/packages/nodes-base/nodes/Matrix/RoomDescription.ts
+++ b/packages/nodes-base/nodes/Matrix/RoomDescription.ts
@@ -129,7 +129,7 @@ export const roomFields: INodeProperties[] = [
 		name: 'roomId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getChannels',
 		},
@@ -151,7 +151,7 @@ export const roomFields: INodeProperties[] = [
 		name: 'roomId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getChannels',
 		},
@@ -189,7 +189,7 @@ export const roomFields: INodeProperties[] = [
 		name: 'roomId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getChannels',
 		},

--- a/packages/nodes-base/nodes/Matrix/RoomMemberDescription.ts
+++ b/packages/nodes-base/nodes/Matrix/RoomMemberDescription.ts
@@ -32,7 +32,7 @@ export const roomMemberFields: INodeProperties[] = [
 		name: 'roomId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getChannels',
 		},

--- a/packages/nodes-base/nodes/Mattermost/v1/actions/channel/addUser/description.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/actions/channel/addUser/description.ts
@@ -18,7 +18,7 @@ export const channelAddUserDescription: ChannelProperties = [
 			},
 		},
 		description:
-			'The ID of the channel to invite user to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the channel to invite user to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'User Name or ID',
@@ -37,6 +37,6 @@ export const channelAddUserDescription: ChannelProperties = [
 			},
 		},
 		description:
-			'The ID of the user to invite into channel. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the user to invite into channel. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 ];

--- a/packages/nodes-base/nodes/Mattermost/v1/actions/channel/create/description.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/actions/channel/create/description.ts
@@ -18,7 +18,7 @@ export const channelCreateDescription: ChannelProperties = [
 			},
 		},
 		description:
-			'The Mattermost Team. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The Mattermost Team. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Display Name',

--- a/packages/nodes-base/nodes/Mattermost/v1/actions/channel/del/description.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/actions/channel/del/description.ts
@@ -18,6 +18,6 @@ export const channelDeleteDescription: ChannelProperties = [
 			},
 		},
 		description:
-			'The ID of the channel to soft delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the channel to soft delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 ];

--- a/packages/nodes-base/nodes/Mattermost/v1/actions/channel/members/description.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/actions/channel/members/description.ts
@@ -18,7 +18,7 @@ export const channelMembersDescription: ChannelProperties = [
 			},
 		},
 		description:
-			'The Mattermost Team. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The Mattermost Team. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Channel Name or ID',
@@ -38,7 +38,7 @@ export const channelMembersDescription: ChannelProperties = [
 			},
 		},
 		description:
-			'The Mattermost Team. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The Mattermost Team. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Resolve Data',

--- a/packages/nodes-base/nodes/Mattermost/v1/actions/channel/search/description.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/actions/channel/search/description.ts
@@ -18,7 +18,7 @@ export const channelSearchDescription: ChannelProperties = [
 			},
 		},
 		description:
-			'The Mattermost Team. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The Mattermost Team. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Search Term',

--- a/packages/nodes-base/nodes/Mattermost/v1/actions/channel/statistics/description.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/actions/channel/statistics/description.ts
@@ -18,6 +18,6 @@ export const channelStatisticsDescription: ChannelProperties = [
 			},
 		},
 		description:
-			'The ID of the channel to get the statistics from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the channel to get the statistics from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 ];

--- a/packages/nodes-base/nodes/Mattermost/v1/actions/message/post/description.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/actions/message/post/description.ts
@@ -18,7 +18,7 @@ export const messagePostDescription: MessageProperties = [
 			},
 		},
 		description:
-			'The ID of the channel to post to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the channel to post to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Message',

--- a/packages/nodes-base/nodes/Mattermost/v1/actions/message/postEphemeral/description.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/actions/message/postEphemeral/description.ts
@@ -18,7 +18,7 @@ export const messagePostEphemeralDescription: MessageProperties = [
 			},
 		},
 		description:
-			'ID of the user to send the ephemeral message to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the user to send the ephemeral message to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Channel Name or ID',
@@ -36,7 +36,7 @@ export const messagePostEphemeralDescription: MessageProperties = [
 			},
 		},
 		description:
-			'ID of the channel to send the ephemeral message in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the channel to send the ephemeral message in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Message',

--- a/packages/nodes-base/nodes/Mattermost/v1/actions/reaction/create/description.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/actions/reaction/create/description.ts
@@ -18,7 +18,7 @@ export const reactionCreateDescription: ReactionProperties = [
 			},
 		},
 		description:
-			'ID of the user sending the reaction. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the user sending the reaction. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Post ID',

--- a/packages/nodes-base/nodes/Mattermost/v1/actions/reaction/del/description.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/actions/reaction/del/description.ts
@@ -18,7 +18,7 @@ export const reactionDeleteDescription: ReactionProperties = [
 			},
 		},
 		description:
-			'ID of the user whose reaction to delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the user whose reaction to delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Post ID',

--- a/packages/nodes-base/nodes/Mattermost/v1/actions/user/invite/description.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/actions/user/invite/description.ts
@@ -6,7 +6,7 @@ export const userInviteDescription: UserProperties = [
 		name: 'teamId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTeams',
 		},

--- a/packages/nodes-base/nodes/Mautic/CampaignContactDescription.ts
+++ b/packages/nodes-base/nodes/Mautic/CampaignContactDescription.ts
@@ -51,7 +51,7 @@ export const campaignContactFields: INodeProperties[] = [
 		name: 'campaignId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		displayOptions: {
 			show: {

--- a/packages/nodes-base/nodes/Mautic/CompanyDescription.ts
+++ b/packages/nodes-base/nodes/Mautic/CompanyDescription.ts
@@ -180,7 +180,7 @@ export const companyFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Field Value',
@@ -210,7 +210,7 @@ export const companyFields: INodeProperties[] = [
 				name: 'industry',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getIndustries',
 				},
@@ -389,7 +389,7 @@ export const companyFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Field Value',
@@ -419,7 +419,7 @@ export const companyFields: INodeProperties[] = [
 				name: 'industry',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getIndustries',
 				},
@@ -576,7 +576,7 @@ export const companyFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Column to sort by. Can use any column listed in the response. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Column to sort by. Can use any column listed in the response. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Search',

--- a/packages/nodes-base/nodes/Mautic/ContactDescription.ts
+++ b/packages/nodes-base/nodes/Mautic/ContactDescription.ts
@@ -127,7 +127,7 @@ export const contactFields: INodeProperties[] = [
 		name: 'company',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getCompanies',
 		},
@@ -293,7 +293,7 @@ export const contactFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Field Value',
@@ -378,7 +378,7 @@ export const contactFields: INodeProperties[] = [
 				name: 'stage',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getStages',
 				},
@@ -389,7 +389,7 @@ export const contactFields: INodeProperties[] = [
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getTags',
 				},
@@ -625,7 +625,7 @@ export const contactFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Field Value',
@@ -770,7 +770,7 @@ export const contactFields: INodeProperties[] = [
 				name: 'company',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getCompanies',
 				},
@@ -818,7 +818,7 @@ export const contactFields: INodeProperties[] = [
 				name: 'stage',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				displayOptions: {
 					show: {
 						'/jsonParameters': [false],
@@ -834,7 +834,7 @@ export const contactFields: INodeProperties[] = [
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				displayOptions: {
 					show: {
 						'/jsonParameters': [false],
@@ -1275,7 +1275,7 @@ export const contactFields: INodeProperties[] = [
 		name: 'campaignEmailId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		displayOptions: {
 			show: {

--- a/packages/nodes-base/nodes/Mautic/ContactSegmentDescription.ts
+++ b/packages/nodes-base/nodes/Mautic/ContactSegmentDescription.ts
@@ -51,7 +51,7 @@ export const contactSegmentFields: INodeProperties[] = [
 		name: 'segmentId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		displayOptions: {
 			show: {

--- a/packages/nodes-base/nodes/Mautic/MauticTrigger.node.ts
+++ b/packages/nodes-base/nodes/Mautic/MauticTrigger.node.ts
@@ -76,7 +76,7 @@ export class MauticTrigger implements INodeType {
 				name: 'events',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				required: true,
 				typeOptions: {
 					loadOptionsMethod: 'getEvents',

--- a/packages/nodes-base/nodes/Mautic/SegmentEmailDescription.ts
+++ b/packages/nodes-base/nodes/Mautic/SegmentEmailDescription.ts
@@ -31,7 +31,7 @@ export const segmentEmailFields: INodeProperties[] = [
 		name: 'segmentEmailId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		displayOptions: {
 			show: {

--- a/packages/nodes-base/nodes/Medium/Medium.node.ts
+++ b/packages/nodes-base/nodes/Medium/Medium.node.ts
@@ -134,7 +134,7 @@ export class Medium implements INodeType {
 				},
 				default: '',
 				description:
-					'Publication IDs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Publication IDs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Title',

--- a/packages/nodes-base/nodes/Microsoft/Dynamics/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Dynamics/GenericFunctions.ts
@@ -125,14 +125,14 @@ export function getAccountFields(): INodeProperties[] {
 			},
 			default: '',
 			description:
-				'Category to indicate whether the customer account is standard or preferred. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+				'Category to indicate whether the customer account is standard or preferred. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		},
 		{
 			displayName: 'Account Rating Name or ID',
 			name: 'accountratingcode',
 			type: 'options',
 			description:
-				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			typeOptions: {
 				loadOptionsMethod: 'getAccountRatingCodes',
 			},
@@ -157,7 +157,7 @@ export function getAccountFields(): INodeProperties[] {
 							name: 'addresstypecode',
 							type: 'options',
 							description:
-								'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+								'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 							typeOptions: {
 								loadOptionsMethod: 'getAddressTypes',
 							},
@@ -248,14 +248,14 @@ export function getAccountFields(): INodeProperties[] {
 			},
 			default: '',
 			description:
-				'The legal designation or other business type of the account for contracts or reporting purposes. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+				'The legal designation or other business type of the account for contracts or reporting purposes. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		},
 		{
 			displayName: 'Customer Size Name or ID',
 			name: 'customersizecode',
 			type: 'options',
 			description:
-				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			typeOptions: {
 				loadOptionsMethod: 'getCustomerSizeCodes',
 			},
@@ -266,7 +266,7 @@ export function getAccountFields(): INodeProperties[] {
 			name: 'customertypecode',
 			type: 'options',
 			description:
-				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			typeOptions: {
 				loadOptionsMethod: 'getCustomerTypeCodes',
 			},
@@ -324,7 +324,7 @@ export function getAccountFields(): INodeProperties[] {
 			},
 			default: '',
 			description:
-				'The account’s primary industry for use in marketing segmentation and demographic analysis. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+				'The account’s primary industry for use in marketing segmentation and demographic analysis. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		},
 		{
 			displayName: 'Name',
@@ -364,7 +364,7 @@ export function getAccountFields(): INodeProperties[] {
 			},
 			default: '',
 			description:
-				'The payment terms to indicate when the customer needs to pay the total amount. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+				'The payment terms to indicate when the customer needs to pay the total amount. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		},
 		{
 			displayName: 'Preferred Appointment Day Name or ID',
@@ -375,7 +375,7 @@ export function getAccountFields(): INodeProperties[] {
 			},
 			default: '',
 			description:
-				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		},
 		{
 			displayName: 'Preferred Appointment Time Name or ID',
@@ -386,7 +386,7 @@ export function getAccountFields(): INodeProperties[] {
 			},
 			default: '',
 			description:
-				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		},
 		{
 			displayName: 'Preferred Contact Method Name or ID',
@@ -397,7 +397,7 @@ export function getAccountFields(): INodeProperties[] {
 			},
 			default: '',
 			description:
-				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		},
 		{
 			displayName: 'Primary Satori ID',
@@ -436,7 +436,7 @@ export function getAccountFields(): INodeProperties[] {
 			},
 			default: '',
 			description:
-				'Shipping method for deliveries sent to the account’s address to designate the preferred carrier or other delivery option. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+				'Shipping method for deliveries sent to the account’s address to designate the preferred carrier or other delivery option. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		},
 		{
 			displayName: 'SIC',
@@ -490,7 +490,7 @@ export function getAccountFields(): INodeProperties[] {
 			},
 			default: '',
 			description:
-				'Region or territory for the account for use in segmentation and analysis. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+				'Region or territory for the account for use in segmentation and analysis. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		},
 		{
 			displayName: 'Ticker Symbol',

--- a/packages/nodes-base/nodes/Microsoft/Dynamics/descriptions/AccountDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Dynamics/descriptions/AccountDescription.ts
@@ -144,7 +144,7 @@ export const accountFields: INodeProperties[] = [
 				name: 'returnFields',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getAccountFields',
 				},
@@ -155,7 +155,7 @@ export const accountFields: INodeProperties[] = [
 				name: 'expandFields',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getExpandableAccountFields',
 				},
@@ -226,7 +226,7 @@ export const accountFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Fields the response will include. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Fields the response will include. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Microsoft/Excel/v1/TableDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v1/TableDescription.ts
@@ -50,7 +50,7 @@ export const tableFields: INodeProperties[] = [
 		name: 'workbook',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getWorkbooks',
 		},
@@ -67,7 +67,7 @@ export const tableFields: INodeProperties[] = [
 		name: 'worksheet',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		typeOptions: {
 			loadOptionsMethod: 'getworksheets',
@@ -86,7 +86,7 @@ export const tableFields: INodeProperties[] = [
 		name: 'table',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		typeOptions: {
 			loadOptionsMethod: 'getTables',
@@ -134,7 +134,7 @@ export const tableFields: INodeProperties[] = [
 		name: 'workbook',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getWorkbooks',
 		},
@@ -151,7 +151,7 @@ export const tableFields: INodeProperties[] = [
 		name: 'worksheet',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		typeOptions: {
 			loadOptionsMethod: 'getworksheets',
@@ -170,7 +170,7 @@ export const tableFields: INodeProperties[] = [
 		name: 'table',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		typeOptions: {
 			loadOptionsMethod: 'getTables',
@@ -274,7 +274,7 @@ export const tableFields: INodeProperties[] = [
 		name: 'workbook',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getWorkbooks',
 		},
@@ -291,7 +291,7 @@ export const tableFields: INodeProperties[] = [
 		name: 'worksheet',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		typeOptions: {
 			loadOptionsMethod: 'getworksheets',
@@ -310,7 +310,7 @@ export const tableFields: INodeProperties[] = [
 		name: 'table',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		typeOptions: {
 			loadOptionsMethod: 'getTables',
@@ -414,7 +414,7 @@ export const tableFields: INodeProperties[] = [
 		name: 'workbook',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		typeOptions: {
 			loadOptionsMethod: 'getWorkbooks',
@@ -432,7 +432,7 @@ export const tableFields: INodeProperties[] = [
 		name: 'worksheet',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		typeOptions: {
 			loadOptionsMethod: 'getworksheets',
@@ -451,7 +451,7 @@ export const tableFields: INodeProperties[] = [
 		name: 'table',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		typeOptions: {
 			loadOptionsMethod: 'getTables',

--- a/packages/nodes-base/nodes/Microsoft/Excel/v1/WorkbookDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v1/WorkbookDescription.ts
@@ -38,7 +38,7 @@ export const workbookFields: INodeProperties[] = [
 		name: 'workbook',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		typeOptions: {
 			loadOptionsMethod: 'getWorkbooks',

--- a/packages/nodes-base/nodes/Microsoft/Excel/v1/WorksheetDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v1/WorksheetDescription.ts
@@ -38,7 +38,7 @@ export const worksheetFields: INodeProperties[] = [
 		name: 'workbook',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getWorkbooks',
 		},
@@ -111,7 +111,7 @@ export const worksheetFields: INodeProperties[] = [
 		name: 'workbook',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		typeOptions: {
 			loadOptionsMethod: 'getWorkbooks',
@@ -129,7 +129,7 @@ export const worksheetFields: INodeProperties[] = [
 		name: 'worksheet',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		typeOptions: {
 			loadOptionsMethod: 'getworksheets',

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/table/append.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/table/append.operation.ts
@@ -78,7 +78,7 @@ const properties: INodeProperties[] = [
 						name: 'column',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsDependsOn: ['table.value', 'worksheet.value', 'workbook.value'],
 							loadOptionsMethod: 'getTableColumns',

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/table/getRows.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/table/getRows.operation.ts
@@ -81,7 +81,7 @@ const properties: INodeProperties[] = [
 				name: 'column',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsDependsOn: ['table.value', 'worksheet.value', 'workbook.value'],
 					loadOptionsMethod: 'getTableColumns',

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/append.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/append.operation.ts
@@ -78,7 +78,7 @@ const properties: INodeProperties[] = [
 						name: 'column',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsDependsOn: ['worksheet.value'],
 							loadOptionsMethod: 'getWorksheetColumnRow',

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/update.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/update.operation.ts
@@ -103,7 +103,7 @@ const properties: INodeProperties[] = [
 		name: 'columnToMatchOn',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsDependsOn: ['worksheet.value', 'workbook.value', 'range'],
 			loadOptionsMethod: 'getWorksheetColumnRow',
@@ -152,7 +152,7 @@ const properties: INodeProperties[] = [
 						name: 'column',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsDependsOn: ['columnToMatchOn', 'range'],
 							loadOptionsMethod: 'getWorksheetColumnRowSkipColumnToMatchOn',

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/upsert.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/upsert.operation.ts
@@ -68,7 +68,7 @@ const properties: INodeProperties[] = [
 		name: 'columnToMatchOn',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsDependsOn: ['worksheet.value', 'workbook.value', 'range'],
 			loadOptionsMethod: 'getWorksheetColumnRow',
@@ -117,7 +117,7 @@ const properties: INodeProperties[] = [
 						name: 'column',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsDependsOn: ['columnToMatchOn', 'range'],
 							loadOptionsMethod: 'getWorksheetColumnRowSkipColumnToMatchOn',

--- a/packages/nodes-base/nodes/Microsoft/Outlook/trigger/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/trigger/MessageDescription.ts
@@ -66,7 +66,7 @@ export const properties: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			},
 			{
 				displayName: 'Folders to Include',
@@ -77,7 +77,7 @@ export const properties: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			},
 			{
 				displayName: 'Read Status',

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v1/DraftDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v1/DraftDescription.ts
@@ -157,7 +157,7 @@ export const draftFields: INodeProperties[] = [
 				name: 'categories',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getCategories',
 				},

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v1/DraftMessageSharedDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v1/DraftMessageSharedDescription.ts
@@ -92,7 +92,7 @@ export const draftMessageSharedFields: INodeProperties[] = [
 				name: 'categories',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getCategories',
 				},

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v1/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v1/MessageDescription.ts
@@ -452,7 +452,7 @@ export const messageFields: INodeProperties[] = [
 				name: 'categories',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getCategories',
 				},

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/calendar/create.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/calendar/create.operation.ts
@@ -31,7 +31,7 @@ export const properties: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'If set, the calendar will be created in the specified calendar group. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'If set, the calendar will be created in the specified calendar group. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Color',

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/draft/create.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/draft/create.operation.ts
@@ -74,7 +74,7 @@ export const properties: INodeProperties[] = [
 				name: 'categories',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getCategoriesNames',
 				},

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/draft/update.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/draft/update.operation.ts
@@ -28,7 +28,7 @@ export const properties: INodeProperties[] = [
 				name: 'categories',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getCategoriesNames',
 				},

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/event/create.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/event/create.operation.ts
@@ -44,7 +44,7 @@ export const properties: INodeProperties[] = [
 				name: 'categories',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getCategoriesNames',
 				},

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/event/update.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/event/update.operation.ts
@@ -23,7 +23,7 @@ export const properties: INodeProperties[] = [
 				name: 'categories',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getCategoriesNames',
 				},

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/message/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/message/getAll.operation.ts
@@ -138,7 +138,7 @@ export const properties: INodeProperties[] = [
 								},
 								default: [],
 								description:
-									'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 							},
 							{
 								displayName: 'Folders to Include',
@@ -149,7 +149,7 @@ export const properties: INodeProperties[] = [
 								},
 								default: [],
 								description:
-									'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 							},
 							{
 								displayName: 'Read Status',

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/message/send.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/message/send.operation.ts
@@ -81,7 +81,7 @@ export const properties: INodeProperties[] = [
 				name: 'categories',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getCategoriesNames',
 				},

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/message/update.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/message/update.operation.ts
@@ -28,7 +28,7 @@ export const properties: INodeProperties[] = [
 				name: 'categories',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getCategoriesNames',
 				},

--- a/packages/nodes-base/nodes/Microsoft/Teams/v1/ChannelDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v1/ChannelDescription.ts
@@ -57,7 +57,7 @@ export const channelFields: INodeProperties[] = [
 		required: true,
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTeams',
 		},
@@ -132,7 +132,7 @@ export const channelFields: INodeProperties[] = [
 		required: true,
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTeams',
 		},
@@ -149,7 +149,7 @@ export const channelFields: INodeProperties[] = [
 		name: 'channelId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getChannels',
 			loadOptionsDependsOn: ['teamId'],
@@ -172,7 +172,7 @@ export const channelFields: INodeProperties[] = [
 		required: true,
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTeams',
 		},
@@ -189,7 +189,7 @@ export const channelFields: INodeProperties[] = [
 		name: 'channelId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getChannels',
 			loadOptionsDependsOn: ['teamId'],
@@ -212,7 +212,7 @@ export const channelFields: INodeProperties[] = [
 		required: true,
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTeams',
 		},
@@ -265,7 +265,7 @@ export const channelFields: INodeProperties[] = [
 		required: true,
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTeams',
 		},
@@ -282,7 +282,7 @@ export const channelFields: INodeProperties[] = [
 		name: 'channelId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getChannels',
 			loadOptionsDependsOn: ['teamId'],

--- a/packages/nodes-base/nodes/Microsoft/Teams/v1/ChannelMessageDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v1/ChannelMessageDescription.ts
@@ -39,7 +39,7 @@ export const channelMessageFields: INodeProperties[] = [
 		required: true,
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTeams',
 		},
@@ -56,7 +56,7 @@ export const channelMessageFields: INodeProperties[] = [
 		name: 'channelId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getChannels',
 			loadOptionsDependsOn: ['teamId'],
@@ -146,7 +146,7 @@ export const channelMessageFields: INodeProperties[] = [
 		required: true,
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTeams',
 		},
@@ -163,7 +163,7 @@ export const channelMessageFields: INodeProperties[] = [
 		name: 'channelId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getChannels',
 			loadOptionsDependsOn: ['teamId'],

--- a/packages/nodes-base/nodes/Microsoft/Teams/v1/ChatMessageDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v1/ChatMessageDescription.ts
@@ -45,7 +45,7 @@ export const chatMessageFields: INodeProperties[] = [
 		required: true,
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getChats',
 		},
@@ -145,7 +145,7 @@ export const chatMessageFields: INodeProperties[] = [
 		required: true,
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getChats',
 		},

--- a/packages/nodes-base/nodes/Microsoft/Teams/v1/TaskDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v1/TaskDescription.ts
@@ -84,7 +84,7 @@ export const taskFields: INodeProperties[] = [
 		required: true,
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getGroups',
 			loadOptionsDependsOn: ['groupSource'],
@@ -114,7 +114,7 @@ export const taskFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The plan for the task to belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The plan for the task to belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Bucket Name or ID',
@@ -133,7 +133,7 @@ export const taskFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The bucket for the task to belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The bucket for the task to belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Title',
@@ -172,7 +172,7 @@ export const taskFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Who the task should be assigned to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Who the task should be assigned to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Due Date Time',
@@ -192,7 +192,7 @@ export const taskFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Labels to assign to the task. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Labels to assign to the task. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Percent Complete',
@@ -278,7 +278,7 @@ export const taskFields: INodeProperties[] = [
 		required: true,
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getGroups',
 			loadOptionsDependsOn: ['groupSource'],
@@ -296,7 +296,7 @@ export const taskFields: INodeProperties[] = [
 		name: 'memberId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getMembers',
 			loadOptionsDependsOn: ['groupId'],
@@ -315,7 +315,7 @@ export const taskFields: INodeProperties[] = [
 		name: 'planId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getPlans',
 			loadOptionsDependsOn: ['groupId'],
@@ -401,7 +401,7 @@ export const taskFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Who the task should be assigned to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Who the task should be assigned to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Bucket Name or ID',
@@ -413,7 +413,7 @@ export const taskFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The bucket for the task to belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The bucket for the task to belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Due Date Time',
@@ -428,7 +428,7 @@ export const taskFields: INodeProperties[] = [
 				name: 'groupId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getGroups',
 					loadOptionsDependsOn: ['groupSource'],
@@ -445,7 +445,7 @@ export const taskFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Labels to assign to the task. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Labels to assign to the task. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Percent Complete',
@@ -469,7 +469,7 @@ export const taskFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The plan for the task to belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The plan for the task to belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Title',

--- a/packages/nodes-base/nodes/Microsoft/ToDo/LinkedResourceDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/LinkedResourceDescription.ts
@@ -51,7 +51,7 @@ export const linkedResourceFields: INodeProperties[] = [
 		name: 'taskListId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTaskLists',
 		},

--- a/packages/nodes-base/nodes/Microsoft/ToDo/TaskDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/TaskDescription.ts
@@ -62,7 +62,7 @@ export const taskFields: INodeProperties[] = [
 		required: true,
 		default: '',
 		description:
-			'The identifier of the list, unique in the user\'s mailbox. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The identifier of the list, unique in the user\'s mailbox. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Subject',
@@ -185,7 +185,7 @@ export const taskFields: INodeProperties[] = [
 		required: true,
 		default: '',
 		description:
-			'The identifier of the list, unique in the user\'s mailbox. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The identifier of the list, unique in the user\'s mailbox. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Task ID',

--- a/packages/nodes-base/nodes/Misp/descriptions/AttributeDescription.ts
+++ b/packages/nodes-base/nodes/Misp/descriptions/AttributeDescription.ts
@@ -169,7 +169,7 @@ export const attributeFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Use only for when <code>Sharing Group</code> is selected in <code>Distribution</code>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Use only for when <code>Sharing Group</code> is selected in <code>Distribution</code>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getSharingGroups',
 				},
@@ -318,7 +318,7 @@ export const attributeFields: INodeProperties[] = [
 				default: '',
 				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Use only for when <code>Sharing Group</code> is selected in <code>Distribution</code>.',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Use only for when <code>Sharing Group</code> is selected in <code>Distribution</code>.',
 				typeOptions: {
 					loadOptionsMethod: 'getSharingGroups',
 				},

--- a/packages/nodes-base/nodes/Misp/descriptions/EventDescription.ts
+++ b/packages/nodes-base/nodes/Misp/descriptions/EventDescription.ts
@@ -80,7 +80,7 @@ export const eventFields: INodeProperties[] = [
 		default: '',
 		required: true,
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getOrgs',
 		},
@@ -178,7 +178,7 @@ export const eventFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Use only for when <code>Sharing Group</code> is selected in <code>Distribution</code>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Use only for when <code>Sharing Group</code> is selected in <code>Distribution</code>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getSharingGroups',
 				},
@@ -415,7 +415,7 @@ export const eventFields: INodeProperties[] = [
 				default: '',
 				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Use only for when <code>Sharing Group</code> is selected in <code>Distribution</code>.',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Use only for when <code>Sharing Group</code> is selected in <code>Distribution</code>.',
 				typeOptions: {
 					loadOptionsMethod: 'getSharingGroups',
 				},

--- a/packages/nodes-base/nodes/Misp/descriptions/EventTagDescription.ts
+++ b/packages/nodes-base/nodes/Misp/descriptions/EventTagDescription.ts
@@ -49,7 +49,7 @@ export const eventTagFields: INodeProperties[] = [
 		displayName: 'Tag Name or ID',
 		name: 'tagId',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		type: 'options',
 		required: true,
 		default: '',
@@ -85,7 +85,7 @@ export const eventTagFields: INodeProperties[] = [
 		displayName: 'Tag Name or ID',
 		name: 'tagId',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		type: 'options',
 		required: true,
 		default: '',

--- a/packages/nodes-base/nodes/Misp/descriptions/UserDescription.ts
+++ b/packages/nodes-base/nodes/Misp/descriptions/UserDescription.ts
@@ -100,7 +100,7 @@ export const userFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getUsers',
 				},
@@ -110,7 +110,7 @@ export const userFields: INodeProperties[] = [
 				name: 'org_id',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getOrgs',
@@ -233,7 +233,7 @@ export const userFields: INodeProperties[] = [
 				name: 'invited_by',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getUsers',
@@ -244,7 +244,7 @@ export const userFields: INodeProperties[] = [
 				name: 'org_id',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getOrgs',

--- a/packages/nodes-base/nodes/MondayCom/BoardColumnDescription.ts
+++ b/packages/nodes-base/nodes/MondayCom/BoardColumnDescription.ts
@@ -38,7 +38,7 @@ export const boardColumnFields: INodeProperties[] = [
 		name: 'boardId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		typeOptions: {
 			loadOptionsMethod: 'getBoards',
@@ -196,7 +196,7 @@ export const boardColumnFields: INodeProperties[] = [
 		name: 'boardId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		typeOptions: {
 			loadOptionsMethod: 'getBoards',

--- a/packages/nodes-base/nodes/MondayCom/BoardDescription.ts
+++ b/packages/nodes-base/nodes/MondayCom/BoardDescription.ts
@@ -61,7 +61,7 @@ export const boardFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Board unique identifiers. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Board unique identifiers. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	/* -------------------------------------------------------------------------- */
 	/*                                 board:create                               */
@@ -152,7 +152,7 @@ export const boardFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Board unique identifiers. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Board unique identifiers. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	/* -------------------------------------------------------------------------- */
 	/*                                  board:getAll                              */

--- a/packages/nodes-base/nodes/MondayCom/BoardGroupDescription.ts
+++ b/packages/nodes-base/nodes/MondayCom/BoardGroupDescription.ts
@@ -44,7 +44,7 @@ export const boardGroupFields: INodeProperties[] = [
 		name: 'boardId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		typeOptions: {
 			loadOptionsMethod: 'getBoards',
@@ -79,7 +79,7 @@ export const boardGroupFields: INodeProperties[] = [
 		name: 'boardId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getBoards',
 		},
@@ -97,7 +97,7 @@ export const boardGroupFields: INodeProperties[] = [
 		name: 'groupId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		typeOptions: {
 			loadOptionsMethod: 'getGroups',
@@ -119,7 +119,7 @@ export const boardGroupFields: INodeProperties[] = [
 		name: 'boardId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		typeOptions: {
 			loadOptionsMethod: 'getBoards',

--- a/packages/nodes-base/nodes/MondayCom/BoardItemDescription.ts
+++ b/packages/nodes-base/nodes/MondayCom/BoardItemDescription.ts
@@ -122,7 +122,7 @@ export const boardItemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The unique identifier of the board. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The unique identifier of the board. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Item ID',
@@ -155,7 +155,7 @@ export const boardItemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The column\'s unique identifier. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The column\'s unique identifier. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Value',
@@ -191,7 +191,7 @@ export const boardItemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The unique identifier of the board. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The unique identifier of the board. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Item ID',
@@ -233,7 +233,7 @@ export const boardItemFields: INodeProperties[] = [
 		name: 'boardId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getBoards',
 		},
@@ -251,7 +251,7 @@ export const boardItemFields: INodeProperties[] = [
 		name: 'groupId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		typeOptions: {
 			loadOptionsMethod: 'getGroups',
@@ -346,7 +346,7 @@ export const boardItemFields: INodeProperties[] = [
 		name: 'boardId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		typeOptions: {
 			loadOptionsMethod: 'getBoards',
@@ -365,7 +365,7 @@ export const boardItemFields: INodeProperties[] = [
 		default: '',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getGroups',
 			loadOptionsDependsOn: ['boardId'],
@@ -428,7 +428,7 @@ export const boardItemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The unique identifier of the board. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The unique identifier of the board. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Column Name or ID',
@@ -447,7 +447,7 @@ export const boardItemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The column\'s unique identifier. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The column\'s unique identifier. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Column Value',
@@ -502,7 +502,7 @@ export const boardItemFields: INodeProperties[] = [
 		name: 'boardId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getBoards',
 		},
@@ -534,7 +534,7 @@ export const boardItemFields: INodeProperties[] = [
 		name: 'groupId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		typeOptions: {
 			loadOptionsMethod: 'getGroups',

--- a/packages/nodes-base/nodes/MonicaCrm/descriptions/ActivityDescription.ts
+++ b/packages/nodes-base/nodes/MonicaCrm/descriptions/ActivityDescription.ts
@@ -56,7 +56,7 @@ export const activityFields: INodeProperties[] = [
 		name: 'activityTypeId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		default: '',
 		typeOptions: {
@@ -239,7 +239,7 @@ export const activityFields: INodeProperties[] = [
 				name: 'activity_type_id',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getActivityTypes',

--- a/packages/nodes-base/nodes/MonicaCrm/descriptions/ContactDescription.ts
+++ b/packages/nodes-base/nodes/MonicaCrm/descriptions/ContactDescription.ts
@@ -69,7 +69,7 @@ export const contactFields: INodeProperties[] = [
 		name: 'genderId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		default: '',
 		typeOptions: {
@@ -316,7 +316,7 @@ export const contactFields: INodeProperties[] = [
 				name: 'gender_id',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getGenders',

--- a/packages/nodes-base/nodes/MonicaCrm/descriptions/ContactFieldDescription.ts
+++ b/packages/nodes-base/nodes/MonicaCrm/descriptions/ContactFieldDescription.ts
@@ -69,7 +69,7 @@ export const contactFieldFields: INodeProperties[] = [
 		name: 'contactFieldTypeId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		typeOptions: {
 			loadOptionsMethod: 'getContactFieldTypes',
@@ -217,7 +217,7 @@ export const contactFieldFields: INodeProperties[] = [
 		name: 'contactFieldTypeId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getContactFieldTypes',
 		},

--- a/packages/nodes-base/nodes/MonicaCrm/descriptions/ContactTagDescription.ts
+++ b/packages/nodes-base/nodes/MonicaCrm/descriptions/ContactTagDescription.ts
@@ -49,7 +49,7 @@ export const contactTagFields: INodeProperties[] = [
 		displayName: 'Tag Names or IDs',
 		name: 'tagsToAdd',
 		description:
-			'Tags to add to the contact. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Tags to add to the contact. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'multiOptions',
 		typeOptions: {
 			loadOptionsMethod: 'getTagsToAdd',
@@ -85,7 +85,7 @@ export const contactTagFields: INodeProperties[] = [
 		displayName: 'Tag Names or IDs',
 		name: 'tagsToRemove',
 		description:
-			'Tags to remove from the contact. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Tags to remove from the contact. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'multiOptions',
 		required: true,
 		typeOptions: {

--- a/packages/nodes-base/nodes/MonicaCrm/descriptions/ConversationDescription.ts
+++ b/packages/nodes-base/nodes/MonicaCrm/descriptions/ConversationDescription.ts
@@ -64,7 +64,7 @@ export const conversationFields: INodeProperties[] = [
 		name: 'contactFieldTypeId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		default: '',
 		typeOptions: {
@@ -150,7 +150,7 @@ export const conversationFields: INodeProperties[] = [
 		name: 'contactFieldTypeId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		default: '',
 		typeOptions: {

--- a/packages/nodes-base/nodes/MySql/v2/actions/common.descriptions.ts
+++ b/packages/nodes-base/nodes/MySql/v2/actions/common.descriptions.ts
@@ -142,7 +142,7 @@ export const optionsCollection: INodeProperties = {
 			type: 'multiOptions',
 			// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-multi-options
 			description:
-				'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/" target="_blank">expression</a>',
+				'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/" target="_blank">expression</a>',
 			typeOptions: {
 				loadOptionsMethod: 'getColumnsMultiOptions',
 				loadOptionsDependsOn: ['table.value'],
@@ -281,7 +281,7 @@ export const selectRowsFixedCollection: INodeProperties = {
 					type: 'options',
 					// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 					description:
-						'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/" target="_blank">expression</a>',
+						'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/" target="_blank">expression</a>',
 					default: '',
 					placeholder: 'e.g. ID',
 					typeOptions: {
@@ -336,7 +336,7 @@ export const sortFixedCollection: INodeProperties = {
 					type: 'options',
 					// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 					description:
-						'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/" target="_blank">expression</a>',
+						'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/" target="_blank">expression</a>',
 					default: '',
 					typeOptions: {
 						loadOptionsMethod: 'getColumns',

--- a/packages/nodes-base/nodes/MySql/v2/actions/database/insert.operation.ts
+++ b/packages/nodes-base/nodes/MySql/v2/actions/database/insert.operation.ts
@@ -78,7 +78,7 @@ const properties: INodeProperties[] = [
 						type: 'options',
 						// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/" target="_blank">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/" target="_blank">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getColumns',
 							loadOptionsDependsOn: ['table.value'],

--- a/packages/nodes-base/nodes/MySql/v2/actions/database/update.operation.ts
+++ b/packages/nodes-base/nodes/MySql/v2/actions/database/update.operation.ts
@@ -54,7 +54,7 @@ const properties: INodeProperties[] = [
 		required: true,
 		// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/" target="_blank">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/" target="_blank">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getColumns',
 			loadOptionsDependsOn: ['schema.value', 'table.value'],
@@ -102,7 +102,7 @@ const properties: INodeProperties[] = [
 						type: 'options',
 						// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/" target="_blank">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/" target="_blank">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getColumnsWithoutColumnToMatchOn',
 							loadOptionsDependsOn: ['schema.value', 'table.value'],

--- a/packages/nodes-base/nodes/MySql/v2/actions/database/upsert.operation.ts
+++ b/packages/nodes-base/nodes/MySql/v2/actions/database/upsert.operation.ts
@@ -54,7 +54,7 @@ const properties: INodeProperties[] = [
 		required: true,
 		// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 		description:
-			'The column to compare when finding the rows to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/" target="_blank">expression</a>.',
+			'The column to compare when finding the rows to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/" target="_blank">expression</a>.',
 		typeOptions: {
 			loadOptionsMethod: 'getColumns',
 			loadOptionsDependsOn: ['schema.value', 'table.value'],
@@ -102,7 +102,7 @@ const properties: INodeProperties[] = [
 						type: 'options',
 						// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/" target="_blank">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/" target="_blank">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getColumnsWithoutColumnToMatchOn',
 							loadOptionsDependsOn: ['schema.value', 'table.value'],

--- a/packages/nodes-base/nodes/Netlify/DeployDescription.ts
+++ b/packages/nodes-base/nodes/Netlify/DeployDescription.ts
@@ -52,7 +52,7 @@ export const deployFields: INodeProperties[] = [
 			loadOptionsMethod: 'getSites',
 		},
 		description:
-			'Enter the Site ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Enter the Site ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['deploy'],

--- a/packages/nodes-base/nodes/Netlify/NetlifyTrigger.node.ts
+++ b/packages/nodes-base/nodes/Netlify/NetlifyTrigger.node.ts
@@ -52,7 +52,7 @@ export class NetlifyTrigger implements INodeType {
 					loadOptionsMethod: 'getSites',
 				},
 				description:
-					'Select the Site ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Select the Site ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Event',
@@ -94,7 +94,7 @@ export class NetlifyTrigger implements INodeType {
 					loadOptionsMethod: 'getForms',
 				},
 				description:
-					'Select a form. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Select a form. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Simplify',

--- a/packages/nodes-base/nodes/NocoDB/OperationDescription.ts
+++ b/packages/nodes-base/nodes/NocoDB/OperationDescription.ts
@@ -15,7 +15,7 @@ export const operationFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getWorkspaces',
 		},
@@ -32,7 +32,7 @@ export const operationFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsDependsOn: ['workspaceId'],
 			loadOptionsMethod: 'getBases',
@@ -63,7 +63,7 @@ export const operationFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getBases',
 		},
@@ -80,7 +80,7 @@ export const operationFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The table to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The table to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		typeOptions: {
 			loadOptionsDependsOn: ['projectId'],
 			loadOptionsMethod: 'getTables',

--- a/packages/nodes-base/nodes/Notion/shared/descriptions/Blocks.ts
+++ b/packages/nodes-base/nodes/Notion/shared/descriptions/Blocks.ts
@@ -188,7 +188,7 @@ const typeMention: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The ID of the user being mentioned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the user being mentioned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Page ID',
@@ -580,7 +580,7 @@ export const blocks = (resource: string, operation: string): INodeProperties[] =
 						name: 'type',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getBlockTypes',
 						},

--- a/packages/nodes-base/nodes/Notion/shared/descriptions/DatabasePageDescription.ts
+++ b/packages/nodes-base/nodes/Notion/shared/descriptions/DatabasePageDescription.ts
@@ -213,7 +213,7 @@ export const databasePageFields: INodeProperties[] = [
 						name: 'key',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getDatabaseProperties',
 							loadOptionsDependsOn: ['databaseId'],
@@ -292,7 +292,7 @@ export const databasePageFields: INodeProperties[] = [
 						},
 						default: [],
 						description:
-							'Name of the options you want to set. Multiples can be defined separated by comma. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Name of the options you want to set. Multiples can be defined separated by comma. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Option Name or ID',
@@ -308,7 +308,7 @@ export const databasePageFields: INodeProperties[] = [
 						},
 						default: '',
 						description:
-							'Name of the option you want to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Name of the option you want to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Status Name or ID',
@@ -324,7 +324,7 @@ export const databasePageFields: INodeProperties[] = [
 						},
 						default: '',
 						description:
-							'Name of the option you want to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Name of the option you want to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Email',
@@ -375,7 +375,7 @@ export const databasePageFields: INodeProperties[] = [
 						},
 						default: [],
 						description:
-							'List of users. Multiples can be defined separated by comma. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'List of users. Multiples can be defined separated by comma. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Relation IDs',
@@ -496,7 +496,7 @@ export const databasePageFields: INodeProperties[] = [
 						},
 						default: 'default',
 						description:
-							'Time zone to use. By default n8n timezone is used. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Time zone to use. By default n8n timezone is used. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'File URLs',
@@ -680,7 +680,7 @@ export const databasePageFields: INodeProperties[] = [
 						name: 'key',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getDatabaseIdFromPage',
 							loadOptionsDependsOn: ['pageId'],
@@ -750,7 +750,7 @@ export const databasePageFields: INodeProperties[] = [
 						name: 'multiSelectValue',
 						type: 'multiOptions',
 						description:
-							'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getDatabaseOptionsFromPage',
 						},
@@ -766,7 +766,7 @@ export const databasePageFields: INodeProperties[] = [
 						name: 'selectValue',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getDatabaseOptionsFromPage',
 						},
@@ -791,7 +791,7 @@ export const databasePageFields: INodeProperties[] = [
 						},
 						default: '',
 						description:
-							'Name of the option you want to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Name of the option you want to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Email',
@@ -841,7 +841,7 @@ export const databasePageFields: INodeProperties[] = [
 						},
 						default: [],
 						description:
-							'List of users. Multiples can be defined separated by comma. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'List of users. Multiples can be defined separated by comma. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Relation IDs',
@@ -962,7 +962,7 @@ export const databasePageFields: INodeProperties[] = [
 						},
 						default: 'default',
 						description:
-							'Time zone to use. By default n8n timezone is used. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Time zone to use. By default n8n timezone is used. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'File URLs',
@@ -1356,7 +1356,7 @@ export const databasePageFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'The name of the property to filter by. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The name of the property to filter by. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Property Name',

--- a/packages/nodes-base/nodes/Notion/shared/descriptions/Filters.ts
+++ b/packages/nodes-base/nodes/Notion/shared/descriptions/Filters.ts
@@ -9,7 +9,7 @@ export const filters = (conditions: any) => [
 		},
 		default: '',
 		description:
-			'The name of the property to filter by. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The name of the property to filter by. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Type',
@@ -66,7 +66,7 @@ export const filters = (conditions: any) => [
 		name: 'multiSelectValue',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getPropertySelectValues',
 		},
@@ -85,7 +85,7 @@ export const filters = (conditions: any) => [
 		name: 'selectValue',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getPropertySelectValues',
 		},
@@ -113,7 +113,7 @@ export const filters = (conditions: any) => [
 		},
 		default: '',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 	},
 	{
 		displayName: 'Email',
@@ -160,7 +160,7 @@ export const filters = (conditions: any) => [
 		},
 		default: '',
 		description:
-			'List of users. Multiples can be defined separated by comma. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'List of users. Multiples can be defined separated by comma. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'User Name or ID',
@@ -179,7 +179,7 @@ export const filters = (conditions: any) => [
 		},
 		default: '',
 		description:
-			'List of users. Multiples can be defined separated by comma. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'List of users. Multiples can be defined separated by comma. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'User Name or ID',
@@ -198,7 +198,7 @@ export const filters = (conditions: any) => [
 		},
 		default: '',
 		description:
-			'List of users. Multiples can be defined separated by comma. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'List of users. Multiples can be defined separated by comma. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Relation ID',

--- a/packages/nodes-base/nodes/Odoo/descriptions/ContactDescription.ts
+++ b/packages/nodes-base/nodes/Odoo/descriptions/ContactDescription.ts
@@ -102,7 +102,7 @@ export const contactDescription: INodeProperties[] = [
 								name: 'country_id',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								default: '',
 								typeOptions: {
 									loadOptionsMethod: 'getCountries',
@@ -113,7 +113,7 @@ export const contactDescription: INodeProperties[] = [
 								name: 'state_id',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								default: '',
 								typeOptions: {
 									loadOptionsMethod: 'getStates',
@@ -258,7 +258,7 @@ export const contactDescription: INodeProperties[] = [
 				name: 'fieldsList',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getModelFields',
@@ -321,7 +321,7 @@ export const contactDescription: INodeProperties[] = [
 								name: 'country_id',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								default: '',
 								typeOptions: {
 									loadOptionsMethod: 'getCountries',
@@ -332,7 +332,7 @@ export const contactDescription: INodeProperties[] = [
 								name: 'state_id',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								default: '',
 								typeOptions: {
 									loadOptionsMethod: 'getStates',

--- a/packages/nodes-base/nodes/Odoo/descriptions/CustomResourceDescription.ts
+++ b/packages/nodes-base/nodes/Odoo/descriptions/CustomResourceDescription.ts
@@ -6,7 +6,7 @@ export const customResourceOperations: INodeProperties[] = [
 		name: 'customResource',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		typeOptions: {
 			loadOptionsMethod: 'getModels',
@@ -93,7 +93,7 @@ export const customResourceDescription: INodeProperties[] = [
 						name: 'fieldName',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						default: '',
 						typeOptions: {
 							loadOptionsMethod: 'getModelFields',
@@ -179,7 +179,7 @@ export const customResourceDescription: INodeProperties[] = [
 				name: 'fieldsList',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getModelFields',
@@ -215,7 +215,7 @@ export const customResourceDescription: INodeProperties[] = [
 						name: 'fieldName',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						default: '',
 						typeOptions: {
 							loadOptionsDependsOn: ['customResource'],
@@ -325,7 +325,7 @@ export const customResourceDescription: INodeProperties[] = [
 						name: 'fieldName',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						default: '',
 						typeOptions: {
 							loadOptionsMethod: 'getModelFields',

--- a/packages/nodes-base/nodes/Odoo/descriptions/NoteDescription.ts
+++ b/packages/nodes-base/nodes/Odoo/descriptions/NoteDescription.ts
@@ -160,7 +160,7 @@ export const noteDescription: INodeProperties[] = [
 				name: 'fieldsList',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getModelFields',

--- a/packages/nodes-base/nodes/Odoo/descriptions/OpportunityDescription.ts
+++ b/packages/nodes-base/nodes/Odoo/descriptions/OpportunityDescription.ts
@@ -211,7 +211,7 @@ export const opportunityDescription: INodeProperties[] = [
 				name: 'fieldsList',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getModelFields',

--- a/packages/nodes-base/nodes/Onfleet/descriptions/HubDescription.ts
+++ b/packages/nodes-base/nodes/Onfleet/descriptions/HubDescription.ts
@@ -54,7 +54,7 @@ const teamsField = {
 	},
 	default: [],
 	description:
-		'These are the teams that this Hub will be assigned to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+		'These are the teams that this Hub will be assigned to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 } as INodeProperties;
 
 export const hubFields: INodeProperties[] = [

--- a/packages/nodes-base/nodes/Onfleet/descriptions/TeamDescription.ts
+++ b/packages/nodes-base/nodes/Onfleet/descriptions/TeamDescription.ts
@@ -76,7 +76,7 @@ const workersField = {
 	},
 	default: [],
 	description:
-		'A list of workers. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+		'A list of workers. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 } as INodeProperties;
 
 const managersField = {
@@ -88,7 +88,7 @@ const managersField = {
 	},
 	default: [],
 	description:
-		'A list of managing administrators. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+		'A list of managing administrators. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 } as INodeProperties;
 
 const hubField = {
@@ -100,7 +100,7 @@ const hubField = {
 	},
 	default: '',
 	description:
-		'The team\'s hub. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+		'The team\'s hub. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 } as INodeProperties;
 
 const enableSelfAssignmentField = {

--- a/packages/nodes-base/nodes/Onfleet/descriptions/WorkerDescription.ts
+++ b/packages/nodes-base/nodes/Onfleet/descriptions/WorkerDescription.ts
@@ -161,7 +161,7 @@ const teamsField = {
 	},
 	default: [],
 	description:
-		'One or more teams of which the worker is a member. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+		'One or more teams of which the worker is a member. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 } as INodeProperties;
 
 const teamsFilterField = {
@@ -173,7 +173,7 @@ const teamsFilterField = {
 	},
 	default: [],
 	description:
-		'A list of the teams that workers must be part of. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+		'A list of the teams that workers must be part of. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 } as INodeProperties;
 
 const statesFilterField = {
@@ -352,7 +352,7 @@ const scheduleTimezoneField = {
 	},
 	default: '',
 	description:
-		'A valid timezone. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+		'A valid timezone. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 } as INodeProperties;
 
 const scheduleStartField = {

--- a/packages/nodes-base/nodes/Oracle/Sql/actions/common.descriptions.ts
+++ b/packages/nodes-base/nodes/Oracle/Sql/actions/common.descriptions.ts
@@ -270,7 +270,7 @@ export const optionsCollection: INodeProperties[] = [
 				type: 'multiOptions',
 				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-multi-options
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/" target="_blank">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/" target="_blank">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getColumnsMultiOptions',
 					loadOptionsDependsOn: ['table.value'],
@@ -403,7 +403,7 @@ export const whereFixedCollection: INodeProperties = {
 					type: 'options',
 					// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 					description:
-						'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/" target="_blank">expression</a>',
+						'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/" target="_blank">expression</a>',
 					default: '',
 					placeholder: 'e.g. ID',
 					typeOptions: {
@@ -497,7 +497,7 @@ export const sortFixedCollection: INodeProperties = {
 					type: 'options',
 					// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 					description:
-						'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/" target="_blank">expression</a>',
+						'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/" target="_blank">expression</a>',
 					default: '',
 					typeOptions: {
 						loadOptionsMethod: 'getColumns',

--- a/packages/nodes-base/nodes/Orbit/ActivityDescription.ts
+++ b/packages/nodes-base/nodes/Orbit/ActivityDescription.ts
@@ -38,7 +38,7 @@ export const activityFields: INodeProperties[] = [
 		name: 'workspaceId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getWorkspaces',
 		},
@@ -99,7 +99,7 @@ export const activityFields: INodeProperties[] = [
 				},
 				default: 'Deprecated',
 				description:
-					'A user-defined way to group activities of the same nature. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'A user-defined way to group activities of the same nature. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Description',
@@ -147,7 +147,7 @@ export const activityFields: INodeProperties[] = [
 		name: 'workspaceId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getWorkspaces',
 		},

--- a/packages/nodes-base/nodes/Orbit/MemberDescription.ts
+++ b/packages/nodes-base/nodes/Orbit/MemberDescription.ts
@@ -62,7 +62,7 @@ export const memberFields: INodeProperties[] = [
 		name: 'workspaceId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getWorkspaces',
 		},
@@ -97,7 +97,7 @@ export const memberFields: INodeProperties[] = [
 		name: 'workspaceId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getWorkspaces',
 		},
@@ -147,7 +147,7 @@ export const memberFields: INodeProperties[] = [
 		name: 'workspaceId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getWorkspaces',
 		},
@@ -253,7 +253,7 @@ export const memberFields: INodeProperties[] = [
 		name: 'workspaceId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getWorkspaces',
 		},
@@ -394,7 +394,7 @@ export const memberFields: INodeProperties[] = [
 		name: 'workspaceId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getWorkspaces',
 		},
@@ -524,7 +524,7 @@ export const memberFields: INodeProperties[] = [
 		name: 'workspaceId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getWorkspaces',
 		},

--- a/packages/nodes-base/nodes/Orbit/NoteDescription.ts
+++ b/packages/nodes-base/nodes/Orbit/NoteDescription.ts
@@ -44,7 +44,7 @@ export const noteFields: INodeProperties[] = [
 		name: 'workspaceId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getWorkspaces',
 		},
@@ -92,7 +92,7 @@ export const noteFields: INodeProperties[] = [
 		name: 'workspaceId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getWorkspaces',
 		},
@@ -170,7 +170,7 @@ export const noteFields: INodeProperties[] = [
 		name: 'workspaceId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getWorkspaces',
 		},

--- a/packages/nodes-base/nodes/Orbit/PostDescription.ts
+++ b/packages/nodes-base/nodes/Orbit/PostDescription.ts
@@ -44,7 +44,7 @@ export const postFields: INodeProperties[] = [
 		name: 'workspaceId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getWorkspaces',
 		},
@@ -115,7 +115,7 @@ export const postFields: INodeProperties[] = [
 		name: 'workspaceId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getWorkspaces',
 		},
@@ -190,7 +190,7 @@ export const postFields: INodeProperties[] = [
 		name: 'workspaceId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getWorkspaces',
 		},

--- a/packages/nodes-base/nodes/Paddle/CouponDescription.ts
+++ b/packages/nodes-base/nodes/Paddle/CouponDescription.ts
@@ -81,7 +81,7 @@ export const couponFields: INodeProperties[] = [
 		},
 		default: [],
 		description:
-			'Comma-separated list of product IDs. Required if coupon_type is product. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Comma-separated list of product IDs. Required if coupon_type is product. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		required: true,
 	},
 	{

--- a/packages/nodes-base/nodes/Paddle/PaymentDescription.ts
+++ b/packages/nodes-base/nodes/Paddle/PaymentDescription.ts
@@ -195,7 +195,7 @@ export const paymentFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The upcoming subscription payment ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The upcoming subscription payment ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Date',

--- a/packages/nodes-base/nodes/PagerDuty/IncidentDescription.ts
+++ b/packages/nodes-base/nodes/PagerDuty/IncidentDescription.ts
@@ -75,7 +75,7 @@ export const incidentFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The incident will be created on this service. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The incident will be created on this service. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Email',
@@ -114,7 +114,7 @@ export const incidentFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Delegate this incident to the specified escalation policy. Cannot be specified if an assignee is given. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Delegate this incident to the specified escalation policy. Cannot be specified if an assignee is given. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Incident Details',
@@ -140,7 +140,7 @@ export const incidentFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The incident will be created on this service. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The incident will be created on this service. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Urgency',
@@ -340,7 +340,7 @@ export const incidentFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Returns only the incidents associated with the passed service(s). Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Returns only the incidents associated with the passed service(s). Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Since',
@@ -397,7 +397,7 @@ export const incidentFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Time zone in which dates in the result will be rendered. If not set dates will return UTC. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Time zone in which dates in the result will be rendered. If not set dates will return UTC. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Until',
@@ -499,7 +499,7 @@ export const incidentFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Delegate this incident to the specified escalation policy. Cannot be specified if an assignee is given. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Delegate this incident to the specified escalation policy. Cannot be specified if an assignee is given. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Priority Name or ID',
@@ -510,7 +510,7 @@ export const incidentFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The incident will be created on this service. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The incident will be created on this service. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Resolution',

--- a/packages/nodes-base/nodes/PagerDuty/LogEntryDescription.ts
+++ b/packages/nodes-base/nodes/PagerDuty/LogEntryDescription.ts
@@ -144,7 +144,7 @@ export const logEntryFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Time zone in which dates in the result will be rendered. If not set dates will return UTC. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Time zone in which dates in the result will be rendered. If not set dates will return UTC. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Until',

--- a/packages/nodes-base/nodes/PayPal/PayPalTrigger.node.ts
+++ b/packages/nodes-base/nodes/PayPal/PayPalTrigger.node.ts
@@ -48,7 +48,7 @@ export class PayPalTrigger implements INodeType {
 				required: true,
 				default: [],
 				description:
-					'The event to listen to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The event to listen to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getEvents',
 				},

--- a/packages/nodes-base/nodes/Phantombuster/AgentDescription.ts
+++ b/packages/nodes-base/nodes/Phantombuster/AgentDescription.ts
@@ -56,7 +56,7 @@ export const agentFields: INodeProperties[] = [
 		name: 'agentId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getAgents',
 		},
@@ -130,7 +130,7 @@ export const agentFields: INodeProperties[] = [
 		name: 'agentId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getAgents',
 		},
@@ -231,7 +231,7 @@ export const agentFields: INodeProperties[] = [
 		name: 'agentId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getAgents',
 		},

--- a/packages/nodes-base/nodes/PhilipsHue/LightDescription.ts
+++ b/packages/nodes-base/nodes/PhilipsHue/LightDescription.ts
@@ -119,7 +119,7 @@ export const lightFields: INodeProperties[] = [
 		name: 'lightId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getLights',
 		},

--- a/packages/nodes-base/nodes/Pipedrive/Pipedrive.node.ts
+++ b/packages/nodes-base/nodes/Pipedrive/Pipedrive.node.ts
@@ -697,7 +697,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the organization this activity will be associated with. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the organization this activity will be associated with. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Person ID',
@@ -715,7 +715,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the active user whom the activity will be assigned to. If omitted, the activity will be assigned to the authorized user. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the active user whom the activity will be assigned to. If omitted, the activity will be assigned to the authorized user. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Custom Properties',
@@ -875,7 +875,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the organization this activity will be associated with. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the organization this activity will be associated with. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Person ID',
@@ -916,7 +916,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the active user whom the activity will be assigned to. If omitted, the activity will be assigned to the authorized user. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the active user whom the activity will be assigned to. If omitted, the activity will be assigned to the authorized user. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Custom Properties',
@@ -1073,7 +1073,7 @@ export class Pipedrive implements INodeType {
 										},
 										default: '',
 										description:
-											'Name of the property to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+											'Name of the property to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 									},
 									{
 										displayName: 'Property Value',
@@ -1091,7 +1091,7 @@ export class Pipedrive implements INodeType {
 						name: 'label',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getDealLabels',
 						},
@@ -1148,7 +1148,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the stage this deal will be placed in a pipeline. If omitted, the deal will be placed in the first stage of the default pipeline. (PIPELINE > STAGE). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the stage this deal will be placed in a pipeline. If omitted, the deal will be placed in the first stage of the default pipeline. (PIPELINE > STAGE). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Status',
@@ -1185,7 +1185,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the active user whom the activity will be assigned to. If omitted, the activity will be assigned to the authorized user. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the active user whom the activity will be assigned to. If omitted, the activity will be assigned to the authorized user. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Value',
@@ -1331,7 +1331,7 @@ export class Pipedrive implements INodeType {
 										},
 										default: '',
 										description:
-											'Name of the custom field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+											'Name of the custom field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 									},
 									{
 										displayName: 'Property Value',
@@ -1353,14 +1353,14 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the active user whom the activity will be assigned to. If omitted, the activity will be assigned to the authorized user. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the active user whom the activity will be assigned to. If omitted, the activity will be assigned to the authorized user. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Label Name or ID',
 						name: 'label',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getDealLabels',
 						},
@@ -1382,7 +1382,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the organization this deal will be associated with. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the organization this deal will be associated with. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Person ID',
@@ -1411,7 +1411,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the stage this deal will be placed in a pipeline. If omitted, the deal will be placed in the first stage of the default pipeline. (PIPELINE > STAGE). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the stage this deal will be placed in a pipeline. If omitted, the deal will be placed in the first stage of the default pipeline. (PIPELINE > STAGE). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Status',
@@ -1492,7 +1492,7 @@ export class Pipedrive implements INodeType {
 					},
 				},
 				description:
-					'The ID of the deal to add a product to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The ID of the deal to add a product to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Product Name or ID',
@@ -1510,7 +1510,7 @@ export class Pipedrive implements INodeType {
 					},
 				},
 				description:
-					'The ID of the product to add to a deal. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The ID of the product to add to a deal. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Item Price',
@@ -1608,7 +1608,7 @@ export class Pipedrive implements INodeType {
 					},
 				},
 				description:
-					'The ID of the deal whose product to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The ID of the deal whose product to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Product Attachment Name or ID',
@@ -1627,7 +1627,7 @@ export class Pipedrive implements INodeType {
 					},
 				},
 				description:
-					'ID of the deal-product (the ID of the product attached to the deal). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the deal-product (the ID of the product attached to the deal). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Update Fields',
@@ -1711,7 +1711,7 @@ export class Pipedrive implements INodeType {
 					},
 				},
 				description:
-					'The ID of the deal whose product to remove. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The ID of the deal whose product to remove. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Product Attachment Name or ID',
@@ -1730,7 +1730,7 @@ export class Pipedrive implements INodeType {
 					},
 				},
 				description:
-					'ID of the deal-product (the ID of the product attached to the deal). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the deal-product (the ID of the product attached to the deal). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			// ----------------------------------
 			//        dealProduct:getAll
@@ -1751,7 +1751,7 @@ export class Pipedrive implements INodeType {
 					},
 				},
 				description:
-					'The ID of the deal whose products to retrieve. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The ID of the deal whose products to retrieve. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 
 			// ----------------------------------
@@ -1955,7 +1955,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the organization this deal will be associated with. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the organization this deal will be associated with. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Person ID',
@@ -2193,7 +2193,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: [],
 						description:
-							'ID of the labels to attach to the lead to create. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the labels to attach to the lead to create. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Organization ID',
@@ -2216,7 +2216,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the user who will own the lead to create. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the user who will own the lead to create. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Person ID',
@@ -2343,7 +2343,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the user who will own the lead to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the user who will own the lead to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Label Names or IDs',
@@ -2354,7 +2354,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: [],
 						description:
-							'ID of the labels to attach to the lead to update. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the labels to attach to the lead to update. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Person Name or ID',
@@ -2365,7 +2365,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the person to link to this lead. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the person to link to this lead. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Value',
@@ -2573,7 +2573,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the organization this deal will be associated with. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the organization this deal will be associated with. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Person ID',
@@ -2657,7 +2657,7 @@ export class Pipedrive implements INodeType {
 						name: 'label',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getOrganizationLabels',
 						},
@@ -2862,7 +2862,7 @@ export class Pipedrive implements INodeType {
 						name: 'label',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getOrganizationLabels',
 						},
@@ -2962,7 +2962,7 @@ export class Pipedrive implements INodeType {
 										},
 										default: '',
 										description:
-											'Name of the custom field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+											'Name of the custom field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 									},
 									{
 										displayName: 'Property Value',
@@ -2991,7 +2991,7 @@ export class Pipedrive implements INodeType {
 						name: 'label',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getPersonLabels',
 						},
@@ -3032,7 +3032,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the organization this deal will be associated with. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the organization this deal will be associated with. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Phone',
@@ -3071,7 +3071,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the User this deal will be associated with. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the User this deal will be associated with. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 				],
 			},
@@ -3167,7 +3167,7 @@ export class Pipedrive implements INodeType {
 										},
 										default: '',
 										description:
-											'Name of the custom field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+											'Name of the custom field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 									},
 									{
 										displayName: 'Property Value',
@@ -3196,7 +3196,7 @@ export class Pipedrive implements INodeType {
 						name: 'label',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getPersonLabels',
 						},
@@ -3244,7 +3244,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the organization this deal will be associated with. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the organization this deal will be associated with. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Phone',
@@ -3265,7 +3265,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the User this person will be associated with. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the User this person will be associated with. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Visible To',
@@ -3370,7 +3370,7 @@ export class Pipedrive implements INodeType {
 					},
 				},
 				description:
-					'The ID of the deal whose activity to retrieve. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The ID of the deal whose activity to retrieve. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Additional Fields',
@@ -3475,7 +3475,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the filter to use. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the filter to use. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 				],
 			},
@@ -3505,7 +3505,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the filter to use. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the filter to use. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'First Char',
@@ -3638,7 +3638,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the organization this deal will be associated with. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the organization this deal will be associated with. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Person ID',
@@ -3690,7 +3690,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'The ID of the Filter to use (will narrow down results if used together with user_id parameter). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The ID of the Filter to use (will narrow down results if used together with user_id parameter). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Star Date',
@@ -3709,7 +3709,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: [],
 						description:
-							'Type of the Activity. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Type of the Activity. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'User Name or ID',
@@ -3720,7 +3720,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'The ID of the User whose Activities will be fetched. If omitted, the User associated with the API token will be used. If 0, Activities for all company Users will be fetched based on the permission sets. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The ID of the User whose Activities will be fetched. If omitted, the User associated with the API token will be used. If 0, Activities for all company Users will be fetched based on the permission sets. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 				],
 			},
@@ -3749,7 +3749,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'Predefined filter to apply to the deals to retrieve. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Predefined filter to apply to the deals to retrieve. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Stage Name or ID',
@@ -3760,7 +3760,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the stage to filter deals by. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the stage to filter deals by. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Status',
@@ -3800,7 +3800,7 @@ export class Pipedrive implements INodeType {
 						},
 						default: '',
 						description:
-							'ID of the user to filter deals by. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the user to filter deals by. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 				],
 			},

--- a/packages/nodes-base/nodes/Postgres/v2/actions/common.descriptions.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/common.descriptions.ts
@@ -136,7 +136,7 @@ export const optionsCollection: INodeProperties = {
 			type: 'multiOptions',
 			// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-multi-options
 			description:
-				'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/" target="_blank">expression</a>',
+				'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/" target="_blank">expression</a>',
 			typeOptions: {
 				loadOptionsMethod: 'getColumnsMultiOptions',
 				loadOptionsDependsOn: ['table.value'],
@@ -265,7 +265,7 @@ export const whereFixedCollection: INodeProperties = {
 					type: 'options',
 					// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 					description:
-						'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/" target="_blank">expression</a>',
+						'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/" target="_blank">expression</a>',
 					default: '',
 					placeholder: 'e.g. ID',
 					typeOptions: {
@@ -320,7 +320,7 @@ export const sortFixedCollection: INodeProperties = {
 					type: 'options',
 					// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 					description:
-						'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/" target="_blank">expression</a>',
+						'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/" target="_blank">expression</a>',
 					default: '',
 					typeOptions: {
 						loadOptionsMethod: 'getColumns',

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/insert.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/insert.operation.ts
@@ -97,7 +97,7 @@ const properties: INodeProperties[] = [
 						type: 'options',
 						// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/" target="_blank">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/" target="_blank">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getColumns',
 							loadOptionsDependsOn: ['schema.value', 'table.value'],

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/update.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/update.operation.ts
@@ -76,7 +76,7 @@ const properties: INodeProperties[] = [
 		required: true,
 		// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 		description:
-			'The column to compare when finding the rows to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/" target="_blank">expression</a>.',
+			'The column to compare when finding the rows to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/" target="_blank">expression</a>.',
 		typeOptions: {
 			loadOptionsMethod: 'getColumns',
 			loadOptionsDependsOn: ['schema.value', 'table.value'],
@@ -131,7 +131,7 @@ const properties: INodeProperties[] = [
 						type: 'options',
 						// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/" target="_blank">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/" target="_blank">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getColumnsWithoutColumnToMatchOn',
 							loadOptionsDependsOn: ['schema.value', 'table.value'],

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/upsert.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/upsert.operation.ts
@@ -75,7 +75,7 @@ const properties: INodeProperties[] = [
 		required: true,
 		// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 		description:
-			'The column to compare when finding the rows to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/" target="_blank">expression</a>.',
+			'The column to compare when finding the rows to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/" target="_blank">expression</a>.',
 		typeOptions: {
 			loadOptionsMethod: 'getColumns',
 			loadOptionsDependsOn: ['schema.value', 'table.value'],
@@ -130,7 +130,7 @@ const properties: INodeProperties[] = [
 						type: 'options',
 						// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/" target="_blank">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/" target="_blank">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getColumnsWithoutColumnToMatchOn',
 							loadOptionsDependsOn: ['schema.value', 'table.value'],

--- a/packages/nodes-base/nodes/ProfitWell/MetricDescription.ts
+++ b/packages/nodes-base/nodes/ProfitWell/MetricDescription.ts
@@ -106,7 +106,7 @@ export const metricFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Only return the metric for this Plan ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Only return the metric for this Plan ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Metrics',

--- a/packages/nodes-base/nodes/Pushbullet/Pushbullet.node.ts
+++ b/packages/nodes-base/nodes/Pushbullet/Pushbullet.node.ts
@@ -244,7 +244,7 @@ export class Pushbullet implements INodeType {
 				},
 				default: '',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			},
 			{
 				displayName: 'Push ID',

--- a/packages/nodes-base/nodes/Pushcut/Pushcut.node.ts
+++ b/packages/nodes-base/nodes/Pushcut/Pushcut.node.ts
@@ -72,7 +72,7 @@ export class Pushcut implements INodeType {
 				name: 'notificationName',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getNotifications',
 				},
@@ -106,7 +106,7 @@ export class Pushcut implements INodeType {
 						},
 						default: [],
 						description:
-							'List of devices this notification is sent to. (default is all devices). Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'List of devices this notification is sent to. (default is all devices). Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Input',

--- a/packages/nodes-base/nodes/Pushover/Pushover.node.ts
+++ b/packages/nodes-base/nodes/Pushover/Pushover.node.ts
@@ -234,7 +234,7 @@ export class Pushover implements INodeType {
 						},
 						default: '',
 						description:
-							'The name of one of the sounds supported by device clients to override the user\'s default sound choice. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The name of one of the sounds supported by device clients to override the user\'s default sound choice. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Timestamp',

--- a/packages/nodes-base/nodes/QuickBase/RecordDescription.ts
+++ b/packages/nodes-base/nodes/QuickBase/RecordDescription.ts
@@ -117,7 +117,7 @@ export const recordFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Specify an array of field IDs that will return data for any updates or added record. Record ID (FID 3) is always returned if any field ID is requested. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Specify an array of field IDs that will return data for any updates or added record. Record ID (FID 3) is always returned if any field ID is requested. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Use Field IDs',
@@ -231,7 +231,7 @@ export const recordFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'An array of field IDs for the fields that should be returned in the response. If empty, the default columns on the table will be returned. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'An array of field IDs for the fields that should be returned in the response. If empty, the default columns on the table will be returned. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Sort By',
@@ -256,7 +256,7 @@ export const recordFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'The unique identifier of a field in a table. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The unique identifier of a field in a table. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Order',
@@ -372,7 +372,7 @@ export const recordFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Specify an array of field IDs that will return data for any updates or added record. Record ID (FID 3) is always returned if any field ID is requested. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Specify an array of field IDs that will return data for any updates or added record. Record ID (FID 3) is always returned if any field ID is requested. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Use Field IDs',
@@ -456,7 +456,7 @@ export const recordFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'<p>You\'re updating records in a Quick Base table with data from an external file. In order for a merge like this to work, Quick Base needs a way to match records in the source data with corresponding records in the destination table.</p><p>You make this possible by choosing the field in the app table that holds unique matching values. This is called a merge field.</p>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'<p>You\'re updating records in a Quick Base table with data from an external file. In order for a merge like this to work, Quick Base needs a way to match records in the source data with corresponding records in the destination table.</p><p>You make this possible by choosing the field in the app table that holds unique matching values. This is called a merge field.</p>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Simplify',
@@ -494,7 +494,7 @@ export const recordFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Specify an array of field IDs that will return data for any updates or added record. Record ID (FID 3) is always returned if any field ID is requested. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Specify an array of field IDs that will return data for any updates or added record. Record ID (FID 3) is always returned if any field ID is requested. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Use Field IDs',

--- a/packages/nodes-base/nodes/QuickBooks/descriptions/Bill/BillDescription.ts
+++ b/packages/nodes-base/nodes/QuickBooks/descriptions/Bill/BillDescription.ts
@@ -54,7 +54,7 @@ export const billFields: INodeProperties[] = [
 		type: 'options',
 		required: true,
 		description:
-			'The ID of the vendor who the bill is for. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the vendor who the bill is for. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		default: [],
 		typeOptions: {
 			loadOptionsMethod: 'getVendors',
@@ -124,7 +124,7 @@ export const billFields: INodeProperties[] = [
 				name: 'itemId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getItems',

--- a/packages/nodes-base/nodes/QuickBooks/descriptions/Estimate/EstimateAdditionalFieldsOptions.ts
+++ b/packages/nodes-base/nodes/QuickBooks/descriptions/Estimate/EstimateAdditionalFieldsOptions.ts
@@ -88,7 +88,7 @@ export const estimateAdditionalFieldsOptions: INodeProperties[] = [
 						},
 						default: '',
 						description:
-							'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Field Value',

--- a/packages/nodes-base/nodes/QuickBooks/descriptions/Estimate/EstimateDescription.ts
+++ b/packages/nodes-base/nodes/QuickBooks/descriptions/Estimate/EstimateDescription.ts
@@ -59,7 +59,7 @@ export const estimateFields: INodeProperties[] = [
 		type: 'options',
 		required: true,
 		description:
-			'The ID of the customer who the estimate is for. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the customer who the estimate is for. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		default: [],
 		typeOptions: {
 			loadOptionsMethod: 'getCustomers',
@@ -119,7 +119,7 @@ export const estimateFields: INodeProperties[] = [
 				name: 'itemId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getItems',
@@ -137,7 +137,7 @@ export const estimateFields: INodeProperties[] = [
 				name: 'TaxCodeRef',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getTaxCodeRefs',

--- a/packages/nodes-base/nodes/QuickBooks/descriptions/Invoice/InvoiceAdditionalFieldsOptions.ts
+++ b/packages/nodes-base/nodes/QuickBooks/descriptions/Invoice/InvoiceAdditionalFieldsOptions.ts
@@ -97,7 +97,7 @@ export const invoiceAdditionalFieldsOptions: INodeProperties[] = [
 						},
 						default: '',
 						description:
-							'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Field Value',

--- a/packages/nodes-base/nodes/QuickBooks/descriptions/Invoice/InvoiceDescription.ts
+++ b/packages/nodes-base/nodes/QuickBooks/descriptions/Invoice/InvoiceDescription.ts
@@ -64,7 +64,7 @@ export const invoiceFields: INodeProperties[] = [
 		type: 'options',
 		required: true,
 		description:
-			'The ID of the customer who the invoice is for. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the customer who the invoice is for. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		default: [],
 		typeOptions: {
 			loadOptionsMethod: 'getCustomers',
@@ -124,7 +124,7 @@ export const invoiceFields: INodeProperties[] = [
 				name: 'itemId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getItems',
@@ -142,7 +142,7 @@ export const invoiceFields: INodeProperties[] = [
 				name: 'TaxCodeRef',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getTaxCodeRefs',

--- a/packages/nodes-base/nodes/QuickBooks/descriptions/Payment/PaymentDescription.ts
+++ b/packages/nodes-base/nodes/QuickBooks/descriptions/Payment/PaymentDescription.ts
@@ -64,7 +64,7 @@ export const paymentFields: INodeProperties[] = [
 		type: 'options',
 		required: true,
 		description:
-			'The ID of the customer who the payment is for. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the customer who the payment is for. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		default: [],
 		typeOptions: {
 			loadOptionsMethod: 'getCustomers',

--- a/packages/nodes-base/nodes/QuickBooks/descriptions/Transaction/TransactionDescription.ts
+++ b/packages/nodes-base/nodes/QuickBooks/descriptions/Transaction/TransactionDescription.ts
@@ -97,7 +97,7 @@ export const transactionFields: INodeProperties[] = [
 				type: 'multiOptions',
 				default: [],
 				description:
-					'Customer to filter results by. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Customer to filter results by. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getCustomers',
 				},
@@ -257,7 +257,7 @@ export const transactionFields: INodeProperties[] = [
 				type: 'multiOptions',
 				default: [],
 				description:
-					'Department to filter results by. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Department to filter results by. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getDepartments',
 				},
@@ -283,7 +283,7 @@ export const transactionFields: INodeProperties[] = [
 				type: 'multiOptions',
 				default: [],
 				description:
-					'Memo to filter results by. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Memo to filter results by. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getMemos',
 				},
@@ -349,7 +349,7 @@ export const transactionFields: INodeProperties[] = [
 				type: 'multiOptions',
 				default: [],
 				description:
-					'Term to filter results by. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Term to filter results by. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getTerms',
 				},
@@ -378,7 +378,7 @@ export const transactionFields: INodeProperties[] = [
 				type: 'multiOptions',
 				default: [],
 				description:
-					'Vendor to filter results by. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Vendor to filter results by. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				typeOptions: {
 					loadOptionsMethod: 'getVendors',
 				},

--- a/packages/nodes-base/nodes/Raindrop/descriptions/BookmarkDescription.ts
+++ b/packages/nodes-base/nodes/Raindrop/descriptions/BookmarkDescription.ts
@@ -51,7 +51,7 @@ export const bookmarkFields: INodeProperties[] = [
 		name: 'collectionId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		displayOptions: {
 			show: {
 				resource: ['bookmark'],
@@ -178,7 +178,7 @@ export const bookmarkFields: INodeProperties[] = [
 		default: [],
 		required: true,
 		description:
-			'The ID of the collection from which to retrieve all bookmarks. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the collection from which to retrieve all bookmarks. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['bookmark'],
@@ -253,7 +253,7 @@ export const bookmarkFields: INodeProperties[] = [
 				name: 'collectionId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getCollections',
 				},

--- a/packages/nodes-base/nodes/Raindrop/descriptions/TagDescription.ts
+++ b/packages/nodes-base/nodes/Raindrop/descriptions/TagDescription.ts
@@ -68,7 +68,7 @@ export const tagFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'It\'s possible to restrict remove action to just one collection. It\'s optional. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'It\'s possible to restrict remove action to just one collection. It\'s optional. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -124,7 +124,7 @@ export const tagFields: INodeProperties[] = [
 				name: 'collectionId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getCollections',
 				},

--- a/packages/nodes-base/nodes/Salesforce/AccountDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/AccountDescription.ts
@@ -88,7 +88,7 @@ export const accountFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The field to check to see if the account already exists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The field to check to see if the account already exists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Value to Match',
@@ -159,7 +159,7 @@ export const accountFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The source of the account record. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The source of the account record. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Billing City',
@@ -224,7 +224,7 @@ export const accountFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -280,7 +280,7 @@ export const accountFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The owner of the account. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The owner of the account. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Parent ID',
@@ -301,7 +301,7 @@ export const accountFields: INodeProperties[] = [
 				name: 'recordTypeId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getRecordTypes',
 				},
@@ -324,7 +324,7 @@ export const accountFields: INodeProperties[] = [
 					loadOptionsMethod: 'getAccountTypes',
 				},
 				description:
-					'Type of account. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Type of account. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Shipping City',
@@ -423,7 +423,7 @@ export const accountFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The source of the account record. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The source of the account record. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Annual Revenue',
@@ -498,7 +498,7 @@ export const accountFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -561,7 +561,7 @@ export const accountFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The owner of the account. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The owner of the account. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Parent ID',
@@ -582,7 +582,7 @@ export const accountFields: INodeProperties[] = [
 				name: 'recordTypeId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getRecordTypes',
 				},
@@ -645,7 +645,7 @@ export const accountFields: INodeProperties[] = [
 					loadOptionsMethod: 'getAccountTypes',
 				},
 				description:
-					'Type of account. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Type of account. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Website',
@@ -771,7 +771,7 @@ export const accountFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'For date, number, or boolean, please use expressions. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'For date, number, or boolean, please use expressions. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Operation',
@@ -883,7 +883,7 @@ export const accountFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the user who owns the note. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user who owns the note. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Salesforce/AttachmentDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/AttachmentDescription.ts
@@ -137,7 +137,7 @@ export const attachmentFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the User who owns the attachment. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the User who owns the attachment. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -212,7 +212,7 @@ export const attachmentFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the User who owns the attachment. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the User who owns the attachment. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -324,7 +324,7 @@ export const attachmentFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'For date, number, or boolean, please use expressions. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'For date, number, or boolean, please use expressions. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							// eslint-disable-next-line n8n-nodes-base/node-param-operation-without-no-data-expression
 							{

--- a/packages/nodes-base/nodes/Salesforce/CaseDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/CaseDescription.ts
@@ -79,7 +79,7 @@ export const caseFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The type of case. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The type of case. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Additional Fields',
@@ -132,7 +132,7 @@ export const caseFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -168,7 +168,7 @@ export const caseFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The source of the case, such as Email, Phone, or Web. Label is Case Origin. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The source of the case, such as Email, Phone, or Web. Label is Case Origin. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Owner Name or ID',
@@ -179,7 +179,7 @@ export const caseFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The owner of the case. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The owner of the case. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Parent ID',
@@ -197,7 +197,7 @@ export const caseFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The importance or urgency of the case, such as High, Medium, or Low. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The importance or urgency of the case, such as High, Medium, or Low. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Reason Name or ID',
@@ -208,14 +208,14 @@ export const caseFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The reason why the case was created, such as Instructions not clear, or User didn’t attend training. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The reason why the case was created, such as Instructions not clear, or User didn’t attend training. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Record Type Name or ID',
 				name: 'recordTypeId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getRecordTypes',
 				},
@@ -230,7 +230,7 @@ export const caseFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The status of the case, such as “New,” “Closed,” or “Escalated.” This field directly controls the IsClosed flag. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The status of the case, such as “New,” “Closed,” or “Escalated.” This field directly controls the IsClosed flag. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Subject',
@@ -342,7 +342,7 @@ export const caseFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -378,7 +378,7 @@ export const caseFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The source of the case, such as Email, Phone, or Web. Label is Case Origin. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The source of the case, such as Email, Phone, or Web. Label is Case Origin. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Owner Name or ID',
@@ -389,7 +389,7 @@ export const caseFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The owner of the case. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The owner of the case. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Parent ID',
@@ -407,7 +407,7 @@ export const caseFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The importance or urgency of the case, such as High, Medium, or Low. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The importance or urgency of the case, such as High, Medium, or Low. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Reason Name or ID',
@@ -418,14 +418,14 @@ export const caseFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The reason why the case was created, such as Instructions not clear, or User didn’t attend training. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The reason why the case was created, such as Instructions not clear, or User didn’t attend training. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Record Type Name or ID',
 				name: 'recordTypeId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getRecordTypes',
 				},
@@ -440,7 +440,7 @@ export const caseFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The status of the case, such as “New,” “Closed,” or “Escalated.” This field directly controls the IsClosed flag. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The status of the case, such as “New,” “Closed,” or “Escalated.” This field directly controls the IsClosed flag. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Subject',
@@ -490,7 +490,7 @@ export const caseFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The type of case. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The type of case. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -602,7 +602,7 @@ export const caseFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'For date, number, or boolean, please use expressions. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'For date, number, or boolean, please use expressions. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							// eslint-disable-next-line n8n-nodes-base/node-param-operation-without-no-data-expression
 							{

--- a/packages/nodes-base/nodes/Salesforce/ContactDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/ContactDescription.ts
@@ -94,7 +94,7 @@ export const contactFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The field to check to see if the contact already exists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The field to check to see if the contact already exists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Value to Match',
@@ -147,7 +147,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the account that is the parent of this contact. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the account that is the parent of this contact. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Assistant Name',
@@ -194,7 +194,7 @@ export const contactFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -283,7 +283,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Source from which the lead was obtained. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Source from which the lead was obtained. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Mailing City',
@@ -370,7 +370,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The owner of the contact. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The owner of the contact. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Phone',
@@ -384,7 +384,7 @@ export const contactFields: INodeProperties[] = [
 				name: 'recordTypeId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getRecordTypes',
 				},
@@ -447,7 +447,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the account that is the parent of this contact. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the account that is the parent of this contact. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Assistant Name',
@@ -494,7 +494,7 @@ export const contactFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -590,7 +590,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Source from which the lead was obtained. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Source from which the lead was obtained. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Mailing City',
@@ -677,7 +677,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The owner of the contact. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The owner of the contact. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Phone',
@@ -691,7 +691,7 @@ export const contactFields: INodeProperties[] = [
 				name: 'recordTypeId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getRecordTypes',
 				},
@@ -822,7 +822,7 @@ export const contactFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'For date, number, or boolean, please use expressions. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'For date, number, or boolean, please use expressions. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							// eslint-disable-next-line n8n-nodes-base/node-param-operation-without-no-data-expression
 							{
@@ -906,7 +906,7 @@ export const contactFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the campaign that needs to be fetched. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the campaign that needs to be fetched. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Options',
@@ -999,7 +999,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the user who owns the note. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user who owns the note. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Salesforce/CustomObjectDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/CustomObjectDescription.ts
@@ -73,7 +73,7 @@ export const customObjectFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Name of the custom object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Name of the custom object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		// eslint-disable-next-line n8n-nodes-base/node-param-display-name-wrong-for-dynamic-options
@@ -93,7 +93,7 @@ export const customObjectFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The field to check to see if the object already exists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The field to check to see if the object already exists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Value to Match',
@@ -141,7 +141,7 @@ export const customObjectFields: INodeProperties[] = [
 						},
 						default: '',
 						description:
-							'The ID of the field. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The ID of the field. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Value',
@@ -174,7 +174,7 @@ export const customObjectFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Name of the custom object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Name of the custom object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Record ID',
@@ -221,7 +221,7 @@ export const customObjectFields: INodeProperties[] = [
 						},
 						default: '',
 						description:
-							'The ID of the field. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The ID of the field. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Value',
@@ -254,7 +254,7 @@ export const customObjectFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Name of the custom object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Name of the custom object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Record ID',
@@ -290,7 +290,7 @@ export const customObjectFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Name of the custom object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Name of the custom object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Record ID',
@@ -326,7 +326,7 @@ export const customObjectFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Name of the custom object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Name of the custom object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',
@@ -397,7 +397,7 @@ export const customObjectFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'For date, number, or boolean, please use expressions. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'For date, number, or boolean, please use expressions. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							// eslint-disable-next-line n8n-nodes-base/node-param-operation-without-no-data-expression
 							{
@@ -448,7 +448,7 @@ export const customObjectFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Fields to include separated by commas. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Fields to include separated by commas. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -470,7 +470,7 @@ export const customObjectFields: INodeProperties[] = [
 				name: 'recordTypeId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getRecordTypes',
 					loadOptionsDependsOn: ['customObject'],
@@ -497,7 +497,7 @@ export const customObjectFields: INodeProperties[] = [
 				name: 'recordTypeId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getRecordTypes',
 					loadOptionsDependsOn: ['customObject'],

--- a/packages/nodes-base/nodes/Salesforce/DocumentDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/DocumentDescription.ts
@@ -94,7 +94,7 @@ export const documentFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the owner of this document. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the owner of this document. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Salesforce/LeadDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/LeadDescription.ts
@@ -93,7 +93,7 @@ export const leadFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The field to check to see if the lead already exists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The field to check to see if the lead already exists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Value to Match',
@@ -200,7 +200,7 @@ export const leadFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -290,7 +290,7 @@ export const leadFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Source from which the lead was obtained. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Source from which the lead was obtained. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Mobile Phone',
@@ -315,7 +315,7 @@ export const leadFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The owner of the lead. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The owner of the lead. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Phone',
@@ -336,7 +336,7 @@ export const leadFields: INodeProperties[] = [
 				name: 'recordTypeId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getRecordTypes',
 				},
@@ -372,7 +372,7 @@ export const leadFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Status code for this converted lead. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Status code for this converted lead. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Street',
@@ -484,7 +484,7 @@ export const leadFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -581,7 +581,7 @@ export const leadFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Source from which the lead was obtained. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Source from which the lead was obtained. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Mobile Phone',
@@ -606,7 +606,7 @@ export const leadFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The owner of the lead. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The owner of the lead. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Postal Code',
@@ -627,7 +627,7 @@ export const leadFields: INodeProperties[] = [
 				name: 'recordTypeId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getRecordTypes',
 				},
@@ -663,7 +663,7 @@ export const leadFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Status code for this converted lead. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Status code for this converted lead. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Street',
@@ -796,7 +796,7 @@ export const leadFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'For date, number, or boolean, please use expressions. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'For date, number, or boolean, please use expressions. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							// eslint-disable-next-line n8n-nodes-base/node-param-operation-without-no-data-expression
 							{
@@ -880,7 +880,7 @@ export const leadFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the campaign that needs to be fetched. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the campaign that needs to be fetched. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Options',
@@ -973,7 +973,7 @@ export const leadFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the user who owns the note. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user who owns the note. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Salesforce/OpportunityDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/OpportunityDescription.ts
@@ -88,7 +88,7 @@ export const opportunityFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The field to check to see if the opportunity already exists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The field to check to see if the opportunity already exists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Value to Match',
@@ -149,7 +149,7 @@ export const opportunityFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Required. Date when the opportunity is expected to close. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Required. Date when the opportunity is expected to close. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Additional Fields',
@@ -173,7 +173,7 @@ export const opportunityFields: INodeProperties[] = [
 					loadOptionsMethod: 'getAccounts',
 				},
 				description:
-					'ID of the account associated with this opportunity. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the account associated with this opportunity. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Amount',
@@ -194,7 +194,7 @@ export const opportunityFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the campaign that needs to be fetched. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the campaign that needs to be fetched. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Custom Fields',
@@ -220,7 +220,7 @@ export const opportunityFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -257,7 +257,7 @@ export const opportunityFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Source from which the lead was obtained. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Source from which the lead was obtained. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Next Step',
@@ -275,7 +275,7 @@ export const opportunityFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The owner of the opportunity. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The owner of the opportunity. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Phone',
@@ -361,7 +361,7 @@ export const opportunityFields: INodeProperties[] = [
 					loadOptionsMethod: 'getAccounts',
 				},
 				description:
-					'ID of the account associated with this opportunity. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the account associated with this opportunity. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Amount',
@@ -382,7 +382,7 @@ export const opportunityFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the campaign that needs to be fetched. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the campaign that needs to be fetched. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Close Date',
@@ -415,7 +415,7 @@ export const opportunityFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -452,7 +452,7 @@ export const opportunityFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Source from which the lead was obtained. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Source from which the lead was obtained. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Name',
@@ -477,7 +477,7 @@ export const opportunityFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The owner of the opportunity. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The owner of the opportunity. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Phone',
@@ -512,7 +512,7 @@ export const opportunityFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Required. Date when the opportunity is expected to close. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Required. Date when the opportunity is expected to close. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Type',
@@ -642,7 +642,7 @@ export const opportunityFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'For date, number, or boolean, please use expressions. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'For date, number, or boolean, please use expressions. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							// eslint-disable-next-line n8n-nodes-base/node-param-operation-without-no-data-expression
 							{
@@ -761,7 +761,7 @@ export const opportunityFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the user who owns the note. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user who owns the note. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Salesforce/SalesforceTrigger.node.ts
+++ b/packages/nodes-base/nodes/Salesforce/SalesforceTrigger.node.ts
@@ -157,7 +157,7 @@ export class SalesforceTrigger implements INodeType {
 					},
 				},
 				description:
-					'Name of the custom object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Name of the custom object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	};

--- a/packages/nodes-base/nodes/Salesforce/TaskDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/TaskDescription.ts
@@ -73,7 +73,7 @@ export const taskFields: INodeProperties[] = [
 			loadOptionsMethod: 'getTaskStatuses',
 		},
 		description:
-			'The current status of the task, such as In Progress or Completed. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The current status of the task, such as In Progress or Completed. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Additional Fields',
@@ -129,7 +129,7 @@ export const taskFields: INodeProperties[] = [
 					loadOptionsMethod: 'getTaskCallTypes',
 				},
 				description:
-					'The type of call being answered: Inbound, Internal, or Outbound. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The type of call being answered: Inbound, Internal, or Outbound. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Custom Fields',
@@ -155,7 +155,7 @@ export const taskFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -191,7 +191,7 @@ export const taskFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the User who owns the record. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the User who owns the record. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Priority Name or ID',
@@ -202,7 +202,7 @@ export const taskFields: INodeProperties[] = [
 					loadOptionsMethod: 'getTaskPriorities',
 				},
 				description:
-					'Indicates the importance or urgency of a task, such as high or low. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Indicates the importance or urgency of a task, such as high or low. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Recurrence Type Name or ID',
@@ -213,7 +213,7 @@ export const taskFields: INodeProperties[] = [
 					loadOptionsMethod: 'getTaskRecurrenceTypes',
 				},
 				description:
-					'Recurrence Type of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Recurrence Type of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Recurrence Instance Name or ID',
@@ -224,7 +224,7 @@ export const taskFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The frequency of the recurring task. For example, “2nd” or “3rd.”. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The frequency of the recurring task. For example, “2nd” or “3rd.”. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Recurrence Interval',
@@ -369,7 +369,7 @@ export const taskFields: INodeProperties[] = [
 					loadOptionsMethod: 'getTaskSubjects',
 				},
 				description:
-					'The subject line of the task, such as “Call” or “Send Quote.” Limit: 255 characters. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The subject line of the task, such as “Call” or “Send Quote.” Limit: 255 characters. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Type Name or ID',
@@ -380,7 +380,7 @@ export const taskFields: INodeProperties[] = [
 					loadOptionsMethod: 'getTaskTypes',
 				},
 				description:
-					'Represents Type of the task, such as Call or Meeting. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Represents Type of the task, such as Call or Meeting. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'What ID',
@@ -472,7 +472,7 @@ export const taskFields: INodeProperties[] = [
 					loadOptionsMethod: 'getTaskCallTypes',
 				},
 				description:
-					'The type of call being answered: Inbound, Internal, or Outbound. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The type of call being answered: Inbound, Internal, or Outbound. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Custom Fields',
@@ -498,7 +498,7 @@ export const taskFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'The ID of the field to add custom field to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -534,7 +534,7 @@ export const taskFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the User who owns the record. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the User who owns the record. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Priority Name or ID',
@@ -545,7 +545,7 @@ export const taskFields: INodeProperties[] = [
 					loadOptionsMethod: 'getTaskPriorities',
 				},
 				description:
-					'Indicates the importance or urgency of a task, such as high or low. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Indicates the importance or urgency of a task, such as high or low. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Status Name or ID',
@@ -556,7 +556,7 @@ export const taskFields: INodeProperties[] = [
 					loadOptionsMethod: 'getTaskStatuses',
 				},
 				description:
-					'The current status of the task, such as In Progress or Completed. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The current status of the task, such as In Progress or Completed. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Subject Name or ID',
@@ -567,7 +567,7 @@ export const taskFields: INodeProperties[] = [
 					loadOptionsMethod: 'getTaskSubjects',
 				},
 				description:
-					'The subject line of the task, such as “Call” or “Send Quote.” Limit: 255 characters. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The subject line of the task, such as “Call” or “Send Quote.” Limit: 255 characters. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Recurrence Day Of Month',
@@ -601,7 +601,7 @@ export const taskFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The frequency of the recurring task. For example, “2nd” or “3rd.”. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The frequency of the recurring task. For example, “2nd” or “3rd.”. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Recurrence Interval',
@@ -707,7 +707,7 @@ export const taskFields: INodeProperties[] = [
 					loadOptionsMethod: 'getTaskRecurrenceTypes',
 				},
 				description:
-					'Website for the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Website for the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Recurrence TimeZone SidKey',
@@ -734,7 +734,7 @@ export const taskFields: INodeProperties[] = [
 					loadOptionsMethod: 'getTaskTypes',
 				},
 				description:
-					'Represents Type of the task, such as Call or Meeting. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Represents Type of the task, such as Call or Meeting. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'What ID',
@@ -862,7 +862,7 @@ export const taskFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'For date, number, or boolean, please use expressions. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'For date, number, or boolean, please use expressions. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							// eslint-disable-next-line n8n-nodes-base/node-param-operation-without-no-data-expression
 							{

--- a/packages/nodes-base/nodes/Salesforce/UserDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/UserDescription.ts
@@ -119,7 +119,7 @@ export const userFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'For date, number, or boolean, please use expressions. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'For date, number, or boolean, please use expressions. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							// eslint-disable-next-line n8n-nodes-base/node-param-operation-without-no-data-expression
 							{

--- a/packages/nodes-base/nodes/Salesmate/ActivityDescription.ts
+++ b/packages/nodes-base/nodes/Salesmate/ActivityDescription.ts
@@ -69,7 +69,7 @@ export const activityFields: INodeProperties[] = [
 		name: 'owner',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		typeOptions: {
 			loadOptionsMethod: 'getUsers',

--- a/packages/nodes-base/nodes/Salesmate/CompanyDescription.ts
+++ b/packages/nodes-base/nodes/Salesmate/CompanyDescription.ts
@@ -69,7 +69,7 @@ export const companyFields: INodeProperties[] = [
 		name: 'owner',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		typeOptions: {
 			loadOptionsMethod: 'getUsers',
@@ -265,7 +265,7 @@ export const companyFields: INodeProperties[] = [
 				name: 'owner',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getUsers',

--- a/packages/nodes-base/nodes/Salesmate/DealDescription.ts
+++ b/packages/nodes-base/nodes/Salesmate/DealDescription.ts
@@ -69,7 +69,7 @@ export const dealFields: INodeProperties[] = [
 		name: 'owner',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		typeOptions: {
 			loadOptionsMethod: 'getUsers',
@@ -97,7 +97,7 @@ export const dealFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Primary contact for the deal. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Primary contact for the deal. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		required: true,
 	},
 	{
@@ -240,7 +240,7 @@ export const dealFields: INodeProperties[] = [
 				name: 'primaryCompany',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getCompanies',
 				},
@@ -360,7 +360,7 @@ export const dealFields: INodeProperties[] = [
 				name: 'owner',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getUsers',
@@ -371,7 +371,7 @@ export const dealFields: INodeProperties[] = [
 				name: 'primaryContact',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getContacts',
@@ -462,7 +462,7 @@ export const dealFields: INodeProperties[] = [
 				name: 'primaryCompany',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getCompanies',
 				},

--- a/packages/nodes-base/nodes/SeaTable/v1/RowDescription.ts
+++ b/packages/nodes-base/nodes/SeaTable/v1/RowDescription.ts
@@ -86,7 +86,7 @@ export const rowFields: INodeProperties[] = [
 		default: '',
 
 		description:
-			'The name of SeaTable table to access. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The name of SeaTable table to access. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 
 	// ----------------------------------

--- a/packages/nodes-base/nodes/SeaTable/v1/SeaTableTriggerV1.node.ts
+++ b/packages/nodes-base/nodes/SeaTable/v1/SeaTableTriggerV1.node.ts
@@ -44,7 +44,7 @@ export class SeaTableTriggerV1 implements INodeType {
 					},
 					default: '',
 					description:
-						'The name of SeaTable table to access. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						'The name of SeaTable table to access. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				},
 				{
 					displayName: 'Event',

--- a/packages/nodes-base/nodes/SeaTable/v2/actions/asset/upload.operation.ts
+++ b/packages/nodes-base/nodes/SeaTable/v2/actions/asset/upload.operation.ts
@@ -38,7 +38,7 @@ const properties: INodeProperties[] = [
 		default: '',
 		// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 		description:
-			'Choose from the list, or specify the name using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify the name using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 	},
 	{
 		// eslint-disable-next-line n8n-nodes-base/node-param-display-name-wrong-for-dynamic-options
@@ -46,7 +46,7 @@ const properties: INodeProperties[] = [
 		name: 'rowId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		typeOptions: {
 			loadOptionsDependsOn: ['tableName'],

--- a/packages/nodes-base/nodes/SeaTable/v2/actions/link/list.operation.ts
+++ b/packages/nodes-base/nodes/SeaTable/v2/actions/link/list.operation.ts
@@ -42,7 +42,7 @@ export const properties: INodeProperties[] = [
 		name: 'rowId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		typeOptions: {
 			loadOptionsDependsOn: ['tableName'],

--- a/packages/nodes-base/nodes/SeaTable/v2/actions/row/create.operation.ts
+++ b/packages/nodes-base/nodes/SeaTable/v2/actions/row/create.operation.ts
@@ -100,7 +100,7 @@ export const properties: INodeProperties[] = [
 						name: 'columnName',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsDependsOn: ['tableName'],
 							loadOptionsMethod: 'getTableUpdateAbleColumns',

--- a/packages/nodes-base/nodes/SeaTable/v2/actions/row/sharedProperties.ts
+++ b/packages/nodes-base/nodes/SeaTable/v2/actions/row/sharedProperties.ts
@@ -13,7 +13,7 @@ export const sharedProperties: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		displayOptions: {
 			show: {
 				resource: ['row'],
@@ -26,7 +26,7 @@ export const sharedProperties: INodeProperties[] = [
 		name: 'rowId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		typeOptions: {
 			loadOptionsDependsOn: ['tableName'],

--- a/packages/nodes-base/nodes/SeaTable/v2/actions/row/update.operation.ts
+++ b/packages/nodes-base/nodes/SeaTable/v2/actions/row/update.operation.ts
@@ -72,7 +72,7 @@ export const properties: INodeProperties[] = [
 						name: 'columnName',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsDependsOn: ['tableName'],
 							loadOptionsMethod: 'getTableUpdateAbleColumns',

--- a/packages/nodes-base/nodes/SendGrid/ContactDescription.ts
+++ b/packages/nodes-base/nodes/SendGrid/ContactDescription.ts
@@ -225,7 +225,7 @@ export const contactFields: INodeProperties[] = [
 								},
 								default: [],
 								description:
-									'ID of the field to set. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'ID of the field to set. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 						],
 					},
@@ -255,7 +255,7 @@ export const contactFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'ID of the field. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'ID of the field. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Field Value',

--- a/packages/nodes-base/nodes/SendGrid/MailDescription.ts
+++ b/packages/nodes-base/nodes/SendGrid/MailDescription.ts
@@ -141,7 +141,7 @@ export const mailFields: INodeProperties[] = [
 		name: 'templateId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: [],
 		typeOptions: {
 			loadOptionsMethod: 'getTemplateIds',

--- a/packages/nodes-base/nodes/SentryIo/EventDescription.ts
+++ b/packages/nodes-base/nodes/SentryIo/EventDescription.ts
@@ -49,7 +49,7 @@ export const eventFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the organization the events belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the organization the events belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Project Slug Name or ID',
@@ -68,7 +68,7 @@ export const eventFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the project the events belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the project the events belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Full',
@@ -135,7 +135,7 @@ export const eventFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the organization the events belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the organization the events belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Project Slug Name or ID',
@@ -153,7 +153,7 @@ export const eventFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the project the events belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the project the events belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Event ID',

--- a/packages/nodes-base/nodes/SentryIo/IssueDescription.ts
+++ b/packages/nodes-base/nodes/SentryIo/IssueDescription.ts
@@ -80,7 +80,7 @@ export const issueFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the organization the issues belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the organization the issues belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Project Slug Name or ID',
@@ -99,7 +99,7 @@ export const issueFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the project the issues belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the project the issues belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',

--- a/packages/nodes-base/nodes/SentryIo/OrganizationDescription.ts
+++ b/packages/nodes-base/nodes/SentryIo/OrganizationDescription.ts
@@ -125,7 +125,7 @@ export const organizationFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the organization the team should be created for. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the organization the team should be created for. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 
 	/* -------------------------------------------------------------------------- */
@@ -202,7 +202,7 @@ export const organizationFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the organization to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the organization to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Update Fields',

--- a/packages/nodes-base/nodes/SentryIo/ProjectDescription.ts
+++ b/packages/nodes-base/nodes/SentryIo/ProjectDescription.ts
@@ -67,7 +67,7 @@ export const projectFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the organization the events belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the organization the events belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Project Slug Name or ID',
@@ -86,7 +86,7 @@ export const projectFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the project to retrieve. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the project to retrieve. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Team Slug Name or ID',
@@ -105,7 +105,7 @@ export const projectFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the team to create a new project for. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the team to create a new project for. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Name',
@@ -199,7 +199,7 @@ export const projectFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the organization the project belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the organization the project belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Project Slug Name or ID',
@@ -218,7 +218,7 @@ export const projectFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the project to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the project to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Update Fields',
@@ -305,7 +305,7 @@ export const projectFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the organization the project belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the organization the project belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Project Slug Name or ID',
@@ -324,6 +324,6 @@ export const projectFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the project to delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the project to delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 ];

--- a/packages/nodes-base/nodes/SentryIo/ReleaseDescription.ts
+++ b/packages/nodes-base/nodes/SentryIo/ReleaseDescription.ts
@@ -67,7 +67,7 @@ export const releaseFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the organization the releases belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the organization the releases belong to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',
@@ -142,7 +142,7 @@ export const releaseFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the organization the release belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the organization the release belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Version',
@@ -178,7 +178,7 @@ export const releaseFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the organization the release belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the organization the release belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Version',
@@ -226,7 +226,7 @@ export const releaseFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'A list of project slugs that are involved in this release. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'A list of project slugs that are involved in this release. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Additional Fields',
@@ -423,7 +423,7 @@ export const releaseFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the organization the release belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the organization the release belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Version',

--- a/packages/nodes-base/nodes/SentryIo/TeamDescription.ts
+++ b/packages/nodes-base/nodes/SentryIo/TeamDescription.ts
@@ -67,7 +67,7 @@ export const teamFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the organization for which the teams should be listed. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the organization for which the teams should be listed. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',
@@ -120,7 +120,7 @@ export const teamFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the organization the team belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the organization the team belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Team Slug Name or ID',
@@ -139,7 +139,7 @@ export const teamFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the team to get. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the team to get. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 
 	/* -------------------------------------------------------------------------- */
@@ -161,7 +161,7 @@ export const teamFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the organization the team belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the organization the team belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Name',
@@ -220,7 +220,7 @@ export const teamFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the organization the team belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the organization the team belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Team Slug Name or ID',
@@ -239,7 +239,7 @@ export const teamFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the team to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the team to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Update Fields',
@@ -290,7 +290,7 @@ export const teamFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the organization the team belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the organization the team belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Team Slug Name or ID',
@@ -309,6 +309,6 @@ export const teamFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The slug of the team to delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The slug of the team to delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 ];

--- a/packages/nodes-base/nodes/ServiceNow/AttachmentDescription.ts
+++ b/packages/nodes-base/nodes/ServiceNow/AttachmentDescription.ts
@@ -51,7 +51,7 @@ export const attachmentFields: INodeProperties[] = [
 		name: 'tableName',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTables',
 		},

--- a/packages/nodes-base/nodes/ServiceNow/BusinessServiceDescription.ts
+++ b/packages/nodes-base/nodes/ServiceNow/BusinessServiceDescription.ts
@@ -87,7 +87,7 @@ export const businessServiceFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				hint: 'String of comma separated values or an array of strings can be set in an expression',
 			},
 			{

--- a/packages/nodes-base/nodes/ServiceNow/ConfigurationItemsDescription.ts
+++ b/packages/nodes-base/nodes/ServiceNow/ConfigurationItemsDescription.ts
@@ -87,7 +87,7 @@ export const configurationItemsFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				hint: 'String of comma separated values or an array of strings can be set in an expression',
 			},
 			{

--- a/packages/nodes-base/nodes/ServiceNow/DepartmentDescription.ts
+++ b/packages/nodes-base/nodes/ServiceNow/DepartmentDescription.ts
@@ -87,7 +87,7 @@ export const departmentFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				hint: 'String of comma separated values or an array of strings can be set in an expression',
 			},
 			{

--- a/packages/nodes-base/nodes/ServiceNow/DictionaryDescription.ts
+++ b/packages/nodes-base/nodes/ServiceNow/DictionaryDescription.ts
@@ -87,7 +87,7 @@ export const dictionaryFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				hint: 'String of comma separated values or an array of strings can be set in an expression',
 			},
 			{

--- a/packages/nodes-base/nodes/ServiceNow/IncidentDescription.ts
+++ b/packages/nodes-base/nodes/ServiceNow/IncidentDescription.ts
@@ -85,7 +85,7 @@ export const incidentFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Which user is the incident assigned to. Requires the selection of an assignment group. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Which user is the incident assigned to. Requires the selection of an assignment group. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Assignment Group Name or ID',
@@ -97,14 +97,14 @@ export const incidentFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The assignment group of the incident. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The assignment group of the incident. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Business Service Name or ID',
 				name: 'business_service',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					// nodelinter-ignore-next-line
 					loadOptionsMethod: 'getBusinessServices',
@@ -128,7 +128,7 @@ export const incidentFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The category of the incident. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The category of the incident. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Close Notes',
@@ -147,7 +147,7 @@ export const incidentFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Configuration Items, \'cmdb_ci\' in metadata. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Configuration Items, \'cmdb_ci\' in metadata. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Contact Type',
@@ -211,7 +211,7 @@ export const incidentFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The resolution code of the incident, \'close_code\' in metadata. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The resolution code of the incident, \'close_code\' in metadata. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'State Name or ID',
@@ -223,7 +223,7 @@ export const incidentFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The state of the incident. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The state of the incident. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Subcategory Name or ID',
@@ -236,7 +236,7 @@ export const incidentFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The subcategory of the incident. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The subcategory of the incident. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Urgency',
@@ -326,7 +326,7 @@ export const incidentFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				hint: 'String of comma separated values or an array of strings can be set in an expression',
 			},
 			{
@@ -408,7 +408,7 @@ export const incidentFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				hint: 'String of comma separated values or an array of strings can be set in an expression',
 			},
 			{
@@ -476,7 +476,7 @@ export const incidentFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Which user is the incident assigned to. Requires the selection of an assignment group. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Which user is the incident assigned to. Requires the selection of an assignment group. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Assignment Group Name or ID',
@@ -488,14 +488,14 @@ export const incidentFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The assignment group of the incident. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The assignment group of the incident. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Business Service Name or ID',
 				name: 'business_service',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					// nodelinter-ignore-next-line
 					loadOptionsMethod: 'getBusinessServices',
@@ -519,7 +519,7 @@ export const incidentFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The category of the incident. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The category of the incident. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Close Notes',
@@ -538,7 +538,7 @@ export const incidentFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Configuration Items, \'cmdb_ci\' in metadata. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Configuration Items, \'cmdb_ci\' in metadata. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Contact Type',
@@ -603,7 +603,7 @@ export const incidentFields: INodeProperties[] = [
 				default: '',
 				// nodelinter-ignore-next-line
 				description:
-					'The resolution code of the incident. \'close_code\' in metadata. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The resolution code of the incident. \'close_code\' in metadata. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'On Hold Reason Name or ID',
@@ -615,7 +615,7 @@ export const incidentFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The on hold reason for the incident. It applies if the state is <code>On Hold</code>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The on hold reason for the incident. It applies if the state is <code>On Hold</code>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'State Name or ID',
@@ -627,7 +627,7 @@ export const incidentFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The state of the incident. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The state of the incident. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Subcategory Name or ID',
@@ -640,7 +640,7 @@ export const incidentFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The subcategory of the incident. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The subcategory of the incident. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Urgency',

--- a/packages/nodes-base/nodes/ServiceNow/TableRecordDescription.ts
+++ b/packages/nodes-base/nodes/ServiceNow/TableRecordDescription.ts
@@ -51,7 +51,7 @@ export const tableRecordFields: INodeProperties[] = [
 		name: 'tableName',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTables',
 		},
@@ -134,7 +134,7 @@ export const tableRecordFields: INodeProperties[] = [
 						name: 'column',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getColumns',
 							loadOptionsDependsOn: ['tableName'],
@@ -160,7 +160,7 @@ export const tableRecordFields: INodeProperties[] = [
 		name: 'tableName',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTables',
 		},
@@ -234,7 +234,7 @@ export const tableRecordFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				hint: 'String of comma separated values or an array of strings can be set in an expression',
 			},
 			{
@@ -288,7 +288,7 @@ export const tableRecordFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'Name of the table in which the record exists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Name of the table in which the record exists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Table Record ID',
@@ -334,7 +334,7 @@ export const tableRecordFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				hint: 'String of comma separated values or an array of strings can be set in an expression',
 			},
 			{
@@ -369,7 +369,7 @@ export const tableRecordFields: INodeProperties[] = [
 		name: 'tableName',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTables',
 		},
@@ -466,7 +466,7 @@ export const tableRecordFields: INodeProperties[] = [
 						name: 'column',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getColumns',
 							loadOptionsDependsOn: ['tableName'],

--- a/packages/nodes-base/nodes/ServiceNow/UserDescription.ts
+++ b/packages/nodes-base/nodes/ServiceNow/UserDescription.ts
@@ -211,7 +211,7 @@ export const userFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Roles of the user. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Roles of the user. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Source',
@@ -315,7 +315,7 @@ export const userFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				hint: 'String of comma separated values or an array of strings can be set in an expression',
 			},
 			{
@@ -451,7 +451,7 @@ export const userFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				hint: 'String of comma separated values or an array of strings can be set in an expression',
 			},
 			{
@@ -645,7 +645,7 @@ export const userFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'Roles of the user. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Roles of the user. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Source',

--- a/packages/nodes-base/nodes/ServiceNow/UserGroupDescription.ts
+++ b/packages/nodes-base/nodes/ServiceNow/UserGroupDescription.ts
@@ -86,7 +86,7 @@ export const userGroupFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				hint: 'String of comma separated values or an array of strings can be set in an expression',
 			},
 			{

--- a/packages/nodes-base/nodes/ServiceNow/UserRoleDescription.ts
+++ b/packages/nodes-base/nodes/ServiceNow/UserRoleDescription.ts
@@ -86,7 +86,7 @@ export const userRoleFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'A list of fields to return. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				hint: 'String of comma separated values or an array of strings can be set in an expression',
 			},
 			{

--- a/packages/nodes-base/nodes/Shopify/OrderDescription.ts
+++ b/packages/nodes-base/nodes/Shopify/OrderDescription.ts
@@ -269,7 +269,7 @@ export const orderFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The ID of the physical location where the order was processed. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The ID of the physical location where the order was processed. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Note',
@@ -423,7 +423,7 @@ export const orderFields: INodeProperties[] = [
 						},
 						default: '',
 						description:
-							'The ID of the product that the line item belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The ID of the product that the line item belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Variant ID',
@@ -807,7 +807,7 @@ export const orderFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The ID of the physical location where the order was processed. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The ID of the physical location where the order was processed. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Note',

--- a/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
+++ b/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
@@ -228,7 +228,7 @@ export class SlackTrigger implements INodeType {
 						},
 						default: [],
 						description:
-							'A comma-separated string of encoded user IDs. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'A comma-separated string of encoded user IDs. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 				],
 			},

--- a/packages/nodes-base/nodes/Slack/V1/ChannelDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V1/ChannelDescription.ts
@@ -139,7 +139,7 @@ export const channelFields: INodeProperties[] = [
 		default: '',
 		required: true,
 		description:
-			'The name of the channel to archive. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The name of the channel to archive. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 
 	/* -------------------------------------------------------------------------- */
@@ -161,7 +161,7 @@ export const channelFields: INodeProperties[] = [
 		default: '',
 		required: true,
 		description:
-			'The name of the channel to close. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The name of the channel to close. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 
 	/* -------------------------------------------------------------------------- */
@@ -224,7 +224,7 @@ export const channelFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The ID of the channel to invite user to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the channel to invite user to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'User Names or IDs',
@@ -242,7 +242,7 @@ export const channelFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The ID of the user to invite into channel. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the user to invite into channel. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 
 	/* -------------------------------------------------------------------------- */
@@ -304,14 +304,14 @@ export const channelFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The name of the channel to create. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The name of the channel to create. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'User Name or ID',
 		name: 'userId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getUsers',
 		},
@@ -332,7 +332,7 @@ export const channelFields: INodeProperties[] = [
 		name: 'channelId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getChannels',
 		},
@@ -451,7 +451,7 @@ export const channelFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The name of the channel to create. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The name of the channel to create. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',
@@ -541,7 +541,7 @@ export const channelFields: INodeProperties[] = [
 		default: '',
 		required: true,
 		description:
-			'The name of the channel to leave. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The name of the channel to leave. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 
 	/* -------------------------------------------------------------------------- */
@@ -552,7 +552,7 @@ export const channelFields: INodeProperties[] = [
 		name: 'channelId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getChannels',
 		},
@@ -651,7 +651,7 @@ export const channelFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'If only one user is included, this creates a 1:1 DM. The ordering of the users is preserved whenever a multi-person direct message is returned. Supply a channel when not supplying users. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'If only one user is included, this creates a 1:1 DM. The ordering of the users is preserved whenever a multi-person direct message is returned. Supply a channel when not supplying users. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -675,7 +675,7 @@ export const channelFields: INodeProperties[] = [
 		default: '',
 		required: true,
 		description:
-			'The name of the channel to rename. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The name of the channel to rename. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Name',
@@ -712,7 +712,7 @@ export const channelFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The name of the channel to create. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The name of the channel to create. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'TS',
@@ -816,7 +816,7 @@ export const channelFields: INodeProperties[] = [
 		default: '',
 		required: true,
 		description:
-			'Conversation to set the purpose of. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Conversation to set the purpose of. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Purpose',
@@ -852,7 +852,7 @@ export const channelFields: INodeProperties[] = [
 		default: '',
 		required: true,
 		description:
-			'Conversation to set the topic of. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Conversation to set the topic of. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Topic',
@@ -888,6 +888,6 @@ export const channelFields: INodeProperties[] = [
 		default: '',
 		required: true,
 		description:
-			'The ID of the channel to unarchive. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the channel to unarchive. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 ];

--- a/packages/nodes-base/nodes/Slack/V1/FileDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V1/FileDescription.ts
@@ -106,7 +106,7 @@ export const fileFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The channels to send the file to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The channels to send the file to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'File Name',
@@ -196,7 +196,7 @@ export const fileFields: INodeProperties[] = [
 					loadOptionsMethod: 'getChannels',
 				},
 				description:
-					'Channel containing the file to be listed. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Channel containing the file to be listed. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Show Files Hidden By Limit',
@@ -267,7 +267,7 @@ export const fileFields: INodeProperties[] = [
 					loadOptionsMethod: 'getUsers',
 				},
 				description:
-					'Filter files created by a single user. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Filter files created by a single user. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Slack/V1/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V1/MessageDescription.ts
@@ -67,7 +67,7 @@ export const messageFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Channel containing the message. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Channel containing the message. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Timestamp',
@@ -406,7 +406,7 @@ export const messageFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Channel containing the message to be updated. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Channel containing the message to be updated. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Text',
@@ -1576,7 +1576,7 @@ export const messageFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Channel containing the message to be deleted. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Channel containing the message to be deleted. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Timestamp',

--- a/packages/nodes-base/nodes/Slack/V1/ReactionDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V1/ReactionDescription.ts
@@ -52,7 +52,7 @@ export const reactionFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Channel containing the message. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Channel containing the message. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Emoji',

--- a/packages/nodes-base/nodes/Slack/V1/StarDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V1/StarDescription.ts
@@ -62,7 +62,7 @@ export const starFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Channel to add star to, or channel where the message to add star to was posted (used with timestamp). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Channel to add star to, or channel where the message to add star to was posted (used with timestamp). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'File Comment',
@@ -114,7 +114,7 @@ export const starFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Channel to add star to, or channel where the message to add star to was posted (used with timestamp). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Channel to add star to, or channel where the message to add star to was posted (used with timestamp). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'File ID',

--- a/packages/nodes-base/nodes/Slack/V1/UserGroupDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V1/UserGroupDescription.ts
@@ -87,7 +87,7 @@ export const userGroupFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'A comma-separated string of encoded channel IDs for which the User Group uses as a default. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'A comma-separated string of encoded channel IDs for which the User Group uses as a default. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Description',
@@ -299,7 +299,7 @@ export const userGroupFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'A comma-separated string of encoded channel IDs for which the User Group uses as a default. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'A comma-separated string of encoded channel IDs for which the User Group uses as a default. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Description',

--- a/packages/nodes-base/nodes/Slack/V1/UserProfileDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V1/UserProfileDescription.ts
@@ -69,7 +69,7 @@ export const userProfileFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Field Value',

--- a/packages/nodes-base/nodes/Slack/V2/ChannelDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/ChannelDescription.ts
@@ -237,7 +237,7 @@ export const channelFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The ID of the user to invite into channel. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the user to invite into channel. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 
 	/* -------------------------------------------------------------------------- */
@@ -305,7 +305,7 @@ export const channelFields: INodeProperties[] = [
 		name: 'userId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getUsers',
 		},
@@ -635,7 +635,7 @@ export const channelFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'If only one user is included, this creates a 1:1 DM. The ordering of the users is preserved whenever a multi-person direct message is returned. Supply a channel when not supplying users. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'If only one user is included, this creates a 1:1 DM. The ordering of the users is preserved whenever a multi-person direct message is returned. Supply a channel when not supplying users. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Slack/V2/FileDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/FileDescription.ts
@@ -128,7 +128,7 @@ export const fileFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The channels to send the file to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The channels to send the file to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Channel Name or ID',
@@ -144,7 +144,7 @@ export const fileFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The channel to send the file to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The channel to send the file to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'File Name',
@@ -232,7 +232,7 @@ export const fileFields: INodeProperties[] = [
 					loadOptionsMethod: 'getChannels',
 				},
 				description:
-					'Channel containing the file to be listed. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Channel containing the file to be listed. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Show Files Hidden By Limit',
@@ -303,7 +303,7 @@ export const fileFields: INodeProperties[] = [
 					loadOptionsMethod: 'getUsers',
 				},
 				description:
-					'Filter files created by a single user. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Filter files created by a single user. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
@@ -1127,7 +1127,7 @@ export const messageFields: INodeProperties[] = [
 				name: 'searchChannel',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getChannelsName',

--- a/packages/nodes-base/nodes/Slack/V2/StarDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/StarDescription.ts
@@ -160,7 +160,7 @@ export const starFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Channel to add star to, or channel where the message to add star to was posted (used with timestamp). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Channel to add star to, or channel where the message to add star to was posted (used with timestamp). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'File ID',

--- a/packages/nodes-base/nodes/Slack/V2/UserDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/UserDescription.ts
@@ -210,7 +210,7 @@ export const userFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'ID of the field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Field Value',

--- a/packages/nodes-base/nodes/Slack/V2/UserGroupDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/UserGroupDescription.ts
@@ -92,7 +92,7 @@ export const userGroupFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'A comma-separated string of encoded channel IDs for which the User Group uses as a default. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'A comma-separated string of encoded channel IDs for which the User Group uses as a default. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Description',
@@ -304,7 +304,7 @@ export const userGroupFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'A comma-separated string of encoded channel IDs for which the User Group uses as a default. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'A comma-separated string of encoded channel IDs for which the User Group uses as a default. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Description',
@@ -369,7 +369,7 @@ export const userGroupFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'Users to add to the User Group. Existing users will be preserved. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Users to add to the User Group. Existing users will be preserved. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Options',

--- a/packages/nodes-base/nodes/Splunk/v1/descriptions/UserDescription.ts
+++ b/packages/nodes-base/nodes/Splunk/v1/descriptions/UserDescription.ts
@@ -70,7 +70,7 @@ export const userFields: INodeProperties[] = [
 		name: 'roles',
 		type: 'multiOptions',
 		description:
-			'Comma-separated list of roles to assign to the user. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Comma-separated list of roles to assign to the user. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		required: true,
 		default: [],
 		typeOptions: {
@@ -253,7 +253,7 @@ export const userFields: INodeProperties[] = [
 				name: 'roles',
 				type: 'multiOptions',
 				description:
-					'Comma-separated list of roles to assign to the user. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Comma-separated list of roles to assign to the user. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getRoles',

--- a/packages/nodes-base/nodes/Splunk/v2/actions/user/create.operation.ts
+++ b/packages/nodes-base/nodes/Splunk/v2/actions/user/create.operation.ts
@@ -20,7 +20,7 @@ const properties: INodeProperties[] = [
 		name: 'roles',
 		type: 'multiOptions',
 		description:
-			'Comma-separated list of roles to assign to the user. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Comma-separated list of roles to assign to the user. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		required: true,
 		default: ['user'],
 		typeOptions: {

--- a/packages/nodes-base/nodes/Splunk/v2/actions/user/update.operation.ts
+++ b/packages/nodes-base/nodes/Splunk/v2/actions/user/update.operation.ts
@@ -40,7 +40,7 @@ const properties: INodeProperties[] = [
 				name: 'roles',
 				type: 'multiOptions',
 				description:
-					'Comma-separated list of roles to assign to the user. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Comma-separated list of roles to assign to the user. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getRoles',

--- a/packages/nodes-base/nodes/Storyblok/StoryManagementDescription.ts
+++ b/packages/nodes-base/nodes/Storyblok/StoryManagementDescription.ts
@@ -327,7 +327,7 @@ export const storyManagementFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The name of the space. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The name of the space. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Story ID',
@@ -365,7 +365,7 @@ export const storyManagementFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The name of the space. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The name of the space. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Story ID',
@@ -403,7 +403,7 @@ export const storyManagementFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The name of the space. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The name of the space. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',
@@ -482,7 +482,7 @@ export const storyManagementFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The name of the space. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The name of the space. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Story ID',
@@ -551,7 +551,7 @@ export const storyManagementFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The name of the space. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The name of the space. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Story ID',

--- a/packages/nodes-base/nodes/Stripe/descriptions/ChargeDescription.ts
+++ b/packages/nodes-base/nodes/Stripe/descriptions/ChargeDescription.ts
@@ -88,7 +88,7 @@ export const chargeFields: INodeProperties[] = [
 		required: true,
 		default: '',
 		description:
-			'Three-letter ISO currency code, e.g. <code>USD</code> or <code>EUR</code>. It must be a <a href="https://stripe.com/docs/currencies">Stripe-supported currency</a>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Three-letter ISO currency code, e.g. <code>USD</code> or <code>EUR</code>. It must be a <a href="https://stripe.com/docs/currencies">Stripe-supported currency</a>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['charge'],

--- a/packages/nodes-base/nodes/Stripe/descriptions/CouponDescription.ts
+++ b/packages/nodes-base/nodes/Stripe/descriptions/CouponDescription.ts
@@ -111,7 +111,7 @@ export const couponFields: INodeProperties[] = [
 		required: true,
 		default: '',
 		description:
-			'Three-letter ISO currency code, e.g. <code>USD</code> or <code>EUR</code>. It must be a <a href="https://stripe.com/docs/currencies">Stripe-supported currency</a>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Three-letter ISO currency code, e.g. <code>USD</code> or <code>EUR</code>. It must be a <a href="https://stripe.com/docs/currencies">Stripe-supported currency</a>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['coupon'],

--- a/packages/nodes-base/nodes/Stripe/descriptions/SourceDescription.ts
+++ b/packages/nodes-base/nodes/Stripe/descriptions/SourceDescription.ts
@@ -100,7 +100,7 @@ export const sourceFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'Three-letter ISO currency code, e.g. <code>USD</code> or <code>EUR</code>. It must be a <a href="https://stripe.com/docs/currencies">Stripe-supported currency</a>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Three-letter ISO currency code, e.g. <code>USD</code> or <code>EUR</code>. It must be a <a href="https://stripe.com/docs/currencies">Stripe-supported currency</a>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['source'],

--- a/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
@@ -177,7 +177,7 @@ export function getFilters(
 							name: 'keyName',
 							type: 'options',
 							description:
-								'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+								'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 							typeOptions: {
 								loadOptionsDependsOn: ['tableId'],
 								loadOptionsMethod: 'getTableColumns',

--- a/packages/nodes-base/nodes/Supabase/RowDescription.ts
+++ b/packages/nodes-base/nodes/Supabase/RowDescription.ts
@@ -58,7 +58,7 @@ export const rowFields: INodeProperties[] = [
 		name: 'tableId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsDependsOn: ['useCustomSchema', 'schema'],
 			loadOptionsMethod: 'getTables',
@@ -154,7 +154,7 @@ export const rowFields: INodeProperties[] = [
 						name: 'fieldId',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsDependsOn: ['tableId'],
 							loadOptionsMethod: 'getTableColumns',
@@ -222,7 +222,7 @@ export const rowFields: INodeProperties[] = [
 						},
 						default: '',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 					},
 					{
 						displayName: 'Value',

--- a/packages/nodes-base/nodes/SurveyMonkey/SurveyMonkeyTrigger.node.ts
+++ b/packages/nodes-base/nodes/SurveyMonkey/SurveyMonkeyTrigger.node.ts
@@ -229,7 +229,7 @@ export class SurveyMonkeyTrigger implements INodeType {
 				name: 'surveyIds',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				displayOptions: {
 					show: {
 						objectType: ['survey'],
@@ -250,7 +250,7 @@ export class SurveyMonkeyTrigger implements INodeType {
 				name: 'surveyId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				displayOptions: {
 					show: {
 						objectType: ['collector'],
@@ -267,7 +267,7 @@ export class SurveyMonkeyTrigger implements INodeType {
 				name: 'collectorIds',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				displayOptions: {
 					show: {
 						objectType: ['collector'],

--- a/packages/nodes-base/nodes/Switch/V2/SwitchV2.node.ts
+++ b/packages/nodes-base/nodes/Switch/V2/SwitchV2.node.ts
@@ -510,7 +510,7 @@ export class SwitchV2 implements INodeType {
 					},
 					default: -1,
 					description:
-						'The output to which to route all items which do not match any of the rules. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						'The output to which to route all items which do not match any of the rules. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				},
 			],
 		};

--- a/packages/nodes-base/nodes/Taiga/TaigaTrigger.node.ts
+++ b/packages/nodes-base/nodes/Taiga/TaigaTrigger.node.ts
@@ -51,7 +51,7 @@ export class TaigaTrigger implements INodeType {
 				name: 'projectId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getUserProjects',
 				},

--- a/packages/nodes-base/nodes/Taiga/descriptions/EpicDescription.ts
+++ b/packages/nodes-base/nodes/Taiga/descriptions/EpicDescription.ts
@@ -55,7 +55,7 @@ export const epicFields: INodeProperties[] = [
 		displayName: 'Project Name or ID',
 		name: 'projectId',
 		description:
-			'ID of the project to which the epic belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the project to which the epic belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		typeOptions: {
 			loadOptionsMethod: 'getProjects',
@@ -105,7 +105,7 @@ export const epicFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the user to assign the epic to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user to assign the epic to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Blocked Note',
@@ -139,7 +139,7 @@ export const epicFields: INodeProperties[] = [
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getTags',
@@ -192,7 +192,7 @@ export const epicFields: INodeProperties[] = [
 		displayName: 'Project Name or ID',
 		name: 'projectId',
 		description:
-			'ID of the project to which the epic belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the project to which the epic belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		typeOptions: {
 			loadOptionsMethod: 'getProjects',
@@ -259,7 +259,7 @@ export const epicFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the user whom the epic is assigned to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user whom the epic is assigned to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Is Closed',
@@ -283,7 +283,7 @@ export const epicFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'ID of the project to set the epic to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the project to set the epic to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['epic'],
@@ -328,7 +328,7 @@ export const epicFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the user to whom the epic is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user to whom the epic is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Blocked Note',
@@ -368,7 +368,7 @@ export const epicFields: INodeProperties[] = [
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getTags',

--- a/packages/nodes-base/nodes/Taiga/descriptions/IssueDescription.ts
+++ b/packages/nodes-base/nodes/Taiga/descriptions/IssueDescription.ts
@@ -55,7 +55,7 @@ export const issueFields: INodeProperties[] = [
 		displayName: 'Project Name or ID',
 		name: 'projectId',
 		description:
-			'ID of the project to which the issue belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the project to which the issue belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		typeOptions: {
 			loadOptionsMethod: 'getProjects',
@@ -105,7 +105,7 @@ export const issueFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the user to whom the issue is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user to whom the issue is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Blocked Note',
@@ -137,14 +137,14 @@ export const issueFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the milestone of the issue. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the milestone of the issue. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Priority Name or ID',
 				name: 'priority',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getPriorities',
@@ -156,7 +156,7 @@ export const issueFields: INodeProperties[] = [
 				name: 'severity',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getSeverities',
@@ -173,14 +173,14 @@ export const issueFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the status of the issue. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the status of the issue. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Tag Names or IDs',
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getTags',
@@ -192,7 +192,7 @@ export const issueFields: INodeProperties[] = [
 				name: 'type',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getTypes',
@@ -245,7 +245,7 @@ export const issueFields: INodeProperties[] = [
 		displayName: 'Project Name or ID',
 		name: 'projectId',
 		description:
-			'ID of the project to which the issue belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the project to which the issue belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		typeOptions: {
 			loadOptionsMethod: 'getProjects',
@@ -306,7 +306,7 @@ export const issueFields: INodeProperties[] = [
 				displayName: 'Assignee Name or ID',
 				name: 'assigned_to',
 				description:
-					'ID of the user to assign the issue to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user to assign the issue to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				type: 'options',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
@@ -363,7 +363,7 @@ export const issueFields: INodeProperties[] = [
 				displayName: 'Owner Name or ID',
 				name: 'owner',
 				description:
-					'ID of the owner of the issue. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the owner of the issue. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				type: 'options',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
@@ -376,7 +376,7 @@ export const issueFields: INodeProperties[] = [
 				name: 'priority',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getPriorities',
@@ -388,7 +388,7 @@ export const issueFields: INodeProperties[] = [
 				name: 'role',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getRoles',
@@ -400,7 +400,7 @@ export const issueFields: INodeProperties[] = [
 				name: 'severity',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getSeverities',
@@ -411,7 +411,7 @@ export const issueFields: INodeProperties[] = [
 				displayName: 'Status Name or ID',
 				name: 'status',
 				description:
-					'ID of the status of the issue. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the status of the issue. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				type: 'options',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
@@ -424,7 +424,7 @@ export const issueFields: INodeProperties[] = [
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getTags',
@@ -436,7 +436,7 @@ export const issueFields: INodeProperties[] = [
 				name: 'type',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getTypes',
@@ -458,7 +458,7 @@ export const issueFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'ID of the project to set the issue to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the project to set the issue to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['issue'],
@@ -503,7 +503,7 @@ export const issueFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the user whom the issue is assigned to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user whom the issue is assigned to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Blocked Note',
@@ -535,14 +535,14 @@ export const issueFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the milestone of the issue. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the milestone of the issue. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Priority Name or ID',
 				name: 'priority',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getPriorities',
@@ -554,7 +554,7 @@ export const issueFields: INodeProperties[] = [
 				name: 'severity',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getSeverities',
@@ -571,7 +571,7 @@ export const issueFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the status of the issue. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the status of the issue. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Subject',
@@ -584,7 +584,7 @@ export const issueFields: INodeProperties[] = [
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getTags',
@@ -596,7 +596,7 @@ export const issueFields: INodeProperties[] = [
 				name: 'type',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getTypes',

--- a/packages/nodes-base/nodes/Taiga/descriptions/TaskDescription.ts
+++ b/packages/nodes-base/nodes/Taiga/descriptions/TaskDescription.ts
@@ -55,7 +55,7 @@ export const taskFields: INodeProperties[] = [
 		displayName: 'Project Name or ID',
 		name: 'projectId',
 		description:
-			'ID of the project to which the task belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the project to which the task belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		typeOptions: {
 			loadOptionsMethod: 'getProjects',
@@ -105,7 +105,7 @@ export const taskFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the user to whom the task is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user to whom the task is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Blocked Note',
@@ -137,7 +137,7 @@ export const taskFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the milestone of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the milestone of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Status Name or ID',
@@ -149,14 +149,14 @@ export const taskFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the status of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the status of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Tag Names or IDs',
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getTags',
@@ -183,7 +183,7 @@ export const taskFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the user story of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user story of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'User Story Order',
@@ -241,7 +241,7 @@ export const taskFields: INodeProperties[] = [
 		displayName: 'Project Name or ID',
 		name: 'projectId',
 		description:
-			'ID of the project to which the task belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the project to which the task belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		typeOptions: {
 			loadOptionsMethod: 'getProjects',
@@ -308,7 +308,7 @@ export const taskFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the user whom the task is assigned to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user whom the task is assigned to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Is Closed',
@@ -327,13 +327,13 @@ export const taskFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the milestone of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the milestone of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Owner Name or ID',
 				name: 'owner',
 				description:
-					'ID of the owner of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the owner of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				type: 'options',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
@@ -346,7 +346,7 @@ export const taskFields: INodeProperties[] = [
 				name: 'role',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getRoles',
@@ -357,7 +357,7 @@ export const taskFields: INodeProperties[] = [
 				displayName: 'Status Name or ID',
 				name: 'status',
 				description:
-					'ID of the status of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the status of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				type: 'options',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
@@ -370,7 +370,7 @@ export const taskFields: INodeProperties[] = [
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getTags',
@@ -381,7 +381,7 @@ export const taskFields: INodeProperties[] = [
 				displayName: 'User Story Name or ID',
 				name: 'userStory',
 				description:
-					'ID of the user story to which the task belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user story to which the task belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				type: 'options',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
@@ -399,7 +399,7 @@ export const taskFields: INodeProperties[] = [
 		displayName: 'Project Name or ID',
 		name: 'projectId',
 		description:
-			'ID of the project to set the task to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the project to set the task to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		typeOptions: {
 			loadOptionsMethod: 'getProjects',
@@ -449,7 +449,7 @@ export const taskFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the user to assign the task to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user to assign the task to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Blocked Note',
@@ -481,7 +481,7 @@ export const taskFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the milestone of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the milestone of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Status Name or ID',
@@ -493,7 +493,7 @@ export const taskFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the status of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the status of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Subject',
@@ -511,7 +511,7 @@ export const taskFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the user story of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user story of the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'User Story Order',
@@ -528,7 +528,7 @@ export const taskFields: INodeProperties[] = [
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getTags',

--- a/packages/nodes-base/nodes/Taiga/descriptions/UserStoryDescription.ts
+++ b/packages/nodes-base/nodes/Taiga/descriptions/UserStoryDescription.ts
@@ -55,7 +55,7 @@ export const userStoryFields: INodeProperties[] = [
 		displayName: 'Project Name or ID',
 		name: 'projectId',
 		description:
-			'ID of the project to which the user story belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the project to which the user story belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		typeOptions: {
 			loadOptionsMethod: 'getProjects',
@@ -105,7 +105,7 @@ export const userStoryFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the user to whom the user story is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user to whom the user story is assigned. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Backlog Order',
@@ -158,7 +158,7 @@ export const userStoryFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the milestone of the user story. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the milestone of the user story. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Sprint Order',
@@ -180,14 +180,14 @@ export const userStoryFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the status of the user story. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the status of the user story. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Tag Names or IDs',
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getTags',
@@ -199,7 +199,7 @@ export const userStoryFields: INodeProperties[] = [
 				name: 'type',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getTypes',
@@ -252,7 +252,7 @@ export const userStoryFields: INodeProperties[] = [
 		displayName: 'Project Name or ID',
 		name: 'projectId',
 		description:
-			'ID of the project to which the user story belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the project to which the user story belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		type: 'options',
 		typeOptions: {
 			loadOptionsMethod: 'getProjects',
@@ -313,7 +313,7 @@ export const userStoryFields: INodeProperties[] = [
 				displayName: 'Assignee Name or ID',
 				name: 'assigned_to',
 				description:
-					'ID of the user whom the user story is assigned to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user whom the user story is assigned to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				type: 'options',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
@@ -325,7 +325,7 @@ export const userStoryFields: INodeProperties[] = [
 				displayName: 'Epic Name or ID',
 				name: 'epic',
 				description:
-					'ID of the epic to which the user story belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the epic to which the user story belongs. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				type: 'options',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
@@ -357,14 +357,14 @@ export const userStoryFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the milestone of the user story. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the milestone of the user story. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Role Name or ID',
 				name: 'role',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getRoles',
@@ -375,7 +375,7 @@ export const userStoryFields: INodeProperties[] = [
 				displayName: 'Status Name or ID',
 				name: 'status',
 				description:
-					'ID of the status of the user story. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the status of the user story. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				type: 'options',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
@@ -388,7 +388,7 @@ export const userStoryFields: INodeProperties[] = [
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getTags',
@@ -410,7 +410,7 @@ export const userStoryFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'ID of the project to set the user story to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the project to set the user story to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['userStory'],
@@ -455,7 +455,7 @@ export const userStoryFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the user to assign the the user story to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user to assign the the user story to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Backlog Order',
@@ -508,7 +508,7 @@ export const userStoryFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the milestone of the user story. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the milestone of the user story. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Subject',
@@ -536,14 +536,14 @@ export const userStoryFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the status of the user story. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the status of the user story. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Tag Names or IDs',
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getTags',
@@ -555,7 +555,7 @@ export const userStoryFields: INodeProperties[] = [
 				name: 'type',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['projectId'],
 					loadOptionsMethod: 'getTypes',

--- a/packages/nodes-base/nodes/Tapfiliate/ProgramAffiliateDescription.ts
+++ b/packages/nodes-base/nodes/Tapfiliate/ProgramAffiliateDescription.ts
@@ -67,7 +67,7 @@ export const programAffiliateFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the Program to add the affiliate to. This ID can be found as part of the URL when viewing the program on the platform. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the Program to add the affiliate to. This ID can be found as part of the URL when viewing the program on the platform. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Affiliate ID',
@@ -132,7 +132,7 @@ export const programAffiliateFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the Program to add the affiliate to. This ID can be found as part of the URL when viewing the program on the platform. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the Program to add the affiliate to. This ID can be found as part of the URL when viewing the program on the platform. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Affiliate ID',
@@ -166,7 +166,7 @@ export const programAffiliateFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the Program to add the affiliate to. This ID can be found as part of the URL when viewing the program on the platform. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the Program to add the affiliate to. This ID can be found as part of the URL when viewing the program on the platform. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Affiliate ID',
@@ -201,7 +201,7 @@ export const programAffiliateFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the Program to add the affiliate to. This ID can be found as part of the URL when viewing the program on the platform. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the Program to add the affiliate to. This ID can be found as part of the URL when viewing the program on the platform. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Affiliate ID',
@@ -237,7 +237,7 @@ export const programAffiliateFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the Program to add the affiliate to. This ID can be found as part of the URL when viewing the program on the platform. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the Program to add the affiliate to. This ID can be found as part of the URL when viewing the program on the platform. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',

--- a/packages/nodes-base/nodes/TheHive/descriptions/AlertDescription.ts
+++ b/packages/nodes-base/nodes/TheHive/descriptions/AlertDescription.ts
@@ -8,7 +8,7 @@ export const alertOperations: INodeProperties[] = [
 		name: 'operation',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		noDataExpression: true,
 		required: true,
 		typeOptions: {
@@ -325,7 +325,7 @@ export const alertFields: INodeProperties[] = [
 							loadOptionsMethod: 'loadObservableTypes',
 						},
 						description:
-							'Type of the observable. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Type of the observable. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Data',
@@ -373,7 +373,7 @@ export const alertFields: INodeProperties[] = [
 		name: 'responder',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		default: '',
 		typeOptions: {
@@ -448,7 +448,7 @@ export const alertFields: INodeProperties[] = [
 								name: 'field',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								typeOptions: {
 									loadOptionsMethod: 'loadCustomFields',
 								},
@@ -540,7 +540,7 @@ export const alertFields: INodeProperties[] = [
 									loadOptionsMethod: 'loadObservableTypes',
 								},
 								description:
-									'Type of the observable. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Type of the observable. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Data',
@@ -605,7 +605,7 @@ export const alertFields: INodeProperties[] = [
 								name: 'field',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								typeOptions: {
 									loadOptionsMethod: 'loadCustomFields',
 								},
@@ -818,7 +818,7 @@ export const alertFields: INodeProperties[] = [
 								name: 'field',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								typeOptions: {
 									loadOptionsMethod: 'loadCustomFields',
 								},

--- a/packages/nodes-base/nodes/TheHive/descriptions/CaseDescription.ts
+++ b/packages/nodes-base/nodes/TheHive/descriptions/CaseDescription.ts
@@ -10,7 +10,7 @@ export const caseOperations: INodeProperties[] = [
 		default: 'getAll',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		noDataExpression: true,
 		required: true,
 		displayOptions: {
@@ -221,7 +221,7 @@ export const caseFields: INodeProperties[] = [
 		name: 'responder',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		required: true,
 		typeOptions: {
@@ -288,7 +288,7 @@ export const caseFields: INodeProperties[] = [
 								name: 'field',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								typeOptions: {
 									loadOptionsMethod: 'loadCustomFields',
 								},
@@ -383,7 +383,7 @@ export const caseFields: INodeProperties[] = [
 								name: 'field',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								typeOptions: {
 									loadOptionsMethod: 'loadCustomFields',
 								},
@@ -654,7 +654,7 @@ export const caseFields: INodeProperties[] = [
 								name: 'field',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								typeOptions: {
 									loadOptionsMethod: 'loadCustomFields',
 								},

--- a/packages/nodes-base/nodes/TheHive/descriptions/LogDescription.ts
+++ b/packages/nodes-base/nodes/TheHive/descriptions/LogDescription.ts
@@ -160,7 +160,7 @@ export const logFields: INodeProperties[] = [
 		name: 'responder',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		default: '',
 		typeOptions: {

--- a/packages/nodes-base/nodes/TheHive/descriptions/ObservableDescription.ts
+++ b/packages/nodes-base/nodes/TheHive/descriptions/ObservableDescription.ts
@@ -8,7 +8,7 @@ export const observableOperations: INodeProperties[] = [
 		name: 'operation',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		noDataExpression: true,
 		required: true,
 		default: 'getAll',
@@ -101,7 +101,7 @@ export const observableFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 	},
 	{
 		displayName: 'Data',
@@ -252,7 +252,7 @@ export const observableFields: INodeProperties[] = [
 		name: 'analyzers',
 		type: 'multiOptions',
 		description:
-			'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		default: [],
 		typeOptions: {
@@ -276,7 +276,7 @@ export const observableFields: INodeProperties[] = [
 		name: 'responder',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		default: '',
 		typeOptions: {
@@ -448,7 +448,7 @@ export const observableFields: INodeProperties[] = [
 					loadOptionsMethod: 'loadObservableTypes',
 				},
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 			},
 			{
 				displayName: 'Date Range',

--- a/packages/nodes-base/nodes/TheHive/descriptions/TaskDescription.ts
+++ b/packages/nodes-base/nodes/TheHive/descriptions/TaskDescription.ts
@@ -7,7 +7,7 @@ export const taskOperations: INodeProperties[] = [
 		default: 'getAll',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		noDataExpression: true,
 		required: true,
 		displayOptions: {
@@ -147,7 +147,7 @@ export const taskFields: INodeProperties[] = [
 		name: 'responder',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		default: '',
 		typeOptions: {

--- a/packages/nodes-base/nodes/TheHiveProject/actions/alert/promote.operation.ts
+++ b/packages/nodes-base/nodes/TheHiveProject/actions/alert/promote.operation.ts
@@ -24,7 +24,7 @@ const properties: INodeProperties[] = [
 				name: 'caseTemplate',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'loadCaseTemplate',

--- a/packages/nodes-base/nodes/TheHiveProject/actions/alert/status.operation.ts
+++ b/packages/nodes-base/nodes/TheHiveProject/actions/alert/status.operation.ts
@@ -12,7 +12,7 @@ const properties: INodeProperties[] = [
 		name: 'status',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: '',
 		required: true,
 		typeOptions: {

--- a/packages/nodes-base/nodes/TheHiveProject/actions/case/deleteAttachment.operation.ts
+++ b/packages/nodes-base/nodes/TheHiveProject/actions/case/deleteAttachment.operation.ts
@@ -14,7 +14,7 @@ const properties: INodeProperties[] = [
 		default: '',
 		required: true,
 		description:
-			'ID of the attachment. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the attachment. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		typeOptions: {
 			loadOptionsMethod: 'loadCaseAttachments',
 		},

--- a/packages/nodes-base/nodes/TheHiveProject/actions/case/getAttachment.operation.ts
+++ b/packages/nodes-base/nodes/TheHiveProject/actions/case/getAttachment.operation.ts
@@ -19,7 +19,7 @@ const properties: INodeProperties[] = [
 		default: '',
 		required: true,
 		description:
-			'ID of the attachment. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the attachment. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		typeOptions: {
 			loadOptionsMethod: 'loadCaseAttachments',
 			loadOptionsDependsOn: ['caseId.value'],

--- a/packages/nodes-base/nodes/TheHiveProject/actions/log/deleteAttachment.operation.ts
+++ b/packages/nodes-base/nodes/TheHiveProject/actions/log/deleteAttachment.operation.ts
@@ -14,7 +14,7 @@ const properties: INodeProperties[] = [
 		default: '',
 		required: true,
 		description:
-			'ID of the attachment. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the attachment. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		typeOptions: {
 			loadOptionsMethod: 'loadLogAttachments',
 			loadOptionsDependsOn: ['logId.value'],

--- a/packages/nodes-base/nodes/TheHiveProject/actions/observable/create.operation.ts
+++ b/packages/nodes-base/nodes/TheHiveProject/actions/observable/create.operation.ts
@@ -55,7 +55,7 @@ const properties: INodeProperties[] = [
 		name: 'dataType',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		default: 'file',
 		typeOptions: {

--- a/packages/nodes-base/nodes/TheHiveProject/actions/observable/executeAnalyzer.operation.ts
+++ b/packages/nodes-base/nodes/TheHiveProject/actions/observable/executeAnalyzer.operation.ts
@@ -18,7 +18,7 @@ const properties: INodeProperties[] = [
 		name: 'analyzers',
 		type: 'multiOptions',
 		description:
-			'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		default: [],
 		typeOptions: {

--- a/packages/nodes-base/nodes/TheHiveProject/descriptions/common.description.ts
+++ b/packages/nodes-base/nodes/TheHiveProject/descriptions/common.description.ts
@@ -32,7 +32,7 @@ export const responderOptions: INodeProperties = {
 	name: 'responder',
 	type: 'options',
 	description:
-		'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+		'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 	required: true,
 	default: '',
 	typeOptions: {
@@ -107,7 +107,7 @@ export const observableTypeOptions: INodeProperties = {
 		loadOptionsMethod: 'loadObservableTypes',
 	},
 	description:
-		'Type of the observable. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+		'Type of the observable. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 };
 
 export const alertStatusOptions: INodeProperties = {

--- a/packages/nodes-base/nodes/TheHiveProject/descriptions/filter.description.ts
+++ b/packages/nodes-base/nodes/TheHiveProject/descriptions/filter.description.ts
@@ -24,7 +24,7 @@ const field: INodeProperties[] = [
 			loadOptionsMethod: 'loadAlertFields',
 		},
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		displayOptions: {
 			show: {
 				'/resource': ['alert'],
@@ -41,7 +41,7 @@ const field: INodeProperties[] = [
 			loadOptionsMethod: 'loadCaseFields',
 		},
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		displayOptions: {
 			show: {
 				'/resource': ['case'],
@@ -58,7 +58,7 @@ const field: INodeProperties[] = [
 			loadOptionsMethod: 'loadTaskFields',
 		},
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		displayOptions: {
 			show: {
 				'/resource': ['task'],
@@ -75,7 +75,7 @@ const field: INodeProperties[] = [
 			loadOptionsMethod: 'loadObservableFields',
 		},
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		displayOptions: {
 			show: {
 				'/resource': ['observable'],

--- a/packages/nodes-base/nodes/Todoist/v1/TodoistV1.node.ts
+++ b/packages/nodes-base/nodes/Todoist/v1/TodoistV1.node.ts
@@ -224,7 +224,7 @@ const versionDescription: INodeTypeDescription = {
 			},
 			default: '',
 			description:
-				'Section to which you want move the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+				'Section to which you want move the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		},
 		{
 			displayName: 'Label Names or IDs',
@@ -241,7 +241,7 @@ const versionDescription: INodeTypeDescription = {
 			},
 			default: [],
 			description:
-				'Optional labels that will be assigned to a created task. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+				'Optional labels that will be assigned to a created task. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		},
 		{
 			displayName: 'Content',
@@ -327,7 +327,7 @@ const versionDescription: INodeTypeDescription = {
 					},
 					default: {},
 					description:
-						'The parent task you want to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						'The parent task you want to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				},
 				{
 					displayName: 'Priority',
@@ -350,7 +350,7 @@ const versionDescription: INodeTypeDescription = {
 					},
 					default: {},
 					description:
-						'The section you want to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						'The section you want to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				},
 			],
 		},
@@ -422,7 +422,7 @@ const versionDescription: INodeTypeDescription = {
 					},
 					default: {},
 					description:
-						'Filter tasks by label. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						'Filter tasks by label. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				},
 				{
 					displayName: 'Lang',
@@ -442,7 +442,7 @@ const versionDescription: INodeTypeDescription = {
 					},
 					default: '',
 					description:
-						'Filter tasks by parent task ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						'Filter tasks by parent task ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				},
 				{
 					displayName: 'Project Name or ID',
@@ -453,7 +453,7 @@ const versionDescription: INodeTypeDescription = {
 					},
 					default: '',
 					description:
-						'Filter tasks by project ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						'Filter tasks by project ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				},
 				{
 					displayName: 'Section Name or ID',
@@ -465,7 +465,7 @@ const versionDescription: INodeTypeDescription = {
 					},
 					default: '',
 					description:
-						'Filter tasks by section ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						'Filter tasks by section ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				},
 			],
 		},
@@ -532,7 +532,7 @@ const versionDescription: INodeTypeDescription = {
 					name: 'labels',
 					type: 'multiOptions',
 					description:
-						'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+						'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 					typeOptions: {
 						loadOptionsMethod: 'getLabels',
 					},

--- a/packages/nodes-base/nodes/Todoist/v2/TodoistV2.node.ts
+++ b/packages/nodes-base/nodes/Todoist/v2/TodoistV2.node.ts
@@ -514,7 +514,7 @@ const versionDescription: INodeTypeDescription = {
 			},
 			default: '',
 			description:
-				'Section to which you want move the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+				'Section to which you want move the task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		},
 		{
 			displayName: 'Additional Fields',
@@ -540,7 +540,7 @@ const versionDescription: INodeTypeDescription = {
 					},
 					default: '',
 					description:
-						'The destination section. The task becomes the last root task of the section. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						'The destination section. The task becomes the last root task of the section. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				},
 				{
 					displayName: 'Parent Name or ID',
@@ -552,7 +552,7 @@ const versionDescription: INodeTypeDescription = {
 					},
 					default: '',
 					description:
-						'The destination parent task. The task becomes the last child task of the parent task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						'The destination parent task. The task becomes the last child task of the parent task. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				},
 			],
 		},
@@ -572,7 +572,7 @@ const versionDescription: INodeTypeDescription = {
 			},
 			default: [],
 			description:
-				'Optional labels that will be assigned to a created task. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+				'Optional labels that will be assigned to a created task. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		},
 		{
 			displayName: 'Content',
@@ -700,7 +700,7 @@ const versionDescription: INodeTypeDescription = {
 					},
 					default: {},
 					description:
-						'The parent task you want to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						'The parent task you want to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				},
 				{
 					displayName: 'Priority',
@@ -723,7 +723,7 @@ const versionDescription: INodeTypeDescription = {
 					},
 					default: {},
 					description:
-						'The section you want to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						'The section you want to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				},
 				{
 					displayName: 'Order',
@@ -849,7 +849,7 @@ const versionDescription: INodeTypeDescription = {
 					},
 					default: {},
 					description:
-						'Filter tasks by label. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						'Filter tasks by label. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				},
 				{
 					displayName: 'Lang',
@@ -869,7 +869,7 @@ const versionDescription: INodeTypeDescription = {
 					},
 					default: '',
 					description:
-						'Filter tasks by parent task ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						'Filter tasks by parent task ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				},
 				{
 					displayName: 'Project Name or ID',
@@ -880,7 +880,7 @@ const versionDescription: INodeTypeDescription = {
 					},
 					default: '',
 					description:
-						'Filter tasks by project ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						'Filter tasks by project ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				},
 				{
 					displayName: 'Section Name or ID',
@@ -892,7 +892,7 @@ const versionDescription: INodeTypeDescription = {
 					},
 					default: '',
 					description:
-						'Filter tasks by section ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						'Filter tasks by section ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				},
 			],
 		},
@@ -960,7 +960,7 @@ const versionDescription: INodeTypeDescription = {
 					name: 'labels',
 					type: 'multiOptions',
 					description:
-						'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+						'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 					typeOptions: {
 						loadOptionsMethod: 'getLabels',
 					},
@@ -1296,7 +1296,7 @@ const versionDescription: INodeTypeDescription = {
 					},
 					default: '',
 					description:
-						'Filter sections by project. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						'Filter sections by project. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				},
 			],
 		},

--- a/packages/nodes-base/nodes/Twake/Twake.node.ts
+++ b/packages/nodes-base/nodes/Twake/Twake.node.ts
@@ -116,7 +116,7 @@ export class Twake implements INodeType {
 				},
 				default: '',
 				description:
-					'Channel\'s ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Channel\'s ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Content',

--- a/packages/nodes-base/nodes/Twist/ChannelDescription.ts
+++ b/packages/nodes-base/nodes/Twist/ChannelDescription.ts
@@ -79,7 +79,7 @@ export const channelFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The ID of the workspace. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the workspace. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Name',
@@ -197,7 +197,7 @@ export const channelFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The users that will participate in the channel. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The users that will participate in the channel. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -239,7 +239,7 @@ export const channelFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The ID of the workspace. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the workspace. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',

--- a/packages/nodes-base/nodes/Twist/CommentDescription.ts
+++ b/packages/nodes-base/nodes/Twist/CommentDescription.ts
@@ -194,7 +194,7 @@ export const commentFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The users that are directly mentioned. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The users that are directly mentioned. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Mark Thread Position',
@@ -213,7 +213,7 @@ export const commentFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The users that will attached to the comment. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The users that will attached to the comment. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Temporary ID',
@@ -505,7 +505,7 @@ export const commentFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The users that are directly mentioned. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The users that are directly mentioned. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Twist/MessageConversationDescription.ts
+++ b/packages/nodes-base/nodes/Twist/MessageConversationDescription.ts
@@ -67,7 +67,7 @@ export const messageConversationFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The ID of the workspace. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the workspace. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Conversation Name or ID',
@@ -86,7 +86,7 @@ export const messageConversationFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The ID of the conversation. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the conversation. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Content',
@@ -217,7 +217,7 @@ export const messageConversationFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The users that are directly mentioned. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The users that are directly mentioned. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			// {
 			// 	displayName: 'Direct Group Mentions ',
@@ -251,7 +251,7 @@ export const messageConversationFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The ID of the workspace. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the workspace. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Conversation Name or ID',
@@ -270,7 +270,7 @@ export const messageConversationFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'The ID of the conversation. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the conversation. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Additional Fields',
@@ -486,7 +486,7 @@ export const messageConversationFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The users that are directly mentioned. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The users that are directly mentioned. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Twist/ThreadDescription.ts
+++ b/packages/nodes-base/nodes/Twist/ThreadDescription.ts
@@ -208,7 +208,7 @@ export const threadFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The users that are directly mentioned. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The users that are directly mentioned. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Recipient Names or IDs',
@@ -220,7 +220,7 @@ export const threadFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The users that will attached to the thread. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The users that will attached to the thread. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Send as Integration',
@@ -501,7 +501,7 @@ export const threadFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The users that are directly mentioned. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The users that are directly mentioned. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Title',

--- a/packages/nodes-base/nodes/Twitter/V1/TweetDescription.ts
+++ b/packages/nodes-base/nodes/Twitter/V1/TweetDescription.ts
@@ -240,7 +240,7 @@ export const tweetFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Restricts tweets to the given language, given by an ISO 639-1 code. Language detection is best-effort. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Restricts tweets to the given language, given by an ISO 639-1 code. Language detection is best-effort. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Location',

--- a/packages/nodes-base/nodes/Typeform/TypeformTrigger.node.ts
+++ b/packages/nodes-base/nodes/Typeform/TypeformTrigger.node.ts
@@ -93,7 +93,7 @@ export class TypeformTrigger implements INodeType {
 				default: '',
 				required: true,
 				description:
-					'Form which should trigger workflow on submission. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Form which should trigger workflow on submission. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Simplify Answers',

--- a/packages/nodes-base/nodes/Venafi/ProtectCloud/CertificateDescription.ts
+++ b/packages/nodes-base/nodes/Venafi/ProtectCloud/CertificateDescription.ts
@@ -303,7 +303,7 @@ export const certificateFields: INodeProperties[] = [
 		name: 'applicationId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getApplications',
 		},
@@ -332,7 +332,7 @@ export const certificateFields: INodeProperties[] = [
 		name: 'certificateIssuingTemplateId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getCertificateIssuingTemplates',
 		},

--- a/packages/nodes-base/nodes/Venafi/ProtectCloud/CertificateRequestDescription.ts
+++ b/packages/nodes-base/nodes/Venafi/ProtectCloud/CertificateRequestDescription.ts
@@ -44,7 +44,7 @@ export const certificateRequestFields: INodeProperties[] = [
 		name: 'applicationId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getApplications',
 		},
@@ -61,7 +61,7 @@ export const certificateRequestFields: INodeProperties[] = [
 		name: 'certificateIssuingTemplateId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getCertificateIssuingTemplates',
 			loadOptionsDependsOn: ['applicationId'],

--- a/packages/nodes-base/nodes/Venafi/ProtectCloud/VenafiTlsProtectCloudTrigger.node.ts
+++ b/packages/nodes-base/nodes/Venafi/ProtectCloud/VenafiTlsProtectCloudTrigger.node.ts
@@ -51,7 +51,7 @@ export class VenafiTlsProtectCloudTrigger implements INodeType {
 				required: true,
 				default: [],
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				// eslint-disable-next-line n8n-nodes-base/node-param-display-name-wrong-for-dynamic-multi-options
@@ -65,7 +65,7 @@ export class VenafiTlsProtectCloudTrigger implements INodeType {
 				required: true,
 				default: [],
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	};

--- a/packages/nodes-base/nodes/Webflow/V1/ItemDescription.ts
+++ b/packages/nodes-base/nodes/Webflow/V1/ItemDescription.ts
@@ -62,7 +62,7 @@ export const itemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the site containing the collection whose items to add to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the site containing the collection whose items to add to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Collection Name or ID',
@@ -81,7 +81,7 @@ export const itemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the collection to add an item to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the collection to add an item to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Live',
@@ -127,7 +127,7 @@ export const itemFields: INodeProperties[] = [
 						},
 						default: '',
 						description:
-							'Field to set for the item to create. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Field to set for the item to create. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Field Value',
@@ -160,7 +160,7 @@ export const itemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the site containing the collection whose items to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the site containing the collection whose items to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Collection Name or ID',
@@ -179,7 +179,7 @@ export const itemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the collection whose items to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the collection whose items to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Item ID',
@@ -214,7 +214,7 @@ export const itemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the site containing the collection whose items to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the site containing the collection whose items to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Collection Name or ID',
@@ -233,7 +233,7 @@ export const itemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the collection whose items to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the collection whose items to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Item ID',
@@ -293,7 +293,7 @@ export const itemFields: INodeProperties[] = [
 						},
 						default: '',
 						description:
-							'Field to set for the item to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Field to set for the item to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Field Value',
@@ -325,7 +325,7 @@ export const itemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the site containing the collection whose items to retrieve. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the site containing the collection whose items to retrieve. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Collection Name or ID',
@@ -344,7 +344,7 @@ export const itemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the collection whose items to retrieve. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the collection whose items to retrieve. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',

--- a/packages/nodes-base/nodes/Webflow/V1/WebflowTriggerV1.node.ts
+++ b/packages/nodes-base/nodes/Webflow/V1/WebflowTriggerV1.node.ts
@@ -84,7 +84,7 @@ export class WebflowTriggerV1 implements INodeType {
 						loadOptionsMethod: 'getSites',
 					},
 					description:
-						'Site that will trigger the events. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						'Site that will trigger the events. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				},
 				{
 					displayName: 'Event',

--- a/packages/nodes-base/nodes/Webflow/V2/WebflowTriggerV2.node.ts
+++ b/packages/nodes-base/nodes/Webflow/V2/WebflowTriggerV2.node.ts
@@ -54,7 +54,7 @@ export class WebflowTriggerV2 implements INodeType {
 						loadOptionsMethod: 'getSites',
 					},
 					description:
-						'Site that will trigger the events. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						'Site that will trigger the events. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				},
 				{
 					displayName: 'Event',

--- a/packages/nodes-base/nodes/Webflow/V2/actions/Item/create.operation.ts
+++ b/packages/nodes-base/nodes/Webflow/V2/actions/Item/create.operation.ts
@@ -19,7 +19,7 @@ const properties: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'ID of the site containing the collection whose items to add to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the site containing the collection whose items to add to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Collection Name or ID',
@@ -32,7 +32,7 @@ const properties: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'ID of the collection to add an item to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the collection to add an item to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Live',
@@ -66,7 +66,7 @@ const properties: INodeProperties[] = [
 						},
 						default: '',
 						description:
-							'Field to set for the item to create. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Field to set for the item to create. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Field Value',

--- a/packages/nodes-base/nodes/Webflow/V2/actions/Item/delete.operation.ts
+++ b/packages/nodes-base/nodes/Webflow/V2/actions/Item/delete.operation.ts
@@ -19,7 +19,7 @@ const properties: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'ID of the site containing the collection whose items to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the site containing the collection whose items to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Collection Name or ID',
@@ -32,7 +32,7 @@ const properties: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'ID of the collection whose items to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the collection whose items to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Item ID',

--- a/packages/nodes-base/nodes/Webflow/V2/actions/Item/get.operation.ts
+++ b/packages/nodes-base/nodes/Webflow/V2/actions/Item/get.operation.ts
@@ -19,7 +19,7 @@ const properties: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'ID of the site containing the collection whose items to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the site containing the collection whose items to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Collection Name or ID',
@@ -32,7 +32,7 @@ const properties: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'ID of the collection whose items to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the collection whose items to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Item ID',

--- a/packages/nodes-base/nodes/Webflow/V2/actions/Item/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Webflow/V2/actions/Item/getAll.operation.ts
@@ -19,7 +19,7 @@ const properties: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'ID of the site containing the collection whose items to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the site containing the collection whose items to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Collection Name or ID',
@@ -32,7 +32,7 @@ const properties: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'ID of the collection whose items to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the collection whose items to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',

--- a/packages/nodes-base/nodes/Webflow/V2/actions/Item/update.operation.ts
+++ b/packages/nodes-base/nodes/Webflow/V2/actions/Item/update.operation.ts
@@ -19,7 +19,7 @@ const properties: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'ID of the site containing the collection whose items to add to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the site containing the collection whose items to add to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Collection Name or ID',
@@ -32,7 +32,7 @@ const properties: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'ID of the collection to add an item to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the collection to add an item to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Item ID',
@@ -74,7 +74,7 @@ const properties: INodeProperties[] = [
 						},
 						default: '',
 						description:
-							'Field to set for the item to create. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Field to set for the item to create. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Field Value',

--- a/packages/nodes-base/nodes/Wekan/BoardDescription.ts
+++ b/packages/nodes-base/nodes/Wekan/BoardDescription.ts
@@ -79,7 +79,7 @@ export const boardFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The user ID in Wekan. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The user ID in Wekan. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Additional Fields',
@@ -237,7 +237,7 @@ export const boardFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the user that boards are attached. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the user that boards are attached. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',

--- a/packages/nodes-base/nodes/Wekan/CardCommentDescription.ts
+++ b/packages/nodes-base/nodes/Wekan/CardCommentDescription.ts
@@ -61,7 +61,7 @@ export const cardCommentFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the board that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the board that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'List Name or ID',
@@ -80,7 +80,7 @@ export const cardCommentFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Card Name or ID',
@@ -99,7 +99,7 @@ export const cardCommentFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the card. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the card. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Author Name or ID',
@@ -117,7 +117,7 @@ export const cardCommentFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The user who posted the comment. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The user who posted the comment. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Comment',
@@ -153,7 +153,7 @@ export const cardCommentFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the board that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the board that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'List Name or ID',
@@ -172,7 +172,7 @@ export const cardCommentFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Card Name or ID',
@@ -191,7 +191,7 @@ export const cardCommentFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the card. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the card. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Comment Name or ID',
@@ -210,7 +210,7 @@ export const cardCommentFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the comment to delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the comment to delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 
 	// ----------------------------------
@@ -247,7 +247,7 @@ export const cardCommentFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Card Name or ID',
@@ -266,7 +266,7 @@ export const cardCommentFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the card. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the card. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Comment ID',
@@ -302,7 +302,7 @@ export const cardCommentFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the board that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the board that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'List Name or ID',
@@ -321,7 +321,7 @@ export const cardCommentFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Card Name or ID',
@@ -340,7 +340,7 @@ export const cardCommentFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the card. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the card. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',

--- a/packages/nodes-base/nodes/Wekan/CardDescription.ts
+++ b/packages/nodes-base/nodes/Wekan/CardDescription.ts
@@ -68,9 +68,9 @@ export const cardFields: INodeProperties[] = [
 				operation: ['create'],
 				resource: ['card'],
 			},
-		}, // Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>
+		}, // Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>
 		description:
-			'The ID of the board that list belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the board that list belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'List Name or ID',
@@ -89,7 +89,7 @@ export const cardFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the list to create card in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the list to create card in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Title',
@@ -123,14 +123,14 @@ export const cardFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The swimlane ID of the new card. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The swimlane ID of the new card. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Author Name or ID',
 		name: 'authorId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getUsers',
 		},
@@ -165,7 +165,7 @@ export const cardFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The new list of assignee IDs attached to the card. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The new list of assignee IDs attached to the card. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Description',
@@ -183,7 +183,7 @@ export const cardFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The new list of member IDs attached to the card. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The new list of member IDs attached to the card. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -207,7 +207,7 @@ export const cardFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the board that list belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the board that list belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'List Name or ID',
@@ -226,7 +226,7 @@ export const cardFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Card Name or ID',
@@ -245,7 +245,7 @@ export const cardFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the card to delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the card to delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 
 	// ----------------------------------
@@ -267,7 +267,7 @@ export const cardFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the board that list belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the board that list belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'List Name or ID',
@@ -286,7 +286,7 @@ export const cardFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Card ID',
@@ -322,7 +322,7 @@ export const cardFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the board that list belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the board that list belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'From Object',
@@ -365,7 +365,7 @@ export const cardFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Swimlane Name or ID',
@@ -384,7 +384,7 @@ export const cardFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the swimlane that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the swimlane that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',
@@ -437,7 +437,7 @@ export const cardFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the board that list belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the board that list belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'List Name or ID',
@@ -456,7 +456,7 @@ export const cardFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Card Name or ID',
@@ -475,7 +475,7 @@ export const cardFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the card to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the card to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Update Fields',
@@ -499,7 +499,7 @@ export const cardFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Update the owner of the card. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Update the owner of the card. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Assignee Names or IDs',
@@ -510,7 +510,7 @@ export const cardFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The new list of assignee IDs attached to the card. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The new list of assignee IDs attached to the card. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Color',
@@ -659,7 +659,7 @@ export const cardFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The new list ID of the card (move operation). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The new list ID of the card (move operation). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Member Names or IDs',
@@ -670,7 +670,7 @@ export const cardFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The new list of member IDs attached to the card. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The new list of member IDs attached to the card. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Over Time',
@@ -690,7 +690,7 @@ export const cardFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The parent of the card. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The parent of the card. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Received At',
@@ -733,7 +733,7 @@ export const cardFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The new swimlane ID of the card. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The new swimlane ID of the card. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Title',

--- a/packages/nodes-base/nodes/Wekan/ChecklistDescription.ts
+++ b/packages/nodes-base/nodes/Wekan/ChecklistDescription.ts
@@ -64,7 +64,7 @@ export const checklistFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the board where the card is in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the board where the card is in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'List Name or ID',
@@ -83,7 +83,7 @@ export const checklistFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Card Name or ID',
@@ -102,7 +102,7 @@ export const checklistFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the card to add checklist to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the card to add checklist to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Title',
@@ -155,7 +155,7 @@ export const checklistFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the board that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the board that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'List Name or ID',
@@ -174,7 +174,7 @@ export const checklistFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Card Name or ID',
@@ -193,7 +193,7 @@ export const checklistFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the card that checklist belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the card that checklist belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Checklist Name or ID',
@@ -212,7 +212,7 @@ export const checklistFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the checklist to delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the checklist to delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 
 	// ----------------------------------
@@ -234,7 +234,7 @@ export const checklistFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the board that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the board that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'List Name or ID',
@@ -253,7 +253,7 @@ export const checklistFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Card Name or ID',
@@ -272,7 +272,7 @@ export const checklistFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the card that checklist belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the card that checklist belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Checklist Name or ID',
@@ -291,7 +291,7 @@ export const checklistFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the checklist to get. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the checklist to get. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 
 	// ----------------------------------
@@ -313,7 +313,7 @@ export const checklistFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the board that list belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the board that list belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'List Name or ID',
@@ -332,7 +332,7 @@ export const checklistFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Card Name or ID',
@@ -351,7 +351,7 @@ export const checklistFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the card to get checklists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the card to get checklists. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',

--- a/packages/nodes-base/nodes/Wekan/ChecklistItemDescription.ts
+++ b/packages/nodes-base/nodes/Wekan/ChecklistItemDescription.ts
@@ -58,7 +58,7 @@ export const checklistItemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the board that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the board that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'List Name or ID',
@@ -77,7 +77,7 @@ export const checklistItemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Card Name or ID',
@@ -96,7 +96,7 @@ export const checklistItemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the card that checklistItem belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the card that checklistItem belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Checklist Name or ID',
@@ -115,7 +115,7 @@ export const checklistItemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the checklistItem that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the checklistItem that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Checklist Item Name or ID',
@@ -134,7 +134,7 @@ export const checklistItemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the checklistItem item to get. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the checklistItem item to get. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 
 	// ----------------------------------
@@ -156,7 +156,7 @@ export const checklistItemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the board that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the board that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'List Name or ID',
@@ -175,7 +175,7 @@ export const checklistItemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Card Name or ID',
@@ -194,7 +194,7 @@ export const checklistItemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the card that checklistItem belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the card that checklistItem belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Checklist ID',
@@ -227,7 +227,7 @@ export const checklistItemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the checklistItem item to get. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the checklistItem item to get. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 
 	// ----------------------------------
@@ -249,7 +249,7 @@ export const checklistItemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the board that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the board that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'List Name or ID',
@@ -268,7 +268,7 @@ export const checklistItemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the list that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Card Name or ID',
@@ -287,7 +287,7 @@ export const checklistItemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the card that checklistItem belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the card that checklistItem belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'CheckList Name or ID',
@@ -306,7 +306,7 @@ export const checklistItemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the checklistItem that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the checklistItem that card belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Checklist Item Name or ID',
@@ -325,7 +325,7 @@ export const checklistItemFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the checklistItem item to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the checklistItem item to update. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Update Fields',

--- a/packages/nodes-base/nodes/Wekan/ListDescription.ts
+++ b/packages/nodes-base/nodes/Wekan/ListDescription.ts
@@ -64,7 +64,7 @@ export const listFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the board the list should be created in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the board the list should be created in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Title',
@@ -101,7 +101,7 @@ export const listFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the board that list belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the board that list belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'List Name or ID',
@@ -120,7 +120,7 @@ export const listFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the list to delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the list to delete. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 
 	// ----------------------------------
@@ -142,7 +142,7 @@ export const listFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The ID of the board that list belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The ID of the board that list belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'List ID',
@@ -178,7 +178,7 @@ export const listFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'ID of the board where the lists are in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the board where the lists are in. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Return All',

--- a/packages/nodes-base/nodes/Wise/WiseTrigger.node.ts
+++ b/packages/nodes-base/nodes/Wise/WiseTrigger.node.ts
@@ -47,7 +47,7 @@ export class WiseTrigger implements INodeType {
 				name: 'profileId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				required: true,
 				typeOptions: {
 					loadOptionsMethod: 'getProfiles',

--- a/packages/nodes-base/nodes/Wise/descriptions/AccountDescription.ts
+++ b/packages/nodes-base/nodes/Wise/descriptions/AccountDescription.ts
@@ -49,7 +49,7 @@ export const accountFields: INodeProperties[] = [
 			loadOptionsMethod: 'getProfiles',
 		},
 		description:
-			'ID of the user profile to retrieve the balance of. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the user profile to retrieve the balance of. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['account'],
@@ -70,7 +70,7 @@ export const accountFields: INodeProperties[] = [
 			loadOptionsMethod: 'getProfiles',
 		},
 		description:
-			'ID of the user profile whose account to retrieve the statement of. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the user profile whose account to retrieve the statement of. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['account'],
@@ -89,7 +89,7 @@ export const accountFields: INodeProperties[] = [
 			loadOptionsDependsOn: ['profileId'],
 		},
 		description:
-			'ID of the borderless account to retrieve the statement of. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the borderless account to retrieve the statement of. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['account'],

--- a/packages/nodes-base/nodes/Wise/descriptions/ProfileDescription.ts
+++ b/packages/nodes-base/nodes/Wise/descriptions/ProfileDescription.ts
@@ -41,7 +41,7 @@ export const profileFields: INodeProperties[] = [
 			loadOptionsMethod: 'getProfiles',
 		},
 		description:
-			'ID of the user profile to retrieve. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the user profile to retrieve. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['profile'],

--- a/packages/nodes-base/nodes/Wise/descriptions/QuoteDescription.ts
+++ b/packages/nodes-base/nodes/Wise/descriptions/QuoteDescription.ts
@@ -41,7 +41,7 @@ export const quoteFields: INodeProperties[] = [
 			loadOptionsMethod: 'getProfiles',
 		},
 		description:
-			'ID of the user profile to create the quote under. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the user profile to create the quote under. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['quote'],
@@ -59,7 +59,7 @@ export const quoteFields: INodeProperties[] = [
 			loadOptionsMethod: 'getRecipients',
 		},
 		description:
-			'ID of the account that will receive the funds. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the account that will receive the funds. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['quote'],

--- a/packages/nodes-base/nodes/Wise/descriptions/TransferDescription.ts
+++ b/packages/nodes-base/nodes/Wise/descriptions/TransferDescription.ts
@@ -57,7 +57,7 @@ export const transferFields: INodeProperties[] = [
 			loadOptionsDependsOn: ['profileId'],
 		},
 		description:
-			'ID of the user profile to retrieve the balance of. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the user profile to retrieve the balance of. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['transfer'],
@@ -89,7 +89,7 @@ export const transferFields: INodeProperties[] = [
 			loadOptionsMethod: 'getRecipients',
 		},
 		description:
-			'ID of the account that will receive the funds. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the account that will receive the funds. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['transfer'],
@@ -151,7 +151,7 @@ export const transferFields: INodeProperties[] = [
 			loadOptionsMethod: 'getProfiles',
 		},
 		description:
-			'ID of the user profile to execute the transfer under. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the user profile to execute the transfer under. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['transfer'],
@@ -251,7 +251,7 @@ export const transferFields: INodeProperties[] = [
 			loadOptionsMethod: 'getProfiles',
 		},
 		description:
-			'ID of the user profile to retrieve. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the user profile to retrieve. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['transfer'],

--- a/packages/nodes-base/nodes/WooCommerce/ProductDescription.ts
+++ b/packages/nodes-base/nodes/WooCommerce/ProductDescription.ts
@@ -139,7 +139,7 @@ export const productFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'List of categories. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'List of categories. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Cross Sell IDs',
@@ -336,7 +336,7 @@ export const productFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'List of tags. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'List of tags. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Tax Class',
@@ -632,7 +632,7 @@ export const productFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'List of categories. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'List of categories. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Cross Sell IDs',
@@ -836,7 +836,7 @@ export const productFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'List of tags. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'List of tags. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Tax Class',
@@ -1128,7 +1128,7 @@ export const productFields: INodeProperties[] = [
 					loadOptionsMethod: 'getCategories',
 				},
 				description:
-					'Limit result set to products assigned a specific category ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Limit result set to products assigned a specific category ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Context',
@@ -1298,7 +1298,7 @@ export const productFields: INodeProperties[] = [
 					loadOptionsMethod: 'getTags',
 				},
 				description:
-					'Limit result set to products assigned a specific tag ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Limit result set to products assigned a specific tag ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Tax Class',

--- a/packages/nodes-base/nodes/Wordpress/PageDescription.ts
+++ b/packages/nodes-base/nodes/Wordpress/PageDescription.ts
@@ -81,7 +81,7 @@ export const pageFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The ID for the author of the object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The ID for the author of the object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Parent ID',
@@ -296,7 +296,7 @@ export const pageFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The ID for the author of the object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The ID for the author of the object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Parent ID',
@@ -620,7 +620,7 @@ export const pageFields: INodeProperties[] = [
 					loadOptionsMethod: 'getAuthors',
 				},
 				description:
-					'Limit result set to pages assigned to specific authors. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Limit result set to pages assigned to specific authors. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Before',

--- a/packages/nodes-base/nodes/Wordpress/PostDescription.ts
+++ b/packages/nodes-base/nodes/Wordpress/PostDescription.ts
@@ -81,7 +81,7 @@ export const postFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The ID for the author of the object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The ID for the author of the object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Content',
@@ -240,7 +240,7 @@ export const postFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The terms assigned to the object in the category taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The terms assigned to the object in the category taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Tag Names or IDs',
@@ -251,7 +251,7 @@ export const postFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The terms assigned to the object in the post_tag taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The terms assigned to the object in the post_tag taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Template',
@@ -360,7 +360,7 @@ export const postFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The ID for the author of the object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The ID for the author of the object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Title',
@@ -526,7 +526,7 @@ export const postFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The terms assigned to the object in the category taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The terms assigned to the object in the category taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Tag Names or IDs',
@@ -537,7 +537,7 @@ export const postFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The terms assigned to the object in the post_tag taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The terms assigned to the object in the post_tag taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Template',
@@ -731,7 +731,7 @@ export const postFields: INodeProperties[] = [
 					loadOptionsMethod: 'getAuthors',
 				},
 				description:
-					'Limit result set to posts assigned to specific authors. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Limit result set to posts assigned to specific authors. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Before',
@@ -749,7 +749,7 @@ export const postFields: INodeProperties[] = [
 					loadOptionsMethod: 'getCategories',
 				},
 				description:
-					'Limit result set to all items that have the specified term assigned in the categories taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Limit result set to all items that have the specified term assigned in the categories taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Context',
@@ -782,7 +782,7 @@ export const postFields: INodeProperties[] = [
 					loadOptionsMethod: 'getCategories',
 				},
 				description:
-					'Limit result set to all items except those that have the specified term assigned in the categories taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Limit result set to all items except those that have the specified term assigned in the categories taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				// eslint-disable-next-line n8n-nodes-base/node-param-display-name-wrong-for-dynamic-multi-options
@@ -794,7 +794,7 @@ export const postFields: INodeProperties[] = [
 					loadOptionsMethod: 'getTags',
 				},
 				description:
-					'Limit result set to all items except those that have the specified term assigned in the tags taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Limit result set to all items except those that have the specified term assigned in the tags taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Order',
@@ -914,7 +914,7 @@ export const postFields: INodeProperties[] = [
 					loadOptionsMethod: 'getTags',
 				},
 				description:
-					'Limit result set to all items that have the specified term assigned in the tags taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Limit result set to all items that have the specified term assigned in the tags taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Workable/WorkableTrigger.node.ts
+++ b/packages/nodes-base/nodes/Workable/WorkableTrigger.node.ts
@@ -76,7 +76,7 @@ export class WorkableTrigger implements INodeType {
 						},
 						default: '',
 						description:
-							'Get notifications only for one job. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Get notifications only for one job. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Stage Name or ID',
@@ -87,7 +87,7 @@ export class WorkableTrigger implements INodeType {
 						},
 						default: '',
 						description:
-							'Get notifications for specific stages. e.g. \'hired\'. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'Get notifications for specific stages. e.g. \'hired\'. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 					},
 				],
 			},

--- a/packages/nodes-base/nodes/Wufoo/WufooTrigger.node.ts
+++ b/packages/nodes-base/nodes/Wufoo/WufooTrigger.node.ts
@@ -53,7 +53,7 @@ export class WufooTrigger implements INodeType {
 					loadOptionsMethod: 'getForms',
 				},
 				description:
-					'The form upon which will trigger this node when a new entry is made. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The form upon which will trigger this node when a new entry is made. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Only Answers',

--- a/packages/nodes-base/nodes/Xero/ContactDescription.ts
+++ b/packages/nodes-base/nodes/Xero/ContactDescription.ts
@@ -50,7 +50,7 @@ export const contactFields: INodeProperties[] = [
 		name: 'organizationId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTenants',
 		},
@@ -309,7 +309,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The default purchases account code for contacts. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The default purchases account code for contacts. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Sales Default Account Code Name or ID',
@@ -320,7 +320,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The default sales account code for contacts. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The default sales account code for contacts. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Skype',
@@ -353,7 +353,7 @@ export const contactFields: INodeProperties[] = [
 		name: 'organizationId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTenants',
 		},
@@ -387,7 +387,7 @@ export const contactFields: INodeProperties[] = [
 		name: 'organizationId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTenants',
 		},
@@ -494,7 +494,7 @@ export const contactFields: INodeProperties[] = [
 		name: 'organizationId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTenants',
 		},
@@ -759,7 +759,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The default purchases account code for contacts. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The default purchases account code for contacts. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Sales Default Account Code Name or ID',
@@ -770,7 +770,7 @@ export const contactFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The default sales account code for contacts. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The default sales account code for contacts. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Skype',

--- a/packages/nodes-base/nodes/Xero/InvoiceDescription.ts
+++ b/packages/nodes-base/nodes/Xero/InvoiceDescription.ts
@@ -50,7 +50,7 @@ export const invoiceFields: INodeProperties[] = [
 		name: 'organizationId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTenants',
 		},
@@ -153,7 +153,7 @@ export const invoiceFields: INodeProperties[] = [
 						name: 'itemCode',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getItemCodes',
 							loadOptionsDependsOn: ['organizationId'],
@@ -165,7 +165,7 @@ export const invoiceFields: INodeProperties[] = [
 						name: 'accountCode',
 						type: 'options',
 						description:
-							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+							'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 						typeOptions: {
 							loadOptionsMethod: 'getAccountCodes',
 							loadOptionsDependsOn: ['organizationId'],
@@ -288,7 +288,7 @@ export const invoiceFields: INodeProperties[] = [
 				name: 'brandingThemeId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getBrandingThemes',
 					loadOptionsDependsOn: ['organizationId'],
@@ -300,7 +300,7 @@ export const invoiceFields: INodeProperties[] = [
 				name: 'currency',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getCurrencies',
 					loadOptionsDependsOn: ['organizationId'],
@@ -425,7 +425,7 @@ export const invoiceFields: INodeProperties[] = [
 		name: 'organizationId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTenants',
 		},
@@ -469,7 +469,7 @@ export const invoiceFields: INodeProperties[] = [
 				name: 'brandingThemeId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getBrandingThemes',
 					loadOptionsDependsOn: ['organizationId'],
@@ -487,7 +487,7 @@ export const invoiceFields: INodeProperties[] = [
 				name: 'currency',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getCurrencies',
 					loadOptionsDependsOn: ['organizationId'],
@@ -605,7 +605,7 @@ export const invoiceFields: INodeProperties[] = [
 								name: 'itemCode',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								typeOptions: {
 									loadOptionsMethod: 'getItemCodes',
 									loadOptionsDependsOn: ['organizationId'],
@@ -617,7 +617,7 @@ export const invoiceFields: INodeProperties[] = [
 								name: 'accountCode',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								typeOptions: {
 									loadOptionsMethod: 'getAccountCodes',
 									loadOptionsDependsOn: ['organizationId'],
@@ -781,7 +781,7 @@ export const invoiceFields: INodeProperties[] = [
 		name: 'organizationId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTenants',
 		},
@@ -815,7 +815,7 @@ export const invoiceFields: INodeProperties[] = [
 		name: 'organizationId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getTenants',
 		},

--- a/packages/nodes-base/nodes/Zammad/descriptions/GroupDescription.ts
+++ b/packages/nodes-base/nodes/Zammad/descriptions/GroupDescription.ts
@@ -70,7 +70,7 @@ export const groupDescription: INodeProperties[] = [
 		name: 'id',
 		type: 'string',
 		description:
-			'Group to update. Specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Group to update. Specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		default: '',
 		required: true,
 		displayOptions: {
@@ -85,7 +85,7 @@ export const groupDescription: INodeProperties[] = [
 		name: 'id',
 		type: 'string',
 		description:
-			'Group to delete. Specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Group to delete. Specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		default: '',
 		required: true,
 		displayOptions: {
@@ -100,7 +100,7 @@ export const groupDescription: INodeProperties[] = [
 		name: 'id',
 		type: 'string',
 		description:
-			'Group to retrieve. Specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Group to retrieve. Specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		default: '',
 		required: true,
 		displayOptions: {
@@ -153,7 +153,7 @@ export const groupDescription: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Name of the custom field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Name of the custom field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Field Value',
@@ -216,7 +216,7 @@ export const groupDescription: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Name of the custom field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Name of the custom field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Field Value',

--- a/packages/nodes-base/nodes/Zammad/descriptions/OrganizationDescription.ts
+++ b/packages/nodes-base/nodes/Zammad/descriptions/OrganizationDescription.ts
@@ -70,7 +70,7 @@ export const organizationDescription: INodeProperties[] = [
 		name: 'id',
 		type: 'string',
 		description:
-			'Organization to update. Specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Organization to update. Specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		default: '',
 		required: true,
 		displayOptions: {
@@ -85,7 +85,7 @@ export const organizationDescription: INodeProperties[] = [
 		name: 'id',
 		type: 'string',
 		description:
-			'Organization to delete. Specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Organization to delete. Specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		default: '',
 		required: true,
 		displayOptions: {
@@ -100,7 +100,7 @@ export const organizationDescription: INodeProperties[] = [
 		name: 'id',
 		type: 'string',
 		description:
-			'Organization to retrieve. Specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Organization to retrieve. Specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		default: '',
 		required: true,
 		displayOptions: {
@@ -188,7 +188,7 @@ export const organizationDescription: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Name of the custom field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Name of the custom field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -281,7 +281,7 @@ export const organizationDescription: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Name of the custom field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Name of the custom field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',

--- a/packages/nodes-base/nodes/Zammad/descriptions/TicketDescription.ts
+++ b/packages/nodes-base/nodes/Zammad/descriptions/TicketDescription.ts
@@ -69,7 +69,7 @@ export const ticketDescription: INodeProperties[] = [
 		},
 		placeholder: 'First-Level Helpdesk',
 		description:
-			'Group that will own the ticket to create. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Group that will own the ticket to create. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		default: '',
 		required: true,
 		displayOptions: {
@@ -87,7 +87,7 @@ export const ticketDescription: INodeProperties[] = [
 			loadOptionsMethod: 'loadCustomerEmails',
 		},
 		description:
-			'Email address of the customer concerned in the ticket to create. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Email address of the customer concerned in the ticket to create. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		default: '',
 		placeholder: 'hello@n8n.io',
 		required: true,
@@ -103,7 +103,7 @@ export const ticketDescription: INodeProperties[] = [
 		name: 'id',
 		type: 'string',
 		description:
-			'Ticket to retrieve. Specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Ticket to retrieve. Specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		default: '',
 		required: true,
 		displayOptions: {
@@ -119,7 +119,7 @@ export const ticketDescription: INodeProperties[] = [
 		type: 'string',
 		default: '',
 		description:
-			'Ticket to delete. Specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'Ticket to delete. Specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		required: true,
 		displayOptions: {
 			show: {
@@ -277,7 +277,7 @@ export const ticketDescription: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Name of the custom field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Name of the custom field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',

--- a/packages/nodes-base/nodes/Zammad/descriptions/UserDescription.ts
+++ b/packages/nodes-base/nodes/Zammad/descriptions/UserDescription.ts
@@ -91,7 +91,7 @@ export const userDescription: INodeProperties[] = [
 		name: 'id',
 		type: 'string',
 		description:
-			'User to update. Specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'User to update. Specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		default: '',
 		required: true,
 		displayOptions: {
@@ -106,7 +106,7 @@ export const userDescription: INodeProperties[] = [
 		name: 'id',
 		type: 'string',
 		description:
-			'User to delete. Specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'User to delete. Specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		default: '',
 		required: true,
 		displayOptions: {
@@ -121,7 +121,7 @@ export const userDescription: INodeProperties[] = [
 		name: 'id',
 		type: 'string',
 		description:
-			'User to retrieve. Specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'User to retrieve. Specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		default: '',
 		required: true,
 		displayOptions: {
@@ -216,7 +216,7 @@ export const userDescription: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Name of the custom field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Name of the custom field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Field Value',
@@ -261,7 +261,7 @@ export const userDescription: INodeProperties[] = [
 				name: 'organization',
 				type: 'options',
 				description:
-					'Name of the organization to assign to the user. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Name of the organization to assign to the user. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'loadOrganizations',
@@ -389,7 +389,7 @@ export const userDescription: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Name of the custom field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Name of the custom field to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Field Value',
@@ -448,7 +448,7 @@ export const userDescription: INodeProperties[] = [
 				name: 'organization',
 				type: 'options',
 				description:
-					'Name of the organization to assign to the user. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Name of the organization to assign to the user. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'loadOrganizationNames',
@@ -587,7 +587,7 @@ export const userDescription: INodeProperties[] = [
 								name: 'sort_by',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								typeOptions: {
 									loadOptionsMethod: 'loadUserFields',
 								},

--- a/packages/nodes-base/nodes/Zendesk/ConditionDescription.ts
+++ b/packages/nodes-base/nodes/Zendesk/ConditionDescription.ts
@@ -256,7 +256,7 @@ export const conditionFields: INodeProperties[] = [
 		name: 'value',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getGroups',
 		},
@@ -276,7 +276,7 @@ export const conditionFields: INodeProperties[] = [
 		name: 'value',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsMethod: 'getUsers',
 		},

--- a/packages/nodes-base/nodes/Zendesk/OrganizationDescription.ts
+++ b/packages/nodes-base/nodes/Zendesk/OrganizationDescription.ts
@@ -129,7 +129,7 @@ export const organizationFields: INodeProperties[] = [
 								name: 'field',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								typeOptions: {
 									loadOptionsMethod: 'getOrganizationFields',
 								},
@@ -154,7 +154,7 @@ export const organizationFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'IDs of tags applied to this organization. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'IDs of tags applied to this organization. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -233,7 +233,7 @@ export const organizationFields: INodeProperties[] = [
 								name: 'field',
 								type: 'options',
 								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 								typeOptions: {
 									loadOptionsMethod: 'getOrganizationFields',
 								},
@@ -258,7 +258,7 @@ export const organizationFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'IDs of tags applied to this organization. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'IDs of tags applied to this organization. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Zendesk/TicketDescription.ts
+++ b/packages/nodes-base/nodes/Zendesk/TicketDescription.ts
@@ -120,7 +120,7 @@ export const ticketFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Custom field ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Custom field ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -149,7 +149,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The group this ticket is assigned to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The group this ticket is assigned to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Recipient',
@@ -207,7 +207,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The array of tags applied to this ticket. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The array of tags applied to this ticket. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Type',
@@ -327,7 +327,7 @@ export const ticketFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Custom field ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Custom field ID. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -356,7 +356,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The group this ticket is assigned to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The group this ticket is assigned to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Internal Note',
@@ -428,7 +428,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The array of tags applied to this ticket. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The array of tags applied to this ticket. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Type',
@@ -591,7 +591,7 @@ export const ticketFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The group to search. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The group to search. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Query',

--- a/packages/nodes-base/nodes/Zendesk/UserDescription.ts
+++ b/packages/nodes-base/nodes/Zendesk/UserDescription.ts
@@ -142,7 +142,7 @@ export const userFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The user\'s locale. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The user\'s locale. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Moderator',
@@ -174,7 +174,7 @@ export const userFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'The ID of the user\'s organization. If the user has more than one organization memberships, the ID of the user\'s default organization. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The ID of the user\'s organization. If the user has more than one organization memberships, the ID of the user\'s default organization. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Phone',
@@ -244,7 +244,7 @@ export const userFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The array of tags applied to this user. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The array of tags applied to this user. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Ticket Restriction',
@@ -302,7 +302,7 @@ export const userFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Name of the field to sort on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Name of the field to sort on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',
@@ -399,7 +399,7 @@ export const userFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The user\'s locale. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The user\'s locale. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Moderator',
@@ -438,7 +438,7 @@ export const userFields: INodeProperties[] = [
 				type: 'options',
 				default: '',
 				description:
-					'The ID of the user\'s organization. If the user has more than one organization memberships, the ID of the user\'s default organization. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The ID of the user\'s organization. If the user has more than one organization memberships, the ID of the user\'s default organization. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Phone',
@@ -508,7 +508,7 @@ export const userFields: INodeProperties[] = [
 				},
 				default: [],
 				description:
-					'The array of tags applied to this user. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The array of tags applied to this user. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Ticket Restriction',
@@ -566,7 +566,7 @@ export const userFields: INodeProperties[] = [
 								},
 								default: '',
 								description:
-									'Name of the field to sort on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+									'Name of the field to sort on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 							},
 							{
 								displayName: 'Value',

--- a/packages/nodes-base/nodes/Zendesk/ZendeskTrigger.node.ts
+++ b/packages/nodes-base/nodes/Zendesk/ZendeskTrigger.node.ts
@@ -101,7 +101,7 @@ export class ZendeskTrigger implements INodeType {
 						displayName: 'Field Names or IDs',
 						name: 'fields',
 						description:
-							'The fields to return the values of. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+							'The fields to return the values of. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 						type: 'multiOptions',
 						default: [],
 						typeOptions: {

--- a/packages/nodes-base/nodes/Zoho/descriptions/AccountDescription.ts
+++ b/packages/nodes-base/nodes/Zoho/descriptions/AccountDescription.ts
@@ -132,7 +132,7 @@ export const accountFields: INodeProperties[] = [
 				name: 'Account_Type',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getAccountType',
 				},
@@ -309,7 +309,7 @@ export const accountFields: INodeProperties[] = [
 				name: 'Account_Type',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getAccountType',
 				},

--- a/packages/nodes-base/nodes/Zoho/descriptions/DealDescription.ts
+++ b/packages/nodes-base/nodes/Zoho/descriptions/DealDescription.ts
@@ -99,7 +99,7 @@ export const dealFields: INodeProperties[] = [
 		name: 'stage',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		required: true,
 		default: [],
 		typeOptions: {
@@ -343,7 +343,7 @@ export const dealFields: INodeProperties[] = [
 				name: 'Stage',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getDealStage',
 				},

--- a/packages/nodes-base/nodes/Zoho/descriptions/InvoiceDescription.ts
+++ b/packages/nodes-base/nodes/Zoho/descriptions/InvoiceDescription.ts
@@ -143,7 +143,7 @@ export const invoiceFields: INodeProperties[] = [
 					loadOptionsMethod: 'getAccounts',
 				},
 				description:
-					'ID of the account associated with this invoice. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the account associated with this invoice. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Adjustment',
@@ -319,7 +319,7 @@ export const invoiceFields: INodeProperties[] = [
 					loadOptionsMethod: 'getAccounts',
 				},
 				description:
-					'ID of the account associated with this invoice. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the account associated with this invoice. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Adjustment',

--- a/packages/nodes-base/nodes/Zoho/descriptions/PurchaseOrderDescription.ts
+++ b/packages/nodes-base/nodes/Zoho/descriptions/PurchaseOrderDescription.ts
@@ -112,7 +112,7 @@ export const purchaseOrderFields: INodeProperties[] = [
 			loadOptionsMethod: 'getVendors',
 		},
 		description:
-			'ID of the vendor associated with the purchase order. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'ID of the vendor associated with the purchase order. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 		displayOptions: {
 			show: {
 				resource: ['purchaseOrder'],
@@ -299,7 +299,7 @@ export const purchaseOrderFields: INodeProperties[] = [
 					loadOptionsMethod: 'getPurchaseOrderStatus',
 				},
 				description:
-					'Status of the purchase order. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Status of the purchase order. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Sub Total',
@@ -512,7 +512,7 @@ export const purchaseOrderFields: INodeProperties[] = [
 					loadOptionsMethod: 'getPurchaseOrderStatus',
 				},
 				description:
-					'Status of the purchase order. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Status of the purchase order. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Sub Total',

--- a/packages/nodes-base/nodes/Zoho/descriptions/QuoteDescription.ts
+++ b/packages/nodes-base/nodes/Zoho/descriptions/QuoteDescription.ts
@@ -195,7 +195,7 @@ export const quoteFields: INodeProperties[] = [
 					loadOptionsMethod: 'getQuoteStage',
 				},
 				description:
-					'Stage of the quote. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Stage of the quote. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			shippingAddress,
 			{
@@ -374,7 +374,7 @@ export const quoteFields: INodeProperties[] = [
 					loadOptionsMethod: 'getQuoteStage',
 				},
 				description:
-					'Stage of the quote. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Stage of the quote. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			shippingAddress,
 			{

--- a/packages/nodes-base/nodes/Zoho/descriptions/SalesOrderDescription.ts
+++ b/packages/nodes-base/nodes/Zoho/descriptions/SalesOrderDescription.ts
@@ -72,7 +72,7 @@ export const salesOrderFields: INodeProperties[] = [
 		required: true,
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: [],
 		typeOptions: {
 			loadOptionsMethod: 'getAccounts',
@@ -179,7 +179,7 @@ export const salesOrderFields: INodeProperties[] = [
 				name: 'contactId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getContacts',
@@ -199,7 +199,7 @@ export const salesOrderFields: INodeProperties[] = [
 				name: 'dealId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getDeals',
@@ -275,7 +275,7 @@ export const salesOrderFields: INodeProperties[] = [
 					loadOptionsMethod: 'getSalesOrderStatus',
 				},
 				description:
-					'Status of the sales order. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Status of the sales order. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Sub Total',
@@ -387,7 +387,7 @@ export const salesOrderFields: INodeProperties[] = [
 					loadOptionsMethod: 'getAccounts',
 				},
 				description:
-					'ID of the account associated with this invoice. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the account associated with this invoice. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Adjustment',
@@ -412,7 +412,7 @@ export const salesOrderFields: INodeProperties[] = [
 				name: 'contactId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getContacts',
@@ -432,7 +432,7 @@ export const salesOrderFields: INodeProperties[] = [
 				name: 'dealId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 				default: [],
 				typeOptions: {
 					loadOptionsMethod: 'getDeals',
@@ -507,7 +507,7 @@ export const salesOrderFields: INodeProperties[] = [
 					loadOptionsMethod: 'getSalesOrderStatus',
 				},
 				description:
-					'Status of the sales order. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Status of the sales order. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Sub Total',

--- a/packages/nodes-base/nodes/Zoho/descriptions/SharedFields.ts
+++ b/packages/nodes-base/nodes/Zoho/descriptions/SharedFields.ts
@@ -259,7 +259,7 @@ export const productDetailsOptions: INodeProperties[] = [
 		name: 'id',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>',
 		default: [],
 		typeOptions: {
 			loadOptionsMethod: 'getProducts',

--- a/packages/nodes-base/nodes/Zoom/MeetingDescription.ts
+++ b/packages/nodes-base/nodes/Zoom/MeetingDescription.ts
@@ -254,7 +254,7 @@ export const meetingFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Time zone used in the response. The default is the time zone of the calendar. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Time zone used in the response. The default is the time zone of the calendar. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Type',
@@ -655,7 +655,7 @@ export const meetingFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Time zone used in the response. The default is the time zone of the calendar. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Time zone used in the response. The default is the time zone of the calendar. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Topic',

--- a/packages/nodes-base/nodes/Zoom/WebinarDescription.ts
+++ b/packages/nodes-base/nodes/Zoom/WebinarDescription.ts
@@ -229,7 +229,7 @@ export const webinarFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Time zone used in the response. The default is the time zone of the calendar. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Time zone used in the response. The default is the time zone of the calendar. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Webinar Topic',
@@ -576,7 +576,7 @@ export const webinarFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'Time zone used in the response. The default is the time zone of the calendar. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'Time zone used in the response. The default is the time zone of the calendar. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Webinar Topic',

--- a/packages/nodes-base/nodes/Zulip/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Zulip/MessageDescription.ts
@@ -73,7 +73,7 @@ export const messageFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The destination stream, or a comma-separated list containing the usernames (emails) of the recipients. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The destination stream, or a comma-separated list containing the usernames (emails) of the recipients. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Content',
@@ -108,7 +108,7 @@ export const messageFields: INodeProperties[] = [
 			},
 		},
 		description:
-			'The destination stream, or a comma-separated list containing the usernames (emails) of the recipients. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The destination stream, or a comma-separated list containing the usernames (emails) of the recipients. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Topic Name or ID',
@@ -127,7 +127,7 @@ export const messageFields: INodeProperties[] = [
 		},
 		default: '',
 		description:
-			'The topic of the message. Only required if type is stream, ignored otherwise. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			'The topic of the message. Only required if type is stream, ignored otherwise. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/data/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Content',


### PR DESCRIPTION
## Summary

This PR fixes a broken link towards documentation that has 1913 occurences in the codebase.

Broken link currently giving a 404 from multiple places in the UI: https://docs.n8n.io/code/expressions/
Correct link: https://docs.n8n.io/data/expressions/

## Related Linear tickets, Github issues, and Community forum posts

Closes https://linear.app/n8n/issue/DOC-1787/
Resolves https://github.com/n8n-io/n8n-docs/issues/4374

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
I have not carried out any tests. Please let me know if I need to do so.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
