### PR TITLE
fix(instance-ai): Return status from queueCorrection to prevent silent drops

### DIFF
--- a/packages/@n8n/instance-ai/src/runtime/background-task-manager.ts
+++ b/packages/@n8n/instance-ai/src/runtime/background-task-manager.ts
@@ -60,10 +60,15 @@ export class BackgroundTaskManager {
 		);
 	}
 
-	queueCorrection(taskId: string, correction: string): void {
+	queueCorrection(
+		taskId: string,
+		correction: string,
+	): 'queued' | 'task-completed' | 'task-not-found' {
 		const task = this.tasks.get(taskId);
-		if (!task || task.status !== 'running') return;
+		if (!task) return 'task-not-found';
+		if (task.status !== 'running') return 'task-completed';
 		task.corrections.push(correction);
+		return 'queued';
 	}
 
 	cancelTask(threadId: string, taskId: string): ManagedBackgroundTask | undefined {

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/correct-background-task.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/correct-background-task.tool.test.ts
@@ -30,7 +30,7 @@ function createMockContext(overrides: Partial<OrchestrationContext> = {}): Orche
 
 describe('createCorrectBackgroundTaskTool', () => {
 	it('sends correction to the task when sendCorrectionToTask is available', async () => {
-		const sendCorrectionToTask = jest.fn();
+		const sendCorrectionToTask = jest.fn().mockReturnValue('queued');
 		const context = createMockContext({ sendCorrectionToTask });
 		const tool = createCorrectBackgroundTaskTool(context);
 
@@ -53,5 +53,32 @@ describe('createCorrectBackgroundTaskTool', () => {
 		);
 
 		expect((result as { result: string }).result).toContain('Error');
+	});
+
+	it('returns task-completed message when the task has already finished', async () => {
+		const sendCorrectionToTask = jest.fn().mockReturnValue('task-completed');
+		const context = createMockContext({ sendCorrectionToTask });
+		const tool = createCorrectBackgroundTaskTool(context);
+
+		const result = await tool.execute!(
+			{ taskId: 'build-abc123', correction: 'Use the Projects database' },
+			{} as never,
+		);
+
+		expect((result as { result: string }).result).toContain('already completed');
+		expect((result as { result: string }).result).toContain('follow-up task');
+	});
+
+	it('returns task-not-found message when the task does not exist', async () => {
+		const sendCorrectionToTask = jest.fn().mockReturnValue('task-not-found');
+		const context = createMockContext({ sendCorrectionToTask });
+		const tool = createCorrectBackgroundTaskTool(context);
+
+		const result = await tool.execute!(
+			{ taskId: 'build-unknown', correction: 'Use the Projects database' },
+			{} as never,
+		);
+
+		expect((result as { result: string }).result).toContain('not found');
 	});
 });

--- a/packages/@n8n/instance-ai/src/tools/orchestration/correct-background-task.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/correct-background-task.tool.ts
@@ -26,7 +26,19 @@ export function createCorrectBackgroundTaskTool(context: OrchestrationContext) {
 			if (!context.sendCorrectionToTask) {
 				return await Promise.resolve({ result: 'Error: correction delivery not available.' });
 			}
-			context.sendCorrectionToTask(input.taskId, input.correction);
+			const status = context.sendCorrectionToTask(input.taskId, input.correction);
+			if (status === 'task-not-found') {
+				return await Promise.resolve({
+					result: `Task ${input.taskId} not found. It may have already been cleaned up.`,
+				});
+			}
+			if (status === 'task-completed') {
+				return await Promise.resolve({
+					result:
+						`Task ${input.taskId} has already completed. The correction was not delivered. ` +
+						`Incorporate "${input.correction}" into a new follow-up task instead.`,
+				});
+			}
 			return await Promise.resolve({
 				result: `Correction sent to task ${input.taskId}: "${input.correction}". The builder will see this on its next step.`,
 			});

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -766,7 +766,10 @@ export interface OrchestrationContext {
 	/** Thread-scoped iteration log for accumulating attempt history across retries */
 	iterationLog?: IterationLog;
 	/** Send a correction message to a running background task */
-	sendCorrectionToTask?: (taskId: string, correction: string) => void;
+	sendCorrectionToTask?: (
+		taskId: string,
+		correction: string,
+	) => 'queued' | 'task-completed' | 'task-not-found';
 	/** Shared workflow-task state service for build / verify / credential-finalize flows */
 	workflowTaskService?: WorkflowTaskService;
 }

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -363,8 +363,11 @@ export class InstanceAiService {
 	}
 
 	/** Send a correction message to a running background task. */
-	sendCorrectionToTask(taskId: string, correction: string): void {
-		this.backgroundTasks.queueCorrection(taskId, correction);
+	sendCorrectionToTask(
+		taskId: string,
+		correction: string,
+	): 'queued' | 'task-completed' | 'task-not-found' {
+		return this.backgroundTasks.queueCorrection(taskId, correction);
 	}
 
 	/** Cancel a single background task by ID. */


### PR DESCRIPTION
## Summary
- `queueCorrection()` now returns `'queued' | 'task-completed' | 'task-not-found'` instead of `void`
- The `correct-background-task` tool gives the orchestrator accurate feedback when a task has already finished, instead of a false success message
- Prevents the orchestrator from thinking a correction was delivered when the task had already completed, which led to duplicate builder cards via auto-follow-up

## Related
- [Instance AI issues reported](https://www.notion.so/n8n/Instance-AI-issues-reported-3285b6e0c94f802ca27cd2d2e067c5d7)
- Issue: "nothing happened after correct-background-task step"

## Root cause
Race condition: the background task (e.g. data-table-manager) completes before the orchestrator's correction can be delivered. `queueCorrection()` silently returned, the tool reported success, and the auto-follow-up system spawned a duplicate task.

## Test plan
- [ ] Verify existing tests pass (4/4 passing, including 2 new test cases)
- [ ] Verify that when a task has completed, the tool returns a message telling the orchestrator to use a follow-up task instead
- [ ] Verify that when a task is running, corrections are still delivered as before