### PR TITLE
fix(editor): Fix `/diff` route loading in demo mode

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -52,6 +52,8 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 	const readyToRunWorkflowsStore = useReadyToRunWorkflowsStore();
 	const telemetry = useTelemetry();
 
+	const DEMO_ROUTES: RouteRecordNameGeneric[] = [VIEWS.DEMO, VIEWS.DEMO_DIFF];
+
 	const {
 		resetWorkspace,
 		initializeWorkspace,
@@ -85,7 +87,7 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 	}
 
 	const isNewWorkflowRoute = computed(() => route.query.new === 'true');
-	const isDemoRoute = computed(() => route.name === VIEWS.DEMO);
+	const isDemoRoute = computed(() => DEMO_ROUTES.includes(route.name));
 	const isTemplateRoute = computed(() => route.name === VIEWS.TEMPLATE_IMPORT);
 	const isOnboardingRoute = computed(() => route.name === VIEWS.WORKFLOW_ONBOARDING);
 	const isDebugRoute = computed(() => route.name === VIEWS.EXECUTION_DEBUG);

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -1,5 +1,5 @@
 import { ref, computed, shallowRef } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
+import { RouteRecordNameGeneric, useRoute, useRouter } from 'vue-router';
 import { useI18n } from '@n8n/i18n';
 import { useToast } from '@/app/composables/useToast';
 import { useDocumentTitle } from '@/app/composables/useDocumentTitle';

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -1,5 +1,5 @@
 import { ref, computed, shallowRef } from 'vue';
-import { RouteRecordNameGeneric, useRoute, useRouter } from 'vue-router';
+import { type RouteRecordNameGeneric, useRoute, useRouter } from 'vue-router';
 import { useI18n } from '@n8n/i18n';
 import { useToast } from '@/app/composables/useToast';
 import { useDocumentTitle } from '@/app/composables/useDocumentTitle';


### PR DESCRIPTION
## Summary
Adding the diff route to the list of demo routes so it can be initialized properly.

## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-5018

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
