### PR TITLE
fix(http-request): handle empty JSON responses

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -55,6 +55,18 @@ function toText<T>(data: T) {
 	}
 	return data;
 }
+
+function parseJsonResponseBody(
+	body: string,
+	options: { fallbackValue?: JsonObject; errorMessage?: string },
+) {
+	if (body.trim() === '') {
+		return {};
+	}
+
+	return jsonParse(body, options);
+}
+
 export class HttpRequestV3 implements INodeType {
 	description: INodeTypeDescription;
 
@@ -885,7 +897,7 @@ export class HttpRequestV3 implements INodeType {
 									responseContentType,
 									this.helpers,
 								);
-								response.body = jsonParse(data, {
+								response.body = parseJsonResponseBody(data, {
 									...(neverError
 										? { fallbackValue: {} }
 										: { errorMessage: 'Invalid JSON in response body' }),
@@ -1012,7 +1024,8 @@ export class HttpRequestV3 implements INodeType {
 
 							if (responseFormat === 'json' && typeof returnItem.body === 'string') {
 								try {
-									returnItem.body = JSON.parse(returnItem.body);
+									returnItem.body =
+										returnItem.body.trim() === '' ? {} : JSON.parse(returnItem.body);
 								} catch (error) {
 									throw new NodeOperationError(
 										this.getNode(),
@@ -1031,9 +1044,7 @@ export class HttpRequestV3 implements INodeType {
 						} else {
 							if (responseFormat === 'json' && typeof response === 'string') {
 								try {
-									if (typeof response !== 'object') {
-										response = JSON.parse(response);
-									}
+									response = response.trim() === '' ? {} : JSON.parse(response);
 								} catch (error) {
 									throw new NodeOperationError(
 										this.getNode(),

--- a/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts
@@ -59,6 +59,9 @@ describe('HttpRequestV3', () => {
 				assertBinaryData: jest.fn(),
 				getBinaryStream: jest.fn(),
 				getBinaryMetadata: jest.fn(),
+				binaryToBuffer: jest.fn(async (data: string | Buffer) =>
+					Buffer.isBuffer(data) ? data : Buffer.from(data),
+				),
 				binaryToString: jest.fn((buffer: Buffer) => {
 					return buffer.toString();
 				}),
@@ -97,6 +100,69 @@ describe('HttpRequestV3', () => {
 		const result = await node.execute.call(executeFunctions);
 
 		expect(result).toEqual([[{ json: { success: true }, pairedItem: { item: 0 } }]]);
+	});
+
+	it('should treat empty application/json responses as empty objects in autodetect mode', async () => {
+		(executeFunctions.getInputData as jest.Mock).mockReturnValue([{ json: {} }]);
+		(executeFunctions.getNodeParameter as jest.Mock).mockImplementation((paramName: string) => {
+			switch (paramName) {
+				case 'method':
+					return 'POST';
+				case 'url':
+					return baseUrl;
+				case 'authentication':
+					return 'none';
+				case 'options':
+					return options;
+				case 'options.response.response.neverError':
+					return false;
+				default:
+					return undefined;
+			}
+		});
+		const response = {
+			headers: {
+				'content-type': 'application/json',
+				'content-length': '0',
+			},
+			body: Buffer.from(''),
+		};
+
+		(executeFunctions.helpers.request as jest.Mock).mockResolvedValue(response);
+
+		const result = await node.execute.call(executeFunctions);
+
+		expect(result).toEqual([[{ json: {}, pairedItem: { item: 0 } }]]);
+	});
+
+	it('should treat empty responses as empty objects when response format is json', async () => {
+		(executeFunctions.getInputData as jest.Mock).mockReturnValue([{ json: {} }]);
+		(executeFunctions.getNodeParameter as jest.Mock).mockImplementation((paramName: string) => {
+			switch (paramName) {
+				case 'method':
+					return 'POST';
+				case 'url':
+					return baseUrl;
+				case 'authentication':
+					return 'none';
+				case 'options':
+					return options;
+				case 'options.response.response.responseFormat':
+					return 'json';
+				default:
+					return undefined;
+			}
+		});
+		const response = {
+			headers: { 'content-type': 'text/plain' },
+			body: '',
+		};
+
+		(executeFunctions.helpers.request as jest.Mock).mockResolvedValue(response);
+
+		const result = await node.execute.call(executeFunctions);
+
+		expect(result).toEqual([[{ json: {}, pairedItem: { item: 0 } }]]);
 	});
 
 	it('should handle authentication', async () => {


### PR DESCRIPTION
## Summary
- treat empty pplication/json responses as {} instead of throwing Invalid JSON in response body
- apply the same handling when Response Format is explicitly set to JSON
- add regression tests for both flows in HttpRequestV3

## Testing
- pnpm --filter n8n-nodes-base test -- nodes/HttpRequest/test/node/HttpRequestV3.test.ts --runInBand

Fixes #27782
Related to #16326