### PR TITLE
Add Message Thread ID support to Telegram node

### DIFF
--- a/packages/nodes-base/nodes/Telegram/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Telegram/GenericFunctions.ts
@@ -256,6 +256,7 @@ export function getSecretToken(this: IHookFunctions | IWebhookFunctions) {
 
 export function createSendAndWaitMessageBody(context: IExecuteFunctions) {
 	const chat_id = context.getNodeParameter('chatId', 0) as string;
+	const messageThreadId = context.getNodeParameter('messageThreadId', 0, 0) as number;
 
 	const config = getSendAndWaitConfig(context);
 	let text = config.message;
@@ -267,7 +268,7 @@ export function createSendAndWaitMessageBody(context: IExecuteFunctions) {
 		text = `${text}\n\n_${attributionText}_[n8n](${link})`;
 	}
 
-	const body = {
+	const body: IDataObject = {
 		chat_id,
 		text,
 
@@ -284,6 +285,10 @@ export function createSendAndWaitMessageBody(context: IExecuteFunctions) {
 			],
 		},
 	};
+
+	if (messageThreadId) {
+		body.message_thread_id = messageThreadId;
+	}
 
 	return body;
 }

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -1797,6 +1797,14 @@ export class Telegram implements INodeType {
 						description:
 							'Unique identifier for the target chat or username of the target channel (in the format @channelusername). To find your chat ID ask @get_id_bot.',
 					},
+					{
+						displayName: 'Message Thread ID',
+						name: 'messageThreadId',
+						type: 'number',
+						default: 0,
+						description:
+							'The unique identifier of the forum topic to send the message to. Only required when the chat is a forum (supergroup with topics enabled).',
+					},
 				],
 				'message',
 				undefined,


### PR DESCRIPTION
## Summary

Adds support for sending messages to specific forum topics in Telegram by introducing a `Message Thread ID` parameter to the Telegram node. This parameter allows users to target messages to a specific topic within a forum-enabled supergroup (Telegram's forum feature).

The changes include:
- New `messageThreadId` parameter in the Telegram node configuration
- Updated `createSendAndWaitMessageBody` function to include `message_thread_id` in the API request body when specified
- Proper type casting and conditional inclusion of the parameter

## Related Linear tickets, Github issues, and Community forum posts

<!-- Please add relevant issue/ticket links here -->

## Review / Merge checklist

- [ ] PR title and summary are descriptive
- [ ] Docs updated or follow-up ticket created
- [ ] Tests included
- [ ] PR labeled appropriately (if backport needed)

https://claude.ai/code/session_01QkDyjhoQJryNFqC1k5gRvk