### PR TITLE
chore: Mark @n8n/cli as beta in package description

### DIFF
--- a/packages/@n8n/cli/package.json
+++ b/packages/@n8n/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@n8n/cli",
   "version": "0.2.0",
-  "description": "Client CLI for n8n — manage workflows, executions, and credentials from the terminal",
+  "description": "[beta] Client CLI for n8n — manage workflows, executions, and credentials from the terminal",
   "license": "SEE LICENSE IN LICENSE.md",
   "bin": {
     "n8n-cli": "bin/n8n-cli.mjs"


### PR DESCRIPTION
## Summary

Adds `[beta]` prefix to the `@n8n/cli` package description to signal that the package is in beta.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)