### PR TITLE
fix: Track workflow archive/unarchive endpoints in API coverage manifest

### DIFF
--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -103,6 +103,12 @@
 			"status": "covered",
 			"nodeOperation": "workflow:deactivate"
 		},
+		"POST /workflows/{id}/archive": {
+			"status": "gap"
+		},
+		"POST /workflows/{id}/unarchive": {
+			"status": "gap"
+		},
 		"PUT /workflows/{id}/transfer": {
 			"status": "gap"
 		},


### PR DESCRIPTION
## Summary

Fixes a test failure introduced by #27513, which added the workflow archive/unarchive public API endpoints but did not update the coverage manifest. This is blocking the merge queue.

## Related Linear tickets, Github issues, and Community forum posts

n/a
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
