### PR TITLE
feat: Wire expression-based role mapping into OIDC / SAML

### DIFF
--- a/packages/cli/src/modules/sso-oidc/__tests__/oidc.service.ee.test.ts
+++ b/packages/cli/src/modules/sso-oidc/__tests__/oidc.service.ee.test.ts
@@ -2,7 +2,7 @@ import type { OidcConfigDto } from '@n8n/api-types';
 import type { Logger } from '@n8n/backend-common';
 import { mockInstance, mockLogger } from '@n8n/backend-test-utils';
 import type { GlobalConfig } from '@n8n/config';
-import type { AuthIdentityRepository, SettingsRepository, UserRepository } from '@n8n/db';
+import type { AuthIdentityRepository, SettingsRepository, User, UserRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import type { Cipher, InstanceSettings } from 'n8n-core';
@@ -500,7 +500,14 @@ describe('OidcService', () => {
 			expect(user).toBeDefined();
 			expect(user.email).toEqual('john.doe@test.com');
 			// @ts-expect-error - applySsoProvisioning is private and only accessible within class 'OidcService'
-			expect(oidcService.applySsoProvisioning).toHaveBeenCalledWith(user, { sub: 'valid-subject' });
+			expect(oidcService.applySsoProvisioning).toHaveBeenCalledWith(
+				user,
+				{ sub: 'valid-subject' },
+				{
+					email_verified: true,
+					email: 'john.doe@test.com',
+				},
+			);
 		});
 
 		it('should return a user if the user exists but the auth identity does not', async () => {
@@ -530,7 +537,14 @@ describe('OidcService', () => {
 			expect(user).toBeDefined();
 			expect(user.email).toEqual('john.doe@test.com');
 			// @ts-expect-error - applySsoProvisioning is private and only accessible within class 'OidcService'
-			expect(oidcService.applySsoProvisioning).toHaveBeenCalledWith(user, { sub: 'valid-subject' });
+			expect(oidcService.applySsoProvisioning).toHaveBeenCalledWith(
+				user,
+				{ sub: 'valid-subject' },
+				{
+					email_verified: true,
+					email: 'john.doe@test.com',
+				},
+			);
 		});
 
 		it('should create a new user if the user does not exist', async () => {
@@ -561,6 +575,66 @@ describe('OidcService', () => {
 			const user = await oidcService.loginUser(callbackUrl, storedState, storedNonce);
 			expect(user).toBeDefined();
 			expect(user.email).toEqual('john.doe@test.com');
+		});
+	});
+
+	describe('applySsoProvisioning', () => {
+		const claims = { sub: 'user-123', n8n_instance_role: 'global:member' };
+		const userInfo = { email: 'test@example.com', email_verified: true };
+		const user = mock<User>({ id: 'user-id' });
+
+		beforeEach(() => {
+			oidcService.verifyState = jest.fn().mockReturnValue('valid-state');
+			oidcService.verifyNonce = jest.fn().mockReturnValue('valid-nonce');
+			// @ts-expect-error - getOidcConfiguration is private
+			oidcService.getOidcConfiguration = jest.fn().mockResolvedValue({} as client.Configuration);
+			jest.spyOn(client, 'authorizationCodeGrant').mockResolvedValue({
+				access_token: 'valid-access-token',
+				token_type: 'bearer',
+				claims: () => claims,
+			} as unknown as client.TokenEndpointResponse & client.TokenEndpointResponseHelpers);
+			jest.spyOn(client, 'fetchUserInfo').mockResolvedValue(userInfo as any);
+		});
+
+		it('calls provisionExpressionMappedRolesForUser when expression mapping is enabled', async () => {
+			provisioningService.isExpressionMappingEnabled = jest.fn().mockResolvedValue(true);
+			provisioningService.provisionExpressionMappedRolesForUser = jest
+				.fn()
+				.mockResolvedValue(undefined);
+			authIdentityRepository.findOne = jest.fn().mockResolvedValue({ user });
+
+			const callbackUrl = new URL('https://example.com/callback');
+			const storedState = oidcService.generateState().signed;
+			const storedNonce = oidcService.generateNonce().signed;
+			await oidcService.loginUser(callbackUrl, storedState, storedNonce);
+
+			expect(provisioningService.provisionExpressionMappedRolesForUser).toHaveBeenCalledWith(
+				user,
+				expect.objectContaining({ $provider: 'oidc' }),
+			);
+			expect(provisioningService.provisionInstanceRoleForUser).not.toHaveBeenCalled();
+			expect(provisioningService.provisionProjectRolesForUser).not.toHaveBeenCalled();
+		});
+
+		it('falls through to direct-claim provisioning when expression mapping is disabled', async () => {
+			provisioningService.isExpressionMappingEnabled = jest.fn().mockResolvedValue(false);
+			provisioningService.getConfig = jest.fn().mockResolvedValue({
+				scopesInstanceRoleClaimName: 'n8n_instance_role',
+				scopesProjectsRolesClaimName: 'n8n_projects',
+			});
+			provisioningService.provisionInstanceRoleForUser = jest.fn().mockResolvedValue(undefined);
+			authIdentityRepository.findOne = jest.fn().mockResolvedValue({ user });
+
+			const callbackUrl = new URL('https://example.com/callback');
+			const storedState = oidcService.generateState().signed;
+			const storedNonce = oidcService.generateNonce().signed;
+			await oidcService.loginUser(callbackUrl, storedState, storedNonce);
+
+			expect(provisioningService.provisionInstanceRoleForUser).toHaveBeenCalledWith(
+				user,
+				'global:member',
+			);
+			expect(provisioningService.provisionExpressionMappedRolesForUser).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/modules/sso-oidc/oidc.service.ee.ts
+++ b/packages/cli/src/modules/sso-oidc/oidc.service.ee.ts
@@ -21,6 +21,7 @@ import { EnvHttpProxyAgent } from 'undici';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
+import { buildOidcClaimsContext } from '@/modules/provisioning.ee/claims-context.builder';
 import { ProvisioningService } from '@/modules/provisioning.ee/provisioning.service.ee';
 import { JwtService } from '@/services/jwt.service';
 import { UrlService } from '@/services/url.service';
@@ -279,7 +280,11 @@ export class OidcService {
 		});
 
 		if (openidUser) {
-			await this.applySsoProvisioning(openidUser.user, claims);
+			await this.applySsoProvisioning(
+				openidUser.user,
+				claims as Record<string, unknown>,
+				userInfo as Record<string, unknown>,
+			);
 
 			return openidUser.user;
 		}
@@ -301,7 +306,11 @@ export class OidcService {
 			});
 
 			await this.authIdentityRepository.save(id);
-			await this.applySsoProvisioning(foundUser, claims);
+			await this.applySsoProvisioning(
+				foundUser,
+				claims as Record<string, unknown>,
+				userInfo as Record<string, unknown>,
+			);
 
 			return foundUser;
 		}
@@ -330,12 +339,25 @@ export class OidcService {
 			return newUser;
 		});
 
-		await this.applySsoProvisioning(user, claims);
+		await this.applySsoProvisioning(
+			user,
+			claims as Record<string, unknown>,
+			userInfo as Record<string, unknown>,
+		);
 
 		return user;
 	}
 
-	private async applySsoProvisioning(user: User, claims: any) {
+	private async applySsoProvisioning(
+		user: User,
+		claims: Record<string, unknown>,
+		userInfo: Record<string, unknown>,
+	): Promise<void> {
+		if (await this.provisioningService.isExpressionMappingEnabled()) {
+			const context = buildOidcClaimsContext(claims, userInfo);
+			await this.provisioningService.provisionExpressionMappedRolesForUser(user, context);
+			return;
+		}
 		const provisioningConfig = await this.provisioningService.getConfig();
 		const projectRoleMapping = claims[provisioningConfig.scopesProjectsRolesClaimName];
 		const instanceRole = claims[provisioningConfig.scopesInstanceRoleClaimName];

--- a/packages/cli/src/modules/sso-saml/__tests__/saml-helpers.test.ts
+++ b/packages/cli/src/modules/sso-saml/__tests__/saml-helpers.test.ts
@@ -90,6 +90,12 @@ describe('sso/saml/samlHelpers', () => {
 					userPrincipalName: 'test',
 				},
 				missingAttributes: [],
+				rawAttributes: {
+					email: 'test@test.com',
+					firstName: 'test',
+					lastName: 'test',
+					userPrincipalName: 'test',
+				},
 			});
 		});
 
@@ -123,6 +129,7 @@ describe('sso/saml/samlHelpers', () => {
 					email: 'test@test.com',
 				},
 				missingAttributes: ['userPrincipalName', 'firstName', 'lastName'],
+				rawAttributes: { email: 'test@test.com' },
 			});
 		});
 		test('returns the attributes from the flow result with instance role', () => {
@@ -162,6 +169,13 @@ describe('sso/saml/samlHelpers', () => {
 					userPrincipalName: 'test',
 				},
 				missingAttributes: [],
+				rawAttributes: {
+					email: 'test@test.com',
+					firstName: 'test',
+					lastName: 'test',
+					userPrincipalName: 'test',
+					instanceRole: 'instanceRole',
+				},
 			});
 		});
 	});
