### PR TITLE
fix: Auto-authorize task-family tools after plan approval

### DIFF
--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -102,6 +102,7 @@ export type {
 } from './workflow-loop';
 export { WorkflowLoopRuntime } from './workflow-loop/runtime';
 export { PlannedTaskCoordinator } from './planned-tasks/planned-task-service';
+export { applyPlannedTaskPermissions } from './planned-tasks/planned-task-permissions';
 export type {
 	InstanceAiContext,
 	InstanceAiWorkflowService,

--- a/packages/@n8n/instance-ai/src/planned-tasks/__tests__/planned-task-permissions.test.ts
+++ b/packages/@n8n/instance-ai/src/planned-tasks/__tests__/planned-task-permissions.test.ts
@@ -1,0 +1,109 @@
+import { DEFAULT_INSTANCE_AI_PERMISSIONS } from '@n8n/api-types';
+
+import type { InstanceAiContext, PlannedTaskKind } from '../../types';
+import { applyPlannedTaskPermissions } from '../planned-task-permissions';
+
+function makeContext(
+	permissionOverrides: Partial<typeof DEFAULT_INSTANCE_AI_PERMISSIONS> = {},
+): InstanceAiContext {
+	return {
+		userId: 'user-1',
+		permissions: { ...DEFAULT_INSTANCE_AI_PERMISSIONS, ...permissionOverrides },
+		workflowService: {} as InstanceAiContext['workflowService'],
+		executionService: {} as InstanceAiContext['executionService'],
+		credentialService: {} as InstanceAiContext['credentialService'],
+		nodeService: {} as InstanceAiContext['nodeService'],
+		dataTableService: {} as InstanceAiContext['dataTableService'],
+	};
+}
+
+describe('applyPlannedTaskPermissions', () => {
+	describe('manage-data-tables', () => {
+		it('should auto-approve data table creation and mutation', () => {
+			const context = makeContext();
+			const result = applyPlannedTaskPermissions(context, 'manage-data-tables');
+
+			expect(result.permissions).toMatchObject({
+				createDataTable: 'always_allow',
+				mutateDataTableSchema: 'always_allow',
+				mutateDataTableRows: 'always_allow',
+			});
+		});
+
+		it('should not affect non-data-table permissions', () => {
+			const context = makeContext();
+			const result = applyPlannedTaskPermissions(context, 'manage-data-tables');
+
+			expect(result.permissions?.runWorkflow).toBe('require_approval');
+			expect(result.permissions?.publishWorkflow).toBe('require_approval');
+			expect(result.permissions?.deleteWorkflow).toBe('require_approval');
+			expect(result.permissions?.fetchUrl).toBe('require_approval');
+			expect(result.permissions?.readFilesystem).toBe('require_approval');
+			expect(result.permissions?.deleteCredential).toBe('require_approval');
+		});
+
+		it('should preserve admin always_allow settings on other keys', () => {
+			const context = makeContext({ fetchUrl: 'always_allow' });
+			const result = applyPlannedTaskPermissions(context, 'manage-data-tables');
+
+			expect(result.permissions?.fetchUrl).toBe('always_allow');
+			expect(result.permissions?.createDataTable).toBe('always_allow');
+		});
+	});
+
+	describe('build-workflow', () => {
+		it('should auto-approve workflow run and publish', () => {
+			const context = makeContext();
+			const result = applyPlannedTaskPermissions(context, 'build-workflow');
+
+			expect(result.permissions).toMatchObject({
+				runWorkflow: 'always_allow',
+				publishWorkflow: 'always_allow',
+			});
+		});
+
+		it('should not affect non-workflow permissions', () => {
+			const context = makeContext();
+			const result = applyPlannedTaskPermissions(context, 'build-workflow');
+
+			expect(result.permissions?.createDataTable).toBe('require_approval');
+			expect(result.permissions?.deleteWorkflow).toBe('require_approval');
+			expect(result.permissions?.fetchUrl).toBe('require_approval');
+		});
+	});
+
+	describe.each<PlannedTaskKind>(['research', 'delegate'])('%s', (kind) => {
+		it('should return the original context unchanged', () => {
+			const context = makeContext();
+			const result = applyPlannedTaskPermissions(context, kind);
+
+			expect(result).toBe(context);
+		});
+	});
+
+	it('should return a new context object for overridden kinds', () => {
+		const context = makeContext();
+		const result = applyPlannedTaskPermissions(context, 'manage-data-tables');
+
+		expect(result).not.toBe(context);
+		expect(result.permissions).not.toBe(context.permissions);
+	});
+
+	it('should not mutate the original context', () => {
+		const context = makeContext();
+		applyPlannedTaskPermissions(context, 'manage-data-tables');
+
+		expect(context.permissions?.createDataTable).toBe('require_approval');
+		expect(context.permissions?.mutateDataTableSchema).toBe('require_approval');
+		expect(context.permissions?.mutateDataTableRows).toBe('require_approval');
+	});
+
+	it('should share service references with the original context', () => {
+		const context = makeContext();
+		const result = applyPlannedTaskPermissions(context, 'manage-data-tables');
+
+		expect(result.dataTableService).toBe(context.dataTableService);
+		expect(result.workflowService).toBe(context.workflowService);
+		expect(result.userId).toBe(context.userId);
+	});
+});

--- a/packages/@n8n/instance-ai/src/planned-tasks/planned-task-permissions.ts
+++ b/packages/@n8n/instance-ai/src/planned-tasks/planned-task-permissions.ts
@@ -1,0 +1,47 @@
+import type { InstanceAiPermissions } from '@n8n/api-types';
+
+import type { InstanceAiContext, PlannedTaskKind } from '../types';
+
+/**
+ * Permission overrides applied when a planned task has been approved by the user.
+ *
+ * Plan approval acts as authorization for the task-family's non-destructive tools,
+ * so the sub-agent can execute without a second confirmation prompt.
+ *
+ * Destructive actions (delete-data-table), open-ended actions (fetch-url, read-file),
+ * and credential deletion are intentionally excluded — they always require explicit approval.
+ */
+const PLANNED_TASK_PERMISSION_OVERRIDES: Partial<
+	Record<PlannedTaskKind, Partial<InstanceAiPermissions>>
+> = {
+	'manage-data-tables': {
+		createDataTable: 'always_allow',
+		mutateDataTableSchema: 'always_allow',
+		mutateDataTableRows: 'always_allow',
+	},
+	'build-workflow': {
+		runWorkflow: 'always_allow',
+		publishWorkflow: 'always_allow',
+	},
+};
+
+/**
+ * Returns a shallow clone of the context with plan-approved permission overrides
+ * applied for the given task kind. If no overrides exist for the kind, the
+ * original context is returned unchanged.
+ */
+export function applyPlannedTaskPermissions(
+	context: InstanceAiContext,
+	taskKind: PlannedTaskKind,
+): InstanceAiContext {
+	const overrides = PLANNED_TASK_PERMISSION_OVERRIDES[taskKind];
+	if (!overrides) return context;
+
+	return {
+		...context,
+		permissions: {
+			...context.permissions,
+			...overrides,
+		} as InstanceAiPermissions,
+	};
+}

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -36,6 +36,7 @@ import {
 	MastraTaskStorage,
 	PlannedTaskCoordinator,
 	PlannedTaskStorage,
+	applyPlannedTaskPermissions,
 	resumeAgentRun,
 	RunStateRegistry,
 	startBuildWorkflowAgentTask,
@@ -1212,31 +1213,35 @@ export class InstanceAiService {
 		task: PlannedTaskRecord,
 		context: OrchestrationContext,
 	): Promise<void> {
+		// Plan approval authorizes the task-family's non-destructive tools,
+		// so the sub-agent can execute without a redundant second confirmation.
+		const taskContext = this.createPlannedTaskContext(task.kind, context);
+
 		let started: { taskId: string; agentId: string; result: string } | null = null;
 
 		switch (task.kind) {
 			case 'build-workflow':
-				started = await startBuildWorkflowAgentTask(context, {
+				started = await startBuildWorkflowAgentTask(taskContext, {
 					task: task.spec,
 					workflowId: task.workflowId,
 					plannedTaskId: task.id,
 				});
 				break;
 			case 'manage-data-tables':
-				started = await startDataTableAgentTask(context, {
+				started = await startDataTableAgentTask(taskContext, {
 					task: task.spec,
 					plannedTaskId: task.id,
 				});
 				break;
 			case 'research':
-				started = await startResearchAgentTask(context, {
+				started = await startResearchAgentTask(taskContext, {
 					goal: task.title,
 					constraints: task.spec,
 					plannedTaskId: task.id,
 				});
 				break;
 			case 'delegate':
-				started = await startDetachedDelegateTask(context, {
+				started = await startDetachedDelegateTask(taskContext, {
 					title: task.title,
 					spec: task.spec,
 					tools: task.tools ?? [],
@@ -1261,6 +1266,27 @@ export class InstanceAiService {
 		if (nextGraph) {
 			await this.syncPlannedTasksToUi(context.threadId, nextGraph);
 		}
+	}
+
+	/**
+	 * Creates a task-scoped OrchestrationContext with plan-approved permission
+	 * overrides. Rebuilds domain tools so each sub-agent gets its own closure
+	 * with the correct permissions, preventing cross-task leakage.
+	 */
+	private createPlannedTaskContext(
+		kind: PlannedTaskRecord['kind'],
+		context: OrchestrationContext,
+	): OrchestrationContext {
+		if (!context.domainContext) return context;
+
+		const taskDomainContext = applyPlannedTaskPermissions(context.domainContext, kind);
+		if (taskDomainContext === context.domainContext) return context;
+
+		return {
+			...context,
+			domainContext: taskDomainContext,
+			domainTools: createAllTools(taskDomainContext),
+		};
 	}
 
 	private async handlePlannedTaskSettlement(

--- a/packages/cli/src/modules/instance-ai/storage/typeorm-memory-storage.ts
+++ b/packages/cli/src/modules/instance-ai/storage/typeorm-memory-storage.ts
@@ -485,12 +485,9 @@ export class TypeORMMemoryStorage extends MemoryStorage {
 		messages: MastraDBMessage[];
 	}): Promise<{ messages: MastraDBMessage[] }> {
 		const entities = messages.map((m) => {
-			if (!m.threadId) {
-				throw new Error(`Message ${m.id} is missing required threadId`);
-			}
 			const entity = this.messageRepo.create({
 				id: m.id,
-				threadId: m.threadId,
+				threadId: m.threadId ?? '',
 				content: JSON.stringify(m.content),
 				role: m.role,
 				type: m.type ?? null,

--- a/packages/cli/src/modules/instance-ai/storage/typeorm-memory-storage.ts
+++ b/packages/cli/src/modules/instance-ai/storage/typeorm-memory-storage.ts
@@ -485,9 +485,12 @@ export class TypeORMMemoryStorage extends MemoryStorage {
 		messages: MastraDBMessage[];
 	}): Promise<{ messages: MastraDBMessage[] }> {
 		const entities = messages.map((m) => {
+			if (!m.threadId) {
+				throw new Error(`Message ${m.id} is missing required threadId`);
+			}
 			const entity = this.messageRepo.create({
 				id: m.id,
-				threadId: m.threadId ?? '',
+				threadId: m.threadId,
 				content: JSON.stringify(m.content),
 				role: m.role,
 				type: m.type ?? null,


### PR DESCRIPTION
## Summary

Fixes [unauthorized creating tables](https://www.notion.so/n8n/unauthorized-creating-tables-3345b6e0c94f80b98ec7c302e5d8e472)

### Problem

When a user approves a plan containing a `manage-data-tables` task, the sub-agent that runs it still triggers a second HITL confirmation for tools like `create-data-table`. The sub-agent treats the denied/timed-out confirmation as "Unauthorized" and the task fails — even though the user already approved the plan.

### Root cause

Tools close over `InstanceAiContext` at creation time and check `context.permissions?.createDataTable !== 'always_allow'` on every call. All dispatched planned tasks share the same `OrchestrationContext` (and the same tool closures), so there's no mechanism for plan approval to propagate into per-tool authorization.

### Solution

When dispatching a planned task, we now create a **task-scoped** `OrchestrationContext` with permission overrides based on the task kind. Domain tools are rebuilt from a cloned `InstanceAiContext` so each sub-agent gets its own closures with the correct permissions — no cross-task leakage.

The override mapping is a single constant:

| Task kind | Auto-approved permissions |
|---|---|
| `manage-data-tables` | `createDataTable`, `mutateDataTableSchema`, `mutateDataTableRows` |
| `build-workflow` | `runWorkflow`, `publishWorkflow` |
| `research` | none |
| `delegate` | none |

**Intentionally excluded** (still require explicit approval):
- Destructive actions: `delete-data-table` (always suspends, no permission check)
- Open-ended actions: `fetch-url`, `read-file`
- Credential/workflow deletion

### What changed

- **New:** `planned-task-permissions.ts` — override mapping + `applyPlannedTaskPermissions()` helper
- **Modified:** `instance-ai.service.ts` — `dispatchPlannedTask` creates a task-scoped context via `createPlannedTaskContext()`
- **Zero changes to tool implementations** — leverages the existing `context.permissions` mechanism
