### PR TITLE
fix(Microsoft Outlook Trigger Node): Wrap folder filter in parentheses to ensure correct OData operator precedence

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/utils/utils.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/utils/utils.test.ts
@@ -68,7 +68,7 @@ describe('Test MicrosoftOutlookV2, prepareContactFields', () => {
 });
 
 describe('Test MicrosoftOutlookV2, prepareFilterString', () => {
-	it('should create filter string', () => {
+	it('should create filter string with a single folder to include', () => {
 		const filters = {
 			filterBy: 'filters',
 			filters: {
@@ -83,7 +83,21 @@ describe('Test MicrosoftOutlookV2, prepareFilterString', () => {
 			},
 		};
 		const result =
-			"parentFolderId eq 'DDDxCCC...=' and parentFolderId ne 'AAAxBBB...=' and (from/emailAddress/address eq 'test@mail.com' or from/emailAddress/name eq 'test@mail.com') and hasAttachments eq true and isRead eq false and receivedDateTime ge 2023-07-31T21:00:00.000Z and receivedDateTime le 2023-08-14T21:00:00.000Z and isRead eq false";
+			"(parentFolderId eq 'DDDxCCC...=') and parentFolderId ne 'AAAxBBB...=' and (from/emailAddress/address eq 'test@mail.com' or from/emailAddress/name eq 'test@mail.com') and hasAttachments eq true and isRead eq false and receivedDateTime ge 2023-07-31T21:00:00.000Z and receivedDateTime le 2023-08-14T21:00:00.000Z and isRead eq false";
+
+		const data = prepareFilterString(filters);
+
+		expect(data).toEqual(result);
+	});
+
+	it('should wrap multiple folders to include in parentheses to ensure correct operator precedence', () => {
+		const filters = {
+			filterBy: 'filters',
+			filters: {
+				foldersToInclude: ['FolderA...=', 'FolderB...='],
+			},
+		};
+		const result = "(parentFolderId eq 'FolderA...=' or parentFolderId eq 'FolderB...=')";
 
 		const data = prepareFilterString(filters);
 

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/helpers/utils.ts
@@ -239,7 +239,7 @@ export function prepareFilterString(filters: IDataObject) {
 			.map((folder) => `parentFolderId eq '${folder}'`)
 			.join(' or ');
 
-		filterString.push(folders);
+		filterString.push(`(${folders})`);
 	}
 
 	if (selectedFilters.foldersToExclude) {


### PR DESCRIPTION
## Summary

The Microsoft Outlook Trigger node was not reliably firing in production when the **Folders to Include** filter was configured. The root cause was missing parentheses around the OData `or` clause in `prepareFilterString`.

When the polling trigger appends a date-range filter in production mode, OData operator precedence causes `and` to bind tighter than `or`, producing an incorrectly grouped query:

```
# Before (broken)
parentFolderId eq 'A' or parentFolderId eq 'B' and receivedDateTime ge ...
# Parsed as: A (all messages) OR (B AND date filter)

# After (fixed)
(parentFolderId eq 'A' or parentFolderId eq 'B') and receivedDateTime ge ...
# Parsed as: (A OR B) AND date filter — correct
```

The fix is a single-line change wrapping the folders clause in parentheses. The existing test was updated to reflect the new output, and a dedicated multi-folder test case was added to prevent regression.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4734
fixes #26106

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)