### PR TITLE
fix(editor): Improve workflow diff design feedback

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -3773,6 +3773,8 @@
 	"workflowHistory.item.active": "Published",
 	"workflowHistory.item.publishedBy": "Published by",
 	"workflowHistory.item.currentChanges": "Current changes",
+	"workflowHistory.item.compareTooltip.compareLine": "Compare “{name}”",
+	"workflowHistory.item.compareTooltip.withLine": "with “{name}”",
 	"workflowHistory.limitDay": "Version history is limited to 1 day",
 	"workflowHistory.limitDays": "Version history is limited to {days} days",
 	"workflowHistory.limitHour": "Version history is limited to 1 hour",

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/workflowDiff.module.scss
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/workflowDiff.module.scss
@@ -21,6 +21,31 @@
 .added,
 .modified {
 	position: relative;
+	--workflow-diff--connector--color: transparent;
+
+	:global(.canvas-node-handle-main-output [data-test-id='canvas-handle-plus-wrapper'].source) {
+		background-color: var(--canvas-node--color--background);
+	}
+
+	:global(.canvas-node-handle-main-output [data-test-id='canvas-handle-plus-wrapper'] line.source) {
+		stroke: var(--workflow-diff--connector--color) !important;
+	}
+
+	:global(.canvas-node-handle-main-output [data-test-id='canvas-handle-plus'] rect.source) {
+		fill: transparent;
+		stroke: var(--workflow-diff--connector--color);
+	}
+
+	:global(.canvas-node-handle-main-output [data-test-id='canvas-handle-plus'] path.source) {
+		stroke: var(--workflow-diff--connector--color);
+	}
+
+	:global(.canvas-node-handle-main-output [class*='dot'].source),
+	:global(.canvas-node-handle-main-input [class*='dot'].target) {
+		background-color: var(--workflow-diff--connector--color);
+		border: none;
+	}
+
 	&::before {
 		position: absolute;
 		top: 0;
@@ -41,6 +66,7 @@
 }
 
 .deleted {
+	--workflow-diff--connector--color: var(--diff--color--deleted);
 	--canvas-node--color--background: var(--diff--color--deleted--faint);
 	--canvas-node--border-color: var(--diff--color--deleted);
 	--sticky--color--background: var(--diff--color--deleted--faint);
@@ -54,11 +80,6 @@
 		content: 'D';
 		background-color: var(--diff--color--deleted);
 	}
-	:global(.canvas-node-handle-main-output .source),
-	:global(.canvas-node-handle-main-input .target) {
-		background-color: var(--diff--color--deleted);
-		border: none;
-	}
 
 	:global([class*='disabled']) {
 		--canvas-node--border-color: var(--diff--color--deleted) !important;
@@ -66,6 +87,7 @@
 }
 
 .added {
+	--workflow-diff--connector--color: var(--diff--color--new);
 	--canvas-node--border-color: var(--diff--color--new);
 	--canvas-node--color--background: var(--diff--color--new--faint);
 	--sticky--color--background: var(--diff--color--new--faint);
@@ -79,12 +101,6 @@
 	&::before {
 		content: 'N';
 		background-color: var(--diff--color--new);
-	}
-
-	:global(.canvas-node-handle-main-output .source),
-	:global(.canvas-node-handle-main-input .target) {
-		background-color: var(--diff--color--new);
-		border: none;
 	}
 
 	:global([class*='disabled']) {
@@ -106,6 +122,7 @@
 }
 
 .modified {
+	--workflow-diff--connector--color: var(--diff--color--modified);
 	--canvas-node--border-width: 2px;
 	--canvas-node--border-color: var(--diff--color--modified);
 	--canvas-node--color--background: var(--diff--color--modified--faint);
@@ -120,11 +137,6 @@
 	&::before {
 		content: 'M';
 		background-color: var(--diff--color--modified);
-	}
-	:global(.canvas-node-handle-main-output .source),
-	:global(.canvas-node-handle-main-input .target) {
-		background-color: var(--diff--color--modified);
-		border: none;
 	}
 
 	:global([class*='disabled']) {

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryListItem.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryListItem.test.ts
@@ -79,6 +79,28 @@ describe('WorkflowHistoryListItem', () => {
 		expect(emitted().compare).toEqual([[{ id: itemToCompareWith.versionId }]]);
 	});
 
+	it('should show a two-line compare tooltip with both version names', async () => {
+		const item = { ...workflowHistoryDataFactory(), name: 'Version 1 name' };
+		const itemToCompareWith = workflowHistoryDataFactory();
+		const compareName = 'Version 2 name';
+		const { getByTestId, findByText } = renderComponent({
+			pinia,
+			props: {
+				item,
+				index: 2,
+				actions,
+				isSelected: false,
+				compareWith: { name: compareName, versionId: itemToCompareWith.versionId },
+				isWorkflowDiffsEnabled: true,
+			},
+		});
+
+		await userEvent.hover(getByTestId('workflow-history-compare-item-button'));
+
+		expect(await findByText('Compare “Version 2 name”')).toBeInTheDocument();
+		expect(await findByText('with “Version 1 name”')).toBeInTheDocument();
+	});
+
 	it('should not emit compare event when compareWith is missing', async () => {
 		const item = workflowHistoryDataFactory();
 		const { getByTestId, emitted } = renderComponent({

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryListItem.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryListItem.vue
@@ -116,8 +116,22 @@ const wrapperProps = computed(() => {
 
 const isCompareDisabled = computed(() => !props.compareWith?.versionId);
 
-const compareTooltipContent = computed(() => {
-	return props.compareWith?.name ? `Compare with ${props.compareWith.name}` : '';
+const compareTooltipLines = computed(() => {
+	if (!props.compareWith?.name) {
+		return null;
+	}
+
+	const compareName = props.isSelected ? versionName.value : props.compareWith.name;
+	const withName = props.isSelected ? props.compareWith.name : versionName.value;
+
+	return {
+		compareLine: i18n.baseText('workflowHistory.item.compareTooltip.compareLine', {
+			interpolate: { name: compareName },
+		}),
+		withLine: i18n.baseText('workflowHistory.item.compareTooltip.withLine', {
+			interpolate: { name: withName },
+		}),
+	};
 });
 
 const onAction = (value: string) => {
@@ -203,10 +217,16 @@ onMounted(() => {
 				</div>
 				<N8nTooltip
 					v-if="props.isWorkflowDiffsEnabled"
-					:content="compareTooltipContent"
 					:disabled="isCompareDisabled"
 					placement="top"
+					:content-class="$style.compareTooltipContent"
 				>
+					<template v-if="compareTooltipLines" #content>
+						<div :class="$style.compareTooltip">
+							<span :class="$style.compareTooltipLine">{{ compareTooltipLines.compareLine }}</span>
+							<span :class="$style.compareTooltipLine">{{ compareTooltipLines.withLine }}</span>
+						</div>
+					</template>
 					<N8nIconButton
 						variant="ghost"
 						icon="file-diff"
@@ -352,5 +372,17 @@ $authorMaxWidth: 130px;
 
 .compareButton {
 	flex-shrink: 0;
+}
+
+.compareTooltip {
+	text-align: start;
+}
+
+.compareTooltipContent {
+	max-width: min(32ch, 80vw);
+}
+
+.compareTooltipLine {
+	display: block;
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistory.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistory.test.ts
@@ -50,6 +50,22 @@ const versionId = faker.string.nanoid();
 const renderComponent = createComponentRenderer(WorkflowHistoryPage, {
 	global: {
 		stubs: {
+			Modal: defineComponent({
+				template: '<div><slot name="content" /></div>',
+			}),
+			WorkflowHistoryDiff: defineComponent({
+				emits: ['versionsChange', 'close'],
+				template: `<div>
+					<button
+						data-test-id="stub-diff-emit-same"
+						@click="$emit('versionsChange', { sourceVersionId: 'v-source', targetVersionId: 'v-target' })"
+					/>
+					<button
+						data-test-id="stub-diff-emit-other"
+						@click="$emit('versionsChange', { sourceVersionId: 'v-other-source', targetVersionId: 'v-other-target' })"
+					/>
+				</div>`,
+			}),
 			WorkflowHistoryContent: true,
 			WorkflowHistoryList: defineComponent({
 				props: {
@@ -287,6 +303,48 @@ describe('WorkflowHistory', () => {
 				query: expect.objectContaining({ diffWith: expect.anything() }),
 			}),
 		);
+	});
+
+	describe('diff versions route sync', () => {
+		const setupDiffRouteSyncState = () => {
+			Object.keys(route.params).forEach((key) => delete route.params[key]);
+			Object.keys(route.query).forEach((key) => delete route.query[key]);
+			settingsStore.settings.enterprise.workflowDiffs = true;
+			route.params.workflowId = workflowId;
+			route.params.versionId = 'v-target';
+			route.query.diffWith = 'v-source';
+		};
+
+		it('should not push route when emitted diff versions already match current URL', async () => {
+			setupDiffRouteSyncState();
+
+			const { getByTestId } = renderComponent({ pinia });
+			await flushPromises();
+			await userEvent.click(getByTestId('stub-diff-emit-same'));
+
+			expect(router.push).not.toHaveBeenCalled();
+		});
+
+		it('should push route when emitted diff versions differ from current URL', async () => {
+			setupDiffRouteSyncState();
+			route.query.preserve = 'yes';
+
+			const { getByTestId } = renderComponent({ pinia });
+			await flushPromises();
+			await userEvent.click(getByTestId('stub-diff-emit-other'));
+
+			expect(router.push).toHaveBeenCalledWith({
+				name: VIEWS.WORKFLOW_HISTORY,
+				params: {
+					workflowId,
+					versionId: 'v-other-target',
+				},
+				query: {
+					diffWith: 'v-other-source',
+					preserve: 'yes',
+				},
+			});
+		});
 	});
 
 	it('should display archived tag on header if workflow is archived', async () => {

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistory.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistory.vue
@@ -133,12 +133,12 @@ const actions = computed<Array<UserAction<IUser>>>(() =>
 );
 
 const isFirstItemShown = computed(() => workflowHistory.value[0]?.versionId === versionId.value);
-const createCompareRoute = (compareVersionId: string) => {
+const createCompareRoute = (compareVersionId: string, selectedVersionId = versionId.value) => {
 	return {
 		name: VIEWS.WORKFLOW_HISTORY,
 		params: {
 			workflowId: workflowId.value,
-			versionId: versionId.value,
+			versionId: selectedVersionId,
 		},
 		query: {
 			...route.query,
@@ -496,6 +496,24 @@ const openCompareView = async (compareVersionId: WorkflowVersionId) => {
 	sendTelemetry('user_clicks_compare_workflows', { source: 'version_history' });
 };
 
+const onDiffVersionsChange = async ({
+	sourceVersionId,
+	targetVersionId,
+}: {
+	sourceVersionId: string;
+	targetVersionId: string;
+}) => {
+	if (!sourceVersionId || !targetVersionId) {
+		return;
+	}
+
+	if (versionId.value === targetVersionId && diffWithVersionId.value === sourceVersionId) {
+		return;
+	}
+
+	await router.push(createCompareRoute(sourceVersionId, targetVersionId));
+};
+
 const closeCompareView = async () => {
 	if (uiStore.modalsById[WORKFLOW_HISTORY_DIFF_MODAL_KEY]?.open) {
 		uiStore.closeModal(WORKFLOW_HISTORY_DIFF_MODAL_KEY);
@@ -631,6 +649,7 @@ watchEffect(async () => {
 					:source-workflow-version-id="diffWithVersionId"
 					:target-workflow-version-id="versionId"
 					:available-versions="workflowHistory"
+					@versions-change="onDiffVersionsChange"
 					@close="closeCompareView"
 				/>
 			</template>

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistoryDiff.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistoryDiff.vue
@@ -23,6 +23,7 @@ const props = defineProps<{
 }>();
 const emit = defineEmits<{
 	close: [];
+	versionsChange: [{ sourceVersionId: string; targetVersionId: string }];
 }>();
 
 const i18n = useI18n();
@@ -163,6 +164,7 @@ watch(
 watch(
 	[selectedSourceVersionId, selectedTargetVersionId],
 	([sourceVersionId, targetVersionId]) => {
+		emit('versionsChange', { sourceVersionId, targetVersionId });
 		void loadComparedVersions(sourceVersionId, targetVersionId);
 	},
 	{ immediate: true },


### PR DESCRIPTION
## Summary

https://www.loom.com/share/b47ceb9fcde04e4ca58318b8a65711c7

This PR addresses design feedback for the workflow diff feature:

1. **Tooltip update**: Changed the diff button tooltip to a two-line format showing "Compare '{name}'" and "with '{name}'" to make it clearer which versions are being compared.
2. **Style fixes**: Fixed the styles for the `+` and `-` connectors in the workflow diff view, and combined/simplified the existing styles.
3. **Bug fix**: Fixed router/URL inconsistency when changing versions in the diff view — the URL now stays in sync when the user switches source or target versions inside the diff modal. Previously, switching versions in the diff did not update the URL.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-361

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)