### PR TITLE
fix(core): Assert thread ownership on instance AI endpoints

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.controller.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.controller.test.ts
@@ -218,6 +218,50 @@ describe('InstanceAiController', () => {
 			// The stream should be closed, not written to
 			expect(sseRes.end).toHaveBeenCalled();
 		});
+
+		it('should close SSE stream when deferred ownership check rejects', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValueOnce('not_found');
+
+			const sseRes = mock<Response & { flush?: () => void }>({
+				setHeader: jest.fn(),
+				flushHeaders: jest.fn(),
+				write: jest.fn(),
+				end: jest.fn(),
+				flush: jest.fn(),
+			});
+
+			let subscribeHandler: ((stored: { id: number; event: unknown }) => void) | undefined;
+			eventBus.subscribe.mockImplementation((_threadId, handler) => {
+				subscribeHandler = handler as typeof subscribeHandler;
+				return jest.fn();
+			});
+			eventBus.getEventsAfter.mockReturnValue([]);
+			instanceAiService.getThreadStatus.mockReturnValue({
+				hasActiveRun: false,
+				isSuspended: false,
+				backgroundTasks: [],
+			} as never);
+
+			const sseReq = mock<AuthenticatedRequest>({
+				user: { id: USER_ID },
+				headers: {},
+				once: jest.fn(),
+			});
+
+			await controller.events(sseReq, sseRes, THREAD_ID, { lastEventId: undefined } as never);
+
+			// Make the deferred ownership check reject with an error
+			memoryService.checkThreadOwnership.mockRejectedValueOnce(new Error('DB connection lost'));
+
+			subscribeHandler!({
+				id: 1,
+				event: { type: 'text-delta', runId: 'r1', agentId: 'a1', payload: { text: 'data' } },
+			});
+
+			await new Promise((resolve) => setImmediate(resolve));
+
+			expect(sseRes.end).toHaveBeenCalled();
+		});
 	});
 
 	describe('cancel', () => {
@@ -393,6 +437,19 @@ describe('InstanceAiController', () => {
 		it('should require instanceAi:message scope', () => {
 			expect(scopeOf('getMemory')).toEqual({ scope: 'instanceAi:message', globalOnly: true });
 		});
+
+		it('should throw ForbiddenError for other user thread', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('other_user');
+
+			await expect(controller.getMemory(req, res, THREAD_ID)).rejects.toThrow(ForbiddenError);
+		});
+
+		it('should allow new threads', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('not_found');
+			memoryService.getWorkingMemory.mockResolvedValue({ content: '', template: '' });
+
+			await expect(controller.getMemory(req, res, THREAD_ID)).resolves.toBeDefined();
+		});
 	});
 
 	describe('updateMemory', () => {
@@ -401,6 +458,7 @@ describe('InstanceAiController', () => {
 		});
 
 		it('should update working memory', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('owned');
 			const payload = mock<InstanceAiUpdateMemoryRequest>({ content: 'new memory' });
 
 			const result = await controller.updateMemory(req, res, THREAD_ID, payload);
@@ -411,6 +469,24 @@ describe('InstanceAiController', () => {
 				THREAD_ID,
 				'new memory',
 			);
+		});
+
+		it('should throw ForbiddenError for other user thread', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('other_user');
+			const payload = mock<InstanceAiUpdateMemoryRequest>({ content: 'new memory' });
+
+			await expect(controller.updateMemory(req, res, THREAD_ID, payload)).rejects.toThrow(
+				ForbiddenError,
+			);
+		});
+
+		it('should allow new threads', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('not_found');
+			const payload = mock<InstanceAiUpdateMemoryRequest>({ content: 'new memory' });
+
+			const result = await controller.updateMemory(req, res, THREAD_ID, payload);
+
+			expect(result).toEqual({ ok: true });
 		});
 	});
 
@@ -461,7 +537,7 @@ describe('InstanceAiController', () => {
 
 			expect(result).toEqual({ ok: true });
 			expect(instanceAiService.clearThreadState).toHaveBeenCalledWith(THREAD_ID);
-			expect(memoryService.deleteThread).toHaveBeenCalledWith(USER_ID, THREAD_ID);
+			expect(memoryService.deleteThread).toHaveBeenCalledWith(THREAD_ID);
 		});
 
 		it('should throw ForbiddenError for other user thread', async () => {
@@ -491,7 +567,7 @@ describe('InstanceAiController', () => {
 			const result = await controller.renameThread(req, res, THREAD_ID, payload);
 
 			expect(result).toEqual({ thread: threadObj });
-			expect(memoryService.renameThread).toHaveBeenCalledWith(USER_ID, THREAD_ID, 'New Title');
+			expect(memoryService.renameThread).toHaveBeenCalledWith(THREAD_ID, 'New Title');
 		});
 	});
 
