### PR TITLE
fix: use fake timers in execution-persistence test to prevent flaky timing (no-changelog)

### DIFF
--- a/packages/cli/src/executions/__tests__/execution-persistence.test.ts
+++ b/packages/cli/src/executions/__tests__/execution-persistence.test.ts
@@ -215,21 +215,21 @@ describe('ExecutionPersistence', () => {
 		const target = { workflowId: 'wf-1', executionId: 'exec-1', storedAt: 'db' as const };
 
 		it('should soft-delete with backdated `deletedAt` when pruning is enabled', async () => {
+			jest.useFakeTimers();
+			const now = Date.now();
+
 			executionsConfig.pruneData = true;
 			executionsConfig.pruneDataHardDeleteBuffer = 1;
 			const executionPersistence = createPersistenceService('db');
 
-			const before = Date.now();
 			await executionPersistence.deleteInFlightExecution(target);
 
 			expect(executionRepository.update).toHaveBeenCalledWith('exec-1', {
-				deletedAt: expect.any(Date),
+				deletedAt: new Date(now - 3600_000),
 			});
-
-			const { deletedAt } = executionRepository.update.mock.calls[0][1] as { deletedAt: Date };
-			// deletedAt should be backdated by ~1 hour (the buffer)
-			expect(deletedAt.getTime()).toBeLessThanOrEqual(before - 3600_000);
 			expect(executionRepository.deleteByIds).not.toHaveBeenCalled();
+
+			jest.useRealTimers();
 		});
 
 		it('should hard-delete immediately when pruning is disabled', async () => {


### PR DESCRIPTION
## Summary
- Fix flaky `execution-persistence` test by using `jest.useFakeTimers()` to freeze `Date.now()`, replacing a timing-sensitive range assertion with an exact match.

## Test plan
- [x] `pnpm test src/executions/__tests__/execution-persistence.test.ts` passes consistently