### PR TITLE
fix(editor): Fix empty project ID when creating resources using RLC

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.test.ts
@@ -3,12 +3,13 @@ import { createComponentRenderer } from '@/__tests__/render';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { ExpressionLocalResolveContextSymbol } from '@/app/constants';
+import { WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
 import { useWorkflowHelpers } from '@/app/composables/useWorkflowHelpers';
 import ResourceLocator from './ResourceLocator.vue';
 import { createTestingPinia } from '@pinia/testing';
 import userEvent from '@testing-library/user-event';
 import { fireEvent, screen, waitFor } from '@testing-library/vue';
-import { computed } from 'vue';
+import { computed, shallowRef } from 'vue';
 import { mockedStore } from '@/__tests__/utils';
 import { vi } from 'vitest';
 import {
@@ -480,6 +481,43 @@ describe('ResourceLocator', () => {
 		);
 
 		expect(nodeTypesStore.getNodeParameterActionResult).not.toHaveBeenCalled();
+	});
+
+	it('falls back to workflow homeProject ID when currentProjectId is not available', async () => {
+		const windowOpenSpy = vi.spyOn(window, 'open');
+		projectsStore.currentProjectId = undefined as unknown as string;
+		nodeTypesStore.getResourceLocatorResults.mockResolvedValue({
+			results: [],
+			paginationToken: null,
+		});
+
+		const mockWorkflowDocumentStore = shallowRef({
+			homeProject: { id: 'home-project-456', name: 'Test Project', type: 'team' },
+		});
+
+		const { getByTestId } = renderComponent({
+			props: {
+				modelValue: TEST_MODEL_VALUE,
+				parameter: TEST_PARAMETER_URL_REDIRECT,
+				path: `parameters.${TEST_PARAMETER_URL_REDIRECT.name}`,
+				node: TEST_NODE_URL_REDIRECT,
+				displayTitle: 'Test Resource Locator',
+				expressionComputedValue: '',
+			},
+			global: {
+				provide: {
+					[WorkflowDocumentStoreKey as symbol]: mockWorkflowDocumentStore,
+				},
+			},
+		});
+
+		await userEvent.click(getByTestId('rlc-input'));
+		await userEvent.click(getByTestId('rlc-item-add-resource'));
+
+		expect(windowOpenSpy).toHaveBeenCalledWith(
+			'/projects/home-project-456/datatables/new',
+			'_blank',
+		);
 	});
 
 	it('clears cached resources after URL redirect so fresh data is fetched on re-open', async () => {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
@@ -57,6 +57,7 @@ import {
 import { completeExpressionSyntax } from '@/app/utils/expressions';
 import { ExpressionLocalResolveContextSymbol } from '@/app/constants';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import FromAiOverrideButton from '../ParameterInputOverrides/FromAiOverrideButton.vue';
 import FromAiOverrideField from '../ParameterInputOverrides/FromAiOverrideField.vue';
 import ParameterOverrideSelectableList from '../ParameterInputOverrides/ParameterOverrideSelectableList.vue';
@@ -161,6 +162,7 @@ const rootStore = useRootStore();
 const uiStore = useUIStore();
 const workflowsStore = useWorkflowsStore();
 const projectsStore = useProjectsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const expressionLocalResolveCtx = inject(ExpressionLocalResolveContextSymbol, undefined);
 
 const appName = computed(() => {
@@ -412,10 +414,12 @@ const handleAddResourceClick = async () => {
 		let resolvedUrl = redirectUrl;
 
 		if (resolvedUrl.includes('{{$projectId}}')) {
-			resolvedUrl = resolvedUrl.replace(
-				/\{\{\$projectId\}\}/g,
-				projectsStore.currentProjectId ?? '',
-			);
+			const projectId =
+				projectsStore.currentProjectId ??
+				workflowDocumentStore?.value?.homeProject?.id ??
+				projectsStore.personalProject?.id ??
+				'';
+			resolvedUrl = resolvedUrl.replace(/\{\{\$projectId\}\}/g, projectId);
 		}
 
 		hideResourceDropdown();


### PR DESCRIPTION
## Summary
Under certain conditions, `projectId` would end up being empty when creating new resources (like data tables) using the RLC component (details in linear ticket). This PR fixes it by using project id from the current workflow if it's not found in the projects store.

## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-5012
Fixes [27294](https://github.com/n8n-io/n8n/issues/27294)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
