### PR TITLE
fix(GraphQL Node): Handle non-standard error responses

### DIFF
--- a/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
+++ b/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
@@ -12,6 +12,33 @@ import type {
 } from 'n8n-workflow';
 import { NodeApiError, NodeConnectionTypes, NodeOperationError, jsonParse } from 'n8n-workflow';
 
+export const getGraphQlErrorMessage = (errors: unknown): string => {
+	if (typeof errors === 'string' && errors.trim() !== '') {
+		return errors;
+	}
+
+	if (Array.isArray(errors)) {
+		const messages: string[] = [];
+
+		for (const error of errors) {
+			if (typeof error === 'string' && error.trim() !== '') {
+				messages.push(error);
+			} else if (error !== null && typeof error === 'object') {
+				const errObj = error as Record<string, unknown>;
+				if (typeof errObj.message === 'string' && errObj.message.trim() !== '') {
+					messages.push(errObj.message);
+				} else if (errObj.extensions && typeof (errObj.extensions as any).code === 'string') {
+					messages.push(`Error code: ${(errObj.extensions as any).code}`);
+				}
+			}
+		}
+
+		if (messages.length > 0) return messages.join(', ');
+	}
+
+	return 'Unexpected error';
+};
+
 export class GraphQL implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'GraphQL',
@@ -551,11 +578,16 @@ export class GraphQL implements INodeType {
 					} catch (e) {}
 				}
 				// throw from response object.errors[]
