### PR TITLE
refactor(core): Add structured logging to expression runtime (no-changelog)

### DIFF
--- a/packages/@n8n/expression-runtime/src/bridge/__tests__/isolated-vm-bridge.test.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/__tests__/isolated-vm-bridge.test.ts
@@ -4,23 +4,7 @@ import type { Logger } from '../../types';
 
 describe('IsolatedVmBridge', () => {
 	describe('logger integration', () => {
-		it('should call logger.debug instead of console.log when debug is enabled', async () => {
-			const logger: Logger = {
-				error: vi.fn(),
-				warn: vi.fn(),
-				info: vi.fn(),
-				debug: vi.fn(),
-			};
-
-			const bridge = new IsolatedVmBridge({ debug: true, logger });
-			await bridge.initialize();
-
-			expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('[IsolatedVmBridge]'));
-
-			await bridge.dispose();
-		});
-
-		it('should not call console.log when a logger is provided', async () => {
+		it('should use logger instead of console.log when debug is enabled', async () => {
 			const consoleSpy = vi.spyOn(console, 'log');
 			const logger: Logger = {
 				error: vi.fn(),
@@ -33,6 +17,7 @@ describe('IsolatedVmBridge', () => {
 			await bridge.initialize();
 			await bridge.dispose();
 
+			expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('[IsolatedVmBridge]'));
 			expect(consoleSpy).not.toHaveBeenCalled();
 			consoleSpy.mockRestore();
 		});

--- a/packages/@n8n/expression-runtime/src/bridge/__tests__/isolated-vm-bridge.test.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/__tests__/isolated-vm-bridge.test.ts
@@ -4,7 +4,7 @@ import type { Logger } from '../../types';
 
 describe('IsolatedVmBridge', () => {
 	describe('logger integration', () => {
-		it('should use logger instead of console.log when debug is enabled', async () => {
+		it('should use logger instead of console.log', async () => {
 			const consoleSpy = vi.spyOn(console, 'log');
 			const logger: Logger = {
 				error: vi.fn(),
@@ -13,7 +13,7 @@ describe('IsolatedVmBridge', () => {
 				debug: vi.fn(),
 			};
 
-			const bridge = new IsolatedVmBridge({ debug: true, logger });
+			const bridge = new IsolatedVmBridge({ logger });
 			await bridge.initialize();
 			await bridge.dispose();
 

--- a/packages/@n8n/expression-runtime/src/bridge/__tests__/isolated-vm-bridge.test.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/__tests__/isolated-vm-bridge.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { IsolatedVmBridge } from '../isolated-vm-bridge';
 import type { Logger } from '../../types';
 
 describe('IsolatedVmBridge', () => {
 	describe('logger integration', () => {
+		afterEach(() => {
+			vi.restoreAllMocks();
+		});
+
 		it('should use logger instead of console.log', async () => {
 			const consoleSpy = vi.spyOn(console, 'log');
 			const logger: Logger = {
@@ -19,7 +23,6 @@ describe('IsolatedVmBridge', () => {
 
 			expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('[IsolatedVmBridge]'));
 			expect(consoleSpy).not.toHaveBeenCalled();
-			consoleSpy.mockRestore();
 		});
 	});
 });

--- a/packages/@n8n/expression-runtime/src/bridge/__tests__/isolated-vm-bridge.test.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/__tests__/isolated-vm-bridge.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { IsolatedVmBridge } from '../isolated-vm-bridge';
+import type { Logger } from '../../types';
+
+describe('IsolatedVmBridge', () => {
+	describe('logger integration', () => {
+		it('should call logger.debug instead of console.log when debug is enabled', async () => {
+			const logger: Logger = {
+				error: vi.fn(),
+				warn: vi.fn(),
+				info: vi.fn(),
+				debug: vi.fn(),
+			};
+
+			const bridge = new IsolatedVmBridge({ debug: true, logger });
+			await bridge.initialize();
+
+			expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('[IsolatedVmBridge]'));
+
+			await bridge.dispose();
+		});
+
+		it('should not call console.log when a logger is provided', async () => {
+			const consoleSpy = vi.spyOn(console, 'log');
+			const logger: Logger = {
+				error: vi.fn(),
+				warn: vi.fn(),
+				info: vi.fn(),
+				debug: vi.fn(),
+			};
+
+			const bridge = new IsolatedVmBridge({ debug: true, logger });
+			await bridge.initialize();
+			await bridge.dispose();
+
+			expect(consoleSpy).not.toHaveBeenCalled();
+			consoleSpy.mockRestore();
+		});
+	});
+});

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -165,7 +165,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 		this.initialized = true;
 
 		if (this.config.debug) {
-			this.logger.debug('[IsolatedVmBridge] Initialized successfully');
+			this.logger.info('[IsolatedVmBridge] Initialized successfully');
 		}
 	}
 
@@ -195,7 +195,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			await this.context.eval(runtimeBundle);
 
 			if (this.config.debug) {
-				this.logger.debug('[IsolatedVmBridge] Runtime bundle loaded');
+				this.logger.info('[IsolatedVmBridge] Runtime bundle loaded');
 			}
 
 			// Verify vendor libraries loaded correctly
@@ -209,7 +209,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			}
 
 			if (this.config.debug) {
-				this.logger.debug('[IsolatedVmBridge] Vendor libraries verified successfully');
+				this.logger.info('[IsolatedVmBridge] Vendor libraries verified successfully');
 			}
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : String(error);
@@ -249,7 +249,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			}
 
 			if (this.config.debug) {
-				this.logger.debug('[IsolatedVmBridge] Proxy system verified successfully');
+				this.logger.info('[IsolatedVmBridge] Proxy system verified successfully');
 			}
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : String(error);
@@ -291,7 +291,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 		`);
 
 		if (this.config.debug) {
-			this.logger.debug('[IsolatedVmBridge] Error handler injected successfully');
+			this.logger.info('[IsolatedVmBridge] Error handler injected successfully');
 		}
 	}
 
@@ -667,7 +667,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 		this.scriptCache.clear();
 
 		if (this.config.debug) {
-			this.logger.debug('[IsolatedVmBridge] Disposed');
+			this.logger.info('[IsolatedVmBridge] Disposed');
 		}
 	}
 

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -164,9 +164,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 
 		this.initialized = true;
 
-		if (this.config.debug) {
-			this.logger.info('[IsolatedVmBridge] Initialized successfully');
-		}
+		this.logger.info('[IsolatedVmBridge] Initialized successfully');
 	}
 
 	/**
@@ -194,9 +192,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			// This makes all exported globals available (DateTime, extend, extendOptional, SafeObject, SafeError, createDeepLazyProxy, resetDataProxies, __data)
 			await this.context.eval(runtimeBundle);
 
-			if (this.config.debug) {
-				this.logger.info('[IsolatedVmBridge] Runtime bundle loaded');
-			}
+			this.logger.info('[IsolatedVmBridge] Runtime bundle loaded');
 
 			// Verify vendor libraries loaded correctly
 			const hasDateTime = await this.context.eval('typeof DateTime !== "undefined"');
@@ -208,9 +204,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 				);
 			}
 
-			if (this.config.debug) {
-				this.logger.info('[IsolatedVmBridge] Vendor libraries verified successfully');
-			}
+			this.logger.info('[IsolatedVmBridge] Vendor libraries verified successfully');
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : String(error);
 			throw new Error(`Failed to load runtime bundle: ${errorMessage}`);
@@ -248,9 +242,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 				);
 			}
 
-			if (this.config.debug) {
-				this.logger.info('[IsolatedVmBridge] Proxy system verified successfully');
-			}
+			this.logger.info('[IsolatedVmBridge] Proxy system verified successfully');
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : String(error);
 			throw new Error(`Failed to verify proxy system: ${errorMessage}`);
@@ -290,9 +282,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			}
 		`);
 
-		if (this.config.debug) {
-			this.logger.info('[IsolatedVmBridge] Error handler injected successfully');
-		}
+		this.logger.info('[IsolatedVmBridge] Error handler injected successfully');
 	}
 
 	/**
@@ -319,9 +309,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 				arguments: { copy: true },
 			});
 
-			if (this.config.debug) {
-				this.logger.debug('[IsolatedVmBridge] Data proxies reset successfully');
-			}
+			this.logger.debug('[IsolatedVmBridge] Data proxies reset successfully');
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : String(error);
 			throw new Error(`Failed to reset data proxies: ${errorMessage}`);
@@ -500,9 +488,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 		this.context.global.setSync('__getArrayElement', getArrayElement);
 		this.context.global.setSync('__callFunctionAtPath', callFunctionAtPath);
 
-		if (this.config.debug) {
-			this.logger.debug('[IsolatedVmBridge] Callbacks registered successfully');
-		}
+		this.logger.debug('[IsolatedVmBridge] Callbacks registered successfully');
 	}
 
 	/**
@@ -574,9 +560,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 				script = this.isolate.compileScriptSync(wrappedCode);
 				this.scriptCache.set(code, script);
 
-				if (this.config.debug) {
-					this.logger.debug('[IsolatedVmBridge] Script compiled and cached');
-				}
+				this.logger.debug('[IsolatedVmBridge] Script compiled and cached');
 			}
 
 			// Step 5: Execute with timeout and copy result back
@@ -590,9 +574,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 				throw this.reconstructError(result);
 			}
 
-			if (this.config.debug) {
-				this.logger.debug('[IsolatedVmBridge] Expression executed successfully');
-			}
+			this.logger.debug('[IsolatedVmBridge] Expression executed successfully');
 
 			return result;
 		} catch (error) {
@@ -666,9 +648,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 		this.initialized = false;
 		this.scriptCache.clear();
 
-		if (this.config.debug) {
-			this.logger.info('[IsolatedVmBridge] Disposed');
-		}
+		this.logger.info('[IsolatedVmBridge] Disposed');
 	}
 
 	/**

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -92,6 +92,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 	private initialized = false;
 	private disposed = false;
 	private config: Required<BridgeConfig>;
+	private logger: Required<BridgeConfig>['logger'];
 
 	// Script compilation cache for performance
 	// Maps expression code -> compiled ivm.Script
@@ -113,6 +114,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			...DEFAULT_BRIDGE_CONFIG,
 			...config,
 		};
+		this.logger = this.config.logger;
 
 		// Create isolate with memory limit
 		// Note: memoryLimit is in MB
@@ -163,7 +165,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 		this.initialized = true;
 
 		if (this.config.debug) {
-			console.log('[IsolatedVmBridge] Initialized successfully');
+			this.logger.debug('[IsolatedVmBridge] Initialized successfully');
 		}
 	}
 
@@ -193,7 +195,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			await this.context.eval(runtimeBundle);
 
 			if (this.config.debug) {
-				console.log('[IsolatedVmBridge] Runtime bundle loaded');
+				this.logger.debug('[IsolatedVmBridge] Runtime bundle loaded');
 			}
 
 			// Verify vendor libraries loaded correctly
@@ -207,7 +209,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			}
 
 			if (this.config.debug) {
-				console.log('[IsolatedVmBridge] Vendor libraries verified successfully');
+				this.logger.debug('[IsolatedVmBridge] Vendor libraries verified successfully');
 			}
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : String(error);
@@ -247,7 +249,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			}
 
 			if (this.config.debug) {
-				console.log('[IsolatedVmBridge] Proxy system verified successfully');
+				this.logger.debug('[IsolatedVmBridge] Proxy system verified successfully');
 			}
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : String(error);
@@ -289,7 +291,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 		`);
 
 		if (this.config.debug) {
-			console.log('[IsolatedVmBridge] Error handler injected successfully');
+			this.logger.debug('[IsolatedVmBridge] Error handler injected successfully');
 		}
 	}
 
@@ -318,7 +320,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			});
 
 			if (this.config.debug) {
-				console.log('[IsolatedVmBridge] Data proxies reset successfully');
+				this.logger.debug('[IsolatedVmBridge] Data proxies reset successfully');
 			}
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : String(error);
@@ -499,7 +501,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 		this.context.global.setSync('__callFunctionAtPath', callFunctionAtPath);
 
 		if (this.config.debug) {
-			console.log('[IsolatedVmBridge] Callbacks registered successfully');
+			this.logger.debug('[IsolatedVmBridge] Callbacks registered successfully');
 		}
 	}
 
@@ -573,7 +575,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 				this.scriptCache.set(code, script);
 
 				if (this.config.debug) {
-					console.log('[IsolatedVmBridge] Script compiled and cached');
+					this.logger.debug('[IsolatedVmBridge] Script compiled and cached');
 				}
 			}
 
@@ -589,7 +591,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			}
 
 			if (this.config.debug) {
-				console.log('[IsolatedVmBridge] Expression executed successfully');
+				this.logger.debug('[IsolatedVmBridge] Expression executed successfully');
 			}
 
 			return result;
@@ -665,7 +667,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 		this.scriptCache.clear();
 
 		if (this.config.debug) {
-			console.log('[IsolatedVmBridge] Disposed');
+			this.logger.debug('[IsolatedVmBridge] Disposed');
 		}
 	}
 

--- a/packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts
+++ b/packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts
@@ -6,6 +6,7 @@ import type {
 	EvaluateOptions,
 	RuntimeBridge,
 } from '../types';
+import { DEFAULT_BRIDGE_CONFIG } from '../types/bridge';
 import { IsolatePool, PoolDisposedError, PoolExhaustedError } from '../pool/isolate-pool';
 import { LruCache } from './lru-cache';
 
@@ -32,15 +33,21 @@ export class ExpressionEvaluator implements IExpressionEvaluator {
 		this.codeCache = new LruCache<string, string>(config.maxCodeCacheSize, () => {
 			this.config.observability?.metrics.counter('expression.code_cache.eviction', 1);
 		});
+		const logger = config.logger ?? DEFAULT_BRIDGE_CONFIG.logger;
 		this.createBridge = async () => {
 			const bridge = config.createBridge();
 			await bridge.initialize();
 			return bridge;
 		};
-		this.pool = new IsolatePool(this.createBridge, config.poolSize ?? 1, (error) => {
-			console.error('[IsolatePool] Failed to replenish bridge:', error);
-			config.observability?.metrics.counter('expression.pool.replenish_failed', 1);
-		});
+		this.pool = new IsolatePool(
+			this.createBridge,
+			config.poolSize ?? 1,
+			(error) => {
+				logger.error('[IsolatePool] Failed to replenish bridge', { error });
+				config.observability?.metrics.counter('expression.pool.replenish_failed', 1);
+			},
+			logger,
+		);
 	}
 
 	async initialize(): Promise<void> {

--- a/packages/@n8n/expression-runtime/src/index.ts
+++ b/packages/@n8n/expression-runtime/src/index.ts
@@ -14,6 +14,7 @@ export type {
 	ExecuteOptions,
 	RuntimeBridge,
 	BridgeConfig,
+	Logger,
 	ObservabilityProvider,
 	MetricsAPI,
 	TracesAPI,

--- a/packages/@n8n/expression-runtime/src/pool/isolate-pool.ts
+++ b/packages/@n8n/expression-runtime/src/pool/isolate-pool.ts
@@ -1,4 +1,5 @@
 import type { RuntimeBridge } from '../types';
+import type { Logger } from '../types/bridge';
 
 export class PoolDisposedError extends Error {
 	constructor() {
@@ -26,6 +27,7 @@ export class IsolatePool {
 		private readonly createBridge: () => Promise<RuntimeBridge>,
 		private readonly size: number,
 		private readonly onReplenishFailed?: (error: unknown) => void,
+		private readonly logger?: Logger,
 	) {}
 
 	async initialize() {
@@ -37,7 +39,9 @@ export class IsolatePool {
 			if (result.status === 'fulfilled') {
 				this.bridges.push(result.value);
 			} else {
-				console.error('[IsolatePool] Failed to create bridge during init:', result.reason);
+				this.logger?.error('[IsolatePool] Failed to create bridge during init', {
+					error: result.reason,
+				});
 			}
 		}
 

--- a/packages/@n8n/expression-runtime/src/types/bridge.ts
+++ b/packages/@n8n/expression-runtime/src/types/bridge.ts
@@ -74,14 +74,6 @@ export interface BridgeConfig {
 	 */
 	timeout?: number;
 
-	/**
-	 * Enable debug mode (inspector protocol).
-	 * Default: false
-	 *
-	 * Phase 2+: Chrome DevTools debugging support
-	 */
-	debug?: boolean;
-
 	/** Optional logger. Falls back to no-op if not provided. */
 	logger?: Logger;
 }
@@ -97,7 +89,6 @@ const NO_OP_LOGGER: Logger = {
 export const DEFAULT_BRIDGE_CONFIG: Required<BridgeConfig> = {
 	memoryLimit: 128,
 	timeout: 5000,
-	debug: false,
 	logger: NO_OP_LOGGER,
 };
 

--- a/packages/@n8n/expression-runtime/src/types/bridge.ts
+++ b/packages/@n8n/expression-runtime/src/types/bridge.ts
@@ -48,6 +48,17 @@ export interface RuntimeBridge {
 }
 
 /**
+ * Logger interface matching n8n-workflow's Logger type.
+ * Accepts an optional metadata bag on each call.
+ */
+export interface Logger {
+	error(message: string, metadata?: Record<string, unknown>): void;
+	warn(message: string, metadata?: Record<string, unknown>): void;
+	info(message: string, metadata?: Record<string, unknown>): void;
+	debug(message: string, metadata?: Record<string, unknown>): void;
+}
+
+/**
  * Configuration for runtime bridges.
  */
 export interface BridgeConfig {
@@ -70,13 +81,24 @@ export interface BridgeConfig {
 	 * Phase 2+: Chrome DevTools debugging support
 	 */
 	debug?: boolean;
+
+	/** Optional logger. Falls back to no-op if not provided. */
+	logger?: Logger;
 }
+
+const NO_OP_LOGGER: Logger = {
+	error: () => {},
+	warn: () => {},
+	info: () => {},
+	debug: () => {},
+};
 
 /** Default values for BridgeConfig. Bridge implementations should use this as their baseline. */
 export const DEFAULT_BRIDGE_CONFIG: Required<BridgeConfig> = {
 	memoryLimit: 128,
 	timeout: 5000,
 	debug: false,
+	logger: NO_OP_LOGGER,
 };
 
 /** Options for a single execute() call. */

--- a/packages/@n8n/expression-runtime/src/types/evaluator.ts
+++ b/packages/@n8n/expression-runtime/src/types/evaluator.ts
@@ -1,5 +1,6 @@
 import type { TournamentHooks } from '@n8n/tournament';
 
+import type { Logger } from './bridge';
 import type { RuntimeBridge } from './bridge';
 
 // ============================================================================
@@ -40,6 +41,9 @@ export interface EvaluatorConfig {
 	 * to give each concurrent execution a pre-warmed bridge.
 	 */
 	poolSize?: number;
+
+	/** Optional logger. Passed through to pool. Falls back to no-op. */
+	logger?: Logger;
 }
 
 /**

--- a/packages/@n8n/expression-runtime/src/types/index.ts
+++ b/packages/@n8n/expression-runtime/src/types/index.ts
@@ -5,7 +5,7 @@
  */
 
 // Bridge types
-export type { RuntimeBridge, BridgeConfig, ExecuteOptions } from './bridge';
+export type { RuntimeBridge, BridgeConfig, ExecuteOptions, Logger } from './bridge';
 export { DEFAULT_BRIDGE_CONFIG } from './bridge';
 
 // Runtime types

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -15,6 +15,7 @@ import {
 	sanitizerName,
 } from './expression-sandboxing';
 import { isExpression } from './expressions/expression-helpers';
+import * as LoggerProxy from './logger-proxy';
 import { extend, extendOptional } from './extensions';
 import { extendSyntax } from './extensions/expression-extension';
 import { extendedFunctions } from './extensions/extended-functions';
@@ -256,13 +257,15 @@ export class Expression {
 			// Dynamic import to avoid loading expression-runtime in browser environments
 			const { ExpressionEvaluator, IsolatedVmBridge } = await import('@n8n/expression-runtime');
 			this.vmEvaluator = new ExpressionEvaluator({
-				createBridge: () => new IsolatedVmBridge({ timeout: options.timeout ?? 5000 }),
+				createBridge: () =>
+					new IsolatedVmBridge({ timeout: options.timeout ?? 5000, logger: LoggerProxy }),
 				maxCodeCacheSize: options.maxCodeCacheSize,
 				poolSize: options.poolSize,
 				hooks: {
 					before: [ThisSanitizer],
 					after: [PrototypeSanitizer, DollarSignValidator],
 				},
+				logger: LoggerProxy,
 			});
 			await this.vmEvaluator.initialize();
 		}


### PR DESCRIPTION
## Summary

Replace all `console.log`/`console.error` calls in `@n8n/expression-runtime` with a proper `Logger` interface wired through from the workflow package's `LoggerProxy`.

**What changed:**
- Added a `Logger` interface to `BridgeConfig` (matching n8n-workflow's `Logger` shape) with a no-op default
- Replaced all `console.log` in `IsolatedVmBridge` and `console.error` in `IsolatePool`/`ExpressionEvaluator` with logger calls
- Wired `LoggerProxy` from the workflow package into the bridge factory and evaluator config
- Lifecycle logs (init, dispose) use `info` level; hot-path logs (per-evaluation) use `debug` level
- Removed the now-redundant `debug` boolean flag from `BridgeConfig` — the logger handles level filtering

## Related Linear tickets, Github issues, and Community forum posts

<!-- Part of expression isolation work -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)