### PR TITLE
refactor(core): Use the common safeJoinPath on instance AI node definitions resolver (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-ai/node-definition-resolver.ts
+++ b/packages/cli/src/modules/instance-ai/node-definition-resolver.ts
@@ -6,8 +6,9 @@
  * pure functions without LangChain dependencies.
  */
 
+import { safeJoinPath } from '@n8n/backend-common';
 import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { dirname } from 'node:path';
 
 // ── Security validation ──────────────────────────────────────────────────────
 
@@ -17,12 +18,6 @@ function isValidPathComponent(component: string): boolean {
 	if (component.includes('/') || component.includes('\\')) return false;
 	if (component === '..' || component.startsWith('..')) return false;
 	return true;
-}
-
-function validatePathWithinBase(filePath: string, baseDir: string): boolean {
-	const resolvedPath = resolve(filePath);
-	const resolvedBase = resolve(baseDir);
-	return resolvedPath.startsWith(resolvedBase + '/') || resolvedPath === resolvedBase;
 }
 
 // ── Path resolution ──────────────────────────────────────────────────────────
@@ -55,7 +50,7 @@ function toSnakeCase(str: string): string {
 }
 
 function getNodesPaths(nodeDefinitionDirs: string[]): string[] {
-	return nodeDefinitionDirs.map((dir) => join(dir, 'nodes'));
+	return nodeDefinitionDirs.map((dir) => safeJoinPath(dir, 'nodes'));
 }
 
 function findNodeDir(
@@ -63,18 +58,22 @@ function findNodeDir(
 	nodesPaths: string[],
 ): { nodesPath: string; nodeDir: string } | null {
 	for (const nodesPath of nodesPaths) {
-		const nodeDir = join(nodesPath, parsed.packageName, parsed.nodeName);
-		if (existsSync(nodeDir)) {
-			return { nodesPath, nodeDir };
+		try {
+			const nodeDir = safeJoinPath(nodesPath, parsed.packageName, parsed.nodeName);
+			if (existsSync(nodeDir)) return { nodesPath, nodeDir };
+		} catch {
+			continue;
 		}
 	}
 	// Tool variant fallback: e.g. "httpRequestTool" -> "httpRequest"
 	if (parsed.nodeName.endsWith('Tool')) {
 		const baseName = parsed.nodeName.slice(0, -4);
 		for (const nodesPath of nodesPaths) {
-			const nodeDir = join(nodesPath, parsed.packageName, baseName);
-			if (existsSync(nodeDir)) {
-				return { nodesPath, nodeDir };
+			try {
+				const nodeDir = safeJoinPath(nodesPath, parsed.packageName, baseName);
+				if (existsSync(nodeDir)) return { nodesPath, nodeDir };
+			} catch {
+				continue;
 			}
 		}
 	}
@@ -145,11 +144,96 @@ function tryResolveNodeFilePath(
 		};
 	}
 
-	const { nodesPath, nodeDir } = found;
-	if (!validatePathWithinBase(nodeDir, nodesPath)) {
+	try {
+		return resolveFilePath(nodeId, version, found.nodeDir, nodeDefinitionDirs, discriminators);
+	} catch {
 		return { error: 'Invalid path - path traversal detected' };
 	}
+}
 
+function resolveResourceOperationFile(
+	nodeId: string,
+	nodeDir: string,
+	targetVersion: string,
+	resources: string[],
+	discriminators?: { resource?: string; operation?: string },
+): PathResolutionResult {
+	if (!discriminators?.resource || !discriminators?.operation) {
+		return {
+			error: `Node '${nodeId}' requires resource and operation discriminators. Available resources: ${resources.join(', ')}.`,
+		};
+	}
+	if (
+		!isValidPathComponent(discriminators.resource) ||
+		!isValidPathComponent(discriminators.operation)
+	) {
+		return { error: 'Invalid discriminator value' };
+	}
+
+	const resourceDir = safeJoinPath(
+		nodeDir,
+		targetVersion,
+		`resource_${toSnakeCase(discriminators.resource)}`,
+	);
+	if (!existsSync(resourceDir)) {
+		return {
+			error: `Invalid resource '${discriminators.resource}' for node '${nodeId}'. Available: ${resources.join(', ')}`,
+		};
+	}
+
+	const filePath = safeJoinPath(
+		nodeDir,
+		targetVersion,
+		`resource_${toSnakeCase(discriminators.resource)}`,
+		`operation_${toSnakeCase(discriminators.operation)}.ts`,
+	);
+	if (!existsSync(filePath)) {
+		const ops = readdirSync(resourceDir)
+			.filter((f) => f.startsWith('operation_') && f.endsWith('.ts'))
+			.map((f) => f.replace('operation_', '').replace('.ts', ''));
+		return {
+			error: `Invalid operation '${discriminators.operation}' for resource '${discriminators.resource}'. Available: ${ops.join(', ')}`,
+		};
+	}
+	return { filePath };
+}
+
+function resolveModeFile(
+	nodeId: string,
+	nodeDir: string,
+	targetVersion: string,
+	modes: string[],
+	discriminators?: { mode?: string },
+): PathResolutionResult {
+	if (!discriminators?.mode) {
+		return {
+			error: `Node '${nodeId}' requires mode discriminator. Available modes: ${modes.join(', ')}.`,
+		};
+	}
+	if (!isValidPathComponent(discriminators.mode)) {
+		return { error: 'Invalid mode value' };
+	}
+
+	const filePath = safeJoinPath(
+		nodeDir,
+		targetVersion,
+		`mode_${toSnakeCase(discriminators.mode)}.ts`,
+	);
+	if (!existsSync(filePath)) {
+		return {
+			error: `Invalid mode '${discriminators.mode}' for node '${nodeId}'. Available: ${modes.join(', ')}`,
+		};
+	}
+	return { filePath };
+}
+
+function resolveFilePath(
+	nodeId: string,
+	version: string | undefined,
+	nodeDir: string,
+	nodeDefinitionDirs: string[],
+	discriminators?: { resource?: string; operation?: string; mode?: string },
+): PathResolutionResult {
 	let targetVersion = version;
 	if (!targetVersion) {
 		const versions = getNodeVersions(nodeId, nodeDefinitionDirs);
@@ -165,7 +249,7 @@ function tryResolveNodeFilePath(
 	}
 
 	// Check split vs flat structure
-	const versionDir = join(nodeDir, targetVersion);
+	const versionDir = safeJoinPath(nodeDir, targetVersion);
 	const isSplit = existsSync(versionDir) && statSync(versionDir).isDirectory();
 
 	if (isSplit) {
@@ -178,73 +262,23 @@ function tryResolveNodeFilePath(
 			.map((e) => e.name.replace('mode_', '').replace('.ts', ''));
 
 		if (resources.length > 0) {
-			// Resource/operation pattern
-			if (!discriminators?.resource || !discriminators?.operation) {
-				return {
-					error: `Node '${nodeId}' requires resource and operation discriminators. Available resources: ${resources.join(', ')}.`,
-				};
-			}
-			if (
-				!isValidPathComponent(discriminators.resource) ||
-				!isValidPathComponent(discriminators.operation)
-			) {
-				return { error: 'Invalid discriminator value' };
-			}
-
-			const resourceDir = join(
+			return resolveResourceOperationFile(
+				nodeId,
 				nodeDir,
 				targetVersion,
-				`resource_${toSnakeCase(discriminators.resource)}`,
+				resources,
+				discriminators,
 			);
-			if (!existsSync(resourceDir)) {
-				return {
-					error: `Invalid resource '${discriminators.resource}' for node '${nodeId}'. Available: ${resources.join(', ')}`,
-				};
-			}
-
-			const filePath = join(resourceDir, `operation_${toSnakeCase(discriminators.operation)}.ts`);
-			if (!validatePathWithinBase(filePath, nodeDir)) {
-				return { error: 'Invalid path - path traversal detected' };
-			}
-			if (!existsSync(filePath)) {
-				const ops = readdirSync(resourceDir)
-					.filter((f) => f.startsWith('operation_') && f.endsWith('.ts'))
-					.map((f) => f.replace('operation_', '').replace('.ts', ''));
-				return {
-					error: `Invalid operation '${discriminators.operation}' for resource '${discriminators.resource}'. Available: ${ops.join(', ')}`,
-				};
-			}
-			return { filePath };
 		}
-
 		if (modes.length > 0) {
-			// Mode pattern
-			if (!discriminators?.mode) {
-				return {
-					error: `Node '${nodeId}' requires mode discriminator. Available modes: ${modes.join(', ')}.`,
-				};
-			}
-			if (!isValidPathComponent(discriminators.mode)) {
-				return { error: 'Invalid mode value' };
-			}
-
-			const filePath = join(nodeDir, targetVersion, `mode_${toSnakeCase(discriminators.mode)}.ts`);
-			if (!validatePathWithinBase(filePath, nodeDir)) {
-				return { error: 'Invalid path - path traversal detected' };
-			}
-			if (!existsSync(filePath)) {
-				return {
-					error: `Invalid mode '${discriminators.mode}' for node '${nodeId}'. Available: ${modes.join(', ')}`,
-				};
-			}
-			return { filePath };
+			return resolveModeFile(nodeId, nodeDir, targetVersion, modes, discriminators);
 		}
 
 		return { error: `Node '${nodeId}' has split structure but no recognized discriminators` };
 	}
 
 	// Flat file
-	const filePath = join(nodeDir, `${targetVersion}.ts`);
+	const filePath = safeJoinPath(nodeDir, `${targetVersion}.ts`);
 	if (!existsSync(filePath)) {
 		return { error: `Version '${version}' not found for node '${nodeId}'` };
 	}
@@ -286,7 +320,7 @@ export function listNodeDiscriminators(
 	const versions = getNodeVersions(nodeId, nodeDefinitionDirs);
 	if (versions.length === 0) return null;
 
-	const versionDir = join(nodeDir, versions[0]);
+	const versionDir = safeJoinPath(nodeDir, versions[0]);
 	if (!existsSync(versionDir) || !statSync(versionDir).isDirectory()) return null;
 
 	const entries = readdirSync(versionDir, { withFileTypes: true });
@@ -296,7 +330,7 @@ export function listNodeDiscriminators(
 
 	const resources = resourceDirs.map((dir) => {
 		const resourceName = dir.name.replace('resource_', '');
-		const resourcePath = join(versionDir, dir.name);
+		const resourcePath = safeJoinPath(versionDir, dir.name);
 		const ops = readdirSync(resourcePath)
 			.filter((f) => f.startsWith('operation_') && f.endsWith('.ts'))
 			.map((f) => f.replace('operation_', '').replace('.ts', ''));
@@ -364,8 +398,8 @@ export function resolveBuiltinNodeDefinitionDirs(): string[] {
 	for (const packageId of ['n8n-nodes-base', '@n8n/n8n-nodes-langchain']) {
 		try {
 			const packageJsonPath = require.resolve(`${packageId}/package.json`);
-			const distDir = join(packageJsonPath, '..'); // dirname
-			const nodeDefsDir = join(distDir, 'dist', 'node-definitions');
+			const distDir = dirname(packageJsonPath);
+			const nodeDefsDir = safeJoinPath(distDir, 'dist', 'node-definitions');
 			if (existsSync(nodeDefsDir)) {
 				dirs.push(nodeDefsDir);
 			}


### PR DESCRIPTION
## Summary

Use the shared `safeJoinPath` helper on instance AI node definitions resolver instead of implementing practically a new copy of it.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
