### PR TITLE
feat(workflow-sdk): Dagre-based layout for AI-generated workflows

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -133,10 +133,8 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 			}
 
 			// Apply Dagre-based layout to produce positions matching the FE's tidy-up
-			layoutWorkflowJSON(result.workflow);
-
 			// Override name if provided
-			const json = result.workflow;
+			const json = layoutWorkflowJSON(result.workflow);
 			if (name) {
 				json.name = name;
 			} else if (!json.name && !workflowId) {

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -1,5 +1,5 @@
 import { createTool } from '@mastra/core/tools';
-import { generateWorkflowCode, layoutWorkflowJSON } from '@n8n/workflow-sdk';
+import { generateWorkflowCode } from '@n8n/workflow-sdk';
 import { z } from 'zod';
 
 import { buildCredentialMap, resolveCredentials } from './resolve-credentials';
@@ -132,9 +132,8 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 				};
 			}
 
-			// Apply Dagre-based layout to produce positions matching the FE's tidy-up
 			// Override name if provided
-			const json = layoutWorkflowJSON(result.workflow);
+			const json = result.workflow;
 			if (name) {
 				json.name = name;
 			} else if (!json.name && !workflowId) {

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -1,5 +1,5 @@
 import { createTool } from '@mastra/core/tools';
-import { generateWorkflowCode } from '@n8n/workflow-sdk';
+import { generateWorkflowCode, layoutWorkflowJSON } from '@n8n/workflow-sdk';
 import { z } from 'zod';
 
 import { buildCredentialMap, resolveCredentials } from './resolve-credentials';
@@ -132,8 +132,9 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 				};
 			}
 
-			// Override name if provided
-			const json = result.workflow;
+			// Apply Dagre layout to produce positions matching the FE's tidy-up.
+			// Temporary: remove once the SDK is published with toJSON({ tidyUp: true }).
+			const json = layoutWorkflowJSON(result.workflow);
 			if (name) {
 				json.name = name;
 			} else if (!json.name && !workflowId) {

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -1,5 +1,5 @@
 import { createTool } from '@mastra/core/tools';
-import { generateWorkflowCode } from '@n8n/workflow-sdk';
+import { generateWorkflowCode, layoutWorkflowJSON } from '@n8n/workflow-sdk';
 import { z } from 'zod';
 
 import { buildCredentialMap, resolveCredentials } from './resolve-credentials';
@@ -131,6 +131,9 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 							: undefined,
 				};
 			}
+
+			// Apply Dagre-based layout to produce positions matching the FE's tidy-up
+			layoutWorkflowJSON(result.workflow);
 
 			// Override name if provided
 			const json = result.workflow;

--- a/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow.tool.ts
@@ -274,10 +274,8 @@ export function createSubmitWorkflowTool(
 			}
 
 			// Apply Dagre-based layout to produce positions matching the FE's tidy-up
-			layoutWorkflowJSON(buildOutput.workflow);
-
 			// Override name if provided
-			const json = buildOutput.workflow;
+			const json = layoutWorkflowJSON(buildOutput.workflow);
 			if (name) {
 				json.name = name;
 			} else if (!json.name && !workflowId) {

--- a/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow.tool.ts
@@ -9,7 +9,7 @@
 import { createTool } from '@mastra/core/tools';
 import type { Workspace } from '@mastra/core/workspace';
 import type { WorkflowJSON } from '@n8n/workflow-sdk';
-import { validateWorkflow, layoutWorkflowJSON } from '@n8n/workflow-sdk';
+import { validateWorkflow } from '@n8n/workflow-sdk';
 import { createHash, randomUUID } from 'node:crypto';
 import { z } from 'zod';
 
@@ -273,9 +273,8 @@ export function createSubmitWorkflowTool(
 				};
 			}
 
-			// Apply Dagre-based layout to produce positions matching the FE's tidy-up
 			// Override name if provided
-			const json = layoutWorkflowJSON(buildOutput.workflow);
+			const json = buildOutput.workflow;
 			if (name) {
 				json.name = name;
 			} else if (!json.name && !workflowId) {

--- a/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow.tool.ts
@@ -9,7 +9,7 @@
 import { createTool } from '@mastra/core/tools';
 import type { Workspace } from '@mastra/core/workspace';
 import type { WorkflowJSON } from '@n8n/workflow-sdk';
-import { validateWorkflow } from '@n8n/workflow-sdk';
+import { validateWorkflow, layoutWorkflowJSON } from '@n8n/workflow-sdk';
 import { createHash, randomUUID } from 'node:crypto';
 import { z } from 'zod';
 
@@ -273,8 +273,10 @@ export function createSubmitWorkflowTool(
 				};
 			}
 
-			// Override name if provided
-			const json = buildOutput.workflow;
+			// Apply Dagre layout to produce positions matching the FE's tidy-up.
+			// Temporary: until the SDK is published with toJSON({ tidyUp: true }) support,
+			// the sandbox's SDK doesn't have Dagre layout, so we apply it server-side.
+			const json = layoutWorkflowJSON(buildOutput.workflow);
 			if (name) {
 				json.name = name;
 			} else if (!json.name && !workflowId) {

--- a/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow.tool.ts
@@ -9,7 +9,7 @@
 import { createTool } from '@mastra/core/tools';
 import type { Workspace } from '@mastra/core/workspace';
 import type { WorkflowJSON } from '@n8n/workflow-sdk';
-import { validateWorkflow } from '@n8n/workflow-sdk';
+import { validateWorkflow, layoutWorkflowJSON } from '@n8n/workflow-sdk';
 import { createHash, randomUUID } from 'node:crypto';
 import { z } from 'zod';
 
@@ -272,6 +272,9 @@ export function createSubmitWorkflowTool(
 							: undefined,
 				};
 			}
+
+			// Apply Dagre-based layout to produce positions matching the FE's tidy-up
+			layoutWorkflowJSON(buildOutput.workflow);
 
 			// Override name if provided
 			const json = buildOutput.workflow;

