### PR TITLE
refactor: Remove persistBuilderSessions feature flag

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -43,8 +43,6 @@ N8N_AI_ENABLED=
 # Base URL of the AI assistant service.
 # When set, requests are sent to this URL instead of the default provider endpoint.
 N8N_AI_ASSISTANT_BASE_URL=
-# Whether to persist AI workflow builder sessions to the database.
-N8N_AI_PERSIST_BUILDER_SESSIONS=
 # API key for the Anthropic (Claude) provider used by the AI workflow builder.
 # When set, enables AI-powered workflow and node building.
 N8N_AI_ANTHROPIC_KEY=

--- a/packages/@n8n/config/src/configs/ai.config.ts
+++ b/packages/@n8n/config/src/configs/ai.config.ts
@@ -21,10 +21,6 @@ export class AiConfig {
 	@Env('N8N_AI_ALLOW_SENDING_PARAMETER_VALUES')
 	allowSendingParameterValues: boolean = true;
 
-	/** Whether to persist AI workflow builder sessions to the database. */
-	@Env('N8N_AI_PERSIST_BUILDER_SESSIONS')
-	persistBuilderSessions: boolean = true;
-
 	get openAiDefaultHeaders(): Record<string, string> {
 		// eslint-disable-next-line @typescript-eslint/naming-convention
 		return { 'openai-platform': 'org-qkmJQuJ2WnvoIKMr2UJwIJkZ' };

--- a/packages/@n8n/config/src/configs/ai.config.ts
+++ b/packages/@n8n/config/src/configs/ai.config.ts
@@ -23,7 +23,7 @@ export class AiConfig {
 
 	/** Whether to persist AI workflow builder sessions to the database. */
 	@Env('N8N_AI_PERSIST_BUILDER_SESSIONS')
-	persistBuilderSessions: boolean = false;
+	persistBuilderSessions: boolean = true;
 
 	get openAiDefaultHeaders(): Record<string, string> {
 		// eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -443,7 +443,7 @@ describe('GlobalConfig', () => {
 		// @ts-expect-error structuredClone ignores properties defined as a getter
 		ai: {
 			enabled: false,
-			persistBuilderSessions: false,
+			persistBuilderSessions: true,
 			timeout: 3600000,
 			allowSendingParameterValues: true,
 		},

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -443,7 +443,6 @@ describe('GlobalConfig', () => {
 		// @ts-expect-error structuredClone ignores properties defined as a getter
 		ai: {
 			enabled: false,
-			persistBuilderSessions: true,
 			timeout: 3600000,
 			allowSendingParameterValues: true,
 		},

--- a/packages/cli/src/services/__tests__/ai-workflow-builder.service.test.ts
+++ b/packages/cli/src/services/__tests__/ai-workflow-builder.service.test.ts
@@ -91,7 +91,6 @@ describe('WorkflowBuilderService', () => {
 		(mockLicense.getConsumerId as jest.Mock).mockReturnValue('test-consumer-id');
 		(mockInstanceSettings.instanceId as unknown) = 'test-instance-id';
 		mockConfig.aiAssistant = { baseUrl: '' };
-		(mockConfig.ai as { persistBuilderSessions: boolean }) = { persistBuilderSessions: false };
 
 		// Reset the mocked AiWorkflowBuilderService
 		MockedAiWorkflowBuilderService.mockClear();
@@ -138,7 +137,7 @@ describe('WorkflowBuilderService', () => {
 
 			expect(MockedAiWorkflowBuilderService).toHaveBeenCalledWith(
 				mockNodeTypeDescriptions,
-				undefined, // No session storage when persistBuilderSessions is false
+				mockSessionRepository,
 				undefined, // No client when baseUrl is not set
 				mockLogger,
 				'test-instance-id', // instanceId
@@ -183,7 +182,7 @@ describe('WorkflowBuilderService', () => {
 
 			expect(MockedAiWorkflowBuilderService).toHaveBeenCalledWith(
 				mockNodeTypeDescriptions,
-				undefined, // No session storage when persistBuilderSessions is false
+				mockSessionRepository,
 				expect.any(AiAssistantClient),
 				mockLogger,
 				'test-instance-id', // instanceId

--- a/packages/cli/src/services/ai-workflow-builder.service.ts
+++ b/packages/cli/src/services/ai-workflow-builder.service.ts
@@ -148,14 +148,9 @@ export class WorkflowBuilderService {
 		await this.loadNodesAndCredentials.postProcessLoaders();
 		const { nodes: nodeTypeDescriptions } = await this.loadNodesAndCredentials.collectTypes();
 
-		// Use persistent session storage if feature flag is enabled
-		const sessionStorage = this.config.ai.persistBuilderSessions
-			? this.sessionRepository
-			: undefined;
-
 		this.service = new AiWorkflowBuilderService(
 			nodeTypeDescriptions,
-			sessionStorage,
+			this.sessionRepository,
 			this.client,
 			this.logger,
 			this.instanceSettings.instanceId,


### PR DESCRIPTION
## Summary

Removes the `persistBuilderSessions` feature flag entirely. AI builder session persistence is now always enabled — the config property, env var (`N8N_AI_PERSIST_BUILDER_SESSIONS`), and conditional logic have been removed.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2222/clean-up-feature-flags-based-on-recent-decisions

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)