### PR TITLE
fix(editor): Fix dependency pill alignment in data table details header (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/core/dataTable/DataTableDetailsView.vue
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/DataTableDetailsView.vue
@@ -267,6 +267,7 @@ onBeforeUnmount(() => {
 
 .actions {
 	display: flex;
+	align-items: center;
 	gap: var(--spacing--3xs);
 	margin-left: auto;
 }


### PR DESCRIPTION
## Summary

Adds `align-items: center` to the `.actions` flex container in the data table details view header so the dependency pill is vertically aligned with the search input and action buttons.

## Related Linear tickets, Github issues, and Community forum posts

<!-- N/A -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)