### PR TITLE
fix(Dropbox Node): Fix Content-Type header for users/get_current_acco…

### DIFF
--- a/packages/nodes-base/nodes/Dropbox/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Dropbox/GenericFunctions.ts
@@ -8,10 +8,6 @@ import type {
 } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
 
-/**
- * Make an API request to Dropbox
- *
- */
 export async function dropboxApiRequest(
 	this: IHookFunctions | IExecuteFunctions,
 	method: IHttpRequestMethods,
@@ -95,6 +91,8 @@ export async function getRootDirectory(this: IHookFunctions | IExecuteFunctions)
 		'POST',
 		'https://api.dropboxapi.com/2/users/get_current_account',
 		{},
+		{},
+		{ 'Content-Type': 'application/json' },
 	);
 }
 


### PR DESCRIPTION
fix(Dropbox Node): Fix Content-Type header for users/get_current_account API call

The Dropbox node was failing when downloading files because the users/get_current_account endpoint was receiving Content-Type: application/x-www-form-urlencoded instead of application/json.

This fix explicitly sets the Content-Type header to application/json for the getRootDirectory function, which calls this specific endpoint.

Fixes: Bad request error when downloading files with Dropbox node

## Summary

This PR fixes a bug in the Dropbox node where file download operations were failing with a "Bad HTTP Content-Type header" error.

**The Solution:**
Explicitly pass `Content-Type: application/json` header to the `dropboxApiRequest` call in the `getRootDirectory` function.

**What Changed:**
- Modified `packages/nodes-base/nodes/Dropbox/GenericFunctions.ts`
- Added explicit `Content-Type` header parameter to `getRootDirectory` function
- Only affects the `users/get_current_account` API call; all other Dropbox operations remain unchanged

**Testing:**
To test this fix:
1. Create a Dropbox workflow with the "Download File" operation
2. Configure with a valid Dropbox credential (OAuth2 or Access Token) with `accessType: 'full'`
3. Set a file path to download
4. Execute the workflow
5. Previously: Would fail with Content-Type error
6. Now: Should successfully download the file

## Related Linear tickets, Github issues, and Community forum posts

fixes #27667

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)