### PR TITLE
fix(editor): Fix callout dismiss action in NDV

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.test.ts
@@ -64,6 +64,19 @@ const testNodeTypes: INodeTypeData = {
 };
 const formWorkflowNodeTypes = createMockNodeTypes(testNodeTypes);
 
+const mockConfirm = vi.fn();
+vi.mock('@/app/composables/useMessage', () => ({
+	useMessage: () => ({
+		confirm: mockConfirm,
+		alert: vi.fn(),
+		message: vi.fn(),
+	}),
+}));
+
+vi.mock('@n8n/rest-api-client/api/users', () => ({
+	updateCurrentUserSettings: vi.fn(),
+}));
+
 vi.mock('vue-router', async () => {
 	const actual = await vi.importActual('vue-router');
 	return {
@@ -863,6 +876,29 @@ describe('ParameterInputList', () => {
 			});
 
 			expect(await findByText('AI Agent Starter Callout')).toBeInTheDocument();
+		});
+
+		it('should hide callout immediately when dismissed', async () => {
+			mockConfirm.mockResolvedValueOnce('confirm');
+
+			ndvStore.activeNode = TEST_NODE_NO_ISSUES;
+			const { findByText, findByTestId, queryByText } = renderComponent({
+				props: {
+					parameters: TEST_PARAMETERS,
+					nodeValues: TEST_NODE_VALUES,
+				},
+			});
+
+			// Callout should be visible initially
+			expect(await findByText('Tip: This is a callout with')).toBeInTheDocument();
+
+			// Click dismiss icon
+			const dismissIcon = await findByTestId('callout-dismiss-icon');
+			await fireEvent.click(dismissIcon);
+			await flushPromises();
+
+			// Callout should be hidden immediately without re-opening NDV
+			expect(queryByText('Tip: This is a callout with')).not.toBeInTheDocument();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
@@ -558,6 +558,11 @@ async function onCalloutDismiss(parameter: INodeProperties) {
 	}
 
 	await dismissCallout(parameter.name);
+
+	const item = parameterItems.value.find((i) => i.parameter.name === parameter.name);
+	if (item) {
+		item.isCalloutVisible = false;
+	}
 }
 
 const parameterRefItems = ref<Map<string, HTMLElement>>(new Map());


### PR DESCRIPTION
## Summary
Fixes the issue where callouts in NDV are not disappearing immediately after dismissing (only after NDV is re-opended).

## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-4998

## How to test:
1. Open NDV for a node with a callout (AI Agent, Pinecone vector store, ...)
2. Dismiss the callout --> should disappear right after confirming

To reset callout --> update `dismissedCallouts` property in `setting` column of the `user` table in your local DB and restart n8n

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
