### PR TITLE
fix(editor): Avoid resource locator cache pollution

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useDebounce.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useDebounce.ts
@@ -6,6 +6,7 @@ import { getDebounceTime } from '@/app/constants/durations';
 export interface DebounceOptions {
 	debounceTime: number;
 	trailing?: boolean;
+	leading?: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/frontend/editor-ui/src/app/composables/useDebounce.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useDebounce.ts
@@ -6,7 +6,6 @@ import { getDebounceTime } from '@/app/constants/durations';
 export interface DebounceOptions {
 	debounceTime: number;
 	trailing?: boolean;
-	leading?: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
@@ -737,7 +737,8 @@ function loadResourcesDebounced(debounceTime: number = DEBOUNCE_TIME.INPUT.SEARC
 
 	void callDebounced(loadResources, {
 		debounceTime,
-		trailing: true,
+		leading: true,
+		trailing: false,
 	});
 }
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
@@ -737,8 +737,7 @@ function loadResourcesDebounced(debounceTime: number = DEBOUNCE_TIME.INPUT.SEARC
 
 	void callDebounced(loadResources, {
 		debounceTime,
-		leading: true,
-		trailing: false,
+		trailing: true,
 	});
 }
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
@@ -55,7 +55,7 @@ import {
 	type FromAIOverride,
 } from '../../utils/fromAIOverride.utils';
 import { completeExpressionSyntax } from '@/app/utils/expressions';
-import { ExpressionLocalResolveContextSymbol } from '@/app/constants';
+import { DEBOUNCE_TIME, ExpressionLocalResolveContextSymbol } from '@/app/constants';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import FromAiOverrideButton from '../ParameterInputOverrides/FromAiOverrideButton.vue';
 import FromAiOverrideField from '../ParameterInputOverrides/FromAiOverrideField.vue';
@@ -729,14 +729,14 @@ async function loadInitialResources(): Promise<void> {
 	}
 }
 
-function loadResourcesDebounced() {
+function loadResourcesDebounced(debounceTime: number = DEBOUNCE_TIME.INPUT.SEARCH) {
 	if (currentResponse.value?.error) {
 		// Clear error response immediately when retrying to show loading state
 		delete cachedResponses.value[currentRequestKey.value];
 	}
 
 	void callDebounced(loadResources, {
-		debounceTime: 1000,
+		debounceTime,
 		trailing: true,
 	});
 }
@@ -834,7 +834,7 @@ async function loadResources() {
 
 		// Restart if the key changed during the request
 		if (currentRequestKey.value !== paramsKey) {
-			loadResourcesDebounced();
+			loadResourcesDebounced(0);
 			return;
 		}
 
@@ -859,7 +859,7 @@ async function loadResources() {
 
 		// Restart if the key changed during the request
 		if (currentRequestKey.value !== paramsKey) {
-			loadResourcesDebounced();
+			loadResourcesDebounced(0);
 		}
 	}
 }

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
@@ -832,10 +832,10 @@ async function loadResources() {
 		// Store response under the original key to prevent cache pollution
 		setResponse(paramsKey, responseData);
 
-		// If the key changed during the request, also store under current key to prevent infinite loading
-		const currentKey = currentRequestKey.value;
-		if (currentKey !== paramsKey) {
-			setResponse(currentKey, responseData);
+		// Restart if the key changed during the request
+		if (currentRequestKey.value !== paramsKey) {
+			loadResourcesDebounced();
+			return;
 		}
 
 		if (params.filter && !hasCompletedASearch.value) {
@@ -857,10 +857,9 @@ async function loadResources() {
 		// Store error under the original key
 		setResponse(paramsKey, errorData);
 
-		// If the key changed during the request, also store under current key to prevent infinite loading
-		const currentKey = currentRequestKey.value;
-		if (currentKey !== paramsKey) {
-			setResponse(currentKey, errorData);
+		// Restart if the key changed during the request
+		if (currentRequestKey.value !== paramsKey) {
+			loadResourcesDebounced();
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Redo resource loading instead of polluting the cache. Also adjust some debounce timings while we're here.

## Related Linear tickets, Github issues, and Community forum posts

#22123 
https://linear.app/n8n/issue/ADO-4977/community-issue-resourcelocator-cache-pollution-in-flight-responses

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
