### PR TITLE
fix(Basic LLM Chain Node): Fix abort signal handling

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/chainExecutor.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/chainExecutor.ts
@@ -108,10 +108,7 @@ async function executeSimpleChain({
 	const chain = prompt.pipe(llm).pipe(outputParser).withConfig(getTracingConfig(context));
 
 	// Execute the chain
-	const response = await chain.invoke({
-		query,
-		signal: context.getExecutionCancelSignal(),
-	});
+	const response = await chain.invoke({ query }, { signal: context.getExecutionCancelSignal() });
 
 	// Ensure response is always returned as an array
 	return [response];

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/chainExecutor.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/chainExecutor.test.ts
@@ -265,7 +265,10 @@ describe('chainExecutor', () => {
 			expect(tracing.getTracingConfig).toHaveBeenCalledWith(mockContext);
 		});
 
-		it('should execute a chain with a single output parser', async () => {
+		it('should execute a chain with a single output parser and pass signal as config', async () => {
+			const abortController = new AbortController();
+			mockContext.getExecutionCancelSignal.mockReturnValue(abortController.signal);
+
 			const fakeLLM = new FakeLLM({ response: 'Test response' });
 			const mockPromptTemplate = new PromptTemplate({
 				template: '{query}\n{formatInstructions}',
@@ -306,6 +309,11 @@ describe('chainExecutor', () => {
 			});
 
 			expect(result).toEqual([{ result: 'Test response' }]);
+			// Signal must be in the config (2nd arg), NOT bundled in the input (1st arg)
+			expect(mockChain.invoke).toHaveBeenCalledWith(
+				{ query: 'Hello' },
+				{ signal: abortController.signal },
+			);
 		});
 
 		it('should wrap non-array responses in an array', async () => {
@@ -345,8 +353,10 @@ describe('chainExecutor', () => {
 			expect(result).toEqual([{ result: 'Test response' }]);
 		});
 
-		it('should pass the execution cancel signal to the chain', async () => {
-			// For this test, we'll just verify that getExecutionCancelSignal is called
+		it('should pass the execution cancel signal as config, not as input', async () => {
+			const abortController = new AbortController();
+			mockContext.getExecutionCancelSignal.mockReturnValue(abortController.signal);
+
 			const fakeLLM = new FakeLLM({ response: 'Test response' });
 			const mockPromptTemplate = new PromptTemplate({
 				template: '{query}',
@@ -377,7 +387,11 @@ describe('chainExecutor', () => {
 			});
 
 			expect(mockContext.getExecutionCancelSignal).toHaveBeenCalled();
-			expect(mockChain.invoke).toHaveBeenCalled();
+			// Signal must be in the config (2nd arg), NOT bundled in the input (1st arg)
+			expect(mockChain.invoke).toHaveBeenCalledWith(
+				{ query: 'Hello' },
+				{ signal: abortController.signal },
+			);
 		});
 
 		it('should support chat models', async () => {


### PR DESCRIPTION
## Summary
The chain.invoke() call in the ChainLLM node was passing the abort signal as part of the input object ({ query, signal }) instead of
  as a config option ({ signal }). LangChain ignores signals bundled in the input — the signal must be passed as the second argument
  (config) for chain.invoke() to respect it. This meant that stopping a workflow execution did not abort in-flight LLM requests.
  Tests updated to verify the signal is passed in the correct position.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-2262

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
