### PR TITLE
feat(instance-ai): Add robust two-tier thread title generation

### DIFF
--- a/packages/@n8n/api-types/src/schemas/agent-run-reducer.ts
+++ b/packages/@n8n/api-types/src/schemas/agent-run-reducer.ts
@@ -361,7 +361,8 @@ export function reduceEvent(state: AgentRunState, event: InstanceAiEvent): Agent
 			break;
 		}
 
-		case 'filesystem-request': {
+		case 'filesystem-request':
+		case 'thread-title-updated': {
 			// Handled externally — no state change
 			break;
 		}

--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -29,6 +29,7 @@ export const instanceAiEventTypeSchema = z.enum([
 	'confirmation-request',
 	'tasks-update',
 	'filesystem-request',
+	'thread-title-updated',
 	'status',
 	'error',
 ]);
@@ -377,6 +378,10 @@ export const tasksUpdatePayloadSchema = z.object({
 	tasks: taskListSchema,
 });
 
+export const threadTitleUpdatedPayloadSchema = z.object({
+	title: z.string(),
+});
+
 // ---------------------------------------------------------------------------
 // Event schema (Zod discriminated union — single source of truth)
 // ---------------------------------------------------------------------------
@@ -414,6 +419,11 @@ export const instanceAiEventSchema = z.discriminatedUnion('type', [
 		...eventBase,
 		payload: filesystemRequestPayloadSchema,
 	}),
+	z.object({
+		type: z.literal('thread-title-updated'),
+		...eventBase,
+		payload: threadTitleUpdatedPayloadSchema,
+	}),
 ]);
 
 // ---------------------------------------------------------------------------
@@ -442,6 +452,10 @@ export type InstanceAiErrorEvent = Extract<InstanceAiEvent, { type: 'error' }>;
 export type InstanceAiFilesystemRequestEvent = Extract<
 	InstanceAiEvent,
 	{ type: 'filesystem-request' }
+>;
+export type InstanceAiThreadTitleUpdatedEvent = Extract<
+	InstanceAiEvent,
+	{ type: 'thread-title-updated' }
 >;
 
 export type InstanceAiFilesystemResponse = z.infer<typeof instanceAiFilesystemResponseSchema>;

--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -28,6 +28,7 @@ export type {
 	WorkflowLoopWorkItemRecord,
 } from './storage';
 export { WORKING_MEMORY_TEMPLATE } from './memory/working-memory-template';
