### PR TITLE
fix(Http Request Node): Handle empty JSON responses gracefully

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -885,11 +885,15 @@ export class HttpRequestV3 implements INodeType {
 									responseContentType,
 									this.helpers,
 								);
-								response.body = jsonParse(data, {
-									...(neverError
-										? { fallbackValue: {} }
-										: { errorMessage: 'Invalid JSON in response body' }),
-								});
+								if (!data) {
+									response.body = {};
+								} else {
+									response.body = jsonParse(data, {
+										...(neverError
+											? { fallbackValue: {} }
+											: { errorMessage: 'Invalid JSON in response body' }),
+									});
+								}
 							}
 						} else if (binaryContentTypes.some((e) => responseContentType.includes(e))) {
 							responseFormat = 'file';

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -885,14 +885,14 @@ export class HttpRequestV3 implements INodeType {
 									responseContentType,
 									this.helpers,
 								);
-								if (!data) {
-									response.body = {};
-								} else {
+								if (data) {
 									response.body = jsonParse(data, {
 										...(neverError
 											? { fallbackValue: {} }
 											: { errorMessage: 'Invalid JSON in response body' }),
 									});
+								} else {
+									response.body = {};
 								}
 							}
 						} else if (binaryContentTypes.some((e) => responseContentType.includes(e))) {

--- a/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts
@@ -542,4 +542,33 @@ describe('HttpRequestV3', () => {
 			);
 		});
 	});
+
+	describe('Empty JSON Response Handling', () => {
+		it('should return empty object for empty JSON response body', async () => {
+			(executeFunctions.getInputData as jest.Mock).mockReturnValue([{ json: {} }]);
+			(executeFunctions.getNodeParameter as jest.Mock).mockImplementation((paramName: string) => {
+				switch (paramName) {
+					case 'method':
+						return 'POST';
+					case 'url':
+						return baseUrl;
+					case 'authentication':
+						return 'none';
+					case 'options':
+						return options;
+					default:
+						return undefined;
+				}
+			});
+			const response = {
+				headers: { 'content-type': 'application/json', 'content-length': '0' },
+				body: Buffer.from(''),
+			};
+			(executeFunctions.helpers.request as jest.Mock).mockResolvedValue(response);
+
+			const result = await node.execute.call(executeFunctions);
+
+			expect(result).toEqual([[{ json: {}, pairedItem: { item: 0 } }]]);
+		});
+	});
 });


### PR DESCRIPTION
## Summary

When an API returns `content-type: application/json` with an empty body (e.g. `content-length: 0`, HTTP 201 Created), the HTTP Request node threw "Invalid JSON in response body" because `JSON.parse("")` fails. With "Never Error" enabled, the same response returned `{}` without error — inconsistent behavior.

This PR adds a guard that checks for an empty response body before attempting JSON parsing, returning `{}` consistently regardless of the "Never Error" setting. This mirrors the existing pattern used for text responses in the same file.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4771
Fixes #27782

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)