@@ -203,6 +217,13 @@ describe('sso/saml/samlHelpers', () => {
 				n8nProjectRoles: ['projectRole1', 'projectRole2'],
 			},
 			missingAttributes: [],
+			rawAttributes: {
+				email: 'test@test.com',
+				firstName: 'test',
+				lastName: 'test',
+				userPrincipalName: 'test',
+				projectRoles: ['projectRole1', 'projectRole2'],
+			},
 		});
 	});
 
@@ -243,6 +264,69 @@ describe('sso/saml/samlHelpers', () => {
 				n8nProjectRoles: ['projectRole1'],
 			},
 			missingAttributes: [],
+			rawAttributes: {
+				email: 'test@test.com',
+				firstName: 'test',
+				lastName: 'test',
+				userPrincipalName: 'test',
+				projectRoles: 'projectRole1',
+			},
 		});
+	});
+
+	test('includes all raw attributes including custom ones not in the mapping', () => {
+		const flowResult = {
+			extract: {
+				attributes: {
+					email: 'test@test.com',
+					firstName: 'test',
+					lastName: 'test',
+					userPrincipalName: 'test',
+					customDepartment: 'engineering',
+					groups: ['devops', 'n8n-admins'],
+				},
+			},
+		} as any;
+		const attributeMapping = {
+			email: 'email',
+			firstName: 'firstName',
+			lastName: 'lastName',
+			userPrincipalName: 'userPrincipalName',
+		};
+		const jitClaimNames = { instanceRole: null, projectRoles: null };
+
+		const result = helpers.getMappedSamlAttributesFromFlowResult(
+			flowResult,
+			attributeMapping,
+			jitClaimNames,
+		);
+
+		expect(result.rawAttributes).toEqual({
+			email: 'test@test.com',
+			firstName: 'test',
+			lastName: 'test',
+			userPrincipalName: 'test',
+			customDepartment: 'engineering',
+			groups: ['devops', 'n8n-admins'],
+		});
+	});
+
+	test('returns empty rawAttributes when flowResult has no attributes', () => {
+		const flowResult = { extract: {} } as any;
+		const attributeMapping = {
+			email: 'email',
+			firstName: 'firstName',
+			lastName: 'lastName',
+			userPrincipalName: 'userPrincipalName',
+		};
+		const jitClaimNames = { instanceRole: null, projectRoles: null };
+
+		const result = helpers.getMappedSamlAttributesFromFlowResult(
+			flowResult,
+			attributeMapping,
+			jitClaimNames,
+		);
+
+		expect(result.rawAttributes).toEqual({});
 	});
 });

