### PR TITLE
feat(core): Add embed auth controller and token exchange service skeleton (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/dto/auth/embed-login-body.dto.ts
+++ b/packages/@n8n/api-types/src/dto/auth/embed-login-body.dto.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+
+export class EmbedLoginBodyDto extends Z.class({
+	token: z.string().min(1),
+}) {}

--- a/packages/@n8n/api-types/src/dto/auth/embed-login-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/auth/embed-login-query.dto.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+
+export class EmbedLoginQueryDto extends Z.class({
+	token: z.string().min(1),
+}) {}

--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -20,6 +20,8 @@ export { BinaryDataSignedQueryDto } from './binary-data/binary-data-signed-query
 
 export { LoginRequestDto } from './auth/login-request.dto';
 export { ResolveSignupTokenQueryDto } from './auth/resolve-signup-token-query.dto';
+export { EmbedLoginQueryDto } from './auth/embed-login-query.dto';
+export { EmbedLoginBodyDto } from './auth/embed-login-body.dto';
 
 export { CreateCredentialResolverDto } from './credential-resolver/create-credential-resolver.dto';
 export { UpdateCredentialResolverDto } from './credential-resolver/update-credential-resolver.dto';

--- a/packages/@n8n/api-types/src/frontend-settings.ts
+++ b/packages/@n8n/api-types/src/frontend-settings.ts
@@ -28,7 +28,7 @@ export interface ITelemetrySettings {
 	config?: ITelemetryClientConfig;
 }
 
-export type AuthenticationMethod = 'email' | 'ldap' | 'saml' | 'oidc';
+export type AuthenticationMethod = 'email' | 'ldap' | 'saml' | 'oidc' | 'token-exchange';
 
 export interface IUserManagementSettings {
 	quota: number;

--- a/packages/@n8n/config/src/configs/logging.config.ts
+++ b/packages/@n8n/config/src/configs/logging.config.ts
@@ -35,6 +35,7 @@ export const LOG_SCOPES = [
 	'workflow-history-compaction',
 	'data-table-csv-import',
 	'ssrf-protection',
+	'token-exchange',
 ] as const;
 
 export type LogScope = (typeof LOG_SCOPES)[number];

--- a/packages/@n8n/db/src/entities/types-db.ts
+++ b/packages/@n8n/db/src/entities/types-db.ts
@@ -306,7 +306,7 @@ export const enum StatisticsNames {
 	dataLoaded = 'data_loaded',
 }
 
-const ALL_AUTH_PROVIDERS = z.enum(['ldap', 'email', 'saml', 'oidc']);
+const ALL_AUTH_PROVIDERS = z.enum(['ldap', 'email', 'saml', 'oidc', 'token-exchange']);
 
 export type AuthProviderType = z.infer<typeof ALL_AUTH_PROVIDERS>;
 

--- a/packages/cli/src/modules/token-exchange/controllers/__tests__/embed-auth.controller.test.ts
+++ b/packages/cli/src/modules/token-exchange/controllers/__tests__/embed-auth.controller.test.ts
@@ -1,0 +1,81 @@
+import { EmbedLoginBodyDto, EmbedLoginQueryDto } from '@n8n/api-types';
+import { GLOBAL_MEMBER_ROLE, type User } from '@n8n/db';
+import type { Response } from 'express';
+import { mock } from 'jest-mock-extended';
+
+import type { AuthService } from '@/auth/auth.service';
+import type { AuthlessRequest } from '@/requests';
+import type { UrlService } from '@/services/url.service';
+
+import { EmbedAuthController } from '../embed-auth.controller';
+import type { TokenExchangeService } from '../../services/token-exchange.service';
+
+const tokenExchangeService = mock<TokenExchangeService>();
+const authService = mock<AuthService>();
+const urlService = mock<UrlService>();
+
+const controller = new EmbedAuthController(tokenExchangeService, authService, urlService);
+
+const mockUser = mock<User>({
+	id: '123',
+	email: 'user@example.com',
+	role: GLOBAL_MEMBER_ROLE,
+});
+
+describe('EmbedAuthController', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		urlService.getInstanceBaseUrl.mockReturnValue('http://localhost:5678');
+	});
+
+	describe('GET /auth/embed', () => {
+		it('should extract token from query, call embedLogin, issue cookie, and redirect', async () => {
+			const req = mock<AuthlessRequest>({
+				browserId: 'browser-id-123',
+			});
+			const res = mock<Response>();
+			const query = new EmbedLoginQueryDto({ token: 'subject-token' });
+			tokenExchangeService.embedLogin.mockResolvedValue(mockUser);
+
+			await controller.getLogin(req, res, query);
+
+			expect(tokenExchangeService.embedLogin).toHaveBeenCalledWith('subject-token');
+			expect(authService.issueCookie).toHaveBeenCalledWith(res, mockUser, true, 'browser-id-123');
+			expect(res.redirect).toHaveBeenCalledWith('http://localhost:5678/');
+		});
+	});
+
+	describe('POST /auth/embed', () => {
+		it('should extract token from body, call embedLogin, issue cookie, and redirect', async () => {
+			const req = mock<AuthlessRequest>({
+				browserId: 'browser-id-456',
+			});
+			const res = mock<Response>();
+			const body = new EmbedLoginBodyDto({ token: 'subject-token' });
+			tokenExchangeService.embedLogin.mockResolvedValue(mockUser);
+
+			await controller.postLogin(req, res, body);
+
+			expect(tokenExchangeService.embedLogin).toHaveBeenCalledWith('subject-token');
+			expect(authService.issueCookie).toHaveBeenCalledWith(res, mockUser, true, 'browser-id-456');
+			expect(res.redirect).toHaveBeenCalledWith('http://localhost:5678/');
+		});
+	});
+
+	describe('error propagation', () => {
+		it('should propagate errors from TokenExchangeService', async () => {
+			const req = mock<AuthlessRequest>({
+				browserId: 'browser-id-789',
+			});
+			const res = mock<Response>();
+			const query = new EmbedLoginQueryDto({ token: 'bad-token' });
+			tokenExchangeService.embedLogin.mockRejectedValue(new Error('Token verification failed'));
+
+			await expect(controller.getLogin(req, res, query)).rejects.toThrow(
+				'Token verification failed',
+			);
+			expect(authService.issueCookie).not.toHaveBeenCalled();
+			expect(res.redirect).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/modules/token-exchange/controllers/embed-auth.controller.ts
+++ b/packages/cli/src/modules/token-exchange/controllers/embed-auth.controller.ts
@@ -1,0 +1,40 @@
+import { EmbedLoginBodyDto, EmbedLoginQueryDto } from '@n8n/api-types';
+import { Body, Get, Post, Query, RestController } from '@n8n/decorators';
+import type { Response } from 'express';
+
+import { AuthService } from '@/auth/auth.service';
+import { AuthlessRequest } from '@/requests';
+import { UrlService } from '@/services/url.service';
+
+import { TokenExchangeService } from '../services/token-exchange.service';
+
+@RestController('/auth/embed')
+export class EmbedAuthController {
+	constructor(
+		private readonly tokenExchangeService: TokenExchangeService,
+		private readonly authService: AuthService,
+		private readonly urlService: UrlService,
+	) {}
+
+	@Get('/', { skipAuth: true })
+	async getLogin(req: AuthlessRequest, res: Response, @Query query: EmbedLoginQueryDto) {
+		return await this.handleLogin(query.token, req, res);
+	}
+
+	@Post('/', { skipAuth: true })
+	async postLogin(req: AuthlessRequest, res: Response, @Body body: EmbedLoginBodyDto) {
+		return await this.handleLogin(body.token, req, res);
+	}
+
+	private async handleLogin(subjectToken: string, req: AuthlessRequest, res: Response) {
+		const user = await this.tokenExchangeService.embedLogin(subjectToken);
+
+		this.authService.issueCookie(res, user, true, req.browserId);
+		// TODO: Override cookie SameSite=None for embed/iframe usage.
+		// The standard issueCookie uses the global config's sameSite setting.
+		// For embed, SameSite=None + Secure is required. Integrate into
+		// AuthService.issueCookie() options in a follow-up PR.
+
+		res.redirect(this.urlService.getInstanceBaseUrl() + '/');
+	}
+}

--- a/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
@@ -1,0 +1,184 @@
+import type { Logger } from '@n8n/backend-common';
+import { GLOBAL_MEMBER_ROLE, type User } from '@n8n/db';
+import jwt from 'jsonwebtoken';
+import { mock } from 'jest-mock-extended';
+
+import { AuthError } from '@/errors/response-errors/auth.error';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+
+import type { ResolvedTrustedKey } from '../../token-exchange.schemas';
+import { IdentityResolutionService } from '../identity-resolution.service';
+import { JtiStoreService } from '../jti-store.service';
+import { TokenExchangeService } from '../token-exchange.service';
+import { TrustedKeyService } from '../trusted-key.service';
+
+const logger = mock<Logger>({ scoped: jest.fn().mockReturnThis() });
+const trustedKeyStore = mock<TrustedKeyService>();
+const jtiStore = mock<JtiStoreService>();
+const identityResolutionService = mock<IdentityResolutionService>();
+
+const service = new TokenExchangeService(
+	logger,
+	trustedKeyStore,
+	jtiStore,
+	identityResolutionService,
+);
+
+const resolvedKey: ResolvedTrustedKey = {
+	kid: 'test-kid',
+	algorithms: ['RS256'],
+	key: 'test-public-key',
+	issuer: 'https://issuer.example.com',
+};
+
+const mockUser = mock<User>({
+	id: '123',
+	email: 'user@example.com',
+	role: GLOBAL_MEMBER_ROLE,
+});
+
+const now = Math.floor(Date.now() / 1000);
+const validClaims = {
+	sub: 'external-user-1',
+	iss: 'https://issuer.example.com',
+	aud: 'n8n',
+	iat: now,
+	exp: now + 30,
+	jti: 'unique-jti-1',
+	email: 'user@example.com',
+};
+
+describe('TokenExchangeService', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		jest.restoreAllMocks();
+	});
+
+	describe('embedLogin', () => {
+		it('should return user on valid token', async () => {
+			jest.spyOn(jwt, 'decode').mockReturnValue({
+				header: { alg: 'RS256', kid: 'test-kid' },
+				payload: validClaims,
+				signature: 'sig',
+			} as unknown as ReturnType<typeof jwt.decode>);
+			jest
+				.spyOn(jwt, 'verify')
+				.mockReturnValue(validClaims as unknown as ReturnType<typeof jwt.verify>);
+			trustedKeyStore.getByKid.mockResolvedValue(resolvedKey);
+			jtiStore.consume.mockResolvedValue(true);
+			identityResolutionService.resolve.mockResolvedValue(mockUser);
+
+			const result = await service.embedLogin('valid-token');
+
+			expect(result).toBe(mockUser);
+			expect(trustedKeyStore.getByKid).toHaveBeenCalledWith('test-kid');
+			expect(jtiStore.consume).toHaveBeenCalledWith(
+				'unique-jti-1',
+				new Date(validClaims.exp * 1000),
+			);
+			expect(identityResolutionService.resolve).toHaveBeenCalledWith(validClaims);
+		});
+
+		it('should throw when token cannot be decoded', async () => {
+			jest.spyOn(jwt, 'decode').mockReturnValue(null);
+
+			await expect(service.embedLogin('garbage')).rejects.toThrow(BadRequestError);
+		});
+
+		it('should throw when kid is missing from JWT header', async () => {
+			jest.spyOn(jwt, 'decode').mockReturnValue({
+				header: { alg: 'RS256' },
+				payload: validClaims,
+				signature: 'sig',
+			} as unknown as ReturnType<typeof jwt.decode>);
+
+			await expect(service.embedLogin('no-kid-token')).rejects.toThrow(BadRequestError);
+		});
+
+		it('should throw when kid is unknown', async () => {
+			jest.spyOn(jwt, 'decode').mockReturnValue({
+				header: { alg: 'RS256', kid: 'unknown-kid' },
+				payload: validClaims,
+				signature: 'sig',
+			} as unknown as ReturnType<typeof jwt.decode>);
+			trustedKeyStore.getByKid.mockResolvedValue(undefined);
+
+			await expect(service.embedLogin('unknown-kid-token')).rejects.toThrow(AuthError);
+		});
+
+		it('should throw when JWT signature verification fails', async () => {
+			jest.spyOn(jwt, 'decode').mockReturnValue({
+				header: { alg: 'RS256', kid: 'test-kid' },
+				payload: validClaims,
+				signature: 'sig',
+			} as unknown as ReturnType<typeof jwt.decode>);
+			jest.spyOn(jwt, 'verify').mockImplementation(() => {
+				throw new Error('invalid signature');
+			});
+			trustedKeyStore.getByKid.mockResolvedValue(resolvedKey);
+
+			await expect(service.embedLogin('bad-sig-token')).rejects.toThrow(AuthError);
+		});
+
+		it('should throw when claims fail Zod validation', async () => {
+			const invalidClaims = { ...validClaims, sub: '' };
+			jest.spyOn(jwt, 'decode').mockReturnValue({
+				header: { alg: 'RS256', kid: 'test-kid' },
+				payload: invalidClaims,
+				signature: 'sig',
+			} as unknown as ReturnType<typeof jwt.decode>);
+			jest
+				.spyOn(jwt, 'verify')
+				.mockReturnValue(invalidClaims as unknown as ReturnType<typeof jwt.verify>);
+			trustedKeyStore.getByKid.mockResolvedValue(resolvedKey);
+
+			await expect(service.embedLogin('invalid-claims-token')).rejects.toThrow();
+		});
+
+		it('should throw when token lifetime exceeds 60 seconds', async () => {
+			const longLivedClaims = { ...validClaims, iat: now, exp: now + 120 };
+			jest.spyOn(jwt, 'decode').mockReturnValue({
+				header: { alg: 'RS256', kid: 'test-kid' },
+				payload: longLivedClaims,
+				signature: 'sig',
+			} as unknown as ReturnType<typeof jwt.decode>);
+			jest
+				.spyOn(jwt, 'verify')
+				.mockReturnValue(longLivedClaims as unknown as ReturnType<typeof jwt.verify>);
+			trustedKeyStore.getByKid.mockResolvedValue(resolvedKey);
+
+			await expect(service.embedLogin('long-lived-token')).rejects.toThrow(AuthError);
+		});
+
+		it('should throw when JTI has already been consumed (replay)', async () => {
+			jest.spyOn(jwt, 'decode').mockReturnValue({
+				header: { alg: 'RS256', kid: 'test-kid' },
+				payload: validClaims,
+				signature: 'sig',
+			} as unknown as ReturnType<typeof jwt.decode>);
+			jest
+				.spyOn(jwt, 'verify')
+				.mockReturnValue(validClaims as unknown as ReturnType<typeof jwt.verify>);
+			trustedKeyStore.getByKid.mockResolvedValue(resolvedKey);
+			jtiStore.consume.mockResolvedValue(false);
+
+			await expect(service.embedLogin('replayed-token')).rejects.toThrow(AuthError);
+		});
+
+		it('should propagate error from IdentityResolutionService', async () => {
+			jest.spyOn(jwt, 'decode').mockReturnValue({
+				header: { alg: 'RS256', kid: 'test-kid' },
+				payload: validClaims,
+				signature: 'sig',
+			} as unknown as ReturnType<typeof jwt.decode>);
+			jest
+				.spyOn(jwt, 'verify')
+				.mockReturnValue(validClaims as unknown as ReturnType<typeof jwt.verify>);
+			trustedKeyStore.getByKid.mockResolvedValue(resolvedKey);
+			jtiStore.consume.mockResolvedValue(true);
+			identityResolutionService.resolve.mockRejectedValue(new Error('User not found'));
+
+			await expect(service.embedLogin('token')).rejects.toThrow('User not found');
+		});
+	});
+});

--- a/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
@@ -7,10 +7,10 @@ import { AuthError } from '@/errors/response-errors/auth.error';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 
 import type { ResolvedTrustedKey } from '../../token-exchange.schemas';
-import { IdentityResolutionService } from '../identity-resolution.service';
-import { JtiStoreService } from '../jti-store.service';
+import type { IdentityResolutionService } from '../identity-resolution.service';
+import type { JtiStoreService } from '../jti-store.service';
 import { TokenExchangeService } from '../token-exchange.service';
-import { TrustedKeyService } from '../trusted-key.service';
+import type { TrustedKeyService } from '../trusted-key.service';
 
 const logger = mock<Logger>({ scoped: jest.fn().mockReturnThis() });
 const trustedKeyStore = mock<TrustedKeyService>();

--- a/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
@@ -1,0 +1,22 @@
+import type { User } from '@n8n/db';
+import { Service } from '@n8n/di';
+
+import { UserError } from 'n8n-workflow';
+
+import type { ExternalTokenClaims } from '../token-exchange.schemas';
+
+/**
+ * Resolves validated external token claims to an n8n User.
+ *
+ * This is a skeleton service — the real implementation with user
+ * lookup/creation logic will be provided in a follow-up ticket.
+ */
+@Service()
+export class IdentityResolutionService {
+	/**
+	 * Map external identity claims to a local n8n user, creating one if necessary.
+	 */
+	async resolve(_claims: ExternalTokenClaims): Promise<User> {
+		throw new UserError('Identity resolution is not yet implemented');
+	}
+}

--- a/packages/cli/src/modules/token-exchange/services/jti-store.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/jti-store.service.ts
@@ -1,0 +1,18 @@
+import { Service } from '@n8n/di';
+
+/**
+ * Tracks consumed JTI (JWT ID) values to prevent token replay attacks.
+ *
+ * This is a skeleton service — the real implementation backed by a
+ * database table will be introduced in IAM-461.
+ */
+@Service()
+export class JtiStoreService {
+	/**
+	 * Attempt to consume a JTI. Returns `true` if consumed successfully
+	 * (first use), `false` if already consumed (replay).
+	 */
+	async consume(_jti: string, _expiresAt: Date): Promise<boolean> {
+		return true;
+	}
+}

--- a/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
@@ -59,12 +59,17 @@ export class TokenExchangeService {
 
 		let payload: jwt.JwtPayload;
 		try {
-			payload = jwt.verify(subjectToken, resolvedKey.key, {
+			const result = jwt.verify(subjectToken, resolvedKey.key, {
 				algorithms: resolvedKey.algorithms,
 				issuer: resolvedKey.issuer,
 				audience: resolvedKey.expectedAudience,
-			}) as jwt.JwtPayload;
+			});
+			if (typeof result === 'string' || !('iat' in result)) {
+				throw new AuthError('Unexpected token format');
+			}
+			payload = result;
 		} catch (error) {
+			if (error instanceof AuthError) throw error;
 			const message = error instanceof Error ? error.message : 'unknown error';
 			this.logger.warn('JWT verification failed', { error: message });
 			throw new AuthError('Token verification failed');

--- a/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
@@ -1,0 +1,96 @@
+import { Logger } from '@n8n/backend-common';
+import type { User } from '@n8n/db';
+import { Service } from '@n8n/di';
+import jwt from 'jsonwebtoken';
+
+import { AuthError } from '@/errors/response-errors/auth.error';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+
+import type { ExternalTokenClaims } from '../token-exchange.schemas';
+import { ExternalTokenClaimsSchema } from '../token-exchange.schemas';
+import { IdentityResolutionService } from './identity-resolution.service';
+import { JtiStoreService } from './jti-store.service';
+import { TrustedKeyService } from './trusted-key.service';
+
+const MAX_TOKEN_LIFETIME_SECONDS = 60;
+
+@Service()
+export class TokenExchangeService {
+	private readonly logger: Logger;
+
+	constructor(
+		logger: Logger,
+		private readonly trustedKeyStore: TrustedKeyService,
+		private readonly jtiStore: JtiStoreService,
+		private readonly identityResolutionService: IdentityResolutionService,
+	) {
+		this.logger = logger.scoped('token-exchange');
+	}
+
+	/**
+	 * Verify and validate an external JWT subject token.
+	 *
+	 * Performs the full verification pipeline:
+	 * 1. Decode and extract the `kid` from the JWT header
+	 * 2. Look up the trusted key source by `kid`
+	 * 3. Cryptographically verify the signature
+	 * 4. Parse and validate the claims against the expected schema
+	 * 5. Optionally enforce maximum token lifetime (for login tokens)
+	 * 6. Consume the JTI to prevent replay attacks
+	 */
+	async verifyToken(
+		subjectToken: string,
+		{ maxLifetimeSeconds }: { maxLifetimeSeconds?: number } = {},
+	): Promise<ExternalTokenClaims> {
+		const decoded = jwt.decode(subjectToken, { complete: true });
+		if (!decoded || typeof decoded === 'string') {
+			throw new BadRequestError('Invalid token format');
+		}
+
+		const { kid } = decoded.header;
+		if (!kid) {
+			throw new BadRequestError('Token header missing kid');
+		}
+
+		const resolvedKey = await this.trustedKeyStore.getByKid(kid);
+		if (!resolvedKey) {
+			throw new AuthError('Unknown key id');
+		}
+
+		let payload: jwt.JwtPayload;
+		try {
+			payload = jwt.verify(subjectToken, resolvedKey.key, {
+				algorithms: resolvedKey.algorithms,
+				issuer: resolvedKey.issuer,
+				audience: resolvedKey.expectedAudience,
+			}) as jwt.JwtPayload;
+		} catch (error) {
+			const message = error instanceof Error ? error.message : 'unknown error';
+			this.logger.warn('JWT verification failed', { error: message });
+			throw new AuthError('Token verification failed');
+		}
+
+		const claims = ExternalTokenClaimsSchema.parse(payload);
+
+		if (maxLifetimeSeconds !== undefined) {
+			const tokenLifetime = claims.exp - claims.iat;
+			if (tokenLifetime > maxLifetimeSeconds) {
+				throw new AuthError('Token lifetime exceeds maximum allowed');
+			}
+		}
+
+		const consumed = await this.jtiStore.consume(claims.jti, new Date(claims.exp * 1000));
+		if (!consumed) {
+			throw new AuthError('Token has already been used');
+		}
+
+		return claims;
+	}
+
+	async embedLogin(subjectToken: string): Promise<User> {
+		const claims = await this.verifyToken(subjectToken, {
+			maxLifetimeSeconds: MAX_TOKEN_LIFETIME_SECONDS,
+		});
+		return await this.identityResolutionService.resolve(claims);
+	}
+}

--- a/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
@@ -1,0 +1,23 @@
+import { Service } from '@n8n/di';
+
+import type { ResolvedTrustedKey } from '../token-exchange.schemas';
+
+/**
+ * Retrieves trusted public keys by Key ID (kid) from the JWT header.
+ *
+ * Returns keys in their resolved, in-memory form with key material
+ * already parsed and ready for `jwt.verify()`.
+ *
+ * This is a skeleton service — the real implementation will be provided
+ * when the trusted-key persistence layer is introduced.
+ */
+@Service()
+export class TrustedKeyService {
+	/**
+	 * Look up a resolved trusted key by its `kid`.
+	 * @returns the resolved key, or `undefined` if the kid is unknown.
+	 */
+	async getByKid(_kid: string): Promise<ResolvedTrustedKey | undefined> {
+		return undefined;
+	}
+}

--- a/packages/cli/src/modules/token-exchange/token-exchange.module.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.module.ts
@@ -2,6 +2,10 @@ import { LICENSE_FEATURES } from '@n8n/constants';
 import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule } from '@n8n/decorators';
 
+function isFeatureFlagEnabled(): boolean {
+	return process.env.N8N_ENV_FEAT_TOKEN_EXCHANGE === 'true';
+}
+
 @BackendModule({
 	name: 'token-exchange',
 	licenseFlag: LICENSE_FEATURES.TOKEN_EXCHANGE,
@@ -9,6 +13,10 @@ import { BackendModule } from '@n8n/decorators';
 })
 export class TokenExchangeModule implements ModuleInterface {
 	async init() {
+		if (!isFeatureFlagEnabled()) {
+			return;
+		}
 		await import('./token-exchange.controller');
+		await import('./controllers/embed-auth.controller');
 	}
 }

--- a/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
@@ -1,7 +1,23 @@
+import type { Algorithm, Secret } from 'jsonwebtoken';
 import { z } from 'zod';
 
 /** RFC 8693 grant type URN for token exchange */
 export const TOKEN_EXCHANGE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:token-exchange' as const;
+
+const JwtAlgorithmSchema = z.enum([
+	'HS256',
+	'HS384',
+	'HS512',
+	'RS256',
+	'RS384',
+	'RS512',
+	'ES256',
+	'ES384',
+	'ES512',
+	'PS256',
+	'PS384',
+	'PS512',
+]) satisfies z.ZodType<Algorithm>;
 
 /**
  * Validates JWT claims originating from an external identity provider.
@@ -33,15 +49,17 @@ export const TrustedKeySourceSchema = z.discriminatedUnion('type', [
 	z.object({
 		type: z.literal('static'),
 		kid: z.string().min(1),
-		algorithms: z.array(z.string()).min(1),
+		algorithms: z.array(JwtAlgorithmSchema).min(1),
 		key: z.string().min(1),
 		issuer: z.string().min(1),
+		expectedAudience: z.string().optional(),
 		allowedRoles: z.array(z.string()).optional(),
 	}),
 	z.object({
 		type: z.literal('jwks'),
 		url: z.string().url(),
 		issuer: z.string().min(1),
+		expectedAudience: z.string().optional(),
 		allowedRoles: z.array(z.string()).optional(),
 		cacheTtlSeconds: z.number().int().positive().optional(),
 	}),
@@ -50,6 +68,32 @@ export const TrustedKeySourceSchema = z.discriminatedUnion('type', [
 export type TrustedKeySource = z.infer<typeof TrustedKeySourceSchema>;
 export type StaticKeySource = Extract<TrustedKeySource, { type: 'static' }>;
 export type JwksKeySource = Extract<TrustedKeySource, { type: 'jwks' }>;
+
+/**
+ * A trusted key that has been normalized and resolved to an in-memory
+ * representation ready for JWT verification. The raw key material from
+ * the config/persistence layer (string PEM, JWKS endpoint, etc.) has
+ * already been parsed into a type accepted by `jwt.verify()`.
+ */
+export interface ResolvedTrustedKey {
+	/** The Key ID that identifies this key in JWT headers. */
+	kid: string;
+
+	/** Allowed signing algorithms for tokens using this key. */
+	algorithms: Algorithm[];
+
+	/** The resolved key material, ready to pass to `jwt.verify()`. */
+	key: Secret;
+
+	/** Expected `iss` claim value for tokens signed with this key. */
+	issuer: string;
+
+	/** Expected `aud` claim value, if restricted. */
+	expectedAudience?: string;
+
+	/** Roles allowed for tokens signed with this key, if restricted. */
+	allowedRoles?: string[];
+}
 
 /**
  * Validates an RFC 8693 token exchange request form body.


### PR DESCRIPTION
## Summary

Adds the foundation for the embed authentication flow, building on top of the token exchange controller (#27844):

- **Embed auth controller** (`/auth/embed`): GET and POST endpoints that accept external JWTs, verify them via the token exchange service, issue an n8n session cookie, and redirect to the app. Marked `skipAuth` since the JWT itself is the authentication.
- **Token exchange service**: Full JWT verification pipeline — decode header to extract `kid`, look up trusted key source, cryptographically verify signature, validate claims against Zod schema, enforce max token lifetime (60s for login tokens), and consume JTI to prevent replay attacks.
- **Supporting services** (shell/stub): `TrustedKeyService` (key lookup by `kid`), `JtiStoreService` (replay prevention via JTI consumption), `IdentityResolutionService` (map external claims → n8n User).
- **API DTOs**: `EmbedLoginBodyDto` and `EmbedLoginQueryDto` for input validation.
- **Module wiring**: Token exchange module registers both the RFC 8693 controller and the new embed auth controller behind a feature flag (`N8N_ENV_FEAT_TOKEN_EXCHANGE`).
- **Unit tests**: Controller tests and comprehensive token exchange service tests covering signature verification, claim validation, lifetime enforcement, and replay prevention.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-457

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
