### PR TITLE
ci: Use track-specific npm dist-tags on publish

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -78,10 +78,16 @@ jobs:
           PUBLISH_BRANCH: ${{ github.event.pull_request.base.ref }}
         run: pnpm --filter n8n publish --publish-branch "$PUBLISH_BRANCH" --access public --tag rc --no-git-checks
 
-      - name: Publish other packages to NPM with latest tag
+      - name: Publish other packages to NPM
         env:
           PUBLISH_BRANCH: ${{ github.event.pull_request.base.ref }}
-        run: pnpm publish -r --filter '!n8n' --publish-branch "$PUBLISH_BRANCH" --access public --no-git-checks
+          PUBLISH_TAG: ${{ needs.determine-version-info.outputs.track == 'stable' && 'latest' || needs.determine-version-info.outputs.track }}
+        run: |
+          # Prefix version-like track names (e.g. "1", "v1") to avoid npm rejecting them as semver ranges
+          if [[ "$PUBLISH_TAG" =~ ^v?[0-9] ]]; then
+            PUBLISH_TAG="release-${PUBLISH_TAG}"
+          fi
+          pnpm publish -r --filter '!n8n' --publish-branch "$PUBLISH_BRANCH" --access public --tag "$PUBLISH_TAG" --no-git-checks
 
       - name: Cleanup rc tag
         run: npm dist-tag rm n8n rc


### PR DESCRIPTION
## Summary

When publishing packages to npm, only set the `latest` dist-tag for `stable` track releases. Other tracks now publish under their own tag:

- `stable` → `latest`
- `beta` → `beta`
- `v1` (and other version-named tracks) → `release-v1` (prefixed to avoid npm rejecting semver-like tag names)

Previously, all non-`n8n` packages were published without an explicit tag, which defaulted to `latest` regardless of track.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Link to Linear ticket: https://linear.app/n8n/issue/[TICKET-ID] -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)