### PR TITLE
feat(editor): Implement preview tag for MCP (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nMenuItem/MenuItem.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMenuItem/MenuItem.vue
@@ -1,16 +1,15 @@
 <script lang="ts" setup>
+import type { IMenuItem } from '@n8n/design-system/types';
 import { computed } from 'vue';
 
-import type { IMenuItem } from '@n8n/design-system/types';
-
 import BetaTag from '../BetaTag/BetaTag.vue';
-import PreviewTag from '../PreviewTag/PreviewTag.vue';
 import N8nIcon from '../N8nIcon';
 import type { IconName } from '../N8nIcon/icons';
 import N8nRoute from '../N8nRoute';
 import N8nTag from '../N8nTag';
 import N8nText from '../N8nText';
 import N8nTooltip from '../N8nTooltip';
+import PreviewTag from '../PreviewTag/PreviewTag.vue';
 
 const props = defineProps<{
 	item: IMenuItem;

--- a/packages/frontend/@n8n/design-system/src/components/N8nMenuItem/MenuItem.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMenuItem/MenuItem.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
-import type { IMenuItem } from '@n8n/design-system/types';
 import { computed } from 'vue';
+
+import type { IMenuItem } from '@n8n/design-system/types';
 
 import BetaTag from '../BetaTag/BetaTag.vue';
 import N8nIcon from '../N8nIcon';

--- a/packages/frontend/@n8n/design-system/src/components/N8nMenuItem/MenuItem.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMenuItem/MenuItem.vue
@@ -4,6 +4,7 @@ import { computed } from 'vue';
 import type { IMenuItem } from '@n8n/design-system/types';
 
 import BetaTag from '../BetaTag/BetaTag.vue';
+import PreviewTag from '../PreviewTag/PreviewTag.vue';
 import N8nIcon from '../N8nIcon';
 import type { IconName } from '../N8nIcon/icons';
 import N8nRoute from '../N8nRoute';
@@ -135,6 +136,7 @@ const tooltipPlacement = computed(() => {
 						{{ item.label }}
 					</N8nText>
 					<BetaTag v-if="!compact && item.beta" />
+					<PreviewTag v-if="!compact && item.preview" />
 					<N8nTag
 						v-if="!compact && item.new"
 						:clickable="false"

--- a/packages/frontend/@n8n/design-system/src/components/PreviewTag/PreviewTag.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/PreviewTag/PreviewTag.stories.ts
@@ -1,0 +1,29 @@
+import type { StoryFn } from '@storybook/vue3-vite';
+
+import PreviewTag from './PreviewTag.vue';
+
+export default {
+	title: 'Core/PreviewTag',
+	component: PreviewTag,
+	argTypes: {
+		size: {
+			control: 'select',
+			options: ['small', 'medium'],
+		},
+	},
+};
+
+const Template: StoryFn = (args, { argTypes }) => ({
+	setup: () => ({ args }),
+	props: Object.keys(argTypes),
+	components: {
+		PreviewTag,
+	},
+	template: '<PreviewTag v-bind="args" />',
+});
+
+export const Small = Template.bind({});
+Small.args = { size: 'small' };
+
+export const Medium = Template.bind({});
+Medium.args = { size: 'medium' };

--- a/packages/frontend/@n8n/design-system/src/components/PreviewTag/PreviewTag.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/PreviewTag/PreviewTag.test.ts
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/vue';
+
+import PreviewTag from './PreviewTag.vue';
+
+describe('PreviewTag', () => {
+	it('renders small preview tag correctly', () => {
+		const { container } = render(PreviewTag, { props: { size: 'small' } });
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders medium preview tag correctly', () => {
+		const { container } = render(PreviewTag, { props: { size: 'medium' } });
+		expect(container).toMatchSnapshot();
+	});
+});

--- a/packages/frontend/@n8n/design-system/src/components/PreviewTag/PreviewTag.vue
+++ b/packages/frontend/@n8n/design-system/src/components/PreviewTag/PreviewTag.vue
@@ -1,0 +1,37 @@
+<script lang="ts" setup>
+import { useI18n } from '../../composables/useI18n';
+
+withDefaults(
+	defineProps<{
+		size?: 'small' | 'medium';
+	}>(),
+	{ size: 'small' },
+);
+
+const { t } = useI18n();
+</script>
+
+<template>
+	<div :class="[$style.preview, $style[size]]">{{ t('previewTag.preview') }}</div>
+</template>
+
+<style lang="scss" module>
+.preview {
+	display: inline-block;
+
+	color: var(--color--secondary);
+	font-weight: var(--font-weight--bold);
+	background-color: var(--color--secondary--tint-2);
+	border-radius: 16px;
+}
+
+.small {
+	font-size: var(--font-size--3xs);
+	padding: var(--spacing--5xs) var(--spacing--4xs);
+}
+
+.medium {
+	font-size: var(--font-size--2xs);
+	padding: var(--spacing--4xs) var(--spacing--2xs);
+}
+</style>

--- a/packages/frontend/@n8n/design-system/src/components/PreviewTag/__snapshots__/PreviewTag.test.ts.snap
+++ b/packages/frontend/@n8n/design-system/src/components/PreviewTag/__snapshots__/PreviewTag.test.ts.snap
@@ -1,0 +1,21 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`PreviewTag > renders medium preview tag correctly 1`] = `
+<div>
+  <div
+    class="preview medium"
+  >
+    Preview
+  </div>
+</div>
+`;
+
+exports[`PreviewTag > renders small preview tag correctly 1`] = `
+<div>
+  <div
+    class="preview small"
+  >
+    Preview
+  </div>
+</div>
+`;

--- a/packages/frontend/@n8n/design-system/src/components/index.ts
+++ b/packages/frontend/@n8n/design-system/src/components/index.ts
@@ -48,6 +48,7 @@ export { default as N8nNotice } from './N8nNotice';
 export { default as N8nOption } from './N8nOption';
 export { default as N8nSectionHeader } from './N8nSectionHeader';
 export { default as N8nSelectableList } from './N8nSelectableList';
+export { default as N8nPreviewTag } from './PreviewTag/PreviewTag.vue';
 export { default as N8nPopover } from './N8nPopover';
 export { default as N8nPopoverReka } from './N8nPopover'; // Alias for backwards compatibility
 export { default as N8nPromptInput } from './N8nPromptInput';

--- a/packages/frontend/@n8n/design-system/src/locale/lang/en.ts
+++ b/packages/frontend/@n8n/design-system/src/locale/lang/en.ts
@@ -34,6 +34,7 @@ export default {
 	'codeDiff.replacing': 'Replacing...',
 	'codeDiff.undo': 'Undo',
 	'betaTag.beta': 'beta',
+	'previewTag.preview': 'preview',
 	'askAssistantButton.askAssistant': 'n8n AI',
 	'assistantChat.builder.name': 'AI Builder',
 	'assistantChat.builder.generatingFinalWorkflow': 'Generating final workflow...',

--- a/packages/frontend/@n8n/design-system/src/locale/lang/en.ts
+++ b/packages/frontend/@n8n/design-system/src/locale/lang/en.ts
@@ -34,7 +34,7 @@ export default {
 	'codeDiff.replacing': 'Replacing...',
 	'codeDiff.undo': 'Undo',
 	'betaTag.beta': 'beta',
-	'previewTag.preview': 'preview',
+	'previewTag.preview': 'Preview',
 	'askAssistantButton.askAssistant': 'n8n AI',
 	'assistantChat.builder.name': 'AI Builder',
 	'assistantChat.builder.generatingFinalWorkflow': 'Generating final workflow...',

--- a/packages/frontend/@n8n/design-system/src/types/menu.ts
+++ b/packages/frontend/@n8n/design-system/src/types/menu.ts
@@ -38,6 +38,7 @@ export type IMenuItem = {
 	notification?: boolean;
 	size?: 'medium' | 'small';
 	beta?: boolean;
+	preview?: boolean;
 	new?: boolean;
 };
 

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2746,6 +2746,7 @@
 	"settings.communityNodes.confirmModal.cancel": "Cancel",
 	"settings.mcp": "Instance-level MCP",
 	"settings.mcp.description": "Let MCP clients like Claude, Lovable, and other AI tools discover and execute your n8n workflows",
+	"settings.mcp.preview.tooltip": "This feature is in research preview. Expect improvements and changes over time.",
 	"settings.mcp.header.toggle.enabled": "Enabled",
 	"settings.mcp.header.toggle.disabled": "Disabled",
 	"settings.mcp.actionBox.heading": "Connect AI assistants to your workflows",

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2746,7 +2746,7 @@
 	"settings.communityNodes.confirmModal.cancel": "Cancel",
 	"settings.mcp": "Instance-level MCP",
 	"settings.mcp.description": "Let MCP clients like Claude, Lovable, and other AI tools discover and execute your n8n workflows",
-	"settings.mcp.preview.tooltip": "This feature is in research preview. Expect improvements and changes over time.",
+	"settings.mcp.preview.tooltip": "This feature is in preview. Expect improvements and changes over time.",
 	"settings.mcp.header.toggle.enabled": "Enabled",
 	"settings.mcp.header.toggle.disabled": "Disabled",
 	"settings.mcp.actionBox.heading": "Connect AI assistants to your workflows",

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/SettingsMCPView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/SettingsMCPView.vue
@@ -16,7 +16,15 @@ import MCPEmptyState from '@/features/ai/mcpAccess/components/MCPEmptyState.vue'
 import MCpHeaderActions from '@/features/ai/mcpAccess/components/header/MCPHeaderActions.vue';
 import WorkflowsTable from '@/features/ai/mcpAccess/components/tabs/WorkflowsTable.vue';
 import OAuthClientsTable from '@/features/ai/mcpAccess/components/tabs/OAuthClientsTable.vue';
-import { N8nHeading, N8nTabs, N8nTooltip, N8nButton, N8nText, N8nLink } from '@n8n/design-system';
+import {
+	N8nHeading,
+	N8nTabs,
+	N8nTooltip,
+	N8nButton,
+	N8nText,
+	N8nLink,
+	N8nPreviewTag,
+} from '@n8n/design-system';
 import type { TabOptions } from '@n8n/design-system';
 import { useMcp } from '@/features/ai/mcpAccess/composables/useMcp';
 import type { OAuthClientResponseDto } from '@n8n/api-types';
@@ -206,7 +214,12 @@ onMounted(async () => {
 	<div :class="$style.container">
 		<header :class="$style['main-header']" data-test-id="mcp-settings-header">
 			<div :class="$style.headings">
-				<N8nHeading size="2xlarge" class="mb-2xs">{{ i18n.baseText('settings.mcp') }}</N8nHeading>
+				<div :class="$style['heading-row']">
+					<N8nHeading size="2xlarge">{{ i18n.baseText('settings.mcp') }}</N8nHeading>
+					<N8nTooltip :content="i18n.baseText('settings.mcp.preview.tooltip')">
+						<N8nPreviewTag size="medium" />
+					</N8nTooltip>
+				</div>
 				<div v-show="mcpStore.mcpAccessEnabled" data-test-id="mcp-settings-description">
 					<N8nText size="small" color="text-light">
 						{{ i18n.baseText('settings.mcp.description') }}.
@@ -309,6 +322,13 @@ onMounted(async () => {
 	display: flex;
 	flex-direction: column;
 	min-height: 60px;
+}
+
+.heading-row {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing--2xs);
+	margin-bottom: var(--spacing--5xs);
 }
 
 .tabs-header {

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/module.descriptor.ts
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/module.descriptor.ts
@@ -36,6 +36,7 @@ export const MCPModule: FrontendModuleDescription = {
 			label: i18n.baseText('settings.mcp'),
 			position: 'top',
 			route: { to: { name: MCP_SETTINGS_VIEW } },
+			preview: true,
 			get available() {
 				return hasPermission(['rbac'], {
 					rbac: { scope: ['mcp:oauth', 'mcpApiKey:create', 'mcpApiKey:rotate'] },


### PR DESCRIPTION
## Summary
Implemented new tag component, `PreviewTag`, that can be used for sidebar modules. Attached it to MCP module


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
