### PR TITLE
fix(core): Rename data table columns during source control pull

### DIFF
--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -2990,7 +2990,7 @@ describe('SourceControlImportService', () => {
 						teamId: 'project1',
 						teamName: 'Team Project 1',
 					},
-					columns: [{ id: 'col1', name: 'Kostenstelle', type: 'string', index: 0 }],
+					columns: [{ id: 'col1', name: 'New Column Name', type: 'string', index: 0 }],
 					createdAt: '2024-01-01T00:00:00.000Z',
 					updatedAt: '2024-01-02T00:00:00.000Z',
 				};
@@ -2999,13 +2999,13 @@ describe('SourceControlImportService', () => {
 					id: 'dt1',
 					name: 'Test Table',
 					projectId: 'project1',
-					columns: [{ id: 'col1', name: 'kostenstelle' }],
+					columns: [{ id: 'col1', name: 'Old Column Name' }],
 				};
 
 				fsReadFile.mockResolvedValue(JSON.stringify(mockDataTable) as any);
 				dataTableRepository.findOne.mockResolvedValue(existingTable as any);
 				dataTableColumnRepository.find.mockResolvedValue([
-					{ id: 'col1', name: 'kostenstelle' },
+					{ id: 'col1', name: 'Old Column Name' },
 				] as any);
 				projectRepository.findOne.mockResolvedValue({ id: 'project1', type: 'team' } as any);
 
@@ -3015,8 +3015,8 @@ describe('SourceControlImportService', () => {
 				// Assert
 				expect(dataTableDDLService.renameColumn).toHaveBeenCalledWith(
 					'dt1',
-					'kostenstelle',
-					'Kostenstelle',
+					'Old Column Name',
+					'New Column Name',
 					'sqlite',
 					expect.anything(),
 				);

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -2980,6 +2980,48 @@ describe('SourceControlImportService', () => {
 				);
 			});
 
+			it('should rename columns when name changes but ID stays the same', async () => {
+				// Arrange
+				const mockDataTable = {
+					id: 'dt1',
+					name: 'Test Table',
+					ownedBy: {
+						type: 'team',
+						teamId: 'project1',
+						teamName: 'Team Project 1',
+					},
+					columns: [{ id: 'col1', name: 'Kostenstelle', type: 'string', index: 0 }],
+					createdAt: '2024-01-01T00:00:00.000Z',
+					updatedAt: '2024-01-02T00:00:00.000Z',
+				};
+
+				const existingTable = {
+					id: 'dt1',
+					name: 'Test Table',
+					projectId: 'project1',
+					columns: [{ id: 'col1', name: 'kostenstelle' }],
+				};
+
+				fsReadFile.mockResolvedValue(JSON.stringify(mockDataTable) as any);
+				dataTableRepository.findOne.mockResolvedValue(existingTable as any);
+				dataTableColumnRepository.find.mockResolvedValue([
+					{ id: 'col1', name: 'kostenstelle' },
+				] as any);
+				projectRepository.findOne.mockResolvedValue({ id: 'project1', type: 'team' } as any);
+
+				// Act
+				await service.importDataTablesFromWorkFolder([mockCandidate], mockUser.id);
+
+				// Assert
+				expect(dataTableDDLService.renameColumn).toHaveBeenCalledWith(
+					'dt1',
+					'kostenstelle',
+					'Kostenstelle',
+					'sqlite',
+					expect.anything(),
+				);
+			});
+
 			it('should delete removed columns', async () => {
 				// Arrange
 				const mockDataTable = {

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -2990,7 +2990,7 @@ describe('SourceControlImportService', () => {
 						teamId: 'project1',
 						teamName: 'Team Project 1',
 					},
-					columns: [{ id: 'col1', name: 'New Column Name', type: 'string', index: 0 }],
+					columns: [{ id: 'col1', name: 'newColumnName', type: 'string', index: 0 }],
 					createdAt: '2024-01-01T00:00:00.000Z',
 					updatedAt: '2024-01-02T00:00:00.000Z',
 				};
@@ -2999,13 +2999,13 @@ describe('SourceControlImportService', () => {
 					id: 'dt1',
 					name: 'Test Table',
 					projectId: 'project1',
-					columns: [{ id: 'col1', name: 'Old Column Name' }],
+					columns: [{ id: 'col1', name: 'oldColumnName' }],
 				};
 
 				fsReadFile.mockResolvedValue(JSON.stringify(mockDataTable) as any);
 				dataTableRepository.findOne.mockResolvedValue(existingTable as any);
 				dataTableColumnRepository.find.mockResolvedValue([
-					{ id: 'col1', name: 'Old Column Name' },
+					{ id: 'col1', name: 'oldColumnName' },
 				] as any);
 				projectRepository.findOne.mockResolvedValue({ id: 'project1', type: 'team' } as any);
 
@@ -3015,8 +3015,8 @@ describe('SourceControlImportService', () => {
 				// Assert
 				expect(dataTableDDLService.renameColumn).toHaveBeenCalledWith(
 					'dt1',
-					'Old Column Name',
-					'New Column Name',
+					'oldColumnName',
+					'newColumnName',
 					'sqlite',
 					expect.anything(),
 				);

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -1422,6 +1422,20 @@ export class SourceControlImportService {
 						});
 						columnEntities.push(columnEntity);
 
+						// Rename columns whose name changed (same ID, different name)
+						if (!isNewTable && existingColumnIds.has(column.id)) {
+							const oldName = existingColumnNameMap.get(column.id);
+							if (oldName && oldName !== column.name) {
+								await this.dataTableDDLService.renameColumn(
+									dataTable.id,
+									oldName,
+									column.name,
+									dbType,
+									trx,
+								);
+							}
+						}
+
 						// Add new columns to existing physical table
 						if (!isNewTable && !existingColumnIds.has(column.id)) {
 							await this.dataTableDDLService.addColumn(dataTable.id, columnEntity, dbType, trx);


### PR DESCRIPTION
## Summary

Source control pull now issues `ALTER TABLE RENAME COLUMN` when a data table column is renamed in git (same column ID, different name). Previously only metadata was updated, leaving the physical PostgreSQL column with the old name and causing query failures.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-404
closes #27143

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<details>
<summary>Implementation plan</summary>

## Root Cause

`source-control-import.service.ee.ts` lines 1406-1429: the column upsert loop handles deleting removed columns and adding new columns, but when an existing column (same ID) has a different name, it only updates metadata via `trx.save()` — never calls `dataTableDDLService.renameColumn()` to issue `ALTER TABLE RENAME COLUMN`.

## Fix

After `trx.save()` in the upsert loop, compare `existingColumnNameMap.get(column.id)` against `column.name`. On mismatch, call `dataTableDDLService.renameColumn()` within the same transaction.

</details>