### PR TITLE
ci: Add 1.x sync and bundle branch automation for n8n-private

### DIFF
--- a/.github/workflows/sec-sync-public-to-private.yml
+++ b/.github/workflows/sec-sync-public-to-private.yml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Sync from public
+      - name: Sync master from public
         run: |
           git fetch https://github.com/n8n-io/n8n.git master:public-master
 
@@ -60,3 +60,26 @@ jobs:
 
           git reset --hard public-master
           git push origin master --force-with-lease
+
+      - name: Sync 1.x from public
+        run: |
+          git fetch https://github.com/n8n-io/n8n.git 1.x:public-1.x
+          git checkout 1.x
+
+          # Check if private is ahead of public, ignore Bundle commits
+          AHEAD_COUNT=$(git rev-list public-1.x..HEAD --pretty=oneline --grep="chore: Bundle" --invert-grep --count)
+
+          if [ "$AHEAD_COUNT" -gt 0 ]; then
+            if [ "${{ github.event_name }}" = "schedule" ]; then
+              echo "Private 1.x is $AHEAD_COUNT commit(s) ahead of public, skipping scheduled sync"
+              exit 0
+            elif [ "${{ inputs.force }}" != "true" ]; then
+              echo "Private 1.x is $AHEAD_COUNT commit(s) ahead of public, skipping (force not enabled)"
+              exit 0
+            else
+              echo "Private 1.x is $AHEAD_COUNT commit(s) ahead of public, force syncing anyway"
+            fi
+          fi
+
+          git reset --hard public-1.x
+          git push origin 1.x --force-with-lease

--- a/.github/workflows/sec-sync-public-to-private.yml
+++ b/.github/workflows/sec-sync-public-to-private.yml
@@ -83,3 +83,25 @@ jobs:
 
           git reset --hard public-1.x
           git push origin 1.x --force-with-lease
+
+      - name: Ensure bundle/2.x exists
+        run: |
+          if git ls-remote --exit-code origin refs/heads/bundle/2.x; then
+            echo "bundle/2.x already exists, skipping"
+          else
+            echo "bundle/2.x not found, creating from master"
+            git checkout master
+            git checkout -b bundle/2.x
+            git push origin bundle/2.x
+          fi
+
+      - name: Ensure bundle/1.x exists
+        run: |
+          if git ls-remote --exit-code origin refs/heads/bundle/1.x; then
+            echo "bundle/1.x already exists, skipping"
+          else
+            echo "bundle/1.x not found, creating from 1.x"
+            git checkout 1.x
+            git checkout -b bundle/1.x
+            git push origin bundle/1.x
+          fi

--- a/.github/workflows/util-backport-bundle.yml
+++ b/.github/workflows/util-backport-bundle.yml
@@ -1,4 +1,4 @@
-name: 'Util: Backport bundle PR to 1.x'
+name: 'Util: Backport bundle PR to bundle/1.x'
 
 run-name: Backport pull request ${{ github.event.pull_request.number || inputs.pull-request-id }}
 

--- a/.github/workflows/util-backport-bundle.yml
+++ b/.github/workflows/util-backport-bundle.yml
@@ -1,0 +1,72 @@
+name: 'Util: Backport bundle PR to 1.x'
+
+run-name: Backport pull request ${{ github.event.pull_request.number || inputs.pull-request-id }}
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - 'bundle/2.x'
+  workflow_dispatch:
+    inputs:
+      pull-request-id:
+        description: 'The ID number of the pull request (e.g. 3342). No #, no extra letters.'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backport:
+    if: |
+      github.repository == 'n8n-io/n8n-private' &&
+      (github.event.pull_request.merged == true ||
+      github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-slim
+    steps:
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.N8N_ASSISTANT_APP_ID }}
+          private-key: ${{ secrets.N8N_ASSISTANT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Backport
+        uses: korthout/backport-action@4aaf0e03a94ff0a619c9a511b61aeb42adea5b02 # v4.2.0
+        with:
+          github_token: ${{ steps.generate-token.outputs.token }}
+          source_pr_number: ${{ github.event.pull_request.number || inputs.pull-request-id }}
+          target_branches: bundle/1.x
+          pull_description: |-
+            # Description
+            Backport of #${pull_number} to `${target_branch}`.
+
+            ## Checklist for the author (@${pull_author}) to go through.
+
+            - [ ] Review the backport changes
+            - [ ] Fix possible conflicts
+            - [ ] Merge to target branch
+
+            After this PR has been merged, it will be picked up in the next patch release for release track.
+
+            # Original description
+
+            ${pull_description}
+          pull_title: ${pull_title} (backport to ${target_branch})
+          add_author_as_assignee: true
+          add_author_as_reviewer: true
+          copy_assignees: true
+          copy_requested_reviewers: false
+          copy_labels_pattern: '^(?!Backport to\b).+'
+          add_labels: 'automation:backport'
+          experimental: >
+            {
+              "conflict_resolution": "draft_commit_conflicts"
+            }


### PR DESCRIPTION
## Summary

This PR adds CI automation to support the `n8n-private` repository's `1.x` and bundle branch workflows:

- **Sync `1.x` from public**: Extends the hourly sync job to also keep `n8n-private/1.x` in sync with `n8n-io/n8n:1.x`, using the same ahead-check and `force` input logic as the existing master sync.
- **Recreate bundle branches after merge**: After each sync, ensures `bundle/2.x` (based on `master`) and `bundle/1.x` (based on `1.x`) exist on `n8n-private`. These branches are deleted when their PRs are merged, so the sync job recreates them automatically within the hour.
- **Auto-backport bundle PRs**: New workflow (`util-backport-bundle.yml`) that triggers whenever a PR is merged into `bundle/2.x` on `n8n-private`, automatically opening a backport PR to `bundle/1.x`. Runs unconditionally (no label required). Only active in `n8n-io/n8n-private`.

> **Note:** All new steps are gated on `github.repository == 'n8n-io/n8n-private'` or only relevant in that repo context, so merging to the public repo has no effect.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2703

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)