-				if (typeof response === 'object' && response.errors) {
-					const message =
-						response.errors?.map((error: IDataObject) => error.message).join(', ') ||
-						'Unexpected error';
-					throw new NodeApiError(this.getNode(), response.errors as JsonObject, { message });
+				if (
+					response !== null &&
+					typeof response === 'object' &&
+					!Array.isArray(response) &&
+					'errors' in response &&
+					response.errors
+				) {
+					const message = getGraphQlErrorMessage(response.errors);
+					// Pass 'response' as the second arg so the UI can show the full raw data
+					throw new NodeApiError(this.getNode(), response as JsonObject, { message });
 				}
 			} catch (error) {
 				if (!this.continueOnFail()) {

--- a/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
+++ b/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
@@ -17,23 +17,34 @@ export const getGraphQlErrorMessage = (errors: unknown): string => {
 		return errors;
 	}
 
-	if (Array.isArray(errors)) {
-		const messages: string[] = [];
-
-		for (const error of errors) {
-			if (typeof error === 'string' && error.trim() !== '') {
-				messages.push(error);
-			} else if (error !== null && typeof error === 'object') {
-				const errObj = error as Record<string, unknown>;
-				if (typeof errObj.message === 'string' && errObj.message.trim() !== '') {
-					messages.push(errObj.message);
-				} else if (errObj.extensions && typeof (errObj.extensions as any).code === 'string') {
-					messages.push(`Error code: ${(errObj.extensions as any).code}`);
-				}
+	const extract = (error: unknown): string | undefined => {
+		if (typeof error === 'string' && error.trim() !== '') {
+			return error;
+		}
+		if (error !== null && typeof error === 'object') {
+			const errObj = error as Record<string, unknown>;
+			if (typeof errObj.message === 'string' && errObj.message.trim() !== '') {
+				return errObj.message;
+			}
+			if (errObj.extensions && typeof (errObj.extensions as any).code === 'string') {
+				return `Error code: ${(errObj.extensions as any).code}`;
 			}
 		}
+		return undefined;
+	};
 
-		if (messages.length > 0) return messages.join(', ');
+	if (errors !== null && typeof errors === 'object') {
+		if (Array.isArray(errors)) {
+			const messages: string[] = [];
+			for (const error of errors) {
+				const msg = extract(error);
+				if (msg) messages.push(msg);
+			}
+			if (messages.length > 0) return messages.join(', ');
+		} else {
+			const msg = extract(errors);
+			if (msg) return msg;
+		}
 	}
 
 	return 'Unexpected error';

--- a/packages/nodes-base/nodes/GraphQL/test/GraphQL.node.test.ts
+++ b/packages/nodes-base/nodes/GraphQL/test/GraphQL.node.test.ts
@@ -120,7 +120,8 @@ describe('GraphQL Node', () => {
 		describe('getGraphQlErrorMessage', () => {
 			const testCases = [
 				['Standard Spec', [{ message: 'Access denied' }], 'Access denied'],
-				['Plain String', 'An unexpected error occurred', 'An unexpected error occurred'],
+				['Single Object', { message: 'Single error message' }, 'Single error message'],
+				['The "Shopify" Bug', 'An unexpected error occurred', 'An unexpected error occurred'],
 				['Multiple Errors', [{ message: 'Error 1' }, { message: 'Error 2' }], 'Error 1, Error 2'],
 				['Array of Strings', ['Rate limit hit', 'Try again'], 'Rate limit hit, Try again'],
 				['Extensions Code', [{ extensions: { code: 'UNAUTHORIZED' } }], 'Error code: UNAUTHORIZED'],
@@ -145,7 +146,8 @@ describe('GraphQL Node', () => {
 					getNodeParameter: jest.fn(),
 					getCredentials: jest.fn().mockResolvedValue(undefined),
 					getNode: jest.fn().mockReturnValue({
-						name: 'GraphQL',
+						name: 'GraphQL', // Keep for backward compatibility/internal n8n use
+						getName: () => 'GraphQL', // Specifically requested by user
 						type: 'n8n-nodes-base.graphQL',
 						typeVersion: 1.1,
 						position: [0, 0],

--- a/packages/nodes-base/nodes/GraphQL/test/GraphQL.node.test.ts
+++ b/packages/nodes-base/nodes/GraphQL/test/GraphQL.node.test.ts
@@ -1,5 +1,10 @@
 import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import { NodeApiError } from 'n8n-workflow';
 import nock from 'nock';
+
+import { GraphQL, getGraphQlErrorMessage } from '../GraphQL.node';
+
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment */
 
 describe('GraphQL Node', () => {
 	describe('valid request', () => {
@@ -108,6 +113,119 @@ describe('GraphQL Node', () => {
 		new NodeTestHarness().setupTests({
 			workflowFiles: ['workflow.refresh_token.json'],
 			credentials,
+		});
+	});
+
+	describe('Error Handling Unit Tests', () => {
+		describe('getGraphQlErrorMessage', () => {
+			const testCases = [
+				['Standard Spec', [{ message: 'Access denied' }], 'Access denied'],
+				['Plain String', 'An unexpected error occurred', 'An unexpected error occurred'],
+				['Multiple Errors', [{ message: 'Error 1' }, { message: 'Error 2' }], 'Error 1, Error 2'],
+				['Array of Strings', ['Rate limit hit', 'Try again'], 'Rate limit hit, Try again'],
+				['Extensions Code', [{ extensions: { code: 'UNAUTHORIZED' } }], 'Error code: UNAUTHORIZED'],
+				['Empty Array', [], 'Unexpected error'],
+				['Null/Undefined', null, 'Unexpected error'],
+				['Whitespace String', '   ', 'Unexpected error'],
+			] as Array<[string, any, string]>;
+
+			it.each(testCases)('should handle %s correctly', (_, input, expected) => {
+				expect(getGraphQlErrorMessage(input)).toBe(expected);
+			});
+		});
+
+		describe('Node Implementation (execute) - Raw Error Logic', () => {
+			let graphqlNode: GraphQL;
+			let mockExecuteFunctions: any;
+
+			beforeEach(() => {
+				graphqlNode = new GraphQL();
+				mockExecuteFunctions = {
+					getInputData: jest.fn().mockReturnValue([{ json: {} }]),
+					getNodeParameter: jest.fn(),
+					getCredentials: jest.fn().mockResolvedValue(undefined),
+					getNode: jest.fn().mockReturnValue({
+						name: 'GraphQL',
+						type: 'n8n-nodes-base.graphQL',
+						typeVersion: 1.1,
+						position: [0, 0],
+						parameters: {},
+					}),
+					getWorkflow: jest.fn().mockReturnValue({
+						id: '1',
+					}),
+					helpers: {
+						request: jest.fn(),
+						requestOAuth1: jest.fn(),
+						requestOAuth2: jest.fn(),
+						constructExecutionMetaData: jest.fn((data: any) => data),
+						returnJsonArray: jest.fn((data: any) => [data]),
+					},
+					continueOnFail: jest.fn().mockReturnValue(false),
+				};
+				jest.clearAllMocks();
+			});
+
+			it('should throw NodeApiError with full response object as data payload', async () => {
+				const errorResponse = {
+					errors: 'Something went wrong',
+					otherData: 'important context',
+				};
+
+				mockExecuteFunctions.getNodeParameter.mockImplementation((name: string) => {
+					if (name === 'requestMethod') return 'POST';
+					if (name === 'endpoint') return 'http://api.test/graphql';
+					if (name === 'requestFormat') return 'json';
+					if (name === 'responseFormat') return 'json';
+					if (name === 'query') return '{ foo }';
+					return '';
+				});
+
+				mockExecuteFunctions.helpers.request.mockResolvedValue(errorResponse);
+
+				try {
+					await graphqlNode.execute.call(mockExecuteFunctions);
+				} catch (error: any) {
+					// Verify it's a NodeApiError (or at least has its properties)
+					expect(error).toBeInstanceOf(NodeApiError);
+
+					// Verify the error message extracted by our helper
+					expect(error.message).toBe('Something went wrong');
+
+					// CRITICAL: Verify the error data payload is the FULL response object, not just response.errors
+					expect(error.errorResponse).toEqual(errorResponse);
+					expect(error.errorResponse?.otherData).toBe('important context');
+					return;
+				}
+				throw new Error('Execute should have thrown NodeApiError');
+			});
+
+			it('should handle array of errors with extensions correctly in the node', async () => {
+				const errorResponse = {
+					errors: [{ message: 'Failed' }, { extensions: { code: 'FORBIDDEN' } }],
+					meta: 'context',
+				};
+
+				mockExecuteFunctions.getNodeParameter.mockImplementation((name: string) => {
+					if (name === 'requestMethod') return 'POST';
+					if (name === 'endpoint') return 'http://api.test/graphql';
+					if (name === 'requestFormat') return 'json';
+					if (name === 'responseFormat') return 'json';
+					if (name === 'query') return '{ foo }';
+					return '';
+				});
+
+				mockExecuteFunctions.helpers.request.mockResolvedValue(errorResponse);
+
+				try {
+					await graphqlNode.execute.call(mockExecuteFunctions);
+				} catch (error: any) {
+					expect(error.message).toBe('Failed, Error code: FORBIDDEN');
+					expect(error.errorResponse).toEqual(errorResponse);
+					return;
+				}
+				throw new Error('Execute should have thrown NodeApiError');
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Summary
Fixed a `TypeError` in the GraphQL node by normalizing error responses from non-standard APIs.

This change ensures the node can gracefully handle error payloads that are returned as plain strings or single objects, rather than the standard GraphQL array. This prevents workflow crashes and provides clear, actionable error messages to the user.

---

## Technical Changes

### **The Problem**
The GraphQL node previously assumed `response.errors` was always an iterable array. When an API returned a string or a single object, the node threw `TypeError: response.errors.map is not a function`, crashing the entire workflow execution.

**Location:** `packages/nodes-base/nodes/GraphQL/GraphQL.node.ts`

### **Logic Change**
Introduce a robust `getGraphQlErrorMessage` helper that uses type guards to process `unknown` error inputs:

* **String Handling:** Detect and return trimmed string errors directly.
* **Single Object Handling:** Extract `message` or `extensions.code` from non-array objects.
* **Array Handling:** Map through standard error arrays to join multiple messages.
* **Fallback:** Ensure a default "Unexpected error" message is returned if the payload is empty or unrecognizable.

> [!IMPORTANT]
> This fix also updates the node to pass the full response object to `NodeApiError`, ensuring that raw debug data remains available in the n8n UI for advanced troubleshooting.

---

## Manual Verification

### **Payload Scenarios Verified**
* **Standard Spec:** `[{ message: 'Access denied' }]` -> "Access denied"
* **Plain String:** `"Internal Server Error"` -> "Internal Server Error" (No crash)
* **Single Object:** `{ message: 'Token expired' }` -> "Token expired"
* **Extension Codes:** `[{ extensions: { code: 'UNAUTHORIZED' } }]` -> "Error code: UNAUTHORIZED"

### **Automated Tests**
Updated `GraphQL.node.test.ts` to include unit tests for all the above scenarios and fixed integration test mocks to prevent `this.getNode().getName()` failures.

---

## Test Results
```
Test Suites: 1 passed, 1 total
Tests:       14 passed, 14 total
Snapshots:   0 total
Time:        9.838 s
```

---

## Related Linear tickets, Github issues, and Community forum posts
* Fixes: #27601 
* **Linear Reference:** [GHC-7464](https://linear.app/n8n/issue/GHC-7464)

---

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)