### PR TITLE
fix(Salesforce Node): Fix private key field stripping newlines in JWT credential

### DIFF
--- a/packages/nodes-base/credentials/SalesforceJwtApi.credentials.ts
+++ b/packages/nodes-base/credentials/SalesforceJwtApi.credentials.ts
@@ -2,6 +2,7 @@ import type { AxiosRequestConfig } from 'axios';
 import axios from 'axios';
 import jwt from 'jsonwebtoken';
 import moment from 'moment-timezone';
+import { formatPrivateKey } from '@utils/utilities';
 import type {
 	ICredentialDataDecryptedObject,
 	ICredentialTestRequest,
@@ -55,6 +56,7 @@ export class SalesforceJwtApi implements ICredentialType {
 			type: 'string',
 			typeOptions: {
 				password: true,
+				rows: 4,
 			},
 			default: '',
 			required: true,
@@ -72,6 +74,7 @@ export class SalesforceJwtApi implements ICredentialType {
 			credentials.environment === 'sandbox'
 				? 'https://test.salesforce.com'
 				: 'https://login.salesforce.com';
+		const privateKey = formatPrivateKey(credentials.privateKey as string);
 		const signature = jwt.sign(
 			{
 				iss: credentials.clientId as string,
@@ -79,7 +82,7 @@ export class SalesforceJwtApi implements ICredentialType {
 				aud: authUrl,
 				exp: now + 3 * 60,
 			},
-			credentials.privateKey as string,
+			privateKey,
 			{
 				algorithm: 'RS256',
 				header: {


### PR DESCRIPTION
## Summary

The Salesforce JWT API credential's **Private Key** field was rendered as a single-line password input, which strips newline characters when a PEM certificate is pasted. This caused JWT signing to always fail with `secretOrPrivateKey must be an asymmetric key when using RS256`.

Two changes:
1. Added `rows: 4` to the field's `typeOptions` so it renders as a textarea — matching the pattern used by SSH Private Key, Snowflake, and Crypto credentials.
2. Used `formatPrivateKey()` from `@utils/utilities` in the `authenticate` function to normalise the key before signing — handles existing stored credentials in any format (real newlines, `\n` literals, or space-separated).

**To test:**
1. Create a Salesforce JWT API credential
2. Paste a PEM private key into the Private Key field — verify it accepts multiline input without stripping newlines
3. Test the credential — it should connect successfully

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3504
fixes #18439

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)