### PR TITLE
fix(MCP Client Node): Ensure MCP connections close on all code paths

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClient/McpClient.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClient/McpClient.node.ts
@@ -238,90 +238,94 @@ export class McpClient implements INodeType {
 			throw mapToNodeOperationError(node, client.error);
 		}
 
-		const inputMode = this.getNodeParameter('inputMode', 0, 'manual') as 'manual' | 'json';
-		const items = this.getInputData();
-		const returnData: INodeExecutionData[] = [];
-		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
-			try {
-				const tool = this.getNodeParameter('tool.value', itemIndex) as string;
-				const options = this.getNodeParameter('options', itemIndex);
-				let parameters: IDataObject = {};
-				if (inputMode === 'manual') {
-					parameters = this.getNodeParameter('parameters.value', itemIndex) as IDataObject;
-				} else {
-					parameters = this.getNodeParameter('jsonInput', itemIndex) as IDataObject;
-				}
-
-				const result = (await client.result.callTool(
-					{
-						name: tool,
-						arguments: parameters,
-					},
-					undefined,
-					{
-						timeout: options.timeout ? Number(options.timeout) : undefined,
-					},
-				)) as CallToolResult;
-
-				let binaryIndex = 0;
-				const binary: IBinaryKeyData = {};
-				const content: IDataObject[] = [];
-				const convertToBinary = options.convertToBinary ?? true;
-				for (const contentItem of result.content) {
-					if (contentItem.type === 'text') {
-						content.push({
-							...contentItem,
-							text: jsonParse(contentItem.text, { fallbackValue: contentItem.text }),
-						});
-						continue;
+		try {
+			const inputMode = this.getNodeParameter('inputMode', 0, 'manual') as 'manual' | 'json';
+			const items = this.getInputData();
+			const returnData: INodeExecutionData[] = [];
+			for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+				try {
+					const tool = this.getNodeParameter('tool.value', itemIndex) as string;
+					const options = this.getNodeParameter('options', itemIndex);
+					let parameters: IDataObject = {};
+					if (inputMode === 'manual') {
+						parameters = this.getNodeParameter('parameters.value', itemIndex) as IDataObject;
+					} else {
+						parameters = this.getNodeParameter('jsonInput', itemIndex) as IDataObject;
 					}
 
-					if (convertToBinary && (contentItem.type === 'image' || contentItem.type === 'audio')) {
-						binary[`data_${binaryIndex}`] = await this.helpers.prepareBinaryData(
-							Buffer.from(contentItem.data, 'base64'),
-							undefined,
-							contentItem.mimeType,
-						);
-						binaryIndex++;
-						continue;
+					const result = (await client.result.callTool(
+						{
+							name: tool,
+							arguments: parameters,
+						},
+						undefined,
+						{
+							timeout: options.timeout ? Number(options.timeout) : undefined,
+						},
+					)) as CallToolResult;
+
+					let binaryIndex = 0;
+					const binary: IBinaryKeyData = {};
+					const content: IDataObject[] = [];
+					const convertToBinary = options.convertToBinary ?? true;
+					for (const contentItem of result.content) {
+						if (contentItem.type === 'text') {
+							content.push({
+								...contentItem,
+								text: jsonParse(contentItem.text, { fallbackValue: contentItem.text }),
+							});
+							continue;
+						}
+
+						if (convertToBinary && (contentItem.type === 'image' || contentItem.type === 'audio')) {
+							binary[`data_${binaryIndex}`] = await this.helpers.prepareBinaryData(
+								Buffer.from(contentItem.data, 'base64'),
+								undefined,
+								contentItem.mimeType,
+							);
+							binaryIndex++;
+							continue;
+						}
+
+						content.push(contentItem as IDataObject);
 					}
 
-					content.push(contentItem as IDataObject);
-				}
-
-				returnData.push({
-					json: {
-						content: content.length > 0 ? content : undefined,
-					},
-					binary: Object.keys(binary).length > 0 ? binary : undefined,
-					pairedItem: {
-						item: itemIndex,
-					},
-				});
-			} catch (e) {
-				const errorMessage =
-					e instanceof ZodError ? prettifyError(e) : e instanceof Error ? e.message : String(e);
-				if (this.continueOnFail()) {
 					returnData.push({
 						json: {
-							error: {
-								message: errorMessage,
-								issues: e instanceof ZodError ? e.issues : undefined,
-							},
+							content: content.length > 0 ? content : undefined,
 						},
+						binary: Object.keys(binary).length > 0 ? binary : undefined,
 						pairedItem: {
 							item: itemIndex,
 						},
 					});
-					continue;
+				} catch (e) {
+					const errorMessage =
+						e instanceof ZodError ? prettifyError(e) : e instanceof Error ? e.message : String(e);
+					if (this.continueOnFail()) {
+						returnData.push({
+							json: {
+								error: {
+									message: errorMessage,
+									issues: e instanceof ZodError ? e.issues : undefined,
+								},
+							},
+							pairedItem: {
+								item: itemIndex,
+							},
+						});
+						continue;
+					}
+
+					throw new NodeOperationError(node, errorMessage, {
+						itemIndex,
+					});
 				}
-
-				throw new NodeOperationError(node, errorMessage, {
-					itemIndex,
-				});
 			}
-		}
 
-		return [returnData];
+			return [returnData];
+		} finally {
+			await client.result.close();
+		}
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClient/listSearch.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClient/listSearch.ts
@@ -31,18 +31,22 @@ export async function getTools(
 		throw mapToNodeOperationError(node, client.error);
 	}
 
-	const result = await client.result.listTools({ cursor: paginationToken });
-	const tools = filter
-		? result.tools.filter((tool) => tool.name.toLowerCase().includes(filter.toLowerCase()))
-		: result.tools;
+	try {
+		const result = await client.result.listTools({ cursor: paginationToken });
+		const tools = filter
+			? result.tools.filter((tool) => tool.name.toLowerCase().includes(filter.toLowerCase()))
+			: result.tools;
 
-	return {
-		results: tools.map((tool) => ({
-			name: tool.name,
-			value: tool.name,
-			description: tool.description,
-			inputSchema: tool.inputSchema,
-		})),
-		paginationToken: result.nextCursor,
-	};
+		return {
+			results: tools.map((tool) => ({
+				name: tool.name,
+				value: tool.name,
+				description: tool.description,
+				inputSchema: tool.inputSchema,
+			})),
+			paginationToken: result.nextCursor,
+		};
+	} finally {
+		await client.result.close();
+	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClient/resourceMapping.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClient/resourceMapping.ts
@@ -35,14 +35,18 @@ export async function getToolParameters(
 		throw mapToNodeOperationError(node, client.error);
 	}
 
-	const result = await getAllTools(client.result);
-	const tool = result.find((tool) => tool.name === toolId);
-	if (!tool) {
-		throw new NodeOperationError(this.getNode(), 'Tool not found');
-	}
+	try {
+		const result = await getAllTools(client.result);
+		const tool = result.find((tool) => tool.name === toolId);
+		if (!tool) {
+			throw new NodeOperationError(this.getNode(), 'Tool not found');
+		}
 
-	const fields = convertJsonSchemaToResourceMapperFields(tool.inputSchema);
-	return {
-		fields,
-	};
+		const fields = convertJsonSchemaToResourceMapperFields(tool.inputSchema);
+		return {
+			fields,
+		};
+	} finally {
+		await client.result.close();
+	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -100,15 +100,20 @@ async function connectAndGetTools(
 		return { client, mcpTools: null, error: client.error };
 	}
 
-	const allTools = await getAllTools(client.result);
-	const mcpTools = getSelectedTools({
-		tools: allTools,
-		mode: config.mode,
-		includeTools: config.includeTools,
-		excludeTools: config.excludeTools,
-	});
+	try {
+		const allTools = await getAllTools(client.result);
+		const mcpTools = getSelectedTools({
+			tools: allTools,
+			mode: config.mode,
+			includeTools: config.includeTools,
+			excludeTools: config.excludeTools,
+		});
 
-	return { client: client.result, mcpTools, error: null };
+		return { client: client.result, mcpTools, error: null };
+	} catch (e) {
+		await client.result.close();
+		throw e;
+	}
 }
 
 export class McpClientTool implements INodeType {
@@ -365,6 +370,7 @@ export class McpClientTool implements INodeType {
 		this.logger.debug('McpClientTool: Successfully connected to MCP Server');
 
 		if (!mcpTools?.length) {
+			await client.close();
 			return setError(
 				new NodeOperationError(node, 'MCP Server returned no tools', {
 					itemIndex,
@@ -411,49 +417,58 @@ export class McpClientTool implements INodeType {
 			}
 
 			if (!mcpTools?.length) {
+				await client.close();
 				throw new NodeOperationError(node, 'MCP Server returned no tools', { itemIndex });
 			}
 
-			for (const tool of mcpTools) {
-				// Check for tool name in item.json.tool (for toolkit execution from agent)
-				// or item.tool (for direct execution)
-				if (!item.json.tool || typeof item.json.tool !== 'string') {
-					throw new NodeOperationError(node, 'Tool name not found in item.json.tool or item.tool', {
-						itemIndex,
-					});
-				}
+			try {
+				for (const tool of mcpTools) {
+					// Check for tool name in item.json.tool (for toolkit execution from agent)
+					// or item.tool (for direct execution)
+					if (!item.json.tool || typeof item.json.tool !== 'string') {
+						throw new NodeOperationError(
+							node,
+							'Tool name not found in item.json.tool or item.tool',
+							{
+								itemIndex,
+							},
+						);
+					}
 
-				const toolName = item.json.tool;
-				if (toolName === tool.name) {
-					// Extract the tool name from arguments before passing to MCP
-					const { tool: _, ...toolArguments } = item.json;
-					const schema: JSONSchema7 = tool.inputSchema;
-					// When additionalProperties is not explicitly true, filter to schema-defined properties.
-					// Otherwise, pass all arguments through
-					const sanitizedToolArguments: IDataObject =
-						schema.additionalProperties !== true
-							? pick(toolArguments, Object.keys(schema.properties ?? {}))
-							: toolArguments;
+					const toolName = item.json.tool;
+					if (toolName === tool.name) {
+						// Extract the tool name from arguments before passing to MCP
+						const { tool: _, ...toolArguments } = item.json;
+						const schema: JSONSchema7 = tool.inputSchema;
+						// When additionalProperties is not explicitly true, filter to schema-defined properties.
+						// Otherwise, pass all arguments through
+						const sanitizedToolArguments: IDataObject =
+							schema.additionalProperties !== true
+								? pick(toolArguments, Object.keys(schema.properties ?? {}))
+								: toolArguments;
 
-					const params: {
-						name: string;
-						arguments: IDataObject;
-					} = {
-						name: tool.name,
-						arguments: sanitizedToolArguments,
-					};
-					const result = await client.callTool(params, CallToolResultSchema, {
-						timeout: config.timeout,
-					});
-					returnData.push({
-						json: {
-							response: result.content as IDataObject,
-						},
-						pairedItem: {
-							item: itemIndex,
-						},
-					});
+						const params: {
+							name: string;
+							arguments: IDataObject;
+						} = {
+							name: tool.name,
+							arguments: sanitizedToolArguments,
+						};
+						const result = await client.callTool(params, CallToolResultSchema, {
+							timeout: config.timeout,
+						});
+						returnData.push({
+							json: {
+								response: result.content as IDataObject,
+							},
+							pairedItem: {
+								item: itemIndex,
+							},
+						});
+					}
 				}
+			} finally {
+				await client.close();
 			}
 		}
 

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/loadOptions.ts
@@ -35,11 +35,15 @@ export async function getTools(this: ILoadOptionsFunctions): Promise<INodeProper
 		throw mapToNodeOperationError(node, client.error);
 	}
 
-	const tools = await getAllTools(client.result);
-	return tools.map((tool) => ({
-		name: tool.name,
-		value: tool.name,
-		description: tool.description,
-		inputSchema: tool.inputSchema,
-	}));
+	try {
+		const tools = await getAllTools(client.result);
+		return tools.map((tool) => ({
+			name: tool.name,
+			value: tool.name,
+			description: tool.description,
+			inputSchema: tool.inputSchema,
+		}));
+	} finally {
+		await client.result.close();
+	}
 }

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -55,6 +55,7 @@ import {
 	TimeoutExecutionCancelledError,
 	ManualExecutionCancelledError,
 	createRunExecutionData,
+	ensureError,
 } from 'n8n-workflow';
 import PCancelable from 'p-cancelable';
 
@@ -1034,23 +1035,24 @@ export class WorkflowExecute {
 			subNodeExecutionResults,
 		);
 
-		let data: INodeExecutionData[][] | EngineRequest | null;
+		let data: INodeExecutionData[][] | EngineRequest | null = null;
+		let executionError: Error | undefined;
 
-		if (customOperation) {
-			data = await customOperation.call(context);
-		} else if (nodeType.execute) {
-			data =
-				nodeType instanceof Node
-					? await nodeType.execute(context, subNodeExecutionResults)
-					: await nodeType.execute.call(context, subNodeExecutionResults);
-		} else {
-			throw new UnexpectedError(
-				"Can't execute node. There is no custom operation and the node has not execute function.",
-			);
-		}
-
-		if (isEngineRequest(data)) {
-			return data;
+		try {
+			if (customOperation) {
+				data = await customOperation.call(context);
+			} else if (nodeType.execute) {
+				data =
+					nodeType instanceof Node
+						? await nodeType.execute(context, subNodeExecutionResults)
+						: await nodeType.execute.call(context, subNodeExecutionResults);
+			} else {
+				throw new UnexpectedError(
+					"Can't execute node. There is no custom operation and the node has not execute function.",
+				);
+			}
+		} catch (e) {
+			executionError = ensureError(e);
 		}
 
 		const closeFunctionsResults = await Promise.allSettled(
@@ -1061,6 +1063,26 @@ export class WorkflowExecute {
 			.filter((result): result is PromiseRejectedResult => result.status === 'rejected')
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 			.map((result) => result.reason);
+
+		if (executionError) {
+			if (closingErrors.length > 0) {
+				Logger.error("Error on execution node's close function(s) during error handling", {
+					nodeName: node.name,
+					nodeType: node.type,
+				});
+			}
+			throw executionError;
+		}
+
+		if (isEngineRequest(data)) {
+			if (closingErrors.length > 0) {
+				Logger.error("Error on execution node's close function(s) during EngineRequest", {
+					nodeName: node.name,
+					nodeType: node.type,
+				});
+			}
+			return data;
+		}
 
 		if (closingErrors.length > 0) {
 			if (closingErrors[0] instanceof Error) throw closingErrors[0];


### PR DESCRIPTION
## Summary

MCP Client connections (Streamable HTTP / SSE) created by the `MCP Client` and `MCP Client Tool` nodes were never properly closed after use, causing resource leaks. Connections persisted indefinitely, consuming memory and available ports on both the n8n instance and the MCP server.

### Root cause analysis

The leak has two independent root causes:

#### 1. Node-level: 5 of 6 MCP call sites never call `client.close()`

All MCP client connections flow through a single function — `connectMcpClient()` in `shared/utils.ts` — which returns a `Client` instance. This client must be explicitly closed via `client.close()` to terminate the underlying transport (which includes a persistent SSE GET connection opened during the MCP protocol handshake).

Before this fix, only **one** of the six call sites closed the client:

| Call site | Closed? |
|---|---|
| `McpClient.node.ts` → `execute()` | **No** |
| `McpClient/listSearch.ts` → `getTools()` | **No** |
| `McpClient/resourceMapping.ts` → `getToolParameters()` | **No** |
| `McpClientTool/loadOptions.ts` → `getTools()` | **No** |
| `McpClientTool.node.ts` → `supplyData()` | Yes (via `closeFunction` callback) |
| `McpClientTool.node.ts` → `execute()` | **No** |

This means every workflow execution, every tool dropdown click, and every parameter panel open in the editor leaked an MCP connection.

#### 2. Engine-level: `closeFunctions` skipped on error and EngineRequest paths

In `workflow-execute.ts`, the `executeNode()` method collects `closeFunctions` (cleanup callbacks registered by `supplyData()` on connected tool nodes). These were only invoked on the **success** path:

```typescript
data = await nodeType.execute.call(context, subNodeExecutionResults);

if (isEngineRequest(data)) {
    return data;  // ← closeFunctions never called
}

// closeFunctions only called here, on the success path
const closeFunctionsResults = await Promise.allSettled(
    closeFunctions.map(async (fn) => await fn()),
);
```

Two paths leaked:
- **EngineRequest return**: When an AI agent node requests tool execution, it returns an `EngineRequest`. The method returned immediately, skipping cleanup. Since `supplyData()` is re-invoked on every execution cycle (including resumptions after EngineRequest), each cycle created fresh connections while the old ones were abandoned.
- **Error throw**: Any error during `execute()` propagated past the cleanup code entirely.

### What this PR changes

**Node-level fixes** — Add `try/finally` with `client.close()` to all 5 leaking call sites:
- `McpClient/listSearch.ts` — UI tool listing
- `McpClient/resourceMapping.ts` — UI parameter schema loading
- `McpClientTool/loadOptions.ts` — UI tool dropdown
- `McpClient/McpClient.node.ts` — Standalone execute
- `McpClientTool/McpClientTool.node.ts` — Execute, connectAndGetTools error path, supplyData empty-tools path

**Engine-level fix** — Restructure `executeNode()` so `closeFunctions` always run:
- Wrap execution in `try/catch` to capture errors
- Always invoke `closeFunctions` via `Promise.allSettled()` after execution completes
- On error path: log close errors, re-throw original error (close errors don't mask execution errors)
- On EngineRequest path: log close errors, return the request (execution must continue)
- On success path: preserve existing behavior — throw on close errors

### How MCP connections work (context for reviewers)

When `connectMcpClient()` creates a `StreamableHTTPClientTransport` and calls `client.connect(transport)`, the MCP SDK:

1. Creates an `AbortController` for the transport
2. Sends a POST `initialize` request
3. Sends a POST `notifications/initialized`
4. On receiving the initialized notification response, opens a **persistent GET request** for SSE (server-sent events) — this is the long-lived connection

When `client.close()` is called, it calls `transport.close()` which calls `_abortController.abort()`, terminating the SSE stream. Without this call, the GET connection stays open indefinitely.

### How to verify

Use the reproduction server at https://github.com/garritfra/mcp-leak-repro to observe the fix.

<details>
<summary><strong>Before fix — connections leak with every workflow run</strong></summary>

Server logs show GET connections opened but never closed (active count climbs):

```
[2026-04-02T10:27:48.620Z] #1 +++ POST OPENED  (active: 1, total: 1)
[2026-04-02T10:27:48.631Z] #1 --- POST CLOSED  (active: 0, total: 1)
[2026-04-02T10:27:48.641Z] #2 +++ POST OPENED  (active: 1, total: 2)
[2026-04-02T10:27:48.643Z] #2 --- POST CLOSED  (active: 0, total: 2)
[2026-04-02T10:27:48.644Z] #3 +++ GET OPENED   (active: 1, total: 3)   ← SSE stream, never closed
[2026-04-02T10:27:48.648Z] #4 +++ POST OPENED  (active: 2, total: 4)
[2026-04-02T10:27:48.650Z] #4 --- POST CLOSED  (active: 1, total: 4)
```

Each workflow run creates 4 connections (2x POST for init, 1x GET for SSE, 1x POST for tool call).
The GET SSE connection (#3) is never closed. After 4 runs:

```bash
$ curl -s http://localhost:3333/status
{"tcpConnections":4,"totalRequests":16}
```

TCP connections accumulate linearly — one leaked per workflow execution.

</details>

<details>
<summary><strong>After fix — all connections properly cleaned up</strong></summary>

```
[2026-04-02T12:33:03.531Z] #1 +++ POST request
[2026-04-02T12:33:03.545Z] #2 +++ POST request
[2026-04-02T12:33:03.548Z] #3 +++ GET request    ← SSE stream, now closed by client.close()
[2026-04-02T12:33:03.549Z] #4 +++ POST request
[2026-04-02T12:33:08.447Z] #5 +++ POST request
[2026-04-02T12:33:08.452Z] #6 +++ POST request
[2026-04-02T12:33:08.454Z] #7 +++ GET request
[2026-04-02T12:33:08.455Z] #8 +++ POST request
[2026-04-02T12:33:09.069Z] #9 +++ POST request
[2026-04-02T12:33:09.072Z] #10 +++ POST request
[2026-04-02T12:33:09.073Z] #11 +++ GET request
[2026-04-02T12:33:09.075Z] #12 +++ POST request
```

After 3 runs (12 total requests), checking actual TCP connections:

```bash
$ curl -s http://localhost:3333/status
{"tcpConnections":0,"totalRequests":12}
```

Zero TCP connections remain — all connections are properly cleaned up after each execution.

</details>

### Note on reproduction methodology

The original issue reporter used `ss -tan | grep ESTABLISHED` and server-side `res.on('close')` to detect leaks. During investigation, we discovered that the MCP SDK's hono-based server wrapper does not fire Node.js `res.on('close')` events for SSE responses, which makes server-side event tracking unreliable for measuring leaks. The reproduction repo uses `lsof`-based TCP counting for accurate results. There is also a brief delay (1-3 seconds) after `client.close()` before TCP connections disappear, due to Node.js undici's connection pool keepalive — this is normal and not a leak.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-4631
- Fixes https://github.com/n8n-io/n8n/issues/25740
- Fixes https://github.com/n8n-io/n8n/issues/23388

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)