### PR TITLE
feat(ai-builder): Add agent text response evaluation and workflow changes binary check (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/cli.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/cli.test.ts
@@ -64,8 +64,10 @@ jest.mock('../cli/webhook', () => ({
 }));
 
 jest.mock('../harness/evaluation-helpers', () => ({
+	collectAgentTextResponse: jest.fn().mockResolvedValue(''),
 	consumeGenerator: (...args: unknown[]): unknown => mockConsumeGenerator(...args),
 	getChatPayload: (...args: unknown[]): unknown => mockGetChatPayload(...args),
+	extractSubgraphMetrics: jest.fn().mockReturnValue({}),
 	createWorkflowGenerator: () =>
 		jest.fn().mockResolvedValue({ name: 'Test', nodes: [], connections: {} }),
 }));

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/evaluation-helpers.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/evaluation-helpers.test.ts
@@ -4,7 +4,11 @@
 
 import pLimit from 'p-limit';
 
-import { withTimeout, extractSubgraphMetrics } from '../harness/evaluation-helpers';
+import {
+	withTimeout,
+	extractSubgraphMetrics,
+	collectAgentTextResponse,
+} from '../harness/evaluation-helpers';
 
 describe('evaluation-helpers', () => {
 	describe('withTimeout()', () => {
@@ -40,6 +44,54 @@ describe('evaluation-helpers', () => {
 
 			await p1;
 			jest.useRealTimers();
+		});
+	});
+
+	describe('collectAgentTextResponse()', () => {
+		it('should collect text from message chunks', async () => {
+			async function* gen() {
+				yield { messages: [{ type: 'message', text: 'Hello ' }] };
+				yield { messages: [{ type: 'tool', toolName: 'search' }] };
+				yield { messages: [{ type: 'message', text: 'world' }] };
+			}
+			const result = await collectAgentTextResponse(gen());
+			expect(result).toBe('Hello world');
+		});
+
+		it('should return empty string when no message chunks', async () => {
+			async function* gen() {
+				yield { messages: [{ type: 'tool', toolName: 'search' }] };
+			}
+			const result = await collectAgentTextResponse(gen());
+			expect(result).toBe('');
+		});
+
+		it('should handle empty generator', async () => {
+			async function* gen() {
+				// yields nothing
+			}
+			const result = await collectAgentTextResponse(
+				gen() as AsyncGenerator<{ messages?: Array<{ type: string; text?: string }> }>,
+			);
+			expect(result).toBe('');
+		});
+
+		it('should handle chunks without messages property', async () => {
+			async function* gen() {
+				yield {} as { messages?: Array<{ type: string; text?: string }> };
+				yield { messages: [{ type: 'message', text: 'hello' }] };
+			}
+			const result = await collectAgentTextResponse(gen());
+			expect(result).toBe('hello');
+		});
+
+		it('should skip message chunks without text', async () => {
+			async function* gen() {
+				yield { messages: [{ type: 'message' }] };
+				yield { messages: [{ type: 'message', text: 'ok' }] };
+			}
+			const result = await collectAgentTextResponse(gen());
+			expect(result).toBe('ok');
 		});
 	});
 

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/evaluators/response-matches-workflow-changes.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/evaluators/response-matches-workflow-changes.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Tests for the response_matches_workflow_changes binary check.
+ */
+
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+
+import { responseMatchesWorkflowChanges } from '../../evaluators/binary-checks/llm-checks/response-matches-workflow-changes';
+
+describe('response_matches_workflow_changes', () => {
+	it('should have correct name and kind', () => {
+		expect(responseMatchesWorkflowChanges.name).toBe('response_matches_workflow_changes');
+		expect(responseMatchesWorkflowChanges.kind).toBe('llm');
+	});
+
+	it('should skip when no LLM is provided', async () => {
+		const result = await responseMatchesWorkflowChanges.run(
+			{ name: 'Test', nodes: [], connections: {} },
+			{ prompt: 'test', nodeTypes: [] },
+		);
+		expect(result.pass).toBe(true);
+		expect(result.comment).toContain('Skipped: no LLM');
+	});
+
+	it('should skip when no agent text response', async () => {
+		const mockLlm = {} as BaseChatModel;
+		const result = await responseMatchesWorkflowChanges.run(
+			{ name: 'Test', nodes: [], connections: {} },
+			{ prompt: 'test', nodeTypes: [], llm: mockLlm },
+		);
+		expect(result.pass).toBe(true);
+		expect(result.comment).toContain('Skipped: no agent text response');
+	});
+
+	it('should skip when agent text response is empty string', async () => {
+		const mockLlm = {} as BaseChatModel;
+		const result = await responseMatchesWorkflowChanges.run(
+			{ name: 'Test', nodes: [], connections: {} },
+			{ prompt: 'test', nodeTypes: [], llm: mockLlm, agentTextResponse: '' },
+		);
+		expect(result.pass).toBe(true);
+		expect(result.comment).toContain('Skipped: no agent text response');
+	});
+});

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
@@ -296,6 +296,26 @@ function isUnknownRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+/** Process a single stream message from CodeWorkflowBuilder, extracting workflow updates and text. */
+function processCodeBuilderMessage(
+	message: { type: string; text?: string; codeSnippet?: string; sourceCode?: string },
+	state: { workflow: SimpleWorkflow | null; generatedCode?: string; textParts: string[] },
+) {
+	if (isWorkflowUpdateChunk(message)) {
+		try {
+			const parsed: unknown = JSON.parse(message.codeSnippet ?? '');
+			if (isSimpleWorkflow(parsed)) {
+				state.workflow = parsed;
+				state.generatedCode = message.sourceCode;
+			}
+		} catch {
+			// Invalid JSON in codeSnippet — skip this message
+		}
+	} else if (message.type === 'message' && typeof message.text === 'string') {
+		state.textParts.push(message.text);
+	}
+}
+
 /**
  * Create a CodeWorkflowBuilder generator function.
  * Uses the CodeWorkflowBuilder which coordinates planning and coding agents to generate
@@ -354,9 +374,11 @@ function createCodeWorkflowBuilderGenerator(
 			? buildHistoryContextFromMessages(datasetInputContext.historicalMessages)
 			: undefined;
 
-		let workflow: SimpleWorkflow | null = null;
-		let generatedCode: string | undefined;
-		const textParts: string[] = [];
+		const streamState: {
+			workflow: SimpleWorkflow | null;
+			generatedCode?: string;
+			textParts: string[];
+		} = { workflow: null, textParts: [] };
 
 		// Create an AbortController to properly cancel the agent on timeout or error.
 		// Without this, the agent continues running even after Promise.race rejects,
@@ -378,16 +400,7 @@ function createCodeWorkflowBuilderGenerator(
 				historyContext,
 			)) {
 				for (const message of output.messages) {
-					if (isWorkflowUpdateChunk(message)) {
-						const parsed: unknown = JSON.parse(message.codeSnippet);
-						if (isSimpleWorkflow(parsed)) {
-							workflow = parsed;
-							generatedCode = message.sourceCode;
-						}
-					}
-					if (message.type === 'message' && 'text' in message && typeof message.text === 'string') {
-						textParts.push(message.text);
-					}
+					processCodeBuilderMessage(message, streamState);
 				}
 			}
 		} finally {
@@ -396,7 +409,7 @@ function createCodeWorkflowBuilderGenerator(
 			}
 		}
 
-		if (!workflow) {
+		if (!streamState.workflow) {
 			throw new WorkflowGenerationError('CodeWorkflowBuilder did not produce a workflow');
 		}
 
@@ -405,7 +418,11 @@ function createCodeWorkflowBuilderGenerator(
 			collectors.tokenUsage({ inputTokens: totalInputTokens, outputTokens: totalOutputTokens });
 		}
 
-		return { workflow, generatedCode, agentTextResponse: textParts.join('') || undefined };
+		return {
+			workflow: streamState.workflow,
+			generatedCode: streamState.generatedCode,
+			agentTextResponse: streamState.textParts.join('') || undefined,
+		};
 	};
 }
 

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
@@ -139,12 +139,12 @@ function createWorkflowGenerator(
 	prompt: string,
 	datasetInputContext?: DatasetInputContext,
 	collectors?: GenerationCollectors,
-) => Promise<SimpleWorkflow | GenerationResult> {
+) => Promise<GenerationResult> {
 	return async (
 		prompt: string,
 		datasetInputContext?: DatasetInputContext,
 		collectors?: GenerationCollectors,
-	): Promise<SimpleWorkflow | GenerationResult> => {
+	): Promise<GenerationResult> => {
 		const runId = generateRunId();
 
 		const agent = createAgent({

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
@@ -198,7 +198,7 @@ function createWorkflowGenerator(
 		// Report introspection events
 		collectors?.introspectionEvents?.(state.values.introspectionEvents ?? []);
 
-		return { workflow, agentTextResponse: agentTextResponse || undefined };
+		return { workflow, agentTextResponse };
 	};
 }
 
@@ -296,7 +296,7 @@ function isUnknownRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-/** Process a single stream message from CodeWorkflowBuilder, extracting workflow updates and text. */
+/** Process a single stream message from CodeWorkflowBuilder, extracting workflow updates and text response */
 function processCodeBuilderMessage(
 	message: StreamChunk,
 	state: { workflow: SimpleWorkflow | null; generatedCode?: string; textParts: string[] },

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
@@ -298,12 +298,12 @@ function isUnknownRecord(value: unknown): value is Record<string, unknown> {
 
 /** Process a single stream message from CodeWorkflowBuilder, extracting workflow updates and text. */
 function processCodeBuilderMessage(
-	message: { type: string; text?: string; codeSnippet?: string; sourceCode?: string },
+	message: StreamChunk,
 	state: { workflow: SimpleWorkflow | null; generatedCode?: string; textParts: string[] },
 ) {
 	if (isWorkflowUpdateChunk(message)) {
 		try {
-			const parsed: unknown = JSON.parse(message.codeSnippet ?? '');
+			const parsed: unknown = JSON.parse(message.codeSnippet);
 			if (isSimpleWorkflow(parsed)) {
 				state.workflow = parsed;
 				state.generatedCode = message.sourceCode;
@@ -311,7 +311,7 @@ function processCodeBuilderMessage(
 		} catch {
 			// Invalid JSON in codeSnippet — skip this message
 		}
-	} else if (message.type === 'message' && typeof message.text === 'string') {
+	} else if (message.type === 'message' && 'text' in message && typeof message.text === 'string') {
 		state.textParts.push(message.text);
 	}
 }

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
@@ -44,7 +44,7 @@ import { loadSubgraphDatasetFile } from './dataset-file-loader';
 import { sendWebhookNotification } from './webhook';
 import { WorkflowGenerationError } from '../errors';
 import {
-	consumeGenerator,
+	collectAgentTextResponse,
 	extractSubgraphMetrics,
 	getChatPayload,
 } from '../harness/evaluation-helpers';
@@ -139,12 +139,12 @@ function createWorkflowGenerator(
 	prompt: string,
 	datasetInputContext?: DatasetInputContext,
 	collectors?: GenerationCollectors,
-) => Promise<SimpleWorkflow> {
+) => Promise<SimpleWorkflow | GenerationResult> {
 	return async (
 		prompt: string,
 		datasetInputContext?: DatasetInputContext,
 		collectors?: GenerationCollectors,
-	): Promise<SimpleWorkflow> => {
+	): Promise<SimpleWorkflow | GenerationResult> => {
 		const runId = generateRunId();
 
 		const agent = createAgent({
@@ -157,7 +157,7 @@ function createWorkflowGenerator(
 		// (supervisor, discovery, builder, responder agents)
 		const tokenTracker = collectors?.tokenUsage ? new TokenUsageTrackingHandler() : undefined;
 
-		await consumeGenerator(
+		const agentTextResponse = await collectAgentTextResponse(
 			agent.chat(
 				getChatPayload({
 					evalType: EVAL_TYPES.LANGSMITH,
@@ -198,7 +198,7 @@ function createWorkflowGenerator(
 		// Report introspection events
 		collectors?.introspectionEvents?.(state.values.introspectionEvents ?? []);
 
-		return workflow;
+		return { workflow, agentTextResponse: agentTextResponse || undefined };
 	};
 }
 
@@ -356,6 +356,7 @@ function createCodeWorkflowBuilderGenerator(
 
 		let workflow: SimpleWorkflow | null = null;
 		let generatedCode: string | undefined;
+		const textParts: string[] = [];
 
 		// Create an AbortController to properly cancel the agent on timeout or error.
 		// Without this, the agent continues running even after Promise.race rejects,
@@ -384,6 +385,9 @@ function createCodeWorkflowBuilderGenerator(
 							generatedCode = message.sourceCode;
 						}
 					}
+					if (message.type === 'message' && 'text' in message && typeof message.text === 'string') {
+						textParts.push(message.text);
+					}
 				}
 			}
 		} finally {
@@ -401,7 +405,7 @@ function createCodeWorkflowBuilderGenerator(
 			collectors.tokenUsage({ inputTokens: totalInputTokens, outputTokens: totalOutputTokens });
 		}
 
-		return { workflow, generatedCode };
+		return { workflow, generatedCode, agentTextResponse: textParts.join('') || undefined };
 	};
 }
 

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/index.ts
@@ -61,6 +61,8 @@ export function createBinaryChecksEvaluator(
 				// Intentionally omit llmCallLimiter: binary-checks LLM judges are small,
 				// cheap calls that should run in parallel, not throttled by the shared limiter.
 				timeoutMs: ctx.timeoutMs,
+				agentTextResponse: ctx.agentTextResponse,
+				existingWorkflow: ctx.datasetInputContext?.existingWorkflow,
 			};
 
 			const results = await Promise.allSettled(

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/create-llm-check.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/create-llm-check.ts
@@ -47,9 +47,9 @@ export function createLlmCheck(options: LlmCheckOptions): BinaryCheck {
 				return await withTimeout({
 					promise: invokeEvaluatorChain(chain, {
 						userPrompt: ctx.prompt,
+						existingWorkflow: ctx.existingWorkflow,
 						generatedWorkflow: workflow,
 						agentTextResponse: ctx.agentTextResponse,
-						existingWorkflow: ctx.existingWorkflow,
 					}),
 					timeoutMs: ctx.timeoutMs,
 					label: `binary-checks:${options.name}`,

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/create-llm-check.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/create-llm-check.ts
@@ -18,18 +18,6 @@ interface LlmCheckOptions {
 	skipIf?: (workflow: SimpleWorkflow, ctx: BinaryCheckContext) => string | undefined;
 }
 
-/**
- * Build extra template variables from BinaryCheckContext fields.
- */
-function buildExtraVars(ctx: BinaryCheckContext): Record<string, string> {
-	return {
-		agentTextResponse: ctx.agentTextResponse ?? '',
-		workflowBefore: ctx.existingWorkflow
-			? JSON.stringify(ctx.existingWorkflow, null, 2)
-			: '{"nodes": [], "connections": {}}',
-	};
-}
-
 export function createLlmCheck(options: LlmCheckOptions): BinaryCheck {
 	const systemPrompt = options.systemPrompt + REASONING_FIRST_SUFFIX;
 
@@ -60,7 +48,8 @@ export function createLlmCheck(options: LlmCheckOptions): BinaryCheck {
 					promise: invokeEvaluatorChain(chain, {
 						userPrompt: ctx.prompt,
 						generatedWorkflow: workflow,
-						extraVars: buildExtraVars(ctx),
+						agentTextResponse: ctx.agentTextResponse,
+						existingWorkflow: ctx.existingWorkflow,
 					}),
 					timeoutMs: ctx.timeoutMs,
 					label: `binary-checks:${options.name}`,

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/create-llm-check.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/create-llm-check.ts
@@ -1,10 +1,7 @@
-import { SystemMessage } from '@langchain/core/messages';
-import { ChatPromptTemplate, HumanMessagePromptTemplate } from '@langchain/core/prompts';
-import { RunnableSequence } from '@langchain/core/runnables';
-
 import { runWithOptionalLimiter, withTimeout } from '../../../harness/evaluation-helpers';
+import { createEvaluatorChain, invokeEvaluatorChain } from '../../llm-judge/evaluators/base';
 import type { BinaryCheck, BinaryCheckContext, SimpleWorkflow } from '../types';
-import { binaryJudgeResultSchema, type BinaryJudgeResult } from './schemas';
+import { binaryJudgeResultSchema } from './schemas';
 
 const REASONING_FIRST_SUFFIX = `
 
@@ -22,17 +19,10 @@ interface LlmCheckOptions {
 }
 
 /**
- * Build template variables from the BinaryCheckContext.
- * All fields are available as template placeholders in humanTemplate.
+ * Build extra template variables from BinaryCheckContext fields.
  */
-function buildTemplateVars(
-	workflow: SimpleWorkflow,
-	ctx: BinaryCheckContext,
-): Record<string, string> {
+function buildExtraVars(ctx: BinaryCheckContext): Record<string, string> {
 	return {
-		userPrompt: ctx.prompt,
-		generatedWorkflow: JSON.stringify(workflow, null, 2),
-		referenceSection: '',
 		agentTextResponse: ctx.agentTextResponse ?? '',
 		workflowBefore: ctx.existingWorkflow
 			? JSON.stringify(ctx.existingWorkflow, null, 2)
@@ -58,20 +48,20 @@ export function createLlmCheck(options: LlmCheckOptions): BinaryCheck {
 				}
 			}
 
-			const chatPrompt = ChatPromptTemplate.fromMessages([
-				new SystemMessage(systemPrompt),
-				HumanMessagePromptTemplate.fromTemplate(options.humanTemplate),
-			]);
-			const llmWithStructuredOutput =
-				ctx.llm.withStructuredOutput<BinaryJudgeResult>(binaryJudgeResultSchema);
-			const chain = RunnableSequence.from<Record<string, string>, BinaryJudgeResult>([
-				chatPrompt,
-				llmWithStructuredOutput,
-			]);
+			const chain = createEvaluatorChain(
+				ctx.llm,
+				binaryJudgeResultSchema,
+				systemPrompt,
+				options.humanTemplate,
+			);
 
 			const result = await runWithOptionalLimiter(async () => {
 				return await withTimeout({
-					promise: chain.invoke(buildTemplateVars(workflow, ctx)),
+					promise: invokeEvaluatorChain(chain, {
+						userPrompt: ctx.prompt,
+						generatedWorkflow: workflow,
+						extraVars: buildExtraVars(ctx),
+					}),
 					timeoutMs: ctx.timeoutMs,
 					label: `binary-checks:${options.name}`,
 				});

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/create-llm-check.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/create-llm-check.ts
@@ -1,17 +1,36 @@
+import { SystemMessage } from '@langchain/core/messages';
+import { ChatPromptTemplate, HumanMessagePromptTemplate } from '@langchain/core/prompts';
+import { RunnableSequence } from '@langchain/core/runnables';
+
 import { runWithOptionalLimiter, withTimeout } from '../../../harness/evaluation-helpers';
 import { createEvaluatorChain, invokeEvaluatorChain } from '../../llm-judge/evaluators/base';
 import type { BinaryCheck, BinaryCheckContext, SimpleWorkflow } from '../types';
-import { binaryJudgeResultSchema } from './schemas';
+import { binaryJudgeResultSchema, type BinaryJudgeResult } from './schemas';
 
 const REASONING_FIRST_SUFFIX = `
 
 IMPORTANT: Write your full reasoning FIRST. Only AFTER completing your analysis, decide on pass or fail based on what you wrote. Do not decide pass/fail before reasoning.`;
 
-export function createLlmCheck(options: {
+interface LlmCheckOptions {
 	name: string;
 	systemPrompt: string;
 	humanTemplate: string;
-}): BinaryCheck {
+	/**
+	 * Optional early-exit check. Return a skip message to skip the check,
+	 * or undefined to proceed with evaluation.
+	 */
+	skipIf?: (workflow: SimpleWorkflow, ctx: BinaryCheckContext) => string | undefined;
+	/**
+	 * Optional extra template variables to pass to the human template.
+	 * These are merged with the default variables (userPrompt, generatedWorkflow, referenceSection).
+	 */
+	extraVars?: (
+		workflow: SimpleWorkflow,
+		ctx: BinaryCheckContext,
+	) => Record<string, string> | undefined;
+}
+
+export function createLlmCheck(options: LlmCheckOptions): BinaryCheck {
 	const systemPrompt = options.systemPrompt + REASONING_FIRST_SUFFIX;
 
 	return {
@@ -22,6 +41,44 @@ export function createLlmCheck(options: {
 				return { pass: true, comment: 'Skipped: no LLM' };
 			}
 
+			if (options.skipIf) {
+				const skipMessage = options.skipIf(workflow, ctx);
+				if (skipMessage) {
+					return { pass: true, comment: skipMessage };
+				}
+			}
+
+			const extras = options.extraVars?.(workflow, ctx);
+
+			if (extras) {
+				// Use custom chain with extra template variables
+				const chatPrompt = ChatPromptTemplate.fromMessages([
+					new SystemMessage(systemPrompt),
+					HumanMessagePromptTemplate.fromTemplate(options.humanTemplate),
+				]);
+				const llmWithStructuredOutput =
+					ctx.llm.withStructuredOutput<BinaryJudgeResult>(binaryJudgeResultSchema);
+				const chain = RunnableSequence.from<Record<string, string>, BinaryJudgeResult>([
+					chatPrompt,
+					llmWithStructuredOutput,
+				]);
+
+				const result = await runWithOptionalLimiter(async () => {
+					return await withTimeout({
+						promise: chain.invoke({
+							userPrompt: ctx.prompt,
+							generatedWorkflow: JSON.stringify(workflow, null, 2),
+							...extras,
+						}),
+						timeoutMs: ctx.timeoutMs,
+						label: `binary-checks:${options.name}`,
+					});
+				}, ctx.llmCallLimiter);
+
+				return { pass: result.pass, comment: result.reasoning };
+			}
+
+			// Default path: use shared evaluator chain
 			const chain = createEvaluatorChain(
 				ctx.llm,
 				binaryJudgeResultSchema,

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/create-llm-check.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/create-llm-check.ts
@@ -3,7 +3,6 @@ import { ChatPromptTemplate, HumanMessagePromptTemplate } from '@langchain/core/
 import { RunnableSequence } from '@langchain/core/runnables';
 
 import { runWithOptionalLimiter, withTimeout } from '../../../harness/evaluation-helpers';
-import { createEvaluatorChain, invokeEvaluatorChain } from '../../llm-judge/evaluators/base';
 import type { BinaryCheck, BinaryCheckContext, SimpleWorkflow } from '../types';
 import { binaryJudgeResultSchema, type BinaryJudgeResult } from './schemas';
 
@@ -20,14 +19,25 @@ interface LlmCheckOptions {
 	 * or undefined to proceed with evaluation.
 	 */
 	skipIf?: (workflow: SimpleWorkflow, ctx: BinaryCheckContext) => string | undefined;
-	/**
-	 * Optional extra template variables to pass to the human template.
-	 * These are merged with the default variables (userPrompt, generatedWorkflow, referenceSection).
-	 */
-	extraVars?: (
-		workflow: SimpleWorkflow,
-		ctx: BinaryCheckContext,
-	) => Record<string, string> | undefined;
+}
+
+/**
+ * Build template variables from the BinaryCheckContext.
+ * All fields are available as template placeholders in humanTemplate.
+ */
+function buildTemplateVars(
+	workflow: SimpleWorkflow,
+	ctx: BinaryCheckContext,
+): Record<string, string> {
+	return {
+		userPrompt: ctx.prompt,
+		generatedWorkflow: JSON.stringify(workflow, null, 2),
+		referenceSection: '',
+		agentTextResponse: ctx.agentTextResponse ?? '',
+		workflowBefore: ctx.existingWorkflow
+			? JSON.stringify(ctx.existingWorkflow, null, 2)
+			: '{"nodes": [], "connections": {}}',
+	};
 }
 
 export function createLlmCheck(options: LlmCheckOptions): BinaryCheck {
@@ -48,50 +58,20 @@ export function createLlmCheck(options: LlmCheckOptions): BinaryCheck {
 				}
 			}
 
-			const extras = options.extraVars?.(workflow, ctx);
-
-			if (extras) {
-				// Use custom chain with extra template variables
-				const chatPrompt = ChatPromptTemplate.fromMessages([
-					new SystemMessage(systemPrompt),
-					HumanMessagePromptTemplate.fromTemplate(options.humanTemplate),
-				]);
-				const llmWithStructuredOutput =
-					ctx.llm.withStructuredOutput<BinaryJudgeResult>(binaryJudgeResultSchema);
-				const chain = RunnableSequence.from<Record<string, string>, BinaryJudgeResult>([
-					chatPrompt,
-					llmWithStructuredOutput,
-				]);
-
-				const result = await runWithOptionalLimiter(async () => {
-					return await withTimeout({
-						promise: chain.invoke({
-							userPrompt: ctx.prompt,
-							generatedWorkflow: JSON.stringify(workflow, null, 2),
-							...extras,
-						}),
-						timeoutMs: ctx.timeoutMs,
-						label: `binary-checks:${options.name}`,
-					});
-				}, ctx.llmCallLimiter);
-
-				return { pass: result.pass, comment: result.reasoning };
-			}
-
-			// Default path: use shared evaluator chain
-			const chain = createEvaluatorChain(
-				ctx.llm,
-				binaryJudgeResultSchema,
-				systemPrompt,
-				options.humanTemplate,
-			);
+			const chatPrompt = ChatPromptTemplate.fromMessages([
+				new SystemMessage(systemPrompt),
+				HumanMessagePromptTemplate.fromTemplate(options.humanTemplate),
+			]);
+			const llmWithStructuredOutput =
+				ctx.llm.withStructuredOutput<BinaryJudgeResult>(binaryJudgeResultSchema);
+			const chain = RunnableSequence.from<Record<string, string>, BinaryJudgeResult>([
+				chatPrompt,
+				llmWithStructuredOutput,
+			]);
 
 			const result = await runWithOptionalLimiter(async () => {
 				return await withTimeout({
-					promise: invokeEvaluatorChain(chain, {
-						userPrompt: ctx.prompt,
-						generatedWorkflow: workflow,
-					}),
+					promise: chain.invoke(buildTemplateVars(workflow, ctx)),
 					timeoutMs: ctx.timeoutMs,
 					label: `binary-checks:${options.name}`,
 				});

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/index.ts
@@ -3,6 +3,7 @@ import { correctNodeOperations } from './correct-node-operations';
 import { descriptiveNodeNames } from './descriptive-node-names';
 import { fulfillsUserRequest } from './fulfills-user-request';
 import { handlesMultipleItems } from './handles-multiple-items';
+import { responseMatchesWorkflowChanges } from './response-matches-workflow-changes';
 import { validDataFlow } from './valid-data-flow';
 
 export const LLM_CHECKS: BinaryCheck[] = [
@@ -11,4 +12,5 @@ export const LLM_CHECKS: BinaryCheck[] = [
 	validDataFlow,
 	handlesMultipleItems,
 	descriptiveNodeNames,
+	responseMatchesWorkflowChanges,
 ];

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/response-matches-workflow-changes.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/response-matches-workflow-changes.ts
@@ -1,0 +1,94 @@
+import { SystemMessage } from '@langchain/core/messages';
+import { ChatPromptTemplate, HumanMessagePromptTemplate } from '@langchain/core/prompts';
+import { RunnableSequence } from '@langchain/core/runnables';
+
+import { runWithOptionalLimiter, withTimeout } from '../../../harness/evaluation-helpers';
+import type { BinaryCheck, BinaryCheckContext, SimpleWorkflow } from '../types';
+import { binaryJudgeResultSchema, type BinaryJudgeResult } from './schemas';
+
+const REASONING_FIRST_SUFFIX = `
+
+IMPORTANT: Write your full reasoning FIRST. Only AFTER completing your analysis, decide on pass or fail based on what you wrote. Do not decide pass/fail before reasoning.`;
+
+const SYSTEM_PROMPT = `You are a strict evaluator checking whether an AI assistant's text response accurately describes the changes it made to an n8n workflow.
+
+You are given:
+- The workflow BEFORE the agent's turn (may be empty for new workflows)
+- The workflow AFTER the agent's turn
+- The agent's text response describing what it did
+
+Your task:
+1. Read the agent's text response and identify all claims about workflow changes (e.g., "I added a Slack node", "I configured the HTTP Request node to use POST method", "I connected the trigger to the filter node").
+2. Compare the before and after workflow JSONs to determine what actually changed.
+3. Verify each claim against the actual diff between before and after workflows.
+4. Pass ONLY if every claim the agent makes is reflected in the actual changes.
+
+Rules:
+- If the agent claims to have added a node, that node must be in the AFTER workflow but NOT in the BEFORE workflow (or be newly configured).
+- If the agent claims a specific configuration change, verify it differs between before and after.
+- If the agent claims connections between nodes, verify those connections exist in the AFTER workflow.
+- Ignore general/vague statements that don't make specific claims (e.g., "I built a workflow for you").
+- If the agent's response contains NO specific claims about workflow changes, pass (nothing to verify).
+- A single verifiably false claim means fail.${REASONING_FIRST_SUFFIX}`;
+
+const HUMAN_TEMPLATE = `User Request: {userPrompt}
+
+Agent's Text Response:
+{agentTextResponse}
+
+Workflow BEFORE agent's turn:
+{workflowBefore}
+
+Workflow AFTER agent's turn:
+{workflowAfter}
+
+Compare the before and after workflows, then verify each specific claim the agent makes. If there are no specific claims, pass.`;
+
+export const responseMatchesWorkflowChanges: BinaryCheck = {
+	name: 'response_matches_workflow_changes',
+	kind: 'llm',
+	async run(workflow: SimpleWorkflow, ctx: BinaryCheckContext) {
+		if (!ctx.llm) {
+			return { pass: true, comment: 'Skipped: no LLM provided' };
+		}
+		const { agentTextResponse } = ctx;
+		if (!agentTextResponse) {
+			return { pass: true, comment: 'Skipped: no agent text response available' };
+		}
+
+		const workflowBefore = ctx.existingWorkflow
+			? JSON.stringify(ctx.existingWorkflow, null, 2)
+			: '{"nodes": [], "connections": {}}';
+
+		const chatPrompt = ChatPromptTemplate.fromMessages([
+			new SystemMessage(SYSTEM_PROMPT),
+			HumanMessagePromptTemplate.fromTemplate(HUMAN_TEMPLATE),
+		]);
+		const llmWithStructuredOutput =
+			ctx.llm.withStructuredOutput<BinaryJudgeResult>(binaryJudgeResultSchema);
+		const chain = RunnableSequence.from<
+			{
+				userPrompt: string;
+				agentTextResponse: string;
+				workflowBefore: string;
+				workflowAfter: string;
+			},
+			BinaryJudgeResult
+		>([chatPrompt, llmWithStructuredOutput]);
+
+		const result = await runWithOptionalLimiter(async () => {
+			return await withTimeout({
+				promise: chain.invoke({
+					userPrompt: ctx.prompt,
+					agentTextResponse,
+					workflowBefore,
+					workflowAfter: JSON.stringify(workflow, null, 2),
+				}),
+				timeoutMs: ctx.timeoutMs,
+				label: 'binary-checks:response_matches_workflow_changes',
+			});
+		}, ctx.llmCallLimiter);
+
+		return { pass: result.pass, comment: result.reasoning };
+	},
+};

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/response-matches-workflow-changes.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/response-matches-workflow-changes.ts
@@ -2,6 +2,8 @@ import { SystemMessage } from '@langchain/core/messages';
 import { ChatPromptTemplate, HumanMessagePromptTemplate } from '@langchain/core/prompts';
 import { RunnableSequence } from '@langchain/core/runnables';
 
+import { prompt } from '@/prompts/builder';
+
 import { runWithOptionalLimiter, withTimeout } from '../../../harness/evaluation-helpers';
 import type { BinaryCheck, BinaryCheckContext, SimpleWorkflow } from '../types';
 import { binaryJudgeResultSchema, type BinaryJudgeResult } from './schemas';
@@ -31,18 +33,18 @@ Rules:
 - If the agent's response contains NO specific claims about workflow changes, pass (nothing to verify).
 - A single verifiably false claim means fail.${REASONING_FIRST_SUFFIX}`;
 
-const HUMAN_TEMPLATE = `User Request: {userPrompt}
-
-Agent's Text Response:
-{agentTextResponse}
-
-Workflow BEFORE agent's turn:
-{workflowBefore}
-
-Workflow AFTER agent's turn:
-{workflowAfter}
-
-Compare the before and after workflows, then verify each specific claim the agent makes. If there are no specific claims, pass.`;
+function buildHumanTemplate() {
+	return prompt({ format: 'plain' })
+		.section('user_request', 'User Request: {userPrompt}')
+		.section('agent_response', "Agent's Text Response:\n{agentTextResponse}")
+		.section('workflow_before', "Workflow BEFORE agent's turn:\n{workflowBefore}")
+		.section('workflow_after', "Workflow AFTER agent's turn:\n{workflowAfter}")
+		.section(
+			'instructions',
+			'Compare the before and after workflows, then verify each specific claim the agent makes. If there are no specific claims, pass.',
+		)
+		.build();
+}
 
 export const responseMatchesWorkflowChanges: BinaryCheck = {
 	name: 'response_matches_workflow_changes',
@@ -62,7 +64,7 @@ export const responseMatchesWorkflowChanges: BinaryCheck = {
 
 		const chatPrompt = ChatPromptTemplate.fromMessages([
 			new SystemMessage(SYSTEM_PROMPT),
-			HumanMessagePromptTemplate.fromTemplate(HUMAN_TEMPLATE),
+			HumanMessagePromptTemplate.fromTemplate(buildHumanTemplate()),
 		]);
 		const llmWithStructuredOutput =
 			ctx.llm.withStructuredOutput<BinaryJudgeResult>(binaryJudgeResultSchema);

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/response-matches-workflow-changes.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/response-matches-workflow-changes.ts
@@ -1,18 +1,10 @@
-import { SystemMessage } from '@langchain/core/messages';
-import { ChatPromptTemplate, HumanMessagePromptTemplate } from '@langchain/core/prompts';
-import { RunnableSequence } from '@langchain/core/runnables';
-
 import { prompt } from '@/prompts/builder';
 
-import { runWithOptionalLimiter, withTimeout } from '../../../harness/evaluation-helpers';
-import type { BinaryCheck, BinaryCheckContext, SimpleWorkflow } from '../types';
-import { binaryJudgeResultSchema, type BinaryJudgeResult } from './schemas';
+import { createLlmCheck } from './create-llm-check';
 
-const REASONING_FIRST_SUFFIX = `
-
-IMPORTANT: Write your full reasoning FIRST. Only AFTER completing your analysis, decide on pass or fail based on what you wrote. Do not decide pass/fail before reasoning.`;
-
-const SYSTEM_PROMPT = `You are a strict evaluator checking whether an AI assistant's text response accurately describes the changes it made to an n8n workflow.
+export const responseMatchesWorkflowChanges = createLlmCheck({
+	name: 'response_matches_workflow_changes',
+	systemPrompt: `You are a strict evaluator checking whether an AI assistant's text response accurately describes the changes it made to an n8n workflow.
 
 You are given:
 - The workflow BEFORE the agent's turn (may be empty for new workflows)
@@ -31,66 +23,27 @@ Rules:
 - If the agent claims connections between nodes, verify those connections exist in the AFTER workflow.
 - Ignore general/vague statements that don't make specific claims (e.g., "I built a workflow for you").
 - If the agent's response contains NO specific claims about workflow changes, pass (nothing to verify).
-- A single verifiably false claim means fail.${REASONING_FIRST_SUFFIX}`;
-
-function buildHumanTemplate() {
-	return prompt({ format: 'plain' })
+- A single verifiably false claim means fail.`,
+	humanTemplate: prompt({ format: 'plain' })
 		.section('user_request', 'User Request: {userPrompt}')
 		.section('agent_response', "Agent's Text Response:\n{agentTextResponse}")
 		.section('workflow_before', "Workflow BEFORE agent's turn:\n{workflowBefore}")
-		.section('workflow_after', "Workflow AFTER agent's turn:\n{workflowAfter}")
+		.section('workflow_after', "Workflow AFTER agent's turn:\n{generatedWorkflow}")
 		.section(
 			'instructions',
 			'Compare the before and after workflows, then verify each specific claim the agent makes. If there are no specific claims, pass.',
 		)
-		.build();
-}
-
-export const responseMatchesWorkflowChanges: BinaryCheck = {
-	name: 'response_matches_workflow_changes',
-	kind: 'llm',
-	async run(workflow: SimpleWorkflow, ctx: BinaryCheckContext) {
-		if (!ctx.llm) {
-			return { pass: true, comment: 'Skipped: no LLM provided' };
+		.build(),
+	skipIf: (_workflow, ctx) => {
+		if (!ctx.agentTextResponse) {
+			return 'Skipped: no agent text response available';
 		}
-		const { agentTextResponse } = ctx;
-		if (!agentTextResponse) {
-			return { pass: true, comment: 'Skipped: no agent text response available' };
-		}
-
-		const workflowBefore = ctx.existingWorkflow
-			? JSON.stringify(ctx.existingWorkflow, null, 2)
-			: '{"nodes": [], "connections": {}}';
-
-		const chatPrompt = ChatPromptTemplate.fromMessages([
-			new SystemMessage(SYSTEM_PROMPT),
-			HumanMessagePromptTemplate.fromTemplate(buildHumanTemplate()),
-		]);
-		const llmWithStructuredOutput =
-			ctx.llm.withStructuredOutput<BinaryJudgeResult>(binaryJudgeResultSchema);
-		const chain = RunnableSequence.from<
-			{
-				userPrompt: string;
-				agentTextResponse: string;
-				workflowBefore: string;
-				workflowAfter: string;
-			},
-			BinaryJudgeResult
-		>([chatPrompt, llmWithStructuredOutput]);
-
-		const result = await runWithOptionalLimiter(async () => {
-			return await withTimeout({
-				promise: chain.invoke({
-					userPrompt: ctx.prompt,
-					agentTextResponse,
-					workflowBefore,
-					workflowAfter: JSON.stringify(workflow, null, 2),
-				}),
-				timeoutMs: ctx.timeoutMs,
-				label: 'binary-checks:response_matches_workflow_changes',
-			});
-		}, ctx.llmCallLimiter);
-
-		return { pass: result.pass, comment: result.reasoning };
+		return undefined;
 	},
-};
+	extraVars: (_workflow, ctx) => ({
+		agentTextResponse: ctx.agentTextResponse ?? '',
+		workflowBefore: ctx.existingWorkflow
+			? JSON.stringify(ctx.existingWorkflow, null, 2)
+			: '{"nodes": [], "connections": {}}',
+	}),
+});

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/response-matches-workflow-changes.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/response-matches-workflow-changes.ts
@@ -1,5 +1,3 @@
-import { prompt } from '@/prompts/builder';
-
 import { createLlmCheck } from './create-llm-check';
 
 export const responseMatchesWorkflowChanges = createLlmCheck({
@@ -24,16 +22,18 @@ Rules:
 - Ignore general/vague statements that don't make specific claims (e.g., "I built a workflow for you").
 - If the agent's response contains NO specific claims about workflow changes, pass (nothing to verify).
 - A single verifiably false claim means fail.`,
-	humanTemplate: prompt({ format: 'plain' })
-		.section('user_request', 'User Request: {userPrompt}')
-		.section('agent_response', "Agent's Text Response:\n{agentTextResponse}")
-		.section('workflow_before', "Workflow BEFORE agent's turn:\n{workflowBefore}")
-		.section('workflow_after', "Workflow AFTER agent's turn:\n{generatedWorkflow}")
-		.section(
-			'instructions',
-			'Compare the before and after workflows, then verify each specific claim the agent makes. If there are no specific claims, pass.',
-		)
-		.build(),
+	humanTemplate: `User Request: {userPrompt}
+
+Agent's Text Response:
+{agentTextResponse}
+
+Workflow BEFORE agent's turn:
+{workflowBefore}
+
+Workflow AFTER agent's turn:
+{generatedWorkflow}
+
+Compare the before and after workflows, then verify each specific claim the agent makes. If there are no specific claims, pass.`,
 	skipIf: (_workflow, ctx) => {
 		if (!ctx.agentTextResponse) {
 			return 'Skipped: no agent text response available';

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/response-matches-workflow-changes.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/response-matches-workflow-changes.ts
@@ -40,10 +40,4 @@ Rules:
 		}
 		return undefined;
 	},
-	extraVars: (_workflow, ctx) => ({
-		agentTextResponse: ctx.agentTextResponse ?? '',
-		workflowBefore: ctx.existingWorkflow
-			? JSON.stringify(ctx.existingWorkflow, null, 2)
-			: '{"nodes": [], "connections": {}}',
-	}),
 });

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/types.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/types.ts
@@ -17,6 +17,9 @@ export interface BinaryCheckContext {
 	llm?: BaseChatModel;
 	llmCallLimiter?: LlmCallLimiter;
 	timeoutMs?: number;
+	agentTextResponse?: string;
+	/** The workflow JSON before this conversation turn (for diff-based checks) */
+	existingWorkflow?: SimpleWorkflow;
 }
 
 export interface BinaryCheck {

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/llm-judge/evaluation.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/llm-judge/evaluation.ts
@@ -92,6 +92,8 @@ export const evaluationInputSchema = z.object({
 	generatedWorkflow: z.custom<SimpleWorkflow>(),
 	referenceWorkflows: z.array(z.custom<SimpleWorkflow>()).optional(),
 	preset: z.enum(['strict', 'standard', 'lenient']).optional(),
+	agentTextResponse: z.string().optional(),
+	existingWorkflow: z.custom<SimpleWorkflow>().optional(),
 });
 
 export type EvaluationInput = z.infer<typeof evaluationInputSchema>;

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/llm-judge/evaluation.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/llm-judge/evaluation.ts
@@ -89,11 +89,11 @@ export type TestCase = z.infer<typeof testCaseSchema>;
 // Evaluation input schema
 export const evaluationInputSchema = z.object({
 	userPrompt: z.string(),
+	existingWorkflow: z.custom<SimpleWorkflow>().optional(),
 	generatedWorkflow: z.custom<SimpleWorkflow>(),
 	referenceWorkflows: z.array(z.custom<SimpleWorkflow>()).optional(),
-	preset: z.enum(['strict', 'standard', 'lenient']).optional(),
 	agentTextResponse: z.string().optional(),
-	existingWorkflow: z.custom<SimpleWorkflow>().optional(),
+	preset: z.enum(['strict', 'standard', 'lenient']).optional(),
 });
 
 export type EvaluationInput = z.infer<typeof evaluationInputSchema>;

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/llm-judge/evaluators/base.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/llm-judge/evaluators/base.ts
@@ -32,7 +32,7 @@ export function createEvaluatorChain<TResult extends Record<string, unknown>>(
 
 export async function invokeEvaluatorChain<TResult>(
 	chain: Runnable<EvaluatorChainInput, TResult>,
-	input: EvaluationInput & { extraVars?: Record<string, string> },
+	input: EvaluationInput,
 	config?: RunnableConfig,
 ): Promise<TResult> {
 	const referenceSection =
@@ -45,7 +45,10 @@ export async function invokeEvaluatorChain<TResult>(
 			userPrompt: input.userPrompt,
 			generatedWorkflow: JSON.stringify(input.generatedWorkflow, null, 2),
 			referenceSection,
-			...input.extraVars,
+			agentTextResponse: input.agentTextResponse ?? '',
+			workflowBefore: input.existingWorkflow
+				? JSON.stringify(input.existingWorkflow, null, 2)
+				: '{"nodes": [], "connections": {}}',
 		},
 		config,
 	);

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/llm-judge/evaluators/base.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/llm-judge/evaluators/base.ts
@@ -8,7 +8,13 @@ import type { z } from 'zod';
 
 import type { EvaluationInput } from '../evaluation';
 
-type EvaluatorChainInput = Record<string, string>;
+type EvaluatorChainInput = {
+	userPrompt: string;
+	generatedWorkflow: string;
+	referenceSection: string;
+	agentTextResponse?: string;
+	workflowBefore?: string;
+};
 
 export function createEvaluatorChain<TResult extends Record<string, unknown>>(
 	llm: BaseChatModel,

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/llm-judge/evaluators/base.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/llm-judge/evaluators/base.ts
@@ -8,11 +8,7 @@ import type { z } from 'zod';
 
 import type { EvaluationInput } from '../evaluation';
 
-type EvaluatorChainInput = {
-	userPrompt: string;
-	generatedWorkflow: string;
-	referenceSection: string;
-};
+type EvaluatorChainInput = Record<string, string>;
 
 export function createEvaluatorChain<TResult extends Record<string, unknown>>(
 	llm: BaseChatModel,
@@ -36,7 +32,7 @@ export function createEvaluatorChain<TResult extends Record<string, unknown>>(
 
 export async function invokeEvaluatorChain<TResult>(
 	chain: Runnable<EvaluatorChainInput, TResult>,
-	input: EvaluationInput,
+	input: EvaluationInput & { extraVars?: Record<string, string> },
 	config?: RunnableConfig,
 ): Promise<TResult> {
 	const referenceSection =
@@ -49,6 +45,7 @@ export async function invokeEvaluatorChain<TResult>(
 			userPrompt: input.userPrompt,
 			generatedWorkflow: JSON.stringify(input.generatedWorkflow, null, 2),
 			referenceSection,
+			...input.extraVars,
 		},
 		config,
 	);

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/evaluation-helpers.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/evaluation-helpers.ts
@@ -25,6 +25,26 @@ export async function consumeGenerator<T>(gen: AsyncGenerator<T>) {
 	}
 }
 
+/**
+ * Consume an async generator of StreamOutput, collecting AgentMessageChunk text.
+ * Returns the concatenated text from all message chunks.
+ */
+export async function collectAgentTextResponse<
+	T extends { messages?: Array<{ type: string; text?: string }> },
+>(gen: AsyncGenerator<T>): Promise<string> {
+	const textParts: string[] = [];
+	for await (const output of gen) {
+		if (output.messages) {
+			for (const chunk of output.messages) {
+				if (chunk.type === 'message' && chunk.text) {
+					textParts.push(chunk.text);
+				}
+			}
+		}
+	}
+	return textParts.join('');
+}
+
 export async function runWithOptionalLimiter<T>(
 	fn: () => Promise<T>,
 	limiter?: LlmCallLimiter,

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
@@ -58,6 +58,8 @@ export interface EvaluationContext {
 	 * Populated from GenerationResult when available.
 	 */
 	generatedCode?: string;
+	/** Agent's text response for this turn (available when captured from stream) */
+	agentTextResponse?: string;
 	/** Pin data for service nodes (used by execution evaluator) */
 	pinData?: IPinData;
 	/** Per-example annotations (e.g., code_necessary) from CSV or LangSmith dataset */
@@ -259,6 +261,8 @@ export interface ExampleResult {
 	subgraphOutput?: SubgraphExampleOutput;
 	/** Generated source code (e.g., TypeScript SDK code from coding agent) */
 	generatedCode?: string;
+	/** Agent's text response for this turn */
+	agentTextResponse?: string;
 	error?: string;
 }
 
@@ -280,6 +284,8 @@ export interface GenerationResult {
 	workflow: SimpleWorkflow;
 	/** Source code that generated the workflow (e.g., TypeScript SDK code) */
 	generatedCode?: string;
+	/** Text response from the agent (e.g., responder output describing what was built) */
+	agentTextResponse?: string;
 }
 
 /**

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/output.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/output.ts
@@ -81,6 +81,11 @@ export function createArtifactSaver(options: ArtifactSaverOptions): ArtifactSave
 				fs.writeFileSync(path.join(exampleDir, 'code.ts'), result.generatedCode, 'utf-8');
 			}
 
+			// Save agent text response if available
+			if (result.agentTextResponse) {
+				fs.writeFileSync(path.join(exampleDir, 'response.txt'), result.agentTextResponse, 'utf-8');
+			}
+
 			// Save feedback
 			const feedbackOutput = formatFeedbackForExport(result);
 			fs.writeFileSync(

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/runner.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/runner.ts
@@ -202,6 +202,7 @@ function buildContext(args: {
 	testCaseContext?: TestCaseContext;
 	referenceWorkflows?: SimpleWorkflow[];
 	generatedCode?: string;
+	agentTextResponse?: string;
 	pinData?: IPinData;
 	datasetInputContext?: DatasetInputContext;
 }): EvaluationContext {
@@ -211,6 +212,7 @@ function buildContext(args: {
 		testCaseContext,
 		referenceWorkflows,
 		generatedCode,
+		agentTextResponse,
 		pinData,
 		datasetInputContext,
 	} = args;
@@ -221,6 +223,7 @@ function buildContext(args: {
 		...(testCaseContext ?? {}),
 		...(referenceWorkflows?.length ? { referenceWorkflows } : {}),
 		...(generatedCode ? { generatedCode } : {}),
+		...(agentTextResponse ? { agentTextResponse } : {}),
 		...(pinData ? { pinData } : {}),
 		...(datasetInputContext ? { datasetInputContext } : {}),
 	};
@@ -593,6 +596,7 @@ async function runLocalExampleSuccess(args: {
 	// Extract workflow and optional generated code
 	const workflow = isGenerationResult(genResult) ? genResult.workflow : genResult;
 	const generatedCode = isGenerationResult(genResult) ? genResult.generatedCode : undefined;
+	const agentTextResponse = isGenerationResult(genResult) ? genResult.agentTextResponse : undefined;
 
 	lifecycle?.onWorkflowGenerated?.(workflow, genDurationMs);
 
@@ -615,6 +619,7 @@ async function runLocalExampleSuccess(args: {
 		testCaseContext: testCase.context,
 		referenceWorkflows: testCase.referenceWorkflows,
 		generatedCode,
+		agentTextResponse,
 		pinData,
 		datasetInputContext: testCase.context?.datasetInputContext,
 	});
@@ -645,6 +650,7 @@ async function runLocalExampleSuccess(args: {
 		introspectionEvents: metrics.introspectionEvents,
 		workflow,
 		generatedCode,
+		agentTextResponse,
 	};
 }
 

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/runner.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/runner.ts
@@ -1468,6 +1468,9 @@ async function runLangsmith(config: LangsmithRunConfig): Promise<RunSummary> {
 			// Extract workflow and optional generated code
 			const workflow = isGenerationResult(genResult) ? genResult.workflow : genResult;
 			const generatedCode = isGenerationResult(genResult) ? genResult.generatedCode : undefined;
+			const agentTextResponse = isGenerationResult(genResult)
+				? genResult.agentTextResponse
+				: undefined;
 
 			lifecycle?.onWorkflowGenerated?.(workflow, genDurationMs);
 
@@ -1490,6 +1493,7 @@ async function runLangsmith(config: LangsmithRunConfig): Promise<RunSummary> {
 				globalContext: effectiveGlobalContext,
 				testCaseContext: extracted,
 				generatedCode,
+				agentTextResponse,
 				pinData,
 				datasetInputContext,
 			});
@@ -1536,6 +1540,7 @@ async function runLangsmith(config: LangsmithRunConfig): Promise<RunSummary> {
 				introspectionEvents: metrics.introspectionEvents,
 				workflow,
 				generatedCode,
+				agentTextResponse,
 			};
 
 			artifactSaver?.saveExample(result);


### PR DESCRIPTION
## Summary

Enables evaluating AI workflow builder based on both text output and workflow changes in the same conversation turn.
Adds a new binary check (LLM-powered) to check if all the claims in Agent's text response are reflected in actual workflow JSON changes.

**Changes:**
- Captures the agent's text response from the stream during evaluation (instead of discarding it via `consumeGenerator`)
- Threads `agentTextResponse` through the full evaluation pipeline: `GenerationResult` → `EvaluationContext` → `BinaryCheckContext` → `ExampleResult`
- Saves agent text response to `response.txt` in evaluation artifacts
- Adds new `response_matches_workflow_changes` LLM binary check that verifies the agent's text claims match actual workflow changes by comparing **before** and **after** workflow JSON
- Passes `existingWorkflow` (pre-turn state) into `BinaryCheckContext` for diff-based evaluation

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2257/feature-create-binary-1-check-for-ai-workflow-builder

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)