### PR TITLE
refactor(core): Extract CommunityPackagesLifecycleService from controller

### DIFF
--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.controller.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.controller.test.ts
@@ -1,5 +1,6 @@
-import type { InstanceSettings } from 'n8n-core';
 import type { CommunityNodeType } from '@n8n/api-types';
+import type { Logger } from '@n8n/backend-common';
+import type { InstanceSettings } from 'n8n-core';
 import { mock } from 'jest-mock-extended';
 
 import type { EventService } from '@/events/event.service';
@@ -13,6 +14,7 @@ import type { CommunityPackagesService } from '../community-packages.service';
 import type { InstalledPackages } from '../installed-packages.entity';
 
 describe('CommunityPackagesController', () => {
+	const logger = mock<Logger>();
 	const push = mock<Push>();
 	const communityPackagesService = mock<CommunityPackagesService>();
 	const eventService = mock<EventService>();
@@ -21,6 +23,7 @@ describe('CommunityPackagesController', () => {
 	(instanceSettings as any).nodesDownloadDir = '/tmp/n8n-nodes-download';
 
 	const lifecycle = new CommunityPackagesLifecycleService(
+		logger,
 		push,
 		communityPackagesService,
 		eventService,

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.lifecycle.service.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.lifecycle.service.test.ts
@@ -1,4 +1,5 @@
 import type { CommunityNodeType } from '@n8n/api-types';
+import type { Logger } from '@n8n/backend-common';
 import { mock } from 'jest-mock-extended';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
@@ -11,6 +12,7 @@ import type { CommunityPackagesService } from '../community-packages.service';
 import type { InstalledPackages } from '../installed-packages.entity';
 
 describe('CommunityPackagesLifecycleService', () => {
+	const logger = mock<Logger>();
 	const push = mock<Push>();
 	const communityPackagesService = mock<CommunityPackagesService>();
 	const eventService = mock<EventService>();
@@ -20,6 +22,7 @@ describe('CommunityPackagesLifecycleService', () => {
 	});
 
 	const lifecycle = new CommunityPackagesLifecycleService(
+		logger,
 		push,
 		communityPackagesService,
 		eventService,
@@ -33,12 +36,12 @@ describe('CommunityPackagesLifecycleService', () => {
 		jest.clearAllMocks();
 	});
 
-	describe('installWithSideEffects', () => {
+	describe('install', () => {
 		it('should throw error if verify in options but no checksum', async () => {
 			communityNodeTypesService.findVetted.mockReturnValue(undefined);
 
 			await expect(
-				lifecycle.installWithSideEffects(
+				lifecycle.install(
 					{ name: 'n8n-nodes-test', verify: true, version: '1.0.0' },
 					user,
 					'ui',
@@ -52,7 +55,7 @@ describe('CommunityPackagesLifecycleService', () => {
 			'should throw error if version is invalid',
 			async (version) => {
 				await expect(
-					lifecycle.installWithSideEffects(
+					lifecycle.install(
 						{ name: 'n8n-nodes-test', verify: true, version },
 						user,
 						'ui',
@@ -83,7 +86,7 @@ describe('CommunityPackagesLifecycleService', () => {
 				}),
 			);
 
-			await lifecycle.installWithSideEffects(
+			await lifecycle.install(
 				{ name: 'n8n-nodes-test', verify: true, version: '1.0.0' },
 				user,
 				'ui',
@@ -103,7 +106,7 @@ describe('CommunityPackagesLifecycleService', () => {
 		});
 	});
 
-	describe('updateWithSideEffects', () => {
+	describe('update', () => {
 		it('should use the version from the request when updating a package', async () => {
 			const previouslyInstalledPackage = mock<InstalledPackages>({
 				installedNodes: [{ type: 'testNode', latestVersion: 1, name: 'testNode' }],
@@ -126,7 +129,7 @@ describe('CommunityPackagesLifecycleService', () => {
 				version: undefined,
 			});
 
-			const result = await lifecycle.updateWithSideEffects(
+			const result = await lifecycle.update(
 				{
 					name: 'n8n-nodes-test',
 					version: '2.0.0',
@@ -150,7 +153,7 @@ describe('CommunityPackagesLifecycleService', () => {
 			'should throw error if version is invalid',
 			async (version) => {
 				await expect(
-					lifecycle.updateWithSideEffects(
+					lifecycle.update(
 						{ name: 'n8n-nodes-test', version, checksum: 'a893hfdsy7399' },
 						user,
 						'badRequest',
@@ -163,7 +166,7 @@ describe('CommunityPackagesLifecycleService', () => {
 			communityPackagesService.findInstalledPackage.mockResolvedValue(null);
 
 			await expect(
-				lifecycle.updateWithSideEffects(
+				lifecycle.update(
 					{ name: 'n8n-nodes-missing', version: '1.0.0' },
 					user,
 					'notFound',
@@ -175,7 +178,7 @@ describe('CommunityPackagesLifecycleService', () => {
 			communityPackagesService.findInstalledPackage.mockResolvedValue(null);
 
 			await expect(
-				lifecycle.updateWithSideEffects(
+				lifecycle.update(
 					{ name: 'n8n-nodes-missing', version: '1.0.0' },
 					user,
 					'badRequest',

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.lifecycle.service.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.lifecycle.service.test.ts
@@ -1,69 +1,67 @@
-import type { InstanceSettings } from 'n8n-core';
 import type { CommunityNodeType } from '@n8n/api-types';
 import { mock } from 'jest-mock-extended';
 
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import type { EventService } from '@/events/event.service';
 import type { Push } from '@/push';
-import type { NodeRequest } from '@/requests';
 
 import type { CommunityNodeTypesService } from '../community-node-types.service';
-import { CommunityPackagesController } from '../community-packages.controller';
 import { CommunityPackagesLifecycleService } from '../community-packages.lifecycle.service';
 import type { CommunityPackagesService } from '../community-packages.service';
 import type { InstalledPackages } from '../installed-packages.entity';
 
-describe('CommunityPackagesController', () => {
+describe('CommunityPackagesLifecycleService', () => {
 	const push = mock<Push>();
 	const communityPackagesService = mock<CommunityPackagesService>();
 	const eventService = mock<EventService>();
 	const communityNodeTypesService = mock<CommunityNodeTypesService>();
-	const instanceSettings = mock<InstanceSettings>();
-	(instanceSettings as any).nodesDownloadDir = '/tmp/n8n-nodes-download';
+	const instanceSettings = mock<{ nodesDownloadDir: string }>({
+		nodesDownloadDir: '/tmp/n8n-nodes-download',
+	});
 
 	const lifecycle = new CommunityPackagesLifecycleService(
 		push,
 		communityPackagesService,
 		eventService,
 		communityNodeTypesService,
-		instanceSettings,
+		instanceSettings as never,
 	);
 
-	const controller = new CommunityPackagesController(lifecycle);
+	const user = { id: 'user123' };
 
 	beforeEach(() => {
 		jest.clearAllMocks();
 	});
 
-	describe('installPackage', () => {
+	describe('installWithSideEffects', () => {
 		it('should throw error if verify in options but no checksum', async () => {
-			const request = mock<NodeRequest.Post>({
-				user: { id: 'user123' },
-				body: { name: 'n8n-nodes-test', verify: true, version: '1.0.0' },
-			});
 			communityNodeTypesService.findVetted.mockReturnValue(undefined);
-			await expect(controller.installPackage(request)).rejects.toThrow(
-				'Package n8n-nodes-test is not vetted for installation',
-			);
+
+			await expect(
+				lifecycle.installWithSideEffects(
+					{ name: 'n8n-nodes-test', verify: true, version: '1.0.0' },
+					user,
+					'ui',
+				),
+			).rejects.toThrow('Package n8n-nodes-test is not vetted for installation');
+
+			expect(communityNodeTypesService.findVetted).toHaveBeenCalledWith('n8n-nodes-test');
 		});
 
 		it.each(['foo', 'echo "hello"', '1.a.b', '0.1.29#;ls'])(
 			'should throw error if version is invalid',
 			async (version) => {
-				const request = mock<NodeRequest.Post>({
-					user: { id: 'user123' },
-					body: { name: 'n8n-nodes-test', verify: true, version },
-				});
-				await expect(controller.installPackage(request)).rejects.toThrow(
-					`Invalid version: ${version}`,
-				);
+				await expect(
+					lifecycle.installWithSideEffects(
+						{ name: 'n8n-nodes-test', verify: true, version },
+						user,
+						'ui',
+					),
+				).rejects.toThrow(`Invalid version: ${version}`);
 			},
 		);
 
-		it('should have correct version', async () => {
-			const request = mock<NodeRequest.Post>({
-				user: { id: 'user123' },
-				body: { name: 'n8n-nodes-test', verify: true, version: '1.0.0' },
-			});
+		it('should install with checksum when verify is true', async () => {
 			communityNodeTypesService.findVetted.mockReturnValue(
 				mock<CommunityNodeType>({
 					checksum: 'checksum',
@@ -85,7 +83,11 @@ describe('CommunityPackagesController', () => {
 				}),
 			);
 
-			await controller.installPackage(request);
+			await lifecycle.installWithSideEffects(
+				{ name: 'n8n-nodes-test', verify: true, version: '1.0.0' },
+				user,
+				'ui',
+			);
 
 			expect(communityPackagesService.installPackage).toHaveBeenCalledWith(
 				'n8n-nodes-test',
@@ -101,17 +103,8 @@ describe('CommunityPackagesController', () => {
 		});
 	});
 
-	describe('updatePackage', () => {
-		it('should use the version from the request body when updating a package', async () => {
-			const req = mock<NodeRequest.Update>({
-				body: {
-					name: 'n8n-nodes-test',
-					version: '2.0.0',
-					checksum: 'a893hfdsy7399',
-				},
-				user: { id: 'user1' },
-			});
-
+	describe('updateWithSideEffects', () => {
+		it('should use the version from the request when updating a package', async () => {
 			const previouslyInstalledPackage = mock<InstalledPackages>({
 				installedNodes: [{ type: 'testNode', latestVersion: 1, name: 'testNode' }],
 				installedVersion: '1.0.0',
@@ -133,7 +126,15 @@ describe('CommunityPackagesController', () => {
 				version: undefined,
 			});
 
-			const result = await controller.updatePackage(req);
+			const result = await lifecycle.updateWithSideEffects(
+				{
+					name: 'n8n-nodes-test',
+					version: '2.0.0',
+					checksum: 'a893hfdsy7399',
+				},
+				user,
+				'badRequest',
+			);
 
 			expect(communityPackagesService.updatePackage).toHaveBeenCalledWith(
 				'n8n-nodes-test',
@@ -148,11 +149,38 @@ describe('CommunityPackagesController', () => {
 		it.each(['foo', 'echo "hello"', '1.a.b', '0.1.29#;ls'])(
 			'should throw error if version is invalid',
 			async (version) => {
-				const req = mock<NodeRequest.Update>({
-					body: { name: 'n8n-nodes-test', version, checksum: 'a893hfdsy7399' },
-				});
-				await expect(controller.updatePackage(req)).rejects.toThrow(`Invalid version: ${version}`);
+				await expect(
+					lifecycle.updateWithSideEffects(
+						{ name: 'n8n-nodes-test', version, checksum: 'a893hfdsy7399' },
+						user,
+						'badRequest',
+					),
+				).rejects.toThrow(`Invalid version: ${version}`);
 			},
 		);
+
+		it('should throw NotFoundError when package missing and whenMissing is notFound', async () => {
+			communityPackagesService.findInstalledPackage.mockResolvedValue(null);
+
+			await expect(
+				lifecycle.updateWithSideEffects(
+					{ name: 'n8n-nodes-missing', version: '1.0.0' },
+					user,
+					'notFound',
+				),
+			).rejects.toMatchObject({ httpStatusCode: 404 });
+		});
+
+		it('should throw BadRequestError when package missing and whenMissing is badRequest', async () => {
+			communityPackagesService.findInstalledPackage.mockResolvedValue(null);
+
+			await expect(
+				lifecycle.updateWithSideEffects(
+					{ name: 'n8n-nodes-missing', version: '1.0.0' },
+					user,
+					'badRequest',
+				),
+			).rejects.toBeInstanceOf(BadRequestError);
+		});
 	});
 });

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.lifecycle.service.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.lifecycle.service.test.ts
@@ -41,11 +41,7 @@ describe('CommunityPackagesLifecycleService', () => {
 			communityNodeTypesService.findVetted.mockReturnValue(undefined);
 
 			await expect(
-				lifecycle.install(
-					{ name: 'n8n-nodes-test', verify: true, version: '1.0.0' },
-					user,
-					'ui',
-				),
+				lifecycle.install({ name: 'n8n-nodes-test', verify: true, version: '1.0.0' }, user, 'ui'),
 			).rejects.toThrow('Package n8n-nodes-test is not vetted for installation');
 
 			expect(communityNodeTypesService.findVetted).toHaveBeenCalledWith('n8n-nodes-test');
@@ -55,11 +51,7 @@ describe('CommunityPackagesLifecycleService', () => {
 			'should throw error if version is invalid',
 			async (version) => {
 				await expect(
-					lifecycle.install(
-						{ name: 'n8n-nodes-test', verify: true, version },
-						user,
-						'ui',
-					),
+					lifecycle.install({ name: 'n8n-nodes-test', verify: true, version }, user, 'ui'),
 				).rejects.toThrow(`Invalid version: ${version}`);
 			},
 		);
@@ -166,11 +158,7 @@ describe('CommunityPackagesLifecycleService', () => {
 			communityPackagesService.findInstalledPackage.mockResolvedValue(null);
 
 			await expect(
-				lifecycle.update(
-					{ name: 'n8n-nodes-missing', version: '1.0.0' },
-					user,
-					'notFound',
-				),
+				lifecycle.update({ name: 'n8n-nodes-missing', version: '1.0.0' }, user, 'notFound'),
 			).rejects.toMatchObject({ httpStatusCode: 404 });
 		});
 
@@ -178,11 +166,7 @@ describe('CommunityPackagesLifecycleService', () => {
 			communityPackagesService.findInstalledPackage.mockResolvedValue(null);
 
 			await expect(
-				lifecycle.update(
-					{ name: 'n8n-nodes-missing', version: '1.0.0' },
-					user,
-					'badRequest',
-				),
+				lifecycle.update({ name: 'n8n-nodes-missing', version: '1.0.0' }, user, 'badRequest'),
 			).rejects.toBeInstanceOf(BadRequestError);
 		});
 	});

--- a/packages/cli/src/modules/community-packages/community-packages.controller.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.controller.ts
@@ -13,11 +13,7 @@ export class CommunityPackagesController {
 	async installPackage(req: NodeRequest.Post) {
 		const { name, verify, version } = req.body;
 
-		return await this.communityPackagesLifecycle.install(
-			{ name, verify, version },
-			req.user,
-			'ui',
-		);
+		return await this.communityPackagesLifecycle.install({ name, verify, version }, req.user, 'ui');
 	}
 
 	@Get('/')

--- a/packages/cli/src/modules/community-packages/community-packages.controller.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.controller.ts
@@ -13,7 +13,7 @@ export class CommunityPackagesController {
 	async installPackage(req: NodeRequest.Post) {
 		const { name, verify, version } = req.body;
 
-		return await this.communityPackagesLifecycle.installWithSideEffects(
+		return await this.communityPackagesLifecycle.install(
 			{ name, verify, version },
 			req.user,
 			'ui',
@@ -23,7 +23,7 @@ export class CommunityPackagesController {
 	@Get('/')
 	@GlobalScope('communityPackage:list')
 	async getInstalledPackages() {
-		return await this.communityPackagesLifecycle.listInstalledPackagesHydrated();
+		return await this.communityPackagesLifecycle.listInstalledPackages();
 	}
 
 	@Delete('/')
@@ -31,7 +31,7 @@ export class CommunityPackagesController {
 	async uninstallPackage(req: NodeRequest.Delete) {
 		const { name } = req.query;
 
-		await this.communityPackagesLifecycle.uninstallWithSideEffects(name, req.user, 'badRequest');
+		await this.communityPackagesLifecycle.uninstall(name, req.user, 'badRequest');
 	}
 
 	@Patch('/')
@@ -39,7 +39,7 @@ export class CommunityPackagesController {
 	async updatePackage(req: NodeRequest.Update) {
 		const { name, version, checksum } = req.body;
 
-		return await this.communityPackagesLifecycle.updateWithSideEffects(
+		return await this.communityPackagesLifecycle.update(
 			{ name, version, checksum },
 			req.user,
 			'badRequest',

--- a/packages/cli/src/modules/community-packages/community-packages.controller.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.controller.ts
@@ -1,204 +1,29 @@
 import { Delete, Get, Patch, Post, RestController, GlobalScope } from '@n8n/decorators';
-import { valid } from 'semver';
 
-import {
-	RESPONSE_ERROR_MESSAGES,
-	STARTER_TEMPLATE_NAME,
-	UNKNOWN_FAILURE_REASON,
-} from '@/constants';
-import { BadRequestError } from '@/errors/response-errors/bad-request.error';
-import { InternalServerError } from '@/errors/response-errors/internal-server.error';
-import { EventService } from '@/events/event.service';
-import { Push } from '@/push';
 import { NodeRequest } from '@/requests';
 
-import { CommunityNodeTypesService } from './community-node-types.service';
-import { CommunityPackagesService } from './community-packages.service';
-import type { CommunityPackages } from './community-packages.types';
-import { InstalledPackages } from './installed-packages.entity';
-import { executeNpmCommand } from './npm-utils';
-import { InstanceSettings } from 'n8n-core';
-
-const {
-	PACKAGE_NOT_INSTALLED,
-	PACKAGE_NAME_NOT_PROVIDED,
-	PACKAGE_VERSION_NOT_FOUND,
-	PACKAGE_DOES_NOT_CONTAIN_NODES,
-	PACKAGE_NOT_FOUND,
-} = RESPONSE_ERROR_MESSAGES;
-
-const isClientError = (error: Error) =>
-	[PACKAGE_VERSION_NOT_FOUND, PACKAGE_DOES_NOT_CONTAIN_NODES, PACKAGE_NOT_FOUND].some(
-		(msg) => typeof error.message === 'string' && error.message.includes(msg),
-	);
-
-export function isNpmError(error: unknown): error is { code: number; stdout: string } {
-	return typeof error === 'object' && error !== null && 'code' in error && 'stdout' in error;
-}
+import { CommunityPackagesLifecycleService } from './community-packages.lifecycle.service';
 
 @RestController('/community-packages')
 export class CommunityPackagesController {
-	constructor(
-		private readonly push: Push,
-		private readonly communityPackagesService: CommunityPackagesService,
-		private readonly eventService: EventService,
-		private readonly communityNodeTypesService: CommunityNodeTypesService,
-		private readonly instanceSettings: InstanceSettings,
-	) {}
+	constructor(private readonly communityPackagesLifecycle: CommunityPackagesLifecycleService) {}
 
 	@Post('/')
 	@GlobalScope('communityPackage:install')
 	async installPackage(req: NodeRequest.Post) {
 		const { name, verify, version } = req.body;
 
-		if (!name) {
-			throw new BadRequestError(PACKAGE_NAME_NOT_PROVIDED);
-		}
-
-		if (version && !valid(version)) {
-			throw new BadRequestError(`Invalid version: ${version}`);
-		}
-
-		let checksum: string | undefined = undefined;
-
-		// Get the checksum for the package if flagged to verify
-		if (verify) {
-			checksum = this.communityNodeTypesService.findVetted(name)?.checksum;
-			if (!checksum) {
-				throw new BadRequestError(`Package ${name} is not vetted for installation`);
-			}
-		}
-
-		let parsed: CommunityPackages.ParsedPackageName;
-
-		try {
-			parsed = this.communityPackagesService.parseNpmPackageName(name);
-		} catch (error) {
-			throw new BadRequestError(
-				error instanceof Error ? error.message : 'Failed to parse package name',
-			);
-		}
-
-		if (parsed.packageName === STARTER_TEMPLATE_NAME) {
-			throw new BadRequestError(
-				[
-					`Package "${parsed.packageName}" is only a template`,
-					'Please enter an actual package to install',
-				].join('.'),
-			);
-		}
-
-		const isInstalled = await this.communityPackagesService.isPackageInstalled(parsed.packageName);
-		const hasLoaded = this.communityPackagesService.hasPackageLoaded(name);
-
-		if (isInstalled && hasLoaded) {
-			throw new BadRequestError(
-				[
-					`Package "${parsed.packageName}" is already installed`,
-					'To update it, click the corresponding button in the UI',
-				].join('.'),
-			);
-		}
-
-		const packageStatus = await this.communityPackagesService.checkNpmPackageStatus(name);
-
-		if (packageStatus.status !== 'OK') {
-			throw new BadRequestError(`Package "${name}" is banned so it cannot be installed`);
-		}
-
-		const packageVersion = version ?? parsed.version;
-		let installedPackage: InstalledPackages;
-		try {
-			installedPackage = await this.communityPackagesService.installPackage(
-				parsed.packageName,
-				packageVersion,
-				checksum,
-			);
-		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : UNKNOWN_FAILURE_REASON;
-
-			this.eventService.emit('community-package-installed', {
-				user: req.user,
-				inputString: name,
-				packageName: parsed.packageName,
-				success: false,
-				packageVersion,
-				failureReason: errorMessage,
-			});
-
-			let message = [`Error loading package "${name}" `, errorMessage].join(':');
-			if (error instanceof Error && error.cause instanceof Error) {
-				message += `\nCause: ${error.cause.message}`;
-			}
-
-			const clientError = error instanceof Error ? isClientError(error) : false;
-			throw new (clientError ? BadRequestError : InternalServerError)(message);
-		}
-
-		if (!hasLoaded) this.communityPackagesService.removePackageFromMissingList(name);
-
-		// broadcast to connected frontends that node list has been updated
-		installedPackage.installedNodes.forEach((node) => {
-			this.push.broadcast({
-				type: 'reloadNodeType',
-				data: {
-					name: node.type,
-					version: node.latestVersion,
-				},
-			});
-		});
-
-		this.eventService.emit('community-package-installed', {
-			user: req.user,
-			inputString: name,
-			packageName: parsed.packageName,
-			success: true,
-			packageVersion,
-			packageNodeNames: installedPackage.installedNodes.map((node) => node.name),
-			packageAuthor: installedPackage.authorName,
-			packageAuthorEmail: installedPackage.authorEmail,
-		});
-
-		return installedPackage;
+		return await this.communityPackagesLifecycle.installWithSideEffects(
+			{ name, verify, version },
+			req.user,
+			'ui',
+		);
 	}
 
 	@Get('/')
 	@GlobalScope('communityPackage:list')
 	async getInstalledPackages() {
-		const installedPackages = await this.communityPackagesService.getAllInstalledPackages();
-
-		if (installedPackages.length === 0) return [];
-
-		let pendingUpdates: CommunityPackages.AvailableUpdates | undefined;
-
-		try {
-			await executeNpmCommand(['outdated', '--json'], {
-				doNotHandleError: true,
-				cwd: this.instanceSettings.nodesDownloadDir,
-			});
-		} catch (error) {
-			// when there are updates, npm exits with code 1
-			// when there are no updates, command succeeds
-			// https://github.com/npm/rfcs/issues/473
-			if (isNpmError(error) && error.code === 1) {
-				pendingUpdates = JSON.parse(error.stdout) as CommunityPackages.AvailableUpdates;
-			}
-		}
-
-		let hydratedPackages = this.communityPackagesService.matchPackagesWithUpdates(
-			installedPackages,
-			pendingUpdates,
-		);
-
-		try {
-			if (this.communityPackagesService.hasMissingPackages) {
-				hydratedPackages = this.communityPackagesService.matchMissingPackages(hydratedPackages);
-			}
-		} catch {
-			// Ignore errors when matching missing packages
-		}
-
-		return hydratedPackages;
+		return await this.communityPackagesLifecycle.listInstalledPackagesHydrated();
 	}
 
 	@Delete('/')
@@ -206,54 +31,7 @@ export class CommunityPackagesController {
 	async uninstallPackage(req: NodeRequest.Delete) {
 		const { name } = req.query;
 
-		if (!name) {
-			throw new BadRequestError(PACKAGE_NAME_NOT_PROVIDED);
-		}
-
-		try {
-			this.communityPackagesService.parseNpmPackageName(name); // sanitize input
-		} catch (error) {
-			const message = error instanceof Error ? error.message : UNKNOWN_FAILURE_REASON;
-
-			throw new BadRequestError(message);
-		}
-
-		const installedPackage = await this.communityPackagesService.findInstalledPackage(name);
-
-		if (!installedPackage) {
-			throw new BadRequestError(PACKAGE_NOT_INSTALLED);
-		}
-
-		try {
-			await this.communityPackagesService.removePackage(name, installedPackage);
-		} catch (error) {
-			const message = [
-				`Error removing package "${name}"`,
-				error instanceof Error ? error.message : UNKNOWN_FAILURE_REASON,
-			].join(':');
-
-			throw new InternalServerError(message, error);
-		}
-
-		// broadcast to connected frontends that node list has been updated
-		installedPackage.installedNodes.forEach((node) => {
-			this.push.broadcast({
-				type: 'removeNodeType',
-				data: {
-					name: node.type,
-					version: node.latestVersion,
-				},
-			});
-		});
-
-		this.eventService.emit('community-package-deleted', {
-			user: req.user,
-			packageName: name,
-			packageVersion: installedPackage.installedVersion,
-			packageNodeNames: installedPackage.installedNodes.map((node) => node.name),
-			packageAuthor: installedPackage.authorName,
-			packageAuthorEmail: installedPackage.authorEmail,
-		});
+		await this.communityPackagesLifecycle.uninstallWithSideEffects(name, req.user, 'badRequest');
 	}
 
 	@Patch('/')
@@ -261,78 +39,10 @@ export class CommunityPackagesController {
 	async updatePackage(req: NodeRequest.Update) {
 		const { name, version, checksum } = req.body;
 
-		if (!name) {
-			throw new BadRequestError(PACKAGE_NAME_NOT_PROVIDED);
-		}
-
-		if (version && !valid(version)) {
-			throw new BadRequestError(`Invalid version: ${version}`);
-		}
-
-		const previouslyInstalledPackage =
-			await this.communityPackagesService.findInstalledPackage(name);
-
-		if (!previouslyInstalledPackage) {
-			throw new BadRequestError(PACKAGE_NOT_INSTALLED);
-		}
-
-		try {
-			const newInstalledPackage = await this.communityPackagesService.updatePackage(
-				this.communityPackagesService.parseNpmPackageName(name).packageName,
-				previouslyInstalledPackage,
-				version,
-				checksum,
-			);
-
-			// broadcast to connected frontends that node list has been updated
-			previouslyInstalledPackage.installedNodes.forEach((node) => {
-				this.push.broadcast({
-					type: 'removeNodeType',
-					data: {
-						name: node.type,
-						version: node.latestVersion,
-					},
-				});
-			});
-
-			newInstalledPackage.installedNodes.forEach((node) => {
-				this.push.broadcast({
-					type: 'reloadNodeType',
-					data: {
-						name: node.type,
-						version: node.latestVersion,
-					},
-				});
-			});
-
-			this.eventService.emit('community-package-updated', {
-				user: req.user,
-				packageName: name,
-				packageVersionCurrent: previouslyInstalledPackage.installedVersion,
-				packageVersionNew: newInstalledPackage.installedVersion,
-				packageNodeNames: newInstalledPackage.installedNodes.map((n) => n.name),
-				packageAuthor: newInstalledPackage.authorName,
-				packageAuthorEmail: newInstalledPackage.authorEmail,
-			});
-
-			return newInstalledPackage;
-		} catch (error) {
-			previouslyInstalledPackage.installedNodes.forEach((node) => {
-				this.push.broadcast({
-					type: 'removeNodeType',
-					data: {
-						name: node.type,
-						version: node.latestVersion,
-					},
-				});
-			});
-
-			const message = [
-				`Error removing package "${name}"`,
-				error instanceof Error ? error.message : UNKNOWN_FAILURE_REASON,
-			].join(':');
-
-			throw new InternalServerError(message, error);
-		}
+		return await this.communityPackagesLifecycle.updateWithSideEffects(
+			{ name, version, checksum },
+			req.user,
+			'badRequest',
+		);
 	}
 }

--- a/packages/cli/src/modules/community-packages/community-packages.lifecycle.service.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.lifecycle.service.ts
@@ -1,0 +1,345 @@
+import { Service } from '@n8n/di';
+import {
+	RESPONSE_ERROR_MESSAGES,
+	STARTER_TEMPLATE_NAME,
+	UNKNOWN_FAILURE_REASON,
+} from '@/constants';
+import type { UserLike } from '@/events/maps/relay.event-map';
+import { EventService } from '@/events/event.service';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { InternalServerError } from '@/errors/response-errors/internal-server.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { Push } from '@/push';
+import { InstanceSettings } from 'n8n-core';
+import { valid } from 'semver';
+import type { PublicInstalledPackage } from 'n8n-workflow';
+
+import { CommunityNodeTypesService } from './community-node-types.service';
+import { CommunityPackagesService } from './community-packages.service';
+import type { CommunityPackages } from './community-packages.types';
+import type { InstalledPackages } from './installed-packages.entity';
+import { executeNpmCommand, isNpmExecErrorWithStdout } from './npm-utils';
+
+const {
+	PACKAGE_NOT_INSTALLED,
+	PACKAGE_NAME_NOT_PROVIDED,
+	PACKAGE_VERSION_NOT_FOUND,
+	PACKAGE_DOES_NOT_CONTAIN_NODES,
+	PACKAGE_NOT_FOUND,
+} = RESPONSE_ERROR_MESSAGES;
+
+const isCommunityPackageInstallClientError = (error: Error) =>
+	[PACKAGE_VERSION_NOT_FOUND, PACKAGE_DOES_NOT_CONTAIN_NODES, PACKAGE_NOT_FOUND].some(
+		(msg) => typeof error.message === 'string' && error.message.includes(msg),
+	);
+
+export type CommunityPackageInstallPresentation = 'ui' | 'publicApi';
+
+export type MissingInstalledPackageBehavior = 'badRequest' | 'notFound';
+
+@Service()
+export class CommunityPackagesLifecycleService {
+	constructor(
+		private readonly push: Push,
+		private readonly communityPackagesService: CommunityPackagesService,
+		private readonly eventService: EventService,
+		private readonly communityNodeTypesService: CommunityNodeTypesService,
+		private readonly instanceSettings: InstanceSettings,
+	) {}
+
+	async listInstalledPackagesHydrated(): Promise<PublicInstalledPackage[] | InstalledPackages[]> {
+		const installedPackages = await this.communityPackagesService.getAllInstalledPackages();
+
+		if (installedPackages.length === 0) return [];
+
+		let pendingUpdates: CommunityPackages.AvailableUpdates | undefined;
+
+		try {
+			await executeNpmCommand(['outdated', '--json'], {
+				doNotHandleError: true,
+				cwd: this.instanceSettings.nodesDownloadDir,
+			});
+		} catch (error) {
+			if (isNpmExecErrorWithStdout(error) && error.code === 1) {
+				pendingUpdates = JSON.parse(error.stdout) as CommunityPackages.AvailableUpdates;
+			}
+		}
+
+		let hydratedPackages = this.communityPackagesService.matchPackagesWithUpdates(
+			installedPackages,
+			pendingUpdates,
+		);
+
+		try {
+			if (this.communityPackagesService.hasMissingPackages) {
+				hydratedPackages = this.communityPackagesService.matchMissingPackages(hydratedPackages);
+			}
+		} catch {
+			// Ignore errors when matching missing packages
+		}
+
+		return hydratedPackages;
+	}
+
+	async installWithSideEffects(
+		args: { name: string | undefined; version?: string; verify?: boolean },
+		user: UserLike,
+		presentation: CommunityPackageInstallPresentation,
+	): Promise<InstalledPackages> {
+		const { name, verify, version } = args;
+
+		if (!name) {
+			throw new BadRequestError(PACKAGE_NAME_NOT_PROVIDED);
+		}
+
+		if (version && !valid(version)) {
+			throw new BadRequestError(`Invalid version: ${version}`);
+		}
+
+		let checksum: string | undefined;
+
+		if (verify) {
+			checksum = this.communityNodeTypesService.findVetted(name)?.checksum;
+			if (!checksum) {
+				throw new BadRequestError(`Package ${name} is not vetted for installation`);
+			}
+		}
+
+		let parsed: CommunityPackages.ParsedPackageName;
+
+		try {
+			parsed = this.communityPackagesService.parseNpmPackageName(name);
+		} catch (error) {
+			throw new BadRequestError(
+				error instanceof Error ? error.message : 'Failed to parse package name',
+			);
+		}
+
+		if (parsed.packageName === STARTER_TEMPLATE_NAME) {
+			const templateMessage =
+				presentation === 'ui'
+					? [
+							`Package "${parsed.packageName}" is only a template`,
+							'Please enter an actual package to install',
+						].join('.')
+					: `Package "${parsed.packageName}" is only a template. Please enter an actual package to install`;
+			throw new BadRequestError(templateMessage);
+		}
+
+		const isInstalled = await this.communityPackagesService.isPackageInstalled(parsed.packageName);
+		const hasLoaded = this.communityPackagesService.hasPackageLoaded(name);
+
+		if (isInstalled && hasLoaded) {
+			const alreadyMessage =
+				presentation === 'ui'
+					? [
+							`Package "${parsed.packageName}" is already installed`,
+							'To update it, click the corresponding button in the UI',
+						].join('.')
+					: `Package "${parsed.packageName}" is already installed`;
+			throw new BadRequestError(alreadyMessage);
+		}
+
+		const packageStatus = await this.communityPackagesService.checkNpmPackageStatus(name);
+
+		if (packageStatus.status !== 'OK') {
+			throw new BadRequestError(`Package "${name}" is banned so it cannot be installed`);
+		}
+
+		const packageVersion = version ?? parsed.version;
+		let installedPackage: InstalledPackages;
+
+		try {
+			installedPackage = await this.communityPackagesService.installPackage(
+				parsed.packageName,
+				packageVersion,
+				checksum,
+			);
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : UNKNOWN_FAILURE_REASON;
+
+			this.eventService.emit('community-package-installed', {
+				user,
+				inputString: name,
+				packageName: parsed.packageName,
+				success: false,
+				packageVersion,
+				failureReason: errorMessage,
+			});
+
+			let message = [`Error loading package "${name}" `, errorMessage].join(':');
+			if (error instanceof Error && error.cause instanceof Error) {
+				message += `\nCause: ${error.cause.message}`;
+			}
+
+			const clientError =
+				error instanceof Error ? isCommunityPackageInstallClientError(error) : false;
+			throw new (clientError ? BadRequestError : InternalServerError)(message);
+		}
+
+		if (!hasLoaded) this.communityPackagesService.removePackageFromMissingList(name);
+
+		installedPackage.installedNodes.forEach((node) => {
+			this.push.broadcast({
+				type: 'reloadNodeType',
+				data: {
+					name: node.type,
+					version: node.latestVersion,
+				},
+			});
+		});
+
+		this.eventService.emit('community-package-installed', {
+			user,
+			inputString: name,
+			packageName: parsed.packageName,
+			success: true,
+			packageVersion,
+			packageNodeNames: installedPackage.installedNodes.map((node) => node.name),
+			packageAuthor: installedPackage.authorName,
+			packageAuthorEmail: installedPackage.authorEmail,
+		});
+
+		return installedPackage;
+	}
+
+	async updateWithSideEffects(
+		args: { name: string | undefined; version?: string; checksum?: string },
+		user: UserLike,
+		whenMissing: MissingInstalledPackageBehavior,
+	): Promise<InstalledPackages> {
+		const { name, version, checksum } = args;
+
+		if (!name) {
+			throw new BadRequestError(PACKAGE_NAME_NOT_PROVIDED);
+		}
+
+		if (version && !valid(version)) {
+			throw new BadRequestError(`Invalid version: ${version}`);
+		}
+
+		const previouslyInstalledPackage =
+			await this.communityPackagesService.findInstalledPackage(name);
+
+		if (!previouslyInstalledPackage) {
+			if (whenMissing === 'notFound') {
+				throw new NotFoundError(PACKAGE_NOT_INSTALLED);
+			}
+			throw new BadRequestError(PACKAGE_NOT_INSTALLED);
+		}
+
+		try {
+			const newInstalledPackage = await this.communityPackagesService.updatePackage(
+				this.communityPackagesService.parseNpmPackageName(name).packageName,
+				previouslyInstalledPackage,
+				version,
+				checksum,
+			);
+
+			previouslyInstalledPackage.installedNodes.forEach((node) => {
+				this.push.broadcast({
+					type: 'removeNodeType',
+					data: {
+						name: node.type,
+						version: node.latestVersion,
+					},
+				});
+			});
+
+			newInstalledPackage.installedNodes.forEach((node) => {
+				this.push.broadcast({
+					type: 'reloadNodeType',
+					data: {
+						name: node.type,
+						version: node.latestVersion,
+					},
+				});
+			});
+
+			this.eventService.emit('community-package-updated', {
+				user,
+				packageName: name,
+				packageVersionCurrent: previouslyInstalledPackage.installedVersion,
+				packageVersionNew: newInstalledPackage.installedVersion,
+				packageNodeNames: newInstalledPackage.installedNodes.map((n) => n.name),
+				packageAuthor: newInstalledPackage.authorName,
+				packageAuthorEmail: newInstalledPackage.authorEmail,
+			});
+
+			return newInstalledPackage;
+		} catch (error) {
+			previouslyInstalledPackage.installedNodes.forEach((node) => {
+				this.push.broadcast({
+					type: 'removeNodeType',
+					data: {
+						name: node.type,
+						version: node.latestVersion,
+					},
+				});
+			});
+
+			const message = [
+				`Error updating package "${name}"`,
+				error instanceof Error ? error.message : UNKNOWN_FAILURE_REASON,
+			].join(':');
+
+			throw new InternalServerError(message, error);
+		}
+	}
+
+	async uninstallWithSideEffects(
+		packageName: string | undefined,
+		user: UserLike,
+		whenMissing: MissingInstalledPackageBehavior,
+	): Promise<void> {
+		if (!packageName) {
+			throw new BadRequestError(PACKAGE_NAME_NOT_PROVIDED);
+		}
+
+		try {
+			this.communityPackagesService.parseNpmPackageName(packageName);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : UNKNOWN_FAILURE_REASON;
+			throw new BadRequestError(message);
+		}
+
+		const installedPackage = await this.communityPackagesService.findInstalledPackage(packageName);
+
+		if (!installedPackage) {
+			if (whenMissing === 'notFound') {
+				throw new NotFoundError(PACKAGE_NOT_INSTALLED);
+			}
+			throw new BadRequestError(PACKAGE_NOT_INSTALLED);
+		}
+
+		try {
+			await this.communityPackagesService.removePackage(packageName, installedPackage);
+		} catch (error) {
+			const message = [
+				`Error removing package "${packageName}"`,
+				error instanceof Error ? error.message : UNKNOWN_FAILURE_REASON,
+			].join(':');
+
+			throw new InternalServerError(message, error);
+		}
+
+		installedPackage.installedNodes.forEach((node) => {
+			this.push.broadcast({
+				type: 'removeNodeType',
+				data: {
+					name: node.type,
+					version: node.latestVersion,
+				},
+			});
+		});
+
+		this.eventService.emit('community-package-deleted', {
+			user,
+			packageName,
+			packageVersion: installedPackage.installedVersion,
+			packageNodeNames: installedPackage.installedNodes.map((node) => node.name),
+			packageAuthor: installedPackage.authorName,
+			packageAuthorEmail: installedPackage.authorEmail,
+		});
+	}
+}

--- a/packages/cli/src/modules/community-packages/community-packages.lifecycle.service.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.lifecycle.service.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
 import {
 	RESPONSE_ERROR_MESSAGES,
@@ -12,7 +13,7 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { Push } from '@/push';
 import { InstanceSettings } from 'n8n-core';
 import { valid } from 'semver';
-import type { PublicInstalledPackage } from 'n8n-workflow';
+import { ensureError, jsonParse, type PublicInstalledPackage } from 'n8n-workflow';
 
 import { CommunityNodeTypesService } from './community-node-types.service';
 import { CommunityPackagesService } from './community-packages.service';
@@ -40,6 +41,7 @@ export type MissingInstalledPackageBehavior = 'badRequest' | 'notFound';
 @Service()
 export class CommunityPackagesLifecycleService {
 	constructor(
+		private readonly logger: Logger,
 		private readonly push: Push,
 		private readonly communityPackagesService: CommunityPackagesService,
 		private readonly eventService: EventService,
@@ -47,7 +49,7 @@ export class CommunityPackagesLifecycleService {
 		private readonly instanceSettings: InstanceSettings,
 	) {}
 
-	async listInstalledPackagesHydrated(): Promise<PublicInstalledPackage[] | InstalledPackages[]> {
+	async listInstalledPackages(): Promise<PublicInstalledPackage[] | InstalledPackages[]> {
 		const installedPackages = await this.communityPackagesService.getAllInstalledPackages();
 
 		if (installedPackages.length === 0) return [];
@@ -61,27 +63,33 @@ export class CommunityPackagesLifecycleService {
 			});
 		} catch (error) {
 			if (isNpmExecErrorWithStdout(error) && error.code === 1) {
-				pendingUpdates = JSON.parse(error.stdout) as CommunityPackages.AvailableUpdates;
+				try {
+					pendingUpdates = jsonParse<CommunityPackages.AvailableUpdates>(error.stdout.trim());
+				} catch (parseError) {
+					this.logger.warn('Failed to parse npm outdated output', {
+						error: ensureError(parseError),
+					});
+				}
 			}
 		}
 
-		let hydratedPackages = this.communityPackagesService.matchPackagesWithUpdates(
+		let packages = this.communityPackagesService.matchPackagesWithUpdates(
 			installedPackages,
 			pendingUpdates,
 		);
 
 		try {
 			if (this.communityPackagesService.hasMissingPackages) {
-				hydratedPackages = this.communityPackagesService.matchMissingPackages(hydratedPackages);
+				packages = this.communityPackagesService.matchMissingPackages(packages);
 			}
 		} catch {
 			// Ignore errors when matching missing packages
 		}
 
-		return hydratedPackages;
+		return packages;
 	}
 
-	async installWithSideEffects(
+	async install(
 		args: { name: string | undefined; version?: string; verify?: boolean },
 		user: UserLike,
 		presentation: CommunityPackageInstallPresentation,
@@ -203,7 +211,7 @@ export class CommunityPackagesLifecycleService {
 		return installedPackage;
 	}
 
-	async updateWithSideEffects(
+	async update(
 		args: { name: string | undefined; version?: string; checksum?: string },
 		user: UserLike,
 		whenMissing: MissingInstalledPackageBehavior,
@@ -287,7 +295,7 @@ export class CommunityPackagesLifecycleService {
 		}
 	}
 
-	async uninstallWithSideEffects(
+	async uninstall(
 		packageName: string | undefined,
 		user: UserLike,
 		whenMissing: MissingInstalledPackageBehavior,

--- a/packages/cli/src/modules/community-packages/community-packages.service.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.service.ts
@@ -174,19 +174,19 @@ export class CommunityPackagesService {
 			})
 			.filter((i): i is string => i !== undefined);
 
-		const hydratedPackageList: PublicInstalledPackage[] = [];
+		const packages: PublicInstalledPackage[] = [];
 
-		installedPackages.forEach((installedPackage) => {
-			const hydratedInstalledPackage = { ...installedPackage };
+		for (const installedPackage of installedPackages) {
+			const pkg = { ...installedPackage };
 
-			if (missingPackagesList.includes(hydratedInstalledPackage.packageName)) {
-				hydratedInstalledPackage.failedLoading = true;
+			if (missingPackagesList.includes(pkg.packageName)) {
+				pkg.failedLoading = true;
 			}
 
-			hydratedPackageList.push(hydratedInstalledPackage);
-		});
+			packages.push(pkg);
+		}
 
-		return hydratedPackageList;
+		return packages;
 	}
 
 	async checkNpmPackageStatus(packageName: string) {

--- a/packages/cli/src/modules/community-packages/npm-utils.ts
+++ b/packages/cli/src/modules/community-packages/npm-utils.ts
@@ -26,6 +26,16 @@ function isDnsError(error: unknown): boolean {
 	return message.includes('getaddrinfo') || message.includes('ENOTFOUND');
 }
 
+/**
+ * Type guard for errors thrown by `executeNpmCommand` with `doNotHandleError: true`
+ * (e.g. npm outdated exits with code 1 when updates exist).
+ */
+export function isNpmExecErrorWithStdout(
+	error: unknown,
+): error is { code: number; stdout: string } {
+	return typeof error === 'object' && error !== null && 'code' in error && 'stdout' in error;
+}
+
 function isNpmError(error: unknown): boolean {
 	const message = error instanceof Error ? error.message : String(error);
 	return (


### PR DESCRIPTION
## Summary
- Extracts shared install/update/uninstall logic from `CommunityPackagesController` into a new `CommunityPackagesLifecycleService`
- Prepares for reuse by the Public API in a follow-up PR

## How to test
Installing, updating and uninstalling of community packages should still work


## Related Linear ticket
https://linear.app/n8n/issue/LIGO-391

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
