### PR TITLE
feat(core): Add instance monitoring service

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/execution-data-reporting.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/execution-data-reporting.service.test.ts
@@ -1,0 +1,175 @@
+import { mockLogger } from '@n8n/backend-test-utils';
+import { Time } from '@n8n/constants';
+import { mock } from 'jest-mock-extended';
+import type { InstanceSettings } from 'n8n-core';
+import { jsonParse } from 'n8n-workflow';
+
+import type { InsightsService } from '../insights.service';
+import { ExecutionDataReportingService } from '../instance-monitoring/execution-data-reporting.service';
+import { InstanceMonitoringConfig } from '../instance-monitoring/instance-monitoring.config';
+
+jest.mock('@/constants', () => ({ N8N_VERSION: '1.2.3' }));
+
+interface ReportPayload {
+	interval: { startTime: string; endTime: string };
+	totalProdExecutions: number;
+	n8nVersion: string;
+	instanceId: string;
+	instanceIdentifier: string;
+}
+
+const SUMMARY_MOCK = {
+	total: { value: 42, unit: 'count' as const, deviation: null },
+	failed: { value: 3, unit: 'count' as const, deviation: null },
+	failureRate: { value: 0.07, unit: 'ratio' as const, deviation: null },
+	averageRunTime: { value: 1200, unit: 'millisecond' as const, deviation: null },
+	timeSaved: { value: 0, unit: 'minute' as const, deviation: null },
+};
+
+function makeConfig(overrides: Partial<InstanceMonitoringConfig> = {}): InstanceMonitoringConfig {
+	const config = new InstanceMonitoringConfig();
+	config.executionDataReportingIntervalMinutes = 5;
+	config.executionDataReportingWebhookUrl = 'https://example.com/webhook';
+	config.executionDataReportingIdentifier = 'my-instance';
+	return Object.assign(config, overrides);
+}
+
+function makeService(
+	config: InstanceMonitoringConfig,
+	insightsService: jest.Mocked<InsightsService>,
+): ExecutionDataReportingService {
+	const instanceSettings = mock<InstanceSettings>({ instanceId: 'abc123' });
+	return new ExecutionDataReportingService(config, insightsService, instanceSettings, mockLogger());
+}
+
+describe('ExecutionDataReportingService', () => {
+	describe('startReporting', () => {
+		afterEach(() => {
+			jest.useRealTimers();
+		});
+
+		test('does not start timer when webhookUrl is not configured', () => {
+			jest.useFakeTimers();
+			const insightsService = mock<InsightsService>();
+			const service = makeService(
+				makeConfig({ executionDataReportingWebhookUrl: '' }),
+				insightsService,
+			);
+			const sendReportSpy = jest.spyOn(service, 'sendReport');
+
+			service.startReporting();
+			jest.advanceTimersByTime(Time.minutes.toMilliseconds * 10);
+
+			expect(sendReportSpy).not.toHaveBeenCalled();
+		});
+
+		test('fires sendReport after interval elapses', () => {
+			jest.useFakeTimers();
+			const insightsService = mock<InsightsService>();
+			const config = makeConfig();
+			const service = makeService(config, insightsService);
+			const sendReportSpy = jest.spyOn(service, 'sendReport').mockResolvedValue(undefined);
+
+			try {
+				service.startReporting();
+				jest.advanceTimersByTime(
+					config.executionDataReportingIntervalMinutes * Time.minutes.toMilliseconds,
+				);
+				expect(sendReportSpy).toHaveBeenCalledTimes(1);
+			} finally {
+				service.stopReporting();
+			}
+		});
+
+		test('fires sendReport on each subsequent interval', () => {
+			jest.useFakeTimers();
+			const insightsService = mock<InsightsService>();
+			const config = makeConfig();
+			const service = makeService(config, insightsService);
+			const sendReportSpy = jest.spyOn(service, 'sendReport').mockResolvedValue(undefined);
+
+			try {
+				service.startReporting();
+				jest.advanceTimersByTime(
+					config.executionDataReportingIntervalMinutes * Time.minutes.toMilliseconds * 3,
+				);
+				expect(sendReportSpy).toHaveBeenCalledTimes(3);
+			} finally {
+				service.stopReporting();
+			}
+		});
+	});
+
+	describe('sendReport', () => {
+		let config: InstanceMonitoringConfig;
+		let insightsService: jest.Mocked<InsightsService>;
+		let service: ExecutionDataReportingService;
+		let mockFetch: jest.SpyInstance<
+			Promise<Response>,
+			[input: RequestInfo | URL, init?: RequestInit]
+		>;
+
+		beforeEach(() => {
+			config = makeConfig();
+			insightsService = mock<InsightsService>();
+			insightsService.getInsightsSummary.mockResolvedValue(SUMMARY_MOCK);
+			service = makeService(config, insightsService);
+			mockFetch = jest
+				.spyOn(global, 'fetch')
+				.mockResolvedValue(new Response(null, { status: 200 }));
+		});
+
+		afterEach(() => {
+			jest.restoreAllMocks();
+		});
+
+		test('posts correct payload to webhookUrl', async () => {
+			await service.sendReport();
+
+			const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+			const headers = options.headers as Record<string, string>;
+			const body = jsonParse<ReportPayload>(options.body as string);
+
+			expect(url).toBe('https://example.com/webhook');
+			expect(options.method).toBe('POST');
+			expect(headers['Content-Type']).toBe('application/json');
+			expect(body.totalProdExecutions).toBe(42);
+			expect(body.n8nVersion).toBe('1.2.3');
+			expect(body.instanceId).toBe('abc123');
+			expect(body.instanceIdentifier).toBe('my-instance');
+			expect(body.interval.startTime).toBeDefined();
+			expect(body.interval.endTime).toBeDefined();
+			expect(new Date(body.interval.endTime).getTime()).toBeGreaterThan(
+				new Date(body.interval.startTime).getTime(),
+			);
+		});
+
+		test('interval startTime is endTime minus configured interval', async () => {
+			await service.sendReport();
+
+			const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+			const body = jsonParse<ReportPayload>(options.body as string);
+			const diffMs =
+				new Date(body.interval.endTime).getTime() - new Date(body.interval.startTime).getTime();
+			const expectedDiffMs =
+				config.executionDataReportingIntervalMinutes * Time.minutes.toMilliseconds;
+
+			expect(diffMs).toBeCloseTo(expectedDiffMs, -2);
+		});
+
+		test('calls getInsightsSummary with interval start and end dates', async () => {
+			await service.sendReport();
+
+			expect(jest.mocked(insightsService.getInsightsSummary)).toHaveBeenCalledWith({
+				startDate: expect.any(Date),
+				endDate: expect.any(Date),
+			});
+		});
+
+		test('catches fetch errors and does not throw', async () => {
+			mockFetch.mockRejectedValue(new Error('Network error'));
+
+			await expect(service.sendReport()).resolves.toBeUndefined();
+		});
+	});
+});

