### PR TITLE
feat(core): Improve Instance AI building with webhook and chat triggers

### DIFF
--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -7,11 +7,24 @@ interface SystemPromptOptions {
 	licenseHints?: string[];
 }
 
+function getInstanceInfoSection(webhookBaseUrl: string): string {
+	return `
+## Instance Info
+
+Webhook base URL: ${webhookBaseUrl}
+When a workflow has webhook triggers, its live URL is: ${webhookBaseUrl}/{path} (where {path} is the webhook path parameter). Always share the full webhook URL with the user after a workflow with webhooks is created.
+
+**Chat Trigger nodes** can expose a hosted chat UI when the node's "public" parameter is set to true. Their URL follows a different pattern: ${webhookBaseUrl}/{webhookId}/chat (where {webhookId} is the node's unique webhook ID, visible in the workflow JSON). The chat UI is only accessible when public=true and the workflow is published (active) — otherwise the endpoint returns 404. Do NOT guess the webhookId — after building a workflow with a Chat Trigger, read the workflow to find the node's webhookId and construct the correct URL.
+
+**These URLs are for sharing with the user only.** Do NOT include them in \`build-workflow-with-agent\` task descriptions — the builder cannot reach the n8n instance via HTTP and will fail if it tries to curl/fetch these URLs.
+`;
+}
+
 export function getSystemPrompt(options: SystemPromptOptions = {}): string {
 	const { researchMode, webhookBaseUrl, filesystemAccess, toolSearchEnabled, licenseHints } =
 		options;
 	return `You are the n8n Instance Agent — an AI assistant embedded in an n8n instance. You help users build, run, debug, and manage workflows through natural language.
-${webhookBaseUrl ? `\n## Instance Info\n\nWebhook base URL: ${webhookBaseUrl}\nWhen a workflow has webhook triggers, its live URL is: ${webhookBaseUrl}/{path} (where {path} is the webhook path parameter). Always share the full webhook URL with the user after a workflow with webhooks is created.\n\n**This URL is for sharing with the user only.** Do NOT include it in \`build-workflow-with-agent\` task descriptions — the builder cannot reach the n8n instance via HTTP and will fail if it tries to curl/fetch this URL.\n` : ''}
+${webhookBaseUrl ? getInstanceInfoSection(webhookBaseUrl) : ''}
 
 You have access to workflow, execution, and credential tools plus a specialized workflow builder. You also have delegation capabilities for complex tasks, and may have access to MCP tools for extended capabilities.
 

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -3,6 +3,7 @@ import { generateWorkflowCode } from '@n8n/workflow-sdk';
 import { z } from 'zod';
 
 import { buildCredentialMap, resolveCredentials } from './resolve-credentials';
+import { ensureWebhookIds } from './submit-workflow.tool';
 import type { InstanceAiContext } from '../../types';
 import { parseAndValidate, partitionWarnings } from '../../workflow-builder';
 import { extractWorkflowCode } from '../../workflow-builder/extract-code';
@@ -148,6 +149,9 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 			// newCredential() produces NewCredentialImpl which serializes to undefined.
 			const credentialMap = await buildCredentialMap(context.credentialService);
 			await resolveCredentials(json, workflowId, context, credentialMap);
+
+			// Ensure webhook nodes have a webhookId so n8n registers clean paths
+			await ensureWebhookIds(json, workflowId, context);
 
 			try {
 				const opts = projectId ? { projectId } : undefined;

--- a/packages/@n8n/instance-ai/src/tools/workflows/get-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/get-workflow.tool.ts
@@ -27,6 +27,7 @@ export function createGetWorkflowTool(context: InstanceAiContext) {
 					type: z.string(),
 					parameters: z.record(z.unknown()).optional(),
 					position: z.array(z.number()).length(2),
+					webhookId: z.string().optional(),
 				}),
 			),
 			connections: z.record(z.unknown()),

--- a/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow.tool.ts
@@ -50,6 +50,7 @@ const WEBHOOK_NODE_TYPES = new Set([
 	'n8n-nodes-base.webhook',
 	'n8n-nodes-base.formTrigger',
 	'@n8n/n8n-nodes-langchain.mcpTrigger',
+	'@n8n/n8n-nodes-langchain.chatTrigger',
 ]);
 
 /**
@@ -60,7 +61,7 @@ const WEBHOOK_NODE_TYPES = new Set([
  * For updates: preserves existing webhookIds from the current workflow so
  * webhook URLs remain stable. Only generates new IDs for new nodes.
  */
-async function ensureWebhookIds(
+export async function ensureWebhookIds(
 	json: WorkflowJSON,
 	workflowId: string | undefined,
 	ctx: InstanceAiContext,

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -47,6 +47,7 @@ export interface WorkflowNode {
 	type: string;
 	parameters?: Record<string, unknown>;
 	position: number[];
+	webhookId?: string;
 }
 
 export interface ExecutionResult {

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -1991,6 +1991,7 @@ function toWorkflowDetail(workflow: WorkflowEntity): WorkflowDetail {
 				type: n.type,
 				parameters: n.parameters,
 				position: n.position,
+				webhookId: n.webhookId,
 			}),
 		),
 		connections: workflow.connections as Record<string, unknown>,

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -11,6 +11,7 @@ import { Time } from '@n8n/constants';
 import type { InstanceAiConfig } from '@n8n/config';
 import type { User } from '@n8n/db';
 import { Service } from '@n8n/di';
+import { UrlService } from '@/services/url.service';
 import {
 	createInstanceAgent,
 	createAllTools,
@@ -191,12 +192,13 @@ export class InstanceAiService {
 		private readonly settingsService: InstanceAiSettingsService,
 		private readonly compositeStore: TypeORMCompositeStore,
 		private readonly compactionService: InstanceAiCompactionService,
+		private readonly urlService: UrlService,
 	) {
 		this.instanceAiConfig = globalConfig.instanceAi;
 		const editorBaseUrl = globalConfig.editorBaseUrl || `http://localhost:${globalConfig.port}`;
 		const restEndpoint = globalConfig.endpoints.rest;
 		this.oauth2CallbackUrl = `${editorBaseUrl.replace(/\/$/, '')}/${restEndpoint}/oauth2-credential/callback`;
-		this.webhookBaseUrl = `${editorBaseUrl.replace(/\/$/, '')}/${globalConfig.endpoints.webhook}`;
+		this.webhookBaseUrl = `${this.urlService.getWebhookBaseUrl()}${globalConfig.endpoints.webhook}`;
 
 		// Initialize per-builder sandbox factory from env vars (credential-based config resolves at runtime)
 		const sbxConfig = this.getSandboxConfigFromEnv();


### PR DESCRIPTION
## Summary

Instance AI thought its webhooks were running on localhost on cloud, fix that.
Also make it aware how chat triggers work, it couldn't understand they were different to webhook triggers and would hallucinate, we were also setting up the chat trigger webhooks wrong - they ended up getting wrong `webhookPath` in webhook_entity table when created with build-workflow-tool.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