--- a/packages/cli/src/modules/sso-saml/__tests__/saml.service.ee.test.ts
+++ b/packages/cli/src/modules/sso-saml/__tests__/saml.service.ee.test.ts
@@ -293,6 +293,7 @@ describe('SamlService', () => {
 					'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/lastname',
 					'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn',
 				],
+				rawAttributes: {},
 			});
 
 			// ACT & ASSERT
@@ -326,20 +327,24 @@ describe('SamlService', () => {
 					n8nProjectRoles: ['projectRole1', 'projectRole2'],
 				},
 				missingAttributes: [],
+				rawAttributes: { email: 'test@test.com', role: 'admin' },
 			});
 
-			const attributes = await samlService.getAttributesFromLoginResponse(
+			const result = await samlService.getAttributesFromLoginResponse(
 				mock<express.Request>(),
 				'post',
 			);
 
-			expect(attributes).toEqual({
-				email: 'test@test.com',
-				firstName: 'test',
-				lastName: 'test',
-				userPrincipalName: 'test',
-				n8nInstanceRole: 'global:admin',
-				n8nProjectRoles: ['projectRole1', 'projectRole2'],
+			expect(result).toEqual({
+				mapped: {
+					email: 'test@test.com',
+					firstName: 'test',
+					lastName: 'test',
+					userPrincipalName: 'test',
+					n8nInstanceRole: 'global:admin',
+					n8nProjectRoles: ['projectRole1', 'projectRole2'],
+				},
+				raw: { email: 'test@test.com', role: 'admin' },
 			});
 		});
 	});
@@ -414,10 +419,8 @@ describe('SamlService', () => {
 	describe('handleSamlLogin', () => {
 		it('throws error for invalid email', async () => {
 			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
-				email: 'invalid',
-				firstName: '',
-				lastName: '',
-				userPrincipalName: '',
+				mapped: { email: 'invalid', firstName: '', lastName: '', userPrincipalName: '' },
+				raw: {},
 			});
 
 			await expect(
@@ -439,7 +442,10 @@ describe('SamlService', () => {
 					{ providerType: 'saml', providerId: samlAttributes.userPrincipalName } as any,
 				],
 			} as any;
-			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue(samlAttributes);
+			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
+				mapped: samlAttributes,
+				raw: {},
+			});
 			jest.spyOn(userRepository, 'findOne').mockResolvedValue(mockUser);
 
 			const loginResult = await samlService.handleSamlLogin(mock<express.Request>(), 'post');
@@ -463,7 +469,10 @@ describe('SamlService', () => {
 				email: samlAttributes.email,
 				authIdentities: [],
 			} as any;
-			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue(samlAttributes);
+			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
+				mapped: samlAttributes,
+				raw: {},
+			});
 			jest.spyOn(userRepository, 'findOne').mockResolvedValue(mockUser);
 			jest.spyOn(samlHelpers, 'updateUserFromSamlAttributes').mockResolvedValue(mockUser);
 
@@ -484,7 +493,10 @@ describe('SamlService', () => {
 				userPrincipalName: 'foo@bar.com',
 			};
 
-			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue(samlAttributes);
+			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
+				mapped: samlAttributes,
+				raw: {},
+			});
 			jest.spyOn(userRepository, 'findOne').mockResolvedValue(null);
 			jest.spyOn(ssoHelpers, 'isSsoJustInTimeProvisioningEnabled').mockReturnValue(false);
 
@@ -508,7 +520,10 @@ describe('SamlService', () => {
 			mockUser.firstName = '';
 			mockUser.lastName = '';
 
-			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue(samlAttributes);
+			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
+				mapped: samlAttributes,
+				raw: {},
+			});
 			jest.spyOn(userRepository, 'findOne').mockResolvedValue(null);
 			jest.spyOn(samlHelpers, 'createUserFromSamlAttributes').mockResolvedValue(mockUser);
 			jest.spyOn(ssoHelpers, 'isSsoJustInTimeProvisioningEnabled').mockReturnValue(true);
@@ -533,7 +548,10 @@ describe('SamlService', () => {
 			mockUser.firstName = 'Jane';
 			mockUser.lastName = 'Doe';
 
-			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue(samlAttributes);
+			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
+				mapped: samlAttributes,
+				raw: {},
+			});
 			jest.spyOn(userRepository, 'findOne').mockResolvedValue(null);
 			jest.spyOn(samlHelpers, 'createUserFromSamlAttributes').mockResolvedValue(mockUser);
 			jest.spyOn(ssoHelpers, 'isSsoJustInTimeProvisioningEnabled').mockReturnValue(true);
@@ -563,7 +581,10 @@ describe('SamlService', () => {
 					{ providerType: 'saml', providerId: samlAttributes.userPrincipalName } as any,
 				],
 			} as any;
-			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue(samlAttributes);
+			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
+				mapped: samlAttributes,
+				raw: {},
+			});
 			jest.spyOn(userRepository, 'findOne').mockResolvedValue(mockUser);
 
 			await samlService.handleSamlLogin(mock<express.Request>(), 'post');
