### PR TITLE
fix(instance-ai): address security issues in tool inspector, SSE, and SSRF guard

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.controller.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.controller.test.ts
@@ -169,6 +169,55 @@ describe('InstanceAiController', () => {
 		it('should require instanceAi:message scope', () => {
 			expect(scopeOf('events')).toEqual({ scope: 'instanceAi:message', globalOnly: true });
 		});
+
+		it('should close SSE stream when thread ownership changes after pre-creation subscribe', async () => {
+			// Simulate: thread does not exist at connect time
+			memoryService.checkThreadOwnership.mockResolvedValueOnce('not_found');
+
+			const sseRes = mock<Response & { flush?: () => void }>({
+				setHeader: jest.fn(),
+				flushHeaders: jest.fn(),
+				write: jest.fn(),
+				end: jest.fn(),
+				flush: jest.fn(),
+			});
+
+			// Capture the subscribe handler
+			let subscribeHandler: ((stored: { id: number; event: unknown }) => void) | undefined;
+			eventBus.subscribe.mockImplementation((_threadId, handler) => {
+				subscribeHandler = handler as typeof subscribeHandler;
+				return jest.fn();
+			});
+			eventBus.getEventsAfter.mockReturnValue([]);
+			instanceAiService.getThreadStatus.mockReturnValue({
+				hasActiveRun: false,
+				isSuspended: false,
+				backgroundTasks: [],
+			} as never);
+
+			const sseReq = mock<AuthenticatedRequest>({
+				user: { id: USER_ID },
+				headers: {},
+				once: jest.fn(),
+			});
+
+			await controller.events(sseReq, sseRes, THREAD_ID, { lastEventId: undefined } as never);
+
+			// Now simulate: another user created the thread, so ownership is 'other_user'
+			memoryService.checkThreadOwnership.mockResolvedValueOnce('other_user');
+
+			// Fire an event through the subscriber
+			subscribeHandler!({
+				id: 1,
+				event: { type: 'text-delta', runId: 'r1', agentId: 'a1', payload: { text: 'secret' } },
+			});
+
+			// Allow the async ownership check to resolve
+			await new Promise((resolve) => setImmediate(resolve));
+
+			// The stream should be closed, not written to
+			expect(sseRes.end).toHaveBeenCalled();
+		});
 	});
 
 	describe('cancel', () => {

--- a/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
@@ -111,6 +111,13 @@ export class InstanceAiController {
 			throw new ForbiddenError('Not authorized for this thread');
 		}
 
+		// Track whether we need to re-validate ownership on first event.
+		// When the thread didn't exist at connect time, another user could create
+		// and own it before events start flowing. We re-check once on the first
+		// event and close the stream if ownership changed.
+		let ownershipVerified = ownership === 'owned';
+		const userId = req.user.id;
+
 		// 1. Set SSE headers
 		res.setHeader('Content-Type', 'text/event-stream; charset=UTF-8');
 		res.setHeader('Cache-Control', 'no-cache');
@@ -193,7 +200,20 @@ export class InstanceAiController {
 		if (liveGroups.size > 0) res.flush?.();
 
 		// 4. Subscribe to live events
+		// When the thread was not_found at connect time, re-validate ownership on
+		// the first event. If another user now owns the thread, close the stream.
 		const unsubscribe = this.eventBus.subscribe(threadId, (stored) => {
+			if (!ownershipVerified) {
+				ownershipVerified = true;
+				void this.memoryService.checkThreadOwnership(userId, threadId).then((currentOwnership) => {
+					if (currentOwnership === 'other_user') {
+						res.end();
+						return;
+					}
+					this.writeSseEvent(res, stored);
+				});
+				return;
+			}
 			this.writeSseEvent(res, stored);
 		});
 

--- a/packages/cli/src/modules/instance-ai/web-research/__tests__/ssrf-guard.test.ts
+++ b/packages/cli/src/modules/instance-ai/web-research/__tests__/ssrf-guard.test.ts
@@ -80,4 +80,36 @@ describe('assertPublicUrl', () => {
 		] as never);
 		await expect(assertPublicUrl('https://dual-stack.example')).rejects.toThrow('private IP');
 	});
+
+	describe('IPv4-mapped IPv6 addresses', () => {
+		it('blocks ::ffff:127.0.0.1 (loopback)', async () => {
+			await expect(assertPublicUrl('http://[::ffff:127.0.0.1]:8080/x')).rejects.toThrow('private');
+		});
+
+		it('blocks ::ffff:10.0.0.1 (RFC-1918)', async () => {
+			await expect(assertPublicUrl('http://[::ffff:10.0.0.1]/x')).rejects.toThrow('private');
+		});
+
+		it('blocks ::ffff:192.168.1.1 (RFC-1918)', async () => {
+			await expect(assertPublicUrl('http://[::ffff:192.168.1.1]/x')).rejects.toThrow('private');
+		});
+
+		it('blocks ::ffff:169.254.169.254 (link-local / cloud metadata)', async () => {
+			await expect(assertPublicUrl('http://[::ffff:169.254.169.254]/x')).rejects.toThrow('private');
+		});
+
+		it('blocks DNS-resolved IPv4-mapped IPv6 loopback', async () => {
+			mockLookup.mockResolvedValue([{ address: '::ffff:127.0.0.1', family: 6 }] as never);
+			await expect(assertPublicUrl('https://sneaky.example')).rejects.toThrow('private');
+		});
+
+		it('blocks DNS-resolved IPv4-mapped IPv6 private range', async () => {
+			mockLookup.mockResolvedValue([{ address: '::ffff:10.0.0.1', family: 6 }] as never);
+			await expect(assertPublicUrl('https://sneaky.example')).rejects.toThrow('private');
+		});
+
+		it('allows ::ffff: mapped public IP', async () => {
+			await expect(assertPublicUrl('http://[::ffff:8.8.8.8]/x')).resolves.toBeUndefined();
+		});
+	});
 });

