### PR TITLE
fix(editor): Remove default for api params

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml
@@ -28,9 +28,9 @@ properties:
   callerPolicy:
     type: string
     enum: ['any', 'none', 'workflowsFromAList', 'workflowsFromSameOwner']
-    default: workflowsFromSameOwner
     description: |
       Controls which workflows are allowed to call this workflow using the Execute Workflow node.
+      Defaults to workflowsFromSameOwner.
 
       Available options:
       - `any`: Any workflow can call this workflow (no restrictions)
@@ -51,9 +51,9 @@ properties:
     description: Estimated time saved per execution in minutes
   availableInMCP:
     type: boolean
-    default: false
     description: |
       Controls whether this workflow is accessible via the Model Context Protocol (MCP).
+      Defaults to false.
 
       When enabled, this workflow can be called by MCP clients (AI assistants and other tools
       that support MCP). This allows external AI tools to discover and execute this workflow

--- a/packages/cli/test/integration/public-api/workflows.test.ts
+++ b/packages/cli/test/integration/public-api/workflows.test.ts
@@ -1889,6 +1889,78 @@ describe('PUT /workflows/:id', () => {
 			callerPolicy: 'workflowsFromSameOwner', // Added
 		});
 	});
+
+	test('should preserve availableInMCP when settings are updated without it', async () => {
+		const workflow = await createWorkflowWithHistory(
+			{
+				name: 'Test Workflow',
+				nodes: [],
+				connections: {},
+				settings: { availableInMCP: true },
+			},
+			member,
+		);
+
+		const payload = {
+			name: workflow.name,
+			nodes: workflow.nodes,
+			connections: workflow.connections,
+			settings: { saveManualExecutions: true },
+		};
+
+		const response = await authMemberAgent.put(`/workflows/${workflow.id}`).send(payload);
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body.settings.availableInMCP).toBe(true);
+	});
+
+	test('should allow explicitly setting availableInMCP to false', async () => {
+		const workflow = await createWorkflowWithHistory(
+			{
+				name: 'Test Workflow',
+				nodes: [],
+				connections: {},
+				settings: { availableInMCP: true },
+			},
+			member,
+		);
+
+		const payload = {
+			name: workflow.name,
+			nodes: workflow.nodes,
+			connections: workflow.connections,
+			settings: { availableInMCP: false },
+		};
+
+		const response = await authMemberAgent.put(`/workflows/${workflow.id}`).send(payload);
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body.settings.availableInMCP).toBe(false);
+	});
+
+	test('should preserve non-default callerPolicy when settings are updated without it', async () => {
+		const workflow = await createWorkflowWithHistory(
+			{
+				name: 'Test Workflow',
+				nodes: [],
+				connections: {},
+				settings: { callerPolicy: 'none' },
+			},
+			member,
+		);
+
+		const payload = {
+			name: workflow.name,
+			nodes: workflow.nodes,
+			connections: workflow.connections,
+			settings: { saveManualExecutions: true },
+		};
+
+		const response = await authMemberAgent.put(`/workflows/${workflow.id}`).send(payload);
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body.settings.callerPolicy).toBe('none');
+	});
 });
 
 describe('GET /workflows/:id/tags', () => {


### PR DESCRIPTION
## Summary
PUT /api/v1/workflows/:id was silently resetting settings.availableInMCP to false and settings.callerPolicy to workflowsFromSameOwner whenever those fields were omitted from the request body.

Root cause: express-openapi-validator runs AJV with useDefaults: true, which injects schema default values into the request body for any missing fields. The settings merge in WorkflowService.update() then spread-overwrote the stored values with these injected defaults.

Fix: remove the default: declarations from availableInMCP and callerPolicy in workflowSettings.yml. The defaults are now documented in the field descriptions only.


<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-5033/community-issue-rest-api-put-apiv1workflowsid-silently-drops
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
