### PR TITLE
fix(editor): AI builder setup wizard positioning and popover collision

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
@@ -497,7 +497,10 @@ defineExpose({
 					:enable-vertical-scroll="true"
 					:enable-horizontal-scroll="false"
 				>
-					<div ref="messagesRef" :class="$style.messagesContent">
+					<div
+						ref="messagesRef"
+						:class="[$style.messagesContent, showFooterRating && $style.messagesContentWithRating]"
+					>
 						<div v-if="normalizedMessages?.length">
 							<data
 								v-for="(message, i) in normalizedMessages"
@@ -774,12 +777,16 @@ defineExpose({
 
 .messagesContent {
 	padding: var(--spacing--xs);
-	padding-bottom: var(--spacing--3xl);
 
 	// Override p line-height from reset.scss (1.8) to use chat standard (1.5)
 	:global(p) {
 		line-height: var(--line-height--xl);
 	}
+}
+
+.messagesContentWithRating {
+	// Extra bottom padding so scroll-to-bottom clears the feedback-wrapper overlay
+	padding-bottom: var(--spacing--3xl);
 }
 
 .message {

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
@@ -464,6 +464,7 @@ defineExpose({
 	focusInput: () => {
 		promptInputRef.value?.focusInput();
 	},
+	scrollToBottom,
 });
 </script>
 

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
@@ -738,6 +738,7 @@ defineExpose({
 	border-top: 0;
 	border-bottom: 0;
 	position: relative;
+	overflow: hidden;
 	line-height: var(--line-height--xl);
 
 	pre,

--- a/packages/frontend/@n8n/design-system/src/components/N8nPopover/Popover.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nPopover/Popover.vue
@@ -20,7 +20,13 @@ import N8nScrollArea from '../N8nScrollArea/N8nScrollArea.vue';
 interface Props
 	extends Pick<
 			PopoverContentProps,
-			'side' | 'align' | 'sideFlip' | 'sideOffset' | 'reference' | 'positionStrategy'
+			| 'side'
+			| 'align'
+			| 'sideFlip'
+			| 'sideOffset'
+			| 'reference'
+			| 'positionStrategy'
+			| 'collisionPadding'
 		>,
 		Pick<PopoverRootProps, 'open'> {
 	/**
@@ -85,6 +91,7 @@ const props = withDefaults(defineProps<Props>(), {
 	scrollType: 'hover',
 	sideOffset: 5,
 	sideFlip: undefined,
+	collisionPadding: 5,
 	suppressAutoFocus: false,
 	zIndex: 999,
 	showArrow: false,
@@ -140,6 +147,7 @@ watch(
 				:side-flip="sideFlip"
 				:align="align"
 				:side-offset="sideOffset"
+				:collision-padding="collisionPadding"
 				:class="[$style.popoverContent, contentClass, { [$style.enableSlideIn]: enableSlideIn }]"
 				:style="{ width, zIndex }"
 				:reference="reference"

--- a/packages/frontend/@n8n/design-system/src/components/N8nPopover/__snapshots__/Popover.test.ts.snap
+++ b/packages/frontend/@n8n/design-system/src/components/N8nPopover/__snapshots__/Popover.test.ts.snap
@@ -4,7 +4,7 @@ exports[`N8nPopover > should render correctly with default props 1`] = `
 "<mock-popover-root>
   <mock-popover-trigger><button></button></mock-popover-trigger>
   <mock-popover-portal disabled="false">
-    <mock-popover-content role="dialog" force-mount="false">
+    <mock-popover-content role="dialog" collision-padding="5" force-mount="false">
       <div dir="ltr" style="position: relative; --reka-scroll-area-corner-width: 0px; --reka-scroll-area-corner-height: 0px;" class="scrollAreaRoot">
         <div data-reka-scroll-area-viewport="" style="overflow-x: hidden; overflow-y: hidden;" class="viewport" tabindex="0">
           <div>

--- a/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
+++ b/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
@@ -24,3 +24,4 @@ export const WorkflowDocumentStoreKey: InjectionKey<
 	ShallowRef<ReturnType<typeof useWorkflowDocumentStore> | null>
 > = Symbol('WorkflowDocumentStore');
 export const ChatHubToolContextKey: InjectionKey<boolean> = Symbol('ChatHubToolContext');
+export const AiBuilderScrollToBottomKey: InjectionKey<() => void> = Symbol('ChatScrollToBottom');

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.vue
@@ -6,7 +6,7 @@ import { useHistoryStore } from '@/app/stores/history.store';
 import { useCollaborationStore } from '@/features/collaboration/collaboration/collaboration.store';
 import { useWorkflowSaveStore } from '@/app/stores/workflowSave.store';
 import { AutoSaveState, VIEWS } from '@/app/constants';
-import { computed, watch, ref, nextTick, useSlots } from 'vue';
+import { computed, watch, ref, nextTick, useSlots, provide } from 'vue';
 import { useInjectWorkflowId } from '@/app/composables/useInjectWorkflowId';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useI18n } from '@n8n/i18n';
@@ -54,6 +54,7 @@ import { watchExecutionCompletion } from '@/features/ai/assistant/composables/us
 
 import { N8nAskAssistantChat, N8nInfoTip } from '@n8n/design-system';
 import BuildModeEmptyState from './BuildModeEmptyState.vue';
+import { AiBuilderScrollToBottomKey } from '@/app/constants/injectionKeys';
 import {
 	isPlanModePlanMessage,
 	isPlanModeQuestionsMessage,
@@ -117,6 +118,7 @@ onDocumentVisible(() => {
 const processedWorkflowUpdates = ref(new Set<string>());
 const accumulatedNodeIdsToTidyUp = ref<string[]>([]);
 const n8nChatRef = ref<InstanceType<typeof N8nAskAssistantChat>>();
+provide(AiBuilderScrollToBottomKey, () => n8nChatRef.value?.scrollToBottom());
 const chatInputRef = ref<InstanceType<typeof ChatInputWithMention>>();
 const suggestionsInputRef = ref<InstanceType<typeof ChatInputWithMention>>();
 const inputText = ref('');

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/BuilderSetupWizard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/BuilderSetupWizard.vue
@@ -99,7 +99,8 @@ watch(currentCard, () => {
 
 // Auto-scroll so the wizard footer stays visible when switching to a taller card.
 // requestAnimationFrame ensures the new card has been laid out before we read scrollHeight.
-watch(currentStepIndex, () => {
+watch([currentStepIndex, showCard], ([_, showCard]) => {
+	if (!showCard) return;
 	requestAnimationFrame(() => scrollToBottom());
 });
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/BuilderSetupWizard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/BuilderSetupWizard.vue
@@ -48,6 +48,7 @@ const showCard = computed(
 
 const showWizard = computed(() => !wizardDismissed.value);
 
+const containerRef = ref<HTMLElement>();
 const isHovering = ref(false);
 
 function onMouseEnter() {
@@ -93,6 +94,17 @@ const highlightedNodeIds = computed(
 // Clear section override when navigating to a different card (unmount won't fire mouseleave)
 watch(currentCard, () => {
 	sectionHighlightOverride.value = null;
+});
+
+// Auto-scroll so the wizard footer stays visible when switching to a taller card.
+// requestAnimationFrame ensures the new card has been laid out before we read scrollHeight.
+watch(currentStepIndex, () => {
+	requestAnimationFrame(() => {
+		const viewport = containerRef.value?.closest(
+			'[data-reka-scroll-area-viewport]',
+		) as HTMLElement | null;
+		viewport?.scrollTo({ top: viewport.scrollHeight, behavior: 'smooth' });
+	});
 });
 
 watch([isHovering, highlightedNodeIds, showWizard], ([hovering, nodeIds, visible]) => {
@@ -179,6 +191,7 @@ watch(
 
 <template>
 	<div
+		ref="containerRef"
 		v-if="showWizard"
 		data-test-id="builder-setup-wizard"
 		:class="$style.container"

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/BuilderSetupWizard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/BuilderSetupWizard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed, inject, ref, watch } from 'vue';
 import { useI18n, type BaseTextKey } from '@n8n/i18n';
 import { N8nIcon, N8nText } from '@n8n/design-system';
 
@@ -9,6 +9,7 @@ import { useBuilderSetupCards } from '@/features/ai/assistant/composables/useBui
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 import { useSetupPanelStore } from '@/features/setupPanel/setupPanel.store';
 import { isNodeGroupCard } from '@/features/setupPanel/setupPanel.utils';
+import { AiBuilderScrollToBottomKey } from '@/app/constants/injectionKeys';
 
 const emit = defineEmits<{
 	workflowExecuted: [];
@@ -18,6 +19,7 @@ const emit = defineEmits<{
 const i18n = useI18n();
 const builderStore = useBuilderStore();
 const setupPanelStore = useSetupPanelStore();
+const scrollToBottom = inject(AiBuilderScrollToBottomKey, () => {});
 
 const {
 	currentStepIndex,
@@ -48,7 +50,6 @@ const showCard = computed(
 
 const showWizard = computed(() => !wizardDismissed.value);
 
-const containerRef = ref<HTMLElement>();
 const isHovering = ref(false);
 
 function onMouseEnter() {
@@ -99,12 +100,7 @@ watch(currentCard, () => {
 // Auto-scroll so the wizard footer stays visible when switching to a taller card.
 // requestAnimationFrame ensures the new card has been laid out before we read scrollHeight.
 watch(currentStepIndex, () => {
-	requestAnimationFrame(() => {
-		const viewport = containerRef.value?.closest(
-			'[data-reka-scroll-area-viewport]',
-		) as HTMLElement | null;
-		viewport?.scrollTo({ top: viewport.scrollHeight, behavior: 'smooth' });
-	});
+	requestAnimationFrame(() => scrollToBottom());
 });
 
 watch([isHovering, highlightedNodeIds, showWizard], ([hovering, nodeIds, visible]) => {
@@ -191,7 +187,6 @@ watch(
 
 <template>
 	<div
-		ref="containerRef"
 		v-if="showWizard"
 		data-test-id="builder-setup-wizard"
 		:class="$style.container"


### PR DESCRIPTION
## Summary
- Auto-scroll chat to bottom when navigating between wizard cards of different heights, keeping the card footer visible
- Only apply bottom padding on messages container when the rating overlay is shown (avoids unnecessary spacing)
- Add `collisionPadding` prop to `N8nPopover` (default 5px) so dropdowns flip before clipping overflow boundaries
- Expose `scrollToBottom` from `N8nAskAssistantChat` and provide it via inject to the wizard

before:

https://github.com/user-attachments/assets/3aef1885-d155-4cb6-a2d1-91664212305e

after:

https://github.com/user-attachments/assets/0b865b52-1195-4370-b719-22e3b0b91163

https://www.notion.so/n8n/Z-index-The-dropdown-of-the-Resource-Locator-appears-behing-theehind-the-thumbs-up-down-icons-3335b6e0c94f80d7bc4df7adc786182b?source=copy_link

https://www.notion.so/n8n/Keep-the-setup-fixed-to-the-bottom-of-the-chat-when-resizing-32f5b6e0c94f8016b8e5d656826689bb?v=31e5b6e0c94f8171b1a7000c71d5169b&source=copy_link


## Test plan
- [ ] Use the "Invoice processing" suggested workflow on the empty builder state to create test workflow. May explicitly ask for google sheets node

🤖 Generated with [Claude Code](https://claude.com/claude-code)