### PR TITLE
fix(nodes-base): implement S3 bucket delete operation and fix related issues

### DIFF
--- a/packages/nodes-base/nodes/S3/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/S3/GenericFunctions.ts
@@ -144,6 +144,10 @@ export async function s3ApiRequestSOAP(
 		option,
 		region,
 	);
+	// Empty responses (e.g. HTTP 204 No Content) are valid and should return undefined,
+	// not swallow a parse error silently.
+	if (!response) return undefined;
+
 	try {
 		return await new Promise((resolve, reject) => {
 			parseString(response as string, { explicitArray: false }, (err, data) => {
@@ -154,7 +158,7 @@ export async function s3ApiRequestSOAP(
 			});
 		});
 	} catch (error) {
-		return error;
+		throw error;
 	}
 }
 

--- a/packages/nodes-base/nodes/S3/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/S3/GenericFunctions.ts
@@ -144,9 +144,11 @@ export async function s3ApiRequestSOAP(
 		option,
 		region,
 	);
-	// Empty responses (e.g. HTTP 204 No Content) are valid and should return undefined,
+	const nodeVersion = this.getNode().typeVersion ?? 1;
+
+	// v1.1+: Empty responses (e.g. HTTP 204 No Content) are valid and should return undefined,
 	// not swallow a parse error silently.
-	if (!response) return undefined;
+	if (nodeVersion >= 1.1 && !response) return undefined;
 
 	try {
 		return await new Promise((resolve, reject) => {
@@ -158,7 +160,9 @@ export async function s3ApiRequestSOAP(
 			});
 		});
 	} catch (error) {
-		throw error;
+		// v1.1+: Re-throw parse errors instead of silently returning them as data.
+		if (nodeVersion >= 1.1) throw error;
+		return error;
 	}
 }
 

--- a/packages/nodes-base/nodes/S3/S3.node.ts
+++ b/packages/nodes-base/nodes/S3/S3.node.ts
@@ -23,7 +23,7 @@ export class S3 implements INodeType {
 		// eslint-disable-next-line n8n-nodes-base/node-class-description-icon-not-svg
 		icon: 'file:s3.png',
 		group: ['output'],
-		version: 1,
+		version: [1, 1.1],
 		subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 		description: 'Sends data to any S3-compatible service',
 		defaults: {
@@ -558,10 +558,13 @@ export class S3 implements INodeType {
 							).toUpperCase();
 						}
 
-						// Normalize: ensure destinationPath starts with '/' (e.g. '/bucket/key')
-						const normalizedDestination = destinationPath.startsWith('/')
-							? destinationPath
-							: `/${destinationPath}`;
+						// v1.1+: Normalize destinationPath to accept paths without a leading slash.
+						// Previously, omitting '/' caused the bucket name to be parsed as the file key.
+						const nodeVersion = this.getNode().typeVersion;
+						const normalizedDestination =
+							nodeVersion >= 1.1 && !destinationPath.startsWith('/')
+								? `/${destinationPath}`
+								: destinationPath;
 						const destinationParts = normalizedDestination.split('/');
 
 						const bucketName = destinationParts[1];

--- a/packages/nodes-base/nodes/S3/S3.node.ts
+++ b/packages/nodes-base/nodes/S3/S3.node.ts
@@ -162,6 +162,16 @@ export class S3 implements INodeType {
 						returnData.push(...executionData);
 						// returnData.push({ success: true });
 					}
+					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html
+					if (operation === 'delete') {
+						const name = this.getNodeParameter('name', i) as string;
+						await s3ApiRequestSOAP.call(this, `${name}`, 'DELETE', '');
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray({ success: true }),
+							{ itemData: { item: i } },
+						);
+						returnData.push(...executionData);
+					}
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html
 					if (operation === 'getAll') {
 						const returnAll = this.getNodeParameter('returnAll', 0);
@@ -548,7 +558,11 @@ export class S3 implements INodeType {
 							).toUpperCase();
 						}
 
