### PR TITLE
feat(core): Instance ai improvements

### DIFF
--- a/packages/@n8n/api-types/src/chat-hub.ts
+++ b/packages/@n8n/api-types/src/chat-hub.ts
@@ -315,26 +315,8 @@ export const chatAttachmentSchema = z.object({
 	fileName: z.string(),
 });
 
-export const isValidTimeZone = (tz: string): boolean => {
-	try {
-		// Throws if invalid timezone
-		new Intl.DateTimeFormat('en-US', { timeZone: tz });
-		return true;
-	} catch {
-		return false;
-	}
-};
-
-export const StrictTimeZoneSchema = z
-	.string()
-	.min(1)
-	.max(50)
-	.regex(/^[A-Za-z0-9_/+-]+$/)
-	.refine(isValidTimeZone, {
-		message: 'Unknown or invalid time zone',
-	});
-
-export const TimeZoneSchema = StrictTimeZoneSchema.optional().catch(undefined);
+import { TimeZoneSchema } from './schemas/timezone.schema';
+export { isValidTimeZone, StrictTimeZoneSchema, TimeZoneSchema } from './schemas/timezone.schema';
 
 export type ChatAttachment = z.infer<typeof chatAttachmentSchema>;
 

--- a/packages/@n8n/api-types/src/chat-hub.ts
+++ b/packages/@n8n/api-types/src/chat-hub.ts
@@ -9,7 +9,10 @@ import {
 } from 'n8n-workflow';
 import { z } from 'zod';
 
+import { TimeZoneSchema } from './schemas/timezone.schema';
 import { Z } from './zod-class';
