### PR TITLE
fix(core): Include custom headers when loading OpenAI models

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/methods/__tests__/loadModels.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/methods/__tests__/loadModels.test.ts
@@ -156,6 +156,25 @@ describe('searchModels', () => {
 		]);
 	});
 
+	it('should include custom credential headers in the OpenAI client', async () => {
+		mockContext.getCredentials.mockResolvedValueOnce({
+			apiKey: 'test-api-key',
+			header: true,
+			headerName: 'X-Custom-Auth',
+			headerValue: 'custom-value',
+		});
+
+		await searchModels.call(mockContext);
+
+		expect(mockOpenAI).toHaveBeenCalledWith(
+			expect.objectContaining({
+				defaultHeaders: expect.objectContaining({
+					'X-Custom-Auth': 'custom-value',
+				}),
+			}),
+		);
+	});
+
 	it('should return models sorted alphabetically by id', async () => {
 		// Setup a mock with scrambled order
 		const mockUnsortedInstance = {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/methods/loadModels.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/methods/loadModels.ts
@@ -1,10 +1,11 @@
+import { getProxyAgent } from '@n8n/ai-utilities';
+import { AiConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
 import type { ILoadOptionsFunctions, INodeListSearchResult } from 'n8n-workflow';
 import OpenAI from 'openai';
 
+import { mergeCustomHeaders } from '../../../../utils/helpers';
 import { shouldIncludeModel } from '../../../vendors/OpenAi/helpers/modelFiltering';
-import { getProxyAgent } from '@n8n/ai-utilities';
-import { Container } from '@n8n/di';
-import { AiConfig } from '@n8n/config';
 
 export async function searchModels(
 	this: ILoadOptionsFunctions,
@@ -15,7 +16,8 @@ export async function searchModels(
 		(this.getNodeParameter('options.baseURL', '') as string) ||
 		(credentials.url as string) ||
 		'https://api.openai.com/v1';
-	const { openAiDefaultHeaders: defaultHeaders } = Container.get(AiConfig);
+	const { openAiDefaultHeaders } = Container.get(AiConfig);
+	const defaultHeaders = mergeCustomHeaders(credentials, openAiDefaultHeaders ?? {});
 
 	const openai = new OpenAI({
 		baseURL,


### PR DESCRIPTION
## Summary

We were not including custom headers from OpenAI (compatible) credentials when loading models on Chat hub and on canvas node details view resource locators.

This PR fixes that, and changes us to properly include custom headers on OpenAI `loadModels` calls.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-171/chathub-model-selector-missing-mergecustomheaders-custom-credential

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
