### PR TITLE
ci: Remove prerelease tag when promoting previous beta to latest

### DIFF
--- a/.github/scripts/promote-github-release.mjs
+++ b/.github/scripts/promote-github-release.mjs
@@ -29,6 +29,7 @@ async function promoteGitHubRelease() {
 		owner,
 		repo,
 		release_id: existingRelease.id,
+		prerelease: false,
 		make_latest: 'true',
 	});
 


### PR DESCRIPTION
## Summary

Prerelease is not implicitly removed from GitHub releases, so we need to remove it manually when updating the releases to latest.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
