### PR TITLE
feat(core): Make data redaction available without feature flag

### DIFF
--- a/packages/cli/src/modules/redaction/__tests__/redaction.module.test.ts
+++ b/packages/cli/src/modules/redaction/__tests__/redaction.module.test.ts
@@ -12,7 +12,6 @@ describe('RedactionModule', () => {
 	let module: RedactionModule;
 	let executionRedactionService: jest.Mocked<ExecutionRedactionService>;
 	let executionRedactionServiceProxy: jest.Mocked<ExecutionRedactionServiceProxy>;
-	const originalEnv = process.env.N8N_ENV_FEAT_EXECUTION_REDACTION;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -29,37 +28,8 @@ describe('RedactionModule', () => {
 		module = new RedactionModule();
 	});
 
-	afterEach(() => {
-		// Restore original environment variable
-		if (originalEnv !== undefined) {
-			process.env.N8N_ENV_FEAT_EXECUTION_REDACTION = originalEnv;
-		} else {
-			delete process.env.N8N_ENV_FEAT_EXECUTION_REDACTION;
-		}
-	});
-
 	describe('init', () => {
-		it.each([
-			['not set', undefined],
-			['"false"', 'false'],
-			['empty string', ''],
-			['"1"', '1'],
-		])('should not initialize when N8N_ENV_FEAT_EXECUTION_REDACTION is %s', async (_, value) => {
-			if (value === undefined) {
-				delete process.env.N8N_ENV_FEAT_EXECUTION_REDACTION;
-			} else {
-				process.env.N8N_ENV_FEAT_EXECUTION_REDACTION = value;
-			}
-
-			await module.init();
-
-			expect(executionRedactionService.init).not.toHaveBeenCalled();
-			expect(executionRedactionServiceProxy.setExecutionRedaction).not.toHaveBeenCalled();
-		});
-
-		it('should initialize ExecutionRedactionService and wire up proxy when N8N_ENV_FEAT_EXECUTION_REDACTION is "true"', async () => {
-			process.env.N8N_ENV_FEAT_EXECUTION_REDACTION = 'true';
-
+		it('should initialize ExecutionRedactionService and wire up proxy', async () => {
 			await module.init();
 
 			expect(executionRedactionService.init).toHaveBeenCalledTimes(1);

--- a/packages/cli/src/modules/redaction/redaction.module.ts
+++ b/packages/cli/src/modules/redaction/redaction.module.ts
@@ -4,16 +4,9 @@ import { Container } from '@n8n/di';
 
 import { ExecutionRedactionServiceProxy } from '@/executions/execution-redaction-proxy.service';
 
-function isExecutionRedactionEnabled(): boolean {
-	return process.env.N8N_ENV_FEAT_EXECUTION_REDACTION === 'true';
-}
-
 @BackendModule({ name: 'redaction', instanceTypes: ['main'] })
 export class RedactionModule implements ModuleInterface {
 	async init() {
-		if (!isExecutionRedactionEnabled()) {
-			return;
-		}
 		const { ExecutionRedactionService } = await import('./executions/execution-redaction.service');
 		const executionRedactionService = Container.get(ExecutionRedactionService);
 		await executionRedactionService.init();

--- a/packages/cli/test/integration/execution-redaction.test.ts
+++ b/packages/cli/test/integration/execution-redaction.test.ts
@@ -22,9 +22,6 @@ import {
 } from './shared/db/users';
 import { setupTestServer } from './shared/utils';
 
-// Must be set before setupTestServer() so RedactionModule.init() wires the real service
-process.env.N8N_ENV_FEAT_EXECUTION_REDACTION = 'true';
-
 mockInstance(WaitTracker);
 mockInstance(ConcurrencyControlService, {
 	// @ts-expect-error Private property

--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.test.ts
@@ -903,13 +903,6 @@ describe('WorkflowSettingsVue', () => {
 	});
 
 	describe('Redaction Policy', () => {
-		it('should not render redaction policy when env feature flag is missing', async () => {
-			const { queryByTestId } = createComponent({ pinia });
-			await nextTick();
-
-			expect(queryByTestId('workflow-settings-redaction-policy')).not.toBeInTheDocument();
-		});
-
 		it('should not render redaction policy when redaction module is inactive', async () => {
 			vi.spyOn(settingsStore, 'isModuleActive').mockImplementation(
 				(name: string) => name !== 'redaction',
@@ -941,8 +934,6 @@ describe('WorkflowSettingsVue', () => {
 
 		it('should render redaction policy when module is active and user has scope', async () => {
 			vi.spyOn(settingsStore, 'isModuleActive').mockReturnValue(true);
-			settingsStore.settings.envFeatureFlags.N8N_ENV_FEAT_REDACTION_POLICY = true;
-
 			const workflowWithRedactionScope = createTestWorkflow({
 				id: '1',
 				name: 'Test Workflow',
@@ -1055,8 +1046,6 @@ describe('WorkflowSettingsVue', () => {
 
 		it('should disable production redaction select and force "Redact" when dynamic credentials are configured', async () => {
 			vi.spyOn(settingsStore, 'isModuleActive').mockReturnValue(true);
-			settingsStore.settings.envFeatureFlags.N8N_ENV_FEAT_REDACTION_POLICY = true;
-
 			const workflowWithRedactionScope = createTestWorkflow({
 				id: '1',
 				name: 'Test Workflow',

--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
@@ -6,7 +6,6 @@ import { usePostHog } from '@/app/stores/posthog.store';
 import type { ITimeoutHMS, IWorkflowSettings, IWorkflowShortResponse } from '@/Interface';
 import type { WorkflowDataUpdate } from '@n8n/rest-api-client/api/workflows';
 import Modal from '@/app/components/Modal.vue';
-import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
 import {
 	EnterpriseEditionFeature,
 	WORKFLOW_SETTINGS_MODAL_KEY,
@@ -92,8 +91,6 @@ const workflowDocumentStore = computed(() => {
 const workflowsEEStore = useWorkflowsEEStore();
 const nodeCreatorStore = useNodeCreatorStore();
 const posthogStore = usePostHog();
-const { check } = useEnvFeatureFlag();
-
 const isLoading = ref(true);
 const workflowCallerPolicyOptions = ref<Array<{ key: string; value: string }>>([]);
 const redactionToggleOptions = ref<Array<{ key: string; value: string }>>([
@@ -215,7 +212,6 @@ const isDataRedactionLicensed = computed(
 const isRedactionSettingVisible = computed(
 	() =>
 		settingsStore.isModuleActive('redaction') &&
-		check.value('EXECUTION_REDACTION') &&
 		(isDataRedactionLicensed.value ? workflowPermissions.value.updateRedactionSetting : true),
 );
 


### PR DESCRIPTION
## Summary

Remove the `N8N_ENV_FEAT_EXECUTION_REDACTION` environment variable gate from the data redaction feature. The redaction module now always initializes on startup, and the frontend UI is shown whenever the module is active and the user has the `updateRedactionSetting` permission, no feature flag required. This makes data redaction available to customers out of the box.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-508

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)