### PR TITLE
fix(editor): Populate workflowDocumentStore in execution preview iframe

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.test.ts
@@ -3,6 +3,7 @@ import { shallowRef } from 'vue';
 import { setActivePinia } from 'pinia';
 import { createTestingPinia } from '@pinia/testing';
 import { usePostMessageHandler } from './usePostMessageHandler';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import type { WorkflowState } from '@/app/composables/useWorkflowState';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
 
@@ -216,6 +217,44 @@ describe('usePostMessageHandler', () => {
 			await vi.waitFor(() => {
 				expect(mockIsProductionExecutionPreview.value).toBe(true);
 			});
+
+			cleanup();
+		});
+
+		it('should set currentWorkflowDocumentStore after opening execution', async () => {
+			const workflowsStore = useWorkflowsStore();
+
+			mockOpenExecution.mockImplementation(async () => {
+				// Simulate what openExecution does: sets workflowId on the store
+				workflowsStore.workflow.id = 'test-wf-id';
+				return {
+					workflowData: { id: 'test-wf-id', name: 'Test' },
+					mode: 'trigger',
+					finished: true,
+				};
+			});
+
+			const storeRef = shallowRef(null);
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: storeRef,
+			});
+			setup();
+
+			const messageEvent = new MessageEvent('message', {
+				data: JSON.stringify({
+					command: 'openExecution',
+					executionId: 'exec-1',
+					executionMode: 'trigger',
+				}),
+			});
+			window.dispatchEvent(messageEvent);
+
+			await vi.waitFor(() => {
+				expect(mockOpenExecution).toHaveBeenCalled();
+			});
+
+			expect(storeRef.value).not.toBeNull();
 
 			cleanup();
 		});

--- a/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.ts
@@ -16,8 +16,13 @@ import type { ExecutionPreviewNodeSchema } from '@/features/execution/executions
 import type { IWorkflowDb } from '@/Interface';
 import type { WorkflowDataUpdate } from '@n8n/rest-api-client/api/workflows';
 import type { WorkflowState } from '@/app/composables/useWorkflowState';
-import type { useWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import {
+	type useWorkflowDocumentStore,
+	useWorkflowDocumentStore as createWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useWorkflowImport } from '@/app/composables/useWorkflowImport';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
 
 interface PostMessageHandlerDeps {
 	workflowState: WorkflowState;
@@ -38,6 +43,7 @@ export function usePostMessageHandler({
 	const telemetry = useTelemetry();
 	const nodeHelpers = useNodeHelpers();
 
+	const workflowsStore = useWorkflowsStore();
 	const { resetWorkspace, openExecution, fitView } = useCanvasOperations();
 	const { importWorkflowExact } = useWorkflowImport(currentWorkflowDocumentStore);
 
@@ -90,6 +96,13 @@ export function usePostMessageHandler({
 		const data = await openExecution(json.executionId, json.nodeId);
 		if (!data) {
 			return;
+		}
+
+		const wfId = workflowsStore.workflowId;
+		if (wfId) {
+			currentWorkflowDocumentStore.value = createWorkflowDocumentStore(
+				createWorkflowDocumentId(wfId),
+			);
 		}
 
 		void nextTick(() => {


### PR DESCRIPTION
## Summary

Two related bugs caused by the `workflowDocumentStore` migration where injected/computed store refs were `null`/`undefined` in certain contexts:

### 1. Input panel broken on execution preview (N8N-9831)
The `handleOpenExecution` post-message handler (used by the execution preview iframe) was not updating the `currentWorkflowDocumentStore` ref after initializing the workspace. After the NDV migration to `workflowDocumentStore` (PR #27158), `InputPanel.vue` reads nodes via the injected store ref — which stayed `null` in the execution preview iframe, causing the input panel to always show the "not connected" empty state.

**Fix:** Populate `currentWorkflowDocumentStore` after `openExecution()` completes, matching what the other two post-message code paths (`handleOpenWorkflow` and `handleOpenExecutionPreview`) already do via `importWorkflowExact`.

### 2. Demo/preview instance not rendering workflows correctly (ADO-4999)
In `initializeWorkspace`, connections were set via `workflowDocumentStore?.value?.setConnections()` — using a computed ref that evaluates to `undefined` when `workflowsStore.workflowId` is empty (which it is right after `resetWorkspace()`). The optional chaining silently skipped the call, leaving `workflowsStore.workflow.connections` empty. This caused AI agent nodes to render as squares with missing sub-connections in the demo/preview instance.

**Fix:** Use the already-available `initializedDocumentStore` direct reference (returned by `initState`) instead of the computed ref.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/N8N-9831
- https://linear.app/n8n/issue/ADO-4999

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.