### PR TITLE
ci: Parse pnpm ls with jq to prevent buffer overload

### DIFF
--- a/.github/scripts/detect-new-packages.mjs
+++ b/.github/scripts/detect-new-packages.mjs
@@ -20,7 +20,13 @@ import { writeGithubOutput } from './github-helpers.mjs';
 
 const exec = promisify(child_process.exec);
 
-const packages = JSON.parse((await exec('pnpm ls -r --only-projects --json')).stdout);
+const packages = JSON.parse(
+	(
+		await exec(
+			`pnpm ls -r --only-projects --json | jq -r '[.[] | { name:.name, private: .private}]'`,
+		)
+	).stdout,
+);
 
 const newPackages = [];
 


### PR DESCRIPTION
## Summary

Prevent buffer overload by parsin the output of pnpm ls through JQ before returning to javascript.

[Assumes ubuntu-slim has jq installed ](https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md)

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/actions/runs/23749456123/job/69187206198

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
