### PR TITLE
fix(instance-ai): Seamless orchestrator-to-builder handover (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -84,7 +84,9 @@ To fix or modify an existing workflow, use a \`build-workflow\` task (via \`plan
 
 The detached builder handles node discovery, schema lookups, resource discovery, code generation, validation, and saving. Describe **what** to build (or fix), not **how**: user goal, integrations, credential names, data flow, data table schemas. Don't specify node types or parameter configurations.
 
-Planned build tasks run in the background. After calling \`plan\`, acknowledge briefly in one sentence and end your turn.
+Always pass \`conversationContext\` when spawning any background agent (\`build-workflow-with-agent\`, \`delegate\`, \`research-with-agent\`, \`manage-data-tables-with-agent\`) — summarize what was discussed, decisions made, and information gathered (credentials found, user preferences, etc.). This lets the agent continue naturally without repeating what the user already knows.
+
+**After spawning any background agent** (\`build-workflow-with-agent\`, \`delegate\`, or a \`plan\`): do NOT write any acknowledgement, status update, or filler text. The agent's progress is visible to the user in real time. End your turn immediately and silently. The only exception is \`plan\`, where you may acknowledge briefly in one sentence before ending your turn.
 
 **Credentials**: Call \`list-credentials\` first to know what's available. Build the workflow immediately — the builder auto-resolves available credentials and auto-mocks missing ones. Planned builder tasks handle their own verification and credential finalization flow. For direct builds, after verification succeeds with mocked credentials, call \`setup-workflow\` with the workflowId to let the user configure real credentials, parameters, and triggers through the setup UI.
 

--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -86,7 +86,7 @@ The detached builder handles node discovery, schema lookups, resource discovery,
 
 Always pass \`conversationContext\` when spawning any background agent (\`build-workflow-with-agent\`, \`delegate\`, \`research-with-agent\`, \`manage-data-tables-with-agent\`) — summarize what was discussed, decisions made, and information gathered (credentials found, user preferences, etc.). This lets the agent continue naturally without repeating what the user already knows.
 
-**After spawning any background agent** (\`build-workflow-with-agent\`, \`delegate\`, or a \`plan\`): do NOT write any acknowledgement, status update, or filler text. The agent's progress is visible to the user in real time. End your turn immediately and silently. The only exception is \`plan\`, where you may acknowledge briefly in one sentence before ending your turn.
+**After spawning any background agent** (\`build-workflow-with-agent\`, \`delegate\`, or a \`plan\`): you may write ONE short sentence (max 15 words) to acknowledge what's happening — e.g. the name of the workflow being built or a brief note. Do NOT summarize the plan, list credentials, describe what the agent will do, or add status details. The agent's progress is already visible to the user in real time.
 
 **Credentials**: Call \`list-credentials\` first to know what's available. Build the workflow immediately — the builder auto-resolves available credentials and auto-mocks missing ones. Planned builder tasks handle their own verification and credential finalization flow. For direct builds, after verification succeeds with mocked credentials, call \`setup-workflow\` with the workflowId to let the user configure real credentials, parameters, and triggers through the setup UI.
 

--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -86,7 +86,7 @@ The detached builder handles node discovery, schema lookups, resource discovery,
 
 Always pass \`conversationContext\` when spawning any background agent (\`build-workflow-with-agent\`, \`delegate\`, \`research-with-agent\`, \`manage-data-tables-with-agent\`) — summarize what was discussed, decisions made, and information gathered (credentials found, user preferences, etc.). This lets the agent continue naturally without repeating what the user already knows.
 
-**After spawning any background agent** (\`build-workflow-with-agent\`, \`delegate\`, or a \`plan\`): you may write ONE short sentence (max 15 words) to acknowledge what's happening — e.g. the name of the workflow being built or a brief note. Do NOT summarize the plan, list credentials, describe what the agent will do, or add status details. The agent's progress is already visible to the user in real time.
+**After spawning any background agent** (\`build-workflow-with-agent\`, \`delegate\`, or a \`plan\`): you may write one short sentence to acknowledge what's happening — e.g. the name of the workflow being built or a brief note. Do NOT summarize the plan, list credentials, describe what the agent will do, or add status details. The agent's progress is already visible to the user in real time.
 
 **Credentials**: Call \`list-credentials\` first to know what's available. Build the workflow immediately — the builder auto-resolves available credentials and auto-mocks missing ones. Planned builder tasks handle their own verification and credential finalization flow. For direct builds, after verification succeeds with mocked credentials, call \`setup-workflow\` with the workflowId to let the user configure real credentials, parameters, and triggers through the setup UI.
 

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.prompt.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.prompt.ts
@@ -489,10 +489,11 @@ Always use the IDs from \`explore-node-resources\` results inside the RLC \`valu
 export const BUILDER_AGENT_PROMPT = `You are an expert n8n workflow builder. You generate complete, valid TypeScript code using the @n8n/workflow-sdk.
 
 ## Output Discipline
-- You report to a parent agent, not a human. Be terse.
+- Your text output is visible to the user. Be concise but natural.
 - Do NOT narrate your process ("I'll build this step by step", "Let me start by"). Just do the work.
 - No emojis, no filler phrases, no markdown headers in your text output.
-- Only output text for: errors that need attention, or a final one-line summary of what was built.
+- When conversation context is provided, use it to continue naturally — do not repeat information the user already knows.
+- Only output text for: errors that need attention, or a brief natural completion message.
 
 ## Repair Strategy
 When called with failure details for an existing workflow, start from the pre-loaded code — do not re-discover node types already present.
@@ -506,7 +507,7 @@ When called with failure details for an existing workflow, start from the pre-lo
 2. **Build**: Write TypeScript SDK code and call \`build-workflow\`. Follow the SDK patterns below exactly.
 3. **Fix errors**: If \`build-workflow\` returns errors, use **patch mode**: call \`build-workflow\` with \`patches\` (array of \`{old_str, new_str}\` replacements). Patches apply to your last submitted code, or auto-fetch from the saved workflow if \`workflowId\` is given. Much faster than resending full code.
 4. **Modify existing workflows**: When updating a workflow, call \`build-workflow\` with \`workflowId\` + \`patches\`. The tool fetches the current code and applies your patches. Use \`get-workflow-as-code\` first to see the current code if you need to identify what to replace.
-4. **Done**: When \`build-workflow\` succeeds, output ONE sentence summarizing what was built.
+4. **Done**: When \`build-workflow\` succeeds, output a brief, natural completion message.
 
 Do NOT produce visible output until step 4. All reasoning happens internally.
 
@@ -541,10 +542,11 @@ ${SDK_RULES_AND_PATTERNS}
 export const SANDBOX_BUILDER_AGENT_PROMPT = `You are an expert n8n workflow builder working inside a sandbox with real TypeScript tooling. You write workflow code as files and use \`tsc\` for validation.
 
 ## Output Discipline
-- You report to a parent agent, not a human. Be terse.
+- Your text output is visible to the user. Be concise but natural.
 - Do NOT narrate your process ("I'll build this step by step", "Let me start by"). Just do the work.
 - No emojis, no filler phrases, no markdown headers in your text output.
-- Only output text for: errors that need attention, or a final one-line summary of what was built.
+- When conversation context is provided, use it to continue naturally — do not repeat information the user already knows.
+- Only output text for: errors that need attention, or a brief natural completion message.
 
 ## Workspace Layout
 

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
@@ -141,6 +141,7 @@ function hashContent(content: string | null): string {
 export interface StartBuildWorkflowAgentInput {
 	task: string;
 	workflowId?: string;
+	conversationContext?: string;
 	taskId?: string;
 	agentId?: string;
 	plannedTaskId?: string;
@@ -283,17 +284,21 @@ export async function startBuildWorkflowAgentTask(
 		}
 	}
 
+	const conversationCtx = input.conversationContext
+		? `\n\n[CONVERSATION CONTEXT: ${input.conversationContext}]`
+		: '';
+
 	let briefing: string;
 	if (useSandbox) {
 		if (workflowId) {
-			briefing = `${input.task}\n\n[CONTEXT: Modifying existing workflow ${workflowId}. The current code is pre-loaded in ~/workspace/src/workflow.ts — read it first, then edit. Use workflowId "${workflowId}" when calling submit-workflow.]\n\n[WORK ITEM ID: ${workItemId}]\n\n${DETACHED_BUILDER_REQUIREMENTS}${iterationContext ? `\n\n${iterationContext}` : ''}`;
+			briefing = `${input.task}${conversationCtx}\n\n[CONTEXT: Modifying existing workflow ${workflowId}. The current code is pre-loaded in ~/workspace/src/workflow.ts — read it first, then edit. Use workflowId "${workflowId}" when calling submit-workflow.]\n\n[WORK ITEM ID: ${workItemId}]\n\n${DETACHED_BUILDER_REQUIREMENTS}${iterationContext ? `\n\n${iterationContext}` : ''}`;
 		} else {
-			briefing = `${input.task}\n\n[WORK ITEM ID: ${workItemId}]\n\n${DETACHED_BUILDER_REQUIREMENTS}${iterationContext ? `\n\n${iterationContext}` : ''}`;
+			briefing = `${input.task}${conversationCtx}\n\n[WORK ITEM ID: ${workItemId}]\n\n${DETACHED_BUILDER_REQUIREMENTS}${iterationContext ? `\n\n${iterationContext}` : ''}`;
 		}
 	} else if (workflowId) {
-		briefing = `${input.task}\n\n[CONTEXT: Modifying existing workflow ${workflowId}. Use workflowId "${workflowId}" when calling build-workflow.]${iterationContext ? `\n\n${iterationContext}` : ''}`;
+		briefing = `${input.task}${conversationCtx}\n\n[CONTEXT: Modifying existing workflow ${workflowId}. Use workflowId "${workflowId}" when calling build-workflow.]${iterationContext ? `\n\n${iterationContext}` : ''}`;
 	} else {
-		briefing = `${input.task}${iterationContext ? `\n\n${iterationContext}` : ''}`;
+		briefing = `${input.task}${conversationCtx}${iterationContext ? `\n\n${iterationContext}` : ''}`;
 	}
 
 	context.spawnBackgroundTask({
@@ -528,7 +533,7 @@ export async function startBuildWorkflowAgentTask(
 	});
 
 	return {
-		result: `Workflow build started (task: ${taskId}). Acknowledge briefly and move on.`,
+		result: `Workflow build started (task: ${taskId}). Do NOT write any text to the user — the builder is already visible. End your turn silently.`,
 		taskId,
 		agentId: subAgentId,
 	};
@@ -552,6 +557,12 @@ export function createBuildWorkflowAgentTool(context: OrchestrationContext) {
 				.optional()
 				.describe(
 					'Existing workflow ID to modify. When provided, the agent starts with the current workflow code pre-loaded.',
+				),
+			conversationContext: z
+				.string()
+				.optional()
+				.describe(
+					'Brief summary of the conversation so far — what was discussed, decisions made, and information gathered (e.g., which credentials are available). The builder uses this to avoid repeating information the user already knows.',
 				),
 		}),
 		outputSchema: z.object({

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
@@ -533,7 +533,7 @@ export async function startBuildWorkflowAgentTask(
 	});
 
 	return {
-		result: `Workflow build started (task: ${taskId}). Do NOT write any text to the user — the builder is already visible. End your turn silently.`,
+		result: `Workflow build started (task: ${taskId}). Reply with ONE short sentence (max 15 words) — e.g. name what's being built. Do NOT summarize the plan or list details.`,
 		taskId,
 		agentId: subAgentId,
 	};

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
@@ -533,7 +533,7 @@ export async function startBuildWorkflowAgentTask(
 	});
 
 	return {
-		result: `Workflow build started (task: ${taskId}). Reply with ONE short sentence (max 15 words) — e.g. name what's being built. Do NOT summarize the plan or list details.`,
+		result: `Workflow build started (task: ${taskId}). Reply with one short sentence — e.g. name what's being built. Do NOT summarize the plan or list details.`,
 		taskId,
 		agentId: subAgentId,
 	};