--- a/packages/@n8n/instance-ai/src/workflow-builder/parse-validate.ts
+++ b/packages/@n8n/instance-ai/src/workflow-builder/parse-validate.ts
@@ -64,7 +64,6 @@ export function parseAndValidate(code: string): ParseAndValidateResult {
 		collectValidationIssues(graphValidation.errors, allWarnings);
 		collectValidationIssues(graphValidation.warnings, allWarnings);
 
-		// Convert to JSON (auto-layout calculates positions for nodes without config.position)
 		const json = builder.toJSON();
 
 		// Stage 2: Schema validation via Zod schemas from schemaBaseDirs

--- a/packages/@n8n/workflow-sdk/package.json
+++ b/packages/@n8n/workflow-sdk/package.json
@@ -53,6 +53,7 @@
     "adm-zip": "^0.5.16"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^1.1.4",
     "acorn": "8.14.0",
     "n8n-workflow": "workspace:*",
     "uuid": "catalog:",

--- a/packages/@n8n/workflow-sdk/src/index.ts
+++ b/packages/@n8n/workflow-sdk/src/index.ts
@@ -4,6 +4,7 @@ export type {
 	WorkflowBuilder,
 	WorkflowBuilderStatic,
 	WorkflowBuilderOptions,
+	ToJSONOptions,
 	WorkflowSettings,
 	WorkflowJSON,
 	NodeJSON,
@@ -144,6 +145,9 @@ export { runOnceForAllItems, runOnceForEachItem } from './utils/code-helpers';
 
 // Utility functions
 export { isPlainObject, getProperty, hasProperty } from './utils/safe-access';
+
+// Layout
+export { layoutWorkflowJSON } from './workflow-builder/layout-utils';
 
 // Validation
 export {

--- a/packages/@n8n/workflow-sdk/src/index.ts
+++ b/packages/@n8n/workflow-sdk/src/index.ts
@@ -145,9 +145,6 @@ export { runOnceForAllItems, runOnceForEachItem } from './utils/code-helpers';
 // Utility functions
 export { isPlainObject, getProperty, hasProperty } from './utils/safe-access';
 
-// Layout
-export { layoutWorkflowJSON } from './workflow-builder/layout-utils';
-
 // Validation
 export {
 	validateWorkflow,

--- a/packages/@n8n/workflow-sdk/src/index.ts
+++ b/packages/@n8n/workflow-sdk/src/index.ts
@@ -145,6 +145,9 @@ export { runOnceForAllItems, runOnceForEachItem } from './utils/code-helpers';
 // Utility functions
 export { isPlainObject, getProperty, hasProperty } from './utils/safe-access';
 
+// Layout
+export { layoutWorkflowJSON } from './workflow-builder/layout-utils';
+
 // Validation
 export {
 	validateWorkflow,

--- a/packages/@n8n/workflow-sdk/src/types/base.ts
+++ b/packages/@n8n/workflow-sdk/src/types/base.ts
@@ -902,6 +902,11 @@ export interface GeneratePinDataOptions {
 	beforeWorkflow?: WorkflowJSON;
 }
 
+export interface ToJSONOptions {
+	/** Use Dagre-based layout matching the FE's tidy-up algorithm. Defaults to false (BFS layout). */
+	tidyUp?: boolean;
+}
+
 /**
  * Workflow builder for constructing workflows with a fluent API
  */
@@ -969,7 +974,7 @@ export interface WorkflowBuilder {
 	 */
 	validate(options?: ValidationOptions): ValidationResult;
 
-	toJSON(): WorkflowJSON;
+	toJSON(options?: ToJSONOptions): WorkflowJSON;
 
 	/**
 	 * Serialize the workflow to a specific format using registered serializers.

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.ts
@@ -10,6 +10,7 @@ import type {
 	NodeChain,
 	GeneratePinDataOptions,
 	WorkflowBuilderOptions,
+	ToJSONOptions,
 } from './types/base';
 import { isNodeChain } from './types/base';
 import type { ValidationOptions, ValidationResult, ValidationErrorCode } from './validation/index';
@@ -439,7 +440,7 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 		return undefined;
 	}
 
-	toJSON(): WorkflowJSON {
+	toJSON(options?: ToJSONOptions): WorkflowJSON {
 		// Ensure composite targets from .onError() connections are added to the graph.
 		// This handles cases where a chain node has .onError(ifElseBuilder) — the composite
 		// isn't in the chain's allNodes, so it wasn't dispatched during chain processing.
@@ -456,6 +457,7 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 			settings: this._settings,
 			pinData: this._pinData,
 			meta: this._meta,
+			tidyUp: options?.tidyUp ?? false,
 			resolveTargetNodeName: (target: unknown) => this.resolveTargetNodeName(target),
 		};
 

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/constants.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/constants.test.ts
@@ -1,22 +1,69 @@
 import { describe, it, expect } from '@jest/globals';
 
-import { NODE_SPACING_X, DEFAULT_Y, START_X } from './constants';
+import {
+	GRID_SIZE,
+	DEFAULT_NODE_SIZE,
+	CONFIGURATION_NODE_SIZE,
+	CONFIGURABLE_NODE_SIZE,
+	NODE_X_SPACING,
+	NODE_Y_SPACING,
+	SUBGRAPH_SPACING,
+	AI_X_SPACING,
+	AI_Y_SPACING,
+	NODE_SPACING_X,
+	DEFAULT_Y,
+	START_X,
+} from './constants';
 
 describe('workflow-builder/constants', () => {
-	describe('NODE_SPACING_X', () => {
-		it('is 200 pixels', () => {
+	describe('layout constants match FE', () => {
+		it('GRID_SIZE is 16', () => {
+			expect(GRID_SIZE).toBe(16);
+		});
+
+		it('DEFAULT_NODE_SIZE is 96x96', () => {
+			expect(DEFAULT_NODE_SIZE).toEqual([96, 96]);
+		});
+
+		it('CONFIGURATION_NODE_SIZE is 80x80', () => {
+			expect(CONFIGURATION_NODE_SIZE).toEqual([80, 80]);
+		});
+
+		it('CONFIGURABLE_NODE_SIZE is 256x96', () => {
+			expect(CONFIGURABLE_NODE_SIZE).toEqual([256, 96]);
+		});
+
+		it('NODE_X_SPACING is GRID_SIZE * 8', () => {
+			expect(NODE_X_SPACING).toBe(128);
+		});
+
+		it('NODE_Y_SPACING is GRID_SIZE * 6', () => {
+			expect(NODE_Y_SPACING).toBe(96);
+		});
+
+		it('SUBGRAPH_SPACING is GRID_SIZE * 8', () => {
+			expect(SUBGRAPH_SPACING).toBe(128);
+		});
+
+		it('AI_X_SPACING is GRID_SIZE * 3', () => {
+			expect(AI_X_SPACING).toBe(48);
+		});
+
+		it('AI_Y_SPACING is GRID_SIZE * 8', () => {
+			expect(AI_Y_SPACING).toBe(128);
+		});
+	});
+
+	describe('legacy constants', () => {
+		it('NODE_SPACING_X is 200', () => {
 			expect(NODE_SPACING_X).toBe(200);
 		});
-	});
 
-	describe('DEFAULT_Y', () => {
-		it('is 300 pixels', () => {
+		it('DEFAULT_Y is 300', () => {
 			expect(DEFAULT_Y).toBe(300);
 		});
-	});
 
-	describe('START_X', () => {
-		it('is 100 pixels', () => {
+		it('START_X is 100', () => {
 			expect(START_X).toBe(100);
 		});
 	});

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/constants.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/constants.test.ts
@@ -10,7 +10,6 @@ import {
 	SUBGRAPH_SPACING,
 	AI_X_SPACING,
 	AI_Y_SPACING,
-	NODE_SPACING_X,
 	DEFAULT_Y,
 	START_X,
 } from './constants';
@@ -55,10 +54,6 @@ describe('workflow-builder/constants', () => {
 	});
 
 	describe('legacy constants', () => {
-		it('NODE_SPACING_X is 200', () => {
-			expect(NODE_SPACING_X).toBe(200);
-		});
-
 		it('DEFAULT_Y is 300', () => {
 			expect(DEFAULT_Y).toBe(300);
 		});

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/constants.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/constants.ts
@@ -1,18 +1,33 @@
 /**
  * Layout constants for workflow builder
+ *
+ * These match the frontend's canvas layout constants to ensure
+ * SDK-generated positions match what the FE tidy-up would produce.
  */
 
-/**
- * Default horizontal spacing between nodes
- */
+export const GRID_SIZE = 16;
+
+// Node dimensions (defaults — can be refined with node type descriptions later)
+export const DEFAULT_NODE_SIZE: [number, number] = [GRID_SIZE * 6, GRID_SIZE * 6]; // 96x96
+export const CONFIGURATION_NODE_RADIUS = (GRID_SIZE * 5) / 2; // 40
+export const CONFIGURATION_NODE_SIZE: [number, number] = [
+	CONFIGURATION_NODE_RADIUS * 2,
+	CONFIGURATION_NODE_RADIUS * 2,
+]; // 80x80
+export const CONFIGURABLE_NODE_SIZE: [number, number] = [GRID_SIZE * 16, GRID_SIZE * 6]; // 256x96
+export const NODE_MIN_INPUT_ITEMS_COUNT = 4;
+
+// Layout spacing (matching FE useCanvasLayout)
+export const NODE_X_SPACING = GRID_SIZE * 8; // 128
+export const NODE_Y_SPACING = GRID_SIZE * 6; // 96
+export const SUBGRAPH_SPACING = GRID_SIZE * 8; // 128
+export const AI_X_SPACING = GRID_SIZE * 3; // 48
+export const AI_Y_SPACING = GRID_SIZE * 8; // 128
+export const STICKY_BOTTOM_PADDING = GRID_SIZE * 4; // 64
+
+export const STICKY_NODE_TYPE = 'n8n-nodes-base.stickyNote';
+
+// Legacy constants (used by json-serializer.ts for fallback positioning)
 export const NODE_SPACING_X = 200;
-
-/**
- * Default vertical position for nodes
- */
 export const DEFAULT_Y = 300;
-
-/**
- * Starting X position for first node
- */
 export const START_X = 100;

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/constants.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/constants.ts
@@ -27,6 +27,7 @@ export const STICKY_BOTTOM_PADDING = GRID_SIZE * 4; // 64
 
 export const STICKY_NODE_TYPE = 'n8n-nodes-base.stickyNote';
 
-// Legacy constants (used by json-serializer.ts for fallback positioning)
+// BFS layout constants (used by calculateNodePositions for basic positioning)
+export const NODE_SPACING_X = 200;
 export const DEFAULT_Y = 300;
 export const START_X = 100;

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/constants.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/constants.ts
@@ -28,6 +28,5 @@ export const STICKY_BOTTOM_PADDING = GRID_SIZE * 4; // 64
 export const STICKY_NODE_TYPE = 'n8n-nodes-base.stickyNote';
 
 // Legacy constants (used by json-serializer.ts for fallback positioning)
-export const NODE_SPACING_X = 200;
 export const DEFAULT_Y = 300;
 export const START_X = 100;

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.test.ts
@@ -1,21 +1,21 @@
 /**
- * Tests for layout utility functions
+ * Tests for Dagre-based layout utility functions
  */
 
-import { NODE_SPACING_X, DEFAULT_Y, START_X } from './constants';
+import { GRID_SIZE, STICKY_NODE_TYPE } from './constants';
 import { calculateNodePositions } from './layout-utils';
 import type { GraphNode, ConnectionTarget } from '../types/base';
 
-// Helper to create connection targets with correct type
-function makeTarget(node: string, index: number = 0): ConnectionTarget {
-	return { node, type: 'main', index };
+// Helper to create connection targets
+function makeTarget(node: string, type: string = 'main', index: number = 0): ConnectionTarget {
+	return { node, type, index };
 }
 
 // Helper to create a minimal GraphNode for testing
 function createGraphNode(
 	name: string,
 	type: string,
-	connections: Map<string, Map<number, ConnectionTarget[]>> = new Map(),
+	connections: Map<string, Map<number, ConnectionTarget[]>> = new Map([['main', new Map()]]),
 	position?: [number, number],
 ): GraphNode {
 	return {
@@ -38,6 +38,22 @@ function makeMainConns(
 	return result;
 }
 
+// Helper to create AI subnode connection map (subnode -> parent via ai_* type)
+function makeAiConns(
+	parentName: string,
+	aiType: string,
+	index: number = 0,
+): Map<string, Map<number, ConnectionTarget[]>> {
+	const result = new Map<string, Map<number, ConnectionTarget[]>>();
+	result.set('main', new Map());
+	result.set(aiType, new Map([[0, [makeTarget(parentName, aiType, index)]]]));
+	return result;
+}
+
+function isGridAligned(pos: [number, number]): boolean {
+	return pos[0] % GRID_SIZE === 0 && pos[1] % GRID_SIZE === 0;
+}
+
 describe('calculateNodePositions', () => {
 	describe('basic functionality', () => {
 		it('returns empty map for empty nodes', () => {
@@ -46,19 +62,19 @@ describe('calculateNodePositions', () => {
 			expect(positions.size).toBe(0);
 		});
 
-		it('positions single root node at START_X, DEFAULT_Y', () => {
+		it('positions a single node', () => {
 			const nodes = new Map<string, GraphNode>();
 			nodes.set('trigger', createGraphNode('trigger', 'n8n-nodes-base.manualTrigger'));
 
 			const positions = calculateNodePositions(nodes);
 
-			expect(positions.get('trigger')).toEqual([START_X, DEFAULT_Y]);
+			expect(positions.has('trigger')).toBe(true);
+			const pos = positions.get('trigger')!;
+			expect(isGridAligned(pos)).toBe(true);
 		});
 
-		it('positions connected node NODE_SPACING_X to the right of source', () => {
+		it('positions connected nodes left-to-right', () => {
 			const nodes = new Map<string, GraphNode>();
-
-			// Trigger -> Set
 			const triggerConns = makeMainConns([[0, [makeTarget('set')]]]);
 
 			nodes.set(
@@ -69,104 +85,18 @@ describe('calculateNodePositions', () => {
 
 			const positions = calculateNodePositions(nodes);
 
-			expect(positions.get('trigger')).toEqual([START_X, DEFAULT_Y]);
-			expect(positions.get('set')).toEqual([START_X + NODE_SPACING_X, DEFAULT_Y]);
-		});
-	});
-
-	describe('multiple roots', () => {
-		it('positions multiple root nodes with Y offset of 150', () => {
-			const nodes = new Map<string, GraphNode>();
-			nodes.set('trigger1', createGraphNode('trigger1', 'n8n-nodes-base.manualTrigger'));
-			nodes.set('trigger2', createGraphNode('trigger2', 'n8n-nodes-base.scheduleTrigger'));
-
-			const positions = calculateNodePositions(nodes);
-
-			// Both at START_X, different Y
-			const pos1 = positions.get('trigger1');
-			const pos2 = positions.get('trigger2');
-
-			expect(pos1?.[0]).toBe(START_X);
-			expect(pos2?.[0]).toBe(START_X);
-			// Y values should differ by 150
-			expect(Math.abs((pos1?.[1] ?? 0) - (pos2?.[1] ?? 0))).toBe(150);
-		});
-	});
-
-	describe('branching', () => {
-		it('positions branches with Y offset for each branch', () => {
-			const nodes = new Map<string, GraphNode>();
-
-			// IF node with two outputs
-			const ifConns = makeMainConns([
-				[0, [makeTarget('trueBranch')]],
-				[1, [makeTarget('falseBranch')]],
-			]);
-
-			nodes.set('if', createGraphNode('if', 'n8n-nodes-base.if', ifConns));
-			nodes.set('trueBranch', createGraphNode('trueBranch', 'n8n-nodes-base.set'));
-			nodes.set('falseBranch', createGraphNode('falseBranch', 'n8n-nodes-base.set'));
-
-			const positions = calculateNodePositions(nodes);
-
-			const ifPos = positions.get('if');
-			const truePos = positions.get('trueBranch');
-			const falsePos = positions.get('falseBranch');
-
-			// IF at root position
-			expect(ifPos).toEqual([START_X, DEFAULT_Y]);
-
-			// Both branches at same X (NODE_SPACING_X from IF)
-			expect(truePos?.[0]).toBe(START_X + NODE_SPACING_X);
-			expect(falsePos?.[0]).toBe(START_X + NODE_SPACING_X);
-
-			// Different Y positions (offset by 150)
-			expect(Math.abs((truePos?.[1] ?? 0) - (falsePos?.[1] ?? 0))).toBe(150);
-		});
-	});
-
-	describe('explicit positions', () => {
-		it('skips nodes that already have explicit position in config', () => {
-			const nodes = new Map<string, GraphNode>();
-
-			// Node with explicit position
-			nodes.set(
-				'trigger',
-				createGraphNode('trigger', 'n8n-nodes-base.manualTrigger', new Map(), [500, 600]),
-			);
-
-			const positions = calculateNodePositions(nodes);
-
-			// Should not include node with explicit position
-			expect(positions.has('trigger')).toBe(false);
-		});
-
-		it('positions nodes without explicit config but skips those with explicit', () => {
-			const nodes = new Map<string, GraphNode>();
-
-			// Trigger has explicit position
-			const triggerConns = makeMainConns([[0, [makeTarget('set')]]]);
-
-			nodes.set(
-				'trigger',
-				createGraphNode('trigger', 'n8n-nodes-base.manualTrigger', triggerConns, [500, 600]),
-			);
-			nodes.set('set', createGraphNode('set', 'n8n-nodes-base.set'));
-
-			const positions = calculateNodePositions(nodes);
-
-			// Trigger skipped (has explicit position)
-			expect(positions.has('trigger')).toBe(false);
-			// Set still gets calculated position relative to trigger's BFS position
-			expect(positions.has('set')).toBe(true);
+			const triggerPos = positions.get('trigger')!;
+			const setPos = positions.get('set')!;
+			// Set should be to the right of trigger
+			expect(setPos[0]).toBeGreaterThan(triggerPos[0]);
+			// Same Y (roughly)
+			expect(Math.abs(setPos[1] - triggerPos[1])).toBeLessThan(GRID_SIZE * 2);
 		});
 	});
 
 	describe('linear chain', () => {
-		it('positions chain of nodes incrementing X by NODE_SPACING_X', () => {
+		it('positions chain of nodes incrementing X', () => {
 			const nodes = new Map<string, GraphNode>();
-
-			// A -> B -> C -> D
 			const aConns = makeMainConns([[0, [makeTarget('B')]]]);
 			const bConns = makeMainConns([[0, [makeTarget('C')]]]);
 			const cConns = makeMainConns([[0, [makeTarget('D')]]]);
@@ -178,10 +108,202 @@ describe('calculateNodePositions', () => {
 
 			const positions = calculateNodePositions(nodes);
 
-			expect(positions.get('A')).toEqual([START_X, DEFAULT_Y]);
-			expect(positions.get('B')).toEqual([START_X + NODE_SPACING_X, DEFAULT_Y]);
-			expect(positions.get('C')).toEqual([START_X + NODE_SPACING_X * 2, DEFAULT_Y]);
-			expect(positions.get('D')).toEqual([START_X + NODE_SPACING_X * 3, DEFAULT_Y]);
+			const posA = positions.get('A')!;
+			const posB = positions.get('B')!;
+			const posC = positions.get('C')!;
+			const posD = positions.get('D')!;
+
+			// Each node should be further right
+			expect(posB[0]).toBeGreaterThan(posA[0]);
+			expect(posC[0]).toBeGreaterThan(posB[0]);
+			expect(posD[0]).toBeGreaterThan(posC[0]);
+
+			// All at same Y
+			expect(posA[1]).toBe(posB[1]);
+			expect(posB[1]).toBe(posC[1]);
+			expect(posC[1]).toBe(posD[1]);
+		});
+	});
+
+	describe('branching', () => {
+		it('positions branches with Y offset', () => {
+			const nodes = new Map<string, GraphNode>();
+			const ifConns = makeMainConns([
+				[0, [makeTarget('trueBranch')]],
+				[1, [makeTarget('falseBranch')]],
+			]);
+
+			nodes.set('if', createGraphNode('if', 'n8n-nodes-base.if', ifConns));
+			nodes.set('trueBranch', createGraphNode('trueBranch', 'n8n-nodes-base.set'));
+			nodes.set('falseBranch', createGraphNode('falseBranch', 'n8n-nodes-base.set'));
+
+			const positions = calculateNodePositions(nodes);
+
+			const ifPos = positions.get('if')!;
+			const truePos = positions.get('trueBranch')!;
+			const falsePos = positions.get('falseBranch')!;
+
+			// Both branches to the right of IF
+			expect(truePos[0]).toBeGreaterThan(ifPos[0]);
+			expect(falsePos[0]).toBeGreaterThan(ifPos[0]);
+
+			// At same X
+			expect(truePos[0]).toBe(falsePos[0]);
+
+			// Different Y
+			expect(truePos[1]).not.toBe(falsePos[1]);
+		});
+	});
+
+	describe('disconnected subgraphs', () => {
+		it('arranges disconnected components vertically', () => {
+			const nodes = new Map<string, GraphNode>();
+			const aConns = makeMainConns([[0, [makeTarget('B')]]]);
+			const cConns = makeMainConns([[0, [makeTarget('D')]]]);
+
+			// Two independent chains
+			nodes.set('A', createGraphNode('A', 'n8n-nodes-base.manualTrigger', aConns));
+			nodes.set('B', createGraphNode('B', 'n8n-nodes-base.set'));
+			nodes.set('C', createGraphNode('C', 'n8n-nodes-base.scheduleTrigger', cConns));
+			nodes.set('D', createGraphNode('D', 'n8n-nodes-base.set'));
+
+			const positions = calculateNodePositions(nodes);
+
+			expect(positions.size).toBe(4);
+
+			// Both chains should exist with all positions grid-aligned
+			for (const pos of positions.values()) {
+				expect(isGridAligned(pos)).toBe(true);
+			}
+		});
+	});
+
+	describe('AI workflow', () => {
+		it('positions AI subnodes below parent node', () => {
+			const nodes = new Map<string, GraphNode>();
+
+			// Trigger -> Agent, with Model and Tool connected to Agent via ai_* types
+			const triggerConns = makeMainConns([[0, [makeTarget('Agent')]]]);
+			const agentConns = makeMainConns([]); // Agent has no main outgoing
+
+			nodes.set(
+				'trigger',
+				createGraphNode('trigger', 'n8n-nodes-base.manualTrigger', triggerConns),
+			);
+			nodes.set('Agent', createGraphNode('Agent', '@n8n/n8n-nodes-langchain.agent', agentConns));
+			nodes.set(
+				'OpenAI Model',
+				createGraphNode(
+					'OpenAI Model',
+					'@n8n/n8n-nodes-langchain.lmChatOpenAi',
+					makeAiConns('Agent', 'ai_languageModel'),
+				),
+			);
+			nodes.set(
+				'Calculator',
+				createGraphNode(
+					'Calculator',
+					'@n8n/n8n-nodes-langchain.toolCalculator',
+					makeAiConns('Agent', 'ai_tool'),
+				),
+			);
+
+			const positions = calculateNodePositions(nodes);
+
+			const triggerPos = positions.get('trigger')!;
+			const agentPos = positions.get('Agent')!;
+			const modelPos = positions.get('OpenAI Model')!;
+			const calcPos = positions.get('Calculator')!;
+
+			// Agent should be to the right of trigger
+			expect(agentPos[0]).toBeGreaterThan(triggerPos[0]);
+
+			// Subnodes should be below (or at least not above) the agent
+			expect(modelPos[1]).toBeGreaterThanOrEqual(agentPos[1]);
+			expect(calcPos[1]).toBeGreaterThanOrEqual(agentPos[1]);
+
+			// All positions grid-aligned
+			expect(isGridAligned(triggerPos)).toBe(true);
+			expect(isGridAligned(agentPos)).toBe(true);
+			expect(isGridAligned(modelPos)).toBe(true);
+			expect(isGridAligned(calcPos)).toBe(true);
+		});
+	});
+
+	describe('explicit positions', () => {
+		it('skips nodes that already have explicit position in config', () => {
+			const nodes = new Map<string, GraphNode>();
+			nodes.set(
+				'trigger',
+				createGraphNode(
+					'trigger',
+					'n8n-nodes-base.manualTrigger',
+					new Map([['main', new Map()]]),
+					[500, 600],
+				),
+			);
+
+			const positions = calculateNodePositions(nodes);
+			expect(positions.has('trigger')).toBe(false);
+		});
+
+		it('positions nodes without explicit config but skips those with explicit', () => {
+			const nodes = new Map<string, GraphNode>();
+			const triggerConns = makeMainConns([[0, [makeTarget('set')]]]);
+
+			nodes.set(
+				'trigger',
+				createGraphNode('trigger', 'n8n-nodes-base.manualTrigger', triggerConns, [500, 600]),
+			);
+			nodes.set('set', createGraphNode('set', 'n8n-nodes-base.set'));
+
+			const positions = calculateNodePositions(nodes);
+
+			expect(positions.has('trigger')).toBe(false);
+			expect(positions.has('set')).toBe(true);
+		});
+	});
+
+	describe('grid alignment', () => {
+		it('all positions are multiples of GRID_SIZE', () => {
+			const nodes = new Map<string, GraphNode>();
+			const aConns = makeMainConns([[0, [makeTarget('B')]]]);
+			const bConns = makeMainConns([
+				[0, [makeTarget('C')]],
+				[1, [makeTarget('D')]],
+			]);
+
+			nodes.set('A', createGraphNode('A', 'n8n-nodes-base.manualTrigger', aConns));
+			nodes.set('B', createGraphNode('B', 'n8n-nodes-base.if', bConns));
+			nodes.set('C', createGraphNode('C', 'n8n-nodes-base.set'));
+			nodes.set('D', createGraphNode('D', 'n8n-nodes-base.set'));
+
+			const positions = calculateNodePositions(nodes);
+
+			for (const [, pos] of positions) {
+				expect(pos[0] % GRID_SIZE).toBe(0);
+				expect(pos[1] % GRID_SIZE).toBe(0);
+			}
+		});
+	});
+
+	describe('sticky notes', () => {
+		it('excludes sticky notes from main layout', () => {
+			const nodes = new Map<string, GraphNode>();
+			const triggerConns = makeMainConns([[0, [makeTarget('set')]]]);
+
+			nodes.set(
+				'trigger',
+				createGraphNode('trigger', 'n8n-nodes-base.manualTrigger', triggerConns),
+			);
+			nodes.set('set', createGraphNode('set', 'n8n-nodes-base.set'));
+			nodes.set('note', createGraphNode('note', STICKY_NODE_TYPE));
+
+			const positions = calculateNodePositions(nodes);
+
+			// Non-sticky nodes get positions
+			expect(positions.has('trigger')).toBe(true);
+			expect(positions.has('set')).toBe(true);
 		});
 	});
 });

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.test.ts
@@ -1,9 +1,9 @@
 /**
- * Tests for Dagre-based layout utility functions
+ * Tests for layout utility functions (BFS and Dagre)
  */
 
-import { GRID_SIZE, STICKY_NODE_TYPE } from './constants';
-import { calculateNodePositions } from './layout-utils';
+import { GRID_SIZE, STICKY_NODE_TYPE, NODE_SPACING_X, START_X, DEFAULT_Y } from './constants';
+import { calculateNodePositions, calculateNodePositionsDagre } from './layout-utils';
 import type { GraphNode, ConnectionTarget } from '../types/base';
 
 // Helper to create connection targets
@@ -54,11 +54,90 @@ function isGridAligned(pos: [number, number]): boolean {
 	return pos[0] % GRID_SIZE === 0 && pos[1] % GRID_SIZE === 0;
 }
 
-describe('calculateNodePositions', () => {
+// ===========================================================================
+// BFS Layout Tests (calculateNodePositions)
+// ===========================================================================
+
+describe('calculateNodePositions (BFS)', () => {
+	it('returns empty map for empty nodes', () => {
+		const nodes = new Map<string, GraphNode>();
+		const positions = calculateNodePositions(nodes);
+		expect(positions.size).toBe(0);
+	});
+
+	it('positions a single root node at START_X, DEFAULT_Y', () => {
+		const nodes = new Map<string, GraphNode>();
+		nodes.set('trigger', createGraphNode('trigger', 'n8n-nodes-base.manualTrigger'));
+
+		const positions = calculateNodePositions(nodes);
+
+		expect(positions.get('trigger')).toEqual([START_X, DEFAULT_Y]);
+	});
+
+	it('positions connected nodes left-to-right with NODE_SPACING_X', () => {
+		const nodes = new Map<string, GraphNode>();
+		const triggerConns = makeMainConns([[0, [makeTarget('set')]]]);
+
+		nodes.set('trigger', createGraphNode('trigger', 'n8n-nodes-base.manualTrigger', triggerConns));
+		nodes.set('set', createGraphNode('set', 'n8n-nodes-base.set'));
+
+		const positions = calculateNodePositions(nodes);
+
+		expect(positions.get('trigger')).toEqual([START_X, DEFAULT_Y]);
+		expect(positions.get('set')).toEqual([START_X + NODE_SPACING_X, DEFAULT_Y]);
+	});
+
+	it('positions branches with Y offset', () => {
+		const nodes = new Map<string, GraphNode>();
+		const ifConns = makeMainConns([
+			[0, [makeTarget('trueBranch')]],
+			[1, [makeTarget('falseBranch')]],
+		]);
+
+		nodes.set('if', createGraphNode('if', 'n8n-nodes-base.if', ifConns));
+		nodes.set('trueBranch', createGraphNode('trueBranch', 'n8n-nodes-base.set'));
+		nodes.set('falseBranch', createGraphNode('falseBranch', 'n8n-nodes-base.set'));
+
+		const positions = calculateNodePositions(nodes);
+
+		const ifPos = positions.get('if')!;
+		const truePos = positions.get('trueBranch')!;
+		const falsePos = positions.get('falseBranch')!;
+
+		// Both to the right
+		expect(truePos[0]).toBeGreaterThan(ifPos[0]);
+		expect(falsePos[0]).toBeGreaterThan(ifPos[0]);
+
+		// Different Y
+		expect(truePos[1]).not.toBe(falsePos[1]);
+	});
+
+	it('skips nodes with explicit positions', () => {
+		const nodes = new Map<string, GraphNode>();
+		nodes.set(
+			'trigger',
+			createGraphNode(
+				'trigger',
+				'n8n-nodes-base.manualTrigger',
+				new Map([['main', new Map()]]),
+				[500, 600],
+			),
+		);
+
+		const positions = calculateNodePositions(nodes);
+		expect(positions.has('trigger')).toBe(false);
+	});
+});
+
+// ===========================================================================
+// Dagre Layout Tests (calculateNodePositionsDagre)
+// ===========================================================================
+
+describe('calculateNodePositionsDagre', () => {
 	describe('basic functionality', () => {
 		it('returns empty map for empty nodes', () => {
 			const nodes = new Map<string, GraphNode>();
-			const positions = calculateNodePositions(nodes);
+			const positions = calculateNodePositionsDagre(nodes);
 			expect(positions.size).toBe(0);
 		});
 
@@ -66,7 +145,7 @@ describe('calculateNodePositions', () => {
 			const nodes = new Map<string, GraphNode>();
 			nodes.set('trigger', createGraphNode('trigger', 'n8n-nodes-base.manualTrigger'));
 
-			const positions = calculateNodePositions(nodes);
+			const positions = calculateNodePositionsDagre(nodes);
 
 			expect(positions.has('trigger')).toBe(true);
 			const pos = positions.get('trigger')!;
@@ -83,13 +162,11 @@ describe('calculateNodePositions', () => {
 			);
 			nodes.set('set', createGraphNode('set', 'n8n-nodes-base.set'));
 
-			const positions = calculateNodePositions(nodes);
+			const positions = calculateNodePositionsDagre(nodes);
 
 			const triggerPos = positions.get('trigger')!;
 			const setPos = positions.get('set')!;
-			// Set should be to the right of trigger
 			expect(setPos[0]).toBeGreaterThan(triggerPos[0]);
-			// Same Y (roughly)
 			expect(Math.abs(setPos[1] - triggerPos[1])).toBeLessThan(GRID_SIZE * 2);
 		});
 	});
@@ -106,19 +183,17 @@ describe('calculateNodePositions', () => {
 			nodes.set('C', createGraphNode('C', 'n8n-nodes-base.set', cConns));
 			nodes.set('D', createGraphNode('D', 'n8n-nodes-base.set'));
 
-			const positions = calculateNodePositions(nodes);
+			const positions = calculateNodePositionsDagre(nodes);
 
 			const posA = positions.get('A')!;
 			const posB = positions.get('B')!;
 			const posC = positions.get('C')!;
 			const posD = positions.get('D')!;
 
-			// Each node should be further right
 			expect(posB[0]).toBeGreaterThan(posA[0]);
 			expect(posC[0]).toBeGreaterThan(posB[0]);
 			expect(posD[0]).toBeGreaterThan(posC[0]);
 
-			// All at same Y
 			expect(posA[1]).toBe(posB[1]);
 			expect(posB[1]).toBe(posC[1]);
 			expect(posC[1]).toBe(posD[1]);
@@ -137,20 +212,15 @@ describe('calculateNodePositions', () => {
 			nodes.set('trueBranch', createGraphNode('trueBranch', 'n8n-nodes-base.set'));
 			nodes.set('falseBranch', createGraphNode('falseBranch', 'n8n-nodes-base.set'));
 
-			const positions = calculateNodePositions(nodes);
+			const positions = calculateNodePositionsDagre(nodes);
 
 			const ifPos = positions.get('if')!;
 			const truePos = positions.get('trueBranch')!;
 			const falsePos = positions.get('falseBranch')!;
 
-			// Both branches to the right of IF
 			expect(truePos[0]).toBeGreaterThan(ifPos[0]);
 			expect(falsePos[0]).toBeGreaterThan(ifPos[0]);
-
-			// At same X
 			expect(truePos[0]).toBe(falsePos[0]);
-
-			// Different Y
 			expect(truePos[1]).not.toBe(falsePos[1]);
 		});
 	});
@@ -161,17 +231,15 @@ describe('calculateNodePositions', () => {
 			const aConns = makeMainConns([[0, [makeTarget('B')]]]);
 			const cConns = makeMainConns([[0, [makeTarget('D')]]]);
 
-			// Two independent chains
 			nodes.set('A', createGraphNode('A', 'n8n-nodes-base.manualTrigger', aConns));
 			nodes.set('B', createGraphNode('B', 'n8n-nodes-base.set'));
 			nodes.set('C', createGraphNode('C', 'n8n-nodes-base.scheduleTrigger', cConns));
 			nodes.set('D', createGraphNode('D', 'n8n-nodes-base.set'));
 
-			const positions = calculateNodePositions(nodes);
+			const positions = calculateNodePositionsDagre(nodes);
 
 			expect(positions.size).toBe(4);
 
-			// Both chains should exist with all positions grid-aligned
 			for (const pos of positions.values()) {
 				expect(isGridAligned(pos)).toBe(true);
 			}
@@ -182,15 +250,13 @@ describe('calculateNodePositions', () => {
 		it('positions AI subnodes below parent node', () => {
 			const nodes = new Map<string, GraphNode>();
 
-			// Trigger -> Agent, with Model and Tool connected to Agent via ai_* types
 			const triggerConns = makeMainConns([[0, [makeTarget('Agent')]]]);
-			const agentConns = makeMainConns([]); // Agent has no main outgoing
 
 			nodes.set(
 				'trigger',
 				createGraphNode('trigger', 'n8n-nodes-base.manualTrigger', triggerConns),
 			);
-			nodes.set('Agent', createGraphNode('Agent', '@n8n/n8n-nodes-langchain.agent', agentConns));
+			nodes.set('Agent', createGraphNode('Agent', '@n8n/n8n-nodes-langchain.agent'));
 			nodes.set(
 				'OpenAI Model',
 				createGraphNode(
@@ -208,21 +274,17 @@ describe('calculateNodePositions', () => {
 				),
 			);
 
-			const positions = calculateNodePositions(nodes);
+			const positions = calculateNodePositionsDagre(nodes);
 
 			const triggerPos = positions.get('trigger')!;
 			const agentPos = positions.get('Agent')!;
 			const modelPos = positions.get('OpenAI Model')!;
 			const calcPos = positions.get('Calculator')!;
 
-			// Agent should be to the right of trigger
 			expect(agentPos[0]).toBeGreaterThan(triggerPos[0]);
-
-			// Subnodes should be below (or at least not above) the agent
 			expect(modelPos[1]).toBeGreaterThanOrEqual(agentPos[1]);
 			expect(calcPos[1]).toBeGreaterThanOrEqual(agentPos[1]);
 
-			// All positions grid-aligned
 			expect(isGridAligned(triggerPos)).toBe(true);
 			expect(isGridAligned(agentPos)).toBe(true);
 			expect(isGridAligned(modelPos)).toBe(true);
@@ -243,7 +305,7 @@ describe('calculateNodePositions', () => {
 				),
 			);
 
-			const positions = calculateNodePositions(nodes);
+			const positions = calculateNodePositionsDagre(nodes);
 			expect(positions.has('trigger')).toBe(false);
 		});
 
@@ -257,7 +319,7 @@ describe('calculateNodePositions', () => {
 			);
 			nodes.set('set', createGraphNode('set', 'n8n-nodes-base.set'));
 
-			const positions = calculateNodePositions(nodes);
+			const positions = calculateNodePositionsDagre(nodes);
 
 			expect(positions.has('trigger')).toBe(false);
 			expect(positions.has('set')).toBe(true);
@@ -278,7 +340,7 @@ describe('calculateNodePositions', () => {
 			nodes.set('C', createGraphNode('C', 'n8n-nodes-base.set'));
 			nodes.set('D', createGraphNode('D', 'n8n-nodes-base.set'));
 
-			const positions = calculateNodePositions(nodes);
+			const positions = calculateNodePositionsDagre(nodes);
 
 			for (const [, pos] of positions) {
 				expect(pos[0] % GRID_SIZE).toBe(0);
@@ -288,7 +350,7 @@ describe('calculateNodePositions', () => {
 	});
 
 	describe('sticky notes', () => {
-		it('excludes sticky notes from main layout', () => {
+		it('excludes sticky notes from dagre graph but repositions covered ones', () => {
 			const nodes = new Map<string, GraphNode>();
 			const triggerConns = makeMainConns([[0, [makeTarget('set')]]]);
 
@@ -300,7 +362,7 @@ describe('calculateNodePositions', () => {
 			// Sticky note behind the trigger and set nodes (covers them at origin)
 			nodes.set('note', createGraphNode('note', STICKY_NODE_TYPE));
 
-			const positions = calculateNodePositions(nodes);
+			const positions = calculateNodePositionsDagre(nodes);
 
 			// Non-sticky nodes get positions from dagre layout
 			expect(positions.has('trigger')).toBe(true);
@@ -316,7 +378,7 @@ describe('calculateNodePositions', () => {
 				'remote-note',
 				createGraphNode('remote-note', STICKY_NODE_TYPE, undefined, [5000, 5000]),
 			);
-			const positions2 = calculateNodePositions(nodes2);
+			const positions2 = calculateNodePositionsDagre(nodes2);
 			expect(positions2.has('remote-note')).toBe(false);
 		});
 	});

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.test.ts
@@ -15,7 +15,9 @@ function makeTarget(node: string, type: string = 'main', index: number = 0): Con
 function createGraphNode(
 	name: string,
 	type: string,
-	connections: Map<string, Map<number, ConnectionTarget[]>> = new Map([['main', new Map()]]),
+	connections: Map<string, Map<number, ConnectionTarget[]>> = new Map([
+		['main', new Map<number, ConnectionTarget[]>()],
+	]),
 	position?: [number, number],
 ): GraphNode {
 	return {
@@ -119,7 +121,7 @@ describe('calculateNodePositions (BFS)', () => {
 			createGraphNode(
 				'trigger',
 				'n8n-nodes-base.manualTrigger',
-				new Map([['main', new Map()]]),
+				new Map([['main', new Map<number, ConnectionTarget[]>()]]),
 				[500, 600],
 			),
 		);
@@ -300,7 +302,7 @@ describe('calculateNodePositionsDagre', () => {
 				createGraphNode(
 					'trigger',
 					'n8n-nodes-base.manualTrigger',
-					new Map([['main', new Map()]]),
+					new Map([['main', new Map<number, ConnectionTarget[]>()]]),
 					[500, 600],
 				),
 			);

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.test.ts
@@ -297,13 +297,27 @@ describe('calculateNodePositions', () => {
 				createGraphNode('trigger', 'n8n-nodes-base.manualTrigger', triggerConns),
 			);
 			nodes.set('set', createGraphNode('set', 'n8n-nodes-base.set'));
+			// Sticky note behind the trigger and set nodes (covers them at origin)
 			nodes.set('note', createGraphNode('note', STICKY_NODE_TYPE));
 
 			const positions = calculateNodePositions(nodes);
 
-			// Non-sticky nodes get positions
+			// Non-sticky nodes get positions from dagre layout
 			expect(positions.has('trigger')).toBe(true);
 			expect(positions.has('set')).toBe(true);
+
+			// Sticky note is NOT in the dagre graph but gets repositioned
+			// to follow the nodes it covered
+			expect(positions.has('note')).toBe(true);
+
+			// Sticky note that doesn't cover any nodes is excluded entirely
+			const nodes2 = new Map(nodes);
+			nodes2.set(
+				'remote-note',
+				createGraphNode('remote-note', STICKY_NODE_TYPE, undefined, [5000, 5000]),
+			);
+			const positions2 = calculateNodePositions(nodes2);
+			expect(positions2.has('remote-note')).toBe(false);
 		});
 	});
 });

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
@@ -99,9 +99,47 @@ function getAllConnectedAiConfigNodes(
 // ---------------------------------------------------------------------------
 
 /**
- * Get node dimensions based on classification.
- * Uses defaults for now — structured so it can later accept node type descriptions
- * for accurate handle-based sizing.
+ * Count main output indices for a node (from its outgoing main connections).
+ */
+function getMainOutputCount(nodeName: string, nodes: ReadonlyMap<string, GraphNode>): number {
+	const graphNode = nodes.get(nodeName);
+	if (!graphNode) return 1;
+	const mainConns = graphNode.connections.get('main');
+	if (!mainConns || mainConns.size === 0) return 1;
+	return Math.max(...mainConns.keys()) + 1;
+}
+
+/**
+ * Count main input indices targeting a node (from all nodes' outgoing main connections).
+ */
+function getMainInputCount(nodeName: string, nodes: ReadonlyMap<string, GraphNode>): number {
+	let maxIndex = 0;
+	for (const graphNode of nodes.values()) {
+		const mainConns = graphNode.connections.get('main');
+		if (!mainConns) continue;
+		for (const targets of mainConns.values()) {
+			for (const target of targets) {
+				if (target.node === nodeName) {
+					maxIndex = Math.max(maxIndex, target.index + 1);
+				}
+			}
+		}
+	}
+	return Math.max(1, maxIndex);
+}
+
+/**
+ * Calculate node height based on main handle counts.
+ * Matches the FE's calculateNodeSize formula in nodeViewUtils.ts.
+ */
+function calculateNodeHeight(mainInputCount: number, mainOutputCount: number): number {
+	const maxVerticalHandles = Math.max(mainInputCount, mainOutputCount, 1);
+	return DEFAULT_NODE_SIZE[1] + Math.max(0, maxVerticalHandles - 2) * GRID_SIZE * 2;
+}
+
+/**
+ * Get node dimensions based on classification and connection counts.
+ * Matches the FE's calculateNodeSize in nodeViewUtils.ts.
  */
 export function getNodeDimensions(
 	nodeName: string,
@@ -133,7 +171,12 @@ export function getNodeDimensions(
 		return { width, height: CONFIGURABLE_NODE_SIZE[1] };
 	}
 
-	return { width: DEFAULT_NODE_SIZE[0], height: DEFAULT_NODE_SIZE[1] };
+	const mainInputCount = getMainInputCount(nodeName, nodes);
+	const mainOutputCount = getMainOutputCount(nodeName, nodes);
+	return {
+		width: DEFAULT_NODE_SIZE[0],
+		height: calculateNodeHeight(mainInputCount, mainOutputCount),
+	};
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
@@ -22,7 +22,7 @@ import {
 	STICKY_BOTTOM_PADDING,
 	STICKY_NODE_TYPE,
 } from './constants';
-import type { GraphNode, WorkflowJSON, NodeJSON } from '../types/base';
+import type { GraphNode, WorkflowJSON, ConnectionTarget } from '../types/base';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -563,229 +563,69 @@ export function calculateNodePositions(
 
 /**
  * Apply Dagre-based layout to a WorkflowJSON, mutating node positions in-place.
+ * Builds a GraphNode map from the serialized JSON and delegates to calculateNodePositions.
+ *
  * This is the entry point for code paths that don't go through the builder
  * (e.g., sandbox-compiled workflows in instance-ai).
  */
 export function layoutWorkflowJSON(json: WorkflowJSON): void {
-	const nodes = json.nodes;
-	if (!nodes || nodes.length === 0) return;
+	const jsonNodes = json.nodes;
+	if (!jsonNodes || jsonNodes.length === 0) return;
 
 	const connections = json.connections ?? {};
 
-	// Build a node name → NodeJSON index for quick lookup
-	const nodeByName = new Map<string, NodeJSON>();
-	for (const node of nodes) {
-		if (node.name) {
-			nodeByName.set(node.name, node);
-		}
-	}
+	// Build a GraphNode map from WorkflowJSON
+	const graphNodes = new Map<string, GraphNode>();
 
-	// Detect AI parent nodes (targets of ai_* connections)
-	const aiParentNames = new Set<string>();
-	const aiConfigNames = new Set<string>();
-	for (const [sourceName, nodeConns] of Object.entries(connections)) {
-		for (const connType of Object.keys(nodeConns)) {
-			if (!isAiConnectionType(connType)) continue;
-			aiConfigNames.add(sourceName);
-			const outputs = nodeConns[connType];
-			if (!Array.isArray(outputs)) continue;
-			for (const slot of outputs) {
-				if (!Array.isArray(slot)) continue;
-				for (const target of slot) {
-					if (target?.node) {
-						aiParentNames.add(target.node);
-					}
-				}
-			}
-		}
-	}
-
-	// Get node dimensions for layout
-	function getDimensions(nodeName: string): { width: number; height: number } {
-		if (aiConfigNames.has(nodeName)) {
-			return { width: CONFIGURATION_NODE_SIZE[0], height: CONFIGURATION_NODE_SIZE[1] };
-		}
-		if (aiParentNames.has(nodeName)) {
-			// Count distinct ai_* types targeting this node
-			const aiInputTypes = new Set<string>();
-			for (const nodeConns of Object.values(connections)) {
-				for (const [connType, outputs] of Object.entries(nodeConns)) {
-					if (!isAiConnectionType(connType) || !Array.isArray(outputs)) continue;
-					for (const slot of outputs) {
-						if (!Array.isArray(slot)) continue;
-						for (const target of slot) {
-							if (target?.node === nodeName) aiInputTypes.add(connType);
-						}
-					}
-				}
-			}
-			const portCount = Math.max(NODE_MIN_INPUT_ITEMS_COUNT, aiInputTypes.size);
-			const width = CONFIGURATION_NODE_RADIUS * 2 + GRID_SIZE * (portCount - 1) * 3;
-			return { width, height: CONFIGURABLE_NODE_SIZE[1] };
-		}
-		return { width: DEFAULT_NODE_SIZE[0], height: DEFAULT_NODE_SIZE[1] };
-	}
-
-	// Build dagre graph
-	const nonStickyNodes = nodes.filter((n) => n.type !== STICKY_NODE_TYPE);
-	if (nonStickyNodes.length === 0) return;
-
-	const parentGraph = new dagre.graphlib.Graph();
-	parentGraph.setGraph({});
-	parentGraph.setDefaultEdgeLabel(() => ({}));
-
-	const nonStickyNames = new Set<string>();
-	for (const node of nonStickyNodes) {
+	for (const node of jsonNodes) {
 		if (!node.name) continue;
-		nonStickyNames.add(node.name);
-		const { width, height } = getDimensions(node.name);
-		parentGraph.setNode(node.name, { width, height });
+		const connectionsMap = new Map<string, Map<number, ConnectionTarget[]>>();
+		connectionsMap.set('main', new Map());
+		graphNodes.set(node.name, {
+			instance: {
+				type: node.type,
+				name: node.name,
+				version: node.typeVersion,
+				config: {},
+			} as unknown as GraphNode['instance'],
+			connections: connectionsMap,
+		});
 	}
 
-	// Add edges from connections
+	// Populate connections from WorkflowJSON connections structure
 	for (const [sourceName, nodeConns] of Object.entries(connections)) {
-		if (!nonStickyNames.has(sourceName)) continue;
-		for (const outputs of Object.values(nodeConns)) {
+		const graphNode = graphNodes.get(sourceName);
+		if (!graphNode) continue;
+
+		for (const [connType, outputs] of Object.entries(nodeConns)) {
 			if (!Array.isArray(outputs)) continue;
-			for (const slot of outputs) {
+			let outputMap = graphNode.connections.get(connType);
+			if (!outputMap) {
+				outputMap = new Map();
+				graphNode.connections.set(connType, outputMap);
+			}
+			for (let outputIdx = 0; outputIdx < outputs.length; outputIdx++) {
+				const slot = outputs[outputIdx];
 				if (!Array.isArray(slot)) continue;
-				for (const target of slot) {
-					if (target?.node && nonStickyNames.has(target.node)) {
-						parentGraph.setEdge(sourceName, target.node);
-					}
+				const targets: ConnectionTarget[] = slot
+					.filter((t): t is { node: string; type: string; index: number } => !!t?.node)
+					.map((t) => ({ node: t.node, type: t.type, index: t.index }));
+				if (targets.length > 0) {
+					outputMap.set(outputIdx, targets);
 				}
 			}
 		}
 	}
 
-	// Find disconnected subgraphs
-	const components = dagre.graphlib.alg.components(parentGraph);
+	// Calculate positions using the existing Dagre layout
+	const positions = calculateNodePositions(graphNodes);
 
-	const subgraphs = components.map((nodeIds) => {
-		const subgraph = createSubGraph(nodeIds, parentGraph);
-
-		const aiParentsInSubgraph = subgraph.nodes().filter((id) => aiParentNames.has(id));
-
-		const aiGraphs = aiParentsInSubgraph.map((aiParentId) => {
-			const configNodeIds = getAllConnectedAiConfigNodes(subgraph, aiParentId, aiConfigNames);
-			const allAiNodeIds = configNodeIds.concat(aiParentId);
-			const aiGraph = createAiSubGraph(subgraph, allAiNodeIds);
-
-			const configNodeIdSet = new Set(configNodeIds);
-			const rootEdges = subgraph
-				.edges()
-				.filter(
-					(edge) =>
-						(edge.v === aiParentId || edge.w === aiParentId) &&
-						!configNodeIdSet.has(edge.v) &&
-						!configNodeIdSet.has(edge.w),
-				);
-
-			configNodeIds.forEach((id) => subgraph.removeNode(id));
-
-			dagre.layout(aiGraph, { disableOptimalOrderHeuristic: true });
-			const aiBoundingBox = boundingBoxFromGraph(aiGraph);
-
-			subgraph.setNode(aiParentId, {
-				width: aiBoundingBox.width,
-				height: aiBoundingBox.height,
-			});
-			rootEdges.forEach((edge) => subgraph.setEdge(edge));
-
-			return { graph: aiGraph, boundingBox: aiBoundingBox, aiParentId };
-		});
-
-		dagre.layout(subgraph, { disableOptimalOrderHeuristic: true });
-
-		return { graph: subgraph, aiGraphs, boundingBox: boundingBoxFromGraph(subgraph) };
-	});
-
-	// Arrange subgraphs vertically
-	let compositeGraph: dagre.graphlib.Graph | undefined;
-	if (subgraphs.length > 1) {
-		compositeGraph = createVerticalGraph(
-			subgraphs.map(({ boundingBox }, index) => ({
-				box: boundingBox,
-				id: index.toString(),
-			})),
-		);
-		dagre.layout(compositeGraph);
-	}
-
-	// Compute final positions
-	const boundingBoxByNodeId: Record<string, BoundingBox> = {};
-
-	subgraphs.forEach(({ graph, aiGraphs }, index) => {
-		let offset = { x: 0, y: 0 };
-		if (compositeGraph) {
-			const subgraphPosition = compositeGraph.node(index.toString());
-			offset = { x: 0, y: subgraphPosition.y - subgraphPosition.height / 2 };
-		}
-		const aiParentIds = new Set(aiGraphs.map(({ aiParentId }) => aiParentId));
-
-		for (const nodeId of graph.nodes()) {
-			const { x, y, width, height } = graph.node(nodeId);
-			const box: BoundingBox = {
-				x: x + offset.x - width / 2,
-				y: y + offset.y - height / 2,
-				width,
-				height,
-			};
-
-			if (aiParentIds.has(nodeId)) {
-				const aiGraphInfo = aiGraphs.find(({ aiParentId }) => aiParentId === nodeId);
-				if (!aiGraphInfo) continue;
-				const parentOffset = { x: box.x, y: box.y };
-				for (const aiNodeId of aiGraphInfo.graph.nodes()) {
-					const aiNode = aiGraphInfo.graph.node(aiNodeId);
-					boundingBoxByNodeId[aiNodeId] = {
-						x: aiNode.x + parentOffset.x - aiNode.width / 2,
-						y: aiNode.y + parentOffset.y - aiNode.height / 2,
-						width: aiNode.width,
-						height: aiNode.height,
-					};
-				}
-			} else {
-				boundingBoxByNodeId[nodeId] = box;
-			}
-		}
-	});
-
-	// Post-process: top-align AI subtrees
-	subgraphs
-		.flatMap(({ aiGraphs }) => aiGraphs)
-		.forEach(({ graph }) => {
-			const aiNodes = graph.nodes();
-			const boxes = aiNodes
-				.map((id) => boundingBoxByNodeId[id])
-				.filter((b): b is BoundingBox => b !== undefined);
-			if (boxes.length === 0) return;
-
-			const aiGraphBoundingBox = compositeBoundingBox(boxes);
-			const aiNodeVerticalCorrection = aiGraphBoundingBox.height / 2 - DEFAULT_NODE_SIZE[0] / 2;
-			aiGraphBoundingBox.y += aiNodeVerticalCorrection;
-
-			const hasConflictingNodes = Object.entries(boundingBoxByNodeId)
-				.filter(([id]) => !graph.hasNode(id))
-				.some(([, nodeBoundingBox]) =>
-					intersects(aiGraphBoundingBox, nodeBoundingBox, NODE_Y_SPACING),
-				);
-
-			if (!hasConflictingNodes) {
-				for (const aiNode of aiNodes) {
-					if (boundingBoxByNodeId[aiNode]) {
-						boundingBoxByNodeId[aiNode].y += aiNodeVerticalCorrection;
-					}
-				}
-			}
-		});
-
-	// Apply positions to nodes
-	for (const node of nodes) {
-		if (!node.name || node.type === STICKY_NODE_TYPE) continue;
-		const box = boundingBoxByNodeId[node.name];
-		if (box) {
-			node.position = [snapToGrid(box.x), snapToGrid(box.y)];
+	// Apply positions back to JSON nodes
+	for (const node of jsonNodes) {
+		if (!node.name) continue;
+		const pos = positions.get(node.name);
+		if (pos) {
+			node.position = pos;
 		}
 	}
 }

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
@@ -1,80 +1,791 @@
 /**
  * Layout Utility Functions
  *
- * Functions for calculating node positions in workflow layouts.
+ * Dagre-based layout that mirrors the frontend's useCanvasLayout algorithm
+ * to produce positions matching what the FE tidy-up would generate.
  */
 
-import { NODE_SPACING_X, DEFAULT_Y, START_X } from './constants';
-import type { GraphNode } from '../types/base';
+import dagre from '@dagrejs/dagre';
+
+import {
+	GRID_SIZE,
+	DEFAULT_NODE_SIZE,
+	CONFIGURATION_NODE_SIZE,
+	CONFIGURATION_NODE_RADIUS,
+	CONFIGURABLE_NODE_SIZE,
+	NODE_MIN_INPUT_ITEMS_COUNT,
+	NODE_X_SPACING,
+	NODE_Y_SPACING,
+	SUBGRAPH_SPACING,
+	AI_X_SPACING,
+	AI_Y_SPACING,
+	STICKY_BOTTOM_PADDING,
+	STICKY_NODE_TYPE,
+} from './constants';
+import type { GraphNode, WorkflowJSON, NodeJSON } from '../types/base';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface BoundingBox {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: AI node detection
+// ---------------------------------------------------------------------------
+
+function isAiConnectionType(type: string): boolean {
+	return type.startsWith('ai_');
+}
 
 /**
- * Calculate positions for nodes using BFS left-to-right layout.
- * Only sets positions for nodes without explicit config.position.
+ * Find nodes that are AI parents (targets of ai_* connections).
+ * Returns a set of node names that receive ai_* connections.
+ */
+function getAiParentNames(nodes: ReadonlyMap<string, GraphNode>): Set<string> {
+	const parents = new Set<string>();
+	for (const graphNode of nodes.values()) {
+		for (const [connType, outputMap] of graphNode.connections) {
+			if (!isAiConnectionType(connType)) continue;
+			for (const targets of outputMap.values()) {
+				for (const target of targets) {
+					parents.add(target.node);
+				}
+			}
+		}
+	}
+	return parents;
+}
+
+/**
+ * Find nodes that are AI config nodes (have outgoing ai_* connections).
+ * Returns a set of node names.
+ */
+function getAiConfigNames(nodes: ReadonlyMap<string, GraphNode>): Set<string> {
+	const configs = new Set<string>();
+	for (const [name, graphNode] of nodes) {
+		for (const connType of graphNode.connections.keys()) {
+			if (isAiConnectionType(connType)) {
+				configs.add(name);
+				break;
+			}
+		}
+	}
+	return configs;
+}
+
+/**
+ * Recursively find all AI config nodes connected to a parent node.
+ * Uses dagre graph predecessors (since ai edges go config -> parent in the graph).
+ */
+function getAllConnectedAiConfigNodes(
+	graph: dagre.graphlib.Graph,
+	rootId: string,
+	aiConfigNames: Set<string>,
+): string[] {
+	const predecessors = (graph.predecessors(rootId) as unknown as string[]) ?? [];
+	return predecessors
+		.filter((id) => aiConfigNames.has(id))
+		.flatMap((id) => [id, ...getAllConnectedAiConfigNodes(graph, id, aiConfigNames)]);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: Node dimensions
+// ---------------------------------------------------------------------------
+
+/**
+ * Get node dimensions based on classification.
+ * Uses defaults for now — structured so it can later accept node type descriptions
+ * for accurate handle-based sizing.
+ */
+export function getNodeDimensions(
+	nodeName: string,
+	aiParentNames: Set<string>,
+	aiConfigNames: Set<string>,
+	nodes: ReadonlyMap<string, GraphNode>,
+): { width: number; height: number } {
+	if (aiConfigNames.has(nodeName)) {
+		return { width: CONFIGURATION_NODE_SIZE[0], height: CONFIGURATION_NODE_SIZE[1] };
+	}
+
+	if (aiParentNames.has(nodeName)) {
+		// Count distinct ai_* connection types targeting this node to determine port count
+		const aiInputTypes = new Set<string>();
+		for (const graphNode of nodes.values()) {
+			for (const [connType, outputMap] of graphNode.connections) {
+				if (!isAiConnectionType(connType)) continue;
+				for (const targets of outputMap.values()) {
+					for (const target of targets) {
+						if (target.node === nodeName) {
+							aiInputTypes.add(connType);
+						}
+					}
+				}
+			}
+		}
+		const portCount = Math.max(NODE_MIN_INPUT_ITEMS_COUNT, aiInputTypes.size);
+		const width = CONFIGURATION_NODE_RADIUS * 2 + GRID_SIZE * (portCount - 1) * 3;
+		return { width, height: CONFIGURABLE_NODE_SIZE[1] };
+	}
+
+	return { width: DEFAULT_NODE_SIZE[0], height: DEFAULT_NODE_SIZE[1] };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: Grid & bounding box
+// ---------------------------------------------------------------------------
+
+function snapToGrid(value: number): number {
+	return Math.round(value / GRID_SIZE) * GRID_SIZE;
+}
+
+function compositeBoundingBox(boxes: BoundingBox[]): BoundingBox {
+	const { minX, minY, maxX, maxY } = boxes.reduce(
+		(bbox, node) => ({
+			minX: Math.min(bbox.minX, node.x),
+			maxX: Math.max(bbox.maxX, node.x + node.width),
+			minY: Math.min(bbox.minY, node.y),
+			maxY: Math.max(bbox.maxY, node.y + node.height),
+		}),
+		{ minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity },
+	);
+	return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+}
+
+function boundingBoxFromDagreNode(node: dagre.Node): BoundingBox {
+	return {
+		x: node.x - node.width / 2,
+		y: node.y - node.height / 2,
+		width: node.width,
+		height: node.height,
+	};
+}
+
+function boundingBoxFromGraph(graph: dagre.graphlib.Graph): BoundingBox {
+	const nodeIds = graph.nodes();
+	if (nodeIds.length === 0) {
+		return { x: 0, y: 0, width: 0, height: 0 };
+	}
+	return compositeBoundingBox(
+		nodeIds.map((nodeId) => boundingBoxFromDagreNode(graph.node(nodeId))),
+	);
+}
+
+function intersects(container: BoundingBox, target: BoundingBox, padding = 0): boolean {
+	const t = {
+		x: target.x - padding,
+		y: target.y - padding,
+		width: target.width + padding * 2,
+		height: target.height + padding * 2,
+	};
+	return !(
+		t.x + t.width < container.x ||
+		t.x > container.x + container.width ||
+		t.y + t.height < container.y ||
+		t.y > container.y + container.height
+	);
+}
+
+function isCoveredBy(parent: BoundingBox, child: BoundingBox): boolean {
+	return (
+		child.x >= parent.x &&
+		child.y >= parent.y &&
+		child.x + child.width <= parent.x + parent.width &&
+		child.y + child.height <= parent.y + parent.height
+	);
+}
+
+function centerHorizontally(container: BoundingBox, target: BoundingBox): number {
+	return container.x + container.width / 2 - target.width / 2;
+}
+
+// ---------------------------------------------------------------------------
+// Dagre graph builders
+// ---------------------------------------------------------------------------
+
+function createSubGraph(nodeIds: string[], parent: dagre.graphlib.Graph): dagre.graphlib.Graph {
+	const subGraph = new dagre.graphlib.Graph();
+	subGraph.setGraph({
+		rankdir: 'LR',
+		edgesep: NODE_Y_SPACING,
+		nodesep: NODE_Y_SPACING,
+		ranksep: NODE_X_SPACING,
+	});
+	subGraph.setDefaultEdgeLabel(() => ({}));
+	const nodeIdSet = new Set(nodeIds);
+
+	parent
+		.nodes()
+		.filter((id) => nodeIdSet.has(id))
+		.forEach((id) => subGraph.setNode(id, parent.node(id)));
+
+	parent
+		.edges()
+		.filter((edge) => nodeIdSet.has(edge.v) && nodeIdSet.has(edge.w))
+		.forEach((edge) => subGraph.setEdge(edge.v, edge.w, parent.edge(edge)));
+
+	return subGraph;
+}
+
+function createVerticalGraph(items: Array<{ id: string; box: BoundingBox }>): dagre.graphlib.Graph {
+	const graph = new dagre.graphlib.Graph();
+	graph.setGraph({
+		rankdir: 'TB',
+		align: 'UL',
+		edgesep: SUBGRAPH_SPACING,
+		nodesep: SUBGRAPH_SPACING,
+		ranksep: SUBGRAPH_SPACING,
+	});
+	graph.setDefaultEdgeLabel(() => ({}));
+
+	items.forEach(({ id, box: { x, y, width, height } }) =>
+		graph.setNode(id, { x, y, width, height }),
+	);
+	items.forEach(({ id }, index) => {
+		if (items[index + 1]) {
+			graph.setEdge(id, items[index + 1].id);
+		}
+	});
+
+	return graph;
+}
+
+function createAiSubGraph(parent: dagre.graphlib.Graph, nodeIds: string[]): dagre.graphlib.Graph {
+	const graph = new dagre.graphlib.Graph();
+	graph.setGraph({
+		rankdir: 'TB',
+		edgesep: AI_X_SPACING,
+		nodesep: AI_X_SPACING,
+		ranksep: AI_Y_SPACING,
+	});
+	graph.setDefaultEdgeLabel(() => ({}));
+	const nodeIdSet = new Set(nodeIds);
+
+	parent
+		.nodes()
+		.filter((id) => nodeIdSet.has(id))
+		.forEach((id) => graph.setNode(id, parent.node(id)));
+
+	// Reverse edges: in the parent graph, edges go config -> parent.
+	// For TB layout we want parent at top, so reverse to parent -> config.
+	parent
+		.edges()
+		.filter((edge) => nodeIdSet.has(edge.v) && nodeIdSet.has(edge.w))
+		.forEach((edge) => graph.setEdge(edge.w, edge.v));
+
+	return graph;
+}
+
+// ---------------------------------------------------------------------------
+// Sticky note repositioning
+// ---------------------------------------------------------------------------
+
+/**
+ * Reposition sticky notes to cover the same nodes they covered before layout.
+ * Structured as a standalone function for easy future refinement.
+ */
+function repositionStickyNotes(
+	stickyNames: string[],
+	nonStickyNames: string[],
+	positionsBefore: Map<string, BoundingBox>,
+	positionsAfter: Map<string, BoundingBox>,
+	result: Map<string, [number, number]>,
+): void {
+	for (const stickyName of stickyNames) {
+		const stickyBoxBefore = positionsBefore.get(stickyName);
+		if (!stickyBoxBefore) continue;
+
+		// Find which non-sticky nodes the sticky covered before layout
+		const coveredNames = nonStickyNames.filter((name) => {
+			const nodeBox = positionsBefore.get(name);
+			return nodeBox && isCoveredBy(stickyBoxBefore, nodeBox);
+		});
+
+		if (coveredNames.length === 0) continue;
+
+		// Get the bounding box of those nodes after layout
+		const coveredBoxesAfter = coveredNames
+			.map((name) => positionsAfter.get(name))
+			.filter((box): box is BoundingBox => box !== undefined);
+
+		if (coveredBoxesAfter.length === 0) continue;
+
+		const coveredAfter = compositeBoundingBox(coveredBoxesAfter);
+		const newX = centerHorizontally(coveredAfter, stickyBoxBefore);
+		const newY =
+			coveredAfter.y + coveredAfter.height - stickyBoxBefore.height + STICKY_BOTTOM_PADDING;
+
+		result.set(stickyName, [snapToGrid(newX), snapToGrid(newY)]);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Main layout function
+// ---------------------------------------------------------------------------
+
+/**
+ * Calculate positions for nodes using Dagre hierarchical layout.
+ * Mirrors the frontend's useCanvasLayout algorithm.
  *
- * @param nodes Map of node names to GraphNode objects
- * @returns Map of node names to [x, y] positions
+ * Only sets positions for nodes without explicit config.position.
  */
 export function calculateNodePositions(
 	nodes: ReadonlyMap<string, GraphNode>,
 ): Map<string, [number, number]> {
 	const positions = new Map<string, [number, number]>();
 
-	// Find root nodes (nodes with no incoming connections)
-	const hasIncoming = new Set<string>();
-	for (const graphNode of nodes.values()) {
-		for (const typeConns of graphNode.connections.values()) {
-			for (const targets of typeConns.values()) {
-				for (const target of targets) {
-					hasIncoming.add(target.node);
-				}
-			}
+	if (nodes.size === 0) return positions;
+
+	// Classify nodes
+	const aiParentNames = getAiParentNames(nodes);
+	const aiConfigNames = getAiConfigNames(nodes);
+
+	// Separate sticky notes
+	const stickyNames: string[] = [];
+	const nonStickyNames: string[] = [];
+	for (const [name, graphNode] of nodes) {
+		if (graphNode.instance.type === STICKY_NODE_TYPE) {
+			stickyNames.push(name);
+		} else {
+			nonStickyNames.push(name);
 		}
 	}
 
-	const rootNodes = [...nodes.keys()].filter((name) => !hasIncoming.has(name));
+	if (nonStickyNames.length === 0) return positions;
 
-	// BFS to assign positions
-	const visited = new Set<string>();
-	const queue: Array<{ name: string; x: number; y: number }> = [];
-
-	// Initialize queue with root nodes
-	let y = DEFAULT_Y;
-	for (const rootName of rootNodes) {
-		queue.push({ name: rootName, x: START_X, y });
-		y += 150; // Offset Y for multiple roots
-	}
-
-	while (queue.length > 0) {
-		const { name, x, y: nodeY } = queue.shift()!;
-
-		if (visited.has(name)) continue;
-		visited.add(name);
-
-		// Only set position if node doesn't have explicit position
+	// Check if any nodes actually need positioning
+	const needsLayout = nonStickyNames.some((name) => {
 		const node = nodes.get(name);
-		if (node && !node.instance.config?.position) {
-			positions.set(name, [x, nodeY]);
-		}
+		return node && !node.instance.config?.position;
+	});
 
-		// Queue connected nodes
-		if (node) {
-			let branchOffset = 0;
-			for (const typeConns of node.connections.values()) {
-				for (const targets of typeConns.values()) {
-					for (const target of targets) {
-						if (!visited.has(target.node)) {
-							queue.push({
-								name: target.node,
-								x: x + NODE_SPACING_X,
-								y: nodeY + branchOffset * 150,
-							});
-							branchOffset++;
-						}
+	if (!needsLayout) return positions;
+
+	// Build parent dagre graph with all non-sticky nodes
+	const parentGraph = new dagre.graphlib.Graph();
+	parentGraph.setGraph({});
+	parentGraph.setDefaultEdgeLabel(() => ({}));
+
+	for (const name of nonStickyNames) {
+		const { width, height } = getNodeDimensions(name, aiParentNames, aiConfigNames, nodes);
+		parentGraph.setNode(name, { width, height });
+	}
+
+	// Add edges from connections
+	const nonStickySet = new Set(nonStickyNames);
+	for (const name of nonStickyNames) {
+		const graphNode = nodes.get(name)!;
+		for (const [, outputMap] of graphNode.connections) {
+			for (const targets of outputMap.values()) {
+				for (const target of targets) {
+					if (nonStickySet.has(target.node)) {
+						parentGraph.setEdge(name, target.node);
 					}
 				}
 			}
 		}
 	}
 
+	// Divide into disconnected subgraphs
+	const components = dagre.graphlib.alg.components(parentGraph);
+
+	const subgraphs = components.map((nodeIds) => {
+		const subgraph = createSubGraph(nodeIds, parentGraph);
+
+		// Find AI parent nodes in this subgraph
+		const aiParentsInSubgraph = subgraph.nodes().filter((id) => aiParentNames.has(id));
+
+		// Process each AI parent: create TB sub-layout, replace with bounding box
+		const aiGraphs = aiParentsInSubgraph.map((aiParentId) => {
+			const configNodeIds = getAllConnectedAiConfigNodes(subgraph, aiParentId, aiConfigNames);
+			const allAiNodeIds = configNodeIds.concat(aiParentId);
+			const aiGraph = createAiSubGraph(subgraph, allAiNodeIds);
+
+			// Capture edges connecting the AI parent to non-AI nodes BEFORE removing config nodes
+			const configNodeIdSet = new Set(configNodeIds);
+			const rootEdges = subgraph
+				.edges()
+				.filter(
+					(edge) =>
+						(edge.v === aiParentId || edge.w === aiParentId) &&
+						!configNodeIdSet.has(edge.v) &&
+						!configNodeIdSet.has(edge.w),
+				);
+
+			// Remove config nodes from main subgraph (keep parent)
+			configNodeIds.forEach((id) => subgraph.removeNode(id));
+
+			dagre.layout(aiGraph, { disableOptimalOrderHeuristic: true });
+			const aiBoundingBox = boundingBoxFromGraph(aiGraph);
+
+			// Replace parent node with bounding box of entire AI subtree
+			subgraph.setNode(aiParentId, {
+				width: aiBoundingBox.width,
+				height: aiBoundingBox.height,
+			});
+			rootEdges.forEach((edge) => subgraph.setEdge(edge));
+
+			return { graph: aiGraph, boundingBox: aiBoundingBox, aiParentId };
+		});
+
+		dagre.layout(subgraph, { disableOptimalOrderHeuristic: true });
+
+		return { graph: subgraph, aiGraphs, boundingBox: boundingBoxFromGraph(subgraph) };
+	});
+
+	// Arrange subgraphs vertically (skip composite layout for single subgraph)
+	let compositeGraph: dagre.graphlib.Graph | undefined;
+	if (subgraphs.length > 1) {
+		compositeGraph = createVerticalGraph(
+			subgraphs.map(({ boundingBox }, index) => ({
+				box: boundingBox,
+				id: index.toString(),
+			})),
+		);
+		dagre.layout(compositeGraph);
+	}
+
+	// Compute final positions
+	const boundingBoxByNodeId: Record<string, BoundingBox> = {};
+
+	subgraphs.forEach(({ graph, aiGraphs }, index) => {
+		let offset = { x: 0, y: 0 };
+		if (compositeGraph) {
+			const subgraphPosition = compositeGraph.node(index.toString());
+			offset = {
+				x: 0,
+				y: subgraphPosition.y - subgraphPosition.height / 2,
+			};
+		}
+		const aiParentIds = new Set(aiGraphs.map(({ aiParentId }) => aiParentId));
+
+		for (const nodeId of graph.nodes()) {
+			const { x, y, width, height } = graph.node(nodeId);
+			const box: BoundingBox = {
+				x: x + offset.x - width / 2,
+				y: y + offset.y - height / 2,
+				width,
+				height,
+			};
+
+			if (aiParentIds.has(nodeId)) {
+				const aiGraphInfo = aiGraphs.find(({ aiParentId }) => aiParentId === nodeId);
+				if (!aiGraphInfo) continue;
+
+				const parentOffset = { x: box.x, y: box.y };
+				for (const aiNodeId of aiGraphInfo.graph.nodes()) {
+					const aiNode = aiGraphInfo.graph.node(aiNodeId);
+					boundingBoxByNodeId[aiNodeId] = {
+						x: aiNode.x + parentOffset.x - aiNode.width / 2,
+						y: aiNode.y + parentOffset.y - aiNode.height / 2,
+						width: aiNode.width,
+						height: aiNode.height,
+					};
+				}
+			} else {
+				boundingBoxByNodeId[nodeId] = box;
+			}
+		}
+	});
+
+	// Post-process: top-align AI subtrees when no conflicts
+	subgraphs
+		.flatMap(({ aiGraphs }) => aiGraphs)
+		.forEach(({ graph }) => {
+			const aiNodes = graph.nodes();
+			const boxes = aiNodes
+				.map((id) => boundingBoxByNodeId[id])
+				.filter((b): b is BoundingBox => b !== undefined);
+			if (boxes.length === 0) return;
+
+			const aiGraphBoundingBox = compositeBoundingBox(boxes);
+			const aiNodeVerticalCorrection = aiGraphBoundingBox.height / 2 - DEFAULT_NODE_SIZE[0] / 2;
+			aiGraphBoundingBox.y += aiNodeVerticalCorrection;
+
+			const hasConflictingNodes = Object.entries(boundingBoxByNodeId)
+				.filter(([id]) => !graph.hasNode(id))
+				.some(([, nodeBoundingBox]) =>
+					intersects(aiGraphBoundingBox, nodeBoundingBox, NODE_Y_SPACING),
+				);
+
+			if (!hasConflictingNodes) {
+				for (const aiNode of aiNodes) {
+					if (boundingBoxByNodeId[aiNode]) {
+						boundingBoxByNodeId[aiNode].y += aiNodeVerticalCorrection;
+					}
+				}
+			}
+		});
+
+	// Snap to grid and build result (skip nodes with explicit positions)
+	for (const [name, box] of Object.entries(boundingBoxByNodeId)) {
+		const node = nodes.get(name);
+		if (node && !node.instance.config?.position) {
+			positions.set(name, [snapToGrid(box.x), snapToGrid(box.y)]);
+		}
+	}
+
+	// Reposition sticky notes
+	if (stickyNames.length > 0) {
+		// Build "before" bounding boxes from original positions
+		const positionsBefore = new Map<string, BoundingBox>();
+		for (const [name, graphNode] of nodes) {
+			const pos = graphNode.instance.config?.position;
+			const { width, height } = getNodeDimensions(name, aiParentNames, aiConfigNames, nodes);
+			positionsBefore.set(name, {
+				x: pos ? pos[0] : 0,
+				y: pos ? pos[1] : 0,
+				width,
+				height,
+			});
+		}
+
+		// Build "after" bounding boxes from computed positions
+		const positionsAfter = new Map<string, BoundingBox>();
+		for (const [name, box] of Object.entries(boundingBoxByNodeId)) {
+			positionsAfter.set(name, box);
+		}
+
+		repositionStickyNotes(stickyNames, nonStickyNames, positionsBefore, positionsAfter, positions);
+	}
+
 	return positions;
+}
+
+// ---------------------------------------------------------------------------
+// WorkflowJSON layout (operates on serialized workflow, not builder graph)
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply Dagre-based layout to a WorkflowJSON, mutating node positions in-place.
+ * This is the entry point for code paths that don't go through the builder
+ * (e.g., sandbox-compiled workflows in instance-ai).
+ */
+export function layoutWorkflowJSON(json: WorkflowJSON): void {
+	const nodes = json.nodes;
+	if (!nodes || nodes.length === 0) return;
+
+	const connections = json.connections ?? {};
+
+	// Build a node name → NodeJSON index for quick lookup
+	const nodeByName = new Map<string, NodeJSON>();
+	for (const node of nodes) {
+		if (node.name) {
+			nodeByName.set(node.name, node);
+		}
+	}
+
+	// Detect AI parent nodes (targets of ai_* connections)
+	const aiParentNames = new Set<string>();
+	const aiConfigNames = new Set<string>();
+	for (const [sourceName, nodeConns] of Object.entries(connections)) {
+		for (const connType of Object.keys(nodeConns)) {
+			if (!isAiConnectionType(connType)) continue;
+			aiConfigNames.add(sourceName);
+			const outputs = nodeConns[connType];
+			if (!Array.isArray(outputs)) continue;
+			for (const slot of outputs) {
+				if (!Array.isArray(slot)) continue;
+				for (const target of slot) {
+					if (target?.node) {
+						aiParentNames.add(target.node);
+					}
+				}
+			}
+		}
+	}
+
+	// Get node dimensions for layout
+	function getDimensions(nodeName: string): { width: number; height: number } {
+		if (aiConfigNames.has(nodeName)) {
+			return { width: CONFIGURATION_NODE_SIZE[0], height: CONFIGURATION_NODE_SIZE[1] };
+		}
+		if (aiParentNames.has(nodeName)) {
+			// Count distinct ai_* types targeting this node
+			const aiInputTypes = new Set<string>();
+			for (const nodeConns of Object.values(connections)) {
+				for (const [connType, outputs] of Object.entries(nodeConns)) {
+					if (!isAiConnectionType(connType) || !Array.isArray(outputs)) continue;
+					for (const slot of outputs) {
+						if (!Array.isArray(slot)) continue;
+						for (const target of slot) {
+							if (target?.node === nodeName) aiInputTypes.add(connType);
+						}
+					}
+				}
+			}
+			const portCount = Math.max(NODE_MIN_INPUT_ITEMS_COUNT, aiInputTypes.size);
+			const width = CONFIGURATION_NODE_RADIUS * 2 + GRID_SIZE * (portCount - 1) * 3;
+			return { width, height: CONFIGURABLE_NODE_SIZE[1] };
+		}
+		return { width: DEFAULT_NODE_SIZE[0], height: DEFAULT_NODE_SIZE[1] };
+	}
+
+	// Build dagre graph
+	const nonStickyNodes = nodes.filter((n) => n.type !== STICKY_NODE_TYPE);
+	if (nonStickyNodes.length === 0) return;
+
+	const parentGraph = new dagre.graphlib.Graph();
+	parentGraph.setGraph({});
+	parentGraph.setDefaultEdgeLabel(() => ({}));
+
+	const nonStickyNames = new Set<string>();
+	for (const node of nonStickyNodes) {
+		if (!node.name) continue;
+		nonStickyNames.add(node.name);
+		const { width, height } = getDimensions(node.name);
+		parentGraph.setNode(node.name, { width, height });
+	}
+
+	// Add edges from connections
+	for (const [sourceName, nodeConns] of Object.entries(connections)) {
+		if (!nonStickyNames.has(sourceName)) continue;
+		for (const outputs of Object.values(nodeConns)) {
+			if (!Array.isArray(outputs)) continue;
+			for (const slot of outputs) {
+				if (!Array.isArray(slot)) continue;
+				for (const target of slot) {
+					if (target?.node && nonStickyNames.has(target.node)) {
+						parentGraph.setEdge(sourceName, target.node);
+					}
+				}
+			}
+		}
+	}
+
+	// Find disconnected subgraphs
+	const components = dagre.graphlib.alg.components(parentGraph);
+
+	const subgraphs = components.map((nodeIds) => {
+		const subgraph = createSubGraph(nodeIds, parentGraph);
+
+		const aiParentsInSubgraph = subgraph.nodes().filter((id) => aiParentNames.has(id));
+
+		const aiGraphs = aiParentsInSubgraph.map((aiParentId) => {
+			const configNodeIds = getAllConnectedAiConfigNodes(subgraph, aiParentId, aiConfigNames);
+			const allAiNodeIds = configNodeIds.concat(aiParentId);
+			const aiGraph = createAiSubGraph(subgraph, allAiNodeIds);
+
+			const configNodeIdSet = new Set(configNodeIds);
+			const rootEdges = subgraph
+				.edges()
+				.filter(
+					(edge) =>
+						(edge.v === aiParentId || edge.w === aiParentId) &&
+						!configNodeIdSet.has(edge.v) &&
+						!configNodeIdSet.has(edge.w),
+				);
+
+			configNodeIds.forEach((id) => subgraph.removeNode(id));
+
+			dagre.layout(aiGraph, { disableOptimalOrderHeuristic: true });
+			const aiBoundingBox = boundingBoxFromGraph(aiGraph);
+
+			subgraph.setNode(aiParentId, {
+				width: aiBoundingBox.width,
+				height: aiBoundingBox.height,
+			});
+			rootEdges.forEach((edge) => subgraph.setEdge(edge));
+
+			return { graph: aiGraph, boundingBox: aiBoundingBox, aiParentId };
+		});
+
+		dagre.layout(subgraph, { disableOptimalOrderHeuristic: true });
+
+		return { graph: subgraph, aiGraphs, boundingBox: boundingBoxFromGraph(subgraph) };
+	});
+
+	// Arrange subgraphs vertically
+	let compositeGraph: dagre.graphlib.Graph | undefined;
+	if (subgraphs.length > 1) {
+		compositeGraph = createVerticalGraph(
+			subgraphs.map(({ boundingBox }, index) => ({
+				box: boundingBox,
+				id: index.toString(),
+			})),
+		);
+		dagre.layout(compositeGraph);
+	}
+
+	// Compute final positions
+	const boundingBoxByNodeId: Record<string, BoundingBox> = {};
+
+	subgraphs.forEach(({ graph, aiGraphs }, index) => {
+		let offset = { x: 0, y: 0 };
+		if (compositeGraph) {
+			const subgraphPosition = compositeGraph.node(index.toString());
+			offset = { x: 0, y: subgraphPosition.y - subgraphPosition.height / 2 };
+		}
+		const aiParentIds = new Set(aiGraphs.map(({ aiParentId }) => aiParentId));
+
+		for (const nodeId of graph.nodes()) {
+			const { x, y, width, height } = graph.node(nodeId);
+			const box: BoundingBox = {
+				x: x + offset.x - width / 2,
+				y: y + offset.y - height / 2,
+				width,
+				height,
+			};
+
+			if (aiParentIds.has(nodeId)) {
+				const aiGraphInfo = aiGraphs.find(({ aiParentId }) => aiParentId === nodeId);
+				if (!aiGraphInfo) continue;
+				const parentOffset = { x: box.x, y: box.y };
+				for (const aiNodeId of aiGraphInfo.graph.nodes()) {
+					const aiNode = aiGraphInfo.graph.node(aiNodeId);
+					boundingBoxByNodeId[aiNodeId] = {
+						x: aiNode.x + parentOffset.x - aiNode.width / 2,
+						y: aiNode.y + parentOffset.y - aiNode.height / 2,
+						width: aiNode.width,
+						height: aiNode.height,
+					};
+				}
+			} else {
+				boundingBoxByNodeId[nodeId] = box;
+			}
+		}
+	});
+
+	// Post-process: top-align AI subtrees
+	subgraphs
+		.flatMap(({ aiGraphs }) => aiGraphs)
+		.forEach(({ graph }) => {
+			const aiNodes = graph.nodes();
+			const boxes = aiNodes
+				.map((id) => boundingBoxByNodeId[id])
+				.filter((b): b is BoundingBox => b !== undefined);
+			if (boxes.length === 0) return;
+
+			const aiGraphBoundingBox = compositeBoundingBox(boxes);
+			const aiNodeVerticalCorrection = aiGraphBoundingBox.height / 2 - DEFAULT_NODE_SIZE[0] / 2;
+			aiGraphBoundingBox.y += aiNodeVerticalCorrection;
+
+			const hasConflictingNodes = Object.entries(boundingBoxByNodeId)
+				.filter(([id]) => !graph.hasNode(id))
+				.some(([, nodeBoundingBox]) =>
+					intersects(aiGraphBoundingBox, nodeBoundingBox, NODE_Y_SPACING),
+				);
+
+			if (!hasConflictingNodes) {
+				for (const aiNode of aiNodes) {
+					if (boundingBoxByNodeId[aiNode]) {
+						boundingBoxByNodeId[aiNode].y += aiNodeVerticalCorrection;
+					}
+				}
+			}
+		});
+
+	// Apply positions to nodes
+	for (const node of nodes) {
+		if (!node.name || node.type === STICKY_NODE_TYPE) continue;
+		const box = boundingBoxByNodeId[node.name];
+		if (box) {
+			node.position = [snapToGrid(box.x), snapToGrid(box.y)];
+		}
+	}
 }

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
@@ -22,7 +22,7 @@ import {
 	STICKY_BOTTOM_PADDING,
 	STICKY_NODE_TYPE,
 } from './constants';
-import type { GraphNode, WorkflowJSON, ConnectionTarget } from '../types/base';
+import type { GraphNode } from '../types/base';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -598,79 +598,4 @@ export function calculateNodePositions(
 	}
 
 	return positions;
-}
-
-// ---------------------------------------------------------------------------
-// WorkflowJSON layout (operates on serialized workflow, not builder graph)
-// ---------------------------------------------------------------------------
-
-/**
- * Return a new WorkflowJSON with Dagre-computed node positions.
- * Builds a GraphNode map from the serialized JSON and delegates to calculateNodePositions.
- *
- * Pure function — does not mutate the input.
- *
- * This is the entry point for code paths that don't go through the builder
- * (e.g., sandbox-compiled workflows in instance-ai).
- */
-export function layoutWorkflowJSON(json: WorkflowJSON): WorkflowJSON {
-	const jsonNodes = json.nodes;
-	if (!jsonNodes || jsonNodes.length === 0) return json;
-
-	const connections = json.connections ?? {};
-
-	// Build a GraphNode map from WorkflowJSON
-	const graphNodes = new Map<string, GraphNode>();
-
-	for (const node of jsonNodes) {
-		if (!node.name) continue;
-		const connectionsMap = new Map<string, Map<number, ConnectionTarget[]>>();
-		connectionsMap.set('main', new Map());
-		graphNodes.set(node.name, {
-			instance: {
-				type: node.type,
-				name: node.name,
-				version: node.typeVersion,
-				config: {},
-			} as unknown as GraphNode['instance'],
-			connections: connectionsMap,
-		});
-	}
-
-	// Populate connections from WorkflowJSON connections structure
-	for (const [sourceName, nodeConns] of Object.entries(connections)) {
-		const graphNode = graphNodes.get(sourceName);
-		if (!graphNode) continue;
-
-		for (const [connType, outputs] of Object.entries(nodeConns)) {
-			if (!Array.isArray(outputs)) continue;
-			let outputMap = graphNode.connections.get(connType);
-			if (!outputMap) {
-				outputMap = new Map();
-				graphNode.connections.set(connType, outputMap);
-			}
-			for (let outputIdx = 0; outputIdx < outputs.length; outputIdx++) {
-				const slot = outputs[outputIdx];
-				if (!Array.isArray(slot)) continue;
-				const targets: ConnectionTarget[] = slot
-					.filter((t): t is { node: string; type: string; index: number } => !!t?.node)
-					.map((t) => ({ node: t.node, type: t.type, index: t.index }));
-				if (targets.length > 0) {
-					outputMap.set(outputIdx, targets);
-				}
-			}
-		}
-	}
-
-	// Calculate positions using the existing Dagre layout
-	const positions = calculateNodePositions(graphNodes);
-
-	// Return new WorkflowJSON with updated positions
-	return {
-		...json,
-		nodes: jsonNodes.map((node) => {
-			const pos = node.name ? positions.get(node.name) : undefined;
-			return pos ? { ...node, position: pos } : node;
-		}),
-	};
 }

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
@@ -1,8 +1,10 @@
 /**
  * Layout Utility Functions
  *
- * Dagre-based layout that mirrors the frontend's useCanvasLayout algorithm
- * to produce positions matching what the FE tidy-up would generate.
+ * Two layout strategies:
+ * 1. BFS layout (calculateNodePositions) — simple left-to-right BFS, used by default toJSON()
+ * 2. Dagre layout (calculateNodePositionsDagre) — mirrors the FE's useCanvasLayout algorithm,
+ *    used by toJSON({ tidyUp: true }) and layoutWorkflowJSON()
  */
 
 import dagre from '@dagrejs/dagre';
@@ -21,8 +23,88 @@ import {
 	AI_Y_SPACING,
 	STICKY_BOTTOM_PADDING,
 	STICKY_NODE_TYPE,
+	NODE_SPACING_X,
+	DEFAULT_Y,
+	START_X,
 } from './constants';
-import type { GraphNode } from '../types/base';
+import type { GraphNode, WorkflowJSON, ConnectionTarget } from '../types/base';
+
+// ===========================================================================
+// BFS Layout (default)
+// ===========================================================================
+
+/**
+ * Calculate positions for nodes using BFS left-to-right layout.
+ * Only sets positions for nodes without explicit config.position.
+ */
+export function calculateNodePositions(
+	nodes: ReadonlyMap<string, GraphNode>,
+): Map<string, [number, number]> {
+	const positions = new Map<string, [number, number]>();
+
+	// Find root nodes (nodes with no incoming connections)
+	const hasIncoming = new Set<string>();
+	for (const graphNode of nodes.values()) {
+		for (const typeConns of graphNode.connections.values()) {
+			for (const targets of typeConns.values()) {
+				for (const target of targets) {
+					hasIncoming.add(target.node);
+				}
+			}
+		}
+	}
+
+	const rootNodes = [...nodes.keys()].filter((name) => !hasIncoming.has(name));
+
+	// BFS to assign positions
+	const visited = new Set<string>();
+	const queue: Array<{ name: string; x: number; y: number }> = [];
+
+	// Initialize queue with root nodes
+	let y = DEFAULT_Y;
+	for (const rootName of rootNodes) {
+		queue.push({ name: rootName, x: START_X, y });
+		y += 150; // Offset Y for multiple roots
+	}
+
+	while (queue.length > 0) {
+		const { name, x, y: nodeY } = queue.shift()!;
+
+		if (visited.has(name)) continue;
+		visited.add(name);
+
+		// Only set position if node doesn't have explicit position
+		const node = nodes.get(name);
+		if (node && !node.instance.config?.position) {
+			positions.set(name, [x, nodeY]);
+		}
+
+		// Queue connected nodes
+		if (node) {
+			let branchOffset = 0;
+			for (const typeConns of node.connections.values()) {
+				for (const targets of typeConns.values()) {
+					for (const target of targets) {
+						if (!visited.has(target.node)) {
+							queue.push({
+								name: target.node,
+								x: x + NODE_SPACING_X,
+								y: nodeY + branchOffset * 150,
+							});
+							branchOffset++;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return positions;
+}
+
+// ===========================================================================
+// Dagre Layout (tidyUp)
+// ===========================================================================
 
 // ---------------------------------------------------------------------------
 // Types
@@ -43,10 +125,6 @@ function isAiConnectionType(type: string): boolean {
 	return type.startsWith('ai_');
 }
 
-/**
- * Find nodes that are AI parents (targets of ai_* connections).
- * Returns a set of node names that receive ai_* connections.
- */
 function getAiParentNames(nodes: ReadonlyMap<string, GraphNode>): Set<string> {
 	const parents = new Set<string>();
 	for (const graphNode of nodes.values()) {
@@ -62,10 +140,6 @@ function getAiParentNames(nodes: ReadonlyMap<string, GraphNode>): Set<string> {
 	return parents;
 }
 
-/**
- * Find nodes that are AI config nodes (have outgoing ai_* connections).
- * Returns a set of node names.
- */
 function getAiConfigNames(nodes: ReadonlyMap<string, GraphNode>): Set<string> {
 	const configs = new Set<string>();
 	for (const [name, graphNode] of nodes) {
@@ -79,10 +153,6 @@ function getAiConfigNames(nodes: ReadonlyMap<string, GraphNode>): Set<string> {
 	return configs;
 }
 
-/**
- * Recursively find all AI config nodes connected to a parent node.
- * Uses dagre graph predecessors (since ai edges go config -> parent in the graph).
- */
 function getAllConnectedAiConfigNodes(
 	graph: dagre.graphlib.Graph,
 	rootId: string,
@@ -98,9 +168,6 @@ function getAllConnectedAiConfigNodes(
 // Helpers: Node dimensions
 // ---------------------------------------------------------------------------
 
-/**
- * Count main output indices for a node (from its outgoing main connections).
- */
 function getMainOutputCount(nodeName: string, nodes: ReadonlyMap<string, GraphNode>): number {
 	const graphNode = nodes.get(nodeName);
 	if (!graphNode) return 1;
@@ -109,9 +176,6 @@ function getMainOutputCount(nodeName: string, nodes: ReadonlyMap<string, GraphNo
 	return Math.max(...mainConns.keys()) + 1;
 }
 
-/**
- * Count main input indices targeting a node (from all nodes' outgoing main connections).
- */
 function getMainInputCount(nodeName: string, nodes: ReadonlyMap<string, GraphNode>): number {
 	let maxIndex = 0;
 	for (const graphNode of nodes.values()) {
@@ -128,19 +192,11 @@ function getMainInputCount(nodeName: string, nodes: ReadonlyMap<string, GraphNod
 	return Math.max(1, maxIndex);
 }
 
-/**
- * Calculate node height based on main handle counts.
- * Matches the FE's calculateNodeSize formula in nodeViewUtils.ts.
- */
 function calculateNodeHeight(mainInputCount: number, mainOutputCount: number): number {
 	const maxVerticalHandles = Math.max(mainInputCount, mainOutputCount, 1);
 	return DEFAULT_NODE_SIZE[1] + Math.max(0, maxVerticalHandles - 2) * GRID_SIZE * 2;
 }
 
-/**
- * Get node dimensions based on classification and connection counts.
- * Matches the FE's calculateNodeSize in nodeViewUtils.ts.
- */
 export function getNodeDimensions(
 	nodeName: string,
 	aiParentNames: Set<string>,
@@ -152,7 +208,6 @@ export function getNodeDimensions(
 	}
 
 	if (aiParentNames.has(nodeName)) {
-		// Count distinct ai_* connection types targeting this node to determine port count
 		const aiInputTypes = new Set<string>();
 		for (const graphNode of nodes.values()) {
 			for (const [connType, outputMap] of graphNode.connections) {
@@ -328,10 +383,6 @@ function createAiSubGraph(parent: dagre.graphlib.Graph, nodeIds: string[]): dagr
 // Sticky note repositioning
 // ---------------------------------------------------------------------------
 
-/**
- * Reposition sticky notes to cover the same nodes they covered before layout.
- * Structured as a standalone function for easy future refinement.
- */
 function repositionStickyNotes(
 	stickyNames: string[],
 	nonStickyNames: string[],
@@ -343,7 +394,6 @@ function repositionStickyNotes(
 		const stickyBoxBefore = positionsBefore.get(stickyName);
 		if (!stickyBoxBefore) continue;
 
-		// Find which non-sticky nodes the sticky covered before layout
 		const coveredNames = nonStickyNames.filter((name) => {
 			const nodeBox = positionsBefore.get(name);
 			return nodeBox && isCoveredBy(stickyBoxBefore, nodeBox);
@@ -351,7 +401,6 @@ function repositionStickyNotes(
 
 		if (coveredNames.length === 0) continue;
 
-		// Get the bounding box of those nodes after layout
 		const coveredBoxesAfter = coveredNames
 			.map((name) => positionsAfter.get(name))
 			.filter((box): box is BoundingBox => box !== undefined);
@@ -368,7 +417,7 @@ function repositionStickyNotes(
 }
 
 // ---------------------------------------------------------------------------
-// Main layout function
+// Dagre layout function
 // ---------------------------------------------------------------------------
 
 /**
@@ -377,7 +426,7 @@ function repositionStickyNotes(
  *
  * Only sets positions for nodes without explicit config.position.
  */
-export function calculateNodePositions(
+export function calculateNodePositionsDagre(
 	nodes: ReadonlyMap<string, GraphNode>,
 ): Map<string, [number, number]> {
 	const positions = new Map<string, [number, number]>();
@@ -575,7 +624,6 @@ export function calculateNodePositions(
 
 	// Reposition sticky notes
 	if (stickyNames.length > 0) {
-		// Build "before" bounding boxes from original positions
 		const positionsBefore = new Map<string, BoundingBox>();
 		for (const [name, graphNode] of nodes) {
 			const pos = graphNode.instance.config?.position;
@@ -588,7 +636,6 @@ export function calculateNodePositions(
 			});
 		}
 
-		// Build "after" bounding boxes from computed positions
 		const positionsAfter = new Map<string, BoundingBox>();
 		for (const [name, box] of Object.entries(boundingBoxByNodeId)) {
 			positionsAfter.set(name, box);
@@ -598,4 +645,80 @@ export function calculateNodePositions(
 	}
 
 	return positions;
+}
+
+// ===========================================================================
+// WorkflowJSON layout (operates on serialized workflow, not builder graph)
+// ===========================================================================
+
+/**
+ * Return a new WorkflowJSON with Dagre-computed node positions.
+ * Builds a GraphNode map from the serialized JSON and delegates to calculateNodePositionsDagre.
+ *
+ * Pure function — does not mutate the input.
+ *
+ * This is the entry point for code paths that receive pre-built WorkflowJSON
+ * (e.g., sandbox-compiled workflows in instance-ai) and need proper layout
+ * before the SDK is published with tidyUp support.
+ */
+export function layoutWorkflowJSON(json: WorkflowJSON): WorkflowJSON {
+	const jsonNodes = json.nodes;
+	if (!jsonNodes || jsonNodes.length === 0) return json;
+
+	const connections = json.connections ?? {};
+
+	// Build a GraphNode map from WorkflowJSON
+	const graphNodes = new Map<string, GraphNode>();
+
+	for (const node of jsonNodes) {
+		if (!node.name) continue;
+		const connectionsMap = new Map<string, Map<number, ConnectionTarget[]>>();
+		connectionsMap.set('main', new Map());
+		graphNodes.set(node.name, {
+			instance: {
+				type: node.type,
+				name: node.name,
+				version: node.typeVersion,
+				config: {},
+			} as unknown as GraphNode['instance'],
+			connections: connectionsMap,
+		});
+	}
+
+	// Populate connections from WorkflowJSON connections structure
+	for (const [sourceName, nodeConns] of Object.entries(connections)) {
+		const graphNode = graphNodes.get(sourceName);
+		if (!graphNode) continue;
+
+		for (const [connType, outputs] of Object.entries(nodeConns)) {
+			if (!Array.isArray(outputs)) continue;
+			let outputMap = graphNode.connections.get(connType);
+			if (!outputMap) {
+				outputMap = new Map();
+				graphNode.connections.set(connType, outputMap);
+			}
+			for (let outputIdx = 0; outputIdx < outputs.length; outputIdx++) {
+				const slot = outputs[outputIdx];
+				if (!Array.isArray(slot)) continue;
+				const targets: ConnectionTarget[] = slot
+					.filter((t): t is { node: string; type: string; index: number } => !!t?.node)
+					.map((t) => ({ node: t.node, type: t.type, index: t.index }));
+				if (targets.length > 0) {
+					outputMap.set(outputIdx, targets);
+				}
+			}
+		}
+	}
+
+	// Calculate positions using the Dagre layout
+	const positions = calculateNodePositionsDagre(graphNodes);
+
+	// Return new WorkflowJSON with updated positions
+	return {
+		...json,
+		nodes: jsonNodes.map((node) => {
+			const pos = node.name ? positions.get(node.name) : undefined;
+			return pos ? { ...node, position: pos } : node;
+		}),
+	};
 }

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
@@ -562,15 +562,17 @@ export function calculateNodePositions(
 // ---------------------------------------------------------------------------
 
 /**
- * Apply Dagre-based layout to a WorkflowJSON, mutating node positions in-place.
+ * Return a new WorkflowJSON with Dagre-computed node positions.
  * Builds a GraphNode map from the serialized JSON and delegates to calculateNodePositions.
+ *
+ * Pure function — does not mutate the input.
  *
  * This is the entry point for code paths that don't go through the builder
  * (e.g., sandbox-compiled workflows in instance-ai).
  */
-export function layoutWorkflowJSON(json: WorkflowJSON): void {
+export function layoutWorkflowJSON(json: WorkflowJSON): WorkflowJSON {
 	const jsonNodes = json.nodes;
-	if (!jsonNodes || jsonNodes.length === 0) return;
+	if (!jsonNodes || jsonNodes.length === 0) return json;
 
 	const connections = json.connections ?? {};
 
@@ -620,12 +622,12 @@ export function layoutWorkflowJSON(json: WorkflowJSON): void {
 	// Calculate positions using the existing Dagre layout
 	const positions = calculateNodePositions(graphNodes);
 
-	// Apply positions back to JSON nodes
-	for (const node of jsonNodes) {
-		if (!node.name) continue;
-		const pos = positions.get(node.name);
-		if (pos) {
-			node.position = pos;
-		}
-	}
+	// Return new WorkflowJSON with updated positions
+	return {
+		...json,
+		nodes: jsonNodes.map((node) => {
+			const pos = node.name ? positions.get(node.name) : undefined;
+			return pos ? { ...node, position: pos } : node;
+		}),
+	};
 }

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/serializers/json-serializer.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/serializers/json-serializer.ts
@@ -15,7 +15,7 @@ import type {
 	GraphNode,
 } from '../../../types/base';
 import { START_X, DEFAULT_Y } from '../../constants';
-import { calculateNodePositions } from '../../layout-utils';
+import { calculateNodePositions, calculateNodePositionsDagre } from '../../layout-utils';
 import {
 	normalizeResourceLocators,
 	escapeNewlinesInExpressionStrings,
@@ -193,7 +193,9 @@ export const jsonSerializer: SerializerPlugin<WorkflowJSON> = {
 		const connections: IConnections = {};
 
 		// Calculate positions for nodes without explicit positions
-		const nodePositions = calculateNodePositions(ctx.nodes);
+		const nodePositions = ctx.tidyUp
+			? calculateNodePositionsDagre(ctx.nodes)
+			: calculateNodePositions(ctx.nodes);
 
 		// Convert nodes and connections
 		for (const [mapKey, graphNode] of ctx.nodes) {

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/types.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/types.ts
@@ -348,6 +348,9 @@ export interface SerializerContext extends PluginContext {
 
 	/** Workflow meta information (if set) */
 	readonly meta?: Record<string, unknown>;
+
+	/** Whether to use Dagre-based layout for node positioning */
+	readonly tidyUp?: boolean;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2243,6 +2243,9 @@ importers:
 
   packages/@n8n/workflow-sdk:
     dependencies:
+      '@dagrejs/dagre':
+        specifier: ^1.1.4
+        version: 1.1.4
       acorn:
         specifier: 8.14.0
         version: 8.14.0


### PR DESCRIPTION
## Summary
- Replace the SDK's simple BFS layout with a Dagre-based algorithm matching the FE's `useCanvasLayout`.
- Apply layout in `submit-workflow` and `build-workflow` tools before saving to DB, since the sandbox runs its own SDK copy
- Export `layoutWorkflowJSON()` that builds a `GraphNode` map from serialized JSON and delegates to `calculateNodePositions`

# Prompt
Make one workflow. Add a Webhook node connected to an AI Agent with OpenAI, web search, calculator and memory tools. Separately in the same workflow, add a Schedule Trigger connected to Google Sheets, then a Switch with 4 outputs, each connected to a Slack node. Do NOT create two workflows.

| Before | After |
| ------------- | ------------- |
| <img width="831" height="802" alt="image" src="https://github.com/user-attachments/assets/dd12c23d-b801-4403-9720-e63e3b63a3d5" /> | <img width="831" height="802" alt="image" src="https://github.com/user-attachments/assets/1a13799e-ee03-461f-808d-370af56bc626" />  |

## Test plan
- [ ] Generate AI workflow (agent + subnodes) — verify positions match FE tidy-up layout
- [ ] Generate simple linear workflow — verify LR positioning
- [ ] Generate disconnected subgraphs — verify vertical arrangement
- [ ] Existing `pnpm test` in workflow-sdk passes (11,411 tests)
- [ ] Full build passes