### PR TITLE
build: Stabilize lodash resolution with rolldown

### DIFF
--- a/packages/@n8n/ai-utilities/package.json
+++ b/packages/@n8n/ai-utilities/package.json
@@ -48,6 +48,7 @@
     "@langchain/textsplitters": "1.0.1",
     "@langchain/openai": "catalog:",
     "langchain": "catalog:",
+    "lodash": "catalog:",
     "@n8n/config": "workspace:*",
     "@n8n/typescript-config": "workspace:*",
     "tmp-promise": "3.0.3",

--- a/packages/@n8n/workflow-sdk/package.json
+++ b/packages/@n8n/workflow-sdk/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "acorn": "8.14.0",
+    "lodash": "catalog:",
     "n8n-workflow": "workspace:*",
     "uuid": "catalog:",
     "zod": "catalog:"

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -71,6 +71,9 @@ const alias = [
 		find: /^@n8n\/utils(.+)$/,
 		replacement: resolve(packagesDir, '@n8n', 'utils', 'src$1'),
 	},
+	// Keep vue-agile imports on their modular lodash packages.
+	{ find: /^lodash\.throttle$/i, replacement: 'lodash.throttle' },
+	{ find: /^lodash\.orderby$/i, replacement: 'lodash.orderby' },
 	...['orderBy', 'camelCase', 'cloneDeep', 'startCase'].map((name) => ({
 		find: new RegExp(`^lodash.${name}$`, 'i'),
 		replacement: `lodash/${name}`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -616,6 +616,9 @@ importers:
       langchain:
         specifier: 'catalog:'
         version: 1.2.30(@langchain/core@1.1.34(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vue@3.5.26(typescript@5.9.2))(zod-to-json-schema@3.23.3(zod@3.25.67))
+      lodash:
+        specifier: 'catalog:'
+        version: 4.17.23
       proxy-from-env:
         specifier: ^1.1.0
         version: 1.1.0
@@ -1994,6 +1997,9 @@ importers:
       acorn:
         specifier: 8.14.0
         version: 8.14.0
+      lodash:
+        specifier: 'catalog:'
+        version: 4.17.23
       n8n-workflow:
         specifier: workspace:*
         version: link:../../workflow


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

- add explicit `lodash` dependencies to packages that import lodash in runtime code
- update editor-ui alias mapping so rolldown resolves `lodash.throttle` and `lodash.orderby` used by `vue-agile`
- stabilize lodash module resolution so builds are less dependent on hoisting and local cache state

### Notes

I initially hit lodash resolution errors during the rolldown migration, including failures resolving `lodash.throttle` and `lodash.orderby`.
After cleaning local artifacts and caches (`git clean -xfd`, `turbo clean`) and reinstalling dependencies, the build passed again.

This suggests the issue is at least partly environment- or cache-sensitive. Even so, these changes make dependency resolution more explicit and reduce reliance on hoisted dependencies and local cache state.

### How to test

- `git clean -xfd`
- `turbo clean`
- `pnpm i`
- `pnpm build`

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
