### PR TITLE
chore: Add grill-me agent skill

### DIFF
--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: grill-me
+description: Interviews the user relentlessly about a plan or design until shared understanding, resolving each branch of the decision tree. Use when the user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.


### PR DESCRIPTION
## Summary

Adds a **grill-me** agent skill under `.claude/skills/grill-me/`. The skill steers the agent to stress-test a plan or design by working through the decision tree, preferring codebase exploration over asking when the answer is in the repo.

**How to review:** Read `.claude/skills/grill-me/SKILL.md` and confirm the behavior matches how you want this workflow invoked.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4675

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

Made with [Cursor](https://cursor.com)