### PR TITLE
fix(editor): Improve colorings update logic in resolvableHighlighter …

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/resolvableHighlighter.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/resolvableHighlighter.ts
@@ -64,7 +64,10 @@ const coloringStateField = StateField.define<DecorationSet>({
 	},
 	update(colorings, transaction) {
 		try {
-			colorings = colorings.map(transaction.changes); // recalculate positions for new doc
+			if (!transaction.changes.empty) {
+				colorings = Decoration.none;
+			}
+			colorings = colorings.map(transaction.changes);
 
 			for (const txEffect of transaction.effects) {
 				if (txEffect.is(coloringStateEffects.removeColorEffect)) {


### PR DESCRIPTION
…to handle non-empty transactions

## Summary

When the expression changes, now decorations are cleared (Decoration.none) instead of remapped, so styles are not applied until updateHighlighting runs with the updated segments.

## Related Linear tickets, Github issues, and Community forum posts

Fixes [CAT-2112](https://linear.app/n8n/issue/CAT-2112/expression-highlighting-does-not-get-removed-if-pasting-over-it-or)


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