-						const destinationParts = destinationPath.split('/');
+						// Normalize: ensure destinationPath starts with '/' (e.g. '/bucket/key')
+						const normalizedDestination = destinationPath.startsWith('/')
+							? destinationPath
+							: `/${destinationPath}`;
+						const destinationParts = normalizedDestination.split('/');
 
 						const bucketName = destinationParts[1];
 

--- a/packages/nodes-base/nodes/S3/__schema__/v1.0.0/bucket/delete.json
+++ b/packages/nodes-base/nodes/S3/__schema__/v1.0.0/bucket/delete.json
@@ -1,0 +1,9 @@
+{
+    "type": "object",
+    "properties": {
+        "success": {
+            "type": "boolean"
+        }
+    },
+    "version": 1
+}

--- a/packages/nodes-base/nodes/S3/__tests__/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/S3/__tests__/GenericFunctions.test.ts
@@ -17,7 +17,7 @@ describe('S3 Node Generic Functions', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		mockContext = {
-			getNode: jest.fn().mockReturnValue({ name: 'S3' }),
+			getNode: jest.fn().mockReturnValue({ name: 'S3', typeVersion: 1 }),
 			getCredentials: jest.fn().mockResolvedValue({
 				endpoint: 'https://s3.amazonaws.com',
 				accessKeyId: 'test-key',
@@ -114,14 +114,53 @@ describe('S3 Node Generic Functions', () => {
 			expect(result).toEqual(mockParsedResponse);
 		});
 
-		it('should handle XML parsing errors', async () => {
-			const mockError = new Error('XML Parse Error');
-			mockContext.helpers.request.mockResolvedValueOnce('<invalid>xml');
-			(parseString as jest.Mock).mockImplementation((_, __, callback) => callback(mockError));
+		describe('v1 (legacy behaviour)', () => {
+			it('should return parse error as data instead of throwing', async () => {
+				const mockError = new Error('XML Parse Error');
+				mockContext.helpers.request.mockResolvedValueOnce('<invalid>xml');
+				(parseString as jest.Mock).mockImplementation((_, __, callback) => callback(mockError));
 
-			const result = await s3ApiRequestSOAP.call(mockContext, 'test-bucket', 'GET', '/');
+				const result = await s3ApiRequestSOAP.call(mockContext, 'test-bucket', 'GET', '/');
 
-			expect(result).toEqual(mockError);
+				expect(result).toEqual(mockError);
+			});
+
+			it('should attempt to parse empty response instead of returning undefined', async () => {
+				mockContext.helpers.request.mockResolvedValueOnce('');
+				const mockParsed = {};
+				(parseString as jest.Mock).mockImplementation((_, __, callback) =>
+					callback(null, mockParsed),
+				);
+
+				const result = await s3ApiRequestSOAP.call(mockContext, 'test-bucket', 'DELETE', '/');
+
+				expect(result).toEqual(mockParsed);
+			});
+		});
+
+		describe('v1.1 (new behaviour)', () => {
+			beforeEach(() => {
+				mockContext.getNode.mockReturnValue({ name: 'S3', typeVersion: 1.1 });
+			});
+
+			it('should return undefined for empty response (HTTP 204)', async () => {
+				mockContext.helpers.request.mockResolvedValueOnce('');
+
+				const result = await s3ApiRequestSOAP.call(mockContext, 'test-bucket', 'DELETE', '/');
+
+				expect(result).toBeUndefined();
+				expect(parseString).not.toHaveBeenCalled();
+			});
+
+			it('should throw on XML parse error instead of returning it as data', async () => {
+				const mockError = new Error('XML Parse Error');
+				mockContext.helpers.request.mockResolvedValueOnce('<invalid>xml');
+				(parseString as jest.Mock).mockImplementation((_, __, callback) => callback(mockError));
+
+				await expect(
+					s3ApiRequestSOAP.call(mockContext, 'test-bucket', 'GET', '/'),
+				).rejects.toThrow('XML Parse Error');
+			});
 		});
 	});
 

--- a/packages/nodes-base/nodes/S3/__tests__/S3.node.test.ts
+++ b/packages/nodes-base/nodes/S3/__tests__/S3.node.test.ts
@@ -1,0 +1,153 @@
+import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+
+import { S3 } from '../S3.node';
+import * as GenericFunctions from '../GenericFunctions';
+
+jest.mock('../GenericFunctions', () => ({
+	s3ApiRequestSOAP: jest.fn(),
+	s3ApiRequestSOAPAllItems: jest.fn(),
+	s3ApiRequestREST: jest.fn(),
+	s3ApiRequest: jest.fn(),
+}));
+
+function buildMockContext(overrides: {
+	resource: string;
+	operation: string;
+	typeVersion?: number;
+	params?: Record<string, unknown>;
+}): IExecuteFunctions {
+	const { resource, operation, typeVersion = 1.1, params = {} } = overrides;
+
+	const paramMap: Record<string, unknown> = {
+		resource,
+		operation,
+		...params,
+	};
+
+	return {
+		getInputData: jest.fn().mockReturnValue([{ json: {} }]),
+		getNode: jest.fn().mockReturnValue({ name: 'S3', typeVersion }),
+		getNodeParameter: jest.fn().mockImplementation((name: string) => paramMap[name] ?? ''),
+		getCredentials: jest.fn().mockResolvedValue({
+			endpoint: 'https://s3.example.com',
+			region: 'us-east-1',
+		}),
+		helpers: {
+			constructExecutionMetaData: jest
+				.fn()
+				.mockImplementation((data: INodeExecutionData[], meta: unknown) => data),
+			returnJsonArray: jest.fn().mockImplementation((data: unknown) => [{ json: data }]),
+			request: jest.fn(),
+		},
+		continueOnFail: jest.fn().mockReturnValue(false),
+	} as unknown as IExecuteFunctions;
+}
+
+describe('S3 Node', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('bucket > delete', () => {
+		it('should call DELETE on the bucket and return success', async () => {
+			const mockSOAP = jest
+				.spyOn(GenericFunctions, 's3ApiRequestSOAP')
+				.mockResolvedValue(undefined);
+
+			const ctx = buildMockContext({
+				resource: 'bucket',
+				operation: 'delete',
+				params: { name: 'my-bucket' },
+			});
+
+			const node = new S3();
+			const result = await node.execute.call(ctx);
+
+			expect(mockSOAP).toHaveBeenCalledWith('my-bucket', 'DELETE', '');
+			expect(result[0][0].json).toEqual({ success: true });
+		});
+	});
+
+	describe('file > copy — destinationPath normalization', () => {
+		function setupCopyMock(ctx: IExecuteFunctions, locationRegion = '') {
+			const mockSOAP = jest.spyOn(GenericFunctions, 's3ApiRequestSOAP');
+
+			// First call: GET location
+			mockSOAP.mockResolvedValueOnce({
+				LocationConstraint: { _: locationRegion },
+			});
+			// Second call: PUT copy
+			mockSOAP.mockResolvedValueOnce({
+				CopyObjectResult: { ETag: '"abc"', LastModified: '2026-01-01' },
+			});
+
+			return mockSOAP;
+		}
+
+		it('v1 — destinationPath without leading slash is NOT normalized (legacy)', async () => {
+			const ctx = buildMockContext({
+				resource: 'file',
+				operation: 'copy',
+				typeVersion: 1,
+				params: {
+					sourcePath: '/source-bucket/file.txt',
+					destinationPath: 'dest-bucket/file.txt',
+					additionalFields: {},
+				},
+			});
+
+			const mockSOAP = setupCopyMock(ctx);
+
+			const node = new S3();
+			await node.execute.call(ctx);
+
+			// With v1, no leading slash means destinationParts[1] is 'dest-bucket'... but split('/')
+			// on 'dest-bucket/file.txt' gives ['dest-bucket', 'file.txt'], so [1] is 'file.txt'.
+			// The GET location call should receive the wrong bucket name.
+			const getLocationCall = mockSOAP.mock.calls[0];
+			expect(getLocationCall[0]).toBe('file.txt'); // wrong bucket — legacy bug
+		});
+
+		it('v1.1 — destinationPath without leading slash is normalized correctly', async () => {
+			const ctx = buildMockContext({
+				resource: 'file',
+				operation: 'copy',
+				typeVersion: 1.1,
+				params: {
+					sourcePath: '/source-bucket/file.txt',
+					destinationPath: 'dest-bucket/file.txt',
+					additionalFields: {},
+				},
+			});
+
+			const mockSOAP = setupCopyMock(ctx);
+
+			const node = new S3();
+			await node.execute.call(ctx);
+
+			const getLocationCall = mockSOAP.mock.calls[0];
+			expect(getLocationCall[0]).toBe('dest-bucket'); // correct bucket after normalization
+		});
+
+		it('v1.1 — destinationPath with leading slash works unchanged', async () => {
+			const ctx = buildMockContext({
+				resource: 'file',
+				operation: 'copy',
+				typeVersion: 1.1,
+				params: {
+					sourcePath: '/source-bucket/file.txt',
+					destinationPath: '/dest-bucket/file.txt',
+					additionalFields: {},
+				},
+			});
+
+			const mockSOAP = setupCopyMock(ctx);
+
+			const node = new S3();
+			await node.execute.call(ctx);
+
+			const getLocationCall = mockSOAP.mock.calls[0];
+			expect(getLocationCall[0]).toBe('dest-bucket');
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #27396

Three issues were found and fixed in the S3 node:

### 1. `bucket > delete` operation not implemented

The **Delete** operation was defined in `BucketDescription.ts` and visible in the UI, but the execution block was **never implemented** in `S3.node.ts`. When triggered, it silently returned `success` with 0 output items in ~2ms — without making any HTTP request.

**Fix:** Added the missing `if (operation === 'delete')` block inside `if (resource === 'bucket')`.

```typescript
//https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html
if (operation === 'delete') {
  const name = this.getNodeParameter('name', i) as string;
  await s3ApiRequestSOAP.call(this, `${name}`, 'DELETE', '');
  const executionData = this.helpers.constructExecutionMetaData(
    this.helpers.returnJsonArray({ success: true }),
    { itemData: { item: i } },
  );
  returnData.push(...executionData);
}
```

### 2. `s3ApiRequestSOAP` silently swallows errors on empty responses

In `GenericFunctions.ts`, the `s3ApiRequestSOAP` function had a `catch (error) { return error }` pattern. Any S3 operation returning a non-XML response (e.g. `HTTP 204 No Content`) would cause `parseString` to throw, which was silently caught and **returned as data** instead of being re-thrown. This masked real failures.

**Fix:** Empty responses (`HTTP 204`) now return `undefined` early. Parse errors are re-thrown correctly.

### 3. `destinationPath` in file copy requires undocumented leading slash

The `file > copy` operation parses `destinationPath` assuming it starts with `/` (using `split('/')[1]` to extract the bucket name). However, the UI field description does not mention this requirement, unlike `sourcePath` which explicitly states *"should start with (/)"*. Without the leading slash, the bucket name resolves to the file key, causing a `"resource not found"` error.

**Fix:** Normalize `destinationPath` to always start with `/` before parsing, making it resilient to both `bucket/key` and `/bucket/key` formats.

## Test plan

- [ ] Create a bucket via S3 node (`bucket > create`) ✅
- [ ] Delete a bucket via S3 node (`bucket > delete`) — previously broken, now fixed
- [ ] Copy a file with `destinationPath` without leading slash — previously broken, now fixed
- [ ] Verify existing operations (upload, download, getAll, search, folder ops) are unaffected

## Notes

- Verified against MinIO (S3-compatible). `DELETE /{bucket}` returns `HTTP 204 No Content`, which was the root cause of the silent failure in `s3ApiRequestSOAP`.
- The same `BucketDescription.ts` is shared with the AWS S3 node — that node should be checked for the same missing `delete` implementation.