### PR TITLE
refactor(editor): Migrate shared editors and setup panel connections to workflowDocumentStore (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.ts
@@ -343,8 +343,8 @@ export const useWorkflowSetupState = (
 
 		return sortNodesByExecutionOrder(
 			nodesForSetup,
-			workflowsStore.connectionsBySourceNode,
-			workflowsStore.connectionsByDestinationNode,
+			workflowDocumentStore.value?.connectionsBySourceNode ?? {},
+			workflowDocumentStore.value?.connectionsByDestinationNode ?? {},
 			allNodeTypes,
 		);
 	});

--- a/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/completions/jsonField.completions.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/completions/jsonField.completions.ts
@@ -176,7 +176,9 @@ function useJsonFieldCompletions() {
 		try {
 			const activeNode = ndvStore.activeNode;
 			if (activeNode) {
-				const input = workflowDocumentStore?.value?.connectionsByDestinationNode[activeNode.name];
+				const input = (workflowDocumentStore?.value?.connectionsByDestinationNode ?? {})[
+					activeNode.name
+				];
 				return input?.main[0]?.[0]?.node ?? null;
 			}
 		} catch (e) {

--- a/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/completions/jsonField.completions.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/completions/jsonField.completions.ts
@@ -176,8 +176,8 @@ function useJsonFieldCompletions() {
 		try {
 			const activeNode = ndvStore.activeNode;
 			if (activeNode) {
-				const input = workflowsStore.connectionsByDestinationNode[activeNode.name];
-				return input.main[0] ? input.main[0][0].node : null;
+				const input = workflowDocumentStore?.value?.connectionsByDestinationNode[activeNode.name];
+				return input?.main[0]?.[0]?.node ?? null;
 			}
 		} catch (e) {
 			console.error(e);


### PR DESCRIPTION
## Summary

Migrate `connectionsByDestinationNode` and `connectionsBySourceNode` reads from `workflowsStore` to `workflowDocumentStore` in:
- `jsonField.completions.ts` — code node editor autocomplete
- `useWorkflowSetupState.ts` — setup panel node ordering

Note: `removeAllConnections` cleanup in `useWorkflowState.ts` is deferred — `builder.store.ts` still calls it (blocked on CAT-2642).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2643

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.