### PR TITLE
feat(core): Add redactExecutionData query param to public API executions

### DIFF
--- a/packages/@n8n/api-types/src/dto/executions/execution-redaction-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/executions/execution-redaction-query.dto.ts
@@ -2,9 +2,11 @@ import { z } from 'zod';
 
 import { booleanFromString } from '../../schemas/boolean-from-string';
 
+const booleanFromStringOrBoolean = z.union([booleanFromString, z.boolean()]);
+
 export const ExecutionRedactionQueryDtoSchema = z
 	.object({
-		redactExecutionData: booleanFromString.optional(),
+		redactExecutionData: booleanFromStringOrBoolean.optional(),
 	})
 	.passthrough();
 

--- a/packages/cli/src/public-api/types.ts
+++ b/packages/cli/src/public-api/types.ts
@@ -33,13 +33,19 @@ export declare namespace ExecutionRequest {
 			cursor?: string;
 			offset?: number;
 			includeData?: boolean;
+			redactExecutionData?: boolean;
 			workflowId?: string;
 			lastId?: string;
 			projectId?: string;
 		}
 	>;
 
-	type Get = AuthenticatedRequest<{ id: string }, {}, {}, { includeData?: boolean }>;
+	type Get = AuthenticatedRequest<
+		{ id: string },
+		{},
+		{},
+		{ includeData?: boolean; redactExecutionData?: boolean }
+	>;
 	type Delete = Get;
 	type Retry = AuthenticatedRequest<{ id: string }, {}, { loadWorkflow?: boolean }, {}>;
 	type Stop = AuthenticatedRequest<{ id: string }>;

--- a/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
@@ -4,6 +4,7 @@ import { Container } from '@n8n/di';
 import type express from 'express';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { QueryFailedError } from '@n8n/typeorm';
+import { ExecutionRedactionQueryDtoSchema } from '@n8n/api-types';
 import { type ExecutionStatus, replaceCircularReferences } from 'n8n-workflow';
 
 import { ActiveExecutions } from '@/active-executions';
@@ -12,6 +13,7 @@ import { AbortedExecutionRetryError } from '@/errors/aborted-execution-retry.err
 import { MissingExecutionStopError } from '@/errors/missing-execution-stop.error';
 import { QueuedExecutionRetryError } from '@/errors/queued-execution-retry.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { ResponseError } from '@/errors/response-errors/abstract/response.error';
 import { EventService } from '@/events/event.service';
 import { ExecutionPersistence } from '@/executions/execution-persistence';
 import type { RedactableExecution } from '@/executions/execution-redaction';
