### PR TITLE
fix(nodes-base): implement missing Delete Bucket operation for S3 node

### DIFF
--- a/packages/nodes-base/nodes/S3/S3.node.ts
+++ b/packages/nodes-base/nodes/S3/S3.node.ts
@@ -162,6 +162,36 @@ export class S3 implements INodeType {
 						returnData.push(...executionData);
 						// returnData.push({ success: true });
 					}
+
+					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html
+					if (operation === 'delete') {
+						const bucketName = this.getNodeParameter('bucketName', i) as string;
+
+						responseData = await s3ApiRequestSOAP.call(this, bucketName, 'GET', '', '', {
+							location: '',
+						});
+
+						const region = responseData.LocationConstraint?._ as string | undefined;
+
+						responseData = await s3ApiRequestSOAP.call(
+							this,
+							bucketName,
+							'DELETE',
+							'',
+							'',
+							qs,
+							headers,
+							{},
+							region,
+						);
+
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray({ success: true }),
+							{ itemData: { item: i } },
+						);
+						returnData.push(...executionData);
+					}
+
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html
 					if (operation === 'getAll') {
 						const returnAll = this.getNodeParameter('returnAll', 0);
@@ -266,9 +296,9 @@ export class S3 implements INodeType {
 						);
 						returnData.push(...executionData);
 						// if (Array.isArray(responseData)) {
-						// 	returnData.push.apply(returnData, responseData);
+						//  returnData.push.apply(returnData, responseData);
 						// } else {
-						// 	returnData.push(responseData);
+						//  returnData.push(responseData);
 						// }
 					}
 				}


### PR DESCRIPTION
## Summary
This PR implements the missing delete operation for the bucket resource in the S3 node, calling the AWS SDK as expected.

## Related Linear tickets, Github issues, and Community forum posts
Fixes #27396