### PR TITLE
fix(Oracle Node): Avoid stack overflow when query returns many rows

### DIFF
--- a/packages/nodes-base/nodes/Oracle/Sql/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Oracle/Sql/helpers/utils.ts
@@ -415,7 +415,9 @@ function _getResponseForOutbinds(
 				itemData: { item: j },
 			});
 			if (executionData) {
-				returnData.push(...executionData);
+				for (const item of executionData) {
+					returnData.push(item);
+				}
 			}
 		}
 	}
@@ -583,9 +585,9 @@ export function configureQueryRunner(
 								{ itemData: { item: i } },
 							);
 
-							returnData.push.apply(returnData, executionData);
+							returnData = returnData.concat(executionData);
 						} else {
-							returnData.push.apply(returnData, resultOutBinds);
+							returnData = returnData.concat(resultOutBinds);
 						}
 					} catch (caughtError) {
 						const error = parseOracleError(node, caughtError, i);
@@ -639,9 +641,9 @@ export function configureQueryRunner(
 								wrapData(rowData as IDataObject[]),
 								{ itemData: { item: i } },
 							);
-							returnData.push.apply(returnData, executionData);
+							returnData = returnData.concat(executionData);
 						} else {
-							returnData.push.apply(returnData, resultOutBinds);
+							returnData = returnData.concat(resultOutBinds);
 						}
 					} catch (caughtError) {
 						const error = parseOracleError(node, caughtError, i);


### PR DESCRIPTION
## Summary

Replace `push.apply()` and `push(...spread)` with `concat()`/loop in the Oracle Database node to prevent "Maximum call stack size exceeded" when Select/Execute operations return large result sets (10k+ rows).

This is the same pattern already fixed in Microsoft SQL (#8334), FTP (#8657), MongoDB (#8530), and MySQL (#10965).

### Changes in `packages/nodes-base/nodes/Oracle/Sql/helpers/utils.ts`

- **Transaction branch**: `returnData.push.apply(returnData, executionData)` → `returnData = returnData.concat(executionData)` (×2)
- **Independent branch**: same replacement (×2)
- **`_getResponseForOutbinds`**: `returnData.push(...executionData)` → loop-based push (parameter can't be reassigned)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4706
Fixes #26985

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)