### PR TITLE
fix(Schedule Node): Skip recurrence check during manual execution

### DIFF
--- a/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
+++ b/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
@@ -441,9 +441,11 @@ export class ScheduleTrigger implements INodeType {
 			}
 		}
 
-		const executeTrigger = (recurrence: IRecurrenceRule) => {
-			const shouldTrigger = recurrenceCheck(recurrence, staticData.recurrenceRules, timezone);
-			if (!shouldTrigger) return;
+		const executeTrigger = (recurrence: IRecurrenceRule, skipRecurrenceCheck = false) => {
+			if (!skipRecurrenceCheck) {
+				const shouldTrigger = recurrenceCheck(recurrence, staticData.recurrenceRules, timezone);
+				if (!shouldTrigger) return;
+			}
 
 			const momentTz = moment.tz(timezone);
 			const resultData = {
@@ -500,7 +502,7 @@ export class ScheduleTrigger implements INodeType {
 						});
 					}
 				}
-				executeTrigger(recurrence);
+				executeTrigger(recurrence, true);
 			};
 
 			return { manualTriggerFunction };

--- a/packages/nodes-base/nodes/Schedule/test/ScheduleTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Schedule/test/ScheduleTrigger.node.test.ts
@@ -135,6 +135,19 @@ describe('ScheduleTrigger', () => {
 			});
 		});
 
+		it('should emit when manually executed even with existing recurrence rules', async () => {
+			const { emit, manualTriggerFunction } = await testTriggerNode(ScheduleTrigger, {
+				mode: 'manual',
+				timezone,
+				node: { parameters: { rule: { interval: [{ field: 'hours', hoursInterval: 2 }] } } },
+				workflowStaticData: { recurrenceRules: [5] },
+			});
+
+			await manualTriggerFunction?.();
+
+			expect(emit).toHaveBeenCalledTimes(1);
+		});
+
 		it('should throw on invalid cron expressions in manual mode', async () => {
 			const { manualTriggerFunction } = await testTriggerNode(ScheduleTrigger, {
 				mode: 'manual',


### PR DESCRIPTION
## Summary

Fixes manual execution of Schedule Trigger workflows hanging indefinitely when the trigger has an `intervalSize > 1` (e.g. every 2 hours, every 3 days) and the workflow has previously run on a schedule.

**Root cause:** PR #25737 changed the `runManually` endpoint to load the workflow from the database instead of using frontend-submitted data. The DB-loaded workflow includes `staticData` containing `recurrenceRules` from previous scheduled executions. When `recurrenceCheck()` sees populated `recurrenceRules` and the current time doesn't match the recurrence interval pattern, it returns `false` — `emit()` is never called and the execution hangs.

**Fix:** Skip the `recurrenceCheck` when executing in manual mode. Manual execution is user-initiated and should always fire immediately regardless of recurrence state.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-447

## How to test manually

1. Import a workflow with a Schedule Trigger set to "every 2 hours" connected to a No-Op node
2. Activate the workflow and let it run at least once (or inject `staticData` via SQL to simulate a prior run)
3. Deactivate the workflow
4. Click "Execute workflow" and select the Schedule Trigger as the starting point
5. **Before fix:** execution hangs indefinitely with no data flowing
6. **After fix:** execution completes immediately with timestamp data

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)