### PR TITLE
feat(instance-ai): Pin data for nodes that bypass HTTP mock layer (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -704,6 +704,8 @@ export interface InstanceAiEvalMockHints {
 	nodeHints: Record<string, string>;
 	/** Warnings from Phase 1 hint generation or Phase 2 mock execution (API errors, empty results, etc.) */
 	warnings: string[];
+	/** Pin data generated for nodes that bypass the HTTP mock layer (AI roots, protocol nodes) */
+	bypassPinData: Record<string, Array<{ json: Record<string, unknown> }>>;
 }
 
 export interface InstanceAiEvalExecutionResult {

--- a/packages/cli/src/modules/instance-ai/__tests__/eval-workflow-analysis.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/eval-workflow-analysis.test.ts
@@ -1,0 +1,222 @@
+jest.mock('@n8n/instance-ai', () => ({
+	createEvalAgent: jest.fn(),
+	extractText: jest.fn(),
+}));
+
+jest.mock('../eval-node-config', () => ({
+	extractNodeConfig: jest.fn(),
+}));
+
+import type { IConnections, INode, IWorkflowBase } from 'n8n-workflow';
+
+import { identifyNodesForHints, identifyNodesForPinData } from '../eval-workflow-analysis';
+
+function makeNode(overrides: Partial<INode> & { name: string; type: string }): INode {
+	return {
+		id: overrides.name,
+		name: overrides.name,
+		type: overrides.type,
+		typeVersion: overrides.typeVersion ?? 1,
+		position: [0, 0],
+		parameters: {},
+		...overrides,
+	};
+}
+
+function makeWorkflow(nodes: INode[], connections: IConnections = {}): IWorkflowBase {
+	return {
+		id: 'test-workflow',
+		name: 'Test',
+		active: false,
+		nodes,
+		connections,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+	};
+}
+
+describe('identifyNodesForPinData', () => {
+	it('should identify AI root nodes as needing pin data', () => {
+		const nodes = [
+			makeNode({ name: 'ChatOpenAI', type: '@n8n/n8n-nodes-langchain.lmChatOpenAi' }),
+			makeNode({ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+			makeNode({ name: 'Set', type: 'n8n-nodes-base.set' }),
+		];
+		const connections: IConnections = {
+			ChatOpenAI: { ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 0 }]] },
+		};
+
+		const result = identifyNodesForPinData(makeWorkflow(nodes, connections));
+		const names = result.map((n) => n.name);
+
+		expect(names).toContain('Agent');
+		expect(names).not.toContain('ChatOpenAI');
+		expect(names).not.toContain('Set');
+	});
+
+	it('should identify protocol/bypass nodes as needing pin data', () => {
+		const nodes = [
+			makeNode({ name: 'My Redis', type: 'n8n-nodes-base.redis' }),
+			makeNode({ name: 'My Postgres', type: 'n8n-nodes-base.postgres' }),
+			makeNode({ name: 'My Kafka', type: 'n8n-nodes-base.kafka' }),
+			makeNode({ name: 'HTTP Request', type: 'n8n-nodes-base.httpRequest' }),
+			makeNode({ name: 'Set', type: 'n8n-nodes-base.set' }),
+		];
+
+		const result = identifyNodesForPinData(makeWorkflow(nodes));
+		const names = result.map((n) => n.name);
+
+		expect(names).toContain('My Redis');
+		expect(names).toContain('My Postgres');
+		expect(names).toContain('My Kafka');
+		expect(names).not.toContain('HTTP Request');
+		expect(names).not.toContain('Set');
+	});
+
+	it('should exclude disabled nodes', () => {
+		const nodes = [
+			makeNode({ name: 'My Redis', type: 'n8n-nodes-base.redis', disabled: true }),
+			makeNode({ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent', disabled: true }),
+		];
+		const connections: IConnections = {
+			ChatOpenAI: { ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 0 }]] },
+		};
+
+		const result = identifyNodesForPinData(makeWorkflow(nodes, connections));
+
+		expect(result).toHaveLength(0);
+	});
+
+	it('should return empty for workflow with only logic nodes', () => {
+		const nodes = [
+			makeNode({ name: 'Set', type: 'n8n-nodes-base.set' }),
+			makeNode({ name: 'IF', type: 'n8n-nodes-base.if' }),
+			makeNode({ name: 'Merge', type: 'n8n-nodes-base.merge' }),
+		];
+
+		const result = identifyNodesForPinData(makeWorkflow(nodes));
+
+		expect(result).toHaveLength(0);
+	});
+
+	it('should handle Agent with multiple sub-nodes', () => {
+		const nodes = [
+			makeNode({ name: 'OpenAI', type: '@n8n/n8n-nodes-langchain.lmChatOpenAi' }),
+			makeNode({ name: 'Memory', type: '@n8n/n8n-nodes-langchain.memoryBufferWindow' }),
+			makeNode({ name: 'Calculator', type: '@n8n/n8n-nodes-langchain.toolCalculator' }),
+			makeNode({ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+		];
+		const connections: IConnections = {
+			OpenAI: { ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 0 }]] },
+			Memory: { ai_memory: [[{ node: 'Agent', type: 'ai_memory', index: 0 }]] },
+			Calculator: { ai_tool: [[{ node: 'Agent', type: 'ai_tool', index: 0 }]] },
+		};
+
+		const result = identifyNodesForPinData(makeWorkflow(nodes, connections));
+		const names = result.map((n) => n.name);
+
+		expect(names).toEqual(['Agent']);
+	});
+
+	it('should identify all bypass node types', () => {
+		const bypassTypes = [
+			'n8n-nodes-base.redis',
+			'n8n-nodes-base.mongoDb',
+			'n8n-nodes-base.mySql',
+			'n8n-nodes-base.postgres',
+			'n8n-nodes-base.microsoftSql',
+			'n8n-nodes-base.snowflake',
+			'n8n-nodes-base.kafka',
+			'n8n-nodes-base.rabbitmq',
+			'n8n-nodes-base.mqtt',
+			'n8n-nodes-base.amqp',
+			'n8n-nodes-base.ftp',
+			'n8n-nodes-base.ssh',
+			'n8n-nodes-base.ldap',
+			'n8n-nodes-base.emailSend',
+			'n8n-nodes-base.rssFeedRead',
+			'n8n-nodes-base.git',
+		];
+
+		const nodes = bypassTypes.map((type, i) => makeNode({ name: `Node${i}`, type }));
+		const result = identifyNodesForPinData(makeWorkflow(nodes));
+
+		expect(result).toHaveLength(bypassTypes.length);
+	});
+});
+
+describe('identifyNodesForHints', () => {
+	it('should exclude AI sub-nodes from hints', () => {
+		const nodes = [
+			makeNode({ name: 'OpenAI', type: '@n8n/n8n-nodes-langchain.lmChatOpenAi' }),
+			makeNode({ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+			makeNode({ name: 'Slack', type: 'n8n-nodes-base.slack' }),
+		];
+		const connections: IConnections = {
+			OpenAI: { ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 0 }]] },
+		};
+
+		const result = identifyNodesForHints(makeWorkflow(nodes, connections));
+		const names = result.map((n) => n.name);
+
+		expect(names).not.toContain('OpenAI');
+		expect(names).not.toContain('Agent');
+		expect(names).toContain('Slack');
+	});
+
+	it('should exclude pinned bypass nodes from hints', () => {
+		const nodes = [
+			makeNode({ name: 'Webhook', type: 'n8n-nodes-base.webhook' }),
+			makeNode({ name: 'Redis', type: 'n8n-nodes-base.redis' }),
+			makeNode({ name: 'Slack', type: 'n8n-nodes-base.slack' }),
+			makeNode({ name: 'Set', type: 'n8n-nodes-base.set' }),
+		];
+
+		const result = identifyNodesForHints(makeWorkflow(nodes));
+		const names = result.map((n) => n.name);
+
+		expect(names).not.toContain('Redis');
+		expect(names).toContain('Webhook');
+		expect(names).toContain('Slack');
+		expect(names).toContain('Set');
+	});
+
+	it('should exclude disabled nodes', () => {
+		const nodes = [
+			makeNode({ name: 'Slack', type: 'n8n-nodes-base.slack', disabled: true }),
+			makeNode({ name: 'Gmail', type: 'n8n-nodes-base.gmail' }),
+		];
+
+		const result = identifyNodesForHints(makeWorkflow(nodes));
+		const names = result.map((n) => n.name);
+
+		expect(names).not.toContain('Slack');
+		expect(names).toContain('Gmail');
+	});
+
+	it('should return only HTTP-interceptible nodes for a mixed workflow', () => {
+		const nodes = [
+			makeNode({ name: 'Webhook', type: 'n8n-nodes-base.webhook' }),
+			makeNode({ name: 'OpenAI', type: '@n8n/n8n-nodes-langchain.lmChatOpenAi' }),
+			makeNode({ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+			makeNode({ name: 'Postgres', type: 'n8n-nodes-base.postgres' }),
+			makeNode({ name: 'Slack', type: 'n8n-nodes-base.slack' }),
+			makeNode({ name: 'Set', type: 'n8n-nodes-base.set' }),
+		];
+		const connections: IConnections = {
+			OpenAI: { ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 0 }]] },
+		};
+
+		const result = identifyNodesForHints(makeWorkflow(nodes, connections));
+		const names = result.map((n) => n.name);
+
+		// Should include: Webhook (trigger, gets hints), Slack (HTTP service), Set (logic)
+		expect(names).toContain('Webhook');
+		expect(names).toContain('Slack');
+		expect(names).toContain('Set');
+		// Should exclude: OpenAI (AI sub-node), Agent (AI root, pinned), Postgres (bypass, pinned)
+		expect(names).not.toContain('OpenAI');
+		expect(names).not.toContain('Agent');
+		expect(names).not.toContain('Postgres');
+	});
+});

