### PR TITLE
fix: add connection pool limits to MongoDB Chat Memory node (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryMongoDbChat/MemoryMongoDbChat.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryMongoDbChat/MemoryMongoDbChat.node.ts
@@ -128,7 +128,11 @@ export class MemoryMongoDbChat implements INodeType {
 		}
 
 		try {
-			const client = new MongoClient(connectionString);
+			const client = new MongoClient(connectionString, {
+				minPoolSize: 0,
+				maxPoolSize: 1,
+				maxIdleTimeMS: 30_000,
+			});
 			await client.connect();
 
 			const db = client.db(dbName);


### PR DESCRIPTION
## Summary

The MongoDB Chat Memory node was creating a new `MongoClient` on every workflow execution with no connection pool constraints (defaulting to 100 connections per client). The `closeFunction` returned by `supplyData()` is not reliably called by the execution engine — particularly in high-frequency AI agent workflows or when errors occur. This leads to leaked `MongoClient` instances that accumulate heartbeat connections indefinitely.

This PR adds connection pool options to the `MongoClient` constructor to limit the blast radius:
- `maxPoolSize: 1` — caps connections per client to 1 (down from 100)
- `minPoolSize: 0` — allows the pool to fully drain when idle
- `maxIdleTimeMS: 30_000` — connections are released after 30 seconds of inactivity

## Related Linear tickets, Github issues, and Community forum posts

Fixes #27980

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)