### PR TITLE
fix(Data Table Node): Change copy for Limit to indicate it applies per input row

### DIFF
--- a/packages/nodes-base/nodes/DataTable/actions/row/get.operation.ts
+++ b/packages/nodes-base/nodes/DataTable/actions/row/get.operation.ts
@@ -31,7 +31,7 @@ export const description: INodeProperties[] = [
 		description: 'Whether to return all results or only up to a given limit',
 	},
 	{
-		displayName: 'Limit per Input Row',
+		displayName: 'Limit Per Input Row',
 		name: 'limit',
 		type: 'number',
 		displayOptions: {

--- a/packages/nodes-base/nodes/DataTable/actions/row/get.operation.ts
+++ b/packages/nodes-base/nodes/DataTable/actions/row/get.operation.ts
@@ -31,7 +31,7 @@ export const description: INodeProperties[] = [
 		description: 'Whether to return all results or only up to a given limit',
 	},
 	{
-		displayName: 'Limit',
+		displayName: 'Limit per Input Row',
 		name: 'limit',
 		type: 'number',
 		displayOptions: {

--- a/packages/nodes-base/nodes/DataTable/actions/table/list.operation.ts
+++ b/packages/nodes-base/nodes/DataTable/actions/table/list.operation.ts
@@ -28,7 +28,7 @@ export const description: INodeProperties[] = [
 		displayOptions,
 	},
 	{
-		displayName: 'Limit',
+		displayName: 'Limit Per Input Row',
 		name: 'limit',
 		type: 'number',
 		default: ROWS_LIMIT_DEFAULT,
@@ -88,8 +88,8 @@ export async function execute(
 	this: IExecuteFunctions,
 	index: number,
 ): Promise<INodeExecutionData[]> {
-	const returnAll = this.getNodeParameter('returnAll', index) as boolean;
-	const limit = this.getNodeParameter('limit', index, ROWS_LIMIT_DEFAULT) as number;
+	const returnAll = this.getNodeParameter('returnAll', index);
+	const limit = this.getNodeParameter('limit', index, ROWS_LIMIT_DEFAULT);
 	const options = this.getNodeParameter('options', index, {}) as {
 		filterName?: string;
 		sortField?: string;


### PR DESCRIPTION
## Summary

Let's be a bit more explicit here since this has repeatedly caused confusion and user intention is usually to execute this node once anyway.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4976

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