--- a/packages/cli/src/modules/instance-ai/web-research/ssrf-guard.ts
+++ b/packages/cli/src/modules/instance-ai/web-research/ssrf-guard.ts
@@ -19,6 +19,10 @@ const PRIVATE_RANGES = [
 /** IPv6 loopback and link-local prefixes. */
 const PRIVATE_IPV6_PREFIXES = ['::1', 'fe80:', 'fd', 'fc'];
 
+/** Regex for IPv4-mapped IPv6 addresses like ::ffff:127.0.0.1 or ::ffff:7f00:1 */
+const IPV4_MAPPED_IPV6_DOTTED = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i;
+const IPV4_MAPPED_IPV6_HEX = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i;
+
 function ip4ToNum(ip: string): number {
 	const parts = ip.split('.').map(Number);
 	// eslint-disable-next-line no-bitwise
@@ -30,8 +34,35 @@ function isPrivateIPv4(ip: string): boolean {
 	return PRIVATE_RANGES.some((r) => num >= r.start && num <= r.end);
 }
 
+/**
+ * Extract the embedded IPv4 address from an IPv4-mapped IPv6 address.
+ * Handles both dotted notation (::ffff:127.0.0.1) and hex notation (::ffff:7f00:1).
+ * Returns null if the address is not an IPv4-mapped IPv6 address.
+ */
+function extractMappedIPv4(ip: string): string | null {
+	const dottedMatch = IPV4_MAPPED_IPV6_DOTTED.exec(ip);
+	if (dottedMatch) return dottedMatch[1];
+
+	const hexMatch = IPV4_MAPPED_IPV6_HEX.exec(ip);
+	if (hexMatch) {
+		const high = parseInt(hexMatch[1], 16);
+		const low = parseInt(hexMatch[2], 16);
+		// eslint-disable-next-line no-bitwise
+		return `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
+	}
+
+	return null;
+}
+
 function isPrivateIPv6(ip: string): boolean {
 	const lower = ip.toLowerCase();
+
+	// Check IPv4-mapped IPv6 addresses (e.g. ::ffff:127.0.0.1, ::ffff:7f00:1)
+	const mappedIPv4 = extractMappedIPv4(lower);
+	if (mappedIPv4 !== null) {
+		return isPrivateIPv4(mappedIPv4);
+	}
+
 	return PRIVATE_IPV6_PREFIXES.some((prefix) => lower.startsWith(prefix));
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/ToolResultJson.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/ToolResultJson.vue
@@ -5,12 +5,25 @@ const props = defineProps<{
 	value: unknown;
 }>();
 
+function escapeHtml(text: string): string {
+	return text
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;');
+}
+
 function highlightJson(value: unknown): string {
 	const json = JSON.stringify(value, null, 2);
-	if (!json) return String(value);
+	if (!json) return escapeHtml(String(value));
 
-	return json.replace(
-		/("(?:\\.|[^"\\])*")\s*:|("(?:\\.|[^"\\])*")|(true|false|null)|(\d+\.?\d*)/g,
+	// First HTML-escape the entire JSON string to neutralize any embedded markup,
+	// then apply syntax-highlighting spans on the safe output.
+	const escaped = escapeHtml(json);
+
+	return escaped.replace(
+		/(&quot;(?:\\.|[^&]|&(?!quot;))*?&quot;)\s*:|(&quot;(?:\\.|[^&]|&(?!quot;))*?&quot;)|(true|false|null)|(\d+\.?\d*)/g,
 		(
 			match,
 			key: string | undefined,


### PR DESCRIPTION
## Summary
- **XSS in tool inspector**: HTML-escape JSON values in `ToolResultJson.vue` before `v-html` rendering to prevent stored XSS from malicious page content
- **Cross-user SSE leak**: Re-validate thread ownership on first SSE event when the thread was `not_found` at connect time, closing the stream if another user now owns it
- **SSRF guard bypass**: Detect IPv4-mapped IPv6 addresses (`::ffff:x.x.x.x`) and check the embedded IPv4 against private ranges

## Test plan
- [x] ssrf-guard.test.ts: 7 new tests for IPv4-mapped IPv6 blocking (dotted + DNS-resolved + public allowed)
- [x] instance-ai.controller.test.ts: 1 new test verifying SSE stream closes when ownership changes after pre-creation subscribe
- [ ] Manual: verify `ToolResultJson` renders `<script>` tags as escaped text, not executable DOM