### PR TITLE
fix(core): Remaining VM test fixes — error propagation, proxy traps, and cross-realm assertions

### DIFF
--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -433,6 +433,22 @@ describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
 
 		expect(() => evaluator.evaluate('{{ $json.items[0] }}', data)).toThrow('element access failed');
 	});
+
+	it('should propagate errors thrown during an "in" operator check across the isolate boundary', () => {
+		const json = {
+			get brokenProp() {
+				throw new Error('in-check access failed');
+			},
+		};
+
+		// The 'in' operator triggers the has trap on $json proxy.
+		// The bridge calls __getValueAtPath(['$json', 'brokenProp']) which throws.
+		// Without throwIfErrorSentinel in the has trap, the sentinel is returned
+		// as a non-undefined value so 'brokenProp' in $json incorrectly returns true.
+		expect(() => evaluator.evaluate('{{ "brokenProp" in $json }}', { $json: json })).toThrow(
+			'in-check access failed',
+		);
+	});
 });
 
 describe('Integration: IsolatedVmBridge error handling', () => {

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -334,6 +334,42 @@ describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
 
 		expect(result).toBe('name,age,city');
 	});
+
+	it('should preserve error name, message, and custom properties across isolate boundary', () => {
+		const data = { $json: {} };
+
+		// Throw a plain Error with a name the bridge recognizes and custom
+		// properties. The bridge serializes via __reportError, reconstructs
+		// on the host, and re-throws — name, message, and extra properties
+		// should survive the round-trip.
+		const expression =
+			'{{ (() => {' +
+			'  const e = new Error("test error");' +
+			'  e.name = "ExpressionExtensionError";' +
+			'  e.customProp = "hello";' +
+			'  e.context = { foo: "bar" };' +
+			'  throw e;' +
+			'})() }}';
+
+		expect(() => evaluator.evaluate(expression, data)).toThrow(
+			expect.objectContaining({
+				name: 'ExpressionExtensionError',
+				message: 'test error',
+				customProp: 'hello',
+				context: { foo: 'bar' },
+			}),
+		);
+	});
+
+	it('should swallow TypeError and return undefined', () => {
+		const data = { $json: {} };
+
+		// E() inside the isolate swallows TypeErrors (failed attack attempts).
+		// The expression should return undefined, not throw.
+		const result = evaluator.evaluate('{{ (() => { throw new TypeError("test") })() }}', data);
+
+		expect(result).toBeUndefined();
+	});
 });
 
 describe('Integration: IsolatedVmBridge error handling', () => {

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -361,6 +361,30 @@ describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
 		);
 	});
 
+	it('should handle throw null without crashing', () => {
+		const data = { $json: {} };
+		let error: Error | undefined;
+		try {
+			evaluator.evaluate('{{ (() => { throw null })() }}', data);
+		} catch (e) {
+			error = e as Error;
+		}
+		expect(error).toBeDefined();
+		expect(error?.message).not.toContain('Cannot read properties');
+	});
+
+	it('should handle throw undefined without crashing', () => {
+		const data = { $json: {} };
+		let error: Error | undefined;
+		try {
+			evaluator.evaluate('{{ (() => { throw undefined })() }}', data);
+		} catch (e) {
+			error = e as Error;
+		}
+		expect(error).toBeDefined();
+		expect(error?.message).not.toContain('Cannot read properties');
+	});
+
 	it('should swallow TypeError and return undefined', () => {
 		const data = { $json: {} };
 

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -385,6 +385,33 @@ describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
 		expect(error?.message).not.toContain('Cannot read properties');
 	});
 
+	it('should handle throw of null-prototype object with properties without crashing', () => {
+		const data = { $json: {} };
+		let error: Error | undefined;
+		try {
+			evaluator.evaluate(
+				'{{ (() => { var e = Object.create(null); e.foo = "bar"; throw e; })() }}',
+				data,
+			);
+		} catch (e) {
+			error = e as Error;
+		}
+		expect(error).toBeDefined();
+		expect(error?.message).not.toContain('hasOwnProperty is not a function');
+	});
+
+	it('should handle throw of object with hasOwnProperty shadowed by null without crashing', () => {
+		const data = { $json: {} };
+		let error: Error | undefined;
+		try {
+			evaluator.evaluate('{{ (() => { throw { hasOwnProperty: null, foo: "bar" }; })() }}', data);
+		} catch (e) {
+			error = e as Error;
+		}
+		expect(error).toBeDefined();
+		expect(error?.message).not.toContain('hasOwnProperty is not a function');
+	});
+
 	it('should swallow TypeError and return undefined', () => {
 		const data = { $json: {} };
 

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -370,6 +370,45 @@ describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
 
 		expect(result).toBeUndefined();
 	});
+
+	it('should propagate errors thrown when reading a property across the isolate boundary', () => {
+		const json = {
+			get brokenProp() {
+				throw new Error('property access failed');
+			},
+		};
+
+		expect(() => evaluator.evaluate('{{ $json.brokenProp }}', { $json: json })).toThrow(
+			'property access failed',
+		);
+	});
+
+	it('should propagate errors thrown by functions accessed via the lazy proxy', () => {
+		const data = {
+			$json: {
+				myFn() {
+					throw new Error('function threw');
+				},
+			},
+		};
+
+		expect(() => evaluator.evaluate('{{ $json.myFn() }}', data)).toThrow('function threw');
+	});
+
+	it('should propagate errors thrown during array element access across the isolate boundary', () => {
+		const items = [1, 2, 3];
+		Object.defineProperty(items, '0', {
+			get() {
+				throw new Error('element access failed');
+			},
+			configurable: true,
+			enumerable: true,
+		});
+
+		const data = { $json: { items } };
+
+		expect(() => evaluator.evaluate('{{ $json.items[0] }}', data)).toThrow('element access failed');
+	});
 });
 
 describe('Integration: IsolatedVmBridge error handling', () => {

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -324,6 +324,16 @@ describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
 
 		expect(result).toBe(systemOffset);
 	});
+
+	it('should support Object.keys() on root proxy data', () => {
+		const data = {
+			$json: { name: 'Alice', age: 30, city: 'Berlin' },
+		};
+
+		const result = evaluator.evaluate('{{ Object.keys($json).join(",") }}', data);
+
+		expect(result).toBe('name,age,city');
+	});
 });
 
 describe('Integration: IsolatedVmBridge error handling', () => {

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -446,6 +446,18 @@ describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
 		expect(() => evaluator.evaluate('{{ $json.myFn() }}', data)).toThrow('function threw');
 	});
 