--- a/packages/cli/src/modules/insights/insights.module.ts
+++ b/packages/cli/src/modules/insights/insights.module.ts
@@ -13,6 +13,11 @@ export class InsightsModule implements ModuleInterface {
 
 		const { InsightsService } = await import('./insights.service');
 		await Container.get(InsightsService).init();
+
+		const { ExecutionDataReportingService } = await import(
+			'./instance-monitoring/execution-data-reporting.service'
+		);
+		Container.get(ExecutionDataReportingService).startReporting();
 	}
 
 	async entities() {
@@ -32,7 +37,11 @@ export class InsightsModule implements ModuleInterface {
 	@OnShutdown()
 	async shutdown() {
 		const { InsightsService } = await import('./insights.service');
-
 		await Container.get(InsightsService).shutdown();
+
+		const { ExecutionDataReportingService } = await import(
+			'./instance-monitoring/execution-data-reporting.service'
+		);
+		Container.get(ExecutionDataReportingService).stopReporting();
 	}
 }

--- a/packages/cli/src/modules/insights/instance-monitoring/execution-data-reporting.service.ts
+++ b/packages/cli/src/modules/insights/instance-monitoring/execution-data-reporting.service.ts
@@ -1,0 +1,76 @@
+import { Logger } from '@n8n/backend-common';
+import { Time } from '@n8n/constants';
+import { Service } from '@n8n/di';
+import { InstanceSettings } from 'n8n-core';
+
+import { N8N_VERSION } from '@/constants';
+
+import { InsightsService } from '../insights.service';
+import { InstanceMonitoringConfig } from './instance-monitoring.config';
+
+@Service()
+export class ExecutionDataReportingService {
+	private reportingTimer: NodeJS.Timeout | undefined;
+
+	constructor(
+		private readonly config: InstanceMonitoringConfig,
+		private readonly insightsService: InsightsService,
+		private readonly instanceSettings: InstanceSettings,
+		private readonly logger: Logger,
+	) {
+		this.logger = this.logger.scoped('insights');
+	}
+
+	startReporting(): void {
+		if (!this.config.executionDataReportingWebhookUrl) return;
+
+		this.stopReporting();
+		this.reportingTimer = setInterval(
+			async () => await this.sendReport(),
+			this.config.executionDataReportingIntervalMinutes * Time.minutes.toMilliseconds,
+		);
+		this.logger.debug('Started execution data reporting timer');
+	}
+
+	stopReporting(): void {
+		if (this.reportingTimer !== undefined) {
+			clearInterval(this.reportingTimer);
+			this.reportingTimer = undefined;
+			this.logger.debug('Stopped execution data reporting timer');
+		}
+	}
+
+	async sendReport(): Promise<void> {
+		const endTime = new Date();
+		const startTime = new Date(
+			endTime.getTime() -
+				this.config.executionDataReportingIntervalMinutes * Time.minutes.toMilliseconds,
+		);
+
+		const summary = await this.insightsService.getInsightsSummary({
+			startDate: startTime,
+			endDate: endTime,
+		});
+
+		const payload = {
+			interval: {
+				startTime: startTime.toISOString(),
+				endTime: endTime.toISOString(),
+			},
+			totalProdExecutions: summary.total.value,
+			n8nVersion: N8N_VERSION,
+			instanceId: this.instanceSettings.instanceId,
+			instanceIdentifier: this.config.executionDataReportingIdentifier,
+		};
+
+		try {
+			await fetch(this.config.executionDataReportingWebhookUrl, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(payload),
+			});
+		} catch (error) {
+			this.logger.error('Failed to send execution data report', { error });
+		}
+	}
+}

--- a/packages/cli/src/modules/insights/instance-monitoring/instance-monitoring.config.ts
+++ b/packages/cli/src/modules/insights/instance-monitoring/instance-monitoring.config.ts
@@ -1,0 +1,13 @@
+import { Config, Env } from '@n8n/config';
+
+@Config
+export class InstanceMonitoringConfig {
+	@Env('N8N_WORKFLOW_EXECUTION_DATA_REPORTING_INTERVAL_MINUTES')
+	executionDataReportingIntervalMinutes: number;
+
+	@Env('N8N_WORKFLOW_EXECUTION_DATA_REPORTING_INSTANCE_IDENTIFIER')
+	executionDataReportingIdentifier: string;
+
+	@Env('N8N_WORKFLOW_EXECUTION_DATA_REPORTING_WEBHOOK_URL')
+	executionDataReportingWebhookUrl: string;
+}


### PR DESCRIPTION
## Summary

As someone who is self-hosting many n8n instances, I'd like to aggregate usage data of all my instances in one service.
This PR adds the means to send prod execution numbers to a remote service, which can use this data to aggregate it.

See also https://github.com/n8n-io/n8n-hosting/pull/103

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-406/spike-run-multiple-n8n-instances-in-local-n8n-cluster-and-consume

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
