### PR TITLE
feat(core): Move id extraction logic into resolver (no-changelog)

### DIFF
--- a/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/__tests__/slack-signature-extractor.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/__tests__/slack-signature-extractor.test.ts
@@ -15,7 +15,6 @@ function createSlackTriggerItem(
 			headers: {
 				'x-slack-request-timestamp': '1234567890',
 				'x-slack-signature': 'v0=somesignature',
-				'content-type': 'application/x-www-form-urlencoded',
 				...overrides.headers,
 			},
 			body: overrides.body ?? {
@@ -85,7 +84,6 @@ describe('SlackSignatureExtractor', () => {
 				headers: {
 					'x-slack-request-timestamp': '1700000000',
 					'x-slack-signature': 'v0=abc123',
-					'content-type': 'application/x-www-form-urlencoded',
 				},
 				body: { user_id: 'U12345', team_id: 'T67890' },
 			});
@@ -96,9 +94,6 @@ describe('SlackSignatureExtractor', () => {
 			expect(result.contextUpdate?.credentials?.identity).toBe('user_id=U12345&team_id=T67890');
 			expect(result.contextUpdate?.credentials?.metadata?.timestamp).toBe('1700000000');
 			expect(result.contextUpdate?.credentials?.metadata?.signature).toBe('v0=abc123');
-			expect(result.contextUpdate?.credentials?.metadata?.contentType).toBe(
-				'application/x-www-form-urlencoded',
-			);
 		});
 
 		it('should mask signature headers in trigger items', async () => {
@@ -158,7 +153,6 @@ describe('SlackSignatureExtractor', () => {
 					headers: {
 						'x-slack-request-timestamp': '1234567890',
 						'x-slack-signature': 'v0=somesignature',
-						'content-type': 'application/x-www-form-urlencoded',
 					},
 				},
 				pairedItem: { item: 0 },
@@ -168,23 +162,6 @@ describe('SlackSignatureExtractor', () => {
 			await expect(extractor.execute(options)).rejects.toThrow(
 				'Could not retrieve raw body for Slack signature verification',
 			);
-		});
-
-		it('should throw when content-type header is missing', async () => {
-			const triggerItem: INodeExecutionData = {
-				json: {
-					headers: {
-						'x-slack-request-timestamp': '1234567890',
-						'x-slack-signature': 'v0=somesignature',
-						// no content-type
-					},
-					body: { user_id: 'U12345' },
-				},
-				pairedItem: { item: 0 },
-			};
-
-			const options = createOptions({ triggerItems: [triggerItem] });
-			await expect(extractor.execute(options)).rejects.toThrow('Missing Content-Type header');
 		});
 
 		it('should throw when headers are missing entirely', async () => {

--- a/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/__tests__/slack-signature-extractor.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/__tests__/slack-signature-extractor.test.ts
@@ -7,18 +7,9 @@ import { SlackSignatureExtractor } from '../slack-signature-extractor';
 function createSlackTriggerItem(
 	overrides: Partial<{
 		headers: Record<string, unknown>;
-		body: Record<string, unknown>;
-		rawBody: string;
+		body: Record<string, string>;
 	}> = {},
 ): INodeExecutionData {
-	const body = overrides.body ?? {
-		user_id: 'U12345',
-		team_id: 'T67890',
-		command: '/connect',
-		text: '',
-	};
-	const rawBody = overrides.rawBody ?? 'user_id=U12345&team_id=T67890&command=%2Fconnect&text=';
-
 	return {
 		json: {
 			headers: {
@@ -27,8 +18,12 @@ function createSlackTriggerItem(
 				'content-type': 'application/x-www-form-urlencoded',
 				...overrides.headers,
 			},
-			body,
-			rawBody,
+			body: overrides.body ?? {
+				user_id: 'U12345',
+				team_id: 'T67890',
+				command: '/connect',
+				text: '',
+			},
 		},
 		pairedItem: { item: 0 },
 	};
@@ -85,79 +80,25 @@ describe('SlackSignatureExtractor', () => {
 	});
 
 	describe('execute', () => {
-		it('should extract user_id from slash command payload', async () => {
-			const options = createOptions();
-			const result = await extractor.execute(options);
-
-			expect(result.contextUpdate?.credentials).toEqual({
-				version: 1,
-				identity: 'U12345',
-				metadata: expect.objectContaining({
-					source: 'slack-signature',
-					team_id: 'T67890',
-				}),
-			});
-		});
-
-		it('should extract user_id from interactive payload (nested user object)', async () => {
-			const body = {
-				user: { id: 'U99999', name: 'testuser' },
-				team: { id: 'TAAAAA' },
-				type: 'block_actions',
-			};
-
-			const triggerItem = createSlackTriggerItem({ body, rawBody: JSON.stringify(body) });
-			const options = createOptions({ triggerItems: [triggerItem] });
-			const result = await extractor.execute(options);
-
-			expect(result.contextUpdate?.credentials?.identity).toBe('U99999');
-			expect(result.contextUpdate?.credentials?.metadata?.team_id).toBe('TAAAAA');
-		});
-
-		it('should extract user from event payload', async () => {
-			const body = {
-				event: { type: 'message', user: 'UEVENT1' },
-				team_id: 'TEVENT1',
-			};
-
-			const triggerItem = createSlackTriggerItem({ body, rawBody: JSON.stringify(body) });
-			const options = createOptions({ triggerItems: [triggerItem] });
-			const result = await extractor.execute(options);
-
-			expect(result.contextUpdate?.credentials?.identity).toBe('UEVENT1');
-			expect(result.contextUpdate?.credentials?.metadata?.team_id).toBe('TEVENT1');
-		});
-
-		it('should include enterprise_id in metadata when present', async () => {
-			const body = {
-				user_id: 'U12345',
-				team_id: 'T67890',
-				enterprise_id: 'E11111',
-			};
-
-			const triggerItem = createSlackTriggerItem({ body });
-			const options = createOptions({ triggerItems: [triggerItem] });
-			const result = await extractor.execute(options);
-
-			expect(result.contextUpdate?.credentials?.metadata?.enterprise_id).toBe('E11111');
-		});
-
-		it('should carry raw verification data in metadata for resolver', async () => {
+		it('should reconstruct form-encoded identity from parsed body', async () => {
 			const triggerItem = createSlackTriggerItem({
 				headers: {
 					'x-slack-request-timestamp': '1700000000',
 					'x-slack-signature': 'v0=abc123',
+					'content-type': 'application/x-www-form-urlencoded',
 				},
-				rawBody: 'user_id=U12345&team_id=T67890',
+				body: { user_id: 'U12345', team_id: 'T67890' },
 			});
 
 			const options = createOptions({ triggerItems: [triggerItem] });
 			const result = await extractor.execute(options);
 
-			const metadata = result.contextUpdate?.credentials?.metadata;
-			expect(metadata?.timestamp).toBe('1700000000');
-			expect(metadata?.rawBody).toBe('user_id=U12345&team_id=T67890');
-			expect(metadata?.signature).toBe('v0=abc123');
+			expect(result.contextUpdate?.credentials?.identity).toBe('user_id=U12345&team_id=T67890');
+			expect(result.contextUpdate?.credentials?.metadata?.timestamp).toBe('1700000000');
+			expect(result.contextUpdate?.credentials?.metadata?.signature).toBe('v0=abc123');
+			expect(result.contextUpdate?.credentials?.metadata?.contentType).toBe(
+				'application/x-www-form-urlencoded',
+			);
 		});
 
 		it('should mask signature headers in trigger items', async () => {
@@ -183,7 +124,6 @@ describe('SlackSignatureExtractor', () => {
 						// no x-slack-signature
 					},
 					body: { user_id: 'U12345' },
-					rawBody: 'user_id=U12345',
 				},
 				pairedItem: { item: 0 },
 			};
@@ -201,7 +141,6 @@ describe('SlackSignatureExtractor', () => {
 						// no x-slack-request-timestamp
 					},
 					body: { user_id: 'U12345' },
-					rawBody: 'user_id=U12345',
 				},
 				pairedItem: { item: 0 },
 			};
@@ -213,52 +152,14 @@ describe('SlackSignatureExtractor', () => {
 			);
 		});
 
-		it('should throw when user_id cannot be extracted', async () => {
-			const body = { some_field: 'no user info' };
-
-			const triggerItem = createSlackTriggerItem({ body, rawBody: JSON.stringify(body) });
-			const options = createOptions({ triggerItems: [triggerItem] });
-
-			await expect(extractor.execute(options)).rejects.toThrow('Could not extract user_id');
-		});
-
-		it('should extract enterprise_id from interactive payload', async () => {
-			const body = {
-				user: { id: 'U99999', name: 'testuser' },
-				team: { id: 'TAAAAA' },
-				enterprise: { id: 'EAAAAA' },
-				type: 'block_actions',
-			};
-
-			const triggerItem = createSlackTriggerItem({ body, rawBody: JSON.stringify(body) });
-			const options = createOptions({ triggerItems: [triggerItem] });
-			const result = await extractor.execute(options);
-
-			expect(result.contextUpdate?.credentials?.metadata?.enterprise_id).toBe('EAAAAA');
-		});
-
-		it('should extract enterprise_id from event payload', async () => {
-			const body = {
-				event: { type: 'message', user: 'UEVENT1' },
-				team_id: 'TEVENT1',
-				enterprise_id: 'EEVENT1',
-			};
-
-			const triggerItem = createSlackTriggerItem({ body, rawBody: JSON.stringify(body) });
-			const options = createOptions({ triggerItems: [triggerItem] });
-			const result = await extractor.execute(options);
-
-			expect(result.contextUpdate?.credentials?.metadata?.enterprise_id).toBe('EEVENT1');
-		});
-
-		it('should throw when rawBody is not available and body is a parsed object', async () => {
+		it('should throw when body is missing', async () => {
 			const triggerItem: INodeExecutionData = {
 				json: {
 					headers: {
 						'x-slack-request-timestamp': '1234567890',
 						'x-slack-signature': 'v0=somesignature',
+						'content-type': 'application/x-www-form-urlencoded',
 					},
-					body: { user_id: 'U12345', team_id: 'T67890' },
 				},
 				pairedItem: { item: 0 },
 			};
@@ -269,29 +170,27 @@ describe('SlackSignatureExtractor', () => {
 			);
 		});
 
-		it('should throw when no raw body can be determined', async () => {
+		it('should throw when content-type header is missing', async () => {
 			const triggerItem: INodeExecutionData = {
 				json: {
 					headers: {
 						'x-slack-request-timestamp': '1234567890',
 						'x-slack-signature': 'v0=somesignature',
+						// no content-type
 					},
-					body: null,
+					body: { user_id: 'U12345' },
 				},
 				pairedItem: { item: 0 },
 			};
 
 			const options = createOptions({ triggerItems: [triggerItem] });
-			await expect(extractor.execute(options)).rejects.toThrow(
-				'Could not retrieve raw body for Slack signature verification',
-			);
+			await expect(extractor.execute(options)).rejects.toThrow('Missing Content-Type header');
 		});
 
 		it('should throw when headers are missing entirely', async () => {
 			const triggerItem: INodeExecutionData = {
 				json: {
 					body: { user_id: 'U12345' },
-					rawBody: 'user_id=U12345',
 				},
 				pairedItem: { item: 0 },
 			};

--- a/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/slack-signature-extractor.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/slack-signature-extractor.ts
@@ -6,29 +6,10 @@ import {
 	type HookDescription,
 	type IContextEstablishmentHook,
 } from '@n8n/decorators';
-import { z } from 'zod';
 
 function isHeaderObject(obj: unknown): obj is Record<string, unknown> {
 	return obj !== null && obj !== undefined && typeof obj === 'object' && !Array.isArray(obj);
 }
-
-const FlatPayloadSchema = z.object({
-	user_id: z.string(),
-	team_id: z.string().optional(),
-	enterprise_id: z.string().optional(),
-});
-
-const InteractivePayloadSchema = z.object({
-	user: z.object({ id: z.string().optional() }),
-	team: z.object({ id: z.string() }).optional(),
-	enterprise: z.object({ id: z.string() }).optional(),
-});
-
-const EventPayloadSchema = z.object({
-	event: z.object({ user: z.string().optional() }),
-	team_id: z.string().optional(),
-	enterprise_id: z.string().optional(),
-});
 
 /**
  * Extracts Slack identity from webhook requests.
@@ -60,6 +41,7 @@ export class SlackSignatureExtractor implements IContextEstablishmentHook {
 
 	async execute(options: ContextEstablishmentOptions): Promise<ContextEstablishmentResult> {
 		if (!options.triggerItems || options.triggerItems.length === 0) {
+			this.logger.error('No trigger items found for Slack identity extraction');
 			throw new Error('No trigger items found for Slack identity extraction');
 		}
 
@@ -67,55 +49,46 @@ export class SlackSignatureExtractor implements IContextEstablishmentHook {
 		const headers = triggerItem.json['headers'];
 
 		if (!isHeaderObject(headers)) {
+			this.logger.error('No headers found in trigger item for Slack identity extraction');
 			throw new Error('No headers found in trigger item for Slack identity extraction');
 		}
 
 		// Extract Slack-specific headers
 		const timestamp = this.getHeader(headers, 'x-slack-request-timestamp');
 		const signature = this.getHeader(headers, 'x-slack-signature');
+		const contentType = this.getHeader(headers, 'content-type');
 
 		if (!timestamp) {
+			this.logger.error('Missing X-Slack-Request-Timestamp header');
 			throw new Error('Missing X-Slack-Request-Timestamp header');
 		}
 		if (!signature) {
+			this.logger.error('Missing X-Slack-Signature header');
 			throw new Error('Missing X-Slack-Signature header');
+		}
+		if (!contentType) {
+			this.logger.error('Missing Content-Type header');
+			throw new Error('Missing Content-Type header');
 		}
 
 		// Get the raw body — needed by the resolver for signature verification
 		const rawBody = this.getRawBody(triggerItem);
 
-		// Extract identity from the Slack payload
-		const body = triggerItem.json['body'];
-		const { userId, teamId, enterpriseId } = this.extractSlackIdentity(body);
-
-		if (!userId) {
-			throw new Error('Could not extract user_id from Slack payload');
-		}
-
 		// Mask Slack signature headers in trigger items to avoid leaking them
 		headers['x-slack-signature'] = '**********';
 		headers['x-slack-request-timestamp'] = '**********';
-
-		this.logger.debug('Slack identity extracted', {
-			userId,
-			teamId: teamId ?? 'unknown',
-		});
 
 		return {
 			triggerItems: options.triggerItems,
 			contextUpdate: {
 				credentials: {
+					identity: rawBody,
 					version: 1,
-					identity: userId,
 					metadata: {
 						source: 'slack-signature',
-						team_id: teamId,
-						enterprise_id: enterpriseId,
-						// Carry raw verification data so the resolver can verify
-						// the signature using the signing secret from its config
 						timestamp,
-						rawBody,
 						signature,
+						contentType,
 					},
 				},
 			},
@@ -128,91 +101,19 @@ export class SlackSignatureExtractor implements IContextEstablishmentHook {
 	}
 
 	/**
-	 * Extracts the raw body string from the trigger item.
-	 * Slack sends form-encoded payloads for slash commands and interactions.
+	 * Reconstructs the URL-encoded form body from the parsed body object.
+	 * Slack sends form-urlencoded payloads for slash commands and interactions,
+	 * which n8n parses into a JSON object. We reconstruct the encoded string
+	 * to use as the HMAC input for Slack signature verification.
 	 */
 	private getRawBody(triggerItem: { json: Record<string, unknown> }): string {
-		// The webhook node stores rawBody when available
-		if (typeof triggerItem.json['rawBody'] === 'string') {
-			return triggerItem.json['rawBody'];
-		}
-
-		// Fallback: reconstruct from body if it's a string
 		const body = triggerItem.json['body'];
-		if (typeof body === 'string') {
-			return body;
+
+		if (body !== null && body !== undefined && typeof body === 'object') {
+			return new URLSearchParams(body as Record<string, string>).toString();
 		}
 
-		throw new Error(
-			'Could not retrieve raw body for Slack signature verification. ' +
-				'The webhook node must be configured with "Raw Body" enabled so the original ' +
-				'request body is preserved for HMAC signature verification.',
-		);
-	}
-
-	/**
-	 * Extracts Slack user identity from various payload formats.
-	 * Slack sends different payload structures for:
-	 * - Slash commands (form-encoded: user_id, team_id)
-	 * - Interactive messages (JSON: user.id, team.id)
-	 * - Events (JSON: event.user, team_id)
-	 */
-	private extractSlackIdentity(body: unknown): {
-		userId: string | undefined;
-		teamId: string | undefined;
-		enterpriseId: string | undefined;
-	} {
-		return (
-			this.extractFlatFieldBody(body) ??
-			this.extractInteractivePayloadBody(body) ??
-			this.extractEventPayloadBody(body) ?? {
-				userId: undefined,
-				teamId: undefined,
-				enterpriseId: undefined,
-			}
-		);
-	}
-
-	/** Slash commands and some interactions: flat fields */
-	private extractFlatFieldBody(
-		body: unknown,
-	): { userId: string; teamId: string | undefined; enterpriseId: string | undefined } | undefined {
-		const result = FlatPayloadSchema.safeParse(body);
-		if (!result.success) return undefined;
-		return {
-			userId: result.data.user_id,
-			teamId: result.data.team_id,
-			enterpriseId: result.data.enterprise_id,
-		};
-	}
-
-	/** Interactive payloads: nested user object */
-	private extractInteractivePayloadBody(
-		body: unknown,
-	):
-		| { userId: string | undefined; teamId: string | undefined; enterpriseId: string | undefined }
-		| undefined {
-		const result = InteractivePayloadSchema.safeParse(body);
-		if (!result.success) return undefined;
-		return {
-			userId: result.data.user.id,
-			teamId: result.data.team?.id,
-			enterpriseId: result.data.enterprise?.id,
-		};
-	}
-
-	/** Event payloads: event.user at top level */
-	private extractEventPayloadBody(
-		body: unknown,
-	):
-		| { userId: string | undefined; teamId: string | undefined; enterpriseId: string | undefined }
-		| undefined {
-		const result = EventPayloadSchema.safeParse(body);
-		if (!result.success) return undefined;
-		return {
-			userId: result.data.event.user,
-			teamId: result.data.team_id,
-			enterpriseId: result.data.enterprise_id,
-		};
+		this.logger.error('Could not retrieve raw body for Slack signature verification');
+		throw new Error('Could not retrieve raw body for Slack signature verification.');
 	}
 }

--- a/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/slack-signature-extractor.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/slack-signature-extractor.ts
@@ -57,7 +57,6 @@ export class SlackSignatureExtractor implements IContextEstablishmentHook {
 		// Extract Slack-specific headers
 		const timestamp = this.getHeader(headers, 'x-slack-request-timestamp');
 		const signature = this.getHeader(headers, 'x-slack-signature');
-		const contentType = this.getHeader(headers, 'content-type');
 
 		if (!timestamp) {
 			this.logger.error('Missing X-Slack-Request-Timestamp header');
@@ -66,10 +65,6 @@ export class SlackSignatureExtractor implements IContextEstablishmentHook {
 		if (!signature) {
 			this.logger.error('Missing X-Slack-Signature header');
 			throw new Error('Missing X-Slack-Signature header');
-		}
-		if (!contentType) {
-			this.logger.error('Missing Content-Type header');
-			throw new Error('Missing Content-Type header');
 		}
 
 		// Get the raw body — needed by the resolver for signature verification
@@ -89,7 +84,6 @@ export class SlackSignatureExtractor implements IContextEstablishmentHook {
 						source: 'slack-signature',
 						timestamp,
 						signature,
-						contentType,
 					},
 				},
 			},

--- a/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/slack-signature-extractor.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/slack-signature-extractor.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@n8n/backend-common';
+import { z } from 'zod';
 import {
 	ContextEstablishmentHook,
 	type ContextEstablishmentOptions,
@@ -107,13 +108,13 @@ export class SlackSignatureExtractor implements IContextEstablishmentHook {
 	 * to use as the HMAC input for Slack signature verification.
 	 */
 	private getRawBody(triggerItem: { json: Record<string, unknown> }): string {
-		const body = triggerItem.json['body'];
+		const result = z.record(z.string(), z.string()).safeParse(triggerItem.json['body']);
 
-		if (body !== null && body !== undefined && typeof body === 'object') {
-			return new URLSearchParams(body as Record<string, string>).toString();
+		if (!result.success) {
+			this.logger.error('Could not retrieve raw body for Slack signature verification');
+			throw new Error('Could not retrieve raw body for Slack signature verification.');
 		}
 
-		this.logger.error('Could not retrieve raw body for Slack signature verification');
-		throw new Error('Could not retrieve raw body for Slack signature verification.');
+		return new URLSearchParams(result.data).toString();
 	}
 }

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/slack-signature-identifier.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/slack-signature-identifier.test.ts
@@ -67,16 +67,21 @@ describe('SlackSignatureIdentifier', () => {
 	});
 
 	describe('resolve', () => {
-		describe('with user_id subject claim', () => {
+		describe('with form-encoded payload (slash commands)', () => {
 			it('should return the user_id as identity', async () => {
 				const timestamp = Math.floor(Date.now() / 1000).toString();
 				const rawBody = 'user_id=U12345';
 				const signature = computeSlackSignature(TEST_SIGNING_SECRET, timestamp, rawBody);
 
 				const context = {
-					identity: 'U12345',
+					identity: rawBody,
 					version: 1 as const,
-					metadata: { source: 'slack-signature', rawBody, timestamp, signature },
+					metadata: {
+						source: 'slack-signature',
+						timestamp,
+						signature,
+						contentType: 'application/x-www-form-urlencoded',
+					},
 				};
 
 				const result = await identifier.resolve(context, {
@@ -87,15 +92,20 @@ describe('SlackSignatureIdentifier', () => {
 				expect(result).toBe('U12345');
 			});
 
-			it('should return user_id when no subjectClaim specified (default)', async () => {
+			it('should return user_id when no subjectClaim specified (defaults to user_id)', async () => {
 				const timestamp = Math.floor(Date.now() / 1000).toString();
 				const rawBody = 'user_id=UDEFAULT';
 				const signature = computeSlackSignature(TEST_SIGNING_SECRET, timestamp, rawBody);
 
 				const context = {
-					identity: 'UDEFAULT',
+					identity: rawBody,
 					version: 1 as const,
-					metadata: { rawBody, timestamp, signature },
+					metadata: {
+						source: 'slack-signature',
+						timestamp,
+						signature,
+						contentType: 'application/x-www-form-urlencoded',
+					},
 				};
 
 				const result = await identifier.resolve(context, {
@@ -104,23 +114,20 @@ describe('SlackSignatureIdentifier', () => {
 
 				expect(result).toBe('UDEFAULT');
 			});
-		});
 
-		describe('with team_user subject claim', () => {
-			it('should return team_id:user_id composite key', async () => {
+			it('should return team_id:user_id composite key for team_user claim', async () => {
 				const timestamp = Math.floor(Date.now() / 1000).toString();
 				const rawBody = 'user_id=U12345&team_id=T67890';
 				const signature = computeSlackSignature(TEST_SIGNING_SECRET, timestamp, rawBody);
 
 				const context = {
-					identity: 'U12345',
+					identity: rawBody,
 					version: 1 as const,
 					metadata: {
 						source: 'slack-signature',
-						team_id: 'T67890',
-						rawBody,
 						timestamp,
 						signature,
+						contentType: 'application/x-www-form-urlencoded',
 					},
 				};
 
@@ -134,13 +141,18 @@ describe('SlackSignatureIdentifier', () => {
 
 			it('should throw when team_id is missing for team_user claim', async () => {
 				const timestamp = Math.floor(Date.now() / 1000).toString();
-				const rawBody = 'user_id=U12345';
+				const rawBody = 'user_id=U12345'; // no team_id
 				const signature = computeSlackSignature(TEST_SIGNING_SECRET, timestamp, rawBody);
 
 				const context = {
-					identity: 'U12345',
+					identity: rawBody,
 					version: 1 as const,
-					metadata: { source: 'slack-signature', rawBody, timestamp, signature },
+					metadata: {
+						source: 'slack-signature',
+						timestamp,
+						signature,
+						contentType: 'application/x-www-form-urlencoded',
+					},
 				};
 
 				await expect(
@@ -152,20 +164,20 @@ describe('SlackSignatureIdentifier', () => {
 			});
 		});
 
-		describe('signature re-verification', () => {
-			it('should re-verify signature when raw verification data is present', async () => {
+		describe('with JSON payload (interactive messages)', () => {
+			it('should extract user_id from nested user object', async () => {
 				const timestamp = Math.floor(Date.now() / 1000).toString();
-				const rawBody = 'user_id=U12345&team_id=T67890';
+				const rawBody = JSON.stringify({ user: { id: 'U12345' }, team: { id: 'T67890' } });
 				const signature = computeSlackSignature(TEST_SIGNING_SECRET, timestamp, rawBody);
 
 				const context = {
-					identity: 'U12345',
+					identity: rawBody,
 					version: 1 as const,
 					metadata: {
 						source: 'slack-signature',
-						rawBody,
 						timestamp,
 						signature,
+						contentType: 'application/json',
 					},
 				};
 
@@ -177,18 +189,95 @@ describe('SlackSignatureIdentifier', () => {
 				expect(result).toBe('U12345');
 			});
 
-			it('should throw when re-verification fails with wrong secret', async () => {
+			it('should return team_id:user_id from nested interactive payload for team_user', async () => {
+				const timestamp = Math.floor(Date.now() / 1000).toString();
+				const rawBody = JSON.stringify({ user: { id: 'U12345' }, team: { id: 'T67890' } });
+				const signature = computeSlackSignature(TEST_SIGNING_SECRET, timestamp, rawBody);
+
+				const context = {
+					identity: rawBody,
+					version: 1 as const,
+					metadata: {
+						source: 'slack-signature',
+						timestamp,
+						signature,
+						contentType: 'application/json',
+					},
+				};
+
+				const result = await identifier.resolve(context, {
+					signingSecret: TEST_SIGNING_SECRET,
+					subjectClaim: 'team_user',
+				});
+
+				expect(result).toBe('T67890:U12345');
+			});
+		});
+
+		describe('with JSON payload (event callbacks)', () => {
+			it('should extract user_id from event.user field', async () => {
+				const timestamp = Math.floor(Date.now() / 1000).toString();
+				const rawBody = JSON.stringify({ event: { user: 'U12345' }, team_id: 'T67890' });
+				const signature = computeSlackSignature(TEST_SIGNING_SECRET, timestamp, rawBody);
+
+				const context = {
+					identity: rawBody,
+					version: 1 as const,
+					metadata: {
+						source: 'slack-signature',
+						timestamp,
+						signature,
+						contentType: 'application/json',
+					},
+				};
+
+				const result = await identifier.resolve(context, {
+					signingSecret: TEST_SIGNING_SECRET,
+					subjectClaim: 'user_id',
+				});
+
+				expect(result).toBe('U12345');
+			});
+		});
+
+		describe('signature re-verification', () => {
+			it('should verify the Slack signature before resolving', async () => {
+				const timestamp = Math.floor(Date.now() / 1000).toString();
+				const rawBody = 'user_id=U12345&team_id=T67890';
+				const signature = computeSlackSignature(TEST_SIGNING_SECRET, timestamp, rawBody);
+
+				const context = {
+					identity: rawBody,
+					version: 1 as const,
+					metadata: {
+						source: 'slack-signature',
+						timestamp,
+						signature,
+						contentType: 'application/x-www-form-urlencoded',
+					},
+				};
+
+				const result = await identifier.resolve(context, {
+					signingSecret: TEST_SIGNING_SECRET,
+					subjectClaim: 'user_id',
+				});
+
+				expect(result).toBe('U12345');
+			});
+
+			it('should throw when signature does not match the signing secret', async () => {
 				const timestamp = Math.floor(Date.now() / 1000).toString();
 				const rawBody = 'user_id=U12345';
 				const signature = computeSlackSignature('wrong-secret', timestamp, rawBody);
 
 				const context = {
-					identity: 'U12345',
+					identity: rawBody,
 					version: 1 as const,
 					metadata: {
-						rawBody,
+						source: 'slack-signature',
 						timestamp,
 						signature,
+						contentType: 'application/x-www-form-urlencoded',
 					},
 				};
 
@@ -200,18 +289,42 @@ describe('SlackSignatureIdentifier', () => {
 				).rejects.toThrow(IdentifierValidationError);
 			});
 
-			it('should throw when timestamp in metadata is too old', async () => {
+			it('should throw when timestamp is too old (replay attack prevention)', async () => {
 				const oldTimestamp = '0';
 				const rawBody = 'user_id=U12345';
 				const signature = computeSlackSignature(TEST_SIGNING_SECRET, oldTimestamp, rawBody);
 
 				const context = {
-					identity: 'U12345',
+					identity: rawBody,
 					version: 1 as const,
 					metadata: {
-						rawBody,
+						source: 'slack-signature',
 						timestamp: oldTimestamp,
 						signature,
+						contentType: 'application/x-www-form-urlencoded',
+					},
+				};
+
+				await expect(
+					identifier.resolve(context, {
+						signingSecret: TEST_SIGNING_SECRET,
+						subjectClaim: 'user_id',
+					}),
+				).rejects.toThrow(IdentifierValidationError);
+			});
+
+			it('should throw when timestamp is not a valid number', async () => {
+				const rawBody = 'user_id=U12345';
+				const signature = computeSlackSignature(TEST_SIGNING_SECRET, 'not-a-number', rawBody);
+
+				const context = {
+					identity: rawBody,
+					version: 1 as const,
+					metadata: {
+						source: 'slack-signature',
+						timestamp: 'not-a-number',
+						signature,
+						contentType: 'application/x-www-form-urlencoded',
 					},
 				};
 
@@ -225,7 +338,7 @@ describe('SlackSignatureIdentifier', () => {
 
 			it('should throw when metadata is missing signature verification data', async () => {
 				const context = {
-					identity: 'U12345',
+					identity: 'user_id=U12345',
 					version: 1 as const,
 					metadata: { source: 'slack-signature' },
 				};
@@ -240,8 +353,32 @@ describe('SlackSignatureIdentifier', () => {
 
 			it('should throw when metadata is missing entirely', async () => {
 				const context = {
-					identity: 'U12345',
+					identity: 'user_id=U12345',
 					version: 1 as const,
+				};
+
+				await expect(
+					identifier.resolve(context, {
+						signingSecret: TEST_SIGNING_SECRET,
+						subjectClaim: 'user_id',
+					}),
+				).rejects.toThrow(IdentifierValidationError);
+			});
+
+			it('should throw for unsupported content type', async () => {
+				const timestamp = Math.floor(Date.now() / 1000).toString();
+				const rawBody = 'user_id=U12345';
+				const signature = computeSlackSignature(TEST_SIGNING_SECRET, timestamp, rawBody);
+
+				const context = {
+					identity: rawBody,
+					version: 1 as const,
+					metadata: {
+						source: 'slack-signature',
+						timestamp,
+						signature,
+						contentType: 'text/plain',
+					},
 				};
 
 				await expect(
@@ -257,6 +394,7 @@ describe('SlackSignatureIdentifier', () => {
 			const context = {
 				identity: '',
 				version: 1 as const,
+				metadata: { source: 'slack-signature' },
 			};
 
 			await expect(
@@ -267,59 +405,47 @@ describe('SlackSignatureIdentifier', () => {
 			).rejects.toThrow(IdentifierValidationError);
 		});
 
-		it('should throw when timestamp is not a valid number', async () => {
-			const rawBody = 'user_id=U12345';
-			const signature = computeSlackSignature(TEST_SIGNING_SECRET, 'not-a-number', rawBody);
-
-			const context = {
-				identity: 'U12345',
-				version: 1 as const,
-				metadata: { rawBody, timestamp: 'not-a-number', signature },
-			};
-
-			await expect(
-				identifier.resolve(context, {
-					signingSecret: TEST_SIGNING_SECRET,
-					subjectClaim: 'user_id',
-				}),
-			).rejects.toThrow(IdentifierValidationError);
-		});
-
-		it('should throw when resolve is called with invalid options', async () => {
+		it('should throw when called with invalid options', async () => {
 			const timestamp = Math.floor(Date.now() / 1000).toString();
 			const rawBody = 'user_id=U12345';
 			const signature = computeSlackSignature(TEST_SIGNING_SECRET, timestamp, rawBody);
 
 			const context = {
-				identity: 'U12345',
+				identity: rawBody,
 				version: 1 as const,
-				metadata: { rawBody, timestamp, signature },
+				metadata: {
+					source: 'slack-signature',
+					timestamp,
+					signature,
+					contentType: 'application/x-www-form-urlencoded',
+				},
 			};
 
 			await expect(identifier.resolve(context, { signingSecret: '' })).rejects.toThrow(
 				IdentifierValidationError,
 			);
 		});
-
-		it('should throw when resolveKey is called with invalid options', () => {
-			const context = {
-				identity: 'U12345',
-				version: 1 as const,
-			};
-
-			expect(() => identifier.resolveKey(context, { signingSecret: '' })).toThrow(
-				IdentifierValidationError,
-			);
-		});
 	});
 
 	describe('resolveKey', () => {
-		it('should derive key without signature verification', () => {
+		// resolveKey parses the raw body like resolve(), but skips signature verification —
+		// any signature value is accepted. Use only for pre-verified trusted paths.
+		const fakeSignature = 'v0=intentionally-wrong-signature';
+
+		it('should derive key without verifying the signature', () => {
+			const rawBody = 'user_id=U12345';
 			const context = {
-				identity: 'U12345',
+				identity: rawBody,
 				version: 1 as const,
+				metadata: {
+					source: 'slack-signature',
+					timestamp: '1234567890',
+					signature: fakeSignature,
+					contentType: 'application/x-www-form-urlencoded',
+				},
 			};
 
+			// A wrong signature is accepted — no HMAC verification happens here
 			const result = identifier.resolveKey(context, {
 				signingSecret: TEST_SIGNING_SECRET,
 				subjectClaim: 'user_id',
@@ -328,11 +454,17 @@ describe('SlackSignatureIdentifier', () => {
 			expect(result).toBe('U12345');
 		});
 
-		it('should derive team_user composite key', () => {
+		it('should derive team_user composite key from body fields', () => {
+			const rawBody = 'user_id=U12345&team_id=T67890';
 			const context = {
-				identity: 'U12345',
+				identity: rawBody,
 				version: 1 as const,
-				metadata: { team_id: 'T67890' },
+				metadata: {
+					source: 'slack-signature',
+					timestamp: '1234567890',
+					signature: fakeSignature,
+					contentType: 'application/x-www-form-urlencoded',
+				},
 			};
 
 			const result = identifier.resolveKey(context, {
@@ -343,10 +475,32 @@ describe('SlackSignatureIdentifier', () => {
 			expect(result).toBe('T67890:U12345');
 		});
 
-		it('should throw when identity is empty', () => {
+		it('should throw for team_user when body contains no team_id', () => {
+			const rawBody = 'user_id=U12345'; // no team_id
 			const context = {
-				identity: '',
+				identity: rawBody,
 				version: 1 as const,
+				metadata: {
+					source: 'slack-signature',
+					timestamp: '1234567890',
+					signature: fakeSignature,
+					contentType: 'application/x-www-form-urlencoded',
+				},
+			};
+
+			expect(() =>
+				identifier.resolveKey(context, {
+					signingSecret: TEST_SIGNING_SECRET,
+					subjectClaim: 'team_user',
+				}),
+			).toThrow(IdentifierValidationError);
+		});
+
+		it('should throw when metadata is missing', () => {
+			const context = {
+				identity: 'user_id=U12345',
+				version: 1 as const,
+				// no metadata — fails SlackIdentitySchema
 			};
 
 			expect(() =>
@@ -355,6 +509,23 @@ describe('SlackSignatureIdentifier', () => {
 					subjectClaim: 'user_id',
 				}),
 			).toThrow(IdentifierValidationError);
+		});
+
+		it('should throw when called with invalid options', () => {
+			const context = {
+				identity: 'user_id=U12345',
+				version: 1 as const,
+				metadata: {
+					source: 'slack-signature',
+					timestamp: '1234567890',
+					signature: fakeSignature,
+					contentType: 'application/x-www-form-urlencoded',
+				},
+			};
+
+			expect(() => identifier.resolveKey(context, { signingSecret: '' })).toThrow(
+				IdentifierValidationError,
+			);
 		});
 	});
 });

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/slack-signature-identifier.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/slack-signature-identifier.test.ts
@@ -80,7 +80,6 @@ describe('SlackSignatureIdentifier', () => {
 						source: 'slack-signature',
 						timestamp,
 						signature,
-						contentType: 'application/x-www-form-urlencoded',
 					},
 				};
 
@@ -104,7 +103,6 @@ describe('SlackSignatureIdentifier', () => {
 						source: 'slack-signature',
 						timestamp,
 						signature,
-						contentType: 'application/x-www-form-urlencoded',
 					},
 				};
 
@@ -127,7 +125,6 @@ describe('SlackSignatureIdentifier', () => {
 						source: 'slack-signature',
 						timestamp,
 						signature,
-						contentType: 'application/x-www-form-urlencoded',
 					},
 				};
 
@@ -151,7 +148,6 @@ describe('SlackSignatureIdentifier', () => {
 						source: 'slack-signature',
 						timestamp,
 						signature,
-						contentType: 'application/x-www-form-urlencoded',
 					},
 				};
 
@@ -164,10 +160,10 @@ describe('SlackSignatureIdentifier', () => {
 			});
 		});
 
-		describe('with JSON payload (interactive messages)', () => {
-			it('should extract user_id from nested user object', async () => {
+		describe('when user_id is absent (flat schema does not match)', () => {
+			it('should throw when body has no user_id field', async () => {
 				const timestamp = Math.floor(Date.now() / 1000).toString();
-				const rawBody = JSON.stringify({ user: { id: 'U12345' }, team: { id: 'T67890' } });
+				const rawBody = 'team_id=T67890&command=%2Fconnect';
 				const signature = computeSlackSignature(TEST_SIGNING_SECRET, timestamp, rawBody);
 
 				const context = {
@@ -177,21 +173,20 @@ describe('SlackSignatureIdentifier', () => {
 						source: 'slack-signature',
 						timestamp,
 						signature,
-						contentType: 'application/json',
 					},
 				};
 
-				const result = await identifier.resolve(context, {
-					signingSecret: TEST_SIGNING_SECRET,
-					subjectClaim: 'user_id',
-				});
-
-				expect(result).toBe('U12345');
+				await expect(
+					identifier.resolve(context, {
+						signingSecret: TEST_SIGNING_SECRET,
+						subjectClaim: 'user_id',
+					}),
+				).rejects.toThrow(IdentifierValidationError);
 			});
 
-			it('should return team_id:user_id from nested interactive payload for team_user', async () => {
+			it('should throw when body is empty', async () => {
 				const timestamp = Math.floor(Date.now() / 1000).toString();
-				const rawBody = JSON.stringify({ user: { id: 'U12345' }, team: { id: 'T67890' } });
+				const rawBody = '';
 				const signature = computeSlackSignature(TEST_SIGNING_SECRET, timestamp, rawBody);
 
 				const context = {
@@ -201,42 +196,15 @@ describe('SlackSignatureIdentifier', () => {
 						source: 'slack-signature',
 						timestamp,
 						signature,
-						contentType: 'application/json',
 					},
 				};
 
-				const result = await identifier.resolve(context, {
-					signingSecret: TEST_SIGNING_SECRET,
-					subjectClaim: 'team_user',
-				});
-
-				expect(result).toBe('T67890:U12345');
-			});
-		});
-
-		describe('with JSON payload (event callbacks)', () => {
-			it('should extract user_id from event.user field', async () => {
-				const timestamp = Math.floor(Date.now() / 1000).toString();
-				const rawBody = JSON.stringify({ event: { user: 'U12345' }, team_id: 'T67890' });
-				const signature = computeSlackSignature(TEST_SIGNING_SECRET, timestamp, rawBody);
-
-				const context = {
-					identity: rawBody,
-					version: 1 as const,
-					metadata: {
-						source: 'slack-signature',
-						timestamp,
-						signature,
-						contentType: 'application/json',
-					},
-				};
-
-				const result = await identifier.resolve(context, {
-					signingSecret: TEST_SIGNING_SECRET,
-					subjectClaim: 'user_id',
-				});
-
-				expect(result).toBe('U12345');
+				await expect(
+					identifier.resolve(context, {
+						signingSecret: TEST_SIGNING_SECRET,
+						subjectClaim: 'user_id',
+					}),
+				).rejects.toThrow(IdentifierValidationError);
 			});
 		});
 
@@ -253,7 +221,6 @@ describe('SlackSignatureIdentifier', () => {
 						source: 'slack-signature',
 						timestamp,
 						signature,
-						contentType: 'application/x-www-form-urlencoded',
 					},
 				};
 
@@ -277,7 +244,6 @@ describe('SlackSignatureIdentifier', () => {
 						source: 'slack-signature',
 						timestamp,
 						signature,
-						contentType: 'application/x-www-form-urlencoded',
 					},
 				};
 
@@ -301,7 +267,6 @@ describe('SlackSignatureIdentifier', () => {
 						source: 'slack-signature',
 						timestamp: oldTimestamp,
 						signature,
-						contentType: 'application/x-www-form-urlencoded',
 					},
 				};
 
@@ -324,7 +289,6 @@ describe('SlackSignatureIdentifier', () => {
 						source: 'slack-signature',
 						timestamp: 'not-a-number',
 						signature,
-						contentType: 'application/x-www-form-urlencoded',
 					},
 				};
 
@@ -364,30 +328,6 @@ describe('SlackSignatureIdentifier', () => {
 					}),
 				).rejects.toThrow(IdentifierValidationError);
 			});
-
-			it('should throw for unsupported content type', async () => {
-				const timestamp = Math.floor(Date.now() / 1000).toString();
-				const rawBody = 'user_id=U12345';
-				const signature = computeSlackSignature(TEST_SIGNING_SECRET, timestamp, rawBody);
-
-				const context = {
-					identity: rawBody,
-					version: 1 as const,
-					metadata: {
-						source: 'slack-signature',
-						timestamp,
-						signature,
-						contentType: 'text/plain',
-					},
-				};
-
-				await expect(
-					identifier.resolve(context, {
-						signingSecret: TEST_SIGNING_SECRET,
-						subjectClaim: 'user_id',
-					}),
-				).rejects.toThrow(IdentifierValidationError);
-			});
 		});
 
 		it('should throw when identity is empty', async () => {
@@ -417,7 +357,6 @@ describe('SlackSignatureIdentifier', () => {
 					source: 'slack-signature',
 					timestamp,
 					signature,
-					contentType: 'application/x-www-form-urlencoded',
 				},
 			};
 
@@ -441,7 +380,6 @@ describe('SlackSignatureIdentifier', () => {
 					source: 'slack-signature',
 					timestamp: '1234567890',
 					signature: fakeSignature,
-					contentType: 'application/x-www-form-urlencoded',
 				},
 			};
 
@@ -463,7 +401,6 @@ describe('SlackSignatureIdentifier', () => {
 					source: 'slack-signature',
 					timestamp: '1234567890',
 					signature: fakeSignature,
-					contentType: 'application/x-www-form-urlencoded',
 				},
 			};
 
@@ -484,7 +421,6 @@ describe('SlackSignatureIdentifier', () => {
 					source: 'slack-signature',
 					timestamp: '1234567890',
 					signature: fakeSignature,
-					contentType: 'application/x-www-form-urlencoded',
 				},
 			};
 
@@ -519,7 +455,6 @@ describe('SlackSignatureIdentifier', () => {
 					source: 'slack-signature',
 					timestamp: '1234567890',
 					signature: fakeSignature,
-					contentType: 'application/x-www-form-urlencoded',
 				},
 			};
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/slack-signature-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/slack-signature-identifier.ts
@@ -4,20 +4,44 @@ import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
 import type { ICredentialContext } from 'n8n-workflow';
 import { z } from 'zod';
-
 import { IdentifierValidationError, type ITokenIdentifier } from './identifier-interface';
+import { jsonParse } from 'n8n-workflow';
+import { parse as parseQueryString } from 'querystring';
 
 const MAX_TIMESTAMP_AGE_SECONDS = 300; // 5 minutes — Slack's recommended window
 
-const SlackMetadataSchema = z.object({
-	rawBody: z.string(),
-	signature: z.string(),
-	timestamp: z.string(),
+const SlackIdentitySchema = z.object({
+	identity: z.string(),
+	version: z.number(),
+	metadata: z.object({
+		source: z.literal('slack-signature'),
+		timestamp: z.string(),
+		signature: z.string(),
+		contentType: z.string(),
+	}),
 });
 
 export const SlackSignatureOptionsSchema = z.object({
 	signingSecret: z.string().min(1, 'Slack signing secret is required'),
 	subjectClaim: z.enum(['user_id', 'team_user']).default('user_id'),
+});
+
+const FlatPayloadSchema = z.object({
+	user_id: z.string(),
+	team_id: z.string().optional(),
+	enterprise_id: z.string().optional(),
+});
+
+const InteractivePayloadSchema = z.object({
+	user: z.object({ id: z.string().optional() }),
+	team: z.object({ id: z.string() }).optional(),
+	enterprise: z.object({ id: z.string() }).optional(),
+});
+
+const EventPayloadSchema = z.object({
+	event: z.object({ user: z.string().optional() }),
+	team_id: z.string().optional(),
+	enterprise_id: z.string().optional(),
 });
 
 type SlackSignatureOptions = z.infer<typeof SlackSignatureOptionsSchema>;
@@ -53,19 +77,19 @@ export class SlackSignatureIdentifier implements ITokenIdentifier {
 	): Promise<string> {
 		const options = this.parseOptions(identifierOptions);
 
-		const metadataResult = SlackMetadataSchema.safeParse(context.metadata);
-		if (!metadataResult.success) {
+		const result = SlackIdentitySchema.safeParse(context);
+		if (!result.success) {
 			throw new IdentifierValidationError('Missing Slack signature verification data');
 		}
 		this.verifySlackSignature(
 			options.signingSecret,
-			metadataResult.data.timestamp,
-			metadataResult.data.rawBody,
-			metadataResult.data.signature,
+			result.data.metadata.timestamp,
+			result.data.identity,
+			result.data.metadata.signature,
 		);
 		this.logger.debug('Slack signature verified');
 
-		return this.deriveKey(context, options);
+		return this.deriveKey(result.data.identity, result.data.metadata.contentType, options);
 	}
 
 	/**
@@ -73,28 +97,28 @@ export class SlackSignatureIdentifier implements ITokenIdentifier {
 	 * Use this only for trusted internal paths where the identity was already
 	 * verified upstream (e.g. OAuth callback where identity comes from
 	 * encrypted CSRF state).
+	 *
 	 */
 	resolveKey(context: ICredentialContext, identifierOptions: Record<string, unknown>): string {
 		const options = this.parseOptions(identifierOptions);
-		return this.deriveKey(context, options);
+		const result = SlackIdentitySchema.safeParse(context);
+		if (!result.success) {
+			throw new IdentifierValidationError('Missing Slack signature verification data');
+		}
+		return this.deriveKey(result.data.identity, result.data.metadata.contentType, options);
 	}
 
-	private deriveKey(context: ICredentialContext, options: SlackSignatureOptions): string {
-		const userId = context.identity;
+	private deriveKey(identity: string, contentType: string, options: SlackSignatureOptions): string {
+		const { userId, teamId } = this.extractSlackIdentity(identity, contentType);
 		if (!userId) {
-			throw new IdentifierValidationError('Slack user_id not found in credential context');
+			throw new IdentifierValidationError('Slack user_id not found in identity');
 		}
 
 		if (options.subjectClaim === 'team_user') {
-			const teamId = context.metadata?.team_id;
-			if (!teamId || typeof teamId !== 'string') {
-				throw new IdentifierValidationError(
-					'Slack team_id not found in credential context metadata',
-				);
+			if (!teamId) {
+				throw new IdentifierValidationError('Slack team_id not found for team_user claim');
 			}
-			const subject = `${teamId}:${userId}`;
-			this.logger.debug('Slack identity resolved', { subject: `${teamId}:***` });
-			return subject;
+			return `${teamId}:${userId}`;
 		}
 
 		return userId;
@@ -142,5 +166,74 @@ export class SlackSignatureIdentifier implements ITokenIdentifier {
 		) {
 			throw new IdentifierValidationError('Slack signature verification failed');
 		}
+	}
+
+	/**
+	 * Extracts Slack user identity from various payload formats.
+	 * Slack sends different payload structures for:
+	 * - Slash commands (form-encoded: user_id, team_id)
+	 * - Interactive messages (JSON: user.id, team.id)
+	 * - Events (JSON: event.user, team_id)
+	 */
+	private extractSlackIdentity(
+		body: string,
+		contentType: string,
+	): {
+		userId: string | undefined;
+		teamId: string | undefined;
+	} {
+		let parsedBody: unknown;
+		if (contentType === 'application/json') {
+			parsedBody = jsonParse(body);
+		} else if (contentType === 'application/x-www-form-urlencoded') {
+			parsedBody = parseQueryString(body);
+		} else {
+			this.logger.error('Unsupported Slack content type', { contentType });
+			throw new IdentifierValidationError('Unsupported Slack content type');
+		}
+		return (
+			this.extractFlatFieldBody(parsedBody) ??
+			this.extractInteractivePayloadBody(parsedBody) ??
+			this.extractEventPayloadBody(parsedBody) ?? {
+				userId: undefined,
+				teamId: undefined,
+			}
+		);
+	}
+
+	/** Slash commands and some interactions: flat fields */
+	private extractFlatFieldBody(
+		body: unknown,
+	): { userId: string; teamId: string | undefined } | undefined {
+		const result = FlatPayloadSchema.safeParse(body);
+		if (!result.success) return undefined;
+		return {
+			userId: result.data.user_id,
+			teamId: result.data.team_id,
+		};
+	}
+
+	/** Interactive payloads: nested user object */
+	private extractInteractivePayloadBody(
+		body: unknown,
+	): { userId: string | undefined; teamId: string | undefined } | undefined {
+		const result = InteractivePayloadSchema.safeParse(body);
+		if (!result.success) return undefined;
+		return {
+			userId: result.data.user.id,
+			teamId: result.data.team?.id,
+		};
+	}
+
+	/** Event payloads: event.user at top level */
+	private extractEventPayloadBody(
+		body: unknown,
+	): { userId: string | undefined; teamId: string | undefined } | undefined {
+		const result = EventPayloadSchema.safeParse(body);
+		if (!result.success) return undefined;
+		return {
+			userId: result.data.event.user,
+			teamId: result.data.team_id,
+		};
 	}
 }

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/slack-signature-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/slack-signature-identifier.ts
@@ -5,7 +5,6 @@ import { Service } from '@n8n/di';
 import type { ICredentialContext } from 'n8n-workflow';
 import { z } from 'zod';
 import { IdentifierValidationError, type ITokenIdentifier } from './identifier-interface';
-import { jsonParse } from 'n8n-workflow';
 import { parse as parseQueryString } from 'querystring';
 
 const MAX_TIMESTAMP_AGE_SECONDS = 300; // 5 minutes — Slack's recommended window
@@ -17,7 +16,6 @@ const SlackIdentitySchema = z.object({
 		source: z.literal('slack-signature'),
 		timestamp: z.string(),
 		signature: z.string(),
-		contentType: z.string(),
 	}),
 });
 
@@ -89,7 +87,7 @@ export class SlackSignatureIdentifier implements ITokenIdentifier {
 		);
 		this.logger.debug('Slack signature verified');
 
-		return this.deriveKey(result.data.identity, result.data.metadata.contentType, options);
+		return this.deriveKey(result.data.identity, options);
 	}
 
 	/**
@@ -105,11 +103,11 @@ export class SlackSignatureIdentifier implements ITokenIdentifier {
 		if (!result.success) {
 			throw new IdentifierValidationError('Missing Slack signature verification data');
 		}
-		return this.deriveKey(result.data.identity, result.data.metadata.contentType, options);
+		return this.deriveKey(result.data.identity, options);
 	}
 
-	private deriveKey(identity: string, contentType: string, options: SlackSignatureOptions): string {
-		const { userId, teamId } = this.extractSlackIdentity(identity, contentType);
+	private deriveKey(identity: string, options: SlackSignatureOptions): string {
+		const { userId, teamId } = this.extractSlackIdentity(identity);
 		if (!userId) {
 			throw new IdentifierValidationError('Slack user_id not found in identity');
 		}
@@ -175,22 +173,11 @@ export class SlackSignatureIdentifier implements ITokenIdentifier {
 	 * - Interactive messages (JSON: user.id, team.id)
 	 * - Events (JSON: event.user, team_id)
 	 */
-	private extractSlackIdentity(
-		body: string,
-		contentType: string,
-	): {
+	private extractSlackIdentity(body: string): {
 		userId: string | undefined;
 		teamId: string | undefined;
 	} {
-		let parsedBody: unknown;
-		if (contentType === 'application/json') {
-			parsedBody = jsonParse(body);
-		} else if (contentType === 'application/x-www-form-urlencoded') {
-			parsedBody = parseQueryString(body);
-		} else {
-			this.logger.error('Unsupported Slack content type', { contentType });
-			throw new IdentifierValidationError('Unsupported Slack content type');
-		}
+		const parsedBody = parseQueryString(body);
 		return (
 			this.extractFlatFieldBody(parsedBody) ??
 			this.extractInteractivePayloadBody(parsedBody) ??


### PR DESCRIPTION
## Summary
This PR is part 3 of the Slack dynamic credentials implementation
  (IAM-211).

  - Removed rawBody dependency in the extractor:
  SlackSignatureExtractor no longer requires the "Raw Body" option to
  be enabled on the webhook node. Instead of reading from binary data,
   it reconstructs the URL-encoded form body from the already-parsed
  json.body object using URLSearchParams. This matches how the spike
  worked and avoids adding friction for users configuring the webhook.
  - Moved identity parsing into the resolver: Previously the extractor
   parsed user_id/team_id from the Slack payload and set the user ID
  as the context identity. This logic has been moved into
  SlackSignatureIdentifier (the resolver), centralizing all identity
  resolution and signature verification in one place. The extractor
  now passes the reconstructed raw body as the identity, and the
  resolver is responsible for verifying the Slack signature and
  deriving the storage key.

  ## How to test:

  1. Add the dynamic-creds-test Slack app to a channel
  2. Call the /test-get-emails slash command (app configured at
  https://api.slack.com/apps/A0AGW5T570C/general)
  3. The related n8n workflow should execute and return results — no
  "Raw Body" setting needed on the webhook node https://test-iam211-slack-cred-rs.stage-app.n8n.cloud/workflow/p4dN8dHH35Jm6FmJ

  ## Related Linear tickets, Github issues, and Community forum posts

 https://linear.app/n8n/issue/IAM-211

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
