### PR TITLE
fix(editor): Improve tooltip behavior in collapsed sidebar

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nTooltip/Tooltip.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nTooltip/Tooltip.vue
@@ -9,8 +9,8 @@ import {
 } from 'reka-ui';
 import { computed, defineComponent, inject, ref, watch } from 'vue';
 
-import type { N8nTooltipProps } from './Tooltip.types';
 import { TOOLTIP_GROUP_INJECTION_KEY } from './constants';
+import type { N8nTooltipProps } from './Tooltip.types';
 import { useInjectTooltipAppendTo } from '../../composables/useTooltipAppendTo';
 import { n8nHtml as vN8nHtml } from '../../directives';
 import N8nButton from '../N8nButton';

--- a/packages/frontend/@n8n/design-system/src/components/N8nTooltip/Tooltip.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nTooltip/Tooltip.vue
@@ -7,12 +7,21 @@ import {
 	TooltipPortal,
 	TooltipArrow,
 } from 'reka-ui';
-import { computed, ref, watch } from 'vue';
+import { computed, defineComponent, inject, ref, watch } from 'vue';
 
 import type { N8nTooltipProps } from './Tooltip.types';
+import { TOOLTIP_GROUP_INJECTION_KEY } from './constants';
 import { useInjectTooltipAppendTo } from '../../composables/useTooltipAppendTo';
 import { n8nHtml as vN8nHtml } from '../../directives';
 import N8nButton from '../N8nButton';
