### PR TITLE
fix(core): Send client_id and client_secret in body for OAuth2 PKCE flow

### DIFF
--- a/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
@@ -529,6 +529,69 @@ describe('OAuth2CredentialController', () => {
 			expect(oauthService.encryptAndSaveData).toHaveBeenCalled();
 		});
 
+		it('should include client_id and client_secret in body for PKCE flow with body authentication', async () => {
+			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
+			const mockGetToken = jest.fn().mockResolvedValue({
+				data: { access_token: 'new_token' },
+			});
+			jest.mocked(ClientOAuth2).mockImplementation(
+				() =>
+					({
+						code: {
+							getToken: mockGetToken,
+						},
+					}) as any,
+			);
+
+			const mockResolvedCredential = mock<CredentialsEntity>({ id: '1' });
+			const mockState = {
+				token: 'token',
+				cid: '1',
+				userId: '123',
+				origin: 'static-credential' as const,
+				createdAt: timestamp,
+				data: 'encrypted-data',
+			};
+			oauthService.resolveCredential.mockResolvedValueOnce([
+				mockResolvedCredential,
+				{ csrfSecret: 'csrf-secret', codeVerifier: 'code_verifier' },
+				{
+					clientId: 'client_id',
+					clientSecret: 'client_secret',
+					authUrl: 'https://example.domain/oauth2/auth',
+					accessTokenUrl: 'https://example.domain/oauth2/token',
+					scope: 'openid',
+					grantType: 'pkce',
+					authentication: 'body',
+				},
+				mockState,
+			]);
+			oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
+			externalHooks.run.mockResolvedValue(undefined);
+
+			const req = mock<OAuthRequest.OAuth2Credential.Callback>({
+				query: {
+					code: 'auth_code',
+					state: validState,
+				},
+				originalUrl: '/oauth2-credential/callback?code=auth_code&state=state',
+			});
+
+			await controller.handleCallback(req, res);
+
+			expect(mockGetToken).toHaveBeenCalledWith(
+				expect.stringContaining('code=auth_code'),
+				expect.objectContaining({
+					body: expect.objectContaining({
+						code_verifier: 'code_verifier',
+						client_id: 'client_id',
+						client_secret: 'client_secret',
+					}),
+				}),
+			);
+			expect(oauthService.encryptAndSaveData).toHaveBeenCalled();
+		});
+
 		it('should handle body authentication method', async () => {
 			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
 			const mockGetToken = jest.fn().mockResolvedValue({

--- a/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
@@ -50,23 +50,30 @@ export class OAuth2CredentialController {
 			const [credential, decryptedDataOriginal, oauthCredentials, state] =
 				await this.oauthService.resolveCredential<OAuth2CredentialData>(req);
 
-			let options: Partial<ClientOAuth2Options> = {};
-
 			const oAuthOptions = this.convertCredentialToOptions(oauthCredentials);
 
-			if (oauthCredentials.grantType === 'pkce') {
-				options = {
-					body: { code_verifier: decryptedDataOriginal.codeVerifier },
-				};
-			} else if (oauthCredentials.authentication === 'body') {
-				options = {
-					body: {
-						...(oAuthOptions.body ?? {}),
-						client_id: oAuthOptions.clientId,
-						client_secret: oAuthOptions.clientSecret,
-					},
-				};
+			const isPkce = oauthCredentials.grantType === 'pkce';
+			const isBodyAuth = oauthCredentials.authentication === 'body';
+
+			const body: Record<string, string> = { ...(oAuthOptions.body ?? {}) };
+
+			if (isPkce) {
+				body.code_verifier = decryptedDataOriginal.codeVerifier as string;
+			}
+
+			if (isBodyAuth) {
+				body.client_id = oAuthOptions.clientId;
+				if (oAuthOptions.clientSecret) {
+					body.client_secret = oAuthOptions.clientSecret;
+				}
+				// Remove clientSecret so code-flow.ts won't also send it
+				// via the Authorization header
 				delete oAuthOptions.clientSecret;
+			}
+
+			let options: Partial<ClientOAuth2Options> = {};
+			if (isPkce || isBodyAuth) {
+				options = { body };
 			}
 
 			await this.externalHooks.run('oauth2.callback', [oAuthOptions]);


### PR DESCRIPTION
## Summary

When OAuth2 PKCE grant type was used with "body" authentication, `client_id` and `client_secret` were not included in the token exchange request body (client authentication was done via header). This caused failures for APIs (e.g. Mercado Livre, SoundCloud) that require these parameters during PKCE flow.

The fix unifies the PKCE and body-auth logic so that `code_verifier` is added when PKCE is selected, and `client_id`/`client_secret` are added to the body when body authentication is selected — both can now apply together.

### Token exchange behavior by configuration

| Grant Type | Auth Method | Before | After |
|---|---|---|---|
| Authorization Code | Header | `client_id`/`client_secret` in `Authorization: Basic` header | No change |
| Authorization Code | Body | `client_id`/`client_secret` in request body | No change |
| PKCE | Header | `code_verifier` in body, `client_id`/`client_secret` in `Authorization: Basic` header | No change |
| **PKCE** | **Body** | **Only `code_verifier` in body; `client_id`/`client_secret` sent via header instead of body (bug)** | **`code_verifier`, `client_id`, and `client_secret` all sent in request body** |

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-981
Fixes #14497

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)