### PR TITLE
feat(editor): Track telemetry when user clicks dependency pill item (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/DependencyPill.vue
+++ b/packages/frontend/editor-ui/src/app/components/DependencyPill.vue
@@ -150,6 +150,12 @@ function onSelect(value: string) {
 	const dep = (depsResult.value?.dependencies ?? []).find((d) => d.type === type && d.id === id);
 	if (!dep) return;
 
+	telemetry.track('User clicked dependency pill item', {
+		source: props.source,
+		dependency_type: dep.type,
+		dependency_count: effectiveCount.value,
+	});
+
 	switch (dep.type) {
 		case 'credentialId':
 			uiStore.openExistingCredential(dep.id);


### PR DESCRIPTION
## Summary

Adds a new telemetry event `'User clicked dependency pill item'` that fires when a user clicks on an item in the dependency pill dropdown. Tracks the source card type, dependency type clicked, and total dependency count. Complements the existing `'User opened dependency pill'` event to give visibility into which dependencies users actually navigate to.

## Related Linear tickets, Github issues, and Community forum posts

<!-- N/A -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)