+
+// Transparent wrapper that renders children without adding a DOM element
+const Fragment = defineComponent({
+	name: 'Fragment',
+	render() {
+		return this.$slots.default?.();
+	},
+});
 
 defineOptions({
 	name: 'N8nTooltip',
@@ -73,13 +82,17 @@ const isControlled = computed(() => props.visible !== undefined);
 const handleOpenChange = (open: boolean) => {
 	isOpen.value = open;
 };
+
+// When inside an N8nTooltipGroup, skip creating our own TooltipProvider
+const isInsideGroup = inject(TOOLTIP_GROUP_INJECTION_KEY, false);
+const providerWrapper = computed(() => (isInsideGroup ? Fragment : TooltipProvider));
 </script>
 
 <template>
-	<TooltipProvider>
+	<component :is="providerWrapper">
 		<TooltipRoot
 			:disabled="disabled"
-			:delay-duration="showAfter"
+			:delay-duration="isInsideGroup ? undefined : showAfter"
 			:open="isControlled ? isOpen : undefined"
 			:disable-hoverable-content="disableHoverableContent"
 			@update:open="handleOpenChange"
@@ -115,7 +128,7 @@ const handleOpenChange = (open: boolean) => {
 				</TooltipContent>
 			</TooltipPortal>
 		</TooltipRoot>
-	</TooltipProvider>
+	</component>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/@n8n/design-system/src/components/N8nTooltip/TooltipGroup.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nTooltip/TooltipGroup.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { TooltipProvider } from 'reka-ui';
+import { provide } from 'vue';
+
+import { TOOLTIP_GROUP_INJECTION_KEY } from './constants';
+
+defineOptions({
+	name: 'N8nTooltipGroup',
+});
+
+withDefaults(
+	defineProps<{
+		/** Delay in milliseconds before the first tooltip in the group opens */
+		delayDuration?: number;
+		/** Grace period in milliseconds for instant switching between tooltips. 0 = instant */
+		skipDelayDuration?: number;
+	}>(),
+	{
+		delayDuration: 500,
+		skipDelayDuration: 0,
+	},
+);
+
+provide(TOOLTIP_GROUP_INJECTION_KEY, true);
+</script>
+
+<template>
+	<TooltipProvider :delay-duration="delayDuration" :skip-delay-duration="skipDelayDuration">
+		<slot />
+	</TooltipProvider>
+</template>

--- a/packages/frontend/@n8n/design-system/src/components/N8nTooltip/constants.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nTooltip/constants.ts
@@ -1,0 +1,3 @@
+import type { InjectionKey } from 'vue';
+
+export const TOOLTIP_GROUP_INJECTION_KEY: InjectionKey<boolean> = Symbol('n8n-tooltip-group');

--- a/packages/frontend/@n8n/design-system/src/components/N8nTooltip/index.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nTooltip/index.ts
@@ -1,4 +1,5 @@
 import N8nTooltip from './Tooltip.vue';
 
 export default N8nTooltip;
+export { default as N8nTooltipGroup } from './TooltipGroup.vue';
 export type * from './Tooltip.types';

--- a/packages/frontend/@n8n/design-system/src/components/index.ts
+++ b/packages/frontend/@n8n/design-system/src/components/index.ts
@@ -66,7 +66,7 @@ export { default as N8nTabs } from './N8nTabs';
 export { default as N8nTag } from './N8nTag';
 export { default as N8nTags } from './N8nTags';
 export { default as N8nText } from './N8nText';
-export { default as N8nTooltip } from './N8nTooltip';
+export { default as N8nTooltip, N8nTooltipGroup } from './N8nTooltip';
 export { default as N8nTree } from './N8nTree';
 export { default as N8nUserStack } from './N8nUserStack';
 export { default as N8nUserInfo } from './N8nUserInfo';

--- a/packages/frontend/editor-ui/src/app/components/MainSidebar.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebar.vue
@@ -2,7 +2,12 @@
 import { computed, onBeforeUnmount, onMounted, ref, nextTick, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { useI18n } from '@n8n/i18n';
-import { N8nScrollArea, N8nResizeWrapper, type IMenuItem } from '@n8n/design-system';
+import {
+	N8nScrollArea,
+	N8nResizeWrapper,
+	N8nTooltipGroup,
+	type IMenuItem,
+} from '@n8n/design-system';
 import { ABOUT_MODAL_KEY, VIEWS, WHATS_NEW_MODAL_KEY } from '@/app/constants';
 import { EXTERNAL_LINKS } from '@/app/constants/externalLinks';
 import { hasPermission } from '@/app/utils/rbac/permissions';
@@ -347,27 +352,29 @@ useKeybindings({
 			@collapse="toggleCollapse"
 			@open-command-bar="openCommandBar"
 		/>
-		<div
-			:class="{
-				[$style.scrollAreaWrapper]: true,
-				[$style.scrollAreaWrapperWithBottomBorder]: hasOverflow && !isCollapsed,
-				[$style.scrollAreaWrapperWithTopBorder]: hasScrolledFromTop && !isCollapsed,
-			}"
-		>
-			<N8nScrollArea ref="scrollAreaRef" @scroll-capture="checkOverflow">
-				<ProjectNavigation
-					:collapsed="isCollapsed"
-					:plan-name="cloudPlanStore.currentPlanData?.displayName"
-				/>
-			</N8nScrollArea>
-		</div>
-		<BottomMenu
-			:items="visibleMenuItems"
-			:is-collapsed="isCollapsed"
-			@logout="onLogout"
-			@select="handleSelect"
-		/>
-		<MainSidebarSourceControl :is-collapsed="isCollapsed" />
+		<N8nTooltipGroup :delay-duration="500" :skip-delay-duration="0">
+			<div
+				:class="{
+					[$style.scrollAreaWrapper]: true,
+					[$style.scrollAreaWrapperWithBottomBorder]: hasOverflow && !isCollapsed,
+					[$style.scrollAreaWrapperWithTopBorder]: hasScrolledFromTop && !isCollapsed,
+				}"
+			>
+				<N8nScrollArea ref="scrollAreaRef" @scroll-capture="checkOverflow">
+					<ProjectNavigation
+						:collapsed="isCollapsed"
+						:plan-name="cloudPlanStore.currentPlanData?.displayName"
+					/>
+				</N8nScrollArea>
+			</div>
+			<BottomMenu
+				:items="visibleMenuItems"
+				:is-collapsed="isCollapsed"
+				@logout="onLogout"
+				@select="handleSelect"
+			/>
+			<MainSidebarSourceControl :is-collapsed="isCollapsed" />
+		</N8nTooltipGroup>
 		<ResourceCenterTooltip />
 	</N8nResizeWrapper>
 </template>


### PR DESCRIPTION
## Summary

Implements improved tooltip behavior for the collapsed sidebar by adding a grouped tooltip system with intelligent show/hide coordination. Tooltips now display after a small delay on first hover (preventing accidental activation) but switch instantly when moving between items without animation restart.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4843/tooltip-behavior-delayed-first-open-no-animationno-delay-when-moving

## Manual Testing Steps

1. Run `pnpm dev` from repo root and open the app (usually http://localhost:5678)
2. **Collapse the left sidebar** using the collapse toggle
3. **Test delayed first open:** Hover a sidebar item (e.g., 'Workflows'). Tooltip appears after ~300ms, not instantly.
4. **Test instant switch:** With a tooltip showing, move pointer to next sidebar item. Tooltip switches instantly with no delay or fade animation.
5. **Test no animation restart:** Quickly move pointer across multiple sidebar items. Each tooltip appears immediately without repeated 'ramp up' animation.
6. **Test grace period reset:** Hover an item to show tooltip → move pointer away from sidebar → wait ~1 second → hover again. Behaves like step 3 again (delayed first open).
7. **Test no accidental activation:** Quickly traverse the sidebar without pausing. Tooltips should NOT flash or appear during rapid movement.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)