### PR TITLE
ci: Replace vars context with runner.name in composite action

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -72,11 +72,11 @@ runs:
       uses: rharkor/caching-for-turbo@0abc2381e688c4d2832f0665a68a01c6e82f0d6c # v2.3.11
 
     - name: Setup Docker Builder for Docker Cache (Blacksmith)
-      if: ${{ inputs.enable-docker-cache == 'true' && vars.RUNNER_PROVIDER != 'github' }}
+      if: ${{ inputs.enable-docker-cache == 'true' && contains(runner.name, 'blacksmith') }}
       uses: useblacksmith/setup-docker-builder@ef12d5b165b596e3aa44ea8198d8fde563eab402 # v1.4.0
 
     - name: Setup Docker Builder (GitHub fallback)
-      if: ${{ inputs.enable-docker-cache == 'true' && vars.RUNNER_PROVIDER == 'github' }}
+      if: ${{ inputs.enable-docker-cache == 'true' && !contains(runner.name, 'blacksmith') }}
       uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
     - name: Build Project


### PR DESCRIPTION
## Summary

The `vars` context is not supported in composite actions (only in workflow files). Upgrading to `actions/setup-node@v6.3.0` in #26949 introduced a stricter template validator that throws `TemplateValidationException` at action load time — even when the `if:` condition would evaluate to `false`.

Replaces `vars.RUNNER_PROVIDER` checks with `contains(runner.name, 'blacksmith')`, which uses the `runner` context that is fully supported in composite actions. The logic is equivalent since all Blacksmith runners follow the `blacksmith-*` naming convention.

No caller changes needed.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/actions/runs/23531866039

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created. (N/A — CI config only)
- [x] Tests included. (N/A — CI config only)
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)