### PR TITLE
refactor(core): Clean up dead migration code from early settings

### DIFF
--- a/packages/cli/src/modules/instance-ai/instance-ai-settings.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-settings.service.ts
@@ -108,20 +108,10 @@ export class InstanceAiSettingsService {
 		const row = await this.settingsRepository.findByKey(ADMIN_SETTINGS_KEY);
 		if (!row) return;
 
-		const persisted = jsonParse<PersistedAdminSettings & PersistedUserPreferences>(row.value, {
+		const persisted = jsonParse<PersistedAdminSettings>(row.value, {
 			fallbackValue: {},
 		});
 		this.applyAdminSettings(persisted);
-
-		// Migrate legacy user fields from admin settings (credentialId, modelName)
-		// — these were previously stored in the shared settings blob.
-		// They become defaults for users who haven't set their own preferences yet.
-		if (persisted.credentialId !== undefined || persisted.modelName !== undefined) {
-			this.userPreferences.set('__legacy_default__', {
-				credentialId: persisted.credentialId,
-				modelName: persisted.modelName,
-			});
-		}
 	}
 
 	// ── Admin settings ────────────────────────────────────────────────────
@@ -402,16 +392,10 @@ export class InstanceAiSettingsService {
 		if (persisted.subAgentMaxSteps !== undefined) c.subAgentMaxSteps = persisted.subAgentMaxSteps;
 		if (persisted.browserMcp !== undefined) c.browserMcp = persisted.browserMcp;
 		if (persisted.permissions) {
-			// Migrate legacy "activateWorkflow" → "publishWorkflow"
-			const perms = { ...persisted.permissions } as Record<string, unknown>;
-			if ('activateWorkflow' in perms && !('publishWorkflow' in perms)) {
-				perms.publishWorkflow = perms.activateWorkflow;
-				delete perms.activateWorkflow;
-			}
 			this.permissions = {
 				...DEFAULT_INSTANCE_AI_PERMISSIONS,
-				...perms,
-			} as typeof this.permissions;
+				...persisted.permissions,
+			};
 		}
 		if (persisted.mcpServers !== undefined) c.mcpServers = persisted.mcpServers;
 		if (persisted.sandboxEnabled !== undefined) c.sandboxEnabled = persisted.sandboxEnabled;
@@ -437,9 +421,7 @@ export class InstanceAiSettingsService {
 			return { ...prefs };
 		}
 
-		// Fall back to legacy defaults (migrated from old shared settings)
-		const legacy = this.userPreferences.get('__legacy_default__');
-		return legacy ? { ...legacy } : {};
+		return {};
 	}
 
 	private async persistAdminSettings(): Promise<void> {


### PR DESCRIPTION
## Summary

More seemingly dead code to support migration of instance AI settings, but these old early settings don't exist in any actual instances and we shouldn't need this.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
