### PR TITLE
fix(core): Confirm messages immediately when no destination is listening

### DIFF
--- a/packages/cli/src/eventbus/message-event-bus/message-event-bus.ts
+++ b/packages/cli/src/eventbus/message-event-bus/message-event-bus.ts
@@ -206,7 +206,7 @@ export class MessageEventBus extends EventEmitter {
 			this.logger.debug(`Found unsent event messages: ${unsentMessages.length}`);
 			for (const unsentMsg of unsentMessages) {
 				this.logger.debug(`Retrying: ${unsentMsg.id} ${unsentMsg.__type}`);
-				await this.emitMessage(unsentMsg);
+				this.emitMessageWithCallback('message', unsentMsg);
 			}
 		}
 	}
@@ -223,31 +223,31 @@ export class MessageEventBus extends EventEmitter {
 			msgs = [msgs];
 		}
 		for (const msg of msgs) {
+			// 1. Write the message to the log file
 			this.logWriter?.putMessage(msg);
-			// If no destination is listening (e.g. log-streaming module not licensed),
-			// confirm the message immediately to prevent unbounded accumulation across restarts.
-			if (this.listenerCount('message') === 0) {
-				this.confirmSent(msg, { id: '0', name: 'eventBus' });
+
+			// 2. Emit for internal metrics (e.g. Prometheus)
+			this.emit('metrics.eventBus.event', msg);
+
+			// 3. Emit for external destinations (e.g. log-streaming to syslog/webhook/sentry).
+			//    Returns true if at least one listener is registered, false otherwise.
+			const hasDestinationListener = this.emitMessageWithCallback('message', msg);
+
+			// 4. If no external listener is registered (e.g. log-streaming module
+			//    not licensed), confirm it immediately to prevent unbounded log accumulation.
+			if (!hasDestinationListener) {
+				this.confirmMessageDelivered(msg, { id: '0', name: 'eventBus' });
 			}
-			await this.emitMessage(msg);
 		}
 	}
 
-	confirmSent(msg: EventMessageTypes, source?: EventMessageConfirmSource) {
+	confirmMessageDelivered(msg: EventMessageTypes, source?: EventMessageConfirmSource) {
 		this.logWriter?.confirmMessageSent(msg.id, source);
-	}
-
-	private async emitMessage(msg: EventMessageTypes) {
-		this.emit('metrics.eventBus.event', msg);
-
-		// generic emit for external modules to capture events
-		// this is for internal use ONLY and not for use with custom destinations!
-		this.emitMessageWithCallback('message', msg);
 	}
 
 	private emitMessageWithCallback(eventName: string, msg: EventMessageTypes): boolean {
 		const confirmCallback = (message: EventMessageTypes, src: EventMessageConfirmSource) =>
-			this.confirmSent(message, src);
+			this.confirmMessageDelivered(message, src);
 		return this.emit(eventName, msg, confirmCallback);
 	}
 

--- a/packages/cli/src/eventbus/message-event-bus/message-event-bus.ts
+++ b/packages/cli/src/eventbus/message-event-bus/message-event-bus.ts
@@ -224,6 +224,11 @@ export class MessageEventBus extends EventEmitter {
 		}
 		for (const msg of msgs) {
 			this.logWriter?.putMessage(msg);
+			// If no destination is listening (e.g. log-streaming module not licensed),
+			// confirm the message immediately to prevent unbounded accumulation across restarts.
+			if (this.listenerCount('message') === 0) {
+				this.confirmSent(msg, { id: '0', name: 'eventBus' });
+			}
 			await this.emitMessage(msg);
 		}
 	}