@@ -101,9 +103,29 @@ export = {
 			}
 
 			if (includeData && isRedactableExecution(execution)) {
-				await Container.get(ExecutionRedactionServiceProxy).processExecution(execution, {
-					user: req.user,
-				});
+				const redactQuery = ExecutionRedactionQueryDtoSchema.safeParse(req.query);
+				const redactExecutionData = redactQuery.success
+					? redactQuery.data.redactExecutionData
+					: undefined;
+
+				try {
+					await Container.get(ExecutionRedactionServiceProxy).processExecution(execution, {
+						user: req.user,
+						redactExecutionData,
+						ipAddress: req.ip ?? '',
+						userAgent: req.headers['user-agent'] ?? '',
+					});
+				} catch (error) {
+					if (error instanceof ResponseError) {
+						return res.status(error.httpStatusCode).json({
+							code: error.httpStatusCode,
+							message: error.message,
+							hint: error.hint,
+							meta: 'meta' in error ? error.meta : undefined,
+						});
+					}
+					throw error;
+				}
 			}
 
 			Container.get(EventService).emit('user-retrieved-execution', {
@@ -164,11 +186,33 @@ export = {
 				await Container.get(ExecutionRepository).getExecutionsCountForPublicApi(filters);
 
 			if (includeData) {
+				const redactQuery = ExecutionRedactionQueryDtoSchema.safeParse(req.query);
+				const redactExecutionData = redactQuery.success
+					? redactQuery.data.redactExecutionData
+					: undefined;
+
 				const redactableExecutions = executions.filter(isRedactableExecution);
-				await Container.get(ExecutionRedactionServiceProxy).processExecutions(
-					redactableExecutions,
-					{ user: req.user },
-				);
+				try {
+					await Container.get(ExecutionRedactionServiceProxy).processExecutions(
+						redactableExecutions,
+						{
+							user: req.user,
+							redactExecutionData,
+							ipAddress: req.ip ?? '',
+							userAgent: req.headers['user-agent'] ?? '',
+						},
+					);
+				} catch (error) {
+					if (error instanceof ResponseError) {
+						return res.status(error.httpStatusCode).json({
+							code: error.httpStatusCode,
+							message: error.message,
+							hint: error.hint,
+							meta: 'meta' in error ? error.meta : undefined,
+						});
+					}
+					throw error;
+				}
 			}
 
 			Container.get(EventService).emit('user-retrieved-all-executions', {

--- a/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.id.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.id.yml
@@ -8,6 +8,7 @@ get:
   parameters:
     - $ref: '../schemas/parameters/executionId.yml'
     - $ref: '../schemas/parameters/includeData.yml'
+    - $ref: '../schemas/parameters/redactExecutionData.yml'
   responses:
     '200':
       description: Operation successful.
@@ -17,6 +18,8 @@ get:
             $ref: '../schemas/execution.yml'
     '401':
       $ref: '../../../../shared/spec/responses/unauthorized.yml'
+    '403':
+      $ref: '../../../../shared/spec/responses/forbidden.yml'
     '404':
       $ref: '../../../../shared/spec/responses/notFound.yml'
 delete:

--- a/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.yml
@@ -7,6 +7,7 @@ get:
   description: Retrieve all executions from your instance.
   parameters:
     - $ref: '../schemas/parameters/includeData.yml'
+    - $ref: '../schemas/parameters/redactExecutionData.yml'
     - name: status
       in: query
       description: Status to filter the executions by.
@@ -40,5 +41,7 @@ get:
             $ref: '../schemas/executionList.yml'
     '401':
       $ref: '../../../../shared/spec/responses/unauthorized.yml'
+    '403':
+      $ref: '../../../../shared/spec/responses/forbidden.yml'
     '404':
       $ref: '../../../../shared/spec/responses/notFound.yml'

--- a/packages/cli/src/public-api/v1/handlers/executions/spec/schemas/execution.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/schemas/execution.yml
@@ -5,6 +5,24 @@ properties:
     example: 1000
   data:
     type: object
+    additionalProperties: true
+    description: >
+      Detailed execution data. Only included when `includeData` is `true`.
+    properties:
+      redactionInfo:
+        type: object
+        nullable: true
+        description: Present when execution data has been redacted.
+        properties:
+          isRedacted:
+            type: boolean
+            description: Whether the execution data was redacted.
+          reason:
+            type: string
+            description: The reason for redaction.
+          canReveal:
+            type: boolean
+            description: Whether the current user has permission to reveal the redacted data.
   finished:
     type: boolean
     example: true

--- a/packages/cli/src/public-api/v1/handlers/executions/spec/schemas/parameters/redactExecutionData.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/schemas/parameters/redactExecutionData.yml
@@ -1,0 +1,9 @@
+name: redactExecutionData
+in: query
+description: >
+  Controls execution data redaction. When `true`, execution output data is always
+  redacted. When `false`, requests unredacted (revealed) data — requires the
+  `execution:reveal` scope. When omitted, follows the workflow redaction policy.
+required: false
+schema:
+  type: boolean

--- a/packages/cli/src/public-api/v1/shared/spec/parameters/_index.yml
+++ b/packages/cli/src/public-api/v1/shared/spec/parameters/_index.yml
@@ -10,6 +10,8 @@ TagId:
   $ref: '../../../handlers/tags/spec/schemas/parameters/tagId.yml'
 IncludeData:
   $ref: '../../../handlers/executions/spec/schemas/parameters/includeData.yml'
+RedactExecutionData:
+  $ref: '../../../handlers/executions/spec/schemas/parameters/redactExecutionData.yml'
 UserIdentifier:
   $ref: '../../../handlers/users/spec/schemas/parameters/userIdentifier.yml'
 IncludeRole:

--- a/packages/cli/test/integration/execution-redaction.test.ts
+++ b/packages/cli/test/integration/execution-redaction.test.ts
@@ -681,6 +681,87 @@ describe('GET /api/v1/executions/:id — Execution Redaction', () => {
 			expect(response.body.data).toBeUndefined();
 		});
 	});
+
+	describe('explicit redactExecutionData=true query param', () => {
+		test('always redacts even when policy is "none"', async () => {
+			const workflow = await createWorkflow({}, publicApiOwner);
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+				policy: 'none',
+			});
+
+			const response = await testServer
+				.publicApiAgentFor(publicApiOwner)
+				.get(`/executions/${execution.id}?includeData=true&redactExecutionData=true`)
+				.expect(200);
+
+			assertRedacted(response.body.data as IRunExecutionData, 'user_requested');
+		});
+	});
+
+	describe('explicit redactExecutionData=false query param (reveal)', () => {
+		test('owner can reveal unredacted data', async () => {
+			const workflow = await createWorkflow({}, publicApiOwner);
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+				policy: 'all',
+			});
+
+			const response = await testServer
+				.publicApiAgentFor(publicApiOwner)
+				.get(`/executions/${execution.id}?includeData=true&redactExecutionData=false`)
+				.expect(200);
+
+			assertNotRedacted(response.body.data as IRunExecutionData);
+		});
+
+		test('member without execution:reveal scope gets 403', async () => {
+			testServer.license.enable('feat:sharing');
+
+			const teamProject = await createTeamProject();
+			await linkUserToProject(publicApiMember, teamProject, 'project:editor');
+
+			const workflow = await createWorkflow({}, teamProject);
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+				policy: 'all',
+			});
+
+			const response = await testServer
+				.publicApiAgentFor(publicApiMember)
+				.get(`/executions/${execution.id}?includeData=true&redactExecutionData=false`)
+				.expect(403);
+
+			expect(response.body).toMatchObject({
+				code: 403,
+				message: expect.stringContaining('execution:reveal'),
+			});
+		});
+
+		test('member without execution:reveal scope can still reveal when policy allows it (policy=none)', async () => {
+			testServer.license.enable('feat:sharing');
+
+			const teamProject = await createTeamProject();
+			await linkUserToProject(publicApiMember, teamProject, 'project:editor');
+
+			const workflow = await createWorkflow({}, teamProject);
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+				policy: 'none',
+			});
+
+			const response = await testServer
+				.publicApiAgentFor(publicApiMember)
+				.get(`/executions/${execution.id}?includeData=true&redactExecutionData=false`)
+				.expect(200);
+
+			assertNotRedacted(response.body.data as IRunExecutionData);
+		});
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -786,5 +867,67 @@ describe('GET /api/v1/executions — Execution Redaction', () => {
 		assertNotRedacted(wf1Manual!.data);
 		assertNotRedacted(wf2Trigger!.data);
 		assertRedacted(wf2Webhook!.data, 'workflow_redaction_policy', false);
+	});
+
+	describe('explicit redactExecutionData=true query param', () => {
+		test('always redacts even when policy is "none"', async () => {
+			const workflow = await createWorkflow({}, publicApiOwner);
+			await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+				policy: 'none',
+			});
+
+			const response = await testServer
+				.publicApiAgentFor(publicApiOwner)
+				.get('/executions?includeData=true&redactExecutionData=true')
+				.expect(200);
+
+			expect(response.body.data).toHaveLength(1);
+			assertRedacted(response.body.data[0].data as IRunExecutionData, 'user_requested');
+		});
+	});
+
+	describe('explicit redactExecutionData=false query param (reveal)', () => {
+		test('owner can reveal unredacted data in list', async () => {
+			const workflow = await createWorkflow({}, publicApiOwner);
+			await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+				policy: 'all',
+			});
+
+			const response = await testServer
+				.publicApiAgentFor(publicApiOwner)
+				.get('/executions?includeData=true&redactExecutionData=false')
+				.expect(200);
+
+			expect(response.body.data).toHaveLength(1);
+			assertNotRedacted(response.body.data[0].data as IRunExecutionData);
+		});
+
+		test('member without execution:reveal scope gets 403 in list', async () => {
+			testServer.license.enable('feat:sharing');
+
+			const teamProject = await createTeamProject();
+			await linkUserToProject(publicApiMember, teamProject, 'project:editor');
+
+			const workflow = await createWorkflow({}, teamProject);
+			await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+				policy: 'all',
+			});
+
+			const response = await testServer
+				.publicApiAgentFor(publicApiMember)
+				.get('/executions?includeData=true&redactExecutionData=false')
+				.expect(403);
+
+			expect(response.body).toMatchObject({
+				code: 403,
+				message: expect.stringContaining('execution:reveal'),
+			});
+		});
 	});
 });


### PR DESCRIPTION
## Summary

- Adds `redactExecutionData` query parameter to `GET /executions` and `GET /executions/:id` public API endpoints, allowing callers to explicitly control execution data redaction
- Documents the `redactionInfo` field inside `execution.data` in the OpenAPI spec
- Adds proper 403 error handling when a user lacks the `execution:reveal` scope
- Includes integration tests covering redaction, reveal, and scope-forbidden scenarios

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-200

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)