### PR TITLE
fix(Basic LLM Chain Node): Don't force JSON parsing for thinking mode

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/chainExecutor.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/chainExecutor.ts
@@ -77,10 +77,6 @@ export function getOutputParserForLLM(
 		return new NaiveJsonOutputParser();
 	}
 
-	if (isModelInThinkingMode(llm)) {
-		return new NaiveJsonOutputParser();
-	}
-
 	// For example Mistral's Magistral models (LmChatMistralCloud node)
 	if (llm.metadata?.output_format === 'json') {
 		return new NaiveJsonOutputParser();

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/chainExecutor.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/chainExecutor.test.ts
@@ -67,7 +67,7 @@ describe('chainExecutor', () => {
 			expect(parser).toBeInstanceOf(StringOutputParser);
 		});
 
-		it('should return NaiveJsonOutputParser for Anthropic models in thinking mode', () => {
+		it('should return StringOutputParser for Anthropic models in thinking mode', () => {
 			const model = {
 				lc_kwargs: {
 					invocationKwargs: {
@@ -78,7 +78,7 @@ describe('chainExecutor', () => {
 				},
 			};
 			const parser = chainExecutor.getOutputParserForLLM(model as unknown as BaseChatModel);
-			expect(parser).toBeInstanceOf(NaiveJsonOutputParser);
+			expect(parser).toBeInstanceOf(StringOutputParser);
 		});
 
 		it('should return NaiveJsonOutputParser for models with metadata output_format set to json', () => {
@@ -99,6 +99,33 @@ describe('chainExecutor', () => {
 			});
 			const parser = chainExecutor.getOutputParserForLLM(model);
 			expect(parser).toBeInstanceOf(StringOutputParser);
+		});
+	});
+
+	describe('StringOutputParser with thinking content blocks', () => {
+		it('should skip thinking blocks and extract only text content', () => {
+			const parser = new StringOutputParser();
+			const contentBlocks = [
+				{ type: 'thinking', thinking: 'Let me analyze this request...' },
+				{ type: 'text', text: 'Here is the generated prompt.' },
+			];
+
+			// Access the protected method that handles content block arrays
+			// This is the exact code path that failed with "Cannot coerce 'thinking' message part"
+			// before @langchain/core added native thinking block support
+			const result = (parser as any)._baseMessageContentToString(contentBlocks);
+			expect(result).toBe('Here is the generated prompt.');
+		});
+
+		it('should handle redacted_thinking blocks', () => {
+			const parser = new StringOutputParser();
+			const contentBlocks = [
+				{ type: 'redacted_thinking', data: 'REDACTED' },
+				{ type: 'text', text: 'Final answer.' },
+			];
+
+			const result = (parser as any)._baseMessageContentToString(contentBlocks);
+			expect(result).toBe('Final answer.');
 		});
 	});
 
@@ -587,6 +614,45 @@ describe('chainExecutor', () => {
 			expect(promptUtils.getAgentStepsParser).not.toHaveBeenCalled();
 			expect(pipeMock).toHaveBeenCalledWith(fakeLLM);
 			expect(pipeOutputParserMock).toHaveBeenCalledWith(mockOutputParser);
+		});
+
+		it('should use StringOutputParser for thinking mode models returning plain text', async () => {
+			const fakeThinkingModel = new FakeChatModel({});
+			(fakeThinkingModel as unknown as { lc_kwargs: Record<string, unknown> }).lc_kwargs = {
+				invocationKwargs: {
+					thinking: { type: 'enabled' },
+				},
+			};
+
+			const mockPromptTemplate = new PromptTemplate({
+				template: '{query}',
+				inputVariables: ['query'],
+			});
+
+			const mockChain = {
+				invoke: jest.fn().mockResolvedValue('This is plain text, not JSON'),
+			};
+
+			const withConfigMock = jest.fn().mockReturnValue(mockChain);
+			const pipeOutputParserMock = jest.fn().mockReturnValue({
+				withConfig: withConfigMock,
+			});
+
+			mockPromptTemplate.pipe = jest.fn().mockReturnValue({
+				pipe: pipeOutputParserMock,
+			});
+
+			(promptUtils.createPromptTemplate as jest.Mock).mockResolvedValue(mockPromptTemplate);
+
+			const result = await executeChain({
+				context: mockContext,
+				itemIndex: 0,
+				query: 'Hello',
+				llm: fakeThinkingModel,
+			});
+
+			expect(pipeOutputParserMock).toHaveBeenCalledWith(expect.any(StringOutputParser));
+			expect(result).toEqual(['This is plain text, not JSON']);
 		});
 
 		it('should handle fallback LLM with built-in tools', async () => {


### PR DESCRIPTION
## Summary
When using the Basic LLM Chain node with an Anthropic model in thinking mode, the node crashes with `Unexpected token ... is not valid JSON` if the LLM returns plain text (not JSON).

## Root Cause
PR #15381 worked around `StringOutputParser` not handling thinking content blocks in `@langchain/core@0.3.x` by routing all thinking-mode responses through `NaiveJsonOutputParser`. Since n8n has upgraded to `@langchain/core@1.1.34`, `StringOutputParser` natively handles `thinking`/`reasoning`/`redacted_thinking` content blocks (returns empty string for them, extracts only text). The workaround is now unnecessary and causes a regression for non-JSON outputs.

## Changes
- Remove the `isModelInThinkingMode` → `NaiveJsonOutputParser` branch in `getOutputParserForLLM()`
- Update existing test expectation (NaiveJsonOutputParser → StringOutputParser)
- Add tests verifying `StringOutputParser` correctly handles thinking/redacted_thinking content blocks (proves original #14374 won't regress)
- Add test for thinking-mode model returning plain text through `executeChain`

## Related Linear tickets, Github issues, and Community forum posts
- Fixes regression introduced by #15381
- Original issue: #14374

## Review / Merge checklist
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)