### PR TITLE
ci: Allow manual execution of release-schedule-patch-prs

### DIFF
--- a/.github/workflows/release-schedule-patch-prs.yml
+++ b/.github/workflows/release-schedule-patch-prs.yml
@@ -1,6 +1,7 @@
 name: 'Release: Schedule Patch Release PRs'
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 8 * * 2-5' # 9am CET (UTC+1), Tuesday–Friday
 


### PR DESCRIPTION
## Summary

Allow manually executing a patch release schedule on all release tracks. Previously manual execution was only available on the [per-track patch releaser](https://github.com/n8n-io/n8n/actions/workflows/release-create-patch-pr.yml).

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
