### PR TITLE
chore: version 0.1.0-rc1 for mcp-browser and fs-proxy

### DIFF
--- a/packages/@n8n/fs-proxy/package.json
+++ b/packages/@n8n/fs-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n8n/fs-proxy",
-  "version": "0.1.0",
+  "version": "0.1.0-rc1",
   "description": "Local AI gateway for n8n Instance AI — filesystem, shell, screenshots, mouse/keyboard, and browser automation",
   "bin": {
     "n8n-fs-proxy": "dist/cli.js"

--- a/packages/@n8n/mcp-browser/package.json
+++ b/packages/@n8n/mcp-browser/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@n8n/mcp-browser",
-	"version": "1.0.0",
+	"version": "0.1.0-rc1",
 	"description": "Browser automation MCP tools built on Playwright, WebDriver BiDi, and safaridriver",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Set prerelease versions for `mcp-browser` and `fs-proxy` packages

## Related Linear tickets, Github issues, and Community forum posts




## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