+
+export { isValidTimeZone, StrictTimeZoneSchema, TimeZoneSchema } from './schemas/timezone.schema';
 
 /**
  * Supported AI model providers
@@ -314,9 +317,6 @@ export const chatAttachmentSchema = z.object({
 	mimeType: z.string(),
 	fileName: z.string(),
 });
-
-import { TimeZoneSchema } from './schemas/timezone.schema';
-export { isValidTimeZone, StrictTimeZoneSchema, TimeZoneSchema } from './schemas/timezone.schema';
 
 export type ChatAttachment = z.infer<typeof chatAttachmentSchema>;
 

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -272,6 +272,15 @@ export {
 	domainAccessMetaSchema,
 	credentialFlowSchema,
 	InstanceAiSendMessageRequest,
+	instanceAiGatewayKeySchema,
+	InstanceAiGatewayEventsQuery,
+	InstanceAiEventsQuery,
+	InstanceAiCorrectTaskRequest,
+	InstanceAiUpdateMemoryRequest,
+	InstanceAiEnsureThreadRequest,
+	InstanceAiThreadMessagesQuery,
+	InstanceAiAdminSettingsUpdateRequest,
+	InstanceAiUserPreferencesUpdateRequest,
 } from './schemas/instance-ai.schema';
 
 export type {
@@ -323,9 +332,7 @@ export type {
 	InstanceAiRichMessagesResponse,
 	InstanceAiThreadStatusResponse,
 	InstanceAiAdminSettingsResponse,
-	InstanceAiAdminSettingsUpdateRequest,
 	InstanceAiUserPreferencesResponse,
-	InstanceAiUserPreferencesUpdateRequest,
 	InstanceAiModelCredential,
 	InstanceAiPermissionMode,
 	InstanceAiPermissions,

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -84,6 +84,8 @@ export {
 	VECTOR_STORE_PROVIDER_CREDENTIAL_TYPE_MAP,
 } from './chat-hub';
 
+export { isValidTimeZone, StrictTimeZoneSchema, TimeZoneSchema } from './schemas/timezone.schema';
+
 export type {
 	ChatHubPushMessage,
 	ChatHubStreamEvent,
@@ -269,6 +271,7 @@ export {
 	domainAccessActionSchema,
 	domainAccessMetaSchema,
 	credentialFlowSchema,
+	InstanceAiSendMessageRequest,
 } from './schemas/instance-ai.schema';
 
 export type {
@@ -303,7 +306,6 @@ export type {
 	McpToolCallResult,
 	InstanceAiEvent,
 	InstanceAiAttachment,
-	InstanceAiSendMessageRequest,
 	InstanceAiSendMessageResponse,
 	InstanceAiConfirmResponse,
 	InstanceAiToolCallState,

--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
 
+import { Z } from '../zod-class';
+import { TimeZoneSchema } from './timezone.schema';
+
 // ---------------------------------------------------------------------------
 // Branded ID types — prevent swapping runId/agentId/threadId/toolCallId
 // ---------------------------------------------------------------------------
@@ -366,19 +369,20 @@ export type InstanceAiFilesystemResponse = z.infer<typeof instanceAiFilesystemRe
 // API types
 // ---------------------------------------------------------------------------
 
-export interface InstanceAiAttachment {
-	data: string;
-	mimeType: string;
-	fileName: string;
-}
+const instanceAiAttachmentSchema = z.object({
+	data: z.string(),
+	mimeType: z.string(),
+	fileName: z.string(),
+});
 
-export interface InstanceAiSendMessageRequest {
-	message: string;
-	researchMode?: boolean;
-	attachments?: InstanceAiAttachment[];
-	/** IANA time zone identifier from the client (e.g. "Europe/Helsinki") */
-	timeZone?: string;
-}
+export type InstanceAiAttachment = z.infer<typeof instanceAiAttachmentSchema>;
+
+export class InstanceAiSendMessageRequest extends Z.class({
+	message: z.string().min(1),
+	researchMode: z.boolean().optional(),
+	attachments: z.array(instanceAiAttachmentSchema).optional(),
+	timeZone: TimeZoneSchema,
+}) {}
 
 export interface InstanceAiSendMessageResponse {
 	runId: string;

--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -376,6 +376,8 @@ export interface InstanceAiSendMessageRequest {
 	message: string;
 	researchMode?: boolean;
 	attachments?: InstanceAiAttachment[];
+	/** IANA time zone identifier from the client (e.g. "Europe/Helsinki") */
+	timeZone?: string;
 }
 
 export interface InstanceAiSendMessageResponse {

--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -384,6 +384,34 @@ export class InstanceAiSendMessageRequest extends Z.class({
 	timeZone: TimeZoneSchema,
 }) {}
 
+export class InstanceAiCorrectTaskRequest extends Z.class({
+	message: z.string().min(1),
+}) {}
+
+export class InstanceAiUpdateMemoryRequest extends Z.class({
+	content: z.string(),
+}) {}
+
+export class InstanceAiEnsureThreadRequest extends Z.class({
+	threadId: z.string().uuid().optional(),
+}) {}
+
+export const instanceAiGatewayKeySchema = z.string().min(1).max(256);
+
+export class InstanceAiGatewayEventsQuery extends Z.class({
+	apiKey: instanceAiGatewayKeySchema,
+}) {}
+
+export class InstanceAiEventsQuery extends Z.class({
+	lastEventId: z.coerce.number().int().nonnegative().optional(),
+}) {}
+
+export class InstanceAiThreadMessagesQuery extends Z.class({
+	limit: z.coerce.number().int().positive().default(50),
+	page: z.coerce.number().int().nonnegative().default(0),
+	raw: z.enum(['true', 'false']).optional(),
+}) {}
+
 export interface InstanceAiSendMessageResponse {
 	runId: string;
 }
@@ -575,25 +603,29 @@ export interface InstanceAiThreadStatusResponse {
 // Settings types (runtime-configurable subset of InstanceAiConfig)
 // ---------------------------------------------------------------------------
 
-export type InstanceAiPermissionMode = 'require_approval' | 'always_allow';
+const instanceAiPermissionModeSchema = z.enum(['require_approval', 'always_allow']);
 
-export interface InstanceAiPermissions {
-	runWorkflow: InstanceAiPermissionMode;
-	publishWorkflow: InstanceAiPermissionMode;
-	deleteWorkflow: InstanceAiPermissionMode;
-	deleteCredential: InstanceAiPermissionMode;
-	createFolder: InstanceAiPermissionMode;
-	deleteFolder: InstanceAiPermissionMode;
-	moveWorkflowToFolder: InstanceAiPermissionMode;
-	tagWorkflow: InstanceAiPermissionMode;
-	createDataTable: InstanceAiPermissionMode;
-	mutateDataTableSchema: InstanceAiPermissionMode;
-	mutateDataTableRows: InstanceAiPermissionMode;
-	cleanupTestExecutions: InstanceAiPermissionMode;
-	readFilesystem: InstanceAiPermissionMode;
-	fetchUrl: InstanceAiPermissionMode;
-	restoreWorkflowVersion: InstanceAiPermissionMode;
-}
+export type InstanceAiPermissionMode = z.infer<typeof instanceAiPermissionModeSchema>;
+
+const instanceAiPermissionsSchema = z.object({
+	runWorkflow: instanceAiPermissionModeSchema,
+	publishWorkflow: instanceAiPermissionModeSchema,
+	deleteWorkflow: instanceAiPermissionModeSchema,
+	deleteCredential: instanceAiPermissionModeSchema,
+	createFolder: instanceAiPermissionModeSchema,
+	deleteFolder: instanceAiPermissionModeSchema,
+	moveWorkflowToFolder: instanceAiPermissionModeSchema,
+	tagWorkflow: instanceAiPermissionModeSchema,
+	createDataTable: instanceAiPermissionModeSchema,
+	mutateDataTableSchema: instanceAiPermissionModeSchema,
+	mutateDataTableRows: instanceAiPermissionModeSchema,
+	cleanupTestExecutions: instanceAiPermissionModeSchema,
+	readFilesystem: instanceAiPermissionModeSchema,
+	fetchUrl: instanceAiPermissionModeSchema,
+	restoreWorkflowVersion: instanceAiPermissionModeSchema,
+});
+
+export type InstanceAiPermissions = z.infer<typeof instanceAiPermissionsSchema>;
 
 export const DEFAULT_INSTANCE_AI_PERMISSIONS: InstanceAiPermissions = {
 	runWorkflow: 'require_approval',
@@ -634,22 +666,22 @@ export interface InstanceAiAdminSettingsResponse {
 	searchCredentialId: string | null;
 }
 
-export interface InstanceAiAdminSettingsUpdateRequest {
-	lastMessages?: number;
-	embedderModel?: string;
-	semanticRecallTopK?: number;
-	timeout?: number;
-	subAgentMaxSteps?: number;
-	browserMcp?: boolean;
-	permissions?: Partial<InstanceAiPermissions>;
-	mcpServers?: string;
-	sandboxEnabled?: boolean;
-	sandboxProvider?: string;
-	sandboxImage?: string;
-	sandboxTimeout?: number;
-	daytonaCredentialId?: string | null;
-	searchCredentialId?: string | null;
-}
+export class InstanceAiAdminSettingsUpdateRequest extends Z.class({
+	lastMessages: z.number().int().positive().optional(),
+	embedderModel: z.string().optional(),
+	semanticRecallTopK: z.number().int().positive().optional(),
+	timeout: z.number().int().positive().optional(),
+	subAgentMaxSteps: z.number().int().positive().optional(),
+	browserMcp: z.boolean().optional(),
+	permissions: instanceAiPermissionsSchema.partial().optional(),
+	mcpServers: z.string().optional(),
+	sandboxEnabled: z.boolean().optional(),
+	sandboxProvider: z.string().optional(),
+	sandboxImage: z.string().optional(),
+	sandboxTimeout: z.number().int().positive().optional(),
+	daytonaCredentialId: z.string().nullable().optional(),
+	searchCredentialId: z.string().nullable().optional(),
+}) {}
 
 // ---------------------------------------------------------------------------
 // User preferences — per-user, self-service
@@ -663,11 +695,11 @@ export interface InstanceAiUserPreferencesResponse {
 	filesystemDisabled: boolean;
 }
 
-export interface InstanceAiUserPreferencesUpdateRequest {
-	credentialId?: string | null;
-	modelName?: string;
-	filesystemDisabled?: boolean;
-}
+export class InstanceAiUserPreferencesUpdateRequest extends Z.class({
+	credentialId: z.string().nullable().optional(),
+	modelName: z.string().optional(),
+	filesystemDisabled: z.boolean().optional(),
+}) {}
 
 export interface InstanceAiModelCredential {
 	id: string;

--- a/packages/@n8n/api-types/src/schemas/timezone.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/timezone.schema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const isValidTimeZone = (tz: string): boolean => {
+	try {
+		// Throws if invalid timezone
+		new Intl.DateTimeFormat('en-US', { timeZone: tz });
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+export const StrictTimeZoneSchema = z
+	.string()
+	.min(1)
+	.max(50)
+	.regex(/^[A-Za-z0-9_/+-]+$/)
+	.refine(isValidTimeZone, {
+		message: 'Unknown or invalid time zone',
+	});
+
+export const TimeZoneSchema = StrictTimeZoneSchema.optional().catch(undefined);

--- a/packages/@n8n/instance-ai/package.json
+++ b/packages/@n8n/instance-ai/package.json
@@ -35,6 +35,7 @@
     "@n8n/api-types": "workspace:*",
     "@n8n/utils": "workspace:*",
     "@n8n/workflow-sdk": "workspace:*",
+    "luxon": "catalog:",
     "nanoid": "catalog:",
     "zod": "catalog:",
     "@mozilla/readability": "^0.6.0",
@@ -46,6 +47,7 @@
   },
   "devDependencies": {
     "@n8n/typescript-config": "workspace:*",
+    "@types/luxon": "3.2.0",
     "@types/turndown": "^5.0.5"
   }
 }

--- a/packages/@n8n/instance-ai/src/agent/instance-agent.ts
+++ b/packages/@n8n/instance-ai/src/agent/instance-agent.ts
@@ -269,6 +269,7 @@ export async function createInstanceAgent(options: CreateInstanceAgentOptions): 
 				filesystemAccess: !!(context.localMcpServer ?? context.filesystemService),
 				toolSearchEnabled: hasDeferrableTools,
 				licenseHints: context.licenseHints,
+				timeZone: options.timeZone,
 			}),
 			providerOptions: {
 				anthropic: { cacheControl: { type: 'ephemeral' } },

--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -1,3 +1,5 @@
+import { DateTime } from 'luxon';
+
 interface SystemPromptOptions {
 	researchMode?: boolean;
 	webhookBaseUrl?: string;
@@ -5,13 +7,27 @@ interface SystemPromptOptions {
 	toolSearchEnabled?: boolean;
 	/** Human-readable hints about licensed features that are NOT available on this instance. */
 	licenseHints?: string[];
+	/** IANA time zone identifier for the current user (e.g. "Europe/Helsinki"). */
+	timeZone?: string;
 }
 
 export function getSystemPrompt(options: SystemPromptOptions = {}): string {
-	const { researchMode, webhookBaseUrl, filesystemAccess, toolSearchEnabled, licenseHints } =
-		options;
+	const {
+		researchMode,
+		webhookBaseUrl,
+		filesystemAccess,
+		toolSearchEnabled,
+		licenseHints,
+		timeZone,
+	} = options;
+
+	const now = timeZone ? DateTime.now().setZone(timeZone) : DateTime.now();
+	const isoTime = now.toISO({ includeOffset: true });
+	const tzLabel = timeZone ? ` (timezone: ${timeZone})` : '';
+	const dateTimeBlock = `\n## Current Date and Time\n\nThe user's current local date and time is: ${isoTime}${tzLabel}.\nWhen you need to reference "now", use this date and time.\n`;
+
 	return `You are the n8n Instance Agent — an AI assistant embedded in an n8n instance. You help users build, run, debug, and manage workflows through natural language.
-${webhookBaseUrl ? `\n## Instance Info\n\nWebhook base URL: ${webhookBaseUrl}\nWhen a workflow has webhook triggers, its live URL is: ${webhookBaseUrl}/{path} (where {path} is the webhook path parameter). Always share the full webhook URL with the user after a workflow with webhooks is created.\n\n**This URL is for sharing with the user only.** Do NOT include it in \`build-workflow-with-agent\` task descriptions — the builder cannot reach the n8n instance via HTTP and will fail if it tries to curl/fetch this URL.\n` : ''}
+${dateTimeBlock}${webhookBaseUrl ? `\n## Instance Info\n\nWebhook base URL: ${webhookBaseUrl}\nWhen a workflow has webhook triggers, its live URL is: ${webhookBaseUrl}/{path} (where {path} is the webhook path parameter). Always share the full webhook URL with the user after a workflow with webhooks is created.\n\n**This URL is for sharing with the user only.** Do NOT include it in \`build-workflow-with-agent\` task descriptions — the builder cannot reach the n8n instance via HTTP and will fail if it tries to curl/fetch this URL.\n` : ''}
 
 You have access to workflow, execution, and credential tools plus a specialized workflow builder. You also have delegation capabilities for complex tasks, and may have access to MCP tools for extended capabilities.
 

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -669,4 +669,6 @@ export interface CreateInstanceAgentOptions {
 	workspace?: Workspace;
 	/** When true, all tools are loaded eagerly (no ToolSearchProcessor). Workaround for Mastra bug where toModelOutput is not called for deferred tools. */
 	disableDeferredTools?: boolean;
+	/** IANA time zone for the current user (e.g. "Europe/Helsinki"). Falls back to instance default. */
+	timeZone?: string;
 }

--- a/packages/@n8n/permissions/src/__tests__/__snapshots__/scope-information.test.ts.snap
+++ b/packages/@n8n/permissions/src/__tests__/__snapshots__/scope-information.test.ts.snap
@@ -179,6 +179,10 @@ exports[`Scope Information ensure scopes are defined correctly 1`] = `
   "credentialResolver:delete",
   "credentialResolver:list",
   "credentialResolver:*",
+  "instanceAi:message",
+  "instanceAi:manage",
+  "instanceAi:gateway",
+  "instanceAi:*",
   "*",
 ]
 `;

--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -59,6 +59,7 @@ export const RESOURCES = {
 	breakingChanges: ['list'] as const,
 	apiKey: ['manage'] as const,
 	credentialResolver: [...DEFAULT_OPERATIONS] as const,
+	instanceAi: ['message', 'manage', 'gateway'] as const,
 } as const;
 
 export const API_KEY_RESOURCES = {

--- a/packages/@n8n/permissions/src/roles/scopes/global-scopes.ee.ts
+++ b/packages/@n8n/permissions/src/roles/scopes/global-scopes.ee.ts
@@ -127,6 +127,9 @@ export const GLOBAL_OWNER_SCOPES: Scope[] = [
 	'credentialResolver:update',
 	'credentialResolver:delete',
 	'credentialResolver:list',
+	'instanceAi:message',
+	'instanceAi:manage',
+	'instanceAi:gateway',
 ];
 
 export const GLOBAL_ADMIN_SCOPES = GLOBAL_OWNER_SCOPES.concat();
@@ -158,6 +161,8 @@ export const GLOBAL_MEMBER_SCOPES: Scope[] = [
 	'chatHubAgent:list',
 	'apiKey:manage',
 	'credentialResolver:list',
+	'instanceAi:message',
+	'instanceAi:gateway',
 ];
 
 export const GLOBAL_CHAT_USER_SCOPES: Scope[] = [

--- a/packages/@n8n/permissions/src/utilities/__tests__/get-resource-permissions.test.ts
+++ b/packages/@n8n/permissions/src/utilities/__tests__/get-resource-permissions.test.ts
@@ -46,6 +46,7 @@ describe('permissions', () => {
 			breakingChanges: {},
 			apiKey: {},
 			credentialResolver: {},
+			instanceAi: {},
 		});
 	});
 	it('getResourcePermissions', () => {
@@ -169,6 +170,7 @@ describe('permissions', () => {
 				manage: true,
 			},
 			credentialResolver: {},
+			instanceAi: {},
 		};
 
 		expect(getResourcePermissions(scopes)).toEqual(permissionRecord);

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.controller.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.controller.test.ts
@@ -1,0 +1,670 @@
+import { z } from 'zod';
+
+jest.mock('@n8n/instance-ai', () => ({
+	createMemory: jest.fn(),
+	WORKING_MEMORY_TEMPLATE: '',
+	workflowLoopStateSchema: z.string(),
+	attemptRecordSchema: z.object({}),
+	workflowBuildOutcomeSchema: z.string(),
+}));
+
+import type {
+	InstanceAiSendMessageRequest,
+	InstanceAiCorrectTaskRequest,
+	InstanceAiConfirmRequestDto,
+	InstanceAiUpdateMemoryRequest,
+	InstanceAiEnsureThreadRequest,
+	InstanceAiThreadMessagesQuery,
+	InstanceAiUserPreferencesUpdateRequest,
+	InstanceAiUserPreferencesResponse,
+	InstanceAiRenameThreadRequestDto,
+	InstanceAiEnsureThreadResponse,
+	InstanceAiThreadInfo,
+	InstanceAiRichMessagesResponse,
+	InstanceAiThreadMessagesResponse,
+} from '@n8n/api-types';
+import type { ModuleRegistry } from '@n8n/backend-common';
+import type { GlobalConfig } from '@n8n/config';
+import type { AuthenticatedRequest } from '@n8n/db';
+import { ControllerRegistryMetadata } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+import type { Scope } from '@n8n/permissions';
+import type { Request, Response } from 'express';
+import { mock } from 'jest-mock-extended';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ConflictError } from '@/errors/response-errors/conflict.error';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import type { Push } from '@/push';
+
+import type { InProcessEventBus } from '../event-bus/in-process-event-bus';
+import type { InstanceAiMemoryService } from '../instance-ai-memory.service';
+import type { InstanceAiSettingsService } from '../instance-ai-settings.service';
+import { InstanceAiController } from '../instance-ai.controller';
+import type { InstanceAiService } from '../instance-ai.service';
+
+const USER_ID = 'user-1';
+const THREAD_ID = 'thread-1';
+
+const routeMetadata = Container.get(ControllerRegistryMetadata);
+
+// Scope metadata helper, reads the decorator metadata that @GlobalScope writes at class-definition time.
+function scopeOf(handlerName: string): { scope: Scope; globalOnly: boolean } | undefined {
+	const route = routeMetadata.getRouteMetadata(
+		InstanceAiController as unknown as Parameters<typeof routeMetadata.getRouteMetadata>[0],
+		handlerName,
+	);
+	return route.accessScope;
+}
+
+describe('InstanceAiController', () => {
+	const instanceAiService = mock<InstanceAiService>();
+	const memoryService = mock<InstanceAiMemoryService>();
+	const settingsService = mock<InstanceAiSettingsService>();
+	const eventBus = mock<InProcessEventBus>();
+	const moduleRegistry = mock<ModuleRegistry>();
+	const push = mock<Push>();
+	const globalConfig = mock<GlobalConfig>({
+		instanceAi: { gatewayApiKey: 'static-key' },
+		editorBaseUrl: 'http://localhost:5678',
+		port: 5678,
+	});
+
+	const controller = new InstanceAiController(
+		instanceAiService,
+		memoryService,
+		settingsService,
+		eventBus,
+		moduleRegistry,
+		push,
+		globalConfig,
+	);
+
+	const req = mock<AuthenticatedRequest>({ user: { id: USER_ID } });
+	const res = mock<Response>();
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('chat', () => {
+		const payload = mock<InstanceAiSendMessageRequest>({
+			message: 'hello',
+			researchMode: false,
+			timeZone: 'Europe/Helsinki',
+		});
+
+		it('should require instanceAi:message scope', () => {
+			expect(scopeOf('chat')).toEqual({ scope: 'instanceAi:message', globalOnly: true });
+		});
+
+		it('should start a run and return runId', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('owned');
+			instanceAiService.hasActiveRun.mockReturnValue(false);
+			instanceAiService.startRun.mockReturnValue('run-1');
+
+			const result = await controller.chat(req, res, THREAD_ID, payload);
+
+			expect(result).toEqual({ runId: 'run-1' });
+			expect(instanceAiService.startRun).toHaveBeenCalledWith(
+				req.user,
+				THREAD_ID,
+				payload.message,
+				payload.researchMode,
+				payload.attachments,
+				payload.timeZone,
+			);
+		});
+
+		it('should allow new threads', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('not_found');
+			instanceAiService.hasActiveRun.mockReturnValue(false);
+			instanceAiService.startRun.mockReturnValue('run-1');
+
+			await expect(controller.chat(req, res, THREAD_ID, payload)).resolves.toEqual({
+				runId: 'run-1',
+			});
+		});
+
+		it('should throw ConflictError when a run is already active', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('owned');
+			instanceAiService.hasActiveRun.mockReturnValue(true);
+
+			await expect(controller.chat(req, res, THREAD_ID, payload)).rejects.toThrow(ConflictError);
+		});
+
+		it('should throw ForbiddenError when thread belongs to another user', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('other_user');
+
+			await expect(controller.chat(req, res, THREAD_ID, payload)).rejects.toThrow(ForbiddenError);
+		});
+	});
+
+	describe('events', () => {
+		it('should require instanceAi:message scope', () => {
+			expect(scopeOf('events')).toEqual({ scope: 'instanceAi:message', globalOnly: true });
+		});
+	});
+
+	describe('cancel', () => {
+		it('should require instanceAi:message scope', () => {
+			expect(scopeOf('cancel')).toEqual({ scope: 'instanceAi:message', globalOnly: true });
+		});
+
+		it('should cancel the run', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('owned');
+
+			const result = await controller.cancel(req, res, THREAD_ID);
+
+			expect(result).toEqual({ ok: true });
+			expect(instanceAiService.cancelRun).toHaveBeenCalledWith(THREAD_ID);
+		});
+
+		it('should throw ForbiddenError for other user thread', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('other_user');
+
+			await expect(controller.cancel(req, res, THREAD_ID)).rejects.toThrow(ForbiddenError);
+		});
+
+		it('should throw NotFoundError for missing thread', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('not_found');
+
+			await expect(controller.cancel(req, res, THREAD_ID)).rejects.toThrow(NotFoundError);
+		});
+	});
+
+	describe('cancelTask', () => {
+		it('should require instanceAi:message scope', () => {
+			expect(scopeOf('cancelTask')).toEqual({ scope: 'instanceAi:message', globalOnly: true });
+		});
+
+		it('should cancel the background task', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('owned');
+
+			const result = await controller.cancelTask(req, res, THREAD_ID, 'task-1');
+
+			expect(result).toEqual({ ok: true });
+			expect(instanceAiService.cancelBackgroundTask).toHaveBeenCalledWith(THREAD_ID, 'task-1');
+		});
+	});
+
+	describe('correctTask', () => {
+		it('should require instanceAi:message scope', () => {
+			expect(scopeOf('correctTask')).toEqual({ scope: 'instanceAi:message', globalOnly: true });
+		});
+
+		it('should send correction to the task', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('owned');
+			const payload = mock<InstanceAiCorrectTaskRequest>({ message: 'fix this' });
+
+			const result = await controller.correctTask(req, res, THREAD_ID, 'task-1', payload);
+
+			expect(result).toEqual({ ok: true });
+			expect(instanceAiService.sendCorrectionToTask).toHaveBeenCalledWith('task-1', 'fix this');
+		});
+	});
+
+	describe('confirm', () => {
+		it('should require instanceAi:message scope', () => {
+			expect(scopeOf('confirm')).toEqual({ scope: 'instanceAi:message', globalOnly: true });
+		});
+
+		it('should resolve confirmation', async () => {
+			instanceAiService.resolveConfirmation.mockResolvedValue(true);
+			const body = mock<InstanceAiConfirmRequestDto>({ approved: true });
+
+			const result = await controller.confirm(req, res, 'req-1', body);
+
+			expect(result).toEqual({ ok: true });
+			expect(instanceAiService.resolveConfirmation).toHaveBeenCalledWith(
+				USER_ID,
+				'req-1',
+				expect.objectContaining({ approved: true }),
+			);
+		});
+
+		it('should throw NotFoundError when confirmation not found', async () => {
+			instanceAiService.resolveConfirmation.mockResolvedValue(false);
+			const body = mock<InstanceAiConfirmRequestDto>({ approved: false });
+
+			await expect(controller.confirm(req, res, 'req-1', body)).rejects.toThrow(NotFoundError);
+		});
+	});
+
+	describe('getAdminSettings', () => {
+		it('should require instanceAi:manage scope', () => {
+			expect(scopeOf('getAdminSettings')).toEqual({
+				scope: 'instanceAi:manage',
+				globalOnly: true,
+			});
+		});
+	});
+
+	describe('updateAdminSettings', () => {
+		it('should require instanceAi:manage scope', () => {
+			expect(scopeOf('updateAdminSettings')).toEqual({
+				scope: 'instanceAi:manage',
+				globalOnly: true,
+			});
+		});
+	});
+
+	describe('getUserPreferences', () => {
+		it('should require instanceAi:message scope', () => {
+			expect(scopeOf('getUserPreferences')).toEqual({
+				scope: 'instanceAi:message',
+				globalOnly: true,
+			});
+		});
+	});
+
+	describe('updateUserPreferences', () => {
+		it('should require instanceAi:message scope', () => {
+			expect(scopeOf('updateUserPreferences')).toEqual({
+				scope: 'instanceAi:message',
+				globalOnly: true,
+			});
+		});
+
+		it('should refresh module settings when filesystemDisabled changes', async () => {
+			const payload = mock<InstanceAiUserPreferencesUpdateRequest>({
+				filesystemDisabled: true,
+			});
+			settingsService.updateUserPreferences.mockResolvedValue(
+				mock<InstanceAiUserPreferencesResponse>(),
+			);
+
+			await controller.updateUserPreferences(req, res, payload);
+
+			expect(moduleRegistry.refreshModuleSettings).toHaveBeenCalledWith('instance-ai');
+		});
+
+		it('should not refresh module settings when filesystemDisabled is not in payload', async () => {
+			const payload = mock<InstanceAiUserPreferencesUpdateRequest>({
+				filesystemDisabled: undefined,
+			});
+			settingsService.updateUserPreferences.mockResolvedValue(
+				mock<InstanceAiUserPreferencesResponse>(),
+			);
+
+			await controller.updateUserPreferences(req, res, payload);
+
+			expect(moduleRegistry.refreshModuleSettings).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('listModelCredentials', () => {
+		it('should require instanceAi:message scope', () => {
+			expect(scopeOf('listModelCredentials')).toEqual({
+				scope: 'instanceAi:message',
+				globalOnly: true,
+			});
+		});
+	});
+
+	describe('listServiceCredentials', () => {
+		it('should require instanceAi:manage scope', () => {
+			expect(scopeOf('listServiceCredentials')).toEqual({
+				scope: 'instanceAi:manage',
+				globalOnly: true,
+			});
+		});
+	});
+
+	describe('getMemory', () => {
+		it('should require instanceAi:message scope', () => {
+			expect(scopeOf('getMemory')).toEqual({ scope: 'instanceAi:message', globalOnly: true });
+		});
+	});
+
+	describe('updateMemory', () => {
+		it('should require instanceAi:message scope', () => {
+			expect(scopeOf('updateMemory')).toEqual({ scope: 'instanceAi:message', globalOnly: true });
+		});
+
+		it('should update working memory', async () => {
+			const payload = mock<InstanceAiUpdateMemoryRequest>({ content: 'new memory' });
+
+			const result = await controller.updateMemory(req, res, THREAD_ID, payload);
+
+			expect(result).toEqual({ ok: true });
+			expect(memoryService.updateWorkingMemory).toHaveBeenCalledWith(
+				USER_ID,
+				THREAD_ID,
+				'new memory',
+			);
+		});
+	});
+
+	describe('listThreads', () => {
+		it('should require instanceAi:message scope', () => {
+			expect(scopeOf('listThreads')).toEqual({ scope: 'instanceAi:message', globalOnly: true });
+		});
+	});
+
+	describe('ensureThread', () => {
+		it('should require instanceAi:message scope', () => {
+			expect(scopeOf('ensureThread')).toEqual({ scope: 'instanceAi:message', globalOnly: true });
+		});
+
+		it('should create thread with provided threadId', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('not_found');
+			const threadResult = mock<InstanceAiEnsureThreadResponse>();
+			memoryService.ensureThread.mockResolvedValue(threadResult);
+			const payload = mock<InstanceAiEnsureThreadRequest>({ threadId: 'custom-id' });
+
+			const result = await controller.ensureThread(req, res, payload);
+
+			expect(result).toBe(threadResult);
+			expect(memoryService.ensureThread).toHaveBeenCalledWith(USER_ID, 'custom-id');
+		});
+
+		it('should generate a UUID when threadId is not provided', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('not_found');
+			memoryService.ensureThread.mockResolvedValue(mock<InstanceAiEnsureThreadResponse>());
+			const payload = mock<InstanceAiEnsureThreadRequest>({ threadId: undefined });
+
+			await controller.ensureThread(req, res, payload);
+
+			// The controller generates a UUID — just verify ensureThread was called with some string
+			expect(memoryService.ensureThread).toHaveBeenCalledWith(USER_ID, expect.any(String));
+		});
+	});
+
+	describe('deleteThread', () => {
+		it('should require instanceAi:message scope', () => {
+			expect(scopeOf('deleteThread')).toEqual({ scope: 'instanceAi:message', globalOnly: true });
+		});
+
+		it('should delete thread', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('owned');
+
+			const result = await controller.deleteThread(req, res, THREAD_ID);
+
+			expect(result).toEqual({ ok: true });
+			expect(memoryService.deleteThread).toHaveBeenCalledWith(USER_ID, THREAD_ID);
+		});
+
+		it('should throw ForbiddenError for other user thread', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('other_user');
+
+			await expect(controller.deleteThread(req, res, THREAD_ID)).rejects.toThrow(ForbiddenError);
+		});
+
+		it('should throw NotFoundError for missing thread', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('not_found');
+
+			await expect(controller.deleteThread(req, res, THREAD_ID)).rejects.toThrow(NotFoundError);
+		});
+	});
+
+	describe('renameThread', () => {
+		it('should require instanceAi:message scope', () => {
+			expect(scopeOf('renameThread')).toEqual({ scope: 'instanceAi:message', globalOnly: true });
+		});
+
+		it('should rename thread', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('owned');
+			const threadObj = mock<InstanceAiThreadInfo>();
+			memoryService.renameThread.mockResolvedValue(threadObj);
+			const payload = mock<InstanceAiRenameThreadRequestDto>({ title: 'New Title' });
+
+			const result = await controller.renameThread(req, res, THREAD_ID, payload);
+
+			expect(result).toEqual({ thread: threadObj });
+			expect(memoryService.renameThread).toHaveBeenCalledWith(USER_ID, THREAD_ID, 'New Title');
+		});
+	});
+
+	describe('getThreadMessages', () => {
+		it('should require instanceAi:message scope', () => {
+			expect(scopeOf('getThreadMessages')).toEqual({
+				scope: 'instanceAi:message',
+				globalOnly: true,
+			});
+		});
+
+		it('should return rich messages with nextEventId', async () => {
+			const richResult = mock<Omit<InstanceAiRichMessagesResponse, 'nextEventId'>>();
+			memoryService.getRichMessages.mockResolvedValue(richResult);
+			eventBus.getNextEventId.mockReturnValue(42);
+			const query = mock<InstanceAiThreadMessagesQuery>({
+				limit: 50,
+				page: 0,
+				raw: undefined,
+			});
+
+			const result = await controller.getThreadMessages(req, res, THREAD_ID, query);
+
+			expect(result).toMatchObject({ nextEventId: 42 });
+			expect(memoryService.getRichMessages).toHaveBeenCalledWith(USER_ID, THREAD_ID, {
+				limit: 50,
+				page: 0,
+			});
+		});
+
+		it('should return raw messages when raw=true', async () => {
+			const rawResult = mock<InstanceAiThreadMessagesResponse>();
+			memoryService.getThreadMessages.mockResolvedValue(rawResult);
+			const query = mock<InstanceAiThreadMessagesQuery>({
+				limit: 50,
+				page: 0,
+				raw: 'true',
+			});
+
+			const result = await controller.getThreadMessages(req, res, THREAD_ID, query);
+
+			expect(result).toBe(rawResult);
+			expect(memoryService.getThreadMessages).toHaveBeenCalledWith(USER_ID, THREAD_ID, {
+				limit: 50,
+				page: 0,
+			});
+			expect(memoryService.getRichMessages).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('getThreadStatus', () => {
+		it('should require instanceAi:message scope', () => {
+			expect(scopeOf('getThreadStatus')).toEqual({
+				scope: 'instanceAi:message',
+				globalOnly: true,
+			});
+		});
+	});
+
+	describe('getThreadContext', () => {
+		it('should require instanceAi:message scope', () => {
+			expect(scopeOf('getThreadContext')).toEqual({
+				scope: 'instanceAi:message',
+				globalOnly: true,
+			});
+		});
+	});
+
+	describe('createGatewayLink', () => {
+		it('should require instanceAi:gateway scope', () => {
+			expect(scopeOf('createGatewayLink')).toEqual({
+				scope: 'instanceAi:gateway',
+				globalOnly: true,
+			});
+		});
+
+		it('should return token and command', async () => {
+			instanceAiService.generatePairingToken.mockReturnValue('pairing-token');
+
+			const result = await controller.createGatewayLink(req);
+
+			expect(result).toEqual({
+				token: 'pairing-token',
+				command: 'npx @n8n/fs-proxy http://localhost:5678 pairing-token',
+			});
+			expect(instanceAiService.generatePairingToken).toHaveBeenCalledWith(USER_ID);
+		});
+	});
+
+	describe('gatewayInit', () => {
+		const makeGatewayReq = (key: string | undefined, body: unknown) =>
+			({ headers: key ? { 'x-gateway-key': key } : {}, body }) as unknown as Request;
+
+		it('should have no access scope (skipAuth)', () => {
+			expect(scopeOf('gatewayInit')).toBeUndefined();
+		});
+
+		it('should initialize gateway with valid key and body', () => {
+			instanceAiService.getUserIdForApiKey.mockReturnValue(USER_ID);
+			instanceAiService.consumePairingToken.mockReturnValue(null);
+			const gatewayReq = makeGatewayReq('session-key', { rootPath: '/home/user' });
+
+			const result = controller.gatewayInit(gatewayReq);
+
+			expect(result).toEqual({ ok: true });
+			expect(instanceAiService.initGateway).toHaveBeenCalledWith(
+				USER_ID,
+				expect.objectContaining({ rootPath: '/home/user' }),
+			);
+			expect(push.sendToUsers).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'instanceAiGatewayStateChanged',
+					data: { connected: true, directory: '/home/user' },
+				}),
+				[USER_ID],
+			);
+		});
+
+		it('should return sessionKey when pairing token is consumed', () => {
+			instanceAiService.getUserIdForApiKey.mockReturnValue(USER_ID);
+			instanceAiService.consumePairingToken.mockReturnValue('new-session-key');
+			const gatewayReq = makeGatewayReq('pairing-token', { rootPath: '/tmp' });
+
+			const result = controller.gatewayInit(gatewayReq);
+
+			expect(result).toEqual({ ok: true, sessionKey: 'new-session-key' });
+		});
+
+		it('should accept static env var key', () => {
+			instanceAiService.consumePairingToken.mockReturnValue(null);
+			const gatewayReq = makeGatewayReq('static-key', { rootPath: '/tmp' });
+
+			const result = controller.gatewayInit(gatewayReq);
+
+			expect(result).toEqual({ ok: true });
+			expect(instanceAiService.initGateway).toHaveBeenCalledWith('env-gateway', expect.anything());
+		});
+
+		it('should throw ForbiddenError with missing API key', () => {
+			const gatewayReq = makeGatewayReq(undefined, { rootPath: '/tmp' });
+
+			expect(() => controller.gatewayInit(gatewayReq)).toThrow(ForbiddenError);
+		});
+
+		it('should throw ForbiddenError with invalid API key', () => {
+			instanceAiService.getUserIdForApiKey.mockReturnValue(undefined);
+			const gatewayReq = makeGatewayReq('wrong-key', { rootPath: '/tmp' });
+
+			expect(() => controller.gatewayInit(gatewayReq)).toThrow(ForbiddenError);
+		});
+
+		it('should throw BadRequestError when body fails schema validation', () => {
+			instanceAiService.getUserIdForApiKey.mockReturnValue(USER_ID);
+			const gatewayReq = makeGatewayReq('session-key', { unexpected: 123 });
+
+			expect(() => controller.gatewayInit(gatewayReq)).toThrow(BadRequestError);
+		});
+	});
+
+	describe('gatewayEvents', () => {
+		it('should have no access scope (skipAuth)', () => {
+			expect(scopeOf('gatewayEvents')).toBeUndefined();
+		});
+	});
+
+	describe('gatewayResponse', () => {
+		const makeGatewayReq = (key: string, body: unknown) =>
+			({ headers: { 'x-gateway-key': key }, body }) as unknown as Request;
+
+		it('should have no access scope (skipAuth)', () => {
+			expect(scopeOf('gatewayResponse')).toBeUndefined();
+		});
+
+		it('should resolve gateway request', () => {
+			instanceAiService.getUserIdForApiKey.mockReturnValue(USER_ID);
+			instanceAiService.resolveGatewayRequest.mockReturnValue(true);
+			const gatewayReq = makeGatewayReq('session-key', { result: { content: [] } });
+
+			const result = controller.gatewayResponse(gatewayReq, res, 'req-1');
+
+			expect(result).toEqual({ ok: true });
+			expect(instanceAiService.resolveGatewayRequest).toHaveBeenCalledWith(
+				USER_ID,
+				'req-1',
+				{ content: [] },
+				undefined,
+			);
+		});
+
+		it('should throw NotFoundError when request not found', () => {
+			instanceAiService.getUserIdForApiKey.mockReturnValue(USER_ID);
+			instanceAiService.resolveGatewayRequest.mockReturnValue(false);
+			const gatewayReq = makeGatewayReq('session-key', { result: { content: [] } });
+
+			expect(() => controller.gatewayResponse(gatewayReq, res, 'req-1')).toThrow(NotFoundError);
+		});
+
+		it('should throw BadRequestError when body fails schema validation', () => {
+			instanceAiService.getUserIdForApiKey.mockReturnValue(USER_ID);
+			const gatewayReq = makeGatewayReq('session-key', { result: 'not-an-object' });
+
+			expect(() => controller.gatewayResponse(gatewayReq, res, 'req-1')).toThrow(BadRequestError);
+		});
+	});
+
+	describe('gatewayDisconnect', () => {
+		it('should have no access scope (skipAuth)', () => {
+			expect(scopeOf('gatewayDisconnect')).toBeUndefined();
+		});
+
+		it('should disconnect gateway and send push notification', () => {
+			instanceAiService.getUserIdForApiKey.mockReturnValue(USER_ID);
+			const gatewayReq = {
+				headers: { 'x-gateway-key': 'session-key' },
+			} as unknown as Request;
+
+			const result = controller.gatewayDisconnect(gatewayReq);
+
+			expect(result).toEqual({ ok: true });
+			expect(instanceAiService.clearDisconnectTimer).toHaveBeenCalledWith(USER_ID);
+			expect(instanceAiService.disconnectGateway).toHaveBeenCalledWith(USER_ID);
+			expect(instanceAiService.clearActiveSessionKey).toHaveBeenCalledWith(USER_ID);
+			expect(push.sendToUsers).toHaveBeenCalledWith(
+				{ type: 'instanceAiGatewayStateChanged', data: { connected: false, directory: null } },
+				[USER_ID],
+			);
+		});
+	});
+
+	describe('gatewayStatus', () => {
+		it('should require instanceAi:gateway scope', () => {
+			expect(scopeOf('gatewayStatus')).toEqual({
+				scope: 'instanceAi:gateway',
+				globalOnly: true,
+			});
+		});
+	});
+
+	describe('getGatewayKeyHeader', () => {
+		it('should extract first element from array header', () => {
+			instanceAiService.getUserIdForApiKey.mockReturnValue(USER_ID);
+			instanceAiService.resolveGatewayRequest.mockReturnValue(true);
+			const gatewayReq = {
+				headers: { 'x-gateway-key': ['key1', 'key2'] },
+				body: { result: { content: [] } },
+			} as unknown as Request;
+
+			controller.gatewayResponse(gatewayReq, res, 'req-1');
+
+			// validateGatewayApiKey receives 'key1' (the first element)
+			expect(instanceAiService.getUserIdForApiKey).toHaveBeenCalledWith('key1');
+		});
+	});
+});

