### PR TITLE
feat(core): Enable community package management via Public API

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -237,3 +237,8 @@ export {
 	testSecretProviderConnectionResponseSchema,
 	reloadSecretProviderConnectionResponseSchema,
 } from './schemas/secrets-provider.schema';
+
+export {
+	communityPackageResponseSchema,
+	type CommunityPackageResponse,
+} from './schemas/community-package.schema';

--- a/packages/@n8n/api-types/src/schemas/community-package.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/community-package.schema.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod/v4';
+
+/**
+ * Per-node payload from npm / the nodes loader. Only the package-level object is
+ * strictly shaped; node entries use `looseObject` so keys are not stripped.
+ */
+const communityPackageInstalledNodeSchema = z.looseObject({});
+
+/**
+ * Public API community package response (matches OpenAPI `communityPackage.yml`
+ * at the top level).
+ */
+export const communityPackageResponseSchema = z.object({
+	packageName: z.string(),
+	installedVersion: z.string(),
+	authorName: z.string().optional(),
+	authorEmail: z.string().optional(),
+	installedNodes: z.array(communityPackageInstalledNodeSchema),
+	createdAt: z.string(),
+	updatedAt: z.string(),
+	updateAvailable: z.string().optional(),
+	failedLoading: z.boolean().optional(),
+});
+
+export type CommunityPackageResponse = z.infer<typeof communityPackageResponseSchema>;

--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -74,6 +74,7 @@ export const API_KEY_RESOURCES = {
 	sourceControl: ['pull'] as const,
 	workflowTags: ['update', 'list'] as const,
 	executionTags: ['update', 'list'] as const,
+	communityPackage: ['install', 'uninstall', 'update', 'list'] as const,
 	dataTable: ['create', 'read', 'update', 'delete', 'list'] as const,
 	dataTableRow: ['create', 'read', 'update', 'delete', 'upsert'] as const,
 } as const;

--- a/packages/cli/src/public-api/types.ts
+++ b/packages/cli/src/public-api/types.ts
@@ -279,6 +279,17 @@ export declare namespace DataTableRequest {
 }
 
 // ----------------------------------
+//           /community-packages
+// ----------------------------------
+
+export declare namespace CommunityPackageRequest {
+	type Install = AuthenticatedRequest<{}, {}, { name: string; version?: string }>;
+	type List = AuthenticatedRequest;
+	type Update = AuthenticatedRequest<{ packageName: string }, {}, { version?: string }>;
+	type Uninstall = AuthenticatedRequest<{ packageName: string }>;
+}
+
+// ----------------------------------
 //           /audit
 // ----------------------------------
 

