### PR TITLE
fix: deduplicate follow-up run messages by messageGroupId (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -153,8 +153,8 @@ import { AddRoleColumnToProjectSecretsProviderAccess1772619247761 } from '../com
 import { ChangeWorkflowPublishedVersionFKsToRestrict1772619247762 } from '../common/1772619247762-ChangeWorkflowPublishedVersionFKsToRestrict';
 import { AddTypeToChatHubSessions1772700000000 } from '../common/1772700000000-AddTypeToChatHubSessions';
 import { CreateRoleMappingRuleTable1772800000000 } from '../common/1772800000000-CreateRoleMappingRuleTable';
-import { CreateInstanceAiTables1773000000000 } from '../common/1773000000000-CreateInstanceAiTables';
 import { CreateCredentialDependencyTable1773000000000 } from '../common/1773000000000-CreateCredentialDependencyTable';
+import { CreateInstanceAiTables1773000000000 } from '../common/1773000000000-CreateInstanceAiTables';
 import { CreateInstanceAiSnapshotAndLogTables1774000000000 } from '../common/1774000000000-CreateInstanceAiSnapshotAndLogTables';
 import type { Migration } from '../migration-types';
 

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -147,8 +147,8 @@ import { AddRoleColumnToProjectSecretsProviderAccess1772619247761 } from '../com
 import { ChangeWorkflowPublishedVersionFKsToRestrict1772619247762 } from '../common/1772619247762-ChangeWorkflowPublishedVersionFKsToRestrict';
 import { AddTypeToChatHubSessions1772700000000 } from '../common/1772700000000-AddTypeToChatHubSessions';
 import { CreateRoleMappingRuleTable1772800000000 } from '../common/1772800000000-CreateRoleMappingRuleTable';
-import { CreateInstanceAiTables1773000000000 } from '../common/1773000000000-CreateInstanceAiTables';
 import { CreateCredentialDependencyTable1773000000000 } from '../common/1773000000000-CreateCredentialDependencyTable';
+import { CreateInstanceAiTables1773000000000 } from '../common/1773000000000-CreateInstanceAiTables';
 import { CreateInstanceAiSnapshotAndLogTables1774000000000 } from '../common/1774000000000-CreateInstanceAiSnapshotAndLogTables';
 import type { Migration } from '../migration-types';
 

--- a/packages/@n8n/fs-proxy/src/sharp.d.ts
+++ b/packages/@n8n/fs-proxy/src/sharp.d.ts
@@ -1,0 +1,18 @@
+declare module 'sharp' {
+	interface Sharp {
+		resize(width: number, height?: number): Sharp;
+		png(): Sharp;
+		jpeg(options?: { quality?: number }): Sharp;
+		toBuffer(): Promise<Buffer>;
+		metadata(): Promise<{ width?: number; height?: number; format?: string }>;
+	}
+
+	interface SharpOptions {
+		raw?: { width: number; height: number; channels: 1 | 2 | 3 | 4 };
+	}
+
+	function sharp(input?: Buffer | string, options?: SharpOptions): Sharp;
+
+	// eslint-disable-next-line import-x/no-default-export
+	export default sharp;
+}

--- a/packages/@n8n/fs-proxy/src/tools/screenshot/screenshot.test.ts
+++ b/packages/@n8n/fs-proxy/src/tools/screenshot/screenshot.test.ts
@@ -1,4 +1,5 @@
 import { Monitor } from 'node-screenshots';
+
 import sharp from 'sharp';
 
 import { ScreenshotModule } from './index';

--- a/packages/@n8n/fs-proxy/src/tools/screenshot/screenshot.ts
+++ b/packages/@n8n/fs-proxy/src/tools/screenshot/screenshot.ts
@@ -1,5 +1,6 @@
-import sharp from 'sharp';
 import { z } from 'zod';
+
+import sharp from 'sharp';
 
 import { getPrimaryMonitor } from '../monitor-utils';
 import type { ToolContext, ToolDefinition } from '../types';

--- a/packages/cli/src/modules/instance-ai/message-parser.ts
+++ b/packages/cli/src/modules/instance-ai/message-parser.ts
@@ -268,5 +268,19 @@ export function parseStoredMessages(
 		// in the assistant message's content
 	}
 
+	// Deduplicate assistant messages by messageGroupId.
+	// Follow-up runs in the same group produce separate DB rows; keep only
+	// the latest (which carries the full runIds array and complete tree).
+	const seen = new Set<string>();
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const gid = messages[i].messageGroupId;
+		if (!gid) continue;
+		if (seen.has(gid)) {
+			messages.splice(i, 1);
+		} else {
+			seen.add(gid);
+		}
+	}
+
 	return messages;
 }

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.store.ts
@@ -109,6 +109,44 @@ let groupIdByRunId: Record<string, string> = {};
 // Stale EventSource instances from previous threads discard events.
 let sseGeneration = 0;
 
