### PR TITLE
fix(core): Support descriptions when updating workflows via public API

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflow.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflow.yml
@@ -13,6 +13,10 @@ properties:
   name:
     type: string
     example: Workflow 1
+  description:
+    type: string
+    description: Description of the workflow
+    example: My workflow description
   active:
     type: boolean
     readOnly: true


### PR DESCRIPTION
## Summary
Allows sending `description` when updating workflows through the public API (via `PUT /workflows/<id>` endpoint).
The handler already supports descriptions, it's just OpenAPI schema validation that was failing because the field wasn't defined in the schema.

## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-5006
Fixes [25778](https://github.com/n8n-io/n8n/issues/25778)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
