### PR TITLE
fix(cli): support sticky dist-tags for community packages

### DIFF
--- a/packages/@n8n/db/src/migrations/common/1772800000000-AddRequestedDistTagToInstalledPackages.ts
+++ b/packages/@n8n/db/src/migrations/common/1772800000000-AddRequestedDistTagToInstalledPackages.ts
@@ -1,0 +1,17 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+export class AddRequestedDistTagToInstalledPackages1772800000000 implements ReversibleMigration {
+	async up({ escape, runQuery }: MigrationContext) {
+		const tableName = escape.tableName('installed_packages');
+		const columnName = escape.columnName('requestedDistTag');
+
+		await runQuery(`ALTER TABLE ${tableName} ADD COLUMN ${columnName} VARCHAR(255)`);
+	}
+
+	async down({ escape, runQuery }: MigrationContext) {
+		const tableName = escape.tableName('installed_packages');
+		const columnName = escape.columnName('requestedDistTag');
+
+		await runQuery(`ALTER TABLE ${tableName} DROP COLUMN ${columnName}`);
+	}
+}

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -152,6 +152,7 @@ import { AddSuggestedPromptsToAgentTable1772000000000 } from '../common/17720000
 import { AddRoleColumnToProjectSecretsProviderAccess1772619247761 } from '../common/1772619247761-AddRoleColumnToProjectSecretsProviderAccess';
 import { ChangeWorkflowPublishedVersionFKsToRestrict1772619247762 } from '../common/1772619247762-ChangeWorkflowPublishedVersionFKsToRestrict';
 import { AddTypeToChatHubSessions1772700000000 } from '../common/1772700000000-AddTypeToChatHubSessions';
