### PR TITLE
fix(editor): Fix stop button size mismatch in split-trigger mode

### DIFF
--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -101,6 +101,7 @@ import { useTagsStore } from '@/features/shared/tags/tags.store';
 
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { getBounds, getNodeViewTab } from '@/app/utils/nodeViewUtils';
+import { isChatNode } from '@/app/utils/aiUtils';
 import CanvasStopCurrentExecutionButton from '@/features/workflows/canvas/components/elements/buttons/CanvasStopCurrentExecutionButton.vue';
 import CanvasStopWaitingForWebhookButton from '@/features/workflows/canvas/components/elements/buttons/CanvasStopWaitingForWebhookButton.vue';
 import { nodeViewEventBus } from '@/app/event-bus';
@@ -403,6 +404,13 @@ const containsTriggerNodes = computed(() => triggerNodes.value.length > 0);
 const allTriggerNodesDisabled = computed(() => {
 	const disabledTriggerNodes = triggerNodes.value.filter((node) => node.disabled);
 	return disabledTriggerNodes.length === triggerNodes.value.length;
+});
+
+const isRunButtonSplit = computed(() => {
+	const selectableTriggerNodes = triggerNodes.value.filter(
+		(node) => !node.disabled && !isChatNode(node),
+	);
+	return selectableTriggerNodes.length > 1 && workflowsStore.selectedTriggerNodeName !== undefined;
 });
 
 function onTidyUp(
@@ -1864,10 +1872,12 @@ onBeforeUnmount(() => {
 				<CanvasStopCurrentExecutionButton
 					v-if="isStopExecutionButtonVisible"
 					:stopping="isStoppingExecution"
+					:size="isRunButtonSplit ? 'xlarge' : 'large'"
 					@click="onStopExecution"
 				/>
 				<CanvasStopWaitingForWebhookButton
 					v-if="isStopWaitingForWebhookButtonVisible"
+					:size="isRunButtonSplit ? 'xlarge' : 'large'"
 					@click="onStopWaitingForWebhook"
 				/>
 			</div>

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasRunWorkflowButton.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasRunWorkflowButton.vue
@@ -160,7 +160,7 @@ function getNodeTypeByName(name: string): INodeTypeDescription | null {
 
 .button {
 	.split & {
-		height: var(--spacing--2xl);
+		height: var(--height--xl);
 
 		padding-inline-start: var(--spacing--xs);
 		padding-block: 0;
@@ -170,7 +170,7 @@ function getNodeTypeByName(name: string): INodeTypeDescription | null {
 
 	.split &[data-icon-only] {
 		padding-inline-start: 0;
-		width: var(--spacing--2xl);
+		width: var(--height--xl);
 	}
 }
 
@@ -181,7 +181,7 @@ function getNodeTypeByName(name: string): INodeTypeDescription | null {
 
 .chevron {
 	width: 40px;
-	height: var(--spacing--2xl);
+	height: var(--height--xl);
 	border-top-left-radius: 0;
 	border-bottom-left-radius: 0;
 }

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasStopCurrentExecutionButton.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasStopCurrentExecutionButton.vue
@@ -5,6 +5,7 @@ import { computed } from 'vue';
 import { N8nIconButton } from '@n8n/design-system';
 const props = defineProps<{
 	stopping?: boolean;
+	size?: 'small' | 'medium' | 'large' | 'xlarge';
 }>();
 
 const i18n = useI18n();
@@ -20,7 +21,7 @@ const title = computed(() =>
 	<N8nIconButton
 		variant="subtle"
 		icon="square"
-		size="large"
+		:size="size ?? 'large'"
 		class="stop-execution"
 		:title="title"
 		:loading="stopping"

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasStopWaitingForWebhookButton.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasStopWaitingForWebhookButton.vue
@@ -2,6 +2,9 @@
 import { useI18n } from '@n8n/i18n';
 
 import { N8nIconButton } from '@n8n/design-system';
+const props = defineProps<{
+	size?: 'small' | 'medium' | 'large' | 'xlarge';
+}>();
 const i18n = useI18n();
 </script>
 <template>
@@ -9,7 +12,7 @@ const i18n = useI18n();
 		variant="subtle"
 		class="stop-execution"
 		icon="square"
-		size="large"
+		:size="props.size ?? 'large'"
 		:title="i18n.baseText('nodeView.stopWaitingForWebhookCall')"
 		data-test-id="stop-execution-waiting-for-webhook-button"
 	/>


### PR DESCRIPTION
## Summary

When a workflow has multiple selectable trigger nodes, the run button enters "split mode" with a CSS height override of \`var(--spacing--2xl)\` (48px). The stop buttons always used \`size="large"\` (36px), causing a visible height mismatch when both buttons are visible simultaneously during execution.

**Fix:**
- Changed split mode height in \`CanvasRunWorkflowButton\` from 48px → 40px (\`var(--height--xl)\`)
- Added optional \`size\` prop to \`CanvasStopCurrentExecutionButton\` and \`CanvasStopWaitingForWebhookButton\`
- In \`NodeView\`, compute \`isRunButtonSplit\` and pass \`xlarge\` size to stop buttons when in split mode

| Mode | Before | After |
|------|--------|-------|
| Single trigger + executing | ✅ both 36px | ✅ both 36px |
| Multiple triggers + executing | ❌ run 48px / stop 36px | ✅ both 40px |

Before:
<img width="1420" height="1402" alt="grafik" src="https://github.com/user-attachments/assets/88381e71-6459-4d66-82c5-89a07dc8ee66" />


After:
<img width="589" height="680" alt="grafik" src="https://github.com/user-attachments/assets/0b024a6e-a9eb-403c-b5d1-51284bbb1205" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2605

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)