### PR TITLE
fix(core): Restore missing axios request interceptor dropped during 1.x backport

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/axios-config.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/axios-config.ts
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import { stringify } from 'qs';
 
+import { setAxiosAgents } from './axios-utils';
+
 // Global axios defaults
 
 axios.defaults.timeout = 300000;
@@ -17,3 +19,15 @@ axios.defaults.paramsSerializer = (params) => {
 // Disable axios proxy, we handle it ourselves
 // Axios proxy option has problems: https://github.com/axios/axios/issues/4531
 axios.defaults.proxy = false;
+
+// Interceptor (side effect)
+axios.interceptors.request.use((config) => {
+	// If no content-type is set by us, prevent axios from force-setting the content-type to `application/x-www-form-urlencoded`
+	if (config.data === undefined) {
+		config.headers.setContentType(false, false);
+	}
+
+	setAxiosAgents(config);
+
+	return config;
+});


### PR DESCRIPTION
## Summary

- Restores the axios request interceptor that was omitted when PR #26852 was backported to the 1.x branch
- Without this interceptor, axios force-sets `Content-Type: application/x-www-form-urlencoded` on bodyless POST/PUT/PATCH requests, breaking APIs that validate Content-Type headers
- Also restores proxy agent configuration via `setAxiosAgents`

## Related Linear tickets, Github issues, and Community forum posts

Fixes #27769 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)