### PR TITLE
fix(Read/Write Files from Disk Node): Add search aliases for binary file nodes

### DIFF
--- a/packages/nodes-base/nodes/Files/ReadWriteFile/ReadWriteFile.node.json
+++ b/packages/nodes-base/nodes/Files/ReadWriteFile/ReadWriteFile.node.json
@@ -10,7 +10,20 @@
 			}
 		]
 	},
-	"alias": ["Binary", "File", "Text", "Open", "Import", "Save", "Export", "Disk", "Transfer"],
+	"alias": [
+		"Binary",
+		"Binary File",
+		"File",
+		"Text",
+		"Open",
+		"Import",
+		"Save",
+		"Export",
+		"Disk",
+		"Transfer",
+		"Read Binary File",
+		"Write Binary File"
+	],
 	"subcategories": {
 		"Core Nodes": ["Files"]
 	}


### PR DESCRIPTION
## Summary

Adds `Binary File`, `Read Binary File`, and `Write Binary File` as search aliases to the Read/Write Files from Disk node. This makes it easier for users to find this node when searching for the legacy binary file node names.

> Note: This only happens because the alias search only matches on the full phrase. (When using the Search Term `Write Binary File` the alias `Binary` does not trigger.) Decided against rewriting the alias matching functionality to also match on alias that appear in the search term as a sub-term, due to the small nature of the issue (XS + onboarding + low prio) and unclear side effects. 

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4225

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)