### PR TITLE
feat(ai-builder): Support dataset context and conversation history in evaluations (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/runner-langsmith.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/runner-langsmith.test.ts
@@ -180,6 +180,7 @@ describe('Runner - LangSmith Mode', () => {
 					tokenUsage: expect.any(Function),
 					subgraphMetrics: expect.any(Function),
 				}),
+				undefined,
 			);
 			expect(evaluator.evaluate).toHaveBeenCalledWith(
 				workflow,

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/runner-langsmith.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/runner-langsmith.test.ts
@@ -176,11 +176,11 @@ describe('Runner - LangSmith Mode', () => {
 			// Collectors are passed explicitly from the traceable wrapper to capture token usage and subgraph metrics
 			expect(generateWorkflow).toHaveBeenCalledWith(
 				'Create a workflow',
+				undefined,
 				expect.objectContaining({
 					tokenUsage: expect.any(Function),
 					subgraphMetrics: expect.any(Function),
 				}),
-				undefined,
 			);
 			expect(evaluator.evaluate).toHaveBeenCalledWith(
 				workflow,

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/argument-parser.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/argument-parser.ts
@@ -58,9 +58,6 @@ export interface EvaluationArgs {
 	/** Write regenerated state back to the dataset source */
 	writeBack?: boolean;
 
-	/** LangSmith API key (overrides LANGSMITH_API_KEY env var) */
-	langsmithApiKey?: string;
-
 	/** URL to POST evaluation results to when complete */
 	webhookUrl?: string;
 	/** Secret for HMAC-SHA256 signature of webhook payload */
@@ -146,7 +143,6 @@ const cliSchema = z
 		numJudges: z.coerce.number().int().positive().default(DEFAULTS.NUM_JUDGES),
 
 		checks: z.string().min(1).optional(),
-		langsmithApiKey: z.string().min(1).optional(),
 		langsmith: z.boolean().optional(),
 		templateExamples: z.boolean().default(false),
 		webhookUrl: z.string().url().optional(),
@@ -279,12 +275,6 @@ const FLAG_DEFS: Record<string, FlagDef> = {
 		kind: 'boolean',
 		group: 'langsmith',
 		desc: 'Shorthand for --backend langsmith',
-	},
-	'--langsmith-api-key': {
-		key: 'langsmithApiKey',
-		kind: 'string',
-		group: 'langsmith',
-		desc: 'LangSmith API key (overrides LANGSMITH_API_KEY env var)',
 	},
 	'--name': { key: 'experimentName', kind: 'string', group: 'langsmith', desc: 'Experiment name' },
 	'--filter': {
@@ -688,7 +678,6 @@ export function parseEvaluationArgs(argv: string[] = process.argv.slice(2)): Eva
 		webhookUrl: parsed.webhookUrl,
 		webhookSecret: parsed.webhookSecret,
 		checks: parsed.checks?.split(',').map((s) => s.trim()),
-		langsmithApiKey: parsed.langsmithApiKey,
 		// Model configuration
 		model: parsed.model,
 		judgeModel: parsed.judgeModel,

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/argument-parser.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/argument-parser.ts
@@ -58,6 +58,9 @@ export interface EvaluationArgs {
 	/** Write regenerated state back to the dataset source */
 	writeBack?: boolean;
 
+	/** LangSmith API key (overrides LANGSMITH_API_KEY env var) */
+	langsmithApiKey?: string;
+
 	/** URL to POST evaluation results to when complete */
 	webhookUrl?: string;
 	/** Secret for HMAC-SHA256 signature of webhook payload */
@@ -143,6 +146,7 @@ const cliSchema = z
 		numJudges: z.coerce.number().int().positive().default(DEFAULTS.NUM_JUDGES),
 
 		checks: z.string().min(1).optional(),
+		langsmithApiKey: z.string().min(1).optional(),
 		langsmith: z.boolean().optional(),
 		templateExamples: z.boolean().default(false),
 		webhookUrl: z.string().url().optional(),
@@ -275,6 +279,12 @@ const FLAG_DEFS: Record<string, FlagDef> = {
 		kind: 'boolean',
 		group: 'langsmith',
 		desc: 'Shorthand for --backend langsmith',
+	},
+	'--langsmith-api-key': {
+		key: 'langsmithApiKey',
+		kind: 'string',
+		group: 'langsmith',
+		desc: 'LangSmith API key (overrides LANGSMITH_API_KEY env var)',
 	},
 	'--name': { key: 'experimentName', kind: 'string', group: 'langsmith', desc: 'Experiment name' },
 	'--filter': {
@@ -678,6 +688,7 @@ export function parseEvaluationArgs(argv: string[] = process.argv.slice(2)): Eva
 		webhookUrl: parsed.webhookUrl,
 		webhookSecret: parsed.webhookSecret,
 		checks: parsed.checks?.split(',').map((s) => s.trim()),
+		langsmithApiKey: parsed.langsmithApiKey,
 		// Model configuration
 		model: parsed.model,
 		judgeModel: parsed.judgeModel,

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
@@ -9,6 +9,8 @@ import type { INodeTypeDescription } from 'n8n-workflow';
 import pLimit from 'p-limit';
 
 import { CodeWorkflowBuilder } from '@/code-builder';
+import type { HistoryContext } from '@/code-builder';
+import type { ConversationEntry } from '@/code-builder/utils/code-builder-session';
 import type { CoordinationLogEntry } from '@/types/coordination';
 import type { StreamChunk, WorkflowUpdateChunk } from '@/types/streaming';
 import type { SimpleWorkflow } from '@/types/workflow';
@@ -232,6 +234,58 @@ function createEvaluators(params: {
 }
 
 /**
+ * Convert raw LangChain messages from dataset into HistoryContext for the code builder.
+ * Pairs up human/AI messages as conversation entries.
+ */
+function buildHistoryContextFromMessages(messages: unknown[]): HistoryContext | undefined {
+	if (messages.length === 0) return undefined;
+
+	const entries: ConversationEntry[] = [];
+
+	for (let i = 0; i < messages.length; i++) {
+		const msg = messages[i];
+		if (!isUnknownRecord(msg)) continue;
+
+		const msgId = msg.id;
+		const isHuman = Array.isArray(msgId) && msgId.includes('HumanMessage');
+
+		if (!isHuman) continue;
+
+		const kwargs = msg.kwargs;
+		if (!isUnknownRecord(kwargs) || typeof kwargs.content !== 'string') continue;
+
+		const userContent = kwargs.content;
+
+		// Look for a following AI message to pair with
+		const nextMsg = i + 1 < messages.length ? messages[i + 1] : undefined;
+		const nextIsAI =
+			isUnknownRecord(nextMsg) && Array.isArray(nextMsg.id) && nextMsg.id.includes('AIMessage');
+
+		if (nextIsAI && isUnknownRecord(nextMsg)) {
+			const nextKwargs = nextMsg.kwargs;
+			const aiContent =
+				isUnknownRecord(nextKwargs) && typeof nextKwargs.content === 'string'
+					? nextKwargs.content
+					: '';
+			entries.push({
+				type: 'assistant-exchange',
+				userQuery: userContent,
+				assistantSummary: aiContent,
+			});
+			i++; // Skip the AI message
+		} else {
+			entries.push({ type: 'build-request', message: userContent });
+		}
+	}
+
+	return entries.length > 0 ? { conversationEntries: entries } : undefined;
+}
+
+function isUnknownRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
  * Create a CodeWorkflowBuilder generator function.
  * Uses the CodeWorkflowBuilder which coordinates planning and coding agents to generate
  * workflows via TypeScript SDK code and emits workflow JSON directly in the stream.
@@ -284,6 +338,11 @@ function createCodeWorkflowBuilderGenerator(
 			mode: datasetInputContext?.mode,
 		});
 
+		// Build history context from dataset messages if available
+		const historyContext = datasetInputContext?.historicalMessages
+			? buildHistoryContextFromMessages(datasetInputContext.historicalMessages)
+			: undefined;
+
 		let workflow: SimpleWorkflow | null = null;
 		let generatedCode: string | undefined;
 
@@ -304,6 +363,7 @@ function createCodeWorkflowBuilderGenerator(
 				payload,
 				EVAL_USERS.LANGSMITH,
 				abortController.signal,
+				historyContext,
 			)) {
 				for (const message of output.messages) {
 					if (isWorkflowUpdateChunk(message)) {

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
@@ -496,11 +496,6 @@ export async function runV2Evaluation(): Promise<void> {
 	const lifecycle = createConsoleLifecycle({ verbose: args.verbose, logger });
 	const stageModels = argsToStageModels(args);
 
-	// Override LangSmith API key if provided via CLI
-	if (args.langsmithApiKey) {
-		process.env.LANGSMITH_API_KEY = args.langsmithApiKey;
-	}
-
 	const env = await setupTestEnvironment(stageModels, logger);
 
 	// Validate LangSmith client early if langsmith backend is requested

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
@@ -377,7 +377,6 @@ function createCodeWorkflowBuilderGenerator(
 				historyContext,
 			)) {
 				for (const message of output.messages) {
-					console.log(`Received message chunk: ${JSON.stringify(message)}`);
 					if (isWorkflowUpdateChunk(message)) {
 						const parsed: unknown = JSON.parse(message.codeSnippet);
 						if (isSimpleWorkflow(parsed)) {

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
@@ -5,7 +5,6 @@
  * Can be run directly or used as a reference for custom setups.
  */
 
-import type { BaseMessage } from '@langchain/core/messages';
 import type { INodeTypeDescription } from 'n8n-workflow';
 import pLimit from 'p-limit';
 
@@ -171,7 +170,7 @@ function createWorkflowGenerator(
 				EVAL_USERS.LANGSMITH,
 				undefined, // abortSignal
 				tokenTracker ? [tokenTracker] : undefined, // externalCallbacks
-				datasetInputContext?.historicalMessages as BaseMessage[] | undefined,
+				datasetInputContext?.historicalMessages,
 			),
 		);
 

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
@@ -5,6 +5,7 @@
  * Can be run directly or used as a reference for custom setups.
  */
 
+import type { BaseMessage } from '@langchain/core/messages';
 import type { INodeTypeDescription } from 'n8n-workflow';
 import pLimit from 'p-limit';
 
@@ -135,8 +136,16 @@ function createWorkflowGenerator(
 	parsedNodeTypes: INodeTypeDescription[],
 	llms: ResolvedStageLLMs,
 	featureFlags?: BuilderFeatureFlags,
-): (prompt: string, collectors?: GenerationCollectors) => Promise<SimpleWorkflow> {
-	return async (prompt: string, collectors?: GenerationCollectors): Promise<SimpleWorkflow> => {
+): (
+	prompt: string,
+	collectors?: GenerationCollectors,
+	datasetInputContext?: DatasetInputContext,
+) => Promise<SimpleWorkflow> {
+	return async (
+		prompt: string,
+		collectors?: GenerationCollectors,
+		datasetInputContext?: DatasetInputContext,
+	): Promise<SimpleWorkflow> => {
 		const runId = generateRunId();
 
 		const agent = createAgent({
@@ -156,10 +165,13 @@ function createWorkflowGenerator(
 					message: prompt,
 					workflowId: runId,
 					featureFlags,
+					workflowContext: datasetInputContext?.workflowContext,
+					mode: datasetInputContext?.mode,
 				}),
 				EVAL_USERS.LANGSMITH,
 				undefined, // abortSignal
 				tokenTracker ? [tokenTracker] : undefined, // externalCallbacks
+				datasetInputContext?.historicalMessages as BaseMessage[] | undefined,
 			),
 		);
 
@@ -366,6 +378,7 @@ function createCodeWorkflowBuilderGenerator(
 				historyContext,
 			)) {
 				for (const message of output.messages) {
+					console.log(`Received message chunk: ${JSON.stringify(message)}`);
 					if (isWorkflowUpdateChunk(message)) {
 						const parsed: unknown = JSON.parse(message.codeSnippet);
 						if (isSimpleWorkflow(parsed)) {

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
@@ -258,17 +258,9 @@ function createCodeWorkflowBuilderGenerator(
 	llms: ResolvedStageLLMs,
 	timeoutMs?: number,
 	nodeDefinitionDirs?: string[],
-): (
-	prompt: string,
-	collectors?: GenerationCollectors,
-	datasetInputContext?: DatasetInputContext,
-) => Promise<GenerationResult> {
+): (prompt: string, collectors?: GenerationCollectors) => Promise<GenerationResult> {
 	// Subgraph metrics are not applicable since CodeWorkflowBuilder doesn't use coordination logs.
-	return async (
-		prompt: string,
-		collectors?: GenerationCollectors,
-		datasetInputContext?: DatasetInputContext,
-	): Promise<GenerationResult> => {
+	return async (prompt: string, collectors?: GenerationCollectors): Promise<GenerationResult> => {
 		const runId = generateRunId();
 
 		// Accumulate token usage across all LLM calls
@@ -292,8 +284,6 @@ function createCodeWorkflowBuilderGenerator(
 			message: prompt,
 			workflowId: runId,
 			featureFlags: { codeBuilder: true },
-			workflowContext: datasetInputContext?.workflowContext,
-			mode: datasetInputContext?.mode,
 		});
 
 		let workflow: SimpleWorkflow | null = null;

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
@@ -47,6 +47,7 @@ import {
 	getChatPayload,
 } from '../harness/evaluation-helpers';
 import { createLogger } from '../harness/logger';
+import type { DatasetInputContext } from '../harness/harness-types';
 import type { GenerationCollectors, SubgraphMetricsCollector } from '../harness/runner';
 import { TokenUsageTrackingHandler } from '../harness/token-tracking-handler';
 import {
@@ -132,8 +133,16 @@ function createWorkflowGenerator(
 	parsedNodeTypes: INodeTypeDescription[],
 	llms: ResolvedStageLLMs,
 	featureFlags?: BuilderFeatureFlags,
-): (prompt: string, collectors?: GenerationCollectors) => Promise<SimpleWorkflow> {
-	return async (prompt: string, collectors?: GenerationCollectors): Promise<SimpleWorkflow> => {
+): (
+	prompt: string,
+	collectors?: GenerationCollectors,
+	datasetInputContext?: DatasetInputContext,
+) => Promise<SimpleWorkflow> {
+	return async (
+		prompt: string,
+		collectors?: GenerationCollectors,
+		datasetInputContext?: DatasetInputContext,
+	): Promise<SimpleWorkflow> => {
 		const runId = generateRunId();
 
 		const agent = createAgent({
@@ -153,10 +162,15 @@ function createWorkflowGenerator(
 					message: prompt,
 					workflowId: runId,
 					featureFlags,
+					workflowContext: datasetInputContext?.workflowContext,
+					mode: datasetInputContext?.mode,
 				}),
 				EVAL_USERS.LANGSMITH,
 				undefined, // abortSignal
 				tokenTracker ? [tokenTracker] : undefined, // externalCallbacks
+				datasetInputContext?.historicalMessages as
+					| import('@langchain/core/messages').BaseMessage[]
+					| undefined,
 			),
 		);
 
@@ -245,9 +259,17 @@ function createCodeWorkflowBuilderGenerator(
 	llms: ResolvedStageLLMs,
 	timeoutMs?: number,
 	nodeDefinitionDirs?: string[],
-): (prompt: string, collectors?: GenerationCollectors) => Promise<GenerationResult> {
+): (
+	prompt: string,
+	collectors?: GenerationCollectors,
+	datasetInputContext?: DatasetInputContext,
+) => Promise<GenerationResult> {
 	// Subgraph metrics are not applicable since CodeWorkflowBuilder doesn't use coordination logs.
-	return async (prompt: string, collectors?: GenerationCollectors): Promise<GenerationResult> => {
+	return async (
+		prompt: string,
+		collectors?: GenerationCollectors,
+		datasetInputContext?: DatasetInputContext,
+	): Promise<GenerationResult> => {
 		const runId = generateRunId();
 
 		// Accumulate token usage across all LLM calls
@@ -271,6 +293,8 @@ function createCodeWorkflowBuilderGenerator(
 			message: prompt,
 			workflowId: runId,
 			featureFlags: { codeBuilder: true },
+			workflowContext: datasetInputContext?.workflowContext,
+			mode: datasetInputContext?.mode,
 		});
 
 		let workflow: SimpleWorkflow | null = null;

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
@@ -137,13 +137,13 @@ function createWorkflowGenerator(
 	featureFlags?: BuilderFeatureFlags,
 ): (
 	prompt: string,
-	collectors?: GenerationCollectors,
 	datasetInputContext?: DatasetInputContext,
+	collectors?: GenerationCollectors,
 ) => Promise<SimpleWorkflow> {
 	return async (
 		prompt: string,
-		collectors?: GenerationCollectors,
 		datasetInputContext?: DatasetInputContext,
+		collectors?: GenerationCollectors,
 	): Promise<SimpleWorkflow> => {
 		const runId = generateRunId();
 
@@ -313,14 +313,14 @@ function createCodeWorkflowBuilderGenerator(
 	nodeDefinitionDirs?: string[],
 ): (
 	prompt: string,
-	collectors?: GenerationCollectors,
 	datasetInputContext?: DatasetInputContext,
+	collectors?: GenerationCollectors,
 ) => Promise<GenerationResult> {
 	// Subgraph metrics are not applicable since CodeWorkflowBuilder doesn't use coordination logs.
 	return async (
 		prompt: string,
-		collectors?: GenerationCollectors,
 		datasetInputContext?: DatasetInputContext,
+		collectors?: GenerationCollectors,
 	): Promise<GenerationResult> => {
 		const runId = generateRunId();
 

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
@@ -5,7 +5,6 @@
  * Can be run directly or used as a reference for custom setups.
  */
 
-import type { BaseMessage } from '@langchain/core/messages';
 import type { INodeTypeDescription } from 'n8n-workflow';
 import pLimit from 'p-limit';
 
@@ -134,16 +133,8 @@ function createWorkflowGenerator(
 	parsedNodeTypes: INodeTypeDescription[],
 	llms: ResolvedStageLLMs,
 	featureFlags?: BuilderFeatureFlags,
-): (
-	prompt: string,
-	collectors?: GenerationCollectors,
-	datasetInputContext?: DatasetInputContext,
-) => Promise<SimpleWorkflow> {
-	return async (
-		prompt: string,
-		collectors?: GenerationCollectors,
-		datasetInputContext?: DatasetInputContext,
-	): Promise<SimpleWorkflow> => {
+): (prompt: string, collectors?: GenerationCollectors) => Promise<SimpleWorkflow> {
+	return async (prompt: string, collectors?: GenerationCollectors): Promise<SimpleWorkflow> => {
 		const runId = generateRunId();
 
 		const agent = createAgent({
@@ -163,13 +154,10 @@ function createWorkflowGenerator(
 					message: prompt,
 					workflowId: runId,
 					featureFlags,
-					workflowContext: datasetInputContext?.workflowContext,
-					mode: datasetInputContext?.mode,
 				}),
 				EVAL_USERS.LANGSMITH,
 				undefined, // abortSignal
 				tokenTracker ? [tokenTracker] : undefined, // externalCallbacks
-				datasetInputContext?.historicalMessages as BaseMessage[] | undefined,
 			),
 		);
 
@@ -258,9 +246,17 @@ function createCodeWorkflowBuilderGenerator(
 	llms: ResolvedStageLLMs,
 	timeoutMs?: number,
 	nodeDefinitionDirs?: string[],
-): (prompt: string, collectors?: GenerationCollectors) => Promise<GenerationResult> {
+): (
+	prompt: string,
+	collectors?: GenerationCollectors,
+	datasetInputContext?: DatasetInputContext,
+) => Promise<GenerationResult> {
 	// Subgraph metrics are not applicable since CodeWorkflowBuilder doesn't use coordination logs.
-	return async (prompt: string, collectors?: GenerationCollectors): Promise<GenerationResult> => {
+	return async (
+		prompt: string,
+		collectors?: GenerationCollectors,
+		datasetInputContext?: DatasetInputContext,
+	): Promise<GenerationResult> => {
 		const runId = generateRunId();
 
 		// Accumulate token usage across all LLM calls
@@ -284,6 +280,8 @@ function createCodeWorkflowBuilderGenerator(
 			message: prompt,
 			workflowId: runId,
 			featureFlags: { codeBuilder: true },
+			workflowContext: datasetInputContext?.workflowContext,
+			mode: datasetInputContext?.mode,
 		});
 
 		let workflow: SimpleWorkflow | null = null;

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
@@ -508,6 +508,12 @@ export async function runV2Evaluation(): Promise<void> {
 	const logger = createLogger(args.verbose);
 	const lifecycle = createConsoleLifecycle({ verbose: args.verbose, logger });
 	const stageModels = argsToStageModels(args);
+
+	// Override LangSmith API key if provided via CLI
+	if (args.langsmithApiKey) {
+		process.env.LANGSMITH_API_KEY = args.langsmithApiKey;
+	}
+
 	const env = await setupTestEnvironment(stageModels, logger);
 
 	// Validate LangSmith client early if langsmith backend is requested

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
@@ -5,6 +5,7 @@
  * Can be run directly or used as a reference for custom setups.
  */
 
+import type { BaseMessage } from '@langchain/core/messages';
 import type { INodeTypeDescription } from 'n8n-workflow';
 import pLimit from 'p-limit';
 
@@ -46,8 +47,8 @@ import {
 	extractSubgraphMetrics,
 	getChatPayload,
 } from '../harness/evaluation-helpers';
-import { createLogger } from '../harness/logger';
 import type { DatasetInputContext } from '../harness/harness-types';
+import { createLogger } from '../harness/logger';
 import type { GenerationCollectors, SubgraphMetricsCollector } from '../harness/runner';
 import { TokenUsageTrackingHandler } from '../harness/token-tracking-handler';
 import {
@@ -168,9 +169,7 @@ function createWorkflowGenerator(
 				EVAL_USERS.LANGSMITH,
 				undefined, // abortSignal
 				tokenTracker ? [tokenTracker] : undefined, // externalCallbacks
-				datasetInputContext?.historicalMessages as
-					| import('@langchain/core/messages').BaseMessage[]
-					| undefined,
+				datasetInputContext?.historicalMessages as BaseMessage[] | undefined,
 			),
 		);
 

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/evaluation-helpers.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/evaluation-helpers.ts
@@ -67,18 +67,23 @@ export interface GetChatPayloadOptions {
 	message: string;
 	workflowId: string;
 	featureFlags?: BuilderFeatureFlags;
+	/** Full workflowContext from dataset (overrides default empty context) */
+	workflowContext?: ChatPayload['workflowContext'];
+	/** Builder mode from dataset */
+	mode?: 'build' | 'plan';
 }
 
 export function getChatPayload(options: GetChatPayloadOptions): ChatPayload {
-	const { evalType, message, workflowId, featureFlags } = options;
+	const { evalType, message, workflowId, featureFlags, workflowContext, mode } = options;
 
 	return {
 		id: `${evalType}-${uuid()}`,
 		featureFlags: featureFlags ?? DEFAULTS.FEATURE_FLAGS,
 		message,
-		workflowContext: {
+		workflowContext: workflowContext ?? {
 			currentWorkflow: { id: workflowId, nodes: [], connections: {} },
 		},
+		...(mode ? { mode } : {}),
 	};
 }
 

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/evaluation-helpers.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/evaluation-helpers.ts
@@ -82,6 +82,8 @@ export function getChatPayload(options: GetChatPayloadOptions): ChatPayload {
 		? {
 				...workflowContext,
 				currentWorkflow: {
+					nodes: [],
+					connections: {},
 					...((workflowContext.currentWorkflow as Record<string, unknown>) ?? {}),
 					id: workflowId,
 				},

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/evaluation-helpers.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/evaluation-helpers.ts
@@ -76,13 +76,23 @@ export interface GetChatPayloadOptions {
 export function getChatPayload(options: GetChatPayloadOptions): ChatPayload {
 	const { evalType, message, workflowId, featureFlags, workflowContext, mode } = options;
 
+	// Always use the eval runId as currentWorkflow.id so getState() can find the thread.
+	// When workflowContext is provided from a dataset, override its currentWorkflow.id.
+	const resolvedContext = workflowContext
+		? {
+				...workflowContext,
+				currentWorkflow: {
+					...((workflowContext.currentWorkflow as Record<string, unknown>) ?? {}),
+					id: workflowId,
+				},
+			}
+		: { currentWorkflow: { id: workflowId, nodes: [], connections: {} } };
+
 	return {
 		id: `${evalType}-${uuid()}`,
 		featureFlags: featureFlags ?? DEFAULTS.FEATURE_FLAGS,
 		message,
-		workflowContext: workflowContext ?? {
-			currentWorkflow: { id: workflowId, nodes: [], connections: {} },
-		},
+		workflowContext: resolvedContext,
 		...(mode ? { mode } : {}),
 	};
 }

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
@@ -144,8 +144,8 @@ export interface RunConfigBase {
 	/** Function to generate workflow from prompt. May return GenerationResult with source code. Optional collectors receive metrics. */
 	generateWorkflow: (
 		prompt: string,
-		collectors?: GenerationCollectors,
 		datasetInputContext?: DatasetInputContext,
+		collectors?: GenerationCollectors,
 	) => Promise<SimpleWorkflow | GenerationResult>;
 	/** Evaluators to run on each generated workflow */
 	evaluators: Array<Evaluator<EvaluationContext>>;

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
@@ -1,3 +1,4 @@
+import type { BaseMessage } from '@langchain/core/messages';
 import type { Client as LangsmithClient } from 'langsmith/client';
 import type { IPinData } from 'n8n-workflow';
 import type pLimit from 'p-limit';
@@ -19,8 +20,8 @@ export interface DatasetInputContext {
 	workflowContext?: ChatPayload['workflowContext'];
 	/** The existing workflow JSON before this turn */
 	existingWorkflow?: SimpleWorkflow;
-	/** Historical messages from prior conversation turns (LangChain serialized) */
-	historicalMessages?: unknown[];
+	/** Historical messages from prior conversation turns (deserialized BaseMessage instances) */
+	historicalMessages?: BaseMessage[];
 	/** Builder mode from dataset */
 	mode?: 'build' | 'plan';
 	/** Feature flags from dataset metadata */

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
@@ -25,7 +25,7 @@ export interface DatasetInputContext {
 	/** Builder mode from dataset */
 	mode?: 'build' | 'plan';
 	/** Feature flags from dataset metadata */
-	featureFlags?: Record<string, unknown>;
+	featureFlags?: ChatPayload['featureFlags'];
 }
 
 /**

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
@@ -6,8 +6,26 @@ import type { EvalLogger } from './logger';
 import type { GenerationCollectors } from './runner';
 import type { IntrospectionEvent } from '../../src/tools/introspect.tool.js';
 import type { SimpleWorkflow } from '../../src/types/workflow';
+import type { ChatPayload } from '../../src/workflow-builder-agent';
 
 export type LlmCallLimiter = ReturnType<typeof pLimit>;
+
+/**
+ * Full dataset input context from a LangSmith example.
+ * Contains all the context fields the agent needs for realistic generation.
+ */
+export interface DatasetInputContext {
+	/** The complete workflowContext from the dataset (executionSchema, executionData, etc.) */
+	workflowContext?: ChatPayload['workflowContext'];
+	/** The existing workflow JSON before this turn */
+	existingWorkflow?: SimpleWorkflow;
+	/** Historical messages from prior conversation turns (LangChain serialized) */
+	historicalMessages?: unknown[];
+	/** Builder mode from dataset */
+	mode?: 'build' | 'plan';
+	/** Feature flags from dataset metadata */
+	featureFlags?: Record<string, unknown>;
+}
 
 /**
  * Shared context passed to all evaluators.
@@ -43,6 +61,8 @@ export interface EvaluationContext {
 	pinData?: IPinData;
 	/** Per-example annotations (e.g., code_necessary) from CSV or LangSmith dataset */
 	annotations?: Record<string, unknown>;
+	/** Full dataset input context for trace-based evaluation */
+	datasetInputContext?: DatasetInputContext;
 }
 
 /** Context attached to an individual test case (prompt is provided separately). */
@@ -124,6 +144,7 @@ export interface RunConfigBase {
 	generateWorkflow: (
 		prompt: string,
 		collectors?: GenerationCollectors,
+		datasetInputContext?: DatasetInputContext,
 	) => Promise<SimpleWorkflow | GenerationResult>;
 	/** Evaluators to run on each generated workflow */
 	evaluators: Array<Evaluator<EvaluationContext>>;
@@ -248,7 +269,7 @@ export interface SubgraphExampleOutput {
 	response?: string;
 	/** The workflow produced by the subgraph (for builder/configurator) */
 	workflow?: SimpleWorkflow;
-};
+}
 
 /**
  * Result from workflow generation that may include source code.

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/runner.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/runner.ts
@@ -1,4 +1,4 @@
-import { AIMessage, HumanMessage, SystemMessage, type BaseMessage } from '@langchain/core/messages';
+import { AIMessage, HumanMessage, type BaseMessage } from '@langchain/core/messages';
 import { evaluate } from 'langsmith/evaluation';
 import type { Run, Example } from 'langsmith/schemas';
 import { traceable } from 'langsmith/traceable';
@@ -1050,26 +1050,26 @@ function enrichExamplesWithHistory(examples: Example[]): Example[] {
  * Deserialize raw LangChain `lc` serialization format messages into BaseMessage instances.
  * Dataset messages use the format: {id, lc: 1, type: "constructor", kwargs: {content, ...}}
  * with the class ID in `id` array (e.g. ["langchain_core", "messages", "HumanMessage"]).
+ *
+ * Only keeps HumanMessage and AIMessage — tool calls/results are stripped
+ * to simplify the context passed to the code builder.
  */
 function deserializeLcMessages(rawMessages: unknown[]): BaseMessage[] {
 	return rawMessages
-		.filter((msg): msg is Record<string, unknown> => isUnknownRecord(msg))
+		.filter((msg): msg is Record<string, unknown> => {
+			if (!isUnknownRecord(msg)) return false;
+			const id = Array.isArray(msg.id) ? (msg.id as unknown[]) : [];
+			const last: unknown = id[id.length - 1];
+			return last === 'HumanMessage' || last === 'AIMessage';
+		})
 		.map((msg) => {
 			const kwargs = isUnknownRecord(msg.kwargs) ? msg.kwargs : {};
 			const content = typeof kwargs.content === 'string' ? kwargs.content : '';
-			const id = Array.isArray(msg.id) ? msg.id : [];
-			const className = typeof id[id.length - 1] === 'string' ? (id[id.length - 1] as string) : '';
+			const id = Array.isArray(msg.id) ? (msg.id as unknown[]) : [];
 
-			switch (className) {
-				case 'HumanMessage':
-					return new HumanMessage(content);
-				case 'AIMessage':
-					return new AIMessage(content);
-				case 'SystemMessage':
-					return new SystemMessage(content);
-				default:
-					return new HumanMessage(content);
-			}
+			return id[id.length - 1] === 'HumanMessage'
+				? new HumanMessage(content)
+				: new AIMessage(content);
 		});
 }
 

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/runner.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/runner.ts
@@ -973,6 +973,8 @@ interface LangsmithDatasetInput {
 	workflowContext?: unknown;
 	workflowOperations?: unknown[];
 	mode?: string;
+	/** Injected by enrichExamplesWithHistory - historical messages from outputs */
+	_historicalMessages?: unknown[];
 	[key: string]: unknown;
 }
 
@@ -995,6 +997,56 @@ function extractPrompt(inputs: LangsmithDatasetInput): string {
 }
 
 /**
+ * Pre-process LangSmith examples to extract conversation history from outputs
+ * and inject it into inputs for the target function.
+ *
+ * The dataset format has:
+ * - inputs.messages[0]: The latest user turn
+ * - outputs.messages: The FULL conversation (all prior turns + latest + AI response)
+ *
+ * We find the latest turn in outputs and extract everything before it as historical.
+ */
+function enrichExamplesWithHistory(examples: Example[]): Example[] {
+	return examples.map((example) => {
+		const outputMessages = example.outputs?.messages;
+		if (!Array.isArray(outputMessages) || outputMessages.length <= 1) {
+			return example; // No history to extract
+		}
+
+		const inputMessages = example.inputs?.messages;
+		if (!Array.isArray(inputMessages) || inputMessages.length === 0) {
+			return example;
+		}
+
+		// Get the content of the latest turn from inputs
+		const inputMsg = inputMessages[0] as Record<string, unknown> | undefined;
+		const inputContent = (inputMsg?.kwargs as Record<string, unknown> | undefined)?.content;
+		if (typeof inputContent !== 'string') return example;
+
+		// Find the index of the latest turn in output messages by matching content
+		const latestTurnIndex = outputMessages.findIndex((msg: unknown) => {
+			if (!isUnknownRecord(msg)) return false;
+			const kwargs = msg.kwargs;
+			if (!isUnknownRecord(kwargs)) return false;
+			return kwargs.content === inputContent;
+		});
+
+		if (latestTurnIndex <= 0) return example; // No history before the latest turn
+
+		// Extract all messages before the latest turn as historical
+		const historicalMessages = outputMessages.slice(0, latestTurnIndex);
+
+		return {
+			...example,
+			inputs: {
+				...example.inputs,
+				_historicalMessages: historicalMessages,
+			},
+		};
+	});
+}
+
+/**
  * Extract DatasetInputContext from LangSmith dataset inputs.
  * Captures the full agent context (workflowContext, existing workflow, mode)
  * needed to replay the generation realistically.
@@ -1002,7 +1054,8 @@ function extractPrompt(inputs: LangsmithDatasetInput): string {
 function extractDatasetInputContext(
 	inputs: LangsmithDatasetInput,
 ): DatasetInputContext | undefined {
-	const hasContext = inputs.workflowContext || inputs.workflowJSON || inputs.mode;
+	const hasContext =
+		inputs.workflowContext || inputs.workflowJSON || inputs.mode || inputs._historicalMessages;
 	if (!hasContext) return undefined;
 
 	const context: DatasetInputContext = {};
@@ -1017,6 +1070,10 @@ function extractDatasetInputContext(
 
 	if (inputs.mode === 'build' || inputs.mode === 'plan') {
 		context.mode = inputs.mode;
+	}
+
+	if (Array.isArray(inputs._historicalMessages) && inputs._historicalMessages.length > 0) {
+		context.historicalMessages = inputs._historicalMessages as unknown[];
 	}
 
 	return Object.keys(context).length > 0 ? context : undefined;
@@ -1481,6 +1538,11 @@ async function runLangsmith(config: LangsmithRunConfig): Promise<RunSummary> {
 			maxExamples: langsmithOptions.maxExamples,
 			filters: langsmithOptions.filters,
 		});
+	}
+
+	// Enrich pre-loaded examples with conversation history from outputs
+	if (Array.isArray(data)) {
+		data = enrichExamplesWithHistory(data);
 	}
 
 	const effectiveData = applyRepetitions(data, langsmithOptions.repetitions);

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/runner.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/runner.ts
@@ -1,4 +1,4 @@
-import type { BaseMessage } from '@langchain/core/messages';
+import { AIMessage, HumanMessage, SystemMessage, type BaseMessage } from '@langchain/core/messages';
 import { evaluate } from 'langsmith/evaluation';
 import type { Run, Example } from 'langsmith/schemas';
 import { traceable } from 'langsmith/traceable';
@@ -1047,6 +1047,33 @@ function enrichExamplesWithHistory(examples: Example[]): Example[] {
 }
 
 /**
+ * Deserialize raw LangChain `lc` serialization format messages into BaseMessage instances.
+ * Dataset messages use the format: {id, lc: 1, type: "constructor", kwargs: {content, ...}}
+ * with the class ID in `id` array (e.g. ["langchain_core", "messages", "HumanMessage"]).
+ */
+function deserializeLcMessages(rawMessages: unknown[]): BaseMessage[] {
+	return rawMessages
+		.filter((msg): msg is Record<string, unknown> => isUnknownRecord(msg))
+		.map((msg) => {
+			const kwargs = isUnknownRecord(msg.kwargs) ? msg.kwargs : {};
+			const content = typeof kwargs.content === 'string' ? kwargs.content : '';
+			const id = Array.isArray(msg.id) ? msg.id : [];
+			const className = typeof id[id.length - 1] === 'string' ? (id[id.length - 1] as string) : '';
+
+			switch (className) {
+				case 'HumanMessage':
+					return new HumanMessage(content);
+				case 'AIMessage':
+					return new AIMessage(content);
+				case 'SystemMessage':
+					return new SystemMessage(content);
+				default:
+					return new HumanMessage(content);
+			}
+		});
+}
+
+/**
  * Extract DatasetInputContext from LangSmith dataset inputs.
  * Captures the full agent context (workflowContext, existing workflow, mode)
  * needed to replay the generation realistically.
@@ -1073,7 +1100,7 @@ function extractDatasetInputContext(
 	}
 
 	if (Array.isArray(inputs._historicalMessages) && inputs._historicalMessages.length > 0) {
-		context.historicalMessages = inputs._historicalMessages;
+		context.historicalMessages = deserializeLcMessages(inputs._historicalMessages);
 	}
 
 	return Object.keys(context).length > 0 ? context : undefined;

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/runner.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/runner.ts
@@ -1008,12 +1008,12 @@ function extractPrompt(inputs: LangsmithDatasetInput): string {
  */
 function enrichExamplesWithHistory(examples: Example[]): Example[] {
 	return examples.map((example) => {
-		const outputMessages = example.outputs?.messages;
+		const outputMessages = (example.outputs as Record<string, unknown> | undefined)?.messages;
 		if (!Array.isArray(outputMessages) || outputMessages.length <= 1) {
 			return example; // No history to extract
 		}
 
-		const inputMessages = example.inputs?.messages;
+		const inputMessages = (example.inputs as Record<string, unknown> | undefined)?.messages;
 		if (!Array.isArray(inputMessages) || inputMessages.length === 0) {
 			return example;
 		}
@@ -1055,7 +1055,7 @@ function extractDatasetInputContext(
 	inputs: LangsmithDatasetInput,
 ): DatasetInputContext | undefined {
 	const hasContext =
-		inputs.workflowContext || inputs.workflowJSON || inputs.mode || inputs._historicalMessages;
+		inputs.workflowContext ?? inputs.workflowJSON ?? inputs.mode ?? inputs._historicalMessages;
 	if (!hasContext) return undefined;
 
 	const context: DatasetInputContext = {};
@@ -1073,7 +1073,7 @@ function extractDatasetInputContext(
 	}
 
 	if (Array.isArray(inputs._historicalMessages) && inputs._historicalMessages.length > 0) {
-		context.historicalMessages = inputs._historicalMessages as unknown[];
+		context.historicalMessages = inputs._historicalMessages;
 	}
 
 	return Object.keys(context).length > 0 ? context : undefined;
@@ -1273,6 +1273,35 @@ function updateStats(
 	if (status === 'pass') stats.passed++;
 	else if (status === 'fail') stats.failed++;
 	else stats.errors++;
+}
+
+/**
+ * Resolve LangSmith dataset examples and enrich them with conversation history.
+ * Handles fallback preloading when filters/maxExamples are requested on a string dataset.
+ */
+async function resolveAndEnrichLangsmithData(params: {
+	dataset: string;
+	langsmithOptions: LangsmithRunConfig['langsmithOptions'];
+	lsClient: LangsmithRunConfig['langsmithClient'];
+	logger: EvalLogger;
+}): Promise<string | Example[]> {
+	const { dataset, langsmithOptions, lsClient, logger } = params;
+	let data = await resolveLangsmithData({ dataset, langsmithOptions, lsClient, logger });
+	// Defensive: if maxExamples/filters were requested but we still got a dataset name,
+	// fall back to preloading so we can honor limits instead of streaming everything.
+	if (
+		typeof data === 'string' &&
+		((langsmithOptions.maxExamples ?? 0) > 0 || langsmithOptions.filters !== undefined)
+	) {
+		data = await loadExamplesFromDataset({
+			lsClient,
+			datasetName: data,
+			maxExamples: langsmithOptions.maxExamples,
+			filters: langsmithOptions.filters,
+		});
+	}
+	// Enrich pre-loaded examples with conversation history from outputs
+	return Array.isArray(data) ? enrichExamplesWithHistory(data) : data;
 }
 
 /**
@@ -1520,30 +1549,11 @@ async function runLangsmith(config: LangsmithRunConfig): Promise<RunSummary> {
 
 	const feedbackExtractor = createLangsmithFeedbackExtractor();
 
-	// Load examples if maxExamples is set
 	if (typeof dataset !== 'string') {
 		throw new Error('LangSmith mode requires dataset to be a dataset name string');
 	}
 
-	let data = await resolveLangsmithData({ dataset, langsmithOptions, lsClient, logger });
-	// Defensive: if maxExamples/filters were requested but we still got a dataset name,
-	// fall back to preloading so we can honor limits instead of streaming everything.
-	if (
-		typeof data === 'string' &&
-		((langsmithOptions.maxExamples ?? 0) > 0 || langsmithOptions.filters !== undefined)
-	) {
-		data = await loadExamplesFromDataset({
-			lsClient,
-			datasetName: data,
-			maxExamples: langsmithOptions.maxExamples,
-			filters: langsmithOptions.filters,
-		});
-	}
-
-	// Enrich pre-loaded examples with conversation history from outputs
-	if (Array.isArray(data)) {
-		data = enrichExamplesWithHistory(data);
-	}
+	const data = await resolveAndEnrichLangsmithData({ dataset, langsmithOptions, lsClient, logger });
 
 	const effectiveData = applyRepetitions(data, langsmithOptions.repetitions);
 

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/runner.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/runner.ts
@@ -554,8 +554,8 @@ async function runLocalExampleSuccess(args: {
 	testCase: TestCase;
 	generateWorkflow: (
 		prompt: string,
-		collectors?: GenerationCollectors,
 		datasetInputContext?: DatasetInputContext,
+		collectors?: GenerationCollectors,
 	) => Promise<SimpleWorkflow | GenerationResult>;
 	evaluators: Array<Evaluator<EvaluationContext>>;
 	globalContext?: GlobalRunContext;
@@ -583,7 +583,7 @@ async function runLocalExampleSuccess(args: {
 
 	const genResult = await runWithOptionalLimiter(async () => {
 		return await withTimeout({
-			promise: generateWorkflow(testCase.prompt, collectors, testCase.context?.datasetInputContext),
+			promise: generateWorkflow(testCase.prompt, testCase.context?.datasetInputContext, collectors),
 			timeoutMs,
 			label: 'workflow_generation',
 		});
@@ -654,8 +654,8 @@ async function runLocalExample(args: {
 	testCase: TestCase;
 	generateWorkflow: (
 		prompt: string,
-		collectors?: GenerationCollectors,
 		datasetInputContext?: DatasetInputContext,
+		collectors?: GenerationCollectors,
 	) => Promise<SimpleWorkflow | GenerationResult>;
 	evaluators: Array<Evaluator<EvaluationContext>>;
 	globalContext?: GlobalRunContext;
@@ -734,8 +734,8 @@ async function runLocalDataset(params: {
 	testCases: TestCase[];
 	generateWorkflow: (
 		prompt: string,
-		collectors?: GenerationCollectors,
 		datasetInputContext?: DatasetInputContext,
+		collectors?: GenerationCollectors,
 	) => Promise<SimpleWorkflow | GenerationResult>;
 	evaluators: Array<Evaluator<EvaluationContext>>;
 	globalContext?: GlobalRunContext;
@@ -1375,8 +1375,8 @@ async function runLangsmith(config: LangsmithRunConfig): Promise<RunSummary> {
 			prompt: string;
 			genFn: (
 				prompt: string,
-				collectors?: GenerationCollectors,
 				datasetInputContext?: DatasetInputContext,
+				collectors?: GenerationCollectors,
 			) => Promise<SimpleWorkflow | GenerationResult>;
 			collectors?: GenerationCollectors;
 			limiter?: LlmCallLimiter;
@@ -1385,7 +1385,7 @@ async function runLangsmith(config: LangsmithRunConfig): Promise<RunSummary> {
 		}): Promise<SimpleWorkflow | GenerationResult> => {
 			return await runWithOptionalLimiter(async () => {
 				return await withTimeout({
-					promise: args.genFn(args.prompt, args.collectors, args.datasetInputContext),
+					promise: args.genFn(args.prompt, args.datasetInputContext, args.collectors),
 					timeoutMs: args.genTimeoutMs,
 					label: 'workflow_generation',
 				});

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/runner.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/runner.ts
@@ -9,6 +9,7 @@ import { runWithOptionalLimiter, withTimeout } from './evaluation-helpers';
 import { toLangsmithEvaluationResult } from './feedback';
 import {
 	isGenerationResult,
+	type DatasetInputContext,
 	type Evaluator,
 	type TestCase,
 	type EvaluationContext,
@@ -34,6 +35,7 @@ import {
 } from './score-calculator';
 import type { IntrospectionEvent } from '../../src/tools/introspect.tool.js';
 import type { SimpleWorkflow } from '../../src/types/workflow';
+import type { ChatPayload } from '../../src/workflow-builder-agent';
 import { extractMessageContent } from '../langsmith/types';
 
 const DEFAULT_PASS_THRESHOLD = 0.7;
@@ -201,9 +203,17 @@ function buildContext(args: {
 	referenceWorkflows?: SimpleWorkflow[];
 	generatedCode?: string;
 	pinData?: IPinData;
+	datasetInputContext?: DatasetInputContext;
 }): EvaluationContext {
-	const { prompt, globalContext, testCaseContext, referenceWorkflows, generatedCode, pinData } =
-		args;
+	const {
+		prompt,
+		globalContext,
+		testCaseContext,
+		referenceWorkflows,
+		generatedCode,
+		pinData,
+		datasetInputContext,
+	} = args;
 
 	return {
 		prompt,
@@ -212,6 +222,7 @@ function buildContext(args: {
 		...(referenceWorkflows?.length ? { referenceWorkflows } : {}),
 		...(generatedCode ? { generatedCode } : {}),
 		...(pinData ? { pinData } : {}),
+		...(datasetInputContext ? { datasetInputContext } : {}),
 	};
 }
 
@@ -544,6 +555,7 @@ async function runLocalExampleSuccess(args: {
 	generateWorkflow: (
 		prompt: string,
 		collectors?: GenerationCollectors,
+		datasetInputContext?: DatasetInputContext,
 	) => Promise<SimpleWorkflow | GenerationResult>;
 	evaluators: Array<Evaluator<EvaluationContext>>;
 	globalContext?: GlobalRunContext;
@@ -571,7 +583,7 @@ async function runLocalExampleSuccess(args: {
 
 	const genResult = await runWithOptionalLimiter(async () => {
 		return await withTimeout({
-			promise: generateWorkflow(testCase.prompt, collectors),
+			promise: generateWorkflow(testCase.prompt, collectors, testCase.context?.datasetInputContext),
 			timeoutMs,
 			label: 'workflow_generation',
 		});
@@ -604,6 +616,7 @@ async function runLocalExampleSuccess(args: {
 		referenceWorkflows: testCase.referenceWorkflows,
 		generatedCode,
 		pinData,
+		datasetInputContext: testCase.context?.datasetInputContext,
 	});
 
 	// Run evaluators in parallel
@@ -642,6 +655,7 @@ async function runLocalExample(args: {
 	generateWorkflow: (
 		prompt: string,
 		collectors?: GenerationCollectors,
+		datasetInputContext?: DatasetInputContext,
 	) => Promise<SimpleWorkflow | GenerationResult>;
 	evaluators: Array<Evaluator<EvaluationContext>>;
 	globalContext?: GlobalRunContext;
@@ -721,6 +735,7 @@ async function runLocalDataset(params: {
 	generateWorkflow: (
 		prompt: string,
 		collectors?: GenerationCollectors,
+		datasetInputContext?: DatasetInputContext,
 	) => Promise<SimpleWorkflow | GenerationResult>;
 	evaluators: Array<Evaluator<EvaluationContext>>;
 	globalContext?: GlobalRunContext;
@@ -954,6 +969,10 @@ interface LangsmithDatasetInput {
 	prompt?: string;
 	messages?: BaseMessage[];
 	evals?: Record<string, unknown>;
+	workflowJSON?: unknown;
+	workflowContext?: unknown;
+	workflowOperations?: unknown[];
+	mode?: string;
 	[key: string]: unknown;
 }
 
@@ -973,6 +992,34 @@ function extractPrompt(inputs: LangsmithDatasetInput): string {
 	}
 
 	throw new Error('No prompt found in inputs - expected "prompt" string or "messages" array');
+}
+
+/**
+ * Extract DatasetInputContext from LangSmith dataset inputs.
+ * Captures the full agent context (workflowContext, existing workflow, mode)
+ * needed to replay the generation realistically.
+ */
+function extractDatasetInputContext(
+	inputs: LangsmithDatasetInput,
+): DatasetInputContext | undefined {
+	const hasContext = inputs.workflowContext || inputs.workflowJSON || inputs.mode;
+	if (!hasContext) return undefined;
+
+	const context: DatasetInputContext = {};
+
+	if (isUnknownRecord(inputs.workflowContext)) {
+		context.workflowContext = inputs.workflowContext as ChatPayload['workflowContext'];
+	}
+
+	if (isSimpleWorkflow(inputs.workflowJSON)) {
+		context.existingWorkflow = inputs.workflowJSON;
+	}
+
+	if (inputs.mode === 'build' || inputs.mode === 'plan') {
+		context.mode = inputs.mode;
+	}
+
+	return Object.keys(context).length > 0 ? context : undefined;
 }
 
 function createLangsmithFeedbackExtractor(): (
@@ -1216,14 +1263,16 @@ async function runLangsmith(config: LangsmithRunConfig): Promise<RunSummary> {
 			genFn: (
 				prompt: string,
 				collectors?: GenerationCollectors,
+				datasetInputContext?: DatasetInputContext,
 			) => Promise<SimpleWorkflow | GenerationResult>;
 			collectors?: GenerationCollectors;
 			limiter?: LlmCallLimiter;
 			genTimeoutMs?: number;
+			datasetInputContext?: DatasetInputContext;
 		}): Promise<SimpleWorkflow | GenerationResult> => {
 			return await runWithOptionalLimiter(async () => {
 				return await withTimeout({
-					promise: args.genFn(args.prompt, args.collectors),
+					promise: args.genFn(args.prompt, args.collectors, args.datasetInputContext),
 					timeoutMs: args.genTimeoutMs,
 					label: 'workflow_generation',
 				});
@@ -1278,6 +1327,7 @@ async function runLangsmith(config: LangsmithRunConfig): Promise<RunSummary> {
 		const index = targetCallCount;
 		// Extract prompt from inputs (supports both direct prompt and messages array)
 		const prompt = extractPrompt(inputs);
+		const datasetInputContext = extractDatasetInputContext(inputs);
 		const { evals: datasetContext, ...rest } = inputs;
 
 		lifecycle?.onExampleStart?.(index, totalExamples, prompt);
@@ -1292,6 +1342,7 @@ async function runLangsmith(config: LangsmithRunConfig): Promise<RunSummary> {
 				collectors,
 				limiter: effectiveGlobalContext.llmCallLimiter,
 				genTimeoutMs: timeoutMs,
+				datasetInputContext,
 			});
 			const genDurationMs = Date.now() - genStart;
 
@@ -1321,6 +1372,7 @@ async function runLangsmith(config: LangsmithRunConfig): Promise<RunSummary> {
 				testCaseContext: extracted,
 				generatedCode,
 				pinData,
+				datasetInputContext,
 			});
 
 			// Run all evaluators in parallel (wrapped in traceable so it appears

--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/code-workflow-builder.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/code-workflow-builder.ts
@@ -23,8 +23,9 @@ import type { StreamOutput } from '../types/streaming';
 import type { ChatPayload } from '../workflow-builder-agent';
 import { CodeBuilderAgent } from './code-builder-agent';
 import { SessionChatHandler } from './handlers/session-chat-handler';
+import type { HistoryContext } from './prompts';
 import type { TokenUsage } from './types';
-export type { TokenUsage };
+export type { HistoryContext, TokenUsage };
 
 /**
  * Configuration for CodeWorkflowBuilder
@@ -122,12 +123,14 @@ export class CodeWorkflowBuilder {
 	 * @param payload - Chat payload with message and workflow context
 	 * @param userId - User ID for logging
 	 * @param abortSignal - Optional abort signal
+	 * @param historyContext - Optional conversation history (used in evals when no session handler)
 	 * @yields StreamOutput chunks for messages, tool progress, and workflow updates
 	 */
 	async *chat(
 		payload: ChatPayload,
 		userId: string,
 		abortSignal?: AbortSignal,
+		historyContext?: HistoryContext,
 	): AsyncGenerator<StreamOutput, void, unknown> {
 		const workflowId = payload.workflowContext?.currentWorkflow?.id;
 
@@ -150,7 +153,12 @@ export class CodeWorkflowBuilder {
 			// No session handler - track generation success and call callback manually
 			let generationSucceeded = false;
 
-			for await (const chunk of this.codeBuilderAgent.chat(payload, userId, abortSignal)) {
+			for await (const chunk of this.codeBuilderAgent.chat(
+				payload,
+				userId,
+				abortSignal,
+				historyContext,
+			)) {
 				// Check if this chunk indicates successful workflow generation
 				if (chunk.messages?.some((msg) => msg.type === 'workflow-updated')) {
 					generationSucceeded = true;

--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/index.ts
@@ -12,7 +12,7 @@ export type { CodeBuilderAgentConfig, ParseAndValidateResult, ValidationWarning 
 
 // Code Workflow Builder
 export { CodeWorkflowBuilder } from './code-workflow-builder';
-export type { CodeWorkflowBuilderConfig } from './code-workflow-builder';
+export type { CodeWorkflowBuilderConfig, HistoryContext } from './code-workflow-builder';
 
 // Session utilities
 export { generateCodeBuilderThreadId } from './utils/code-builder-session';


### PR DESCRIPTION
## Summary

Extends the AI workflow builder evaluation harness to support LangSmith dataset examples that contain full agent state snapshots — existing workflow, workflow context (execution data, schema, expression values), and multi-turn conversation history.

This enables evaluating AI workflow builder changes beyond initial generation, using real traced conversations as evaluation inputs. Key changes:

- **`DatasetInputContext` type** — carries workflowContext, existingWorkflow, historicalMessages, mode, and featureFlags through the evaluation pipeline
- **`enrichExamplesWithHistory()`** — pre-processes LangSmith examples to extract conversation history from **output** messages into inputs
- **`deserializeLcMessages()`** — converts raw LangChain `lc` serialization format objects into proper `BaseMessage` instances, keeping only human/AI messages (stripping tool calls to make it possible to test code builder using traces of multi-agent builder)
- **`getChatPayload` / `agent.chat()`** — extended to pass through workflowContext, mode, and historicalMessages from dataset examples

## Related issues
- https://linear.app/n8n/issue/AI-2304/feature-support-evaluation-beyond-initial-generation

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)