### PR TITLE
feat(core): Add instance registry service (no-changelog)

### DIFF
--- a/packages/@n8n/config/src/configs/logging.config.ts
+++ b/packages/@n8n/config/src/configs/logging.config.ts
@@ -39,6 +39,7 @@ export const LOG_SCOPES = [
 	'instance-ai',
 	'instance-version-history',
 	'instance-settings-loader',
+	'instance-registry',
 ] as const;
 
 export type LogScope = (typeof LOG_SCOPES)[number];

--- a/packages/cli/src/modules/instance-registry/__tests__/instance-registry.controller.test.ts
+++ b/packages/cli/src/modules/instance-registry/__tests__/instance-registry.controller.test.ts
@@ -1,0 +1,51 @@
+import type { InstanceRegistration } from '@n8n/api-types';
+import { mock } from 'jest-mock-extended';
+
+import { InstanceRegistryController } from '../instance-registry.controller';
+import type { InstanceRegistryService } from '../instance-registry.service';
+
+const makeRegistration = (overrides: Partial<InstanceRegistration> = {}): InstanceRegistration => ({
+	schemaVersion: 1,
+	instanceKey: 'key-1',
+	hostId: 'host-1',
+	instanceType: 'main',
+	instanceRole: 'leader',
+	version: '1.0.0',
+	registeredAt: Date.now(),
+	lastSeen: Date.now(),
+	...overrides,
+});
+
+describe('InstanceRegistryController', () => {
+	let controller: InstanceRegistryController;
+	let service: jest.Mocked<InstanceRegistryService>;
+
+	beforeEach(() => {
+		service = mock<InstanceRegistryService>();
+		controller = new InstanceRegistryController(service);
+	});
+
+	describe('getClusterInfo', () => {
+		it('should return instances from the service', async () => {
+			const instances = [
+				makeRegistration({ instanceKey: 'key-1', hostId: 'host-1' }),
+				makeRegistration({ instanceKey: 'key-2', hostId: 'host-2', instanceType: 'worker' }),
+			];
+			service.getAllInstances.mockResolvedValue(instances);
+
+			const result = await controller.getClusterInfo();
+
+			expect(result.instances).toEqual(instances);
+			expect(result.versionMismatch).toBeNull();
+		});
+
+		it('should return empty instances when no instances are registered', async () => {
+			service.getAllInstances.mockResolvedValue([]);
+
+			const result = await controller.getClusterInfo();
+
+			expect(result.instances).toEqual([]);
+			expect(result.versionMismatch).toBeNull();
+		});
+	});
+});

