### PR TITLE
feat(core): Add audit logs for wait nodes waiting and resuming

### DIFF
--- a/packages/cli/src/__tests__/wait-tracker.test.ts
+++ b/packages/cli/src/__tests__/wait-tracker.test.ts
@@ -31,10 +31,14 @@ describe('WaitTracker', () => {
 		data: mock({
 			pushRef: 'push_ref',
 			parentExecution: undefined,
+			resultData: {
+				lastNodeExecuted: undefined,
+				runData: {},
+			},
 		}),
 		startedAt: undefined,
 	});
-	execution.workflowData = mock<IWorkflowBase>({ id: 'abcd' });
+	execution.workflowData = mock<IWorkflowBase>({ id: 'abcd', nodes: [] });
 
 	let waitTracker: WaitTracker;
 	beforeEach(() => {
@@ -45,6 +49,7 @@ describe('WaitTracker', () => {
 			activeExecutions,
 			workflowRunner,
 			instanceSettings,
+			mock(),
 		);
 		multiMainSetup.on.mockReturnThis();
 	});
@@ -151,8 +156,9 @@ describe('WaitTracker', () => {
 				const parentExecution = mock<IExecutionResponse>({
 					id: 'parent_execution_id',
 					finished: false,
+					data: createRunExecutionData(),
 				});
-				parentExecution.workflowData = mock<IWorkflowBase>({ id: 'parent_workflow_id' });
+				parentExecution.workflowData = mock<IWorkflowBase>({ id: 'parent_workflow_id', nodes: [] });
 				execution.data.parentExecution = {
 					executionId: parentExecution.id,
 					workflowId: parentExecution.workflowData.id,
@@ -310,7 +316,7 @@ describe('WaitTracker', () => {
 					finished: false,
 					status: 'waiting',
 					waitTill: WAIT_INDEFINITELY,
-					workflowData: mock<IWorkflowBase>({ id: 'parent_workflow_id' }),
+					workflowData: mock<IWorkflowBase>({ id: 'parent_workflow_id', nodes: [] }),
 					customData: {},
 					annotation: { tags: [] },
 					createdAt: new Date(),

--- a/packages/cli/src/__tests__/wait-tracker.test.ts
+++ b/packages/cli/src/__tests__/wait-tracker.test.ts
@@ -562,6 +562,7 @@ describe('WaitTracker', () => {
 				activeExecutions,
 				workflowRunner,
 				mock<InstanceSettings>({ isLeader: false, isMultiMain: false }),
+				mock(),
 			);
 
 			executionRepository.getWaitingExecutions.mockResolvedValue([]);

--- a/packages/cli/src/__tests__/wait-tracker.test.ts
+++ b/packages/cli/src/__tests__/wait-tracker.test.ts
@@ -7,6 +7,8 @@ import type { IWorkflowBase, IRun, INode, IExecuteData, ITaskData } from 'n8n-wo
 import { createDeferredPromise, createRunExecutionData, WAIT_INDEFINITELY } from 'n8n-workflow';
 
 import type { ActiveExecutions } from '@/active-executions';
+import { ExecutionAlreadyResumingError } from '@/errors/execution-already-resuming.error';
+import type { EventService } from '@/events/event.service';
 import type { MultiMainSetup } from '@/scaling/multi-main-setup.ee';
 import type { OwnershipService } from '@/services/ownership.service';
 import { WaitTracker } from '@/wait-tracker';
@@ -21,6 +23,7 @@ describe('WaitTracker', () => {
 	const executionRepository = mock<ExecutionRepository>();
 	const multiMainSetup = mock<MultiMainSetup>();
 	const instanceSettings = mock<InstanceSettings>({ isLeader: true, isMultiMain: false });
+	const eventService = mock<EventService>();
 
 	const project = mock<Project>({ id: 'projectId' });
 	const execution = mock<IExecutionResponse>({
@@ -49,7 +52,7 @@ describe('WaitTracker', () => {
 			activeExecutions,
 			workflowRunner,
 			instanceSettings,
-			mock(),
+			eventService,
 		);
 		multiMainSetup.on.mockReturnThis();
 	});
@@ -149,6 +152,28 @@ describe('WaitTracker', () => {
 				false,
 				execution.id,
 			);
+		});
+
+		it('should emit execution-resumed after run() succeeds', async () => {
+			await waitTracker.startExecution(execution.id);
+
+			expect(eventService.emit).toHaveBeenCalledWith(
+				'execution-resumed',
+				expect.objectContaining({
+					executionId: execution.id,
+					workflowId: execution.workflowData.id,
+					workflowName: execution.workflowData.name,
+					resumeSource: 'timer',
+				}),
+			);
+		});
+
+		it('should not emit execution-resumed when run() throws ExecutionAlreadyResumingError', async () => {
+			workflowRunner.run.mockRejectedValueOnce(new ExecutionAlreadyResumingError(execution.id));
+
+			await waitTracker.startExecution(execution.id);
+
+			expect(eventService.emit).not.toHaveBeenCalledWith('execution-resumed', expect.anything());
 		});
 
 		describe('parent execution with waiting sub-workflow', () => {

--- a/packages/cli/src/eventbus/event-message-classes/index.ts
+++ b/packages/cli/src/eventbus/event-message-classes/index.ts
@@ -83,6 +83,8 @@ export const eventNamesAudit = [
 	'n8n.audit.workflow.created',
 	'n8n.audit.workflow.deleted',
 	'n8n.audit.workflow.updated',
+	'n8n.audit.workflow.waiting',
+	'n8n.audit.workflow.resumed',
 	'n8n.audit.workflow.archived',
 	'n8n.audit.workflow.unarchived',
 	'n8n.audit.workflow.activated',

--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -2043,6 +2043,94 @@ describe('LogStreamingEventRelay', () => {
 				},
 			});
 		});
+
+		it('should log on `execution-waiting` event with a concrete waitTill date', () => {
+			const waitTill = new Date('2025-06-01T12:00:00.000Z');
+			const event: RelayEventMap['execution-waiting'] = {
+				executionId: 'exec-waiting-123',
+				workflowId: 'wf-waiting-456',
+				workflowName: 'Waiting Workflow',
+				nodeName: 'Wait Node',
+				nodeId: 'node-wait-id',
+				nodeType: 'n8n-nodes-base.wait',
+				waitTill,
+			};
+
+			eventService.emit('execution-waiting', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.workflow.waiting',
+				payload: {
+					executionId: 'exec-waiting-123',
+					workflowId: 'wf-waiting-456',
+					workflowName: 'Waiting Workflow',
+					nodeName: 'Wait Node',
+					nodeId: 'node-wait-id',
+					nodeType: 'n8n-nodes-base.wait',
+					waitTill: waitTill.toISOString(),
+				},
+			});
+		});
+
+		it('should log on `execution-waiting` event with null waitTill (indefinite wait)', () => {
+			const event: RelayEventMap['execution-waiting'] = {
+				executionId: 'exec-waiting-indefinite',
+				workflowId: 'wf-waiting-789',
+				workflowName: 'Send And Wait Workflow',
+				nodeName: 'Send and Wait',
+				nodeId: 'node-saw-id',
+				nodeType: 'n8n-nodes-base.sendAndWait',
+				waitTill: null,
+			};
+
+			eventService.emit('execution-waiting', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.workflow.waiting',
+				payload: {
+					executionId: 'exec-waiting-indefinite',
+					workflowId: 'wf-waiting-789',
+					workflowName: 'Send And Wait Workflow',
+					nodeName: 'Send and Wait',
+					nodeId: 'node-saw-id',
+					nodeType: 'n8n-nodes-base.sendAndWait',
+					waitTill: null,
+				},
+			});
+		});
+
+		it.each(['webhook', 'form', 'timer'] as const)(
+			'should log on `execution-resumed` event with resumeSource %s',
+			(resumeSource) => {
+				const responseAt = new Date('2025-06-02T08:00:00.000Z');
+				const event: RelayEventMap['execution-resumed'] = {
+					executionId: 'exec-resumed-123',
+					workflowId: 'wf-resumed-456',
+					workflowName: 'Resumed Workflow',
+					nodeName: 'Wait Node',
+					nodeId: 'node-wait-id',
+					nodeType: 'n8n-nodes-base.wait',
+					resumeSource,
+					responseAt,
+				};
+
+				eventService.emit('execution-resumed', event);
+
+				expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+					eventName: 'n8n.audit.workflow.resumed',
+					payload: {
+						executionId: 'exec-resumed-123',
+						workflowId: 'wf-resumed-456',
+						workflowName: 'Resumed Workflow',
+						nodeName: 'Wait Node',
+						nodeId: 'node-wait-id',
+						nodeType: 'n8n-nodes-base.wait',
+						resumeSource,
+						responseAt: responseAt.toISOString(),
+					},
+				});
+			},
+		);
 	});
 
 	describe('AI events', () => {

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -482,6 +482,30 @@ export type RelayEventMap = {
 		rejectionReason: string;
 	};
 
+	'execution-waiting': {
+		executionId: string;
+		workflowId: string;
+		workflowName: string;
+		nodeName: string;
+		nodeId?: string;
+		nodeType?: string;
+		/**
+		 * A value of null means waiting indefinitely (no timeout).
+		 */
+		waitTill: Date | null;
+	};
+
+	'execution-resumed': {
+		executionId: string;
+		workflowId: string;
+		workflowName: string;
+		nodeName: string;
+		nodeId?: string;
+		nodeType?: string;
+		resumeSource: 'webhook' | 'form' | 'timer';
+		responseAt: Date;
+	};
+
 	// #endregion
 
 	// #region Project

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -84,6 +84,8 @@ export class LogStreamingEventRelay extends EventRelay {
 			'execution-deleted': (event) => this.executionDeleted(event),
 			'execution-data-revealed': (event) => this.executionDataRevealed(event),
 			'execution-data-reveal-failure': (event) => this.executionDataRevealFailure(event),
+			'execution-waiting': (event) => this.executionWaiting(event),
+			'execution-resumed': (event) => this.executionResumed(event),
 			'ai-messages-retrieved-from-memory': (event) => this.aiMessagesRetrievedFromMemory(event),
 			'ai-message-added-to-memory': (event) => this.aiMessageAddedToMemory(event),
 			'ai-output-parsed': (event) => this.aiOutputParsed(event),
@@ -780,6 +782,54 @@ export class LogStreamingEventRelay extends EventRelay {
 				userAgent,
 				redactionPolicy,
 				rejectionReason,
+			},
+		});
+	}
+
+	private executionWaiting({
+		executionId,
+		workflowId,
+		workflowName,
+		nodeName,
+		nodeId,
+		nodeType,
+		waitTill,
+	}: RelayEventMap['execution-waiting']) {
+		void this.eventBus.sendAuditEvent({
+			eventName: 'n8n.audit.workflow.waiting',
+			payload: {
+				executionId,
+				workflowId,
+				workflowName,
+				nodeName,
+				nodeId,
+				nodeType,
+				waitTill: waitTill?.toISOString() ?? null,
+			},
+		});
+	}
+
+	private executionResumed({
+		executionId,
+		workflowId,
+		workflowName,
+		nodeName,
+		nodeId,
+		nodeType,
+		resumeSource,
+		responseAt,
+	}: RelayEventMap['execution-resumed']) {
+		void this.eventBus.sendAuditEvent({
+			eventName: 'n8n.audit.workflow.resumed',
+			payload: {
+				executionId,
+				workflowId,
+				workflowName,
+				nodeName,
+				nodeId,
+				nodeType,
+				resumeSource,
+				responseAt: responseAt.toISOString(),
 			},
 		});
 	}

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -116,6 +116,12 @@ describe('Execution Lifecycle Hooks', () => {
 		status: 'waiting',
 		waitTill: new Date(),
 		storedAt: 'db',
+		data: {
+			resultData: {
+				lastNodeExecuted: undefined,
+				runData: {},
+			},
+		},
 	});
 	const successfulRunWithMetadata = mock<IRun>({
 		status: 'success',

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -22,6 +22,7 @@ import type {
 	WorkflowExecuteMode,
 	IWorkflowExecutionDataProcess,
 } from 'n8n-workflow';
+import { WAIT_INDEFINITELY } from 'n8n-workflow';
 
 import { EventService } from '@/events/event.service';
 import type { RedactableExecution } from '@/executions/execution-redaction';
@@ -142,7 +143,23 @@ function hookFunctionsWorkflowEvents(hooks: ExecutionLifecycleHooks, userId?: st
 		eventService.emit('workflow-pre-execute', { executionId, data: workflowData, mode });
 	});
 	hooks.addHandler('workflowExecuteAfter', function (runData) {
-		if (runData.status === 'waiting') return;
+		if (runData.status === 'waiting') {
+			const { executionId, workflowData: workflow } = this;
+			const lastNodeName = runData.data.resultData.lastNodeExecuted ?? '';
+			const node = workflow.nodes.find((n) => n.name === lastNodeName);
+			const isIndefinite = runData.waitTill?.getTime() === WAIT_INDEFINITELY.getTime();
+
+			eventService.emit('execution-waiting', {
+				executionId,
+				workflowId: workflow.id,
+				workflowName: workflow.name,
+				nodeName: lastNodeName,
+				nodeId: node?.id,
+				nodeType: node?.type,
+				waitTill: isIndefinite ? null : (runData.waitTill ?? null),
+			});
+			return;
+		}
 
 		const { executionId, workflowData: workflow } = this;
 

--- a/packages/cli/src/wait-tracker.ts
+++ b/packages/cli/src/wait-tracker.ts
@@ -131,16 +131,6 @@ export class WaitTracker {
 
 		const lastNodeName = fullExecutionData.data.resultData.lastNodeExecuted ?? '';
 		const resumedNode = fullExecutionData.workflowData.nodes.find((n) => n.name === lastNodeName);
-		this.eventService.emit('execution-resumed', {
-			executionId,
-			workflowId,
-			workflowName: fullExecutionData.workflowData.name,
-			nodeName: lastNodeName,
-			nodeId: resumedNode?.id,
-			nodeType: resumedNode?.type,
-			resumeSource: 'timer',
-			responseAt: new Date(),
-		});
 
 		// Start the execution again
 		try {
@@ -158,6 +148,17 @@ export class WaitTracker {
 			// Rethrow any other errors
 			throw error;
 		}
+
+		this.eventService.emit('execution-resumed', {
+			executionId,
+			workflowId,
+			workflowName: fullExecutionData.workflowData.name,
+			nodeName: lastNodeName,
+			nodeId: resumedNode?.id,
+			nodeType: resumedNode?.type,
+			resumeSource: 'timer',
+			responseAt: new Date(),
+		});
 
 		const { parentExecution } = fullExecutionData.data;
 		if (shouldRestartParentExecution(parentExecution)) {

--- a/packages/cli/src/wait-tracker.ts
+++ b/packages/cli/src/wait-tracker.ts
@@ -7,6 +7,7 @@ import { UnexpectedError, type IWorkflowExecutionDataProcess } from 'n8n-workflo
 
 import { ActiveExecutions } from '@/active-executions';
 import { ExecutionAlreadyResumingError } from '@/errors/execution-already-resuming.error';
+import { EventService } from '@/events/event.service';
 import { OwnershipService } from '@/services/ownership.service';
 import { WorkflowRunner } from '@/workflow-runner';
 import {
@@ -32,6 +33,7 @@ export class WaitTracker {
 		private readonly activeExecutions: ActiveExecutions,
 		private readonly workflowRunner: WorkflowRunner,
 		private readonly instanceSettings: InstanceSettings,
+		private readonly eventService: EventService,
 	) {
 		this.logger = this.logger.scoped('waiting-executions');
 	}
@@ -126,6 +128,19 @@ export class WaitTracker {
 			pushRef: fullExecutionData.data.pushRef,
 			startedAt: fullExecutionData.startedAt,
 		};
+
+		const lastNodeName = fullExecutionData.data.resultData.lastNodeExecuted ?? '';
+		const resumedNode = fullExecutionData.workflowData.nodes.find((n) => n.name === lastNodeName);
+		this.eventService.emit('execution-resumed', {
+			executionId,
+			workflowId,
+			workflowName: fullExecutionData.workflowData.name,
+			nodeName: lastNodeName,
+			nodeId: resumedNode?.id,
+			nodeType: resumedNode?.type,
+			resumeSource: 'timer',
+			responseAt: new Date(),
+		});
 
 		// Start the execution again
 		try {

--- a/packages/cli/src/webhooks/__tests__/waiting-forms.test.ts
+++ b/packages/cli/src/webhooks/__tests__/waiting-forms.test.ts
@@ -16,7 +16,14 @@ class TestWaitingForms extends WaitingForms {
 
 describe('WaitingForms', () => {
 	const executionRepository = mock<ExecutionRepository>();
-	const waitingForms = new TestWaitingForms(mock(), mock(), executionRepository, mock(), mock());
+	const waitingForms = new TestWaitingForms(
+		mock(),
+		mock(),
+		executionRepository,
+		mock(),
+		mock(),
+		mock(),
+	);
 
 	beforeEach(() => {
 		jest.restoreAllMocks();

--- a/packages/cli/src/webhooks/__tests__/waiting-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/waiting-webhooks.test.ts
@@ -32,6 +32,7 @@ describe('WaitingWebhooks', () => {
 		executionRepository,
 		mockWebhookService,
 		mockInstanceSettings,
+		mock(),
 	);
 
 	beforeEach(() => {

--- a/packages/cli/src/webhooks/__tests__/waiting-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/waiting-webhooks.test.ts
@@ -4,9 +4,11 @@ import { mock } from 'jest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
 import { generateUrlSignature, prepareUrlForSigning, WAITING_TOKEN_QUERY_PARAM } from 'n8n-core';
 import type { IWorkflowBase, Workflow } from 'n8n-workflow';
+import { SEND_AND_WAIT_OPERATION } from 'n8n-workflow';
 
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import type { EventService } from '@/events/event.service';
 import * as WebhookHelpers from '@/webhooks/webhook-helpers';
 import { WaitingWebhooks } from '@/webhooks/waiting-webhooks';
 import type { WebhookService } from '@/webhooks/webhook.service';
@@ -26,13 +28,14 @@ describe('WaitingWebhooks', () => {
 	const mockInstanceSettings = mock<InstanceSettings>({
 		hmacSignatureSecret: SIGNING_SECRET,
 	});
+	const mockEventService = mock<EventService>();
 	const waitingWebhooks = new TestWaitingWebhooks(
 		mock(),
 		mock(),
 		executionRepository,
 		mockWebhookService,
 		mockInstanceSettings,
-		mock(),
+		mockEventService,
 	);
 
 	beforeEach(() => {
@@ -832,6 +835,300 @@ describe('WaitingWebhooks', () => {
 
 			// Should have empty array after popping and not adding placeholder
 			expect(runDataArray).toHaveLength(0);
+		});
+
+		it('should emit execution-resumed event when execution successfully resumes', async () => {
+			/**
+			 * Arrange
+			 */
+			const executionId = 'test-execution-id';
+			const lastNodeExecuted = 'WaitNode';
+
+			const mockExecution = mock<IExecutionResponse>({
+				id: executionId,
+				status: 'waiting',
+				finished: false,
+				mode: 'manual',
+				data: {
+					executionData: {
+						nodeExecutionStack: [
+							{
+								node: {
+									name: lastNodeExecuted,
+									type: 'n8n-nodes-base.wait',
+									typeVersion: 1,
+									parameters: {},
+									id: 'node-id',
+									position: [0, 0],
+									disabled: false,
+								},
+								data: {},
+								source: null,
+							},
+						],
+					},
+					resultData: {
+						runData: {
+							[lastNodeExecuted]: [
+								{ startTime: 0, executionTime: 0, executionIndex: 0, source: [] },
+							],
+						},
+						lastNodeExecuted,
+					},
+				},
+				workflowData: {
+					id: 'workflow-id',
+					name: 'Test Workflow',
+					nodes: [
+						{
+							name: lastNodeExecuted,
+							type: 'n8n-nodes-base.wait',
+							typeVersion: 1,
+							parameters: {},
+							id: 'node-id',
+							position: [0, 0],
+						},
+					],
+					connections: {},
+					active: false,
+					activeVersionId: null,
+					settings: {},
+					staticData: {},
+					isArchived: false,
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				},
+			});
+
+			mockExecution.data.resultData.error = undefined;
+			executionRepository.findSingleExecution.mockResolvedValue(mockExecution);
+
+			const mockReq = mock<WaitingWebhookRequest>({
+				params: { path: executionId, suffix: undefined },
+				method: 'POST',
+			});
+			const mockRes = mock<express.Response>();
+
+			jest
+				.spyOn(WebhookHelpers, 'executeWebhook')
+				.mockImplementation(
+					async (_w, _wd, _wfd, _wsn, _m, _pr, _red, _eid, _req, _res, callback) => {
+						callback(null, { noWebhookResponse: true });
+						return undefined;
+					},
+				);
+
+			mockWebhookService.getNodeWebhooks.mockReturnValue([
+				{
+					httpMethod: 'POST',
+					path: '',
+					webhookDescription: {
+						restartWebhook: true,
+						httpMethod: 'POST',
+						name: 'default',
+						path: '',
+						nodeType: undefined,
+					} as any,
+				},
+			] as any);
+
+			jest.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue({} as any);
+
+			/**
+			 * Act
+			 */
+			await waitingWebhooks.executeWebhook(mockReq, mockRes);
+
+			/**
+			 * Assert
+			 */
+			expect(mockEventService.emit).toHaveBeenCalledWith(
+				'execution-resumed',
+				expect.objectContaining({ executionId, workflowId: 'workflow-id' }),
+			);
+		});
+
+		it('should not emit execution-resumed event when no matching webhook found', async () => {
+			/**
+			 * Arrange
+			 */
+			const executionId = 'test-execution-id';
+			const lastNodeExecuted = 'WaitNode';
+
+			const mockExecution = mock<IExecutionResponse>({
+				id: executionId,
+				status: 'waiting',
+				finished: false,
+				mode: 'manual',
+				data: {
+					executionData: {
+						nodeExecutionStack: [
+							{
+								node: {
+									name: lastNodeExecuted,
+									type: 'n8n-nodes-base.wait',
+									typeVersion: 1,
+									parameters: {},
+									id: 'node-id',
+									position: [0, 0],
+									disabled: false,
+								},
+								data: {},
+								source: null,
+							},
+						],
+					},
+					resultData: {
+						runData: {
+							[lastNodeExecuted]: [
+								{ startTime: 0, executionTime: 0, executionIndex: 0, source: [] },
+							],
+						},
+						lastNodeExecuted,
+					},
+				},
+				workflowData: {
+					id: 'workflow-id',
+					name: 'Test Workflow',
+					nodes: [
+						{
+							name: lastNodeExecuted,
+							type: 'n8n-nodes-base.wait',
+							typeVersion: 1,
+							parameters: {},
+							id: 'node-id',
+							position: [0, 0],
+						},
+					],
+					connections: {},
+					active: false,
+					activeVersionId: null,
+					settings: {},
+					staticData: {},
+					isArchived: false,
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				},
+			});
+
+			mockExecution.data.resultData.error = undefined;
+			executionRepository.findSingleExecution.mockResolvedValue(mockExecution);
+
+			const mockReq = mock<WaitingWebhookRequest>({
+				params: { path: executionId, suffix: undefined },
+				method: 'POST',
+			});
+			const mockRes = mock<express.Response>();
+
+			mockWebhookService.getNodeWebhooks.mockReturnValue([]);
+			jest.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue({} as any);
+
+			/**
+			 * Act
+			 */
+			await expect(waitingWebhooks.executeWebhook(mockReq, mockRes)).rejects.toThrowError(
+				NotFoundError,
+			);
+
+			/**
+			 * Assert
+			 */
+			expect(mockEventService.emit).not.toHaveBeenCalledWith(
+				'execution-resumed',
+				expect.anything(),
+			);
+		});
+
+		it('should not emit execution-resumed event for send-and-wait already-responded requests', async () => {
+			/**
+			 * Arrange
+			 */
+			const executionId = 'test-execution-id';
+			const lastNodeExecuted = 'SendAndWaitNode';
+			const sendAndWaitNodeId = 'send-and-wait-node-id';
+
+			const mockExecution = mock<IExecutionResponse>({
+				id: executionId,
+				status: 'waiting',
+				finished: false,
+				mode: 'manual',
+				data: {
+					executionData: {
+						nodeExecutionStack: [
+							{
+								node: {
+									name: lastNodeExecuted,
+									type: 'n8n-nodes-base.sendAndWait',
+									typeVersion: 1,
+									parameters: { operation: SEND_AND_WAIT_OPERATION },
+									id: sendAndWaitNodeId,
+									position: [0, 0],
+									disabled: false,
+								},
+								data: {},
+								source: null,
+							},
+						],
+					},
+					resultData: {
+						runData: {
+							[lastNodeExecuted]: [
+								{ startTime: 0, executionTime: 0, executionIndex: 0, source: [] },
+							],
+						},
+						lastNodeExecuted,
+					},
+				},
+				workflowData: {
+					id: 'workflow-id',
+					name: 'Test Workflow',
+					nodes: [
+						{
+							name: lastNodeExecuted,
+							type: 'n8n-nodes-base.sendAndWait',
+							typeVersion: 1,
+							parameters: { operation: SEND_AND_WAIT_OPERATION },
+							id: sendAndWaitNodeId,
+							position: [0, 0],
+						},
+					],
+					connections: {},
+					active: false,
+					activeVersionId: null,
+					settings: {},
+					staticData: {},
+					isArchived: false,
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				},
+			});
+
+			mockExecution.data.resultData.error = undefined;
+			mockExecution.data.validateSignature = false;
+			executionRepository.findSingleExecution.mockResolvedValue(mockExecution);
+
+			const mockReq = mock<WaitingWebhookRequest>({
+				params: { path: executionId, suffix: sendAndWaitNodeId },
+				method: 'POST',
+			});
+			const mockRes = mock<express.Response>();
+
+			mockWebhookService.getNodeWebhooks.mockReturnValue([]);
+			jest.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue({} as any);
+
+			/**
+			 * Act
+			 */
+			const result = await waitingWebhooks.executeWebhook(mockReq, mockRes);
+
+			/**
+			 * Assert
+			 */
+			expect(result).toEqual({ noWebhookResponse: true });
+			expect(mockEventService.emit).not.toHaveBeenCalledWith(
+				'execution-resumed',
+				expect.anything(),
+			);
 		});
 
 		it('should not set rewireOutputLogTo for non-HITL nodes', async () => {

--- a/packages/cli/src/webhooks/waiting-webhooks.ts
+++ b/packages/cli/src/webhooks/waiting-webhooks.ts
@@ -28,6 +28,8 @@ import type {
 	WaitingWebhookRequest,
 } from './webhook.types';
 
+import { EventService } from '@/events/event.service';
+
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { getWorkflowActiveStatusFromWorkflowData } from '@/executions/execution.utils';
@@ -52,6 +54,7 @@ export class WaitingWebhooks implements IWebhookManager {
 		private readonly executionRepository: ExecutionRepository,
 		private readonly webhookService: WebhookService,
 		private readonly instanceSettings: InstanceSettings,
+		private readonly eventService: EventService,
 	) {}
 
 	// TODO: implement `getWebhookMethods` for CORS support
@@ -183,6 +186,8 @@ export class WaitingWebhooks implements IWebhookManager {
 
 		applyCors(req, res);
 
+		this.emitExecutionResumedEvent(execution, executionId, lastNodeExecuted);
+
 		return await this.getWebhookExecutionData({
 			execution,
 			req,
@@ -190,6 +195,25 @@ export class WaitingWebhooks implements IWebhookManager {
 			lastNodeExecuted,
 			executionId,
 			suffix,
+		});
+	}
+
+	private emitExecutionResumedEvent(
+		execution: IExecutionResponse,
+		executionId: string,
+		lastNodeExecuted: string,
+	) {
+		const resumeSource: 'webhook' | 'form' = this.includeForms ? 'form' : 'webhook';
+		const resumedNode = execution.workflowData.nodes.find((n) => n.name === lastNodeExecuted);
+		this.eventService.emit('execution-resumed', {
+			executionId,
+			workflowId: execution.workflowData.id,
+			workflowName: execution.workflowData.name,
+			nodeName: lastNodeExecuted,
+			nodeId: resumedNode?.id,
+			nodeType: resumedNode?.type,
+			resumeSource,
+			responseAt: new Date(),
 		});
 	}
 
@@ -239,6 +263,7 @@ export class WaitingWebhooks implements IWebhookManager {
 		const additionalData = await WorkflowExecuteAdditionalData.getBase({
 			workflowId: workflow.id,
 		});
+
 		const webhookData = this.webhookService
 			.getNodeWebhooks(workflow, workflowStartNode, additionalData)
 			.find(

--- a/packages/cli/src/webhooks/waiting-webhooks.ts
+++ b/packages/cli/src/webhooks/waiting-webhooks.ts
@@ -186,8 +186,6 @@ export class WaitingWebhooks implements IWebhookManager {
 
 		applyCors(req, res);
 
-		this.emitExecutionResumedEvent(execution, executionId, lastNodeExecuted);
-
 		return await this.getWebhookExecutionData({
 			execution,
 			req,
@@ -304,6 +302,8 @@ export class WaitingWebhooks implements IWebhookManager {
 		}
 
 		const runExecutionData = execution.data;
+
+		this.emitExecutionResumedEvent(execution, executionId, lastNodeExecuted);
 
 		return await new Promise((resolve, reject) => {
 			void WebhookHelpers.executeWebhook(


### PR DESCRIPTION
## Summary

Disclaimer: all code was written by Claude. I reviewed the code and iterated with additional prompts.

Extends the audit log with two new events to cover "Send & Wait" and "Human in the Loop" node lifecycle — gaps identified in the existing audit trail.

- `n8n.audit.workflow.waiting` — emitted when an execution enters a waiting state. Includes node context (`nodeName`, `nodeId`, `nodeType`) and `waitTill` (ISO timestamp or `null` for indefinite waits, e.g. Send & Wait).
- `n8n.audit.workflow.resumed` — emitted when a waiting execution is resumed. Includes node context and `resumeSource` (webhook | form | timer) to distinguish how the execution was unblocked, plus `responseAt` timestamp.

FYI: all types of nodes that have this waiting mechanism (whether it's "human in the loop" or "wait"), use the `putExecutionToWait()` API of our execution engine. This `putExecutionToWait` will set `runData.status = 'waiting'`. Then in the `workflowExecuteAfter` hook we amended inside `execution-lifecycle-hooks.ts`, there is now a new event being emitted for this `waiting` case.

### Testing locally

Helpful guide for testing locally: https://github.com/n8n-io/n8n/blob/29bd48acbd6d52d93b9f0424db3c9a9a7c2a80bf/packages/cli/test/integration/eventbus/README-manual-test-syslog.md

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-378/be-add-audit-logs-for-send-and-waithuman-in-the-loop-nodes


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
