### PR TITLE
fix(Notion Node): Fix formula filter type mapping for Notion API

### DIFF
--- a/packages/nodes-base/nodes/Notion/shared/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Notion/shared/GenericFunctions.ts
@@ -561,14 +561,19 @@ export function mapFilters(filtersList: IDataObject[], timezone: string) {
 		}
 
 		if (value.type === 'formula') {
+			const returnType = value.returnType === 'text' ? 'string' : value.returnType;
+
 			if (['is_empty', 'is_not_empty'].includes(value.condition as string)) {
-				key = value.returnType;
+				return Object.assign(obj, {
+					['property']: getNameAndType(value.key as string).name,
+					[key]: { [returnType]: { [`${value.condition}`]: true } },
+				});
 			} else {
 				const vpropertyName = value[`${camelCase(value.returnType as string)}Value`];
 
 				return Object.assign(obj, {
 					['property']: getNameAndType(value.key as string).name,
-					[key]: { [value.returnType]: { [`${value.condition}`]: vpropertyName } },
+					[key]: { [returnType]: { [`${value.condition}`]: vpropertyName } },
 				});
 			}
 		}

--- a/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
@@ -8,6 +8,7 @@ import {
 	extractPageId,
 	formatBlocks,
 	getPageId,
+	mapFilters,
 	notionApiRequest,
 } from '../shared/GenericFunctions';
 
@@ -104,6 +105,235 @@ describe('Test Notion', () => {
 				const result = extractPageId(extractIdFromUrl(page));
 				expect(result).toBe(testId);
 			}
+		});
+	});
+});
+
+describe('Test NotionV2, mapFilters', () => {
+	const timezone = 'America/New_York';
+
+	describe('formula filters', () => {
+		it('should map text formula filter with "contains" to use "string" sub-type', () => {
+			const filters = [
+				{
+					key: 'My Formula|formula',
+					type: 'formula',
+					returnType: 'text',
+					condition: 'contains',
+					textValue: 'search term',
+				},
+			];
+
+			const result = mapFilters(filters, timezone);
+
+			expect(result).toEqual({
+				property: 'My Formula',
+				formula: { string: { contains: 'search term' } },
+			});
+		});
+
+		it('should map text formula filter with "equals" to use "string" sub-type', () => {
+			const filters = [
+				{
+					key: 'Title Formula|formula',
+					type: 'formula',
+					returnType: 'text',
+					condition: 'equals',
+					textValue: 'exact match',
+				},
+			];
+
+			const result = mapFilters(filters, timezone);
+
+			expect(result).toEqual({
+				property: 'Title Formula',
+				formula: { string: { equals: 'exact match' } },
+			});
+		});
+
+		it('should map number formula filter preserving "number" sub-type', () => {
+			const filters = [
+				{
+					key: 'Score|formula',
+					type: 'formula',
+					returnType: 'number',
+					condition: 'greater_than',
+					numberValue: 50,
+				},
+			];
+
+			const result = mapFilters(filters, timezone);
+
+			expect(result).toEqual({
+				property: 'Score',
+				formula: { number: { greater_than: 50 } },
+			});
+		});
+
+		it('should map checkbox formula filter preserving "checkbox" sub-type', () => {
+			const filters = [
+				{
+					key: 'Is Active|formula',
+					type: 'formula',
+					returnType: 'checkbox',
+					condition: 'equals',
+					checkboxValue: true,
+				},
+			];
+
+			const result = mapFilters(filters, timezone);
+
+			expect(result).toEqual({
+				property: 'Is Active',
+				formula: { checkbox: { equals: true } },
+			});
+		});
+
+		it('should map date formula filter preserving "date" sub-type', () => {
+			const filters = [
+				{
+					key: 'Due Date|formula',
+					type: 'formula',
+					returnType: 'date',
+					condition: 'after',
+					dateValue: '2026-01-01',
+				},
+			];
+
+			const result = mapFilters(filters, timezone);
+
+			expect(result).toEqual({
+				property: 'Due Date',
+				formula: { date: { after: '2026-01-01' } },
+			});
+		});
+
+		it('should map text formula "is_empty" with formula wrapper and "string" sub-type', () => {
+			const filters = [
+				{
+					key: 'Notes Formula|formula',
+					type: 'formula',
+					returnType: 'text',
+					condition: 'is_empty',
+				},
+			];
+
+			const result = mapFilters(filters, timezone);
+
+			expect(result).toEqual({
+				property: 'Notes Formula',
+				formula: { string: { is_empty: true } },
+			});
+		});
+
+		it('should map text formula "is_not_empty" with formula wrapper and "string" sub-type', () => {
+			const filters = [
+				{
+					key: 'Notes Formula|formula',
+					type: 'formula',
+					returnType: 'text',
+					condition: 'is_not_empty',
+				},
+			];
+
+			const result = mapFilters(filters, timezone);
+
+			expect(result).toEqual({
+				property: 'Notes Formula',
+				formula: { string: { is_not_empty: true } },
+			});
+		});
+
+		it('should map number formula "is_empty" with formula wrapper', () => {
+			const filters = [
+				{
+					key: 'Count|formula',
+					type: 'formula',
+					returnType: 'number',
+					condition: 'is_empty',
+				},
+			];
+
+			const result = mapFilters(filters, timezone);
+
+			expect(result).toEqual({
+				property: 'Count',
+				formula: { number: { is_empty: true } },
+			});
+		});
+
+		it('should map checkbox formula "is_not_empty" with formula wrapper', () => {
+			const filters = [
+				{
+					key: 'Flag|formula',
+					type: 'formula',
+					returnType: 'checkbox',
+					condition: 'is_not_empty',
+				},
+			];
+
+			const result = mapFilters(filters, timezone);
+
+			expect(result).toEqual({
+				property: 'Flag',
+				formula: { checkbox: { is_not_empty: true } },
+			});
+		});
+	});
+
+	describe('non-formula filters', () => {
+		it('should map rich_text filter', () => {
+			const filters = [
+				{
+					key: 'Description|rich_text',
+					type: 'rich_text',
+					condition: 'contains',
+					richTextValue: 'hello',
+				},
+			];
+
+			const result = mapFilters(filters, timezone);
+
+			expect(result).toEqual({
+				property: 'Description',
+				text: { contains: 'hello' },
+			});
+		});
+
+		it('should map number filter', () => {
+			const filters = [
+				{
+					key: 'Amount|number',
+					type: 'number',
+					condition: 'equals',
+					numberValue: 42,
+				},
+			];
+
+			const result = mapFilters(filters, timezone);
+
+			expect(result).toEqual({
+				property: 'Amount',
+				number: { equals: 42 },
+			});
+		});
+
+		it('should map checkbox filter', () => {
+			const filters = [
+				{
+					key: 'Done|checkbox',
+					type: 'checkbox',
+					condition: 'equals',
+					checkboxValue: true,
+				},
+			];
+
+			const result = mapFilters(filters, timezone);
+
+			expect(result).toEqual({
+				property: 'Done',
+				checkbox: { equals: true },
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Fix the Notion node's "Get Many" database operation failing with
"Unable to filter based on a formula of unknown type" when filtering
by formula properties.

Two bugs in `mapFilters()`:
1. The Notion API expects `"string"` for text formula filters, but
   n8n sent `"text"`
2. `is_empty`/`is_not_empty` conditions on formula properties lost
   the `"formula"` wrapper, producing an incorrect filter structure

## Related Linear tickets, Github issues, and Community forum posts

Fixes #27420

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.