### PR TITLE
chore: Update n8n-plan skill to save plans and link them in PRs (no-changelog)

### DIFF
--- a/.claude/commands/n8n-plan.md
+++ b/.claude/commands/n8n-plan.md
@@ -4,7 +4,7 @@ argument-hint: [PAY-XXXX | DEV-XXXX | ENG-XXXX]
 allowed-tools: Task, Agent, Read, Glob, Grep, Write, Bash
 ---
 
-Launch a Plan agent (built-in) to create an implementation plan for Linear issue $ARGUMENTS.
+Launch a Plan agent (built-in) to research and design an implementation plan for Linear issue $ARGUMENTS.
 
 The agent should:
 1. Fetch and analyze the Linear ticket using Linear MCP
@@ -15,11 +15,11 @@ The agent should:
 
 Apply n8n architectural patterns (monorepo structure, TypeScript standards, Vue 3 Composition API, Controller-Service-Repository, etc.).
 
-Save the plan to `.claude/plans/<TICKET-ID>.md` (e.g. `.claude/plans/PAY-1234.md`). This directory is gitignored. The file should contain:
+The agent should return the full plan as text (it cannot write files). After receiving the result, save it to `.claude/plans/<TICKET-ID>.md` (e.g. `.claude/plans/PAY-1234.md`). Create the directory if needed. This directory is gitignored.
+
+The plan file should contain:
 - The ticket title and link
 - A summary of the ticket
 - The full implementation plan
 - Testing strategy
 - Risks and open questions
-
-Return the path to the saved plan file.

--- a/.claude/commands/n8n-plan.md
+++ b/.claude/commands/n8n-plan.md
@@ -1,7 +1,7 @@
 ---
 description: Plan n8n Linear ticket implementation
 argument-hint: [PAY-XXXX | DEV-XXXX | ENG-XXXX]
-allowed-tools: Task
+allowed-tools: Task, Agent, Read, Glob, Grep, Write, Bash
 ---
 
 Launch a Plan agent (built-in) to create an implementation plan for Linear issue $ARGUMENTS.
@@ -15,4 +15,11 @@ The agent should:
 
 Apply n8n architectural patterns (monorepo structure, TypeScript standards, Vue 3 Composition API, Controller-Service-Repository, etc.).
 
-Return a detailed, actionable plan ready for implementation.
+Save the plan to `.claude/plans/<TICKET-ID>.md` (e.g. `.claude/plans/PAY-1234.md`). This directory is gitignored. The file should contain:
+- The ticket title and link
+- A summary of the ticket
+- The full implementation plan
+- Testing strategy
+- Risks and open questions
+
+Return the path to the saved plan file.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,9 @@
 			"Bash(pnpm test:*)",
 			"Bash(pnpm typecheck:*)",
 			"Bash(popd)",
-			"Bash(pushd:*)"
+			"Bash(pushd:*)",
+			"Bash(mkdir -p .claude/plans)",
+			"Write(.claude/plans/*)"
 		]
 	}
 }

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -53,20 +53,27 @@ Creates GitHub PRs with titles that pass n8n's `check-pr-title` CI validation.
    git log origin/master..HEAD --oneline
    ```
 
-2. **If this is a security fix**, audit every public-facing artifact before
+2. **Check for implementation plan**: Look for a plan file in `.claude/plans/`
+   that matches the current branch's ticket ID (e.g. if branch is
+   `scdekov/PAY-1234-some-feature`, check for `.claude/plans/PAY-1234.md`).
+   If a plan file exists, ask the user whether they want to include it in the
+   PR description as a collapsible `<details>` section (see Plan Section below).
+   Only include the plan if the user explicitly approves.
+
+3. **If this is a security fix**, audit every public-facing artifact before
    proceeding (see Security Fixes below).
 
-3. **Analyze changes** to determine:
+4. **Analyze changes** to determine:
    - Type: What kind of change is this?
    - Scope: Which package/area is affected?
    - Summary: What does the change do?
 
-4. **Push branch if needed**:
+5. **Push branch if needed**:
    ```bash
    git push -u origin HEAD
    ```
 
-5. **Create PR** using gh CLI with the template from `.github/pull_request_template.md`:
+6. **Create PR** using gh CLI with the template from `.github/pull_request_template.md`:
    ```bash
    gh pr create --draft --title "<type>(<scope>): <summary>" --body "$(cat <<'EOF'
    ## Summary
@@ -155,6 +162,21 @@ Key validation rules:
 - Exclamation mark for breaking changes goes before the colon
 - Summary must start with capital letter
 - Summary must not end with a period
+
+## Plan Section
+
+If a matching plan file was found in `.claude/plans/` and the user has approved
+including it, add a collapsible section at the end of the PR body (after the
+checklist, before `EOF`):
+
+```markdown
+<details>
+<summary>Implementation plan</summary>
+
+<!-- paste plan file contents here -->
+
+</details>
+```
 
 ## Security Fixes
 

--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,6 @@ packages/cli/src/commands/export/outputs
 .data
 .data/
 .claude/settings.local.json
+.claude/plans/
 lefthook-local.yml
 .playwright-mcp


### PR DESCRIPTION
## Summary

Updates `/n8n-plan` and `/create-pr` skills

- **n8n-plan**:  Now saves the plans into a git ignored directory
- **create-pr**: Checks if there is a plan file for the current work and if there is one suggests to add it to the PR description as a collapsible section

## Related Linear tickets, Github issues, and Community forum posts

N/A — internal tooling improvement

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)