### PR TITLE
fix(instance-ai): improve working memory relevance

### DIFF
--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -239,6 +239,15 @@ ${licenseHints.map((h) => `- ${h}`).join('\n')}
 
 When \`<conversation-summary>\` is present in your input, treat it as compressed prior context from earlier turns. Use the recent raw messages for exact wording and details; use the summary for long-range continuity (user goals, past decisions, workflow state). Do not repeat the summary back to the user.
 
+## Working Memory
+
+Working memory persists across all your conversations with this user. Keep it focused and useful:
+
+- **User Context & Workflow Preferences**: Update when you learn stable facts (name, role, preferred integrations). These rarely change.
+- **Active Project**: Track ONLY the currently active project. When a project is completed or the user moves on, replace it — do not accumulate a history of past projects.
+- **Instance Knowledge**: Do not store credential IDs or workflow IDs — you can look these up via tools. Only note custom node types if the user has them.
+- **General principle**: Working memory should be a concise snapshot of the user's current state, not a historical log. If a section grows beyond a few lines, prune older entries that are no longer relevant.
+
 ## Detached Tasks
 
 Detached execution is planner-driven. Submit detached work through \`plan\`, then acknowledge briefly and end your turn.

--- a/packages/@n8n/instance-ai/src/memory/working-memory-template.ts
+++ b/packages/@n8n/instance-ai/src/memory/working-memory-template.ts
@@ -10,13 +10,12 @@ export const WORKING_MEMORY_TEMPLATE = `
 - **Workflow naming conventions**:
 - **Error handling patterns**:
 
-# Current Goals
-- **Active project/task**:
-- **Known issues being debugged**:
-- **Pending workflow changes**:
+# Active Project
+<!-- Keep only the ONE project the user is currently working on. Replace when the user switches projects. -->
+- **Project**:
+- **Status**:
+- **Key details**:
 
-# Instance Knowledge
-- **Frequently used credentials**:
-- **Key workflow IDs and names**:
-- **Custom node types available**:
+# Known Issues
+<!-- Only unresolved issues. Remove when fixed. -->
 `;


### PR DESCRIPTION
## Summary

- Adds a `## Working Memory` section to the system prompt with explicit hygiene instructions: track only the active project, don't store discoverable IDs, prune stale entries
- Restructures the working memory template to prevent unbounded accumulation — replaces "Current Goals" (multi-project list) with singular "Active Project", removes "Instance Knowledge" section (credential/workflow IDs are discoverable via tools)

## Related

https://www.notion.so/n8n/The-memory-feels-super-unrelated-to-what-I-m-doing-3345b6e0c94f809c9d77ee97338edbaf