### PR TITLE
ci: Prevent buffer overflow in other helper scripts

### DIFF
--- a/.github/scripts/bump-versions.mjs
+++ b/.github/scripts/bump-versions.mjs
@@ -29,10 +29,16 @@ assert.match(releaseType, /^(patch|minor|major|experimental|premajor)$/, 'Invali
 // TODO: if releaseType is `auto` determine release type based on the changelog
 
 const lastTag = (await exec('git describe --tags --match "n8n@*" --abbrev=0')).stdout.trim();
-const packages = JSON.parse((await exec('pnpm ls -r --only-projects --json')).stdout);
+const packages = JSON.parse(
+	(
+		await exec(
+			`pnpm ls -r --only-projects --json | jq -r '[.[] | { name: .name, version: .version, path: .path,  private: .private}]'`,
+		)
+	).stdout,
+);
 
 const packageMap = {};
-for (let { name, path, version, private: isPrivate, dependencies } of packages) {
+for (let { name, path, version, private: isPrivate } of packages) {
 	if (isPrivate && path !== rootDir) continue;
 	if (path === rootDir) name = 'monorepo-root';
 

--- a/.github/scripts/ensure-provenance-fields.mjs
+++ b/.github/scripts/ensure-provenance-fields.mjs
@@ -9,7 +9,13 @@ const exec = promisify(child_process.exec);
 const commonFiles = ['LICENSE.md', 'LICENSE_EE.md'];
 
 const baseDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
-const packages = JSON.parse((await exec('pnpm ls -r --only-projects --json')).stdout);
+const packages = JSON.parse(
+	(
+		await exec(
+			`pnpm ls -r --only-projects --json | jq -r '[.[] | { name: .name, version: .version, path: .path,  private: .private}]'`,
+		)
+	).stdout,
+);
 
 for (let { name, path, version, private: isPrivate } of packages) {
 	if (isPrivate) continue;


### PR DESCRIPTION
## Summary

Continuation for https://github.com/n8n-io/n8n/pull/27770

Turns out the command was used across multiple files in this manner.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
