### PR TITLE
feat(Notion Node): Add support for OAuth

### DIFF
--- a/packages/nodes-base/nodes/Notion/NotionTrigger.node.ts
+++ b/packages/nodes-base/nodes/Notion/NotionTrigger.node.ts
@@ -33,12 +33,42 @@ export class NotionTrigger implements INodeType {
 			{
 				name: 'notionApi',
 				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['apiKey'],
+					},
+				},
+			},
+			{
+				name: 'notionOAuth2Api',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['oAuth2'],
+					},
+				},
 			},
 		],
 		polling: true,
 		inputs: [],
 		outputs: [NodeConnectionTypes.Main],
 		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				options: [
+					{
+						name: 'API Key',
+						value: 'apiKey',
+					},
+					{
+						name: 'OAuth2',
+						value: 'oAuth2',
+					},
+				],
+				default: 'apiKey',
+			},
 			{
 				displayName: 'Event',
 				name: 'event',

--- a/packages/nodes-base/nodes/Notion/shared/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Notion/shared/GenericFunctions.ts
@@ -71,7 +71,9 @@ export async function notionApiRequest(
 			delete options.body;
 		}
 		if (!uri) {
-			return await this.helpers.requestWithAuthentication.call(this, 'notionApi', options);
+			const authentication = this.getNodeParameter('authentication', 0, 'apiKey') as string;
+			const credentialType = authentication === 'oAuth2' ? 'notionOAuth2Api' : 'notionApi';
+			return await this.helpers.requestWithAuthentication.call(this, credentialType, options);
 		}
 		return await this.helpers.request(options);
 	} catch (error) {

--- a/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
@@ -256,7 +256,7 @@ describe('Test Notion, notionApiRequest', () => {
 	});
 
 	it('should default to notionApi credential when authentication parameter is not set', async () => {
-		mockExecuteFunctions.getNodeParameter.mockReturnValue('apiKey');
+		mockExecuteFunctions.getNodeParameter.mockReturnValue(undefined);
 
 		await notionApiRequest.call(mockExecuteFunctions, 'GET', '/users');
 

--- a/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
@@ -4,7 +4,12 @@ import type { IExecuteFunctions, INode, INodeParameterResourceLocator } from 'n8
 import { NodeOperationError } from 'n8n-workflow';
 
 import { databasePageUrlExtractionRegexp } from '../shared/constants';
-import { extractPageId, formatBlocks, getPageId } from '../shared/GenericFunctions';
+import {
+	extractPageId,
+	formatBlocks,
+	getPageId,
+	notionApiRequest,
+} from '../shared/GenericFunctions';
 
 describe('Test NotionV2, formatBlocks', () => {
 	it('should format to_do block', () => {
@@ -209,6 +214,55 @@ describe('Test Notion, getPageId', () => {
 		expect(() => getPageId.call(mockExecuteFunctions, 0)).toThrow(NodeOperationError);
 		expect(() => getPageId.call(mockExecuteFunctions, 0)).toThrow(
 			'Could not extract page ID from URL: 123',
+		);
+	});
+});
+
+describe('Test Notion, notionApiRequest', () => {
+	let mockExecuteFunctions: MockProxy<IExecuteFunctions>;
+
+	beforeEach(() => {
+		mockExecuteFunctions = mock<IExecuteFunctions>();
+		mockExecuteFunctions.getNode.mockReturnValue(mock<INode>({ typeVersion: 2 }));
+		mockExecuteFunctions.helpers = {
+			requestWithAuthentication: jest.fn().mockResolvedValue({}),
+		} as any;
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should use notionApi credential when authentication is apiKey', async () => {
+		mockExecuteFunctions.getNodeParameter.mockReturnValue('apiKey');
+
+		await notionApiRequest.call(mockExecuteFunctions, 'GET', '/users');
+
+		expect(mockExecuteFunctions.helpers.requestWithAuthentication).toHaveBeenCalledWith(
+			'notionApi',
+			expect.objectContaining({ method: 'GET', uri: 'https://api.notion.com/v1/users' }),
+		);
+	});
+
+	it('should use notionOAuth2Api credential when authentication is oAuth2', async () => {
+		mockExecuteFunctions.getNodeParameter.mockReturnValue('oAuth2');
+
+		await notionApiRequest.call(mockExecuteFunctions, 'GET', '/users');
+
+		expect(mockExecuteFunctions.helpers.requestWithAuthentication).toHaveBeenCalledWith(
+			'notionOAuth2Api',
+			expect.objectContaining({ method: 'GET', uri: 'https://api.notion.com/v1/users' }),
+		);
+	});
+
+	it('should default to notionApi credential when authentication parameter is not set', async () => {
+		mockExecuteFunctions.getNodeParameter.mockReturnValue('apiKey');
+
+		await notionApiRequest.call(mockExecuteFunctions, 'GET', '/users');
+
+		expect(mockExecuteFunctions.helpers.requestWithAuthentication).toHaveBeenCalledWith(
+			'notionApi',
+			expect.objectContaining({ method: 'GET' }),
 		);
 	});
 });

--- a/packages/nodes-base/nodes/Notion/v2/VersionDescription.ts
+++ b/packages/nodes-base/nodes/Notion/v2/VersionDescription.ts
@@ -28,44 +28,39 @@ export const versionDescription: INodeTypeDescription = {
 		{
 			name: 'notionApi',
 			required: true,
-			// displayOptions: {
-			// 	show: {
-			// 		authentication: [
-			// 			'apiKey',
-			// 		],
-			// 	},
-			// },
+			displayOptions: {
+				show: {
+					authentication: ['apiKey'],
+				},
+			},
 		},
-		// {
-		// 	name: 'notionOAuth2Api',
-		// 	required: true,
-		// 	displayOptions: {
-		// 		show: {
-		// 			authentication: [
-		// 				'oAuth2',
-		// 			],
-		// 		},
-		// 	},
-		// },
+		{
+			name: 'notionOAuth2Api',
+			required: true,
+			displayOptions: {
+				show: {
+					authentication: ['oAuth2'],
+				},
+			},
+		},
 	],
 	properties: [
-		// {
-		// 	displayName: 'Authentication',
-		// 	name: 'authentication',
-		// 	type: 'options',
-		// 	options: [
-		// 		{
-		// 			name: 'API Key',
-		// 			value: 'apiKey',
-		// 		},
-		// 		{
-		// 			name: 'OAuth2',
-		// 			value: 'oAuth2',
-		// 		},
-		// 	],
-		// 	default: 'apiKey',
-		// 	description: 'The resource to operate on.',
-		// },
+		{
+			displayName: 'Authentication',
+			name: 'authentication',
+			type: 'options',
+			options: [
+				{
+					name: 'API Key',
+					value: 'apiKey',
+				},
+				{
+					name: 'OAuth2',
+					value: 'oAuth2',
+				},
+			],
+			default: 'apiKey',
+		},
 		{
 			displayName:
 				'In Notion, make sure to <a href="https://www.notion.so/help/add-and-manage-connections-with-the-api" target="_blank">add your connection</a> to the pages you want to access.',


### PR DESCRIPTION
## Summary
Adds support for OAuth to the Notion node

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-4660


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
