### PR TITLE
fix: pin 3 unpinned action(s),extract 10 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -62,11 +62,13 @@ jobs:
           node .github/scripts/docker/docker-config.mjs \
             --event "${{ github.event_name }}" \
             --pr "${{ github.event.pull_request.number }}" \
-            --branch "${{ github.ref_name }}" \
+            --branch "${REF_NAME}" \
             --version "${{ inputs.n8n_version }}" \
             --release-type "${{ inputs.release_type }}" \
             --push-enabled "${{ inputs.push_enabled }}"
 
+        env:
+          REF_NAME: ${{ github.ref_name }}
   build-and-push-docker:
     name: Build App, then Build and Push Docker Image (${{ matrix.platform }})
     needs: determine-build-context
@@ -232,7 +234,7 @@ jobs:
         if: needs.determine-build-context.outputs.push_to_docker == 'true'
         run: |
           VERSION="${{ needs.determine-build-context.outputs.n8n_version }}"
-          DOCKER_BASE="${{ secrets.DOCKER_USERNAME }}"
+          DOCKER_BASE="${DOCKER_USERNAME}"
 
           # Create manifests for each image type
           declare -A images=(
@@ -252,6 +254,8 @@ jobs:
               "${DOCKER_BASE}/${IMAGE_NAME}:${TAG_SUFFIX}-arm64"
           done
 
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       - name: Get manifest digests for attestation
         id: get-digests
         env:
@@ -286,7 +290,7 @@ jobs:
       id-token: write
       packages: write
       actions: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       image: ${{ needs.create_multi_arch_manifest.outputs.n8n_image }}
       digest: ${{ needs.create_multi_arch_manifest.outputs.n8n_digest }}
@@ -304,7 +308,7 @@ jobs:
       id-token: write
       packages: write
       actions: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       image: ${{ needs.create_multi_arch_manifest.outputs.runners_image }}
       digest: ${{ needs.create_multi_arch_manifest.outputs.runners_digest }}
@@ -322,7 +326,7 @@ jobs:
       id-token: write
       packages: write
       actions: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       image: ${{ needs.create_multi_arch_manifest.outputs.runners_distroless_image }}
       digest: ${{ needs.create_multi_arch_manifest.outputs.runners_distroless_digest }}

--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -78,7 +78,9 @@ jobs:
           node-version: 24.13.1
 
       # Remove after https://github.com/npm/cli/issues/8547 gets resolved
-      - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+      - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Add beta/next tags to NPM
         if: needs.validate-inputs.outputs.release_channel == 'beta'
@@ -113,19 +115,23 @@ jobs:
       - name: Tag stable/latest Docker image
         if: needs.validate-inputs.outputs.release_channel == 'stable'
         run: |
-          docker buildx imagetools create -t "${{ secrets.DOCKER_USERNAME }}/n8n:stable" "${{ secrets.DOCKER_USERNAME }}/n8n:${{ needs.validate-inputs.outputs.version }}"
-          docker buildx imagetools create -t "${{ secrets.DOCKER_USERNAME }}/n8n:latest" "${{ secrets.DOCKER_USERNAME }}/n8n:${{ needs.validate-inputs.outputs.version }}"
-          docker buildx imagetools create -t "${{ secrets.DOCKER_USERNAME }}/runners:stable" "${{ secrets.DOCKER_USERNAME }}/runners:${{ needs.validate-inputs.outputs.version }}"
-          docker buildx imagetools create -t "${{ secrets.DOCKER_USERNAME }}/runners:latest" "${{ secrets.DOCKER_USERNAME }}/runners:${{ needs.validate-inputs.outputs.version }}"
+          docker buildx imagetools create -t "${DOCKER_USERNAME}/n8n:stable" "${DOCKER_USERNAME}/n8n:${{ needs.validate-inputs.outputs.version }}"
+          docker buildx imagetools create -t "${DOCKER_USERNAME}/n8n:latest" "${DOCKER_USERNAME}/n8n:${{ needs.validate-inputs.outputs.version }}"
+          docker buildx imagetools create -t "${DOCKER_USERNAME}/runners:stable" "${DOCKER_USERNAME}/runners:${{ needs.validate-inputs.outputs.version }}"
+          docker buildx imagetools create -t "${DOCKER_USERNAME}/runners:latest" "${DOCKER_USERNAME}/runners:${{ needs.validate-inputs.outputs.version }}"
 
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       - name: Tag beta/next Docker image
         if: needs.validate-inputs.outputs.release_channel == 'beta'
         run: |
-          docker buildx imagetools create -t "${{ secrets.DOCKER_USERNAME }}/n8n:beta" "${{ secrets.DOCKER_USERNAME }}/n8n:${{ needs.validate-inputs.outputs.version }}"
-          docker buildx imagetools create -t "${{ secrets.DOCKER_USERNAME }}/n8n:next" "${{ secrets.DOCKER_USERNAME }}/n8n:${{ needs.validate-inputs.outputs.version }}"
-          docker buildx imagetools create -t "${{ secrets.DOCKER_USERNAME }}/runners:beta" "${{ secrets.DOCKER_USERNAME }}/runners:${{ needs.validate-inputs.outputs.version }}"
-          docker buildx imagetools create -t "${{ secrets.DOCKER_USERNAME }}/runners:next" "${{ secrets.DOCKER_USERNAME }}/runners:${{ needs.validate-inputs.outputs.version }}"
+          docker buildx imagetools create -t "${DOCKER_USERNAME}/n8n:beta" "${DOCKER_USERNAME}/n8n:${{ needs.validate-inputs.outputs.version }}"
+          docker buildx imagetools create -t "${DOCKER_USERNAME}/n8n:next" "${DOCKER_USERNAME}/n8n:${{ needs.validate-inputs.outputs.version }}"
+          docker buildx imagetools create -t "${DOCKER_USERNAME}/runners:beta" "${DOCKER_USERNAME}/runners:${{ needs.validate-inputs.outputs.version }}"
+          docker buildx imagetools create -t "${DOCKER_USERNAME}/runners:next" "${DOCKER_USERNAME}/runners:${{ needs.validate-inputs.outputs.version }}"
 
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
   release-to-github-container-registry:
     name: Release to GitHub Container Registry
     runs-on: ubuntu-latest
@@ -164,4 +170,6 @@ jobs:
     environment: release
     steps:
       - continue-on-error: true
-        run: curl -u docsWorkflows:${{ secrets.N8N_WEBHOOK_DOCS_PASSWORD }} --request GET 'https://internal.users.n8n.cloud/webhook/update-latest-next'
+        run: curl -u docsWorkflows:${N8N_WEBHOOK_DOCS_PASSWORD} --request GET 'https://internal.users.n8n.cloud/webhook/update-latest-next'
+        env:
+          N8N_WEBHOOK_DOCS_PASSWORD: ${{ secrets.N8N_WEBHOOK_DOCS_PASSWORD }}

--- a/.github/workflows/test-evals-ai.yml
+++ b/.github/workflows/test-evals-ai.yml
@@ -116,7 +116,7 @@ jobs:
           if [ "$EVENT_NAME" = "push" ]; then
             # Merge to master: spec evals use 1 rep, 1 judge
             {
-              echo "branch=${{ github.ref_name }}"
+              echo "branch=${REF_NAME}"
               echo "spec_repetitions=1"
               echo "spec_judges=1"
               echo "experiment_prefix="
@@ -131,6 +131,8 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
+        env:
+          REF_NAME: ${{ github.ref_name }}
   run-pairwise-evals:
     name: Run Pairwise (Spec) Evaluations
     needs: determine-config

--- a/.github/workflows/util-claude-task.yml
+++ b/.github/workflows/util-claude-task.yml
@@ -115,9 +115,12 @@ jobs:
             }
           }
           MCPEOF