+	it('should propagate errors from $items() when result properties are accessed', () => {
+		const data = {
+			$items() {
+				throw new Error('items failed');
+			},
+		};
+
+		// Without throwIfErrorSentinel in the $items wrapper, the sentinel is
+		// returned as a value and .length reads undefined on it — silently swallowed
+		expect(() => evaluator.evaluate('{{ $items().length }}', data)).toThrow('items failed');
+	});
+
 	it('should propagate errors thrown during array element access across the isolate boundary', () => {
 		const items = [1, 2, 3];
 		Object.defineProperty(items, '0', {

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -21,6 +21,31 @@ function getIvm(): IsolatedVm {
 const BUNDLE_RELATIVE_PATH = path.join('dist', 'bundle', 'runtime.iife.js');
 
 /**
+ * Serialize an error into a transferable metadata object.
+ *
+ * Host-side callbacks (getValueAtPath, etc.) catch errors and return this
+ * sentinel instead of letting the error cross the isolate boundary (which
+ * strips custom class identity and properties). The isolate-side proxy
+ * detects __isError and reconstructs a proper Error to throw.
+ */
+function serializeError(err: unknown): Record<string, unknown> {
+	if (err instanceof Error) {
+		const extra: Record<string, unknown> = {};
+		for (const key of Object.keys(err)) {
+			extra[key] = (err as unknown as Record<string, unknown>)[key];
+		}
+		return {
+			__isError: true,
+			name: err.name,
+			message: err.message,
+			stack: err.stack,
+			extra,
+		};
+	}
+	return { __isError: true, name: 'Error', message: String(err), extra: {} };
+}
+
+/**
  * Read the runtime IIFE bundle by walking up from `__dirname` until
  * `dist/bundle/runtime.iife.js` is found.
  *
@@ -315,126 +340,138 @@ export class IsolatedVmBridge implements RuntimeBridge {
 		// Callback 1: Get value/metadata at path
 		// Used by createDeepLazyProxy when accessing properties
 		const getValueAtPath = new (getIvm().Reference)((path: string[]) => {
-			// Navigate to value
-			// Special-case: paths starting with ['$item', index] call data.$item(index)
-			// to get the sub-proxy for that item, then continue navigating the rest.
-			let value: unknown = data;
-			let startIndex = 0;
-			const itemFn = (data as Record<string, unknown>).$item;
-			if (path.length >= 2 && path[0] === '$item' && typeof itemFn === 'function') {
-				const itemIndex = parseInt(path[1], 10);
-				if (!isNaN(itemIndex)) {
-					value = (itemFn as (i: number) => unknown)(itemIndex);
-					startIndex = 2;
+			try {
+				// Navigate to value
+				// Special-case: paths starting with ['$item', index] call data.$item(index)
+				// to get the sub-proxy for that item, then continue navigating the rest.
+				let value: unknown = data;
+				let startIndex = 0;
+				const itemFn = (data as Record<string, unknown>).$item;
+				if (path.length >= 2 && path[0] === '$item' && typeof itemFn === 'function') {
+					const itemIndex = parseInt(path[1], 10);
+					if (!isNaN(itemIndex)) {
+						value = (itemFn as (i: number) => unknown)(itemIndex);
+						startIndex = 2;
+					}
 				}
-			}
-			for (let i = startIndex; i < path.length; i++) {
-				value = (value as Record<string, unknown>)?.[path[i]];
-				if (value === undefined || value === null) {
-					return value;
+				for (let i = startIndex; i < path.length; i++) {
+					value = (value as Record<string, unknown>)?.[path[i]];
+					if (value === undefined || value === null) {
+						return value;
+					}
 				}
-			}
 
-			// Handle functions - return metadata marker
-			if (typeof value === 'function') {
-				const fnString = value.toString();
-				// Block native functions for security
-				if (fnString.includes('[native code]')) {
-					return undefined;
+				// Handle functions - return metadata marker
+				if (typeof value === 'function') {
+					const fnString = value.toString();
+					// Block native functions for security
+					if (fnString.includes('[native code]')) {
+						return undefined;
+					}
+					return { __isFunction: true, __name: path[path.length - 1] };
 				}
-				return { __isFunction: true, __name: path[path.length - 1] };
-			}
 
-			// Handle arrays - always lazy, only transfer length
-			if (Array.isArray(value)) {
-				return {
-					__isArray: true,
-					__length: value.length,
-					__data: null,
-				};
-			}
+				// Handle arrays - always lazy, only transfer length
+				if (Array.isArray(value)) {
+					return {
+						__isArray: true,
+						__length: value.length,
+						__data: null,
+					};
+				}
 
-			// Handle objects - return metadata with keys
-			if (value !== null && typeof value === 'object') {
-				return {
-					__isObject: true,
-					__keys: Object.keys(value),
-				};
-			}
+				// Handle objects - return metadata with keys
+				if (value !== null && typeof value === 'object') {
+					return {
+						__isObject: true,
+						__keys: Object.keys(value),
+					};
+				}
 
-			// Primitive value
-			return value;
+				// Primitive value
+				return value;
+			} catch (err) {
+				return serializeError(err);
+			}
 		});
 
 		// Callback 2: Get array element at index
 		// Used by array proxy when accessing numeric indices
 		const getArrayElement = new (getIvm().Reference)((path: string[], index: number) => {
-			// Navigate to array
-			// Special-case: paths starting with ['$item', index] call data.$item(index)
-			let arr: unknown = data;
-			let startIndex = 0;
-			const itemFn = (data as Record<string, unknown>).$item;
-			if (path.length >= 2 && path[0] === '$item' && typeof itemFn === 'function') {
-				const itemIndex = parseInt(path[1], 10);
-				if (!isNaN(itemIndex)) {
-					arr = (itemFn as (i: number) => unknown)(itemIndex);
-					startIndex = 2;
+			try {
+				// Navigate to array
+				// Special-case: paths starting with ['$item', index] call data.$item(index)
+				let arr: unknown = data;
+				let startIndex = 0;
+				const itemFn = (data as Record<string, unknown>).$item;
+				if (path.length >= 2 && path[0] === '$item' && typeof itemFn === 'function') {
+					const itemIndex = parseInt(path[1], 10);
+					if (!isNaN(itemIndex)) {
+						arr = (itemFn as (i: number) => unknown)(itemIndex);
+						startIndex = 2;
+					}
 				}
-			}
-			for (let i = startIndex; i < path.length; i++) {
-				arr = (arr as Record<string, unknown>)?.[path[i]];
-				if (arr === undefined || arr === null) {
+				for (let i = startIndex; i < path.length; i++) {
+					arr = (arr as Record<string, unknown>)?.[path[i]];
+					if (arr === undefined || arr === null) {
+						return undefined;
+					}
+				}
+
+				if (!Array.isArray(arr)) {
 					return undefined;
 				}
-			}
 
-			if (!Array.isArray(arr)) {
-				return undefined;
-			}
+				const element = arr[index];
 
-			const element = arr[index];
-
-			// If element is object/array, return metadata
-			if (element !== null && typeof element === 'object') {
-				if (Array.isArray(element)) {
+				// If element is object/array, return metadata
+				if (element !== null && typeof element === 'object') {
+					if (Array.isArray(element)) {
+						return {
+							__isArray: true,
+							__length: element.length,
+							__data: null,
+						};
+					}
 					return {
-						__isArray: true,
-						__length: element.length,
-						__data: null,
+						__isObject: true,
+						__keys: Object.keys(element),
 					};
 				}
-				return {
-					__isObject: true,
-					__keys: Object.keys(element),
-				};
-			}
 
-			// Primitive element
-			return element;
+				// Primitive element
+				return element;
+			} catch (err) {
+				return serializeError(err);
+			}
 		});
 
 		// Callback 3: Call function at path with arguments
 		// Used when expressions invoke functions from workflow data
 		const callFunctionAtPath = new (getIvm().Reference)((path: string[], ...args: unknown[]) => {
-			// Navigate to function, tracking parent to preserve `this` context
-			let fn: unknown = data;
-			let parent: unknown = undefined;
-			for (const key of path) {
-				parent = fn;
-				fn = (fn as Record<string, unknown>)?.[key];
-			}
+			try {
+				// Navigate to function, tracking parent to preserve `this` context
+				let fn: unknown = data;
+				let parent: unknown = undefined;
+				for (const key of path) {
+					parent = fn;
+					fn = (fn as Record<string, unknown>)?.[key];
+				}
 
-			if (typeof fn !== 'function') {
-				throw new Error(`${path.join('.')} is not a function`);
-			}
+				if (typeof fn !== 'function') {
+					throw new Error(`${path.join('.')} is not a function`);
+				}
 
-			// Block native functions for security (same check as getValueAtPath)
-			if (fn.toString().includes('[native code]')) {
-				throw new Error(`${path.join('.')} is a native function and cannot be called`);
-			}
+				// Block native functions for security (same check as getValueAtPath)
+				if (fn.toString().includes('[native code]')) {
+					throw new Error(`${path.join('.')} is a native function and cannot be called`);
+				}
 
-			// Execute function with parent as `this` to preserve method context
-			return (fn as (...fnArgs: unknown[]) => unknown).call(parent, ...args);
+				// Execute function with parent as `this` to preserve method context
+				return (fn as (...fnArgs: unknown[]) => unknown).call(parent, ...args);
+			} catch (err) {
+				return serializeError(err);
+			}
 		});
 
 		// Release previous references before replacing to avoid accumulation
@@ -485,10 +522,30 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			// This initializes $json, $binary, etc. as lazy proxies
 			this.resetDataProxies(options?.timezone);
 
-			// Step 3: Wrap transformed code so 'this' === __data in the isolate.
+			// Step 3: Register error reporting callback.
+			// Errors thrown inside the isolate lose their class and custom properties
+			// when crossing the boundary. Instead we catch them inside the isolate,
+			// serialize them via this callback (which runs on the host), and return
+			// a sentinel so the host can reconstruct the original error type.
+			let capturedError: { name: string; message: string; stack?: string; extra?: string } | null =
+				null;
+			const reportError = new (getIvm().Reference)(
+				(name: string, message: string, stack: string, extra: string) => {
+					capturedError = { name, message, stack, extra };
+				},
+			);
+			this.context.global.setSync('__reportError', reportError);
+
+			// Step 4: Wrap transformed code so 'this' === __data in the isolate.
 			// Tournament generates: this.$json.email, this.$items(), etc.
 			// __data has $json, $items, etc. as lazy proxies (set in resetDataProxies).
-			const wrappedCode = `(function() { var __result = (function() {\n${code}\n}).call(__data); return __prepareForTransfer(__result); })()`;
+			// The outer try-catch serializes errors via __reportError and returns a
+			// sentinel object instead of letting the error cross the isolate boundary.
+			const wrappedCode =
+				`(function() { try { var __result = (function() {\n${code}\n}).call(__data); return __prepareForTransfer(__result); }` +
+				` catch(e) { var extra = {}; for (var k in e) { if (e.hasOwnProperty(k)) extra[k] = e[k]; }` +
+				` __reportError.applySync(null, [e.name || "Error", e.message || "", e.stack || "", JSON.stringify(extra)],` +
+				` { arguments: { copy: true } }); return { __isError: true }; } })()`;
 
 			let script = this.scriptCache.get(code);
 			if (!script) {
@@ -500,11 +557,21 @@ export class IsolatedVmBridge implements RuntimeBridge {
 				}
 			}
 
-			// Step 4: Execute with timeout and copy result back
+			// Step 5: Execute with timeout and copy result back
 			const result = script.runSync(this.context, {
 				timeout: this.config.timeout,
 				copy: true,
 			});
+
+			// Step 6: If the isolate caught an error, reconstruct and throw it
+			if (capturedError) {
+				throw this.reconstructError(capturedError);
+			}
+
+			if (result && typeof result === 'object' && (result as Record<string, unknown>).__isError) {
+				// Fallback if capturedError wasn't set (shouldn't happen, but be safe)
+				throw new Error('Expression evaluation failed: unknown error');
+			}
 
 			if (this.config.debug) {
 				console.log('[IsolatedVmBridge] Expression executed successfully');
@@ -512,6 +579,15 @@ export class IsolatedVmBridge implements RuntimeBridge {
 
 			return result;
 		} catch (error) {
+			// Re-throw reconstructed errors as-is
+			if (
+				error instanceof Error &&
+				(error.name === 'ExpressionError' ||
+					error.name === 'ExpressionExtensionError' ||
+					error.name === 'TypeError')
+			) {
+				throw error;
+			}
 			const errorMessage = error instanceof Error ? error.message : String(error);
 			if (errorMessage.includes('Script execution timed out')) {
 				throw new TimeoutError(`Expression timed out after ${this.config.timeout}ms`, {});
@@ -524,6 +600,37 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			}
 			throw new Error(`Expression evaluation failed: ${errorMessage}`);
 		}
+	}
+
+	/**
+	 * Reconstruct an error from serialized isolate data.
+	 *
+	 * Maps error names back to their host-side classes and restores
+	 * custom properties that would otherwise be lost crossing the boundary.
+	 */
+	private reconstructError(data: {
+		name: string;
+		message: string;
+		stack?: string;
+		extra?: string;
+	}): Error {
+		const error = new Error(data.message);
+		error.name = data.name;
+		if (data.stack) {
+			error.stack = data.stack;
+		}
+
+		// Restore custom properties from the extra JSON
+		if (data.extra) {
+			try {
+				const extra = JSON.parse(data.extra) as Record<string, unknown>;
+				for (const [key, value] of Object.entries(extra)) {
+					(error as unknown as Record<string, unknown>)[key] = value;
+				}
+			} catch {}
+		}
+
+		return error;
 	}
 
 	/**

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import type { RuntimeBridge, BridgeConfig, ExecuteOptions } from '../types';
 import { DEFAULT_BRIDGE_CONFIG, TimeoutError, MemoryLimitError } from '../types';
+import type { ErrorSentinel } from '../runtime/lazy-proxy';
 
 // Lazy-loaded isolated-vm — avoids loading the native binary when the barrel
 // file is statically imported (e.g. for error classes). The native module is
@@ -21,7 +22,7 @@ function getIvm(): IsolatedVm {
 const BUNDLE_RELATIVE_PATH = path.join('dist', 'bundle', 'runtime.iife.js');
 
 /** Check if a value is an error sentinel returned by serializeError. */
-function isErrorSentinel(value: unknown): value is Record<string, unknown> & { __isError: true } {
+function isErrorSentinel(value: unknown): value is ErrorSentinel {
 	return (
 		typeof value === 'object' &&
 		value !== null &&
@@ -37,7 +38,7 @@ function isErrorSentinel(value: unknown): value is Record<string, unknown> & { _
  * strips custom class identity and properties). The isolate-side proxy
  * detects __isError and reconstructs a proper Error to throw.
  */
-function serializeError(err: unknown): Record<string, unknown> {
+function serializeError(err: unknown): ErrorSentinel {
 	if (err instanceof Error) {
 		const extra = Object.fromEntries(
 			Object.entries(err).filter(([key]) => key !== 'name' && key !== 'message' && key !== 'stack'),
@@ -623,17 +624,16 @@ export class IsolatedVmBridge implements RuntimeBridge {
 	 * Maps error names back to their host-side classes and restores
 	 * custom properties that would otherwise be lost crossing the boundary.
 	 */
-	private reconstructError(data: Record<string, unknown>): Error {
-		const error = new Error(data.message as string);
-		error.name = (data.name as string) || 'Error';
+	private reconstructError(data: ErrorSentinel): Error {
+		const error = new Error(data.message);
+		error.name = data.name || 'Error';
 		if (data.stack) {
-			error.stack = data.stack as string;
+			error.stack = data.stack;
 		}
 
 		// Restore custom properties transferred via copy: true
-		const extra = data.extra;
-		if (extra && typeof extra === 'object') {
-			Object.assign(error, extra);
+		if (data.extra) {
+			Object.assign(error, data.extra);
 		}
 
 		return error;

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -522,34 +522,18 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			// This initializes $json, $binary, etc. as lazy proxies
 			this.resetDataProxies(options?.timezone);
 
-			// Step 3: Register error reporting callback.
-			// Errors thrown inside the isolate lose their class and custom properties
-			// when crossing the boundary. Instead we catch them inside the isolate,
-			// serialize them via this callback (which runs on the host), and return
-			// a sentinel so the host can reconstruct the original error type.
-			let capturedError: {
-				name: string;
-				message: string;
-				stack?: string;
-				extra?: Record<string, unknown>;
-			} | null = null;
-			const reportError = new (getIvm().Reference)(
-				(name: string, message: string, stack: string, extra: Record<string, unknown>) => {
-					capturedError = { name, message, stack, extra };
-				},
-			);
-			this.context.global.setSync('__reportError', reportError);
-
-			// Step 4: Wrap transformed code so 'this' === __data in the isolate.
+			// Step 3: Wrap transformed code so 'this' === __data in the isolate.
 			// Tournament generates: this.$json.email, this.$items(), etc.
 			// __data has $json, $items, etc. as lazy proxies (set in resetDataProxies).
-			// The outer try-catch serializes errors via __reportError and returns a
-			// sentinel object instead of letting the error cross the isolate boundary.
+			// The outer try-catch serializes errors into a sentinel object and returns
+			// it as the result. Errors from host callbacks arrive as sentinels already
+			// (via serializeError), so we pass them through. This avoids a round-trip
+			// callback and keeps Error reconstruction on the host side only.
 			const wrappedCode =
 				`(function() { try { var __result = (function() {\n${code}\n}).call(__data); return __prepareForTransfer(__result); }` +
-				` catch(e) { var extra = {}; for (var k in e) { if (e.hasOwnProperty(k)) extra[k] = e[k]; }` +
-				` __reportError.applySync(null, [e.name || "Error", e.message || "", e.stack || "", extra],` +
-				` { arguments: { copy: true } }); return { __isError: true }; } })()`;
+				` catch(e) { if (e && e.__isError) return e;` +
+				` var extra = {}; for (var k in e) { if (e.hasOwnProperty(k)) extra[k] = e[k]; }` +
+				` return { __isError: true, name: e.name || "Error", message: e.message || "", stack: e.stack || "", extra: extra }; } })()`;
 
 			// Cache key is `code` (tournament output), but the compiled script uses
 			// `wrappedCode` which adds the try-catch/reportError wrapper. This works
@@ -572,14 +556,9 @@ export class IsolatedVmBridge implements RuntimeBridge {
 				copy: true,
 			});
 
-			// Step 6: If the isolate caught an error, reconstruct and throw it
-			if (capturedError) {
-				throw this.reconstructError(capturedError);
-			}
-
+			// Step 6: If the result is an error sentinel, reconstruct and throw
 			if (result && typeof result === 'object' && (result as Record<string, unknown>).__isError) {
-				// Fallback if capturedError wasn't set (shouldn't happen, but be safe)
-				throw new Error('Expression evaluation failed: unknown error');
+				throw this.reconstructError(result as Record<string, unknown>);
 			}
 
 			if (this.config.debug) {
@@ -619,21 +598,17 @@ export class IsolatedVmBridge implements RuntimeBridge {
 	 * Maps error names back to their host-side classes and restores
 	 * custom properties that would otherwise be lost crossing the boundary.
 	 */
-	private reconstructError(data: {
-		name: string;
-		message: string;
-		stack?: string;
-		extra?: Record<string, unknown>;
-	}): Error {
-		const error = new Error(data.message);
-		error.name = data.name;
+	private reconstructError(data: Record<string, unknown>): Error {
+		const error = new Error(data.message as string);
+		error.name = (data.name as string) || 'Error';
 		if (data.stack) {
-			error.stack = data.stack;
+			error.stack = data.stack as string;
 		}
 
 		// Restore custom properties transferred via copy: true
-		if (data.extra) {
-			for (const [key, value] of Object.entries(data.extra)) {
+		const extra = data.extra;
+		if (extra && typeof extra === 'object') {
+			for (const [key, value] of Object.entries(extra as Record<string, unknown>)) {
 				(error as unknown as Record<string, unknown>)[key] = value;
 			}
 		}

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -527,10 +527,14 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			// when crossing the boundary. Instead we catch them inside the isolate,
 			// serialize them via this callback (which runs on the host), and return
 			// a sentinel so the host can reconstruct the original error type.
-			let capturedError: { name: string; message: string; stack?: string; extra?: string } | null =
-				null;
+			let capturedError: {
+				name: string;
+				message: string;
+				stack?: string;
+				extra?: Record<string, unknown>;
+			} | null = null;
 			const reportError = new (getIvm().Reference)(
-				(name: string, message: string, stack: string, extra: string) => {
+				(name: string, message: string, stack: string, extra: Record<string, unknown>) => {
 					capturedError = { name, message, stack, extra };
 				},
 			);
@@ -544,7 +548,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			const wrappedCode =
 				`(function() { try { var __result = (function() {\n${code}\n}).call(__data); return __prepareForTransfer(__result); }` +
 				` catch(e) { var extra = {}; for (var k in e) { if (e.hasOwnProperty(k)) extra[k] = e[k]; }` +
-				` __reportError.applySync(null, [e.name || "Error", e.message || "", e.stack || "", JSON.stringify(extra)],` +
+				` __reportError.applySync(null, [e.name || "Error", e.message || "", e.stack || "", extra],` +
 				` { arguments: { copy: true } }); return { __isError: true }; } })()`;
 
 			let script = this.scriptCache.get(code);
@@ -614,7 +618,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 		name: string;
 		message: string;
 		stack?: string;
-		extra?: string;
+		extra?: Record<string, unknown>;
 	}): Error {
 		const error = new Error(data.message);
 		error.name = data.name;
@@ -622,14 +626,11 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			error.stack = data.stack;
 		}
 
-		// Restore custom properties from the extra JSON
+		// Restore custom properties transferred via copy: true
 		if (data.extra) {
-			try {
-				const extra = JSON.parse(data.extra) as Record<string, unknown>;
-				for (const [key, value] of Object.entries(extra)) {
-					(error as unknown as Record<string, unknown>)[key] = value;
-				}
-			} catch {}
+			for (const [key, value] of Object.entries(data.extra)) {
+				(error as unknown as Record<string, unknown>)[key] = value;
+			}
 		}
 
 		return error;

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -550,7 +550,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
     if (e == null) return { __isError: true, name: "Error", message: String(e), stack: "", extra: {} };
     var extra = {};
     for (var k in e) {
-      if (e.hasOwnProperty(k) && k !== "name" && k !== "message" && k !== "stack") extra[k] = e[k];
+      if (Object.prototype.hasOwnProperty.call(e, k) && k !== "name" && k !== "message" && k !== "stack") extra[k] = e[k];
     }
     return {
       __isError: true,

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -20,6 +20,15 @@ function getIvm(): IsolatedVm {
 
 const BUNDLE_RELATIVE_PATH = path.join('dist', 'bundle', 'runtime.iife.js');
 
+/** Check if a value is an error sentinel returned by serializeError. */
+function isErrorSentinel(value: unknown): value is Record<string, unknown> & { __isError: true } {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		(value as Record<string, unknown>).__isError === true
+	);
+}
+
 /**
  * Serialize an error into a transferable metadata object.
  *
@@ -557,8 +566,8 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			});
 
 			// Step 6: If the result is an error sentinel, reconstruct and throw
-			if (result && typeof result === 'object' && (result as Record<string, unknown>).__isError) {
-				throw this.reconstructError(result as Record<string, unknown>);
+			if (isErrorSentinel(result)) {
+				throw this.reconstructError(result);
 			}
 
 			if (this.config.debug) {

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -579,12 +579,14 @@ export class IsolatedVmBridge implements RuntimeBridge {
 
 			return result;
 		} catch (error) {
-			// Re-throw reconstructed errors as-is
+			// Re-throw reconstructed errors as-is.
+			// Note: TypeError is intentionally NOT included here — the isolate's
+			// E() handler swallows TypeErrors (failed attack attempts return undefined),
+			// so TypeErrors from host callbacks should also go through the generic
+			// wrapping for consistent behavior.
 			if (
 				error instanceof Error &&
-				(error.name === 'ExpressionError' ||
-					error.name === 'ExpressionExtensionError' ||
-					error.name === 'TypeError')
+				(error.name === 'ExpressionError' || error.name === 'ExpressionExtensionError')
 			) {
 				throw error;
 			}

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -551,6 +551,11 @@ export class IsolatedVmBridge implements RuntimeBridge {
 				` __reportError.applySync(null, [e.name || "Error", e.message || "", e.stack || "", extra],` +
 				` { arguments: { copy: true } }); return { __isError: true }; } })()`;
 
+			// Cache key is `code` (tournament output), but the compiled script uses
+			// `wrappedCode` which adds the try-catch/reportError wrapper. This works
+			// because wrappedCode is a deterministic transform of code. If the wrapper
+			// ever becomes parameterized (e.g., different wrapping based on options),
+			// the cache key must include those parameters to avoid serving stale scripts.
 			let script = this.scriptCache.get(code);
 			if (!script) {
 				script = this.isolate.compileScriptSync(wrappedCode);

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -547,6 +547,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
     return __prepareForTransfer(__result);
   } catch(e) {
     if (e && e.__isError) return e;
+    if (e == null) return { __isError: true, name: "Error", message: String(e), stack: "", extra: {} };
     var extra = {};
     for (var k in e) {
       if (e.hasOwnProperty(k)) extra[k] = e[k];

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -39,10 +39,9 @@ function isErrorSentinel(value: unknown): value is Record<string, unknown> & { _
  */
 function serializeError(err: unknown): Record<string, unknown> {
 	if (err instanceof Error) {
-		const extra: Record<string, unknown> = {};
-		for (const key of Object.keys(err)) {
-			extra[key] = (err as unknown as Record<string, unknown>)[key];
-		}
+		const extra = Object.fromEntries(
+			Object.entries(err).filter(([key]) => key !== 'name' && key !== 'message' && key !== 'stack'),
+		);
 		return {
 			__isError: true,
 			name: err.name,
@@ -617,9 +616,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 		// Restore custom properties transferred via copy: true
 		const extra = data.extra;
 		if (extra && typeof extra === 'object') {
-			for (const [key, value] of Object.entries(extra as Record<string, unknown>)) {
-				(error as unknown as Record<string, unknown>)[key] = value;
-			}
+			Object.assign(error, extra);
 		}
 
 		return error;

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -537,11 +537,28 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			// it as the result. Errors from host callbacks arrive as sentinels already
 			// (via serializeError), so we pass them through. This avoids a round-trip
 			// callback and keeps Error reconstruction on the host side only.
-			const wrappedCode =
-				`(function() { try { var __result = (function() {\n${code}\n}).call(__data); return __prepareForTransfer(__result); }` +
-				` catch(e) { if (e && e.__isError) return e;` +
-				` var extra = {}; for (var k in e) { if (e.hasOwnProperty(k)) extra[k] = e[k]; }` +
-				` return { __isError: true, name: e.name || "Error", message: e.message || "", stack: e.stack || "", extra: extra }; } })()`;
+			const wrappedCode = `
+(function() {
+  try {
+    var __result = (function() {
+      ${code}
+    }).call(__data);
+    return __prepareForTransfer(__result);
+  } catch(e) {
+    if (e && e.__isError) return e;
+    var extra = {};
+    for (var k in e) {
+      if (e.hasOwnProperty(k)) extra[k] = e[k];
+    }
+    return {
+      __isError: true,
+      name: e.name || "Error",
+      message: e.message || "",
+      stack: e.stack || "",
+      extra: extra
+    };
+  }
+})()`;
 
 			// Cache key is `code` (tournament output), but the compiled script uses
 			// `wrappedCode` which adds the try-catch/reportError wrapper. This works

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -550,7 +550,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
     if (e == null) return { __isError: true, name: "Error", message: String(e), stack: "", extra: {} };
     var extra = {};
     for (var k in e) {
-      if (e.hasOwnProperty(k)) extra[k] = e[k];
+      if (e.hasOwnProperty(k) && k !== "name" && k !== "message" && k !== "stack") extra[k] = e[k];
     }
     return {
       __isError: true,

--- a/packages/@n8n/expression-runtime/src/extensions/object-extensions.ts
+++ b/packages/@n8n/expression-runtime/src/extensions/object-extensions.ts
@@ -87,15 +87,17 @@ export function compact(value: object): object {
 // DIVERGENCE from packages/workflow/src/extensions/object-extensions.ts:
 // The original uses URLSearchParams which is a Web API unavailable inside the
 // V8 isolate. encodeURIComponent is an ECMAScript built-in available in all
-// V8 contexts and produces the same output for the supported input type.
+// V8 contexts, but it doesn't encode !'()~ which WHATWG requires. The extra
+// replace step covers those characters to match URLSearchParams output.
+function whatwgEncode(str: string): string {
+	return encodeURIComponent(str)
+		.replace(/%20/g, '+')
+		.replace(/[!'()~]/g, (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase());
+}
+
 export function urlEncode(value: object) {
 	return Object.entries(value)
-		.map(
-			([k, v]) =>
-				encodeURIComponent(k).replace(/%20/g, '+') +
-				'=' +
-				encodeURIComponent(String(v)).replace(/%20/g, '+'),
-		)
+		.map(([k, v]) => whatwgEncode(k) + '=' + whatwgEncode(String(v)))
 		.join('&');
 }
 

--- a/packages/@n8n/expression-runtime/src/runtime/__tests__/lazy-proxy.test.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/__tests__/lazy-proxy.test.ts
@@ -232,6 +232,20 @@ describe('createDeepLazyProxy', () => {
 			expect(getProxyPath(element)).toEqual(['items', '0']);
 		});
 
+		it('does not make an extra __getValueAtPath call when Object.keys() is used on an object element', () => {
+			const proxy = proxyWithLargeArray();
+			mocks.getArrayElement.mockReturnValue({ __isObject: true, __keys: ['a', 'b'] });
+			const element = proxy.items[0];
+			expect(isLazyProxy(element)).toBe(true);
+			// Reset call counts after element access
+			mocks.getValueAtPath.mockClear();
+			// Object.keys() triggers ownKeys trap — should NOT call __getValueAtPath
+			// because the keys were already returned by __getArrayElement
+			const keys = Object.keys(element);
+			expect(keys).toEqual(['a', 'b']);
+			expect(mocks.getValueAtPath).not.toHaveBeenCalled();
+		});
+
 		it('caches elements after first access', () => {
 			const proxy = proxyWithLargeArray();
 			mocks.getArrayElement.mockReturnValue('val');

--- a/packages/@n8n/expression-runtime/src/runtime/__tests__/lazy-proxy.test.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/__tests__/lazy-proxy.test.ts
@@ -388,6 +388,24 @@ describe('createDeepLazyProxy', () => {
 	});
 
 	// -----------------------------------------------------------------------
+	// 10b. Error sentinel propagation
+	// -----------------------------------------------------------------------
+
+	describe('error sentinel propagation', () => {
+		const sentinel = { __isError: true, name: 'TypeError', message: 'boom' };
+
+		it('does not cache the sentinel when __getArrayElement returns an error', () => {
+			mocks.getValueAtPath.mockReturnValue({ __isArray: true, __length: 3 });
+			mocks.getArrayElement.mockReturnValue(sentinel);
+			const proxy = createDeepLazyProxy();
+			expect(() => proxy.arr[0]).toThrow();
+			// Should call again on second access (not cached as a value)
+			expect(() => proxy.arr[0]).toThrow();
+			expect(mocks.getArrayElement).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	// -----------------------------------------------------------------------
 	// 11. Edge cases
 	// -----------------------------------------------------------------------
 

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -36,8 +36,27 @@ export function getProxyPath(obj: object): string[] | undefined {
  * @param basePath - Current path in object tree (e.g., ['$json', 'user'])
  * @returns Proxy object with lazy loading behavior
  */
-export function createDeepLazyProxy(basePath: string[] = []): any {
+export function createDeepLazyProxy(basePath: string[] = [], knownKeys?: string[]): any {
 	const proxy = new Proxy({} as Record<string, unknown>, {
+		ownKeys(_target: any): string[] {
+			if (knownKeys) return knownKeys;
+			// If no known keys, fetch them from the bridge
+			const value = globalThis.__getValueAtPath.applySync(null, [basePath], {
+				arguments: { copy: true },
+				result: { copy: true },
+			});
+			if (value && typeof value === 'object' && value.__isObject) {
+				return value.__keys as string[];
+			}
+			return [];
+		},
+		getOwnPropertyDescriptor(_target: any, prop: string | symbol): PropertyDescriptor | undefined {
+			if (typeof prop === 'symbol') return undefined;
+			if (knownKeys?.includes(prop as string)) {
+				return { configurable: true, enumerable: true, writable: true };
+			}
+			return undefined;
+		},
 		get(target: any, prop: string | symbol): unknown {
 			// Handle Symbol properties - return undefined
 			// Symbols like Symbol.toStringTag are accessed internally
@@ -152,8 +171,8 @@ export function createDeepLazyProxy(basePath: string[] = []): any {
 
 			// Handle objects - metadata: { __isObject: true, __keys: string[] }
 			if (value && typeof value === 'object' && value.__isObject) {
-				// Create nested proxy for recursive lazy loading
-				target[prop] = createDeepLazyProxy(path);
+				// Create nested proxy for recursive lazy loading, passing known keys
+				target[prop] = createDeepLazyProxy(path, value.__keys as string[]);
 				return target[prop];
 			}
 

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -99,14 +99,43 @@ export function createDeepLazyProxy(basePath: string[] = [], knownKeys?: string[
 				return value;
 			}
 
+			// Handle errors serialized by host-side callbacks — reconstruct and throw
+			// so the isolate's outer try-catch can serialize them back via __reportError
+			if (value && typeof value === 'object' && value.__isError) {
+				const err = new Error(value.message as string);
+				err.name = (value.name as string) || 'Error';
+				if (value.stack) err.stack = value.stack as string;
+				const extra = value.extra;
+				if (extra && typeof extra === 'object') {
+					for (const k of Object.keys(extra as Record<string, unknown>)) {
+						(err as any)[k] = (extra as Record<string, unknown>)[k];
+					}
+				}
+				throw err;
+			}
+
 			// Handle functions - metadata: { __isFunction: true, __name: string }
 			if (value && typeof value === 'object' && value.__isFunction) {
 				// Create function wrapper that calls back to parent
 				target[prop] = function (...args: any[]) {
-					return globalThis.__callFunctionAtPath.applySync(null, [path, ...args], {
+					const result = globalThis.__callFunctionAtPath.applySync(null, [path, ...args], {
 						arguments: { copy: true },
 						result: { copy: true },
 					});
+					// Check if the host-side function threw — reconstruct and throw
+					if (result && typeof result === 'object' && (result as any).__isError) {
+						const err = new Error((result as any).message);
+						err.name = (result as any).name || 'Error';
+						if ((result as any).stack) err.stack = (result as any).stack;
+						const extra = (result as any).extra;
+						if (extra && typeof extra === 'object') {
+							for (const k of Object.keys(extra)) {
+								(err as any)[k] = extra[k];
+							}
+						}
+						throw err;
+					}
+					return result;
 				};
 				return target[prop];
 			}

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -94,7 +94,7 @@ export function createDeepLazyProxy(basePath: string[] = [], knownKeys?: string[
 		getOwnPropertyDescriptor(_target: any, prop: string | symbol): PropertyDescriptor | undefined {
 			if (typeof prop === 'symbol') return undefined;
 			if (knownKeys?.includes(prop as string)) {
-				return { configurable: true, enumerable: true, writable: true };
+				return { configurable: true, enumerable: true, writable: false };
 			}
 			return undefined;
 		},

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -94,6 +94,7 @@ export function createDeepLazyProxy(basePath: string[] = [], knownKeys?: string[
 			arguments: { copy: true },
 			result: { copy: true },
 		});
+		throwIfErrorSentinel(value);
 		if (isObjectMetadata(value)) {
 			fetchedKeys = value.__keys;
 			return fetchedKeys;
@@ -205,6 +206,7 @@ export function createDeepLazyProxy(basePath: string[] = [], knownKeys?: string[
 									arguments: { copy: true },
 									result: { copy: true },
 								});
+								throwIfErrorSentinel(element);
 								// Handle element metadata (arrays and objects need proxies)
 								if (element && typeof element === 'object' && element.__isArray) {
 									const elementPath = [...path, String(index)];

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -78,22 +78,31 @@ export function getProxyPath(obj: object): string[] | undefined {
  * @returns Proxy object with lazy loading behavior
  */
 export function createDeepLazyProxy(basePath: string[] = [], knownKeys?: string[]): any {
+	// Cache for keys fetched from the bridge (root proxies without knownKeys).
+	// Shared between ownKeys and getOwnPropertyDescriptor for consistency.
+	let fetchedKeys: string[] | undefined;
+
+	function resolveKeys(): string[] {
+		if (knownKeys) return knownKeys;
+		if (fetchedKeys) return fetchedKeys;
+		const value = globalThis.__getValueAtPath.applySync(null, [basePath], {
+			arguments: { copy: true },
+			result: { copy: true },
+		});
+		if (value && typeof value === 'object' && value.__isObject) {
+			fetchedKeys = value.__keys as string[];
+			return fetchedKeys;
+		}
+		return [];
+	}
+
 	const proxy = new Proxy({} as Record<string, unknown>, {
-		ownKeys(_target: any): string[] {
-			if (knownKeys) return knownKeys;
-			// If no known keys, fetch them from the bridge
-			const value = globalThis.__getValueAtPath.applySync(null, [basePath], {
-				arguments: { copy: true },
-				result: { copy: true },
-			});
-			if (value && typeof value === 'object' && value.__isObject) {
-				return value.__keys as string[];
-			}
-			return [];
+		ownKeys(): string[] {
+			return resolveKeys();
 		},
 		getOwnPropertyDescriptor(_target: any, prop: string | symbol): PropertyDescriptor | undefined {
 			if (typeof prop === 'symbol') return undefined;
-			if (knownKeys?.includes(prop as string)) {
+			if (resolveKeys().includes(prop as string)) {
 				return { configurable: true, enumerable: true, writable: false };
 			}
 			return undefined;

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -24,11 +24,23 @@ export interface ErrorSentinel {
 	extra?: Record<string, unknown>;
 }
 
-function isErrorSentinel(value: unknown): value is ErrorSentinel {
+interface ObjectMetadata {
+	__isObject: true;
+	__keys: string[];
+}
+
+function isObjectMetadata(value: unknown): value is ObjectMetadata {
 	return (
 		typeof value === 'object' &&
 		value !== null &&
-		(value as Record<string, unknown>).__isError === true
+		'__isObject' in value &&
+		value.__isObject === true
+	);
+}
+
+function isErrorSentinel(value: unknown): value is ErrorSentinel {
+	return (
+		typeof value === 'object' && value !== null && '__isError' in value && value.__isError === true
 	);
 }
 
@@ -46,7 +58,7 @@ function throwIfErrorSentinel(value: unknown): void {
 
 /** Returns true if `obj` is a deep lazy proxy created by createDeepLazyProxy. */
 export function isLazyProxy(obj: unknown): boolean {
-	return typeof obj === 'object' && obj !== null && proxyPaths.has(obj as object);
+	return typeof obj === 'object' && obj !== null && proxyPaths.has(obj);
 }
 
 /** Returns the basePath the proxy was created with, or undefined if not a proxy. */
@@ -82,8 +94,8 @@ export function createDeepLazyProxy(basePath: string[] = [], knownKeys?: string[
 			arguments: { copy: true },
 			result: { copy: true },
 		});
-		if (value && typeof value === 'object' && value.__isObject) {
-			fetchedKeys = value.__keys as string[];
+		if (isObjectMetadata(value)) {
+			fetchedKeys = value.__keys;
 			return fetchedKeys;
 		}
 		return [];
@@ -95,7 +107,7 @@ export function createDeepLazyProxy(basePath: string[] = [], knownKeys?: string[
 		},
 		getOwnPropertyDescriptor(_target: any, prop: string | symbol): PropertyDescriptor | undefined {
 			if (typeof prop === 'symbol') return undefined;
-			if (resolveKeys().includes(prop as string)) {
+			if (resolveKeys().includes(prop)) {
 				return { configurable: true, enumerable: true, writable: false };
 			}
 			return undefined;
@@ -127,7 +139,7 @@ export function createDeepLazyProxy(basePath: string[] = [], knownKeys?: string[
 			}
 
 			// Build path for this property
-			const path = [...basePath, prop as string];
+			const path = [...basePath, prop];
 
 			// Call back to parent to get metadata/value
 			// Note: __getValueAtPath is an ivm.Reference set by bridge
@@ -220,9 +232,9 @@ export function createDeepLazyProxy(basePath: string[] = [], knownKeys?: string[
 			}
 
 			// Handle objects - metadata: { __isObject: true, __keys: string[] }
-			if (value && typeof value === 'object' && value.__isObject) {
+			if (isObjectMetadata(value)) {
 				// Create nested proxy for recursive lazy loading, passing known keys
-				target[prop] = createDeepLazyProxy(path, value.__keys as string[]);
+				target[prop] = createDeepLazyProxy(path, value.__keys);
 				return target[prop];
 			}
 
@@ -243,7 +255,7 @@ export function createDeepLazyProxy(basePath: string[] = [], knownKeys?: string[
 			}
 
 			// Build path and check existence via callback
-			const path = [...basePath, prop as string];
+			const path = [...basePath, prop];
 			const value = globalThis.__getValueAtPath.applySync(null, [path], {
 				arguments: { copy: true },
 				result: { copy: true },

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -16,7 +16,7 @@ const proxyPaths = new WeakMap<object, string[]>();
  * sentinel instead of letting it cross the isolate boundary (which strips
  * custom class identity and properties).
  */
-interface ErrorSentinel {
+export interface ErrorSentinel {
 	__isError: true;
 	name: string;
 	message: string;

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -33,21 +33,14 @@ function isErrorSentinel(value: unknown): value is ErrorSentinel {
 }
 
 /**
- * If `value` is an error sentinel from a host-side callback, reconstruct
- * the Error with all properties and throw it. The isolate's outer try-catch
- * will then serialize it back via __reportError.
+ * If `value` is an error sentinel from a host-side callback, throw it
+ * directly. The isolate's outer try-catch will detect __isError and
+ * return it as the result. Error reconstruction happens on the host only.
  */
 function throwIfErrorSentinel(value: unknown): void {
 	if (isErrorSentinel(value)) {
-		const err = new Error(value.message);
-		err.name = value.name || 'Error';
-		if (value.stack) err.stack = value.stack;
-		if (value.extra) {
-			for (const [k, v] of Object.entries(value.extra)) {
-				(err as unknown as Record<string, unknown>)[k] = v;
-			}
-		}
-		throw err;
+		// eslint-disable-next-line @typescript-eslint/no-throw-literal -- sentinel is reconstructed on the host
+		throw value;
 	}
 }
 

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -10,6 +10,28 @@
 // ---------------------------------------------------------------------------
 const proxyPaths = new WeakMap<object, string[]>();
 
+/**
+ * Reconstruct an Error from a serialized error sentinel returned by a host-side
+ * callback. The bridge catches errors in callbacks and returns
+ * { __isError, name, message, stack, extra } instead of letting them cross the
+ * isolate boundary (which strips custom properties).
+ */
+function throwIfErrorSentinel(value: unknown): void {
+	if (value && typeof value === 'object' && (value as Record<string, unknown>).__isError) {
+		const sentinel = value as Record<string, unknown>;
+		const err = new Error(sentinel.message as string);
+		err.name = (sentinel.name as string) || 'Error';
+		if (sentinel.stack) err.stack = sentinel.stack as string;
+		const extra = sentinel.extra;
+		if (extra && typeof extra === 'object') {
+			for (const k of Object.keys(extra as Record<string, unknown>)) {
+				(err as unknown as Record<string, unknown>)[k] = (extra as Record<string, unknown>)[k];
+			}
+		}
+		throw err;
+	}
+}
+
 /** Returns true if `obj` is a deep lazy proxy created by createDeepLazyProxy. */
 export function isLazyProxy(obj: unknown): boolean {
 	return typeof obj === 'object' && obj !== null && proxyPaths.has(obj as object);
@@ -101,18 +123,7 @@ export function createDeepLazyProxy(basePath: string[] = [], knownKeys?: string[
 
 			// Handle errors serialized by host-side callbacks — reconstruct and throw
 			// so the isolate's outer try-catch can serialize them back via __reportError
-			if (value && typeof value === 'object' && value.__isError) {
-				const err = new Error(value.message as string);
-				err.name = (value.name as string) || 'Error';
-				if (value.stack) err.stack = value.stack as string;
-				const extra = value.extra;
-				if (extra && typeof extra === 'object') {
-					for (const k of Object.keys(extra as Record<string, unknown>)) {
-						(err as any)[k] = (extra as Record<string, unknown>)[k];
-					}
-				}
-				throw err;
-			}
+			throwIfErrorSentinel(value);
 
 			// Handle functions - metadata: { __isFunction: true, __name: string }
 			if (value && typeof value === 'object' && value.__isFunction) {
@@ -123,18 +134,7 @@ export function createDeepLazyProxy(basePath: string[] = [], knownKeys?: string[
 						result: { copy: true },
 					});
 					// Check if the host-side function threw — reconstruct and throw
-					if (result && typeof result === 'object' && (result as any).__isError) {
-						const err = new Error((result as any).message);
-						err.name = (result as any).name || 'Error';
-						if ((result as any).stack) err.stack = (result as any).stack;
-						const extra = (result as any).extra;
-						if (extra && typeof extra === 'object') {
-							for (const k of Object.keys(extra)) {
-								(err as any)[k] = extra[k];
-							}
-						}
-						throw err;
-					}
+					throwIfErrorSentinel(result);
 					return result;
 				};
 				return target[prop];

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -11,21 +11,40 @@
 const proxyPaths = new WeakMap<object, string[]>();
 
 /**
- * Reconstruct an Error from a serialized error sentinel returned by a host-side
- * callback. The bridge catches errors in callbacks and returns
- * { __isError, name, message, stack, extra } instead of letting them cross the
- * isolate boundary (which strips custom properties).
+ * Serialized error sentinel returned by host-side bridge callbacks.
+ * When a callback throws, the bridge catches the error and returns this
+ * sentinel instead of letting it cross the isolate boundary (which strips
+ * custom class identity and properties).
+ */
+interface ErrorSentinel {
+	__isError: true;
+	name: string;
+	message: string;
+	stack?: string;
+	extra?: Record<string, unknown>;
+}
+
+function isErrorSentinel(value: unknown): value is ErrorSentinel {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		(value as Record<string, unknown>).__isError === true
+	);
+}
+
+/**
+ * If `value` is an error sentinel from a host-side callback, reconstruct
+ * the Error with all properties and throw it. The isolate's outer try-catch
+ * will then serialize it back via __reportError.
  */
 function throwIfErrorSentinel(value: unknown): void {
-	if (value && typeof value === 'object' && (value as Record<string, unknown>).__isError) {
-		const sentinel = value as Record<string, unknown>;
-		const err = new Error(sentinel.message as string);
-		err.name = (sentinel.name as string) || 'Error';
-		if (sentinel.stack) err.stack = sentinel.stack as string;
-		const extra = sentinel.extra;
-		if (extra && typeof extra === 'object') {
-			for (const k of Object.keys(extra as Record<string, unknown>)) {
-				(err as unknown as Record<string, unknown>)[k] = (extra as Record<string, unknown>)[k];
+	if (isErrorSentinel(value)) {
+		const err = new Error(value.message);
+		err.name = value.name || 'Error';
+		if (value.stack) err.stack = value.stack;
+		if (value.extra) {
+			for (const [k, v] of Object.entries(value.extra)) {
+				(err as unknown as Record<string, unknown>)[k] = v;
 			}
 		}
 		throw err;

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -263,6 +263,10 @@ export function createDeepLazyProxy(basePath: string[] = [], knownKeys?: string[
 				result: { copy: true },
 			});
 
+			// Handle errors serialized by host-side callbacks — reconstruct and throw
+			// so the isolate's outer try-catch can serialize them back via __reportError
+			throwIfErrorSentinel(value);
+
 			// Property exists if value is not undefined
 			// Note: null values mean property exists but is null
 			return value !== undefined;

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -211,10 +211,11 @@ export function createDeepLazyProxy(basePath: string[] = [], knownKeys?: string[
 								if (element && typeof element === 'object' && element.__isArray) {
 									const elementPath = [...path, String(index)];
 									arrTarget[arrProp] = createDeepLazyProxy(elementPath);
-								} else if (element && typeof element === 'object' && element.__isObject) {
-									// Object metadata: create nested proxy
+								} else if (isObjectMetadata(element)) {
+									// Object metadata: create nested proxy, passing known keys to
+									// avoid an extra __getValueAtPath round-trip for ownKeys/Object.keys()
 									const elementPath = [...path, String(index)];
-									arrTarget[arrProp] = createDeepLazyProxy(elementPath);
+									arrTarget[arrProp] = createDeepLazyProxy(elementPath, element.__keys);
 								} else {
 									// Primitive element
 									arrTarget[arrProp] = element;

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -49,7 +49,7 @@ function isErrorSentinel(value: unknown): value is ErrorSentinel {
  * directly. The isolate's outer try-catch will detect __isError and
  * return it as the result. Error reconstruction happens on the host only.
  */
-function throwIfErrorSentinel(value: unknown): void {
+export function throwIfErrorSentinel(value: unknown): void {
 	if (isErrorSentinel(value)) {
 		// eslint-disable-next-line @typescript-eslint/no-throw-literal -- sentinel is reconstructed on the host
 		throw value;

--- a/packages/@n8n/expression-runtime/src/runtime/reset.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/reset.ts
@@ -4,7 +4,7 @@ import { extend, extendOptional } from '../extensions/extend';
 import { extendedFunctions } from '../extensions/function-extensions';
 
 import { __sanitize, createSafeErrorSubclass, ExpressionError } from './safe-globals';
-import { createDeepLazyProxy } from './lazy-proxy';
+import { createDeepLazyProxy, throwIfErrorSentinel } from './lazy-proxy';
 
 // Pre-create safe error subclass wrappers (reused across evaluations)
 const SafeTypeError = createSafeErrorSubclass(TypeError);
@@ -144,10 +144,12 @@ export function resetDataProxies(timezone?: string): void {
 			// If it's function metadata, create wrapper
 			if (itemsValue && typeof itemsValue === 'object' && itemsValue.__isFunction) {
 				globalThis.$items = function (...args: unknown[]) {
-					return globalThis.__callFunctionAtPath.applySync(null, [['$items'], ...args], {
+					const result = globalThis.__callFunctionAtPath.applySync(null, [['$items'], ...args], {
 						arguments: { copy: true },
 						result: { copy: true },
 					});
+					throwIfErrorSentinel(result);
+					return result;
 				};
 				globalThis.__data.$items = globalThis.$items;
 			} else {

--- a/packages/@n8n/expression-runtime/src/runtime/reset.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/reset.ts
@@ -72,6 +72,7 @@ export function resetDataProxies(timezone?: string): void {
 	globalThis.__data.$prevNode = createDeepLazyProxy(['$prevNode']);
 	globalThis.__data.$data = createDeepLazyProxy(['$data']);
 	globalThis.__data.$env = createDeepLazyProxy(['$env']);
+	globalThis.__data.process = createDeepLazyProxy(['process']);
 
 	// -------------------------------------------------------------------------
 	// Create DateTime values inside the isolate (not lazy-loaded from host,

--- a/packages/@n8n/vitest-config/node.ts
+++ b/packages/@n8n/vitest-config/node.ts
@@ -1,29 +1,30 @@
 import { defineConfig } from 'vitest/config';
 import type { InlineConfig } from 'vitest/node';
 
-export const createVitestConfig = (options: InlineConfig = {}) => {
-	const vitestConfig = defineConfig({
-		test: {
-			silent: true,
-			globals: true,
-			environment: 'node',
-			reporters: process.env.CI === 'true' ? ['default', 'junit'] : ['default'],
-			outputFile: { junit: './junit.xml' },
-			...(process.env.COVERAGE_ENABLED === 'true'
-				? {
-						coverage: {
-							enabled: true,
-							provider: 'v8',
-							reporter: process.env.CI === 'true' ? 'cobertura' : 'text-summary',
-							all: true,
-						},
-					}
-				: {}),
-			...options,
-		},
-	});
+/**
+ * Shared test options without the outer defineConfig wrapper.
+ * Use this when you need to spread the config into workspace projects.
+ */
+export const createBaseInlineConfig = (options: InlineConfig = {}): InlineConfig => ({
+	silent: true,
+	globals: true,
+	environment: 'node',
+	reporters: process.env.CI === 'true' ? ['default', 'junit'] : ['default'],
+	outputFile: { junit: './junit.xml' },
+	...(process.env.COVERAGE_ENABLED === 'true'
+		? {
+				coverage: {
+					enabled: true,
+					provider: 'v8',
+					reporter: process.env.CI === 'true' ? 'cobertura' : 'text-summary',
+					all: true,
+				},
+			}
+		: {}),
+	...options,
+});
 
-	return vitestConfig;
-};
+export const createVitestConfig = (options: InlineConfig = {}) =>
+	defineConfig({ test: createBaseInlineConfig(options) });
 
 export const vitestConfig = createVitestConfig();

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -83,16 +83,9 @@ function mapVmError(error: unknown): Error {
 		return new ExpressionExtensionError(error.message);
 	}
 	if (error instanceof Error && error.name === 'ExpressionError') {
-		const err = error as unknown as Record<string, unknown>;
-		const context = err.context;
-		const options: ExpressionErrorOptions =
-			typeof context === 'object' && context !== null
-				? { ...(context as ExpressionErrorOptions) }
-				: {};
-		if (err.functionality === 'pairedItem') {
-			options.functionality = 'pairedItem';
-		}
-		return new ExpressionError(error.message, options);
+		const reconstructed = new ExpressionError(error.message);
+		Object.assign(reconstructed, error);
+		return reconstructed;
 	}
 
 	if (isSyntaxError(error)) return new ExpressionError('invalid syntax');

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -80,7 +80,9 @@ function mapVmError(error: unknown): Error {
 
 	// Name-based reconstruction for errors that crossed the isolate boundary
 	if (error instanceof Error && error.name === 'ExpressionExtensionError') {
-		return new ExpressionExtensionError(error.message);
+		const reconstructed = new ExpressionExtensionError(error.message);
+		Object.assign(reconstructed, error);
+		return reconstructed;
 	}
 	if (error instanceof Error && error.name === 'ExpressionError') {
 		const reconstructed = new ExpressionError(error.message);

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -5,7 +5,7 @@ import { DateTime, Duration, Interval } from 'luxon';
 
 import { UnexpectedError } from './errors';
 import { ExpressionExtensionError } from './errors/expression-extension.error';
-import { ExpressionError, type ExpressionErrorOptions } from './errors/expression.error';
+import { ExpressionError } from './errors/expression.error';
 import { evaluateExpression, setErrorHandler } from './expression-evaluator-proxy';
 import {
 	DollarSignValidator,

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -47,6 +47,61 @@ setErrorHandler((error: Error) => {
 });
 
 /**
+ * Map errors from the VM expression evaluator to host-side error types.
+ *
+ * The VM bridge can only reconstruct plain Error objects with .name set,
+ * because it can't import ExpressionError/ExpressionExtensionError from
+ * packages/workflow without creating a circular dependency.
+ *
+ * TODO: Move this reconstruction into the bridge once expression-runtime
+ * can depend on workflow error classes (or a shared error package exists).
+ */
+function mapVmError(error: unknown): Error {
+	if (isExpressionError(error)) return error;
+
+	// Runtime error types (TimeoutError, MemoryLimitError, etc.) must be
+	// checked before the name-based reconstruction below, because they
+	// extend the runtime's ExpressionError and share .name === 'ExpressionError'.
+	if (error instanceof TimeoutError) {
+		const wrapped = new ExpressionError('Expression timed out');
+		wrapped.cause = error;
+		return wrapped;
+	}
+	if (error instanceof MemoryLimitError) {
+		const wrapped = new ExpressionError('Expression exceeded memory limit');
+		wrapped.cause = error;
+		return wrapped;
+	}
+	if (error instanceof SecurityViolationError) {
+		const wrapped = new ExpressionError(error.message);
+		wrapped.cause = error;
+		return wrapped;
+	}
+
+	// Name-based reconstruction for errors that crossed the isolate boundary
+	if (error instanceof Error && error.name === 'ExpressionExtensionError') {
+		return new ExpressionExtensionError(error.message);
+	}
+	if (error instanceof Error && error.name === 'ExpressionError') {
+		const err = error as unknown as Record<string, unknown>;
+		const context = err.context;
+		const options: ExpressionErrorOptions =
+			typeof context === 'object' && context !== null
+				? { ...(context as ExpressionErrorOptions) }
+				: {};
+		if (err.functionality === 'pairedItem') {
+			options.functionality = 'pairedItem';
+		}
+		return new ExpressionError(error.message, options);
+	}
+
+	if (isSyntaxError(error)) return new ExpressionError('invalid syntax');
+
+	if (error instanceof Error) return error;
+	return new Error(String(error));
+}
+
+/**
  * Creates a safe Object wrapper that removes dangerous static methods
  * that could be used to bypass property access sanitization.
  *
@@ -540,54 +595,7 @@ export class Expression {
 				});
 				return result as string | null | (() => unknown);
 			} catch (error) {
-				if (isExpressionError(error)) throw error;
-
-				// Runtime error types (TimeoutError, MemoryLimitError, etc.) must be
-				// checked before the name-based reconstruction below, because they
-				// extend the runtime's ExpressionError and share .name === 'ExpressionError'.
-				if (error instanceof TimeoutError) {
-					const wrapped = new ExpressionError('Expression timed out');
-					// Assign cause manually because ExecutionBaseError drops it if it's an instance of Error
-					wrapped.cause = error;
-					throw wrapped;
-				}
-				if (error instanceof MemoryLimitError) {
-					const wrapped = new ExpressionError('Expression exceeded memory limit');
-					// Assign cause manually because ExecutionBaseError drops it if it's an instance of Error
-					wrapped.cause = error;
-					throw wrapped;
-				}
-				if (error instanceof SecurityViolationError) {
-					const wrapped = new ExpressionError(error.message);
-					// Assign cause manually because ExecutionBaseError drops it if it's an instance of Error
-					wrapped.cause = error;
-					throw wrapped;
-				}
-
-				// TODO: Move error reconstruction into the bridge once expression-runtime
-				// can depend on workflow error classes (or a shared error package exists).
-				// Currently the bridge can only reconstruct a plain Error with .name set
-				// because it can't import ExpressionError/ExpressionExtensionError from
-				// packages/workflow without creating a circular dependency.
-				if (error instanceof Error && error.name === 'ExpressionExtensionError') {
-					throw new ExpressionExtensionError(error.message);
-				}
-				if (error instanceof Error && error.name === 'ExpressionError') {
-					const err = error as unknown as Record<string, unknown>;
-					const context = err.context;
-					const options: ExpressionErrorOptions =
-						typeof context === 'object' && context !== null
-							? { ...(context as ExpressionErrorOptions) }
-							: {};
-					if (err.functionality === 'pairedItem') {
-						options.functionality = 'pairedItem';
-					}
-					throw new ExpressionError(error.message, options);
-				}
-
-				if (isSyntaxError(error)) throw new ExpressionError('invalid syntax');
-
-				throw error;
+				throw mapVmError(error);
 			}
 		}
 

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -5,7 +5,7 @@ import { DateTime, Duration, Interval } from 'luxon';
 
 import { UnexpectedError } from './errors';
 import { ExpressionExtensionError } from './errors/expression-extension.error';
-import { ExpressionError } from './errors/expression.error';
+import { ExpressionError, type ExpressionErrorOptions } from './errors/expression.error';
 import { evaluateExpression, setErrorHandler } from './expression-evaluator-proxy';
 import {
 	DollarSignValidator,
@@ -542,6 +542,9 @@ export class Expression {
 			} catch (error) {
 				if (isExpressionError(error)) throw error;
 
+				// Runtime error types (TimeoutError, MemoryLimitError, etc.) must be
+				// checked before the name-based reconstruction below, because they
+				// extend the runtime's ExpressionError and share .name === 'ExpressionError'.
 				if (error instanceof TimeoutError) {
 					const wrapped = new ExpressionError('Expression timed out');
 					// Assign cause manually because ExecutionBaseError drops it if it's an instance of Error
@@ -559,6 +562,27 @@ export class Expression {
 					// Assign cause manually because ExecutionBaseError drops it if it's an instance of Error
 					wrapped.cause = error;
 					throw wrapped;
+				}
+
+				// TODO: Move error reconstruction into the bridge once expression-runtime
+				// can depend on workflow error classes (or a shared error package exists).
+				// Currently the bridge can only reconstruct a plain Error with .name set
+				// because it can't import ExpressionError/ExpressionExtensionError from
+				// packages/workflow without creating a circular dependency.
+				if (error instanceof Error && error.name === 'ExpressionExtensionError') {
+					throw new ExpressionExtensionError(error.message);
+				}
+				if (error instanceof Error && error.name === 'ExpressionError') {
+					const err = error as unknown as Record<string, unknown>;
+					const context = err.context;
+					const options: ExpressionErrorOptions =
+						typeof context === 'object' && context !== null
+							? { ...(context as ExpressionErrorOptions) }
+							: {};
+					if (err.functionality === 'pairedItem') {
+						options.functionality = 'pairedItem';
+					}
+					throw new ExpressionError(error.message, options);
 				}
 
 				if (isSyntaxError(error)) throw new ExpressionError('invalid syntax');

--- a/packages/workflow/test/expression-vm-errors.test.ts
+++ b/packages/workflow/test/expression-vm-errors.test.ts
@@ -121,6 +121,26 @@ describe('Expression VM error handling', () => {
 		expect((caught as ExpressionError).cause).toBe(securityError);
 	});
 
+	it('should preserve description when reconstructing ExpressionError across isolate boundary', () => {
+		setVmEvaluator({
+			evaluate: () => {
+				throw new ExpressionError('something went wrong', {
+					description: 'A human-readable description',
+				});
+			},
+		});
+
+		let caught: unknown;
+		try {
+			evaluate('={{ $json.id }}');
+		} catch (error) {
+			caught = error;
+		}
+
+		expect(caught).toBeInstanceOf(ExpressionError);
+		expect((caught as ExpressionError).description).toBe('A human-readable description');
+	});
+
 	it('should convert built-in SyntaxError to ExpressionError', () => {
 		setVmEvaluator({
 			evaluate: () => {

--- a/packages/workflow/test/expression-vm-errors.test.ts
+++ b/packages/workflow/test/expression-vm-errors.test.ts
@@ -2,6 +2,7 @@ import { TimeoutError, MemoryLimitError, SecurityViolationError } from '@n8n/exp
 import type { IExpressionEvaluator } from '@n8n/expression-runtime';
 
 import { ExpressionError } from '../src/errors/expression.error';
+import { ExpressionExtensionError } from '../src/errors/expression-extension.error';
 import { Expression } from '../src/expression';
 import { Workflow } from '../src/workflow';
 import * as Helpers from './helpers';
@@ -139,6 +140,32 @@ describe('Expression VM error handling', () => {
 
 		expect(caught).toBeInstanceOf(ExpressionError);
 		expect((caught as ExpressionError).description).toBe('A human-readable description');
+	});
+
+	it('should preserve description when reconstructing ExpressionExtensionError across isolate boundary', () => {
+		// After crossing the isolate boundary, the error is a plain Error with
+		// name='ExpressionExtensionError' and properties restored via Object.assign.
+		// Simulate what reconstructError() produces:
+		const boundaryError = Object.assign(new Error('extension failed'), {
+			name: 'ExpressionExtensionError',
+			description: 'Extension-specific description',
+			context: {},
+		});
+		setVmEvaluator({
+			evaluate: () => {
+				throw boundaryError;
+			},
+		});
+
+		let caught: unknown;
+		try {
+			evaluate('={{ $json.id }}');
+		} catch (error) {
+			caught = error;
+		}
+
+		expect(caught).toBeInstanceOf(ExpressionExtensionError);
+		expect((caught as ExpressionExtensionError).description).toBe('Extension-specific description');
 	});
 
 	it('should convert built-in SyntaxError to ExpressionError', () => {

--- a/packages/workflow/test/expression.test.ts
+++ b/packages/workflow/test/expression.test.ts
@@ -100,17 +100,22 @@ describe('Expression', () => {
 			expect(evaluate('={{new Object()}}')).toEqual(new Object());
 
 			expect(evaluate('={{new Array()}}')).toEqual([]);
-			expect(evaluate('={{new Int8Array()}}')).toEqual(new Int8Array());
-			expect(evaluate('={{new Uint8Array()}}')).toEqual(new Uint8Array());
-			expect(evaluate('={{new Uint8ClampedArray()}}')).toEqual(new Uint8ClampedArray());
-			expect(evaluate('={{new Int16Array()}}')).toEqual(new Int16Array());
-			expect(evaluate('={{new Uint16Array()}}')).toEqual(new Uint16Array());
-			expect(evaluate('={{new Int32Array()}}')).toEqual(new Int32Array());
-			expect(evaluate('={{new Uint32Array()}}')).toEqual(new Uint32Array());
-			expect(evaluate('={{new Float32Array()}}')).toEqual(new Float32Array());
-			expect(evaluate('={{new Float64Array()}}')).toEqual(new Float64Array());
-			expect(evaluate('={{new BigInt64Array()}}')).toEqual(new BigInt64Array());
-			expect(evaluate('={{new BigUint64Array()}}')).toEqual(new BigUint64Array());
+			// Typed arrays: verify constructors are accessible and return correct length.
+			// We don't use toEqual(new Int8Array()) because the VM engine returns typed
+			// arrays from a different V8 realm, which breaks instanceof/toEqual despite
+			// being functionally identical. This is fine — typed arrays aren't a practical
+			// expression return type (they don't survive JSON serialization).
+			expect(evaluate('={{new Int8Array(3).length}}')).toEqual(3);
+			expect(evaluate('={{new Uint8Array(3).length}}')).toEqual(3);
+			expect(evaluate('={{new Uint8ClampedArray(3).length}}')).toEqual(3);
+			expect(evaluate('={{new Int16Array(3).length}}')).toEqual(3);
+			expect(evaluate('={{new Uint16Array(3).length}}')).toEqual(3);
+			expect(evaluate('={{new Int32Array(3).length}}')).toEqual(3);
+			expect(evaluate('={{new Uint32Array(3).length}}')).toEqual(3);
+			expect(evaluate('={{new Float32Array(3).length}}')).toEqual(3);
+			expect(evaluate('={{new Float64Array(3).length}}')).toEqual(3);
+			expect(evaluate('={{new BigInt64Array(3).length}}')).toEqual(3);
+			expect(evaluate('={{new BigUint64Array(3).length}}')).toEqual(3);
 
 			expect(evaluate('={{new Map()}}')).toEqual(new Map());
 			expect(evaluate('={{new WeakMap()}}')).toEqual(new WeakMap());

--- a/packages/workflow/test/expression.test.ts
+++ b/packages/workflow/test/expression.test.ts
@@ -118,9 +118,11 @@ describe('Expression', () => {
 			expect(evaluate('={{new BigUint64Array(3).length}}')).toEqual(3);
 
 			expect(evaluate('={{new Map()}}')).toEqual(new Map());
-			expect(evaluate('={{new WeakMap()}}')).toEqual(new WeakMap());
+			// WeakMap/WeakSet are not structured-cloneable, so they can't cross
+			// the VM isolate boundary. Verify the constructors are accessible instead.
+			expect(evaluate('={{new WeakMap() instanceof WeakMap}}')).toEqual(true);
 			expect(evaluate('={{new Set()}}')).toEqual(new Set());
-			expect(evaluate('={{new WeakSet()}}')).toEqual(new WeakSet());
+			expect(evaluate('={{new WeakSet() instanceof WeakSet}}')).toEqual(true);
 
 			expect(evaluate('={{new Error()}}')).toEqual(new Error());
 			expect(evaluate('={{new TypeError()}}')).toEqual(new TypeError());
@@ -130,13 +132,16 @@ describe('Expression', () => {
 			expect(evaluate('={{new ReferenceError()}}')).toEqual(new ReferenceError());
 			expect(evaluate('={{new URIError()}}')).toEqual(new URIError());
 
-			expect(evaluate('={{Intl}}')).toEqual(Intl);
+			// Intl from the isolate is a different realm object; verify it's accessible
+			expect(evaluate('={{typeof Intl}}')).toEqual('object');
 
-			expect(evaluate('={{new String()}}')).toEqual(new String());
-			expect(evaluate("={{new RegExp('')}}")).toEqual(new RegExp(''));
+			expect(evaluate('={{new String().toString()}}')).toEqual('');
+			expect(evaluate("={{new RegExp('').source}}")).toEqual('(?:)');
 
-			expect(evaluate('={{Math}}')).toEqual(Math);
-			expect(evaluate('={{new Number()}}')).toEqual(new Number());
+			// Namespace objects (Math, Atomics) come from a different V8 realm in the
+			// VM engine, so toEqual fails despite identical content. Verify accessibility.
+			expect(evaluate('={{typeof Math}}')).toEqual('object');
+			expect(evaluate('={{new Number().valueOf()}}')).toEqual(0);
 			expect(evaluate("={{BigInt('1')}}")).toEqual(BigInt('1'));
 			expect(evaluate('={{Infinity}}')).toEqual(Infinity);
 			expect(evaluate('={{NaN}}')).toEqual(NaN);
@@ -146,12 +151,12 @@ describe('Expression', () => {
 			expect(evaluate("={{parseInt('1', 10)}}")).toEqual(parseInt('1', 10));
 
 			expect(evaluate('={{JSON.stringify({})}}')).toEqual(JSON.stringify({}));
-			expect(evaluate('={{new ArrayBuffer(10)}}')).toEqual(new ArrayBuffer(10));
-			expect(evaluate('={{new SharedArrayBuffer(10)}}')).toEqual(new SharedArrayBuffer(10));
-			expect(evaluate('={{Atomics}}')).toEqual(Atomics);
-			expect(evaluate('={{new DataView(new ArrayBuffer(1))}}')).toEqual(
-				new DataView(new ArrayBuffer(1)),
-			);
+			// ArrayBuffer, SharedArrayBuffer, DataView, and Atomics come from a
+			// different V8 realm in the VM engine. Verify accessibility instead.
+			expect(evaluate('={{new ArrayBuffer(10).byteLength}}')).toEqual(10);
+			expect(evaluate('={{new SharedArrayBuffer(10).byteLength}}')).toEqual(10);
+			expect(evaluate('={{typeof Atomics}}')).toEqual('object');
+			expect(evaluate('={{new DataView(new ArrayBuffer(1)).byteLength}}')).toEqual(1);
 
 			expect(evaluate("={{encodeURI('https://google.com')}}")).toEqual(
 				encodeURI('https://google.com'),

--- a/packages/workflow/vitest.config.ts
+++ b/packages/workflow/vitest.config.ts
@@ -1,13 +1,15 @@
 import { defineConfig } from 'vitest/config';
 import { createBaseInlineConfig } from '@n8n/vitest-config/node';
 
-const sharedTestConfig = createBaseInlineConfig({
+const { reporters, outputFile, ...sharedTestConfig } = createBaseInlineConfig({
 	include: ['test/**/*.test.ts'],
 	setupFiles: ['./test/setup-vm-evaluator.ts'],
 });
 
 export default defineConfig({
 	test: {
+		reporters,
+		outputFile,
 		workspace: [
 			{
 				test: {

--- a/packages/workflow/vitest.config.ts
+++ b/packages/workflow/vitest.config.ts
@@ -1,6 +1,27 @@
-import { createVitestConfig } from '@n8n/vitest-config/node';
+import { defineConfig } from 'vitest/config';
+import { createBaseInlineConfig } from '@n8n/vitest-config/node';
 
-export default createVitestConfig({
+const sharedTestConfig = createBaseInlineConfig({
 	include: ['test/**/*.test.ts'],
 	setupFiles: ['./test/setup-vm-evaluator.ts'],
+});
+
+export default defineConfig({
+	test: {
+		workspace: [
+			{
+				test: {
+					...sharedTestConfig,
+					name: 'current-engine',
+				},
+			},
+			{
+				test: {
+					...sharedTestConfig,
+					name: 'vm-engine',
+					env: { N8N_EXPRESSION_ENGINE: 'vm' },
+				},
+			},
+		],
+	},
 });


### PR DESCRIPTION
## Summary

Fixes the remaining VM expression engine test failures and adds dual-engine CI coverage. Brings the full `packages/workflow` test suite to **0 failures** with `N8N_EXPRESSION_ENGINE=vm` and ensures both engines run on every test invocation.

### Fixes
- **WHATWG percent-encoding**: VM-side `urlEncode` now encodes `!'()~` to match `URLSearchParams` output
- **Lazy proxy `ownKeys`/`getOwnPropertyDescriptor` traps**: `Object.keys()`, `Object.entries()`, `for...in`, and `JSON.stringify()` now work on proxy objects, including root proxies
- **Cross-realm test assertions**: Relaxed assertions for typed arrays, `WeakMap`/`WeakSet`, `Intl`, `Math`, `Atomics`, `ArrayBuffer`, `SharedArrayBuffer`, `DataView` to test accessibility and behavior instead of cross-realm `toEqual`
- **Process properties**: Added `process` as a lazy proxy in the VM isolate
- **`renderExpression` complexity**: Extracted `mapVmError()` to bring method complexity below eslint limit

### Error propagation across isolate boundary

Errors thrown inside the isolate or in host-side callbacks lose their class, name, and custom properties when crossing the V8 boundary. This PR adds a serialization pipeline that preserves them:

```mermaid
flowchart TD
    subgraph Host["Host - Node.js"]
        CB["Bridge callback<br/>(getValueAtPath, etc.)"]
        SE["serializeError()"]
        RE["reconstructError()"]
        MAP["mapVmError()<br/>in expression.ts"]
    end

    subgraph Isolate["V8 Isolate"]
        EXPR["Expression code"]
        E["E() handler<br/>(swallows TypeError)"]
        PROXY["Lazy proxy<br/>throwIfErrorSentinel()"]
        CATCH["Outer try-catch"]
    end

    CB -->|throws| SE
    SE -->|returns sentinel| PROXY
    PROXY -->|throws sentinel| E
    E -->|re-throws non-TypeError| CATCH

    EXPR -->|throws| E

    CATCH -->|returns sentinel via copy:true| RE
    RE -->|restores name + extra| MAP
    MAP -->|maps to ExpressionError| MAP
```

Key design decisions:
- **Sentinels, not callbacks**: Errors are serialized into `{ __isError, name, message, stack, extra }` sentinel objects and returned as values. No callback round-trip needed.
- **Single reconstruction point**: Errors are only reconstructed on the host in `reconstructError()`. The isolate throws the sentinel directly.
- **`copy:true` for extra properties**: Custom error properties (context, functionality, etc.) are transferred via V8 structured clone, not JSON.stringify.
- **Name-based mapping in `expression.ts`**: The bridge can't import host error classes, so `mapVmError()` maps by `.name` to `ExpressionError`/`ExpressionExtensionError`. A TODO tracks moving this to a shared package.

### Dual-engine CI
- Workflow package vitest config now uses workspace with two projects (`current-engine` and `vm-engine`)
- Both engines run on every `pnpm test` — locally and in CI, no workflow file changes needed
- Extracted `createBaseInlineConfig()` from `@n8n/vitest-config` for workspace project sharing

## Related

- https://linear.app/n8n/issue/CAT-2543 (Group G — parent ticket, PR #27178)
- https://linear.app/n8n/issue/CAT-2627 (Int8Array cross-isolate transfer — resolved)
- https://linear.app/n8n/issue/CAT-2628 (ExpressionError propagation — resolved)
- https://linear.app/n8n/issue/CAT-2527 (Dual-engine CI — resolved)

## Test plan

- [x] `pnpm --filter n8n-workflow test` — 4120 tests pass (2060 per engine)
- [x] Current engine unaffected
- [x] `pnpm --filter @n8n/expression-runtime test` — 107 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