@@ -557,6 +633,24 @@ describe('InstanceAiController', () => {
 				scope: 'instanceAi:message',
 				globalOnly: true,
 			});
+		});
+
+		it('should throw ForbiddenError for other user thread', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('other_user');
+
+			await expect(controller.getThreadContext(req, res, THREAD_ID)).rejects.toThrow(
+				ForbiddenError,
+			);
+		});
+
+		it('should allow new threads', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('not_found');
+			memoryService.getThreadContext.mockResolvedValue({
+				threadId: THREAD_ID,
+				workingMemory: null,
+			});
+
+			await expect(controller.getThreadContext(req, res, THREAD_ID)).resolves.toBeDefined();
 		});
 	});
 

--- a/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
@@ -231,16 +231,12 @@ export class InstanceAiMemoryService {
 		return thread.resourceId === userId ? 'owned' : 'other_user';
 	}
 
-	async deleteThread(_userId: string, threadId: string): Promise<void> {
+	async deleteThread(threadId: string): Promise<void> {
 		const memory = this.createMemoryInstance();
 		await memory.deleteThread(threadId);
 	}
 
-	async renameThread(
-		_userId: string,
-		threadId: string,
-		title: string,
-	): Promise<InstanceAiThreadInfo> {
+	async renameThread(threadId: string, title: string): Promise<InstanceAiThreadInfo> {
 		const memory = this.createMemoryInstance();
 		const updated = await patchThread(memory, {
 			threadId,

--- a/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
@@ -216,17 +216,23 @@ export class InstanceAiController {
 			if (ownershipCheckInFlight) return;
 			ownershipCheckInFlight = true;
 
-			void this.memoryService.checkThreadOwnership(userId, threadId).then((currentOwnership) => {
-				if (currentOwnership === 'other_user') {
+			void this.memoryService
+				.checkThreadOwnership(userId, threadId)
+				.then((currentOwnership) => {
+					if (currentOwnership === 'other_user') {
+						res.end();
+						return;
+					}
+					ownershipVerified = true;
+					for (const buffered of pendingEvents) {
+						this.writeSseEvent(res, buffered);
+					}
+					pendingEvents.length = 0;
+				})
+				.catch(() => {
+					pendingEvents.length = 0;
 					res.end();
-					return;
-				}
-				ownershipVerified = true;
-				for (const buffered of pendingEvents) {
-					this.writeSseEvent(res, buffered);
-				}
-				pendingEvents.length = 0;
-			});
+				});
 		});
 
 		// 5. Keep-alive
@@ -369,6 +375,7 @@ export class InstanceAiController {
 	@Get('/memory/:threadId')
 	@GlobalScope('instanceAi:message')
 	async getMemory(req: AuthenticatedRequest, _res: Response, @Param('threadId') threadId: string) {
+		await this.assertThreadAccess(req.user.id, threadId, { allowNew: true });
 		return await this.memoryService.getWorkingMemory(req.user.id, threadId);
 	}
 
@@ -380,6 +387,7 @@ export class InstanceAiController {
 		@Param('threadId') threadId: string,
 		@Body payload: InstanceAiUpdateMemoryRequest,
 	) {
+		await this.assertThreadAccess(req.user.id, threadId, { allowNew: true });
 		await this.memoryService.updateWorkingMemory(req.user.id, threadId, payload.content);
 		return { ok: true };
 	}
@@ -411,7 +419,7 @@ export class InstanceAiController {
 	) {
 		await this.assertThreadAccess(req.user.id, threadId);
 		await this.instanceAiService.clearThreadState(threadId);
-		await this.memoryService.deleteThread(req.user.id, threadId);
+		await this.memoryService.deleteThread(threadId);
 		return { ok: true };
 	}
 
@@ -424,7 +432,7 @@ export class InstanceAiController {
 		@Body payload: InstanceAiRenameThreadRequestDto,
 	) {
 		await this.assertThreadAccess(req.user.id, threadId);
-		const thread = await this.memoryService.renameThread(req.user.id, threadId, payload.title);
+		const thread = await this.memoryService.renameThread(threadId, payload.title);
 		return { thread };
 	}
 
@@ -476,6 +484,7 @@ export class InstanceAiController {
 		_res: Response,
 		@Param('threadId') threadId: string,
 	) {
+		await this.assertThreadAccess(req.user.id, threadId, { allowNew: true });
 		return await this.memoryService.getThreadContext(req.user.id, threadId);
 	}
 


### PR DESCRIPTION
## Summary

Add missing thread ownership checks.
We queried the memory by resourceId (=user) anyways so this didn't matter too much, but good to fix so that we don't leave this footgun if we change how we access the memory in future.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