-          sed -i "s|MCP_LINEAR_API_KEY_PLACEHOLDER|${{ secrets.MCP_LINEAR_API_KEY }}|g" /tmp/mcp-config.json
-          sed -i "s|MCP_NOTION_TOKEN_PLACEHOLDER|${{ secrets.MCP_NOTION_TOKEN }}|g" /tmp/mcp-config.json
+          sed -i "s|MCP_LINEAR_API_KEY_PLACEHOLDER|${MCP_LINEAR_API_KEY}|g" /tmp/mcp-config.json
+          sed -i "s|MCP_NOTION_TOKEN_PLACEHOLDER|${MCP_NOTION_TOKEN}|g" /tmp/mcp-config.json
 
+        env:
+          MCP_LINEAR_API_KEY: ${{ secrets.MCP_LINEAR_API_KEY }}
+          MCP_NOTION_TOKEN: ${{ secrets.MCP_NOTION_TOKEN }}
       - name: Run Claude
         id: claude
         continue-on-error: true

--- a/.github/workflows/util-sync-api-docs.yml
+++ b/.github/workflows/util-sync-api-docs.yml
@@ -82,11 +82,12 @@ jobs:
         if: steps.verify_file.outputs.file_exists == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           echo "Finding last successful workflow run..."
           LAST_SUCCESS_SHA=$(gh run list \
             --workflow "${{ github.workflow }}" \
-            --branch "${{ github.ref_name }}" \
+            --branch "${REF_NAME}" \
             --status "success" \
             --json "headSha" \
             --jq '.[0].headSha // empty' \


### PR DESCRIPTION
## Fix: CI/CD Security Vulnerabilities in GitHub Actions

Hi! [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), an open-source
CI/CD security scanner by [Vigilant Cyber Security](https://www.vigilantdefense.com),
identified security vulnerabilities in this repository's GitHub Actions workflows.

This PR applies automated fixes where possible and reports additional findings
for your review.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/docker-build-push.yml` | Pinned 3 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/docker-build-push.yml` | Extracted 2 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/release-push-to-channel.yml` | Extracted 4 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/test-evals-ai.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/util-claude-task.yml` | Extracted 2 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/util-sync-api-docs.yml` | Extracted 1 unsafe expression(s) to env vars |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-012 | high | `.github/workflows/release-push-to-channel.yml` | Secret Exfiltration via Outbound HTTP Request |
| RGS-012 | high | `.github/workflows/test-e2e-reusable.yml` | Secret Exfiltration via Outbound HTTP Request |
| RGS-004 | high | `.github/workflows/test-workflows-pr-comment.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/util-claude.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/util-claude.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-005 | medium | `.github/workflows/util-claude.yml` | Excessive Permissions on Untrusted Trigger |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)
- **Debug env removal** (RGS-015): Removes `ACTIONS_RUNNER_DEBUG`/`ACTIONS_STEP_DEBUG`
  which leak secrets in workflow logs

Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.