### PR TITLE
ci: Bring .github/scripts up to date in 1.x

### DIFF
--- a/.github/scripts/bump-versions.mjs
+++ b/.github/scripts/bump-versions.mjs
@@ -29,10 +29,16 @@ assert.match(releaseType, /^(patch|minor|major|experimental|premajor)$/, 'Invali
 // TODO: if releaseType is `auto` determine release type based on the changelog
 
 const lastTag = (await exec('git describe --tags --match "n8n@*" --abbrev=0')).stdout.trim();
-const packages = JSON.parse((await exec('pnpm ls -r --only-projects --json')).stdout);
+const packages = JSON.parse(
+	(
+		await exec(
+			`pnpm ls -r --only-projects --json | jq -r '[.[] | { name: .name, version: .version, path: .path,  private: .private}]'`,
+		)
+	).stdout,
+);
 
 const packageMap = {};
-for (let { name, path, version, private: isPrivate, dependencies } of packages) {
+for (let { name, path, version, private: isPrivate } of packages) {
 	if (isPrivate && path !== rootDir) continue;
 	if (path === rootDir) name = 'monorepo-root';
 
@@ -48,6 +54,28 @@ assert.ok(
 	'No changes found since the last release',
 );
 
+// Propagate isDirty transitively: if a package's dependency will be bumped,
+// that package also needs a bump (e.g. design-system → editor-ui → cli).
+
+const depsByPackage = {};
+for (const packageName in packageMap) {
+	const packageFile = resolve(packageMap[packageName].path, 'package.json');
+	const packageJson = JSON.parse(await readFile(packageFile, 'utf-8'));
+	depsByPackage[packageName] = Object.keys(packageJson.dependencies || {});
+}
+
+let changed = true;
+while (changed) {
+	changed = false;
+	for (const packageName in packageMap) {
+		if (packageMap[packageName].isDirty) continue;
+		if (depsByPackage[packageName].some((dep) => packageMap[dep]?.isDirty)) {
+			packageMap[packageName].isDirty = true;
+			changed = true;
+		}
+	}
+}
+
 // Keep the monorepo version up to date with the released version
 packageMap['monorepo-root'].version = packageMap['n8n'].version;
 
@@ -56,17 +84,32 @@ for (const packageName in packageMap) {
 	const packageFile = resolve(path, 'package.json');
 	const packageJson = JSON.parse(await readFile(packageFile, 'utf-8'));
 
-	packageJson.version = packageMap[packageName].nextVersion =
-		isDirty ||
-		Object.keys(packageJson.dependencies || {}).some(
-			(dependencyName) => packageMap[dependencyName]?.isDirty,
-		)
-			? releaseType === 'experimental'
-				? generateExperimentalVersion(version)
-				: releaseType === 'premajor'
-				? semver.inc(version, version.includes('-rc.') ? 'prerelease' : 'premajor', undefined, 'rc')
-					: semver.inc(version, releaseType)
-			: version;
+	const dependencyIsDirty = Object.keys(packageJson.dependencies || {}).some(
+		(dependencyName) => packageMap[dependencyName]?.isDirty,
+	);
+
+	let newVersion = version;
+
+	if (isDirty || dependencyIsDirty) {
+		switch (releaseType) {
+			case 'experimental':
+				newVersion = generateExperimentalVersion(version);
+				break;
+			case 'premajor':
+				newVersion = semver.inc(
+					version,
+					version.includes('-rc.') ? 'prerelease' : 'premajor',
+					undefined,
+					'rc',
+				);
+				break;
+			default:
+				newVersion = semver.inc(version, releaseType);
+				break;
+		}
+	}
+
+	packageJson.version = packageMap[packageName].nextVersion = newVersion;
 
 	await writeFile(packageFile, JSON.stringify(packageJson, null, 2) + '\n');
 }

--- a/.github/scripts/create-github-release.mjs
+++ b/.github/scripts/create-github-release.mjs
@@ -1,0 +1,81 @@
+import {
+	deleteRelease,
+	ensureEnvVar,
+	getExistingRelease,
+	initGithub,
+	isReleaseTrack,
+	writeGithubOutput,
+} from './github-helpers.mjs';
+
+/**
+ * Creates release in GitHub.
+ *
+ * Required env variables:
+ *	- RELEASE_TAG	 - Release tag on git e.g. n8n@2.13.0
+ *	- BODY - Body of the release. Contains release notes etc.
+ *	- IS_PRE_RELEASE - If releasing in pre-release. Currently only for beta track.
+ *	- MAKE_LATEST - If released version should be marked as latest on GitHub
+ *	- COMMIT	- Commitish for release to point to
+ *
+ * Optional env variables:
+ *	- ADDITIONAL_TAGS	-	Comma-separated list of additional tags to release under e.g. beta
+ *
+ * GitHub variables
+ *	- GITHUB_TOKEN	-	 Used to authenticate to octokit - Can be overwritten for privileged access
+ *	- GITHUB_REPOSITORY	-	 Used to determine target repository
+ * */
+async function createGitHubRelease() {
+	const RELEASE_TAG = ensureEnvVar('RELEASE_TAG');
+	const ADDITIONAL_TAGS = process.env.ADDITIONAL_TAGS ?? '';
+	const BODY = ensureEnvVar('BODY');
+	const IS_PRE_RELEASE = ensureEnvVar('IS_PRE_RELEASE');
+	const MAKE_LATEST = ensureEnvVar('MAKE_LATEST');
+	const COMMIT = ensureEnvVar('COMMIT');
+
+	const { octokit, owner, repo } = initGithub();
+
+	const allTags = [
+		RELEASE_TAG,
+		...ADDITIONAL_TAGS.split(',')
+			.map((t) => t.trim())
+			.filter(Boolean),
+	];
+	const releases = [];
+
+	for (const tag of allTags) {
+		const existingRelease = await getExistingRelease(tag);
+		const isReleaseTrackTag = isReleaseTrack(tag);
+
+		// If we have an existing track release, we want to
+		// delete the old release before pushing a new one.
+		if (isReleaseTrackTag && existingRelease) {
+			await deleteRelease(existingRelease.id);
+		}
+
+		const releaseResponse = await octokit.rest.repos.createRelease({
+			tag_name: tag,
+			name: tag,
+			body: BODY,
+			draft: false,
+			prerelease: IS_PRE_RELEASE === 'true',
+			make_latest: MAKE_LATEST === 'true' ? 'true' : 'false',
+			target_commitish: COMMIT,
+			owner,
+			repo,
+		});
+
+		const release = releaseResponse.data;
+		releases.push(release);
+
+		console.log(`Successfully created release ${release.html_url}`);
+	}
+
+	writeGithubOutput({
+		release_urls: releases.map((release) => release.html_url).join(', '),
+	});
+}
+
+// only run when executed directly, not when imported by tests
+if (import.meta.url === `file://${process.argv[1]}`) {
+	createGitHubRelease();
+}

--- a/.github/scripts/detect-new-packages.mjs
+++ b/.github/scripts/detect-new-packages.mjs
@@ -16,10 +16,17 @@
 
 import child_process from 'child_process';
 import { promisify } from 'util';
+import { writeGithubOutput } from './github-helpers.mjs';
 
 const exec = promisify(child_process.exec);
 
-const packages = JSON.parse((await exec('pnpm ls -r --only-projects --json')).stdout);
+const packages = JSON.parse(
+	(
+		await exec(
+			`pnpm ls -r --only-projects --json | jq -r '[.[] | { name:.name, private: .private}]'`,
+		)
+	).stdout,
+);
 
 const newPackages = [];
 
@@ -31,6 +38,7 @@ for (const { name, private: isPrivate } of packages) {
 	const url = `https://registry.npmjs.org/${encodedName}`;
 
 	try {
+		console.log(`Checking if ${name} exists...`);
 		const response = await fetch(url, { method: 'HEAD' });
 		if (response.status === 404) {
 			newPackages.push(name);
@@ -63,7 +71,6 @@ OIDC Trusted Publishing until they have been published at least once manually:
 `);
 
 for (const pkg of newPackages) {
-	console.log(`  - ${pkg}`);
 	console.log(
 		`::error::Package "${pkg}" has never been published to npm. A manual first-publish with an NPM token is required before it can use OIDC Trusted Publishing.`,
 	);
@@ -88,4 +95,10 @@ Steps to unblock the release, for each new package listed above:
   3. Re-run the Release: Publish workflow.
 
 `);
+
+const output = {
+	packages: newPackages.join(','),
+};
+console.log(` -- Writing to github output: ${JSON.stringify(output)}`);
+writeGithubOutput(output);
 process.exit(1);

--- a/.github/scripts/determine-release-candidate-branch-for-track.mjs
+++ b/.github/scripts/determine-release-candidate-branch-for-track.mjs
@@ -1,5 +1,4 @@
 import {
-	countCommitsBetweenRefs,
 	ensureEnvVar,
 	listCommitsBetweenRefs,
 	resolveRcBranchForTrack,
@@ -25,12 +24,26 @@ function main() {
 	console.log(`Commits between ${releaseCandidateBranch} and ${currentTag.tag}:`);
 	console.log(listCommitsBetweenRefs(releaseCandidateBranch, currentTag.tag));
 
-	const commitCount = countCommitsBetweenRefs(releaseCandidateBranch, currentTag.tag);
+	const commitList = listCommitsBetweenRefs(releaseCandidateBranch, currentTag.tag)
+		.split('\n')
+		.filter((commit) => commit.trim().length > 0);
+	const actionableCommitList = filterActionableCommits(commitList);
 
-	writeGithubOutput({
+	const output = {
 		release_candidate_branch: releaseCandidateBranch,
-		should_update: commitCount > 0 ? 'true' : 'false',
-	});
+		should_update: actionableCommitList.length > 0 ? 'true' : 'false',
+	};
+
+	console.log(output);
+
+	writeGithubOutput(output);
+}
+
+/**
+ * @param { string[] } commitList
+ * */
+export function filterActionableCommits(commitList) {
+	return commitList.filter((commit) => !commit.trimStart().startsWith('ci:'));
 }
 
 // only run when executed directly, not when imported by tests

--- a/.github/scripts/determine-version-info.mjs
+++ b/.github/scripts/determine-version-info.mjs
@@ -1,6 +1,10 @@
 import { readFileSync } from 'node:fs';
-import { RELEASE_TRACKS, resolveReleaseTagForTrack, writeGithubOutput } from './github-helpers.mjs';
-import { tagVersionInfoToReleaseCandidateBranchName } from './ensure-release-candidate-branches.mjs';
+import {
+	RELEASE_TRACKS,
+	resolveReleaseTagForTrack,
+	tagVersionInfoToReleaseCandidateBranchName,
+	writeGithubOutput,
+} from './github-helpers.mjs';
 import semver from 'semver';
 
 /**
@@ -70,7 +74,9 @@ export function determineTrack(packageVersion) {
 
 	writeGithubOutput(output);
 	console.log(
-		`Determined track info: track=${track}, version=${packageVersion}, previous_version=${previousVersion}, new_stable_version=${newStable}, release_type=${releaseType}, rc_branch=${rc_branch}`,
+		`Determined track info: ${Object.entries(output)
+			.map(([key, val]) => `${key}=${val}`)
+			.join(', ')}`,
 	);
 
 	return output;

--- a/.github/scripts/determine-version-info.test.mjs
+++ b/.github/scripts/determine-version-info.test.mjs
@@ -1,5 +1,6 @@
 import { describe, it, mock, before } from 'node:test';
 import assert from 'node:assert/strict';
+import { tagVersionInfoToReleaseCandidateBranchName } from './github-helpers.mjs';
 
 /**
  * Run these tests by running
@@ -18,6 +19,7 @@ mock.module('./github-helpers.mjs', {
 			if (track === 'beta') return { version: '2.10.1', tag: 'n8n@2.10.1' };
 			return { version: '1.123.33', tag: 'n8n@1.123.33' };
 		},
+		tagVersionInfoToReleaseCandidateBranchName,
 		writeGithubOutput: () => {}, // no-op in tests
 		getCommitForRef: () => {}, // no-op
 		localRefExists: () => {}, // no-op
@@ -101,5 +103,17 @@ describe('determine-tracks', () => {
 		assert.equal(output.new_stable_version, null);
 		assert.equal(output.release_type, 'rc');
 		assert.equal(output.rc_branch, 'release-candidate/2.10.x');
+	});
+
+	it('Determines correct branches on 1.x', () => {
+		const output = determineTrack('1.123.34');
+
+		assert.equal(output.track, 'v1');
+		assert.equal(output.version, '1.123.34');
+		assert.equal(output.previous_version, '1.123.33');
+		assert.equal(output.bump, 'patch');
+		assert.equal(output.new_stable_version, null);
+		assert.equal(output.release_type, 'stable');
+		assert.equal(output.rc_branch, '1.x');
 	});
 });

--- a/.github/scripts/ensure-provenance-fields.mjs
+++ b/.github/scripts/ensure-provenance-fields.mjs
@@ -9,7 +9,13 @@ const exec = promisify(child_process.exec);
 const commonFiles = ['LICENSE.md', 'LICENSE_EE.md'];
 
 const baseDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
-const packages = JSON.parse((await exec('pnpm ls -r --only-projects --json')).stdout);
+const packages = JSON.parse(
+	(
+		await exec(
+			`pnpm ls -r --only-projects --json | jq -r '[.[] | { name: .name, version: .version, path: .path,  private: .private}]'`,
+		)
+	).stdout,
+);
 
 for (let { name, path, version, private: isPrivate } of packages) {
 	if (isPrivate) continue;

--- a/.github/scripts/ensure-release-candidate-branches.mjs
+++ b/.github/scripts/ensure-release-candidate-branches.mjs
@@ -2,13 +2,14 @@ import semver from 'semver';
 import {
 	getCommitForRef,
 	localRefExists,
+	RELEASE_CANDIDATE_BRANCH_PREFIX,
 	remoteBranchExists,
 	resolveReleaseTagForTrack,
 	sh,
+	tagVersionInfoToReleaseCandidateBranchName,
+	trySh,
 	writeGithubOutput,
 } from './github-helpers.mjs';
-
-const RELEASE_CANDIDATE_BRANCH_PREFIX = 'release-candidate/';
 
 /**
  * @typedef BranchChanges
@@ -52,20 +53,6 @@ export function determineBranchChanges() {
 }
 
 /**
- * Takes a TagVersionInfo object and returns a rc-branch name.
- *
- * e.g. release-candidate/2.8.x
- *
- * @param {import('./github-helpers.mjs').TagVersionInfo} tagVersionInfo
- *
- * @returns { `${RELEASE_CANDIDATE_BRANCH_PREFIX}${number}.${number}.x` }
- * */
-export function tagVersionInfoToReleaseCandidateBranchName(tagVersionInfo) {
-	const version = tagVersionInfo.version;
-	return `${RELEASE_CANDIDATE_BRANCH_PREFIX}${semver.major(version)}.${semver.minor(version)}.x`;
-}
-
-/**
  * @param {import("./github-helpers.mjs").TagVersionInfo} tagInfo
  */
 function ensureBranch(tagInfo) {
@@ -102,12 +89,12 @@ function removeBranch(branch) {
 
 	console.log(`Removing remote branch ${branch} from origin...`);
 	// Delete remote branch
-	sh('git', ['push', 'origin', '--delete', branch]);
+	trySh('git', ['push', 'origin', '--delete', branch]);
 
 	// Optional local cleanup (keeps reruns tidy)
 	if (localRefExists(`refs/heads/${branch}`)) {
 		console.log(`Removing local branch ${branch}...`);
-		sh('git', ['branch', '-D', branch]);
+		trySh('git', ['branch', '-D', branch]);
 	}
 
 	return branch;

--- a/.github/scripts/ensure-release-candidate-branches.test.mjs
+++ b/.github/scripts/ensure-release-candidate-branches.test.mjs
@@ -1,5 +1,6 @@
 import { describe, it, mock, before } from 'node:test';
 import assert from 'node:assert/strict';
+import { RELEASE_CANDIDATE_BRANCH_PREFIX } from './github-helpers.mjs';
 
 /**
  * Run these tests by running
@@ -7,12 +8,19 @@ import assert from 'node:assert/strict';
  * node --test --experimental-test-module-mocks ./.github/scripts/ensure-release-candidate-branches.test.mjs
  * */
 
+let tagVersionInfoToReleaseCandidateBranchName;
+before(async () => {
+	({ tagVersionInfoToReleaseCandidateBranchName } = await import('./github-helpers.mjs'));
+});
+
 // mock.module must be called before the module under test is imported,
 // because static imports are hoisted and resolve before any code runs.
 mock.module('./github-helpers.mjs', {
 	namedExports: {
 		RELEASE_TRACKS: ['stable', 'beta', 'v1'],
 		RELEASE_PREFIX: 'n8n@',
+		RELEASE_CANDIDATE_BRANCH_PREFIX: RELEASE_CANDIDATE_BRANCH_PREFIX,
+		tagVersionInfoToReleaseCandidateBranchName,
 		resolveReleaseTagForTrack: (track) => {
 			// Always return deterministic data
 			if (track === 'stable') return { version: '2.9.2', tag: 'n8n@2.9.2' };
@@ -21,17 +29,16 @@ mock.module('./github-helpers.mjs', {
 		},
 		writeGithubOutput: () => {}, // no-op in tests
 		sh: () => {}, // no-op in tests
+		trySh: () => {}, // no-op in tests
 		getCommitForRef: () => {}, // no-op in tests
 		remoteBranchExists: () => {}, // no-op in tests
 		localRefExists: () => {}, // no-op in tests
 	},
 });
 
-let determineBranchChanges, tagVersionInfoToReleaseCandidateBranchName;
+let determineBranchChanges;
 before(async () => {
-	({ determineBranchChanges, tagVersionInfoToReleaseCandidateBranchName } = await import(
-		'./ensure-release-candidate-branches.mjs'
-	));
+	({ determineBranchChanges } = await import('./ensure-release-candidate-branches.mjs'));
 });
 
 describe('Determine branch changes', () => {

--- a/.github/scripts/github-helpers.mjs
+++ b/.github/scripts/github-helpers.mjs
@@ -4,12 +4,19 @@ import fs from 'node:fs';
 import path from 'node:path';
 import semver from 'semver';
 
+export const CURRENT_MAJOR_VERSION = 2;
+export const RELEASE_CANDIDATE_BRANCH_PREFIX = 'release-candidate/';
+
 export const RELEASE_TRACKS = /** @type { const } */ ([
 	//
 	'stable',
 	'beta',
 	'v1',
 ]);
+
+/**
+ * @typedef { InstanceType<typeof import("@actions/github/lib/utils").GitHub> } GitHubInstance
+ * */
 
 /**
  * @typedef {typeof RELEASE_TRACKS[number]} ReleaseTrack
@@ -24,7 +31,7 @@ export const RELEASE_TRACKS = /** @type { const } */ ([
  * */
 
 /**
- * @typedef {{ tag: ReleaseVersion, version: SemVer}} TagVersionInfo
+ * @typedef {{ tag: ReleaseVersion, version: SemVer }} TagVersionInfo
  * */
 
 export const RELEASE_PREFIX = 'n8n@';
@@ -45,6 +52,15 @@ export function pickHighestReleaseTag(tags) {
 		.sort((a, b) => semver.rcompare(a.v, b.v));
 
 	return /** @type { ReleaseVersion } */ (versions[0]?.tag) ?? null;
+}
+
+/**
+ * @param {any} track
+ *
+ * @returns { track is ReleaseTrack }
+ * */
+export function isReleaseTrack(track) {
+	return RELEASE_TRACKS.includes(track);
 }
 
 /**
@@ -113,6 +129,25 @@ export function resolveRcBranchForTrack(track) {
 }
 
 /**
+ * Takes a TagVersionInfo object and returns a rc-branch name.
+ *
+ * e.g. release-candidate/2.8.x or 1.x
+ *
+ * @param {import('./github-helpers.mjs').TagVersionInfo} tagVersionInfo
+ *
+ * @returns { `${RELEASE_CANDIDATE_BRANCH_PREFIX}${number}.${number}.x` | `${number}.x` }
+ * */
+export function tagVersionInfoToReleaseCandidateBranchName(tagVersionInfo) {
+	const version = tagVersionInfo.version;
+	const majorVersion = semver.major(version);
+	if (majorVersion < CURRENT_MAJOR_VERSION) {
+		return `${majorVersion}.x`;
+	}
+
+	return `${RELEASE_CANDIDATE_BRANCH_PREFIX}${majorVersion}.${semver.minor(version)}.x`;
+}
+
+/**
  * @param {string} tag
  *
  * @returns { SemVer }
@@ -150,8 +185,9 @@ export function readPrLabels(pullRequest) {
 /**
  * Ensures git tag exists.
  *
- * @throws { Error } if no tag was found
- * */
+ * @param {string} tag
+ * @throws {Error} if no tag was found
+ */
 export function ensureTagExists(tag) {
 	sh('git', ['fetch', '--force', '--no-tags', 'origin', `refs/tags/${tag}:refs/tags/${tag}`]);
 }
@@ -250,7 +286,7 @@ export function listTagsPointingAt(commit) {
  * @param {string} to
  */
 export function listCommitsBetweenRefs(from, to) {
-	return sh('git', ['--no-pager', 'log', '--format="- %s (%h)', `${to}..origin/${from}`]);
+	return sh('git', ['--no-pager', 'log', '--format=%s (%h)', `${to}..origin/${from}`]);
 }
 
 /**
@@ -313,4 +349,38 @@ export async function getPullRequestById(pullRequestId) {
 	});
 
 	return pullRequest.data;
+}
+
+/**
+ * @param {string} tag
+ */
+export async function getExistingRelease(tag) {
+	const { octokit, owner, repo } = initGithub();
+
+	try {
+		const releaseRequest = await octokit.rest.repos.getReleaseByTag({
+			owner,
+			repo,
+			tag,
+		});
+
+		return releaseRequest.data;
+	} catch (ex) {
+		if (ex?.status === 404) {
+			return undefined;
+		}
+		throw ex;
+	}
+}
+
+/**
+ * @param {number} releaseId
+ */
+export async function deleteRelease(releaseId) {
+	const { octokit, owner, repo } = initGithub();
+	await octokit.rest.repos.deleteRelease({
+		owner,
+		repo,
+		release_id: releaseId,
+	});
 }

--- a/.github/scripts/jsconfig.json
+++ b/.github/scripts/jsconfig.json
@@ -3,7 +3,7 @@
     "module": "esnext",
     "target": "esnext",
     "checkJs": true,
-    "moduleResolution": "node"
+    "moduleResolution": "bundler"
   },
   "exclude": ["node_modules"]
 }

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -5,6 +5,7 @@
   },
   "dependencies": {
     "@actions/github": "9.0.0",
+    "@octokit/core": "7.0.6",
     "conventional-changelog": "7.2.0",
     "debug": "4.4.3",
     "glob": "13.0.6",
@@ -12,6 +13,6 @@
     "tempfile": "6.0.1"
   },
   "devDependencies": {
-    "conventional-changelog-angular": "^8.3.0"
+    "conventional-changelog-angular": "8.3.0"
   }
 }

--- a/.github/scripts/pnpm-lock.yaml
+++ b/.github/scripts/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@actions/github':
         specifier: 9.0.0
         version: 9.0.0
+      '@octokit/core':
+        specifier: 7.0.6
+        version: 7.0.6
       conventional-changelog:
         specifier: 7.2.0
         version: 7.2.0(conventional-commits-filter@5.0.0)
@@ -28,7 +31,7 @@ importers:
         version: 6.0.1
     devDependencies:
       conventional-changelog-angular:
-        specifier: ^8.3.0
+        specifier: 8.3.0
         version: 8.3.0
 
 packages:

--- a/.github/scripts/promote-github-release.mjs
+++ b/.github/scripts/promote-github-release.mjs
@@ -1,0 +1,68 @@
+import {
+	deleteRelease,
+	ensureEnvVar,
+	getExistingRelease,
+	initGithub,
+	writeGithubOutput,
+} from './github-helpers.mjs';
+
+/**
+ * Promotes a GitHub release to latest
+ *
+ * Required env variables:
+ *	- RELEASE_TAG	 - Release tag on git e.g. n8n@2.13.0
+ *
+ * GitHub variables
+ *	- GITHUB_TOKEN	-	 Used to authenticate to octokit - Can be overwritten for privileged access
+ *	- GITHUB_REPOSITORY	-	 Used to determine target repository
+ * */
+async function promoteGitHubRelease() {
+	const RELEASE_TAG = ensureEnvVar('RELEASE_TAG');
+	const { octokit, owner, repo } = initGithub();
+
+	const existingRelease = await getExistingRelease(RELEASE_TAG);
+	if (!existingRelease) {
+		console.warn("Couldn't find release by tag. Exiting...");
+		process.exit(1);
+	}
+
+	const releaseResponse = await octokit.rest.repos.updateRelease({
+		owner,
+		repo,
+		release_id: existingRelease.id,
+		prerelease: false,
+		make_latest: 'true',
+	});
+
+	console.log(`Successfully updated release ${releaseResponse.data.html_url}`);
+
+	const existingStableRelease = await getExistingRelease('stable');
+	if (existingStableRelease) {
+		await deleteRelease(existingStableRelease.id);
+		console.log("Deleted previous 'stable' release.");
+	}
+
+	const stableReleaseResponse = await octokit.rest.repos.createRelease({
+		tag_name: 'stable',
+		name: 'stable',
+		body: releaseResponse.data.body,
+		draft: false,
+		prerelease: false,
+		make_latest: 'false',
+		target_commitish: releaseResponse.data.target_commitish,
+		owner,
+		repo,
+	});
+
+	console.log(`Successfully created new stable release ${stableReleaseResponse.data.html_url}`);
+
+	writeGithubOutput({
+		release_url: releaseResponse.data.html_url,
+		stable_release_url: stableReleaseResponse.data.html_url,
+	});
+}
+
+// only run when executed directly, not when imported by tests
+if (import.meta.url === `file://${process.argv[1]}`) {
+	promoteGitHubRelease();
+}

--- a/.github/scripts/update-changelog.mjs
+++ b/.github/scripts/update-changelog.mjs
@@ -1,5 +1,5 @@
 import createTempFile from 'tempfile';
-import { ConventionalChangelog, packagePrefix } from 'conventional-changelog';
+import { ConventionalChangelog } from 'conventional-changelog';
 import { resolve } from 'path';
 import { createReadStream, createWriteStream } from 'fs';
 import { dirname } from 'path';
@@ -30,7 +30,23 @@ const changelogStream = new ConventionalChangelog()
 			const isBenchmarkScope = commit.scope === 'benchmark';
 
 			// Ignore commits that have 'benchmark' scope or '(no-changelog)' in the header
-			return hasNoChangelogInHeader || isBenchmarkScope ? null : commit;
+			if (hasNoChangelogInHeader || isBenchmarkScope) return null;
+
+			// Strip backport information from commit subject, e.g.:
+			// "Fix something (backport to release-candidate/2.12.x) (#123)" → "Fix something (#123)"
+			if (commit.subject) {
+				// The commit.subject is immutable so we need to recreate the commit object
+
+				/** @type { import("conventional-changelog").Commit } */
+				let newCommit = /** @type { any } */ ({
+					...commit,
+					subject: commit.subject.replace(/\s*\(backport to [^)]+\)/g, ''),
+				});
+
+				return newCommit;
+			}
+
+			return commit;
 		},
 	})
 	.writeStream()


### PR DESCRIPTION
## Summary

Follow-up on https://github.com/n8n-io/n8n/pull/27154 . The .github/scripts folder drifted out of sync and we just refresh it now.

## Related Linear tickets, Github issues, and Community forum posts




## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
