### PR TITLE
fix(instance-ai): Move snapshots and iteration logs out of thread metadata

### DIFF
--- a/packages/@n8n/db/src/migrations/common/1774000000000-CreateInstanceAiSnapshotAndLogTables.ts
+++ b/packages/@n8n/db/src/migrations/common/1774000000000-CreateInstanceAiSnapshotAndLogTables.ts
@@ -1,0 +1,46 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+const table = {
+	threads: 'instance_ai_threads',
+	runSnapshots: 'instance_ai_run_snapshots',
+	iterationLogs: 'instance_ai_iteration_logs',
+} as const;
+
+export class CreateInstanceAiSnapshotAndLogTables1774000000000 implements ReversibleMigration {
+	async up({ schemaBuilder: { createTable, column } }: MigrationContext) {
+		await createTable(table.runSnapshots)
+			.withColumns(
+				column('threadId').varchar().primary.notNull,
+				column('runId').varchar().primary.notNull,
+				column('messageGroupId').varchar(),
+				column('runIds').json,
+				column('tree').text.notNull,
+			)
+			.withIndexOn(['threadId', 'messageGroupId'])
+			.withIndexOn(['threadId', 'createdAt'])
+			.withForeignKey('threadId', {
+				tableName: table.threads,
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			}).withTimestamps;
+
+		await createTable(table.iterationLogs)
+			.withColumns(
+				column('id').varchar().primary.notNull,
+				column('threadId').varchar().notNull,
+				column('taskKey').varchar().notNull,
+				column('entry').text.notNull,
+			)
+			.withIndexOn(['threadId', 'taskKey', 'createdAt'])
+			.withForeignKey('threadId', {
+				tableName: table.threads,
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			}).withTimestamps;
+	}
+
+	async down({ schemaBuilder: { dropTable } }: MigrationContext) {
+		await dropTable(table.iterationLogs);
+		await dropTable(table.runSnapshots);
+	}
+}

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -153,6 +153,7 @@ import { AddRoleColumnToProjectSecretsProviderAccess1772619247761 } from '../com
 import { ChangeWorkflowPublishedVersionFKsToRestrict1772619247762 } from '../common/1772619247762-ChangeWorkflowPublishedVersionFKsToRestrict';
 import { AddTypeToChatHubSessions1772700000000 } from '../common/1772700000000-AddTypeToChatHubSessions';
 import { CreateInstanceAiTables1773000000000 } from '../common/1773000000000-CreateInstanceAiTables';
