### PR TITLE
ci: Set initial npm publish to function with it's own token

### DIFF
--- a/.github/workflows/release-publish-new-package.yml
+++ b/.github/workflows/release-publish-new-package.yml
@@ -33,7 +33,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
 
       - name: Configure NPM token
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_INITIAL_PUBLISH_TOKEN }}" > ~/.npmrc
 
       - name: Publish package
         working-directory: ${{ github.event.inputs.package-path }}

--- a/.github/workflows/release-publish-new-package.yml
+++ b/.github/workflows/release-publish-new-package.yml
@@ -32,6 +32,20 @@ jobs:
       - name: Setup and Build
         uses: ./.github/actions/setup-nodejs
 
+      - name: Check package does not already exist on NPM
+        working-directory: ${{ github.event.inputs.package-path }}
+        run: |
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          if [ "$PACKAGE_NAME" = "n8n-monorepo" ]; then
+            echo "::error::Package 'n8n-monorepo' cannot be published."
+            exit 1
+          fi
+          if npm view "$PACKAGE_NAME" > /dev/null 2>&1; then
+            echo "::error::Package '$PACKAGE_NAME' already exists on NPM. Use the regular release workflow for updates."
+            exit 1
+          fi
+          echo "Package '$PACKAGE_NAME' does not exist on NPM yet. Proceeding with publish."
+
       - name: Configure NPM token
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_INITIAL_PUBLISH_TOKEN }}" > ~/.npmrc
 


### PR DESCRIPTION
## Summary

Publishing via workflows required a bit more granluar of a token, so I've created a separate token for usage within publishing workflows. This token has access to create new NPM packages in the npm namespace so we want to have it as it's own thing.

## Related Linear tickets, Github issues, and Community forum posts

Failing runs of publish action.

https://github.com/n8n-io/n8n/actions/runs/23593663446/job/68704799288

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
