### PR TITLE
chore: Lock @types/node to a version in @n8n/cli

### DIFF
--- a/packages/@n8n/cli/package.json
+++ b/packages/@n8n/cli/package.json
@@ -39,7 +39,7 @@
 	},
 	"devDependencies": {
 		"@n8n/typescript-config": "workspace:*",
-		"@types/node": "catalog:",
+		"@types/node": "24.10.1",
 		"vitest": "catalog:"
 	}
 }


### PR DESCRIPTION
## Summary

Set @types/node version in `@n8n/cli` package instead of workspace reference..

This blocks publishing currently due to missing references.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/actions/runs/23477442287/job/68313202085

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