+import { CreateInstanceAiSnapshotAndLogTables1774000000000 } from '../common/1774000000000-CreateInstanceAiSnapshotAndLogTables';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -311,4 +312,5 @@ export const postgresMigrations: Migration[] = [
 	ChangeWorkflowPublishedVersionFKsToRestrict1772619247762,
 	AddTypeToChatHubSessions1772700000000,
 	CreateInstanceAiTables1773000000000,
+	CreateInstanceAiSnapshotAndLogTables1774000000000,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -147,6 +147,7 @@ import { AddRoleColumnToProjectSecretsProviderAccess1772619247761 } from '../com
 import { ChangeWorkflowPublishedVersionFKsToRestrict1772619247762 } from '../common/1772619247762-ChangeWorkflowPublishedVersionFKsToRestrict';
 import { AddTypeToChatHubSessions1772700000000 } from '../common/1772700000000-AddTypeToChatHubSessions';
 import { CreateInstanceAiTables1773000000000 } from '../common/1773000000000-CreateInstanceAiTables';
+import { CreateInstanceAiSnapshotAndLogTables1774000000000 } from '../common/1774000000000-CreateInstanceAiSnapshotAndLogTables';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -299,6 +300,7 @@ const sqliteMigrations: Migration[] = [
 	ChangeWorkflowPublishedVersionFKsToRestrict1772619247762,
 	AddTypeToChatHubSessions1772700000000,
 	CreateInstanceAiTables1773000000000,
+	CreateInstanceAiSnapshotAndLogTables1774000000000,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
@@ -51,7 +51,13 @@ function createService(): InstanceAiMemoryService {
 	};
 	const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
 	const mockCompositeStore = {} as never;
-	return new InstanceAiMemoryService(mockLogger as never, mockConfig as never, mockCompositeStore);
+	const mockDbSnapshotStorage = {} as never;
+	return new InstanceAiMemoryService(
+		mockLogger as never,
+		mockConfig as never,
+		mockCompositeStore,
+		mockDbSnapshotStorage,
+	);
 }
 
 function makeTree(overrides?: Partial<InstanceAiAgentNode>): InstanceAiAgentNode {

--- a/packages/cli/src/modules/instance-ai/entities/index.ts
+++ b/packages/cli/src/modules/instance-ai/entities/index.ts
@@ -3,3 +3,5 @@ export { InstanceAiMessage } from './instance-ai-message.entity';
 export { InstanceAiResource } from './instance-ai-resource.entity';
 export { InstanceAiObservationalMemory } from './instance-ai-observational-memory.entity';
 export { InstanceAiWorkflowSnapshot } from './instance-ai-workflow-snapshot.entity';
+export { InstanceAiRunSnapshot } from './instance-ai-run-snapshot.entity';
+export { InstanceAiIterationLog } from './instance-ai-iteration-log.entity';

--- a/packages/cli/src/modules/instance-ai/entities/instance-ai-iteration-log.entity.ts
+++ b/packages/cli/src/modules/instance-ai/entities/instance-ai-iteration-log.entity.ts
@@ -1,0 +1,18 @@
+import { WithTimestamps } from '@n8n/db';
+import { Column, Entity, Index, PrimaryColumn } from '@n8n/typeorm';
+
+@Entity({ name: 'instance_ai_iteration_logs' })
+@Index(['threadId', 'taskKey', 'createdAt'])
+export class InstanceAiIterationLog extends WithTimestamps {
+	@PrimaryColumn('varchar')
+	id: string;
+
+	@Column({ type: 'varchar' })
+	threadId: string;
+
+	@Column({ type: 'varchar' })
+	taskKey: string;
+
+	@Column({ type: 'text' })
+	entry: string;
+}

--- a/packages/cli/src/modules/instance-ai/entities/instance-ai-run-snapshot.entity.ts
+++ b/packages/cli/src/modules/instance-ai/entities/instance-ai-run-snapshot.entity.ts
@@ -1,0 +1,22 @@
+import { WithTimestamps } from '@n8n/db';
+import { Column, Entity, Index, PrimaryColumn } from '@n8n/typeorm';
+
+@Entity({ name: 'instance_ai_run_snapshots' })
+@Index(['threadId', 'messageGroupId'])
+@Index(['threadId', 'createdAt'])
+export class InstanceAiRunSnapshot extends WithTimestamps {
+	@PrimaryColumn('varchar')
+	threadId: string;
+
+	@PrimaryColumn('varchar')
+	runId: string;
+
+	@Column({ type: 'varchar', nullable: true })
+	messageGroupId: string | null;
+
+	@Column({ type: 'simple-json', nullable: true })
+	runIds: string[] | null;
+
+	@Column({ type: 'text' })
+	tree: string;
+}

--- a/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
@@ -17,6 +17,8 @@ import {
 	WORKING_MEMORY_TEMPLATE,
 } from '@n8n/instance-ai';
 
+import { DbSnapshotStorage } from './storage/db-snapshot-storage';
+
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
 import { parseStoredMessages } from './message-parser';
@@ -31,6 +33,7 @@ export class InstanceAiMemoryService {
 		private readonly logger: Logger,
 		globalConfig: GlobalConfig,
 		private readonly compositeStore: TypeORMCompositeStore,
+		private readonly dbSnapshotStorage: DbSnapshotStorage,
 	) {
 		this.instanceAiConfig = globalConfig.instanceAi;
 	}
@@ -188,9 +191,22 @@ export class InstanceAiMemoryService {
 			throw error;
 		}
 
-		// Fetch agent tree snapshots from thread metadata
-		const snapshotStorage = new AgentTreeSnapshotStorage(memory);
-		const snapshots = await snapshotStorage.getAll(threadId);
+		// Fetch agent tree snapshots: DB table (new) + legacy metadata fallback
+		const dbSnapshots = await this.dbSnapshotStorage.getAll(threadId).catch((error) => {
+			this.logger.warn('Failed to load DB snapshots, falling back to metadata', {
+				threadId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return [];
+		});
+
+		// Legacy metadata snapshots for threads created before the table migration
+		const legacyStorage = new AgentTreeSnapshotStorage(memory);
+		const legacySnapshots = await legacyStorage.getAll(threadId);
+
+		// Merge: deduplicate by runId (prefer DB version), maintain chronological order
+		const dbRunIds = new Set(dbSnapshots.map((s) => s.runId));
+		const snapshots = [...legacySnapshots.filter((s) => !dbRunIds.has(s.runId)), ...dbSnapshots];
 
 		// Parse into rich messages with agent trees
 		const mastraMessages: MastraDBMessage[] = result.messages.map((m) => ({

--- a/packages/cli/src/modules/instance-ai/instance-ai.module.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.module.ts
@@ -48,6 +48,8 @@ export class InstanceAiModule implements ModuleInterface {
 		const { InstanceAiWorkflowSnapshot } = await import(
 			'./entities/instance-ai-workflow-snapshot.entity'
 		);
+		const { InstanceAiRunSnapshot } = await import('./entities/instance-ai-run-snapshot.entity');
+		const { InstanceAiIterationLog } = await import('./entities/instance-ai-iteration-log.entity');
 
 		return [
 			InstanceAiThread,
@@ -55,6 +57,8 @@ export class InstanceAiModule implements ModuleInterface {
 			InstanceAiResource,
 			InstanceAiObservationalMemory,
 			InstanceAiWorkflowSnapshot,
+			InstanceAiRunSnapshot,
+			InstanceAiIterationLog,
 		];
 	}
 

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -23,11 +23,9 @@ import {
 	BuilderSandboxFactory,
 	SnapshotManager,
 	createDomainAccessTracker,
-	AgentTreeSnapshotStorage,
 	BackgroundTaskManager,
 	buildAgentTreeFromEvents,
 	enrichMessageWithBackgroundTasks,
-	MastraIterationLogStorage,
 	MastraTaskStorage,
 	PlannedTaskCoordinator,
 	PlannedTaskStorage,
@@ -63,6 +61,8 @@ import { InstanceAiAdapterService } from './instance-ai.adapter.service';
 import { AUTO_FOLLOW_UP_MESSAGE } from './internal-messages';
 import { TypeORMCompositeStore } from './storage/typeorm-composite-store';
 import type { TypeORMWorkflowsStorage } from './storage/typeorm-workflows-storage';
+import { DbSnapshotStorage } from './storage/db-snapshot-storage';
+import { DbIterationLogStorage } from './storage/db-iteration-log-storage';
 import { InstanceAiCompactionService } from './compaction.service';
 
 function getErrorMessage(error: unknown): string {
@@ -128,6 +128,8 @@ export class InstanceAiService {
 		private readonly compositeStore: TypeORMCompositeStore,
 		private readonly compactionService: InstanceAiCompactionService,
 		private readonly urlService: UrlService,
+		private readonly dbSnapshotStorage: DbSnapshotStorage,
+		private readonly dbIterationLogStorage: DbIterationLogStorage,
 	) {
 		this.instanceAiConfig = globalConfig.instanceAi;
 		this.defaultTimeZone = globalConfig.generic.timezone;
@@ -634,8 +636,8 @@ export class InstanceAiService {
 		await this.ensureThreadExists(memory, threadId, user.id);
 
 		const taskStorage = new MastraTaskStorage(memory);
-		const iterationLog = new MastraIterationLogStorage(memory);
-		const snapshotStorage = new AgentTreeSnapshotStorage(memory);
+		const iterationLog = this.dbIterationLogStorage;
+		const snapshotStorage = this.dbSnapshotStorage;
 		const workflowLoopStorage = new WorkflowLoopStorage(memory);
 		const workflowTasks = new WorkflowTaskCoordinator(threadId, workflowLoopStorage);
 		const plannedTaskStorage = new PlannedTaskStorage(memory);
@@ -1109,15 +1111,6 @@ export class InstanceAiService {
 			...(data.answers ? { answers: data.answers } : {}),
 		};
 
-		// Create snapshot storage for saving agent tree after resumed run completes
-		const memory = createMemory({
-			storage: this.compositeStore,
-			embedderModel: this.instanceAiConfig.embedderModel || undefined,
-			lastMessages: this.instanceAiConfig.lastMessages,
-			semanticRecallTopK: this.instanceAiConfig.semanticRecallTopK,
-		});
-		const snapshotStorage = new AgentTreeSnapshotStorage(memory);
-
 		void this.processResumedStream(agent, resumeData, {
 			runId,
 			mastraRunId,
@@ -1126,7 +1119,7 @@ export class InstanceAiService {
 			toolCallId,
 			signal: abortController.signal,
 			abortController,
-			snapshotStorage,
+			snapshotStorage: this.dbSnapshotStorage,
 		});
 		return true;
 	}
@@ -1142,7 +1135,7 @@ export class InstanceAiService {
 			toolCallId: string;
 			signal: AbortSignal;
 			abortController: AbortController;
-			snapshotStorage: AgentTreeSnapshotStorage;
+			snapshotStorage: DbSnapshotStorage;
 		},
 	): Promise<void> {
 		try {
@@ -1216,7 +1209,7 @@ export class InstanceAiService {
 	private spawnBackgroundTask(
 		runId: string,
 		opts: SpawnBackgroundTaskOptions,
-		snapshotStorage: AgentTreeSnapshotStorage,
+		snapshotStorage: DbSnapshotStorage,
 		messageGroupIdOverride?: string,
 	): void {
 		this.backgroundTasks.spawn({
@@ -1335,7 +1328,7 @@ export class InstanceAiService {
 		threadId: string,
 		runId: string,
 		status: 'completed' | 'cancelled',
-		snapshotStorage: AgentTreeSnapshotStorage,
+		snapshotStorage: DbSnapshotStorage,
 	): Promise<void> {
 		this.publishRunFinish(threadId, runId, status);
 		if (status === 'completed') {
@@ -1370,7 +1363,7 @@ export class InstanceAiService {
 	private async saveAgentTreeSnapshot(
 		threadId: string,
 		runId: string,
-		snapshotStorage: AgentTreeSnapshotStorage,
+		snapshotStorage: DbSnapshotStorage,
 		isUpdate = false,
 		overrideMessageGroupId?: string,
 	): Promise<void> {

--- a/packages/cli/src/modules/instance-ai/repositories/index.ts
+++ b/packages/cli/src/modules/instance-ai/repositories/index.ts
@@ -3,3 +3,5 @@ export { InstanceAiMessageRepository } from './instance-ai-message.repository';
 export { InstanceAiResourceRepository } from './instance-ai-resource.repository';
 export { InstanceAiObservationalMemoryRepository } from './instance-ai-observational-memory.repository';
 export { InstanceAiWorkflowSnapshotRepository } from './instance-ai-workflow-snapshot.repository';
+export { InstanceAiRunSnapshotRepository } from './instance-ai-run-snapshot.repository';
+export { InstanceAiIterationLogRepository } from './instance-ai-iteration-log.repository';

--- a/packages/cli/src/modules/instance-ai/repositories/instance-ai-iteration-log.repository.ts
+++ b/packages/cli/src/modules/instance-ai/repositories/instance-ai-iteration-log.repository.ts
@@ -1,0 +1,11 @@
+import { Service } from '@n8n/di';
+import { DataSource, Repository } from '@n8n/typeorm';
+
+import { InstanceAiIterationLog } from '../entities/instance-ai-iteration-log.entity';
+
+@Service()
+export class InstanceAiIterationLogRepository extends Repository<InstanceAiIterationLog> {
+	constructor(dataSource: DataSource) {
+		super(InstanceAiIterationLog, dataSource.manager);
+	}
+}

--- a/packages/cli/src/modules/instance-ai/repositories/instance-ai-run-snapshot.repository.ts
+++ b/packages/cli/src/modules/instance-ai/repositories/instance-ai-run-snapshot.repository.ts
@@ -1,0 +1,11 @@
+import { Service } from '@n8n/di';
+import { DataSource, Repository } from '@n8n/typeorm';
+
+import { InstanceAiRunSnapshot } from '../entities/instance-ai-run-snapshot.entity';
+
+@Service()
+export class InstanceAiRunSnapshotRepository extends Repository<InstanceAiRunSnapshot> {
+	constructor(dataSource: DataSource) {
+		super(InstanceAiRunSnapshot, dataSource.manager);
+	}
+}

--- a/packages/cli/src/modules/instance-ai/storage/db-iteration-log-storage.ts
+++ b/packages/cli/src/modules/instance-ai/storage/db-iteration-log-storage.ts
@@ -1,0 +1,32 @@
+import { Service } from '@n8n/di';
+import type { IterationEntry, IterationLog } from '@n8n/instance-ai';
+import { generateNanoId } from '@n8n/utils';
+import { jsonParse } from 'n8n-workflow';
+
+import { InstanceAiIterationLogRepository } from '../repositories/instance-ai-iteration-log.repository';
+
+@Service()
+export class DbIterationLogStorage implements IterationLog {
+	constructor(private readonly repo: InstanceAiIterationLogRepository) {}
+
+	async append(threadId: string, taskKey: string, entry: IterationEntry): Promise<void> {
+		await this.repo.insert({
+			id: generateNanoId(),
+			threadId,
+			taskKey,
+			entry: JSON.stringify(entry),
+		});
+	}
+
+	async getForTask(threadId: string, taskKey: string): Promise<IterationEntry[]> {
+		const rows = await this.repo.find({
+			where: { threadId, taskKey },
+			order: { createdAt: 'ASC' },
+		});
+		return rows.map((r) => jsonParse<IterationEntry>(r.entry));
+	}
+
+	async clear(threadId: string): Promise<void> {
+		await this.repo.delete({ threadId });
+	}
+}

--- a/packages/cli/src/modules/instance-ai/storage/db-snapshot-storage.ts
+++ b/packages/cli/src/modules/instance-ai/storage/db-snapshot-storage.ts
@@ -1,0 +1,88 @@
+import type { InstanceAiAgentNode } from '@n8n/api-types';
+import { Service } from '@n8n/di';
+import type { AgentTreeSnapshot } from '@n8n/instance-ai';
+import { jsonParse } from 'n8n-workflow';
+
+import { InstanceAiRunSnapshotRepository } from '../repositories/instance-ai-run-snapshot.repository';
+
+@Service()
+export class DbSnapshotStorage {
+	constructor(private readonly repo: InstanceAiRunSnapshotRepository) {}
+
+	async save(
+		threadId: string,
+		agentTree: InstanceAiAgentNode,
+		runId: string,
+		messageGroupId?: string,
+		runIds?: string[],
+	): Promise<void> {
+		await this.repo.upsert(
+			{
+				threadId,
+				runId,
+				messageGroupId: messageGroupId ?? null,
+				runIds: runIds ?? null,
+				tree: JSON.stringify(agentTree),
+			},
+			['threadId', 'runId'],
+		);
+	}
+
+	async updateLast(
+		threadId: string,
+		agentTree: InstanceAiAgentNode,
+		runId: string,
+		messageGroupId?: string,
+		runIds?: string[],
+	): Promise<void> {
+		// Prefer lookup by messageGroupId when available
+		if (messageGroupId) {
+			const existing = await this.repo.findOne({
+				where: { threadId, messageGroupId },
+				order: { createdAt: 'DESC' },
+			});
+			if (existing) {
+				await this.repo.update(
+					{ threadId: existing.threadId, runId: existing.runId },
+					{
+						runId,
+						tree: JSON.stringify(agentTree),
+						messageGroupId,
+						runIds: runIds ?? existing.runIds,
+					},
+				);
+				return;
+			}
+		}
+
+		// Fall back to runId lookup
+		const byRunId = await this.repo.findOneBy({ threadId, runId });
+		if (byRunId) {
+			await this.repo.update(
+				{ threadId, runId },
+				{
+					tree: JSON.stringify(agentTree),
+					messageGroupId: messageGroupId ?? byRunId.messageGroupId,
+					runIds: runIds ?? byRunId.runIds,
+				},
+			);
+			return;
+		}
+
+		// No existing row — insert
+		await this.save(threadId, agentTree, runId, messageGroupId, runIds);
+	}
+
+	async getAll(threadId: string): Promise<AgentTreeSnapshot[]> {
+		const rows = await this.repo.find({
+			where: { threadId },
+			order: { createdAt: 'ASC' },
+		});
+		return rows.map((r) => ({
+			tree: jsonParse<InstanceAiAgentNode>(r.tree),
+			runId: r.runId,
+			messageGroupId: r.messageGroupId ?? undefined,
+			runIds: r.runIds ?? undefined,
+		}));
+	}
+}

--- a/packages/cli/src/modules/instance-ai/storage/index.ts
+++ b/packages/cli/src/modules/instance-ai/storage/index.ts
@@ -1,3 +1,5 @@
 export { TypeORMMemoryStorage } from './typeorm-memory-storage';
 export { TypeORMWorkflowsStorage } from './typeorm-workflows-storage';
 export { TypeORMCompositeStore } from './typeorm-composite-store';
+export { DbSnapshotStorage } from './db-snapshot-storage';
+export { DbIterationLogStorage } from './db-iteration-log-storage';


### PR DESCRIPTION
## Summary

- Moves agent tree snapshots from `instance_ai_threads.metadata` JSON blob into a dedicated `instance_ai_run_snapshots` table
- Moves iteration logs into a dedicated `instance_ai_iteration_logs` table
- Replaces per-run metadata-backed storage with DI-injected DB-backed `DbSnapshotStorage` and `DbIterationLogStorage`
- Adds backward-compatible merge of legacy metadata snapshots with DB snapshots for existing threads

## Problem

Every assistant turn appends a full agent tree snapshot (150-400 KB each) to a JSON array inside `instance_ai_threads.metadata`. After 30 turns, this blob reaches 3-5 MB. Every `patchThread()` call — 3-10 per user message — loads, deep-clones, and re-serializes the entire blob, even when modifying unrelated fields like tasks or compaction state. This creates ~10-15 MB of transient heap per `patchThread()` and ~300-500 MB GC pressure per message burst with 20 concurrent users.

## Expected savings

| Metric | Before | After |
|--------|--------|-------|
| Metadata blob size (30-turn thread) | 3-5 MB | 10-50 KB |
| Data cloned per `patchThread()` | 3-5 MB | 10-50 KB |
| Transient heap per user message (5 patches) | 15-25 MB | 50-250 KB |
| 20 concurrent users, GC pressure per msg burst | ~300-500 MB | ~1-5 MB |

Same total DB storage as data moves from a JSON column to table rows, not duplicated.