--- a/packages/cli/src/modules/instance-ai/eval-execution.service.ts
+++ b/packages/cli/src/modules/instance-ai/eval-execution.service.ts
@@ -31,7 +31,17 @@ import { NodeTypes } from '@/node-types';
 import { getBase } from '@/workflow-execute-additional-data';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
-import { generateMockHints, identifyNodesForHints, type MockHints } from './eval-workflow-analysis';
+import type { WorkflowJSON } from '@n8n/workflow-sdk';
+import { normalizePinData } from '@n8n/workflow-sdk';
+
+import { generatePinData } from '@n8n/instance-ai/evaluations/support/pin-data-generator';
+
+import {
+	generateMockHints,
+	identifyNodesForHints,
+	identifyNodesForPinData,
+	type MockHints,
+} from './eval-workflow-analysis';
 import { createLlmMockHandler } from './llm-mock-handler';
 
 // ---------------------------------------------------------------------------
@@ -91,6 +101,7 @@ export class EvalExecutionService {
 		workflowEntity: IWorkflowBase,
 		scenarioHints?: string,
 	): Promise<MockHints> {
+		// Phase 1: Generate mock hints for HTTP-interceptible nodes
 		const hintNodes = identifyNodesForHints(workflowEntity);
 		const nodeNames = hintNodes.map((n) => n.name);
 
@@ -114,7 +125,54 @@ export class EvalExecutionService {
 			`[EvalMock] Phase 1 result — globalContext: ${hints.globalContext ? 'present' : 'EMPTY'}, triggerContent keys: ${JSON.stringify(Object.keys(hints.triggerContent))}, nodeHints: ${Object.keys(hints.nodeHints).join(', ')}`,
 		);
 
+		// Phase 1.5: Generate pin data for nodes that bypass the HTTP mock layer
+		const bypassNodes = identifyNodesForPinData(workflowEntity);
+		const bypassNodeNames = bypassNodes.map((n) => n.name);
+
+		if (bypassNodeNames.length > 0) {
+			this.logger.debug(
+				`[EvalMock] Generating pin data for ${bypassNodeNames.length} bypass nodes: ${bypassNodeNames.join(', ')}`,
+			);
+			hints.bypassPinData = await this.generateBypassPinData(
+				workflowEntity,
+				bypassNodeNames,
+				hints.globalContext,
+			);
+			this.logger.debug(
+				`[EvalMock] Phase 1.5 result — pinned nodes: ${Object.keys(hints.bypassPinData).join(', ') || 'none'}`,
+			);
+		}
+
 		return hints;
+	}
+
+	// ── Phase 1.5: Pin data for bypass nodes ─────────────────────────────
+
+	/**
+	 * Generate pin data for nodes that bypass the HTTP mock layer.
+	 * Uses the existing LLM-based pin data generator with Phase 1's globalContext
+	 * for cross-node data consistency.
+	 */
+	private async generateBypassPinData(
+		workflowEntity: IWorkflowBase,
+		bypassNodeNames: string[],
+		globalContext: string,
+	): Promise<IPinData> {
+		if (bypassNodeNames.length === 0) return {};
+
+		try {
+			const result = await generatePinData({
+				workflow: workflowEntity as unknown as WorkflowJSON,
+				nodeNames: bypassNodeNames,
+				instructions: globalContext ? { dataDescription: globalContext } : undefined,
+			});
+
+			return normalizePinData(result as unknown as IPinData);
+		} catch (error) {
+			const errorMsg = error instanceof Error ? error.message : String(error);
+			this.logger.error(`[EvalMock] Phase 1.5 pin data generation failed: ${errorMsg}`);
+			return {};
+		}
 	}
 
 	// ── Phase 2: Mock execution ────────────────────────────────────────────