@@ -576,6 +597,74 @@ describe('SamlService', () => {
 				mockUser.id,
 				samlAttributes.n8nProjectRoles,
 			);
+		});
+
+		it('calls provisionExpressionMappedRolesForUser when expression mapping is enabled', async () => {
+			const samlAttributes = {
+				email: 'foo@bar.com',
+				firstName: 'Foo',
+				lastName: 'Bar',
+				userPrincipalName: 'foo@bar.com',
+			};
+			const rawAttributes = { email: 'foo@bar.com', department: 'engineering', role: 'admin' };
+			const mockUser = {
+				id: '123',
+				email: samlAttributes.email,
+				authIdentities: [
+					{ providerType: 'saml', providerId: samlAttributes.userPrincipalName } as any,
+				],
+			} as any;
+
+			provisioningService.isExpressionMappingEnabled = jest.fn().mockResolvedValue(true);
+			provisioningService.provisionExpressionMappedRolesForUser = jest
+				.fn()
+				.mockResolvedValue(undefined);
+			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
+				mapped: samlAttributes,
+				raw: rawAttributes,
+			});
+			jest.spyOn(userRepository, 'findOne').mockResolvedValue(mockUser);
+
+			await samlService.handleSamlLogin(mock<express.Request>(), 'post');
+
+			expect(provisioningService.provisionExpressionMappedRolesForUser).toHaveBeenCalledWith(
+				mockUser,
+				expect.objectContaining({ $provider: 'saml', $saml: { attributes: rawAttributes } }),
+			);
+			expect(provisioningService.provisionInstanceRoleForUser).not.toHaveBeenCalled();
+			expect(provisioningService.provisionProjectRolesForUser).not.toHaveBeenCalled();
+		});
+
+		it('falls through to direct-claim provisioning when expression mapping is disabled', async () => {
+			const samlAttributes = {
+				email: 'foo@bar.com',
+				firstName: '',
+				lastName: '',
+				userPrincipalName: 'foo@bar.com',
+				n8nInstanceRole: 'global:admin',
+			};
+			const mockUser = {
+				id: '123',
+				email: samlAttributes.email,
+				authIdentities: [
+					{ providerType: 'saml', providerId: samlAttributes.userPrincipalName } as any,
+				],
+			} as any;
+
+			provisioningService.isExpressionMappingEnabled = jest.fn().mockResolvedValue(false);
+			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
+				mapped: samlAttributes,
+				raw: {},
+			});
+			jest.spyOn(userRepository, 'findOne').mockResolvedValue(mockUser);
+
+			await samlService.handleSamlLogin(mock<express.Request>(), 'post');
+
+			expect(provisioningService.provisionInstanceRoleForUser).toHaveBeenCalledWith(
+				mockUser,
+				'global:admin',
+			);
+			expect(provisioningService.provisionExpressionMappedRolesForUser).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/modules/sso-saml/saml-helpers.ts
+++ b/packages/cli/src/modules/sso-saml/saml-helpers.ts
@@ -111,6 +111,7 @@ export async function updateUserFromSamlAttributes(
 type GetMappedSamlReturn = {
 	attributes: SamlUserAttributes | undefined;
 	missingAttributes: string[];
+	rawAttributes: Record<string, unknown>;
 };
 
 export function getMappedSamlAttributesFromFlowResult(
@@ -124,11 +125,13 @@ export function getMappedSamlAttributesFromFlowResult(
 	const result: GetMappedSamlReturn = {
 		attributes: undefined,
 		missingAttributes: [] as string[],
+		rawAttributes: {},
 	};
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 	if (flowResult?.extract?.attributes) {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 		const attributes = flowResult.extract.attributes as { [key: string]: string | string[] };
+		result.rawAttributes = attributes as Record<string, unknown>;
 		// TODO:SAML: fetch mapped attributes from flowResult.extract.attributes and create or login user
 		const email = attributes[attributeMapping.email] as string;
 		const firstName = attributes[attributeMapping.firstName] as string;

--- a/packages/cli/src/modules/sso-saml/saml.service.ee.ts
+++ b/packages/cli/src/modules/sso-saml/saml.service.ee.ts
@@ -15,6 +15,7 @@ import type { BindingContext, PostBindingContext } from 'samlify/types/src/entit
 
 import { AuthError } from '@/errors/response-errors/auth.error';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { buildSamlClaimsContext } from '@/modules/provisioning.ee/claims-context.builder';
 import { ProvisioningService } from '@/modules/provisioning.ee/provisioning.service.ee';
 import { UrlService } from '@/services/url.service';
 import {
@@ -321,7 +322,10 @@ export class SamlService {
 		attributes: SamlUserAttributes;
 		onboardingRequired: boolean;
 	}> {
-		const attributes = await this.getAttributesFromLoginResponse(req, binding);
+		const { mapped: attributes, raw: rawAttributes } = await this.getAttributesFromLoginResponse(
+			req,
+			binding,
+		);
 
 		if (attributes.email) {
 			const lowerCasedEmail = attributes.email.toLowerCase();
@@ -341,7 +345,7 @@ export class SamlService {
 						(e) => e.providerType === 'saml' && e.providerId === attributes.userPrincipalName,
 					)
 				) {
-					await this.applySsoProvisioning(user, attributes);
+					await this.applySsoProvisioning(user, attributes, rawAttributes);
 					return {
 						authenticatedUser: user,
 						attributes,
@@ -351,7 +355,7 @@ export class SamlService {
 					// Login path for existing users that are NOT fully set up for SAML
 					const updatedUser = await updateUserFromSamlAttributes(user, attributes);
 					const onboardingRequired = !updatedUser.firstName || !updatedUser.lastName;
-					await this.applySsoProvisioning(updatedUser, attributes);
+					await this.applySsoProvisioning(updatedUser, attributes, rawAttributes);
 					return {
 						authenticatedUser: updatedUser,
 						attributes,
@@ -362,7 +366,7 @@ export class SamlService {
 				// New users to be created JIT based on SAML attributes
 				if (isSsoJustInTimeProvisioningEnabled()) {
 					const newUser = await createUserFromSamlAttributes(attributes);
-					await this.applySsoProvisioning(newUser, attributes);
+					await this.applySsoProvisioning(newUser, attributes, rawAttributes);
 					return {
 						authenticatedUser: newUser,
 						attributes,
@@ -379,7 +383,16 @@ export class SamlService {
 		};
 	}
 
-	private async applySsoProvisioning(user: User, attributes: SamlPreferencesAttributeMapping) {
+	private async applySsoProvisioning(
+		user: User,
+		attributes: SamlPreferencesAttributeMapping,
+		rawAttributes: Record<string, unknown>,
+	): Promise<void> {
+		if (await this.provisioningService.isExpressionMappingEnabled()) {
+			const context = buildSamlClaimsContext(rawAttributes);
+			await this.provisioningService.provisionExpressionMappedRolesForUser(user, context);
+			return;
+		}
 		if (attributes?.n8nInstanceRole) {
 			await this.provisioningService.provisionInstanceRoleForUser(user, attributes.n8nInstanceRole);
 		}
@@ -647,7 +660,7 @@ export class SamlService {
 	async getAttributesFromLoginResponse(
 		req: express.Request,
 		binding: SamlLoginBinding,
-	): Promise<SamlUserAttributes> {
+	): Promise<{ mapped: SamlUserAttributes; raw: Record<string, unknown> }> {
 		let parsedSamlResponse;
 		if (!this._samlPreferences.mapping)
 			throw new BadRequestError('Error fetching SAML Attributes, no Attribute mapping set');
@@ -665,7 +678,7 @@ export class SamlService {
 				`SAML Authentication failed. Could not parse SAML response. ${error instanceof Error ? error.message : error}`,
 			);
 		}
-		const { attributes, missingAttributes } = getMappedSamlAttributesFromFlowResult(
+		const { attributes, missingAttributes, rawAttributes } = getMappedSamlAttributesFromFlowResult(
 			parsedSamlResponse,
 			this._samlPreferences.mapping,
 			{
@@ -683,7 +696,7 @@ export class SamlService {
 				)}).`,
 			);
 		}
-		return attributes;
+		return { mapped: attributes, raw: rawAttributes };
 	}
 
 	/**

--- a/packages/cli/test/integration/oidc/oidc.service.ee.test.ts
+++ b/packages/cli/test/integration/oidc/oidc.service.ee.test.ts
@@ -12,7 +12,7 @@ jest.mock('openid-client', () => ({
 import type { OidcConfigDto, ProvisioningConfigDto } from '@n8n/api-types';
 import { createTeamProject, getProjectRoleForUser, testDb } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
-import { type User, UserRepository } from '@n8n/db';
+import { type User, UserRepository, RoleRepository, RoleMappingRuleRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { UserError } from 'n8n-workflow';
 import type * as mocked_oidc_client from 'openid-client';
@@ -922,6 +922,114 @@ describe('OIDC service', () => {
 
 				const projectRole = await getProjectRoleForUser(project.id, user.id);
 				expect(projectRole).toEqual('project:editor');
+			});
+
+			describe('expression-based role mapping', () => {
+				let originalEnvFlag: string | undefined;
+				let roleMappingRuleRepository: RoleMappingRuleRepository;
+				let roleRepository: RoleRepository;
+
+				beforeAll(() => {
+					roleMappingRuleRepository = Container.get(RoleMappingRuleRepository);
+					roleRepository = Container.get(RoleRepository);
+				});
+
+				beforeEach(() => {
+					originalEnvFlag = process.env.N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY;
+					process.env.N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY = 'true';
+				});
+
+				afterEach(async () => {
+					if (originalEnvFlag === undefined) {
+						delete process.env.N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY;
+					} else {
+						process.env.N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY = originalEnvFlag;
+					}
+					await roleMappingRuleRepository.delete({});
+				});
+
+				it('should provision instance role via expression mapping', async () => {
+					const provisioningService = Container.get(ProvisioningService);
+					// @ts-expect-error - provisioningConfig is private
+					provisioningService.provisioningConfig.scopesUseExpressionMapping = true;
+
+					const adminRole = await roleRepository.findOneOrFail({
+						where: { slug: 'global:admin' },
+					});
+					await roleMappingRuleRepository.save(
+						roleMappingRuleRepository.create({
+							expression: "{{ $claims.n8n_role === 'admin' }}",
+							role: adminRole,
+							type: 'instance',
+							order: 0,
+						}),
+					);
+
+					const state = oidcService.generateState();
+					const nonce = oidcService.generateNonce();
+					const callbackUrl = new URL(
+						`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state.plaintext}`,
+					);
+
+					const mockTokens = createProvisioningMockTokens('oidc-expr-instance-role-sub', {
+						n8n_role: 'admin',
+					});
+					authorizationCodeGrantMock.mockResolvedValueOnce(mockTokens);
+					fetchUserInfoMock.mockResolvedValueOnce({
+						email_verified: true,
+						email: 'oidc-expr-instance-role@example.com',
+					});
+
+					const user = await oidcService.loginUser(callbackUrl, state.signed, nonce.signed);
+					expect(user).toBeDefined();
+
+					const userFromDB = await userRepository.findOne({
+						where: { id: user.id },
+						relations: ['role'],
+					});
+					expect(userFromDB!.role.slug).toEqual('global:admin');
+				});
+
+				it('should provision project role via expression mapping', async () => {
+					const project = await createTeamProject('oidc-expr-project-role-test');
+
+					const provisioningService = Container.get(ProvisioningService);
+					// @ts-expect-error - provisioningConfig is private
+					provisioningService.provisioningConfig.scopesUseExpressionMapping = true;
+
+					const editorRole = await roleRepository.findOneOrFail({
+						where: { slug: 'project:editor' },
+					});
+					const rule = roleMappingRuleRepository.create({
+						expression: "{{ $claims.department === 'engineering' }}",
+						role: editorRole,
+						type: 'project',
+						order: 0,
+					});
+					rule.projects = [project];
+					await roleMappingRuleRepository.save(rule);
+
+					const state = oidcService.generateState();
+					const nonce = oidcService.generateNonce();
+					const callbackUrl = new URL(
+						`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state.plaintext}`,
+					);
+
+					const mockTokens = createProvisioningMockTokens('oidc-expr-project-role-sub', {
+						department: 'engineering',
+					});
+					authorizationCodeGrantMock.mockResolvedValueOnce(mockTokens);
+					fetchUserInfoMock.mockResolvedValueOnce({
+						email_verified: true,
+						email: 'oidc-expr-project-role@example.com',
+					});
+
+					const user = await oidcService.loginUser(callbackUrl, state.signed, nonce.signed);
+					expect(user).toBeDefined();
+
+					const projectRole = await getProjectRoleForUser(project.id, user.id);
+					expect(projectRole).toEqual('project:editor');
+				});
 			});
 		});
 

--- a/packages/cli/test/integration/saml/saml.api.test.ts
+++ b/packages/cli/test/integration/saml/saml.api.test.ts
@@ -1,7 +1,13 @@
 import type { SamlPreferences } from '@n8n/api-types';
-import { randomEmail, randomName, randomValidPassword } from '@n8n/backend-test-utils';
+import {
+	createTeamProject,
+	getProjectRoleForUser,
+	randomEmail,
+	randomName,
+	randomValidPassword,
+} from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
-import type { User } from '@n8n/db';
+import { type User, UserRepository, RoleRepository, RoleMappingRuleRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import type express from 'express';
 import { CREDENTIAL_BLANKING_VALUE } from 'n8n-workflow';
@@ -15,6 +21,7 @@ import {
 } from '@/modules/sso-saml/__tests__/saml-signing-test-fixtures';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ProvisioningService } from '@/modules/provisioning.ee/provisioning.service.ee';
 import { setSamlLoginEnabled } from '@/modules/sso-saml/saml-helpers';
 import { SamlService } from '@/modules/sso-saml/saml.service.ee';
 import {
@@ -689,5 +696,113 @@ describe('SAML email validation', () => {
 			expect(result).toBeDefined();
 			expect(result.attributes.email).toBe(upperCaseEmail); // Original email should be preserved in attributes
 		});
+	});
+});
+
+describe('SAML SSO provisioning', () => {
+	let samlService: SamlService;
+	let roleMappingRuleRepository: RoleMappingRuleRepository;
+	let roleRepository: RoleRepository;
+	let userRepository: UserRepository;
+	let originalEnvFlag: string | undefined;
+	let savedProvisioningConfig: unknown;
+
+	beforeAll(async () => {
+		samlService = Container.get(SamlService);
+		roleMappingRuleRepository = Container.get(RoleMappingRuleRepository);
+		roleRepository = Container.get(RoleRepository);
+		userRepository = Container.get(UserRepository);
+		await Container.get(ProvisioningService).init();
+	});
+
+	beforeEach(() => {
+		originalEnvFlag = process.env.N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY;
+		process.env.N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY = 'true';
+
+		const provisioningService = Container.get(ProvisioningService);
+		// @ts-expect-error - provisioningConfig is private
+		savedProvisioningConfig = { ...provisioningService.provisioningConfig };
+		// @ts-expect-error - provisioningConfig is private
+		provisioningService.provisioningConfig.scopesUseExpressionMapping = true;
+	});
+
+	afterEach(async () => {
+		if (originalEnvFlag === undefined) {
+			delete process.env.N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY;
+		} else {
+			process.env.N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY = originalEnvFlag;
+		}
+
+		const provisioningService = Container.get(ProvisioningService);
+		// @ts-expect-error - provisioningConfig is private
+		provisioningService.provisioningConfig = { ...savedProvisioningConfig };
+
+		await roleMappingRuleRepository.delete({});
+	});
+
+	it('should provision instance role via expression mapping', async () => {
+		const adminRole = await roleRepository.findOneOrFail({ where: { slug: 'global:admin' } });
+		await roleMappingRuleRepository.save(
+			roleMappingRuleRepository.create({
+				expression: "{{ $claims.department === 'it' }}",
+				role: adminRole,
+				type: 'instance',
+				order: 0,
+			}),
+		);
+
+		jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
+			mapped: {
+				email: 'saml-expr-instance@example.com',
+				firstName: 'SAML',
+				lastName: 'User',
+				userPrincipalName: 'saml-expr-instance',
+			},
+			raw: { department: 'it', email: 'saml-expr-instance@example.com' },
+		});
+
+		const mockRequest = {} as express.Request;
+		const result = await samlService.handleSamlLogin(mockRequest, 'post');
+		expect(result).toBeDefined();
+
+		const userFromDB = await userRepository.findOne({
+			where: { email: 'saml-expr-instance@example.com' },
+			relations: ['role'],
+		});
+		expect(userFromDB!.role.slug).toEqual('global:admin');
+	});
+
+	it('should provision project role via expression mapping', async () => {
+		const project = await createTeamProject('saml-expr-project-role-test');
+
+		const editorRole = await roleRepository.findOneOrFail({ where: { slug: 'project:editor' } });
+		const rule = roleMappingRuleRepository.create({
+			expression: "{{ $claims.groups !== undefined && $claims.groups.includes('n8n-editors') }}",
+			role: editorRole,
+			type: 'project',
+			order: 0,
+		});
+		rule.projects = [project];
+		await roleMappingRuleRepository.save(rule);
+
+		jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
+			mapped: {
+				email: 'saml-expr-project@example.com',
+				firstName: 'SAML',
+				lastName: 'User',
+				userPrincipalName: 'saml-expr-project',
+			},
+			raw: {
+				email: 'saml-expr-project@example.com',
+				groups: ['n8n-editors', 'devops'],
+			},
+		});
+
+		const mockRequest = {} as express.Request;
+		const result = await samlService.handleSamlLogin(mockRequest, 'post');
+		expect(result.authenticatedUser).toBeDefined();
+
+		const projectRole = await getProjectRoleForUser(project.id, result.authenticatedUser!.id);
+		expect(projectRole).toEqual('project:editor');
 	});
 });

--- a/packages/cli/test/integration/saml/saml.api.test.ts
+++ b/packages/cli/test/integration/saml/saml.api.test.ts
@@ -604,11 +604,14 @@ describe('SAML email validation', () => {
 		test('should throw BadRequestError for invalid email format', async () => {
 			// Mock getAttributesFromLoginResponse to return invalid email
 			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
-				email: 'invalid-email-format',
-				firstName: 'John',
-				lastName: 'Doe',
-				userPrincipalName: 'john.doe',
-				n8nInstanceRole: 'n8n_instance_role',
+				mapped: {
+					email: 'invalid-email-format',
+					firstName: 'John',
+					lastName: 'Doe',
+					userPrincipalName: 'john.doe',
+					n8nInstanceRole: 'n8n_instance_role',
+				},
+				raw: {},
 			});
 
 			const mockRequest = {} as express.Request;
@@ -622,11 +625,14 @@ describe('SAML email validation', () => {
 			'should throw BadRequestError for invalid email <%s>',
 			async (invalidEmail) => {
 				jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
-					email: invalidEmail,
-					firstName: 'John',
-					lastName: 'Doe',
-					userPrincipalName: 'john.doe',
-					n8nInstanceRole: 'n8n_instance_role',
+					mapped: {
+						email: invalidEmail,
+						firstName: 'John',
+						lastName: 'Doe',
+						userPrincipalName: 'john.doe',
+						n8nInstanceRole: 'n8n_instance_role',
+					},
+					raw: {},
 				});
 
 				const mockRequest = {} as express.Request;
@@ -646,11 +652,14 @@ describe('SAML email validation', () => {
 			const mockRequest = {} as express.Request;
 
 			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
-				email: validEmail,
-				firstName: 'John',
-				lastName: 'Doe',
-				userPrincipalName: 'john.doe',
-				n8nInstanceRole: 'n8n_instance_role',
+				mapped: {
+					email: validEmail,
+					firstName: 'John',
+					lastName: 'Doe',
+					userPrincipalName: 'john.doe',
+					n8nInstanceRole: 'n8n_instance_role',
+				},
+				raw: {},
 			});
 
 			// Should not throw an error for valid emails
@@ -663,11 +672,14 @@ describe('SAML email validation', () => {
 			const upperCaseEmail = 'USER@EXAMPLE.COM';
 
 			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
-				email: upperCaseEmail,
-				firstName: 'John',
-				lastName: 'Doe',
-				userPrincipalName: 'john.doe',
-				n8nInstanceRole: 'n8n_instance_role',
+				mapped: {
+					email: upperCaseEmail,
+					firstName: 'John',
+					lastName: 'Doe',
+					userPrincipalName: 'john.doe',
+					n8nInstanceRole: 'n8n_instance_role',
+				},
+				raw: {},
 			});
 
 			const mockRequest = {} as express.Request;


### PR DESCRIPTION
## Summary                                                                                       
                                                                                                    
   Wires the expression-based role mapping strategy into the OIDC and SAML SSO login flows. All     
   the infrastructure (rule evaluation, context builders, `RoleResolverService`) existed but was    
   never called during login — this PR connects those call sites.

   **What changes:**
   - `OidcService.applySsoProvisioning` and `SamlService.applySsoProvisioning` now check
   `isExpressionMappingEnabled()` on each login
   - If enabled → builds a `RoleResolverContext` from SSO claims and dispatches to
   `provisionExpressionMappedRolesForUser`
   - If disabled → existing direct-claim provisioning is unchanged
   - For SAML: raw IdP attributes (`flowResult.extract.attributes`) are now surfaced through the
   pipeline so expression rules can reference any custom attribute (e.g. `$claims.department`,
   `$claims.groups`), not just the mapped n8n fields
   - `userInfo` is now passed alongside `claims` in the OIDC path so `buildOidcClaimsContext` can
    produce the correct merged context

   The two strategies remain mutually exclusive — enforced at config-patch time in
   `ProvisioningService`.

   ### Prerequisites

   - `N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY=true` must be set
   - `scopesUseExpressionMapping` must be enabled via config (direct-claim flags must be off)

   ### API Testing

   **Enable expression mapping:**
   ```bash
   curl -X PATCH http://localhost:5678/rest/sso/provisioning/config \
     -H "Content-Type: application/json" \
     -H "Cookie: <your-session-cookie>" \
     -d '{"scopesUseExpressionMapping": true}'
   ```

   **Create an instance role mapping rule:**
   ```bash
   curl -X POST http://localhost:5678/rest/role-mapping-rule \
     -H "Content-Type: application/json" \
     -H "Cookie: <your-session-cookie>" \
     -d '{
       "type": "instance",
       "expression": "{{ $claims.department === '\''engineering'\'' }}",
       "roleId": "<global-admin-role-id>",
       "order": 0
     }'
   ```

   **Create a project role mapping rule:**
   ```bash
   curl -X POST http://localhost:5678/rest/role-mapping-rule \
     -H "Content-Type: application/json" \
     -H "Cookie: <your-session-cookie>" \
     -d '{
       "type": "project",
       "expression": "{{ $claims.groups.includes('\''n8n-editors'\'') }}",
       "roleId": "<project-editor-role-id>",
       "projectIds": ["<project-id>"],
       "order": 0
     }'
   ```

   **List rules:**
   ```bash
   curl http://localhost:5678/rest/role-mapping-rule \
     -H "Cookie: <your-session-cookie>"
   ```

   ### UI Testing (OIDC)

   1. Configure an OIDC provider that includes custom claims in the ID token or userinfo endpoint
    (e.g. `department`, `groups`)
   2. Set `N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY=true` and restart n8n
   3. Enable OIDC login via **Settings → SSO**
   4. Enable expression mapping via `PATCH /sso/provisioning/config` (direct-claim flags must be
   off)
   5. Create role mapping rules via the API above
   6. Sign in via OIDC in a private window and verify the user's instance role and project
   memberships match the rules

   **Fallback check:** Set `scopesUseExpressionMapping: false` and confirm
   `N8N_SSO_SCOPES_PROVISION_INSTANCE_ROLE=true` still assigns roles from the `n8n_instance_role`
    claim as before.

   ### UI Testing (SAML)

   1. Configure a SAML IdP that sends custom attributes in the assertion alongside standard
   email/name attributes
   2. Follow the same env var and config steps as OIDC above
   3. Sign in via SAML — the full raw attribute bag will be available as `$claims.<attr-name>`
   and `$saml.attributes.<attr-name>` in expressions
   4. Verify roles are applied according to the rules

   ## Related Linear tickets, Github issues, and Community forum posts

   https://linear.app/n8n/issue/IAM-395

   ## Review / Merge checklist

   - [x] PR title and summary are descriptive.
   ([conventions](../blob/master/.github/pull_request_title_conventions.md))
   - [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
   - [x] Tests included.
   - [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be
   backported)