### PR TITLE
fix(editor): Fix workflow tag filtering excluding workflows inside folders

### DIFF
--- a/packages/frontend/editor-ui/src/app/views/WorkflowsView.test.ts
+++ b/packages/frontend/editor-ui/src/app/views/WorkflowsView.test.ts
@@ -58,6 +58,10 @@ const router = createRouter({
 			component: { template: '<div></div>' },
 		},
 		{
+			path: '/:projectId/folders/:folderId',
+			component: { template: '<div></div>' },
+		},
+		{
 			path: '/workflow',
 			name: VIEWS.NEW_WORKFLOW,
 			component: { template: '<div></div>' },
@@ -206,7 +210,7 @@ describe('WorkflowsView', () => {
 	});
 
 	describe('filters', () => {
-		it('should set tag filter based on query parameters', async () => {
+		it('should set tag filter based on query parameters and not filter by parent folder', async () => {
 			await router.replace({ query: { tags: 'test-tag' } });
 
 			const TEST_TAG = { id: 'test-tag', name: 'tag' };
@@ -229,8 +233,31 @@ describe('WorkflowsView', () => {
 				expect.objectContaining({
 					tags: [TEST_TAG.name],
 					isArchived: false,
+					parentFolderId: undefined,
 				}),
 				false, // No folders if tag filter is set
+				expect.any(Boolean),
+			);
+		});
+
+		it('should scope search to current folder when inside a folder', async () => {
+			await router.replace({ path: '/project-1/folders/folder-1', query: { search: 'test' } });
+
+			workflowsListStore.fetchWorkflowsPage.mockResolvedValue([]);
+
+			renderComponent({ pinia });
+			await waitAllPromises();
+
+			expect(workflowsListStore.fetchWorkflowsPage).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.any(Number),
+				expect.any(Number),
+				expect.any(String),
+				expect.objectContaining({
+					query: 'test',
+					parentFolderId: 'folder-1',
+				}),
+				expect.any(Boolean),
 				expect.any(Boolean),
 			);
 		});

--- a/packages/frontend/editor-ui/src/app/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/app/views/WorkflowsView.vue
@@ -688,7 +688,10 @@ const fetchWorkflows = async () => {
 
 		// Toggle ownership cards visibility only after we have fetched the workflows
 		showCardsBadge.value =
-			projectPages.isOverviewSubPage || projectPages.isSharedSubPage || filters.value.search !== '';
+			projectPages.isOverviewSubPage ||
+			projectPages.isSharedSubPage ||
+			filters.value.search !== '' ||
+			filters.value.tags.length > 0;
 
 		return fetchedResources;
 	} catch (error) {
@@ -719,6 +722,11 @@ const getParentFolderId = (routeId?: string) => {
 
 	// If we're on overview/shared page or searching, don't filter by parent folder
 	if (projectPages.isOverviewSubPage || projectPages.isSharedSubPage || filters?.value.search) {
+		return undefined;
+	}
+
+	// If filtering by tags, search across all folders
+	if (filters.value.tags.length > 0) {
 		return undefined;
 	}
 


### PR DESCRIPTION
## Summary

When filtering workflows by tag on a project workflows page, only root-level workflows (not inside any folder) were returned. Workflows inside folders matching the tag were excluded from results.

**Root cause:** `getParentFolderId()` returned `PROJECT_ROOT` (`'0'`) by default even when filtering by tags. The backend then applied `parentFolderId IS NULL`, restricting results to root-level workflows only.

**Fix:**
- Return `undefined` from `getParentFolderId()` when tag filters are active, so the query searches across all folders
- Enable folder breadcrumbs on workflow cards during tag filtering, so users can see which folder each result belongs to

<img width="1257" height="436" alt="image" src="https://github.com/user-attachments/assets/e96bf99c-eb6a-4e68-9395-07eb0e2be482" />
<img width="1263" height="376" alt="image" src="https://github.com/user-attachments/assets/176b677f-1dfe-41ec-91a0-1e813662147c" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4927
Fixes https://github.com/n8n-io/n8n/issues/23948

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)