+// --- HMR: preserve module-level state across hot reloads ---
+// During HMR the module is re-evaluated, resetting the variables above while
+// the browser's EventSource connection stays alive. The orphaned connection's
+// closures still reference the OLD module scope, so the generation guard
+// (`gen !== sseGeneration`) passes against the old variable — events keep
+// processing. When the component remounts and creates a second EventSource
+// both connections deliver events to the reducer, producing duplicate messages.
+//
+// Fix: close the orphaned EventSource and carry forward the generation counter
+// and reducer routing maps so a single, consistent SSE lifecycle is maintained.
+if (import.meta.hot) {
+	const prev = import.meta.hot.data as {
+		eventSource?: EventSource | null;
+		sseGeneration?: number;
+		runStateByGroupId?: Record<string, AgentRunState>;
+		groupIdByRunId?: Record<string, string>;
+	};
+	if (prev.eventSource) {
+		prev.eventSource.close();
+	}
+	if (prev.sseGeneration !== undefined) {
+		sseGeneration = prev.sseGeneration;
+	}
+	if (prev.runStateByGroupId) {
+		runStateByGroupId = prev.runStateByGroupId;
+	}
+	if (prev.groupIdByRunId) {
+		groupIdByRunId = prev.groupIdByRunId;
+	}
+
+	import.meta.hot.dispose((data: Record<string, unknown>) => {
+		data.eventSource = eventSource;
+		data.sseGeneration = sseGeneration;
+		data.runStateByGroupId = runStateByGroupId;
+		data.groupIdByRunId = groupIdByRunId;
+	});
+}
+
 export const useInstanceAiStore = defineStore('instanceAi', () => {
 	const rootStore = useRootStore();
 	const settingsStore = useSettingsStore();

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.store.ts
@@ -109,44 +109,6 @@ let groupIdByRunId: Record<string, string> = {};
 // Stale EventSource instances from previous threads discard events.
 let sseGeneration = 0;
 
-// --- HMR: preserve module-level state across hot reloads ---
-// During HMR the module is re-evaluated, resetting the variables above while
-// the browser's EventSource connection stays alive. The orphaned connection's
-// closures still reference the OLD module scope, so the generation guard
-// (`gen !== sseGeneration`) passes against the old variable — events keep
-// processing. When the component remounts and creates a second EventSource
-// both connections deliver events to the reducer, producing duplicate messages.
-//
-// Fix: close the orphaned EventSource and carry forward the generation counter
-// and reducer routing maps so a single, consistent SSE lifecycle is maintained.
-if (import.meta.hot) {
-	const prev = import.meta.hot.data as {
-		eventSource?: EventSource | null;
-		sseGeneration?: number;
-		runStateByGroupId?: Record<string, AgentRunState>;
-		groupIdByRunId?: Record<string, string>;
-	};
-	if (prev.eventSource) {
-		prev.eventSource.close();
-	}
-	if (prev.sseGeneration !== undefined) {
-		sseGeneration = prev.sseGeneration;
-	}
-	if (prev.runStateByGroupId) {
-		runStateByGroupId = prev.runStateByGroupId;
-	}
-	if (prev.groupIdByRunId) {
-		groupIdByRunId = prev.groupIdByRunId;
-	}
-
-	import.meta.hot.dispose((data: Record<string, unknown>) => {
-		data.eventSource = eventSource;
-		data.sseGeneration = sseGeneration;
-		data.runStateByGroupId = runStateByGroupId;
-		data.groupIdByRunId = groupIdByRunId;
-	});
-}
-
 export const useInstanceAiStore = defineStore('instanceAi', () => {
 	const rootStore = useRootStore();
 	const settingsStore = useSettingsStore();


### PR DESCRIPTION
## Summary
- Fix duplicate chat replies when switching threads or reloading the Instance AI chat
- Mastra creates a new assistant message for each `agent.stream()` call — follow-up runs in the same `messageGroupId` produce a second DB row instead of updating the first
- Added deduplication in `parseStoredMessages`: iterates backwards by `messageGroupId` and keeps only the last (most complete) entry, which already carries the full `runIds` array and complete agent tree

## Root cause

Mastra's `Agent.stream()` treats each invocation as a standalone conversation turn and always **inserts** a new user + assistant message pair via `memory.saveMessages()`. It has no concept of message groups — `messageGroupId` is an n8n concept layered on top.

When a follow-up run fires (e.g., after the builder sub-agent completes and the orchestrator sends a final summary):
1. n8n calls `agent.stream()` again with the follow-up context
2. Mastra saves a **new** user message (the auto-follow-up prompt) + a **new** assistant message
3. n8n already hides the auto-follow-up user message via `cleanStoredUserMessage()`, but the duplicate assistant message was not being deduplicated

During live streaming the frontend reducer handles this correctly — `run-start` for a follow-up merges into the existing message by `messageGroupId`. But when messages are loaded from the DB (thread switch, page reload), both rows are returned and rendered as separate replies.

## Mastra limitation

Mastra does not support updating an existing message in place for follow-up runs. The proper upstream fix would be either:
- A message update mode where follow-up runs replace the existing assistant message
- A hook to let the caller control message persistence (skip or merge)

Until that exists, the dedup in `parseStoredMessages` is the pragmatic workaround.

## Test plan
- [ ] Send a message that triggers a follow-up run (e.g. a workflow build request)
- [ ] Switch to another thread and back — verify no duplicate reply
- [ ] Refresh the page — verify no duplicate reply
- [ ] Verify single-run messages are unaffected