### PR TITLE
ci: Detect new unpublished packages after merge and add manual publish workflow

### DIFF
--- a/.github/scripts/detect-new-packages.mjs
+++ b/.github/scripts/detect-new-packages.mjs
@@ -16,6 +16,7 @@
 
 import child_process from 'child_process';
 import { promisify } from 'util';
+import { writeGithubOutput } from './github-helpers.mjs';
 
 const exec = promisify(child_process.exec);
 
@@ -31,6 +32,7 @@ for (const { name, private: isPrivate } of packages) {
 	const url = `https://registry.npmjs.org/${encodedName}`;
 
 	try {
+		console.log(`Checking if ${name} exists...`);
 		const response = await fetch(url, { method: 'HEAD' });
 		if (response.status === 404) {
 			newPackages.push(name);
@@ -63,7 +65,6 @@ OIDC Trusted Publishing until they have been published at least once manually:
 `);
 
 for (const pkg of newPackages) {
-	console.log(`  - ${pkg}`);
 	console.log(
 		`::error::Package "${pkg}" has never been published to npm. A manual first-publish with an NPM token is required before it can use OIDC Trusted Publishing.`,
 	);
@@ -88,4 +89,10 @@ Steps to unblock the release, for each new package listed above:
   3. Re-run the Release: Publish workflow.
 
 `);
+
+const output = {
+	packages: newPackages.join(','),
+};
+console.log(` -- Writing to github output: ${JSON.stringify(output)}`);
+writeGithubOutput(output);
 process.exit(1);

--- a/.github/workflows/ci-detect-new-packages.yml
+++ b/.github/workflows/ci-detect-new-packages.yml
@@ -1,0 +1,47 @@
+name: 'CI: Detect New Packages on Master'
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
+
+jobs:
+  detect-new-packages:
+    name: Check for new unpublished packages
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-nodejs
+        with:
+          build-command: ''
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
+
+      - name: Check for new unpublished packages
+        id: detect
+        continue-on-error: true
+        run: node .github/scripts/detect-new-packages.mjs
+
+      - name: Notify Slack about new packages
+        if: steps.detect.outcome == 'failure' && steps.detect.outputs.packages != ''
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.RELEASE_HELPER_SLACK_TOKEN }}
+          payload: |
+            channel: C036AELNMV0
+            text: |-
+              :warning: *New unpublished packages detected* after merging <${{ github.event.pull_request.html_url }}|PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}>
+
+              The following packages do not exist on npm yet: `${{ steps.detect.outputs.packages }}`
+
+              *If a package is not intended for npm*, set `"private": true` in its `package.json` to exclude it from future checks.
+
+              *Otherwise, to unblock the next release:*
+              1. Run the <${{ github.server_url }}/${{ github.repository }}/actions/workflows/release-publish-new-package.yml|Release: Publish New Package> workflow for each package
+              2. Configure Trusted Publishing on npmjs.com (owner: `n8n-io`, repo: `n8n`, workflow: `release-publish.yml`)

--- a/.github/workflows/release-publish-new-package.yml
+++ b/.github/workflows/release-publish-new-package.yml
@@ -1,0 +1,40 @@
+name: 'Release: Publish New Package'
+
+on:
+  workflow_dispatch:
+    inputs:
+      package-path:
+        description: 'Path to the package to publish (e.g. packages/@n8n/my-new-package)'
+        required: true
+        type: string
+
+concurrency:
+  group: release-new-package-${{ github.event.inputs.package-path }}
+  cancel-in-progress: false
+
+jobs:
+  publish-to-npm:
+    name: Publish to NPM
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: release
+
+    steps:
+      - name: Check branch
+        if: github.ref != 'refs/heads/master'
+        run: |
+          echo "::error::This workflow can only be run from the master branch"
+          exit 1
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup and Build
+        uses: ./.github/actions/setup-nodejs
+
+      - name: Configure NPM token
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+
+      - name: Publish package
+        working-directory: ${{ github.event.inputs.package-path }}
+        run: pnpm publish --access public --no-git-checks


### PR DESCRIPTION
## Summary

Adds two new CI automations to handle new packages that are added to the monorepo but not yet published to npm:

1. **CI: Detect New Packages on Master** (`ci-detect-new-packages.yml`) — runs after every PR is merged to master. Calls the existing `detect-new-packages.mjs` script and, if unpublished packages are found, sends a Slack alert with remediation steps.

2. **Release: Publish New Package** (`release-publish-new-package.yml`) — manual workflow dispatch that publishes a single package by path using an NPM token. This is the first-publish step required before OIDC Trusted Publishing can take over for future releases.

The `detect-new-packages.mjs` script is also updated to:
- Emit a `packages` output (comma-separated list) via `writeGithubOutput` so the workflow can reference it in the Slack message
- Use GitHub Actions `::error::` annotations instead of plain log lines for each new package
- Log progress per-package during the npm registry check

## Related Linear tickets, Github issues, and Community forum posts

<!-- Link to Linear ticket: https://linear.app/n8n/issue/[TICKET-ID] -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)