### PR TITLE
fix(AI Agent Node): Extract tool name correctly for MCP tool calls

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
@@ -154,7 +154,15 @@ function buildMessageContent(
 }
 
 function resolveToolName(tool: EngineResult<RequestResponseMetadata>): string {
-	return tool.action.metadata?.hitl?.toolName ?? nodeNameToToolName(tool.action.nodeName);
+	// For toolkit tools (e.g., MCP Client), the actual tool name is stored in input.tool
+	// by createEngineRequests. Using the node name (e.g., "MCP_Client") instead would
+	// cause the LLM to see a wrong tool name in history and attempt to re-call it,
+	// resulting in createEngineRequests returning an empty actions array and an infinite loop.
+	return (
+		tool.action.metadata?.hitl?.toolName ??
+		(typeof tool.action.input?.tool === 'string' ? tool.action.input.tool : undefined) ??
+		nodeNameToToolName(tool.action.nodeName)
+	);
 }
 
 /**

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
@@ -121,6 +121,50 @@ describe('buildSteps', () => {
 			expect(result[1].action.tool).toBe('Search');
 		});
 
+		it('should use input.tool as the tool name for toolkit tools (e.g., MCP Client)', () => {
+			// When an MCP Client node (a toolkit) exposes sub-tools, createEngineRequests stores
+			// the actual MCP tool name (e.g., "list_tickets") in input.tool.
+			// buildSteps must use this name — not nodeNameToToolName("MCP Client") = "MCP_Client" —
+			// so the LLM sees the correct tool name in the scratchpad and does not loop.
+			const response: EngineResponse<RequestResponseMetadata> = {
+				actionResponses: [
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'MCP Client',
+							input: {
+								id: 'call_123',
+								tool: 'list_tickets', // actual MCP tool name set by createEngineRequests
+								query: 'open tickets',
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_123',
+							metadata: {
+								itemIndex: 0,
+							},
+						},
+						data: {
+							data: {
+								ai_tool: [[{ json: { tickets: [] } }]],
+							},
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+				],
+				metadata: {},
+			};
+
+			const result = buildSteps(response, itemIndex);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].action.tool).toBe('list_tickets');
+			// The messageLog AIMessage must also carry the correct name so the LLM history is accurate
+			expect(result[0].action.messageLog?.[0]?.tool_calls?.[0]?.name).toBe('list_tickets');
+		});
+
 		it('should filter out responses for different item indexes', () => {
 			const response: EngineResponse<RequestResponseMetadata> = {
 				actionResponses: [


### PR DESCRIPTION
Fix Gemini looping when using MCP Client tools in an AI Agent workflow.

  When the MCP Client node (a toolkit) exposes sub-tools, `createEngineRequests` correctly stores the actual MCP tool name (e.g., `list_tickets`) in
  `action.input.tool`. However, `resolveToolName` in `buildSteps.ts` was ignoring this and returning `nodeNameToToolName("MCP Client")` → `"MCP_Client"`
   instead.

  This wrong name was embedded in the `AIMessage` that forms the `{agent_scratchpad}` on every subsequent agent turn. Gemini validates function call
  names against its registered function declarations strictly. On the next turn it would attempt to call `"MCP_Client"` — a name not registered as a
  tool — causing `createEngineRequests` to return an empty actions array. With no tools to execute, the agent was immediately reinvoked with the same
  context, generating the same invalid tool call again. This repeated until the 10-iteration limit was hit.

  OpenAI/Azure OpenAI are more lenient about tool name mismatches in history, which is why they worked fine.

  **Fix:** `resolveToolName` now checks `action.input.tool` (the original MCP sub-tool name stored by `createEngineRequests` for toolkit tools) before
  falling back to the node name. Precedence:
  1. HITL tool name (unchanged)
  2. `input.tool` — the actual registered tool name for toolkit tools (new)
  3. `nodeNameToToolName(nodeName)` — fallback for standalone tools

  ## Related Linear tickets, Github issues, and Community forum posts

  https://linear.app/n8n/issue/AI-2175
  fixes #26561

  ## Review / Merge checklist

  - [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
  - [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
  - [x] Tests included.
  - [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)