### PR TITLE
fix(editor):  Fix type mismatch

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/linter.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/linter.ts
@@ -580,7 +580,7 @@ export const useLinter = (
 		 *
 		 * $("myNode").item -> $("myNode").first()
 		 */
-		if (toValue(mode) === 'runOnceForEachItem') {
+		if (toValue(mode) === 'runOnceForAllItems') {
 			type DollarItemNode = RangeNode & {
 				property: { name: string; type: string } & RangeNode;
 			};

--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/typescript/worker/type-declarations/n8n-once-for-each-item.d.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/typescript/worker/type-declarations/n8n-once-for-each-item.d.ts
@@ -5,6 +5,7 @@ declare global {
 		context: C;
 		item: N8nItem<J, B>;
 		params: P;
+		first(branchIndex?: number, runIndex?: number): J & N8nJson;
 	}
 
 	// @ts-expect-error N8nInputJson is populated dynamically


### PR DESCRIPTION
## Summary

updated the type declaration for once-for-each-item

fixed: wrong linting path


| Before  | After |
| ------------- | ------------- |
| <img width="1494" height="1230" alt="image" src="https://github.com/user-attachments/assets/76f201fb-a8c3-4a43-98c6-88f0ea56cc19" /> | <img width="534" height="433" alt="image" src="https://github.com/user-attachments/assets/fad6db29-d412-4f56-a16f-96880d6688e7" /> |


<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1689/incorrect-tooltip-in-code-node-js-recommends-using-first-when-node-is

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