+export { truncateToTitle, generateThreadTitle } from './memory/title-utils';
 export { createSubAgentMemory, subAgentResourceId } from './memory/sub-agent-memory';
 export {
 	MEMORY_ENABLED_ROLES,

--- a/packages/@n8n/instance-ai/src/memory/__tests__/memory-config.test.ts
+++ b/packages/@n8n/instance-ai/src/memory/__tests__/memory-config.test.ts
@@ -18,7 +18,7 @@ interface MemoryArgs {
 	options: {
 		lastMessages: number;
 		semanticRecall: false | { topK: number };
-		generateTitle: boolean | { model: string; instructions: string };
+		generateTitle: boolean;
 		workingMemory: { enabled: boolean; template: string };
 	};
 	embedder?: string;
@@ -65,12 +65,10 @@ describe('createMemory', () => {
 		expect(args.embedder).toBe('openai/text-embedding-3-small');
 	});
 
-	it('uses custom title model when provided', () => {
-		createMemory({ ...baseConfig, titleModel: 'anthropic/claude-sonnet-4-5' });
+	it('disables Mastra title generation (titles are managed by n8n)', () => {
+		createMemory(baseConfig);
 
 		const args = getLastCallArgs();
-		const title = args.options.generateTitle as { model: string; instructions: string };
-		expect(title.model).toBe('anthropic/claude-sonnet-4-5');
-		expect(title.instructions).toContain('concise title');
+		expect(args.options.generateTitle).toBe(false);
 	});
 });

--- a/packages/@n8n/instance-ai/src/memory/__tests__/title-utils.test.ts
+++ b/packages/@n8n/instance-ai/src/memory/__tests__/title-utils.test.ts
@@ -1,0 +1,60 @@
+jest.mock('@mastra/core/agent', () => {
+	const MockAgent = jest.fn();
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+	MockAgent.prototype.generate = jest.fn().mockResolvedValue({ text: '' });
+	return { Agent: MockAgent };
+});
+
+// eslint-disable-next-line import-x/first
+import { truncateToTitle } from '../title-utils';
+
+describe('truncateToTitle', () => {
+	it('returns short messages unchanged', () => {
+		expect(truncateToTitle('Build a Slack workflow')).toBe('Build a Slack workflow');
+	});
+
+	it('trims whitespace', () => {
+		expect(truncateToTitle('  hello world  ')).toBe('hello world');
+	});
+
+	it('collapses multiple whitespace characters', () => {
+		expect(truncateToTitle('hello\n\nworld\t\tfoo')).toBe('hello world foo');
+	});
+
+	it('truncates long messages at a word boundary', () => {
+		const long =
+			'Build a workflow that connects Gmail to Slack and sends notifications for every new email';
+		const result = truncateToTitle(long);
+		expect(result.length).toBeLessThanOrEqual(61); // 60 + ellipsis
+		expect(result.endsWith('\u2026')).toBe(true);
+	});
+
+	it('truncates at max length when no suitable word boundary', () => {
+		const noSpaces = 'a'.repeat(100);
+		const result = truncateToTitle(noSpaces);
+		expect(result).toBe('a'.repeat(60) + '\u2026');
+	});
+
+	it('handles exactly 60-char messages', () => {
+		const exact = 'x'.repeat(60);
+		expect(truncateToTitle(exact)).toBe(exact);
+	});
+
+	it('handles empty messages', () => {
+		expect(truncateToTitle('')).toBe('');
+		expect(truncateToTitle('   ')).toBe('');
+	});
+
+	it('handles multi-line messages', () => {
+		const multiLine = 'First line\nSecond line\nThird line';
+		expect(truncateToTitle(multiLine)).toBe('First line Second line Third line');
+	});
+
+	it('preserves word boundary only when lastSpace > 20', () => {
+		// Short prefix followed by a long word — lastSpace is at position < 20
+		const msg = 'Hi ' + 'x'.repeat(80);
+		const result = truncateToTitle(msg);
+		// lastSpace is at position 2, which is <= 20, so it should truncate at 60
+		expect(result).toBe(msg.slice(0, 60) + '\u2026');
+	});
+});

--- a/packages/@n8n/instance-ai/src/memory/memory-config.ts
+++ b/packages/@n8n/instance-ai/src/memory/memory-config.ts
@@ -11,18 +11,11 @@ import { WORKING_MEMORY_TEMPLATE } from './working-memory-template';
  * predictable in minimal deployments.
  */
 export function createMemory(config: InstanceAiMemoryConfig): Memory {
-	const TITLE_INSTRUCTIONS = [
-		'Generate a concise title (max 60 chars) summarizing what the user wants.',
-		'Return ONLY the title text. No quotes, colons, or explanation.',
-		'Focus on the user intent, not what the assistant might reply.',
-		'Examples: "Build Gmail to Slack workflow", "Debug failed execution", "Show project files"',
-	].join('\n');
-
 	const memoryOptions: ConstructorParameters<typeof Memory>[0] = {
 		storage: config.storage,
 		options: {
 			lastMessages: config.lastMessages ?? 20,
-			generateTitle: true,
+			generateTitle: false,
 			workingMemory: {
 				enabled: true,
 				template: WORKING_MEMORY_TEMPLATE,
@@ -41,16 +34,6 @@ export function createMemory(config: InstanceAiMemoryConfig): Memory {
 			};
 		}
 		(memoryOptions as Record<string, unknown>).embedder = config.embedderModel;
-	}
-
-	// Mastra's MemoryConfig type requires DynamicArgument<MastraModelConfig> for model,
-	// but at runtime it accepts a plain model ID string (e.g. "anthropic/claude-sonnet-4-5").
-	// Override the generateTitle config after construction to inject custom title instructions.
-	if (config.titleModel && memoryOptions.options) {
-		(memoryOptions.options as Record<string, unknown>).generateTitle = {
-			model: config.titleModel,
-			instructions: TITLE_INSTRUCTIONS,
-		};
 	}
 
 	return new Memory(memoryOptions);

--- a/packages/@n8n/instance-ai/src/memory/title-utils.ts
+++ b/packages/@n8n/instance-ai/src/memory/title-utils.ts
@@ -1,0 +1,49 @@
+import { Agent } from '@mastra/core/agent';
+
+import type { ModelConfig } from '../types';
+
+const MAX_TITLE_LENGTH = 60;
+
+/** Truncate a user message to a concise thread title (max 60 chars, word-boundary). */
+export function truncateToTitle(message: string): string {
+	const text = message.trim().replace(/\s+/g, ' ');
+	if (text.length <= MAX_TITLE_LENGTH) return text;
+	const truncated = text.slice(0, MAX_TITLE_LENGTH);
+	const lastSpace = truncated.lastIndexOf(' ');
+	return (lastSpace > 20 ? truncated.slice(0, lastSpace) : truncated) + '\u2026';
+}
+
+const TITLE_SYSTEM_PROMPT = [
+	'Generate a concise title (max 60 chars) summarizing what the user wants.',
+	'Return ONLY the title text. No quotes, colons, or explanation.',
+	'Focus on the user intent, not what the assistant might reply.',
+	'Examples: "Build Gmail to Slack workflow", "Debug failed execution", "Show project files"',
+].join('\n');
+
+/**
+ * Generate a polished thread title via a lightweight LLM call.
+ * Returns the cleaned title string or null on failure.
+ */
+export async function generateThreadTitle(
+	modelId: ModelConfig,
+	userMessage: string,
+): Promise<string | null> {
+	try {
+		const agent = new Agent({
+			id: 'thread-title-generator',
+			name: 'Thread Title Generator',
+			instructions: {
+				role: 'system' as const,
+				content: TITLE_SYSTEM_PROMPT,
+			},
+			model: modelId,
+		});
+
+		const result = await agent.generate(userMessage, { maxSteps: 1 });
+		const title = result.text.trim().replace(/^["']|["']$/g, '');
+		if (!title) return null;
+		return title.length > MAX_TITLE_LENGTH ? truncateToTitle(title) : title;
+	} catch {
+		return null;
+	}
+}

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -664,8 +664,6 @@ export interface InstanceAiMemoryConfig {
 	embedderModel?: string;
 	lastMessages?: number;
 	semanticRecallTopK?: number;
-	/** Model ID for title generation (e.g. "anthropic/claude-sonnet-4-5"). When set, custom title instructions are used. */
-	titleModel?: string;
 	/** Thread TTL in days. Threads older than this are auto-expired on cleanup. 0 = no expiration. */
 	threadTtlDays?: number;
 }

--- a/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
@@ -258,7 +258,7 @@ export class InstanceAiMemoryService {
 		const memory = this.createMemoryInstance();
 		const updated = await patchThread(memory, {
 			threadId,
-			update: ({ metadata }) => ({ title, metadata }),
+			update: ({ metadata }) => ({ title, metadata: { ...metadata, titleRefined: true } }),
 		});
 		if (!updated) {
 			throw new NotFoundError(`Thread ${threadId} not found`);

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -36,6 +36,9 @@ import {
 	startDetachedDelegateTask,
 	startResearchAgentTask,
 	streamAgentRun,
+	truncateToTitle,
+	generateThreadTitle,
+	patchThread,
 	type ConfirmationData,
 	type DomainAccessTracker,
 	type ManagedBackgroundTask,
@@ -514,13 +517,12 @@ export class InstanceAiService {
 		this.logger.debug('Instance AI service shut down');
 	}
 
-	private createMemoryConfig(titleModel?: string) {
+	private createMemoryConfig() {
 		return {
 			storage: this.compositeStore,
 			embedderModel: this.instanceAiConfig.embedderModel || undefined,
 			lastMessages: this.instanceAiConfig.lastMessages,
 			semanticRecallTopK: this.instanceAiConfig.semanticRecallTopK,
-			titleModel,
 		};
 	}
 
@@ -591,8 +593,8 @@ export class InstanceAiService {
 		return `<planned-task-follow-up type="${type}">\n${JSON.stringify(payload, null, 2)}\n</planned-task-follow-up>\n\n${AUTO_FOLLOW_UP_MESSAGE}`;
 	}
 
-	private async createPlannedTaskState(titleModel?: string) {
-		const memory = createMemory(this.createMemoryConfig(titleModel));
+	private async createPlannedTaskState() {
+		const memory = createMemory(this.createMemoryConfig());
 		const taskStorage = new MastraTaskStorage(memory);
 		const plannedTaskStorage = new PlannedTaskStorage(memory);
 		const plannedTaskService = new PlannedTaskCoordinator(plannedTaskStorage);
@@ -641,8 +643,7 @@ export class InstanceAiService {
 		context.runId = runId;
 
 		const modelId = await this.resolveModel(user);
-		const titleModel = typeof modelId === 'string' ? modelId : modelId.id;
-		const memory = createMemory(this.createMemoryConfig(titleModel));
+		const memory = createMemory(this.createMemoryConfig());
 		await this.ensureThreadExists(memory, threadId, user.id);
 
 		const taskStorage = new MastraTaskStorage(memory);
@@ -936,9 +937,16 @@ export class InstanceAiService {
 					messageGroupId,
 					executionPushRef,
 				);
-			const memoryConfig = this.createMemoryConfig(
-				typeof modelId === 'string' ? modelId : modelId.id,
-			);
+			const memoryConfig = this.createMemoryConfig();
+
+			// Set heuristic title before agent starts — thread always has a title
+			const thread = await memory.getThreadById({ threadId });
+			if (thread && !thread.title) {
+				await patchThread(memory, {
+					threadId,
+					update: () => ({ title: truncateToTitle(message) }),
+				});
+			}
 
 			const existingTasks = await taskStorage.get(threadId);
 			if (existingTasks) {
@@ -1047,7 +1055,10 @@ export class InstanceAiService {
 				return;
 			}
 
-			await this.finalizeRun(threadId, runId, result.status, snapshotStorage);
+			await this.finalizeRun(threadId, runId, result.status, snapshotStorage, {
+				userId: user.id,
+				modelId,
+			});
 		} catch (error) {
 			if (signal.aborted) {
 				this.publishRunFinish(threadId, runId, 'cancelled', 'user_cancelled');
@@ -1343,10 +1354,67 @@ export class InstanceAiService {
 		runId: string,
 		status: 'completed' | 'cancelled',
 		snapshotStorage: DbSnapshotStorage,
+		options?: { userId?: string; modelId?: ModelConfig },
 	): Promise<void> {
 		this.publishRunFinish(threadId, runId, status);
 		if (status === 'completed') {
 			await this.saveAgentTreeSnapshot(threadId, runId, snapshotStorage);
+			if (options?.userId && options?.modelId) {
+				void this.refineTitleIfNeeded(threadId, options.userId, options.modelId);
+			}
+		}
+	}
+
+	/**
+	 * Refine the thread title with an LLM-generated version after a run completes.
+	 * Fires asynchronously and is best-effort — the heuristic title remains if this fails.
+	 */
+	private async refineTitleIfNeeded(
+		threadId: string,
+		userId: string,
+		modelId: ModelConfig,
+	): Promise<void> {
+		try {
+			const memory = createMemory(this.createMemoryConfig());
+			const thread = await memory.getThreadById({ threadId });
+			if (!thread?.title) return;
+
+			// Skip if thread already has an LLM-refined title
+			if (thread.metadata?.titleRefined) return;
+
+			// Get first user message
+			const result = await memory.recall({ threadId, resourceId: userId, perPage: 5 });
+			const firstUserMsg = result.messages.find((m) => m.role === 'user');
+			if (!firstUserMsg) return;
+			const userText =
+				typeof firstUserMsg.content === 'string'
+					? firstUserMsg.content
+					: JSON.stringify(firstUserMsg.content);
+
+			const llmTitle = await generateThreadTitle(modelId, userText);
+			if (!llmTitle) return;
+
+			await patchThread(memory, {
+				threadId,
+				update: ({ metadata }) => ({
+					title: llmTitle,
+					metadata: { ...metadata, titleRefined: true },
+				}),
+			});
+
+			// Push SSE event so frontend updates immediately
+			this.eventBus.publish(threadId, {
+				type: 'thread-title-updated',
+				runId: '',
+				agentId: ORCHESTRATOR_AGENT_ID,
+				payload: { title: llmTitle },
+			});
+		} catch (error) {
+			this.logger.warn('Failed to refine thread title', {
+				threadId,
+				error: getErrorMessage(error),
+			});
+			// Non-fatal — heuristic title remains
 		}
 	}
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.reducer.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.reducer.ts
@@ -488,6 +488,7 @@ export function handleEvent(state: InstanceAiReducerState, event: InstanceAiEven
 		}
 
 		case 'filesystem-request':
+		case 'thread-title-updated':
 			return state.activeRunId;
 
 		case 'run-finish': {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.store.ts
@@ -255,6 +255,12 @@ export const useInstanceAiStore = defineStore('instanceAi', () => {
 			if (parsed.data.type === 'tasks-update') {
 				latestTasks.value = parsed.data.payload.tasks;
 			}
+			if (parsed.data.type === 'thread-title-updated') {
+				const thread = threads.value.find((t) => t.id === currentThreadId.value);
+				if (thread) {
+					thread.title = parsed.data.payload.title;
+				}
+			}
 			// Force Vue reactivity when streaming state changes (run-start can
 			// re-activate a completed message for auto-follow-up runs, run-finish
 			// marks it done). In-place mutation of message properties may not


### PR DESCRIPTION
## Summary

- Replace Mastra's built-in `generateTitle` (been buggy since they released Mastra lol) with n8n-owned two-tier title generation that guarantees threads always have a title
- **Tier 1 (heuristic)**: Truncated first user message is set as thread title before the agent starts — zero-latency, always works
- **Tier 2 (LLM refinement)**: After the first run completes, a dedicated LLM call generates a polished title and pushes it to the frontend via a new `thread-title-updated` SSE event
- Threads with manually renamed titles are protected via a `titleRefined` metadata flag