### PR TITLE
feat(core): Keep track of workflows created on direct builder mode

### DIFF
--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -140,7 +140,7 @@ When \`<conversation-summary>\` is present in your input, treat it as compressed
 
 ## Background Tasks
 
-Workflow builds and data table operations run in the background. Acknowledge briefly ("Building your Gmail → Slack workflow.") and move on. When \`<background-tasks>\` context reports a completed task, confirm the result. If a task failed, explain concisely and offer to retry.
+Workflow builds and data table operations run in the background. Acknowledge briefly ("Building your Gmail → Slack workflow.") and move on. When \`<background-tasks>\` context reports a completed task, confirm the result. The task result includes any relevant IDs (e.g. workflowId) — use them directly with \`get-workflow\` instead of searching via \`list-workflows\`. If a task failed, explain concisely and offer to retry.
 
 If the user sends a correction while a build is running, call \`correct-background-task\` with the task ID and correction.
 

--- a/packages/@n8n/instance-ai/src/stream/consume-with-hitl.ts
+++ b/packages/@n8n/instance-ai/src/stream/consume-with-hitl.ts
@@ -15,6 +15,8 @@ export interface ConsumeWithHitlOptions {
 	waitForConfirmation?: (requestId: string) => Promise<Record<string, unknown>>;
 	/** Drain queued user corrections (mid-flight steering for background tasks). */
 	drainCorrections?: () => string[];
+	/** Optional callback invoked for each successful tool result, with the tool name and result. */
+	onToolResult?: (toolName: string, result: unknown) => void;
 }
 
 export interface ConsumeWithHitlResult {
@@ -42,12 +44,17 @@ export async function consumeStreamWithHitl(
 		abortSignal,
 		waitForConfirmation,
 		drainCorrections,
+		onToolResult,
 	} = options;
 
 	let subAgentStream: AsyncIterable<unknown> = options.stream.fullStream;
 	let subMastraRunId = options.stream.runId ?? '';
 	let textPromise: Promise<string> = options.stream.text;
 	let streamCompleted = false;
+
+	// Track toolCallId → toolName so we can pair tool-result chunks with their tool name.
+	// Persists across HITL resumes since a tool call may span a suspend/resume cycle.
+	const toolCallNames = onToolResult ? new Map<string, string>() : undefined;
 
 	while (!streamCompleted) {
 		let suspended: { toolCallId: string; requestId: string } | null = null;
@@ -67,6 +74,18 @@ export async function consumeStreamWithHitl(
 			const event = mapMastraChunkToEvent(runId, agentId, chunk);
 			if (event) {
 				eventBus.publish(threadId, event);
+			}
+
+			// Invoke onToolResult callback for successful tool results
+			if (onToolResult && toolCallNames && event) {
+				if (event.type === 'tool-call') {
+					toolCallNames.set(event.payload.toolCallId, event.payload.toolName);
+				} else if (event.type === 'tool-result') {
+					const toolName = toolCallNames.get(event.payload.toolCallId);
+					if (toolName) {
+						onToolResult(toolName, event.payload.result);
+					}
+				}
 			}
 
 			// Surface queued user corrections in the event stream

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
@@ -27,6 +27,7 @@ import type { TriggerType, WorkflowBuildOutcome } from '../../workflow-loop';
 import type { BuilderWorkspace } from '../../workspace/builder-sandbox-factory';
 import { readFileViaSandbox } from '../../workspace/sandbox-fs';
 import { getWorkspaceRoot } from '../../workspace/sandbox-setup';
+import { createBuildWorkflowTool } from '../workflows/build-workflow.tool';
 import { buildCredentialMap, type CredentialMap } from '../workflows/resolve-credentials';
 import {
 	createSubmitWorkflowTool,
@@ -389,6 +390,16 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 						}
 
 						// Tool mode (no sandbox) — original approach
+						if (!domainContext) {
+							return { text: 'Error: domain context not available for tool mode.' };
+						}
+
+						// Create a per-builder build-workflow tool to isolate lastCode
+						// patching state and track the saved workflow ID.
+						// NOTE: This feels pretty fragile, maybe revisit this.
+						const buildWorkflowTool = createBuildWorkflowTool(domainContext);
+						builderTools['build-workflow'] = buildWorkflowTool;
+
 						const subAgent = new Agent({
 							id: subAgentId,
 							name: 'Workflow Builder Agent',
@@ -441,7 +452,22 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 						});
 
 						const toolFinalText = await hitlResult.text;
-						// Tool mode has no submit tracking — return text only
+
+						// Build a structured outcome from the tool's tracked save result
+						// so the orchestrator gets the workflow ID via actionToGuidance()
+						const savedId = buildWorkflowTool.lastSavedWorkflowId;
+						if (savedId) {
+							const attempt: SubmitWorkflowAttempt = {
+								filePath: 'tool-mode',
+								success: true,
+								workflowId: savedId,
+								sourceHash: '',
+							};
+							return {
+								text: toolFinalText,
+								outcome: buildOutcome(workItemId, taskId, attempt, toolFinalText),
+							};
+						}
 						return { text: toolFinalText };
 					} finally {
 						await builderWs?.cleanup();

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
@@ -27,7 +27,6 @@ import type { TriggerType, WorkflowBuildOutcome } from '../../workflow-loop';
 import type { BuilderWorkspace } from '../../workspace/builder-sandbox-factory';
 import { readFileViaSandbox } from '../../workspace/sandbox-fs';
 import { getWorkspaceRoot } from '../../workspace/sandbox-setup';
-import { createBuildWorkflowTool } from '../workflows/build-workflow.tool';
 import { buildCredentialMap, type CredentialMap } from '../workflows/resolve-credentials';
 import {
 	createSubmitWorkflowTool,
@@ -46,6 +45,20 @@ function detectTriggerType(attempt: SubmitWorkflowAttempt | undefined): TriggerT
 	}
 	const hasTestable = attempt.triggerNodeTypes.some((t) => TESTABLE_TRIGGERS.has(t));
 	return hasTestable ? 'manual_or_testable' : 'trigger_only';
+}
+
+interface BuildWorkflowResult {
+	success: boolean;
+	workflowId?: string;
+}
+
+function isBuildWorkflowResult(value: unknown): value is BuildWorkflowResult {
+	return (
+		value !== null &&
+		typeof value === 'object' &&
+		'success' in value &&
+		typeof value.success === 'boolean'
+	);
 }
 
 function buildOutcome(
@@ -390,15 +403,9 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 						}
 
 						// Tool mode (no sandbox) — original approach
-						if (!domainContext) {
-							return { text: 'Error: domain context not available for tool mode.' };
-						}
-
-						// Create a per-builder build-workflow tool to isolate lastCode
-						// patching state and track the saved workflow ID.
-						// NOTE: This feels pretty fragile, maybe revisit this.
-						const buildWorkflowTool = createBuildWorkflowTool(domainContext);
-						builderTools['build-workflow'] = buildWorkflowTool;
+						// Track the last successful build-workflow result from the stream
+						// so we can construct a structured outcome with the workflow ID
+						let lastBuildWorkflowId: string | undefined;
 
 						const subAgent = new Agent({
 							id: subAgentId,
@@ -449,18 +456,22 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 							abortSignal: signal,
 							waitForConfirmation: context.waitForConfirmation,
 							drainCorrections,
+							onToolResult: (toolName, result) => {
+								if (toolName === 'build-workflow' && isBuildWorkflowResult(result)) {
+									lastBuildWorkflowId = result.workflowId;
+								}
+							},
 						});
 
 						const toolFinalText = await hitlResult.text;
 
-						// Build a structured outcome from the tool's tracked save result
-						// so the orchestrator gets the workflow ID via actionToGuidance()
-						const savedId = buildWorkflowTool.lastSavedWorkflowId;
-						if (savedId) {
+						// Build a structured outcome so the orchestrator gets the
+						// workflow ID via actionToGuidance()
+						if (lastBuildWorkflowId) {
 							const attempt: SubmitWorkflowAttempt = {
 								filePath: 'tool-mode',
 								success: true,
-								workflowId: savedId,
+								workflowId: lastBuildWorkflowId,
 								sourceHash: '',
 							};
 							return {

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -19,7 +19,11 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 	// and always match the LLM's own code — not a roundtripped version.
 	let lastCode: string | null = null;
 
-	return createTool({
+	// Tracks the workflow ID from the most recent successful save.
+	// Read by the builder agent tool to construct a structured outcome.
+	let lastSavedWorkflowId: string | undefined;
+
+	const tool = createTool({
 		id: 'build-workflow',
 		description:
 			'Build a workflow from TypeScript SDK code. Two modes:\n' +
@@ -161,6 +165,7 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 						json,
 						opts,
 					);
+					lastSavedWorkflowId = updated.id;
 					return {
 						success: true,
 						workflowId: updated.id,
@@ -171,6 +176,7 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 					};
 				} else {
 					const created = await context.workflowService.createFromWorkflowJSON(json, opts);
+					lastSavedWorkflowId = created.id;
 					return {
 						success: true,
 						workflowId: created.id,
@@ -188,6 +194,12 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 					],
 				};
 			}
+		},
+	});
+
+	return Object.assign(tool, {
+		get lastSavedWorkflowId() {
+			return lastSavedWorkflowId;
 		},
 	});
 }

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -19,11 +19,7 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 	// and always match the LLM's own code — not a roundtripped version.
 	let lastCode: string | null = null;
 
-	// Tracks the workflow ID from the most recent successful save.
-	// Read by the builder agent tool to construct a structured outcome.
-	let lastSavedWorkflowId: string | undefined;
-
-	const tool = createTool({
+	return createTool({
 		id: 'build-workflow',
 		description:
 			'Build a workflow from TypeScript SDK code. Two modes:\n' +
@@ -165,7 +161,6 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 						json,
 						opts,
 					);
-					lastSavedWorkflowId = updated.id;
 					return {
 						success: true,
 						workflowId: updated.id,
@@ -176,7 +171,6 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 					};
 				} else {
 					const created = await context.workflowService.createFromWorkflowJSON(json, opts);
-					lastSavedWorkflowId = created.id;
 					return {
 						success: true,
 						workflowId: created.id,
@@ -194,12 +188,6 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 					],
 				};
 			}
-		},
-	});
-
-	return Object.assign(tool, {
-		get lastSavedWorkflowId() {
-			return lastSavedWorkflowId;
 		},
 	});
 }


### PR DESCRIPTION
## Summary

In un-sandboxed mode orchestrator appears to lose track of the workflow that was created.

Capture created workflows from `build-workflow` tool calls and pass the last one of those to the orchestrator - this allows the instance AI to skip the fault prune `list-workflows` queries.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
