### PR TITLE
feat(core): Implement MemoryInstanceStorage for single-instance deployments (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-registry/storage/__tests__/memory-storage.test.ts
+++ b/packages/cli/src/modules/instance-registry/storage/__tests__/memory-storage.test.ts
@@ -1,0 +1,171 @@
+import type { InstanceRegistration } from '@n8n/api-types';
+
+import { MemoryInstanceStorage } from '../memory-storage';
+
+const makeRegistration = (overrides: Partial<InstanceRegistration> = {}): InstanceRegistration => ({
+	schemaVersion: 1 as const,
+	instanceKey: 'instance-1',
+	hostId: 'host-1',
+	instanceType: 'main',
+	instanceRole: 'leader',
+	version: '1.0.0',
+	registeredAt: Date.now(),
+	lastSeen: Date.now(),
+	...overrides,
+});
+
+describe('MemoryInstanceStorage', () => {
+	let storage: MemoryInstanceStorage;
+
+	beforeEach(() => {
+		storage = new MemoryInstanceStorage();
+	});
+
+	it('should have kind "memory"', () => {
+		expect(storage.kind).toBe('memory');
+	});
+
+	describe('register', () => {
+		it('should store registration', async () => {
+			const reg = makeRegistration();
+
+			await storage.register(reg);
+
+			const result = await storage.getRegistration('instance-1');
+			expect(result).toEqual(reg);
+		});
+	});
+
+	describe('heartbeat', () => {
+		it('should update stored registration', async () => {
+			const reg = makeRegistration();
+			await storage.register(reg);
+
+			const updated = makeRegistration({ lastSeen: Date.now() + 30_000 });
+			await storage.heartbeat(updated);
+
+			const result = await storage.getRegistration('instance-1');
+			expect(result).toEqual(updated);
+		});
+	});
+
+	describe('unregister', () => {
+		it('should clear registration when key matches', async () => {
+			await storage.register(makeRegistration());
+
+			await storage.unregister('instance-1');
+
+			const result = await storage.getRegistration('instance-1');
+			expect(result).toBeNull();
+		});
+
+		it('should not clear registration when key does not match', async () => {
+			const reg = makeRegistration();
+			await storage.register(reg);
+
+			await storage.unregister('other-instance');
+
+			const result = await storage.getRegistration('instance-1');
+			expect(result).toEqual(reg);
+		});
+
+		it('should be safe to call when no registration exists', async () => {
+			await expect(storage.unregister('instance-1')).resolves.toBeUndefined();
+		});
+	});
+
+	describe('getAllRegistrations', () => {
+		it('should return empty array when no registration exists', async () => {
+			const result = await storage.getAllRegistrations();
+			expect(result).toEqual([]);
+		});
+
+		it('should return array with single registration', async () => {
+			const reg = makeRegistration();
+			await storage.register(reg);
+
+			const result = await storage.getAllRegistrations();
+			expect(result).toEqual([reg]);
+		});
+
+		it('should return empty array after unregistering', async () => {
+			await storage.register(makeRegistration());
+			await storage.unregister('instance-1');
+
+			const result = await storage.getAllRegistrations();
+			expect(result).toEqual([]);
+		});
+	});
+
+	describe('getRegistration', () => {
+		it('should return null when no registration exists', async () => {
+			const result = await storage.getRegistration('instance-1');
+			expect(result).toBeNull();
+		});
+
+		it('should return null when key does not match', async () => {
+			await storage.register(makeRegistration());
+
+			const result = await storage.getRegistration('other-instance');
+			expect(result).toBeNull();
+		});
+
+		it('should return registration when key matches', async () => {
+			const reg = makeRegistration();
+			await storage.register(reg);
+
+			const result = await storage.getRegistration('instance-1');
+			expect(result).toEqual(reg);
+		});
+	});
+
+	describe('getLastKnownState', () => {
+		it('should return empty map initially', async () => {
+			const result = await storage.getLastKnownState();
+			expect(result.size).toBe(0);
+		});
+
+		it('should return a copy, not the internal reference', async () => {
+			const state = new Map<string, InstanceRegistration>();
+			state.set('instance-1', makeRegistration());
+			await storage.saveLastKnownState(state);
+
+			const result = await storage.getLastKnownState();
+			result.delete('instance-1');
+
+			const resultAfterMutation = await storage.getLastKnownState();
+			expect(resultAfterMutation.size).toBe(1);
+		});
+	});
+
+	describe('saveLastKnownState', () => {
+		it('should persist state', async () => {
+			const state = new Map<string, InstanceRegistration>();
+			const reg = makeRegistration();
+			state.set('instance-1', reg);
+
+			await storage.saveLastKnownState(state);
+
+			const result = await storage.getLastKnownState();
+			expect(result.get('instance-1')).toEqual(reg);
+		});
+
+		it('should not be affected by mutations to the input map', async () => {
+			const state = new Map<string, InstanceRegistration>();
+			state.set('instance-1', makeRegistration());
+			await storage.saveLastKnownState(state);
+
+			state.delete('instance-1');
+
+			const result = await storage.getLastKnownState();
+			expect(result.size).toBe(1);
+		});
+	});
+
+	describe('cleanupStaleMembers', () => {
+		it('should return 0', async () => {
+			const result = await storage.cleanupStaleMembers();
+			expect(result).toBe(0);
+		});
+	});
+});

--- a/packages/cli/src/modules/instance-registry/storage/memory-storage.ts
+++ b/packages/cli/src/modules/instance-registry/storage/memory-storage.ts
@@ -1,0 +1,52 @@
+import type { InstanceRegistration } from '@n8n/api-types';
+
+import type { InstanceStorage } from './instance-storage.interface';
+
+/**
+ * In-memory storage backend for single-instance deployments.
+ * Stores a single local registration with no external dependencies.
+ */
+export class MemoryInstanceStorage implements InstanceStorage {
+	readonly kind = 'memory';
+
+	private localRegistration: InstanceRegistration | null = null;
+
+	private lastKnownStateMap = new Map<string, InstanceRegistration>();
+
+	async register(registration: InstanceRegistration): Promise<void> {
+		this.localRegistration = registration;
+	}
+
+	async heartbeat(registration: InstanceRegistration): Promise<void> {
+		this.localRegistration = registration;
+	}
+
+	async unregister(instanceKey: string): Promise<void> {
+		if (this.localRegistration?.instanceKey === instanceKey) {
+			this.localRegistration = null;
+		}
+	}
+
+	async getAllRegistrations(): Promise<InstanceRegistration[]> {
+		return this.localRegistration ? [this.localRegistration] : [];
+	}
+
+	async getRegistration(instanceKey: string): Promise<InstanceRegistration | null> {
+		if (this.localRegistration?.instanceKey === instanceKey) {
+			return this.localRegistration;
+		}
+		return null;
+	}
+
+	async getLastKnownState(): Promise<Map<string, InstanceRegistration>> {
+		return new Map(this.lastKnownStateMap);
+	}
+
+	async saveLastKnownState(state: Map<string, InstanceRegistration>): Promise<void> {
+		this.lastKnownStateMap = new Map(state);
+	}
+
+	async cleanupStaleMembers(): Promise<number> {
+		return 0;
+	}
+}


### PR DESCRIPTION
## Summary

Implement `MemoryInstanceStorage` for the instance-registry module, providing
an in-memory fallback when Redis is not available. This enables the module to
work in single-instance deployments without external dependencies.

- Implements all `InstanceStorage` interface methods using pure in-memory state
- Stores a single local registration (register, heartbeat, unregister, get)
- Manages leader state via an in-memory `Map` with defensive copies
- `cleanupStaleMembers()` is a no-op returning 0
- Includes comprehensive unit tests (17 test cases)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-328

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)