### PR TITLE
fix(core): Treat sub-node connections as non-blocking for partial execution root detection

### DIFF
--- a/packages/core/src/execution-engine/partial-execution-utils/__tests__/find-trigger-for-partial-execution.test.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/__tests__/find-trigger-for-partial-execution.test.ts
@@ -1,10 +1,13 @@
 import { mock } from 'jest-mock-extended';
 import type { IConnections, INode, INodeType, INodeTypes, IPinData, IRunData } from 'n8n-workflow';
-import { Workflow } from 'n8n-workflow';
+import { NodeConnectionTypes, Workflow } from 'n8n-workflow';
 
 import { createNodeData, toIConnections, toITaskData } from './helpers';
 import { DirectedGraph } from '../directed-graph';
-import { findTriggerForPartialExecution } from '../find-trigger-for-partial-execution';
+import {
+	anyReachableRootHasRunData,
+	findTriggerForPartialExecution,
+} from '../find-trigger-for-partial-execution';
 
 describe('findTriggerForPartialExecution', () => {
 	const nodeTypes = mock<INodeTypes>();
@@ -234,5 +237,63 @@ describe('findTriggerForPartialExecution', () => {
 			// ASSERT
 			expect(chosenTrigger).toBe(trigger1);
 		});
+	});
+});
+
+describe('anyReachableRootHasRunData', () => {
+	//  ┌────────────┐   Main   ┌───────┐
+	//  │ChatTrigger  ├─────────►│NodeX  │
+	//  └──────▲──────┘         └───────┘
+	//         │ ai_chatMemory
+	//  ┌──────┴──────┐
+	//  │ ChatMemory  │
+	//  └─────────────┘
+	it('should treat trigger with only sub-node parents as a root node', () => {
+		const chatTrigger = createNodeData({ name: 'Chat Trigger' });
+		const chatMemory = createNodeData({ name: 'Chat Memory' });
+		const nodeX = createNodeData({ name: 'Node X' });
+
+		const graph = new DirectedGraph()
+			.addNodes(chatTrigger, chatMemory, nodeX)
+			.addConnections(
+				{ from: chatTrigger, to: nodeX },
+				{ from: chatMemory, to: chatTrigger, type: NodeConnectionTypes.AiMemory },
+			);
+
+		const runData: IRunData = {
+			[chatTrigger.name]: [toITaskData([{ data: { chatInput: 'hello' } }])],
+		};
+
+		expect(anyReachableRootHasRunData(graph, nodeX.name, runData)).toBe(true);
+	});
+
+	it('should return false when trigger has no run data and sub-node has no run data', () => {
+		const chatTrigger = createNodeData({ name: 'Chat Trigger' });
+		const chatMemory = createNodeData({ name: 'Chat Memory' });
+		const nodeX = createNodeData({ name: 'Node X' });
+
+		const graph = new DirectedGraph()
+			.addNodes(chatTrigger, chatMemory, nodeX)
+			.addConnections(
+				{ from: chatTrigger, to: nodeX },
+				{ from: chatMemory, to: chatTrigger, type: NodeConnectionTypes.AiMemory },
+			);
+
+		expect(anyReachableRootHasRunData(graph, nodeX.name, {})).toBe(false);
+	});
+
+	it('should return true for simple trigger with run data and no sub-nodes', () => {
+		const trigger = createNodeData({ name: 'Trigger' });
+		const nodeX = createNodeData({ name: 'Node X' });
+
+		const graph = new DirectedGraph()
+			.addNodes(trigger, nodeX)
+			.addConnections({ from: trigger, to: nodeX });
+
+		const runData: IRunData = {
+			[trigger.name]: [toITaskData([{ data: { value: 1 } }])],
+		};
+
+		expect(anyReachableRootHasRunData(graph, nodeX.name, runData)).toBe(true);
 	});
 });

--- a/packages/core/src/execution-engine/partial-execution-utils/find-trigger-for-partial-execution.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/find-trigger-for-partial-execution.ts
@@ -1,5 +1,11 @@
 import * as assert from 'assert/strict';
-import type { INode, INodeType, IRunData, Workflow } from 'n8n-workflow';
+import {
+	NodeConnectionTypes,
+	type INode,
+	type INodeType,
+	type IRunData,
+	type Workflow,
+} from 'n8n-workflow';
 
 import type { DirectedGraph } from './directed-graph';
 
@@ -44,11 +50,16 @@ export function anyReachableRootHasRunData(
 		parentNodes.add(connection.from);
 	}
 
-	// Find all root nodes (nodes with no incoming connections)
+	// Find all root nodes (nodes with no incoming Main connections).
+	// Sub-node connections (ai_chatMemory, ai_languageModel, etc.) should not
+	// disqualify a trigger from being a root – sub-nodes are executed internally
+	// by their parent and are not independent starting points.
 	const rootNodes = new Set<INode>();
 	for (const parentNode of parentNodes) {
-		const hasParents = workflow.getDirectParentConnections(parentNode).length > 0;
-		if (!hasParents) {
+		const hasMainParents = workflow
+			.getDirectParentConnections(parentNode)
+			.some((c) => c.type === NodeConnectionTypes.Main);
+		if (!hasMainParents) {
 			rootNodes.add(parentNode);
 		}
 	}


### PR DESCRIPTION
## Summary

When executing a node downstream of a Chat Trigger that has already been executed (cached data), the backend's `anyReachableRootHasRunData` check incorrectly classified the Chat Trigger as a non-root node. This happened because sub-node connections (e.g. `ai_chatMemory` from Chat Memory → Chat Trigger) were counted as incoming connections, making Chat Memory the only "root." Since sub-nodes typically don't have independent run data, the check failed, causing the backend to upgrade to a full execution — re-registering the webhook and waiting for a new chat message instead of reusing the cached trigger data.

The fix only considers Main connections when determining root nodes, so trigger nodes with sub-node inputs are correctly recognised as starting points for partial execution.

**How to test:**
1. Create a workflow: Chat Trigger (with Chat Memory sub-node) → any node (e.g. Set)
2. Execute the Chat Trigger via chat (send a message)
3. Click "Test Node" on the downstream node
4. Expected: the node executes using cached Chat Trigger data (no new chat message needed)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2720

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)