### PR TITLE
feat(anthropicNode): Add structured output support via output_config.…

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/Anthropic.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/Anthropic.node.test.ts
@@ -272,6 +272,72 @@ describe('Anthropic Node', () => {
 				enableAnthropicBetas: {},
 			});
 		});
+
+		it('should send output_config and return structured_output when structured output is enabled', async () => {
+			const schema = {
+				type: 'object',
+				properties: {
+					name: { type: 'string' },
+					email: { type: 'string' },
+				},
+				required: ['name', 'email'],
+				additionalProperties: false,
+			};
+			executeFunctionsMock.getNodeParameter.mockImplementation((parameter: string) => {
+				switch (parameter) {
+					case 'modelId':
+						return 'claude-sonnet-4-20250514';
+					case 'messages.values':
+						return [{ role: 'user', content: 'Extract name and email from: John Smith, john@example.com' }];
+					case 'simplify':
+						return true;
+					case 'addAttachments':
+						return false;
+					case 'options':
+						return {
+							structuredOutputSchema: JSON.stringify(schema),
+							maxTokens: 1024,
+						};
+					default:
+						return undefined;
+				}
+			});
+			executeFunctionsMock.getNodeInputs.mockReturnValue([{ type: 'main' }]);
+			getConnectedToolsMock.mockResolvedValue([]);
+			apiRequestMock.mockResolvedValue({
+				content: [{ type: 'text', text: JSON.stringify({ name: 'John Smith', email: 'john@example.com' }) }],
+				stop_reason: 'end_turn',
+			});
+
+			const result = await text.message.execute.call(executeFunctionsMock, 0);
+
+			expect(result).toEqual([
+				{
+					json: {
+						content: [{ type: 'text', text: JSON.stringify({ name: 'John Smith', email: 'john@example.com' }) }],
+						structured_output: { name: 'John Smith', email: 'john@example.com' },
+					},
+					pairedItem: { item: 0 },
+				},
+			]);
+			expect(apiRequestMock).toHaveBeenCalledWith('POST', '/v1/messages', {
+				body: {
+					model: 'claude-sonnet-4-20250514',
+					max_tokens: 1024,
+					messages: [{ role: 'user', content: 'Extract name and email from: John Smith, john@example.com' }],
+					tools: [],
+					output_config: {
+						format: {
+							type: 'json_schema',
+							schema,
+						},
+					},
+				},
+				enableAnthropicBetas: {
+					codeExecution: undefined,
+				},
+			});
+		});
 	});
 
 	describe('File -> Upload', () => {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/text/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/text/message.operation.ts
@@ -268,6 +268,15 @@ const properties: INodeProperties[] = [
 					numberPrecision: 0,
 				},
 			},
+			{
+				displayName: 'Structured Output Schema',
+				name: 'structuredOutputSchema',
+				type: 'json',
+				default: '',
+				description:
+					'Provide a JSON Schema to constrain the response format. When set, Claude will always return valid JSON matching this schema. Supported by Claude 3.5+ models.',
+				hint: 'See <a target="_blank" href="https://platform.claude.com/docs/en/build-with-claude/structured-outputs">Anthropic structured outputs docs</a>. All object types in the schema must include <code>"additionalProperties": false</code>.',
+			},
 		],
 	},
 ];
@@ -293,6 +302,7 @@ interface MessageOptions {
 	temperature?: number;
 	topP?: number;
 	topK?: number;
+	structuredOutputSchema?: string;
 }
 
 function getFileTypeOrThrow(this: IExecuteFunctions, mimeType?: string): 'image' | 'document' {
@@ -327,6 +337,25 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 		}
 	}
 
+	let structuredOutputConfig: IDataObject = {};
+	if (options.structuredOutputSchema) {
+		try {
+			structuredOutputConfig = {
+				output_config: {
+					format: {
+						type: 'json_schema',
+						schema: JSON.parse(options.structuredOutputSchema),
+					},
+				},
+			};
+		} catch {
+			throw new NodeOperationError(
+				this.getNode(),
+				'Structured Output Schema contains invalid JSON',
+			);
+		}
+	}
+
 	const body = {
 		model,
 		messages,
@@ -336,6 +365,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 		temperature: options.temperature,
 		top_p: options.topP,
 		top_k: options.topK,
+		...structuredOutputConfig,
 	};
 
 	let response = (await apiRequest.call(this, 'POST', '/v1/messages', {
@@ -391,12 +421,25 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 				.join('')
 		: undefined;
 
+	let structuredOutput: IDataObject | undefined;
+	if (options.structuredOutputSchema) {
+		const textContent = response.content.find((c) => c.type === 'text');
+		if (textContent?.type === 'text') {
+			try {
+				structuredOutput = JSON.parse(textContent.text) as IDataObject;
+			} catch {
+				// Response is not valid JSON; leave structured_output undefined
+			}
+		}
+	}
+
 	if (simplify) {
 		return [
 			{
 				json: {
 					content: response.content,
 					merged_response: mergedResponse,
+					...(structuredOutput !== undefined ? { structured_output: structuredOutput } : {}),
 				},
 				pairedItem: { item: i },
 			},
@@ -405,7 +448,11 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 
 	return [
 		{
-			json: { ...response, merged_response: mergedResponse },
+			json: {
+				...response,
+				merged_response: mergedResponse,
+				...(structuredOutput !== undefined ? { structured_output: structuredOutput } : {}),
+			},
 			pairedItem: { item: i },
 		},
 	];


### PR DESCRIPTION


## Summary
This allows forcing the output format of the anthropic message API. eg. I can force it to be a single boolean value.

This helps users such as me who want to do some classification based tasks.

For example, with this I can force the Anthropic API to give me one of three categories of task, eg. "shipping", "production", "backoffice", classify it with a category like "isToil"  as a boolean value, etc. It lets me be sure of the response format so that I can craft better decisions for nodes ahead of this one.

I built&tested it practically and can see the right behavior.

Documenation on the functionality this is adding: https://platform.claude.com/docs/en/build-with-claude/structured-outputs

To test, you would insert into the field this adds a JSON such as:

```
{
  "type": "object",
  "properties": {
    "name": {
      "type": "string"
    },
    "coolness_score_percentage": {
      "type": "integer"
    }
  },
  "required": [
    "name",
    "email"
  ],
  "additionalProperties": false
}
```


It would look like this:

<img width="1200" height="871" alt="image" src="https://github.com/user-attachments/assets/29eeb7b2-35fa-4bfd-97c1-42e5bfc3c885" />


<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
