### PR TITLE
ci: Don't error on release candidate cleanup when branch is missing

### DIFF
--- a/.github/scripts/ensure-release-candidate-branches.mjs
+++ b/.github/scripts/ensure-release-candidate-branches.mjs
@@ -7,6 +7,7 @@ import {
 	resolveReleaseTagForTrack,
 	sh,
 	tagVersionInfoToReleaseCandidateBranchName,
+	trySh,
 	writeGithubOutput,
 } from './github-helpers.mjs';
 
@@ -88,12 +89,12 @@ function removeBranch(branch) {
 
 	console.log(`Removing remote branch ${branch} from origin...`);
 	// Delete remote branch
-	sh('git', ['push', 'origin', '--delete', branch]);
+	trySh('git', ['push', 'origin', '--delete', branch]);
 
 	// Optional local cleanup (keeps reruns tidy)
 	if (localRefExists(`refs/heads/${branch}`)) {
 		console.log(`Removing local branch ${branch}...`);
-		sh('git', ['branch', '-D', branch]);
+		trySh('git', ['branch', '-D', branch]);
 	}
 
 	return branch;

--- a/.github/scripts/ensure-release-candidate-branches.test.mjs
+++ b/.github/scripts/ensure-release-candidate-branches.test.mjs
@@ -29,6 +29,7 @@ mock.module('./github-helpers.mjs', {
 		},
 		writeGithubOutput: () => {}, // no-op in tests
 		sh: () => {}, // no-op in tests
+		trySh: () => {}, // no-op in tests
 		getCommitForRef: () => {}, // no-op in tests
 		remoteBranchExists: () => {}, // no-op in tests
 		localRefExists: () => {}, // no-op in tests


### PR DESCRIPTION
## Summary

Sometimes release-candidate branch cleanup can use stale refs and errors out when trying to delete already removed branch. Change `sh` to `trySh` to prevent erroring out on missing refs.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/actions/runs/23585227865/job/68680205979

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