--- a/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
@@ -17,22 +17,33 @@ import {
 import { ModuleRegistry } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { AuthenticatedRequest } from '@n8n/db';
-import { RestController, Get, Post, Put, Patch, Delete, Param, Body, Query } from '@n8n/decorators';
+import {
+	RestController,
+	GlobalScope,
+	Get,
+	Post,
+	Put,
+	Patch,
+	Delete,
+	Param,
+	Body,
+	Query,
+} from '@n8n/decorators';
 import type { StoredEvent } from '@n8n/instance-ai';
 import type { Request, Response } from 'express';
 import { randomUUID, timingSafeEqual } from 'node:crypto';
-
-import { BadRequestError } from '@/errors/response-errors/bad-request.error';
-import { ConflictError } from '@/errors/response-errors/conflict.error';
-import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
-import { NotFoundError } from '@/errors/response-errors/not-found.error';
-import { Push } from '@/push';
 
 import { buildAgentTreeFromEvents } from './agent-tree-builder';
 import { InProcessEventBus } from './event-bus/in-process-event-bus';
 import { InstanceAiMemoryService } from './instance-ai-memory.service';
 import { InstanceAiSettingsService } from './instance-ai-settings.service';
 import { InstanceAiService } from './instance-ai.service';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ConflictError } from '@/errors/response-errors/conflict.error';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { Push } from '@/push';
 
 type FlushableResponse = Response & { flush?: () => void };
 
