### PR TITLE
refactor: Rename foreground token values to match design system names

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nActionBox/ActionBox.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nActionBox/ActionBox.vue
@@ -37,7 +37,7 @@ withDefaults(defineProps<ActionBoxProps>(), {
 				:icon="icon.value"
 				:size="40"
 				:stroke-width="1.5"
-				color="foreground-xdark"
+				color="foreground-shade-2"
 			/>
 			<span v-else>{{ icon.value }}</span>
 		</div>

--- a/packages/frontend/@n8n/design-system/src/components/N8nActionBox/__snapshots__/ActionBox.test.ts.snap
+++ b/packages/frontend/@n8n/design-system/src/components/N8nActionBox/__snapshots__/ActionBox.test.ts.snap
@@ -18,7 +18,7 @@ exports[`N8NActionBox > should render correctly with emoji 1`] = `
 exports[`N8NActionBox > should render correctly with icon 1`] = `
 "<div class="n8n-action-box container" data-test-id="action-box">
   <div class="icon">
-    <n8n-icon-stub icon="plus" strokewidth="1.5" size="40" spin="false" color="foreground-xdark"></n8n-icon-stub>
+    <n8n-icon-stub icon="plus" strokewidth="1.5" size="40" spin="false" color="foreground-shade-2"></n8n-icon-stub>
   </div>
   <div class="heading">
     <n8n-heading-stub align="center" tag="span" bold="false" size="xlarge"></n8n-heading-stub>

--- a/packages/frontend/@n8n/design-system/src/components/N8nIcon/Icon.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nIcon/Icon.stories.ts
@@ -34,8 +34,8 @@ export default {
 				'danger',
 				'success',
 				'warning',
-				'foreground-dark',
-				'foreground-xdark',
+				'foreground-shade-1',
+				'foreground-shade-2',
 			],
 		},
 		strokeWidth: {
@@ -191,12 +191,12 @@ export const AllColors: StoryFn = (args, { argTypes }) => ({
 				<span style="font-size: 12px;">warning</span>
 			</div>
 			<div style="display: flex; align-items: center; gap: 8px;">
-				<n8n-icon icon="circle" color="foreground-dark" size="large" />
-				<span style="font-size: 12px;">foreground-dark</span>
+				<n8n-icon icon="circle" color="foreground-shade-1" size="large" />
+				<span style="font-size: 12px;">foreground-shade-1</span>
 			</div>
 			<div style="display: flex; align-items: center; gap: 8px;">
-				<n8n-icon icon="circle" color="foreground-xdark" size="large" />
-				<span style="font-size: 12px;">foreground-xdark</span>
+				<n8n-icon icon="circle" color="foreground-shade-2" size="large" />
+				<span style="font-size: 12px;">foreground-shade-2</span>
 			</div>
 		</div>
 	`,

--- a/packages/frontend/@n8n/design-system/src/components/N8nIcon/Icon.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nIcon/Icon.vue
@@ -69,8 +69,8 @@ const colorMap: Record<IconColor, string> = {
 	danger: '--color--danger',
 	success: '--color--success',
 	warning: '--color--warning',
-	'foreground-dark': '--color--foreground--shade-1',
-	'foreground-xdark': '--color--foreground--shade-2',
+	'foreground-shade-1': '--color--foreground--shade-1',
+	'foreground-shade-2': '--color--foreground--shade-2',
 };
 
 const styles = computed(() => {

--- a/packages/frontend/@n8n/design-system/src/components/N8nSuggestedActions/SuggestedActions.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nSuggestedActions/SuggestedActions.vue
@@ -101,7 +101,7 @@ const handleIgnoreClick = (actionId: string) => {
 				>
 					<div :class="$style.checkboxContainer">
 						<N8nIcon v-if="action.completed" icon="circle-check" color="success" />
-						<N8nIcon v-else icon="circle" color="foreground-dark" />
+						<N8nIcon v-else icon="circle" color="foreground-shade-1" />
 					</div>
 					<div :class="$style.actionItemBody">
 						<div :class="[action.completed ? '' : 'mb-3xs', $style.actionHeader]">

--- a/packages/frontend/@n8n/design-system/src/components/N8nText/Text.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nText/Text.vue
@@ -122,11 +122,11 @@ const classes = computed(() => {
 	color: var(--color--warning);
 }
 
-.foreground-dark {
+.foreground-shade-1 {
 	color: var(--color--foreground--shade-1);
 }
 
-.foreground-xdark {
+.foreground-shade-2 {
 	color: var(--color--foreground--shade-2);
 }
 

--- a/packages/frontend/@n8n/design-system/src/types/text.ts
+++ b/packages/frontend/@n8n/design-system/src/types/text.ts
@@ -11,8 +11,8 @@ const TEXT_COLOR = [
 	'danger',
 	'success',
 	'warning',
-	'foreground-dark',
-	'foreground-xdark',
+	'foreground-shade-1',
+	'foreground-shade-2',
 ] as const;
 export type TextColor = (typeof TEXT_COLOR)[number];
 

--- a/packages/frontend/editor-ui/src/app/components/layouts/EmptyStateLayout.vue
+++ b/packages/frontend/editor-ui/src/app/components/layouts/EmptyStateLayout.vue
@@ -175,7 +175,7 @@ const handleAppSelectionContinue = () => {
 								<N8nIcon
 									:class="$style.cardIcon"
 									icon="zap"
-									color="foreground-dark"
+									color="foreground-shade-1"
 									:stroke-width="1.5"
 								/>
 								<N8nText size="large" class="mt-xs">
@@ -195,7 +195,7 @@ const handleAppSelectionContinue = () => {
 								<N8nIcon
 									:class="$style.cardIcon"
 									icon="file"
-									color="foreground-dark"
+									color="foreground-shade-1"
 									:stroke-width="1.5"
 								/>
 								<N8nText size="large" class="mt-xs">

--- a/packages/frontend/editor-ui/src/app/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/app/views/WorkflowsView.vue
@@ -2044,7 +2044,7 @@ const onNameSubmit = async (name: string) => {
 							<N8nIcon
 								:class="$style.emptyStateCardIcon"
 								icon="file"
-								color="foreground-dark"
+								color="foreground-shade-1"
 								:stroke-width="1.5"
 							/>
 							<N8nText size="large" class="mt-xs">

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/evaluation.constants.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/evaluation.constants.ts
@@ -66,7 +66,7 @@ export const statusDictionary: Record<
 > = {
 	new: {
 		icon: 'status-new',
-		color: 'foreground-xdark',
+		color: 'foreground-shade-2',
 	},
 	running: {
 		icon: 'spinner',
@@ -82,7 +82,7 @@ export const statusDictionary: Record<
 	},
 	cancelled: {
 		icon: 'status-canceled',
-		color: 'foreground-xdark',
+		color: 'foreground-shade-2',
 	},
 	warning: {
 		icon: 'status-warning',

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsListItem.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsListItem.vue
@@ -97,7 +97,7 @@ const executionIconStatusDictionary: Record<ExecutionStatus, { icon: IconName; c
 		},
 		[EXECUTION_STATUS.NEW]: {
 			icon: 'status-new',
-			color: 'foreground-xdark',
+			color: 'foreground-shade-2',
 		},
 		[EXECUTION_STATUS.RUNNING]: {
 			icon: 'spinner',
@@ -105,11 +105,11 @@ const executionIconStatusDictionary: Record<ExecutionStatus, { icon: IconName; c
 		},
 		[EXECUTION_STATUS.UNKNOWN]: {
 			icon: 'status-unknown',
-			color: 'foreground-xdark',
+			color: 'foreground-shade-2',
 		},
 		[EXECUTION_STATUS.CANCELED]: {
 			icon: 'status-canceled',
-			color: 'foreground-xdark',
+			color: 'foreground-shade-2',
 		},
 	};
 

--- a/packages/frontend/editor-ui/src/features/project-roles/ProjectRolesView.vue
+++ b/packages/frontend/editor-ui/src/features/project-roles/ProjectRolesView.vue
@@ -259,13 +259,13 @@ function addRole() {
 			<div :class="$style.paywallContainer">
 				<div :class="$style.paywallIcons">
 					<div :class="[$style.iconBox, $style.iconBoxLeft]">
-						<N8nIcon icon="eye-off" :size="20" color="foreground-xdark" />
+						<N8nIcon icon="eye-off" :size="20" color="foreground-shade-2" />
 					</div>
 					<div :class="[$style.iconBox, $style.iconBoxCenter]">
-						<N8nIcon icon="shield-user" :size="20" color="foreground-xdark" />
+						<N8nIcon icon="shield-user" :size="20" color="foreground-shade-2" />
 					</div>
 					<div :class="[$style.iconBox, $style.iconBoxRight]">
-						<N8nIcon icon="pencil-off" :size="20" color="foreground-xdark" />
+						<N8nIcon icon="pencil-off" :size="20" color="foreground-shade-2" />
 					</div>
 				</div>
 				<div :class="$style.paywallText">

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeAddNodes.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeAddNodes.vue
@@ -62,7 +62,7 @@ async function onClickTemplatesLink() {
 	<div ref="container" :class="$style.addNodes" data-test-id="canvas-add-button">
 		<N8nTooltip placement="top" :visible="isTooltipVisible" :show-after="700">
 			<button :class="$style.button" data-test-id="canvas-plus-button" @click.stop="onClick">
-				<N8nIcon icon="plus" color="foreground-xdark" :size="40" />
+				<N8nIcon icon="plus" color="foreground-shade-2" :size="40" />
 			</button>
 			<template #content>
 				{{ i18n.baseText('nodeView.canvasAddButton.addATriggerNodeBeforeExecuting') }}

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeChoicePrompt.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeChoicePrompt.vue
@@ -76,7 +76,7 @@ async function onClickTemplatesLink() {
 					data-test-id="canvas-add-first-step-button"
 					@mousedown.stop.prevent="onAddFirstStepClick"
 				>
-					<N8nIcon icon="plus" color="foreground-xdark" :size="40" />
+					<N8nIcon icon="plus" color="foreground-shade-2" :size="40" />
 				</button>
 			</div>
 			<p :class="$style.label">
@@ -106,7 +106,7 @@ async function onClickTemplatesLink() {
 					data-test-id="canvas-build-with-ai-button"
 					@mousedown.stop.prevent="onBuildWithAIClick"
 				>
-					<N8nIcon icon="wand-sparkles" color="foreground-xdark" :size="40" />
+					<N8nIcon icon="wand-sparkles" color="foreground-shade-2" :size="40" />
 				</button>
 			</div>
 			<p :class="$style.label">


### PR DESCRIPTION
## Summary

Resolves a `@TODO` in `Icon.vue` by renaming foreground property values to align with design token names. This keeps the component consistent with the token naming system and establishes the pattern for follow-up PRs that will address similar mismatches in other components (e.g. `text-dark` → `text-shade-1` in `Text.vue`).

## Changes

- `foreground-dark` → `foreground-shade-1`
- `foreground-xdark` → `foreground-shade-2`

## Follow-up

Several other `@TODO` comments exist in components like `Text.vue` with the same issue. This PR is intentionally scoped to `Icon.vue` as a low-risk first step; the remaining changes will be handled in a follow-up PR.
