### PR TITLE
fix(core): Decrease workflow history compaction retention periods

### DIFF
--- a/packages/@n8n/config/src/configs/workflow-history-compaction.config.ts
+++ b/packages/@n8n/config/src/configs/workflow-history-compaction.config.ts
@@ -24,7 +24,7 @@ export class WorkflowHistoryCompactionConfig {
 	 * Versions trimmed are those with `createdAt` between `trimmingMinimumAgeDays - trimmingTimeWindowDays` and `trimmingMinimumAgeDays`.
 	 */
 	@Env('N8N_WORKFLOW_HISTORY_TRIMMING_MINIMUM_AGE_DAYS')
-	trimmingMinimumAgeDays: number = 7;
+	trimmingMinimumAgeDays: number = 6;
 
 	/**
 	 * Time window in days used when selecting versions to trim. Trimming runs once per day.

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -458,7 +458,7 @@ describe('GlobalConfig', () => {
 			batchSize: 100,
 			optimizingMinimumAgeHours: 0.25,
 			optimizingTimeWindowHours: 2,
-			trimmingMinimumAgeDays: 7,
+			trimmingMinimumAgeDays: 6,
 			trimmingTimeWindowDays: 2,
 			trimOnStartUp: false,
 		},

--- a/packages/cli/src/services/pruning/workflow-history-compaction.service.ts
+++ b/packages/cli/src/services/pruning/workflow-history-compaction.service.ts
@@ -29,7 +29,7 @@ import { strict } from 'node:assert';
  *    by `trimmingMinimumAgeDays` and `trimmingTimeWindowDays`
  *
  * 2. For each workflow, fetch all versions in that window and leave behind
- *    only one version every minute to eight hours, depending on the size of the
+ *    only one version every minute to ten hours, depending on the size of the
  *    workflow.
  *
  * Neither of these operations will remove active or named versions, and a version

--- a/packages/cli/src/services/pruning/workflow-history-compaction.service.ts
+++ b/packages/cli/src/services/pruning/workflow-history-compaction.service.ts
@@ -29,7 +29,7 @@ import { strict } from 'node:assert';
  *    by `trimmingMinimumAgeDays` and `trimmingTimeWindowDays`
  *
  * 2. For each workflow, fetch all versions in that window and leave behind
- *    only one version every minute to four hours, depending on the size of the
+ *    only one version every minute to eight hours, depending on the size of the
  *    workflow.
  *
  * Neither of these operations will remove active or named versions, and a version
@@ -162,10 +162,10 @@ export class WorkflowHistoryCompactionService {
 					RULES.makeMergeDependingOnSizeRule(
 						new Map([
 							[0, 60 * 1_000],
-							[100, 5 * 60 * 1_000],
-							[1000, 30 * 60 * 1_000],
-							[5000, 60 * 60 * 1_000],
-							[10000, 4 * 60 * 60 * 1_000],
+							[100, 10 * 60 * 1_000],
+							[1000, 2 * 60 * 60 * 1_000],
+							[5000, 5 * 60 * 60 * 1_000],
+							[10000, 10 * 60 * 60 * 1_000],
 						]),
 					),
 				],

--- a/packages/cli/test/integration/workflow-history-compaction.service.test.ts
+++ b/packages/cli/test/integration/workflow-history-compaction.service.test.ts
@@ -229,7 +229,7 @@ describe('compacting cycle', () => {
 		expect(0 + +includesWf1 + +includesWf2 + +includesWf3).toBe(1);
 	});
 	describe('long term compaction', () => {
-		it('leaves one version every four hours for >10000 characters', async () => {
+		it('leaves one version every ten hours for >10000 characters', async () => {
 			// ARRANGE
 			const wf1 = await createWorkflow({ versionId: wf1_versions[0] });
 
@@ -261,13 +261,16 @@ describe('compacting cycle', () => {
 			await compactionService['trimLongRunningHistories']();
 
 			// ASSERT
+			// All versions span ~9.6 hours which is under the 10-hour threshold,
+			// so the algorithm merges all earlier versions into the last one
 			const allHistories = await Container.get(WorkflowHistoryRepository).find({});
-			const expectedVersions = [wf1_history[0], wf1_history[2], wf1_history[5]].map((x) => x[1]);
+			const expectedVersions = [wf1_history[5]].map((x) => x[1]);
 			expect(allHistories.map((x) => x.versionId)).toEqual(
 				expect.arrayContaining(expectedVersions),
 			);
+			expect(allHistories).toHaveLength(1);
 		});
-		it('leaves one version every hour for >5000 characters', async () => {
+		it('leaves one version every five hours for >5000 characters', async () => {
 			// ARRANGE
 			const wf1 = await createWorkflow({ versionId: wf1_versions[0] });
 
@@ -299,17 +302,15 @@ describe('compacting cycle', () => {
 			await compactionService['trimLongRunningHistories']();
 
 			// ASSERT
+			// Total span is ~9.6 hours with a 5-hour threshold.
+			// The algorithm iterates backwards, merging consecutive pairs closer than 5 hours,
+			// leaving the first (lastWeekA) and last (lastWeekF) which are 9.6 hours apart.
 			const allHistories = await Container.get(WorkflowHistoryRepository).find({});
-			const expectedVersions = [
-				wf1_history[0],
-				wf1_history[2],
-				wf1_history[3],
-				wf1_history[4],
-				wf1_history[5],
-			].map((x) => x[1]);
+			const expectedVersions = [wf1_history[0], wf1_history[5]].map((x) => x[1]);
 			expect(allHistories.map((x) => x.versionId)).toEqual(
 				expect.arrayContaining(expectedVersions),
 			);
+			expect(allHistories).toHaveLength(2);
 		});
 
 		it('leaves one version every five minutes for >100 characters', async () => {


### PR DESCRIPTION
## Summary

Reduce retention periods to decrease storage usage. Only decrease day by one to avoid awkward gap a bigger jump would create.

## Related Linear tickets, Github issues, and Community forum posts

n/a


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
