### PR TITLE
fix(editor): Skip unsaved-changes confirmation when closing new credential modal

### DIFF
--- a/packages/frontend/@n8n/design-system/src/css/dialog.scss
+++ b/packages/frontend/@n8n/design-system/src/css/dialog.scss
@@ -73,6 +73,7 @@
 		outline: none;
 		cursor: pointer;
 		font-size: var.$message-close-size;
+		z-index: 2;
 
 		.el-dialog__close {
 			color: var(--color--info);

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -495,7 +495,7 @@ onMounted(async () => {
 async function beforeClose() {
 	let keepEditing = false;
 
-	if (hasUnsavedChanges.value) {
+	if (hasUnsavedChanges.value && !isNewCredential.value) {
 		const displayName = credentialType.value ? credentialType.value.displayName : '';
 		const confirmAction = await message.confirm(
 			i18n.baseText('credentialEdit.credentialEdit.confirmMessage.beforeClose1.message', {


### PR DESCRIPTION
## Summary
- When closing a new (never-saved) credential modal with unsaved changes, `beforeClose` showed a confirmation dialog (`message.confirm`) that rendered behind the modal — making the X button appear broken
- Skip the unsaved-changes confirmation for new credentials since there is nothing to lose
- This fixes the issue where the credential modal opened from the Instance AI workflow setup could not be closed

## Related
https://www.notion.so/n8n/Permissions-modal-cannot-be-closed-3365b6e0c94f80fd8e5fe6ea35cb5fbb

## Test plan
- [ ] Open Instance AI workflow setup, trigger credential creation
- [ ] Fill in some credential data, then click X — modal should close immediately
- [ ] Open an existing credential, make changes, click X — unsaved-changes confirmation should still appear
- [ ] Verify other modal close flows still work (NDV, expression editor)