### PR TITLE
ci: Modify immutable commit subject via spreading

### DIFF
--- a/.github/scripts/update-changelog.mjs
+++ b/.github/scripts/update-changelog.mjs
@@ -1,5 +1,5 @@
 import createTempFile from 'tempfile';
-import { ConventionalChangelog, packagePrefix } from 'conventional-changelog';
+import { ConventionalChangelog } from 'conventional-changelog';
 import { resolve } from 'path';
 import { createReadStream, createWriteStream } from 'fs';
 import { dirname } from 'path';
@@ -35,7 +35,15 @@ const changelogStream = new ConventionalChangelog()
 			// Strip backport information from commit subject, e.g.:
 			// "Fix something (backport to release-candidate/2.12.x) (#123)" → "Fix something (#123)"
 			if (commit.subject) {
-				commit.subject = commit.subject.replace(/\s*\(backport to [^)]+\)/g, '');
+				// The commit.subject is immutable so we need to recreate the commit object
+
+				/** @type { import("conventional-changelog").Commit } */
+				let newCommit = /** @type { any } */ ({
+					...commit,
+					subject: commit.subject.replace(/\s*\(backport to [^)]+\)/g, ''),
+				});
+
+				return newCommit;
 			}
 
 			return commit;


### PR DESCRIPTION
## Summary

conventional-changelog has undocumented immutabilities in the transformCommit function call's params. Fix issue by spreading into new objects instead of trying to modify in place.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/actions/runs/23440056396/job/68188184874

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
