### PR TITLE
feat(instance-ai): Separate patch and rebuild paths in workflow loop (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/src/agent/instance-agent.ts
+++ b/packages/@n8n/instance-ai/src/agent/instance-agent.ts
@@ -157,6 +157,7 @@ export async function createInstanceAgent(options: CreateInstanceAgentOptions): 
 		'search-template-parameters',
 		'build-workflow',
 		'get-workflow-as-code',
+		'patch-workflow',
 	]);
 
 	// Write/mutate data-table tools stay behind manage-data-tables-with-agent.

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/report-verification-verdict.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/report-verification-verdict.tool.test.ts
@@ -81,14 +81,15 @@ describe('report-verification-verdict tool', () => {
 		expect((result as { guidance: string }).guidance).toContain('run-workflow');
 	});
 
-	it('returns rebuild guidance when needs_patch routes through builder', async () => {
-		const rebuildAction: WorkflowLoopAction = {
-			type: 'rebuild',
+	it('returns patch guidance when needs_patch produces patch action', async () => {
+		const patchAction: WorkflowLoopAction = {
+			type: 'patch',
 			workflowId: 'wf-123',
-			failureDetails:
-				'Failed node: HTTP Request. Suggested parameter fix: {"url":"https://example.com"}',
+			failedNodeName: 'HTTP Request',
+			diagnosis: 'Invalid URL',
+			patch: { url: 'https://example.com' },
 		};
-		const reportVerificationVerdict = jest.fn().mockResolvedValue(rebuildAction);
+		const reportVerificationVerdict = jest.fn().mockResolvedValue(patchAction);
 		const context = createMockContext({ reportVerificationVerdict });
 		const tool = createReportVerificationVerdictTool(context);
 
@@ -102,8 +103,9 @@ describe('report-verification-verdict tool', () => {
 			{} as never,
 		);
 
-		expect((result as { guidance: string }).guidance).toContain('REBUILD NEEDED');
-		expect((result as { guidance: string }).guidance).toContain('build-workflow-with-agent');
+		expect((result as { guidance: string }).guidance).toContain('PATCH NEEDED');
+		expect((result as { guidance: string }).guidance).toContain('mode');
+		expect((result as { guidance: string }).guidance).toContain('patch');
 	});
 
 	it('returns rebuild guidance when action is rebuild', async () => {

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.prompt.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.prompt.ts
@@ -4,7 +4,7 @@
  * Three variants:
  * - BUILDER_AGENT_PROMPT: Original tool-based builder (no sandbox)
  * - SANDBOX_BUILDER_AGENT_PROMPT: Sandbox-based builder with real files + tsc
- * - SANDBOX_PATCH_PROMPT: Minimal prompt for targeted single-node fixes
+ * - PATCH_AGENT_PROMPT: Minimal prompt for targeted single-node fixes
  */
 
 import {
@@ -846,7 +846,7 @@ ${SDK_RULES_AND_PATTERNS}
 
 // ── Patch-mode builder prompt ────────────────────────────────────────────────
 
-export const SANDBOX_PATCH_PROMPT = `You fix a single failing node in an n8n workflow using \`patch-workflow\`. Be terse — you report to a parent agent.
+export const PATCH_AGENT_PROMPT = `You fix a single failing node in an n8n workflow using \`patch-workflow\`. Be terse — you report to a parent agent.
 
 If the fix requires adding/removing nodes or rewiring connections, say so and stop.
 `;

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.prompt.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.prompt.ts
@@ -1,9 +1,10 @@
 /**
  * System prompts for the preconfigured workflow builder agent.
  *
- * Two variants:
+ * Three variants:
  * - BUILDER_AGENT_PROMPT: Original tool-based builder (no sandbox)
  * - SANDBOX_BUILDER_AGENT_PROMPT: Sandbox-based builder with real files + tsc
+ * - SANDBOX_PATCH_PROMPT: Minimal prompt for targeted single-node fixes
  */
 
 import {
@@ -496,10 +497,7 @@ export const BUILDER_AGENT_PROMPT = `You are an expert n8n workflow builder. You
 - Only output text for: errors that need attention, or a final one-line summary of what was built.
 
 ## Repair Strategy
-When called with failure details for an existing workflow:
-1. If the failure is a single-node parameter/credential issue, use \`patch-workflow\` for a targeted fix
-2. If the failure requires structural changes (add/remove nodes, rewire connections), regenerate code
-3. Always re-verify after patching by reporting completion
+When called with failure details for an existing workflow, start from the pre-loaded code — do not re-discover node types already present.
 
 ## Escalation
 - If you are stuck or need information only a human can provide (e.g., a chat ID, API key, external resource name), use the \`ask-user\` tool to ask a clear question.
@@ -715,10 +713,7 @@ When \`explore-node-resources\` returns no results for a required resource:
 **For resources that can't be created via n8n** (e.g., Slack channels, external API resources), explain clearly in your summary what the user needs to create manually and what ID to put where.
 
 ## Repair Strategy
-When called with failure details for an existing workflow:
-1. If the failure is a single-node parameter/credential issue, use \`patch-workflow\` for a targeted fix
-2. If the failure requires structural changes (add/remove nodes, rewire connections), regenerate code
-3. Always re-verify after patching by reporting completion
+When called with failure details for an existing workflow, start from the pre-loaded code — do not re-discover node types already present.
 
 ## Escalation
 - If you are stuck or need information only a human can provide (e.g., a chat ID, API key, external resource name), use the \`ask-user\` tool to ask a clear question.
@@ -847,4 +842,11 @@ Keep entries short (one bullet each). Remove stale entries when updating.
 If your memory contains sections not in the current template, discard them and retain only matching facts.
 
 ${SDK_RULES_AND_PATTERNS}
+`;
+
+// ── Patch-mode builder prompt ────────────────────────────────────────────────
+
+export const SANDBOX_PATCH_PROMPT = `You fix a single failing node in an n8n workflow using \`patch-workflow\`. Be terse — you report to a parent agent.
+
+If the fix requires adding/removing nodes or rewiring connections, say so and stop.
 `;

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
@@ -87,6 +87,7 @@ function buildOutcome(
 
 const BUILDER_MAX_STEPS = 30;
 const PATCH_MAX_STEPS = 8;
+const PATCH_TOOL_NAMES = ['patch-workflow', 'list-credentials', 'test-credential'] as const;
 
 function hashContent(content: string | null): string {
 	return createHash('sha256')
@@ -128,9 +129,10 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 				return { result: 'Error: background task support not available.' };
 			}
 
+			const isPatch = input.mode === 'patch';
 			const factory = context.builderSandboxFactory;
 			const domainContext = context.domainContext;
-			const useSandbox = !!factory && !!domainContext;
+			const useSandbox = !!factory && !!domainContext && !isPatch;
 
 			// Build the appropriate tool set based on mode
 			let builderTools: ToolsInput;
@@ -142,38 +144,29 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 			if (useSandbox) {
 				credMap = await buildCredentialMap(domainContext.credentialService);
 
-				const isPatch = input.mode === 'patch';
-
-				const toolNames = isPatch
-					? [
-							// Patch mode: minimal tool set for targeted fixes
-							'patch-workflow',
-							'list-credentials',
-							'test-credential',
-						]
-					: [
-							// Full build/rebuild mode: node discovery, credential/execution tools
-							// submit-workflow is created per-builder inside run: (needs the builder's workspace)
-							'search-nodes',
-							'get-suggested-nodes',
-							'get-workflow-as-code',
-							'get-node-type-definition',
-							'explore-node-resources',
-							'list-workflows',
-							'list-credentials',
-							'test-credential',
-							'run-workflow',
-							'get-execution',
-							'debug-execution',
-							'publish-workflow',
-							'unpublish-workflow',
-							'list-data-tables',
-							'create-data-table',
-							'get-data-table-schema',
-							'add-data-table-column',
-							'query-data-table-rows',
-							'insert-data-table-rows',
-						];
+				const toolNames = [
+					// Full build/rebuild mode: node discovery, credential/execution tools
+					// submit-workflow is created per-builder inside run: (needs the builder's workspace)
+					'search-nodes',
+					'get-suggested-nodes',
+					'get-workflow-as-code',
+					'get-node-type-definition',
+					'explore-node-resources',
+					'list-workflows',
+					'list-credentials',
+					'test-credential',
+					'run-workflow',
+					'get-execution',
+					'debug-execution',
+					'publish-workflow',
+					'unpublish-workflow',
+					'list-data-tables',
+					'create-data-table',
+					'get-data-table-schema',
+					'add-data-table-column',
+					'query-data-table-rows',
+					'insert-data-table-rows',
+				];
 
 				builderTools = {};
 				for (const name of toolNames) {
@@ -181,15 +174,13 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 						builderTools[name] = context.domainTools[name];
 					}
 				}
-				prompt = isPatch ? PATCH_AGENT_PROMPT : SANDBOX_BUILDER_AGENT_PROMPT;
+				prompt = SANDBOX_BUILDER_AGENT_PROMPT;
 			} else {
-				// Tool mode: original approach with build-workflow + get-node-type-definition
+				// Tool mode: original approach, also used for all patch invocations
 				builderTools = {};
 
-				const isPatch = input.mode === 'patch';
-
 				const toolNames = isPatch
-					? ['patch-workflow', 'list-credentials', 'test-credential']
+					? [...PATCH_TOOL_NAMES]
 					: [
 							'build-workflow',
 							'get-node-type-definition',
@@ -235,7 +226,7 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 					tools: Object.keys(builderTools),
 					taskId,
 					kind: 'builder',
-					title: input.mode === 'patch' ? 'Patching workflow' : 'Building workflow',
+					title: isPatch ? 'Patching workflow' : 'Building workflow',
 					subtitle: truncateLabel(input.task),
 					goal: input.task,
 					targetResource: input.workflowId
@@ -259,7 +250,7 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 			}
 
 			let briefing: string;
-			if (input.mode === 'patch' && workflowId) {
+			if (isPatch && workflowId) {
 				briefing = `${input.task}\n\n[CONTEXT: Patching workflow ${workflowId}.]${iterationContext ? `\n\n${iterationContext}` : ''}`;
 			} else if (workflowId) {
 				briefing = `${input.task}\n\n[CONTEXT: Modifying existing workflow ${workflowId}. The current code is pre-loaded in ~/workspace/src/workflow.ts — read it first, then edit. Use workflowId "${workflowId}" when calling submit-workflow.]${iterationContext ? `\n\n${iterationContext}` : ''}`;
@@ -314,17 +305,14 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 								}
 							}
 
-							// Patch mode uses patch-workflow directly — no submit tool needed
-							if (input.mode !== 'patch') {
-								builderTools['submit-workflow'] = createSubmitWorkflowTool(
-									domainContext,
-									workspace,
-									credMap,
-									(attempt) => {
-										submitAttempts.set(attempt.filePath, attempt);
-									},
-								);
-							}
+							builderTools['submit-workflow'] = createSubmitWorkflowTool(
+								domainContext,
+								workspace,
+								credMap,
+								(attempt) => {
+									submitAttempts.set(attempt.filePath, attempt);
+								},
+							);
 
 							const subAgent = new Agent({
 								id: subAgentId,
@@ -351,7 +339,7 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 									}
 								: undefined;
 
-							const maxSteps = input.mode === 'patch' ? PATCH_MAX_STEPS : BUILDER_MAX_STEPS;
+							const maxSteps = BUILDER_MAX_STEPS;
 
 							const stream = await subAgent.stream(briefing, {
 								maxSteps,
@@ -379,11 +367,6 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 							});
 
 							const finalText = await hitlResult.text;
-
-							// Patch mode: no submit-workflow tracking — patch was applied directly
-							if (input.mode === 'patch') {
-								return { text: finalText };
-							}
 
 							const root = await getWorkspaceRoot(workspace);
 							const mainWorkflowPath = `${root}/src/workflow.ts`;
@@ -450,10 +433,10 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 								}
 							: undefined;
 
-						const toolMaxSteps = input.mode === 'patch' ? PATCH_MAX_STEPS : BUILDER_MAX_STEPS;
+						const maxSteps = isPatch ? PATCH_MAX_STEPS : BUILDER_MAX_STEPS;
 
 						const stream = await subAgent.stream(briefing, {
-							maxSteps: toolMaxSteps,
+							maxSteps,
 							abortSignal: signal,
 							providerOptions: {
 								anthropic: { cacheControl: { type: 'ephemeral' } },

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
@@ -185,33 +185,37 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 			} else {
 				// Tool mode: original approach with build-workflow + get-node-type-definition
 				builderTools = {};
-				const toolNames = [
-					'build-workflow',
-					'get-node-type-definition',
-					'get-workflow-as-code',
-					'list-workflows',
-					'search-nodes',
-					'get-suggested-nodes',
-					// Data table management
-					'list-data-tables',
-					'create-data-table',
-					'get-data-table-schema',
-					'add-data-table-column',
-					'query-data-table-rows',
-					'insert-data-table-rows',
-					...(context.researchMode ? ['web-search', 'fetch-url'] : []),
-				];
+
+				const isPatch = input.mode === 'patch';
+
+				const toolNames = isPatch
+					? ['patch-workflow', 'list-credentials', 'test-credential']
+					: [
+							'build-workflow',
+							'get-node-type-definition',
+							'get-workflow-as-code',
+							'list-workflows',
+							'search-nodes',
+							'get-suggested-nodes',
+							'list-data-tables',
+							'create-data-table',
+							'get-data-table-schema',
+							'add-data-table-column',
+							'query-data-table-rows',
+							'insert-data-table-rows',
+							...(context.researchMode ? ['web-search', 'fetch-url'] : []),
+						];
 				for (const name of toolNames) {
 					if (name in context.domainTools) {
 						builderTools[name] = context.domainTools[name];
 					}
 				}
 
-				if (!builderTools['build-workflow']) {
+				if (!isPatch && !builderTools['build-workflow']) {
 					return { result: 'Error: build-workflow tool not available.' };
 				}
 
-				prompt = BUILDER_AGENT_PROMPT;
+				prompt = isPatch ? SANDBOX_PATCH_PROMPT : BUILDER_AGENT_PROMPT;
 			}
 
 			const builderMemory = createSubAgentMemory(context.storage, 'workflow-builder');
@@ -446,8 +450,10 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 								}
 							: undefined;
 
+						const toolMaxSteps = input.mode === 'patch' ? PATCH_MAX_STEPS : BUILDER_MAX_STEPS;
+
 						const stream = await subAgent.stream(briefing, {
-							maxSteps: BUILDER_MAX_STEPS,
+							maxSteps: toolMaxSteps,
 							abortSignal: signal,
 							providerOptions: {
 								anthropic: { cacheControl: { type: 'ephemeral' } },

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
@@ -130,6 +130,9 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 			}
 
 			const isPatch = input.mode === 'patch';
+			if (isPatch && !input.workflowId) {
+				return { result: 'Error: workflowId is required in patch mode.' };
+			}
 			const factory = context.builderSandboxFactory;
 			const domainContext = context.domainContext;
 			const useSandbox = !!factory && !!domainContext && !isPatch;
@@ -202,6 +205,9 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 					}
 				}
 
+				if (isPatch && !builderTools['patch-workflow']) {
+					return { result: 'Error: patch-workflow tool not available.' };
+				}
 				if (!isPatch && !builderTools['build-workflow']) {
 					return { result: 'Error: build-workflow tool not available.' };
 				}

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
@@ -20,7 +20,7 @@ import { z } from 'zod';
 import {
 	BUILDER_AGENT_PROMPT,
 	SANDBOX_BUILDER_AGENT_PROMPT,
-	SANDBOX_PATCH_PROMPT,
+	PATCH_AGENT_PROMPT,
 } from './build-workflow-agent.prompt';
 import { truncateLabel } from './display-utils';
 import { registerWithMastra } from '../../agent/register-with-mastra';
@@ -181,7 +181,7 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 						builderTools[name] = context.domainTools[name];
 					}
 				}
-				prompt = isPatch ? SANDBOX_PATCH_PROMPT : SANDBOX_BUILDER_AGENT_PROMPT;
+				prompt = isPatch ? PATCH_AGENT_PROMPT : SANDBOX_BUILDER_AGENT_PROMPT;
 			} else {
 				// Tool mode: original approach with build-workflow + get-node-type-definition
 				builderTools = {};
@@ -215,7 +215,7 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 					return { result: 'Error: build-workflow tool not available.' };
 				}
 
-				prompt = isPatch ? SANDBOX_PATCH_PROMPT : BUILDER_AGENT_PROMPT;
+				prompt = isPatch ? PATCH_AGENT_PROMPT : BUILDER_AGENT_PROMPT;
 			}
 
 			const builderMemory = createSubAgentMemory(context.storage, 'workflow-builder');

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
@@ -17,7 +17,11 @@ import { nanoid } from 'nanoid';
 import { createHash } from 'node:crypto';
 import { z } from 'zod';
 
-import { BUILDER_AGENT_PROMPT, SANDBOX_BUILDER_AGENT_PROMPT } from './build-workflow-agent.prompt';
+import {
+	BUILDER_AGENT_PROMPT,
+	SANDBOX_BUILDER_AGENT_PROMPT,
+	SANDBOX_PATCH_PROMPT,
+} from './build-workflow-agent.prompt';
 import { truncateLabel } from './display-utils';
 import { registerWithMastra } from '../../agent/register-with-mastra';
 import { createSubAgentMemory, subAgentResourceId } from '../../memory/sub-agent-memory';
@@ -82,6 +86,7 @@ function buildOutcome(
 }
 
 const BUILDER_MAX_STEPS = 30;
+const PATCH_MAX_STEPS = 8;
 
 function hashContent(content: string | null): string {
 	return createHash('sha256')
@@ -108,6 +113,12 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 				.describe(
 					'Existing workflow ID to modify. When provided, the agent starts with the current workflow code pre-loaded.',
 				),
+			mode: z
+				.enum(['build', 'patch'])
+				.default('build')
+				.describe(
+					'Operation mode. "build" for full builds/rebuilds. "patch" for targeted single-node fixes with reduced tool set and step budget.',
+				),
 		}),
 		outputSchema: z.object({
 			result: z.string(),
@@ -131,43 +142,46 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 			if (useSandbox) {
 				credMap = await buildCredentialMap(domainContext.credentialService);
 
-				// Sandbox mode: node discovery, credential/execution tools
-				// submit-workflow is created per-builder inside run: (needs the builder's workspace)
-				const sandboxToolNames = [
-					// Node discovery
-					'search-nodes',
-					'get-suggested-nodes',
-					'get-workflow-as-code',
-					'get-node-type-definition',
-					'explore-node-resources',
-					// Workflow discovery
-					'list-workflows',
-					// Credential awareness
-					'list-credentials',
-					'test-credential',
-					// Execution & debugging
-					'run-workflow',
-					'get-execution',
-					'debug-execution',
-					// Workflow lifecycle
-					'publish-workflow',
-					'unpublish-workflow',
-					// Data table management (create/inspect tables used by workflows)
-					'list-data-tables',
-					'create-data-table',
-					'get-data-table-schema',
-					'add-data-table-column',
-					'query-data-table-rows',
-					'insert-data-table-rows',
-				];
+				const isPatch = input.mode === 'patch';
+
+				const toolNames = isPatch
+					? [
+							// Patch mode: minimal tool set for targeted fixes
+							'patch-workflow',
+							'list-credentials',
+							'test-credential',
+						]
+					: [
+							// Full build/rebuild mode: node discovery, credential/execution tools
+							// submit-workflow is created per-builder inside run: (needs the builder's workspace)
+							'search-nodes',
+							'get-suggested-nodes',
+							'get-workflow-as-code',
+							'get-node-type-definition',
+							'explore-node-resources',
+							'list-workflows',
+							'list-credentials',
+							'test-credential',
+							'run-workflow',
+							'get-execution',
+							'debug-execution',
+							'publish-workflow',
+							'unpublish-workflow',
+							'list-data-tables',
+							'create-data-table',
+							'get-data-table-schema',
+							'add-data-table-column',
+							'query-data-table-rows',
+							'insert-data-table-rows',
+						];
 
 				builderTools = {};
-				for (const name of sandboxToolNames) {
+				for (const name of toolNames) {
 					if (context.domainTools[name]) {
 						builderTools[name] = context.domainTools[name];
 					}
 				}
-				prompt = SANDBOX_BUILDER_AGENT_PROMPT;
+				prompt = isPatch ? SANDBOX_PATCH_PROMPT : SANDBOX_BUILDER_AGENT_PROMPT;
 			} else {
 				// Tool mode: original approach with build-workflow + get-node-type-definition
 				builderTools = {};
@@ -217,7 +231,7 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 					tools: Object.keys(builderTools),
 					taskId,
 					kind: 'builder',
-					title: 'Building workflow',
+					title: input.mode === 'patch' ? 'Patching workflow' : 'Building workflow',
 					subtitle: truncateLabel(input.task),
 					goal: input.task,
 					targetResource: input.workflowId
@@ -240,9 +254,14 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 				}
 			}
 
-			const briefing = workflowId
-				? `${input.task}\n\n[CONTEXT: Modifying existing workflow ${workflowId}. The current code is pre-loaded in ~/workspace/src/workflow.ts — read it first, then edit. Use workflowId "${workflowId}" when calling submit-workflow.]${iterationContext ? `\n\n${iterationContext}` : ''}`
-				: `${input.task}${iterationContext ? `\n\n${iterationContext}` : ''}`;
+			let briefing: string;
+			if (input.mode === 'patch' && workflowId) {
+				briefing = `${input.task}\n\n[CONTEXT: Patching workflow ${workflowId}.]${iterationContext ? `\n\n${iterationContext}` : ''}`;
+			} else if (workflowId) {
+				briefing = `${input.task}\n\n[CONTEXT: Modifying existing workflow ${workflowId}. The current code is pre-loaded in ~/workspace/src/workflow.ts — read it first, then edit. Use workflowId "${workflowId}" when calling submit-workflow.]${iterationContext ? `\n\n${iterationContext}` : ''}`;
+			} else {
+				briefing = `${input.task}${iterationContext ? `\n\n${iterationContext}` : ''}`;
+			}
 
 			// Spawn builder as a background task — returns immediately
 			context.spawnBackgroundTask({
@@ -291,15 +310,17 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 								}
 							}
 
-							// Create submit tool scoped to THIS builder's workspace
-							builderTools['submit-workflow'] = createSubmitWorkflowTool(
-								domainContext,
-								workspace,
-								credMap,
-								(attempt) => {
-									submitAttempts.set(attempt.filePath, attempt);
-								},
-							);
+							// Patch mode uses patch-workflow directly — no submit tool needed
+							if (input.mode !== 'patch') {
+								builderTools['submit-workflow'] = createSubmitWorkflowTool(
+									domainContext,
+									workspace,
+									credMap,
+									(attempt) => {
+										submitAttempts.set(attempt.filePath, attempt);
+									},
+								);
+							}
 
 							const subAgent = new Agent({
 								id: subAgentId,
@@ -326,8 +347,10 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 									}
 								: undefined;
 
+							const maxSteps = input.mode === 'patch' ? PATCH_MAX_STEPS : BUILDER_MAX_STEPS;
+
 							const stream = await subAgent.stream(briefing, {
-								maxSteps: BUILDER_MAX_STEPS,
+								maxSteps,
 								abortSignal: signal,
 								providerOptions: {
 									anthropic: { cacheControl: { type: 'ephemeral' } },
@@ -352,6 +375,12 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 							});
 
 							const finalText = await hitlResult.text;
+
+							// Patch mode: no submit-workflow tracking — patch was applied directly
+							if (input.mode === 'patch') {
+								return { text: finalText };
+							}
+
 							const root = await getWorkspaceRoot(workspace);
 							const mainWorkflowPath = `${root}/src/workflow.ts`;
 							const mainWorkflowAttempt = submitAttempts.get(mainWorkflowPath);

--- a/packages/@n8n/instance-ai/src/tools/orchestration/report-verification-verdict.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/report-verification-verdict.tool.ts
@@ -47,6 +47,14 @@ function actionToGuidance(action: WorkflowLoopAction): string {
 				`Call \`build-workflow-with-agent\` again with these details: ${action.failureDetails}. ` +
 				'The build outcome will trigger verification automatically.'
 			);
+		case 'patch':
+			return (
+				`PATCH NEEDED: Node "${action.failedNodeName}" in workflow ${action.workflowId} needs a targeted fix. ` +
+				`Diagnosis: ${action.diagnosis}. ` +
+				(action.patch ? `Suggested fix: ${JSON.stringify(action.patch)}. ` : '') +
+				`Call \`build-workflow-with-agent\` with mode "patch", workflowId "${action.workflowId}", and these details in the task. ` +
+				'The build outcome will trigger verification automatically.'
+			);
 	}
 }
 

--- a/packages/@n8n/instance-ai/src/tools/workflows/patch-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/patch-workflow.tool.ts
@@ -13,7 +13,7 @@ export function createPatchWorkflowTool(context: InstanceAiContext) {
 		inputSchema: z.object({
 			workflowId: z.string().describe('ID of the workflow to patch'),
 			nodeName: z.string().describe('Exact name of the node to patch'),
-			newName: z.string().optional().describe('Rename the node to this value'),
+			newName: z.string().min(1).optional().describe('Rename the node to this value'),
 			parameterPatch: z
 				.record(z.unknown())
 				.optional()
@@ -48,7 +48,7 @@ export function createPatchWorkflowTool(context: InstanceAiContext) {
 					credentials: credentialPatch,
 					disabled,
 				});
-				return { success: true, workflowId, nodeName: newName || nodeName };
+				return { success: true, workflowId, nodeName: newName ?? nodeName };
 			} catch (error) {
 				return {
 					success: false,

--- a/packages/@n8n/instance-ai/src/tools/workflows/patch-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/patch-workflow.tool.ts
@@ -7,12 +7,13 @@ export function createPatchWorkflowTool(context: InstanceAiContext) {
 	return createTool({
 		id: 'patch-workflow',
 		description:
-			'Patch a single node in a workflow: update parameters, swap credentials, or enable/disable. ' +
-			'Use for quick fixes (placeholder IDs, credential swaps, toggling nodes). ' +
+			'Patch a single node in a workflow: rename, update parameters, swap credentials, or enable/disable. ' +
+			'Use for quick fixes (renaming, placeholder IDs, credential swaps, toggling nodes). ' +
 			'For structural changes (add/remove nodes, rewire connections), use build-workflow-with-agent instead.',
 		inputSchema: z.object({
 			workflowId: z.string().describe('ID of the workflow to patch'),
 			nodeName: z.string().describe('Exact name of the node to patch'),
+			newName: z.string().optional().describe('Rename the node to this value'),
 			parameterPatch: z
 				.record(z.unknown())
 				.optional()
@@ -30,7 +31,7 @@ export function createPatchWorkflowTool(context: InstanceAiContext) {
 			error: z.string().optional(),
 		}),
 		execute: async (input) => {
-			const { workflowId, nodeName, parameterPatch, credentialPatch, disabled } = input;
+			const { workflowId, nodeName, newName, parameterPatch, credentialPatch, disabled } = input;
 			if (!context.workflowService.patchNode) {
 				return {
 					success: false,
@@ -42,11 +43,12 @@ export function createPatchWorkflowTool(context: InstanceAiContext) {
 
 			try {
 				await context.workflowService.patchNode(workflowId, nodeName, {
+					name: newName,
 					parameters: parameterPatch,
 					credentials: credentialPatch,
 					disabled,
 				});
-				return { success: true, workflowId, nodeName };
+				return { success: true, workflowId, nodeName: newName ?? nodeName };
 			} catch (error) {
 				return {
 					success: false,

--- a/packages/@n8n/instance-ai/src/tools/workflows/patch-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/patch-workflow.tool.ts
@@ -48,7 +48,7 @@ export function createPatchWorkflowTool(context: InstanceAiContext) {
 					credentials: credentialPatch,
 					disabled,
 				});
-				return { success: true, workflowId, nodeName: newName ?? nodeName };
+				return { success: true, workflowId, nodeName: newName || nodeName };
 			} catch (error) {
 				return {
 					success: false,

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -163,6 +163,7 @@ export interface InstanceAiWorkflowService {
 		workflowId: string,
 		nodeName: string,
 		patch: {
+			name?: string;
 			parameters?: Record<string, unknown>;
 			credentials?: Record<string, { id: string; name: string }>;
 			disabled?: boolean;

--- a/packages/@n8n/instance-ai/src/workflow-loop/__tests__/workflow-loop-controller.test.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/__tests__/workflow-loop-controller.test.ts
@@ -201,37 +201,43 @@ describe('handleVerificationVerdict', () => {
 		expect(next.lastFailureSignature).toBe('node:timeout');
 	});
 
-	it('routes needs_patch through builder-based rebuild', () => {
+	it('produces a patch action for needs_patch verdict', () => {
 		const state = makeState({ phase: 'verifying', workflowId: 'wf_123' });
 		const verdict = makeVerdict({
 			verdict: 'needs_patch',
 			failedNodeName: 'Gmail Send',
+			diagnosis: 'Invalid recipient address',
 			patch: { parameters: { to: 'fix@example.com' } },
 			failureSignature: 'gmail:invalid_recipient',
 		});
 
-		const { state: next, action } = handleVerificationVerdict(state, [], verdict);
+		const { state: next, action, attempt } = handleVerificationVerdict(state, [], verdict);
 
 		expect(next.phase).toBe('repairing');
 		expect(next.rebuildAttempts).toBe(1);
-		expect(action.type).toBe('rebuild');
-		if (action.type === 'rebuild') {
-			expect(action.failureDetails).toContain('Gmail Send');
-			expect(action.failureDetails).toContain('gmail:invalid_recipient');
+		expect(action.type).toBe('patch');
+		if (action.type === 'patch') {
+			expect(action.workflowId).toBe('wf_123');
+			expect(action.failedNodeName).toBe('Gmail Send');
+			expect(action.diagnosis).toBe('Invalid recipient address');
+			expect(action.patch).toEqual({ parameters: { to: 'fix@example.com' } });
 		}
+		expect(attempt.action).toBe('patch');
 	});
 
-	it('escalates to rebuild when patch lacks required info', () => {
+	it('produces patch action with fallback node name when failedNodeName is missing', () => {
 		const state = makeState({ phase: 'verifying', workflowId: 'wf_123' });
 		const verdict = makeVerdict({
 			verdict: 'needs_patch',
 			failureSignature: 'gmail:error',
-			// Missing failedNodeName and patch — insufficient for targeted fix
 		});
 
 		const { action } = handleVerificationVerdict(state, [], verdict);
 
-		expect(action.type).toBe('rebuild');
+		expect(action.type).toBe('patch');
+		if (action.type === 'patch') {
+			expect(action.failedNodeName).toBe('unknown');
+		}
 	});
 
 	it('transitions to repairing with rebuild on needs_rebuild', () => {
@@ -260,7 +266,7 @@ describe('retry policy', () => {
 				workItemId: 'wi_test',
 				phase: 'repairing',
 				attempt: 1,
-				action: 'rebuild',
+				action: 'patch',
 				result: 'failure',
 				failureSignature: 'gmail:auth_error',
 				createdAt: new Date().toISOString(),
@@ -303,14 +309,14 @@ describe('retry policy', () => {
 		expect(action.type).toBe('blocked');
 	});
 
-	it('allows rebuild for a different failureSignature', () => {
+	it('allows patch for a different failureSignature', () => {
 		const state = makeState({ phase: 'verifying', workflowId: 'wf_123', rebuildAttempts: 1 });
 		const priorAttempts: AttemptRecord[] = [
 			{
 				workItemId: 'wi_test',
 				phase: 'repairing',
 				attempt: 1,
-				action: 'rebuild',
+				action: 'patch',
 				result: 'failure',
 				failureSignature: 'gmail:auth_error',
 				createdAt: new Date().toISOString(),
@@ -325,7 +331,32 @@ describe('retry policy', () => {
 
 		const { action } = handleVerificationVerdict(state, priorAttempts, verdict);
 
-		expect(action.type).toBe('rebuild');
+		expect(action.type).toBe('patch');
+	});
+
+	it('blocks when patch follows a rebuild with the same failureSignature', () => {
+		const state = makeState({ phase: 'verifying', workflowId: 'wf_123', rebuildAttempts: 1 });
+		const priorAttempts: AttemptRecord[] = [
+			{
+				workItemId: 'wi_test',
+				phase: 'repairing',
+				attempt: 1,
+				action: 'rebuild',
+				result: 'failure',
+				failureSignature: 'node:error',
+				createdAt: new Date().toISOString(),
+			},
+		];
+		const verdict = makeVerdict({
+			verdict: 'needs_patch',
+			failureSignature: 'node:error',
+			failedNodeName: 'Code',
+		});
+
+		const { state: next, action } = handleVerificationVerdict(state, priorAttempts, verdict);
+
+		expect(next.phase).toBe('blocked');
+		expect(action.type).toBe('blocked');
 	});
 
 	it('parallel work items do not collide in attempt history', () => {

--- a/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-controller.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-controller.ts
@@ -183,58 +183,43 @@ export function handleVerificationVerdict(
 		case 'needs_patch': {
 			attempt.result = 'failure';
 			attempt.action = 'patch';
-
-			// Check retry policy: 1 repair per unique failureSignature
-			if (verdict.failureSignature && hasRepeatedRepair(attempts, verdict.failureSignature)) {
-				return {
-					state: {
-						...state,
-						phase: 'blocked',
-						status: 'blocked',
-						lastFailureSignature: verdict.failureSignature,
-					},
-					action: {
-						type: 'blocked',
-						reason: `Repeated repair failure: ${verdict.failureSignature}`,
-					},
-					attempt,
-				};
-			}
-
-			return {
-				state: {
-					...state,
-					phase: 'repairing',
-					status: 'active',
-					rebuildAttempts: state.rebuildAttempts + 1,
-					lastFailureSignature: verdict.failureSignature,
-					lastExecutionId: verdict.executionId,
-				},
-				action: {
-					type: 'patch',
-					workflowId: verdict.workflowId,
-					failedNodeName: verdict.failedNodeName ?? 'unknown',
-					diagnosis: verdict.diagnosis ?? verdict.summary,
-					patch: verdict.patch,
-				},
-				attempt,
-			};
+			return escalateToRepair(state, attempts, verdict, attempt, {
+				type: 'patch',
+				workflowId: verdict.workflowId,
+				failedNodeName: verdict.failedNodeName ?? 'unknown',
+				diagnosis: verdict.diagnosis ?? verdict.summary,
+				patch: verdict.patch,
+			});
 		}
 
 		case 'needs_rebuild': {
 			attempt.result = 'failure';
-			return escalateToRebuild(state, attempts, verdict, attempt);
+
+			const failureDetails = [
+				verdict.diagnosis ?? '',
+				verdict.failedNodeName ? `Failed node: ${verdict.failedNodeName}` : '',
+				verdict.failureSignature ? `Signature: ${verdict.failureSignature}` : '',
+			]
+				.filter(Boolean)
+				.join('. ');
+
+			return escalateToRepair(state, attempts, verdict, attempt, {
+				type: 'rebuild',
+				workflowId: verdict.workflowId,
+				failureDetails: failureDetails || verdict.summary,
+			});
 		}
 	}
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-function escalateToRebuild(
+function escalateToRepair(
 	state: WorkflowLoopState,
 	attempts: AttemptRecord[],
 	verdict: VerificationResult,
 	attempt: AttemptRecord,
+	action: WorkflowLoopAction,
 ): TransitionResult {
 	// Check retry policy: only 1 repair (patch or rebuild) per unique failureSignature
 	if (verdict.failureSignature && hasRepeatedRepair(attempts, verdict.failureSignature)) {
@@ -247,19 +232,11 @@ function escalateToRebuild(
 			},
 			action: {
 				type: 'blocked',
-				reason: `Repeated rebuild failure: ${verdict.failureSignature}`,
+				reason: `Repeated repair failure: ${verdict.failureSignature}`,
 			},
 			attempt,
 		};
 	}
-
-	const failureDetails = [
-		verdict.diagnosis ?? '',
-		verdict.failedNodeName ? `Failed node: ${verdict.failedNodeName}` : '',
-		verdict.failureSignature ? `Signature: ${verdict.failureSignature}` : '',
-	]
-		.filter(Boolean)
-		.join('. ');
 
 	return {
 		state: {
@@ -270,11 +247,7 @@ function escalateToRebuild(
 			lastFailureSignature: verdict.failureSignature,
 			lastExecutionId: verdict.executionId,
 		},
-		action: {
-			type: 'rebuild',
-			workflowId: verdict.workflowId,
-			failureDetails: failureDetails || verdict.summary,
-		},
+		action,
 		attempt,
 	};
 }

--- a/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-controller.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-controller.ts
@@ -7,8 +7,8 @@
  * Five phases: building → verifying → repairing → done | blocked
  *
  * Retry policy:
- * - At most 1 automatic rebuild per unique failureSignature
- * - Same failureSignature after rebuild → blocked (no silent loops)
+ * - At most 1 automatic repair (patch or rebuild) per unique failureSignature
+ * - Same failureSignature after repair → blocked (no silent loops)
  */
 
 import { nanoid } from 'nanoid';
@@ -182,20 +182,43 @@ export function handleVerificationVerdict(
 
 		case 'needs_patch': {
 			attempt.result = 'failure';
+			attempt.action = 'patch';
 
-			// All repairs — including single-node fixes — go through the builder.
-			// Enrich the diagnosis with node-level details so the builder can
-			// make a targeted modification on the existing workflow.
-			const patchDetails = [
-				verdict.diagnosis ?? '',
-				verdict.failedNodeName ? `Failed node: ${verdict.failedNodeName}` : '',
-				verdict.patch ? `Suggested parameter fix: ${JSON.stringify(verdict.patch)}` : '',
-				verdict.failureSignature ? `Signature: ${verdict.failureSignature}` : '',
-			]
-				.filter(Boolean)
-				.join('. ');
+			// Check retry policy: 1 repair per unique failureSignature
+			if (verdict.failureSignature && hasRepeatedRepair(attempts, verdict.failureSignature)) {
+				return {
+					state: {
+						...state,
+						phase: 'blocked',
+						status: 'blocked',
+						lastFailureSignature: verdict.failureSignature,
+					},
+					action: {
+						type: 'blocked',
+						reason: `Repeated repair failure: ${verdict.failureSignature}`,
+					},
+					attempt,
+				};
+			}
 
-			return escalateToRebuild(state, attempts, { ...verdict, diagnosis: patchDetails }, attempt);
+			return {
+				state: {
+					...state,
+					phase: 'repairing',
+					status: 'active',
+					rebuildAttempts: state.rebuildAttempts + 1,
+					lastFailureSignature: verdict.failureSignature,
+					lastExecutionId: verdict.executionId,
+				},
+				action: {
+					type: 'patch',
+					workflowId: verdict.workflowId,
+					failedNodeName: verdict.failedNodeName ?? 'unknown',
+					diagnosis: verdict.diagnosis ?? verdict.summary,
+					patch: verdict.patch,
+				},
+				attempt,
+			};
 		}
 
 		case 'needs_rebuild': {
@@ -213,8 +236,8 @@ function escalateToRebuild(
 	verdict: VerificationResult,
 	attempt: AttemptRecord,
 ): TransitionResult {
-	// Check retry policy: only 1 rebuild per unique failureSignature
-	if (verdict.failureSignature && hasRepeatedRebuild(attempts, verdict.failureSignature)) {
+	// Check retry policy: only 1 repair (patch or rebuild) per unique failureSignature
+	if (verdict.failureSignature && hasRepeatedRepair(attempts, verdict.failureSignature)) {
 		return {
 			state: {
 				...state,
@@ -257,12 +280,15 @@ function escalateToRebuild(
 }
 
 /**
- * Check if we've already attempted a rebuild for the same failure signature.
- * Returns true when a prior rebuild attempt exists with the same failureSignature,
+ * Check if we've already attempted a repair (patch or rebuild) for the same failure signature.
+ * Returns true when a prior repair attempt exists with the same failureSignature,
  * which means we should stop and block to avoid infinite loops.
  */
-function hasRepeatedRebuild(attempts: AttemptRecord[], failureSignature: string): boolean {
-	return attempts.some((a) => a.action === 'rebuild' && a.failureSignature === failureSignature);
+function hasRepeatedRepair(attempts: AttemptRecord[], failureSignature: string): boolean {
+	return attempts.some(
+		(a) =>
+			(a.action === 'rebuild' || a.action === 'patch') && a.failureSignature === failureSignature,
+	);
 }
 
 function makeAttempt(

--- a/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-controller.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-controller.ts
@@ -194,6 +194,7 @@ export function handleVerificationVerdict(
 
 		case 'needs_rebuild': {
 			attempt.result = 'failure';
+			attempt.action = 'rebuild';
 
 			const failureDetails = [
 				verdict.diagnosis ?? '',

--- a/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-state.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-state.ts
@@ -38,7 +38,7 @@ export type WorkflowLoopState = z.infer<typeof workflowLoopStateSchema>;
 
 // ── AttemptRecord ───────────────────────────────────────────────────────────
 
-export const attemptActionSchema = z.enum(['build', 'verify', 'rebuild']);
+export const attemptActionSchema = z.enum(['build', 'verify', 'rebuild', 'patch']);
 export const attemptResultSchema = z.enum(['success', 'failure', 'blocked']);
 
 export const attemptRecordSchema = z.object({
@@ -117,5 +117,12 @@ export type VerificationResult = z.infer<typeof verificationResultSchema>;
 export type WorkflowLoopAction =
 	| { type: 'verify'; workflowId: string }
 	| { type: 'rebuild'; workflowId: string; failureDetails: string }
+	| {
+			type: 'patch';
+			workflowId: string;
+			failedNodeName: string;
+			diagnosis: string;
+			patch?: Record<string, unknown>;
+	  }
 	| { type: 'done'; workflowId?: string; summary: string; mockedCredentialTypes?: string[] }
 	| { type: 'blocked'; reason: string };

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -79,6 +79,7 @@ import {
 	WEBHOOK_NODE_TYPE,
 	SCHEDULE_TRIGGER_NODE_TYPE,
 	TimeoutExecutionCancelledError,
+	isSafeObjectProperty,
 } from 'n8n-workflow';
 
 import { ActiveExecutions } from '@/active-executions';
@@ -344,8 +345,12 @@ export class InstanceAiAdapterService {
 					throw new Error(`Node "${nodeName}" not found in workflow ${workflowId}`);
 				}
 
-				// Rename node (also update references in connections)
+				// Rename node (also update references in connections and pinData)
 				if (patch.name && patch.name !== node.name) {
+					if (!isSafeObjectProperty(patch.name)) {
+						throw new Error(`Invalid node name "${patch.name}"`);
+					}
+
 					const oldName = node.name;
 					node.name = patch.name;
 
@@ -366,6 +371,12 @@ export class InstanceAiAdapterService {
 								}
 							}
 						}
+					}
+
+					// Update pinData that references the old name
+					if (workflow.pinData?.[oldName]) {
+						workflow.pinData[patch.name] = workflow.pinData[oldName];
+						delete workflow.pinData[oldName];
 					}
 				}
 
@@ -389,7 +400,7 @@ export class InstanceAiAdapterService {
 
 				const updateData = workflowRepository.create({
 					nodes,
-					...(patch.name ? { connections: workflow.connections } : {}),
+					...(patch.name ? { connections: workflow.connections, pinData: workflow.pinData } : {}),
 				} as Partial<WorkflowEntity>);
 
 				const updated = await workflowService.update(user, updateData, workflowId);

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -344,6 +344,31 @@ export class InstanceAiAdapterService {
 					throw new Error(`Node "${nodeName}" not found in workflow ${workflowId}`);
 				}
 
+				// Rename node (also update references in connections)
+				if (patch.name && patch.name !== node.name) {
+					const oldName = node.name;
+					node.name = patch.name;
+
+					// Update connections that reference the old name
+					const connections = workflow.connections ?? {};
+					if (connections[oldName]) {
+						connections[patch.name] = connections[oldName];
+						delete connections[oldName];
+					}
+					for (const conns of Object.values(connections)) {
+						for (const outputGroup of Object.values(conns)) {
+							for (const outputs of outputGroup) {
+								if (!outputs) continue;
+								for (const conn of outputs) {
+									if (conn.node === oldName) {
+										conn.node = patch.name;
+									}
+								}
+							}
+						}
+					}
+				}
+
 				// Shallow-merge parameters
 				if (patch.parameters) {
 					node.parameters = {
@@ -364,6 +389,7 @@ export class InstanceAiAdapterService {
 
 				const updateData = workflowRepository.create({
 					nodes,
+					...(patch.name ? { connections: workflow.connections } : {}),
 				} as Partial<WorkflowEntity>);
 
 				const updated = await workflowService.update(user, updateData, workflowId);

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -1363,6 +1363,12 @@ export class InstanceAiService {
 					`REBUILD NEEDED: The workflow at ${action.workflowId} needs structural repair. ` +
 					`Call \`build-workflow-with-agent\` again with these details: ${action.failureDetails}`
 				);
+			case 'patch':
+				return (
+					`PATCH NEEDED: Node "${action.failedNodeName}" in workflow ${action.workflowId} needs a targeted fix. ` +
+					`Diagnosis: ${action.diagnosis}. ` +
+					`Call \`build-workflow-with-agent\` with mode "patch" and workflowId "${action.workflowId}".`
+				);
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Introduces a distinct `patch` action in the workflow loop controller, separating single-node fixes from full rebuilds
- The builder agent tool now accepts a `mode` parameter (`"build"` | `"patch"`) controlling tool set, prompt, and step budget
- Patch mode: 3 tools (`patch-workflow`, `list-credentials`, `test-credential`), 8 max steps, 2-line prompt
- Build/rebuild mode: unchanged (full tool set, 30 max steps)
- Unified retry policy blocks repeated repairs (patch or rebuild) with the same failure signature
- Cleaned up builder prompt: removed stale `patch-workflow` references from build-mode repair strategy