### PR TITLE
fix(core): Fix hard-coded path style in external storage configuration

### DIFF
--- a/packages/core/src/binary-data/object-store/__tests__/object-store.service.test.ts
+++ b/packages/core/src/binary-data/object-store/__tests__/object-store.service.test.ts
@@ -45,6 +45,7 @@ describe('ObjectStoreService', () => {
 			authAutoDetect: false,
 		},
 		protocol: 'https',
+		forcePathStyle: true,
 	});
 
 	let objectStoreService: ObjectStoreService;
@@ -66,12 +67,27 @@ describe('ObjectStoreService', () => {
 
 		it('should return client config with endpoint and forcePathStyle when custom host is provided', () => {
 			s3Config.host = 'example.com';
+			s3Config.forcePathStyle = true;
 
 			const clientConfig = objectStoreService.getClientConfig();
 
 			expect(clientConfig).toEqual({
 				endpoint: 'https://example.com',
 				forcePathStyle: true,
+				region: mockBucket.region,
+				credentials,
+			});
+		});
+
+		it('should return client config with forcePathStyle disabled when configured', () => {
+			s3Config.host = 'example.com';
+			s3Config.forcePathStyle = false;
+
+			const clientConfig = objectStoreService.getClientConfig();
+
+			expect(clientConfig).toEqual({
+				endpoint: 'https://example.com',
+				forcePathStyle: false,
 				region: mockBucket.region,
 				credentials,
 			});

--- a/packages/core/src/binary-data/object-store/object-store.config.ts
+++ b/packages/core/src/binary-data/object-store/object-store.config.ts
@@ -47,6 +47,10 @@ export class ObjectStoreConfig {
 	@Env('N8N_EXTERNAL_STORAGE_S3_PROTOCOL', protocolSchema)
 	protocol: Protocol = 'https';
 
+	/** Whether to use path-style addressing for S3 requests (e.g. `https://host/bucket` instead of `https://bucket.host`) */
+	@Env('N8N_EXTERNAL_STORAGE_S3_FORCE_PATH_STYLE')
+	forcePathStyle: boolean = true;
+
 	@Nested
 	bucket: ObjectStoreBucketConfig = {} as ObjectStoreBucketConfig;
 

--- a/packages/core/src/binary-data/object-store/object-store.service.ee.ts
+++ b/packages/core/src/binary-data/object-store/object-store.service.ee.ts
@@ -55,7 +55,7 @@ export class ObjectStoreService {
 		const endpoint = host ? `${protocol}://${host}` : undefined;
 		if (endpoint) {
 			clientConfig.endpoint = endpoint;
-			clientConfig.forcePathStyle = true; // Needed for non-AWS S3 compatible services
+			clientConfig.forcePathStyle = this.s3Config.forcePathStyle;
 		}
 		if (bucket.region.length) {
 			clientConfig.region = bucket.region;


### PR DESCRIPTION
## Summary
Allowing users to configure path style via the new env variable (`N8N_EXTERNAL_STORAGE_S3_FORCE_PATH_STYLE`) when connecting to external storage. 
Our previous hard-coded `false` value was not working for some providers, like DigitalOcean.

## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-5005
Fixes [23269](https://github.com/n8n-io/n8n/issues/23269)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
