### PR TITLE
feat(editor): instance AI visual tweaks and color token migration

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMarkdownChunk.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMarkdownChunk.vue
@@ -105,7 +105,7 @@ defineExpose({
 	--markdown--spacing: var(--spacing--2xs);
 
 	display: block;
-	color: var(--color--text--shade-1);
+	color: var(--text-color);
 
 	// Paragraphs and normal text
 	p,

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiView.vue
@@ -331,12 +331,14 @@ function handleStop() {
 
 			<!-- Floating input -->
 			<div ref="inputContainer" :class="$style.inputContainer">
-				<InstanceAiStatusBar />
-				<InstanceAiInput
-					:is-streaming="store.isStreaming"
-					@submit="handleSubmit"
-					@stop="handleStop"
-				/>
+				<div :class="$style.inputInner">
+					<InstanceAiStatusBar />
+					<InstanceAiInput
+						:is-streaming="store.isStreaming"
+						@submit="handleSubmit"
+						@stop="handleStop"
+					/>
+				</div>
 			</div>
 
 			<!-- Side panels -->
@@ -433,14 +435,16 @@ function handleStop() {
 	bottom: 0;
 	left: 0;
 	right: 0;
-	padding: 0 var(--spacing--lg) var(--spacing--sm);
 	background: linear-gradient(transparent 0%, var(--color--background--light-2) 30%);
 	pointer-events: none;
 	z-index: 2;
+}
 
-	& > * {
-		pointer-events: auto;
-	}
+.inputInner {
+	max-width: calc(750px + 2 * var(--spacing--lg));
+	margin: 0 auto;
+	padding: 0 var(--spacing--lg) var(--spacing--sm);
+	pointer-events: auto;
 }
 </style>
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/AgentActivityTree.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/AgentActivityTree.vue
@@ -53,7 +53,7 @@ const hasReasoning = computed(() => props.agentNode.reasoning.length > 0);
 	align-items: center;
 	gap: var(--spacing--4xs);
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	background: none;
 	border: none;
 	cursor: pointer;
@@ -61,14 +61,14 @@ const hasReasoning = computed(() => props.agentNode.reasoning.length > 0);
 	font-family: var(--font-family);
 
 	&:hover {
-		color: var(--color--text--tint-1);
+		color: var(--text-color--subtle);
 	}
 }
 
 .reasoningContent {
 	padding: var(--spacing--4xs) var(--spacing--xs);
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	font-style: italic;
 	border-left: 2px solid var(--color--foreground);
 	margin-left: var(--spacing--4xs);

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/AgentNodeSection.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/AgentNodeSection.vue
@@ -150,7 +150,7 @@ const runResults = computed(() => {
 	cursor: pointer;
 	font-family: var(--font-family);
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 
 	&:hover {
 		background: var(--color--foreground--tint-1);
@@ -181,7 +181,7 @@ const runResults = computed(() => {
 	background: var(--color--foreground);
 	border: var(--border);
 	border-radius: var(--radius--sm);
-	color: var(--color--text);
+	color: var(--text-color);
 }
 
 .content {
@@ -198,7 +198,7 @@ const runResults = computed(() => {
 	align-items: center;
 	gap: var(--spacing--4xs);
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	background: none;
 	border: none;
 	cursor: pointer;
@@ -206,14 +206,14 @@ const runResults = computed(() => {
 	font-family: var(--font-family);
 
 	&:hover {
-		color: var(--color--text--tint-1);
+		color: var(--text-color--subtle);
 	}
 }
 
 .reasoningContent {
 	padding: var(--spacing--4xs) var(--spacing--xs);
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	font-style: italic;
 	border-left: var(--border-width) var(--border-style) var(--color--foreground);
 	margin-left: var(--spacing--4xs);
@@ -222,7 +222,7 @@ const runResults = computed(() => {
 .textContent {
 	font-size: var(--font-size--sm);
 	line-height: var(--line-height--xl);
-	color: var(--color--text);
+	color: var(--text-color);
 	margin-top: var(--spacing--2xs);
 }
 
@@ -272,7 +272,7 @@ const runResults = computed(() => {
 }
 
 .cancelledIcon {
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .errorIcon {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/AgentTimeline.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/AgentTimeline.vue
@@ -109,11 +109,11 @@ const childrenById = computed(() => {
 .textContent {
 	font-size: var(--font-size--sm);
 	line-height: var(--line-height--xl);
-	color: var(--color--text);
+	color: var(--text-color);
 }
 
 .compactText {
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/BuilderCard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/BuilderCard.vue
@@ -394,11 +394,11 @@ watch(
 
 .title {
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text);
+	color: var(--text-color);
 }
 
 .subtitle {
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	font-weight: var(--font-weight--regular);
 	max-width: 280px;
 	overflow: hidden;
@@ -418,7 +418,7 @@ watch(
 	align-items: center;
 	gap: var(--spacing--4xs);
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .phaseActive {
@@ -438,7 +438,7 @@ watch(
 }
 
 .phaseIconPending {
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .phaseLabel {
@@ -466,7 +466,7 @@ watch(
 	font-family: var(--font-family);
 	font-size: var(--font-size--3xs);
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
 
@@ -641,7 +641,7 @@ watch(
 .modalTitle {
 	font-size: var(--font-size--sm);
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text);
+	color: var(--text-color);
 }
 
 .modalClose {
@@ -655,7 +655,7 @@ watch(
 	border: none;
 	border-radius: var(--radius);
 	cursor: pointer;
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 
 	&:hover {
 		background: var(--color--background--shade-1);

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/CollapsibleMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/CollapsibleMessage.vue
@@ -102,7 +102,7 @@ onMounted(() => {
 	font-family: var(--font-family);
 	font-size: var(--font-size--2xs);
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	background: var(--color--background);
 	border: var(--border);
 	border-radius: var(--radius--xl);

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/DataTableCard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/DataTableCard.vue
@@ -195,11 +195,11 @@ const isCompleted = computed(
 
 .title {
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text);
+	color: var(--text-color);
 }
 
 .subtitle {
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	font-weight: var(--font-weight--regular);
 	max-width: 280px;
 	overflow: hidden;
@@ -219,7 +219,7 @@ const isCompleted = computed(
 	align-items: center;
 	gap: var(--spacing--4xs);
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .phaseActive {
@@ -239,7 +239,7 @@ const isCompleted = computed(
 }
 
 .phaseIconPending {
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .phaseLabel {
@@ -267,7 +267,7 @@ const isCompleted = computed(
 	font-family: var(--font-family);
 	font-size: var(--font-size--3xs);
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/DelegateCard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/DelegateCard.vue
@@ -95,12 +95,12 @@ const briefing = computed(() => {
 }
 
 .delegatingLabel {
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .role {
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text);
+	color: var(--text-color);
 }
 
 .spinner {
@@ -122,7 +122,7 @@ const briefing = computed(() => {
 .toolsLabel {
 	font-size: var(--font-size--3xs);
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
 	margin-right: var(--spacing--4xs);
@@ -136,7 +136,7 @@ const briefing = computed(() => {
 	background: var(--color--foreground);
 	border: var(--border);
 	border-radius: var(--radius--sm);
-	color: var(--color--text);
+	color: var(--text-color);
 }
 
 .briefingBlock {
@@ -155,7 +155,7 @@ const briefing = computed(() => {
 	font-family: var(--font-family);
 	font-size: var(--font-size--3xs);
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
 
@@ -167,7 +167,7 @@ const briefing = computed(() => {
 .briefingContent {
 	padding: var(--spacing--4xs) var(--spacing--xs) var(--spacing--2xs);
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	line-height: var(--line-height--xl);
 
 	p {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/DomainAccessApproval.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/DomainAccessApproval.vue
@@ -87,7 +87,7 @@ function handleAction(approved: boolean, domainAccessAction?: string) {
 	align-items: flex-start;
 	gap: var(--spacing--3xs);
 	font-size: var(--font-size--2xs);
-	color: var(--color--text);
+	color: var(--text-color);
 	margin-bottom: var(--spacing--2xs);
 }
 
@@ -100,7 +100,7 @@ function handleAction(approved: boolean, domainAccessAction?: string) {
 .urlPreview {
 	font-family: monospace;
 	font-size: var(--font-size--3xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	word-break: break-all;
 	margin-bottom: var(--spacing--2xs);
 	padding: var(--spacing--4xs) var(--spacing--2xs);
@@ -124,7 +124,7 @@ function handleAction(approved: boolean, domainAccessAction?: string) {
 	cursor: pointer;
 	border: var(--border);
 	background: var(--color--background);
-	color: var(--color--text);
+	color: var(--text-color);
 
 	&:hover {
 		background: var(--color--background--shade-1);
@@ -132,11 +132,11 @@ function handleAction(approved: boolean, domainAccessAction?: string) {
 }
 
 .denyBtn {
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .secondaryBtn {
-	color: var(--color--text);
+	color: var(--text-color);
 }
 
 .primaryBtn {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/ExecutionPreviewCard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/ExecutionPreviewCard.vue
@@ -218,7 +218,7 @@ watch(
 .modalTitle {
 	font-size: var(--font-size--sm);
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text);
+	color: var(--text-color);
 }
 
 .modalClose {
@@ -232,7 +232,7 @@ watch(
 	border: none;
 	border-radius: var(--radius);
 	cursor: pointer;
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 
 	&:hover {
 		background: var(--color--background--shade-1);

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiArtifactsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiArtifactsPanel.vue
@@ -223,7 +223,7 @@ watch(
 }
 
 .chevron {
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	flex-shrink: 0;
 	transition: transform 0.15s ease;
 }
@@ -242,14 +242,14 @@ watch(
 	background: var(--color--foreground);
 	border-radius: var(--radius--sm);
 	text-transform: uppercase;
-	color: var(--color--text);
+	color: var(--text-color);
 	flex-shrink: 0;
 }
 
 .progress {
 	margin-left: auto;
 	font-size: var(--font-size--3xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	flex-shrink: 0;
 }
 
@@ -297,13 +297,13 @@ watch(
 }
 
 .taskDescription {
-	color: var(--color--text);
+	color: var(--text-color);
 	flex: 1;
 	min-width: 0;
 }
 
 .todoIcon {
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .inProgressIcon {
@@ -318,6 +318,6 @@ watch(
 	padding: var(--spacing--lg) var(--spacing--sm);
 	text-align: center;
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
@@ -1,14 +1,11 @@
 <script lang="ts" setup>
 import { ref, computed } from 'vue';
-import { N8nButton, N8nIcon, N8nText } from '@n8n/design-system';
+import { N8nButton, N8nIcon } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import type { InstanceAiCredentialRequest, InstanceAiCredentialFlow } from '@n8n/api-types';
 import { useInstanceAiStore } from '../instanceAi.store';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import CredentialPicker from '@/features/credentials/components/CredentialPicker/CredentialPicker.vue';
-import CredentialIcon from '@/features/credentials/components/CredentialIcon.vue';
-import WizardNavigationFooter from '@/features/ai/shared/components/WizardNavigationFooter.vue';
-import { useWizardNavigation } from '@/features/ai/shared/composables/useWizardNavigation';
 
 const props = defineProps<{
 	requestId: string;
@@ -22,11 +19,6 @@ const i18n = useI18n();
 const store = useInstanceAiStore();
 const credentialsStore = useCredentialsStore();
 
-const totalSteps = computed(() => props.credentialRequests.length);
-
-const { currentStepIndex, isPrevDisabled, isNextDisabled, goToNext, goToPrev } =
-	useWizardNavigation({ totalSteps });
-
 const isFinalize = computed(() => props.credentialFlow?.stage === 'finalize');
 
 const isSubmitted = ref(false);
@@ -36,14 +28,8 @@ const selections = ref<Record<string, string | null>>(
 	Object.fromEntries(props.credentialRequests.map((r) => [r.credentialType, null])),
 );
 
-const currentRequest = computed(() => props.credentialRequests[currentStepIndex.value]);
-
 const allSelected = computed(() =>
 	props.credentialRequests.every((r) => selections.value[r.credentialType] !== null),
-);
-
-const currentSelected = computed(
-	() => currentRequest.value && selections.value[currentRequest.value.credentialType] !== null,
 );
 
 function getDisplayName(credentialType: string): string {
@@ -79,79 +65,52 @@ function handleLater() {
 <template>
 	<div :class="$style.root">
 		<template v-if="!isSubmitted">
-			<div
-				v-if="currentRequest"
-				data-test-id="instance-ai-credential-card"
-				:class="[$style.card, { [$style.completed]: allSelected }]"
-			>
-				<!-- Header -->
-				<header :class="$style.header">
-					<CredentialIcon :credential-type-name="currentRequest.credentialType" :size="16" />
-					<N8nText :class="$style.title" size="medium" color="text-dark" bold>
-						{{ getDisplayName(currentRequest.credentialType) }}
-					</N8nText>
-					<N8nText
-						v-if="currentSelected"
-						data-test-id="instance-ai-credential-step-check"
-						:class="$style.completeLabel"
-						size="medium"
-						color="success"
-					>
-						<N8nIcon icon="check" size="large" />
-					</N8nText>
-				</header>
-
-				<!-- Content -->
-				<div :class="$style.content">
-					<N8nText
-						v-if="currentRequest.reason"
-						:class="$style.reason"
-						size="small"
-						color="text-light"
-					>
-						{{ currentRequest.reason }}
-					</N8nText>
-
-					<CredentialPicker
-						:key="currentRequest.credentialType"
-						:app-name="getDisplayName(currentRequest.credentialType)"
-						:credential-type="currentRequest.credentialType"
-						:selected-credential-id="selections[currentRequest.credentialType]"
-						:project-id="props.projectId"
-						create-button-variant="outline"
-						@credential-selected="handleCredentialSelected(currentRequest.credentialType, $event)"
-						@credential-deselected="handleCredentialDeselected(currentRequest.credentialType)"
-					/>
-				</div>
-
-				<!-- Footer -->
-				<WizardNavigationFooter
-					:step-index="currentStepIndex"
-					:total-steps="totalSteps"
-					:is-prev-disabled="isPrevDisabled"
-					:is-next-disabled="isNextDisabled"
-					@prev="goToPrev"
-					@next="goToNext"
+			<ul :class="$style.credentialList">
+				<li
+					v-for="req in props.credentialRequests"
+					:key="req.credentialType"
+					:class="$style.credentialRow"
 				>
-					<template #actions>
-						<button :class="$style.secondaryButton" @click="handleLater">
-							{{
-								i18n.baseText(
-									isFinalize
-										? 'instanceAi.credential.finalize.later'
-										: 'instanceAi.credential.deny',
-								)
-							}}
-						</button>
-						<N8nButton
-							size="small"
-							:label="i18n.baseText('instanceAi.credential.continueButton')"
-							:disabled="!allSelected"
-							data-test-id="instance-ai-credential-continue-button"
-							@click="handleContinue"
+					<N8nIcon icon="key-round" size="small" :class="$style.icon" />
+					<div :class="$style.credentialText">
+						<span :class="$style.credentialName">{{ getDisplayName(req.credentialType) }}</span>
+						<span v-if="req.reason" :class="$style.credentialReason">{{ req.reason }}</span>
+					</div>
+					<span :class="$style.picker">
+						<CredentialPicker
+							:app-name="getDisplayName(req.credentialType)"
+							:credential-type="req.credentialType"
+							:selected-credential-id="selections[req.credentialType]"
+							:project-id="props.projectId"
+							create-button-variant="outline"
+							@credential-selected="handleCredentialSelected(req.credentialType, $event)"
+							@credential-deselected="handleCredentialDeselected(req.credentialType)"
 						/>
-					</template>
-				</WizardNavigationFooter>
+					</span>
+					<N8nIcon
+						v-if="selections[req.credentialType]"
+						icon="check"
+						size="small"
+						:class="$style.checkIcon"
+					/>
+				</li>
+			</ul>
+
+			<div :class="$style.actions">
+				<button :class="$style.secondaryButton" @click="handleLater">
+					{{
+						i18n.baseText(
+							isFinalize ? 'instanceAi.credential.finalize.later' : 'instanceAi.credential.deny',
+						)
+					}}
+				</button>
+				<N8nButton
+					size="small"
+					:label="i18n.baseText('instanceAi.credential.continueButton')"
+					:disabled="!allSelected"
+					data-test-id="instance-ai-credential-continue-button"
+					@click="handleContinue"
+				/>
 			</div>
 		</template>
 
@@ -177,56 +136,64 @@ function handleLater() {
 <style lang="scss" module>
 .root {
 	border-top: var(--border);
-	background: var(--color--background--shade-1);
 	padding: var(--spacing--xs);
+	background: var(--color--background--shade-1);
 }
 
-.card {
-	width: 100%;
+.credentialList {
+	list-style: none;
+	padding: 0;
+	margin: 0 0 var(--spacing--xs) 0;
 	display: flex;
 	flex-direction: column;
-	gap: var(--spacing--sm);
-	padding: 0;
-	background-color: var(--color--background--light-3);
-	border: var(--border);
-	border-radius: var(--radius);
-
-	&.completed {
-		border-color: var(--color--success);
-	}
-}
-
-.header {
-	display: flex;
-	align-items: center;
 	gap: var(--spacing--2xs);
-	padding: var(--spacing--sm) var(--spacing--sm) 0;
 }
 
-.title {
+.credentialRow {
+	display: flex;
+	align-items: flex-start;
+	gap: var(--spacing--3xs);
+}
+
+.icon {
+	color: var(--color--primary);
+	flex-shrink: 0;
+}
+
+.credentialText {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--5xs);
+	min-width: 0;
 	flex: 1;
 }
 
-.completeLabel {
+.credentialName {
+	font-size: var(--font-size--2xs);
+	font-weight: var(--font-weight--bold);
+	color: var(--text-color);
+}
+
+.credentialReason {
+	font-size: var(--font-size--3xs);
+	color: var(--text-color--subtle);
+}
+
+.picker {
+	margin-left: auto;
+	flex-shrink: 0;
+}
+
+.checkIcon {
+	color: var(--color--success);
+	flex-shrink: 0;
+}
+
+.actions {
 	display: flex;
+	gap: var(--spacing--2xs);
+	justify-content: flex-end;
 	align-items: center;
-	gap: var(--spacing--4xs);
-	white-space: nowrap;
-}
-
-.content {
-	display: flex;
-	flex-direction: column;
-	gap: var(--spacing--sm);
-	padding: 0 var(--spacing--sm);
-
-	:global([data-test-id='create-credential']) {
-		width: auto;
-	}
-}
-
-.reason {
-	color: var(--color--text--tint-1);
 }
 
 .secondaryButton {
@@ -237,10 +204,10 @@ function handleLater() {
 	cursor: pointer;
 	border: none;
 	background: none;
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 
 	&:hover {
-		color: var(--color--text);
+		color: var(--text-color);
 		text-decoration: underline;
 	}
 }
@@ -250,7 +217,7 @@ function handleLater() {
 	align-items: center;
 	gap: var(--spacing--4xs);
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .successIcon {
@@ -258,6 +225,6 @@ function handleLater() {
 }
 
 .skippedIcon {
-	color: var(--color--text--tint-2);
+	color: var(--text-color--subtler);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiDebugPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiDebugPanel.vue
@@ -366,7 +366,7 @@ onMounted(() => {
 	cursor: pointer;
 	border: var(--border);
 	background: var(--color--background);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 
 	&:hover {
 		background: var(--color--background--shade-1);
@@ -387,14 +387,14 @@ onMounted(() => {
 	cursor: pointer;
 	border: none;
 	background: none;
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	border-bottom: 2px solid transparent;
 	transition:
 		color 0.15s,
 		border-color 0.15s;
 
 	&:hover {
-		color: var(--color--text);
+		color: var(--text-color);
 	}
 }
 
@@ -410,7 +410,7 @@ onMounted(() => {
 	gap: var(--spacing--3xs);
 	padding: var(--spacing--4xs) var(--spacing--sm);
 	font-size: var(--font-size--3xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	border-bottom: var(--border);
 }
 
@@ -418,7 +418,7 @@ onMounted(() => {
 	width: 6px;
 	height: 6px;
 	border-radius: 50%;
-	background: var(--color--text--tint-1);
+	background: var(--text-color--subtle);
 
 	&[data-state='connected'] {
 		background: var(--color--success);
@@ -442,7 +442,7 @@ onMounted(() => {
 .timingTitle {
 	font-size: var(--font-size--3xs);
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
 	margin-bottom: var(--spacing--4xs);
@@ -457,12 +457,12 @@ onMounted(() => {
 
 .timingName {
 	font-family: monospace;
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .timingDuration {
 	font-family: monospace;
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .eventList {
@@ -489,7 +489,7 @@ onMounted(() => {
 
 .eventTime {
 	font-family: monospace;
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .eventType {
@@ -506,7 +506,7 @@ onMounted(() => {
 
 .finish {
 	background: var(--color--foreground);
-	color: var(--color--text);
+	color: var(--text-color);
 }
 
 .start {
@@ -521,7 +521,7 @@ onMounted(() => {
 
 .text {
 	background: var(--color--foreground);
-	color: var(--color--text);
+	color: var(--text-color);
 }
 
 .confirm {
@@ -531,7 +531,7 @@ onMounted(() => {
 
 .default {
 	background: var(--color--foreground);
-	color: var(--color--text);
+	color: var(--text-color);
 }
 
 .eventPayload {
@@ -546,7 +546,7 @@ onMounted(() => {
 	word-break: break-word;
 	max-height: 200px;
 	overflow-y: auto;
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 /* Thread Inspector styles */
@@ -561,7 +561,7 @@ onMounted(() => {
 .sectionLabel {
 	font-size: var(--font-size--3xs);
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
 }
@@ -571,14 +571,14 @@ onMounted(() => {
 	align-items: center;
 	justify-content: center;
 	padding: var(--spacing--lg);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .emptyState {
 	padding: var(--spacing--lg) var(--spacing--sm);
 	text-align: center;
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .threadList {
@@ -613,7 +613,7 @@ onMounted(() => {
 
 .threadTitle {
 	font-size: var(--font-size--2xs);
-	color: var(--color--text);
+	color: var(--text-color);
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
@@ -630,7 +630,7 @@ onMounted(() => {
 
 .threadTime {
 	font-size: var(--font-size--3xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .threadDetailHeader {
@@ -645,14 +645,14 @@ onMounted(() => {
 	cursor: pointer;
 	border: none;
 	background: none;
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	border-bottom: 2px solid transparent;
 	transition:
 		color 0.15s,
 		border-color 0.15s;
 
 	&:hover {
-		color: var(--color--text);
+		color: var(--text-color);
 	}
 }
 
@@ -687,7 +687,7 @@ onMounted(() => {
 
 .messagePreview {
 	font-size: var(--font-size--3xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
@@ -700,7 +700,7 @@ onMounted(() => {
 .contextLabel {
 	font-size: var(--font-size--3xs);
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
 	margin-bottom: var(--spacing--4xs);
@@ -717,6 +717,6 @@ onMounted(() => {
 	word-break: break-word;
 	max-height: 400px;
 	overflow-y: auto;
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiEmptyState.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiEmptyState.vue
@@ -137,13 +137,13 @@ const suggestions = [
 .cardTitle {
 	font-size: var(--font-size--sm);
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text);
+	color: var(--text-color);
 	line-height: var(--line-height--md);
 }
 
 .cardDescription {
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	line-height: var(--line-height--lg);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiInput.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiInput.vue
@@ -146,7 +146,7 @@ function handleFileRemove(file: File) {
 	border: var(--border);
 	border-radius: var(--radius--lg);
 	background: transparent;
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	font-size: var(--font-size--2xs);
 	font-family: var(--font-family);
 	cursor: pointer;
@@ -157,7 +157,7 @@ function handleFileRemove(file: File) {
 	user-select: none;
 
 	&:hover {
-		color: var(--color--text);
+		color: var(--text-color);
 		border-color: var(--color--foreground--shade-1);
 	}
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiMarkdown.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiMarkdown.vue
@@ -14,11 +14,11 @@ const wrapperRef = ref<HTMLElement | null>(null);
 /** Icon SVG paths for each resource type — matches the n8n design system icons. */
 const ICON_SVGS: Record<string, string> = {
 	workflow:
-		'<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.17 8H7.83a1.83 1.83 0 1 0 0 3.66h8.34a1.83 1.83 0 0 1 0 3.66H2.83"/><path d="m18 2 4 4-4 4"/><path d="m6 20-4-4 4-4"/></svg>',
+		'<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.17 8H7.83a1.83 1.83 0 1 0 0 3.66h8.34a1.83 1.83 0 0 1 0 3.66H2.83"/><path d="m18 2 4 4-4 4"/><path d="m6 20-4-4 4-4"/></svg>',
 	credential:
-		'<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15.5 7.5 2.3 2.3a1 1 0 0 0 1.4 0l2.1-2.1a1 1 0 0 0 0-1.4L19 4"/><path d="m21 2-9.6 9.6"/><circle cx="7.5" cy="15.5" r="5.5"/></svg>',
+		'<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15.5 7.5 2.3 2.3a1 1 0 0 0 1.4 0l2.1-2.1a1 1 0 0 0 0-1.4L19 4"/><path d="m21 2-9.6 9.6"/><circle cx="7.5" cy="15.5" r="5.5"/></svg>',
 	'data-table':
-		'<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v18"/><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M3 9h18"/><path d="M3 15h18"/></svg>',
+		'<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v18"/><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M3 9h18"/><path d="M3 15h18"/></svg>',
 };
 
 /** URL builders for each resource type. */
@@ -127,24 +127,22 @@ onUpdated(enhanceResourceLinks);
 
 <style lang="scss" module>
 .resourceChip {
-	display: inline-flex !important;
-	align-items: center !important;
-	gap: 2px !important;
-	padding: 1px var(--spacing--4xs) !important;
-	font-size: var(--font-size--2xs) !important;
-	font-weight: var(--font-weight--bold) !important;
-	background: var(--color--background--shade-1) !important;
-	border: var(--border) !important;
-	border-radius: var(--radius) !important;
-	color: var(--color--primary) !important;
-	text-decoration: none !important;
+	display: inline !important;
+	padding: 0 !important;
+	font-size: inherit !important;
+	font-weight: var(--font-weight--regular) !important;
+	background: none !important;
+	border: none !important;
+	border-radius: 0 !important;
+	color: inherit !important;
+	text-decoration: underline !important;
+	text-decoration-color: var(--text-color--subtle) !important;
 	cursor: pointer !important;
 	vertical-align: baseline !important;
-	line-height: var(--line-height--md) !important;
+	line-height: inherit !important;
 
 	&:hover {
-		background: color-mix(in srgb, var(--color--primary) 12%, var(--color--background)) !important;
-		border-color: var(--color--primary) !important;
+		background: none !important;
 		color: var(--color--primary) !important;
 	}
 }
@@ -152,6 +150,7 @@ onUpdated(enhanceResourceLinks);
 .resourceChipIcon {
 	display: inline-flex;
 	align-items: center;
-	flex-shrink: 0;
+	vertical-align: middle;
+	margin-right: var(--spacing--5xs);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiMemoryPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiMemoryPanel.vue
@@ -107,7 +107,7 @@ function handleSave() {
 	align-items: center;
 	justify-content: center;
 	height: 100%;
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .textarea {
@@ -120,7 +120,7 @@ function handleSave() {
 	font-size: var(--font-size--2xs);
 	line-height: var(--line-height--xl);
 	resize: none;
-	color: var(--color--text);
+	color: var(--text-color);
 	background: var(--color--background);
 
 	&:focus {
@@ -144,7 +144,7 @@ function handleSave() {
 	cursor: pointer;
 	border: var(--border);
 	background: var(--color--background);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 
 	&:hover:not(:disabled) {
 		background: var(--color--background--shade-1);

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiMessage.vue
@@ -223,7 +223,7 @@ function formatJson(value: unknown): string {
 
 .userBubble {
 	background: var(--color--background);
-	color: var(--color--text);
+	color: var(--text-color);
 	padding: var(--spacing--xs) var(--spacing--sm);
 	border-radius: var(--radius--xl);
 	max-width: 80%;

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiMessage.vue
@@ -250,7 +250,7 @@ function formatJson(value: unknown): string {
 .textContent {
 	font-size: var(--font-size--sm);
 	line-height: var(--line-height--xl);
-	color: var(--color--text);
+	color: var(--text-color);
 }
 
 .actionButtons {
@@ -271,7 +271,7 @@ function formatJson(value: unknown): string {
 }
 
 .feedbackSuccess {
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	font-size: var(--font-size--2xs);
 	margin: var(--spacing--2xs) 0 0;
 }
@@ -283,7 +283,7 @@ function formatJson(value: unknown): string {
 	padding: var(--spacing--3xs) 0;
 	margin-top: var(--spacing--4xs);
 	font-size: var(--font-size--2xs);
-	color: var(--color--text);
+	color: var(--text-color);
 }
 
 .statusIndicator {
@@ -291,7 +291,7 @@ function formatJson(value: unknown): string {
 	align-items: center;
 	gap: var(--spacing--3xs);
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	padding: var(--spacing--4xs) 0;
 	animation: status-fade-in 0.2s ease;
 }
@@ -327,7 +327,7 @@ function formatJson(value: unknown): string {
 	display: inline-block;
 	width: 2px;
 	height: 1.2em;
-	background: var(--color--text);
+	background: var(--text-color);
 	animation: cursor-blink 1s step-end infinite;
 	vertical-align: text-bottom;
 }
@@ -429,6 +429,6 @@ function formatJson(value: unknown): string {
 	word-break: break-word;
 	max-height: 300px;
 	overflow-y: auto;
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiStatusBar.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiStatusBar.vue
@@ -98,7 +98,7 @@ onUnmounted(() => {
 	gap: var(--spacing--3xs);
 	padding: var(--spacing--4xs) var(--spacing--2xs) var(--spacing--2xs) 0;
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	pointer-events: none;
 }
 
@@ -124,20 +124,20 @@ onUnmounted(() => {
 
 .label {
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .separator {
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .detail {
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .elapsed {
 	font-variant-numeric: tabular-nums;
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 </style>
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiStatusBar.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiStatusBar.vue
@@ -96,7 +96,7 @@ onUnmounted(() => {
 	display: flex;
 	align-items: center;
 	gap: var(--spacing--3xs);
-	padding: var(--spacing--4xs) var(--spacing--2xs) var(--spacing--2xs);
+	padding: var(--spacing--4xs) var(--spacing--2xs) var(--spacing--2xs) 0;
 	font-size: var(--font-size--2xs);
 	color: var(--color--text--tint-1);
 	pointer-events: none;

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiThreadList.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiThreadList.vue
@@ -240,7 +240,7 @@ function handleThreadAction(action: string, threadId: string) {
 	flex: 1;
 	min-width: 0;
 	padding: var(--spacing--2xs) var(--spacing--xs);
-	color: var(--color--text);
+	color: var(--text-color);
 	text-decoration: none;
 	outline: none;
 	cursor: pointer;
@@ -248,7 +248,7 @@ function handleThreadAction(action: string, threadId: string) {
 
 .threadIcon {
 	flex-shrink: 0;
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .threadTitle {
@@ -290,7 +290,7 @@ function handleThreadAction(action: string, threadId: string) {
 	font-family: var(--font-family);
 	font-size: var(--font-size--sm);
 	line-height: var(--line-height--xl);
-	color: var(--color--text);
+	color: var(--text-color);
 	background: var(--color--background--light-2);
 	border: var(--border);
 	border-color: var(--color--primary);

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiToolCall.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiToolCall.vue
@@ -152,7 +152,7 @@ const resolvedAction = computed((): 'approved' | 'denied' | 'deferred' | null =>
 	cursor: pointer;
 	font-family: var(--font-family);
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 
 	&:hover {
 		background: var(--color--background--shade-1);
@@ -205,7 +205,7 @@ const resolvedAction = computed((): 'approved' | 'denied' | 'deferred' | null =>
 .sectionLabel {
 	font-size: var(--font-size--3xs);
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
 	margin-bottom: var(--spacing--4xs);
@@ -218,7 +218,7 @@ const resolvedAction = computed((): 'approved' | 'denied' | 'deferred' | null =>
 	white-space: pre-wrap;
 	word-break: break-word;
 	margin: 0;
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	max-height: 200px;
 	overflow-y: auto;
 }
@@ -243,7 +243,97 @@ const resolvedAction = computed((): 'approved' | 'denied' | 'deferred' | null =>
 }
 
 .deferredIcon {
-	color: var(--color--text--tint-2);
+	color: var(--text-color--subtler);
+}
+
+.confirmationMessage {
+	display: flex;
+	align-items: flex-start;
+	gap: var(--spacing--3xs);
+	font-size: var(--font-size--2xs);
+	color: var(--text-color);
+	margin-bottom: var(--spacing--2xs);
+}
+
+.destructiveIcon {
+	color: var(--color--danger);
+}
+
+.warningIcon {
+	color: var(--color--warning);
+}
+
+.infoIcon {
+	color: var(--color--primary);
+}
+
+.confirmationActions {
+	display: flex;
+	gap: var(--spacing--2xs);
+	justify-content: flex-end;
+}
+
+.confirmButton {
+	padding: var(--spacing--4xs) var(--spacing--xs);
+	border-radius: var(--radius);
+	font-size: var(--font-size--2xs);
+	font-family: var(--font-family);
+	cursor: pointer;
+	border: var(--border);
+	background: var(--color--background);
+	color: var(--text-color);
+
+	&:hover {
+		background: var(--color--background--shade-1);
+	}
+}
+
+.denyButton {
+	color: var(--text-color--subtle);
+}
+
+.approveButton {
+	background: var(--color--primary);
+	color: var(--button--color--text--primary);
+	border-color: var(--color--primary);
+
+	&:hover {
+		background: var(--color--primary--shade-1);
+	}
+}
+
+.approveDestructive {
+	background: var(--color--danger);
+	color: var(--button--color--text--primary);
+	border-color: var(--color--danger);
+
+	&:hover {
+		background: var(--color--danger--shade-1);
+	}
+}
+
+.textInputWrapper {
+	margin-bottom: var(--spacing--2xs);
+}
+
+.textInput {
+	width: 100%;
+	padding: var(--spacing--4xs) var(--spacing--2xs);
+	border: var(--border);
+	border-radius: var(--radius);
+	font-size: var(--font-size--2xs);
+	font-family: var(--font-family);
+	background: var(--color--background);
+	color: var(--text-color);
+	outline: none;
+
+	&:focus {
+		border-color: var(--color--primary);
+	}
+
+	&::placeholder {
+		color: var(--text-color--subtle);
+	}
 }
 
 .confirmationStatus {
@@ -253,6 +343,6 @@ const resolvedAction = computed((): 'approved' | 'denied' | 'deferred' | null =>
 	align-items: center;
 	gap: var(--spacing--4xs);
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/ResearchCard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/ResearchCard.vue
@@ -181,7 +181,7 @@ const headerTitle = computed(() => {
 
 .title {
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text);
+	color: var(--text-color);
 }
 
 .checklist {
@@ -196,12 +196,12 @@ const headerTitle = computed(() => {
 	align-items: center;
 	gap: var(--spacing--4xs);
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	min-width: 0;
 }
 
 .checkItemActive {
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .checkItemDone {
@@ -247,7 +247,7 @@ const headerTitle = computed(() => {
 	font-family: var(--font-family);
 	font-size: var(--font-size--3xs);
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/ToolResultCode.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/ToolResultCode.vue
@@ -61,6 +61,6 @@ async function handleCopy() {
 	word-break: break-word;
 	margin: 0;
 	padding: var(--spacing--xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/ToolResultJson.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/ToolResultJson.vue
@@ -45,7 +45,7 @@ const highlighted = computed(() => highlightJson(props.value));
 	margin: 0;
 	max-height: 200px;
 	overflow-y: auto;
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 </style>
 
@@ -63,7 +63,7 @@ const highlighted = computed(() => highlightJson(props.value));
 }
 
 .json-bool {
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	font-style: italic;
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/ToolResultTable.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/ToolResultTable.vue
@@ -71,7 +71,7 @@ function formatCell(value: unknown): string {
 	text-align: left;
 	padding: var(--spacing--4xs) var(--spacing--2xs);
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
 	border-bottom: var(--border);
@@ -89,7 +89,7 @@ function formatCell(value: unknown): string {
 
 .td {
 	padding: var(--spacing--4xs) var(--spacing--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	max-width: 200px;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -99,7 +99,7 @@ function formatCell(value: unknown): string {
 .more {
 	padding: var(--spacing--4xs) var(--spacing--2xs);
 	font-size: var(--font-size--3xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	font-style: italic;
 	text-align: center;
 	border-top: var(--border);

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/settings/AdvancedSection.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/settings/AdvancedSection.vue
@@ -82,7 +82,7 @@ const { store, getString, getNumber, getBool } = useSettingsField();
 	gap: var(--spacing--3xs);
 	font-size: var(--font-size--xs);
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text);
+	color: var(--text-color);
 	padding-bottom: var(--spacing--4xs);
 	border-bottom: var(--border);
 }
@@ -96,6 +96,6 @@ const { store, getString, getNumber, getBool } = useSettingsField();
 
 .switchLabel {
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/settings/InstanceAiSettingsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/settings/InstanceAiSettingsPanel.vue
@@ -110,7 +110,7 @@ watch(
 	align-items: center;
 	justify-content: center;
 	height: 100%;
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .sections {
@@ -135,7 +135,7 @@ watch(
 	cursor: pointer;
 	border: var(--border);
 	background: var(--color--background);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 
 	&:hover:not(:disabled) {
 		background: var(--color--background--shade-1);

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/settings/LocalGatewaySection.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/settings/LocalGatewaySection.vue
@@ -115,7 +115,7 @@ onMounted(() => {
 	gap: var(--spacing--3xs);
 	font-size: var(--font-size--xs);
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text);
+	color: var(--text-color);
 	padding-bottom: var(--spacing--4xs);
 	border-bottom: var(--border);
 }
@@ -129,7 +129,7 @@ onMounted(() => {
 
 .switchLabel {
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 
 .statusRow {
@@ -201,6 +201,6 @@ onMounted(() => {
 	font-size: var(--font-size--3xs);
 	font-family: monospace;
 	word-break: break-all;
-	color: var(--color--text);
+	color: var(--text-color);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/settings/MemorySection.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/settings/MemorySection.vue
@@ -68,7 +68,7 @@ const { store, getString, getNumber } = useSettingsField();
 	gap: var(--spacing--3xs);
 	font-size: var(--font-size--xs);
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text);
+	color: var(--text-color);
 	padding-bottom: var(--spacing--4xs);
 	border-bottom: var(--border);
 }

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/settings/ModelSection.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/settings/ModelSection.vue
@@ -74,7 +74,7 @@ function handleCredentialChange(value: string | number | boolean | null) {
 	gap: var(--spacing--3xs);
 	font-size: var(--font-size--xs);
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text);
+	color: var(--text-color);
 	padding-bottom: var(--spacing--4xs);
 	border-bottom: var(--border);
 }

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/settings/PermissionsSection.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/settings/PermissionsSection.vue
@@ -94,14 +94,14 @@ const store = useInstanceAiSettingsStore();
 	gap: var(--spacing--3xs);
 	font-size: var(--font-size--xs);
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text);
+	color: var(--text-color);
 	padding-bottom: var(--spacing--4xs);
 	border-bottom: var(--border);
 }
 
 .permissionDescription {
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 	line-height: var(--line-height--xl);
 }
 
@@ -114,6 +114,6 @@ const store = useInstanceAiSettingsStore();
 
 .switchLabel {
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/settings/SandboxSection.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/settings/SandboxSection.vue
@@ -163,7 +163,7 @@ watch(
 	gap: var(--spacing--3xs);
 	font-size: var(--font-size--xs);
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text);
+	color: var(--text-color);
 	padding-bottom: var(--spacing--4xs);
 	border-bottom: var(--border);
 }
@@ -177,6 +177,6 @@ watch(
 
 .switchLabel {
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/settings/SearchSection.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/settings/SearchSection.vue
@@ -106,7 +106,7 @@ watch(
 	gap: var(--spacing--3xs);
 	font-size: var(--font-size--xs);
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text);
+	color: var(--text-color);
 	padding-bottom: var(--spacing--4xs);
 	border-bottom: var(--border);
 }


### PR DESCRIPTION
## Summary
- Restyle Instance AI resource chips: remove background/border, use underline link style with regular font size and weight
- Migrate all Instance AI components from legacy color tokens (`--color--text`, `--color--text--tint-1`, `--color--text--tint-2`) to new design system tokens (`--text-color`, `--text-color--subtle`, `--text-color--subtler`)
- Update `ChatMarkdownChunk` to use `--text-color` for primary message text
- Constrain Instance AI chat input to 750px max-width

## Test plan
- [ ] Verify resource chips render as underlined inline links matching surrounding text size
- [ ] Verify resource chip icons use regular text color
- [ ] Verify text colors across all Instance AI views (chat, settings, debug, artifacts, etc.)
- [ ] Verify dark mode renders correctly with new tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)