### PR TITLE
fix(core): Add format validation to source control branch name

### DIFF
--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-preferences.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-preferences.service.ee.test.ts
@@ -40,6 +40,26 @@ describe('SourceControlPreferencesService', () => {
 		expect(validationResult).toBeTruthy();
 	});
 
+	describe('branchName validation', () => {
+		it.each(['main', 'develop', 'feature/my-branch', 'release-1.0', 'v2.3.4'])(
+			'should accept valid branch name: %s',
+			async (branchName) => {
+				await expect(
+					service.validateSourceControlPreferences({ branchName }),
+				).resolves.not.toThrow();
+			},
+		);
+
+		it.each(['--option-like-value', '-flag', '--receive-pack=cmd', '--upload-pack=cmd'])(
+			'should reject branch name that does not start with an alphanumeric character: %s',
+			async (branchName) => {
+				await expect(service.validateSourceControlPreferences({ branchName })).rejects.toThrow(
+					'Invalid source control preferences',
+				);
+			},
+		);
+	});
+
 	describe('line ending normalization', () => {
 		let tempDir: string;
 

--- a/packages/cli/src/modules/source-control.ee/types/source-control-preferences.ts
+++ b/packages/cli/src/modules/source-control.ee/types/source-control-preferences.ts
@@ -1,4 +1,4 @@
-import { IsBoolean, IsHexColor, IsOptional, IsString, IsIn } from 'class-validator';
+import { IsBoolean, IsHexColor, IsOptional, IsString, IsIn, Matches } from 'class-validator';
 
 import { KeyPairType } from './key-pair-type';
 
@@ -14,6 +14,9 @@ export class SourceControlPreferences {
 	repositoryUrl: string;
 
 	@IsString()
+	@Matches(/^[a-zA-Z0-9]/, {
+		message: 'branchName must start with an alphanumeric character',
+	})
 	branchName = 'main';
 
 	@IsBoolean()


### PR DESCRIPTION
## Summary

Add input validation to the `branchName` field in source control preferences. The field previously only validated that the value was a string (`@IsString()`), without checking the format. This adds a `@Matches` constraint ensuring branch names start with an alphanumeric character, consistent with valid git ref format requirements.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Reported via responsible disclosure -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)