### PR TITLE
feat(core): Add binary file pruning service

### DIFF
--- a/packages/@n8n/config/src/configs/binary-data-pruning.config.ts
+++ b/packages/@n8n/config/src/configs/binary-data-pruning.config.ts
@@ -1,0 +1,16 @@
+import { Config, Env } from '../decorators';
+
+@Config
+export class BinaryDataPruningConfig {
+	/** Max disk usage in MiB for binary data. 0 = pruning disabled. */
+	@Env('N8N_BINARY_DATA_STORAGE_QUOTA_MIB')
+	quotaMiB: number = 0;
+
+	/** Minutes between pruning checks. */
+	@Env('N8N_BINARY_DATA_PRUNING_INTERVAL')
+	intervalMinutes: number = 60;
+
+	/** Max execution dirs to delete per pruning pass. */
+	@Env('N8N_BINARY_DATA_PRUNING_BATCH_SIZE')
+	batchSize: number = 100;
+}

--- a/packages/@n8n/config/src/index.ts
+++ b/packages/@n8n/config/src/index.ts
@@ -4,6 +4,7 @@ import { AiAssistantConfig } from './configs/ai-assistant.config';
 import { AiBuilderConfig } from './configs/ai-builder.config';
 import { AiConfig } from './configs/ai.config';
 import { AuthConfig } from './configs/auth.config';
+import { BinaryDataPruningConfig } from './configs/binary-data-pruning.config';
 import { CacheConfig } from './configs/cache.config';
 import { ChatHubConfig } from './configs/chat-hub.config';
 import { CredentialsConfig } from './configs/credentials.config';
@@ -43,6 +44,7 @@ import { Config, Env, Nested } from './decorators';
 
 export { Config, Env, Nested } from './decorators';
 export { AiConfig } from './configs/ai.config';
+export { BinaryDataPruningConfig } from './configs/binary-data-pruning.config';
 export { DatabaseConfig, SqliteConfig } from './configs/database.config';
 export { InstanceSettingsConfig } from './configs/instance-settings-config';
 export { sampleRateSchema } from './configs/sentry.config';
