### PR TITLE
fix(editor): Keep Back before Continue in MFA login footer

### DIFF
--- a/packages/frontend/editor-ui/src/features/core/auth/views/MfaView.vue
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/MfaView.vue
@@ -241,6 +241,13 @@ onMounted(() => {
 			</div>
 			<div :class="$style.footer">
 				<N8nButton
+					variant="subtle"
+					float="left"
+					:label="i18.baseText('mfa.button.back')"
+					size="large"
+					@click="onBackClick"
+				/>
+				<N8nButton
 					float="right"
 					:loading="verifyingMfaCode"
 					:label="
@@ -251,13 +258,6 @@ onMounted(() => {
 					size="large"
 					:disabled="!hasAnyChanges"
 					@click="onSaveClick"
-				/>
-				<N8nButton
-					variant="subtle"
-					float="left"
-					:label="i18.baseText('mfa.button.back')"
-					size="large"
-					@click="onBackClick"
 				/>
 			</div>
 		</N8nCard>


### PR DESCRIPTION
## Summary
Fix the MFA/login flow button ordering so the secondary action (`Back`) appears on the left and the primary action (`Continue`/`Verify`) appears on the right, addressing the UI inconsistency reported in CX-45.

https://linear.app/n8n/issue/CX-45/login-button-order-shifted-continue-left-back-right