--- a/packages/@n8n/instance-ai/src/tools/orchestration/data-table-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/data-table-agent.tool.ts
@@ -156,7 +156,7 @@ export function startDataTableAgentTask(
 	});
 
 	return {
-		result: `Data table operation started (task: ${taskId}). Do NOT write any text to the user — the agent is already visible. End your turn silently.`,
+		result: `Data table operation started (task: ${taskId}). Reply with ONE short sentence (max 15 words). Do NOT summarize the plan or list details.`,
 		taskId,
 		agentId: subAgentId,
 	};

--- a/packages/@n8n/instance-ai/src/tools/orchestration/data-table-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/data-table-agent.tool.ts
@@ -156,7 +156,7 @@ export function startDataTableAgentTask(
 	});
 
 	return {
-		result: `Data table operation started (task: ${taskId}). Reply with ONE short sentence (max 15 words). Do NOT summarize the plan or list details.`,
+		result: `Data table operation started (task: ${taskId}). Reply with one short sentence. Do NOT summarize the plan or list details.`,
 		taskId,
 		agentId: subAgentId,
 	};

--- a/packages/@n8n/instance-ai/src/tools/orchestration/data-table-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/data-table-agent.tool.ts
@@ -37,6 +37,7 @@ const DATA_TABLE_TOOL_NAMES = [
 
 export interface StartDataTableAgentInput {
 	task: string;
+	conversationContext?: string;
 	taskId?: string;
 	agentId?: string;
 	plannedTaskId?: string;
@@ -121,7 +122,12 @@ export function startDataTableAgentTask(
 					}
 				: undefined;
 
-			const stream = await subAgent.stream(input.task, {
+			const conversationCtx = input.conversationContext
+				? `\n\n[CONVERSATION CONTEXT: ${input.conversationContext}]`
+				: '';
+			const briefing = `${input.task}${conversationCtx}`;
+
+			const stream = await subAgent.stream(briefing, {
 				maxSteps: DATA_TABLE_MAX_STEPS,
 				abortSignal: signal,
 				providerOptions: {
@@ -150,7 +156,7 @@ export function startDataTableAgentTask(
 	});
 
 	return {
-		result: `Data table operation started (task: ${taskId}). Acknowledge briefly and move on.`,
+		result: `Data table operation started (task: ${taskId}). Do NOT write any text to the user — the agent is already visible. End your turn silently.`,
 		taskId,
 		agentId: subAgentId,
 	};
@@ -168,6 +174,12 @@ export function createDataTableAgentTool(context: OrchestrationContext) {
 				.string()
 				.describe(
 					'What to do: describe the data table operation. Include table names, column details, data to insert, or query criteria.',
+				),
+			conversationContext: z
+				.string()
+				.optional()
+				.describe(
+					'Brief summary of the conversation so far — what was discussed, decisions made, and information gathered. The agent uses this to avoid repeating information the user already knows.',
 				),
 		}),
 		outputSchema: z.object({

--- a/packages/@n8n/instance-ai/src/tools/orchestration/delegate.schemas.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/delegate.schemas.ts
@@ -18,6 +18,12 @@ export const delegateInputSchema = z.object({
 		.record(z.unknown())
 		.optional()
 		.describe('Relevant IDs, data, or context (workflow IDs, credential IDs, etc.)'),
+	conversationContext: z
+		.string()
+		.optional()
+		.describe(
+			'Brief summary of the conversation so far — what was discussed, decisions made, and information gathered. The sub-agent uses this to avoid repeating information the user already knows.',
+		),
 });
 
 export type DelegateInput = z.infer<typeof delegateInputSchema>;

--- a/packages/@n8n/instance-ai/src/tools/orchestration/delegate.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/delegate.tool.ts
@@ -206,7 +206,7 @@ export async function startDetachedDelegateTask(
 	});
 
 	return {
-		result: `Delegation started (task: ${taskId}). Reply with ONE short sentence (max 15 words). Do NOT summarize the plan or list details.`,
+		result: `Delegation started (task: ${taskId}). Reply with one short sentence. Do NOT summarize the plan or list details.`,
 		taskId,
 		agentId: subAgentId,
 	};

--- a/packages/@n8n/instance-ai/src/tools/orchestration/delegate.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/delegate.tool.ts
@@ -55,8 +55,12 @@ async function buildDelegateBriefing(
 	role: string,
 	briefing: string,
 	artifacts?: unknown,
+	conversationContext?: string,
 ): Promise<string> {
 	const serializedArtifacts = artifacts ? `\n\nArtifacts: ${JSON.stringify(artifacts)}` : '';
+	const conversationCtx = conversationContext
+		? `\n\n[CONVERSATION CONTEXT: ${conversationContext}]`
+		: '';
 
 	let iterationContext = '';
 	if (context.iterationLog) {
@@ -69,7 +73,7 @@ async function buildDelegateBriefing(
 		}
 	}
 
-	return `${briefing}${serializedArtifacts}${iterationContext ? `\n\n${iterationContext}` : ''}\n\nRemember: ${SUB_AGENT_PROTOCOL}`;
+	return `${briefing}${conversationCtx}${serializedArtifacts}${iterationContext ? `\n\n${iterationContext}` : ''}\n\nRemember: ${SUB_AGENT_PROTOCOL}`;
 }
 
 export interface DetachedDelegateTaskInput {
@@ -77,6 +81,7 @@ export interface DetachedDelegateTaskInput {
 	spec: string;
 	tools: string[];
 	artifacts?: unknown;
+	conversationContext?: string;
 	taskId?: string;
 	agentId?: string;
 	plannedTaskId?: string;
@@ -137,7 +142,13 @@ export async function startDetachedDelegateTask(
 		},
 	});
 
-	const briefingMessage = await buildDelegateBriefing(context, role, input.spec, input.artifacts);
+	const briefingMessage = await buildDelegateBriefing(
+		context,
+		role,
+		input.spec,
+		input.artifacts,
+		input.conversationContext,
+	);
 
 	context.spawnBackgroundTask({
 		taskId,
@@ -195,7 +206,7 @@ export async function startDetachedDelegateTask(
 	});
 
 	return {
-		result: `Delegation started (task: ${taskId}). Acknowledge briefly and move on.`,
+		result: `Delegation started (task: ${taskId}). Do NOT write any text to the user — the agent is already visible. End your turn silently.`,
 		taskId,
 		agentId: subAgentId,
 	};
@@ -263,6 +274,7 @@ export function createDelegateTool(context: OrchestrationContext) {
 					input.role,
 					input.briefing,
 					input.artifacts,
+					input.conversationContext,
 				);
 
 				// 5. Stream sub-agent with HITL support

--- a/packages/@n8n/instance-ai/src/tools/orchestration/delegate.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/delegate.tool.ts
@@ -206,7 +206,7 @@ export async function startDetachedDelegateTask(
 	});
 
 	return {
-		result: `Delegation started (task: ${taskId}). Do NOT write any text to the user — the agent is already visible. End your turn silently.`,
+		result: `Delegation started (task: ${taskId}). Reply with ONE short sentence (max 15 words). Do NOT summarize the plan or list details.`,
 		taskId,
 		agentId: subAgentId,
 	};

--- a/packages/@n8n/instance-ai/src/tools/orchestration/research-with-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/research-with-agent.tool.ts
@@ -22,6 +22,7 @@ const RESEARCH_MAX_STEPS = 25;
 export interface StartResearchAgentInput {
 	goal: string;
 	constraints?: string;
+	conversationContext?: string;
 	taskId?: string;
 	agentId?: string;
 	plannedTaskId?: string;
@@ -72,9 +73,12 @@ export function startResearchAgentTask(
 		},
 	});
 
+	const conversationCtx = input.conversationContext
+		? `\n\n[CONVERSATION CONTEXT: ${input.conversationContext}]`
+		: '';
 	const briefing = input.constraints
-		? `${input.goal}\n\nConstraints: ${input.constraints}`
-		: input.goal;
+		? `${input.goal}${conversationCtx}\n\nConstraints: ${input.constraints}`
+		: `${input.goal}${conversationCtx}`;
 
 	context.spawnBackgroundTask({
 		taskId,
@@ -124,7 +128,7 @@ export function startResearchAgentTask(
 	});
 
 	return {
-		result: `Research started (task: ${taskId}). Acknowledge briefly and move on.`,
+		result: `Research started (task: ${taskId}). Do NOT write any text to the user — the agent is already visible. End your turn silently.`,
 		taskId,
 		agentId: subAgentId,
 	};
@@ -149,6 +153,12 @@ export function createResearchWithAgentTool(context: OrchestrationContext) {
 				.string()
 				.optional()
 				.describe('Optional constraints, e.g. "Focus on REST API, not GraphQL"'),
+			conversationContext: z
+				.string()
+				.optional()
+				.describe(
+					'Brief summary of the conversation so far — what was discussed, decisions made, and information gathered. The agent uses this to avoid repeating information the user already knows.',
+				),
 		}),
 		outputSchema: z.object({
 			result: z.string(),

--- a/packages/@n8n/instance-ai/src/tools/orchestration/research-with-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/research-with-agent.tool.ts
@@ -128,7 +128,7 @@ export function startResearchAgentTask(
 	});
 
 	return {
-		result: `Research started (task: ${taskId}). Do NOT write any text to the user — the agent is already visible. End your turn silently.`,
+		result: `Research started (task: ${taskId}). Reply with ONE short sentence (max 15 words). Do NOT summarize the plan or list details.`,
 		taskId,
 		agentId: subAgentId,
 	};

--- a/packages/@n8n/instance-ai/src/tools/orchestration/research-with-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/research-with-agent.tool.ts
@@ -128,7 +128,7 @@ export function startResearchAgentTask(
 	});
 
 	return {
-		result: `Research started (task: ${taskId}). Reply with ONE short sentence (max 15 words). Do NOT summarize the plan or list details.`,
+		result: `Research started (task: ${taskId}). Reply with one short sentence. Do NOT summarize the plan or list details.`,
 		taskId,
 		agentId: subAgentId,
 	};


### PR DESCRIPTION
## Summary

- Constrain the orchestrator to **one short sentence** after spawning background agents — no more verbose status updates like "Your workflow is being built with OpenWeatherMap and Email credentials, using a schedule trigger...". The agent's progress is already visible to the user in real time via the agent card UI.
- Add `conversationContext` parameter to **all sub-agent tools** (`build-workflow-with-agent`, `delegate`, `research-with-agent`, `manage-data-tables-with-agent`) so the orchestrator passes a summary of the conversation. This lets agents continue naturally without repeating information the user already knows.
- Update builder output discipline from "you report to a parent agent, not a human" to "your text output is visible to the user" for more natural, user-facing completion messages.

## Test plan

- [x] Typecheck passes (`pnpm typecheck`)
- [x] All 467 unit tests pass (`pnpm test`)
- [ ] Manual test: Start an Instance AI conversation, ask it to build a workflow, and confirm:
  - The orchestrator replies with only a brief sentence after spawning the builder
  - The builder picks up naturally without repeating what was discussed
  - The conversation flows as one seamless thread