--- a/packages/cli/src/modules/log-streaming.ee/__tests__/log-streaming-destination.service.test.ts
+++ b/packages/cli/src/modules/log-streaming.ee/__tests__/log-streaming-destination.service.test.ts
@@ -20,7 +20,7 @@ describe('LogStreamingDestinationService', () => {
 	const eventBus = {
 		on: jest.fn(),
 		removeListener: jest.fn(),
-		confirmSent: jest.fn(),
+		confirmMessageDelivered: jest.fn(),
 	} as unknown as MessageEventBus;
 	const publisher = mock<Publisher>();
 

--- a/packages/cli/src/modules/log-streaming.ee/log-streaming-destination.service.ts
+++ b/packages/cli/src/modules/log-streaming.ee/log-streaming-destination.service.ts
@@ -158,7 +158,7 @@ export class LogStreamingDestinationService {
 	) {
 		// If there are no destinations that should receive this message, mark it as sent immediately
 		if (!this.shouldSendMsg(msg)) {
-			this.eventBus.confirmSent(msg, { id: '0', name: 'eventBus' });
+			confirmCallback(msg, { id: '0', name: 'eventBus' });
 			return;
 		}
 
@@ -200,7 +200,8 @@ export class LogStreamingDestinationService {
 		if (destination.length > 0) {
 			const sendResult = await this.destinations[destinationId].receiveFromEventBus({
 				msg,
-				confirmCallback: () => this.eventBus.confirmSent(msg, { id: '0', name: 'eventBus' }),
+				confirmCallback: () =>
+					this.eventBus.confirmMessageDelivered(msg, { id: '0', name: 'eventBus' }),
 			});
 			return sendResult;
 		}

--- a/packages/cli/test/integration/eventbus.ee.test.ts
+++ b/packages/cli/test/integration/eventbus.ee.test.ts
@@ -113,65 +113,63 @@ test('should have a running logwriter process', () => {
 	expect(thread).toBeDefined();
 });
 
-test('should confirm messages immediately when no destination is listening', async () => {
-	// Remove the log-streaming listener to simulate an unlicensed instance
-	eventBus.removeAllListeners('message');
-
-	const testMessage = new EventMessageGeneric({
-		eventName: 'n8n.test.message' as EventNamesTypes,
-		id: uuid(),
+describe('message confirmation', () => {
+	afterEach(async () => {
+		// Restore the log-streaming destination listener for subsequent tests
+		destinationService['isListening'] = false;
+		await destinationService.initialize();
 	});
 
-	await eventBus.send(testMessage);
-	await new Promise((resolve) => {
-		eventBus.logWriter.worker?.on(
-			'message',
-			async function handler(msg: { command: string; data: any }) {
-				if (msg.command === 'confirmMessageSent') {
-					await confirmIdSent(testMessage.id);
-					eventBus.logWriter.worker?.removeListener('message', handler);
-					resolve(true);
-				}
-			},
-		);
+	test('should confirm messages immediately when no listener is registered', async () => {
+		// Simulate an unlicensed instance: remove all message listeners
+		eventBus.removeAllListeners('message');
+
+		const testMessage = new EventMessageGeneric({
+			eventName: 'n8n.test.message' as EventNamesTypes,
+			id: uuid(),
+		});
+
+		await eventBus.send(testMessage);
+		await new Promise((resolve) => {
+			eventBus.logWriter.worker?.on(
+				'message',
+				async function handler(msg: { command: string; data: any }) {
+					if (msg.command === 'confirmMessageSent') {
+						await confirmIdSent(testMessage.id);
+						eventBus.logWriter.worker?.removeListener('message', handler);
+						resolve(true);
+					}
+				},
+			);
+		});
 	});
 
-	// Restore the listener for subsequent tests
-	destinationService['isListening'] = false;
-	await destinationService.initialize();
-});
+	test('should delegate confirmation to listener when one is registered', async () => {
+		const testMessage = new EventMessageGeneric({
+			eventName: 'n8n.test.message' as EventNamesTypes,
+			id: uuid(),
+		});
 
-test('should not confirm messages in send() when a destination is listening', async () => {
-	// Verify that the log-streaming destination service is listening
-	expect(eventBus.listenerCount('message')).toBeGreaterThan(0);
-
-	const testMessage = new EventMessageGeneric({
-		eventName: 'n8n.test.message' as EventNamesTypes,
-		id: uuid(),
-	});
-
-	await eventBus.send(testMessage);
-	// The first worker message should be appendMessageToLog, not confirmMessageSent.
-	// This proves send() did not inline-confirm — it delegated to the listener.
-	await new Promise((resolve) => {
-		const workerMessages: string[] = [];
-		eventBus.logWriter.worker?.on(
-			'message',
-			function handler(msg: { command: string; data: unknown }) {
-				workerMessages.push(msg.command);
-				// Wait for both the append and the confirm from the destination service
-				if (
-					workerMessages.includes('appendMessageToLog') &&
-					workerMessages.includes('confirmMessageSent')
-				) {
-					// The first message must be appendMessageToLog, proving send() did not
-					// inline-confirm before emitting to listeners
-					expect(workerMessages[0]).toBe('appendMessageToLog');
-					eventBus.logWriter.worker?.removeListener('message', handler);
-					resolve(true);
-				}
-			},
-		);
+		await eventBus.send(testMessage);
+		// The first worker message should be appendMessageToLog, not confirmMessageSent.
+		// This proves the event bus delegated to the handler instead of auto-confirming.
+		await new Promise((resolve) => {
+			const workerMessages: string[] = [];
+			eventBus.logWriter.worker?.on(
+				'message',
+				function handler(msg: { command: string; data: unknown }) {
+					workerMessages.push(msg.command);
+					if (
+						workerMessages.includes('appendMessageToLog') &&
+						workerMessages.includes('confirmMessageSent')
+					) {
+						expect(workerMessages[0]).toBe('appendMessageToLog');
+						eventBus.logWriter.worker?.removeListener('message', handler);
+						resolve(true);
+					}
+				},
+			);
+		});
 	});
 });
 
@@ -346,7 +344,7 @@ test('should send message to sentry ', async () => {
 
 	const mockedSentryCaptureMessage = jest.spyOn(sentryDestination.sentryClient!, 'captureMessage');
 	mockedSentryCaptureMessage.mockImplementation((_m, _level, _hint, _scope) => {
-		eventBus.confirmSent(testMessage, {
+		eventBus.confirmMessageDelivered(testMessage, {
 			id: sentryDestination.id,
 			name: sentryDestination.label,
 		});

--- a/packages/cli/test/integration/eventbus.ee.test.ts
+++ b/packages/cli/test/integration/eventbus.ee.test.ts
@@ -113,6 +113,68 @@ test('should have a running logwriter process', () => {
 	expect(thread).toBeDefined();
 });
 
+test('should confirm messages immediately when no destination is listening', async () => {
+	// Remove the log-streaming listener to simulate an unlicensed instance
+	eventBus.removeAllListeners('message');
+
+	const testMessage = new EventMessageGeneric({
+		eventName: 'n8n.test.message' as EventNamesTypes,
+		id: uuid(),
+	});
+
+	await eventBus.send(testMessage);
+	await new Promise((resolve) => {
+		eventBus.logWriter.worker?.on(
+			'message',
+			async function handler(msg: { command: string; data: any }) {
+				if (msg.command === 'confirmMessageSent') {
+					await confirmIdSent(testMessage.id);
+					eventBus.logWriter.worker?.removeListener('message', handler);
+					resolve(true);
+				}
+			},
+		);
+	});
+
+	// Restore the listener for subsequent tests
+	destinationService['isListening'] = false;
+	await destinationService.initialize();
+});
+
+test('should not confirm messages in send() when a destination is listening', async () => {
+	// Verify that the log-streaming destination service is listening
+	expect(eventBus.listenerCount('message')).toBeGreaterThan(0);
+
+	const testMessage = new EventMessageGeneric({
+		eventName: 'n8n.test.message' as EventNamesTypes,
+		id: uuid(),
+	});
+
+	await eventBus.send(testMessage);
+	// The first worker message should be appendMessageToLog, not confirmMessageSent.
+	// This proves send() did not inline-confirm — it delegated to the listener.
+	await new Promise((resolve) => {
+		const workerMessages: string[] = [];
+		eventBus.logWriter.worker?.on(
+			'message',
+			function handler(msg: { command: string; data: unknown }) {
+				workerMessages.push(msg.command);
+				// Wait for both the append and the confirm from the destination service
+				if (
+					workerMessages.includes('appendMessageToLog') &&
+					workerMessages.includes('confirmMessageSent')
+				) {
+					// The first message must be appendMessageToLog, proving send() did not
+					// inline-confirm before emitting to listeners
+					expect(workerMessages[0]).toBe('appendMessageToLog');
+					eventBus.logWriter.worker?.removeListener('message', handler);
+					resolve(true);
+				}
+			},
+		);
+	});
+});
+
 test('should have logwriter log messages', async () => {
 	const testMessage = new EventMessageGeneric({
 		eventName: 'n8n.test.message' as EventNamesTypes,


### PR DESCRIPTION
## Summary

Restores inline message confirmation for unlicensed instances where the log-streaming module is not initialized. Previously, messages would accumulate indefinitely across restarts since confirmations only occurred through the licensed module, causing OOM errors when reading unfinished executions on startup.

The fix adds a check in `send()` to confirm messages immediately when no `'message'` listener exists, while preserving the existing behavior for licensed instances where the destination service handles confirmation.

## Related Linear tickets, Github issues, and Community forum posts

Fixes https://linear.app/n8n/issue/IAM-404

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included (two new integration tests validating both paths)
- [x] Code follows existing patterns from prior implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)