### PR TITLE
fix(editor): Node references in expressions not updated when the renamed node has quotes

### DIFF
--- a/packages/workflow/src/node-reference-parser-utils.ts
+++ b/packages/workflow/src/node-reference-parser-utils.ts
@@ -101,24 +101,51 @@ const ACCESS_PATTERNS: AccessPattern[] = [
 	},
 ];
 
+export function prepareOldNodeName(nodeName: string) {
+	// if node name contains literal \ -> replace with \\
+	// since that's how it'll be written in a JS expression
+	const doubleSlashes = nodeName.replace('\\', '\\\\');
+	// escape special characters for regex
+	const escaped = backslashEscape(doubleSlashes);
+	// quotes may or may not be escaped in the JS expression
+	// so we replace literal quotes with regexes handle that
+	return escaped.replace(/"/g, '(?:\\\\?")').replace(/'/g, "(?:\\\\?')");
+}
+
+export function prepareNewNodeName(nodeName: string) {
+	// escape $ for replacement regex
+	const dollarEscaped = dollarEscape(nodeName);
+	// escape literal \ ' " characters
+	return dollarEscaped.replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll("'", "\\'");
+}
+
 export function applyAccessPatterns(expression: string, previousName: string, newName: string) {
 	// To not run the "expensive" regex stuff when it is not needed
-	// make a simple check first if it really contains the node-name
-	if (!expression.includes(previousName)) return expression;
+	// make a simple check first if it contains any of the access patterns
+	let noMatch = true;
+	for (const pattern of ACCESS_PATTERNS) {
+		if (expression.includes(pattern.checkPattern)) {
+			noMatch = false;
+			break;
+		}
+	}
 
-	// Really contains node-name (even though we do not know yet if really as $node-expression)
-	const escapedOldName = backslashEscape(previousName); // for match
-	const escapedNewName = dollarEscape(newName); // for replacement
+	if (noMatch) {
+		return expression;
+	}
+
+	const preparedOldName = prepareOldNodeName(previousName);
+	const preparedNewName = prepareNewNodeName(newName);
 
 	for (const pattern of ACCESS_PATTERNS) {
 		if (expression.includes(pattern.checkPattern)) {
 			expression = expression.replace(
-				new RegExp(pattern.replacePattern(escapedOldName), 'g'),
-				`$1${escapedNewName}$2`,
+				new RegExp(pattern.replacePattern(preparedOldName), 'g'),
+				`$1${preparedNewName}$2`,
 			);
 
 			if (pattern.customCallback) {
-				expression = pattern.customCallback(expression, newName, escapedNewName);
+				expression = pattern.customCallback(expression, newName, preparedNewName);
 			}
 		}
 	}

--- a/packages/workflow/src/node-reference-parser-utils.ts
+++ b/packages/workflow/src/node-reference-parser-utils.ts
@@ -101,7 +101,7 @@ const ACCESS_PATTERNS: AccessPattern[] = [
 	},
 ];
 
-export function prepareOldNodeName(nodeName: string) {
+function prepareOldNodeName(nodeName: string) {
 	// if node name contains literal \ -> replace with \\
 	// since that's how it'll be written in a JS expression
 	const doubleSlashes = nodeName.replaceAll('\\', '\\\\');
@@ -112,7 +112,7 @@ export function prepareOldNodeName(nodeName: string) {
 	return escaped.replace(/"/g, '(?:\\\\?")').replace(/'/g, "(?:\\\\?')");
 }
 
-export function prepareNewNodeName(nodeName: string) {
+function prepareNewNodeName(nodeName: string) {
 	// escape $ for replacement regex
 	const dollarEscaped = dollarEscape(nodeName);
 	// escape literal \ ' " characters

--- a/packages/workflow/src/node-reference-parser-utils.ts
+++ b/packages/workflow/src/node-reference-parser-utils.ts
@@ -104,7 +104,7 @@ const ACCESS_PATTERNS: AccessPattern[] = [
 export function prepareOldNodeName(nodeName: string) {
 	// if node name contains literal \ -> replace with \\
 	// since that's how it'll be written in a JS expression
-	const doubleSlashes = nodeName.replace('\\', '\\\\');
+	const doubleSlashes = nodeName.replaceAll('\\', '\\\\');
 	// escape special characters for regex
 	const escaped = backslashEscape(doubleSlashes);
 	// quotes may or may not be escaped in the JS expression

--- a/packages/workflow/test/node-reference-parser-utils.test.ts
+++ b/packages/workflow/test/node-reference-parser-utils.test.ts
@@ -126,10 +126,50 @@ describe('NodeReferenceParserUtils', () => {
 				expected: 'someRandomExpression("oldName")',
 			},
 			{
-				expression: '$("old\\"Name")',
-				previousName: 'old\\"Name',
+				expression: '$("someone\'s node")',
+				previousName: "someone's node",
+				newName: 'other node',
+				expected: '$("other node")',
+			},
+			{
+				expression: '$(\'some "node"\')',
+				previousName: 'some "node"',
+				newName: 'other node',
+				expected: "$('other node')",
+			},
+			{
+				expression: '$("test\\\\some")',
+				previousName: 'test\\some',
+				newName: 'other node',
+				expected: '$("other node")',
+			},
+			{
+				expression: '$("old name")',
+				previousName: 'old name',
+				newName: 'new "name"',
+				expected: '$("new \\"name\\"")',
+			},
+			{
+				expression: '$("old name")',
+				previousName: 'old name',
+				newName: "new 'name'",
+				expected: '$("new \\\'name\\\'")',
+			},
+			{
+				expression: '$("test some")',
+				previousName: 'test some',
+				newName: 'other\\node',
+				expected: '$("other\\\\node")',
+			},
+			{
+				// $("old\"Na\\me\'") -> old"Na\me'
+				expression: '$("old\\"Na\\\\me\\\'")',
+				// old"Na\me'
+				previousName: 'old"Na\\me\'',
+				// n\'ew\"Name
 				newName: 'n\\\'ew\\"Name',
-				expected: '$("n\\\'ew\\"Name")',
+				// $("n\\\'ew\\\"Name") -> n\'ew\"Name
+				expected: '$("n\\\\\\\'ew\\\\\\"Name")',
 			},
 		])(
 			'should correctly transform expression "$expression" with previousName "$previousName" and newName "$newName"',


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Whenever a node that has quotes in the name (for example, `Call 'Some workflow'`) was renamed, expressions referencing the node weren't updated. This was due to the fact that the expression contained literal backslashes (`$('Call \'Some workflow\'')`) that weren't taken into account. This PR fixes that, also makes sure that backslashes and quotes are properly escaped when replacing the old name with a new one

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/IAM-378/node-renaming-breaks-when-there-are-quotes-in-the-node-name


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
