### PR TITLE
fix(core): Force full execution data fetching for evaluation test runs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,6 +33,21 @@
 			"killBehavior": "forceful"
 		},
 		{
+			"name": "Launch n8n CLI worker dev with debug",
+			"runtimeExecutable": "pnpm",
+			"cwd": "${workspaceFolder}/packages/cli",
+			"runtimeArgs": ["run", "dev:worker", "--", "--inspect-brk"],
+			"console": "integratedTerminal",
+			"restart": true,
+			"autoAttachChildProcesses": true,
+			"request": "launch",
+			"skipFiles": ["<node_internals>/**"],
+			"type": "node",
+			"envFile": "${workspaceFolder}/.env",
+			"outputCapture": "std",
+			"killBehavior": "polite"
+		},
+		{
 			"name": "Launch n8n CLI dev with debug",
 			"runtimeExecutable": "pnpm",
 			"cwd": "${workspaceFolder}/packages/cli",

--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -572,6 +572,57 @@ describe('workflow timeout with startedAt', () => {
 	});
 });
 
+describe('needsFullExecutionData', () => {
+	const originalEnv = process.env.N8N_MINIMIZE_EXECUTION_DATA_FETCHING;
+
+	afterEach(() => {
+		if (originalEnv === undefined) {
+			delete process.env.N8N_MINIMIZE_EXECUTION_DATA_FETCHING;
+		} else {
+			process.env.N8N_MINIMIZE_EXECUTION_DATA_FETCHING = originalEnv;
+		}
+	});
+
+	it('should return true when forceFullExecutionData is true even with N8N_MINIMIZE_EXECUTION_DATA_FETCHING set', () => {
+		process.env.N8N_MINIMIZE_EXECUTION_DATA_FETCHING = 'true';
+
+		// @ts-expect-error Private method
+		const result = runner.needsFullExecutionData('evaluation', 'exec-id', true);
+
+		expect(result).toBe(true);
+	});
+
+	it('should return true when env var is not set and forceFullExecutionData is undefined', () => {
+		delete process.env.N8N_MINIMIZE_EXECUTION_DATA_FETCHING;
+
+		// @ts-expect-error Private method
+		const result = runner.needsFullExecutionData('webhook', 'exec-id', undefined);
+
+		expect(result).toBe(true);
+	});
+
+	it('should return false when env var is set, forceFullExecutionData is undefined, and mode is not integrated', () => {
+		process.env.N8N_MINIMIZE_EXECUTION_DATA_FETCHING = 'true';
+
+		const activeExecutions = Container.get(ActiveExecutions);
+		jest.spyOn(activeExecutions, 'getResponseMode').mockReturnValue('responseNode');
+
+		// @ts-expect-error Private method
+		const result = runner.needsFullExecutionData('webhook', 'exec-id', undefined);
+
+		expect(result).toBe(false);
+	});
+
+	it('should return true when env var is set and mode is integrated', () => {
+		process.env.N8N_MINIMIZE_EXECUTION_DATA_FETCHING = 'true';
+
+		// @ts-expect-error Private method
+		const result = runner.needsFullExecutionData('integrated', 'exec-id', undefined);
+
+		expect(result).toBe(true);
+	});
+});
+
 describe('streaming functionality', () => {
 	it('should setup sendChunk handler when streaming is enabled and execution mode is not manual', async () => {
 		// ARRANGE

--- a/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -489,6 +489,7 @@ describe('TestRunnerService', () => {
 				resource: 'dataset',
 				operation: 'getRows',
 			});
+			expect(runCallArg).toHaveProperty('forceFullExecutionData', true);
 		});
 
 		test('should call workflowRunner.run with correct data in queue execution mode and manual offload', async () => {
@@ -575,6 +576,7 @@ describe('TestRunnerService', () => {
 				resource: 'dataset',
 				operation: 'getRows',
 			});
+			expect(runCallArg).toHaveProperty('forceFullExecutionData', true);
 
 			// after reset
 			delete process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS;
@@ -742,6 +744,7 @@ describe('TestRunnerService', () => {
 						},
 					},
 					userId: metadata.userId,
+					forceFullExecutionData: true,
 					triggerToStartFrom: {
 						name: triggerNodeName,
 					},
@@ -869,6 +872,7 @@ describe('TestRunnerService', () => {
 				expect(runCallArg).toEqual(
 					expect.objectContaining({
 						executionMode: 'evaluation',
+						forceFullExecutionData: true,
 						pinData: {
 							[triggerNodeName]: [testCase],
 						},

--- a/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
@@ -250,6 +250,7 @@ export class TestRunnerService {
 		const data: IWorkflowExecutionDataProcess = {
 			executionMode: 'evaluation',
 			pinData,
+			forceFullExecutionData: true,
 			workflowData: {
 				...workflow,
 				settings: {
@@ -336,6 +337,7 @@ export class TestRunnerService {
 			destinationNode: { nodeName: triggerNode.name, mode: 'inclusive' },
 			executionMode: 'manual',
 			runData: {},
+			forceFullExecutionData: true,
 			workflowData: {
 				...workflow,
 				settings: {

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -489,7 +489,10 @@ export class WorkflowRunner {
 
 				let runData: IRun;
 
-				if (!jobResult || this.needsFullExecutionData(data.executionMode, executionId)) {
+				if (
+					!jobResult ||
+					this.needsFullExecutionData(data.executionMode, executionId, data.forceFullExecutionData)
+				) {
 					const fullExecutionData = await this.executionRepository.findSingleExecution(
 						executionId,
 						{
@@ -561,7 +564,12 @@ export class WorkflowRunner {
 	 * In all other cases we can skip the DB fetch and use the lightweight
 	 * result summary sent by the worker via the job progress message.
 	 */
-	private needsFullExecutionData(executionMode: WorkflowExecuteMode, executionId: string): boolean {
+	private needsFullExecutionData(
+		executionMode: WorkflowExecuteMode,
+		executionId: string,
+		forceFullExecutionData?: boolean,
+	): boolean {
+		if (forceFullExecutionData) return true;
 		if (!process.env.N8N_MINIMIZE_EXECUTION_DATA_FETCHING) return true;
 
 		return (

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2881,6 +2881,11 @@ export interface IWorkflowExecutionDataProcess {
 	restartExecutionId?: string;
 	executionMode: WorkflowExecuteMode;
 	/**
+	 * When true, forces the execution data to be present in the run data
+	 * ignores N8N_MINIMIZE_EXECUTION_DATA_FETCHING environment variable if set
+	 */
+	forceFullExecutionData?: boolean;
+	/**
 	 * The data that is sent in the body of the webhook that started this
 	 * execution.
 	 */


### PR DESCRIPTION
## Summary

In multi-main queue mode with `N8N_MINIMIZE_EXECUTION_DATA_FETCHING` enabled, evaluation test runs were failing because the worker returned lightweight job result summaries instead of full execution data. The evaluation test runner needs complete execution data (including `runData`) to compare outputs and compute metrics.

This PR introduces a `forceFullExecutionData` property on `IWorkflowExecutionDataProcess` that, when set to `true`, forces the main process to fetch full execution data from the DB regardless of the `N8N_MINIMIZE_EXECUTION_DATA_FETCHING` environment variable. Both `runTestCase` and `runDatasetTrigger` in the test runner service now set this flag.

### How to test
1. Enable queue mode with `N8N_MINIMIZE_EXECUTION_DATA_FETCHING=true`
2. Run an evaluation test suite
3. Verify evaluation metrics are computed correctly (not empty/failed)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2103

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)