### PR TITLE
feat(editor): Add topic descriptions to CLI help output (no-changelog)

### DIFF
--- a/packages/@n8n/cli/package.json
+++ b/packages/@n8n/cli/package.json
@@ -33,7 +33,42 @@
       "target": "./dist/index.js",
       "identifier": "commands"
     },
-    "topicSeparator": " "
+    "topicSeparator": " ",
+    "topics": {
+      "workflow": {
+        "description": "Create, update, and manage workflows"
+      },
+      "execution": {
+        "description": "Monitor and control workflow executions"
+      },
+      "credential": {
+        "description": "Create, update, and manage credentials"
+      },
+      "project": {
+        "description": "Create and manage projects and team members"
+      },
+      "tag": {
+        "description": "Create, update, and manage tags"
+      },
+      "variable": {
+        "description": "Create, update, and manage variables"
+      },
+      "data-table": {
+        "description": "Create and manage data tables and rows"
+      },
+      "user": {
+        "description": "List and look up instance users"
+      },
+      "config": {
+        "description": "View and update CLI configuration"
+      },
+      "source-control": {
+        "description": "Pull changes from the configured source control provider"
+      },
+      "skill": {
+        "description": "Install n8n CLI skills for AI coding agents"
+      }
+    }
   },
   "dependencies": {
     "@oclif/core": "^4.5.2"


### PR DESCRIPTION
## Summary

Adds `topics` configuration to the oclif config in `package.json` so that `n8n-cli --help` shows meaningful descriptions for each command group instead of falling back to the first alphabetical subcommand's description.

ex: 
Before:
```
TOPICS
  workflow  Activate (publish) a workflow
  execution  Delete an execution
  ...
```

After:
```
TOPICS
  workflow  Create, update, and manage workflows
  execution  Monitor and control workflow executions
  ...
```

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created.
- [x] Tests included.