### PR TITLE
feat(core): Add Zod validation schemas for token-exchange external input

### DIFF
--- a/packages/cli/src/modules/token-exchange/__tests__/token-exchange.schemas.test.ts
+++ b/packages/cli/src/modules/token-exchange/__tests__/token-exchange.schemas.test.ts
@@ -1,0 +1,289 @@
+import {
+	ExternalTokenClaimsSchema,
+	TOKEN_EXCHANGE_GRANT_TYPE,
+	TokenExchangeRequestSchema,
+	TrustedKeySourceSchema,
+} from '../token-exchange.schemas';
+
+describe('token-exchange.schemas', () => {
+	describe('ExternalTokenClaimsSchema', () => {
+		const validClaims = {
+			sub: 'user-123',
+			iss: 'https://idp.example.com',
+			aud: 'my-service',
+			iat: 1700000000,
+			exp: 1700003600,
+			jti: 'unique-jwt-id',
+		};
+
+		describe('valid input', () => {
+			test('accepts minimal required claims', () => {
+				expect(ExternalTokenClaimsSchema.safeParse(validClaims).success).toBe(true);
+			});
+
+			test('accepts aud as array of strings', () => {
+				const result = ExternalTokenClaimsSchema.safeParse({
+					...validClaims,
+					aud: ['service-a', 'service-b'],
+				});
+				expect(result.success).toBe(true);
+			});
+
+			test('accepts all optional fields', () => {
+				const result = ExternalTokenClaimsSchema.safeParse({
+					...validClaims,
+					email: 'alice@example.com',
+					given_name: 'Alice',
+					family_name: 'Smith',
+					role: 'admin',
+				});
+				expect(result.success).toBe(true);
+			});
+
+			test('accepts role as array', () => {
+				const result = ExternalTokenClaimsSchema.safeParse({
+					...validClaims,
+					role: ['admin', 'viewer'],
+				});
+				expect(result.success).toBe(true);
+			});
+		});
+
+		describe('invalid input', () => {
+			test.each([
+				{
+					name: 'missing sub',
+					input: { ...validClaims, sub: undefined },
+					errorPath: ['sub'],
+				},
+				{
+					name: 'missing iss',
+					input: { ...validClaims, iss: undefined },
+					errorPath: ['iss'],
+				},
+				{
+					name: 'iss is not a valid URL',
+					input: { ...validClaims, iss: 'not-a-url' },
+					errorPath: ['iss'],
+				},
+				{
+					name: 'missing aud',
+					input: { ...validClaims, aud: undefined },
+					errorPath: ['aud'],
+				},
+				{
+					name: 'missing iat',
+					input: { ...validClaims, iat: undefined },
+					errorPath: ['iat'],
+				},
+				{
+					name: 'missing exp',
+					input: { ...validClaims, exp: undefined },
+					errorPath: ['exp'],
+				},
+				{
+					name: 'missing jti',
+					input: { ...validClaims, jti: undefined },
+					errorPath: ['jti'],
+				},
+				{
+					name: 'email is not a valid email',
+					input: { ...validClaims, email: 'not-an-email' },
+					errorPath: ['email'],
+				},
+				{
+					name: 'sub is empty string',
+					input: { ...validClaims, sub: '' },
+					errorPath: ['sub'],
+				},
+				{
+					name: 'jti is empty string',
+					input: { ...validClaims, jti: '' },
+					errorPath: ['jti'],
+				},
+			])('rejects $name', ({ input, errorPath }) => {
+				const result = ExternalTokenClaimsSchema.safeParse(input);
+				expect(result.success).toBe(false);
+				expect(result.error?.issues[0].path).toEqual(errorPath);
+			});
+		});
+	});
+
+	describe('TrustedKeySourceSchema', () => {
+		const validStatic = {
+			type: 'static' as const,
+			kid: 'key-1',
+			algorithms: ['RS256'],
+			key: '-----BEGIN PUBLIC KEY-----\nMIIBIjAN...\n-----END PUBLIC KEY-----',
+			issuer: 'https://idp.example.com',
+		};
+
+		const validJwks = {
+			type: 'jwks' as const,
+			url: 'https://idp.example.com/.well-known/jwks.json',
+			issuer: 'https://idp.example.com',
+		};
+
+		describe('static key source', () => {
+			test('accepts valid static key source', () => {
+				expect(TrustedKeySourceSchema.safeParse(validStatic).success).toBe(true);
+			});
+
+			test('accepts static key source with optional allowedRoles', () => {
+				const result = TrustedKeySourceSchema.safeParse({
+					...validStatic,
+					allowedRoles: ['admin', 'viewer'],
+				});
+				expect(result.success).toBe(true);
+			});
+
+			test.each([
+				{
+					name: 'missing kid',
+					input: { ...validStatic, kid: undefined },
+					errorPath: ['kid'],
+				},
+				{
+					name: 'missing algorithms',
+					input: { ...validStatic, algorithms: undefined },
+					errorPath: ['algorithms'],
+				},
+				{
+					name: 'empty algorithms array',
+					input: { ...validStatic, algorithms: [] },
+					errorPath: ['algorithms'],
+				},
+				{
+					name: 'missing key',
+					input: { ...validStatic, key: undefined },
+					errorPath: ['key'],
+				},
+				{
+					name: 'missing issuer',
+					input: { ...validStatic, issuer: undefined },
+					errorPath: ['issuer'],
+				},
+			])('rejects static source with $name', ({ input, errorPath }) => {
+				const result = TrustedKeySourceSchema.safeParse(input);
+				expect(result.success).toBe(false);
+				expect(result.error?.issues[0].path).toEqual(errorPath);
+			});
+		});
+
+		describe('jwks key source', () => {
+			test('accepts valid jwks key source', () => {
+				expect(TrustedKeySourceSchema.safeParse(validJwks).success).toBe(true);
+			});
+
+			test('accepts jwks key source with all optional fields', () => {
+				const result = TrustedKeySourceSchema.safeParse({
+					...validJwks,
+					allowedRoles: ['admin'],
+					cacheTtlSeconds: 300,
+				});
+				expect(result.success).toBe(true);
+			});
+
+			test.each([
+				{
+					name: 'missing url',
+					input: { ...validJwks, url: undefined },
+					errorPath: ['url'],
+				},
+				{
+					name: 'url is not a valid URL',
+					input: { ...validJwks, url: 'not-a-url' },
+					errorPath: ['url'],
+				},
+				{
+					name: 'missing issuer',
+					input: { ...validJwks, issuer: undefined },
+					errorPath: ['issuer'],
+				},
+				{
+					name: 'cacheTtlSeconds is zero',
+					input: { ...validJwks, cacheTtlSeconds: 0 },
+					errorPath: ['cacheTtlSeconds'],
+				},
+				{
+					name: 'cacheTtlSeconds is negative',
+					input: { ...validJwks, cacheTtlSeconds: -1 },
+					errorPath: ['cacheTtlSeconds'],
+				},
+			])('rejects jwks source with $name', ({ input, errorPath }) => {
+				const result = TrustedKeySourceSchema.safeParse(input);
+				expect(result.success).toBe(false);
+				expect(result.error?.issues[0].path).toEqual(errorPath);
+			});
+		});
+
+		test('rejects unknown type', () => {
+			const result = TrustedKeySourceSchema.safeParse({ type: 'unknown' });
+			expect(result.success).toBe(false);
+		});
+
+		test('rejects input without type', () => {
+			const result = TrustedKeySourceSchema.safeParse({ url: 'https://example.com' });
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe('TokenExchangeRequestSchema', () => {
+		const validRequest = {
+			grant_type: TOKEN_EXCHANGE_GRANT_TYPE,
+			subject_token: 'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.sig',
+		};
+
+		describe('valid input', () => {
+			test('accepts minimal required fields', () => {
+				expect(TokenExchangeRequestSchema.safeParse(validRequest).success).toBe(true);
+			});
+
+			test('accepts all optional fields', () => {
+				const result = TokenExchangeRequestSchema.safeParse({
+					...validRequest,
+					subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
+					actor_token: 'actor.jwt.token',
+					actor_token_type: 'urn:ietf:params:oauth:token-type:jwt',
+					requested_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+					scope: 'openid profile',
+					audience: 'https://api.example.com',
+					resource: 'https://api.example.com/resource',
+				});
+				expect(result.success).toBe(true);
+			});
+		});
+
+		describe('invalid input', () => {
+			test.each([
+				{
+					name: 'missing grant_type',
+					input: { ...validRequest, grant_type: undefined },
+					errorPath: ['grant_type'],
+				},
+				{
+					name: 'wrong grant_type value',
+					input: {
+						...validRequest,
+						grant_type: 'urn:ietf:params:oauth:grant-type:client_credentials',
+					},
+					errorPath: ['grant_type'],
+				},
+				{
+					name: 'missing subject_token',
+					input: { ...validRequest, subject_token: undefined },
+					errorPath: ['subject_token'],
+				},
+				{
+					name: 'empty subject_token',
+					input: { ...validRequest, subject_token: '' },
+					errorPath: ['subject_token'],
+				},
+			])('rejects $name', ({ input, errorPath }) => {
+				const result = TokenExchangeRequestSchema.safeParse(input);
+				expect(result.success).toBe(false);
+				expect(result.error?.issues[0].path).toEqual(errorPath);
+			});
+		});
+	});
+});

--- a/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod';
+
+/** RFC 8693 grant type URN for token exchange */
+export const TOKEN_EXCHANGE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:token-exchange' as const;
+
+/**
+ * Validates JWT claims originating from an external identity provider.
+ * Required: sub, iss (must be a valid URL), aud, iat, exp, jti
+ * Optional: email (must be valid email format), given_name, family_name, role
+ */
+export const ExternalTokenClaimsSchema = z.object({
+	sub: z.string().min(1),
+	iss: z.string().url(),
+	aud: z.union([z.string(), z.array(z.string())]),
+	iat: z.number().int(),
+	exp: z.number().int(),
+	jti: z.string().min(1),
+	email: z.string().email().optional(),
+	given_name: z.string().optional(),
+	family_name: z.string().optional(),
+	role: z.union([z.string(), z.array(z.string())]).optional(),
+});
+
+export type ExternalTokenClaims = z.infer<typeof ExternalTokenClaimsSchema>;
+
+/**
+ * Validates a trusted key source configuration.
+ * Discriminated union on 'type':
+ *   - 'static': inline public key with kid, algorithms, key, issuer
+ *   - 'jwks':   remote JWKS endpoint with url, issuer, optional cache TTL
+ */
+export const TrustedKeySourceSchema = z.discriminatedUnion('type', [
+	z.object({
+		type: z.literal('static'),
+		kid: z.string().min(1),
+		algorithms: z.array(z.string()).min(1),
+		key: z.string().min(1),
+		issuer: z.string().min(1),
+		allowedRoles: z.array(z.string()).optional(),
+	}),
+	z.object({
+		type: z.literal('jwks'),
+		url: z.string().url(),
+		issuer: z.string().min(1),
+		allowedRoles: z.array(z.string()).optional(),
+		cacheTtlSeconds: z.number().int().positive().optional(),
+	}),
+]);
+
+export type TrustedKeySource = z.infer<typeof TrustedKeySourceSchema>;
+export type StaticKeySource = Extract<TrustedKeySource, { type: 'static' }>;
+export type JwksKeySource = Extract<TrustedKeySource, { type: 'jwks' }>;
+
+/**
+ * Validates an RFC 8693 token exchange request form body.
+ * grant_type must be the token-exchange URN; subject_token is required.
+ */
+export const TokenExchangeRequestSchema = z.object({
+	grant_type: z.literal(TOKEN_EXCHANGE_GRANT_TYPE),
+	subject_token: z.string().min(1),
+	subject_token_type: z.string().optional(),
+	actor_token: z.string().optional(),
+	actor_token_type: z.string().optional(),
+	requested_token_type: z.string().optional(),
+	scope: z.string().optional(),
+	audience: z.string().optional(),
+	resource: z.string().optional(),
+});
+
+export type TokenExchangeRequest = z.infer<typeof TokenExchangeRequestSchema>;


### PR DESCRIPTION
 ## Summary                                                                                        
                                                                                                    
  Introduces three Zod validation schemas for all data originating from external                    
  sources in the token-exchange flow. These schemas act as the parse boundary for
  external input and are shared by services and controllers in subsequent tickets.                  
                                                                                                    
  **`ExternalTokenClaimsSchema`** — validates JWT claims from an external identity provider:        
  - Required: `sub`, `iss` (valid URL), `aud` (string or string[]), `iat`, `exp`, `jti`             
  - Optional: `email` (valid email format), `given_name`, `family_name`, `role` (string or string[])
                                                                                                    
  **`TrustedKeySourceSchema`** — discriminated union on `type`:                                     
  - `'static'`: inline public key with `kid`, `algorithms[]`, `key`, `issuer`; optional             
  `allowedRoles`                                                                                    
  - `'jwks'`: remote JWKS endpoint with `url` (valid URL), `issuer`; optional `allowedRoles`,
  `cacheTtlSeconds` (positive int)                                                                  
                  
  **`TokenExchangeRequestSchema`** — RFC 8693 token exchange form body:                             
  - `grant_type` locked to `urn:ietf:params:oauth:grant-type:token-exchange`
  - `subject_token` required; all other RFC 8693 fields optional                                    
                                                                                                    
  All schemas export their inferred TypeScript types. 36 unit tests cover valid                     
  input, optional fields, format validation (URL, email, positive int), and                         
  discriminated union edge cases.                                                                   
                                                                                                    
  ## Related Linear tickets, Github issues, and Community forum posts                               
                                                                                                    
  https://linear.app/n8n/issue/IAM-456                                                              
                  
  ## Review / Merge checklist                                                                       
                  
  - [x] PR title and summary are descriptive.                                                       
  ([conventions](../blob/master/.github/pull_request_title_conventions.md))
  - [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.             
  - [x] Tests included.                                                                             
  - [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