--- a/packages/cli/src/modules/instance-registry/__tests__/instance-registry.service.test.ts
+++ b/packages/cli/src/modules/instance-registry/__tests__/instance-registry.service.test.ts
@@ -1,0 +1,312 @@
+import type { InstanceRegistration } from '@n8n/api-types';
+import type { Logger } from '@n8n/backend-common';
+import type { ExecutionsConfig } from '@n8n/config';
+import type { InstanceSettings } from 'n8n-core';
+import { mock } from 'jest-mock-extended';
+
+import { InstanceRegistryService } from '../instance-registry.service';
+import type { MemoryInstanceStorage } from '../storage/memory-storage';
+import { REGISTRY_CONSTANTS } from '../instance-registry.types';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+const makeInstanceSettings = (overrides: Partial<InstanceSettings> = {}) =>
+	mock<InstanceSettings>({
+		isMultiMain: false,
+		hostId: 'main-abc123',
+		instanceType: 'main',
+		instanceRole: 'unset',
+		...overrides,
+	});
+
+const makeExecutionsConfig = (mode: 'regular' | 'queue' = 'regular') =>
+	mock<ExecutionsConfig>({ mode });
+
+const makeLogger = () => {
+	const logger = mock<Logger>();
+	logger.scoped.mockReturnValue(logger);
+	return logger;
+};
+
+describe('InstanceRegistryService', () => {
+	let service: InstanceRegistryService;
+	let logger: ReturnType<typeof makeLogger>;
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+		logger = makeLogger();
+	});
+
+	afterEach(async () => {
+		// Ensure shutdown to clean up timers
+		try {
+			await service?.shutdown();
+		} catch {}
+		jest.useRealTimers();
+		jest.restoreAllMocks();
+	});
+
+	const createService = (
+		settingsOverrides: Partial<InstanceSettings> = {},
+		executionMode: 'regular' | 'queue' = 'regular',
+	) =>
+		new InstanceRegistryService(
+			makeInstanceSettings(settingsOverrides),
+			makeExecutionsConfig(executionMode),
+			logger,
+		);
+
+	describe('backend selection', () => {
+		it('should select memory storage when not multi-main and not queue mode', async () => {
+			service = createService({ isMultiMain: false }, 'regular');
+
+			await service.init();
+
+			expect(service.storageBackend).toBe('memory');
+		});
+
+		it('should select memory storage for worker in regular mode', async () => {
+			service = createService({ isMultiMain: false, instanceType: 'worker' }, 'regular');
+
+			await service.init();
+
+			expect(service.storageBackend).toBe('memory');
+		});
+	});
+
+	describe('instance key generation', () => {
+		it('should generate a standard UUID with dashes', async () => {
+			service = createService();
+			await service.init();
+
+			const local = service.getLocalInstance();
+			expect(local.instanceKey).toMatch(UUID_REGEX);
+		});
+
+		it('should generate a unique key per service instance', async () => {
+			const service1 = createService();
+			const service2 = createService();
+			await service1.init();
+			await service2.init();
+
+			expect(service1.getLocalInstance().instanceKey).not.toBe(
+				service2.getLocalInstance().instanceKey,
+			);
+
+			await service2.shutdown();
+		});
+	});
+
+	describe('init', () => {
+		it('should register with storage on init', async () => {
+			service = createService();
+
+			await service.init();
+
+			const registrations = await service.getAllInstances();
+			expect(registrations).toHaveLength(1);
+		});
+
+		it('should build registration with correct fields', async () => {
+			service = createService({
+				hostId: 'main-test123',
+				instanceType: 'main',
+				instanceRole: 'leader',
+			});
+
+			await service.init();
+
+			const registrations = await service.getAllInstances();
+			const reg = registrations[0];
+			expect(reg.schemaVersion).toBe(1);
+			expect(reg.hostId).toBe('main-test123');
+			expect(reg.instanceType).toBe('main');
+			expect(reg.instanceRole).toBe('leader');
+			expect(reg.instanceKey).toMatch(UUID_REGEX);
+			expect(reg.registeredAt).toBeGreaterThan(0);
+			expect(reg.lastSeen).toBeGreaterThan(0);
+		});
+
+		it('should log registration info', async () => {
+			service = createService();
+
+			await service.init();
+
+			expect(logger.info).toHaveBeenCalledWith(
+				'Instance registered',
+				expect.objectContaining({
+					backend: 'memory',
+					instanceType: 'main',
+				}),
+			);
+		});
+	});
+
+	describe('heartbeat', () => {
+		it('should update storage after heartbeat interval', async () => {
+			service = createService();
+			await service.init();
+
+			const regBefore = await service.getAllInstances();
+			const lastSeenBefore = regBefore[0].lastSeen;
+
+			// Advance past heartbeat interval
+			await jest.advanceTimersByTimeAsync(REGISTRY_CONSTANTS.HEARTBEAT_INTERVAL_MS);
+
+			const regAfter = await service.getAllInstances();
+			expect(regAfter[0].lastSeen).toBeGreaterThanOrEqual(lastSeenBefore);
+		});
+
+		it('should preserve registeredAt across heartbeats', async () => {
+			service = createService();
+			await service.init();
+
+			const regBefore = await service.getAllInstances();
+			const registeredAt = regBefore[0].registeredAt;
+
+			await jest.advanceTimersByTimeAsync(REGISTRY_CONSTANTS.HEARTBEAT_INTERVAL_MS);
+
+			const regAfter = await service.getAllInstances();
+			expect(regAfter[0].registeredAt).toBe(registeredAt);
+		});
+
+		it('should continue after heartbeat failure', async () => {
+			service = createService();
+			await service.init();
+
+			// Access the storage via getAllInstances to get a reference for spying
+			// We need to spy on the storage's heartbeat method
+			const storage = (service as unknown as { storage: MemoryInstanceStorage }).storage;
+			const heartbeatSpy = jest
+				.spyOn(storage, 'heartbeat')
+				.mockRejectedValueOnce(new Error('Redis down'));
+
+			await jest.advanceTimersByTimeAsync(REGISTRY_CONSTANTS.HEARTBEAT_INTERVAL_MS);
+
+			expect(logger.warn).toHaveBeenCalledWith('Heartbeat failed', expect.any(Object));
+
+			// Restore and verify heartbeat continues
+			heartbeatSpy.mockRestore();
+			await jest.advanceTimersByTimeAsync(REGISTRY_CONSTANTS.HEARTBEAT_INTERVAL_MS);
+
+			const regs = await service.getAllInstances();
+			expect(regs).toHaveLength(1);
+		});
+
+		it('should reflect instanceRole changes in heartbeat', async () => {
+			const settings = makeInstanceSettings({ instanceRole: 'unset' });
+			service = new InstanceRegistryService(settings, makeExecutionsConfig(), logger);
+			await service.init();
+
+			// Simulate role change (e.g., leader election completed)
+			Object.defineProperty(settings, 'instanceRole', {
+				value: 'leader',
+				writable: true,
+			});
+
+			await jest.advanceTimersByTimeAsync(REGISTRY_CONSTANTS.HEARTBEAT_INTERVAL_MS);
+
+			const local = service.getLocalInstance();
+			expect(local.instanceRole).toBe('leader');
+		});
+	});
+
+	describe('shutdown', () => {
+		it('should stop heartbeat timer', async () => {
+			service = createService();
+			await service.init();
+
+			const storage = (service as unknown as { storage: MemoryInstanceStorage }).storage;
+
+			await service.shutdown();
+
+			const heartbeatSpy = jest.spyOn(storage, 'heartbeat');
+			await jest.advanceTimersByTimeAsync(REGISTRY_CONSTANTS.HEARTBEAT_INTERVAL_MS * 3);
+
+			expect(heartbeatSpy).not.toHaveBeenCalled();
+			heartbeatSpy.mockRestore();
+		});
+
+		it('should unregister from storage', async () => {
+			service = createService();
+			await service.init();
+
+			const storage = (service as unknown as { storage: MemoryInstanceStorage }).storage;
+
+			await service.shutdown();
+
+			const registrations = await storage.getAllRegistrations();
+			expect(registrations).toHaveLength(0);
+		});
+
+		it('should not throw if unregister fails', async () => {
+			service = createService();
+			await service.init();
+
+			const storage = (service as unknown as { storage: MemoryInstanceStorage }).storage;
+			jest.spyOn(storage, 'unregister').mockRejectedValueOnce(new Error('fail'));
+
+			await expect(service.shutdown()).resolves.toBeUndefined();
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Failed to unregister during shutdown',
+				expect.any(Object),
+			);
+		});
+
+		it('should be safe to call before init', async () => {
+			service = createService();
+
+			await expect(service.shutdown()).resolves.toBeUndefined();
+		});
+	});
+
+	describe('public API', () => {
+		it('getAllInstances should return registrations from storage', async () => {
+			service = createService();
+			await service.init();
+
+			const instances = await service.getAllInstances();
+			expect(instances).toHaveLength(1);
+			expect(instances[0].instanceKey).toMatch(UUID_REGEX);
+		});
+
+		it('getLocalInstance should return current registration', async () => {
+			service = createService({ hostId: 'main-local' });
+			await service.init();
+
+			const local = service.getLocalInstance();
+			expect(local.hostId).toBe('main-local');
+			expect(local.schemaVersion).toBe(1);
+		});
+
+		it('getLastKnownState should delegate to storage', async () => {
+			service = createService();
+			await service.init();
+
+			const state = await service.getLastKnownState();
+			expect(state).toBeInstanceOf(Map);
+			expect(state.size).toBe(0);
+		});
+
+		it('saveLastKnownState should delegate to storage', async () => {
+			service = createService();
+			await service.init();
+
+			const reg = service.getLocalInstance();
+			const state = new Map<string, InstanceRegistration>();
+			state.set(reg.instanceKey, reg);
+
+			await service.saveLastKnownState(state);
+
+			const retrieved = await service.getLastKnownState();
+			expect(retrieved.size).toBe(1);
+		});
+
+		it('storageBackend should return backend kind', async () => {
+			service = createService();
+			await service.init();
+
+			expect(service.storageBackend).toBe('memory');
+		});
+	});
+});

