### PR TITLE
fix(GraphQL Node): Handle string and object error payloads

### DIFF
--- a/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
+++ b/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
@@ -12,6 +12,35 @@ import type {
 } from 'n8n-workflow';
 import { NodeApiError, NodeConnectionTypes, NodeOperationError, jsonParse } from 'n8n-workflow';
 
+const hasErrorsProperty = (value: unknown): value is { errors: unknown } =>
+	typeof value === 'object' && value !== null && 'errors' in value;
+
+const extractGraphQlErrorMessage = (errors: unknown): string => {
+	if (Array.isArray(errors)) {
+		const messages = errors
+			.filter((error): error is IDataObject => typeof error === 'object' && error !== null)
+			.map((error) => error.message)
+			.filter((message): message is string => typeof message === 'string' && message.length > 0);
+
+		if (messages.length > 0) {
+			return messages.join(', ');
+		}
+	}
+
+	if (typeof errors === 'string' && errors.length > 0) {
+		return errors;
+	}
+
+	if (typeof errors === 'object' && errors !== null && 'message' in errors) {
+		const message = errors.message;
+		if (typeof message === 'string' && message.length > 0) {
+			return message;
+		}
+	}
+
+	return 'Unexpected error';
+};
+
 export class GraphQL implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'GraphQL',
@@ -551,10 +580,8 @@ export class GraphQL implements INodeType {
 					} catch (e) {}
 				}
 				// throw from response object.errors[]
-				if (typeof response === 'object' && response.errors) {
-					const message =
-						response.errors?.map((error: IDataObject) => error.message).join(', ') ||
-						'Unexpected error';
+				if (hasErrorsProperty(response) && response.errors) {
+					const message = extractGraphQlErrorMessage(response.errors);
 					throw new NodeApiError(this.getNode(), response.errors as JsonObject, { message });
 				}
 			} catch (error) {

--- a/packages/nodes-base/nodes/GraphQL/test/GraphQL.node.test.ts
+++ b/packages/nodes-base/nodes/GraphQL/test/GraphQL.node.test.ts
@@ -65,6 +65,19 @@ describe('GraphQL Node', () => {
 		});
 	});
 
+	describe('error response with string errors field', () => {
+		const baseUrl = 'http://test';
+		nock(baseUrl)
+			.post('/graphql', '{"query":"query { foo }","variables":{},"operationName":null}')
+			.reply(200, {
+				errors: 'An unexpected error occurred',
+			});
+
+		new NodeTestHarness().setupTests({
+			workflowFiles: ['workflow.error_string_errors_field.json'],
+		});
+	});
+
 	describe('oauth2 refresh token', () => {
 		const credentials = {
 			oAuth2Api: {

--- a/packages/nodes-base/nodes/GraphQL/test/workflow.error_string_errors_field.json
+++ b/packages/nodes-base/nodes/GraphQL/test/workflow.error_string_errors_field.json
@@ -1,0 +1,53 @@
+{
+	"name": "GraphQL Error String Field",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "737a85de-287d-4feb-89e2-15245f3ea176",
+			"name": "When clicking 'Execute workflow'",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [220, 280]
+		},
+		{
+			"parameters": {
+				"endpoint": "http://test/graphql",
+				"requestFormat": "json",
+				"query": "query { foo }"
+			},
+			"id": "6f815da0-5458-4bfc-ba02-fd9476a71154",
+			"name": "GraphQL",
+			"type": "n8n-nodes-base.graphql",
+			"typeVersion": 1,
+			"position": [500, 280],
+			"onError": "continueRegularOutput"
+		}
+	],
+	"pinData": {
+		"GraphQL": [
+			{
+				"json": {
+					"errors": "An unexpected error occurred"
+				}
+			},
+			{
+				"json": {
+					"error": "An unexpected error occurred"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking 'Execute workflow'": {
+			"main": [
+				[
+					{
+						"node": "GraphQL",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Handle GraphQL responses where `errors` is not an array (for example, a string or a single object with `message`).
- Prevent runtime `TypeError` from calling `.map()` on non-array `errors`, and surface a meaningful `NodeApiError` message instead.
- Add a regression test workflow and test case to cover string-based `errors` payloads.

### How to test

- Run unit regression test from `packages/nodes-base`:
  - `pnpm test nodes/GraphQL/test/GraphQL.node.test.ts -t error response with string errors field`
- Run integration tests from `packages/nodes-base`:
  - `pnpm test:integration:skip`
- Run package typecheck:
  - `pnpm typecheck`

## Related Linear tickets, Github issues, and Community forum posts

- fixes #27601

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)