### PR TITLE
fix(editor): Truncate long workflow names in insights table

### DIFF
--- a/packages/frontend/editor-ui/src/features/execution/insights/components/tables/InsightsTableWorkflows.vue
+++ b/packages/frontend/editor-ui/src/features/execution/insights/components/tables/InsightsTableWorkflows.vue
@@ -234,6 +234,10 @@ watch(sortBy, (newValue) => {
 	max-width: 100%;
 	overflow: hidden;
 	min-width: 0;
+	& > * {
+		min-width: 0;
+		overflow: hidden;
+	}
 	&:hover {
 		color: var(--color--text--shade-1);
 	}

--- a/packages/frontend/editor-ui/src/features/execution/insights/components/tables/InsightsTableWorkflows.vue
+++ b/packages/frontend/editor-ui/src/features/execution/insights/components/tables/InsightsTableWorkflows.vue
@@ -222,17 +222,18 @@ watch(sortBy, (newValue) => {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	line-height: 1.2;
-	width: fit-content;
 	max-width: 100%;
 }
 
 .link {
-	display: inline-flex;
+	display: flex;
 	height: 100%;
 	align-items: center;
 	color: var(--color--text);
 	text-decoration: underline;
 	max-width: 100%;
+	overflow: hidden;
+	min-width: 0;
 	&:hover {
 		color: var(--color--text--shade-1);
 	}


### PR DESCRIPTION
## Summary

Fixes CSS so that long workflow and project names in the Insights table are properly truncated with an ellipsis instead of overflowing their column.

The `.ellipsis` class had `width: fit-content` which prevented truncation. The `.link` wrapper used `inline-flex` and lacked overflow constraints needed for flex-based text truncation.

### Fixed

<img width="1254" height="742" alt="CleanShot 2026-03-26 at 16 35 18" src="https://github.com/user-attachments/assets/cc8b6f90-e193-490b-ab09-979339a56e80" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-411

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)