### PR TITLE
fix(s3): implement missing Delete Bucket operation (#27396)

### DIFF
--- a/packages/nodes-base/nodes/S3/S3.node.ts
+++ b/packages/nodes-base/nodes/S3/S3.node.ts
@@ -271,6 +271,16 @@ export class S3 implements INodeType {
 						// 	returnData.push(responseData);
 						// }
 					}
+					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html
+					if (operation === 'delete') {
+						const name = this.getNodeParameter('name', i) as string;
+						await s3ApiRequestSOAP.call(this, `${name}`, 'DELETE', '', '');
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray({ success: true }),
+							{ itemData: { item: i } },
+						);
+						returnData.push(...executionData);
+					}
 				}
 				if (resource === 'folder') {
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html


### PR DESCRIPTION
## Summary

The S3 node's **bucket > delete** operation was defined in  (displaying it in the UI) but **never implemented** in . Selecting it returns  with 0 output items in ~2ms without making any S3 API call.

## Root Cause

In , the `resource === 'bucket'` block only handled , , and  operations. The  handler was entirely missing.

## Fix

Added the  operation handler inside the `resource === 'bucket'` block, after the  block:

```typescript
//https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html
if (operation === 'delete') {
  const name = this.getNodeParameter('name', i) as string;
  await s3ApiRequestSOAP.call(this, `${name}`, 'DELETE', '', '');
  const executionData = this.helpers.constructExecutionMetaData(
    this.helpers.returnJsonArray({ success: true }),
    { itemData: { item: i } },
  );
  returnData.push(...executionData);
}
```

## Testing

1. Set S3 node Resource = **Bucket**, Operation = **Delete**
2. Provide valid bucket name and S3-compatible credentials
3. Execute → should return  with actual DELETE call to S3 API

Fixes #27396