@@ -241,4 +243,7 @@ export class GlobalConfig {
 
 	@Nested
 	chatHub: ChatHubConfig;
+
+	@Nested
+	binaryDataPruning: BinaryDataPruningConfig;
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -256,6 +256,11 @@ describe('GlobalConfig', () => {
 			maxBufferedChunks: 1000,
 			streamStateTtl: 300,
 		},
+		binaryDataPruning: {
+			quotaMiB: 0,
+			intervalMinutes: 60,
+			batchSize: 100,
+		},
 		queue: {
 			health: {
 				active: false,

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -15,6 +15,7 @@ import {
 	IsNull,
 	LessThan,
 	LessThanOrEqual,
+	MoreThan,
 	MoreThanOrEqual,
 	Not,
 	Repository,
@@ -56,6 +57,9 @@ import type {
 	IExecutionResponse,
 } from '../entities/types-db';
 import { separate } from '../utils/separate';
+
+/** Execution statuses that indicate the execution is still in progress. */
+const IN_PROGRESS_STATUSES: ExecutionStatus[] = ['new', 'running', 'waiting'];
 
 class PostgresLiveRowsRetrievalError extends UnexpectedError {
 	constructor(rows: unknown) {
@@ -556,7 +560,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			.where({
 				deletedAt: IsNull(),
 				// Only mark executions as deleted if they are in an end state
-				status: Not(In(['new', 'running', 'waiting'])),
+				status: Not(In(IN_PROGRESS_STATUSES)),
 			})
 			// Only mark executions as deleted if they are not annotated
 			.andWhere('id NOT IN ' + annotatedExecutionsSubQuery.getQuery())
@@ -593,6 +597,26 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			executionId,
 			storedAt,
 		}));
+	}
+
+	/**
+	 * Return completed executions ordered by ID ascending, optionally starting
+	 * after `afterId`. Excludes in-progress executions (new, running, waiting).
+	 */
+	async findCompletedExecutionsAfter(afterId: string | undefined, batchSize: number) {
+		const where: FindOptionsWhere<ExecutionEntity> = {
+			status: Not(In(IN_PROGRESS_STATUSES)),
+			...(afterId && { id: MoreThan(afterId) }),
+		};
+
+		const results = await this.find({
+			select: ['id', 'workflowId'],
+			where,
+			order: { id: 'ASC' },
+			take: batchSize,
+		});
+
+		return results.map(({ id, workflowId }) => ({ executionId: id, workflowId }));
 	}
 
 	async deleteByIds(executionIds: string[]) {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -28,6 +28,7 @@ import { PubSubRegistry } from '@/scaling/pubsub/pubsub.registry';
 import { Subscriber } from '@/scaling/pubsub/subscriber.service';
 import { Server } from '@/server';
 import { OwnershipService } from '@/services/ownership.service';
+import { BinaryDataPruningService } from '@/services/pruning/binary-data-pruning.service';
 import { ExecutionsPruningService } from '@/services/pruning/executions-pruning.service';
 import { UrlService } from '@/services/url.service';
 import { WaitTracker } from '@/wait-tracker';
@@ -358,6 +359,7 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 		await this.server.start();
 
 		Container.get(ExecutionsPruningService).init();
+		Container.get(BinaryDataPruningService).init();
 		Container.get(WorkflowHistoryCompactionService).init();
 
 		if (this.globalConfig.executions.mode === 'regular') {

--- a/packages/cli/src/services/pruning/__tests__/binary-data-pruning.service.test.ts
+++ b/packages/cli/src/services/pruning/__tests__/binary-data-pruning.service.test.ts
@@ -1,0 +1,292 @@
+import { mockLogger } from '@n8n/backend-test-utils';
+import type { BinaryDataPruningConfig } from '@n8n/config';
+import type { DbConnection, ExecutionRepository } from '@n8n/db';
+import { mock } from 'jest-mock-extended';
+import type { BinaryDataConfig, BinaryDataService, InstanceSettings } from 'n8n-core';
+
+import { BinaryDataPruningService } from '../binary-data-pruning.service';
+
+describe('BinaryDataPruningService', () => {
+	const dbConnection = mock<DbConnection>({
+		connectionState: { migrated: true },
+	});
+
+	function createService({
+		isLeader = true,
+		instanceType = 'main' as const,
+		quotaMiB = 100,
+		binaryDataMode = 'filesystem' as const,
+		intervalMinutes = 60,
+		batchSize = 100,
+		executionRepository = mock<ExecutionRepository>(),
+		binaryDataService = mock<BinaryDataService>(),
+	} = {}) {
+		const instanceSettings = mock<InstanceSettings>({
+			isLeader,
+			instanceType,
+			isMultiMain: true,
+		});
+
+		const binaryDataConfig = mock<BinaryDataConfig>({
+			mode: binaryDataMode,
+			localStoragePath: '/tmp/n8n/storage',
+		});
+
+		const pruningConfig = mock<BinaryDataPruningConfig>({
+			quotaMiB,
+			intervalMinutes,
+			batchSize,
+		});
+
+		const service = new BinaryDataPruningService(
+			mockLogger(),
+			instanceSettings,
+			dbConnection,
+			executionRepository,
+			binaryDataService,
+			binaryDataConfig,
+			pruningConfig,
+		);
+
+		return { service, instanceSettings, executionRepository, binaryDataService };
+	}
+
+	describe('init', () => {
+		it('should start pruning on main instance that is the leader', () => {
+			const { service } = createService();
+			const spy = jest.spyOn(service, 'startPruning');
+
+			service.init();
+
+			expect(spy).toHaveBeenCalled();
+		});
+
+		it('should not start pruning on follower', () => {
+			const { service } = createService({ isLeader: false });
+			const spy = jest.spyOn(service, 'startPruning');
+
+			service.init();
+
+			expect(spy).not.toHaveBeenCalled();
+		});
+
+		it('should throw if quota is set but mode is not filesystem', () => {
+			const { service } = createService({ binaryDataMode: 's3' as 'filesystem' });
+
+			expect(() => service.init()).toThrow(
+				'Binary data pruning is only supported in filesystem mode',
+			);
+		});
+
+		it('should not throw if quota is 0 regardless of mode', () => {
+			const { service } = createService({ quotaMiB: 0, binaryDataMode: 's3' as 'filesystem' });
+
+			expect(() => service.init()).not.toThrow();
+		});
+	});
+
+	describe('isEnabled', () => {
+		it('should return true when quota > 0 and leader main', () => {
+			const { service } = createService({ quotaMiB: 100 });
+
+			expect(service.isEnabled).toBe(true);
+		});
+
+		it('should return false when quota is 0', () => {
+			const { service } = createService({ quotaMiB: 0 });
+
+			expect(service.isEnabled).toBe(false);
+		});
+
+		it('should return false when not leader', () => {
+			const { service } = createService({ isLeader: false });
+
+			expect(service.isEnabled).toBe(false);
+		});
+
+		it('should return false when not main instance type', () => {
+			const { service } = createService({ instanceType: 'worker' as 'main' });
+
+			expect(service.isEnabled).toBe(false);
+		});
+	});
+
+	describe('startPruning', () => {
+		it('should not schedule if service is disabled', () => {
+			const { service } = createService({ quotaMiB: 0 });
+			const spy = jest.spyOn(
+				service,
+				// @ts-expect-error Private method
+				'scheduleNextPruning',
+			);
+
+			service.startPruning();
+
+			expect(spy).not.toHaveBeenCalled();
+		});
+
+		it('should schedule if service is enabled and DB is migrated', () => {
+			const { service } = createService();
+			const spy = jest
+				// @ts-expect-error Private method
+				.spyOn(service, 'scheduleNextPruning')
+				.mockImplementation();
+
+			service.startPruning();
+
+			expect(spy).toHaveBeenCalled();
+		});
+	});
+
+	describe('stopPruning', () => {
+		afterEach(() => jest.restoreAllMocks());
+
+		it('should clear timeout when stopping', () => {
+			const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+
+			const { service } = createService();
+
+			// Simulate an active timer
+			// @ts-expect-error Private field
+			service.pruningTimeout = setTimeout(() => {}, 100_000);
+
+			service.stopPruning();
+
+			expect(clearTimeoutSpy).toHaveBeenCalled();
+		});
+	});
+
+	describe('prune', () => {
+		it('should do nothing when under quota', async () => {
+			const { service, binaryDataService } = createService({ quotaMiB: 100 });
+			binaryDataService.getTotalStorageSize.mockResolvedValue(50 * 1024 * 1024); // 50 MiB
+
+			const delay = await service.prune();
+
+			expect(delay).toBe(60 * 60 * 1000); // intervalMinutes in ms
+			expect(binaryDataService.deleteMany).not.toHaveBeenCalled();
+		});
+
+		it('should delete binary data for oldest executions when over quota', async () => {
+			const executionRepository = mock<ExecutionRepository>();
+			const binaryDataService = mock<BinaryDataService>();
+			const { service } = createService({ quotaMiB: 10, executionRepository, binaryDataService });
+
+			// Prevent restart fast-forward from triggering
+			jest
+				.spyOn(service as never, 'executionBinaryDataExists' as never)
+				.mockResolvedValue(true as never);
+
+			binaryDataService.getTotalStorageSize
+				.mockResolvedValueOnce(20 * 1024 * 1024) // 20 MiB - over quota
+				.mockResolvedValueOnce(5 * 1024 * 1024); // 5 MiB - under after deletion
+
+			executionRepository.findCompletedExecutionsAfter.mockResolvedValue([
+				{ executionId: '1', workflowId: 'wf1' },
+				{ executionId: '2', workflowId: 'wf1' },
+			]);
+
+			const delay = await service.prune();
+
+			expect(binaryDataService.deleteMany).toHaveBeenCalledTimes(1);
+			expect(binaryDataService.deleteMany).toHaveBeenCalledWith([
+				{ type: 'execution', workflowId: 'wf1', executionId: '1' },
+				{ type: 'execution', workflowId: 'wf1', executionId: '2' },
+			]);
+			expect(delay).toBe(60 * 60 * 1000); // back to normal interval
+		});
+
+		it('should return 1s delay when still over quota after batch', async () => {
+			const executionRepository = mock<ExecutionRepository>();
+			const binaryDataService = mock<BinaryDataService>();
+			const { service } = createService({
+				quotaMiB: 10,
+				batchSize: 2,
+				executionRepository,
+				binaryDataService,
+			});
+
+			jest
+				.spyOn(service as never, 'executionBinaryDataExists' as never)
+				.mockResolvedValue(true as never);
+
+			binaryDataService.getTotalStorageSize
+				.mockResolvedValueOnce(100 * 1024 * 1024) // way over quota
+				.mockResolvedValueOnce(90 * 1024 * 1024); // still over after batch
+
+			executionRepository.findCompletedExecutionsAfter.mockResolvedValue([
+				{ executionId: '1', workflowId: 'wf1' },
+				{ executionId: '2', workflowId: 'wf1' },
+			]);
+
+			const delay = await service.prune();
+
+			expect(binaryDataService.deleteMany).toHaveBeenCalledTimes(1);
+			expect(delay).toBe(1_000); // 1 second - need more work
+		});
+
+		it('should advance cursor across multiple prune calls', async () => {
+			const executionRepository = mock<ExecutionRepository>();
+			const binaryDataService = mock<BinaryDataService>();
+			const { service } = createService({
+				quotaMiB: 10,
+				batchSize: 2,
+				executionRepository,
+				binaryDataService,
+			});
+
+			// First call: over quota
+			binaryDataService.getTotalStorageSize
+				.mockResolvedValueOnce(20 * 1024 * 1024)
+				.mockResolvedValueOnce(15 * 1024 * 1024); // still over
+
+			executionRepository.findCompletedExecutionsAfter.mockResolvedValueOnce([
+				{ executionId: '5', workflowId: 'wf1' },
+				{ executionId: '8', workflowId: 'wf1' },
+			]);
+
+			await service.prune();
+
+			// Second call: still over quota
+			binaryDataService.getTotalStorageSize
+				.mockResolvedValueOnce(15 * 1024 * 1024)
+				.mockResolvedValueOnce(5 * 1024 * 1024); // now under
+
+			executionRepository.findCompletedExecutionsAfter.mockResolvedValueOnce([
+				{ executionId: '10', workflowId: 'wf2' },
+			]);
+
+			await service.prune();
+
+			// Verify cursor was passed correctly on second call
+			expect(executionRepository.findCompletedExecutionsAfter).toHaveBeenNthCalledWith(
+				1,
+				undefined, // no cursor on first call
+				2,
+			);
+			expect(executionRepository.findCompletedExecutionsAfter).toHaveBeenNthCalledWith(
+				2,
+				'8', // cursor from first call (last in batch)
+				2,
+			);
+		});
+
+		it('should return interval delay when no executions remain', async () => {
+			const executionRepository = mock<ExecutionRepository>();
+			const binaryDataService = mock<BinaryDataService>();
+			const { service } = createService({
+				quotaMiB: 10,
+				executionRepository,
+				binaryDataService,
+			});
+
+			binaryDataService.getTotalStorageSize.mockResolvedValue(20 * 1024 * 1024);
+			executionRepository.findCompletedExecutionsAfter.mockResolvedValue([]);
+
+			const delay = await service.prune();
+
+			expect(delay).toBe(60 * 60 * 1000);
+			expect(binaryDataService.deleteMany).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/services/pruning/binary-data-pruning.service.ts
+++ b/packages/cli/src/services/pruning/binary-data-pruning.service.ts
@@ -1,0 +1,190 @@
+import { Logger } from '@n8n/backend-common';
+import { BinaryDataPruningConfig } from '@n8n/config';
+import { Time } from '@n8n/constants';
+import { ExecutionRepository, DbConnection } from '@n8n/db';
+import { OnLeaderStepdown, OnLeaderTakeover, OnShutdown } from '@n8n/decorators';
+import { Service } from '@n8n/di';
+import { BinaryDataConfig, BinaryDataService, InstanceSettings } from 'n8n-core';
+import { ensureError, UnexpectedError } from 'n8n-workflow';
+import { strict } from 'node:assert';
+
+const MiB = 1024 * 1024;
+
+/**
+ * Responsible for deleting binary data files from disk when total storage
+ * exceeds a configurable quota.
+ *
+ * - Disabled by default (quota = 0). Opt-in via N8N_BINARY_DATA_STORAGE_QUOTA_MIB.
+ * - Only works in filesystem binary data mode.
+ * - Walks executions oldest-first (by DB ID) and deletes their binary data
+ *   directories until usage drops below the quota.
+ * - Tracks a cursor in memory to avoid re-scanning already-pruned executions.
+ * - On restart, short-circuits by checking file existence to fast-forward
+ *   the cursor past already-cleaned executions.
+ */
+@Service()
+export class BinaryDataPruningService {
+	private pruningTimeout: NodeJS.Timeout | undefined;
+
+	private isShuttingDown = false;
+
+	/** Cursor: ID of the newest execution whose binary data has been pruned. */
+	private lastPrunedExecutionId: string | undefined;
+
+	private readonly intervalMs: number;
+
+	constructor(
+		private readonly logger: Logger,
+		private readonly instanceSettings: InstanceSettings,
+		private readonly dbConnection: DbConnection,
+		private readonly executionRepository: ExecutionRepository,
+		private readonly binaryDataService: BinaryDataService,
+		private readonly binaryDataConfig: BinaryDataConfig,
+		private readonly pruningConfig: BinaryDataPruningConfig,
+	) {
+		this.logger = this.logger.scoped('pruning');
+		this.intervalMs = this.pruningConfig.intervalMinutes * Time.minutes.toMilliseconds;
+	}
+
+	init() {
+		strict(this.instanceSettings.instanceRole !== 'unset', 'Instance role is not set');
+
+		if (this.pruningConfig.quotaMiB > 0 && this.binaryDataConfig.mode !== 'filesystem') {
+			throw new UnexpectedError(
+				`N8N_BINARY_DATA_STORAGE_QUOTA_MIB is set but binary data mode is '${this.binaryDataConfig.mode}'. ` +
+					'Binary data pruning is only supported in filesystem mode.',
+			);
+		}
+
+		if (this.instanceSettings.isLeader) this.startPruning();
+	}
+
+	get isEnabled() {
+		return (
+			this.pruningConfig.quotaMiB > 0 &&
+			this.instanceSettings.instanceType === 'main' &&
+			this.instanceSettings.isLeader
+		);
+	}
+
+	@OnLeaderTakeover()
+	startPruning() {
+		const { connectionState } = this.dbConnection;
+		if (!this.isEnabled || !connectionState.migrated || this.isShuttingDown) return;
+
+		this.scheduleNextPruning();
+
+		this.logger.debug('Started binary data pruning timer');
+	}
+
+	@OnLeaderStepdown()
+	stopPruning() {
+		if (this.pruningTimeout) {
+			clearTimeout(this.pruningTimeout);
+			this.pruningTimeout = undefined;
+			this.logger.debug('Stopped binary data pruning timer');
+		}
+	}
+
+	@OnShutdown()
+	shutdown(): void {
+		this.isShuttingDown = true;
+		this.stopPruning();
+	}
+
+	private scheduleNextPruning(delayMs = this.intervalMs) {
+		this.pruningTimeout = setTimeout(() => {
+			this.prune()
+				.then((nextDelay) => this.scheduleNextPruning(nextDelay))
+				.catch((error) => {
+					this.scheduleNextPruning(1 * Time.seconds.toMilliseconds);
+					this.logger.error('Failed to prune binary data', { error: ensureError(error) });
+				});
+		}, delayMs);
+
+		this.logger.debug(
+			`Next binary data pruning check in ${delayMs * Time.milliseconds.toMinutes} minutes`,
+		);
+	}
+
+	/**
+	 * Main pruning loop. Checks total storage size, then deletes binary data
+	 * for the oldest executions until under quota.
+	 *
+	 * @returns Delay in milliseconds until next pruning check
+	 */
+	async prune(): Promise<number> {
+		const quotaBytes = this.pruningConfig.quotaMiB * MiB;
+		const totalBytes = await this.binaryDataService.getTotalStorageSize();
+
+		if (totalBytes <= quotaBytes) {
+			this.logger.debug('Binary data within quota', {
+				usedMiB: Math.round(totalBytes / MiB),
+				quotaMiB: this.pruningConfig.quotaMiB,
+			});
+			return this.intervalMs;
+		}
+
+		this.logger.info('Binary data exceeds quota, pruning oldest executions', {
+			usedMiB: Math.round(totalBytes / MiB),
+			quotaMiB: this.pruningConfig.quotaMiB,
+		});
+
+		const executions = await this.executionRepository.findCompletedExecutionsAfter(
+			this.lastPrunedExecutionId,
+			this.pruningConfig.batchSize,
+		);
+
+		if (executions.length === 0) {
+			this.logger.debug('No more executions to prune binary data for');
+			return this.intervalMs;
+		}
+
+		// On restart (no cursor), fast-forward past executions whose binary data
+		// is already gone by checking the last execution in the batch.
+		if (this.lastPrunedExecutionId === undefined) {
+			const last = executions[executions.length - 1];
+			const dirExists = await this.executionBinaryDataExists(last.workflowId, last.executionId);
+
+			if (!dirExists) {
+				this.lastPrunedExecutionId = last.executionId;
+				this.logger.debug('Fast-forwarding cursor past already-pruned executions', {
+					cursor: this.lastPrunedExecutionId,
+				});
+				return 1 * Time.seconds.toMilliseconds;
+			}
+		}
+
+		const locations = executions.map(({ executionId, workflowId }) => ({
+			type: 'execution' as const,
+			workflowId,
+			executionId,
+		}));
+
+		await this.binaryDataService.deleteMany(locations);
+
+		this.lastPrunedExecutionId = executions[executions.length - 1].executionId;
+
+		this.logger.info('Pruned binary data', { deletedExecutions: executions.length });
+
+		// Re-check size to decide scheduling
+		const newTotalBytes = await this.binaryDataService.getTotalStorageSize();
+
+		if (newTotalBytes > quotaBytes) {
+			return 1 * Time.seconds.toMilliseconds;
+		}
+
+		return this.intervalMs;
+	}
+
+	private async executionBinaryDataExists(
+		workflowId: string,
+		executionId: string,
+	): Promise<boolean> {
+		return await this.binaryDataService.locationExists({
+			type: 'execution',
+			workflowId,
+			executionId,
+		});
+	}
+}

--- a/packages/cli/test/integration/binary-data-pruning.service.test.ts
+++ b/packages/cli/test/integration/binary-data-pruning.service.test.ts
@@ -1,0 +1,214 @@
+import { mockLogger, createWorkflow, testDb, mockInstance } from '@n8n/backend-test-utils';
+import { BinaryDataPruningConfig } from '@n8n/config';
+import { ExecutionRepository, DbConnection } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { mock } from 'jest-mock-extended';
+import type { BinaryDataConfig, BinaryDataService } from 'n8n-core';
+import { InstanceSettings } from 'n8n-core';
+import type { IWorkflowBase } from 'n8n-workflow';
+
+import { BinaryDataPruningService } from '@/services/pruning/binary-data-pruning.service';
+
+import { createExecution, createSuccessfulExecution } from './shared/db/executions';
+
+describe('BinaryDataPruningService (integration)', () => {
+	const instanceSettings = Container.get(InstanceSettings);
+	instanceSettings.markAsLeader();
+
+	const binaryDataService = mock<BinaryDataService>();
+
+	const binaryDataConfig = mock<BinaryDataConfig>({
+		mode: 'filesystem',
+		localStoragePath: '/tmp/n8n/storage',
+	});
+
+	let workflow: IWorkflowBase;
+
+	beforeAll(async () => {
+		await testDb.init();
+		workflow = await createWorkflow();
+	});
+
+	beforeEach(async () => {
+		await testDb.truncate(['ExecutionEntity']);
+		binaryDataService.getTotalStorageSize.mockReset();
+		binaryDataService.deleteMany.mockReset();
+		binaryDataService.getTotalStorageSize.mockResolvedValue(100 * 1024 * 1024); // 100 MiB
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	function createPruningService(quotaMiB = 50, batchSize = 100) {
+		const pruningConfig = mockInstance(BinaryDataPruningConfig);
+		pruningConfig.quotaMiB = quotaMiB;
+		pruningConfig.intervalMinutes = 60;
+		pruningConfig.batchSize = batchSize;
+
+		const service = new BinaryDataPruningService(
+			mockLogger(),
+			instanceSettings,
+			Container.get(DbConnection),
+			Container.get(ExecutionRepository),
+			binaryDataService,
+			binaryDataConfig,
+			pruningConfig,
+		);
+
+		// Prevent restart fast-forward from triggering (no real binary data dirs in test)
+		jest
+			.spyOn(service as never, 'executionBinaryDataExists' as never)
+			.mockResolvedValue(true as never);
+
+		return service;
+	}
+
+	describe('prune', () => {
+		it('should query executions ordered by id ASC (oldest first)', async () => {
+			const service = createPruningService();
+
+			const exec1 = await createSuccessfulExecution(workflow);
+			const exec2 = await createSuccessfulExecution(workflow);
+			const exec3 = await createSuccessfulExecution(workflow);
+
+			// After first batch, still over quota to force re-check
+			binaryDataService.getTotalStorageSize
+				.mockResolvedValueOnce(100 * 1024 * 1024) // over quota
+				.mockResolvedValueOnce(30 * 1024 * 1024); // under after deletion
+
+			await service.prune();
+
+			// Should have been called once with all 3 executions, in order
+			expect(binaryDataService.deleteMany).toHaveBeenCalledTimes(1);
+			expect(binaryDataService.deleteMany).toHaveBeenCalledWith([
+				expect.objectContaining({ executionId: exec1.id }),
+				expect.objectContaining({ executionId: exec2.id }),
+				expect.objectContaining({ executionId: exec3.id }),
+			]);
+		});
+
+		it('should support cursor-based pagination across calls', async () => {
+			const service = createPruningService(50, 2); // batch size 2
+
+			await createSuccessfulExecution(workflow);
+			await createSuccessfulExecution(workflow);
+			const exec3 = await createSuccessfulExecution(workflow);
+			const exec4 = await createSuccessfulExecution(workflow);
+
+			// First prune: over quota before and after
+			binaryDataService.getTotalStorageSize
+				.mockResolvedValueOnce(100 * 1024 * 1024)
+				.mockResolvedValueOnce(80 * 1024 * 1024); // still over
+
+			await service.prune();
+			expect(binaryDataService.deleteMany).toHaveBeenCalledTimes(1);
+
+			// Second prune: still over, but now under after
+			binaryDataService.deleteMany.mockClear();
+			binaryDataService.getTotalStorageSize
+				.mockResolvedValueOnce(80 * 1024 * 1024)
+				.mockResolvedValueOnce(30 * 1024 * 1024);
+
+			await service.prune();
+
+			// Should continue from where it left off (exec3, exec4)
+			expect(binaryDataService.deleteMany).toHaveBeenCalledTimes(1);
+			expect(binaryDataService.deleteMany).toHaveBeenCalledWith([
+				expect.objectContaining({ executionId: exec3.id }),
+				expect.objectContaining({ executionId: exec4.id }),
+			]);
+		});
+
+		it('should skip new, running, and waiting executions', async () => {
+			const service = createPruningService();
+
+			await createExecution(
+				{ status: 'new', startedAt: undefined, stoppedAt: undefined },
+				workflow,
+			);
+			await createExecution({ status: 'running', stoppedAt: undefined }, workflow);
+			await createExecution(
+				{ status: 'waiting', waitTill: new Date(), stoppedAt: new Date() },
+				workflow,
+			);
+			const successExec = await createSuccessfulExecution(workflow);
+
+			binaryDataService.getTotalStorageSize
+				.mockResolvedValueOnce(100 * 1024 * 1024)
+				.mockResolvedValueOnce(30 * 1024 * 1024);
+
+			await service.prune();
+
+			// Only the successful execution should be pruned (single batched call)
+			expect(binaryDataService.deleteMany).toHaveBeenCalledTimes(1);
+			expect(binaryDataService.deleteMany).toHaveBeenCalledWith([
+				expect.objectContaining({ executionId: successExec.id }),
+			]);
+		});
+
+		it('should include error and crashed executions', async () => {
+			const service = createPruningService();
+
+			const errorExec = await createExecution({ status: 'error', finished: false }, workflow);
+			const crashedExec = await createExecution({ status: 'crashed', finished: false }, workflow);
+
+			binaryDataService.getTotalStorageSize
+				.mockResolvedValueOnce(100 * 1024 * 1024)
+				.mockResolvedValueOnce(30 * 1024 * 1024);
+
+			await service.prune();
+
+			expect(binaryDataService.deleteMany).toHaveBeenCalledTimes(1);
+			expect(binaryDataService.deleteMany).toHaveBeenCalledWith([
+				expect.objectContaining({ executionId: errorExec.id }),
+				expect.objectContaining({ executionId: crashedExec.id }),
+			]);
+		});
+
+		it('should return empty batch when cursor is past all executions', async () => {
+			const service = createPruningService(50, 1);
+
+			const exec = await createSuccessfulExecution(workflow);
+
+			// First call: prune the only execution
+			binaryDataService.getTotalStorageSize
+				.mockResolvedValueOnce(100 * 1024 * 1024)
+				.mockResolvedValueOnce(80 * 1024 * 1024);
+
+			await service.prune();
+			expect(binaryDataService.deleteMany).toHaveBeenCalledWith([
+				expect.objectContaining({ executionId: exec.id }),
+			]);
+
+			// Second call: no more executions after cursor
+			binaryDataService.deleteMany.mockClear();
+			binaryDataService.getTotalStorageSize.mockResolvedValueOnce(80 * 1024 * 1024);
+
+			const delay = await service.prune();
+
+			expect(binaryDataService.deleteMany).not.toHaveBeenCalled();
+			expect(delay).toBe(60 * 60 * 1000); // normal interval
+		});
+
+		it('should pass correct workflowId in deleteMany calls', async () => {
+			const service = createPruningService();
+
+			const workflow2 = await createWorkflow();
+			const exec1 = await createSuccessfulExecution(workflow);
+			const exec2 = await createSuccessfulExecution(workflow2);
+
+			binaryDataService.getTotalStorageSize
+				.mockResolvedValueOnce(100 * 1024 * 1024)
+				.mockResolvedValueOnce(30 * 1024 * 1024);
+
+			await service.prune();
+
+			expect(binaryDataService.deleteMany).toHaveBeenCalledTimes(1);
+			expect(binaryDataService.deleteMany).toHaveBeenCalledWith([
+				{ type: 'execution', workflowId: workflow.id, executionId: exec1.id },
+				{ type: 'execution', workflowId: workflow2.id, executionId: exec2.id },
+			]);
+		});
+	});
+});

--- a/packages/core/src/binary-data/binary-data.service.ts
+++ b/packages/core/src/binary-data/binary-data.service.ts
@@ -153,6 +153,38 @@ export class BinaryDataService {
 		return await this.getManager(mode).getMetadata(fileId);
 	}
 
+	/**
+	 * Calculate total size of all binary data in bytes.
+	 * Only supported in filesystem mode.
+	 */
+	async getTotalStorageSize(): Promise<number> {
+		const manager = this.managers[this.mode];
+
+		if (!manager?.getTotalStorageSize) {
+			throw new UnexpectedError(
+				`getTotalStorageSize() is not supported in '${this.mode}' binary data mode`,
+			);
+		}
+
+		return await manager.getTotalStorageSize();
+	}
+
+	/**
+	 * Check whether binary data exists for a given location.
+	 * Only supported in filesystem mode.
+	 */
+	async locationExists(location: BinaryData.FileLocation): Promise<boolean> {
+		const manager = this.managers[this.mode];
+
+		if (!manager?.locationExists) {
+			throw new UnexpectedError(
+				`locationExists() is not supported in '${this.mode}' binary data mode`,
+			);
+		}
+
+		return await manager.locationExists(location);
+	}
+
 	async deleteMany(locations: BinaryData.FileLocation[]) {
 		const manager = this.managers[this.mode];
 

--- a/packages/core/src/binary-data/file-system.manager.ts
+++ b/packages/core/src/binary-data/file-system.manager.ts
@@ -138,6 +138,24 @@ export class FileSystemManager implements BinaryData.Manager {
 		await fs.rm(tempDir, { recursive: true });
 	}
 
+	async getTotalStorageSize(): Promise<number> {
+		const entries = await fs.readdir(this.storagePath, { recursive: true, withFileTypes: true });
+
+		const filePaths = entries
+			.filter((entry) => entry.isFile())
+			.map((entry) => path.join(entry.parentPath, entry.name));
+
+		const sizes = await Promise.all(filePaths.map(async (p) => (await fs.stat(p)).size));
+
+		return sizes.reduce((sum, size) => sum + size, 0);
+	}
+
+	async locationExists(location: BinaryData.FileLocation): Promise<boolean> {
+		const dirPath = this.resolvePath(this.toRelativePath(location), 'binary_data');
+
+		return await exists(dirPath);
+	}
+
 	async deleteManyByFileId(ids: string[]): Promise<void> {
 		const parsedIds = ids.flatMap((id) => {
 			try {

--- a/packages/core/src/binary-data/types.ts
+++ b/packages/core/src/binary-data/types.ts
@@ -58,6 +58,18 @@ export namespace BinaryData {
 		deleteMany?(locations: FileLocation[]): Promise<void>;
 		deleteManyByFileId?(ids: string[]): Promise<void>;
 
+		/**
+		 * Calculate total size of all stored binary data in bytes.
+		 * Present for `FileSystem`, absent for `ObjectStore` and `Database`.
+		 */
+		getTotalStorageSize?(): Promise<number>;
+
+		/**
+		 * Check whether binary data exists for a given location.
+		 * Present for `FileSystem`, absent for `ObjectStore` and `Database`.
+		 */
+		locationExists?(location: FileLocation): Promise<boolean>;
+
 		copyByFileId(targetLocation: FileLocation, sourceFileId: string): Promise<string>;
 		copyByFilePath(
 			targetLocation: FileLocation,

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/BinaryDataDisplayEmbed.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/BinaryDataDisplayEmbed.vue
@@ -57,17 +57,17 @@ onMounted(async () => {
 <template>
 	<span>
 		<div v-if="isLoading">Loading binary data...</div>
-		<div v-else-if="error">Error loading binary data</div>
+		<div v-else-if="error">{{ i18n.baseText('binaryDataDisplay.noDataFoundToDisplay') }}</div>
 		<span v-else>
-			<video v-if="binaryData.fileType === 'video'" controls autoplay>
+			<video v-if="binaryData.fileType === 'video'" controls autoplay @error="error = true">
 				<source :src="embedSource" :type="binaryData.mimeType" />
 				{{ i18n.baseText('binaryDataDisplay.yourBrowserDoesNotSupport') }}
 			</video>
-			<audio v-else-if="binaryData.fileType === 'audio'" controls autoplay>
+			<audio v-else-if="binaryData.fileType === 'audio'" controls autoplay @error="error = true">
 				<source :src="embedSource" :type="binaryData.mimeType" />
 				{{ i18n.baseText('binaryDataDisplay.yourBrowserDoesNotSupport') }}
 			</audio>
-			<img v-else-if="binaryData.fileType === 'image'" :src="embedSource" />
+			<img v-else-if="binaryData.fileType === 'image'" :src="embedSource" @error="error = true" />
 			<VueJsonPretty
 				v-else-if="binaryData.fileType === 'json'"
 				:data="data"


### PR DESCRIPTION
## Summary

This PR adds a regularly running binary file pruner to keep the disk space used by binary files to a constrained value, even if the executions that those .
The goal is to replace the cloud sidecar `bfp-9000` (https://github.com/n8n-io/n8n-cloud/tree/main/packages/bfp-9000) with something built-in to n8n, which is more sustainable.

### Key Design Decisions
- This feature is disabled by default, possible we may only enable this in cloud to replace the existing out-of-bound cleanup
- Only available in filesystem mode, as object storage can have its own lifecycling policies outside of n8n
- Only cleanup binary data of finished workflows, to avoid breaking any in-flight workflows
- Cleanup the oldest binary data first, as this is the binary data the user is least likely to access
- Follow patterns established in existing pruning mechanism

### Testing

Unit tests and integration tests added as part of the PR.

#### Unit Tests
- `init` starts on leader main, skips on follower
- `init` throws if quota set with non-filesystem mode
- `init` does not throw if quota is 0 regardless of mode
- `isEnabled` gates on `quotaMiB > 0`, leader, and main instance type
- `startPruning` does not schedule if disabled; schedules if enabled and migrated
- `stopPruning` clears timeout
- `prune` does nothing when total size is under quota
- `prune` queries executions by `id ASC`, calls batched `deleteMany`
- `prune` advances cursor after each batch
- `prune` returns 1s delay when still over quota, `intervalMinutes` when under
- `prune` returns interval delay when no executions remain

#### Integration Tests
  - Queries oldest executions first (verifies `id ASC` ordering with real DB)
  - Cursor-based pagination works across multiple calls
  - Skips `new`, `running`, `waiting` executions
  - Includes `error` and `crashed` executions
  - Returns correct execution IDs and workflow IDs
  - Empty result when all executions are newer than cursor

#### Manual Tests
Start n8n with the binary file pruner disabled:
```
N8N_DEFAULT_BINARY_DATA_MODE=filesystem
N8N_BINARY_DATA_STORAGE_QUOTA_MIB=0
N8N_BINARY_DATA_PRUNING_INTERVAL=1
N8N_BINARY_DATA_PRUNING_BATCH_SIZE=1
```

Ran a workflow downloading a large (~5MB) image:
<img width="922" height="438" alt="image" src="https://github.com/user-attachments/assets/300c7714-eec6-4e67-834c-63f1a9e7ecbc" />

Manually executed a number of times, wait for the 1 minute interval, viewed the binary directory:
```
du -h storage/workflows/ZXTRIXGm4XjAHd1d/executions/
5.3M	storage/workflows/ZXTRIXGm4XjAHd1d/executions/26/binary_data
5.3M	storage/workflows/ZXTRIXGm4XjAHd1d/executions/26
5.3M	storage/workflows/ZXTRIXGm4XjAHd1d/executions/21/binary_data
5.3M	storage/workflows/ZXTRIXGm4XjAHd1d/executions/21
5.3M	storage/workflows/ZXTRIXGm4XjAHd1d/executions/24/binary_data
5.3M	storage/workflows/ZXTRIXGm4XjAHd1d/executions/24
5.3M	storage/workflows/ZXTRIXGm4XjAHd1d/executions/23/binary_data
5.3M	storage/workflows/ZXTRIXGm4XjAHd1d/executions/23
5.3M	storage/workflows/ZXTRIXGm4XjAHd1d/executions/22/binary_data
5.3M	storage/workflows/ZXTRIXGm4XjAHd1d/executions/22
5.3M	storage/workflows/ZXTRIXGm4XjAHd1d/executions/25/binary_data
5.3M	storage/workflows/ZXTRIXGm4XjAHd1d/executions/25
 32M	storage/workflows/ZXTRIXGm4XjAHd1d/executions/
```

Binary data is not being cleaned up yet, which is good.
We also do not see the logs from the pruner running.

Then restarted n8n with a 20MB quota, so we're expecting some cleanup:
```
N8N_DEFAULT_BINARY_DATA_MODE=filesystem
N8N_BINARY_DATA_STORAGE_QUOTA_MIB=20
N8N_BINARY_DATA_PRUNING_INTERVAL=1
N8N_BINARY_DATA_PRUNING_BATCH_SIZE=1
```

Can see logs shortly after starting that binary pruning has run:
```
Binary data exceeds quota, pruning oldest executions
Pruned binary data
Binary data exceeds quota, pruning oldest executions
Pruned binary data
```

Confirmed storage has been reduced to below 20MB:
```
du -h storage/workflows/ZXTRIXGm4XjAHd1d/executions/
5.3M	storage/workflows/ZXTRIXGm4XjAHd1d/executions/26/binary_data
5.3M	storage/workflows/ZXTRIXGm4XjAHd1d/executions/26
5.3M	storage/workflows/ZXTRIXGm4XjAHd1d/executions/24/binary_data
5.3M	storage/workflows/ZXTRIXGm4XjAHd1d/executions/24
5.3M	storage/workflows/ZXTRIXGm4XjAHd1d/executions/25/binary_data
5.3M	storage/workflows/ZXTRIXGm4XjAHd1d/executions/25
 16M	storage/workflows/ZXTRIXGm4XjAHd1d/executions/
```

And the file is not visible when looking at the older execution:
<img width="2002" height="220" alt="image" src="https://github.com/user-attachments/assets/b783dd81-bc5b-45c0-854c-8fe10e23e14e" />

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

## Claude Code Plan
<details>

<summary>Expand Me</summary>

# Binary Data Disk Pruning Service

## Context

n8n stores binary data (file attachments, images, etc.) on disk in filesystem mode at `{storagePath}/workflows/{workflowId}/executions/{executionId}/binary_data/{uuid}`. There is **no automatic cleanup** of this data — it only gets deleted as a side effect of execution hard-deletion. For instances that generate significant binary data, disk usage grows unbounded. This feature adds an opt-in, size-based pruning service that automatically deletes the oldest binary data when total usage exceeds a configurable threshold.

## Requirements

- **Size-based**: Delete when total filesystem usage exceeds a quota
- **Filesystem only**: S3 has lifecycle policies, DB mode is already bounded
- **Independent**: Own schedule, not tied to execution pruning
- **Single-pass**: No soft-delete phase — scan and delete directly
- **Oldest-first by execution**: Delete all binary data for entire executions, oldest first
- **Leave execution intact**: Only delete files; execution DB records remain (dangling refs OK)
- **Opt-in**: Disabled by default (`quotaMiB = 0`)
- **DB-driven ordering**: Use execution DB (ordered by `id ASC`) to determine deletion order — no filesystem mtime
- **Cursor-based**: Track last-processed execution ID in memory to avoid re-querying
- **Restart recovery**: On restart (cursor lost), short-circuit by checking file existence
- **Config validation**: Error at startup if quota is set but binary data mode is not filesystem
- **Graceful UI**: Frontend handles missing binary data (404) without showing broken images

## Architecture

### Two concerns, two strategies

1. **"Should we prune?"** — `BinaryDataService.getTotalStorageSize()` → delegates to `FileSystemManager.getTotalStorageSize()`. Throws if not in filesystem mode.
2. **"What to delete?"** — Query execution DB ordered by `id ASC`. Use existing `BinaryDataService.deleteMany()` for deletion (batched — single call per pruning pass).

### Abstraction layering

```
BinaryDataPruningService (cli)
  → BinaryDataService.getTotalStorageSize()       (core, service layer)
    → FileSystemManager.getTotalStorageSize()      (core, implementation)
  → BinaryDataService.locationExists(location)     (core, service layer)
    → FileSystemManager.locationExists(location)   (core, implementation)
  → BinaryDataService.deleteMany(locations)        (core, existing)
    → FileSystemManager.deleteMany(locations)      (core, existing)
```

`getTotalStorageSize()` and `locationExists()` are added to the `BinaryData.Manager` interface as optional methods (same pattern as `deleteMany?`), implemented on `FileSystemManager`, and plumbed through `BinaryDataService`. The pruning service never constructs filesystem paths directly — all path knowledge stays inside `FileSystemManager`.

### Config validation

In `BinaryDataPruningService.init()`, if `quotaMiB > 0` but `BinaryDataConfig.mode !== 'filesystem'`, throw an error. The `mode` property is a `ConfigMode` (`'default' | 'filesystem' | 's3' | 'database'`). Only `'filesystem'` uses disk storage that can be pruned (`'default'` is in-memory, `'s3'` uses lifecycle policies, `'database'` is bounded by `dbMaxFileSize`).

### Cursor optimization

- Store `lastPrunedExecutionId: string | undefined` in memory
- Each pass queries: `WHERE id > lastPrunedExecutionId ORDER BY id ASC TAKE batchSize`
- After deleting a batch, advance cursor to the last processed ID
- **Restart short-circuit**: When cursor is undefined, check if the binary data dir exists for the last execution in each batch via `binaryDataService.locationExists()`. If not, skip the batch and advance cursor.

### Execution status constant

`IN_PROGRESS_STATUSES` (`['new', 'running', 'waiting']`) is extracted as a module-level constant in `execution.repository.ts` and shared between `softDeletePrunableExecutions()` and `findCompletedExecutionsAfter()`.

## Files to Create

### 1. `packages/@n8n/config/src/configs/binary-data-pruning.config.ts`

```ts
import { Config, Env } from '../decorators';

@Config
export class BinaryDataPruningConfig {
	/** Max disk usage in MiB for binary data. 0 = pruning disabled. */
	@Env('N8N_BINARY_DATA_STORAGE_QUOTA_MIB')
	quotaMiB: number = 0;

	/** Minutes between pruning checks. */
	@Env('N8N_BINARY_DATA_PRUNING_INTERVAL')
	intervalMinutes: number = 60;

	/** Max execution dirs to delete per pruning pass. */
	@Env('N8N_BINARY_DATA_PRUNING_BATCH_SIZE')
	batchSize: number = 100;
}
```

### 2. `packages/cli/src/services/pruning/binary-data-pruning.service.ts`

Mirrors `ExecutionsPruningService` structure. Key design decisions:

- Uses `'pruning'` log scope (shared with `ExecutionsPruningService`, already in `LOG_SCOPES`)
- Extracts `const MiB = 1024 * 1024` to avoid magic number repetition
- Uses `1 * Time.seconds.toMilliseconds` consistently for fast-retry delays
- Batches all execution locations into a single `binaryDataService.deleteMany(locations)` call per pass, leveraging `FileSystemManager.deleteMany()`'s internal `Promise.all`
- Delegates file existence checks to `binaryDataService.locationExists()` — never constructs filesystem paths directly
- Requires `DbConnection` in constructor (for `connectionState.migrated` check in `startPruning`, matching `ExecutionsPruningService` pattern)

**`prune()` logic:**
1. `binaryDataService.getTotalStorageSize()` → if under quota, return `intervalMinutes` delay
2. Query `executionRepository.findCompletedExecutionsAfter(cursor, batchSize)`
3. **Restart short-circuit**: If cursor is undefined, check file existence for last execution in batch via `binaryDataService.locationExists()`; if missing, advance cursor and re-query
4. Batch all locations, call `binaryDataService.deleteMany(locations)` once
5. Advance cursor to last execution ID in batch
6. Re-check total size. Over quota → return 1s; under → return `intervalMinutes`

### 3. `packages/cli/src/services/pruning/__tests__/binary-data-pruning.service.test.ts`

**Unit tests** using `jest-mock-extended` (following `executions-pruning.service.test.ts`):
- `init` starts on leader main, skips on follower
- `init` throws if quota set with non-filesystem mode
- `init` does not throw if quota is 0 regardless of mode
- `isEnabled` gates on `quotaMiB > 0`, leader, and main instance type
- `startPruning` does not schedule if disabled; schedules if enabled and migrated
- `stopPruning` clears timeout
- `prune` does nothing when total size is under quota
- `prune` queries executions by `id ASC`, calls batched `deleteMany`
- `prune` advances cursor after each batch
- `prune` returns 1s delay when still over quota, `intervalMinutes` when under
- `prune` returns interval delay when no executions remain

Tests that call `prune()` directly mock `executionBinaryDataExists` to return `true` to prevent the restart fast-forward from triggering (no real filesystem in unit tests).

### 4. `packages/cli/test/integration/binary-data-pruning.service.test.ts`

**Integration tests** using real DB (following `test/integration/executions-pruning.service.test.ts`):
- Uses `testDb.init()` / `testDb.truncate()` / `testDb.terminate()`
- Creates real executions via `createExecution()` / `createSuccessfulExecution()` helpers
- Creates real `BinaryDataPruningService` with real `ExecutionRepository` from Container
- Mocks `BinaryDataService` (filesystem operations) — resets mocks in `beforeEach`
- Mocks `executionBinaryDataExists` in `createPruningService` helper
- **Test cases:**
  - Queries oldest executions first (verifies `id ASC` ordering with real DB)
  - Cursor-based pagination works across multiple calls
  - Skips `new`, `running`, `waiting` executions
  - Includes `error` and `crashed` executions
  - Returns correct execution IDs and workflow IDs
  - Empty result when all executions are newer than cursor

## Files to Modify

### 5. `packages/@n8n/config/src/index.ts`

- Add import: `import { BinaryDataPruningConfig } from './configs/binary-data-pruning.config';`
- Add export: `export { BinaryDataPruningConfig } from './configs/binary-data-pruning.config';`
- Add to `GlobalConfig`:
  ```ts
  @Nested
  binaryDataPruning: BinaryDataPruningConfig;
  ```

### 6. `packages/@n8n/config/test/config.test.ts`

Add expected defaults for `binaryDataPruning` to the full GlobalConfig shape test:
```ts
binaryDataPruning: {
	quotaMiB: 0,
	intervalMinutes: 60,
	batchSize: 100,
},
```

### 7. `packages/core/src/binary-data/types.ts`

Add optional `getTotalStorageSize` and `locationExists` to the `Manager` interface:

```ts
export interface Manager {
	// ... existing methods ...

	/**
	 * Calculate total size of all stored binary data in bytes.
	 * Present for `FileSystem`, absent for `ObjectStore` and `Database`.
	 */
	getTotalStorageSize?(): Promise<number>;

	/**
	 * Check whether binary data exists for a given location.
	 * Present for `FileSystem`, absent for `ObjectStore` and `Database`.
	 */
	locationExists?(location: FileLocation): Promise<boolean>;
}
```

### 8. `packages/core/src/binary-data/file-system.manager.ts`

Add two implementations:

```ts
async getTotalStorageSize(): Promise<number> {
	const entries = await fs.readdir(this.storagePath, { recursive: true, withFileTypes: true });
	const filePaths = entries
		.filter((entry) => entry.isFile())
		.map((entry) => path.join(entry.parentPath, entry.name));
	const sizes = await Promise.all(filePaths.map(async (p) => (await fs.stat(p)).size));
	return sizes.reduce((sum, size) => sum + size, 0);
}

async locationExists(location: BinaryData.FileLocation): Promise<boolean> {
	const dirPath = this.resolvePath(this.toRelativePath(location), 'binary_data');
	return await exists(dirPath);
}
```

Note: `getTotalStorageSize` parallelizes stat calls via `Promise.all` for performance. `locationExists` reuses the manager's own `toRelativePath` and `resolvePath` methods — path structure knowledge stays encapsulated.

### 9. `packages/core/src/binary-data/binary-data.service.ts`

Add two public methods that delegate to the active manager:

```ts
async getTotalStorageSize(): Promise<number> {
	const manager = this.managers[this.mode];
	if (!manager?.getTotalStorageSize) {
		throw new UnexpectedError(
			`getTotalStorageSize() is not supported in '${this.mode}' binary data mode`,
		);
	}
	return await manager.getTotalStorageSize();
}

async locationExists(location: BinaryData.FileLocation): Promise<boolean> {
	const manager = this.managers[this.mode];
	if (!manager?.locationExists) {
		throw new UnexpectedError(
			`locationExists() is not supported in '${this.mode}' binary data mode`,
		);
	}
	return await manager.locationExists(location);
}
```

### 10. `packages/@n8n/db/src/repositories/execution.repository.ts`

Extract shared constant and add new query method:

```ts
/** Execution statuses that indicate the execution is still in progress. */
const IN_PROGRESS_STATUSES: ExecutionStatus[] = ['new', 'running', 'waiting'];
```

Used in both `softDeletePrunableExecutions()` (`Not(In(IN_PROGRESS_STATUSES))`) and the new method:

```ts
async findCompletedExecutionsAfter(afterId: string | undefined, batchSize: number) {
	const where: FindOptionsWhere<ExecutionEntity> = {
		status: Not(In(IN_PROGRESS_STATUSES)),
		...(afterId && { id: MoreThan(afterId) }),
	};

	const results = await this.find({
		select: ['id', 'workflowId'],
		where,
		order: { id: 'ASC' },
		take: batchSize,
	});

	return results.map(({ id, workflowId }) => ({ executionId: id, workflowId }));
}
```

Uses TypeORM's `find()` with `Not(In(...))` and `MoreThan()` operators — consistent with the existing repository style rather than raw query builder strings.

### 11. `packages/cli/src/commands/start.ts` (~line 360)

Add after `Container.get(ExecutionsPruningService).init();`:

```ts
Container.get(BinaryDataPruningService).init();
```

Plus import at the top.

### 12. `packages/frontend/editor-ui/src/features/ndv/runData/components/BinaryDataDisplayEmbed.vue`

Add `@error` handlers on media elements to gracefully handle 404s from pruned binary data. When the resource fails to load, the component reactively switches from the broken element to the existing "No data found to display" message.

```html
<video ... @error="error = true">
<audio ... @error="error = true">
<img ... @error="error = true" />
```

Also changed the error state message from hardcoded "Error loading binary data" to `i18n.baseText('binaryDataDisplay.noDataFoundToDisplay')` for consistency with the parent component's empty-state message.

## Data Flow

```
Timer fires (every intervalMinutes)
  → BinaryDataPruningService.prune()
    → binaryDataService.getTotalStorageSize()
      → manager.getTotalStorageSize()  // FileSystemManager: readdir + parallel stat
        ← totalBytes
    → if totalBytes <= quotaBytes: return intervalMinutes (done)
    → executionRepository.findCompletedExecutionsAfter(cursor, batchSize)
      ← [{ executionId, workflowId }, ...]
    → if cursor undefined (restart):
        binaryDataService.locationExists({ type: 'execution', ... })
          → manager.locationExists()  // FileSystemManager: exists(resolvePath(...))
        if no files → advance cursor, re-query (loop)
    → binaryDataService.deleteMany(locations)  // single batched call
      → manager.deleteMany() → Promise.all(fs.rm(...))
    → advance cursor to last execution ID
    → binaryDataService.getTotalStorageSize()
    → still over quota? return 1s : return intervalMinutes
  → scheduleNextPruning(delay)
```

## Environment Variables

| Variable | Type | Default | Description |
|----------|------|---------|-------------|
| `N8N_BINARY_DATA_STORAGE_QUOTA_MIB` | number | `0` | Max binary data disk usage in MiB. 0 = disabled. |
| `N8N_BINARY_DATA_PRUNING_INTERVAL` | number | `60` | Minutes between pruning checks. |
| `N8N_BINARY_DATA_PRUNING_BATCH_SIZE` | number | `100` | Max execution dirs to delete per pass. |

## Key Reuse

- **`BinaryDataService.deleteMany(locations)`** — existing, no changes
- **`BinaryData.Manager` interface** — extended with optional `getTotalStorageSize?()`, `locationExists?()` (same pattern as `deleteMany?`)
- **`FileSystemManager.toRelativePath()` / `resolvePath()`** — reused by `locationExists()`, keeping path structure knowledge encapsulated
- **`exists()` from `@n8n/backend-common`** — reused in `FileSystemManager.locationExists()`
- **`IN_PROGRESS_STATUSES`** — extracted constant, shared between `softDeletePrunableExecutions()` and `findCompletedExecutionsAfter()`
- **`ExecutionRepository`** — one new query method using `find()` with TypeORM operators (`Not`, `In`, `MoreThan`)
- **`testDb` / `createExecution()` helpers** — reused for integration tests from `test/integration/shared/db/executions.ts`
- **`binaryDataDisplay.noDataFoundToDisplay`** — existing i18n key reused for the error state in `BinaryDataDisplayEmbed.vue`

## Post-Implementation

### Simplify

Run the `/simplify` skill on all changed files before verification. This reviews for reuse, quality, and efficiency, then fixes any issues found.

### Verification

Run everything that CI/GitHub Actions would run on a PR. Execute in this order:

1. **Build** (required before typecheck/lint on cross-package changes):
   ```bash
   pnpm build > build.log 2>&1 && tail -20 build.log
   ```

2. **Type check** all modified packages:
   ```bash
   pushd packages/@n8n/config && pnpm typecheck && popd
   pushd packages/@n8n/db && pnpm typecheck && popd
   pushd packages/core && pnpm typecheck && popd
   pushd packages/cli && pnpm typecheck && popd
   pushd packages/frontend/editor-ui && pnpm typecheck && popd
   ```

3. **Lint** all modified packages:
   ```bash
   pushd packages/@n8n/config && pnpm lint && popd
   pushd packages/@n8n/db && pnpm lint && popd
   pushd packages/core && pnpm lint && popd
   pushd packages/cli && pnpm lint && popd
   pushd packages/frontend/editor-ui && pnpm lint && popd
   ```

4. **Unit tests** (new + affected):
   ```bash
   pushd packages/cli && pnpm test src/services/pruning/__tests__/binary-data-pruning.service.test.ts && popd
   pushd packages/core && pnpm test src/binary-data/__tests__/file-system.manager.test.ts && popd
   ```

5. **Integration tests**:
   ```bash
   pushd packages/cli && pnpm test test/integration/binary-data-pruning.service.test.ts && popd
   ```

6. **Affected tests** (catches anything we missed):
   ```bash
   pnpm test:affected
   ```

7. **Manual test**: Set `N8N_BINARY_DATA_STORAGE_QUOTA_MIB=1` with existing binary data, start n8n, verify:
   - Logs show pruning activity
   - UI shows "No data found to display" when viewing pruned binary data (not a broken image)
</details>

