### PR TITLE
ci: Prevent new version patches, if only content is ci changes

### DIFF
--- a/.github/scripts/determine-release-candidate-branch-for-track.mjs
+++ b/.github/scripts/determine-release-candidate-branch-for-track.mjs
@@ -24,7 +24,9 @@ function main() {
 	console.log(`Commits between ${releaseCandidateBranch} and ${currentTag.tag}:`);
 	console.log(listCommitsBetweenRefs(releaseCandidateBranch, currentTag.tag));
 
-	const commitList = listCommitsBetweenRefs(releaseCandidateBranch, currentTag.tag).split('\n');
+	const commitList = listCommitsBetweenRefs(releaseCandidateBranch, currentTag.tag)
+		.split('\n')
+		.filter((commit) => commit.trim().length > 0);
 	const actionableCommitList = filterActionableCommits(commitList);
 
 	const output = {

--- a/.github/scripts/determine-release-candidate-branch-for-track.mjs
+++ b/.github/scripts/determine-release-candidate-branch-for-track.mjs
@@ -1,5 +1,4 @@
 import {
-	countCommitsBetweenRefs,
 	ensureEnvVar,
 	listCommitsBetweenRefs,
 	resolveRcBranchForTrack,
@@ -25,12 +24,24 @@ function main() {
 	console.log(`Commits between ${releaseCandidateBranch} and ${currentTag.tag}:`);
 	console.log(listCommitsBetweenRefs(releaseCandidateBranch, currentTag.tag));
 
-	const commitCount = countCommitsBetweenRefs(releaseCandidateBranch, currentTag.tag);
+	const commitList = listCommitsBetweenRefs(releaseCandidateBranch, currentTag.tag).split('\n');
+	const actionableCommitList = filterActionableCommits(commitList);
 
-	writeGithubOutput({
+	const output = {
 		release_candidate_branch: releaseCandidateBranch,
-		should_update: commitCount > 0 ? 'true' : 'false',
-	});
+		should_update: actionableCommitList.length > 0 ? 'true' : 'false',
+	};
+
+	console.log(output);
+
+	writeGithubOutput(output);
+}
+
+/**
+ * @param { string[] } commitList
+ * */
+export function filterActionableCommits(commitList) {
+	return commitList.filter((commit) => !commit.trimStart().startsWith('ci:'));
 }
 
 // only run when executed directly, not when imported by tests

--- a/.github/scripts/github-helpers.mjs
+++ b/.github/scripts/github-helpers.mjs
@@ -286,7 +286,7 @@ export function listTagsPointingAt(commit) {
  * @param {string} to
  */
 export function listCommitsBetweenRefs(from, to) {
-	return sh('git', ['--no-pager', 'log', '--format="- %s (%h)', `${to}..origin/${from}`]);
+	return sh('git', ['--no-pager', 'log', '--format=%s (%h)', `${to}..origin/${from}`]);
 }
 
 /**


### PR DESCRIPTION
## Summary

Currently the automation kicks off even if there is only ci changes. This fixes it.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2652/dont-create-a-new-patch-if-it-only-contains-ci-fixes

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
