### PR TITLE
fix(core): Allow expressions in OAuth credential URL fields

### DIFF
--- a/packages/cli/src/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.service.test.ts
@@ -2258,4 +2258,57 @@ describe('CredentialsService', () => {
 			).rejects.toThrow('The field "apiKey" is mandatory for credentials of type "apiCredential"');
 		});
 	});
+
+	describe('validateOAuthCredentialUrls', () => {
+		const testProjectId = 'test-project-id';
+
+		beforeEach(() => {
+			credentialsHelper.getCredentialsProperties.mockReturnValue([]);
+			jest.spyOn(validation, 'validateExternalSecretsPermissions').mockResolvedValue();
+		});
+
+		it('should reject an invalid OAuth2 URL', async () => {
+			credentialTypes.getParentTypes.mockReturnValue(['oAuth2Api']);
+			const data = { authUrl: 'javascript:alert(1)' };
+
+			await expect(
+				service.checkCredentialData('myOAuth2Cred', data, ownerUser, testProjectId),
+			).rejects.toThrow('OAuth url must use HTTP or HTTPS protocol');
+		});
+
+		it('should accept a valid OAuth2 URL', async () => {
+			credentialTypes.getParentTypes.mockReturnValue(['oAuth2Api']);
+			const data = { authUrl: 'https://example.com/oauth/authorize' };
+
+			await expect(
+				service.checkCredentialData('myOAuth2Cred', data, ownerUser, testProjectId),
+			).resolves.toBeUndefined();
+		});
+
+		it('should skip validation for expression-prefixed OAuth2 URLs', async () => {
+			credentialTypes.getParentTypes.mockReturnValue(['oAuth2Api']);
+			const data = {
+				authUrl: '=https://example.com/oauth/authorize',
+				accessTokenUrl: '={{ $vars.tokenUrl }}',
+				serverUrl: '={{ $vars.serverUrl }}',
+			};
+
+			await expect(
+				service.checkCredentialData('myOAuth2Cred', data, ownerUser, testProjectId),
+			).resolves.toBeUndefined();
+		});
+
+		it('should skip validation for expression-prefixed OAuth1 URLs', async () => {
+			credentialTypes.getParentTypes.mockReturnValue(['oAuth1Api']);
+			const data = {
+				authUrl: '={{ $vars.authUrl }}',
+				requestTokenUrl: '=https://example.com/request-token',
+				accessTokenUrl: '={{ $vars.tokenUrl }}',
+			};
+
+			await expect(
+				service.checkCredentialData('myOAuth1Cred', data, ownerUser, testProjectId),
+			).resolves.toBeUndefined();
+		});
+	});
 });

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -32,6 +32,7 @@ import {
 	CREDENTIAL_EMPTY_VALUE,
 	deepCopy,
 	displayParameter,
+	isExpression,
 	isINodePropertyCollection,
 	NodeHelpers,
 } from 'n8n-workflow';
@@ -1073,7 +1074,7 @@ export class CredentialsService {
 			const oauthUrlFields = ['authUrl', 'accessTokenUrl', 'serverUrl'] as const;
 			for (const field of oauthUrlFields) {
 				const value = data[field];
-				if (typeof value === 'string' && value.trim() !== '') {
+				if (typeof value === 'string' && value.trim() !== '' && !isExpression(value)) {
 					validateOAuthUrl(value);
 				}
 			}
@@ -1082,7 +1083,7 @@ export class CredentialsService {
 			const oauthUrlFields = ['authUrl', 'requestTokenUrl', 'accessTokenUrl'] as const;
 			for (const field of oauthUrlFields) {
 				const value = data[field];
-				if (typeof value === 'string' && value.trim() !== '') {
+				if (typeof value === 'string' && value.trim() !== '' && !isExpression(value)) {
 					validateOAuthUrl(value);
 				}
 			}


### PR DESCRIPTION
## Summary

This fix allows expression-prefixed values (like `=https://...` and `={{ $vars.url }}`) in OAuth credential URL fields, enabling users to use n8n variables for multi-environment OAuth configurations. The validation that was rejecting these expressions now skips them at save time, since they're properly validated at runtime after expression resolution.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/IAM-386
- Fixes https://github.com/n8n-io/n8n/issues/26940
- Fixes https://github.com/n8n-io/n8n/issues/26131

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [ ] Docs updated or follow-up ticket created
- [x] Tests included (added 4 test cases covering valid/invalid URLs and expression-prefixed values)
- [ ] PR Labeled with `release/backport` (if urgent)