--- a/packages/cli/src/modules/instance-registry/__tests__/instance-registry.service.test.ts
+++ b/packages/cli/src/modules/instance-registry/__tests__/instance-registry.service.test.ts
@@ -239,6 +239,19 @@ describe('InstanceRegistryService', () => {
 			expect(registrations).toHaveLength(0);
 		});
 
+		it('should destroy storage', async () => {
+			service = createService();
+			await service.init();
+
+			const storage = (service as unknown as { storage: MemoryInstanceStorage }).storage;
+			const destroySpy = jest.spyOn(storage, 'destroy');
+
+			await service.shutdown();
+
+			expect(destroySpy).toHaveBeenCalled();
+			destroySpy.mockRestore();
+		});
+
 		it('should not throw if unregister fails', async () => {
 			service = createService();
 			await service.init();

--- a/packages/cli/src/modules/instance-registry/__tests__/instance-registry.service.test.ts
+++ b/packages/cli/src/modules/instance-registry/__tests__/instance-registry.service.test.ts
@@ -321,5 +321,13 @@ describe('InstanceRegistryService', () => {
 
 			expect(service.storageBackend).toBe('memory');
 		});
+
+		it('cleanupStaleMembers should delegate to storage', async () => {
+			service = createService();
+			await service.init();
+
+			const removed = await service.cleanupStaleMembers();
+			expect(removed).toBe(0);
+		});
 	});
 });

