### PR TITLE
perf(core): Make webhook cache writes non-blocking

### DIFF
--- a/packages/cli/src/webhooks/__tests__/webhook.service.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook.service.test.ts
@@ -34,6 +34,7 @@ describe('WebhookService', () => {
 	beforeEach(() => {
 		config.load(config.default);
 		jest.clearAllMocks();
+		cacheService.set.mockResolvedValue(undefined);
 	});
 
 	[true, false].forEach((isCacheEnabled) => {

--- a/packages/cli/src/webhooks/webhook.service.ts
+++ b/packages/cli/src/webhooks/webhook.service.ts
@@ -61,13 +61,11 @@ export class WebhookService {
 		const dbStaticWebhook = await this.findStaticWebhook(method, path);
 
 		if (dbStaticWebhook) {
-			try {
-				await this.cacheService.set(cacheKey, dbStaticWebhook);
-			} catch (error) {
+			void this.cacheService.set(cacheKey, dbStaticWebhook).catch((error) => {
 				this.logger.warn('Failed to cache webhook', {
 					error: ensureError(error).message,
 				});
-			}
+			});
 			return dbStaticWebhook;
 		}
 


### PR DESCRIPTION
## Summary

Webhook cache writes were changed from fire-and-forget to blocking in #21872 out with v1.121.0. This added a Redis round-trip to the critical path on every webhook cache miss, slowing down response times as reported on internal production.

This PR adjusts cache writes back to fire-and-forget while preserving the catch for `cacheService.get` which was the actual fix from #21872 for Redis read failures.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1831

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