+import { AddRequestedDistTagToInstalledPackages1772800000000 } from '../common/1772800000000-AddRequestedDistTagToInstalledPackages';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -309,4 +310,5 @@ export const postgresMigrations: Migration[] = [
 	AddRoleColumnToProjectSecretsProviderAccess1772619247761,
 	ChangeWorkflowPublishedVersionFKsToRestrict1772619247762,
 	AddTypeToChatHubSessions1772700000000,
+	AddRequestedDistTagToInstalledPackages1772800000000,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -146,6 +146,7 @@ import { AddSuggestedPromptsToAgentTable1772000000000 } from '../common/17720000
 import { AddRoleColumnToProjectSecretsProviderAccess1772619247761 } from '../common/1772619247761-AddRoleColumnToProjectSecretsProviderAccess';
 import { ChangeWorkflowPublishedVersionFKsToRestrict1772619247762 } from '../common/1772619247762-ChangeWorkflowPublishedVersionFKsToRestrict';
 import { AddTypeToChatHubSessions1772700000000 } from '../common/1772700000000-AddTypeToChatHubSessions';
+import { AddRequestedDistTagToInstalledPackages1772800000000 } from '../common/1772800000000-AddRequestedDistTagToInstalledPackages';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -297,6 +298,7 @@ const sqliteMigrations: Migration[] = [
 	AddRoleColumnToProjectSecretsProviderAccess1772619247761,
 	ChangeWorkflowPublishedVersionFKsToRestrict1772619247762,
 	AddTypeToChatHubSessions1772700000000,
+	AddRequestedDistTagToInstalledPackages1772800000000,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -165,6 +165,7 @@
     "n8n-workflow": "workspace:*",
     "nanoid": "catalog:",
     "nodemailer": "catalog:",
+    "npm-package-arg": "13.0.2",
     "oauth-1.0a": "2.2.6",
     "open": "7.4.2",
     "openid-client": "6.5.0",

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.controller.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.controller.test.ts
@@ -29,6 +29,7 @@ describe('CommunityPackagesController', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
+		communityPackagesService.toPublicInstalledPackage.mockImplementation((pkg) => pkg as never);
 	});
 
 	describe('installPackage', () => {
@@ -37,18 +38,32 @@ describe('CommunityPackagesController', () => {
 				user: { id: 'user123' },
 				body: { name: 'n8n-nodes-test', verify: true, version: '1.0.0' },
 			});
+			communityPackagesService.parseNpmPackageName.mockReturnValue({
+				rawString: 'n8n-nodes-test',
+				packageName: 'n8n-nodes-test',
+			});
 			communityNodeTypesService.findVetted.mockReturnValue(undefined);
 			await expect(controller.installPackage(request)).rejects.toThrow(
 				'Package n8n-nodes-test is not vetted for installation',
 			);
 		});
 
-		it.each(['foo', 'echo "hello"', '1.a.b', '0.1.29#;ls'])(
+		it.each(['^1.0.0', 'file:./package.tgz', 'npm:other-package@1.0.0'])(
 			'should throw error if version is invalid',
 			async (version) => {
 				const request = mock<NodeRequest.Post>({
 					user: { id: 'user123' },
-					body: { name: 'n8n-nodes-test', verify: true, version },
+					body: { name: 'n8n-nodes-test', verify: false, version },
+				});
+				communityPackagesService.parseNpmPackageName.mockReturnValue({
+					rawString: 'n8n-nodes-test',
+					packageName: 'n8n-nodes-test',
+				});
+				communityPackagesService.checkNpmPackageStatus.mockResolvedValue({
+					status: 'OK',
+				});
+				communityPackagesService.parsePackageVersion.mockImplementation(() => {
+					throw new Error(`Invalid version: ${version}`);
 				});
 				await expect(controller.installPackage(request)).rejects.toThrow(
 					`Invalid version: ${version}`,
@@ -70,6 +85,9 @@ describe('CommunityPackagesController', () => {
 				rawString: 'n8n-nodes-test',
 				packageName: 'n8n-nodes-test',
 				version: '1.1.1',
+			});
+			communityPackagesService.parsePackageVersion.mockReturnValue({
+				version: '1.0.0',
 			});
 			communityPackagesService.isPackageInstalled.mockResolvedValue(false);
 			communityPackagesService.hasPackageLoaded.mockReturnValue(false);
@@ -123,7 +141,15 @@ describe('CommunityPackagesController', () => {
 			});
 
 			communityPackagesService.findInstalledPackage.mockResolvedValue(previouslyInstalledPackage);
+			communityPackagesService.parseNpmPackageName.mockReturnValue({
+				rawString: 'n8n-nodes-test',
+				packageName: 'n8n-nodes-test',
+			});
+			communityPackagesService.parsePackageVersion.mockReturnValue({ version: '2.0.0' });
 			communityPackagesService.updatePackage.mockResolvedValue(newInstalledPackage);
+			communityPackagesService.toPublicInstalledPackage.mockReturnValue(
+				newInstalledPackage as never,
+			);
 
 			const result = await controller.updatePackage(req);
 
@@ -137,11 +163,21 @@ describe('CommunityPackagesController', () => {
 			expect(result).toBe(newInstalledPackage);
 		});
 
-		it.each(['foo', 'echo "hello"', '1.a.b', '0.1.29#;ls'])(
+		it.each(['^1.0.0', 'file:./package.tgz', 'npm:other-package@1.0.0'])(
 			'should throw error if version is invalid',
 			async (version) => {
 				const req = mock<NodeRequest.Update>({
 					body: { name: 'n8n-nodes-test', version, checksum: 'a893hfdsy7399' },
+				});
+				communityPackagesService.parseNpmPackageName.mockReturnValue({
+					rawString: 'n8n-nodes-test',
+					packageName: 'n8n-nodes-test',
+				});
+				communityPackagesService.findInstalledPackage.mockResolvedValue(
+					mock<InstalledPackages>({ packageName: 'n8n-nodes-test' }),
+				);
+				communityPackagesService.parsePackageVersion.mockImplementation(() => {
+					throw new Error(`Invalid version: ${version}`);
 				});
 				await expect(controller.updatePackage(req)).rejects.toThrow(`Invalid version: ${version}`);
 			},

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.integration.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.integration.test.ts
@@ -54,6 +54,8 @@ beforeAll(async () => {
 
 beforeEach(() => {
 	jest.resetAllMocks();
+	communityPackagesService.toPublicInstalledPackage.mockImplementation((pkg) => pkg as never);
+	communityPackagesService.parseNpmPackageName.mockReturnValue(parsedNpmPackageName);
 });
 
 describe('GET /community-packages', () => {
@@ -253,7 +255,7 @@ describe('PATCH /community-packages', () => {
 
 	test('should update a package', async () => {
 		communityPackagesService.findInstalledPackage.mockResolvedValue(mockPackage());
-		communityPackagesService.parseNpmPackageName.mockReturnValue(parsedNpmPackageName);
+		communityPackagesService.updatePackage.mockResolvedValue(mockPackage());
 
 		await authAgent.patch('/community-packages').send({ name: mockPackageName() });
 

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts
@@ -623,6 +623,104 @@ describe('CommunityPackagesService', () => {
 				communityPackagesService.installPackage('n8n-nodes-package', '0.1.0'),
 			).rejects.toThrow('Installation of unverified community packages is forbidden!');
 		});
+
+		test('should preserve requested dist-tag when reinstalling an exact version', async () => {
+			const packageName = 'n8n-nodes-test';
+			const resolvedPackageVersion = '1.0.0-beta.2';
+			const testBlockDownloadDir = instanceSettings.nodesDownloadDir;
+			const testBlockPackageDir = `${testBlockDownloadDir}/node_modules/${packageName}`;
+			const testBlockTarballName = `${packageName}-${resolvedPackageVersion}.tgz`;
+			const testBlockRegistry = config.registry;
+			const execMockForThisTest = ((...args: Parameters<typeof execFile>) => {
+				const command = args[0];
+				const cmdArgs = args[1];
+				const actualCallback = args[args.length - 1] as ExecFileCallback;
+
+				if (command === 'npm' && cmdArgs?.[0] === 'pack') {
+					actualCallback(null, testBlockTarballName, '');
+				} else {
+					actualCallback(null, 'Done', '');
+				}
+			}) as typeof execFile;
+
+			config.unverifiedEnabled = true;
+			license.isCustomNpmRegistryEnabled.mockReturnValue(true);
+			mocked(resolvePackageVersionSpecOrThrow).mockResolvedValue(resolvedPackageVersion);
+			mocked(execFile).mockImplementation(execMockForThisTest);
+			mocked(executeNpmCommand).mockImplementation(async (args: string[]) => {
+				if (args[0] === 'pack') {
+					return testBlockTarballName;
+				}
+				return 'Done';
+			});
+			mocked(readFile).mockResolvedValueOnce(
+				JSON.stringify({
+					name: packageName,
+					version: resolvedPackageVersion,
+					dependencies: { 'some-actual-dep': '1.2.3' },
+					devDependencies: { 'a-dev-dep': '1.0.0' },
+					peerDependencies: { 'a-peer-dep': '2.0.0' },
+					optionalDependencies: { 'an-optional-dep': '3.0.0' },
+				}),
+			);
+			mocked(readFile).mockResolvedValue(JSON.stringify({ dependencies: {} }));
+			mocked(writeFile).mockResolvedValue(undefined);
+
+			const packageDirectoryLoader = mock<PackageDirectoryLoader>({
+				loadedNodes: [{ name: 'a-node-from-the-loader', version: 1 }],
+			});
+			const installedPackage = mock<InstalledPackages>({
+				packageName,
+				installedVersion: resolvedPackageVersion,
+			});
+
+			loadNodesAndCredentials.loadPackage.mockResolvedValue(packageDirectoryLoader);
+			loadNodesAndCredentials.unloadPackage.mockResolvedValue(undefined);
+			loadNodesAndCredentials.postProcessLoaders.mockResolvedValue(undefined);
+			installedPackageRepository.saveInstalledPackageWithNodes.mockResolvedValue(installedPackage);
+			publisher.publishCommand.mockResolvedValue(undefined);
+
+			await communityPackagesService.installPackage(
+				packageName,
+				resolvedPackageVersion,
+				undefined,
+				'beta',
+			);
+
+			expect(resolvePackageVersionSpecOrThrow).toHaveBeenCalledWith(
+				packageName,
+				resolvedPackageVersion,
+				testBlockRegistry,
+			);
+			expect(executeNpmCommand).toHaveBeenNthCalledWith(
+				1,
+				[
+					'pack',
+					`${packageName}@${resolvedPackageVersion}`,
+					`--registry=${testBlockRegistry}`,
+					'--quiet',
+				],
+				{ cwd: testBlockDownloadDir },
+			);
+			expect(writeFile).toHaveBeenLastCalledWith(
+				path.join(nodesDownloadDir, 'package.json'),
+				expect.stringContaining(`"${packageName}": "beta"`),
+				'utf-8',
+			);
+			expect(installedPackageRepository.saveInstalledPackageWithNodes).toHaveBeenCalledWith(
+				packageDirectoryLoader,
+				'beta',
+			);
+			expect(publisher.publishCommand).toHaveBeenCalledWith({
+				command: 'community-package-install',
+				payload: {
+					packageName,
+					packageVersion: resolvedPackageVersion,
+					requestedDistTag: 'beta',
+				},
+			});
+			expect(readFile).toHaveBeenCalledWith(`${testBlockPackageDir}/package.json`, 'utf-8');
+		});
 	});
 
 	describe('ensurePackageJson', () => {
@@ -723,6 +821,7 @@ describe('CommunityPackagesService', () => {
 				'package-1',
 				'1.0.0',
 				undefined,
+				undefined,
 			);
 			expect(loadNodesAndCredentials.postProcessLoaders).toHaveBeenCalled();
 			expect(communityPackagesService.missingPackages).toEqual([]);
@@ -746,6 +845,7 @@ describe('CommunityPackagesService', () => {
 			expect(communityPackagesService.installPackage).toHaveBeenCalledWith(
 				'package-1',
 				'1.0.0',
+				undefined,
 				undefined,
 			);
 			expect(logger.error).toHaveBeenCalledWith(
@@ -773,10 +873,12 @@ describe('CommunityPackagesService', () => {
 				'package-1',
 				'1.0.0',
 				undefined,
+				undefined,
 			);
 			expect(communityPackagesService.installPackage).toHaveBeenCalledWith(
 				'package-2',
 				'2.0.0',
+				undefined,
 				undefined,
 			);
 			expect(logger.error).toHaveBeenCalledWith(
@@ -808,6 +910,7 @@ describe('CommunityPackagesService', () => {
 				'package-1',
 				'1.0.0',
 				'sha512-abc123',
+				undefined,
 			);
 		});
 
@@ -836,6 +939,7 @@ describe('CommunityPackagesService', () => {
 				'package-1',
 				'1.0.0',
 				'sha512-version-specific',
+				undefined,
 			);
 		});
 
@@ -861,6 +965,7 @@ describe('CommunityPackagesService', () => {
 				'package-1',
 				'1.0.0',
 				undefined,
+				undefined,
 			);
 		});
 
@@ -879,6 +984,7 @@ describe('CommunityPackagesService', () => {
 			expect(communityPackagesService.installPackage).toHaveBeenCalledWith(
 				'package-1',
 				'1.0.0',
+				undefined,
 				undefined,
 			);
 		});
@@ -911,11 +1017,35 @@ describe('CommunityPackagesService', () => {
 				'package-1',
 				'1.0.0',
 				'sha512-package1',
+				undefined,
 			);
 			expect(communityPackagesService.installPackage).toHaveBeenCalledWith(
 				'package-2',
 				'2.0.0',
 				'sha512-package2',
+				undefined,
+			);
+		});
+
+		test('should preserve requested dist-tag when reinstalling a missing package', async () => {
+			const tagInstalledPackage = mock<InstalledPackages>({
+				packageName: 'package-1',
+				installedVersion: '1.0.0-beta.2',
+				requestedDistTag: 'beta',
+				installedNodes: [{ type: 'node-type-1' }],
+			});
+
+			installedPackageRepository.find.mockResolvedValue([tagInstalledPackage]);
+			loadNodesAndCredentials.isKnownNode.mockReturnValue(false);
+			config.reinstallMissing = true;
+
+			await communityPackagesService.checkForMissingPackages();
+
+			expect(communityPackagesService.installPackage).toHaveBeenCalledWith(
+				'package-1',
+				'1.0.0-beta.2',
+				undefined,
+				'beta',
 			);
 		});
 

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts
@@ -26,7 +26,7 @@ import { InstalledNodes } from '../installed-nodes.entity';
 import { InstalledNodesRepository } from '../installed-nodes.repository';
 import { InstalledPackages } from '../installed-packages.entity';
 import { InstalledPackagesRepository } from '../installed-packages.repository';
-import { executeNpmCommand } from '../npm-utils';
+import { executeNpmCommand, resolvePackageVersionSpecOrThrow } from '../npm-utils';
 
 jest.mock('node:fs/promises');
 jest.mock('node:child_process');
@@ -37,6 +37,7 @@ jest.mock('../community-node-types-utils', () => ({
 jest.mock('../npm-utils', () => ({
 	...jest.requireActual('../npm-utils'),
 	executeNpmCommand: jest.fn(),
+	resolvePackageVersionSpecOrThrow: jest.fn(),
 }));
 
 type ExecFileCallback = NonNullable<Parameters<typeof execFile>[3]>;
@@ -78,6 +79,7 @@ describe('CommunityPackagesService', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
 		loadNodesAndCredentials.postProcessLoaders.mockResolvedValue(undefined);
+		mocked(resolvePackageVersionSpecOrThrow).mockResolvedValue(COMMUNITY_PACKAGE_VERSION.CURRENT);
 
 		const nodeName = randomName();
 		installedNodesRepository.create.mockImplementation(() => {
@@ -106,11 +108,14 @@ describe('CommunityPackagesService', () => {
 			).toThrowError();
 		});
 
-		test.each(['invalid', '1.a.b'])('should fail with invalid version', (version) => {
-			expect(() =>
-				communityPackagesService.parseNpmPackageName(`n8n-nodes-test@${version}`),
-			).toThrow(`Invalid version: ${version}`);
-		});
+		test.each(['^1.0.0', 'file:./package.tgz', 'npm:other-package@1.0.0'])(
+			'should fail with unsupported version spec',
+			(version) => {
+				expect(() =>
+					communityPackagesService.parseNpmPackageName(`n8n-nodes-test@${version}`),
+				).toThrow(`Invalid version: ${version}`);
+			},
+		);
 
 		test('should parse valid package name', () => {
 			const name = mockPackageName();
@@ -134,6 +139,17 @@ describe('CommunityPackagesService', () => {
 			expect(parsed.version).toBe(version);
 		});
 
+		test('should parse valid package name and dist-tag', () => {
+			const name = mockPackageName();
+			const fullPackageName = `${name}@beta`;
+			const parsed = communityPackagesService.parseNpmPackageName(fullPackageName);
+
+			expect(parsed.rawString).toBe(fullPackageName);
+			expect(parsed.packageName).toBe(name);
+			expect(parsed.version).toBe('beta');
+			expect(parsed.requestedDistTag).toBe('beta');
+		});
+
 		test('should parse valid package name, scope and version', () => {
 			const scope = '@n8n';
 			const name = mockPackageName();
@@ -145,6 +161,14 @@ describe('CommunityPackagesService', () => {
 			expect(parsed.packageName).toBe(`${scope}/${name}`);
 			expect(parsed.scope).toBe(scope);
 			expect(parsed.version).toBe(version);
+		});
+
+		test('should parse explicit latest without storing a sticky tag', () => {
+			const name = mockPackageName();
+			const parsed = communityPackagesService.parseNpmPackageName(`${name}@latest`);
+
+			expect(parsed.version).toBe('latest');
+			expect(parsed.requestedDistTag).toBeUndefined();
 		});
 	});
 
@@ -199,6 +223,44 @@ describe('CommunityPackagesService', () => {
 
 			expect(crossedPkgA.updateAvailable).toBeUndefined();
 			expect(crossedPkgB.updateAvailable).toBe('0.3.0');
+		});
+
+		test('should use wanted for dist-tag installs', () => {
+			const [pkg] = mockPackagePair();
+			pkg.requestedDistTag = 'beta';
+			pkg.installedVersion = '1.0.0-beta.1';
+
+			const updates: CommunityPackages.AvailableUpdates = {
+				[pkg.packageName]: {
+					current: '1.0.0-beta.1',
+					wanted: '1.0.0-beta.2',
+					latest: '1.0.0',
+					location: pkg.packageName,
+				},
+			};
+
+			const [crossedPkg] = communityPackagesService.matchPackagesWithUpdates([pkg], updates);
+
+			expect(crossedPkg.updateAvailable).toBe('1.0.0-beta.2');
+		});
+
+		test('should not mark stable latest as update for dist-tag installs when wanted equals current', () => {
+			const [pkg] = mockPackagePair();
+			pkg.requestedDistTag = 'beta';
+			pkg.installedVersion = '1.0.0-beta.2';
+
+			const updates: CommunityPackages.AvailableUpdates = {
+				[pkg.packageName]: {
+					current: '1.0.0-beta.2',
+					wanted: '1.0.0-beta.2',
+					latest: '1.0.0',
+					location: pkg.packageName,
+				},
+			};
+
+			const [crossedPkg] = communityPackagesService.matchPackagesWithUpdates([pkg], updates);
+
+			expect(crossedPkg.updateAvailable).toBeUndefined();
 		});
 	});
 
@@ -334,6 +396,8 @@ describe('CommunityPackagesService', () => {
 		const PACKAGE_NAME = 'n8n-nodes-test';
 		const installedPackageForUpdateTest = mock<InstalledPackages>({
 			packageName: PACKAGE_NAME,
+			installedVersion: '0.9.0',
+			requestedDistTag: null,
 		});
 
 		const packageDirectoryLoader = mock<PackageDirectoryLoader>({
@@ -342,7 +406,8 @@ describe('CommunityPackagesService', () => {
 
 		const testBlockDownloadDir = instanceSettings.nodesDownloadDir;
 		const testBlockPackageDir = `${testBlockDownloadDir}/node_modules/${PACKAGE_NAME}`;
-		const testBlockTarballName = `${PACKAGE_NAME}-latest.tgz`;
+		const resolvedPackageVersion = '1.0.0';
+		const testBlockTarballName = `${PACKAGE_NAME}-${resolvedPackageVersion}.tgz`;
 		const testBlockRegistry = config.registry;
 		const testBlockNpmInstallArgs = [
 			'--audit=false',
@@ -376,17 +441,19 @@ describe('CommunityPackagesService', () => {
 				}
 				return 'Done';
 			});
+			mocked(resolvePackageVersionSpecOrThrow).mockResolvedValue(resolvedPackageVersion);
 
-			mocked(readFile).mockResolvedValue(
+			mocked(readFile).mockResolvedValueOnce(
 				JSON.stringify({
 					name: PACKAGE_NAME,
-					version: '1.0.0', // Mocked version from package.json inside tarball
+					version: resolvedPackageVersion,
 					dependencies: { 'some-actual-dep': '1.2.3' },
 					devDependencies: { 'a-dev-dep': '1.0.0' },
 					peerDependencies: { 'a-peer-dep': '2.0.0' },
 					optionalDependencies: { 'an-optional-dep': '3.0.0' },
 				}),
 			);
+			mocked(readFile).mockResolvedValue(JSON.stringify({ dependencies: {} }));
 			mocked(writeFile).mockResolvedValue(undefined);
 
 			loadNodesAndCredentials.loadPackage.mockResolvedValue(packageDirectoryLoader);
@@ -414,16 +481,18 @@ describe('CommunityPackagesService', () => {
 			// ASSERT:
 			expect(rm).toHaveBeenCalledTimes(2);
 			expect(rm).toHaveBeenNthCalledWith(1, testBlockPackageDir, { recursive: true, force: true });
-			expect(rm).toHaveBeenNthCalledWith(
-				2,
-				path.join(nodesDownloadDir, 'n8n-nodes-test-latest.tgz'),
-			);
+			expect(rm).toHaveBeenNthCalledWith(2, path.join(nodesDownloadDir, testBlockTarballName));
 
 			// Check executeNpmCommand was called for npm commands
 			expect(executeNpmCommand).toHaveBeenCalledTimes(2);
 			expect(executeNpmCommand).toHaveBeenNthCalledWith(
 				1,
-				['pack', `${PACKAGE_NAME}@latest`, `--registry=${testBlockRegistry}`, '--quiet'],
+				[
+					'pack',
+					`${PACKAGE_NAME}@${resolvedPackageVersion}`,
+					`--registry=${testBlockRegistry}`,
+					'--quiet',
+				],
 				{ cwd: testBlockDownloadDir },
 			);
 
@@ -449,7 +518,7 @@ describe('CommunityPackagesService', () => {
 				JSON.stringify(
 					{
 						name: PACKAGE_NAME,
-						version: '1.0.0',
+						version: resolvedPackageVersion,
 						dependencies: { 'some-actual-dep': '1.2.3' },
 					},
 					null,
@@ -465,11 +534,12 @@ describe('CommunityPackagesService', () => {
 			expect(installedPackageRepository.remove).toHaveBeenCalledWith(installedPackageForUpdateTest);
 			expect(installedPackageRepository.saveInstalledPackageWithNodes).toHaveBeenCalledWith(
 				packageDirectoryLoader,
+				undefined,
 			);
 
 			expect(publisher.publishCommand).toHaveBeenCalledWith({
 				command: 'community-package-update',
-				payload: { packageName: PACKAGE_NAME, packageVersion: 'latest' },
+				payload: { packageName: PACKAGE_NAME, packageVersion: resolvedPackageVersion },
 			});
 		});
 
@@ -487,15 +557,71 @@ describe('CommunityPackagesService', () => {
 				new FeatureNotLicensedError(LICENSE_FEATURES.COMMUNITY_NODES_CUSTOM_REGISTRY),
 			);
 		});
+
+		test('should reuse requested dist-tag on update and keep it in package.json', async () => {
+			const tagInstalledPackage = mock<InstalledPackages>({
+				packageName: PACKAGE_NAME,
+				installedVersion: '0.9.0',
+				requestedDistTag: 'beta',
+			});
+			license.isCustomNpmRegistryEnabled.mockReturnValue(true);
+
+			mocked(readFile).mockResolvedValueOnce(
+				JSON.stringify({
+					name: PACKAGE_NAME,
+					version: resolvedPackageVersion,
+					dependencies: { 'some-actual-dep': '1.2.3' },
+					devDependencies: { 'a-dev-dep': '1.0.0' },
+					peerDependencies: { 'a-peer-dep': '2.0.0' },
+					optionalDependencies: { 'an-optional-dep': '3.0.0' },
+				}),
+			);
+			mocked(readFile).mockResolvedValue(JSON.stringify({ dependencies: {} }));
+
+			await communityPackagesService.updatePackage(PACKAGE_NAME, tagInstalledPackage);
+
+			expect(resolvePackageVersionSpecOrThrow).toHaveBeenCalledWith(
+				PACKAGE_NAME,
+				'beta',
+				testBlockRegistry,
+			);
+			expect(executeNpmCommand).toHaveBeenNthCalledWith(
+				1,
+				[
+					'pack',
+					`${PACKAGE_NAME}@${resolvedPackageVersion}`,
+					`--registry=${testBlockRegistry}`,
+					'--quiet',
+				],
+				{ cwd: testBlockDownloadDir },
+			);
+			expect(writeFile).toHaveBeenLastCalledWith(
+				path.join(nodesDownloadDir, 'package.json'),
+				expect.stringContaining(`"${PACKAGE_NAME}": "beta"`),
+				'utf-8',
+			);
+			expect(installedPackageRepository.saveInstalledPackageWithNodes).toHaveBeenCalledWith(
+				packageDirectoryLoader,
+				'beta',
+			);
+			expect(publisher.publishCommand).toHaveBeenCalledWith({
+				command: 'community-package-update',
+				payload: {
+					packageName: PACKAGE_NAME,
+					packageVersion: resolvedPackageVersion,
+					requestedDistTag: 'beta',
+				},
+			});
+		});
 	});
 
 	describe('installPackage', () => {
 		test('should throw when installation of not vetted packages is forbidden', async () => {
 			config.unverifiedEnabled = false;
 			config.registry = 'https://registry.npmjs.org';
-			await expect(communityPackagesService.installPackage('package', '0.1.0')).rejects.toThrow(
-				'Installation of unverified community packages is forbidden!',
-			);
+			await expect(
+				communityPackagesService.installPackage('n8n-nodes-package', '0.1.0'),
+			).rejects.toThrow('Installation of unverified community packages is forbidden!');
 		});
 	});
 
@@ -875,6 +1001,25 @@ describe('CommunityPackagesService', () => {
 		});
 	});
 
+	describe('removePackageJsonDependency', () => {
+		beforeEach(() => {
+			jest.clearAllMocks();
+			mocked(readFile).mockResolvedValue(
+				JSON.stringify({ dependencies: { 'test-package': '1.0.0', 'other-package': '2.0.0' } }),
+			);
+		});
+
+		test('should remove the requested dependency', async () => {
+			await communityPackagesService.removePackageJsonDependency('test-package');
+
+			expect(writeFile).toHaveBeenCalledWith(
+				path.join(nodesDownloadDir, 'package.json'),
+				JSON.stringify({ dependencies: { 'other-package': '2.0.0' } }, null, 2),
+				'utf-8',
+			);
+		});
+	});
+
 	describe('handleInstallEvent', () => {
 		test('should call unloadPackage before loadPackage to handle already-loaded packages', async () => {
 			const callOrder: string[] = [];
@@ -894,6 +1039,23 @@ describe('CommunityPackagesService', () => {
 			});
 
 			expect(callOrder).toEqual(['unloadPackage', 'loadPackage']);
+		});
+
+		test('should preserve requested dist-tag in package.json when installing from pubsub', async () => {
+			const downloadPackageSpy = jest
+				.spyOn(communityPackagesService as any, 'downloadPackage')
+				.mockResolvedValue(undefined);
+
+			loadNodesAndCredentials.unloadPackage.mockResolvedValue(undefined);
+			loadNodesAndCredentials.loadPackage.mockResolvedValue(mock<PackageDirectoryLoader>());
+
+			await communityPackagesService.handleInstallEvent({
+				packageName: 'n8n-nodes-test',
+				packageVersion: '1.0.0-beta.2',
+				requestedDistTag: 'beta',
+			});
+
+			expect(downloadPackageSpy).toHaveBeenCalledWith('n8n-nodes-test', '1.0.0-beta.2', 'beta');
 		});
 	});
 });

--- a/packages/cli/src/modules/community-packages/__tests__/npm-utils.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/npm-utils.test.ts
@@ -21,7 +21,7 @@ jest.mock('node:util', () => {
 	};
 });
 
-import { executeNpmCommand, verifyIntegrity, checkIfVersionExistsOrThrow } from '../npm-utils';
+import { executeNpmCommand, verifyIntegrity, resolvePackageVersionSpecOrThrow } from '../npm-utils';
 import { NPM_COMMAND_TOKENS, RESPONSE_ERROR_MESSAGES } from '@/constants';
 
 describe('executeNpmCommand', () => {
@@ -513,7 +513,7 @@ describe('verifyIntegrity', () => {
 	});
 });
 
-describe('checkIfVersionExistsOrThrow', () => {
+describe('resolvePackageVersionSpecOrThrow', () => {
 	const registryUrl = 'https://registry.npmjs.org';
 	const packageName = 'test-package';
 	const version = '1.0.0';
@@ -528,7 +528,7 @@ describe('checkIfVersionExistsOrThrow', () => {
 		jest.clearAllMocks();
 	});
 
-	it('should return true when package version exists', async () => {
+	it('should return the exact version when package version exists', async () => {
 		nock(registryUrl)
 			.get(`/${encodeURIComponent(packageName)}/${version}`)
 			.reply(200, {
@@ -536,8 +536,21 @@ describe('checkIfVersionExistsOrThrow', () => {
 				version,
 			});
 
-		const result = await checkIfVersionExistsOrThrow(packageName, version, registryUrl);
-		expect(result).toBe(true);
+		const result = await resolvePackageVersionSpecOrThrow(packageName, version, registryUrl);
+		expect(result).toBe(version);
+	});
+
+	it('should resolve dist-tags from registry metadata', async () => {
+		nock(registryUrl)
+			.get(`/${encodeURIComponent(packageName)}`)
+			.reply(200, {
+				'dist-tags': {
+					beta: '1.0.1-beta.1',
+				},
+			});
+
+		const result = await resolvePackageVersionSpecOrThrow(packageName, 'beta', registryUrl);
+		expect(result).toBe('1.0.1-beta.1');
 	});
 
 	it('should throw UnexpectedError when package version does not exist (404) and CLI fallback also fails', async () => {
@@ -547,9 +560,9 @@ describe('checkIfVersionExistsOrThrow', () => {
 
 		mockAsyncExec.mockRejectedValue(new Error('E404 Not Found'));
 
-		await expect(checkIfVersionExistsOrThrow(packageName, version, registryUrl)).rejects.toThrow(
-			new UnexpectedError('Package version does not exist'),
-		);
+		await expect(
+			resolvePackageVersionSpecOrThrow(packageName, version, registryUrl),
+		).rejects.toThrow(new UnexpectedError('Package version does not exist'));
 	});
 
 	it('should throw UnexpectedError with proper message on 404 when CLI fallback fails', async () => {
@@ -559,9 +572,9 @@ describe('checkIfVersionExistsOrThrow', () => {
 
 		mockAsyncExec.mockRejectedValue(new Error('Some error'));
 
-		await expect(checkIfVersionExistsOrThrow(packageName, version, registryUrl)).rejects.toThrow(
-			new UnexpectedError('Failed to check package version existence'),
-		);
+		await expect(
+			resolvePackageVersionSpecOrThrow(packageName, version, registryUrl),
+		).rejects.toThrow(new UnexpectedError('Failed to check package version existence'));
 	});
 
 	it('should throw UnexpectedError for network failures when CLI fallback fails', async () => {
@@ -571,9 +584,9 @@ describe('checkIfVersionExistsOrThrow', () => {
 
 		mockAsyncExec.mockRejectedValue(new Error('CLI network failure'));
 
-		await expect(checkIfVersionExistsOrThrow(packageName, version, registryUrl)).rejects.toThrow(
-			new UnexpectedError('Failed to check package version existence'),
-		);
+		await expect(
+			resolvePackageVersionSpecOrThrow(packageName, version, registryUrl),
+		).rejects.toThrow(new UnexpectedError('Failed to check package version existence'));
 	});
 
 	it('should throw UnexpectedError for server errors (500) when CLI fallback fails', async () => {
@@ -583,9 +596,9 @@ describe('checkIfVersionExistsOrThrow', () => {
 
 		mockAsyncExec.mockRejectedValue(new Error('CLI error'));
 
-		await expect(checkIfVersionExistsOrThrow(packageName, version, registryUrl)).rejects.toThrow(
-			UnexpectedError,
-		);
+		await expect(
+			resolvePackageVersionSpecOrThrow(packageName, version, registryUrl),
+		).rejects.toThrow(UnexpectedError);
 	});
 
 	it('should return generic message for DNS getaddrinfo errors when CLI fallback fails', async () => {
@@ -595,7 +608,9 @@ describe('checkIfVersionExistsOrThrow', () => {
 
 		mockAsyncExec.mockRejectedValue(new Error('getaddrinfo ENOTFOUND registry.npmjs.org'));
 
-		await expect(checkIfVersionExistsOrThrow(packageName, version, registryUrl)).rejects.toThrow(
+		await expect(
+			resolvePackageVersionSpecOrThrow(packageName, version, registryUrl),
+		).rejects.toThrow(
 			new UnexpectedError(
 				'The community nodes service is temporarily unreachable. Please try again later.',
 			),
@@ -609,7 +624,9 @@ describe('checkIfVersionExistsOrThrow', () => {
 
 		mockAsyncExec.mockRejectedValue(new Error('ENOTFOUND registry.npmjs.org'));
 
-		await expect(checkIfVersionExistsOrThrow(packageName, version, registryUrl)).rejects.toThrow(
+		await expect(
+			resolvePackageVersionSpecOrThrow(packageName, version, registryUrl),
+		).rejects.toThrow(
 			new UnexpectedError(
 				'The community nodes service is temporarily unreachable. Please try again later.',
 			),
@@ -617,7 +634,7 @@ describe('checkIfVersionExistsOrThrow', () => {
 	});
 
 	describe('CLI fallback functionality', () => {
-		it('should fallback to npm CLI when HTTP request fails and return true', async () => {
+		it('should fallback to npm CLI when HTTP request fails and return the resolved version', async () => {
 			nock(registryUrl)
 				.get(`/${encodeURIComponent(packageName)}/${version}`)
 				.replyWithError('Network failure');
@@ -627,8 +644,8 @@ describe('checkIfVersionExistsOrThrow', () => {
 				stderr: '',
 			});
 
-			const result = await checkIfVersionExistsOrThrow(packageName, version, registryUrl);
-			expect(result).toBe(true);
+			const result = await resolvePackageVersionSpecOrThrow(packageName, version, registryUrl);
+			expect(result).toBe(version);
 			expect(mockAsyncExec).toHaveBeenCalledTimes(1);
 			expect(mockAsyncExec).toHaveBeenCalledWith(
 				'npm',
@@ -649,37 +666,55 @@ describe('checkIfVersionExistsOrThrow', () => {
 				stderr: '',
 			});
 
-			await expect(checkIfVersionExistsOrThrow(packageName, version, registryUrl)).rejects.toThrow(
-				new UnexpectedError('Failed to check package version existence'),
-			);
+			await expect(
+				resolvePackageVersionSpecOrThrow(packageName, version, registryUrl),
+			).rejects.toThrow(new UnexpectedError('Failed to check package version existence'));
 			expect(mockAsyncExec).toHaveBeenCalledTimes(1);
 		});
 
-		it('should handle special characters in package name and version safely for checkIfVersionExistsOrThrow', async () => {
-			const specialPackageName = 'test-package; rm -rf /';
-			const specialVersion = '1.0.0 && echo "hacked"';
-
+		it('should fallback to npm CLI for dist-tags', async () => {
 			nock(registryUrl)
-				.get(`/${encodeURIComponent(specialPackageName)}/${specialVersion}`)
+				.get(`/${encodeURIComponent(packageName)}`)
 				.replyWithError('Network failure');
 
 			mockAsyncExec.mockResolvedValue({
-				stdout: JSON.stringify(specialVersion),
+				stdout: JSON.stringify('1.0.1-beta.1'),
 				stderr: '',
 			});
 
-			const result = await checkIfVersionExistsOrThrow(
+			const result = await resolvePackageVersionSpecOrThrow(packageName, 'beta', registryUrl);
+			expect(result).toBe('1.0.1-beta.1');
+			expect(mockAsyncExec).toHaveBeenCalledWith(
+				'npm',
+				['view', `${packageName}@beta`, 'version', `--registry=${registryUrl}`, '--json'],
+				undefined,
+			);
+		});
+
+		it('should handle special characters in package name safely for resolvePackageVersionSpecOrThrow', async () => {
+			const specialPackageName = '@test/test-package';
+
+			nock(registryUrl)
+				.get(`/${encodeURIComponent(specialPackageName)}/${encodeURIComponent(version)}`)
+				.replyWithError('Network failure');
+
+			mockAsyncExec.mockResolvedValue({
+				stdout: JSON.stringify(version),
+				stderr: '',
+			});
+
+			const result = await resolvePackageVersionSpecOrThrow(
 				specialPackageName,
-				specialVersion,
+				version,
 				registryUrl,
 			);
-			expect(result).toBe(true);
+			expect(result).toBe(version);
 			expect(mockAsyncExec).toHaveBeenCalledTimes(1);
 			expect(mockAsyncExec).toHaveBeenCalledWith(
 				'npm',
 				[
 					'view',
-					`${specialPackageName}@${specialVersion}`,
+					`${specialPackageName}@${version}`,
 					'version',
 					`--registry=${registryUrl}`,
 					'--json',
@@ -697,21 +732,23 @@ describe('checkIfVersionExistsOrThrow', () => {
 				new Error('E404 Not Found - GET https://registry.npmjs.org/nonexistent-package'),
 			);
 
-			await expect(checkIfVersionExistsOrThrow(packageName, version, registryUrl)).rejects.toThrow(
-				new UnexpectedError('Package version does not exist'),
-			);
+			await expect(
+				resolvePackageVersionSpecOrThrow(packageName, version, registryUrl),
+			).rejects.toThrow(new UnexpectedError('Package version does not exist'));
 
 			expect(mockAsyncExec).toHaveBeenCalledTimes(1);
 		});
 
-		it('should handle DNS errors in CLI fallback for checkIfVersionExistsOrThrow', async () => {
+		it('should handle DNS errors in CLI fallback for resolvePackageVersionSpecOrThrow', async () => {
 			nock(registryUrl)
 				.get(`/${encodeURIComponent(packageName)}/${version}`)
 				.replyWithError('Network failure');
 
 			mockAsyncExec.mockRejectedValue(new Error('getaddrinfo ENOTFOUND registry.npmjs.org'));
 
-			await expect(checkIfVersionExistsOrThrow(packageName, version, registryUrl)).rejects.toThrow(
+			await expect(
+				resolvePackageVersionSpecOrThrow(packageName, version, registryUrl),
+			).rejects.toThrow(
 				new UnexpectedError(
 					'The community nodes service is temporarily unreachable. Please try again later.',
 				),
@@ -720,14 +757,16 @@ describe('checkIfVersionExistsOrThrow', () => {
 			expect(mockAsyncExec).toHaveBeenCalledTimes(1);
 		});
 
-		it('should handle npm errors in CLI fallback for checkIfVersionExistsOrThrow', async () => {
+		it('should handle npm errors in CLI fallback for resolvePackageVersionSpecOrThrow', async () => {
 			nock(registryUrl)
 				.get(`/${encodeURIComponent(packageName)}/${version}`)
 				.replyWithError('Network failure');
 
 			mockAsyncExec.mockRejectedValue(new Error('npm ERR! 500 Internal Server Error'));
 
-			await expect(checkIfVersionExistsOrThrow(packageName, version, registryUrl)).rejects.toThrow(
+			await expect(
+				resolvePackageVersionSpecOrThrow(packageName, version, registryUrl),
+			).rejects.toThrow(
 				new UnexpectedError(
 					'The community nodes service is temporarily unreachable. Please try again later.',
 				),
@@ -736,16 +775,16 @@ describe('checkIfVersionExistsOrThrow', () => {
 			expect(mockAsyncExec).toHaveBeenCalledTimes(1);
 		});
 
-		it('should handle generic CLI errors for checkIfVersionExistsOrThrow', async () => {
+		it('should handle generic CLI errors for resolvePackageVersionSpecOrThrow', async () => {
 			nock(registryUrl)
 				.get(`/${encodeURIComponent(packageName)}/${version}`)
 				.replyWithError('Network failure');
 
 			mockAsyncExec.mockRejectedValue(new Error('Some other error'));
 
-			await expect(checkIfVersionExistsOrThrow(packageName, version, registryUrl)).rejects.toThrow(
-				new UnexpectedError('Failed to check package version existence'),
-			);
+			await expect(
+				resolvePackageVersionSpecOrThrow(packageName, version, registryUrl),
+			).rejects.toThrow(new UnexpectedError('Failed to check package version existence'));
 
 			expect(mockAsyncExec).toHaveBeenCalledTimes(1);
 		});
@@ -762,8 +801,12 @@ describe('checkIfVersionExistsOrThrow', () => {
 					version,
 				});
 
-			const result = await checkIfVersionExistsOrThrow(packageName, version, registryWithSlashes);
-			expect(result).toBe(true);
+			const result = await resolvePackageVersionSpecOrThrow(
+				packageName,
+				version,
+				registryWithSlashes,
+			);
+			expect(result).toBe(version);
 		});
 	});
 });

--- a/packages/cli/src/modules/community-packages/community-packages.controller.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.controller.ts
@@ -1,5 +1,5 @@
 import { Delete, Get, Patch, Post, RestController, GlobalScope } from '@n8n/decorators';
-import { valid } from 'semver';
+import { InstanceSettings } from 'n8n-core';
 
 import {
 	RESPONSE_ERROR_MESSAGES,
@@ -17,7 +17,6 @@ import { CommunityPackagesService } from './community-packages.service';
 import type { CommunityPackages } from './community-packages.types';
 import { InstalledPackages } from './installed-packages.entity';
 import { executeNpmCommand } from './npm-utils';
-import { InstanceSettings } from 'n8n-core';
 
 const {
 	PACKAGE_NOT_INSTALLED,
@@ -55,20 +54,6 @@ export class CommunityPackagesController {
 			throw new BadRequestError(PACKAGE_NAME_NOT_PROVIDED);
 		}
 
-		if (version && !valid(version)) {
-			throw new BadRequestError(`Invalid version: ${version}`);
-		}
-
-		let checksum: string | undefined = undefined;
-
-		// Get the checksum for the package if flagged to verify
-		if (verify) {
-			checksum = this.communityNodeTypesService.findVetted(name)?.checksum;
-			if (!checksum) {
-				throw new BadRequestError(`Package ${name} is not vetted for installation`);
-			}
-		}
-
 		let parsed: CommunityPackages.ParsedPackageName;
 
 		try {
@@ -77,6 +62,16 @@ export class CommunityPackagesController {
 			throw new BadRequestError(
 				error instanceof Error ? error.message : 'Failed to parse package name',
 			);
+		}
+
+		let checksum: string | undefined = undefined;
+
+		// Get the checksum for the package if flagged to verify
+		if (verify) {
+			checksum = this.communityNodeTypesService.findVetted(parsed.packageName)?.checksum;
+			if (!checksum) {
+				throw new BadRequestError(`Package ${parsed.packageName} is not vetted for installation`);
+			}
 		}
 
 		if (parsed.packageName === STARTER_TEMPLATE_NAME) {
@@ -89,7 +84,7 @@ export class CommunityPackagesController {
 		}
 
 		const isInstalled = await this.communityPackagesService.isPackageInstalled(parsed.packageName);
-		const hasLoaded = this.communityPackagesService.hasPackageLoaded(name);
+		const hasLoaded = this.communityPackagesService.hasPackageLoaded(parsed.packageName);
 
 		if (isInstalled && hasLoaded) {
 			throw new BadRequestError(
@@ -100,13 +95,28 @@ export class CommunityPackagesController {
 			);
 		}
 
-		const packageStatus = await this.communityPackagesService.checkNpmPackageStatus(name);
+		const packageStatus = await this.communityPackagesService.checkNpmPackageStatus(
+			parsed.packageName,
+		);
 
 		if (packageStatus.status !== 'OK') {
 			throw new BadRequestError(`Package "${name}" is banned so it cannot be installed`);
 		}
 
-		const packageVersion = version ?? parsed.version;
+		let packageVersion = parsed.version;
+		if (version) {
+			try {
+				packageVersion = this.communityPackagesService.parsePackageVersion(
+					parsed.packageName,
+					version,
+				).version;
+			} catch (error) {
+				throw new BadRequestError(
+					error instanceof Error ? error.message : 'Failed to parse package version',
+				);
+			}
+		}
+
 		let installedPackage: InstalledPackages;
 		try {
 			installedPackage = await this.communityPackagesService.installPackage(
@@ -135,7 +145,7 @@ export class CommunityPackagesController {
 			throw new (clientError ? BadRequestError : InternalServerError)(message);
 		}
 
-		if (!hasLoaded) this.communityPackagesService.removePackageFromMissingList(name);
+		if (!hasLoaded) this.communityPackagesService.removePackageFromMissingList(parsed.packageName);
 
 		// broadcast to connected frontends that node list has been updated
 		installedPackage.installedNodes.forEach((node) => {
@@ -159,7 +169,7 @@ export class CommunityPackagesController {
 			packageAuthorEmail: installedPackage.authorEmail,
 		});
 
-		return installedPackage;
+		return this.communityPackagesService.toPublicInstalledPackage(installedPackage);
 	}
 
 	@Get('/')
@@ -210,25 +220,28 @@ export class CommunityPackagesController {
 			throw new BadRequestError(PACKAGE_NAME_NOT_PROVIDED);
 		}
 
+		let parsed: CommunityPackages.ParsedPackageName;
 		try {
-			this.communityPackagesService.parseNpmPackageName(name); // sanitize input
+			parsed = this.communityPackagesService.parseNpmPackageName(name);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : UNKNOWN_FAILURE_REASON;
 
 			throw new BadRequestError(message);
 		}
 
-		const installedPackage = await this.communityPackagesService.findInstalledPackage(name);
+		const installedPackage = await this.communityPackagesService.findInstalledPackage(
+			parsed.packageName,
+		);
 
 		if (!installedPackage) {
 			throw new BadRequestError(PACKAGE_NOT_INSTALLED);
 		}
 
 		try {
-			await this.communityPackagesService.removePackage(name, installedPackage);
+			await this.communityPackagesService.removePackage(parsed.packageName, installedPackage);
 		} catch (error) {
 			const message = [
-				`Error removing package "${name}"`,
+				`Error removing package "${parsed.packageName}"`,
 				error instanceof Error ? error.message : UNKNOWN_FAILURE_REASON,
 			].join(':');
 
@@ -248,7 +261,7 @@ export class CommunityPackagesController {
 
 		this.eventService.emit('community-package-deleted', {
 			user: req.user,
-			packageName: name,
+			packageName: parsed.packageName,
 			packageVersion: installedPackage.installedVersion,
 			packageNodeNames: installedPackage.installedNodes.map((node) => node.name),
 			packageAuthor: installedPackage.authorName,
@@ -265,20 +278,39 @@ export class CommunityPackagesController {
 			throw new BadRequestError(PACKAGE_NAME_NOT_PROVIDED);
 		}
 
-		if (version && !valid(version)) {
-			throw new BadRequestError(`Invalid version: ${version}`);
+		let parsed: CommunityPackages.ParsedPackageName;
+		try {
+			parsed = this.communityPackagesService.parseNpmPackageName(name);
+		} catch (error) {
+			throw new BadRequestError(
+				error instanceof Error ? error.message : 'Failed to parse package name',
+			);
 		}
 
-		const previouslyInstalledPackage =
-			await this.communityPackagesService.findInstalledPackage(name);
+		const previouslyInstalledPackage = await this.communityPackagesService.findInstalledPackage(
+			parsed.packageName,
+		);
 
 		if (!previouslyInstalledPackage) {
 			throw new BadRequestError(PACKAGE_NOT_INSTALLED);
 		}
 
+		if (version) {
+			try {
+				this.communityPackagesService.parsePackageVersion(
+					previouslyInstalledPackage.packageName,
+					version,
+				);
+			} catch (error) {
+				throw new BadRequestError(
+					error instanceof Error ? error.message : 'Failed to parse package version',
+				);
+			}
+		}
+
 		try {
 			const newInstalledPackage = await this.communityPackagesService.updatePackage(
-				this.communityPackagesService.parseNpmPackageName(name).packageName,
+				parsed.packageName,
 				previouslyInstalledPackage,
 				version,
 				checksum,
@@ -307,7 +339,7 @@ export class CommunityPackagesController {
 
 			this.eventService.emit('community-package-updated', {
 				user: req.user,
-				packageName: name,
+				packageName: parsed.packageName,
 				packageVersionCurrent: previouslyInstalledPackage.installedVersion,
 				packageVersionNew: newInstalledPackage.installedVersion,
 				packageNodeNames: newInstalledPackage.installedNodes.map((n) => n.name),
@@ -315,7 +347,7 @@ export class CommunityPackagesController {
 				packageAuthorEmail: newInstalledPackage.authorEmail,
 			});
 
-			return newInstalledPackage;
+			return this.communityPackagesService.toPublicInstalledPackage(newInstalledPackage);
 		} catch (error) {
 			previouslyInstalledPackage.installedNodes.forEach((node) => {
 				this.push.broadcast({
@@ -328,7 +360,7 @@ export class CommunityPackagesController {
 			});
 
 			const message = [
-				`Error removing package "${name}"`,
+				`Error removing package "${parsed.packageName}"`,
 				error instanceof Error ? error.message : UNKNOWN_FAILURE_REASON,
 			].join(':');
 

--- a/packages/cli/src/modules/community-packages/community-packages.service.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.service.ts
@@ -3,6 +3,7 @@ import { LICENSE_FEATURES } from '@n8n/constants';
 import { OnPubSubEvent } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import axios from 'axios';
+import npa from 'npm-package-arg';
 import type { PackageDirectoryLoader } from 'n8n-core';
 import { InstanceSettings } from 'n8n-core';
 import {
@@ -16,7 +17,7 @@ import { execFile } from 'node:child_process';
 import { access, constants, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
-import { valid } from 'semver';
+import { gt as semverGt } from 'semver';
 
 import { NODE_PACKAGE_PREFIX, NPM_PACKAGE_STATUS_GOOD, RESPONSE_ERROR_MESSAGES } from '@/constants';
 import { FeatureNotLicensedError } from '@/errors/feature-not-licensed.error';
@@ -30,7 +31,7 @@ import { CommunityPackagesConfig } from './community-packages.config';
 import type { CommunityPackages } from './community-packages.types';
 import { InstalledPackages } from './installed-packages.entity';
 import { InstalledPackagesRepository } from './installed-packages.repository';
-import { checkIfVersionExistsOrThrow, executeNpmCommand, verifyIntegrity } from './npm-utils';
+import { executeNpmCommand, resolvePackageVersionSpecOrThrow, verifyIntegrity } from './npm-utils';
 
 const asyncExecFile = promisify(execFile);
 
@@ -45,12 +46,21 @@ const NPM_INSTALL_ARGS = [
 
 const { PACKAGE_NAME_NOT_PROVIDED } = RESPONSE_ERROR_MESSAGES;
 
-const INVALID_OR_SUSPICIOUS_PACKAGE_NAME = /[^0-9a-z@\-._/]/;
-
 type PackageJson = {
 	name: 'installed-nodes';
 	private: true;
 	dependencies: Record<string, string>;
+};
+
+type PackageVersionSelection = {
+	version: string;
+	requestedDistTag?: string;
+};
+
+type CommunityPackageInstallEventPayload = {
+	packageName: string;
+	packageVersion: string;
+	requestedDistTag?: string;
 };
 
 @Service()
@@ -99,9 +109,15 @@ export class CommunityPackagesService {
 		return await this.installedPackageRepository.remove(packageName);
 	}
 
-	private async persistInstalledPackage(packageLoader: PackageDirectoryLoader) {
+	private async persistInstalledPackage(
+		packageLoader: PackageDirectoryLoader,
+		requestedDistTag?: string,
+	) {
 		try {
-			return await this.installedPackageRepository.saveInstalledPackageWithNodes(packageLoader);
+			return await this.installedPackageRepository.saveInstalledPackageWithNodes(
+				packageLoader,
+				requestedDistTag,
+			);
 		} catch (maybeError) {
 			const error = toError(maybeError);
 
@@ -117,43 +133,92 @@ export class CommunityPackagesService {
 	parseNpmPackageName(rawString?: string): CommunityPackages.ParsedPackageName {
 		if (!rawString) throw new UnexpectedError(PACKAGE_NAME_NOT_PROVIDED);
 
-		if (INVALID_OR_SUSPICIOUS_PACKAGE_NAME.test(rawString)) {
-			throw new UnexpectedError('Package name must be a single word');
+		const versionSpec = this.extractVersionSpec(rawString);
+
+		let parsedPackageSpec: ReturnType<typeof npa>;
+		try {
+			parsedPackageSpec = npa(rawString);
+		} catch {
+			throw this.createInvalidPackageSpecError(rawString);
 		}
 
-		const scope = rawString.includes('/') ? rawString.split('/')[0] : undefined;
-
-		const packageNameWithoutScope = scope ? rawString.replace(`${scope}/`, '') : rawString;
-
-		if (!packageNameWithoutScope.startsWith(NODE_PACKAGE_PREFIX)) {
-			throw new UnexpectedError(`Package name must start with ${NODE_PACKAGE_PREFIX}`);
+		const packageName = parsedPackageSpec.name;
+		if (!packageName) {
+			throw this.createInvalidPackageSpecError(rawString);
 		}
 
-		const version = packageNameWithoutScope.includes('@')
-			? packageNameWithoutScope.split('@')[1]
-			: undefined;
+		this.assertPackageNamePrefix(packageName);
 
-		if (version && !valid(version)) {
+		const scope = parsedPackageSpec.scope;
+
+		if (rawString === packageName) {
+			return { packageName, rawString, scope };
+		}
+
+		if (!parsedPackageSpec.registry || !this.isSupportedRegistrySpec(parsedPackageSpec.type)) {
+			throw new UnexpectedError(`Invalid version: ${versionSpec ?? parsedPackageSpec.rawSpec}`);
+		}
+
+		const requestedVersion = parsedPackageSpec.rawSpec;
+		if (!requestedVersion) {
+			throw this.createInvalidPackageSpecError(rawString);
+		}
+
+		return {
+			packageName,
+			rawString,
+			scope,
+			version: requestedVersion,
+			requestedDistTag:
+				parsedPackageSpec.type === 'tag' && requestedVersion !== 'latest'
+					? requestedVersion
+					: undefined,
+		};
+	}
+
+	parsePackageVersion(packageName: string, version: string): PackageVersionSelection {
+		const parsedPackage = this.parseNpmPackageName(`${packageName}@${version}`);
+
+		if (!parsedPackage.version) {
 			throw new UnexpectedError(`Invalid version: ${version}`);
 		}
 
-		const packageName = version ? rawString.replace(`@${version}`, '') : rawString;
+		return {
+			version: parsedPackage.version,
+			requestedDistTag: parsedPackage.requestedDistTag,
+		};
+	}
 
-		return { packageName, scope, version, rawString };
+	toPublicInstalledPackage(installedPackage: InstalledPackages): PublicInstalledPackage {
+		return {
+			packageName: installedPackage.packageName,
+			installedVersion: installedPackage.installedVersion,
+			authorName: installedPackage.authorName,
+			authorEmail: installedPackage.authorEmail,
+			installedNodes: installedPackage.installedNodes,
+			createdAt: installedPackage.createdAt,
+			updatedAt: installedPackage.updatedAt,
+		};
 	}
 
 	matchPackagesWithUpdates(
 		packages: InstalledPackages[],
 		updates?: CommunityPackages.AvailableUpdates,
 	) {
-		if (!updates) return packages;
+		if (!updates) return packages.map((pkg) => this.toPublicInstalledPackage(pkg));
 
 		return packages.reduce<PublicInstalledPackage[]>((acc, cur) => {
-			const publicPackage: PublicInstalledPackage = { ...cur };
+			const publicPackage = this.toPublicInstalledPackage(cur);
 
 			const update = updates[cur.packageName];
 
-			if (update) publicPackage.updateAvailable = update.latest;
+			if (update) {
+				const updateVersion = cur.requestedDistTag ? update.wanted : update.latest;
+
+				if (updateVersion && semverGt(updateVersion, cur.installedVersion)) {
+					publicPackage.updateAvailable = updateVersion;
+				}
+			}
 
 			acc.push(publicPackage);
 
@@ -356,6 +421,7 @@ export class CommunityPackagesService {
 
 	async removePackage(packageName: string, installedPackage: InstalledPackages): Promise<void> {
 		await this.removeNpmPackage(packageName);
+		await this.removePackageJsonDependency(packageName);
 		await this.removePackageFromDatabase(installedPackage);
 		void this.publisher.publishCommand({
 			command: 'community-package-uninstall',
@@ -388,19 +454,27 @@ export class CommunityPackagesService {
 			| { installedPackage: InstalledPackages; version?: string; checksum?: string } = {},
 	) {
 		const isUpdate = 'installedPackage' in options;
-		const packageVersion = !options.version ? 'latest' : options.version;
-
 		const shouldValidateChecksum = 'checksum' in options && Boolean(options.checksum);
 		this.checkInstallPermissions(shouldValidateChecksum);
+		const requestedVersionSelection = this.getRequestedVersionSelection(packageName, options);
+
+		const registry = this.getNpmRegistry();
+		const resolvedPackageVersion = await resolvePackageVersionSpecOrThrow(
+			packageName,
+			requestedVersionSelection.version,
+			registry,
+		);
 
 		if (options.checksum) {
-			await verifyIntegrity(packageName, packageVersion, this.getNpmRegistry(), options.checksum);
+			await verifyIntegrity(packageName, resolvedPackageVersion, registry, options.checksum);
 		}
 
-		await checkIfVersionExistsOrThrow(packageName, packageVersion, this.getNpmRegistry());
-
 		try {
-			await this.downloadPackage(packageName, packageVersion);
+			await this.downloadPackage(
+				packageName,
+				resolvedPackageVersion,
+				requestedVersionSelection.requestedDistTag ?? resolvedPackageVersion,
+			);
 		} catch (error) {
 			if (error instanceof Error && error.message === RESPONSE_ERROR_MESSAGES.PACKAGE_NOT_FOUND) {
 				throw new UserError('npm package not found', { extra: { packageName } });
@@ -428,10 +502,22 @@ export class CommunityPackagesService {
 				if (isUpdate) {
 					await this.removePackageFromDatabase(options.installedPackage);
 				}
-				const installedPackage = await this.persistInstalledPackage(loader);
+				const installedPackage = await this.persistInstalledPackage(
+					loader,
+					requestedVersionSelection.requestedDistTag,
+				);
+				const pubSubPayload: CommunityPackageInstallEventPayload = {
+					packageName,
+					packageVersion: resolvedPackageVersion,
+				};
+
+				if (requestedVersionSelection.requestedDistTag) {
+					pubSubPayload.requestedDistTag = requestedVersionSelection.requestedDistTag;
+				}
+
 				void this.publisher.publishCommand({
 					command: isUpdate ? 'community-package-update' : 'community-package-install',
-					payload: { packageName, packageVersion },
+					payload: pubSubPayload,
 				});
 				await this.loadNodesAndCredentials.postProcessLoaders();
 				this.loadNodesAndCredentials.releaseTypes();
@@ -459,8 +545,13 @@ export class CommunityPackagesService {
 	async handleInstallEvent({
 		packageName,
 		packageVersion,
-	}: { packageName: string; packageVersion: string }) {
-		await this.installOrUpdateNpmPackage(packageName, packageVersion);
+		requestedDistTag,
+	}: CommunityPackageInstallEventPayload) {
+		await this.installOrUpdateNpmPackage(
+			packageName,
+			packageVersion,
+			requestedDistTag ?? packageVersion,
+		);
 	}
 
 	@OnPubSubEvent('community-package-uninstall')
@@ -468,8 +559,12 @@ export class CommunityPackagesService {
 		await this.removeNpmPackage(packageName);
 	}
 
-	private async installOrUpdateNpmPackage(packageName: string, packageVersion: string) {
-		await this.downloadPackage(packageName, packageVersion);
+	private async installOrUpdateNpmPackage(
+		packageName: string,
+		packageVersion: string,
+		dependencyVersion: string,
+	) {
+		await this.downloadPackage(packageName, packageVersion, dependencyVersion);
 		await this.loadNodesAndCredentials.unloadPackage(packageName);
 		await this.loadNodesAndCredentials.loadPackage(packageName);
 		await this.loadNodesAndCredentials.postProcessLoaders();
@@ -489,7 +584,11 @@ export class CommunityPackagesService {
 		return `${this.downloadFolder}/node_modules/${packageName}`;
 	}
 
-	private async downloadPackage(packageName: string, packageVersion: string): Promise<string> {
+	private async downloadPackage(
+		packageName: string,
+		packageVersion: string,
+		dependencyVersion: string,
+	): Promise<string> {
 		const registry = this.getNpmRegistry();
 		const packageDirectory = this.resolvePackageDirectory(packageName);
 
@@ -533,7 +632,7 @@ export class CommunityPackagesService {
 			await executeNpmCommand(['install', ...this.getNpmInstallArgs()], {
 				cwd: packageDirectory,
 			});
-			await this.updatePackageJsonDependency(packageName, packageJson.version);
+			await this.updatePackageJsonDependency(packageName, dependencyVersion);
 		} finally {
 			await rm(join(this.downloadFolder, tarballName));
 		}
@@ -551,5 +650,63 @@ export class CommunityPackagesService {
 		const packageJson = jsonParse<PackageJson>(existingContent);
 		packageJson.dependencies[packageName] = version;
 		await writeFile(this.packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf-8');
+	}
+
+	async removePackageJsonDependency(packageName: string) {
+		const existingContent = await readFile(this.packageJsonPath, 'utf-8');
+		const packageJson = jsonParse<PackageJson>(existingContent);
+		delete packageJson.dependencies[packageName];
+		await writeFile(this.packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf-8');
+	}
+
+	private getRequestedVersionSelection(
+		packageName: string,
+		options:
+			| { version?: string; checksum?: string }
+			| { installedPackage: InstalledPackages; version?: string; checksum?: string },
+	): PackageVersionSelection {
+		const requestedVersion =
+			options.version ??
+			('installedPackage' in options
+				? (options.installedPackage.requestedDistTag ?? undefined)
+				: undefined);
+
+		if (!requestedVersion) return { version: 'latest' };
+
+		return this.parsePackageVersion(packageName, requestedVersion);
+	}
+
+	private createInvalidPackageSpecError(rawString: string) {
+		const versionSpec = this.extractVersionSpec(rawString);
+
+		if (versionSpec) {
+			return new UnexpectedError(`Invalid version: ${versionSpec}`);
+		}
+
+		return new UnexpectedError('Package name must be a single word');
+	}
+
+	private extractVersionSpec(rawString: string) {
+		const versionSeparatorIndex = rawString.startsWith('@')
+			? rawString.indexOf('@', rawString.indexOf('/') + 1)
+			: rawString.indexOf('@');
+
+		if (versionSeparatorIndex <= 0) return undefined;
+
+		return rawString.slice(versionSeparatorIndex + 1);
+	}
+
+	private assertPackageNamePrefix(packageName: string) {
+		const packageNameWithoutScope = packageName.includes('/')
+			? packageName.split('/').at(-1)
+			: packageName;
+
+		if (!packageNameWithoutScope?.startsWith(NODE_PACKAGE_PREFIX)) {
+			throw new UnexpectedError(`Package name must start with ${NODE_PACKAGE_PREFIX}`);
+		}
+	}
+
+	private isSupportedRegistrySpec(type: string): type is 'tag' | 'version' {
+		return type === 'tag' || type === 'version';
 	}
 }

--- a/packages/cli/src/modules/community-packages/community-packages.service.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.service.ts
@@ -3,7 +3,6 @@ import { LICENSE_FEATURES } from '@n8n/constants';
 import { OnPubSubEvent } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import axios from 'axios';
-import npa from 'npm-package-arg';
 import type { PackageDirectoryLoader } from 'n8n-core';
 import { InstanceSettings } from 'n8n-core';
 import {
@@ -17,6 +16,7 @@ import { execFile } from 'node:child_process';
 import { access, constants, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
+import npa from 'npm-package-arg';
 import { gt as semverGt } from 'semver';
 
 import { NODE_PACKAGE_PREFIX, NPM_PACKAGE_STATUS_GOOD, RESPONSE_ERROR_MESSAGES } from '@/constants';
@@ -54,6 +54,19 @@ type PackageJson = {
 
 type PackageVersionSelection = {
 	version: string;
+	requestedDistTag?: string;
+};
+
+type MissingPackage = {
+	packageName: string;
+	version: string;
+	requestedDistTag?: string;
+};
+
+type InstallOrUpdatePackageOptions = {
+	installedPackage?: InstalledPackages;
+	version?: string;
+	checksum?: string;
 	requestedDistTag?: string;
 };
 
@@ -310,15 +323,16 @@ export class CommunityPackagesService {
 
 	async checkForMissingPackages() {
 		const installedPackages = await this.getAllInstalledPackages();
-		const missingPackages = new Set<{ packageName: string; version: string }>();
+		const missingPackages = new Map<string, MissingPackage>();
 
 		installedPackages.forEach((installedPackage) => {
 			installedPackage.installedNodes.forEach((installedNode) => {
 				if (!this.loadNodesAndCredentials.isKnownNode(installedNode.type)) {
 					// Leave the list ready for installing in case we need.
-					missingPackages.add({
+					missingPackages.set(installedPackage.packageName, {
 						packageName: installedPackage.packageName,
 						version: installedPackage.installedVersion,
+						requestedDistTag: this.normalizeRequestedDistTag(installedPackage.requestedDistTag),
 					});
 				}
 			});
@@ -331,11 +345,12 @@ export class CommunityPackagesService {
 		const { reinstallMissing } = this.config;
 		if (reinstallMissing) {
 			this.logger.info('Attempting to reinstall missing packages', {
-				missingPackages: [...missingPackages],
+				missingPackages: [...missingPackages.values()],
 			});
 			const environment = process.env.ENVIRONMENT === 'staging' ? 'staging' : 'production';
 
-			const packageNames = [...missingPackages].map((p) => p.packageName);
+			const missingPackageEntries = [...missingPackages.values()];
+			const packageNames = missingPackageEntries.map((p) => p.packageName);
 
 			let vettedPackages: StrapiCommunityNodeType[] = [];
 			try {
@@ -357,7 +372,7 @@ export class CommunityPackagesService {
 				);
 			}
 
-			for (const missingPackage of missingPackages) {
+			for (const missingPackage of missingPackageEntries) {
 				try {
 					const vettedPackage = vettedPackages.find(
 						(p) => p.packageName === missingPackage.packageName,
@@ -376,8 +391,13 @@ export class CommunityPackagesService {
 						}
 					}
 
-					await this.installPackage(missingPackage.packageName, missingPackage.version, checksum);
-					missingPackages.delete(missingPackage);
+					await this.installPackage(
+						missingPackage.packageName,
+						missingPackage.version,
+						checksum,
+						missingPackage.requestedDistTag,
+					);
+					missingPackages.delete(missingPackage.packageName);
 				} catch (error) {
 					this.logger.error(
 						`Failed to reinstall community package ${missingPackage.packageName}: ${ensureError(error).message}`,
@@ -397,7 +417,7 @@ export class CommunityPackagesService {
 			);
 		}
 
-		this.missingPackages = [...missingPackages].map(
+		this.missingPackages = [...missingPackages.values()].map(
 			(missingPackage) => `${missingPackage.packageName}@${missingPackage.version}`,
 		);
 	}
@@ -406,8 +426,13 @@ export class CommunityPackagesService {
 		packageName: string,
 		version?: string,
 		checksum?: string,
+		requestedDistTag?: string,
 	): Promise<InstalledPackages> {
-		return await this.installOrUpdatePackage(packageName, { version, checksum });
+		return await this.installOrUpdatePackage(packageName, {
+			version,
+			checksum,
+			requestedDistTag,
+		});
 	}
 
 	async updatePackage(
@@ -449,11 +474,9 @@ export class CommunityPackagesService {
 
 	private async installOrUpdatePackage(
 		packageName: string,
-		options:
-			| { version?: string; checksum?: string }
-			| { installedPackage: InstalledPackages; version?: string; checksum?: string } = {},
+		options: InstallOrUpdatePackageOptions = {},
 	) {
-		const isUpdate = 'installedPackage' in options;
+		const isUpdate = options.installedPackage !== undefined;
 		const shouldValidateChecksum = 'checksum' in options && Boolean(options.checksum);
 		this.checkInstallPermissions(shouldValidateChecksum);
 		const requestedVersionSelection = this.getRequestedVersionSelection(packageName, options);
@@ -499,7 +522,7 @@ export class CommunityPackagesService {
 		if (loader.loadedNodes.length > 0) {
 			// Save info to DB
 			try {
-				if (isUpdate) {
+				if (options.installedPackage) {
 					await this.removePackageFromDatabase(options.installedPackage);
 				}
 				const installedPackage = await this.persistInstalledPackage(
@@ -661,19 +684,31 @@ export class CommunityPackagesService {
 
 	private getRequestedVersionSelection(
 		packageName: string,
-		options:
-			| { version?: string; checksum?: string }
-			| { installedPackage: InstalledPackages; version?: string; checksum?: string },
+		options: InstallOrUpdatePackageOptions,
 	): PackageVersionSelection {
+		if (options.version) {
+			const requestedVersionSelection = this.parsePackageVersion(packageName, options.version);
+
+			// Missing-package recovery reinstalls the exact version that vanished, but updates
+			// should continue to follow the original dist-tag the user selected.
+			if (!requestedVersionSelection.requestedDistTag && options.requestedDistTag) {
+				requestedVersionSelection.requestedDistTag = options.requestedDistTag;
+			}
+
+			return requestedVersionSelection;
+		}
+
 		const requestedVersion =
-			options.version ??
-			('installedPackage' in options
-				? (options.installedPackage.requestedDistTag ?? undefined)
-				: undefined);
+			options.requestedDistTag ??
+			this.normalizeRequestedDistTag(options.installedPackage?.requestedDistTag);
 
 		if (!requestedVersion) return { version: 'latest' };
 
 		return this.parsePackageVersion(packageName, requestedVersion);
+	}
+
+	private normalizeRequestedDistTag(requestedDistTag: unknown): string | undefined {
+		return typeof requestedDistTag === 'string' ? requestedDistTag : undefined;
 	}
 
 	private createInvalidPackageSpecError(rawString: string) {

--- a/packages/cli/src/modules/community-packages/community-packages.types.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.types.ts
@@ -4,11 +4,12 @@ export namespace CommunityPackages {
 		rawString: string;
 		scope?: string;
 		version?: string;
+		requestedDistTag?: string;
 	};
 
 	export type AvailableUpdates = {
 		[packageName: string]: {
-			current: string;
+			current?: string;
 			wanted: string;
 			latest: string;
 			location: string;

--- a/packages/cli/src/modules/community-packages/installed-packages.entity.ts
+++ b/packages/cli/src/modules/community-packages/installed-packages.entity.ts
@@ -11,6 +11,9 @@ export class InstalledPackages extends WithTimestamps {
 	@Column()
 	installedVersion: string;
 
+	@Column({ type: 'varchar', length: 255, nullable: true })
+	requestedDistTag?: string | null;
+
 	@Column()
 	authorName?: string;
 

--- a/packages/cli/src/modules/community-packages/installed-packages.repository.ts
+++ b/packages/cli/src/modules/community-packages/installed-packages.repository.ts
@@ -14,7 +14,10 @@ export class InstalledPackagesRepository extends Repository<InstalledPackages> {
 		super(InstalledPackages, dataSource.manager);
 	}
 
-	async saveInstalledPackageWithNodes(packageLoader: PackageDirectoryLoader) {
+	async saveInstalledPackageWithNodes(
+		packageLoader: PackageDirectoryLoader,
+		requestedDistTag?: string,
+	) {
 		const { packageJson, nodeTypes, loadedNodes } = packageLoader;
 		const { name: packageName, version: installedVersion, author } = packageJson;
 
@@ -25,6 +28,7 @@ export class InstalledPackagesRepository extends Repository<InstalledPackages> {
 				this.create({
 					packageName,
 					installedVersion,
+					requestedDistTag: requestedDistTag ?? null,
 					authorName: author?.name,
 					authorEmail: author?.email,
 				}),

--- a/packages/cli/src/modules/community-packages/npm-utils.ts
+++ b/packages/cli/src/modules/community-packages/npm-utils.ts
@@ -1,8 +1,10 @@
 import { NPM_COMMAND_TOKENS, RESPONSE_ERROR_MESSAGES } from '@/constants';
 import axios from 'axios';
+import npa from 'npm-package-arg';
 import { jsonParse, UnexpectedError, LoggerProxy } from 'n8n-workflow';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { valid as isValidSemver } from 'semver';
 
 const asyncExecFile = promisify(execFile);
 
@@ -108,9 +110,12 @@ export async function verifyIntegrity(
 	const url = `${sanitizeRegistryUrl(registryUrl)}/${encodeURIComponent(packageName)}`;
 
 	try {
-		const metadata = await axios.get<{ dist: { integrity?: string } }>(`${url}/${version}`, {
-			timeout: REQUEST_TIMEOUT,
-		});
+		const metadata = await axios.get<{ dist: { integrity?: string } }>(
+			`${url}/${encodeURIComponent(version)}`,
+			{
+				timeout: REQUEST_TIMEOUT,
+			},
+		);
 
 		const integrity = metadata?.data?.dist?.integrity;
 		if (integrity !== expectedIntegrity) {
@@ -152,22 +157,47 @@ export async function verifyIntegrity(
 	}
 }
 
-export async function checkIfVersionExistsOrThrow(
+export async function resolvePackageVersionSpecOrThrow(
 	packageName: string,
-	version: string,
+	versionSpec: string,
 	registryUrl: string,
-): Promise<true> {
+): Promise<string> {
 	const url = `${sanitizeRegistryUrl(registryUrl)}/${encodeURIComponent(packageName)}`;
+	let parsedSpec: ReturnType<typeof npa.resolve>;
+	try {
+		parsedSpec = npa.resolve(packageName, versionSpec);
+	} catch {
+		throw new UnexpectedError('Failed to check package version existence');
+	}
+
+	if (!parsedSpec.registry || (parsedSpec.type !== 'version' && parsedSpec.type !== 'tag')) {
+		throw new UnexpectedError('Failed to check package version existence');
+	}
 
 	try {
-		await axios.get(`${url}/${version}`, { timeout: REQUEST_TIMEOUT });
-		return true;
+		if (parsedSpec.type === 'version') {
+			await axios.get(`${url}/${encodeURIComponent(versionSpec)}`, {
+				timeout: REQUEST_TIMEOUT,
+			});
+			return versionSpec;
+		}
+
+		const metadata = await axios.get<{ 'dist-tags'?: Record<string, string> }>(url, {
+			timeout: REQUEST_TIMEOUT,
+		});
+
+		const resolvedVersion = metadata.data?.['dist-tags']?.[versionSpec];
+		if (resolvedVersion && isValidSemver(resolvedVersion)) {
+			return resolvedVersion;
+		}
+
+		throw new UnexpectedError('Failed to check package version existence');
 	} catch (error) {
 		try {
 			const stdout = await executeNpmCommand(
 				[
 					'view',
-					`${packageName}@${version}`,
+					`${packageName}@${versionSpec}`,
 					'version',
 					`--registry=${sanitizeRegistryUrl(registryUrl)}`,
 					'--json',
@@ -175,9 +205,13 @@ export async function checkIfVersionExistsOrThrow(
 				{ doNotHandleError: true },
 			);
 
-			const versionInfo = jsonParse(stdout);
-			if (versionInfo === version) {
-				return true;
+			const versionInfo = jsonParse<string | string[]>(stdout);
+			if (typeof versionInfo === 'string' && isValidSemver(versionInfo)) {
+				if (parsedSpec.type === 'version' && versionInfo !== versionSpec) {
+					throw new UnexpectedError('Failed to check package version existence');
+				}
+
+				return versionInfo;
 			}
 
 			throw new UnexpectedError('Failed to check package version existence');

--- a/packages/cli/src/types/npm-package-arg.d.ts
+++ b/packages/cli/src/types/npm-package-arg.d.ts
@@ -1,0 +1,30 @@
+declare module 'npm-package-arg' {
+	export type ResultType =
+		| 'alias'
+		| 'directory'
+		| 'file'
+		| 'git'
+		| 'range'
+		| 'remote'
+		| 'tag'
+		| 'version';
+
+	export interface Result {
+		raw: string;
+		name?: string;
+		scope?: string;
+		rawSpec: string;
+		registry?: boolean;
+		type: ResultType;
+		where?: string;
+		subSpec?: Result;
+	}
+
+	interface NpmPackageArg {
+		(arg: string, where?: string): Result;
+		resolve(name: string | undefined, spec: string, where?: string, arg?: string): Result;
+	}
+
+	const npa: NpmPackageArg;
+	export = npa;
+}

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -5,6 +5,6 @@
 		"outDir": "dist",
 		"tsBuildInfoFile": "dist/build.tsbuildinfo"
 	},
-	"include": ["src/**/*.ts"],
+	"include": ["src/**/*.ts", "src/**/*.d.ts"],
 	"exclude": ["test/**", "src/**/__tests__/**"]
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -18,7 +18,12 @@
 		"strict": false,
 		"useUnknownInCatchVariables": false
 	},
-	"include": ["src/**/*.ts", "test/**/*.ts", "src/sso.ee/saml/saml-schema-metadata-2.0.xsd"],
+	"include": [
+		"src/**/*.ts",
+		"src/**/*.d.ts",
+		"test/**/*.ts",
+		"src/sso.ee/saml/saml-schema-metadata-2.0.xsd"
+	],
 	"references": [
 		{ "path": "../core/tsconfig.build.json" },
 		{ "path": "../nodes-base/tsconfig.build.cjs.json" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2169,6 +2169,9 @@ importers:
       nodemailer:
         specifier: 7.0.11
         version: 7.0.11
+      npm-package-arg:
+        specifier: 13.0.2
+        version: 13.0.2
       oauth-1.0a:
         specifier: 2.2.6
         version: 2.2.6
@@ -10172,6 +10175,7 @@ packages:
 
   '@xata.io/client@0.28.4':
     resolution: {integrity: sha512-B02WHIA/ViHya84XvH6JCo13rd5h4S5vVyY2aYi6fIcjDIbCpsSLJ4oGWpdodovRYeAZy9Go4OhdyZwMIRC4BQ==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       typescript: 5.9.2
 
@@ -13315,6 +13319,10 @@ packages:
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
 
+  hosted-git-info@9.0.2:
+    resolution: {integrity: sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   html-encoding-sniffer@3.0.0:
     resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
     engines: {node: '>=12'}
@@ -15699,6 +15707,10 @@ packages:
     resolution: {integrity: sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  npm-package-arg@13.0.2:
+    resolution: {integrity: sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   npm-run-all2@7.0.2:
     resolution: {integrity: sha512-7tXR+r9hzRNOPNTvXegM+QzCuMjzUIIq66VDunL6j60O4RrExx32XUhlrS7UK4VcdGw5/Wxzb3kfNcFix9JKDA==}
     engines: {node: ^18.17.0 || >=20.5.0, npm: '>= 9'}
@@ -16551,6 +16563,10 @@ packages:
     resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
     engines: {node: '>=6'}
 
+  proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
@@ -17132,6 +17148,7 @@ packages:
   rolldown-vite@7.3.1:
     resolution: {integrity: sha512-LYzdNAjRHhF2yA4JUQm/QyARyi216N2rpJ0lJZb8E9FU2y5v6Vk+xq/U4XBOxMefpWixT5H3TslmAHm1rqIq2w==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    deprecated: Use this package to migrate from Vite 7 to Vite 8. For the most recent updates, migrate to Vite 8 once you're ready.
     hasBin: true
     peerDependencies:
       '@types/node': ^20.17.50
@@ -18764,6 +18781,10 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
+  validate-npm-package-name@7.0.2:
+    resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   validator@13.15.26:
     resolution: {integrity: sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==}
     engines: {node: '>= 0.10'}
@@ -19039,8 +19060,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.2.5:
-    resolution: {integrity: sha512-tkvNr+bU8+xD/onAThIe7CHFvOJ/BO6XCOrxMzeytJq40nTfpGDJuVjyCM8ccGZKfAbGk2YfuZyDMXM56qheZQ==}
+  vue-component-type-helpers@3.2.6:
+    resolution: {integrity: sha512-O02tnvIfOQVmnvoWwuSydwRoHjZVt8UEBR+2p4rT35p8GAy5VTlWP8o5qXfJR/GWCN0nVZoYWsVUvx2jwgdBmQ==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -26607,7 +26628,7 @@ snapshots:
       storybook: 10.1.11(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.6.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(utf-8-validate@5.0.10)
       type-fest: 2.19.0
       vue: 3.5.26(typescript@5.9.2)
-      vue-component-type-helpers: 3.2.5
+      vue-component-type-helpers: 3.2.6
 
   '@stylistic/eslint-plugin@5.0.0(eslint@9.29.0(jiti@2.6.1))':
     dependencies:
@@ -31953,6 +31974,10 @@ snapshots:
 
   hosted-git-info@2.8.9: {}
 
+  hosted-git-info@9.0.2:
+    dependencies:
+      lru-cache: 11.2.2
+
   html-encoding-sniffer@3.0.0:
     dependencies:
       whatwg-encoding: 2.0.0
@@ -35118,6 +35143,13 @@ snapshots:
 
   npm-normalize-package-bin@4.0.0: {}
 
+  npm-package-arg@13.0.2:
+    dependencies:
+      hosted-git-info: 9.0.2
+      proc-log: 6.1.0
+      semver: 7.7.3
+      validate-npm-package-name: 7.0.2
+
   npm-run-all2@7.0.2:
     dependencies:
       ansi-styles: 6.2.1
@@ -36025,6 +36057,8 @@ snapshots:
       parse-ms: 4.0.0
 
   prismjs@1.29.0: {}
+
+  proc-log@6.1.0: {}
 
   process-nextick-args@2.0.1: {}
 
@@ -38798,6 +38832,8 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
+  validate-npm-package-name@7.0.2: {}
+
   validator@13.15.26: {}
 
   vary@1.1.2: {}
@@ -39113,7 +39149,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.2.5: {}
+  vue-component-type-helpers@3.2.6: {}
 
   vue-demi@0.14.10(vue@3.5.26(typescript@5.9.2)):
     dependencies:


### PR DESCRIPTION
## Summary

This PR fixes community package installation and updates for npm `dist-tags` such as `beta` and `next`, while intentionally continuing to reject semver ranges and non-registry package specs.

The original bug was that n8n treated every `name@...` suffix as if it had to be a strict semver version. That meant valid npm selectors like `n8n-nodes-imap@beta` were rejected before n8n ever reached the registry. The failure was reproducible both when the selector was embedded in the package name and when it was passed separately as the `version` field. In practice, this prevented installing community nodes from release channels, even though npm itself supports them.

The implementation replaces the previous semver-only validation with `npm-package-arg`, which is the parser npm itself uses for install specs. However, the fix does **not** simply “remove validation”. During investigation, that turned out to be unsafe: npm specs can also represent aliases, git repositories, tarball URLs, `file:` references, and local directories. Allowing arbitrary npm specs here would widen the install surface beyond registry-backed community packages. To avoid that, the new validation layer explicitly allows only:
- plain package names
- exact registry versions
- registry `dist-tags`

It explicitly rejects:
- semver ranges
- `npm:` aliases
- git specs
- tarball URLs
- `file:` specs
- local directory specs
- malformed selectors

The second part of the fix is making `dist-tag` installs sticky. Installing `n8n-nodes-foo@beta` should not behave like “resolve beta once, then forget it ever came from beta”. If we only stored the resolved version, later update checks would silently fall back to `latest`, which is the wrong channel. To fix that, this PR adds a nullable `requestedDistTag` field to `installed_packages`. n8n still stores the exact installed version as before, but now also remembers the original channel when the install came from a non-`latest` tag.

That storage model is deliberate. The exact version remains the source of truth for what is currently installed and for deterministic verification. The stored tag is only the selector used for future updates. This keeps installation deterministic while preserving channel semantics.

The install/update flow now resolves a tag to an exact version before download. That resolved version is then used for:
- checksum verification
- `npm pack`
- package loading
- pubsub update payloads

This is important for correctness in multi-instance setups. If one instance resolves `beta` to `1.2.3-beta.4`, every instance in the cluster must install that same artifact for the same operation. At the same time, secondaries must not lose the fact that the package is tag-tracked. For that reason, the pubsub payload now carries the exact resolved version **and** the original requested tag when one exists. Secondaries install the exact version, but keep the dependency selector in their local `nodesDownloadDir/package.json` as `beta`, so future `npm outdated` checks continue following the beta channel.

Update-check behavior was also adjusted. For regular installs, n8n keeps the existing behavior and compares against `latest`. For tag-tracked installs, n8n now uses npm’s `wanted` field instead. This matters because `latest` answers the stable channel question, while `wanted` answers the question “what would npm install for the dependency spec currently in package.json”. For a dependency pinned to `beta`, `wanted` is the correct channel-aware target. The code also avoids false positives by only marking an update as available when the chosen target version is actually greater than the installed version.

Update execution follows the same rule. If a package has `requestedDistTag` and the user clicks update without specifying an explicit version, n8n reuses the stored tag. That means `beta` keeps updating against `beta`. Exact-version installs still behave as before. Verified/checksum-based flows remain exact-version-based and are not widened.

A related cleanup in this PR is that uninstall now removes the package entry from the local `nodesDownloadDir/package.json`. This keeps the dependency spec file aligned with the real installed state and avoids stale selectors affecting `npm outdated`.

I explicitly did **not** add semver range support in this PR. During analysis, ranges turned out to need different long-term semantics from tags. A tag is a named channel and maps naturally to a sticky selector such as `beta`. A range such as `^1.2.0` would also need to be stored and preserved to behave correctly over time, but it raises a broader product and implementation question: should n8n treat ranges as sticky user intent, and how should that interact with UI messaging, update display, checksum verification, and restoration of missing packages? That is solvable, but it is a separate scope from the bug at hand. Supporting tags without ranges keeps this fix safe, focused, and easy to reason about.

From a root-cause perspective, the bug came from three coupled assumptions:
1. `name@selector` was assumed to mean `name@exact-semver`.
2. validation was duplicated across controller/service paths.
3. update logic assumed every install should eventually compare against `latest`.

This PR addresses all three:
- parsing is npm-spec-aware instead of semver-only
- validation is centralized around a stricter allowlist
- update behavior now respects the original install channel

Files changed include the controller, service, npm utility helpers, persistence layer, migration registration, and test suites. A local type declaration for `npm-package-arg` was added because the package does not ship TypeScript declarations in this repo setup.

### How to test

Build:
- `pnpm turbo run build --filter=n8n`

Unit tests:
- `pnpm exec jest --config=packages/cli/jest.config.unit.js packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts`
- `pnpm exec jest --config=packages/cli/jest.config.unit.js packages/cli/src/modules/community-packages/__tests__/community-packages.controller.test.ts`
- `pnpm exec jest --config=packages/cli/jest.config.unit.js packages/cli/src/modules/community-packages/__tests__/npm-utils.test.ts`

Integration test:
- `pnpm exec jest --config=packages/cli/jest.config.integration.js packages/cli/src/modules/community-packages/__tests__/community-packages.integration.test.ts`

Manual verification:
- Install a community package with a tag, for example `n8n-nodes-imap@beta`.
- Confirm installation succeeds instead of failing with `Invalid version: beta`.
- Confirm the package remains update-tracked by the `beta` channel rather than switching to `latest`.
- Confirm an uninstall removes the package from the local community-nodes `package.json`.
- Confirm unsupported specs such as `npm:foo`, `file:./pkg.tgz`, or `git+https://...` are rejected.

## Related Linear tickets, Github issues, and Community forum posts

Github issue: [#27401](https://github.com/n8n-io/n8n/issues/27401)

Docs PR: [n8n-io/n8n-docs#4388](https://github.com/n8n-io/n8n-docs/pull/4388)

Closes #27401

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. Docs PR: [#4388](https://github.com/n8n-io/n8n-docs/pull/4388)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
