### PR TITLE
feat(core): Add delegation authorization to token exchange endpoint

### DIFF
--- a/packages/cli/src/modules/token-exchange/__tests__/token-exchange.schemas.test.ts
+++ b/packages/cli/src/modules/token-exchange/__tests__/token-exchange.schemas.test.ts
@@ -39,17 +39,18 @@ describe('token-exchange.schemas', () => {
 				});
 				expect(result.success).toBe(true);
 			});
+		});
 
-			test('accepts role as array', () => {
+		describe('invalid input', () => {
+			test('rejects role as array', () => {
 				const result = ExternalTokenClaimsSchema.safeParse({
 					...validClaims,
 					role: ['admin', 'viewer'],
 				});
-				expect(result.success).toBe(true);
+				expect(result.success).toBe(false);
+				expect(result.error?.issues[0].path).toEqual(['role']);
 			});
-		});
 
-		describe('invalid input', () => {
 			test.each([
 				{
 					name: 'missing sub',

--- a/packages/cli/src/modules/token-exchange/__tests__/token-exchange.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/__tests__/token-exchange.service.test.ts
@@ -6,6 +6,7 @@ import { JwtService } from '@/services/jwt.service';
 
 import { TokenExchangeConfig } from '../token-exchange.config';
 import { TOKEN_EXCHANGE_GRANT_TYPE } from '../token-exchange.schemas';
+import { DelegationAuthorizationService } from '../services/delegation-authorization.service';
 import { TokenExchangeService } from '../token-exchange.service';
 import type { IssuedJwtPayload } from '../token-exchange.types';
 
@@ -17,6 +18,7 @@ function makeExternalToken(
 		aud: string;
 		exp: number;
 		email?: string;
+		role?: string | string[];
 	},
 	secret = 'external-secret',
 ): string {
@@ -30,6 +32,7 @@ function makeExternalToken(
 			exp: claims.exp,
 			jti: 'test-jti',
 			...(claims.email && { email: claims.email }),
+			...(claims.role !== undefined && { role: claims.role }),
 		},
 		secret,
 		{ algorithm: 'HS256' },
@@ -39,6 +42,7 @@ function makeExternalToken(
 describe('TokenExchangeService', () => {
 	mockInstance(JwtService);
 	const tokenExchangeConfig = mockInstance(TokenExchangeConfig);
+	const delegationAuthService = mockInstance(DelegationAuthorizationService);
 
 	const service = Container.get(TokenExchangeService);
 	const jwtService = Container.get(JwtService);
@@ -69,6 +73,7 @@ describe('TokenExchangeService', () => {
 		jest.resetAllMocks();
 		tokenExchangeConfig.enabled = true;
 		tokenExchangeConfig.maxTokenTtl = 900;
+		delegationAuthService.canDelegate.mockResolvedValue({ allowed: true, missingScopes: [] });
 
 		// Use real decode so we can read external token claims, but capture what gets signed.
 		jest.mocked(jwtService.decode).mockImplementation((token: string) => jwt.decode(token));
@@ -243,6 +248,86 @@ describe('TokenExchangeService', () => {
 		test('issued JWT is verifiable with jwtService.verify()', async () => {
 			const result = await service.exchange(baseRequest);
 			expect(() => jwtService.verify(result.accessToken)).not.toThrow();
+		});
+	});
+
+	describe('delegation authorization', () => {
+		const actorWithRole = makeExternalToken({
+			sub: 'actor-456',
+			iss: 'https://idp.example.com',
+			aud: 'n8n',
+			exp: farFuture,
+			role: 'project:editor',
+		});
+
+		test('should call canDelegate with actor role, requested scope, and resource when actor has role claim', async () => {
+			await service.exchange({
+				...baseRequest,
+				actor_token: actorWithRole,
+				scope: 'project:viewer',
+				resource: 'project-123',
+			});
+
+			expect(delegationAuthService.canDelegate).toHaveBeenCalledWith(
+				'project:editor',
+				'project:viewer',
+				'project-123',
+			);
+		});
+
+		test('should throw when actor lacks required scopes for delegation', async () => {
+			delegationAuthService.canDelegate.mockResolvedValue({
+				allowed: false,
+				missingScopes: ['workflow:update', 'workflow:create'],
+			});
+
+			await expect(
+				service.exchange({
+					...baseRequest,
+					actor_token: actorWithRole,
+					scope: 'project:editor',
+				}),
+			).rejects.toThrow('Actor is not permitted to delegate this role');
+		});
+
+		test('should not call canDelegate when actor_token has no role claim', async () => {
+			await service.exchange({ ...baseRequest, actor_token: actorToken, scope: 'project:viewer' });
+
+			expect(delegationAuthService.canDelegate).not.toHaveBeenCalled();
+		});
+
+		test('should not call canDelegate when no scope in request', async () => {
+			await service.exchange({ ...baseRequest, actor_token: actorWithRole });
+
+			expect(delegationAuthService.canDelegate).not.toHaveBeenCalled();
+		});
+
+		test('should not call canDelegate when no actor_token', async () => {
+			await service.exchange({ ...baseRequest, scope: 'project:viewer' });
+
+			expect(delegationAuthService.canDelegate).not.toHaveBeenCalled();
+		});
+
+		test('should use first element when actor role claim is an array', async () => {
+			const actorWithArrayRole = makeExternalToken({
+				sub: 'actor-456',
+				iss: 'https://idp.example.com',
+				aud: 'n8n',
+				exp: farFuture,
+				role: ['project:editor', 'project:admin'],
+			});
+
+			await service.exchange({
+				...baseRequest,
+				actor_token: actorWithArrayRole,
+				scope: 'project:viewer',
+			});
+
+			expect(delegationAuthService.canDelegate).toHaveBeenCalledWith(
+				'project:editor',
+				'project:viewer',
+				undefined,
+			);
 		});
 	});
 

--- a/packages/cli/src/modules/token-exchange/__tests__/token-exchange.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/__tests__/token-exchange.service.test.ts
@@ -18,7 +18,7 @@ function makeExternalToken(
 		aud: string;
 		exp: number;
 		email?: string;
-		role?: string | string[];
+		role?: string;
 	},
 	secret = 'external-secret',
 ): string {
@@ -306,28 +306,6 @@ describe('TokenExchangeService', () => {
 			await service.exchange({ ...baseRequest, scope: 'project:viewer' });
 
 			expect(delegationAuthService.canDelegate).not.toHaveBeenCalled();
-		});
-
-		test('should use first element when actor role claim is an array', async () => {
-			const actorWithArrayRole = makeExternalToken({
-				sub: 'actor-456',
-				iss: 'https://idp.example.com',
-				aud: 'n8n',
-				exp: farFuture,
-				role: ['project:editor', 'project:admin'],
-			});
-
-			await service.exchange({
-				...baseRequest,
-				actor_token: actorWithArrayRole,
-				scope: 'project:viewer',
-			});
-
-			expect(delegationAuthService.canDelegate).toHaveBeenCalledWith(
-				'project:editor',
-				'project:viewer',
-				undefined,
-			);
 		});
 	});
 

--- a/packages/cli/src/modules/token-exchange/services/__tests__/delegation-authorization.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/delegation-authorization.service.test.ts
@@ -1,0 +1,137 @@
+import type { Logger } from '@n8n/backend-common';
+import type { Role, RoleRepository } from '@n8n/db';
+import { mock } from 'jest-mock-extended';
+
+import type { TokenExchangeConfig } from '../../token-exchange.config';
+import {
+	DelegationAuthorizationService,
+	type DelegationCheckResult,
+} from '../delegation-authorization.service';
+
+const makeRole = (slug: string, scopeSlugs: string[]): Role =>
+	mock<Role>({
+		slug,
+		scopes: scopeSlugs.map((s) => mock({ slug: s })),
+	});
+
+const logger = mock<Logger>({ scoped: jest.fn().mockReturnThis() });
+const roleRepository = mock<RoleRepository>();
+const config = mock<TokenExchangeConfig>({ enforceDelegation: true });
+
+const service = new DelegationAuthorizationService(logger, roleRepository, config);
+
+describe('DelegationAuthorizationService', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		config.enforceDelegation = true;
+	});
+
+	describe('canDelegate', () => {
+		it('should allow when actor scopes are a superset of requested role scopes', async () => {
+			roleRepository.findOne
+				.mockResolvedValueOnce(
+					makeRole('project:editor', ['workflow:read', 'workflow:update', 'workflow:create']),
+				)
+				.mockResolvedValueOnce(makeRole('project:viewer', ['workflow:read']));
+
+			const result = await service.canDelegate('project:editor', 'project:viewer');
+
+			expect(result).toEqual<DelegationCheckResult>({ allowed: true, missingScopes: [] });
+			expect(logger.warn).not.toHaveBeenCalled();
+		});
+
+		it('should reject when actor scopes are a strict subset of requested role scopes', async () => {
+			roleRepository.findOne
+				.mockResolvedValueOnce(makeRole('project:viewer', ['workflow:read']))
+				.mockResolvedValueOnce(
+					makeRole('project:editor', ['workflow:read', 'workflow:update', 'workflow:create']),
+				);
+
+			const result = await service.canDelegate('project:viewer', 'project:editor');
+
+			expect(result.allowed).toBe(false);
+			expect(result.missingScopes).toEqual(
+				expect.arrayContaining(['workflow:update', 'workflow:create']),
+			);
+			expect(result.missingScopes).not.toContain('workflow:read');
+		});
+
+		it('should include all missing scopes in the rejection result', async () => {
+			roleRepository.findOne
+				.mockResolvedValueOnce(makeRole('custom:low', ['scope:a']))
+				.mockResolvedValueOnce(makeRole('custom:high', ['scope:a', 'scope:b', 'scope:c']));
+
+			const result = await service.canDelegate('custom:low', 'custom:high');
+
+			expect(result.allowed).toBe(false);
+			expect(result.missingScopes).toEqual(expect.arrayContaining(['scope:b', 'scope:c']));
+			expect(result.missingScopes).toHaveLength(2);
+		});
+
+		it('should always emit a warning log when the check would fail, regardless of enforce setting', async () => {
+			config.enforceDelegation = false;
+			roleRepository.findOne
+				.mockResolvedValueOnce(makeRole('project:viewer', ['workflow:read']))
+				.mockResolvedValueOnce(makeRole('project:editor', ['workflow:read', 'workflow:update']));
+
+			await service.canDelegate('project:viewer', 'project:editor', 'project-123');
+
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Delegation would fail: actor lacks required scopes',
+				expect.objectContaining({
+					actorRoleSlug: 'project:viewer',
+					requestedRoleSlug: 'project:editor',
+					resourceId: 'project-123',
+					missingScopes: expect.arrayContaining(['workflow:update']),
+					enforced: false,
+				}),
+			);
+		});
+
+		it('should allow but still warn when enforceDelegation is false', async () => {
+			config.enforceDelegation = false;
+			roleRepository.findOne
+				.mockResolvedValueOnce(makeRole('project:viewer', ['workflow:read']))
+				.mockResolvedValueOnce(makeRole('project:editor', ['workflow:read', 'workflow:update']));
+
+			const result = await service.canDelegate('project:viewer', 'project:editor');
+
+			expect(result.allowed).toBe(true);
+			expect(result.missingScopes).toEqual(expect.arrayContaining(['workflow:update']));
+			expect(logger.warn).toHaveBeenCalledTimes(1);
+		});
+
+		it('should work with custom roles with arbitrary scope combinations', async () => {
+			roleRepository.findOne
+				.mockResolvedValueOnce(makeRole('custom:full', ['scope:x', 'scope:y', 'scope:z']))
+				.mockResolvedValueOnce(makeRole('custom:partial', ['scope:x', 'scope:z']));
+
+			const result = await service.canDelegate('custom:full', 'custom:partial');
+
+			expect(result).toEqual<DelegationCheckResult>({ allowed: true, missingScopes: [] });
+		});
+
+		it('should treat an unknown actor role slug as having no scopes', async () => {
+			roleRepository.findOne
+				.mockResolvedValueOnce(null)
+				.mockResolvedValueOnce(makeRole('project:viewer', ['workflow:read']));
+
+			const result = await service.canDelegate('unknown:role', 'project:viewer');
+
+			expect(result.allowed).toBe(false);
+			expect(result.missingScopes).toContain('workflow:read');
+			expect(logger.warn).toHaveBeenCalledTimes(1);
+		});
+
+		it('should allow when the requested role has no scopes', async () => {
+			roleRepository.findOne
+				.mockResolvedValueOnce(makeRole('project:viewer', ['workflow:read']))
+				.mockResolvedValueOnce(makeRole('custom:empty', []));
+
+			const result = await service.canDelegate('project:viewer', 'custom:empty');
+
+			expect(result).toEqual<DelegationCheckResult>({ allowed: true, missingScopes: [] });
+			expect(logger.warn).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/modules/token-exchange/services/__tests__/delegation-authorization.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/delegation-authorization.service.test.ts
@@ -1,5 +1,5 @@
 import type { Logger } from '@n8n/backend-common';
-import type { Role, RoleRepository } from '@n8n/db';
+import type { Role, RoleRepository, Scope } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 
 import type { TokenExchangeConfig } from '../../token-exchange.config';
@@ -11,7 +11,7 @@ import {
 const makeRole = (slug: string, scopeSlugs: string[]): Role =>
 	mock<Role>({
 		slug,
-		scopes: scopeSlugs.map((s) => mock({ slug: s })),
+		scopes: scopeSlugs.map((s) => mock<Scope>({ slug: s as Scope['slug'] })),
 	});
 
 const logger = mock<Logger>({ scoped: jest.fn().mockReturnThis() });

--- a/packages/cli/src/modules/token-exchange/services/delegation-authorization.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/delegation-authorization.service.ts
@@ -18,7 +18,7 @@ export class DelegationAuthorizationService {
 		private readonly roleRepository: RoleRepository,
 		private readonly config: TokenExchangeConfig,
 	) {
-		this.logger = logger.scoped('delegation-authorization');
+		this.logger = logger.scoped('token-exchange');
 	}
 
 	/**

--- a/packages/cli/src/modules/token-exchange/services/delegation-authorization.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/delegation-authorization.service.ts
@@ -1,0 +1,64 @@
+import { Logger } from '@n8n/backend-common';
+import { RoleRepository } from '@n8n/db';
+import { Service } from '@n8n/di';
+
+import { TokenExchangeConfig } from '../token-exchange.config';
+
+export interface DelegationCheckResult {
+	allowed: boolean;
+	missingScopes: string[];
+}
+
+@Service()
+export class DelegationAuthorizationService {
+	private readonly logger: Logger;
+
+	constructor(
+		logger: Logger,
+		private readonly roleRepository: RoleRepository,
+		private readonly config: TokenExchangeConfig,
+	) {
+		this.logger = logger.scoped('delegation-authorization');
+	}
+
+	/**
+	 * Determine whether an actor holding `actorRoleSlug` may delegate
+	 * `requestedRoleSlug` to a subject on the given resource.
+	 *
+	 * Allow iff: requestedRole.scopes ⊆ actorRole.scopes
+	 *
+	 * A structured warning is always emitted when the check would fail,
+	 * regardless of the enforceDelegation setting.
+	 */
+	async canDelegate(
+		actorRoleSlug: string,
+		requestedRoleSlug: string,
+		resourceId?: string,
+	): Promise<DelegationCheckResult> {
+		const [actorRole, requestedRole] = await Promise.all([
+			this.roleRepository.findOne({ where: { slug: actorRoleSlug } }),
+			this.roleRepository.findOne({ where: { slug: requestedRoleSlug } }),
+		]);
+
+		const actorScopes = new Set((actorRole?.scopes ?? []).map((s) => s.slug));
+		const requestedScopes = (requestedRole?.scopes ?? []).map((s) => s.slug);
+		const missingScopes = requestedScopes.filter((s) => !actorScopes.has(s));
+
+		if (missingScopes.length > 0) {
+			this.logger.warn('Delegation would fail: actor lacks required scopes', {
+				actorRoleSlug,
+				requestedRoleSlug,
+				resourceId,
+				missingScopes,
+				enforced: this.config.enforceDelegation,
+			});
+
+			return {
+				allowed: !this.config.enforceDelegation,
+				missingScopes,
+			};
+		}
+
+		return { allowed: true, missingScopes: [] };
+	}
+}

--- a/packages/cli/src/modules/token-exchange/token-exchange.config.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.config.ts
@@ -9,4 +9,8 @@ export class TokenExchangeConfig {
 	/** Maximum lifetime in seconds for an issued token. */
 	@Env('N8N_TOKEN_EXCHANGE_MAX_TOKEN_TTL')
 	maxTokenTtl: number = 900;
+
+	/** If true (default), delegation scope checks are enforced and under-scoped actors are rejected. If false, failures emit a warning but the request proceeds. */
+	@Env('N8N_TOKEN_EXCHANGE_ENFORCE_DELEGATION')
+	enforceDelegation: boolean = true;
 }

--- a/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
@@ -34,7 +34,7 @@ export const ExternalTokenClaimsSchema = z.object({
 	email: z.string().email().optional(),
 	given_name: z.string().optional(),
 	family_name: z.string().optional(),
-	role: z.union([z.string(), z.array(z.string())]).optional(),
+	role: z.string().optional(),
 });
 
 export type ExternalTokenClaims = z.infer<typeof ExternalTokenClaimsSchema>;

--- a/packages/cli/src/modules/token-exchange/token-exchange.service.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.service.ts
@@ -11,6 +11,7 @@ import {
 	type TokenExchangeRequest,
 } from './token-exchange.schemas';
 import type { IssuedJwtPayload, IssuedTokenResult } from './token-exchange.types';
+import { DelegationAuthorizationService } from './services/delegation-authorization.service';
 
 @Service()
 export class TokenExchangeService {
@@ -19,6 +20,8 @@ export class TokenExchangeService {
 	private readonly jwtService = Container.get(JwtService);
 
 	private readonly config = Container.get(TokenExchangeConfig);
+
+	private readonly delegationAuthService = Container.get(DelegationAuthorizationService);
 
 	async exchange(request: TokenExchangeRequest): Promise<IssuedTokenResult> {
 		const subjectClaims = this.decodeAndValidate(request.subject_token);
@@ -33,6 +36,24 @@ export class TokenExchangeService {
 		}
 		if (actorClaims && actorClaims.exp <= now) {
 			throw new OperationalError('actor_token is expired');
+		}
+
+		if (actorClaims) {
+			const actorRole = Array.isArray(actorClaims.role) ? actorClaims.role[0] : actorClaims.role;
+
+			if (actorRole && request.scope) {
+				const delegationResult = await this.delegationAuthService.canDelegate(
+					actorRole,
+					request.scope,
+					request.resource,
+				);
+
+				if (!delegationResult.allowed) {
+					throw new OperationalError(
+						`Actor is not permitted to delegate this role. Missing scopes: ${delegationResult.missingScopes.join(', ')}`,
+					);
+				}
+			}
 		}
 
 		const maxTtl = this.config.maxTokenTtl;

--- a/packages/cli/src/modules/token-exchange/token-exchange.service.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.service.ts
@@ -39,11 +39,9 @@ export class TokenExchangeService {
 		}
 
 		if (actorClaims) {
-			const actorRole = Array.isArray(actorClaims.role) ? actorClaims.role[0] : actorClaims.role;
-
-			if (actorRole && request.scope) {
+			if (actorClaims.role && request.scope) {
 				const delegationResult = await this.delegationAuthService.canDelegate(
-					actorRole,
+					actorClaims.role,
 					request.scope,
 					request.resource,
 				);


### PR DESCRIPTION
## Summary

Implements delegation scope authorization for the RFC 8693 token exchange endpoint. When a request includes an `actor_token`, the actor's role scopes are compared against the requested role's scopes. The actor must hold a superset of the scopes of the role they are trying to delegate — preventing privilege escalation through token exchange.

### What changed

- **`DelegationAuthorizationService`** (`services/delegation-authorization.service.ts`) — self-contained service that takes two role slugs and an optional resource ID, loads their scopes from the `role_scope` join table, and returns `{ allowed, missingScopes[] }`. A structured warning log is always emitted when the check would fail, regardless of the enforcement setting.
- **`TokenExchangeService.exchange()`** — wired in the delegation check: when `actor_token` is present, has a `role` claim, and `scope` is specified in the request, `canDelegate()` is called. If the result is `allowed: false`, an `OperationalError` is thrown with the list of missing scopes.
- **`TokenExchangeConfig`** — new `N8N_TOKEN_EXCHANGE_ENFORCE_DELEGATION` env var (default `true`). When `false`, failures are warned but the request proceeds.
- **`ExternalTokenClaimsSchema`** — `role` field tightened from `string | string[]` to `string`. Actor tokens with an array role claim are now rejected at parse time.

### Behaviour

| Scenario | `ENFORCE_DELEGATION=true` (default) | `ENFORCE_DELEGATION=false` |
|---|---|---|
| Actor scopes ⊇ requested scopes | ✅ Allowed, no log | ✅ Allowed, no log |
| Actor scopes ⊄ requested scopes | ❌ Rejected, warning logged | ⚠️ Allowed, warning logged |
| No `role` claim in actor token | ✅ Check skipped | ✅ Check skipped |
| No `scope` in request | ✅ Check skipped | ✅ Check skipped |

---

## Testing with cURL

> **Prerequisites**
> - `N8N_TOKEN_EXCHANGE_ENABLED=true`
> - `N8N_ENV_FEAT_TOKEN_EXCHANGE=true`
> - n8n running on `http://localhost:5678`
> - A key pair configured in the trusted key store with `kid: test-key`

The external tokens below are signed with HS256 for illustration. In practice, use your configured signing key.

---

### 1. Generate test tokens

Use any JWT tool. Example payloads:

**Actor token** (role: `project:editor`):
```json
{
  "sub": "actor-user-1",
  "iss": "https://your-idp.example.com",
  "aud": "n8n",
  "iat": 1700000000,
  "exp": 1700003600,
  "jti": "actor-jti-001",
  "role": "project:editor"
}
```

**Subject token** (the user being granted access):
```json
{
  "sub": "subject-user-1",
  "iss": "https://your-idp.example.com",
  "aud": "n8n",
  "iat": 1700000000,
  "exp": 1700003600,
  "jti": "subject-jti-001"
}
```

---

### 2. Allowed delegation — actor delegates a subset role

Actor has `project:editor`, requesting `project:viewer` (subset → allowed).

```bash
curl -s -X POST http://localhost:5678/rest/auth/oauth/token \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange" \
  -d "subject_token=<SUBJECT_JWT>" \
  -d "actor_token=<ACTOR_JWT_WITH_EDITOR_ROLE>" \
  -d "scope=project%3Aviewer" \
  -d "resource=project-abc-123"
```

**Expected response (200):**
```json
{
  "access_token": "<issued-jwt>",
  "token_type": "Bearer",
  "expires_in": 900,
  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token"
}
```

---

### 3. Rejected delegation — actor tries to delegate a superset role

Actor has `project:viewer`, requesting `project:editor` (superset → rejected).

```bash
curl -s -X POST http://localhost:5678/rest/auth/oauth/token \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange" \
  -d "subject_token=<SUBJECT_JWT>" \
  -d "actor_token=<ACTOR_JWT_WITH_VIEWER_ROLE>" \
  -d "scope=project%3Aeditor" \
  -d "resource=project-abc-123"
```

**Expected response (500):**
```json
{
  "error": "server_error",
  "error_description": "An unexpected error occurred during token exchange"
}
```

The n8n logs will contain a structured warning:
```json
{
  "level": "warn",
  "message": "Delegation would fail: actor lacks required scopes",
  "actorRoleSlug": "project:viewer",
  "requestedRoleSlug": "project:editor",
  "resourceId": "project-abc-123",
  "missingScopes": ["workflow:update", "workflow:create"],
  "enforced": true
}
```

---

### 4. Warn-only mode — delegation proceeds despite missing scopes

Set `N8N_TOKEN_EXCHANGE_ENFORCE_DELEGATION=false` and repeat request 3.

```bash
N8N_TOKEN_EXCHANGE_ENFORCE_DELEGATION=false \
curl -s -X POST http://localhost:5678/rest/auth/oauth/token \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange" \
  -d "subject_token=<SUBJECT_JWT>" \
  -d "actor_token=<ACTOR_JWT_WITH_VIEWER_ROLE>" \
  -d "scope=project%3Aeditor" \
  -d "resource=project-abc-123"
```

**Expected:** token is issued (200), but the same warning is still logged with `"enforced": false`.

---

### 5. No delegation check — actor token has no role claim

```bash
curl -s -X POST http://localhost:5678/rest/auth/oauth/token \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange" \
  -d "subject_token=<SUBJECT_JWT>" \
  -d "actor_token=<ACTOR_JWT_WITHOUT_ROLE_CLAIM>" \
  -d "scope=project%3Aeditor"
```

**Expected:** token is issued (200), delegation check is skipped entirely.

---

## Related Linear tickets

https://linear.app/n8n/issue/IAM-465

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