--- a/packages/cli/src/public-api/types.ts
+++ b/packages/cli/src/public-api/types.ts
@@ -285,8 +285,8 @@ export declare namespace DataTableRequest {
 export declare namespace CommunityPackageRequest {
 	type Install = AuthenticatedRequest<{}, {}, { name: string; version?: string }>;
 	type List = AuthenticatedRequest;
-	type Update = AuthenticatedRequest<{ packageName: string }, {}, { version?: string }>;
-	type Uninstall = AuthenticatedRequest<{ packageName: string }>;
+	type Update = AuthenticatedRequest<{ name: string }, {}, { version?: string }>;
+	type Uninstall = AuthenticatedRequest<{ name: string }>;
 }
 
 // ----------------------------------

--- a/packages/cli/src/public-api/v1/handlers/community-packages/__tests__/community-packages.handler.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/__tests__/community-packages.handler.test.ts
@@ -5,9 +5,10 @@ import type { Response } from 'express';
 import { RESPONSE_ERROR_MESSAGES } from '@/constants';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import type { InstalledPackages } from '@/modules/community-packages/installed-packages.entity';
 import { CommunityPackagesLifecycleService } from '@/modules/community-packages/community-packages.lifecycle.service';
 import * as middlewares from '@/public-api/v1/shared/middlewares/global.middleware';
-import type { InstalledPackages } from '@/modules/community-packages/installed-packages.entity';
+import { mapToCommunityPackage, mapToCommunityPackageList } from '../community-packages.mapper';
 import { mock } from 'jest-mock-extended';
 
 const mockMiddleware = jest.fn(async (_req: unknown, _res: unknown, next: unknown) =>
@@ -64,7 +65,7 @@ describe('CommunityPackages Handler', () => {
 				mockUser,
 				'publicApi',
 			);
-			expect(mockResponse.json).toHaveBeenCalledWith(mockInstalledPackage);
+			expect(mockResponse.json).toHaveBeenCalledWith(mapToCommunityPackage(mockInstalledPackage));
 		});
 
 		it('should return 400 when name is missing', async () => {
@@ -109,7 +110,9 @@ describe('CommunityPackages Handler', () => {
 				mockResponse,
 			);
 
-			expect(mockResponse.json).toHaveBeenCalledWith([mockInstalledPackage]);
+			expect(mockResponse.json).toHaveBeenCalledWith(
+				mapToCommunityPackageList([mockInstalledPackage]),
+			);
 		});
 
 		it('should return empty array when no packages installed', async () => {
@@ -129,7 +132,7 @@ describe('CommunityPackages Handler', () => {
 	describe('updatePackage', () => {
 		it('should update a package successfully', async () => {
 			const req = {
-				params: { packageName: 'n8n-nodes-test' },
+				params: { name: 'n8n-nodes-test' },
 				body: {},
 				user: mockUser,
 			};
@@ -148,12 +151,12 @@ describe('CommunityPackages Handler', () => {
 				mockUser,
 				'notFound',
 			);
-			expect(mockResponse.json).toHaveBeenCalledWith(updatedPackage);
+			expect(mockResponse.json).toHaveBeenCalledWith(mapToCommunityPackage(updatedPackage));
 		});
 
 		it('should return 404 when package is not installed', async () => {
 			const req = {
-				params: { packageName: 'n8n-nodes-missing' },
+				params: { name: 'n8n-nodes-missing' },
 				body: {},
 				user: mockUser,
 			};
@@ -171,7 +174,7 @@ describe('CommunityPackages Handler', () => {
 	describe('uninstallPackage', () => {
 		it('should uninstall a package successfully', async () => {
 			const req = {
-				params: { packageName: 'n8n-nodes-test' },
+				params: { name: 'n8n-nodes-test' },
 				user: mockUser,
 			};
 
@@ -185,7 +188,7 @@ describe('CommunityPackages Handler', () => {
 
 		it('should return 404 when package is not installed', async () => {
 			const req = {
-				params: { packageName: 'n8n-nodes-missing' },
+				params: { name: 'n8n-nodes-missing' },
 				user: mockUser,
 			};
 

--- a/packages/cli/src/public-api/v1/handlers/community-packages/__tests__/community-packages.handler.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/__tests__/community-packages.handler.test.ts
@@ -1,0 +1,201 @@
+import { mockInstance } from '@n8n/backend-test-utils';
+import { Container } from '@n8n/di';
+import type { Response } from 'express';
+
+import { RESPONSE_ERROR_MESSAGES } from '@/constants';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { CommunityPackagesLifecycleService } from '@/modules/community-packages/community-packages.lifecycle.service';
+import * as middlewares from '@/public-api/v1/shared/middlewares/global.middleware';
+import type { InstalledPackages } from '@/modules/community-packages/installed-packages.entity';
+import { mock } from 'jest-mock-extended';
+
+const mockMiddleware = jest.fn(async (_req: unknown, _res: unknown, next: unknown) =>
+	(next as () => void)(),
+) as unknown as middlewares.ScopeTaggedMiddleware;
+jest.spyOn(middlewares, 'apiKeyHasScope').mockReturnValue(mockMiddleware);
+
+const handler = require('../community-packages.handler');
+
+describe('CommunityPackages Handler', () => {
+	let mockLifecycle: jest.Mocked<CommunityPackagesLifecycleService>;
+	let mockResponse: Partial<Response>;
+
+	const mockUser = { id: 'test-user-id', role: { slug: 'global:owner' } };
+
+	const mockInstalledPackage = mock<InstalledPackages>({
+		packageName: 'n8n-nodes-test',
+		installedVersion: '1.0.0',
+		authorName: 'Test Author',
+		authorEmail: 'test@example.com',
+		installedNodes: [{ name: 'TestNode', type: 'n8n-nodes-test.testNode', latestVersion: 1 }],
+		createdAt: new Date(),
+		updatedAt: new Date(),
+	});
+
+	beforeEach(() => {
+		mockLifecycle = mockInstance(CommunityPackagesLifecycleService);
+
+		jest.spyOn(Container, 'get').mockImplementation((serviceClass) => {
+			if (serviceClass === CommunityPackagesLifecycleService) return mockLifecycle as any;
+			return {} as any;
+		});
+
+		mockResponse = {
+			json: jest.fn().mockReturnThis(),
+			status: jest.fn().mockReturnThis(),
+			send: jest.fn().mockReturnThis(),
+		};
+	});
+
+	describe('installPackage', () => {
+		it('should install a package successfully', async () => {
+			const req = {
+				body: { name: 'n8n-nodes-test' },
+				user: mockUser,
+			};
+
+			mockLifecycle.install.mockResolvedValue(mockInstalledPackage as InstalledPackages);
+
+			await handler.installPackage[handler.installPackage.length - 1](req, mockResponse);
+
+			expect(mockLifecycle.install).toHaveBeenCalledWith(
+				{ name: 'n8n-nodes-test', version: undefined, verify: false },
+				mockUser,
+				'publicApi',
+			);
+			expect(mockResponse.json).toHaveBeenCalledWith(mockInstalledPackage);
+		});
+
+		it('should return 400 when name is missing', async () => {
+			const req = {
+				body: {},
+				user: mockUser,
+			};
+
+			mockLifecycle.install.mockRejectedValue(
+				new BadRequestError(RESPONSE_ERROR_MESSAGES.PACKAGE_NAME_NOT_PROVIDED),
+			);
+
+			await handler.installPackage[handler.installPackage.length - 1](req, mockResponse);
+
+			expect(mockResponse.status).toHaveBeenCalledWith(400);
+		});
+
+		it('should return 400 when package is already installed', async () => {
+			const req = {
+				body: { name: 'n8n-nodes-test' },
+				user: mockUser,
+			};
+
+			mockLifecycle.install.mockRejectedValue(
+				new BadRequestError('Package "n8n-nodes-test" is already installed'),
+			);
+
+			await handler.installPackage[handler.installPackage.length - 1](req, mockResponse);
+
+			expect(mockResponse.status).toHaveBeenCalledWith(400);
+		});
+	});
+
+	describe('getInstalledPackages', () => {
+		it('should return installed packages', async () => {
+			const req = { user: mockUser };
+
+			mockLifecycle.listInstalledPackages.mockResolvedValue([mockInstalledPackage]);
+
+			await handler.getInstalledPackages[handler.getInstalledPackages.length - 1](
+				req,
+				mockResponse,
+			);
+
+			expect(mockResponse.json).toHaveBeenCalledWith([mockInstalledPackage]);
+		});
+
+		it('should return empty array when no packages installed', async () => {
+			const req = { user: mockUser };
+
+			mockLifecycle.listInstalledPackages.mockResolvedValue([]);
+
+			await handler.getInstalledPackages[handler.getInstalledPackages.length - 1](
+				req,
+				mockResponse,
+			);
+
+			expect(mockResponse.json).toHaveBeenCalledWith([]);
+		});
+	});
+
+	describe('updatePackage', () => {
+		it('should update a package successfully', async () => {
+			const req = {
+				params: { packageName: 'n8n-nodes-test' },
+				body: {},
+				user: mockUser,
+			};
+
+			const updatedPackage = {
+				...mockInstalledPackage,
+				installedVersion: '2.0.0',
+			};
+
+			mockLifecycle.update.mockResolvedValue(updatedPackage);
+
+			await handler.updatePackage[handler.updatePackage.length - 1](req, mockResponse);
+
+			expect(mockLifecycle.update).toHaveBeenCalledWith(
+				{ name: 'n8n-nodes-test', version: undefined },
+				mockUser,
+				'notFound',
+			);
+			expect(mockResponse.json).toHaveBeenCalledWith(updatedPackage);
+		});
+
+		it('should return 404 when package is not installed', async () => {
+			const req = {
+				params: { packageName: 'n8n-nodes-missing' },
+				body: {},
+				user: mockUser,
+			};
+
+			mockLifecycle.update.mockRejectedValue(
+				new NotFoundError(RESPONSE_ERROR_MESSAGES.PACKAGE_NOT_INSTALLED),
+			);
+
+			await handler.updatePackage[handler.updatePackage.length - 1](req, mockResponse);
+
+			expect(mockResponse.status).toHaveBeenCalledWith(404);
+		});
+	});
+
+	describe('uninstallPackage', () => {
+		it('should uninstall a package successfully', async () => {
+			const req = {
+				params: { packageName: 'n8n-nodes-test' },
+				user: mockUser,
+			};
+
+			mockLifecycle.uninstall.mockResolvedValue(undefined);
+
+			await handler.uninstallPackage[handler.uninstallPackage.length - 1](req, mockResponse);
+
+			expect(mockLifecycle.uninstall).toHaveBeenCalledWith('n8n-nodes-test', mockUser, 'notFound');
+			expect(mockResponse.status).toHaveBeenCalledWith(204);
+		});
+
+		it('should return 404 when package is not installed', async () => {
+			const req = {
+				params: { packageName: 'n8n-nodes-missing' },
+				user: mockUser,
+			};
+
+			mockLifecycle.uninstall.mockRejectedValue(
+				new NotFoundError(RESPONSE_ERROR_MESSAGES.PACKAGE_NOT_INSTALLED),
+			);
+
+			await handler.uninstallPackage[handler.uninstallPackage.length - 1](req, mockResponse);
+
+			expect(mockResponse.status).toHaveBeenCalledWith(404);
+		});
+	});
+});

--- a/packages/cli/src/public-api/v1/handlers/community-packages/community-packages.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/community-packages.handler.ts
@@ -1,0 +1,101 @@
+import type { AuthenticatedRequest } from '@n8n/db';
+import { Container } from '@n8n/di';
+import type express from 'express';
+
+import { ResponseError } from '@/errors/response-errors/abstract/response.error';
+import { CommunityPackagesLifecycleService } from '@/modules/community-packages/community-packages.lifecycle.service';
+
+import { apiKeyHasScope } from '../../shared/middlewares/global.middleware';
+
+function sendResponseError(res: express.Response, error: ResponseError): express.Response {
+	return res.status(error.httpStatusCode).json({ message: error.message });
+}
+
+export = {
+	installPackage: [
+		apiKeyHasScope('communityPackage:install'),
+		async (
+			req: AuthenticatedRequest<Record<string, never>, unknown, { name: string; version?: string }>,
+			res: express.Response,
+		): Promise<express.Response> => {
+			const lifecycle = Container.get(CommunityPackagesLifecycleService);
+
+			try {
+				const installedPackage = await lifecycle.install(
+					{ name: req.body.name, version: req.body.version, verify: false },
+					req.user,
+					'publicApi',
+				);
+				return res.json(installedPackage);
+			} catch (error) {
+				if (error instanceof ResponseError) {
+					return sendResponseError(res, error);
+				}
+				throw error;
+			}
+		},
+	],
+
+	getInstalledPackages: [
+		apiKeyHasScope('communityPackage:list'),
+		async (
+			_req: AuthenticatedRequest<Record<string, never>>,
+			res: express.Response,
+		): Promise<express.Response> => {
+			const lifecycle = Container.get(CommunityPackagesLifecycleService);
+			const packages = await lifecycle.listInstalledPackages();
+			return res.json(packages);
+		},
+	],
+
+	updatePackage: [
+		apiKeyHasScope('communityPackage:update'),
+		async (
+			req: AuthenticatedRequest<
+				{ packageName: string },
+				Record<string, never>,
+				{ version?: string }
+			>,
+			res: express.Response,
+		): Promise<express.Response> => {
+			const lifecycle = Container.get(CommunityPackagesLifecycleService);
+
+			try {
+				const updated = await lifecycle.update(
+					{
+						name: req.params.packageName,
+						version: req.body?.version,
+					},
+					req.user,
+					'notFound',
+				);
+				return res.json(updated);
+			} catch (error) {
+				if (error instanceof ResponseError) {
+					return sendResponseError(res, error);
+				}
+				throw error;
+			}
+		},
+	],
+
+	uninstallPackage: [
+		apiKeyHasScope('communityPackage:uninstall'),
+		async (
+			req: AuthenticatedRequest<{ packageName: string }>,
+			res: express.Response,
+		): Promise<express.Response> => {
+			const lifecycle = Container.get(CommunityPackagesLifecycleService);
+
+			try {
+				await lifecycle.uninstall(req.params.packageName, req.user, 'notFound');
+				return res.status(204).send();
+			} catch (error) {
+				if (error instanceof ResponseError) {
+					return sendResponseError(res, error);
+				}
+				throw error;
+			}
+		},
+	],
+};

--- a/packages/cli/src/public-api/v1/handlers/community-packages/community-packages.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/community-packages.handler.ts
@@ -5,6 +5,7 @@ import type express from 'express';
 import { ResponseError } from '@/errors/response-errors/abstract/response.error';
 import { CommunityPackagesLifecycleService } from '@/modules/community-packages/community-packages.lifecycle.service';
 
+import { mapToCommunityPackage, mapToCommunityPackageList } from './community-packages.mapper';
 import { apiKeyHasScope } from '../../shared/middlewares/global.middleware';
 
 function sendResponseError(res: express.Response, error: ResponseError): express.Response {
@@ -26,7 +27,7 @@ export = {
 					req.user,
 					'publicApi',
 				);
-				return res.json(installedPackage);
+				return res.json(mapToCommunityPackage(installedPackage));
 			} catch (error) {
 				if (error instanceof ResponseError) {
 					return sendResponseError(res, error);
@@ -44,18 +45,14 @@ export = {
 		): Promise<express.Response> => {
 			const lifecycle = Container.get(CommunityPackagesLifecycleService);
 			const packages = await lifecycle.listInstalledPackages();
-			return res.json(packages);
+			return res.json(mapToCommunityPackageList(packages));
 		},
 	],
 
 	updatePackage: [
 		apiKeyHasScope('communityPackage:update'),
 		async (
-			req: AuthenticatedRequest<
-				{ packageName: string },
-				Record<string, never>,
-				{ version?: string }
-			>,
+			req: AuthenticatedRequest<{ name: string }, Record<string, never>, { version?: string }>,
 			res: express.Response,
 		): Promise<express.Response> => {
 			const lifecycle = Container.get(CommunityPackagesLifecycleService);
@@ -63,13 +60,13 @@ export = {
 			try {
 				const updated = await lifecycle.update(
 					{
-						name: req.params.packageName,
+						name: req.params.name,
 						version: req.body?.version,
 					},
 					req.user,
 					'notFound',
 				);
-				return res.json(updated);
+				return res.json(mapToCommunityPackage(updated));
 			} catch (error) {
 				if (error instanceof ResponseError) {
 					return sendResponseError(res, error);
@@ -82,13 +79,13 @@ export = {
 	uninstallPackage: [
 		apiKeyHasScope('communityPackage:uninstall'),
 		async (
-			req: AuthenticatedRequest<{ packageName: string }>,
+			req: AuthenticatedRequest<{ name: string }>,
 			res: express.Response,
 		): Promise<express.Response> => {
 			const lifecycle = Container.get(CommunityPackagesLifecycleService);
 
 			try {
-				await lifecycle.uninstall(req.params.packageName, req.user, 'notFound');
+				await lifecycle.uninstall(req.params.name, req.user, 'notFound');
 				return res.status(204).send();
 			} catch (error) {
 				if (error instanceof ResponseError) {

--- a/packages/cli/src/public-api/v1/handlers/community-packages/community-packages.mapper.ts
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/community-packages.mapper.ts
@@ -1,0 +1,43 @@
+import type { PublicInstalledNode, PublicInstalledPackage } from 'n8n-workflow';
+
+export type PublicApiCommunityPackage = {
+	packageName: string;
+	installedVersion: string;
+	authorName?: string;
+	authorEmail?: string;
+	installedNodes: PublicApiInstalledNode[];
+	createdAt: string;
+	updatedAt: string;
+	updateAvailable?: string;
+	failedLoading?: boolean;
+};
+
+type PublicApiInstalledNode = {
+	name: string;
+	type: string;
+	latestVersion: number;
+};
+
+function mapInstalledNode(node: PublicInstalledNode): PublicApiInstalledNode {
+	return {
+		name: node.name,
+		type: node.type,
+		latestVersion: node.latestVersion,
+	};
+}
+
+export function mapToCommunityPackage(pkg: PublicInstalledPackage): PublicApiCommunityPackage {
+	const { installedNodes, createdAt, updatedAt, ...packageData } = pkg;
+	return {
+		...packageData,
+		installedNodes: installedNodes.map(mapInstalledNode),
+		createdAt: createdAt.toISOString(),
+		updatedAt: updatedAt.toISOString(),
+	};
+}
+
+export function mapToCommunityPackageList(
+	packages: PublicInstalledPackage[],
+): PublicApiCommunityPackage[] {
+	return packages.map(mapToCommunityPackage);
+}

--- a/packages/cli/src/public-api/v1/handlers/community-packages/community-packages.mapper.ts
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/community-packages.mapper.ts
@@ -1,43 +1,38 @@
+import { communityPackageResponseSchema } from '@n8n/api-types';
 import type { PublicInstalledNode, PublicInstalledPackage } from 'n8n-workflow';
 
-export type PublicApiCommunityPackage = {
-	packageName: string;
-	installedVersion: string;
-	authorName?: string;
-	authorEmail?: string;
-	installedNodes: PublicApiInstalledNode[];
-	createdAt: string;
-	updatedAt: string;
-	updateAvailable?: string;
-	failedLoading?: boolean;
-};
-
-type PublicApiInstalledNode = {
-	name: string;
-	type: string;
-	latestVersion: number;
-};
-
-function mapInstalledNode(node: PublicInstalledNode): PublicApiInstalledNode {
-	return {
-		name: node.name,
-		type: node.type,
-		latestVersion: node.latestVersion,
-	};
+function toIsoString(value: Date | string): string {
+	return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
 }
 
-export function mapToCommunityPackage(pkg: PublicInstalledPackage): PublicApiCommunityPackage {
-	const { installedNodes, createdAt, updatedAt, ...packageData } = pkg;
-	return {
-		...packageData,
-		installedNodes: installedNodes.map(mapInstalledNode),
-		createdAt: createdAt.toISOString(),
-		updatedAt: updatedAt.toISOString(),
-	};
+function optionalString(value: unknown): string | undefined {
+	return typeof value === 'string' ? value : undefined;
 }
 
-export function mapToCommunityPackageList(
-	packages: PublicInstalledPackage[],
-): PublicApiCommunityPackage[] {
+function optionalBoolean(value: unknown): boolean | undefined {
+	return typeof value === 'boolean' ? value : undefined;
+}
+
+/** Drop the circular `package` field; keep other npm/node fields as a loose object. */
+function stripInstalledNode(node: PublicInstalledNode): Record<string, unknown> {
+	const { package: _omitPackage, ...rest } = node;
+	return rest;
+}
+
+export function mapToCommunityPackage(pkg: PublicInstalledPackage) {
+	return communityPackageResponseSchema.parse({
+		packageName: pkg.packageName,
+		installedVersion: pkg.installedVersion,
+		authorName: optionalString(pkg.authorName),
+		authorEmail: optionalString(pkg.authorEmail),
+		installedNodes: pkg.installedNodes.map(stripInstalledNode),
+		createdAt: toIsoString(pkg.createdAt),
+		updatedAt: toIsoString(pkg.updatedAt),
+		updateAvailable: optionalString(pkg.updateAvailable),
+		failedLoading: optionalBoolean(pkg.failedLoading),
+	});
+}
+
+export function mapToCommunityPackageList(packages: PublicInstalledPackage[]) {
 	return packages.map(mapToCommunityPackage);
 }

--- a/packages/cli/src/public-api/v1/handlers/community-packages/spec/paths/community-packages.packageName.yml
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/spec/paths/community-packages.packageName.yml
@@ -1,0 +1,65 @@
+patch:
+  x-eov-operation-id: updatePackage
+  x-eov-operation-handler: v1/handlers/community-packages/community-packages.handler
+  tags:
+    - CommunityPackage
+  summary: Update a community package
+  description: Update an installed community package to a new version.
+  parameters:
+    - name: packageName
+      in: path
+      description: npm package name
+      required: true
+      schema:
+        type: string
+  requestBody:
+    description: Update options.
+    required: false
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            version:
+              type: string
+              description: Specific semver version to update to
+  responses:
+    '200':
+      description: Package updated successfully.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/communityPackage.yml'
+    '400':
+      $ref: '../../../../shared/spec/responses/badRequest.yml'
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
+    '404':
+      $ref: '../../../../shared/spec/responses/notFound.yml'
+  security:
+    - ApiKeyAuth: []
+delete:
+  x-eov-operation-id: uninstallPackage
+  x-eov-operation-handler: v1/handlers/community-packages/community-packages.handler
+  tags:
+    - CommunityPackage
+  summary: Uninstall a community package
+  description: Uninstall a community package by name.
+  parameters:
+    - name: packageName
+      in: path
+      description: npm package name
+      required: true
+      schema:
+        type: string
+  responses:
+    '204':
+      description: Package uninstalled successfully.
+    '400':
+      $ref: '../../../../shared/spec/responses/badRequest.yml'
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
+    '404':
+      $ref: '../../../../shared/spec/responses/notFound.yml'
+  security:
+    - ApiKeyAuth: []

--- a/packages/cli/src/public-api/v1/handlers/community-packages/spec/paths/community-packages.packageName.yml
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/spec/paths/community-packages.packageName.yml
@@ -6,7 +6,7 @@ patch:
   summary: Update a community package
   description: Update an installed community package to a new version.
   parameters:
-    - name: packageName
+    - name: name
       in: path
       description: npm package name
       required: true
@@ -46,7 +46,7 @@ delete:
   summary: Uninstall a community package
   description: Uninstall a community package by name.
   parameters:
-    - name: packageName
+    - name: name
       in: path
       description: npm package name
       required: true

--- a/packages/cli/src/public-api/v1/handlers/community-packages/spec/paths/community-packages.yml
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/spec/paths/community-packages.yml
@@ -1,0 +1,45 @@
+post:
+  x-eov-operation-id: installPackage
+  x-eov-operation-handler: v1/handlers/community-packages/community-packages.handler
+  tags:
+    - CommunityPackage
+  summary: Install a community package
+  description: Install a community package by npm name and optional version.
+  requestBody:
+    description: Package to install.
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/installCommunityPackageRequest.yml'
+  responses:
+    '200':
+      description: Package installed successfully.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/communityPackage.yml'
+    '400':
+      $ref: '../../../../shared/spec/responses/badRequest.yml'
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
+  security:
+    - ApiKeyAuth: []
+get:
+  x-eov-operation-id: getInstalledPackages
+  x-eov-operation-handler: v1/handlers/community-packages/community-packages.handler
+  tags:
+    - CommunityPackage
+  summary: List installed community packages
+  description: Retrieve all installed community packages with pending update info.
+  responses:
+    '200':
+      description: Operation successful.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/communityPackageList.yml'
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
+  security:
+    - ApiKeyAuth: []

--- a/packages/cli/src/public-api/v1/handlers/community-packages/spec/schemas/communityPackage.yml
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/spec/schemas/communityPackage.yml
@@ -1,0 +1,38 @@
+type: object
+properties:
+  packageName:
+    type: string
+    description: npm package name
+  installedVersion:
+    type: string
+    description: Currently installed version
+  authorName:
+    type: string
+    description: Package author name
+  authorEmail:
+    type: string
+    description: Package author email
+  installedNodes:
+    type: array
+    description: Nodes included in this package
+    items:
+      type: object
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+        latestVersion:
+          type: number
+  createdAt:
+    type: string
+    format: date-time
+  updatedAt:
+    type: string
+    format: date-time
+  updateAvailable:
+    type: string
+    description: Version available for update, if any
+  failedLoading:
+    type: boolean
+    description: Whether the package failed to load

--- a/packages/cli/src/public-api/v1/handlers/community-packages/spec/schemas/communityPackageList.yml
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/spec/schemas/communityPackageList.yml
@@ -1,0 +1,3 @@
+type: array
+items:
+  $ref: './communityPackage.yml'

--- a/packages/cli/src/public-api/v1/handlers/community-packages/spec/schemas/installCommunityPackageRequest.yml
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/spec/schemas/installCommunityPackageRequest.yml
@@ -1,0 +1,10 @@
+type: object
+required:
+  - name
+properties:
+  name:
+    type: string
+    description: 'npm package name (must start with n8n-nodes-)'
+  version:
+    type: string
+    description: Specific semver version to install

--- a/packages/cli/src/public-api/v1/openapi.yml
+++ b/packages/cli/src/public-api/v1/openapi.yml
@@ -120,7 +120,7 @@ paths:
     $ref: './handlers/projects/spec/paths/projects.projectId.users.userId.yml'
   /community-packages:
     $ref: './handlers/community-packages/spec/paths/community-packages.yml'
-  /community-packages/{packageName}:
+  /community-packages/{name}:
     $ref: './handlers/community-packages/spec/paths/community-packages.packageName.yml'
   /discover:
     $ref: './handlers/discover/spec/paths/discover.yml'

--- a/packages/cli/src/public-api/v1/openapi.yml
+++ b/packages/cli/src/public-api/v1/openapi.yml
@@ -36,6 +36,8 @@ tags:
     description: Operations about data tables and their rows
   - name: Projects
     description: Operations about projects
+  - name: CommunityPackage
+    description: Operations about community packages
   - name: Discover
     description: API capability discovery
 
@@ -116,6 +118,10 @@ paths:
     $ref: './handlers/projects/spec/paths/projects.projectId.users.yml'
   /projects/{projectId}/users/{userId}:
     $ref: './handlers/projects/spec/paths/projects.projectId.users.userId.yml'
+  /community-packages:
+    $ref: './handlers/community-packages/spec/paths/community-packages.yml'
+  /community-packages/{packageName}:
+    $ref: './handlers/community-packages/spec/paths/community-packages.packageName.yml'
   /discover:
     $ref: './handlers/discover/spec/paths/discover.yml'
 components:

--- a/packages/cli/test/integration/public-api/community-packages.test.ts
+++ b/packages/cli/test/integration/public-api/community-packages.test.ts
@@ -1,0 +1,267 @@
+jest.mock('@/modules/community-packages/npm-utils', () => ({
+	...jest.requireActual('@/modules/community-packages/npm-utils'),
+	executeNpmCommand: jest.fn(),
+}));
+
+import { mockInstance, testDb } from '@n8n/backend-test-utils';
+import type { User } from '@n8n/db';
+import type { ApiKeyScope } from '@n8n/permissions';
+import { OWNER_API_KEY_SCOPES } from '@n8n/permissions';
+import path from 'node:path';
+
+import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
+import { CommunityPackagesService } from '@/modules/community-packages/community-packages.service';
+import { executeNpmCommand } from '@/modules/community-packages/npm-utils';
+
+import { COMMUNITY_PACKAGE_VERSION } from '../shared/constants';
+import { addApiKey, createOwner } from '../shared/db/users';
+import { setupTestServer } from '../shared/utils';
+import { mockPackage, mockPackageName } from '../shared/utils/community-nodes';
+
+const COMMUNITY_PACKAGE_API_SCOPES: ApiKeyScope[] = [
+	'communityPackage:install',
+	'communityPackage:list',
+	'communityPackage:update',
+	'communityPackage:uninstall',
+];
+
+const communityPackagesService = mockInstance(CommunityPackagesService, {
+	missingPackages: [],
+	hasMissingPackages: false,
+});
+const mockedExecuteNpmCommand = jest.mocked(executeNpmCommand);
+mockInstance(LoadNodesAndCredentials);
+
+const testServer = setupTestServer({
+	endpointGroups: ['publicApi'],
+	modules: ['community-packages'],
+});
+
+const parsedNpmPackageName = {
+	packageName: 'test',
+	rawString: 'description',
+};
+
+let owner: User;
+
+describe('Community packages (Public API)', () => {
+	beforeAll(async () => {
+		await testDb.init();
+	});
+
+	beforeEach(async () => {
+		jest.resetAllMocks();
+		await testDb.truncate(['User']);
+		const ownerUser = await createOwner();
+		const scopes = [
+			...new Set([...OWNER_API_KEY_SCOPES, ...COMMUNITY_PACKAGE_API_SCOPES]),
+		] as ApiKeyScope[];
+		const apiKey = await addApiKey(ownerUser, { scopes });
+		ownerUser.apiKeys = [apiKey];
+		owner = ownerUser;
+	});
+
+	describe('GET /community-packages', () => {
+		it('should return 401 without API key', async () => {
+			const response = await testServer.publicApiAgentWithoutApiKey().get('/community-packages');
+			expect(response.status).toBe(401);
+		});
+
+		it('should return an empty list when no packages are installed', async () => {
+			communityPackagesService.getAllInstalledPackages.mockResolvedValue([]);
+
+			const response = await testServer.publicApiAgentFor(owner).get('/community-packages');
+
+			expect(response.status).toBe(200);
+			expect(response.body).toEqual([]);
+			expect(mockedExecuteNpmCommand).not.toHaveBeenCalled();
+		});
+
+		it('should return installed packages when present', async () => {
+			const pkg = mockPackage();
+			communityPackagesService.getAllInstalledPackages.mockResolvedValue([pkg]);
+			communityPackagesService.matchPackagesWithUpdates.mockReturnValue([pkg]);
+
+			const response = await testServer.publicApiAgentFor(owner).get('/community-packages');
+
+			expect(response.status).toBe(200);
+			expect(response.body).toHaveLength(1);
+			expect(response.body[0].packageName).toBe(pkg.packageName);
+		});
+
+		it('should run npm outdated when packages exist', async () => {
+			communityPackagesService.getAllInstalledPackages.mockResolvedValue([mockPackage()]);
+			communityPackagesService.matchPackagesWithUpdates.mockReturnValue([]);
+
+			await testServer.publicApiAgentFor(owner).get('/community-packages');
+
+			expect(mockedExecuteNpmCommand).toHaveBeenCalledWith(
+				['outdated', '--json'],
+				expect.objectContaining({ doNotHandleError: true, cwd: expect.any(String) }),
+			);
+		});
+
+		it('should return packages with updateAvailable when outdated', async () => {
+			const pkg = mockPackage();
+			communityPackagesService.getAllInstalledPackages.mockResolvedValue([pkg]);
+
+			mockedExecuteNpmCommand.mockImplementation(() => {
+				throw {
+					code: 1,
+					stdout: JSON.stringify({
+						[pkg.packageName]: {
+							current: COMMUNITY_PACKAGE_VERSION.CURRENT,
+							wanted: COMMUNITY_PACKAGE_VERSION.CURRENT,
+							latest: COMMUNITY_PACKAGE_VERSION.UPDATED,
+							location: path.join('node_modules', pkg.packageName),
+						},
+					}),
+				};
+			});
+
+			communityPackagesService.matchPackagesWithUpdates.mockReturnValue([
+				{
+					...pkg,
+					updateAvailable: COMMUNITY_PACKAGE_VERSION.UPDATED,
+				},
+			]);
+
+			const response = await testServer.publicApiAgentFor(owner).get('/community-packages');
+
+			expect(response.status).toBe(200);
+			expect(response.body[0].updateAvailable).toBe(COMMUNITY_PACKAGE_VERSION.UPDATED);
+		});
+	});
+
+	describe('POST /community-packages', () => {
+		it('should return 400 when package name is missing', async () => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/community-packages')
+				.send({});
+
+			expect(response.status).toBe(400);
+			expect(response.body.message).toBeDefined();
+		});
+
+		it('should return 400 when package is already installed and loaded', async () => {
+			communityPackagesService.isPackageInstalled.mockResolvedValue(true);
+			communityPackagesService.hasPackageLoaded.mockReturnValue(true);
+			communityPackagesService.parseNpmPackageName.mockReturnValue(parsedNpmPackageName);
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/community-packages')
+				.send({ name: mockPackageName() });
+
+			expect(response.status).toBe(400);
+			expect(response.body.message).toContain('already installed');
+		});
+
+		it('should return 200 when package is installed successfully', async () => {
+			const pkg = mockPackage();
+			communityPackagesService.parseNpmPackageName.mockReturnValue(parsedNpmPackageName);
+			communityPackagesService.isPackageInstalled.mockResolvedValue(false);
+			communityPackagesService.hasPackageLoaded.mockReturnValue(true);
+			communityPackagesService.checkNpmPackageStatus.mockResolvedValue({ status: 'OK' });
+			communityPackagesService.installPackage.mockResolvedValue(pkg);
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/community-packages')
+				.send({ name: mockPackageName() });
+
+			expect(response.status).toBe(200);
+			expect(response.body.packageName).toBe(pkg.packageName);
+			expect(communityPackagesService.installPackage).toHaveBeenCalledTimes(1);
+		});
+
+		it('should return 400 when package is banned', async () => {
+			communityPackagesService.checkNpmPackageStatus.mockResolvedValue({ status: 'Banned' });
+			communityPackagesService.parseNpmPackageName.mockReturnValue(parsedNpmPackageName);
+			communityPackagesService.isPackageInstalled.mockResolvedValue(false);
+			communityPackagesService.hasPackageLoaded.mockReturnValue(true);
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/community-packages')
+				.send({ name: mockPackageName() });
+
+			expect(response.status).toBe(400);
+			expect(response.body.message).toContain('banned');
+		});
+	});
+
+	describe('PATCH /community-packages/:packageName', () => {
+		it('should return 200 when package is updated successfully', async () => {
+			const pkg = mockPackage();
+			const updatedPkg = mockPackage();
+			updatedPkg.packageName = pkg.packageName;
+			updatedPkg.installedVersion = COMMUNITY_PACKAGE_VERSION.UPDATED;
+
+			communityPackagesService.findInstalledPackage.mockResolvedValue(pkg);
+			communityPackagesService.parseNpmPackageName.mockReturnValue({
+				packageName: pkg.packageName,
+				rawString: pkg.packageName,
+			});
+			communityPackagesService.updatePackage.mockResolvedValue(updatedPkg);
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.patch(`/community-packages/${encodeURIComponent(pkg.packageName)}`)
+				.send({ version: COMMUNITY_PACKAGE_VERSION.UPDATED });
+
+			expect(response.status).toBe(200);
+			expect(response.body.packageName).toBe(pkg.packageName);
+			expect(communityPackagesService.updatePackage).toHaveBeenCalledTimes(1);
+		});
+
+		it('should return 404 when package is not installed', async () => {
+			const name = mockPackageName();
+			communityPackagesService.findInstalledPackage.mockResolvedValue(null);
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.patch(`/community-packages/${encodeURIComponent(name)}`)
+				.send({});
+
+			expect(response.status).toBe(404);
+			expect(response.body.message).toBeDefined();
+		});
+	});
+
+	describe('DELETE /community-packages/:packageName', () => {
+		it('should return 404 when package is not installed', async () => {
+			const name = mockPackageName();
+			communityPackagesService.parseNpmPackageName.mockReturnValue({
+				packageName: name,
+				rawString: name,
+			});
+			communityPackagesService.findInstalledPackage.mockResolvedValue(null);
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.delete(`/community-packages/${encodeURIComponent(name)}`);
+
+			expect(response.status).toBe(404);
+			expect(response.body.message).toBeDefined();
+		});
+
+		it('should return 204 when uninstall succeeds', async () => {
+			const pkg = mockPackage();
+			communityPackagesService.parseNpmPackageName.mockReturnValue({
+				packageName: pkg.packageName,
+				rawString: pkg.packageName,
+			});
+			communityPackagesService.findInstalledPackage.mockResolvedValue(pkg);
+			communityPackagesService.removePackage.mockResolvedValue(undefined);
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.delete(`/community-packages/${encodeURIComponent(pkg.packageName)}`);
+
+			expect(response.status).toBe(204);
+			expect(communityPackagesService.removePackage).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/packages/cli/test/integration/public-api/community-packages.test.ts
+++ b/packages/cli/test/integration/public-api/community-packages.test.ts
@@ -67,6 +67,21 @@ describe('Community packages (Public API)', () => {
 			expect(response.status).toBe(401);
 		});
 
+		it('should return 403 when API key lacks communityPackage:list scope', async () => {
+			const userWithoutCommunityScopes = await createOwner();
+			const apiKey = await addApiKey(userWithoutCommunityScopes, {
+				scopes: [...OWNER_API_KEY_SCOPES],
+			});
+			userWithoutCommunityScopes.apiKeys = [apiKey];
+
+			const response = await testServer
+				.publicApiAgentFor(userWithoutCommunityScopes)
+				.get('/community-packages');
+
+			expect(response.status).toBe(403);
+			expect(response.body).toEqual({ message: 'Forbidden' });
+		});
+
 		it('should return an empty list when no packages are installed', async () => {
 			communityPackagesService.getAllInstalledPackages.mockResolvedValue([]);
 
@@ -192,7 +207,7 @@ describe('Community packages (Public API)', () => {
 		});
 	});
 
-	describe('PATCH /community-packages/:packageName', () => {
+	describe('PATCH /community-packages/:name', () => {
 		it('should return 200 when package is updated successfully', async () => {
 			const pkg = mockPackage();
 			const updatedPkg = mockPackage();
@@ -230,7 +245,7 @@ describe('Community packages (Public API)', () => {
 		});
 	});
 
-	describe('DELETE /community-packages/:packageName', () => {
+	describe('DELETE /community-packages/:name', () => {
 		it('should return 404 when package is not installed', async () => {
 			const name = mockPackageName();
 			communityPackagesService.parseNpmPackageName.mockReturnValue({

--- a/packages/cli/test/integration/shared/utils/community-nodes.ts
+++ b/packages/cli/test/integration/shared/utils/community-nodes.ts
@@ -10,12 +10,16 @@ import { COMMUNITY_NODE_VERSION, COMMUNITY_PACKAGE_VERSION } from '../constants'
 
 export const mockPackageName = () => NODE_PACKAGE_PREFIX + randomName();
 
-export const mockPackage = () =>
-	Container.get(InstalledPackagesRepository).create({
+export const mockPackage = () => {
+	const now = new Date();
+	return Container.get(InstalledPackagesRepository).create({
 		packageName: mockPackageName(),
 		installedVersion: COMMUNITY_PACKAGE_VERSION.CURRENT,
 		installedNodes: [],
+		createdAt: now,
+		updatedAt: now,
 	});
+};
 
 export const mockNode = (packageName: string) => {
 	const nodeName = randomName();

--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -32,10 +32,10 @@
 		"POST /community-packages": {
 			"status": "gap"
 		},
-		"PATCH /community-packages/{packageName}": {
+		"PATCH /community-packages/{name}": {
 			"status": "gap"
 		},
-		"DELETE /community-packages/{packageName}": {
+		"DELETE /community-packages/{name}": {
 			"status": "gap"
 		},
 		"GET /discover": {

--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -26,6 +26,18 @@
 		"PUT /credentials/{id}/transfer": {
 			"status": "gap"
 		},
+		"GET /community-packages": {
+			"status": "gap"
+		},
+		"POST /community-packages": {
+			"status": "gap"
+		},
+		"PATCH /community-packages/{packageName}": {
+			"status": "gap"
+		},
+		"DELETE /community-packages/{packageName}": {
+			"status": "gap"
+		},
 		"GET /discover": {
 			"status": "gap"
 		},


### PR DESCRIPTION
## Summary
- Adds four Public API endpoints for community package management: POST (install), GET (list), PATCH (update), DELETE (uninstall)
- Permissions are checked via API key scopes  communityPackage:{install,list,update,uninstall}` 
- Added OpenAPI specs for all operations
- Delegates to shared community package service
- 
https://www.loom.com/share/223fcc44f6e9433eafe2d3829c48d9eb

## Related Linear ticket
https://linear.app/n8n/issue/LIGO-391

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
