### PR TITLE
test: fix scope-lockdown violations in page objects

### DIFF
--- a/packages/testing/playwright/pages/CommunityNodesPage.ts
+++ b/packages/testing/playwright/pages/CommunityNodesPage.ts
@@ -3,6 +3,10 @@ import type { Locator } from '@playwright/test';
 import { BasePage } from './BasePage';
 
 export class CommunityNodesPage extends BasePage {
+	async goto(): Promise<void> {
+		await this.page.goto('/settings/community-nodes');
+	}
+
 	// Element getters
 	getCommunityCards(): Locator {
 		return this.page.getByTestId('community-package-card');

--- a/packages/testing/playwright/pages/SettingsEnvironmentPage.ts
+++ b/packages/testing/playwright/pages/SettingsEnvironmentPage.ts
@@ -3,6 +3,10 @@ import { expect, type Locator } from '@playwright/test';
 import { BasePage } from './BasePage';
 
 export class SettingsEnvironmentPage extends BasePage {
+	async goto(): Promise<void> {
+		await this.page.goto('/settings/environments');
+	}
+
 	getConnectButton(): Locator {
 		return this.page.getByTestId('source-control-connect-button');
 	}

--- a/packages/testing/playwright/pages/SettingsLogStreamingPage.ts
+++ b/packages/testing/playwright/pages/SettingsLogStreamingPage.ts
@@ -3,6 +3,10 @@ import type { Locator } from '@playwright/test';
 import { BasePage } from './BasePage';
 
 export class SettingsLogStreamingPage extends BasePage {
+	async goto(): Promise<void> {
+		await this.page.goto('/settings/log-streaming');
+	}
+
 	getActionBoxUnlicensed(): Locator {
 		return this.page.getByTestId('action-box-unlicensed');
 	}

--- a/packages/testing/playwright/pages/SettingsUsersPage.ts
+++ b/packages/testing/playwright/pages/SettingsUsersPage.ts
@@ -3,6 +3,10 @@ import type { Locator } from '@playwright/test';
 import { BasePage } from './BasePage';
 
 export class SettingsUsersPage extends BasePage {
+	async goto(): Promise<void> {
+		await this.page.goto('/settings/users');
+	}
+
 	getSearchInput(): Locator {
 		return this.page.getByTestId('users-list-search');
 	}

--- a/packages/testing/playwright/pages/TemplatesPage.ts
+++ b/packages/testing/playwright/pages/TemplatesPage.ts
@@ -3,6 +3,10 @@ import type { Locator } from '@playwright/test';
 import { BasePage } from './BasePage';
 
 export class TemplatesPage extends BasePage {
+	async goto(): Promise<void> {
+		await this.page.goto('/templates');
+	}
+
 	getPageHeading(): Locator {
 		return this.page.getByRole('heading', { name: /workflow.*templates/i });
 	}

--- a/packages/testing/playwright/pages/VariablesPage.ts
+++ b/packages/testing/playwright/pages/VariablesPage.ts
@@ -4,6 +4,10 @@ import { BasePage } from './BasePage';
 import { VariableModal } from './components/VariableModal';
 
 export class VariablesPage extends BasePage {
+	async goto(): Promise<void> {
+		await this.page.goto('/variables');
+	}
+
 	readonly variableModal = new VariableModal(this.page.getByTestId('variableModal-modal'));
 
 	getUnavailableResourcesList() {

--- a/packages/testing/playwright/pages/WorkflowActivationModal.ts
+++ b/packages/testing/playwright/pages/WorkflowActivationModal.ts
@@ -3,8 +3,12 @@ import type { Locator } from '@playwright/test';
 import { BasePage } from './BasePage';
 
 export class WorkflowActivationModal extends BasePage {
-	getModal(): Locator {
+	get container(): Locator {
 		return this.page.getByTestId('activation-modal');
+	}
+
+	getModal(): Locator {
+		return this.container;
 	}
 
 	getDontShowAgainCheckbox(): Locator {


### PR DESCRIPTION
## Summary
- Add `goto()` navigation methods to 6 page objects that were flagged as ambiguous by the Playwright janitor (`scope-lockdown` rule): `SettingsUsersPage`, `SettingsLogStreamingPage`, `SettingsEnvironmentPage`, `CommunityNodesPage`, `TemplatesPage`, `VariablesPage`
- Add `get container()` getter to `WorkflowActivationModal` to explicitly declare it as a scoped component
- Reduces total janitor violations from 507 → 500

## Test plan
- [x] Janitor rules pass on all changed files (no new violations)
- [x] TypeScript typecheck passes
- [x] Affected E2E test (`production-checklist.spec.ts`) passes via TCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)