### PR TITLE
fix(editor): Prevent toggle animation on Security & Policies page load

### DIFF
--- a/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.test.ts
@@ -355,7 +355,7 @@ describe('SecuritySettings', () => {
 	it('should not show personal space toggles before settings are loaded', async () => {
 		let resolveSettings: (value: typeof defaultSettings) => void = () => {};
 		getSecuritySettings.mockImplementation(
-			() => new Promise((resolve) => (resolveSettings = resolve)),
+			async () => new Promise((resolve) => (resolveSettings = resolve)),
 		);
 
 		const { queryByTestId } = renderView();

--- a/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.test.ts
@@ -352,6 +352,25 @@ describe('SecuritySettings', () => {
 		});
 	});
 
+	it('should not show personal space toggles before settings are loaded', async () => {
+		let resolveSettings: (value: typeof defaultSettings) => void = () => {};
+		getSecuritySettings.mockImplementation(
+			() => new Promise((resolve) => (resolveSettings = resolve)),
+		);
+
+		const { queryByTestId } = renderView();
+
+		expect(queryByTestId('security-personal-space-sharing-toggle')).not.toBeInTheDocument();
+		expect(queryByTestId('security-personal-space-publishing-toggle')).not.toBeInTheDocument();
+
+		resolveSettings(defaultSettings);
+
+		await waitFor(() => {
+			expect(queryByTestId('security-personal-space-sharing-toggle')).toBeInTheDocument();
+			expect(queryByTestId('security-personal-space-publishing-toggle')).toBeInTheDocument();
+		});
+	});
+
 	describe('when personalSpacePolicy feature is not licensed', () => {
 		beforeEach(() => {
 			settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.PersonalSpacePolicy] =

--- a/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.test.ts
@@ -355,7 +355,7 @@ describe('SecuritySettings', () => {
 	it('should not show personal space toggles before settings are loaded', async () => {
 		let resolveSettings: (value: typeof defaultSettings) => void = () => {};
 		getSecuritySettings.mockImplementation(
-			async () => new Promise((resolve) => (resolveSettings = resolve)),
+			async () => await new Promise((resolve) => (resolveSettings = resolve)),
 		);
 
 		const { queryByTestId } = renderView();

--- a/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.vue
+++ b/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.vue
@@ -243,10 +243,18 @@ const sharingCountText = computed(() => {
 						<template #fallback>
 							<N8nTooltip>
 								<ElSwitch
+									v-if="state !== undefined"
 									:model-value="personalSpaceSharing"
 									size="large"
 									:disabled="true"
 									data-test-id="security-personal-space-sharing-toggle"
+								/>
+								<ElSwitch
+									v-else
+									:model-value="false"
+									:loading="true"
+									:disabled="true"
+									size="large"
 								/>
 								<template #content>
 									<I18nT :keypath="personalSpaceTooltipKey" tag="span" scope="global">
@@ -299,10 +307,18 @@ const sharingCountText = computed(() => {
 						<template #fallback>
 							<N8nTooltip>
 								<ElSwitch
+									v-if="state !== undefined"
 									:model-value="personalSpacePublishing"
 									size="large"
 									:disabled="true"
 									data-test-id="security-personal-space-publishing-toggle"
+								/>
+								<ElSwitch
+									v-else
+									:model-value="false"
+									:loading="true"
+									:disabled="true"
+									size="large"
 								/>
 								<template #content>
 									<I18nT :keypath="personalSpaceTooltipKey" tag="span" scope="global">

--- a/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.vue
+++ b/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.vue
@@ -57,7 +57,7 @@ function goToUpgrade() {
 	void pageRedirectionHelper.goToUpgrade('settings-users', 'upgrade-users');
 }
 
-const { state, isLoading } = useAsyncState(async () => {
+const { state } = useAsyncState(async () => {
 	const settings = await securitySettingsApi.getSecuritySettings(rootStore.restApiContext);
 	return {
 		personalSpacePublishing: settings.personalSpacePublishing,

--- a/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.vue
+++ b/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.vue
@@ -234,15 +234,16 @@ const sharingCountText = computed(() => {
 				<div :class="$style.settingsContainerAction">
 					<EnterpriseEdition :features="[EnterpriseEditionFeature.PersonalSpacePolicy]">
 						<ElSwitch
+							v-if="state !== undefined"
 							v-model="personalSpaceSharing"
-							:loading="isLoading"
 							size="large"
 							data-test-id="security-personal-space-sharing-toggle"
 						/>
+						<ElSwitch v-else :model-value="false" :loading="true" :disabled="true" size="large" />
 						<template #fallback>
 							<N8nTooltip>
 								<ElSwitch
-									:model-value="false"
+									:model-value="personalSpaceSharing"
 									size="large"
 									:disabled="true"
 									data-test-id="security-personal-space-sharing-toggle"
@@ -289,15 +290,16 @@ const sharingCountText = computed(() => {
 				<div :class="$style.settingsContainerAction">
 					<EnterpriseEdition :features="[EnterpriseEditionFeature.PersonalSpacePolicy]">
 						<ElSwitch
+							v-if="state !== undefined"
 							v-model="personalSpacePublishing"
-							:loading="isLoading"
 							size="large"
 							data-test-id="security-personal-space-publishing-toggle"
 						/>
+						<ElSwitch v-else :model-value="false" :loading="true" :disabled="true" size="large" />
 						<template #fallback>
 							<N8nTooltip>
 								<ElSwitch
-									:model-value="false"
+									:model-value="personalSpacePublishing"
 									size="large"
 									:disabled="true"
 									data-test-id="security-personal-space-publishing-toggle"

--- a/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.vue
+++ b/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.vue
@@ -239,7 +239,6 @@ const sharingCountText = computed(() => {
 							size="large"
 							data-test-id="security-personal-space-sharing-toggle"
 						/>
-						<ElSwitch v-else :model-value="false" :loading="true" :disabled="true" size="large" />
 						<template #fallback>
 							<N8nTooltip>
 								<ElSwitch
@@ -248,13 +247,6 @@ const sharingCountText = computed(() => {
 									size="large"
 									:disabled="true"
 									data-test-id="security-personal-space-sharing-toggle"
-								/>
-								<ElSwitch
-									v-else
-									:model-value="false"
-									:loading="true"
-									:disabled="true"
-									size="large"
 								/>
 								<template #content>
 									<I18nT :keypath="personalSpaceTooltipKey" tag="span" scope="global">
@@ -303,7 +295,6 @@ const sharingCountText = computed(() => {
 							size="large"
 							data-test-id="security-personal-space-publishing-toggle"
 						/>
-						<ElSwitch v-else :model-value="false" :loading="true" :disabled="true" size="large" />
 						<template #fallback>
 							<N8nTooltip>
 								<ElSwitch
@@ -312,13 +303,6 @@ const sharingCountText = computed(() => {
 									size="large"
 									:disabled="true"
 									data-test-id="security-personal-space-publishing-toggle"
-								/>
-								<ElSwitch
-									v-else
-									:model-value="false"
-									:loading="true"
-									:disabled="true"
-									size="large"
 								/>
 								<template #content>
 									<I18nT :keypath="personalSpaceTooltipKey" tag="span" scope="global">


### PR DESCRIPTION
## Summary

When navigating to the Security & Policies settings page, the Personal Space sharing and publishing toggles would visually animate from OFF to ON, creating the impression that the user had changed settings.

**Root cause:** `useAsyncState` initializes `state` as `undefined`, so the computed getters (`personalSpaceSharing ?? false`, `personalSpacePublishing ?? false`) default to `false` before the API resolves. The `ElSwitch` would render as OFF, then animate to ON once data loaded. The existing `:loading` prop only shows a spinner — it doesn't suppress the transition animation.

**Fix:** Use `v-if="state !== undefined"` on the licensed switches so they don't render until data is available, with a disabled loading placeholder in the `v-else` branch. Also fixed the unlicensed fallback switches which were hardcoded to `false` instead of reflecting the actual setting value (relevant for instances that were licensed, had the feature enabled, then downgraded).

**Before:**
https://github.com/user-attachments/assets/b8ad5b58-1758-461d-bbbb-15ddea93b2ae

**After:**
https://github.com/user-attachments/assets/6ab73780-a484-4d85-8daf-09f74ad6ab1e

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-406

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)