@@ -58,6 +69,7 @@ export class InstanceAiController {
 	}
 
 	@Post('/chat/:threadId')
+	@GlobalScope('instanceAi:message')
 	async chat(
 		req: AuthenticatedRequest,
 		_res: Response,
@@ -85,6 +97,7 @@ export class InstanceAiController {
 
 	// usesTemplates bypasses the send() wrapper so we can write SSE frames directly
 	@Get('/events/:threadId', { usesTemplates: true })
+	@GlobalScope('instanceAi:message')
 	async events(
 		req: AuthenticatedRequest,
 		res: FlushableResponse,
@@ -201,6 +214,7 @@ export class InstanceAiController {
 	}
 
 	@Post('/confirm/:requestId')
+	@GlobalScope('instanceAi:message')
 	async confirm(
 		req: AuthenticatedRequest,
 		_res: Response,
@@ -222,6 +236,7 @@ export class InstanceAiController {
 	}
 
 	@Post('/chat/:threadId/cancel')
+	@GlobalScope('instanceAi:message')
 	async cancel(req: AuthenticatedRequest, _res: Response, @Param('threadId') threadId: string) {
 		await this.assertThreadAccess(req.user.id, threadId);
 		this.instanceAiService.cancelRun(threadId);
@@ -229,6 +244,7 @@ export class InstanceAiController {
 	}
 
 	@Post('/chat/:threadId/tasks/:taskId/cancel')
+	@GlobalScope('instanceAi:message')
 	async cancelTask(
 		req: AuthenticatedRequest,
 		_res: Response,
@@ -241,6 +257,7 @@ export class InstanceAiController {
 	}
 
 	@Post('/chat/:threadId/tasks/:taskId/correct')
+	@GlobalScope('instanceAi:message')
 	async correctTask(
 		req: AuthenticatedRequest,
 		_res: Response,
@@ -256,29 +273,31 @@ export class InstanceAiController {
 	// ── Admin settings (owner/admin only) ──────────────────────────────────
 
 	@Get('/settings')
-	async getAdminSettings(req: AuthenticatedRequest) {
-		this.assertAdmin(req);
+	@GlobalScope('instanceAi:manage')
+	async getAdminSettings(_req: AuthenticatedRequest) {
 		return this.settingsService.getAdminSettings();
 	}
 
 	@Put('/settings')
+	@GlobalScope('instanceAi:manage')
 	async updateAdminSettings(
-		req: AuthenticatedRequest,
+		_req: AuthenticatedRequest,
 		_res: Response,
 		@Body payload: InstanceAiAdminSettingsUpdateRequest,
 	) {
-		this.assertAdmin(req);
 		return await this.settingsService.updateAdminSettings(payload);
 	}
 
 	// ── User preferences (per-user, self-service) ──────────────────────────
 
 	@Get('/preferences')
+	@GlobalScope('instanceAi:message')
 	async getUserPreferences(req: AuthenticatedRequest) {
 		return await this.settingsService.getUserPreferences(req.user);
 	}
 
 	@Put('/preferences')
+	@GlobalScope('instanceAi:message')
 	async updateUserPreferences(
 		req: AuthenticatedRequest,
 		_res: Response,
@@ -292,22 +311,25 @@ export class InstanceAiController {
 	}
 
 	@Get('/settings/credentials')
+	@GlobalScope('instanceAi:message')
 	async listModelCredentials(req: AuthenticatedRequest) {
 		return await this.settingsService.listModelCredentials(req.user);
 	}
 
 	@Get('/settings/service-credentials')
+	@GlobalScope('instanceAi:manage')
 	async listServiceCredentials(req: AuthenticatedRequest) {
-		this.assertAdmin(req);
 		return await this.settingsService.listServiceCredentials(req.user);
 	}
 
 	@Get('/memory/:threadId')
+	@GlobalScope('instanceAi:message')
 	async getMemory(req: AuthenticatedRequest, _res: Response, @Param('threadId') threadId: string) {
 		return await this.memoryService.getWorkingMemory(req.user.id, threadId);
 	}
 
 	@Put('/memory/:threadId')
+	@GlobalScope('instanceAi:message')
 	async updateMemory(
 		req: AuthenticatedRequest,
 		_res: Response,
@@ -319,11 +341,13 @@ export class InstanceAiController {
 	}
 
 	@Get('/threads')
+	@GlobalScope('instanceAi:message')
 	async listThreads(req: AuthenticatedRequest) {
 		return await this.memoryService.listThreads(req.user.id);
 	}
 
 	@Post('/threads')
+	@GlobalScope('instanceAi:message')
 	async ensureThread(
 		req: AuthenticatedRequest,
 		_res: Response,
@@ -335,6 +359,7 @@ export class InstanceAiController {
 	}
 
 	@Delete('/threads/:threadId')
+	@GlobalScope('instanceAi:message')
 	async deleteThread(
 		req: AuthenticatedRequest,
 		_res: Response,
@@ -346,6 +371,7 @@ export class InstanceAiController {
 	}
 
 	@Patch('/threads/:threadId')
+	@GlobalScope('instanceAi:message')
 	async renameThread(
 		req: AuthenticatedRequest,
 		_res: Response,
@@ -358,6 +384,7 @@ export class InstanceAiController {
 	}
 
 	@Get('/threads/:threadId/messages')
+	@GlobalScope('instanceAi:message')
 	async getThreadMessages(
 		req: AuthenticatedRequest,
 		_res: Response,
@@ -384,6 +411,7 @@ export class InstanceAiController {
 	}
 
 	@Get('/threads/:threadId/status')
+	@GlobalScope('instanceAi:message')
 	async getThreadStatus(
 		req: AuthenticatedRequest,
 		_res: Response,
@@ -395,6 +423,7 @@ export class InstanceAiController {
 	}
 
 	@Get('/threads/:threadId/context')
+	@GlobalScope('instanceAi:message')
 	async getThreadContext(
 		req: AuthenticatedRequest,
 		_res: Response,
@@ -406,6 +435,7 @@ export class InstanceAiController {
 	// ── Gateway endpoints (daemon ↔ server) ──────────────────────────────────
 
 	@Post('/gateway/create-link')
+	@GlobalScope('instanceAi:gateway')
 	async createGatewayLink(req: AuthenticatedRequest) {
 		const token = this.instanceAiService.generatePairingToken(req.user.id);
 		const baseUrl = this.instanceBaseUrl.replace(/\/$/, '');
@@ -514,6 +544,7 @@ export class InstanceAiController {
 	}
 
 	@Get('/gateway/status')
+	@GlobalScope('instanceAi:gateway')
 	async gatewayStatus(req: AuthenticatedRequest) {
 		return this.instanceAiService.getGatewayStatus(req.user.id);
 	}
@@ -535,14 +566,6 @@ export class InstanceAiController {
 		}
 		if (!options?.allowNew && ownership === 'not_found') {
 			throw new NotFoundError('Thread not found');
-		}
-	}
-
-	/** Verify the requesting user is an instance owner or admin. */
-	private assertAdmin(req: AuthenticatedRequest): void {
-		const slug = req.user.role?.slug;
-		if (slug !== 'global:owner' && slug !== 'global:admin') {
-			throw new ForbiddenError('Admin access required');
 		}
 	}
 

--- a/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
@@ -54,7 +54,8 @@ export class InstanceAiController {
 
 	@Post('/chat/:threadId')
 	async chat(req: AuthenticatedRequest, _res: Response, @Param('threadId') threadId: string) {
-		const { message, researchMode, attachments } = req.body as InstanceAiSendMessageRequest;
+		const { message, researchMode, attachments, timeZone } =
+			req.body as InstanceAiSendMessageRequest;
 
 		if (!message?.trim()) {
 			throw new BadRequestError('Message is required');
@@ -70,12 +71,14 @@ export class InstanceAiController {
 
 		const safeResearchMode = typeof researchMode === 'boolean' ? researchMode : undefined;
 		const safeAttachments = Array.isArray(attachments) ? attachments : undefined;
+		const safeTimeZone = this.sanitizeTimeZone(timeZone);
 		const runId = this.instanceAiService.startRun(
 			req.user,
 			threadId,
 			message,
 			safeResearchMode,
 			safeAttachments,
+			safeTimeZone,
 		);
 		return { runId };
 	}
@@ -559,6 +562,22 @@ export class InstanceAiController {
 		if (userId) return userId;
 
 		throw new ForbiddenError('Invalid API key');
+	}
+
+	/**
+	 * Validate and sanitize a client-supplied IANA time zone string.
+	 * Returns `undefined` for missing or invalid values so the server can fall back.
+	 */
+	private sanitizeTimeZone(tz: unknown): string | undefined {
+		if (typeof tz !== 'string' || tz.length === 0 || tz.length > 50) return undefined;
+		// Only allow safe IANA characters to prevent prompt injection
+		if (!/^[A-Za-z0-9_/+-]+$/.test(tz)) return undefined;
+		try {
+			new Intl.DateTimeFormat('en-US', { timeZone: tz });
+			return tz;
+		} catch {
+			return undefined;
+		}
 	}
 
 	private writeSseEvent(res: FlushableResponse, stored: StoredEvent): void {

--- a/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
@@ -1,5 +1,4 @@
 import type {
-	InstanceAiSendMessageRequest,
 	InstanceAiAdminSettingsUpdateRequest,
 	InstanceAiUserPreferencesUpdateRequest,
 } from '@n8n/api-types';
@@ -8,6 +7,7 @@ import {
 	instanceAiGatewayCapabilitiesSchema,
 	instanceAiFilesystemResponseSchema,
 	InstanceAiRenameThreadRequestDto,
+	InstanceAiSendMessageRequest,
 } from '@n8n/api-types';
 import { ModuleRegistry } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
@@ -53,14 +53,12 @@ export class InstanceAiController {
 	}
 
 	@Post('/chat/:threadId')
-	async chat(req: AuthenticatedRequest, _res: Response, @Param('threadId') threadId: string) {
-		const { message, researchMode, attachments, timeZone } =
-			req.body as InstanceAiSendMessageRequest;
-
-		if (!message?.trim()) {
-			throw new BadRequestError('Message is required');
-		}
-
+	async chat(
+		req: AuthenticatedRequest,
+		_res: Response,
+		@Param('threadId') threadId: string,
+		@Body payload: InstanceAiSendMessageRequest,
+	) {
 		// Verify the requesting user owns this thread (or it's new)
 		await this.assertThreadAccess(req.user.id, threadId, { allowNew: true });
 
@@ -69,16 +67,13 @@ export class InstanceAiController {
 			throw new ConflictError('A run is already active for this thread');
 		}
 
-		const safeResearchMode = typeof researchMode === 'boolean' ? researchMode : undefined;
-		const safeAttachments = Array.isArray(attachments) ? attachments : undefined;
-		const safeTimeZone = this.sanitizeTimeZone(timeZone);
 		const runId = this.instanceAiService.startRun(
 			req.user,
 			threadId,
-			message,
-			safeResearchMode,
-			safeAttachments,
-			safeTimeZone,
+			payload.message,
+			payload.researchMode,
+			payload.attachments,
+			payload.timeZone,
 		);
 		return { runId };
 	}
@@ -562,22 +557,6 @@ export class InstanceAiController {
 		if (userId) return userId;
 
 		throw new ForbiddenError('Invalid API key');
-	}
-
-	/**
-	 * Validate and sanitize a client-supplied IANA time zone string.
-	 * Returns `undefined` for missing or invalid values so the server can fall back.
-	 */
-	private sanitizeTimeZone(tz: unknown): string | undefined {
-		if (typeof tz !== 'string' || tz.length === 0 || tz.length > 50) return undefined;
-		// Only allow safe IANA characters to prevent prompt injection
-		if (!/^[A-Za-z0-9_/+-]+$/.test(tz)) return undefined;
-		try {
-			new Intl.DateTimeFormat('en-US', { timeZone: tz });
-			return tz;
-		} catch {
-			return undefined;
-		}
 	}
 
 	private writeSseEvent(res: FlushableResponse, stored: StoredEvent): void {

--- a/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
@@ -1,33 +1,38 @@
-import type {
-	InstanceAiAdminSettingsUpdateRequest,
-	InstanceAiUserPreferencesUpdateRequest,
-} from '@n8n/api-types';
 import {
 	InstanceAiConfirmRequestDto,
 	instanceAiGatewayCapabilitiesSchema,
 	instanceAiFilesystemResponseSchema,
 	InstanceAiRenameThreadRequestDto,
 	InstanceAiSendMessageRequest,
+	InstanceAiEventsQuery,
+	InstanceAiGatewayEventsQuery,
+	instanceAiGatewayKeySchema,
+	InstanceAiCorrectTaskRequest,
+	InstanceAiUpdateMemoryRequest,
+	InstanceAiEnsureThreadRequest,
+	InstanceAiThreadMessagesQuery,
+	InstanceAiAdminSettingsUpdateRequest,
+	InstanceAiUserPreferencesUpdateRequest,
 } from '@n8n/api-types';
 import { ModuleRegistry } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { AuthenticatedRequest } from '@n8n/db';
-import { RestController, Get, Post, Put, Patch, Delete, Param, Body } from '@n8n/decorators';
+import { RestController, Get, Post, Put, Patch, Delete, Param, Body, Query } from '@n8n/decorators';
 import type { StoredEvent } from '@n8n/instance-ai';
 import type { Request, Response } from 'express';
 import { randomUUID, timingSafeEqual } from 'node:crypto';
-
-import { buildAgentTreeFromEvents } from './agent-tree-builder';
-import { InProcessEventBus } from './event-bus/in-process-event-bus';
-import { InstanceAiMemoryService } from './instance-ai-memory.service';
-import { InstanceAiSettingsService } from './instance-ai-settings.service';
-import { InstanceAiService } from './instance-ai.service';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { Push } from '@/push';
+
+import { buildAgentTreeFromEvents } from './agent-tree-builder';
+import { InProcessEventBus } from './event-bus/in-process-event-bus';
+import { InstanceAiMemoryService } from './instance-ai-memory.service';
+import { InstanceAiSettingsService } from './instance-ai-settings.service';
+import { InstanceAiService } from './instance-ai.service';
 
 type FlushableResponse = Response & { flush?: () => void };
 
@@ -81,9 +86,10 @@ export class InstanceAiController {
 	// usesTemplates bypasses the send() wrapper so we can write SSE frames directly
 	@Get('/events/:threadId', { usesTemplates: true })
 	async events(
-		req: AuthenticatedRequest<{}, {}, {}, { lastEventId?: string }>,
+		req: AuthenticatedRequest,
 		res: FlushableResponse,
 		@Param('threadId') threadId: string,
+		@Query query: InstanceAiEventsQuery,
 	) {
 		// Verify the requesting user owns this thread before streaming events.
 		// A thread that doesn't exist yet is allowed — the frontend opens the SSE
@@ -101,11 +107,12 @@ export class InstanceAiController {
 		res.flushHeaders();
 
 		// 2. Determine replay cursor
-		//    Last-Event-ID header (auto-reconnect) or ?lastEventId query param
-		const lastEventIdHeader = req.headers['last-event-id'];
-		const lastEventIdQuery = req.query.lastEventId;
-		const rawCursor = lastEventIdHeader ?? lastEventIdQuery;
-		const cursor = rawCursor ? parseInt(String(rawCursor), 10) : 0;
+		//    Last-Event-ID header (browser auto-reconnect) takes precedence over query param.
+		//    Both are validated as non-negative integers; invalid values fall back to 0.
+		const headerValue = req.headers['last-event-id'];
+		const parsedHeader = headerValue ? parseInt(String(headerValue), 10) : NaN;
+		const cursor =
+			Number.isFinite(parsedHeader) && parsedHeader >= 0 ? parsedHeader : (query.lastEventId ?? 0);
 
 		// 3. Replay missed events then subscribe in the same tick.
 		//    Since InProcessEventBus is synchronous and single-threaded (Node.js
@@ -239,13 +246,10 @@ export class InstanceAiController {
 		_res: Response,
 		@Param('threadId') threadId: string,
 		@Param('taskId') taskId: string,
+		@Body payload: InstanceAiCorrectTaskRequest,
 	) {
 		await this.assertThreadAccess(req.user.id, threadId);
-		const { message } = req.body as { message?: string };
-		if (!message?.trim()) {
-			throw new BadRequestError('Correction message is required');
-		}
-		this.instanceAiService.sendCorrectionToTask(taskId, message);
+		this.instanceAiService.sendCorrectionToTask(taskId, payload.message);
 		return { ok: true };
 	}
 
@@ -258,10 +262,13 @@ export class InstanceAiController {
 	}
 
 	@Put('/settings')
-	async updateAdminSettings(req: AuthenticatedRequest) {
+	async updateAdminSettings(
+		req: AuthenticatedRequest,
+		_res: Response,
+		@Body payload: InstanceAiAdminSettingsUpdateRequest,
+	) {
 		this.assertAdmin(req);
-		const body = req.body as InstanceAiAdminSettingsUpdateRequest;
-		return await this.settingsService.updateAdminSettings(body);
+		return await this.settingsService.updateAdminSettings(payload);
 	}
 
 	// ── User preferences (per-user, self-service) ──────────────────────────
@@ -272,10 +279,13 @@ export class InstanceAiController {
 	}
 
 	@Put('/preferences')
-	async updateUserPreferences(req: AuthenticatedRequest) {
-		const body = req.body as InstanceAiUserPreferencesUpdateRequest;
-		const result = await this.settingsService.updateUserPreferences(req.user, body);
-		if (body.filesystemDisabled !== undefined) {
+	async updateUserPreferences(
+		req: AuthenticatedRequest,
+		_res: Response,
+		@Body payload: InstanceAiUserPreferencesUpdateRequest,
+	) {
+		const result = await this.settingsService.updateUserPreferences(req.user, payload);
+		if (payload.filesystemDisabled !== undefined) {
 			await this.moduleRegistry.refreshModuleSettings('instance-ai');
 		}
 		return result;
@@ -302,12 +312,9 @@ export class InstanceAiController {
 		req: AuthenticatedRequest,
 		_res: Response,
 		@Param('threadId') threadId: string,
+		@Body payload: InstanceAiUpdateMemoryRequest,
 	) {
-		const { content } = req.body as { content: string };
-		if (typeof content !== 'string') {
-			throw new BadRequestError('Content is required');
-		}
-		await this.memoryService.updateWorkingMemory(req.user.id, threadId, content);
+		await this.memoryService.updateWorkingMemory(req.user.id, threadId, payload.content);
 		return { ok: true };
 	}
 
@@ -317,11 +324,12 @@ export class InstanceAiController {
 	}
 
 	@Post('/threads')
-	async ensureThread(req: AuthenticatedRequest) {
-		const { threadId } = req.body as { threadId?: string };
-		const requestedThreadId =
-			typeof threadId === 'string' && threadId.trim().length > 0 ? threadId : randomUUID();
-
+	async ensureThread(
+		req: AuthenticatedRequest,
+		_res: Response,
+		@Body payload: InstanceAiEnsureThreadRequest,
+	) {
+		const requestedThreadId = payload.threadId ?? randomUUID();
 		await this.assertThreadAccess(req.user.id, requestedThreadId, { allowNew: true });
 		return await this.memoryService.ensureThread(req.user.id, requestedThreadId);
 	}
@@ -351,21 +359,22 @@ export class InstanceAiController {
 
 	@Get('/threads/:threadId/messages')
 	async getThreadMessages(
-		req: AuthenticatedRequest<{}, {}, {}, { limit?: string; page?: string; raw?: string }>,
+		req: AuthenticatedRequest,
 		_res: Response,
 		@Param('threadId') threadId: string,
+		@Query query: InstanceAiThreadMessagesQuery,
 	) {
 		// ?raw=true returns the old format for the thread inspector
-		if (req.query.raw === 'true') {
+		if (query.raw === 'true') {
 			return await this.memoryService.getThreadMessages(req.user.id, threadId, {
-				limit: req.query.limit ? Number(req.query.limit) : 50,
-				page: req.query.page ? Number(req.query.page) : 0,
+				limit: query.limit,
+				page: query.page,
 			});
 		}
 
 		const result = await this.memoryService.getRichMessages(req.user.id, threadId, {
-			limit: req.query.limit ? Number(req.query.limit) : 50,
-			page: req.query.page ? Number(req.query.page) : 0,
+			limit: query.limit,
+			page: query.page,
 		});
 
 		// Include the next SSE event ID so the frontend can skip past events
@@ -405,8 +414,12 @@ export class InstanceAiController {
 	}
 
 	@Get('/gateway/events', { usesTemplates: true, skipAuth: true })
-	async gatewayEvents(req: Request<{}, {}, {}, { apiKey?: string }>, res: FlushableResponse) {
-		const userId = this.validateGatewayApiKey(req.query.apiKey);
+	async gatewayEvents(
+		req: Request,
+		res: FlushableResponse,
+		@Query query: InstanceAiGatewayEventsQuery,
+	) {
+		const userId = this.validateGatewayApiKey(query.apiKey);
 
 		res.setHeader('Content-Type', 'text/event-stream; charset=UTF-8');
 		res.setHeader('Cache-Control', 'no-cache');
@@ -441,7 +454,7 @@ export class InstanceAiController {
 
 	@Post('/gateway/init', { skipAuth: true })
 	gatewayInit(req: Request) {
-		const key = req.headers['x-gateway-key'] as string | undefined;
+		const key = this.getGatewayKeyHeader(req);
 		const userId = this.validateGatewayApiKey(key);
 
 		const parsed = instanceAiGatewayCapabilitiesSchema.safeParse(req.body);
@@ -468,7 +481,7 @@ export class InstanceAiController {
 
 	@Post('/gateway/disconnect', { skipAuth: true })
 	gatewayDisconnect(req: Request) {
-		const userId = this.validateGatewayApiKey(req.headers['x-gateway-key'] as string | undefined);
+		const userId = this.validateGatewayApiKey(this.getGatewayKeyHeader(req));
 
 		this.instanceAiService.clearDisconnectTimer(userId);
 		this.instanceAiService.disconnectGateway(userId);
@@ -482,7 +495,7 @@ export class InstanceAiController {
 
 	@Post('/gateway/response/:requestId', { skipAuth: true })
 	gatewayResponse(req: Request, _res: Response, @Param('requestId') requestId: string) {
-		const userId = this.validateGatewayApiKey(req.headers['x-gateway-key'] as string | undefined);
+		const userId = this.validateGatewayApiKey(this.getGatewayKeyHeader(req));
 
 		const parsed = instanceAiFilesystemResponseSchema.safeParse(req.body);
 		if (!parsed.success) {
@@ -531,6 +544,18 @@ export class InstanceAiController {
 		if (slug !== 'global:owner' && slug !== 'global:admin') {
 			throw new ForbiddenError('Admin access required');
 		}
+	}
+
+	/**
+	 * Safely extract and validate the x-gateway-key header value.
+	 * Headers can be string | string[] | undefined — take only the first value
+	 * and validate against the shared gateway key schema.
+	 */
+	private getGatewayKeyHeader(req: Request): string | undefined {
+		const raw = req.headers['x-gateway-key'];
+		const value = Array.isArray(raw) ? raw[0] : raw;
+		const parsed = instanceAiGatewayKeySchema.safeParse(value);
+		return parsed.success ? parsed.data : undefined;
 	}
 
 	/**

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -168,6 +168,9 @@ export class InstanceAiService {
 	/** Tracks the last researchMode setting per thread for follow-up runs. */
 	private readonly threadResearchMode = new Map<string, boolean>();
 
+	/** Tracks the last client timezone per thread for follow-up runs. */
+	private readonly threadTimeZone = new Map<string, string>();
+
 	/** Tracks the current messageGroupId per thread for auto-follow-up run merging. */
 	private readonly threadMessageGroupId = new Map<string, string>();
 
@@ -183,6 +186,9 @@ export class InstanceAiService {
 	/** Periodic sweep that auto-rejects timed-out HITL confirmations. */
 	private confirmationTimeoutInterval?: NodeJS.Timeout;
 
+	/** Default IANA timezone for the instance (from GENERIC_TIMEZONE env var). */
+	private readonly defaultTimeZone: string;
+
 	constructor(
 		private readonly logger: Logger,
 		globalConfig: GlobalConfig,
@@ -193,6 +199,7 @@ export class InstanceAiService {
 		private readonly compactionService: InstanceAiCompactionService,
 	) {
 		this.instanceAiConfig = globalConfig.instanceAi;
+		this.defaultTimeZone = globalConfig.generic.timezone;
 		const editorBaseUrl = globalConfig.editorBaseUrl || `http://localhost:${globalConfig.port}`;
 		const restEndpoint = globalConfig.endpoints.rest;
 		this.oauth2CallbackUrl = `${editorBaseUrl.replace(/\/$/, '')}/${restEndpoint}/oauth2-credential/callback`;
@@ -368,6 +375,7 @@ export class InstanceAiService {
 		message: string,
 		researchMode?: boolean,
 		attachments?: InstanceAiAttachment[],
+		timeZone?: string,
 	): string {
 		const runId = `run_${nanoid()}`;
 		const abortController = new AbortController();
@@ -376,6 +384,9 @@ export class InstanceAiService {
 		this.threadUsers.set(threadId, user);
 		if (researchMode !== undefined) {
 			this.threadResearchMode.set(threadId, researchMode);
+		}
+		if (timeZone !== undefined) {
+			this.threadTimeZone.set(threadId, timeZone);
 		}
 
 		// User-initiated runs get a fresh messageGroupId.
@@ -405,6 +416,7 @@ export class InstanceAiService {
 			researchMode,
 			attachments,
 			messageGroupId,
+			timeZone,
 		);
 
 		return runId;
@@ -624,6 +636,7 @@ export class InstanceAiService {
 		researchMode?: boolean,
 		attachments?: InstanceAiAttachment[],
 		messageGroupId?: string,
+		timeZone?: string,
 	): Promise<void> {
 		const signal = abortController.signal;
 		let mastraRunId = '';
@@ -791,6 +804,7 @@ export class InstanceAiService {
 				memory,
 				workspace: sandboxEntry?.workspace,
 				disableDeferredTools: true,
+				timeZone: timeZone ?? this.threadTimeZone.get(threadId) ?? this.defaultTimeZone,
 			});
 
 			// Compact older conversation history into a summary (best-effort, non-blocking on failure)

--- a/packages/frontend/editor-ui/src/app/stores/rbac.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/rbac.store.ts
@@ -51,6 +51,7 @@ export const useRBACStore = defineStore(STORES.RBAC, () => {
 		breakingChanges: {},
 		apiKey: {},
 		credentialResolver: {},
+		instanceAi: {},
 		securitySettings: {},
 	});
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.api.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.api.ts
@@ -17,6 +17,7 @@ export async function postMessage(
 	message: string,
 	researchMode?: boolean,
 	attachments?: InstanceAiAttachment[],
+	timeZone?: string,
 ): Promise<InstanceAiSendMessageResponse> {
 	return await makeRestApiRequest<InstanceAiSendMessageResponse>(
 		context,
@@ -26,6 +27,7 @@ export async function postMessage(
 			message,
 			...(researchMode ? { researchMode } : {}),
 			...(attachments && attachments.length > 0 ? { attachments } : {}),
+			...(timeZone ? { timeZone } : {}),
 		},
 	);
 }

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.store.ts
@@ -585,6 +585,7 @@ export const useInstanceAiStore = defineStore('instanceAi', () => {
 				message,
 				researchMode.value || undefined,
 				attachments,
+				Intl.DateTimeFormat().resolvedOptions().timeZone,
 			);
 		} catch (error: unknown) {
 			const status = error instanceof ResponseError ? error.httpStatusCode : undefined;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1487,6 +1487,9 @@ importers:
       linkedom:
         specifier: ^0.18.9
         version: 0.18.12
+      luxon:
+        specifier: 'catalog:'
+        version: 3.7.2
       nanoid:
         specifier: 'catalog:'
         version: 3.3.8
@@ -1506,6 +1509,9 @@ importers:
       '@n8n/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+      '@types/luxon':
+        specifier: 3.2.0
+        version: 3.2.0
       '@types/turndown':
         specifier: ^5.0.5
         version: 5.0.6


### PR DESCRIPTION
## Summary

Various things I wanted to improve:
- Make instance AI know the current time (and client's timezone) on the system prompt
- Validate requests properly using Zod decorators instead of inline validation code
- Validate access to instance AI endpoints through our RBAC, giving members and admins permissions (and admins permissions to change settings)
- (also add a permission for the local gateway endpoints)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
