### PR TITLE
ci: Create stable release on GitHub promotion

### DIFF
--- a/.github/scripts/promote-github-release.mjs
+++ b/.github/scripts/promote-github-release.mjs
@@ -1,4 +1,5 @@
 import {
+	deleteRelease,
 	ensureEnvVar,
 	getExistingRelease,
 	initGithub,
@@ -34,8 +35,29 @@ async function promoteGitHubRelease() {
 
 	console.log(`Successfully updated release ${releaseResponse.data.html_url}`);
 
+	const existingStableRelease = await getExistingRelease('stable');
+	if (existingStableRelease) {
+		await deleteRelease(existingStableRelease.id);
+		console.log("Deleted previous 'stable' release.");
+	}
+
+	const stableReleaseResponse = await octokit.rest.repos.createRelease({
+		tag_name: 'stable',
+		name: 'stable',
+		body: releaseResponse.data.body,
+		draft: false,
+		prerelease: false,
+		make_latest: 'false',
+		target_commitish: releaseResponse.data.target_commitish,
+		owner,
+		repo,
+	});
+
+	console.log(`Successfully created new stable release ${stableReleaseResponse.data.html_url}`);
+
 	writeGithubOutput({
 		release_url: releaseResponse.data.html_url,
+		stable_release_url: stableReleaseResponse.data.html_url,
 	});
 }
 


### PR DESCRIPTION
## Summary

When promoting a GitHub release to latest, also create (or recreate) a floating `stable` release tag that always points to the most recently promoted version. This makes it easy to reference the latest stable release by a fixed tag name.

Changes:
- After promoting the versioned release, look up and delete any existing `stable` release
- Create a new `stable` release pointing to the same commit and with the same release notes
- Output the stable release URL as a GitHub Actions output (`stable_release_url`)

## Related Linear tickets, Github issues, and Community forum posts

<!-- Link to Linear ticket: https://linear.app/n8n/issue/[TICKET-ID] -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)