### PR TITLE
feat(devcontainer): Update devcontainer to allow docker build & gpg commit signature

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,8 +6,10 @@ ARG NODE_VERSION
 
 RUN apk add --no-cache \
     openssh sudo shadow bash libc-utils \
-    git openssl graphicsmagick tini tzdata ca-certificates libc6-compat
+    git openssl graphicsmagick tini tzdata ca-certificates libc6-compat \
+    docker-cli docker-cli-buildx gnupg
 RUN echo node ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/node && chmod 0440 /etc/sudoers.d/node
+RUN addgroup -S docker && adduser node docker
 RUN mkdir /workspaces && chown node:node /workspaces
 RUN corepack enable
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,10 +6,12 @@
 	"mounts": [
 		"type=bind,source=${localWorkspaceFolder},target=/workspaces,consistency=cached",
 		"type=bind,source=${localEnv:HOME}/.ssh,target=/home/node/.ssh,consistency=cached",
-		"type=bind,source=${localEnv:HOME}/.n8n,target=/home/node/.n8n,consistency=cached"
+		"type=bind,source=${localEnv:HOME}/.gnupg,target=/home/node/.gnupg,consistency=cached",
+		"type=bind,source=${localEnv:HOME}/.n8n,target=/home/node/.n8n,consistency=cached",
+		"type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock"
 	],
 	"forwardPorts": [8080, 5678],
-	"postCreateCommand": "corepack prepare --activate && pnpm install",
+	"postCreateCommand": "corepack prepare --activate && pnpm install && sudo chown root:docker /var/run/docker.sock && sudo chmod 660 /var/run/docker.sock",
 	"postAttachCommand": "pnpm build",
 	"customizations": {
 		"codespaces": {


### PR DESCRIPTION
## Summary

Following a try to build the task runners image, I had difficulties with the devcontainer. So I improve it to have the possibility to:

- do a docker build inside the container (pretty useful to test docker images)
- sign my commit with GPG

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
