### PR TITLE
fix(Gmail Node): Update draft resource hint

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/v2/DraftDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/DraftDescription.ts
@@ -67,7 +67,7 @@ export const draftFields: INodeProperties[] = [
 		placeholder: 'Hello World!',
 	},
 	{
-		displayName: 'To reply to an existing thread, specify the exact subject title of that thread.',
+		displayName: 'To reply to an existing thread, specify the Thread ID from the options below.',
 		name: 'threadNotice',
 		type: 'notice',
 		default: '',


### PR DESCRIPTION
The draft "Create" operation displayed an incorrect hint telling users to match the subject line to reply to a thread. Thread ID is the correct field to use.

Related Linear tickets, Github issues, and Community forum posts:

https://linear.app/n8n/issue/NODE-4607
closes #25897