### PR TITLE
feat(core): Add OIDC test login endpoint with frontend Test button

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -145,6 +145,7 @@ export {
 } from './roles/role-project-members-response.dto';
 
 export { OidcConfigDto } from './oidc/config.dto';
+export { TestOidcConfigResponseDto } from './oidc/test-oidc-config-response.dto';
 
 export { CreateDataTableDto } from './data-table/create-data-table.dto';
 export { UpdateDataTableDto } from './data-table/update-data-table.dto';

--- a/packages/@n8n/api-types/src/dto/oidc/test-oidc-config-response.dto.ts
+++ b/packages/@n8n/api-types/src/dto/oidc/test-oidc-config-response.dto.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+
+export class TestOidcConfigResponseDto extends Z.class({
+	url: z.string().url(),
+}) {}

--- a/packages/cli/src/modules/sso-oidc/__tests__/oidc.controller.ee.test.ts
+++ b/packages/cli/src/modules/sso-oidc/__tests__/oidc.controller.ee.test.ts
@@ -39,6 +39,11 @@ describe('OidcController', () => {
 	});
 
 	describe('callbackHandler', () => {
+		beforeEach(() => {
+			// Default: non-test mode for regular login tests
+			oidcService.verifyState.mockReturnValue({ state: 'n8n_state:uuid' });
+		});
+
 		test('Should issue cookie with MFA flag set to true on successful OIDC login', async () => {
 			const req = mock<AuthlessRequest>({
 				originalUrl: '/sso/oidc/callback?code=auth_code&state=state_value',
@@ -146,6 +151,101 @@ describe('OidcController', () => {
 			// Verify that issueCookie was not called when login fails
 			expect(authService.issueCookie).not.toHaveBeenCalled();
 			expect(res.redirect).not.toHaveBeenCalled();
+		});
+
+		test('Should render success page in test mode without creating session', async () => {
+			const req = mock<AuthlessRequest>({
+				originalUrl: '/sso/oidc/callback?code=auth_code&state=state_value',
+				cookies: {
+					[OIDC_STATE_COOKIE_NAME]: 'state_value',
+					[OIDC_NONCE_COOKIE_NAME]: 'nonce_value',
+				},
+			});
+			const res = mock<Response>({ send: jest.fn().mockReturnThis() });
+
+			oidcService.verifyState.mockReturnValueOnce({
+				state: 'n8n_state:uuid',
+				testMode: true,
+			});
+			oidcService.processTestCallback.mockResolvedValueOnce({
+				claims: { sub: 'test-sub', email: 'test@example.com' },
+				userInfo: {
+					sub: 'test-sub',
+					email: 'test@example.com',
+					given_name: 'Test',
+					family_name: 'User',
+				},
+			});
+
+			await controller.callbackHandler(req, res);
+
+			expect(oidcService.processTestCallback).toHaveBeenCalledWith(
+				expect.any(URL),
+				'state_value',
+				'nonce_value',
+			);
+			expect(res.send).toHaveBeenCalledWith(
+				expect.stringContaining('OIDC Connection Test was successful'),
+			);
+			expect(res.send).toHaveBeenCalledWith(expect.stringContaining('test@example.com'));
+			expect(authService.issueCookie).not.toHaveBeenCalled();
+			expect(res.redirect).not.toHaveBeenCalled();
+		});
+
+		test('Should render failure page in test mode when processTestCallback throws', async () => {
+			const req = mock<AuthlessRequest>({
+				originalUrl: '/sso/oidc/callback?code=auth_code&state=state_value',
+				cookies: {
+					[OIDC_STATE_COOKIE_NAME]: 'state_value',
+					[OIDC_NONCE_COOKIE_NAME]: 'nonce_value',
+				},
+			});
+			const res = mock<Response>({ send: jest.fn().mockReturnThis() });
+
+			oidcService.verifyState.mockReturnValueOnce({
+				state: 'n8n_state:uuid',
+				testMode: true,
+			});
+			oidcService.processTestCallback.mockRejectedValueOnce(
+				new Error('Invalid authorization code'),
+			);
+
+			await controller.callbackHandler(req, res);
+
+			expect(res.send).toHaveBeenCalledWith(expect.stringContaining('OIDC Connection Test failed'));
+			expect(res.send).toHaveBeenCalledWith(expect.stringContaining('Invalid authorization code'));
+			expect(authService.issueCookie).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('testConnection', () => {
+		test('Should return URL and set cookies', async () => {
+			const req = mock<Request>();
+			const res = mock<Response>();
+			globalConfig.auth.cookie = { samesite: 'lax', secure: true };
+
+			const mockAuthUrl = new URL('https://provider.com/auth?client_id=123');
+			oidcService.generateTestLoginUrl.mockResolvedValueOnce({
+				url: mockAuthUrl,
+				state: 'test_state',
+				nonce: 'test_nonce',
+			});
+
+			const result = await controller.testConnection(req, res);
+
+			expect(result).toEqual({ url: 'https://provider.com/auth?client_id=123' });
+			expect(res.cookie).toHaveBeenCalledWith(OIDC_STATE_COOKIE_NAME, 'test_state', {
+				httpOnly: true,
+				sameSite: 'lax',
+				secure: true,
+				maxAge: 15 * Time.minutes.toMilliseconds,
+			});
+			expect(res.cookie).toHaveBeenCalledWith(OIDC_NONCE_COOKIE_NAME, 'test_nonce', {
+				httpOnly: true,
+				sameSite: 'lax',
+				secure: true,
+				maxAge: 15 * Time.minutes.toMilliseconds,
+			});
 		});
 	});
 

--- a/packages/cli/src/modules/sso-oidc/__tests__/oidc.controller.ee.test.ts
+++ b/packages/cli/src/modules/sso-oidc/__tests__/oidc.controller.ee.test.ts
@@ -1,7 +1,7 @@
 import type { Logger } from '@n8n/backend-common';
 import type { GlobalConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
-import { GLOBAL_MEMBER_ROLE, type User } from '@n8n/db';
+import { GLOBAL_MEMBER_ROLE, type AuthenticatedRequest, type User } from '@n8n/db';
 import { type Request, type Response } from 'express';
 import { mock } from 'jest-mock-extended';
 
@@ -220,7 +220,7 @@ describe('OidcController', () => {
 
 	describe('testConnection', () => {
 		test('Should return URL and set cookies', async () => {
-			const req = mock<Request>();
+			const req = mock<AuthenticatedRequest>();
 			const res = mock<Response>();
 			globalConfig.auth.cookie = { samesite: 'lax', secure: true };
 

--- a/packages/cli/src/modules/sso-oidc/oidc.controller.ee.ts
+++ b/packages/cli/src/modules/sso-oidc/oidc.controller.ee.ts
@@ -14,6 +14,7 @@ import { UrlService } from '@/services/url.service';
 
 import { OIDC_CLIENT_SECRET_REDACTED_VALUE } from './constants';
 import { OidcService } from './oidc.service.ee';
+import { renderOidcTestFailure, renderOidcTestSuccess } from './views/oidc-test-result';
 
 @RestController('/sso/oidc')
 export class OidcController {
@@ -49,6 +50,29 @@ export class OidcController {
 		return config;
 	}
 
+	@Post('/config/test')
+	@Licensed('feat:oidc')
+	@GlobalScope('oidc:manage')
+	async testConnection(_req: AuthenticatedRequest, res: Response) {
+		const authorization = await this.oidcService.generateTestLoginUrl();
+		const { samesite, secure } = this.globalConfig.auth.cookie;
+
+		res.cookie(OIDC_STATE_COOKIE_NAME, authorization.state, {
+			maxAge: 15 * Time.minutes.toMilliseconds,
+			httpOnly: true,
+			sameSite: samesite,
+			secure,
+		});
+		res.cookie(OIDC_NONCE_COOKIE_NAME, authorization.nonce, {
+			maxAge: 15 * Time.minutes.toMilliseconds,
+			httpOnly: true,
+			sameSite: samesite,
+			secure,
+		});
+
+		return { url: authorization.url.toString() };
+	}
+
 	@Get('/login', { skipAuth: true })
 	@Licensed('feat:oidc')
 	async redirectToAuthProvider(_req: Request, res: Response) {
@@ -70,7 +94,7 @@ export class OidcController {
 		res.redirect(authorization.url.toString());
 	}
 
-	@Get('/callback', { skipAuth: true })
+	@Get('/callback', { skipAuth: true, usesTemplates: true })
 	@Licensed('feat:oidc')
 	async callbackHandler(req: AuthlessRequest, res: Response) {
 		const fullUrl = `${this.urlService.getInstanceBaseUrl()}${req.originalUrl}`;
@@ -89,12 +113,24 @@ export class OidcController {
 			throw new BadRequestError('Invalid nonce');
 		}
 
-		const user = await this.oidcService.loginUser(callbackUrl, state, nonce);
+		const stateInfo = this.oidcService.verifyState(state);
 
 		res.clearCookie(OIDC_STATE_COOKIE_NAME);
 		res.clearCookie(OIDC_NONCE_COOKIE_NAME);
+
+		if (stateInfo.testMode) {
+			try {
+				const result = await this.oidcService.processTestCallback(callbackUrl, state, nonce);
+				return res.send(renderOidcTestSuccess(result));
+			} catch (error) {
+				return res.send(renderOidcTestFailure(error));
+			}
+		}
+
+		const user = await this.oidcService.loginUser(callbackUrl, state, nonce);
+
 		this.authService.issueCookie(res, user, true, req.browserId);
 
-		res.redirect('/');
+		return res.redirect('/');
 	}
 }

--- a/packages/cli/src/modules/sso-oidc/oidc.service.ee.ts
+++ b/packages/cli/src/modules/sso-oidc/oidc.service.ee.ts
@@ -102,19 +102,25 @@ export class OidcService {
 		};
 	}
 
-	generateState() {
+	generateState(testMode = false) {
 		const state = `n8n_state:${randomUUID()}`;
+		const payload: Record<string, unknown> = { state };
+		if (testMode) {
+			payload.testMode = true;
+		}
 		return {
-			signed: this.jwtService.sign({ state }, { expiresIn: '15m' }),
+			signed: this.jwtService.sign(payload, { expiresIn: '15m' }),
 			plaintext: state,
 		};
 	}
 
-	verifyState(signedState: string) {
+	verifyState(signedState: string): { state: string; testMode?: boolean } {
 		let state: string;
+		let testMode: boolean | undefined;
 		try {
 			const decodedState = this.jwtService.verify(signedState);
 			state = decodedState?.state;
+			testMode = decodedState?.testMode;
 		} catch (error) {
 			this.logger.error('Failed to verify state', { error });
 			throw new BadRequestError('Invalid state');
@@ -140,7 +146,7 @@ export class OidcService {
 			this.logger.error('Provided state is not formatted correctly');
 			throw new BadRequestError('Invalid state');
 		}
-		return state;
+		return { state, testMode };
 	}
 
 	generateNonce() {
@@ -223,7 +229,7 @@ export class OidcService {
 		await this.loadOpenIdClient();
 		const configuration = await this.getOidcConfiguration();
 
-		const expectedState = this.verifyState(storedState);
+		const { state: expectedState } = this.verifyState(storedState);
 		const expectedNonce = this.verifyNonce(storedNonce);
 
 		let tokens;
@@ -333,6 +339,101 @@ export class OidcService {
 		await this.applySsoProvisioning(user, claims);
 
 		return user;
+	}
+
+	async generateTestLoginUrl(): Promise<{ url: URL; state: string; nonce: string }> {
+		await this.loadOpenIdClient();
+		const config = await this.loadConfig(true);
+
+		const configuration = await this.createProxyAwareConfiguration(
+			config.discoveryEndpoint,
+			config.clientId,
+			config.clientSecret,
+		);
+
+		const state = this.generateState(true);
+		const nonce = this.generateNonce();
+
+		const provisioningConfig = await this.provisioningService.getConfig();
+		const provisioningEnabled =
+			provisioningConfig.scopesProvisionInstanceRole ||
+			provisioningConfig.scopesProvisionProjectRoles;
+
+		const scope = provisioningEnabled
+			? `openid email profile ${provisioningConfig.scopesName}`
+			: 'openid email profile';
+
+		const authorizationURL = this.openidClient.buildAuthorizationUrl(configuration, {
+			redirect_uri: this.getCallbackUrl(),
+			response_type: 'code',
+			scope,
+			prompt: config.prompt,
+			state: state.plaintext,
+			nonce: nonce.plaintext,
+			...(config.authenticationContextClassReference.length > 0 && {
+				acr_values: config.authenticationContextClassReference.join(' '),
+			}),
+		});
+
+		return { url: authorizationURL, state: state.signed, nonce: nonce.signed };
+	}
+
+	async processTestCallback(
+		callbackUrl: URL,
+		storedState: string,
+		storedNonce: string,
+	): Promise<{ claims: Record<string, unknown>; userInfo: Record<string, unknown> }> {
+		await this.loadOpenIdClient();
+		const config = await this.loadConfig(true);
+
+		const configuration = await this.createProxyAwareConfiguration(
+			config.discoveryEndpoint,
+			config.clientId,
+			config.clientSecret,
+		);
+
+		const { state: expectedState } = this.verifyState(storedState);
+		const expectedNonce = this.verifyNonce(storedNonce);
+
+		let tokens;
+		try {
+			tokens = await this.openidClient.authorizationCodeGrant(configuration, callbackUrl, {
+				expectedState,
+				expectedNonce,
+			});
+		} catch (error) {
+			this.logger.error('Failed to exchange authorization code for tokens', { error });
+			throw new BadRequestError('Invalid authorization code');
+		}
+
+		let claims;
+		try {
+			claims = tokens.claims();
+		} catch (error) {
+			this.logger.error('Failed to extract claims from tokens', { error });
+			throw new BadRequestError('Invalid token');
+		}
+
+		if (!claims) {
+			throw new ForbiddenError('No claims found in the OIDC token');
+		}
+
+		let userInfo;
+		try {
+			userInfo = await this.openidClient.fetchUserInfo(
+				configuration,
+				tokens.access_token,
+				claims.sub,
+			);
+		} catch (error) {
+			this.logger.error('Failed to fetch user info', { error });
+			throw new BadRequestError('Invalid token');
+		}
+
+		return {
+			claims: claims as unknown as Record<string, unknown>,
+			userInfo: userInfo as unknown as Record<string, unknown>,
+		};
 	}
 
 	private async applySsoProvisioning(user: User, claims: any) {

--- a/packages/cli/src/modules/sso-oidc/oidc.service.ee.ts
+++ b/packages/cli/src/modules/sso-oidc/oidc.service.ee.ts
@@ -431,8 +431,8 @@ export class OidcService {
 		}
 
 		return {
-			claims: claims as unknown as Record<string, unknown>,
-			userInfo: userInfo as unknown as Record<string, unknown>,
+			claims: { ...claims },
+			userInfo: { ...userInfo },
 		};
 	}
 

--- a/packages/cli/src/modules/sso-oidc/views/oidc-test-result.ts
+++ b/packages/cli/src/modules/sso-oidc/views/oidc-test-result.ts
@@ -1,0 +1,63 @@
+const PAGE_STYLES = `
+body { background: rgb(251,252,254); font-family: 'Open Sans', sans-serif; padding: 10px; margin: auto; width: 500px; top: 40%; position: relative; }
+h1 { font-size: 16px; font-weight: 400; margin: 0 0 10px 0; }
+h2 { color: rgb(0, 0, 0); font-size: 12px; font-weight: 400; margin: 0 0 10px 0; }
+button { border: 1px solid rgb(219, 223, 231); background: rgb(255, 255, 255); border-radius: 4px; padding: 10px; cursor: pointer; }
+ul { border: 1px solid rgb(219, 223, 231); border-radius: 4px; padding: 10px; }
+li { list-style: none; margin: 0; color: rgb(125, 125, 125); font-size: 12px; }
+`;
+
+function escapeHtml(value: unknown): string {
+	return String(value ?? '(n/a)')
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;');
+}
+
+export function renderOidcTestSuccess({
+	userInfo,
+}: {
+	claims: Record<string, unknown>;
+	userInfo: Record<string, unknown>;
+}): string {
+	const email = escapeHtml(userInfo.email);
+	const firstName = escapeHtml(userInfo.given_name);
+	const lastName = escapeHtml(userInfo.family_name);
+	const sub = escapeHtml(userInfo.sub);
+
+	return `<!DOCTYPE html>
+<html>
+<head><title>n8n - OIDC Connection Test Result</title><style>${PAGE_STYLES}h1 { color: rgb(0, 0, 0); }</style></head>
+<body>
+<div style="text-align:center">
+	<h1>OIDC Connection Test was successful</h1>
+	<button onclick="window.close()">You can close this window now</button>
+	<p></p>
+	<h2>Here are the attributes returned by your OIDC provider:</h2>
+	<ul>
+		<li><strong>Email:</strong> ${email}</li>
+		<li><strong>First Name:</strong> ${firstName}</li>
+		<li><strong>Last Name:</strong> ${lastName}</li>
+		<li><strong>Subject:</strong> ${sub}</li>
+	</ul>
+</div>
+</body>
+</html>`;
+}
+
+export function renderOidcTestFailure(error: unknown): string {
+	const message = escapeHtml(error instanceof Error ? error.message : String(error));
+
+	return `<!DOCTYPE html>
+<html>
+<head><title>n8n - OIDC Connection Test Result</title><style>${PAGE_STYLES}h1 { color: rgb(240, 60, 60); }</style></head>
+<body>
+<div style="text-align:center">
+	<h1>OIDC Connection Test failed</h1>
+	<h2>${message}</h2>
+	<button onclick="window.close()">You can close this window now</button>
+</div>
+</body>
+</html>`;
+}

--- a/packages/cli/test/integration/oidc/oidc.service.ee.test.ts
+++ b/packages/cli/test/integration/oidc/oidc.service.ee.test.ts
@@ -977,7 +977,7 @@ describe('OIDC service', () => {
 		it('should generate and verify a valid state', () => {
 			const state = oidcService.generateState();
 			const decoded = oidcService.verifyState(state.signed);
-			expect(decoded).toBe(state.plaintext);
+			expect(decoded).toEqual({ state: state.plaintext, testMode: undefined });
 		});
 
 		it('should generate and verify a valid nonce', () => {

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4332,6 +4332,7 @@
 	"settings.sso.settings.userRoleProvisioning.option.instanceRole.label": "Instance role",
 	"settings.sso.settings.userRoleProvisioning.option.instanceAndProjectRoles.label": "Instance and project roles",
 	"settings.sso.settings.test": "Test settings",
+	"settings.sso.settings.test.error": "Error testing OIDC SSO configuration",
 	"settings.sso.settings.save": "Save settings",
 	"settings.sso.settings.unsavedChanges.title": "Unsaved changes",
 	"settings.sso.settings.unsavedChanges.message": "You have unsaved changes. They'll be lost if you leave.",

--- a/packages/frontend/@n8n/rest-api-client/src/api/sso.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/sso.ts
@@ -54,6 +54,10 @@ export const saveOidcConfig = async (
 	return await makeRestApiRequest(context, 'POST', '/sso/oidc/config', data);
 };
 
+export const testOidcConfig = async (context: IRestApiContext): Promise<{ url: string }> => {
+	return await makeRestApiRequest(context, 'POST', '/sso/oidc/config/test');
+};
+
 export const initOidcLogin = async (context: IRestApiContext): Promise<string> => {
 	return await makeRestApiRequest(context, 'GET', '/sso/oidc/login');
 };

--- a/packages/frontend/@n8n/rest-api-client/src/api/sso.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/sso.ts
@@ -1,4 +1,9 @@
-import type { OidcConfigDto, SamlPreferences, SamlToggleDto } from '@n8n/api-types';
+import type {
+	OidcConfigDto,
+	SamlPreferences,
+	SamlToggleDto,
+	TestOidcConfigResponseDto,
+} from '@n8n/api-types';
 
 import type { IRestApiContext } from '../types';
 import { makeRestApiRequest } from '../utils';
@@ -54,7 +59,9 @@ export const saveOidcConfig = async (
 	return await makeRestApiRequest(context, 'POST', '/sso/oidc/config', data);
 };
 
-export const testOidcConfig = async (context: IRestApiContext): Promise<{ url: string }> => {
+export const testOidcConfig = async (
+	context: IRestApiContext,
+): Promise<TestOidcConfigResponseDto> => {
 	return await makeRestApiRequest(context, 'POST', '/sso/oidc/config/test');
 };
 

--- a/packages/frontend/editor-ui/src/features/settings/sso/components/OidcSettingsForm.vue
+++ b/packages/frontend/editor-ui/src/features/settings/sso/components/OidcSettingsForm.vue
@@ -80,7 +80,7 @@ const loadOidcConfig = async () => {
 	try {
 		await getOidcConfig();
 	} catch (error) {
-		toast.showError(error, 'error');
+		toast.showError(error, i18n.baseText('settings.sso.settings.save.error_oidc'));
 	}
 };
 
@@ -198,7 +198,7 @@ const onTest = async () => {
 			window.open(url, '_blank');
 		}
 	} catch (error) {
-		toast.showError(error, 'error');
+		toast.showError(error, i18n.baseText('settings.sso.settings.test.error'));
 	}
 };
 

--- a/packages/frontend/editor-ui/src/features/settings/sso/components/OidcSettingsForm.vue
+++ b/packages/frontend/editor-ui/src/features/settings/sso/components/OidcSettingsForm.vue
@@ -183,6 +183,25 @@ function sendTrackingEvent(config: OidcConfigDto) {
 	telemetry.track('User updated single sign on settings', trackingMetadata);
 }
 
+const isTestEnabled = computed(
+	() =>
+		!!ssoStore.oidcConfig?.discoveryEndpoint &&
+		ssoStore.oidcConfig.discoveryEndpoint !== '' &&
+		!!ssoStore.oidcConfig?.clientId &&
+		!!ssoStore.oidcConfig?.clientSecret,
+);
+
+const onTest = async () => {
+	try {
+		const { url } = await ssoStore.testOidcConfig();
+		if (typeof window !== 'undefined') {
+			window.open(url, '_blank');
+		}
+	} catch (error) {
+		toast.showError(error, 'error');
+	}
+};
+
 const hasUnsavedChanges = computed(() => !cannotSaveOidcSettings.value && !savingForm.value);
 
 defineExpose({ hasUnsavedChanges, onSave: onOidcSettingsSave });
@@ -291,6 +310,15 @@ onMounted(async () => {
 				@click="onOidcSettingsSave(false)"
 			>
 				{{ i18n.baseText('settings.sso.settings.save') }}
+			</N8nButton>
+			<N8nButton
+				variant="subtle"
+				:disabled="!isTestEnabled"
+				size="large"
+				data-test-id="sso-oidc-test"
+				@click="onTest"
+			>
+				{{ i18n.baseText('settings.sso.settings.test') }}
 			</N8nButton>
 		</div>
 	</div>

--- a/packages/frontend/editor-ui/src/features/settings/sso/sso.store.ts
+++ b/packages/frontend/editor-ui/src/features/settings/sso/sso.store.ts
@@ -144,6 +144,8 @@ export const useSSOStore = defineStore('sso', () => {
 		return savedConfig;
 	};
 
+	const testOidcConfig = async () => await ssoApi.testOidcConfig(rootStore.restApiContext);
+
 	const isOidcLoginEnabled = computed({
 		get: () => oidc.value.loginEnabled,
 		set: (value: boolean) => {
@@ -227,6 +229,7 @@ export const useSSOStore = defineStore('sso', () => {
 		isDefaultAuthenticationOidc,
 		getOidcConfig,
 		saveOidcConfig,
+		testOidcConfig,
 
 		ldap,
 		isLdapLoginEnabled,


### PR DESCRIPTION
## Summary

- Add `POST /sso/oidc/config/test` endpoint that initiates an OIDC authorization flow in test mode — captures IdP claims and renders a result page without creating a session or modifying user data
- Encode a `testMode` flag in the OIDC state JWT so the callback handler can distinguish test flows from real logins
- Add a "Test" button to the OIDC settings form in the frontend (enabled when discovery endpoint, client ID, and client secret are configured)
- Render success/failure HTML pages showing returned OIDC attributes (email, name, subject) with proper HTML escaping

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-502/oidc-add-test-login

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

## How to test

1. Configure an OIDC provider in **Settings → SSO → OIDC** (discovery endpoint, client ID, client secret)
2. Click the **Test** button — a new browser tab opens with the IdP login page
3. Authenticate with the IdP — the tab should render a success page showing the returned attributes (email, first name, last name, subject)
4. If authentication fails or the provider returns an error, the tab should render a failure page with the error message
5. Verify that no session cookie is set and no user record is created/modified after the test flow
