### PR TITLE
fix(editor): Use direct store reference for connections in initializeWorkspace

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -3788,6 +3788,31 @@ describe('useCanvasOperations', () => {
 			expect(workflowDocumentStoreInstance.setConnections).toHaveBeenCalled();
 		});
 
+		it('should set connections even when workflowId is initially empty', async () => {
+			const workflowsStore = useWorkflowsStore();
+			// Simulate the state after resetWorkspace() — workflowId is cleared
+			workflowsStore.workflow.id = '';
+
+			const testConnections = {
+				'Node 1': { main: [[{ node: 'Node 2', type: 'main' as const, index: 0 }]] },
+			};
+			const newWorkflowId = 'new-workflow-id';
+			const workflow = createTestWorkflow({
+				id: newWorkflowId,
+				nodes: [createTestNode()],
+				connections: testConnections,
+			});
+
+			const { initializeWorkspace } = useCanvasOperations();
+			await initializeWorkspace(workflow);
+
+			// initState creates a new document store for the workflow ID.
+			// Without the fix, the computed workflowDocumentStore would be undefined
+			// (empty workflowId at start) and setConnections would be silently skipped.
+			const newDocStore = useWorkflowDocumentStore(createWorkflowDocumentId(newWorkflowId));
+			expect(newDocStore.setConnections).toHaveBeenCalledWith(testConnections);
+		});
+
 		it('should initialize node data from node type description', async () => {
 			const nodeTypesStore = mockedStore(useNodeTypesStore);
 			const type = SET_NODE_TYPE;

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -2344,7 +2344,7 @@ export function useCanvasOperations() {
 		});
 
 		initializedDocumentStore.setNodes(data.nodes);
-		workflowDocumentStore?.value?.setConnections(data.connections);
+		initializedDocumentStore.setConnections(data.connections);
 
 		return { workflowDocumentStore: initializedDocumentStore };
 	}


### PR DESCRIPTION
## Summary

`initializeWorkspace` set nodes via the direct `initializedDocumentStore` reference but set connections via the computed `workflowDocumentStore?.value?`. After `resetWorkspace()` clears `workflowId` to `''`, the computed evaluates to `undefined` and `setConnections` is silently skipped — so no connections are loaded.

This broke the workflow preview (used on n8n.io) for all workflows, most visibly for AI agent nodes whose shape depends on sub-node connections (model, memory, tool). Without connections, the agent renders as a plain square instead of a wide rectangle with input slots.

The fix uses `initializedDocumentStore` consistently for both `setNodes` and `setConnections`, matching the direct reference already returned by `initState`.

**Regression introduced in:** #27280

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4999

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.