### PR TITLE
fix(editor): Correct navigation to evaluation tab

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
@@ -247,7 +247,7 @@ async function navigateToEvaluationsView(openInNewTab: boolean) {
 	} else if (route.name !== routeToNavigateTo.name) {
 		dirtyState.value = uiStore.stateIsDirty;
 		workflowToReturnTo.value = workflowId.value;
-		activeHeaderTab.value = MAIN_HEADER_TABS.EXECUTIONS;
+		activeHeaderTab.value = MAIN_HEADER_TABS.EVALUATION;
 		await router.push(routeToNavigateTo);
 	}
 }

--- a/packages/frontend/editor-ui/src/app/utils/nodeViewUtils.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodeViewUtils.test.ts
@@ -7,6 +7,7 @@ import {
 	generateOffsets,
 	getGenericHints,
 	getNewNodePosition,
+	getNodeViewTab,
 	updateViewportToContainNodes,
 	DEFAULT_NODE_SIZE,
 	snapPositionToGrid,
@@ -27,6 +28,8 @@ import type { GraphNode } from '@vue-flow/core';
 import { v4 as uuid } from 'uuid';
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
+import { MAIN_HEADER_TABS, VIEWS } from '@/app/constants';
+import type { RouteLocation } from 'vue-router';
 
 describe('getGenericHints', () => {
 	let mockWorkflowNode: MockProxy<INode>;
@@ -633,5 +636,48 @@ describe('canUsePosition', () => {
 		const pos1: XYPosition = [0, 0];
 		const pos2: XYPosition = [0, DEFAULT_NODE_SIZE[1] + 1];
 		expect(canUsePosition(pos1, pos2)).toBe(true);
+	});
+});
+
+describe('getNodeViewTab', () => {
+	function createRouteLocation(overrides: Partial<RouteLocation>): RouteLocation {
+		return {
+			matched: [],
+			fullPath: '/',
+			query: {},
+			hash: '',
+			redirectedFrom: undefined,
+			path: '/',
+			params: {},
+			name: undefined,
+			meta: {},
+			...overrides,
+		} as RouteLocation;
+	}
+
+	it('should return WORKFLOW for routes with nodeView meta', () => {
+		const route = createRouteLocation({ meta: { nodeView: true } });
+		expect(getNodeViewTab(route)).toBe(MAIN_HEADER_TABS.WORKFLOW);
+	});
+
+	it.each([VIEWS.WORKFLOW_EXECUTIONS, VIEWS.EXECUTION_PREVIEW, VIEWS.EXECUTION_HOME])(
+		'should return EXECUTIONS for %s route',
+		(viewName) => {
+			const route = createRouteLocation({ name: viewName });
+			expect(getNodeViewTab(route)).toBe(MAIN_HEADER_TABS.EXECUTIONS);
+		},
+	);
+
+	it.each([VIEWS.EVALUATION_EDIT, VIEWS.EVALUATION_RUNS_DETAIL])(
+		'should return EVALUATION for %s route',
+		(viewName) => {
+			const route = createRouteLocation({ name: viewName });
+			expect(getNodeViewTab(route)).toBe(MAIN_HEADER_TABS.EVALUATION);
+		},
+	);
+
+	it('should return null for unrecognized routes', () => {
+		const route = createRouteLocation({ name: 'SomeOtherView' });
+		expect(getNodeViewTab(route)).toBeNull();
 	});
 });

--- a/packages/frontend/editor-ui/src/app/utils/nodeViewUtils.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodeViewUtils.ts
@@ -559,6 +559,10 @@ export const getNodeViewTab = (route: RouteLocation): string | null => {
 			.includes(String(route.name))
 	) {
 		return MAIN_HEADER_TABS.EXECUTIONS;
+	} else if (
+		[VIEWS.EVALUATION_EDIT, VIEWS.EVALUATION_RUNS_DETAIL].map(String).includes(String(route.name))
+	) {
+		return MAIN_HEADER_TABS.EVALUATION;
 	}
 	return null;
 };

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -1674,6 +1674,7 @@ onBeforeRouteLeave(async (to, from, next) => {
 
 	const shouldSkipPrompt =
 		toNodeViewTab === MAIN_HEADER_TABS.EXECUTIONS ||
+		toNodeViewTab === MAIN_HEADER_TABS.EVALUATION ||
 		from.name === VIEWS.TEMPLATE_IMPORT ||
 		(toNodeViewTab === MAIN_HEADER_TABS.WORKFLOW && from.name === VIEWS.EXECUTION_DEBUG);
 


### PR DESCRIPTION
## Summary
Switching to the Evaluations tab after deleting an evaluation trigger caused all workflow nodes to disappear. Three issues in the frontend navigation/state management:

  1. MainHeader.vue: navigateToEvaluationsView() incorrectly set activeHeaderTab to EXECUTIONS instead of EVALUATION, causing tab state
  to be out of sync with the route
  2. nodeViewUtils.ts: getNodeViewTab() had no mapping for evaluation routes, returning null and causing downstream logic to misidentify
   the navigation target
  3. NodeView.vue: shouldSkipPrompt in onBeforeRouteLeave didn't include the EVALUATION tab, so navigating to evaluations triggered the
  save confirmation flow which erroneously cleared the workflow ID via setWorkflowId('')

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-2255


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
