### PR TITLE
fix: Fix n8n Gateway start instructions in instance AI

### DIFF
--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -66,7 +66,7 @@ ${capList}
 The gateway is not currently connected. When the user asks for something that requires local machine access (reading files, browsing, etc.), let them know they can connect by either:
 
 1. **Download the Local Gateway app** — https://n8n.io/downloads/local-gateway
-2. **Or run via CLI:** \`npx @n8n/local-gateway\`
+2. **Or run via CLI:** \`npx @n8n/fs-proxy serve\`
 
 Do NOT attempt to use filesystem tools — they are not available until the gateway connects.`;
 	}


### PR DESCRIPTION
## Summary

Fixes the instructions in n8n AI to point to correct npm package in `serve` mode.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
