### PR TITLE
fix(instance-ai): Resolve entity names in tool confirmation messages (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -96,6 +96,7 @@ Always pass \`conversationContext\` when spawning any background agent (\`build-
 - **Test credentials** before referencing them in workflows.
 - **Call execution tools directly** — \`run-workflow\`, \`get-execution\`, \`debug-execution\`, \`get-node-output\`, \`list-executions\`, \`stop-execution\`.
 - **Prefer tool calls over advice** — if you can do it, do it.
+- **Always include entity names** — when a tool accepts an optional name parameter (e.g. \`workflowName\`, \`folderName\`, \`credentialName\`), always pass it. The name is shown to the user in confirmation dialogs.
 - **Data tables**: read directly (\`list-data-tables\`, \`get-data-table-schema\`, \`query-data-table-rows\`); for creates/updates/deletes, use \`plan\` with \`manage-data-tables\` tasks. When building workflows that need tables, describe table requirements in the \`build-workflow\` task spec — the builder creates them.
 
 ${

--- a/packages/@n8n/instance-ai/src/tools/credentials/delete-credential.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/credentials/delete-credential.tool.ts
@@ -11,6 +11,10 @@ export function createDeleteCredentialTool(context: InstanceAiContext) {
 		description: 'Permanently delete a credential by ID. Irreversible.',
 		inputSchema: z.object({
 			credentialId: z.string().describe('ID of the credential to delete'),
+			credentialName: z
+				.string()
+				.optional()
+				.describe('Name of the credential (for confirmation message)'),
 		}),
 		outputSchema: z.object({
 			success: z.boolean(),
@@ -34,7 +38,7 @@ export function createDeleteCredentialTool(context: InstanceAiContext) {
 			if (needsApproval && (resumeData === undefined || resumeData === null)) {
 				await suspend?.({
 					requestId: nanoid(),
-					message: `Delete credential "${input.credentialId}"? This cannot be undone.`,
+					message: `Delete credential "${input.credentialName ?? input.credentialId}"? This cannot be undone.`,
 					severity: 'destructive' as const,
 				});
 				// suspend() never resolves — this line is unreachable but satisfies the type checker

--- a/packages/@n8n/instance-ai/src/tools/executions/run-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/executions/run-workflow.tool.ts
@@ -14,6 +14,10 @@ export function createRunWorkflowTool(context: InstanceAiContext) {
 			'Execute a workflow, wait for completion (with timeout), and return the full result including output data and any errors. Default timeout is 5 minutes.',
 		inputSchema: z.object({
 			workflowId: z.string().describe('ID of the workflow to execute'),
+			workflowName: z
+				.string()
+				.optional()
+				.describe('Name of the workflow (for confirmation message)'),
 			inputData: z
 				.record(z.unknown())
 				.optional()
@@ -58,7 +62,7 @@ export function createRunWorkflowTool(context: InstanceAiContext) {
 			if (needsApproval && (resumeData === undefined || resumeData === null)) {
 				await suspend?.({
 					requestId: nanoid(),
-					message: `Execute workflow "${input.workflowId}"?`,
+					message: `Execute workflow "${input.workflowName ?? input.workflowId}"?`,
 					severity: 'warning' as const,
 				});
 				return {

--- a/packages/@n8n/instance-ai/src/tools/workflows/delete-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/delete-workflow.tool.ts
@@ -12,6 +12,10 @@ export function createDeleteWorkflowTool(context: InstanceAiContext) {
 			'Archive a workflow by ID. This is a soft delete that unpublishes the workflow if needed and can be undone later.',
 		inputSchema: z.object({
 			workflowId: z.string().describe('ID of the workflow to archive'),
+			workflowName: z
+				.string()
+				.optional()
+				.describe('Name of the workflow (for confirmation message)'),
 		}),
 		outputSchema: z.object({
 			success: z.boolean(),
@@ -33,17 +37,9 @@ export function createDeleteWorkflowTool(context: InstanceAiContext) {
 
 			// State 1: First call — suspend for confirmation (unless always_allow)
 			if (needsApproval && (resumeData === undefined || resumeData === null)) {
-				const workflow = await Promise.resolve(context.workflowService.get(input.workflowId)).catch(
-					() => undefined,
-				);
-				const workflowLabel =
-					typeof workflow?.name === 'string' && workflow.name.trim().length > 0
-						? workflow.name
-						: input.workflowId;
-
 				await suspend?.({
 					requestId: nanoid(),
-					message: `Archive workflow "${workflowLabel}"? This will deactivate it if needed and can be undone later.`,
+					message: `Archive workflow "${input.workflowName ?? input.workflowId}"? This will deactivate it if needed and can be undone later.`,
 					severity: 'warning' as const,
 				});
 				// suspend() never resolves — this line is unreachable but satisfies the type checker

--- a/packages/@n8n/instance-ai/src/tools/workflows/publish-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/publish-workflow.tool.ts
@@ -10,6 +10,7 @@ export function createPublishWorkflowTool(context: InstanceAiContext) {
 
 	const baseSchema = z.object({
 		workflowId: z.string().describe('ID of the workflow'),
+		workflowName: z.string().optional().describe('Name of the workflow (for confirmation message)'),
 		versionId: z
 			.string()
 			.optional()
@@ -60,11 +61,13 @@ export function createPublishWorkflowTool(context: InstanceAiContext) {
 			const needsApproval = context.permissions?.publishWorkflow !== 'always_allow';
 
 			if (needsApproval && (resumeData === undefined || resumeData === null)) {
+				const label = input.workflowName ?? input.workflowId;
+
 				await suspend?.({
 					requestId: nanoid(),
 					message: input.versionId
-						? `Publish version "${input.versionId}" of workflow "${input.workflowId}"?`
-						: `Publish workflow "${input.workflowId}"?`,
+						? `Publish version "${input.versionId}" of workflow "${label}"?`
+						: `Publish workflow "${label}"?`,
 					severity: 'warning' as const,
 				});
 				return { success: false };

--- a/packages/@n8n/instance-ai/src/tools/workflows/unpublish-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/unpublish-workflow.tool.ts
@@ -13,6 +13,10 @@ export function createUnpublishWorkflowTool(context: InstanceAiContext) {
 			'The draft is preserved and can be re-published later.',
 		inputSchema: z.object({
 			workflowId: z.string().describe('ID of the workflow to unpublish'),
+			workflowName: z
+				.string()
+				.optional()
+				.describe('Name of the workflow (for confirmation message)'),
 		}),
 		outputSchema: z.object({
 			success: z.boolean(),
@@ -36,7 +40,7 @@ export function createUnpublishWorkflowTool(context: InstanceAiContext) {
 			if (needsApproval && (resumeData === undefined || resumeData === null)) {
 				await suspend?.({
 					requestId: nanoid(),
-					message: `Unpublish workflow "${input.workflowId}"?`,
+					message: `Unpublish workflow "${input.workflowName ?? input.workflowId}"?`,
 					severity: 'warning' as const,
 				});
 				return { success: false };

--- a/packages/@n8n/instance-ai/src/tools/workspace/cleanup-test-executions.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workspace/cleanup-test-executions.tool.ts
@@ -12,6 +12,10 @@ export function createCleanupTestExecutionsTool(context: InstanceAiContext) {
 			'Delete manual/test execution records for a workflow. Defaults to executions older than 1 hour. Requires confirmation.',
 		inputSchema: z.object({
 			workflowId: z.string().describe('ID of the workflow whose test executions to clean up'),
+			workflowName: z
+				.string()
+				.optional()
+				.describe('Name of the workflow (for confirmation message)'),
 			olderThanHours: z
 				.number()
 				.optional()
@@ -40,7 +44,7 @@ export function createCleanupTestExecutionsTool(context: InstanceAiContext) {
 				const hours = input.olderThanHours ?? 1;
 				await suspend?.({
 					requestId: nanoid(),
-					message: `Delete test executions for workflow "${input.workflowId}" older than ${hours} hour(s)?`,
+					message: `Delete test executions for workflow "${input.workflowName ?? input.workflowId}" older than ${hours} hour(s)?`,
 					severity: 'warning' as const,
 				});
 				return { deletedCount: 0 };

--- a/packages/@n8n/instance-ai/src/tools/workspace/delete-folder.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workspace/delete-folder.tool.ts
@@ -12,6 +12,7 @@ export function createDeleteFolderTool(context: InstanceAiContext) {
 			'Delete a folder. Without transferToFolderId, contents are flattened to root and archived. With transferToFolderId, contents are moved first. Requires confirmation.',
 		inputSchema: z.object({
 			folderId: z.string().describe('ID of the folder to delete'),
+			folderName: z.string().optional().describe('Name of the folder (for confirmation message)'),
 			projectId: z.string().describe('ID of the project the folder belongs to'),
 			transferToFolderId: z
 				.string()
@@ -19,6 +20,10 @@ export function createDeleteFolderTool(context: InstanceAiContext) {
 				.describe(
 					'ID of a folder to move contents into before deletion. If omitted, contents are flattened to project root and archived.',
 				),
+			transferToFolderName: z
+				.string()
+				.optional()
+				.describe('Name of the transfer folder (for confirmation message)'),
 		}),
 		outputSchema: z.object({
 			success: z.boolean(),
@@ -41,11 +46,11 @@ export function createDeleteFolderTool(context: InstanceAiContext) {
 			// State 1: First call — suspend for confirmation (unless always_allow)
 			if (needsApproval && (resumeData === undefined || resumeData === null)) {
 				const transferNote = input.transferToFolderId
-					? ` Contents will be moved to folder "${input.transferToFolderId}".`
+					? ` Contents will be moved to folder "${input.transferToFolderName ?? input.transferToFolderId}".`
 					: ' Contents will be flattened to project root and archived.';
 				await suspend?.({
 					requestId: nanoid(),
-					message: `Delete folder "${input.folderId}"?${transferNote}`,
+					message: `Delete folder "${input.folderName ?? input.folderId}"?${transferNote}`,
 					severity: 'destructive' as const,
 				});
 				// suspend() never resolves — this line is unreachable but satisfies the type checker

--- a/packages/@n8n/instance-ai/src/tools/workspace/move-workflow-to-folder.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workspace/move-workflow-to-folder.tool.ts
@@ -11,7 +11,15 @@ export function createMoveWorkflowToFolderTool(context: InstanceAiContext) {
 		description: 'Move a workflow into a folder. Non-destructive — the workflow is not modified.',
 		inputSchema: z.object({
 			workflowId: z.string().describe('ID of the workflow to move'),
+			workflowName: z
+				.string()
+				.optional()
+				.describe('Name of the workflow (for confirmation message)'),
 			folderId: z.string().describe('ID of the destination folder'),
+			folderName: z
+				.string()
+				.optional()
+				.describe('Name of the destination folder (for confirmation message)'),
 		}),
 		outputSchema: z.object({
 			success: z.boolean(),
@@ -35,7 +43,7 @@ export function createMoveWorkflowToFolderTool(context: InstanceAiContext) {
 			if (needsApproval && (resumeData === undefined || resumeData === null)) {
 				await suspend?.({
 					requestId: nanoid(),
-					message: `Move workflow "${input.workflowId}" to folder "${input.folderId}"?`,
+					message: `Move workflow "${input.workflowName ?? input.workflowId}" to folder "${input.folderName ?? input.folderId}"?`,
 					severity: 'info' as const,
 				});
 				// suspend() never resolves — this line is unreachable but satisfies the type checker

--- a/packages/@n8n/instance-ai/src/tools/workspace/tag-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workspace/tag-workflow.tool.ts
@@ -12,6 +12,10 @@ export function createTagWorkflowTool(context: InstanceAiContext) {
 			'Assign tags to a workflow by name. Creates tags that do not exist yet. Replaces all existing tags on the workflow.',
 		inputSchema: z.object({
 			workflowId: z.string().describe('ID of the workflow to tag'),
+			workflowName: z
+				.string()
+				.optional()
+				.describe('Name of the workflow (for confirmation message)'),
 			tags: z.array(z.string()).min(1).describe('Tag names to assign to the workflow'),
 		}),
 		outputSchema: z.object({
@@ -36,7 +40,7 @@ export function createTagWorkflowTool(context: InstanceAiContext) {
 			if (needsApproval && (resumeData === undefined || resumeData === null)) {
 				await suspend?.({
 					requestId: nanoid(),
-					message: `Tag workflow "${input.workflowId}" with [${input.tags.join(', ')}]?`,
+					message: `Tag workflow "${input.workflowName ?? input.workflowId}" with [${input.tags.join(', ')}]?`,
 					severity: 'info' as const,
 				});
 				// suspend() never resolves — this line is unreachable but satisfies the type checker


### PR DESCRIPTION
## Summary
- Add optional name parameters (`workflowName`, `folderName`, `credentialName`) to all tools that show confirmation dialogs
- Use `name ?? id` fallback so confirmation messages show human-readable names instead of raw IDs (e.g. `Delete folder "My Reports"?` instead of `Delete folder "l9SUnmxhlarCXMSd"?`)
- Add system prompt instruction telling the agent to always include entity names when calling tools

## Test plan
- [ ] Trigger a destructive action (e.g. delete folder) and verify the confirmation dialog shows the entity name
- [ ] Verify fallback to ID still works if agent doesn't pass the name