### PR TITLE
feat(Redis Vector Store Node): Consume the `FluentRedisVectorStore` in the RedisVectorStore Node

### DIFF
--- a/packages/@n8n/ai-utilities/src/utils/vector-store/createVectorStoreNode/createVectorStoreNode.ts
+++ b/packages/@n8n/ai-utilities/src/utils/vector-store/createVectorStoreNode/createVectorStoreNode.ts
@@ -55,9 +55,12 @@ export const createVectorStoreNode = <T extends VectorStore = VectorStore>(
 			icon: args.meta.icon,
 			iconColor: args.meta.iconColor,
 			group: ['transform'],
-			// 1.2 has changes to VectorStoreInMemory node.
-			// 1.3 drops `toolName` and uses node name as the tool name.
-			version: [1, 1.1, 1.2, 1.3],
+			// Base versions for all vector store nodes:
+			// 1.1: Batched embeddings support
+			// 1.2: VectorStoreInMemory resource locator changes
+			// 1.3: Drops `toolName` and uses node name as the tool name
+			// 1.4: VectorStoreRedis FluentRedisVectorStore with custom filters and metadata schema
+			version: [1, 1.1, 1.2, 1.3, 1.4],
 			defaults: {
 				name: args.meta.displayName,
 			},

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreRedis/VectorStoreRedis.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreRedis/VectorStoreRedis.node.test.ts
@@ -4,6 +4,18 @@ import { NodeOperationError, type ILoadOptionsFunctions } from 'n8n-workflow';
 // Mock external modules that are not needed for these unit tests
 vi.mock('@langchain/redis', () => {
 	const state: any = { ctorArgs: undefined, filterExpression: undefined };
+	// Legacy RedisVectorStore for v1.3 and below
+	class RedisVectorStore {
+		static fromDocuments = jest.fn();
+		defaultFilter?: string[];
+		constructor(...args: any[]) {
+			state.legacyCtorArgs = args;
+		}
+		async similaritySearchVectorWithScore(_query: number[], _k: number, _filter?: string[]) {
+			return [];
+		}
+	}
+	// New FluentRedisVectorStore for v1.4+
 	class FluentRedisVectorStore {
 		static fromDocuments = vi.fn();
 		constructor(...args: any[]) {
@@ -19,7 +31,16 @@ vi.mock('@langchain/redis', () => {
 		}),
 	});
 	const Custom = (query: string) => ({ type: 'custom', query });
-	return { FluentRedisVectorStore, Tag, Custom, __state: state };
+	// Mock inferMetadataSchema to return empty schema
+	const inferMetadataSchema = jest.fn().mockReturnValue([]);
+	return {
+		RedisVectorStore,
+		FluentRedisVectorStore,
+		Tag,
+		Custom,
+		inferMetadataSchema,
+		__state: state,
+	};
 });
 
 vi.mock('@n8n/ai-utilities', () => ({
@@ -204,7 +225,7 @@ describe('VectorStoreRedis.node', () => {
 	});
 
 	describe('getVectorStoreClient', () => {
-		it('constructs ExtendedRedisVectorSearch with correct options and passes simple filter as Tag expression', async () => {
+		it('constructs ExtendedRedisVectorSearch with correct options for v1.4', async () => {
 			const mockClient = {
 				on: vi.fn(),
 				connect: vi.fn().mockResolvedValue(undefined),
@@ -237,13 +258,12 @@ describe('VectorStoreRedis.node', () => {
 						'options.metadataKey': 'm',
 						'options.contentKey': 'c',
 						'options.vectorKey': 'v',
-						'options.metadataFilter': 'a,b',
 						'options.customFilter': '',
 						'options.metadataSchema': '',
 					};
 					return map[name] ?? '';
 				},
-				getNode: () => ({ name: 'VectorStoreRedis' }),
+				getNode: () => ({ name: 'VectorStoreRedis', typeVersion: 1.4 }),
 				logger: loadOptionsFunctions.logger,
 			} as any;
 
@@ -274,8 +294,8 @@ describe('VectorStoreRedis.node', () => {
 			// Call the overridden method and ensure behavior is as expected
 			const res = await client.similaritySearchVectorWithScore([1, 2], 3);
 			expect(res).toBe('ok');
-			// Validate filter expression is a Tag filter with the metadata key
-			expect(client.defaultFilter).toEqual({ type: 'tag', field: 'm', values: ['a', 'b'] });
+			// v1.4 with no customFilter should have undefined filter
+			expect(client.defaultFilter).toBeUndefined();
 		});
 
 		it('uses Custom filter when customFilter is provided', async () => {
@@ -308,7 +328,7 @@ describe('VectorStoreRedis.node', () => {
 					};
 					return map[name] ?? '';
 				},
-				getNode: () => ({ name: 'VectorStoreRedis' }),
+				getNode: () => ({ name: 'VectorStoreRedis', typeVersion: 1.4 }),
 				logger: loadOptionsFunctions.logger,
 			} as any;
 
@@ -322,7 +342,7 @@ describe('VectorStoreRedis.node', () => {
 			});
 		});
 
-		it('trims and removes empty metadata filter tokens', async () => {
+		it('trims and removes empty metadata filter tokens for legacy v1.3', async () => {
 			const mockClient = {
 				on: vi.fn(),
 				connect: vi.fn().mockResolvedValue(undefined),
@@ -333,8 +353,8 @@ describe('VectorStoreRedis.node', () => {
 
 			(MockCreateClient as any).mockReturnValue(mockClient);
 
-			const FluentRedisVectorStoreMod: any = vi.mocked(await import('@langchain/redis'));
-			FluentRedisVectorStoreMod.FluentRedisVectorStore.prototype.similaritySearchVectorWithScore = vi
+			const LegacyRedisVectorStoreMod: any = vi.mocked(await import('@langchain/redis'));
+			LegacyRedisVectorStoreMod.RedisVectorStore.prototype.similaritySearchVectorWithScore = vi
 				.fn()
 				.mockResolvedValue('ok');
 
@@ -348,24 +368,18 @@ describe('VectorStoreRedis.node', () => {
 						'options.contentKey': '',
 						'options.vectorKey': '',
 						'options.metadataFilter': 'tag1, tag2 , ,tag3',
-						'options.customFilter': '',
-						'options.metadataSchema': '',
 					};
 					return map[name] ?? '';
 				},
-				getNode: () => ({ name: 'VectorStoreRedis' }),
+				getNode: () => ({ name: 'VectorStoreRedis', typeVersion: 1.3 }),
 				logger: loadOptionsFunctions.logger,
 			} as any;
 
 			const node = new RedisNode.VectorStoreRedis();
 			const client = await (node as any).getVectorStoreClient(context, undefined, {}, 0);
 
-			// Ensure trimming/removal works - filter uses default 'metadata' field when metadataKey is empty
-			expect(client.defaultFilter).toEqual({
-				type: 'tag',
-				field: 'metadata',
-				values: ['tag1', 'tag2', 'tag3'],
-			});
+			// Legacy v1.3 uses string[] filter - verify trimming/removal works
+			expect(client.defaultFilter).toEqual(['tag1', 'tag2', 'tag3']);
 		});
 
 		it('omits optional keys when empty/whitespace and handles empty filter as undefined', async () => {
@@ -399,7 +413,7 @@ describe('VectorStoreRedis.node', () => {
 					};
 					return map[name] ?? '';
 				},
-				getNode: () => ({ name: 'VectorStoreRedis' }),
+				getNode: () => ({ name: 'VectorStoreRedis', typeVersion: 1.4 }),
 				logger: loadOptionsFunctions.logger,
 			} as any;
 
@@ -453,7 +467,7 @@ describe('VectorStoreRedis.node', () => {
 					};
 					return map[name] ?? '';
 				},
-				getNode: () => ({ name: 'VectorStoreRedis' }),
+				getNode: () => ({ name: 'VectorStoreRedis', typeVersion: 1.4 }),
 				logger: loadOptionsFunctions.logger,
 			} as any;
 
@@ -477,7 +491,7 @@ describe('VectorStoreRedis.node', () => {
 			const context: any = {
 				getCredentials: vi.fn().mockResolvedValue(baseCredentials),
 				getNodeParameter: (name: string) => (name === 'redisIndex' ? 'idx' : ''),
-				getNode: () => ({ name: 'VectorStoreRedis' }),
+				getNode: () => ({ name: 'VectorStoreRedis', typeVersion: 1.4 }),
 			};
 
 			const node = new RedisNode.VectorStoreRedis();
@@ -521,7 +535,7 @@ describe('VectorStoreRedis.node', () => {
 					};
 					return map[name] ?? '';
 				},
-				getNode: () => ({ name: 'VectorStoreRedis' }),
+				getNode: () => ({ name: 'VectorStoreRedis', typeVersion: 1.4 }),
 				logger: loadOptionsFunctions.logger,
 			} as any;
 
@@ -585,7 +599,7 @@ describe('VectorStoreRedis.node', () => {
 					};
 					return map[name] ?? '';
 				},
-				getNode: () => ({ name: 'VectorStoreRedis' }),
+				getNode: () => ({ name: 'VectorStoreRedis', typeVersion: 1.4 }),
 				logger: loadOptionsFunctions.logger,
 			} as any;
 
@@ -624,7 +638,7 @@ describe('VectorStoreRedis.node', () => {
 			const context: any = {
 				getCredentials: vi.fn().mockResolvedValue(baseCredentials),
 				getNodeParameter: (name: string) => (name === 'redisIndex' ? 'idx' : ''),
-				getNode: () => ({ name: 'VectorStoreRedis' }),
+				getNode: () => ({ name: 'VectorStoreRedis', typeVersion: 1.4 }),
 				logger: loadOptionsFunctions.logger,
 			} as any;
 

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreRedis/VectorStoreRedis.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreRedis/VectorStoreRedis.node.test.ts
@@ -258,7 +258,7 @@ describe('VectorStoreRedis.node', () => {
 						'options.metadataKey': 'm',
 						'options.contentKey': 'c',
 						'options.vectorKey': 'v',
-						'options.customFilter': '',
+						'options.advancedFilter': '',
 						'options.metadataSchema': '',
 					};
 					return map[name] ?? '';
@@ -294,11 +294,11 @@ describe('VectorStoreRedis.node', () => {
 			// Call the overridden method and ensure behavior is as expected
 			const res = await client.similaritySearchVectorWithScore([1, 2], 3);
 			expect(res).toBe('ok');
-			// v1.4 with no customFilter should have undefined filter
+			// v1.4 with no advancedFilter should have undefined filter
 			expect(client.defaultFilter).toBeUndefined();
 		});
 
-		it('uses Custom filter when customFilter is provided', async () => {
+		it('uses Custom filter when advancedFilter is provided', async () => {
 			const mockClient = {
 				on: jest.fn(),
 				connect: jest.fn().mockResolvedValue(undefined),
@@ -323,7 +323,7 @@ describe('VectorStoreRedis.node', () => {
 						'options.contentKey': '',
 						'options.vectorKey': '',
 						'options.metadataFilter': 'ignored',
-						'options.customFilter': '@category:{electronics} @price:[0 100]',
+						'options.advancedFilter': '@category:{electronics} @price:[0 100]',
 						'options.metadataSchema': '',
 					};
 					return map[name] ?? '';
@@ -335,7 +335,7 @@ describe('VectorStoreRedis.node', () => {
 			const node = new RedisNode.VectorStoreRedis();
 			const client = await (node as any).getVectorStoreClient(context, undefined, {}, 0);
 
-			// Custom filter takes priority over simple filter
+			// Advanced filter takes priority over simple filter
 			expect(client.defaultFilter).toEqual({
 				type: 'custom',
 				query: '@category:{electronics} @price:[0 100]',
@@ -408,7 +408,7 @@ describe('VectorStoreRedis.node', () => {
 						'options.contentKey': '',
 						'options.vectorKey': ' \t',
 						'options.metadataFilter': '',
-						'options.customFilter': '',
+						'options.advancedFilter': '',
 						'options.metadataSchema': '',
 					};
 					return map[name] ?? '';
@@ -462,7 +462,7 @@ describe('VectorStoreRedis.node', () => {
 						'options.contentKey': '',
 						'options.vectorKey': '',
 						'options.metadataFilter': '  , , ,  ',
-						'options.customFilter': '',
+						'options.advancedFilter': '',
 						'options.metadataSchema': '',
 					};
 					return map[name] ?? '';

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreRedis/VectorStoreRedis.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreRedis/VectorStoreRedis.node.test.ts
@@ -3,14 +3,23 @@ import { NodeOperationError, type ILoadOptionsFunctions } from 'n8n-workflow';
 
 // Mock external modules that are not needed for these unit tests
 vi.mock('@langchain/redis', () => {
-	const state: any = { ctorArgs: undefined };
-	class RedisVectorStore {
+	const state: any = { ctorArgs: undefined, filterExpression: undefined };
+	class FluentRedisVectorStore {
 		static fromDocuments = vi.fn();
 		constructor(...args: any[]) {
 			state.ctorArgs = args;
 		}
 	}
-	return { RedisVectorStore, __state: state };
+	// Mock filter builders - Tag.eq receives an array of values when called with array
+	const Tag = (field: string) => ({
+		eq: (values: string | string[]) => ({
+			type: 'tag',
+			field,
+			values: Array.isArray(values) ? values : [values],
+		}),
+	});
+	const Custom = (query: string) => ({ type: 'custom', query });
+	return { FluentRedisVectorStore, Tag, Custom, __state: state };
 });
 
 vi.mock('@n8n/ai-utilities', () => ({
@@ -195,7 +204,7 @@ describe('VectorStoreRedis.node', () => {
 	});
 
 	describe('getVectorStoreClient', () => {
-		it('constructs ExtendedRedisVectorSearch with correct options and passes filter tokens', async () => {
+		it('constructs ExtendedRedisVectorSearch with correct options and passes simple filter as Tag expression', async () => {
 			const mockClient = {
 				on: vi.fn(),
 				connect: vi.fn().mockResolvedValue(undefined),
@@ -214,8 +223,8 @@ describe('VectorStoreRedis.node', () => {
 			(MockCreateClient as any).mockReturnValue(mockClient);
 
 			// Provide a base class method that ExtendedRedisVectorSearch will call via super
-			const RedisVectorStoreMod: any = vi.mocked(await import('@langchain/redis'));
-			RedisVectorStoreMod.RedisVectorStore.prototype.similaritySearchVectorWithScore = vi
+			const FluentRedisVectorStoreMod: any = vi.mocked(await import('@langchain/redis'));
+			FluentRedisVectorStoreMod.FluentRedisVectorStore.prototype.similaritySearchVectorWithScore = vi
 				.fn()
 				.mockResolvedValue('ok');
 
@@ -229,8 +238,10 @@ describe('VectorStoreRedis.node', () => {
 						'options.contentKey': 'c',
 						'options.vectorKey': 'v',
 						'options.metadataFilter': 'a,b',
+						'options.customFilter': '',
+						'options.metadataSchema': '',
 					};
-					return map[name];
+					return map[name] ?? '';
 				},
 				getNode: () => ({ name: 'VectorStoreRedis' }),
 				logger: loadOptionsFunctions.logger,
@@ -249,7 +260,7 @@ describe('VectorStoreRedis.node', () => {
 			expect(mockClient.ft.info).toHaveBeenCalledWith('myIndex');
 
 			// The base class constructor should have been called with embeddings and options
-			const state = RedisVectorStoreMod.__state;
+			const state = FluentRedisVectorStoreMod.__state;
 			expect(state.ctorArgs[0]).toBe(embeddings);
 			expect(state.ctorArgs[1]).toMatchObject({
 				redisClient: mockClient,
@@ -263,8 +274,52 @@ describe('VectorStoreRedis.node', () => {
 			// Call the overridden method and ensure behavior is as expected
 			const res = await client.similaritySearchVectorWithScore([1, 2], 3);
 			expect(res).toBe('ok');
-			// Validate filter tokens got captured on the instance
-			expect(client.defaultFilter).toEqual(['a', 'b']);
+			// Validate filter expression is a Tag filter with the metadata key
+			expect(client.defaultFilter).toEqual({ type: 'tag', field: 'm', values: ['a', 'b'] });
+		});
+
+		it('uses Custom filter when customFilter is provided', async () => {
+			const mockClient = {
+				on: jest.fn(),
+				connect: jest.fn().mockResolvedValue(undefined),
+				disconnect: jest.fn(),
+				quit: jest.fn(),
+				ft: { info: jest.fn().mockResolvedValue(undefined) },
+			} as any;
+
+			(MockCreateClient as any).mockReturnValue(mockClient);
+
+			const FluentRedisVectorStoreMod: any = vi.mocked(await import('@langchain/redis'));
+			FluentRedisVectorStoreMod.FluentRedisVectorStore.prototype.similaritySearchVectorWithScore =
+				vi.fn().mockResolvedValue('ok');
+
+			const context: any = {
+				getCredentials: jest.fn().mockResolvedValue(baseCredentials),
+				getNodeParameter: (name: string) => {
+					const map: Record<string, any> = {
+						redisIndex: 'myIndex',
+						'options.keyPrefix': '',
+						'options.metadataKey': '',
+						'options.contentKey': '',
+						'options.vectorKey': '',
+						'options.metadataFilter': 'ignored',
+						'options.customFilter': '@category:{electronics} @price:[0 100]',
+						'options.metadataSchema': '',
+					};
+					return map[name] ?? '';
+				},
+				getNode: () => ({ name: 'VectorStoreRedis' }),
+				logger: loadOptionsFunctions.logger,
+			} as any;
+
+			const node = new RedisNode.VectorStoreRedis();
+			const client = await (node as any).getVectorStoreClient(context, undefined, {}, 0);
+
+			// Custom filter takes priority over simple filter
+			expect(client.defaultFilter).toEqual({
+				type: 'custom',
+				query: '@category:{electronics} @price:[0 100]',
+			});
 		});
 
 		it('trims and removes empty metadata filter tokens', async () => {
@@ -278,8 +333,8 @@ describe('VectorStoreRedis.node', () => {
 
 			(MockCreateClient as any).mockReturnValue(mockClient);
 
-			const RedisVectorStoreMod: any = vi.mocked(await import('@langchain/redis'));
-			RedisVectorStoreMod.RedisVectorStore.prototype.similaritySearchVectorWithScore = vi
+			const FluentRedisVectorStoreMod: any = vi.mocked(await import('@langchain/redis'));
+			FluentRedisVectorStoreMod.FluentRedisVectorStore.prototype.similaritySearchVectorWithScore = vi
 				.fn()
 				.mockResolvedValue('ok');
 
@@ -293,8 +348,10 @@ describe('VectorStoreRedis.node', () => {
 						'options.contentKey': '',
 						'options.vectorKey': '',
 						'options.metadataFilter': 'tag1, tag2 , ,tag3',
+						'options.customFilter': '',
+						'options.metadataSchema': '',
 					};
-					return map[name];
+					return map[name] ?? '';
 				},
 				getNode: () => ({ name: 'VectorStoreRedis' }),
 				logger: loadOptionsFunctions.logger,
@@ -303,11 +360,15 @@ describe('VectorStoreRedis.node', () => {
 			const node = new RedisNode.VectorStoreRedis();
 			const client = await (node as any).getVectorStoreClient(context, undefined, {}, 0);
 
-			// Ensure trimming/removal works
-			expect(client.defaultFilter).toEqual(['tag1', 'tag2', 'tag3']);
+			// Ensure trimming/removal works - filter uses default 'metadata' field when metadataKey is empty
+			expect(client.defaultFilter).toEqual({
+				type: 'tag',
+				field: 'metadata',
+				values: ['tag1', 'tag2', 'tag3'],
+			});
 		});
 
-		it('omits optional keys when empty/whitespace and handles empty filter as null', async () => {
+		it('omits optional keys when empty/whitespace and handles empty filter as undefined', async () => {
 			const mockClient = {
 				on: vi.fn(),
 				connect: vi.fn().mockResolvedValue(undefined),
@@ -318,8 +379,8 @@ describe('VectorStoreRedis.node', () => {
 
 			(MockCreateClient as any).mockReturnValue(mockClient);
 
-			const RedisVectorStoreMod: any = vi.mocked(await import('@langchain/redis'));
-			RedisVectorStoreMod.RedisVectorStore.prototype.similaritySearchVectorWithScore = vi
+			const FluentRedisVectorStoreMod: any = vi.mocked(await import('@langchain/redis'));
+			FluentRedisVectorStoreMod.FluentRedisVectorStore.prototype.similaritySearchVectorWithScore = vi
 				.fn()
 				.mockResolvedValue('ok');
 
@@ -333,8 +394,10 @@ describe('VectorStoreRedis.node', () => {
 						'options.contentKey': '',
 						'options.vectorKey': ' \t',
 						'options.metadataFilter': '',
+						'options.customFilter': '',
+						'options.metadataSchema': '',
 					};
-					return map[name];
+					return map[name] ?? '';
 				},
 				getNode: () => ({ name: 'VectorStoreRedis' }),
 				logger: loadOptionsFunctions.logger,
@@ -347,7 +410,7 @@ describe('VectorStoreRedis.node', () => {
 			// Ensure FT.INFO is called to validate index
 			expect(mockClient.ft.info).toHaveBeenCalledWith('myIndex');
 
-			const opts = RedisVectorStoreMod.__state.ctorArgs[1];
+			const opts = FluentRedisVectorStoreMod.__state.ctorArgs[1];
 			expect(opts).toMatchObject({ redisClient: mockClient, indexName: 'myIndex' });
 			expect(opts).not.toHaveProperty('keyPrefix');
 			expect(opts).not.toHaveProperty('metadataKey');
@@ -370,8 +433,8 @@ describe('VectorStoreRedis.node', () => {
 
 			(MockCreateClient as any).mockReturnValue(mockClient);
 
-			const RedisVectorStoreMod: any = vi.mocked(await import('@langchain/redis'));
-			RedisVectorStoreMod.RedisVectorStore.prototype.similaritySearchVectorWithScore = vi
+			const FluentRedisVectorStoreMod: any = vi.mocked(await import('@langchain/redis'));
+			FluentRedisVectorStoreMod.FluentRedisVectorStore.prototype.similaritySearchVectorWithScore = vi
 				.fn()
 				.mockResolvedValue('ok');
 
@@ -385,8 +448,10 @@ describe('VectorStoreRedis.node', () => {
 						'options.contentKey': '',
 						'options.vectorKey': '',
 						'options.metadataFilter': '  , , ,  ',
+						'options.customFilter': '',
+						'options.metadataSchema': '',
 					};
-					return map[name];
+					return map[name] ?? '';
 				},
 				getNode: () => ({ name: 'VectorStoreRedis' }),
 				logger: loadOptionsFunctions.logger,
@@ -425,7 +490,7 @@ describe('VectorStoreRedis.node', () => {
 	});
 
 	describe('populateVectorStore', () => {
-		it('drops index and deletes the documents when overwrite is true; passes TTL and batch size', async () => {
+		it('drops index and deletes the documents when overwrite is true; passes TTL and custom schema', async () => {
 			const mockClient = {
 				on: vi.fn(),
 				connect: vi.fn().mockResolvedValue(undefined),
@@ -435,8 +500,10 @@ describe('VectorStoreRedis.node', () => {
 			} as any;
 			(MockCreateClient as any).mockReturnValue(mockClient);
 
-			const RedisVectorStoreMod: any = vi.mocked(await import('@langchain/redis'));
-			RedisVectorStoreMod.RedisVectorStore.fromDocuments = vi.fn().mockResolvedValue(undefined);
+			const FluentRedisVectorStoreMod: any = vi.mocked(await import('@langchain/redis'));
+			FluentRedisVectorStoreMod.FluentRedisVectorStore.fromDocuments = vi
+				.fn()
+				.mockResolvedValue(undefined);
 
 			const context: any = {
 				getCredentials: vi.fn().mockResolvedValue(baseCredentials),
@@ -449,9 +516,10 @@ describe('VectorStoreRedis.node', () => {
 						'options.contentKey': 'c',
 						'options.vectorKey': 'v',
 						'options.ttl': 60,
+						'options.metadataSchema': '',
 						embeddingBatchSize: 123,
 					};
-					return map[name];
+					return map[name] ?? '';
 				},
 				getNode: () => ({ name: 'VectorStoreRedis' }),
 				logger: loadOptionsFunctions.logger,
@@ -467,7 +535,7 @@ describe('VectorStoreRedis.node', () => {
 
 			expect(mockClient.ft.dropIndex).toHaveBeenCalledWith('myIndex', { DD: true });
 
-			expect(RedisVectorStoreMod.RedisVectorStore.fromDocuments).toHaveBeenCalledWith(
+			expect(FluentRedisVectorStoreMod.FluentRedisVectorStore.fromDocuments).toHaveBeenCalledWith(
 				[{ pageContent: 'hello', metadata: {} }],
 				{},
 				{
@@ -482,6 +550,62 @@ describe('VectorStoreRedis.node', () => {
 			);
 		});
 
+		it('passes custom metadata schema when provided', async () => {
+			const mockClient = {
+				on: jest.fn(),
+				connect: jest.fn().mockResolvedValue(undefined),
+				disconnect: jest.fn(),
+				quit: jest.fn(),
+				ft: { dropIndex: jest.fn().mockResolvedValue(undefined) },
+			} as any;
+			(MockCreateClient as any).mockReturnValue(mockClient);
+
+			const FluentRedisVectorStoreMod: any = vi.mocked(await import('@langchain/redis'));
+			FluentRedisVectorStoreMod.FluentRedisVectorStore.fromDocuments = vi
+				.fn()
+				.mockResolvedValue(undefined);
+
+			const customSchema = [
+				{ name: 'category', type: 'tag' },
+				{ name: 'price', type: 'numeric', options: { sortable: true } },
+			];
+
+			const context: any = {
+				getCredentials: jest.fn().mockResolvedValue(baseCredentials),
+				getNodeParameter: (name: string) => {
+					const map: Record<string, any> = {
+						redisIndex: 'myIndex',
+						'options.overwriteDocuments': false,
+						'options.keyPrefix': '',
+						'options.metadataKey': '',
+						'options.contentKey': '',
+						'options.vectorKey': '',
+						'options.ttl': 0,
+						'options.metadataSchema': JSON.stringify(customSchema),
+					};
+					return map[name] ?? '';
+				},
+				getNode: () => ({ name: 'VectorStoreRedis' }),
+				logger: loadOptionsFunctions.logger,
+			} as any;
+
+			const node = new RedisNode.VectorStoreRedis();
+			await (node as any).populateVectorStore(
+				context,
+				{},
+				[{ pageContent: 'test', metadata: {} }],
+				0,
+			);
+
+			expect(FluentRedisVectorStoreMod.FluentRedisVectorStore.fromDocuments).toHaveBeenCalledWith(
+				[{ pageContent: 'test', metadata: {} }],
+				{},
+				expect.objectContaining({
+					customSchema,
+				}),
+			);
+		});
+
 		it('logs and throws NodeOperationError on failure', async () => {
 			const mockClient = {
 				on: vi.fn(),
@@ -492,8 +616,8 @@ describe('VectorStoreRedis.node', () => {
 			} as any;
 			(MockCreateClient as any).mockReturnValue(mockClient);
 
-			const RedisVectorStoreMod: any = vi.mocked(await import('@langchain/redis'));
-			RedisVectorStoreMod.RedisVectorStore.fromDocuments = vi
+			const FluentRedisVectorStoreMod: any = vi.mocked(await import('@langchain/redis'));
+			FluentRedisVectorStoreMod.FluentRedisVectorStore.fromDocuments = vi
 				.fn()
 				.mockRejectedValue(new Error('fail'));
 

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreRedis/VectorStoreRedis.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreRedis/VectorStoreRedis.node.test.ts
@@ -501,6 +501,46 @@ describe('VectorStoreRedis.node', () => {
 			await expect(execution).rejects.toThrow(NodeOperationError);
 			await expect(execution).rejects.toThrow('Index idx not found');
 		});
+
+		it('throws NodeOperationError when metadata schema contains non-object entries', async () => {
+			const mockClient = {
+				on: jest.fn(),
+				connect: jest.fn().mockResolvedValue(undefined),
+				disconnect: jest.fn(),
+				quit: jest.fn(),
+				ft: { info: jest.fn().mockResolvedValue(undefined) },
+			} as any;
+			(MockCreateClient as any).mockReturnValue(mockClient);
+
+			const context: any = {
+				getCredentials: jest.fn().mockResolvedValue(baseCredentials),
+				getNodeParameter: (name: string) => {
+					const map: Record<string, any> = {
+						redisIndex: 'idx',
+						'options.keyPrefix': '',
+						'options.metadataKey': '',
+						'options.contentKey': '',
+						'options.vectorKey': '',
+						'options.advancedFilter': '',
+						'options.metadataSchema': '[null, "string", 123]',
+					};
+					return map[name] ?? '';
+				},
+				getNode: () => ({ name: 'VectorStoreRedis', typeVersion: 1.4 }),
+			};
+
+			const node = new RedisNode.VectorStoreRedis();
+			await expect((node as any).getVectorStoreClient(context, undefined, {}, 0)).rejects.toEqual(
+				new NodeOperationError(
+					context.getNode(),
+					'Invalid metadata schema: each entry must be an object',
+					{
+						itemIndex: 0,
+						description: 'Expected format: [{"name": "fieldName", "type": "tag|text|numeric|geo"}]',
+					},
+				),
+			);
+		});
 	});
 
 	describe('populateVectorStore', () => {

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreRedis/VectorStoreRedis.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreRedis/VectorStoreRedis.node.ts
@@ -1,6 +1,12 @@
 import type { EmbeddingsInterface } from '@langchain/core/embeddings';
-import { RedisVectorStore } from '@langchain/redis';
-import type { RedisVectorStoreConfig } from '@langchain/redis/dist/vectorstores';
+import {
+	FluentRedisVectorStore,
+	type FluentRedisVectorStoreConfig,
+	type FilterExpression,
+	type MetadataFieldSchema,
+	Tag,
+	Custom,
+} from '@langchain/redis';
 import {
 	type IExecuteFunctions,
 	type ILoadOptionsFunctions,
@@ -22,6 +28,8 @@ const REDIS_KEY_PREFIX = 'keyPrefix';
 const REDIS_OVERWRITE_DOCUMENTS = 'overwriteDocuments';
 const REDIS_METADATA_KEY = 'metadataKey';
 const REDIS_METADATA_FILTER = 'metadataFilter';
+const REDIS_CUSTOM_FILTER = 'customFilter';
+const REDIS_METADATA_SCHEMA = 'metadataSchema';
 const REDIS_CONTENT_KEY = 'contentKey';
 const REDIS_EMBEDDING_KEY = 'vectorKey';
 const REDIS_TTL = 'ttl';
@@ -54,9 +62,35 @@ const metadataFilterField: INodeProperties = {
 	name: REDIS_METADATA_FILTER,
 	type: 'string',
 	description:
-		'The comma-separated list of words by which to apply additional full-text metadata filtering',
+		'Comma-separated list of words for simple tag-based metadata filtering. For advanced filtering, use Custom Filter instead.',
 	placeholder: 'Item1,Item2,Item3',
 	default: '',
+};
+
+const customFilterField: INodeProperties = {
+	displayName: 'Custom Filter',
+	name: REDIS_CUSTOM_FILTER,
+	type: 'string',
+	description:
+		'Advanced Redis query filter expression. Supports Tag, Numeric, Text, Geo filters with AND/OR logic. Example: <code>@category:{electronics} @price:[0 100]</code>. Leave empty to use simple Metadata Filter.',
+	placeholder: '@category:{electronics} @price:[0 100]',
+	default: '',
+	typeOptions: {
+		rows: 3,
+	},
+};
+
+const metadataSchemaField: INodeProperties = {
+	displayName: 'Metadata Schema',
+	name: REDIS_METADATA_SCHEMA,
+	type: 'string',
+	description:
+		'JSON array defining metadata field types for indexing. If not provided, schema will be inferred from documents. Example: <code>[{"name": "category", "type": "tag"}, {"name": "price", "type": "numeric", "options": {"sortable": true}}]</code>',
+	placeholder: '[{"name": "category", "type": "tag"}, {"name": "price", "type": "numeric"}]',
+	default: '',
+	typeOptions: {
+		rows: 4,
+	},
 };
 
 const metadataKeyField: INodeProperties = {
@@ -125,6 +159,7 @@ const insertFields: INodeProperties[] = [
 			keyPrefixField,
 			overwriteDocuments,
 			metadataKeyField,
+			metadataSchemaField,
 			contentKeyField,
 			embeddingKeyField,
 			ttlField,
@@ -141,6 +176,7 @@ const retrieveFields: INodeProperties[] = [
 		default: {},
 		options: [
 			metadataFilterField,
+			customFilterField,
 			keyPrefixField,
 			metadataKeyField,
 			contentKeyField,
@@ -275,15 +311,19 @@ export function getParameterAsNumber(
 }
 
 /**
- * Extended RedisVectorStore class to handle custom filtering.
+ * Extended FluentRedisVectorStore class to handle custom filtering.
  *
  * This wrapper is necessary because when used as a retriever, the similaritySearchVectorWithScore should
  * use a processed filter
  */
-class ExtendedRedisVectorSearch extends RedisVectorStore {
-	defaultFilter?: string[];
+class ExtendedRedisVectorSearch extends FluentRedisVectorStore {
+	defaultFilter?: FilterExpression;
 
-	constructor(embeddings: EmbeddingsInterface, options: RedisVectorStoreConfig, filter?: string[]) {
+	constructor(
+		embeddings: EmbeddingsInterface,
+		options: FluentRedisVectorStoreConfig,
+		filter?: FilterExpression,
+	) {
 		super(embeddings, options);
 		this.defaultFilter = filter;
 	}
@@ -298,9 +338,53 @@ const getKeyPrefix = getParameter.bind(null, `options.${REDIS_KEY_PREFIX}`);
 const getOverwrite = getParameter.bind(null, `options.${REDIS_OVERWRITE_DOCUMENTS}`);
 const getContentKey = getParameter.bind(null, `options.${REDIS_CONTENT_KEY}`);
 const getMetadataFilter = getParameter.bind(null, `options.${REDIS_METADATA_FILTER}`);
+const getCustomFilter = getParameter.bind(null, `options.${REDIS_CUSTOM_FILTER}`);
+const getMetadataSchema = getParameter.bind(null, `options.${REDIS_METADATA_SCHEMA}`);
 const getMetadataKey = getParameter.bind(null, `options.${REDIS_METADATA_KEY}`);
 const getEmbeddingKey = getParameter.bind(null, `options.${REDIS_EMBEDDING_KEY}`);
 const getTtl = getParameterAsNumber.bind(null, `options.${REDIS_TTL}`);
+
+/**
+ * Parse and validate metadata schema JSON
+ */
+function parseMetadataSchema(
+	context: IExecuteFunctions | ISupplyDataFunctions,
+	schemaJson: string,
+	itemIndex: number,
+): MetadataFieldSchema[] | undefined {
+	if (!schemaJson || !schemaJson.trim()) {
+		return undefined;
+	}
+
+	try {
+		const parsed = JSON.parse(schemaJson);
+
+		// Validate it's an array
+		if (!Array.isArray(parsed)) {
+			throw new Error('Metadata schema must be a JSON array');
+		}
+
+		// Validate each field has required properties
+		for (const field of parsed) {
+			if (!field.name || typeof field.name !== 'string') {
+				throw new Error('Each schema field must have a "name" property');
+			}
+			if (!field.type || !['tag', 'text', 'numeric', 'geo'].includes(field.type)) {
+				throw new Error(
+					`Invalid field type "${field.type}". Must be one of: tag, text, numeric, geo`,
+				);
+			}
+		}
+
+		return parsed as MetadataFieldSchema[];
+	} catch (error) {
+		throw new NodeOperationError(
+			context.getNode(),
+			`Invalid metadata schema JSON: ${error.message}`,
+			{ itemIndex },
+		);
+	}
+}
 
 export class VectorStoreRedis extends createVectorStoreNode({
 	meta: {
@@ -330,7 +414,9 @@ export class VectorStoreRedis extends createVectorStoreNode({
 		const metadataField = getMetadataKey(context, itemIndex).trim();
 		const contentField = getContentKey(context, itemIndex).trim();
 		const embeddingField = getEmbeddingKey(context, itemIndex).trim();
-		const filter = getMetadataFilter(context, itemIndex).trim();
+		const customFilter = getCustomFilter(context, itemIndex).trim();
+		const simpleFilter = getMetadataFilter(context, itemIndex).trim();
+		const metadataSchemaJson = getMetadataSchema(context, itemIndex).trim();
 
 		if (client === null) {
 			throw new NodeOperationError(context.getNode(), 'Redis client not initialized', {
@@ -349,14 +435,26 @@ export class VectorStoreRedis extends createVectorStoreNode({
 			});
 		}
 
-		// Process filter: split by comma, trim, and remove empty strings
-		// If no valid filter terms exist, pass undefined instead of empty array
-		const filterTerms = filter
-			? filter
-					.split(',')
-					.map((s) => s.trim())
-					.filter((s) => s)
-			: [];
+		// Parse custom metadata schema if provided
+		const customSchema = parseMetadataSchema(context, metadataSchemaJson, itemIndex);
+
+		// Process filter: custom filter takes priority over simple filter
+		let filterExpression: FilterExpression | undefined;
+
+		if (customFilter) {
+			// Use custom filter if provided
+			filterExpression = Custom(customFilter);
+		} else if (simpleFilter) {
+			// Fall back to simple tag-based filter
+			const filterTerms = simpleFilter
+				.split(',')
+				.map((s) => s.trim())
+				.filter((s) => s);
+
+			if (filterTerms.length > 0) {
+				filterExpression = Tag(metadataField || 'metadata').eq(filterTerms);
+			}
+		}
 
 		return new ExtendedRedisVectorSearch(
 			embeddings,
@@ -367,8 +465,9 @@ export class VectorStoreRedis extends createVectorStoreNode({
 				...(metadataField ? { metadataKey: metadataField } : {}),
 				...(contentField ? { contentKey: contentField } : {}),
 				...(embeddingField ? { vectorKey: embeddingField } : {}),
+				...(customSchema ? { customSchema } : {}),
 			},
-			filterTerms.length > 0 ? filterTerms : undefined,
+			filterExpression,
 		);
 	},
 	async populateVectorStore(context, embeddings, documents, itemIndex) {
@@ -389,6 +488,10 @@ export class VectorStoreRedis extends createVectorStoreNode({
 			const contentField = getContentKey(context, itemIndex).trim();
 			const embeddingField = getEmbeddingKey(context, itemIndex).trim();
 			const ttl = getTtl(context, itemIndex);
+			const metadataSchemaJson = getMetadataSchema(context, itemIndex).trim();
+
+			// Parse custom metadata schema if provided
+			const customSchema = parseMetadataSchema(context, metadataSchemaJson, itemIndex);
 
 			if (overwrite) {
 				await client.ft.dropIndex(indexField, { DD: true });
@@ -402,6 +505,7 @@ export class VectorStoreRedis extends createVectorStoreNode({
 				...(contentField ? { contentKey: contentField } : {}),
 				...(embeddingField ? { vectorKey: embeddingField } : {}),
 				...(ttl ? { ttl } : {}),
+				...(customSchema ? { customSchema } : {}),
 			});
 		} catch (error) {
 			context.logger.info(`Error while populating the store: ${error.message}`);

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreRedis/VectorStoreRedis.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreRedis/VectorStoreRedis.node.ts
@@ -11,6 +11,7 @@ import {
 	Custom,
 	inferMetadataSchema,
 } from '@langchain/redis';
+import { createVectorStoreNode } from '@n8n/ai-utilities';
 import {
 	type IExecuteFunctions,
 	type ILoadOptionsFunctions,
@@ -21,8 +22,6 @@ import {
 import type { RedisClientOptions } from 'redis';
 import { createClient } from 'redis';
 
-import { createVectorStoreNode } from '@n8n/ai-utilities';
-
 /**
  * Constants for the name of the credentials and Node parameters.
  */
@@ -32,7 +31,7 @@ const REDIS_KEY_PREFIX = 'keyPrefix';
 const REDIS_OVERWRITE_DOCUMENTS = 'overwriteDocuments';
 const REDIS_METADATA_KEY = 'metadataKey';
 const REDIS_METADATA_FILTER = 'metadataFilter';
-const REDIS_CUSTOM_FILTER = 'customFilter';
+const REDIS_ADVANCED_FILTER = 'advancedFilter';
 const REDIS_METADATA_SCHEMA = 'metadataSchema';
 const REDIS_CONTENT_KEY = 'contentKey';
 const REDIS_EMBEDDING_KEY = 'vectorKey';
@@ -76,13 +75,13 @@ const metadataFilterField: INodeProperties = {
 	},
 };
 
-const customFilterField: INodeProperties = {
-	displayName: 'Custom Filter',
-	name: REDIS_CUSTOM_FILTER,
+const advancedFilterField: INodeProperties = {
+	displayName: 'Metadata Filter',
+	name: REDIS_ADVANCED_FILTER,
 	type: 'string',
 	description:
 		'Redis query filter expression. Supports Tag, Numeric, Text, Geo filters with AND/OR logic. Example: <code>@category:{electronics} @price:[0 100]</code>',
-	hint: 'Learn more about Redis vector search filtering <a target="_blank" href="https://docs.langchain.com/oss/javascript/integrations/vectorstores/redis#field-configuration-options">here</a>',
+	hint: 'Learn more about Redis vector search filtering <a target="_blank" href="https://docs.langchain.com/oss/javascript/integrations/vectorstores/redis#advanced-features">here</a>',
 	placeholder: '@category:{electronics} @price:[0 100]',
 	default: '',
 	typeOptions: {
@@ -101,7 +100,7 @@ const metadataSchemaField: INodeProperties = {
 	type: 'string',
 	description:
 		'JSON array defining metadata field types for indexing. If not provided, schema will be inferred from documents. Example: <code>[{"name": "category", "type": "tag"}, {"name": "price", "type": "numeric", "options": {"sortable": true}}]</code>',
-	hint: 'Learn more about metadata schema configuration <a target="_blank" href="https://docs.langchain.com/oss/javascript/integrations/vectorstores/advanced-filtering-with-the-fluent-API">here</a>',
+	hint: 'Learn more about metadata schema configuration <a target="_blank" href="https://docs.langchain.com/oss/javascript/integrations/vectorstores/redis#advanced-features">here</a>',
 	placeholder: '[{"name": "category", "type": "tag"}, {"name": "price", "type": "numeric"}]',
 	default: '',
 	typeOptions: {
@@ -210,7 +209,7 @@ const retrieveFields: INodeProperties[] = [
 		default: {},
 		options: [
 			metadataFilterField,
-			customFilterField,
+			advancedFilterField,
 			metadataSchemaField,
 			keyPrefixField,
 			metadataKeyField,
@@ -388,7 +387,7 @@ const getKeyPrefix = getParameter.bind(null, `options.${REDIS_KEY_PREFIX}`);
 const getOverwrite = getParameter.bind(null, `options.${REDIS_OVERWRITE_DOCUMENTS}`);
 const getContentKey = getParameter.bind(null, `options.${REDIS_CONTENT_KEY}`);
 const getMetadataFilter = getParameter.bind(null, `options.${REDIS_METADATA_FILTER}`);
-const getCustomFilter = getParameter.bind(null, `options.${REDIS_CUSTOM_FILTER}`);
+const getAdvancedFilter = getParameter.bind(null, `options.${REDIS_ADVANCED_FILTER}`);
 const getMetadataSchema = getParameter.bind(null, `options.${REDIS_METADATA_SCHEMA}`);
 const getMetadataKey = getParameter.bind(null, `options.${REDIS_METADATA_KEY}`);
 const getEmbeddingKey = getParameter.bind(null, `options.${REDIS_EMBEDDING_KEY}`);
@@ -496,13 +495,13 @@ export class VectorStoreRedis extends createVectorStoreNode({
 
 		const nodeVersion = context.getNode().typeVersion;
 
-		// Version 1.4+: Use FluentRedisVectorStore with custom filter
+		// Version 1.4+: Use FluentRedisVectorStore with advanced filter and custom metadata schema
 		if (nodeVersion >= 1.4) {
-			const customFilter = getCustomFilter(context, itemIndex).trim();
+			const filter = getAdvancedFilter(context, itemIndex).trim();
 			const metadataSchemaJson = getMetadataSchema(context, itemIndex).trim();
 			const customSchema = parseMetadataSchema(context, metadataSchemaJson, itemIndex);
 
-			const filterExpression = customFilter ? Custom(customFilter) : undefined;
+			const filterExpression = filter ? Custom(filter) : undefined;
 
 			return new ExtendedRedisVectorSearch(
 				embeddings,

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreRedis/VectorStoreRedis.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreRedis/VectorStoreRedis.node.ts
@@ -1,11 +1,15 @@
 import type { EmbeddingsInterface } from '@langchain/core/embeddings';
 import {
+	// Legacy (v1.3 and below)
+	RedisVectorStore,
+	type RedisVectorStoreConfig,
+	// New (v1.4+)
 	FluentRedisVectorStore,
 	type FluentRedisVectorStoreConfig,
 	type FilterExpression,
 	type MetadataFieldSchema,
-	Tag,
 	Custom,
+	inferMetadataSchema,
 } from '@langchain/redis';
 import {
 	type IExecuteFunctions,
@@ -62,9 +66,14 @@ const metadataFilterField: INodeProperties = {
 	name: REDIS_METADATA_FILTER,
 	type: 'string',
 	description:
-		'Comma-separated list of words for simple tag-based metadata filtering. For advanced filtering, use Custom Filter instead.',
+		'The comma-separated list of words by which to apply additional full-text metadata filtering',
 	placeholder: 'Item1,Item2,Item3',
 	default: '',
+	displayOptions: {
+		show: {
+			'@version': [{ _cnd: { lte: 1.3 } }],
+		},
+	},
 };
 
 const customFilterField: INodeProperties = {
@@ -72,11 +81,17 @@ const customFilterField: INodeProperties = {
 	name: REDIS_CUSTOM_FILTER,
 	type: 'string',
 	description:
-		'Advanced Redis query filter expression. Supports Tag, Numeric, Text, Geo filters with AND/OR logic. Example: <code>@category:{electronics} @price:[0 100]</code>. Leave empty to use simple Metadata Filter.',
+		'Redis query filter expression. Supports Tag, Numeric, Text, Geo filters with AND/OR logic. Example: <code>@category:{electronics} @price:[0 100]</code>',
+	hint: 'Learn more about Redis vector search filtering <a target="_blank" href="https://docs.langchain.com/oss/javascript/integrations/vectorstores/redis#field-configuration-options">here</a>',
 	placeholder: '@category:{electronics} @price:[0 100]',
 	default: '',
 	typeOptions: {
 		rows: 3,
+	},
+	displayOptions: {
+		show: {
+			'@version': [{ _cnd: { gte: 1.4 } }],
+		},
 	},
 };
 
@@ -86,10 +101,16 @@ const metadataSchemaField: INodeProperties = {
 	type: 'string',
 	description:
 		'JSON array defining metadata field types for indexing. If not provided, schema will be inferred from documents. Example: <code>[{"name": "category", "type": "tag"}, {"name": "price", "type": "numeric", "options": {"sortable": true}}]</code>',
+	hint: 'Learn more about metadata schema configuration <a target="_blank" href="https://docs.langchain.com/oss/javascript/integrations/vectorstores/advanced-filtering-with-the-fluent-API">here</a>',
 	placeholder: '[{"name": "category", "type": "tag"}, {"name": "price", "type": "numeric"}]',
 	default: '',
 	typeOptions: {
 		rows: 4,
+	},
+	displayOptions: {
+		show: {
+			'@version': [{ _cnd: { gte: 1.4 } }],
+		},
 	},
 };
 
@@ -146,7 +167,20 @@ const ttlField: INodeProperties = {
 	default: '',
 };
 
-const sharedFields: INodeProperties[] = [redisIndexRLC];
+const upgradeNotice: INodeProperties = {
+	displayName:
+		'A newer version of this node is available with advanced filtering and custom metadata schema support. To upgrade, delete this node and add a new Redis Vector Store node. Note: you will need to recreate your index and reimport all your documents to use advanced filtering.',
+	name: 'upgradeNotice',
+	type: 'notice',
+	default: '',
+	displayOptions: {
+		show: {
+			'@version': [{ _cnd: { lte: 1.3 } }],
+		},
+	},
+};
+
+const sharedFields: INodeProperties[] = [redisIndexRLC, upgradeNotice];
 
 const insertFields: INodeProperties[] = [
 	{
@@ -177,6 +211,7 @@ const retrieveFields: INodeProperties[] = [
 		options: [
 			metadataFilterField,
 			customFilterField,
+			metadataSchemaField,
 			keyPrefixField,
 			metadataKeyField,
 			contentKeyField,
@@ -311,10 +346,25 @@ export function getParameterAsNumber(
 }
 
 /**
- * Extended FluentRedisVectorStore class to handle custom filtering.
- *
- * This wrapper is necessary because when used as a retriever, the similaritySearchVectorWithScore should
- * use a processed filter
+ * Legacy ExtendedRedisVectorSearch class for v1.3 and below.
+ * Uses the original RedisVectorStore with string[] filter format.
+ */
+class LegacyRedisVectorSearch extends RedisVectorStore {
+	defaultFilter?: string[];
+
+	constructor(embeddings: EmbeddingsInterface, options: RedisVectorStoreConfig, filter?: string[]) {
+		super(embeddings, options);
+		this.defaultFilter = filter;
+	}
+
+	async similaritySearchVectorWithScore(query: number[], k: number) {
+		return await super.similaritySearchVectorWithScore(query, k, this.defaultFilter);
+	}
+}
+
+/**
+ * Extended FluentRedisVectorStore class for v1.4+.
+ * Uses FluentRedisVectorStore with FilterExpression for advanced filtering.
  */
 class ExtendedRedisVectorSearch extends FluentRedisVectorStore {
 	defaultFilter?: FilterExpression;
@@ -344,6 +394,9 @@ const getMetadataKey = getParameter.bind(null, `options.${REDIS_METADATA_KEY}`);
 const getEmbeddingKey = getParameter.bind(null, `options.${REDIS_EMBEDDING_KEY}`);
 const getTtl = getParameterAsNumber.bind(null, `options.${REDIS_TTL}`);
 
+const SCHEMA_ERROR_DESCRIPTION =
+	'Expected format: [{"name": "fieldName", "type": "tag|text|numeric|geo"}]';
+
 /**
  * Parse and validate metadata schema JSON
  */
@@ -352,38 +405,47 @@ function parseMetadataSchema(
 	schemaJson: string,
 	itemIndex: number,
 ): MetadataFieldSchema[] | undefined {
-	if (!schemaJson || !schemaJson.trim()) {
+	if (!schemaJson?.trim()) {
 		return undefined;
 	}
 
+	let parsed: unknown;
 	try {
-		const parsed = JSON.parse(schemaJson);
-
-		// Validate it's an array
-		if (!Array.isArray(parsed)) {
-			throw new Error('Metadata schema must be a JSON array');
-		}
-
-		// Validate each field has required properties
-		for (const field of parsed) {
-			if (!field.name || typeof field.name !== 'string') {
-				throw new Error('Each schema field must have a "name" property');
-			}
-			if (!field.type || !['tag', 'text', 'numeric', 'geo'].includes(field.type)) {
-				throw new Error(
-					`Invalid field type "${field.type}". Must be one of: tag, text, numeric, geo`,
-				);
-			}
-		}
-
-		return parsed as MetadataFieldSchema[];
+		parsed = JSON.parse(schemaJson);
 	} catch (error) {
 		throw new NodeOperationError(
 			context.getNode(),
 			`Invalid metadata schema JSON: ${error.message}`,
-			{ itemIndex },
+			{ itemIndex, description: SCHEMA_ERROR_DESCRIPTION },
 		);
 	}
+
+	if (!Array.isArray(parsed)) {
+		throw new NodeOperationError(
+			context.getNode(),
+			'Invalid metadata schema: must be a JSON array',
+			{ itemIndex, description: SCHEMA_ERROR_DESCRIPTION },
+		);
+	}
+
+	for (const field of parsed) {
+		if (!field.name || typeof field.name !== 'string') {
+			throw new NodeOperationError(
+				context.getNode(),
+				'Invalid metadata schema: each field must have a "name" property',
+				{ itemIndex, description: SCHEMA_ERROR_DESCRIPTION },
+			);
+		}
+		if (!field.type || !['tag', 'text', 'numeric', 'geo'].includes(field.type)) {
+			throw new NodeOperationError(
+				context.getNode(),
+				`Invalid metadata schema: field type "${field.type}" is not valid. Must be one of: tag, text, numeric, geo`,
+				{ itemIndex, description: SCHEMA_ERROR_DESCRIPTION },
+			);
+		}
+	}
+
+	return parsed as MetadataFieldSchema[];
 }
 
 export class VectorStoreRedis extends createVectorStoreNode({
@@ -414,9 +476,6 @@ export class VectorStoreRedis extends createVectorStoreNode({
 		const metadataField = getMetadataKey(context, itemIndex).trim();
 		const contentField = getContentKey(context, itemIndex).trim();
 		const embeddingField = getEmbeddingKey(context, itemIndex).trim();
-		const customFilter = getCustomFilter(context, itemIndex).trim();
-		const simpleFilter = getMetadataFilter(context, itemIndex).trim();
-		const metadataSchemaJson = getMetadataSchema(context, itemIndex).trim();
 
 		if (client === null) {
 			throw new NodeOperationError(context.getNode(), 'Redis client not initialized', {
@@ -435,28 +494,41 @@ export class VectorStoreRedis extends createVectorStoreNode({
 			});
 		}
 
-		// Parse custom metadata schema if provided
-		const customSchema = parseMetadataSchema(context, metadataSchemaJson, itemIndex);
+		const nodeVersion = context.getNode().typeVersion;
 
-		// Process filter: custom filter takes priority over simple filter
-		let filterExpression: FilterExpression | undefined;
+		// Version 1.4+: Use FluentRedisVectorStore with custom filter
+		if (nodeVersion >= 1.4) {
+			const customFilter = getCustomFilter(context, itemIndex).trim();
+			const metadataSchemaJson = getMetadataSchema(context, itemIndex).trim();
+			const customSchema = parseMetadataSchema(context, metadataSchemaJson, itemIndex);
 
-		if (customFilter) {
-			// Use custom filter if provided
-			filterExpression = Custom(customFilter);
-		} else if (simpleFilter) {
-			// Fall back to simple tag-based filter
-			const filterTerms = simpleFilter
-				.split(',')
-				.map((s) => s.trim())
-				.filter((s) => s);
+			const filterExpression = customFilter ? Custom(customFilter) : undefined;
 
-			if (filterTerms.length > 0) {
-				filterExpression = Tag(metadataField || 'metadata').eq(filterTerms);
-			}
+			return new ExtendedRedisVectorSearch(
+				embeddings,
+				{
+					redisClient: client,
+					indexName: indexField,
+					...(keyPrefixField ? { keyPrefix: keyPrefixField } : {}),
+					...(metadataField ? { metadataKey: metadataField } : {}),
+					...(contentField ? { contentKey: contentField } : {}),
+					...(embeddingField ? { vectorKey: embeddingField } : {}),
+					...(customSchema ? { customSchema } : {}),
+				},
+				filterExpression,
+			);
 		}
 
-		return new ExtendedRedisVectorSearch(
+		// Version 1.3 and below: Use legacy RedisVectorStore with string[] filter
+		const simpleFilter = getMetadataFilter(context, itemIndex).trim();
+		const filterTerms = simpleFilter
+			? simpleFilter
+					.split(',')
+					.map((s) => s.trim())
+					.filter((s) => s)
+			: [];
+
+		return new LegacyRedisVectorSearch(
 			embeddings,
 			{
 				redisClient: client,
@@ -465,9 +537,8 @@ export class VectorStoreRedis extends createVectorStoreNode({
 				...(metadataField ? { metadataKey: metadataField } : {}),
 				...(contentField ? { contentKey: contentField } : {}),
 				...(embeddingField ? { vectorKey: embeddingField } : {}),
-				...(customSchema ? { customSchema } : {}),
 			},
-			filterExpression,
+			filterTerms.length > 0 ? filterTerms : undefined,
 		);
 	},
 	async populateVectorStore(context, embeddings, documents, itemIndex) {
@@ -488,25 +559,42 @@ export class VectorStoreRedis extends createVectorStoreNode({
 			const contentField = getContentKey(context, itemIndex).trim();
 			const embeddingField = getEmbeddingKey(context, itemIndex).trim();
 			const ttl = getTtl(context, itemIndex);
-			const metadataSchemaJson = getMetadataSchema(context, itemIndex).trim();
-
-			// Parse custom metadata schema if provided
-			const customSchema = parseMetadataSchema(context, metadataSchemaJson, itemIndex);
 
 			if (overwrite) {
 				await client.ft.dropIndex(indexField, { DD: true });
 			}
 
-			await ExtendedRedisVectorSearch.fromDocuments(documents, embeddings, {
-				redisClient: client,
-				indexName: indexField,
-				...(keyPrefixField ? { keyPrefix: keyPrefixField } : {}),
-				...(metadataField ? { metadataKey: metadataField } : {}),
-				...(contentField ? { contentKey: contentField } : {}),
-				...(embeddingField ? { vectorKey: embeddingField } : {}),
-				...(ttl ? { ttl } : {}),
-				...(customSchema ? { customSchema } : {}),
-			});
+			const nodeVersion = context.getNode().typeVersion;
+
+			// Version 1.4+: Use FluentRedisVectorStore with custom schema support
+			if (nodeVersion >= 1.4) {
+				const metadataSchemaJson = getMetadataSchema(context, itemIndex).trim();
+				const customSchema =
+					parseMetadataSchema(context, metadataSchemaJson, itemIndex) ??
+					inferMetadataSchema(documents);
+
+				await ExtendedRedisVectorSearch.fromDocuments(documents, embeddings, {
+					redisClient: client,
+					indexName: indexField,
+					...(keyPrefixField ? { keyPrefix: keyPrefixField } : {}),
+					...(metadataField ? { metadataKey: metadataField } : {}),
+					...(contentField ? { contentKey: contentField } : {}),
+					...(embeddingField ? { vectorKey: embeddingField } : {}),
+					...(ttl ? { ttl } : {}),
+					customSchema,
+				});
+			} else {
+				// Version 1.3 and below: Use legacy RedisVectorStore
+				await LegacyRedisVectorSearch.fromDocuments(documents, embeddings, {
+					redisClient: client,
+					indexName: indexField,
+					...(keyPrefixField ? { keyPrefix: keyPrefixField } : {}),
+					...(metadataField ? { metadataKey: metadataField } : {}),
+					...(contentField ? { contentKey: contentField } : {}),
+					...(embeddingField ? { vectorKey: embeddingField } : {}),
+					...(ttl ? { ttl } : {}),
+				});
+			}
 		} catch (error) {
 			context.logger.info(`Error while populating the store: ${error.message}`);
 			throw new NodeOperationError(context.getNode(), `Error: ${error.message}`, {

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreRedis/VectorStoreRedis.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreRedis/VectorStoreRedis.node.ts
@@ -428,6 +428,13 @@ function parseMetadataSchema(
 	}
 
 	for (const field of parsed) {
+		if (typeof field !== 'object' || field === null) {
+			throw new NodeOperationError(
+				context.getNode(),
+				'Invalid metadata schema: each entry must be an object',
+				{ itemIndex, description: SCHEMA_ERROR_DESCRIPTION },
+			);
+		}
 		if (!field.name || typeof field.name !== 'string') {
 			throw new NodeOperationError(
 				context.getNode(),

--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -259,7 +259,7 @@
     "@langchain/openai": "catalog:",
     "@langchain/pinecone": "1.0.1",
     "@langchain/qdrant": "1.0.1",
-    "@langchain/redis": "1.1.0",
+    "@langchain/redis": "1.0.1",
     "@langchain/textsplitters": "1.0.1",
     "@langchain/weaviate": "1.0.1",
     "@microsoft/agents-a365-notifications": "0.1.0-preview.113",

--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -259,7 +259,7 @@
     "@langchain/openai": "catalog:",
     "@langchain/pinecone": "1.0.1",
     "@langchain/qdrant": "1.0.1",
-    "@langchain/redis": "1.0.1",
+    "@langchain/redis": "1.1.0",
     "@langchain/textsplitters": "1.0.1",
     "@langchain/weaviate": "1.0.1",
     "@microsoft/agents-a365-notifications": "0.1.0-preview.113",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2856,8 +2856,8 @@ importers:
         specifier: 1.0.1
         version: 1.0.1(@langchain/core@1.1.41(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(typescript@6.0.2)
       '@langchain/redis':
-        specifier: 1.0.1
-        version: 1.0.1(@langchain/core@1.1.41(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+        specifier: 1.1.0
+        version: 1.1.0(@langchain/core@1.1.41(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@langchain/textsplitters':
         specifier: 1.0.1
         version: 1.0.1(@langchain/core@1.1.41(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
@@ -9170,8 +9170,8 @@ packages:
     peerDependencies:
       '@langchain/core': ^1.0.0
 
-  '@langchain/redis@1.0.1':
-    resolution: {integrity: sha512-7DXozifDAkjpr6lc1oXfwpoFuND+0EEaUxqKrHyakjZ4ecvn5MEll+BtPA7ySUXw5IZkWVZZ+TntMkZ38O0rAQ==}
+  '@langchain/redis@1.1.0':
+    resolution: {integrity: sha512-ZJZOv9kBS8dCX5NGBUlp4qqxEuLeoOFlXeq9jXmTQDTwTO6NhVcrYF2fK3tKL/PFajYPpTCLHV9pD9kuXb0EvA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@langchain/core': ^1.0.0
@@ -26467,10 +26467,11 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@langchain/redis@1.0.1(@langchain/core@1.1.41(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+  '@langchain/redis@1.1.0(@langchain/core@1.1.41(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@langchain/core': 1.1.41(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       redis: 4.6.14
+      uuid: 10.0.0
 
   '@langchain/textsplitters@1.0.1(@langchain/core@1.1.41(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:


### PR DESCRIPTION
## Summary

Upgrades Redis Vector Store node to v1.4 with support for advanced query filtering and custom metadata schema, leveraging the new `FluentRedisVectorStore` from `@langchain/redis`.

**New Features (v1.4+):**
- Advanced metadata filtering using Redis query syntax (e.g., `@category:{electronics} @price:[0 100]`)
- Custom metadata schema definition for precise index field typing (tag, text, numeric, geo)
- Automatic schema inference from documents when no custom schema is provided

**Backward Compatibility:**
- v1.3 and below continue using legacy `RedisVectorStore` with simple comma-separated filter
- Upgrade notice displayed for older node versions

**Technical:**
- New `ExtendedRedisVectorSearch` class wrapping `FluentRedisVectorStore` with `FilterExpression` support
- `LegacyRedisVectorSearch` class preserved for v1.3 compatibility
- Schema validation with clear error messages

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) 
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. 
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

## Related Links

- [langchain-js PR #9240: FluentRedisVectorStore with advanced filtering](https://github.com/langchain-ai/langchainjs/pull/9240)
- [Redis Vector Search filtering docs](https://docs.langchain.com/oss/javascript/integrations/vectorstores/redis#advanced-features)