### PR TITLE
fix(ai-builder): Include langsmith threadId on traces in code-builder (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/test/code-builder-agent-tracing.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/test/code-builder-agent-tracing.test.ts
@@ -76,7 +76,7 @@ function createMockBuilder() {
 }
 
 /**
- * Custom callback handler that captures chain end outputs.
+ * Custom callback handler that captures chain end outputs and chain start metadata.
  * We use a class-based handler to ensure proper integration with
  * LangChain's CallbackManager.
  */
@@ -84,6 +84,20 @@ class ChainEndTracker extends BaseCallbackHandler {
 	name = 'chain-end-tracker';
 
 	chainEndOutputs: Array<Record<string, unknown>> = [];
+	chainStartMetadata: Array<Record<string, unknown>> = [];
+
+	async handleChainStart(
+		_chain: unknown,
+		_inputs: unknown,
+		_runId: string,
+		_parentRunId?: string,
+		_tags?: string[],
+		metadata?: Record<string, unknown>,
+	): Promise<void> {
+		if (metadata) {
+			this.chainStartMetadata.push(metadata);
+		}
+	}
 
 	async handleChainEnd(outputs: Record<string, unknown>): Promise<void> {
 		this.chainEndOutputs.push(outputs);
@@ -203,6 +217,33 @@ describe('CodeBuilderAgent tracing', () => {
 				text: 'Here is your workflow:\n```typescript\nconst workflow = builder.addNode(...);\n```',
 			},
 		]);
+	});
+
+	it('should include ls_thread_id from runMetadata in handleChainStart metadata', async () => {
+		const tracker = new ChainEndTracker();
+
+		const agent = new CodeBuilderAgent({
+			llm: createMockLlm(),
+			nodeTypes: [],
+			callbacks: [tracker],
+			enableTextEditor: false,
+			runMetadata: { ls_thread_id: 'workflow-test-wf-user-test-user' },
+		});
+
+		const chunks = [];
+		for await (const chunk of agent.chat(
+			{ id: 'msg-4', message: 'Create a simple workflow' },
+			'user-1',
+		)) {
+			chunks.push(chunk);
+		}
+
+		// The parent chain start should include ls_thread_id from runMetadata
+		const parentStartMetadata = tracker.chainStartMetadata.find((m) => 'ls_thread_id' in m);
+		expect(parentStartMetadata).toBeDefined();
+		expect(parentStartMetadata).toMatchObject({
+			ls_thread_id: 'workflow-test-wf-user-test-user',
+		});
 	});
 
 	it('should set output to null when no workflow is produced', async () => {

--- a/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
@@ -340,6 +340,9 @@ export class WorkflowBuilderAgent {
 		userId: string | undefined,
 		abortSignal: AbortSignal | undefined,
 	) {
+		const workflowId = payload.workflowContext?.currentWorkflow?.id;
+		const threadId = SessionManagerService.generateThreadId(workflowId, userId);
+
 		const codeWorkflowBuilder = new CodeWorkflowBuilder({
 			llm: this.stageLLMs.builder,
 			nodeTypes: this.parsedNodeTypes,
@@ -351,7 +354,8 @@ export class WorkflowBuilderAgent {
 			runMetadata: {
 				...this.runMetadata,
 				userMessageId: payload.id,
-				workflowId: payload.workflowContext?.currentWorkflow?.id,
+				workflowId,
+				ls_thread_id: threadId,
 			},
 			onTelemetryEvent: this.onTelemetryEvent,
 			generatePinData: payload.featureFlags?.pinData ?? true,


### PR DESCRIPTION
## Summary
The code builder agent uses a custom agentic loop rather than LangGraph, so LangSmith traces are created manually via
  `CallbackManager`. Unlike the multi-agent path (where LangGraph automatically maps `configurable.thread_id` → `ls_thread_id`), these
  traces had no thread ID, making it impossible to correlate them with telemetry events.

  The fix adds `ls_thread_id` to the `runMetadata` passed to `CodeWorkflowBuilder` in `runCodeWorkflowBuilder()`. The value is
  `SessionManagerService.generateThreadId(workflowId, userId)` — the same format already reported as `sequence_id` in backend telemetry
  — so LangSmith traces for the code builder now group under the same thread ID that appears in Posthog events for the same session.

  Since `runMetadata` is forwarded transparently through `CodeBuilderAgent` → `AgentIterationHandler` → every LLM invocation and the
  parent `handleChainStart` call, no other layers needed changes.

  ## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-2252
## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
