### PR TITLE
fix(instance-ai): Use denylist for untestable triggers so polling triggers get verified

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
@@ -33,18 +33,20 @@ import {
 	type SubmitWorkflowAttempt,
 } from '../workflows/submit-workflow.tool';
 
-/** Node types that can be tested via run-workflow with inputData. */
-const TESTABLE_TRIGGERS = new Set([
-	'n8n-nodes-base.manualTrigger',
-	'n8n-nodes-base.executeWorkflowTrigger',
+/** Trigger types that cannot be test-fired programmatically (need an external request). */
+const UNTESTABLE_TRIGGERS = new Set([
+	'n8n-nodes-base.webhook',
+	'n8n-nodes-base.formTrigger',
+	'@n8n/n8n-nodes-langchain.mcpTrigger',
+	'@n8n/n8n-nodes-langchain.chatTrigger',
 ]);
 
 function detectTriggerType(attempt: SubmitWorkflowAttempt | undefined): TriggerType {
 	if (!attempt?.triggerNodeTypes || attempt.triggerNodeTypes.length === 0) {
 		return 'manual_or_testable';
 	}
-	const hasTestable = attempt.triggerNodeTypes.some((t) => TESTABLE_TRIGGERS.has(t));
-	return hasTestable ? 'manual_or_testable' : 'trigger_only';
+	const allUntestable = attempt.triggerNodeTypes.every((t) => UNTESTABLE_TRIGGERS.has(t));
+	return allUntestable ? 'trigger_only' : 'manual_or_testable';
 }
 
 function buildOutcome(


### PR DESCRIPTION
## Summary

- Fixes a bug where `detectTriggerType()` used a **whitelist** of testable triggers (`manualTrigger`, `executeWorkflowTrigger`), causing all other triggers — including `scheduleTrigger` — to be classified as `trigger_only`, which **skips verification entirely**
- This led to the agent claiming it would "mock and verify" credentials but never actually running verification for schedule-based workflows
- Flips to a **denylist** of truly untestable triggers (`webhook`, `formTrigger`, `mcpTrigger`, `chatTrigger`) so polling/schedule triggers correctly go through verification

### Why denylist over whitelist

- The untestable set is smaller and more stable (only triggers needing an external request)
- Better failure mode: with a whitelist, forgetting a trigger silently skips verification; with a denylist, forgetting a trigger attempts verification and fails visibly

Ref: https://www.notion.so/n8n/Says-it-will-mock-creds-and-then-doesn-t-32c5b6e0c94f8037af0fc427e7ad8f85

## Test plan

- [ ] Build a workflow with a schedule trigger + mocked credentials → verify that verification runs instead of being skipped
- [ ] Build a workflow with a webhook trigger + mocked credentials → verify that verification is still skipped (trigger_only)
- [ ] Build a workflow with a manual trigger → verify that verification runs as before