### PR TITLE
ci: Backport security folder to 1.x

### DIFF
--- a/security/trivy-ignore-policy.rego
+++ b/security/trivy-ignore-policy.rego
@@ -1,0 +1,14 @@
+# Trivy ignore policy for n8n security scans.
+# n8n's own published CVEs/GHSAs are intentionally excluded from internal
+# scan results. Vulnerabilities in the n8n package should be visible to
+# anyone running an older version — they indicate an upgrade is required.
+# VEX (vex.openvex.json) covers third-party dependency false positives only.
+package trivy
+
+import future.keywords.if
+
+default ignore := false
+
+ignore if {
+	input.PkgName == "n8n"
+}

--- a/security/trivy.yaml
+++ b/security/trivy.yaml
@@ -1,0 +1,6 @@
+# Trivy configuration for n8n security scans
+# See: https://trivy.dev/latest/docs/references/configuration/config-file/
+vulnerability:
+  vex:
+    - security/vex.openvex.json
+  ignore-policy: security/trivy-ignore-policy.rego

--- a/security/vex.openvex.json
+++ b/security/vex.openvex.json
@@ -1,0 +1,69 @@
+{
+	"_comment": "VEX - CVE false positive triage. To add entries, see Quality Corner or .github/WORKFLOWS.md#vex",
+	"@context": "https://openvex.dev/ns/v0.2.0",
+	"@id": "https://github.com/n8n-io/n8n/vex",
+	"author": "n8n Security Team <security@n8n.io>",
+	"timestamp": "2026-03-01T00:00:00Z",
+	"version": 5,
+	"statements": [
+		{
+			"vulnerability": {
+				"@id": "https://nvd.nist.gov/vuln/detail/CVE-2025-32460",
+				"name": "CVE-2025-32460",
+				"description": "Heap-based buffer over-read in ReadJXLImage in coders/jxl.c in GraphicsMagick before 8e56520"
+			},
+			"products": [
+				{
+					"@id": "pkg:docker/n8nio/n8n",
+					"subcomponents": [
+						{
+							"@id": "pkg:apk/alpine/graphicsmagick@1.3.45-r0"
+						}
+					]
+				}
+			],
+			"status": "not_affected",
+			"justification": "vulnerable_code_not_in_execute_path",
+			"impact_statement": "The JXL (JPEG XL) coder requires libjxl delegate to be compiled into GraphicsMagick. Alpine's graphicsmagick package (1.3.45-r0) does not include libjxl support. Verified via `gm convert -list format` which shows no JXL entry. The vulnerable ReadJXLImage code path is unreachable."
+		},
+		{
+			"vulnerability": {
+				"@id": "https://nvd.nist.gov/vuln/detail/CVE-2025-27795",
+				"name": "CVE-2025-27795",
+				"description": "ReadJXLImage in JXL in GraphicsMagick before 1.3.46 lacks image dimension resource limits"
+			},
+			"products": [
+				{
+					"@id": "pkg:docker/n8nio/n8n",
+					"subcomponents": [
+						{
+							"@id": "pkg:apk/alpine/graphicsmagick@1.3.45-r0"
+						}
+					]
+				}
+			],
+			"status": "not_affected",
+			"justification": "vulnerable_code_not_in_execute_path",
+			"impact_statement": "The JXL (JPEG XL) coder requires libjxl delegate to be compiled into GraphicsMagick. Alpine's graphicsmagick package (1.3.45-r0) does not include libjxl support. Verified via `gm convert -list format` which shows no JXL entry. The vulnerable ReadJXLImage code path is unreachable."
+		},
+		{
+			"vulnerability": {
+				"@id": "https://nvd.nist.gov/vuln/detail/CVE-2025-27796",
+				"name": "CVE-2025-27796",
+				"description": "ReadWPGImage in WPG in GraphicsMagick before 1.3.46 mishandles palette buffer allocation"
+			},
+			"products": [
+				{
+					"@id": "pkg:docker/n8nio/n8n",
+					"subcomponents": [
+						{
+							"@id": "pkg:apk/alpine/graphicsmagick@1.3.45-r0"
+						}
+					]
+				}
+			],
+			"status": "affected",
+			"action_statement": "WPG (WordPerfect Graphics) coder is compiled into Alpine's graphicsmagick package. However, WPG is an obsolete format from the 1980s with no legitimate use case in n8n workflows. Exploitation requires a workflow author to deliberately fetch and process a crafted WPG file via the Edit Image node."
+		}
+	]
+}


### PR DESCRIPTION
## Summary

Backport the `security` folder for VEX attestation

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/actions/runs/23894975712/job/69679841564


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
