### PR TITLE
fix(HubSpot Trigger Node): Add missing tickets scope to OAuth credentials

### DIFF
--- a/packages/nodes-base/credentials/HubspotDeveloperApi.credentials.ts
+++ b/packages/nodes-base/credentials/HubspotDeveloperApi.credentials.ts
@@ -7,6 +7,7 @@ const scopes = [
 	'crm.schemas.companies.read',
 	'crm.objects.deals.read',
 	'crm.schemas.deals.read',
+	'tickets',
 ];
 
 // eslint-disable-next-line n8n-nodes-base/cred-class-name-missing-oauth2-suffix


### PR DESCRIPTION
## Summary

Adds the missing `tickets` scope to the HubSpot Developer API OAuth credentials. Without this scope, the HubSpot Trigger node cannot receive ticket-related webhook events.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3174
Fixes #16594
## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)