@@ -149,7 +207,8 @@ export class EvalExecutionService {
 		additionalData.evalLlmMockHandler = this.createInterceptingHandler(mockHandler, nodeResults);
 		additionalData.hooks = new ExecutionLifecycleHooks('evaluation', executionId, workflowEntity);
 
-		const pinData = this.buildTriggerPinData(startNode, hints.triggerContent);
+		const triggerPinData = this.buildTriggerPinData(startNode, hints.triggerContent);
+		const pinData: IPinData = { ...triggerPinData, ...hints.bypassPinData };
 		const pinDataNodeNames = Object.keys(pinData);
 
 		// Check config completeness before execution — detect missing required parameters
@@ -158,9 +217,20 @@ export class EvalExecutionService {
 
 		// Mark the trigger node as pinned (it gets its output from pin data, not execution)
 		// Preserve any configIssues that checkNodeConfig may have already recorded.
-		if (Object.keys(pinData).length > 0) {
+		if (Object.keys(triggerPinData).length > 0) {
 			const existing = nodeResults[startNode.name];
 			nodeResults[startNode.name] = {
+				output: null,
+				interceptedRequests: [],
+				executionMode: 'pinned',
+				...(existing?.configIssues ? { configIssues: existing.configIssues } : {}),
+			};
+		}
+
+		// Mark bypass nodes as pinned
+		for (const nodeName of Object.keys(hints.bypassPinData)) {
+			const existing = nodeResults[nodeName];
+			nodeResults[nodeName] = {
 				output: null,
 				interceptedRequests: [],
 				executionMode: 'pinned',
@@ -382,7 +452,13 @@ export class EvalExecutionService {
 			success: false,
 			nodeResults: {},
 			errors: [message],
-			hints: { globalContext: '', triggerContent: {}, nodeHints: {}, warnings: [] },
+			hints: {
+				globalContext: '',
+				triggerContent: {},
+				nodeHints: {},
+				warnings: [],
+				bypassPinData: {},
+			},
 		};
 	}
 }

--- a/packages/cli/src/modules/instance-ai/eval-execution.service.ts
+++ b/packages/cli/src/modules/instance-ai/eval-execution.service.ts
@@ -171,7 +171,9 @@ export class EvalExecutionService {
 		} catch (error) {
 			const errorMsg = error instanceof Error ? error.message : String(error);
 			this.logger.error(`[EvalMock] Phase 1.5 pin data generation failed: ${errorMsg}`);
-			return {};
+			return normalizePinData(
+				Object.fromEntries(bypassNodeNames.map((nodeName) => [nodeName, [{ json: {} }]])) as IPinData,
+			);
 		}
 	}
 

--- a/packages/cli/src/modules/instance-ai/eval-workflow-analysis.ts
+++ b/packages/cli/src/modules/instance-ai/eval-workflow-analysis.ts
@@ -12,7 +12,7 @@
 
 import { Logger } from '@n8n/backend-common';
 import { Container } from '@n8n/di';
-import { type INode, type IWorkflowBase, jsonParse } from 'n8n-workflow';
+import { type INode, type IPinData, type IWorkflowBase, jsonParse } from 'n8n-workflow';
 
 import { createEvalAgent, extractText } from '@n8n/instance-ai';
 import { extractNodeConfig } from './eval-node-config';
@@ -22,39 +22,107 @@ import { extractNodeConfig } from './eval-node-config';
 // ---------------------------------------------------------------------------
 
 /**
- * Find node names that are AI sub-nodes (connected via ai_* connection types).
- * These are pinned via their root AI node and should not receive individual hints.
+ * Find node names that are targets of ai_* connections (Agent, Chain nodes).
+ * These are "root" AI nodes whose sub-nodes use vendor SDKs. Pinning the root
+ * prevents supplyData() on all connected sub-nodes, avoiding SDK calls entirely.
+ *
+ * Ported from @n8n/instance-ai/evaluations/support/service-node-classifier.ts
  */
-function findAiSubNodeNames(workflow: IWorkflowBase): Set<string> {
-	const subNodes = new Set<string>();
-	for (const [, nodeConns] of Object.entries(workflow.connections)) {
+function findAiRootNodeNames(workflow: IWorkflowBase): Set<string> {
+	const roots = new Set<string>();
+	for (const nodeConns of Object.values(workflow.connections)) {
 		for (const [connType, outputs] of Object.entries(nodeConns)) {
 			if (!connType.startsWith('ai_') || !Array.isArray(outputs)) continue;
 			for (const group of outputs) {
 				if (!Array.isArray(group)) continue;
 				for (const conn of group) {
 					if (typeof conn === 'object' && conn !== null && 'node' in conn) {
-						subNodes.add((conn as { node: string }).node);
+						roots.add((conn as { node: string }).node);
 					}
 				}
+			}
+		}
+	}
+	return roots;
+}
+
+/**
+ * Find node names that are sources of ai_* connections (LLM models, tools, memory).
+ * These are sub-nodes handled via their root — they should not be pinned individually
+ * or receive mock hints.
+ *
+ * Ported from @n8n/instance-ai/evaluations/support/service-node-classifier.ts
+ */
+function findAiSubNodeNames(workflow: IWorkflowBase): Set<string> {
+	const subNodes = new Set<string>();
+	for (const [sourceName, nodeConns] of Object.entries(workflow.connections)) {
+		for (const connType of Object.keys(nodeConns)) {
+			if (connType.startsWith('ai_')) {
+				subNodes.add(sourceName);
 			}
 		}
 	}
 	return subNodes;
 }
 
+// ---------------------------------------------------------------------------
+// Bypass node types — nodes that use non-HTTP protocols or bypass n8n's
+// request helper functions. These can't be intercepted by the eval mock handler.
+// ---------------------------------------------------------------------------
+
+const BYPASS_NODE_TYPES = new Set([
+	// Databases (TCP/binary protocol)
+	'n8n-nodes-base.redis',
+	'n8n-nodes-base.mongoDb',
+	'n8n-nodes-base.mySql',
+	'n8n-nodes-base.postgres',
+	'n8n-nodes-base.microsoftSql',
+	'n8n-nodes-base.snowflake',
+	// Message queues (TCP/binary protocol)
+	'n8n-nodes-base.kafka',
+	'n8n-nodes-base.rabbitmq',
+	'n8n-nodes-base.mqtt',
+	'n8n-nodes-base.amqp',
+	// File/network protocols
+	'n8n-nodes-base.ftp',
+	'n8n-nodes-base.ssh',
+	'n8n-nodes-base.ldap',
+	'n8n-nodes-base.emailSend',
+	// Non-helper HTTP
+	'n8n-nodes-base.rssFeedRead',
+	'n8n-nodes-base.git',
+]);
+
+/**
+ * Identify nodes that bypass the HTTP mock layer and need pin data instead.
+ * Returns AI root nodes (Agent, Chain) and protocol/bypass nodes.
+ */
+export function identifyNodesForPinData(workflow: IWorkflowBase): INode[] {
+	const aiRootNodes = findAiRootNodeNames(workflow);
+
+	return workflow.nodes.filter((node) => {
+		if (node.disabled) return false;
+		if (aiRootNodes.has(node.name)) return true;
+		if (BYPASS_NODE_TYPES.has(node.type)) return true;
+		return false;
+	});
+}
+
 /**
  * Identify which nodes in a workflow should receive mock hints.
- * Returns all active nodes except AI sub-nodes (which are handled via their root).
- * Hints are generated for every node — the mock handler and execution engine
- * decide how to use them (HTTP interception, pin data, or ignored for logic nodes).
+ * Excludes AI sub-nodes (handled via their root) and nodes that will be
+ * pinned (they don't execute, so hints are irrelevant for them).
  */
 export function identifyNodesForHints(workflow: IWorkflowBase): INode[] {
 	const aiSubNodes = findAiSubNodeNames(workflow);
+	const aiRootNodes = findAiRootNodeNames(workflow);
+	const pinnedNodeNames = new Set(identifyNodesForPinData(workflow).map((n) => n.name));
 
 	return workflow.nodes.filter((node) => {
 		if (node.disabled) return false;
 		if (aiSubNodes.has(node.name)) return false;
+		if (aiRootNodes.has(node.name)) return false;
+		if (pinnedNodeNames.has(node.name)) return false;
 		return true;
 	});
 }
@@ -72,6 +140,8 @@ export interface MockHints {
 	triggerContent: Record<string, unknown>;
 	/** Errors encountered during hint generation or mock execution */
 	warnings: string[];
+	/** Pin data for nodes that bypass the HTTP mock layer (AI roots, protocol nodes) */
+	bypassPinData: IPinData;
 }
 
 export interface GenerateMockHintsOptions {
@@ -160,6 +230,7 @@ export async function generateMockHints(options: GenerateMockHintsOptions): Prom
 		nodeHints: {},
 		triggerContent: {},
 		warnings: [],
+		bypassPinData: {},
 	};
 
 	if (nodeNames.length === 0) return emptyResult;
@@ -226,6 +297,7 @@ export async function generateMockHints(options: GenerateMockHintsOptions): Prom
 			nodeHints,
 			triggerContent: triggerContent as Record<string, unknown>,
 			warnings,
+			bypassPinData: {},
 		};
 	} catch (error) {
 		const errorMsg = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary

Adds Phase 1.5 to the eval framework: detect and pin nodes that bypass n8n's HTTP request helpers, so they skip execution entirely during eval instead of failing with credential/connection errors.

**What gets pinned:**
- **AI root nodes** (Agent, Chain) — detected via `ai_*` connection traversal. Pinning the root prevents `supplyData()` on all connected sub-nodes (LLM models, tools, memory), avoiding vendor SDK calls entirely.
- **Protocol nodes** (Redis, Postgres, MongoDB, Kafka, etc.) — curated `BYPASS_NODE_TYPES` list of 16 node types that use TCP/binary protocols or bypass request helpers.

**What stays unchanged:**
- Standard HTTP service nodes (Slack, Gmail, Google Sheets) continue to use the existing HTTP mock handler.
- Trigger pin data and logic node execution are unaffected.

**How it works:**
1. `identifyNodesForPinData()` detects bypass nodes in the workflow
2. `generateBypassPinData()` calls existing `generatePinData()` from `@n8n/instance-ai` with Phase 1's `globalContext` for cross-node consistency
3. Bypass pin data is merged with trigger pin data before execution
4. Pinned nodes are marked `executionMode: 'pinned'` in results

### Files changed
- `eval-workflow-analysis.ts` — Added `findAiRootNodeNames()`, `findAiSubNodeNames()`, `BYPASS_NODE_TYPES`, `identifyNodesForPinData()`, updated `identifyNodesForHints()`
- `eval-execution.service.ts` — Added Phase 1.5 orchestration, `generateBypassPinData()`, pin data merging
- `instance-ai.schema.ts` — Added `bypassPinData` to `InstanceAiEvalMockHints`
- `eval-workflow-analysis.test.ts` — 10 new tests

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2297

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)