### PR TITLE
fix(core): Debounce per event type in pubsub

### DIFF
--- a/packages/cli/src/scaling/pubsub/__tests__/subscriber.service.test.ts
+++ b/packages/cli/src/scaling/pubsub/__tests__/subscriber.service.test.ts
@@ -6,6 +6,7 @@ import { mock } from 'jest-mock-extended';
 
 import type { RedisClientService } from '@/services/redis-client.service';
 
+import type { PubSubEventBus } from '../pubsub.eventbus';
 import type { McpRelayMessage } from '../subscriber.service';
 import { Subscriber } from '../subscriber.service';
 
@@ -104,6 +105,102 @@ describe('Subscriber', () => {
 				'n8n-instance-1:n8n.worker-response',
 				expect.any(Function),
 			);
+		});
+	});
+
+	describe('debounce', () => {
+		beforeEach(() => {
+			jest.useFakeTimers();
+			client.on.mockClear();
+		});
+
+		afterEach(() => {
+			jest.useRealTimers();
+		});
+
+		function getMessageHandler() {
+			const call = client.on.mock.calls.find(([event]) => event === 'message');
+			expect(call).toBeDefined();
+			return call![1] as (channel: string, msg: string) => void;
+		}
+
+		function makeCommandMsg(command: string, debounce: boolean, payload?: unknown) {
+			return JSON.stringify({ command, senderId: 'other-host', debounce, payload });
+		}
+
+		it('should not drop different debounced commands arriving within 300ms', () => {
+			const pubsubEventBus = mock<PubSubEventBus>();
+			new Subscriber(
+				mockLogger(),
+				mock(),
+				pubsubEventBus,
+				redisClientService,
+				executionsConfig,
+				globalConfig,
+			);
+
+			const messageHandler = getMessageHandler();
+
+			messageHandler('n8n:n8n.commands', makeCommandMsg('reload-license', true));
+			messageHandler('n8n:n8n.commands', makeCommandMsg('reload-external-secrets-providers', true));
+
+			jest.advanceTimersByTime(300);
+
+			expect(pubsubEventBus.emit).toHaveBeenCalledWith('reload-license', undefined);
+			expect(pubsubEventBus.emit).toHaveBeenCalledWith(
+				'reload-external-secrets-providers',
+				undefined,
+			);
+			expect(pubsubEventBus.emit).toHaveBeenCalledTimes(2);
+		});
+
+		it('should debounce repeated identical commands within 300ms', () => {
+			const pubsubEventBus = mock<PubSubEventBus>();
+			new Subscriber(
+				mockLogger(),
+				mock(),
+				pubsubEventBus,
+				redisClientService,
+				executionsConfig,
+				globalConfig,
+			);
+
+			const messageHandler = getMessageHandler();
+
+			messageHandler('n8n:n8n.commands', makeCommandMsg('reload-license', true));
+			messageHandler('n8n:n8n.commands', makeCommandMsg('reload-license', true));
+			messageHandler('n8n:n8n.commands', makeCommandMsg('reload-license', true));
+
+			jest.advanceTimersByTime(300);
+
+			expect(pubsubEventBus.emit).toHaveBeenCalledWith('reload-license', undefined);
+			expect(pubsubEventBus.emit).toHaveBeenCalledTimes(1);
+		});
+
+		it('should not debounce immediate commands', () => {
+			const pubsubEventBus = mock<PubSubEventBus>();
+			new Subscriber(
+				mockLogger(),
+				mock(),
+				pubsubEventBus,
+				redisClientService,
+				executionsConfig,
+				globalConfig,
+			);
+
+			const messageHandler = getMessageHandler();
+
+			const payload = { workflowId: 'wf-1', activeVersionId: 'v-1', activationMode: 'init' };
+			messageHandler(
+				'n8n:n8n.commands',
+				makeCommandMsg('add-webhooks-triggers-and-pollers', false, payload),
+			);
+
+			expect(pubsubEventBus.emit).toHaveBeenCalledWith(
+				'add-webhooks-triggers-and-pollers',
+				payload,
+			);
+			expect(pubsubEventBus.emit).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/packages/cli/src/scaling/pubsub/subscriber.service.ts
+++ b/packages/cli/src/scaling/pubsub/subscriber.service.ts
@@ -43,6 +43,8 @@ export class Subscriber {
 	/** Callback for MCP relay messages. Set by ScalingService. */
 	private mcpRelayHandler?: (msg: McpRelayMessage) => void;
 
+	private readonly debouncedHandlers = new Map<string, ReturnType<typeof debounce>>();
+
 	constructor(
 		private readonly logger: Logger,
 		private readonly instanceSettings: InstanceSettings,
@@ -65,11 +67,8 @@ export class Subscriber {
 		this.client = this.redisClientService.createClient({ type: 'subscriber(n8n)' });
 
 		const handlerFn = (msg: PubSub.Command | PubSub.WorkerResponse) => {
-			const eventName = 'command' in msg ? msg.command : msg.response;
-			this.pubsubEventBus.emit(eventName, msg.payload);
+			this.pubsubEventBus.emit(this.eventNameFrom(msg), msg.payload);
 		};
-
-		const debouncedHandlerFn = debounce(handlerFn, 300);
 
 		this.client.on('message', (channel: string, str: string) => {
 			// Handle MCP relay messages separately
@@ -80,8 +79,17 @@ export class Subscriber {
 
 			const msg = this.parseMessage(str, channel);
 			if (!msg) return;
-			if (msg.debounce) debouncedHandlerFn(msg);
-			else handlerFn(msg);
+			if (msg.debounce) {
+				const eventName = this.eventNameFrom(msg);
+				let handler = this.debouncedHandlers.get(eventName);
+				if (!handler) {
+					handler = debounce(handlerFn, 300);
+					this.debouncedHandlers.set(eventName, handler);
+				}
+				handler(msg);
+			} else {
+				handlerFn(msg);
+			}
 		});
 	}
 
@@ -128,6 +136,7 @@ export class Subscriber {
 
 	// @TODO: Use `@OnShutdown()` decorator
 	shutdown() {
+		for (const handler of this.debouncedHandlers.values()) handler.cancel();
 		this.client.disconnect();
 	}
 
@@ -140,6 +149,10 @@ export class Subscriber {
 
 			this.logger.debug(`Subscribed to channel ${channel}`);
 		});
+	}
+
+	private eventNameFrom(msg: PubSub.Command | PubSub.WorkerResponse) {
+		return 'command' in msg ? msg.command : msg.response;
 	}
 
 	private parseMessage(str: string, channel: string) {
@@ -165,7 +178,7 @@ export class Subscriber {
 			return null;
 		}
 
-		let msgName = 'command' in msg ? msg.command : msg.response;
+		let msgName = this.eventNameFrom(msg);
 
 		const metadata: LogMetadata = { msg: msgName, channel };
 

--- a/packages/cli/src/scaling/pubsub/subscriber.service.ts
+++ b/packages/cli/src/scaling/pubsub/subscriber.service.ts
@@ -79,17 +79,15 @@ export class Subscriber {
 
 			const msg = this.parseMessage(str, channel);
 			if (!msg) return;
-			if (msg.debounce) {
-				const eventName = this.eventNameFrom(msg);
-				let handler = this.debouncedHandlers.get(eventName);
-				if (!handler) {
-					handler = debounce(handlerFn, 300);
-					this.debouncedHandlers.set(eventName, handler);
-				}
-				handler(msg);
-			} else {
-				handlerFn(msg);
+			if (!msg.debounce) return handlerFn(msg);
+
+			const eventName = this.eventNameFrom(msg);
+			let handler = this.debouncedHandlers.get(eventName);
+			if (!handler) {
+				handler = debounce(handlerFn, 300);
+				this.debouncedHandlers.set(eventName, handler);
 			}
+			handler(msg);
 		});
 	}
 


### PR DESCRIPTION
## Summary

Fix shared debounce in pubsub subscriber that could cause one debounced command to silently drop another of a different type arriving within 300ms

## Related Linear tickets, Github issues, and Community forum posts

n/a
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
