### PR TITLE
fix(instance-ai): Derive untestable trigger labels from code instead of hardcoding in prompt

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
@@ -44,6 +44,14 @@ const UNTESTABLE_TRIGGERS = new Set([
 	'@n8n/n8n-nodes-langchain.chatTrigger',
 ]);
 
+/** Human-readable label derived from a node type string, e.g. "n8n-nodes-base.formTrigger" → "form" */
+function triggerLabel(nodeType: string): string {
+	const short = nodeType.split('.').pop() ?? nodeType;
+	return short.replace(/Trigger$/i, '').toLowerCase() || short.toLowerCase();
+}
+
+const UNTESTABLE_TRIGGER_LABELS = [...UNTESTABLE_TRIGGERS].map(triggerLabel).join(', ');
+
 function detectTriggerType(attempt: SubmitWorkflowAttempt | undefined): TriggerType {
 	if (!attempt?.triggerNodeTypes || attempt.triggerNodeTypes.length === 0) {
 		return 'manual_or_testable';
@@ -94,7 +102,7 @@ You are running as a detached background task. Do not stop after a successful su
 
 Your job is done when ONE of these is true:
 - the workflow is verified (ran successfully or publish-workflow succeeded)
-- the workflow uses only event triggers (webhook, form, schedule) and cannot be runtime-tested — publish it and stop
+- the workflow uses only event triggers (${UNTESTABLE_TRIGGER_LABELS}) and cannot be runtime-tested — publish it and stop
 - you are blocked after one repair attempt per unique failure
 
 ### Submit discipline


### PR DESCRIPTION
## Summary
- The builder prompt hardcoded "webhook, form, schedule" as untestable event triggers, but `scheduleTrigger` is **not** in `UNTESTABLE_TRIGGERS` and can be test-fired — causing the builder to skip runtime testing for schedule-trigger workflows
- Now the prompt dynamically derives human-readable labels from the `UNTESTABLE_TRIGGERS` set via a `triggerLabel()` helper, so the prompt and code logic stay in sync automatically

## Related
https://www.notion.so/Builder-thinks-that-a-schedule-trigger-can-t-be-runtime-tested-32f5b6e0c94f80fba7acec534cef5ae6

## Test plan
- [ ] Verify `UNTESTABLE_TRIGGER_LABELS` resolves to `"webhook, form, mcp, chat"`
- [ ] Confirm a workflow with only a Schedule Trigger proceeds to runtime verification instead of being skipped
- [ ] Adding/removing entries in `UNTESTABLE_TRIGGERS` automatically updates the prompt text