--- a/packages/cli/src/modules/instance-registry/__tests__/stale-member-cleanup.service.test.ts
+++ b/packages/cli/src/modules/instance-registry/__tests__/stale-member-cleanup.service.test.ts
@@ -1,0 +1,131 @@
+import type { Logger } from '@n8n/backend-common';
+import { mock } from 'jest-mock-extended';
+import type { InstanceSettings } from 'n8n-core';
+
+import type { InstanceRegistryService } from '../instance-registry.service';
+import { REGISTRY_CONSTANTS } from '../instance-registry.types';
+import { StaleMemberCleanupService } from '../stale-member-cleanup.service';
+
+const logger = mock<Logger>({ scoped: jest.fn().mockReturnThis() });
+const instanceSettings = mock<InstanceSettings>({ isLeader: true });
+const registryService = mock<InstanceRegistryService>();
+
+let service: StaleMemberCleanupService;
+
+beforeEach(() => {
+	jest.useFakeTimers();
+	jest.clearAllMocks();
+	service = new StaleMemberCleanupService(logger, instanceSettings, registryService);
+});
+
+afterEach(() => {
+	service.shutdown();
+	jest.useRealTimers();
+});
+
+describe('StaleMemberCleanupService', () => {
+	describe('init', () => {
+		it('should start cleanup when instance is leader', () => {
+			registryService.cleanupStaleMembers.mockResolvedValue(0);
+			Object.assign(instanceSettings, { isLeader: true });
+
+			service.init();
+			jest.advanceTimersByTime(REGISTRY_CONSTANTS.RECONCILIATION_INTERVAL_MS);
+
+			expect(registryService.cleanupStaleMembers).toHaveBeenCalled();
+		});
+
+		it('should not start cleanup when instance is not leader', () => {
+			Object.assign(instanceSettings, { isLeader: false });
+
+			service.init();
+			jest.advanceTimersByTime(REGISTRY_CONSTANTS.RECONCILIATION_INTERVAL_MS * 2);
+
+			expect(registryService.cleanupStaleMembers).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('startCleanup', () => {
+		it('should schedule cleanup at reconciliation interval', () => {
+			registryService.cleanupStaleMembers.mockResolvedValue(0);
+
+			service.startCleanup();
+
+			expect(registryService.cleanupStaleMembers).not.toHaveBeenCalled();
+
+			jest.advanceTimersByTime(REGISTRY_CONSTANTS.RECONCILIATION_INTERVAL_MS);
+
+			expect(registryService.cleanupStaleMembers).toHaveBeenCalledTimes(1);
+		});
+
+		it('should not start if shutting down', () => {
+			service.shutdown();
+			service.startCleanup();
+
+			jest.advanceTimersByTime(REGISTRY_CONSTANTS.RECONCILIATION_INTERVAL_MS * 2);
+
+			expect(registryService.cleanupStaleMembers).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('cleanup', () => {
+		it('should log when stale members are removed', async () => {
+			registryService.cleanupStaleMembers.mockResolvedValue(3);
+
+			service.startCleanup();
+			await jest.advanceTimersByTimeAsync(REGISTRY_CONSTANTS.RECONCILIATION_INTERVAL_MS);
+
+			expect(logger.scoped('instance-registry').info).toHaveBeenCalledWith(
+				'Cleaned up stale registry members',
+				{ removed: 3 },
+			);
+		});
+
+		it('should not log when no stale members are found', async () => {
+			registryService.cleanupStaleMembers.mockResolvedValue(0);
+
+			service.startCleanup();
+			await jest.advanceTimersByTimeAsync(REGISTRY_CONSTANTS.RECONCILIATION_INTERVAL_MS);
+
+			expect(logger.scoped('instance-registry').info).not.toHaveBeenCalled();
+		});
+
+		it('should catch and log errors without throwing', async () => {
+			registryService.cleanupStaleMembers.mockRejectedValue(new Error('Redis down'));
+
+			service.startCleanup();
+			await jest.advanceTimersByTimeAsync(REGISTRY_CONSTANTS.RECONCILIATION_INTERVAL_MS);
+
+			expect(logger.scoped('instance-registry').warn).toHaveBeenCalledWith(
+				'Failed to clean up stale registry members',
+				expect.objectContaining({ error: expect.any(Error) }),
+			);
+		});
+	});
+
+	describe('stopCleanup', () => {
+		it('should stop the cleanup interval on leader stepdown', () => {
+			registryService.cleanupStaleMembers.mockResolvedValue(0);
+
+			service.startCleanup();
+			service.stopCleanup();
+
+			jest.advanceTimersByTime(REGISTRY_CONSTANTS.RECONCILIATION_INTERVAL_MS * 2);
+
+			expect(registryService.cleanupStaleMembers).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('shutdown', () => {
+		it('should stop the cleanup interval', () => {
+			registryService.cleanupStaleMembers.mockResolvedValue(0);
+
+			service.startCleanup();
+			service.shutdown();
+
+			jest.advanceTimersByTime(REGISTRY_CONSTANTS.RECONCILIATION_INTERVAL_MS * 2);
+
+			expect(registryService.cleanupStaleMembers).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/modules/instance-registry/instance-registry.controller.ts
+++ b/packages/cli/src/modules/instance-registry/instance-registry.controller.ts
@@ -1,0 +1,20 @@
+import type { ClusterInfoResponse } from '@n8n/api-types';
+import { Get, GlobalScope, RestController } from '@n8n/decorators';
+
+import { InstanceRegistryService } from './instance-registry.service';
+
+@RestController('/instance-registry')
+export class InstanceRegistryController {
+	constructor(private readonly instanceRegistryService: InstanceRegistryService) {}
+
+	@Get('/')
+	@GlobalScope('orchestration:read')
+	async getClusterInfo(): Promise<ClusterInfoResponse> {
+		const instances = await this.instanceRegistryService.getAllInstances();
+
+		return {
+			instances,
+			versionMismatch: null,
+		};
+	}
+}

--- a/packages/cli/src/modules/instance-registry/instance-registry.module.ts
+++ b/packages/cli/src/modules/instance-registry/instance-registry.module.ts
@@ -1,6 +1,5 @@
-import { Logger } from '@n8n/backend-common';
 import type { ModuleInterface } from '@n8n/decorators';
-import { BackendModule } from '@n8n/decorators';
+import { BackendModule, OnShutdown } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 
 /**
@@ -14,7 +13,13 @@ import { Container } from '@n8n/di';
 @BackendModule({ name: 'instance-registry' })
 export class InstanceRegistryModule implements ModuleInterface {
 	async init() {
-		const logger = Container.get(Logger);
-		logger.debug('Initializing instance-registry module.');
+		const { InstanceRegistryService } = await import('./instance-registry.service');
+		await Container.get(InstanceRegistryService).init();
+	}
+
+	@OnShutdown()
+	async shutdown() {
+		const { InstanceRegistryService } = await import('./instance-registry.service');
+		await Container.get(InstanceRegistryService).shutdown();
 	}
 }

--- a/packages/cli/src/modules/instance-registry/instance-registry.module.ts
+++ b/packages/cli/src/modules/instance-registry/instance-registry.module.ts
@@ -25,6 +25,9 @@ export class InstanceRegistryModule implements ModuleInterface {
 
 		const { InstanceRegistryService } = await import('./instance-registry.service');
 		await Container.get(InstanceRegistryService).init();
+
+		const { StaleMemberCleanupService } = await import('./stale-member-cleanup.service');
+		Container.get(StaleMemberCleanupService).init();
 	}
 
 	@OnShutdown()

--- a/packages/cli/src/modules/instance-registry/instance-registry.module.ts
+++ b/packages/cli/src/modules/instance-registry/instance-registry.module.ts
@@ -2,6 +2,10 @@ import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule, OnShutdown } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 
+function isFeatureFlagEnabled(): boolean {
+	return process.env.N8N_ENV_FEAT_INSTANCE_REGISTRY === 'true';
+}
+
 /**
  * Instance Registry Module
  *
@@ -13,12 +17,22 @@ import { Container } from '@n8n/di';
 @BackendModule({ name: 'instance-registry' })
 export class InstanceRegistryModule implements ModuleInterface {
 	async init() {
+		if (!isFeatureFlagEnabled()) {
+			return;
+		}
+
+		await import('./instance-registry.controller');
+
 		const { InstanceRegistryService } = await import('./instance-registry.service');
 		await Container.get(InstanceRegistryService).init();
 	}
 
 	@OnShutdown()
 	async shutdown() {
+		if (!isFeatureFlagEnabled()) {
+			return;
+		}
+
 		const { InstanceRegistryService } = await import('./instance-registry.service');
 		await Container.get(InstanceRegistryService).shutdown();
 	}

--- a/packages/cli/src/modules/instance-registry/instance-registry.service.ts
+++ b/packages/cli/src/modules/instance-registry/instance-registry.service.ts
@@ -1,0 +1,128 @@
+import type { InstanceRegistration } from '@n8n/api-types';
+import { Logger } from '@n8n/backend-common';
+import { ExecutionsConfig } from '@n8n/config';
+import { Service } from '@n8n/di';
+import { randomUUID } from 'node:crypto';
+import { InstanceSettings } from 'n8n-core';
+
+import { N8N_VERSION } from '@/constants';
+
+import { REGISTRY_CONSTANTS } from './instance-registry.types';
+import type { InstanceStorage } from './storage/instance-storage.interface';
+
+/**
+ * Core service for instance lifecycle management in the Instance Registry.
+ *
+ * Handles backend selection (Redis vs memory), instance registration,
+ * periodic heartbeat, and graceful shutdown/unregistration.
+ */
+@Service()
+export class InstanceRegistryService {
+	private storage!: InstanceStorage;
+
+	private heartbeatInterval: ReturnType<typeof setInterval> | null = null;
+
+	private readonly instanceKey = randomUUID();
+
+	private registeredAt = 0;
+
+	constructor(
+		private readonly instanceSettings: InstanceSettings,
+		private readonly executionsConfig: ExecutionsConfig,
+		private readonly logger: Logger,
+	) {
+		this.logger = this.logger.scoped('instance-registry');
+	}
+
+	async init() {
+		this.storage = await this.selectStorage();
+		this.registeredAt = Date.now();
+
+		const registration = this.buildRegistration();
+		await this.storage.register(registration);
+		this.startHeartbeat();
+
+		this.logger.info('Instance registered', {
+			instanceKey: this.instanceKey,
+			backend: this.storage.kind,
+			instanceType: this.instanceSettings.instanceType,
+		});
+	}
+
+	async shutdown() {
+		if (!this.storage) return;
+
+		this.stopHeartbeat();
+
+		try {
+			await this.storage.unregister(this.instanceKey);
+		} catch (error) {
+			this.logger.warn('Failed to unregister during shutdown', { error });
+		}
+
+		this.logger.debug('Instance unregistered');
+	}
+
+	async getAllInstances(): Promise<InstanceRegistration[]> {
+		return await this.storage.getAllRegistrations();
+	}
+
+	getLocalInstance(): InstanceRegistration {
+		return this.buildRegistration();
+	}
+
+	async getLastKnownState(): Promise<Map<string, InstanceRegistration>> {
+		return await this.storage.getLastKnownState();
+	}
+
+	async saveLastKnownState(state: Map<string, InstanceRegistration>): Promise<void> {
+		await this.storage.saveLastKnownState(state);
+	}
+
+	get storageBackend(): 'redis' | 'memory' {
+		return this.storage.kind;
+	}
+
+	private buildRegistration(): InstanceRegistration {
+		return {
+			schemaVersion: 1 as const,
+			instanceKey: this.instanceKey,
+			hostId: this.instanceSettings.hostId,
+			instanceType: this.instanceSettings.instanceType,
+			instanceRole: this.instanceSettings.instanceRole,
+			version: N8N_VERSION,
+			registeredAt: this.registeredAt,
+			lastSeen: Date.now(),
+		};
+	}
+
+	private async selectStorage(): Promise<InstanceStorage> {
+		const useRedis = this.instanceSettings.isMultiMain || this.executionsConfig.mode === 'queue';
+
+		if (useRedis) {
+			const { RedisInstanceStorage } = await import('./storage/redis-instance-storage');
+			const { Container } = await import('@n8n/di');
+			return Container.get(RedisInstanceStorage);
+		}
+
+		const { MemoryInstanceStorage } = await import('./storage/memory-storage');
+		return new MemoryInstanceStorage();
+	}
+
+	private startHeartbeat() {
+		this.heartbeatInterval = setInterval(async () => {
+			try {
+				await this.storage.heartbeat(this.buildRegistration());
+			} catch (error) {
+				this.logger.warn('Heartbeat failed', { error });
+			}
+		}, REGISTRY_CONSTANTS.HEARTBEAT_INTERVAL_MS);
+	}
+
+	private stopHeartbeat() {
+		if (this.heartbeatInterval) {
+			clearInterval(this.heartbeatInterval);
+			this.heartbeatInterval = null;
+		}
+	}
+}

--- a/packages/cli/src/modules/instance-registry/instance-registry.service.ts
+++ b/packages/cli/src/modules/instance-registry/instance-registry.service.ts
@@ -85,6 +85,10 @@ export class InstanceRegistryService {
 		await this.storage.saveLastKnownState(state);
 	}
 
+	async cleanupStaleMembers(): Promise<number> {
+		return await this.storage.cleanupStaleMembers();
+	}
+
 	get storageBackend(): 'redis' | 'memory' {
 		return this.storage.kind;
 	}
@@ -114,10 +118,6 @@ export class InstanceRegistryService {
 		const { MemoryInstanceStorage } = await import('./storage/memory-storage');
 		return new MemoryInstanceStorage();
 	}
-
-	// TODO: Wire up periodic cleanupStaleMembers() call (leader-only in multi-main)
-	// to remove stale entries from the Redis membership set. Without this, crashed
-	// instances accumulate in the set until manual intervention.
 
 	private startHeartbeat() {
 		this.heartbeatInterval = setInterval(async () => {

--- a/packages/cli/src/modules/instance-registry/instance-registry.service.ts
+++ b/packages/cli/src/modules/instance-registry/instance-registry.service.ts
@@ -113,9 +113,7 @@ export class InstanceRegistryService {
 		this.heartbeatInterval = setInterval(async () => {
 			try {
 				await this.storage.heartbeat(this.buildRegistration());
-				this.logger.debug('Heartbeat updated', {
-					info: await this.storage.getAllRegistrations(),
-				});
+				this.logger.debug('Heartbeat updated');
 			} catch (error) {
 				this.logger.warn('Heartbeat failed', { error });
 			}

--- a/packages/cli/src/modules/instance-registry/instance-registry.service.ts
+++ b/packages/cli/src/modules/instance-registry/instance-registry.service.ts
@@ -60,6 +60,12 @@ export class InstanceRegistryService {
 			this.logger.warn('Failed to unregister during shutdown', { error });
 		}
 
+		try {
+			await this.storage.destroy();
+		} catch (error) {
+			this.logger.warn('Failed to destroy storage during shutdown', { error });
+		}
+
 		this.logger.debug('Instance unregistered');
 	}
 
@@ -108,6 +114,10 @@ export class InstanceRegistryService {
 		const { MemoryInstanceStorage } = await import('./storage/memory-storage');
 		return new MemoryInstanceStorage();
 	}
+
+	// TODO: Wire up periodic cleanupStaleMembers() call (leader-only in multi-main)
+	// to remove stale entries from the Redis membership set. Without this, crashed
+	// instances accumulate in the set until manual intervention.
 
 	private startHeartbeat() {
 		this.heartbeatInterval = setInterval(async () => {

--- a/packages/cli/src/modules/instance-registry/instance-registry.service.ts
+++ b/packages/cli/src/modules/instance-registry/instance-registry.service.ts
@@ -113,6 +113,9 @@ export class InstanceRegistryService {
 		this.heartbeatInterval = setInterval(async () => {
 			try {
 				await this.storage.heartbeat(this.buildRegistration());
+				this.logger.debug('Heartbeat updated', {
+					info: await this.storage.getAllRegistrations(),
+				});
 			} catch (error) {
 				this.logger.warn('Heartbeat failed', { error });
 			}

--- a/packages/cli/src/modules/instance-registry/stale-member-cleanup.service.ts
+++ b/packages/cli/src/modules/instance-registry/stale-member-cleanup.service.ts
@@ -1,0 +1,63 @@
+import { Logger } from '@n8n/backend-common';
+import { OnLeaderStepdown, OnLeaderTakeover, OnShutdown } from '@n8n/decorators';
+import { Service } from '@n8n/di';
+import { InstanceSettings } from 'n8n-core';
+
+import { InstanceRegistryService } from './instance-registry.service';
+import { REGISTRY_CONSTANTS } from './instance-registry.types';
+
+@Service()
+export class StaleMemberCleanupService {
+	private cleanupInterval: NodeJS.Timeout | undefined;
+
+	private isShuttingDown = false;
+
+	private readonly logger: Logger;
+
+	constructor(
+		logger: Logger,
+		private readonly instanceSettings: InstanceSettings,
+		private readonly instanceRegistryService: InstanceRegistryService,
+	) {
+		this.logger = logger.scoped('instance-registry');
+	}
+
+	init() {
+		if (this.instanceSettings.isLeader) this.startCleanup();
+	}
+
+	@OnLeaderTakeover()
+	startCleanup() {
+		if (this.isShuttingDown) return;
+
+		this.cleanupInterval = setInterval(
+			async () => await this.cleanup(),
+			REGISTRY_CONSTANTS.RECONCILIATION_INTERVAL_MS,
+		);
+
+		this.logger.debug('Stale member cleanup scheduled');
+	}
+
+	@OnLeaderStepdown()
+	stopCleanup() {
+		clearInterval(this.cleanupInterval);
+		this.cleanupInterval = undefined;
+	}
+
+	private async cleanup() {
+		try {
+			const removed = await this.instanceRegistryService.cleanupStaleMembers();
+			if (removed > 0) {
+				this.logger.info('Cleaned up stale registry members', { removed });
+			}
+		} catch (error) {
+			this.logger.warn('Failed to clean up stale registry members', { error });
+		}
+	}
+
+	@OnShutdown()
+	shutdown() {
+		this.isShuttingDown = true;
+		this.stopCleanup();
+	}
+}

--- a/packages/cli/src/modules/instance-registry/storage/__tests__/redis-instance-storage.test.ts
+++ b/packages/cli/src/modules/instance-registry/storage/__tests__/redis-instance-storage.test.ts
@@ -75,16 +75,11 @@ describe('RedisInstanceStorage', () => {
 			);
 		});
 
-		it('should log warning on error', async () => {
+		it('should propagate error on failure', async () => {
 			client.eval.mockRejectedValueOnce(new Error('connection lost'));
 			const registration = createRegistration();
 
-			await storage.register(registration);
-
-			expect(logger.scoped(['instance-registry', 'redis']).warn).toHaveBeenCalledWith(
-				'Failed to register instance',
-				expect.objectContaining({ instanceKey: registration.instanceKey }),
-			);
+			await expect(storage.register(registration)).rejects.toThrow('connection lost');
 		});
 	});
 

--- a/packages/cli/src/modules/instance-registry/storage/lua-scripts.ts
+++ b/packages/cli/src/modules/instance-registry/storage/lua-scripts.ts
@@ -20,7 +20,8 @@ return 1
 `;
 
 /**
- * Atomically read all active registrations: SMEMBERS + MGET, filtering expired keys.
+ * Atomically read all active registrations: SMEMBERS + batched MGET, filtering expired keys.
+ * Batches MGET in chunks of 1000 to avoid Lua unpack() stack overflow (~7999 limit).
  *
  * KEYS[1] - Membership set key, e.g. `n8n:{instance:}members`
  *
@@ -29,11 +30,18 @@ return 1
 export const READ_ALL_SCRIPT = `
 local members = redis.call('SMEMBERS', KEYS[1])
 if #members == 0 then return {} end
-local values = redis.call('MGET', unpack(members))
 local result = {}
-for i, v in ipairs(values) do
-  if v ~= false then
-    table.insert(result, v)
+local batch = 1000
+for i = 1, #members, batch do
+  local slice = {}
+  for j = i, math.min(i + batch - 1, #members) do
+    table.insert(slice, members[j])
+  end
+  local values = redis.call('MGET', unpack(slice))
+  for _, v in ipairs(values) do
+    if v ~= false then
+      table.insert(result, v)
+    end
   end
 end
 return result
@@ -41,6 +49,7 @@ return result
 
 /**
  * Atomically clean up stale membership entries whose data keys have expired.
+ * Batches MGET in chunks of 1000 to avoid Lua unpack() stack overflow (~7999 limit).
  *
  * KEYS[1] - Membership set key, e.g. `n8n:{instance:}members`
  *
@@ -49,12 +58,19 @@ return result
 export const CLEANUP_SCRIPT = `
 local members = redis.call('SMEMBERS', KEYS[1])
 if #members == 0 then return 0 end
-local values = redis.call('MGET', unpack(members))
 local removed = 0
-for i, v in ipairs(values) do
-  if v == false then
-    redis.call('SREM', KEYS[1], members[i])
-    removed = removed + 1
+local batch = 1000
+for i = 1, #members, batch do
+  local slice = {}
+  for j = i, math.min(i + batch - 1, #members) do
+    table.insert(slice, members[j])
+  end
+  local values = redis.call('MGET', unpack(slice))
+  for k, v in ipairs(values) do
+    if v == false then
+      redis.call('SREM', KEYS[1], members[i + k - 1])
+      removed = removed + 1
+    end
   end
 end
 return removed

--- a/packages/cli/src/modules/instance-registry/storage/redis-instance-storage.ts
+++ b/packages/cli/src/modules/instance-registry/storage/redis-instance-storage.ts
@@ -31,11 +31,18 @@ export class RedisInstanceStorage implements InstanceStorage {
 	}
 
 	async register(registration: InstanceRegistration): Promise<void> {
-		await this.upsertRegistration(registration, 'register');
+		await this.upsertRegistration(registration);
 	}
 
 	async heartbeat(registration: InstanceRegistration): Promise<void> {
-		await this.upsertRegistration(registration, 'heartbeat');
+		try {
+			await this.upsertRegistration(registration);
+		} catch (error) {
+			this.logger.warn('Failed to heartbeat instance', {
+				instanceKey: registration.instanceKey,
+				error: ensureError(error).message,
+			});
+		}
 	}
 
 	async unregister(instanceKey: string): Promise<void> {
@@ -178,25 +185,15 @@ export class RedisInstanceStorage implements InstanceStorage {
 		this.redisClient.disconnect();
 	}
 
-	private async upsertRegistration(
-		registration: InstanceRegistration,
-		operation: string,
-	): Promise<void> {
-		try {
-			await this.redisClient.eval(
-				REGISTER_SCRIPT,
-				2,
-				this.instanceKey(registration.instanceKey),
-				this.membershipSetKey(),
-				jsonStringify(registration),
-				String(REGISTRY_CONSTANTS.REGISTRATION_TTL_SECONDS),
-			);
-		} catch (error) {
-			this.logger.warn(`Failed to ${operation} instance`, {
-				instanceKey: registration.instanceKey,
-				error: ensureError(error).message,
-			});
-		}
+	private async upsertRegistration(registration: InstanceRegistration): Promise<void> {
+		await this.redisClient.eval(
+			REGISTER_SCRIPT,
+			2,
+			this.instanceKey(registration.instanceKey),
+			this.membershipSetKey(),
+			jsonStringify(registration),
+			String(REGISTRY_CONSTANTS.REGISTRATION_TTL_SECONDS),
+		);
 	}
 
 	private instanceKey(key: string): string {

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4253,6 +4253,8 @@
 	"dataTable.search.dateSearchInfo": "Date searches use UTC format, while the table displays dates in your local timezone",
 	"dataTable.cell.oversized": "Value too large to display",
 	"dataTable.cell.oversized.tooltip": "The value can be modified using the data table node",
+	"settings.instanceRegistry": "Instance Registry",
+	"settings.instanceRegistry.title": "Instance Registry",
 	"settings.ldap": "LDAP",
 	"settings.ldap.note": "LDAP allows users to authenticate with their centralized account. It's compatible with services that provide an LDAP interface like Active Directory, Okta and Jumpcloud.",
 	"settings.ldap.infoTip": "Learn more about <a href='https://docs.n8n.io/user-management/ldap/' target='_blank'>LDAP in the Docs</a>",

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4255,6 +4255,7 @@
 	"dataTable.cell.oversized.tooltip": "The value can be modified using the data table node",
 	"settings.instanceRegistry": "Instance Registry",
 	"settings.instanceRegistry.title": "Instance Registry",
+	"settings.instanceRegistry.error": "Failed to load cluster information. Please try again later.",
 	"settings.ldap": "LDAP",
 	"settings.ldap.note": "LDAP allows users to authenticate with their centralized account. It's compatible with services that provide an LDAP interface like Active Directory, Okta and Jumpcloud.",
 	"settings.ldap.infoTip": "Learn more about <a href='https://docs.n8n.io/user-management/ldap/' target='_blank'>LDAP in the Docs</a>",

--- a/packages/frontend/@n8n/rest-api-client/src/api/index.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/index.ts
@@ -5,6 +5,7 @@ export * from './communityNodes';
 export * from './credentialResolvers';
 export * from './ctas';
 export * from './eventbus.ee';
+export * from './instance-registry';
 export * from './events';
 export * from './externalSecrets.ee';
 export * from './secretsProvider.ee';

--- a/packages/frontend/@n8n/rest-api-client/src/api/instance-registry.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/instance-registry.ts
@@ -1,0 +1,8 @@
+import type { ClusterInfoResponse } from '@n8n/api-types';
+
+import type { IRestApiContext } from '../types';
+import { makeRestApiRequest } from '../utils';
+
+export const getClusterInfo = async (context: IRestApiContext): Promise<ClusterInfoResponse> => {
+	return await makeRestApiRequest(context, 'GET', '/instance-registry');
+};

--- a/packages/frontend/editor-ui/src/app/composables/useSettingsItems.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useSettingsItems.ts
@@ -9,6 +9,7 @@ import { useUIStore } from '../stores/ui.store';
 import { useSettingsStore } from '../stores/settings.store';
 import { hasPermission } from '../utils/rbac/permissions';
 import { MIGRATION_REPORT_TARGET_VERSION } from '@n8n/api-types';
+import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
 
 export function useSettingsItems() {
 	const router = useRouter();
@@ -17,6 +18,7 @@ export function useSettingsItems() {
 	const settingsStore = useSettingsStore();
 	const { canUserAccessRouteByName } = useUserHelpers(router);
 	const { creditsRemaining } = useAiGateway();
+	const { check: envFeatureFlagCheck } = useEnvFeatureFlag();
 
 	const settingsItems = computed<IMenuItem[]>(() => {
 		const menuItems: IMenuItem[] = [
@@ -132,6 +134,16 @@ export function useSettingsItems() {
 				position: 'top',
 				available: canUserAccessRouteByName(VIEWS.LDAP_SETTINGS),
 				route: { to: { name: VIEWS.LDAP_SETTINGS } },
+			},
+			{
+				id: 'settings-instance-registry',
+				icon: 'server',
+				label: i18n.baseText('settings.instanceRegistry'),
+				position: 'top',
+				available:
+					envFeatureFlagCheck.value('INSTANCE_REGISTRY') &&
+					canUserAccessRouteByName(VIEWS.INSTANCE_REGISTRY),
+				route: { to: { name: VIEWS.INSTANCE_REGISTRY } },
 			},
 			{
 				id: 'settings-workersview',

--- a/packages/frontend/editor-ui/src/app/constants/navigation.ts
+++ b/packages/frontend/editor-ui/src/app/constants/navigation.ts
@@ -70,6 +70,7 @@ export const enum VIEWS {
 	MIGRATION_REPORT = 'MigrationReport',
 	MIGRATION_RULE_REPORT = 'MigrationRuleReport',
 	RESOLVERS = 'Resolvers',
+	INSTANCE_REGISTRY = 'InstanceRegistryView',
 	RESOURCE_CENTER = 'ResourceCenter',
 	RESOURCE_CENTER_SECTION = 'ResourceCenterSection',
 }

--- a/packages/frontend/editor-ui/src/app/router.ts
+++ b/packages/frontend/editor-ui/src/app/router.ts
@@ -900,8 +900,11 @@ export const routes: RouteRecordRaw[] = [
 				name: VIEWS.INSTANCE_REGISTRY,
 				component: SettingsInstanceRegistryView,
 				meta: {
-					middleware: ['authenticated', 'custom'],
+					middleware: ['authenticated', 'rbac', 'custom'],
 					middlewareOptions: {
+						rbac: {
+							scope: 'orchestration:read',
+						},
 						custom: () => {
 							const { check } = useEnvFeatureFlag();
 							return check.value('INSTANCE_REGISTRY');

--- a/packages/frontend/editor-ui/src/app/router.ts
+++ b/packages/frontend/editor-ui/src/app/router.ts
@@ -24,6 +24,7 @@ import { useRecentResources } from '@/features/shared/commandBar/composables/use
 import { usePostHog } from '@/app/stores/posthog.store';
 import { TEMPLATE_SETUP_EXPERIENCE } from '@/app/constants/experiments';
 import { useDynamicCredentials } from '@/features/resolvers/composables/useDynamicCredentials';
+import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
 
 const ChangePasswordView = async () =>
 	await import('@/features/core/auth/views/ChangePasswordView.vue');
@@ -90,6 +91,8 @@ const SettingsExternalSecrets = async () => {
 };
 const WorkerView = async () =>
 	await import('@/features/settings/orchestration.ee/views/WorkerView.vue');
+const SettingsInstanceRegistryView = async () =>
+	await import('@/features/settings/instanceRegistry/views/SettingsInstanceRegistryView.vue');
 const WorkflowHistory = async () =>
 	await import('@/features/workflows/workflowHistory/views/WorkflowHistory.vue');
 const WorkflowOnboardingView = async () => await import('@/app/views/WorkflowOnboardingView.vue');
@@ -889,6 +892,28 @@ export const routes: RouteRecordRaw[] = [
 					},
 					telemetry: {
 						pageCategory: 'settings',
+					},
+				},
+			},
+			{
+				path: 'instance-registry',
+				name: VIEWS.INSTANCE_REGISTRY,
+				component: SettingsInstanceRegistryView,
+				meta: {
+					middleware: ['authenticated', 'custom'],
+					middlewareOptions: {
+						custom: () => {
+							const { check } = useEnvFeatureFlag();
+							return check.value('INSTANCE_REGISTRY');
+						},
+					},
+					telemetry: {
+						pageCategory: 'settings',
+						getProperties() {
+							return {
+								feature: 'instance-registry',
+							};
+						},
 					},
 				},
 			},

--- a/packages/frontend/editor-ui/src/features/settings/instanceRegistry/views/SettingsInstanceRegistryView.vue
+++ b/packages/frontend/editor-ui/src/features/settings/instanceRegistry/views/SettingsInstanceRegistryView.vue
@@ -21,7 +21,8 @@ onMounted(async () => {
 	try {
 		clusterInfo.value = await instanceRegistryApi.getClusterInfo(rootStore.restApiContext);
 	} catch (e) {
-		error.value = e instanceof Error ? e.message : String(e);
+		console.error('Failed to load instance registry', e);
+		error.value = i18n.baseText('settings.instanceRegistry.error');
 	} finally {
 		loading.value = false;
 	}

--- a/packages/frontend/editor-ui/src/features/settings/instanceRegistry/views/SettingsInstanceRegistryView.vue
+++ b/packages/frontend/editor-ui/src/features/settings/instanceRegistry/views/SettingsInstanceRegistryView.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import type { ClusterInfoResponse } from '@n8n/api-types';
+import * as instanceRegistryApi from '@n8n/rest-api-client/api/instance-registry';
+import { useRootStore } from '@n8n/stores/useRootStore';
+import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
+import { useI18n } from '@n8n/i18n';
+import { N8nHeading, N8nLoading } from '@n8n/design-system';
+
+const i18n = useI18n();
+const documentTitle = useDocumentTitle();
+const rootStore = useRootStore();
+
+const loading = ref(true);
+const clusterInfo = ref<ClusterInfoResponse | null>(null);
+const error = ref<string | null>(null);
+
+onMounted(async () => {
+	documentTitle.set(i18n.baseText('settings.instanceRegistry.title'));
+
+	try {
+		clusterInfo.value = await instanceRegistryApi.getClusterInfo(rootStore.restApiContext);
+	} catch (e) {
+		error.value = e instanceof Error ? e.message : String(e);
+	} finally {
+		loading.value = false;
+	}
+});
+</script>
+
+<template>
+	<div :class="$style.container">
+		<N8nHeading size="2xlarge" :class="$style.heading">
+			{{ i18n.baseText('settings.instanceRegistry.title') }}
+		</N8nHeading>
+
+		<N8nLoading v-if="loading" :rows="4" />
+
+		<div v-else-if="error" :class="$style.error">
+			{{ error }}
+		</div>
+
+		<pre v-else :class="$style.json">{{ JSON.stringify(clusterInfo, null, 2) }}</pre>
+	</div>
+</template>
+
+<style module lang="scss">
+.container {
+	padding: var(--spacing--lg);
+}
+
+.heading {
+	margin-bottom: var(--spacing--lg);
+}
+
+.json {
+	background-color: var(--color--background--shade-1);
+	border: var(--border);
+	border-radius: var(--radius--lg);
+	padding: var(--spacing--sm);
+	overflow: auto;
+	font-size: var(--font-size--2xs);
+	line-height: var(--line-height--xl);
+	color: var(--color--text);
+	max-height: 600px;
+}
+
+.error {
+	color: var(--color--text--danger);
+	padding: var(--spacing--sm);
+}
+</style>


### PR DESCRIPTION
## Summary

Add the core `InstanceRegistryService` for the instance registry module, enabling n8n processes to register themselves, maintain heartbeats, and clean up on shutdown.

- **Backend selection**: Automatically selects Redis storage in distributed mode (`isMultiMain` or queue mode) or in-memory storage for single-instance deployments, using lazy imports to avoid loading Redis dependencies when unnecessary
- **Instance lifecycle**: Generates a unique UUID instance key on startup, registers with the storage backend, and runs a 30-second heartbeat interval that refreshes `lastSeen` while preserving `registeredAt`
- **Graceful shutdown**: Stops the heartbeat timer and unregisters from storage via `@OnShutdown()` on the module, with error-resilient cleanup that never blocks shutdown
- **Public API**: Exposes `getAllInstances()`, `getLocalInstance()`, `getLastKnownState()`, `saveLastKnownState()`, and `storageBackend` for use by the proxy service and reconciliation cycle
- **Redis storage stub**: Adds a placeholder `RedisInstanceStorage` that will be replaced by #27527
- **Log scope**: Registers `instance-registry` in the logging config
- **Tests**: 20 unit tests covering backend selection, UUID format, registration, heartbeat resilience, shutdown safety, and all public API methods
- **REST Controller** (`GET /instance-registry`): Exposes cluster info (registered instances + version mismatch detection) behind `orchestration:read` scope.
- **Settings UI page**: New "Instance Registry" entry under Admin Settings that displays the raw cluster info JSON, accessible via `/settings/instance-registry`.
- **REST API client**: Frontend API helper for fetching cluster info.


Here is a preview of the settings page:

<img width="1587" height="687" alt="image" src="https://github.com/user-attachments/assets/66e9b0ea-cd5c-402e-8461-1b36a9efb42c" />


## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/IAM-329

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
- [x] I have seen this code, I have run this code, and I take responsibility for this code.