### PR TITLE
fix(Google Gemini Node): Derive image filename extension from mimeType in edit operation

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/image/edit.operation.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/image/edit.operation.test.ts
@@ -217,7 +217,9 @@ describe('Gemini Node image edit', () => {
 		const result = await execute.call(executeFunctions, 0);
 
 		expect(result[0]?.binary?.enhanced?.mimeType).toBe('image/jpeg');
+		expect(result[0]?.binary?.enhanced?.fileName).toBe('image.jpeg');
 		expect(result[0]?.json?.mimeType).toBe('image/jpeg');
+		expect(result[0]?.json?.fileName).toBe('image.jpeg');
 	});
 
 	it('should handle empty images array when no valid binary property names', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/image/edit.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/image/edit.operation.ts
@@ -211,10 +211,12 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 		}
 
 		const bufferOut = Buffer.from(imagePart.inlineData.data, 'base64');
+		const mimeType = imagePart.inlineData.mimeType ?? 'image/png';
+		const ext = mimeType.split('/')[1] ?? 'png';
 		const binaryOut = await this.helpers.prepareBinaryData(
 			bufferOut,
-			'image.png',
-			imagePart.inlineData.mimeType,
+			`image.${ext}`,
+			mimeType,
 		);
 		return {
 			binary: {


### PR DESCRIPTION
## Summary

The image edit operation (`edit.operation.ts`) hardcoded `image.png` as the output filename regardless of the actual `mimeType` returned by the Gemini API. When the API returns `image/jpeg`, this caused a mismatch where `mimeType` was `image/jpeg` but `fileName` was `image.png` and `fileExtension` was `png`.

This fix derives the file extension from the response `mimeType`, matching the approach already used in the generate operation.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #27382

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.