### PR TITLE
fix(editor): Remove unused options from NDV settings for agent model nodes

### DIFF
--- a/packages/frontend/editor-ui/src/app/stores/nodeTypes.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/nodeTypes.store.test.ts
@@ -1,0 +1,132 @@
+import { setActivePinia } from 'pinia';
+import { createTestingPinia } from '@pinia/testing';
+import { NodeConnectionTypes } from 'n8n-workflow';
+import type { INodeTypeDescription } from 'n8n-workflow';
+import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+
+function makeNodeType(
+	overrides: Partial<INodeTypeDescription> & Pick<INodeTypeDescription, 'name' | 'outputs'>,
+): INodeTypeDescription {
+	return {
+		displayName: overrides.name,
+		group: ['transform'],
+		description: '',
+		version: 1,
+		defaults: {},
+		inputs: ['main'],
+		properties: [],
+		...overrides,
+	} as INodeTypeDescription;
+}
+
+describe('useNodeTypesStore', () => {
+	let store: ReturnType<typeof useNodeTypesStore>;
+
+	beforeEach(() => {
+		setActivePinia(createTestingPinia({ stubActions: true }));
+		store = useNodeTypesStore();
+	});
+
+	describe('isModelNode', () => {
+		it('should return true for a node that outputs AiLanguageModel', () => {
+			const nodeType = makeNodeType({
+				name: '@n8n/n8n-nodes-langchain.lmChatOpenRouter',
+				outputs: [NodeConnectionTypes.AiLanguageModel],
+			});
+
+			store.nodeTypes = {
+				[nodeType.name]: { [nodeType.version as number]: nodeType },
+			};
+
+			expect(store.isModelNode(nodeType.name)).toBe(true);
+		});
+
+		it('should return true when outputs contain object format with AiLanguageModel type', () => {
+			const nodeType = makeNodeType({
+				name: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+				outputs: [{ type: NodeConnectionTypes.AiLanguageModel, displayName: 'Model' }],
+			});
+
+			store.nodeTypes = {
+				[nodeType.name]: { [nodeType.version as number]: nodeType },
+			};
+
+			expect(store.isModelNode(nodeType.name)).toBe(true);
+		});
+
+		it('should return false for a node that outputs Main', () => {
+			const nodeType = makeNodeType({
+				name: 'n8n-nodes-base.httpRequest',
+				outputs: [NodeConnectionTypes.Main],
+			});
+
+			store.nodeTypes = {
+				[nodeType.name]: { [nodeType.version as number]: nodeType },
+			};
+
+			expect(store.isModelNode(nodeType.name)).toBe(false);
+		});
+
+		it('should return false for a tool node', () => {
+			const nodeType = makeNodeType({
+				name: '@n8n/n8n-nodes-langchain.toolCalculator',
+				outputs: [NodeConnectionTypes.AiTool],
+			});
+
+			store.nodeTypes = {
+				[nodeType.name]: { [nodeType.version as number]: nodeType },
+			};
+
+			expect(store.isModelNode(nodeType.name)).toBe(false);
+		});
+
+		it('should return false for an unknown node type', () => {
+			expect(store.isModelNode('nonexistent.node')).toBe(false);
+		});
+	});
+
+	describe('isToolNode', () => {
+		it('should return true for a node that outputs AiTool', () => {
+			const nodeType = makeNodeType({
+				name: '@n8n/n8n-nodes-langchain.toolCalculator',
+				outputs: [NodeConnectionTypes.AiTool],
+			});
+
+			store.nodeTypes = {
+				[nodeType.name]: { [nodeType.version as number]: nodeType },
+			};
+
+			expect(store.isToolNode(nodeType.name)).toBe(true);
+		});
+
+		it('should return false for a model node', () => {
+			const nodeType = makeNodeType({
+				name: '@n8n/n8n-nodes-langchain.lmChatOpenRouter',
+				outputs: [NodeConnectionTypes.AiLanguageModel],
+			});
+
+			store.nodeTypes = {
+				[nodeType.name]: { [nodeType.version as number]: nodeType },
+			};
+
+			expect(store.isToolNode(nodeType.name)).toBe(false);
+		});
+
+		it('should return false for a regular main node', () => {
+			const nodeType = makeNodeType({
+				name: 'n8n-nodes-base.httpRequest',
+				outputs: [NodeConnectionTypes.Main],
+			});
+
+			store.nodeTypes = {
+				[nodeType.name]: { [nodeType.version as number]: nodeType },
+			};
+
+			expect(store.isToolNode(nodeType.name)).toBe(false);
+		});
+
+		it('should return false for an unknown node type', () => {
+			expect(store.isToolNode('nonexistent.node')).toBe(false);
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/app/stores/nodeTypes.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/nodeTypes.store.ts
@@ -195,6 +195,22 @@ export const useNodeTypesStore = defineStore(STORES.NODE_TYPES, () => {
 		};
 	});
 
+	const isModelNode = computed(() => {
+		return (nodeTypeName: string) => {
+			const nodeType = getNodeType.value(nodeTypeName);
+			if (nodeType?.outputs && Array.isArray(nodeType.outputs)) {
+				const outputTypes = nodeType.outputs.map(
+					(output: NodeConnectionType | INodeOutputConfiguration) =>
+						typeof output === 'string' ? output : output.type,
+				);
+
+				return outputTypes.includes(NodeConnectionTypes.AiLanguageModel);
+			} else {
+				return nodeType?.outputs.includes(NodeConnectionTypes.AiLanguageModel) ?? false;
+			}
+		};
+	});
+
 	const isCoreNodeType = computed(() => {
 		return (nodeType: INodeTypeDescription) => {
 			return nodeType.codex?.categories?.includes('Core Nodes');
@@ -457,6 +473,7 @@ export const useNodeTypesStore = defineStore(STORES.NODE_TYPES, () => {
 		isConfigNode,
 		isTriggerNode,
 		isToolNode,
+		isModelNode,
 		isCoreNodeType,
 		visibleNodeTypes,
 		nativelyNumberSuffixedDefaults,

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
@@ -184,6 +184,8 @@ const isTriggerNode = computed(() => !!node.value && nodeTypesStore.isTriggerNod
 
 const isToolNode = computed(() => !!node.value && nodeTypesStore.isToolNode(node.value.type));
 
+const isModelNode = computed(() => !!node.value && nodeTypesStore.isModelNode(node.value.type));
+
 const isExecutable = computed(() =>
 	nodeHelpers.isNodeExecutable(node.value, props.executable, props.foreignCredentials),
 );
@@ -482,7 +484,7 @@ const populateHiddenIssuesSet = () => {
 };
 
 const nodeSettings = computed(() =>
-	createCommonNodeSettings(isToolNode.value, i18n.baseText.bind(i18n)),
+	createCommonNodeSettings(isToolNode.value || isModelNode.value, i18n.baseText.bind(i18n)),
 );
 
 const iconSource = computed(() =>

--- a/packages/frontend/editor-ui/src/features/ndv/shared/ndv.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/ndv.utils.test.ts
@@ -17,6 +17,7 @@ import {
 	parseFromExpression,
 	setValue,
 	shouldSkipParamValidation,
+	createCommonNodeSettings,
 } from './ndv.utils';
 import { CUSTOM_API_CALL_KEY, SWITCH_NODE_TYPE } from '@/app/constants';
 import type { INodeUi, IUpdateInformation } from '@/Interface';
@@ -554,6 +555,45 @@ describe('shouldSkipParamValidation', () => {
 				expect(result).toBe(false);
 			});
 		});
+	});
+});
+
+describe('createCommonNodeSettings', () => {
+	const mockT = (key: string) => key;
+
+	it('should include retry, executeOnce, and alwaysOutputData settings when isToolOrModelNode is false', () => {
+		const settings = createCommonNodeSettings(false, mockT);
+		const names = settings.map((s) => s.name);
+
+		expect(names).toContain('retryOnFail');
+		expect(names).toContain('maxTries');
+		expect(names).toContain('waitBetweenTries');
+		expect(names).toContain('executeOnce');
+		expect(names).toContain('alwaysOutputData');
+		expect(names).toContain('onError');
+	});
+
+	it('should exclude retry, executeOnce, and alwaysOutputData settings when isToolOrModelNode is true', () => {
+		const settings = createCommonNodeSettings(true, mockT);
+		const names = settings.map((s) => s.name);
+
+		expect(names).not.toContain('retryOnFail');
+		expect(names).not.toContain('maxTries');
+		expect(names).not.toContain('waitBetweenTries');
+		expect(names).not.toContain('executeOnce');
+		expect(names).not.toContain('alwaysOutputData');
+		expect(names).not.toContain('onError');
+	});
+
+	it('should always include notes and notesInFlow settings', () => {
+		const regularSettings = createCommonNodeSettings(false, mockT);
+		const toolSettings = createCommonNodeSettings(true, mockT);
+
+		for (const settings of [regularSettings, toolSettings]) {
+			const names = settings.map((s) => s.name);
+			expect(names).toContain('notes');
+			expect(names).toContain('notesInFlow');
+		}
 	});
 });
 

--- a/packages/frontend/editor-ui/src/features/ndv/shared/ndv.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/ndv.utils.ts
@@ -448,10 +448,13 @@ export function shouldSkipParamValidation(
 	);
 }
 
-export function createCommonNodeSettings(isToolNode: boolean, t: (key: BaseTextKey) => string) {
+export function createCommonNodeSettings(
+	isToolOrModelNode: boolean,
+	t: (key: BaseTextKey) => string,
+) {
 	const ret: INodeProperties[] = [];
 
-	if (!isToolNode) {
+	if (!isToolOrModelNode) {
 		ret.push(
 			{
 				displayName: t('nodeSettings.alwaysOutputData.displayName'),


### PR DESCRIPTION
## Summary

The reported issue highlighted 2 problems:
1. We're showing retry options for model nodes in the NDV settings but we don't use those and in that case the user should either set retry on the agent node or do 2.
2. If retry is set on the model using the langchain mechanism we're not retrying 429 errors

Since the user that reported the issue was trying to setup the retry using the option in the NDV settings I've hidden those options (solving problem 1. here). Problem 2 has been tackled in a separate branch

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2164/community-issue-openai-chat-model-node-does-not-retry-429-rate-limit


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
