### PR TITLE
fix(Xero Node): Make OAuth2 scopes configurable to support write operations

### DIFF
--- a/packages/nodes-base/credentials/XeroOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/XeroOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import type { ICredentialType, INodeProperties } from 'n8n-workflow';
 
-const scopes = [
+const defaultScopes = [
 	'offline_access',
 	'accounting.transactions',
 	'accounting.settings',
@@ -36,12 +36,6 @@ export class XeroOAuth2Api implements ICredentialType {
 			default: 'https://identity.xero.com/connect/token',
 		},
 		{
-			displayName: 'Scope',
-			name: 'scope',
-			type: 'hidden',
-			default: scopes.join(' '),
-		},
-		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
 			type: 'hidden',
@@ -52,6 +46,43 @@ export class XeroOAuth2Api implements ICredentialType {
 			name: 'authentication',
 			type: 'hidden',
 			default: 'header',
+		},
+		{
+			displayName: 'Custom Scopes',
+			name: 'customScopes',
+			type: 'boolean',
+			default: false,
+			description: 'Whether to enable custom scopes',
+		},
+		{
+			displayName:
+				'The default scopes needed for the node to work are already set. If you change these the node may not function correctly.',
+			name: 'customScopesNotice',
+			type: 'notice',
+			default: '',
+			displayOptions: {
+				show: {
+					customScopes: [true],
+				},
+			},
+		},
+		{
+			displayName: 'Enabled Scopes',
+			name: 'enabledScopes',
+			type: 'string',
+			displayOptions: {
+				show: {
+					customScopes: [true],
+				},
+			},
+			default: defaultScopes.join(' '),
+			description: 'Scopes that should be enabled',
+		},
+		{
+			displayName: 'Scope',
+			name: 'scope',
+			type: 'hidden',
+			default: '={{$self["customScopes"] ? $self["enabledScopes"] : "' + defaultScopes.join(' ') + '"}}',
 		},
 	];
 }


### PR DESCRIPTION
Fixes #27363 by allowing users to specify custom OAuth2 scopes (like `accounting.contacts`) required for write operations.