### PR TITLE
fix(editor): Fix issue with credential based grouping in setup cards

### DIFF
--- a/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.test.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.test.ts
@@ -1589,7 +1589,7 @@ describe('useWorkflowSetupState', () => {
 			});
 		});
 
-		it('should only show credential picker on first node with same credential type', () => {
+		it('should show credential picker on all nodes when multiple have params', () => {
 			const node1 = createNode({
 				name: 'HTTP Request 1',
 				type: 'n8n-nodes-base.httpRequest',
@@ -1614,10 +1614,12 @@ describe('useWorkflowSetupState', () => {
 
 			expect(state.nodeStates.value).toHaveLength(2);
 			expect(state.nodeStates.value[0].showCredentialPicker).toBe(true);
-			expect(state.nodeStates.value[1].showCredentialPicker).toBe(false);
+			expect(state.nodeStates.value[1].showCredentialPicker).toBe(true);
+			expect(state.nodeStates.value[0].allNodesUsingCredential).toEqual([node1]);
+			expect(state.nodeStates.value[1].allNodesUsingCredential).toEqual([node2]);
 		});
 
-		it('should track all nodes using credential in allNodesUsingCredential', () => {
+		it('should include non-param follower in allNodesUsingCredential when first node has params', () => {
 			const node1 = createNode({
 				name: 'HTTP Request 1',
 				type: 'n8n-nodes-base.httpRequest',
@@ -1644,10 +1646,105 @@ describe('useWorkflowSetupState', () => {
 
 			const state = useWorkflowSetupState();
 
+			// Only 1 per-node card for node1 (has params); node2 is a non-param follower
 			expect(state.nodeStates.value).toHaveLength(1);
-			expect(state.nodeStates.value[0].allNodesUsingCredential).toHaveLength(2);
-			expect(state.nodeStates.value[0].allNodesUsingCredential).toContain(node1);
-			expect(state.nodeStates.value[0].allNodesUsingCredential).toContain(node2);
+			expect(state.nodeStates.value[0].node.name).toBe('HTTP Request 1');
+			expect(state.nodeStates.value[0].showCredentialPicker).toBe(true);
+			expect(state.nodeStates.value[0].allNodesUsingCredential).toEqual([node1, node2]);
+		});
+
+		it('should group non-param followers with credential-only card for 3 nodes with mixed params', () => {
+			const node1 = createNode({
+				name: 'HTTP Request 1',
+				type: 'n8n-nodes-base.httpRequest',
+				issues: { credentials: { httpHeaderAuth: ['Credential is required'] } },
+				parameters: { url: 'https://api.example.com' },
+			});
+			const node2 = createNode({
+				name: 'HTTP Request 2',
+				type: 'n8n-nodes-base.httpRequest',
+				issues: { credentials: { httpHeaderAuth: ['Credential is required'] } },
+				parameters: { url: 'https://api.example.com' },
+			});
+			const node3 = createNode({
+				name: 'HTTP Request 3',
+				type: 'n8n-nodes-base.httpRequest',
+				issues: { credentials: { httpHeaderAuth: ['Credential is required'] } },
+				parameters: { url: 'https://api.example.com' },
+			});
+
+			mockWorkflowDocumentStore.allNodes = [node1, node2, node3];
+			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'httpHeaderAuth' }]);
+			// Only node2 has parameter issues
+			mockGetNodeParametersIssues.mockImplementation((_, node) => {
+				if (node.name === 'HTTP Request 2') return { url: ['URL is required'] };
+				return {};
+			});
+			nodeTypesStore.getNodeType = vi.fn().mockReturnValue({
+				properties: [{ name: 'url', required: true }],
+			});
+
+			const state = useWorkflowSetupState();
+
+			// node1 (first, no params) → credential-only card with node3 as follower
+			// node2 (has params) → per-node card with only itself
+			expect(state.nodeStates.value).toHaveLength(2);
+
+			const node1State = state.nodeStates.value.find((s) => s.node.name === 'HTTP Request 1');
+			const node2State = state.nodeStates.value.find((s) => s.node.name === 'HTTP Request 2');
+
+			expect(node1State).toBeDefined();
+			expect(node1State!.parameterIssues).toEqual({});
+			expect(node1State!.showCredentialPicker).toBe(true);
+			expect(node1State!.allNodesUsingCredential).toEqual([node1, node3]);
+
+			expect(node2State).toBeDefined();
+			expect(node2State!.showCredentialPicker).toBe(true);
+			expect(node2State!.allNodesUsingCredential).toEqual([node2]);
+		});
+
+		it('should create credential-only card for first node without params when second has params', () => {
+			const node1 = createNode({
+				name: 'HTTP Request 1',
+				type: 'n8n-nodes-base.httpRequest',
+				issues: { credentials: { httpHeaderAuth: ['Credential is required'] } },
+				parameters: { url: 'https://api.example.com' },
+			});
+			const node2 = createNode({
+				name: 'HTTP Request 2',
+				type: 'n8n-nodes-base.httpRequest',
+				issues: { credentials: { httpHeaderAuth: ['Credential is required'] } },
+				parameters: { url: 'https://api.example.com' },
+			});
+
+			mockWorkflowDocumentStore.allNodes = [node1, node2];
+			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'httpHeaderAuth' }]);
+			// Only node2 has parameter issues
+			mockGetNodeParametersIssues.mockImplementation((_, node) => {
+				if (node.name === 'HTTP Request 2') return { url: ['URL is required'] };
+				return {};
+			});
+			nodeTypesStore.getNodeType = vi.fn().mockReturnValue({
+				properties: [{ name: 'url', required: true }],
+			});
+
+			const state = useWorkflowSetupState();
+
+			// node1 gets a credential-only card (first in order, no params)
+			// node2 gets a card with credential picker + params
+			expect(state.nodeStates.value).toHaveLength(2);
+
+			const node1State = state.nodeStates.value.find((s) => s.node.name === 'HTTP Request 1');
+			const node2State = state.nodeStates.value.find((s) => s.node.name === 'HTTP Request 2');
+
+			expect(node1State).toBeDefined();
+			expect(node1State!.showCredentialPicker).toBe(true);
+			expect(node1State!.parameterIssues).toEqual({});
+			expect(node1State!.allNodesUsingCredential).toEqual([node1]);
+
+			expect(node2State).toBeDefined();
+			expect(node2State!.showCredentialPicker).toBe(true);
+			expect(node2State!.allNodesUsingCredential).toEqual([node2]);
 		});
 
 		it('should persist cards even after parameters are filled', async () => {

--- a/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.ts
@@ -321,7 +321,7 @@ export const useWorkflowSetupState = (
 	 * Sorted by execution order (grouped by trigger, DFS through connections).
 	 */
 	const nodesRequiringSetup = computed(() => {
-		const nodesForSetup = sourceNodes.value
+		const filteredNodes = sourceNodes.value
 			.filter((node) => !node.disabled)
 			.map((node) => ({
 				node,
@@ -338,16 +338,16 @@ export const useWorkflowSetupState = (
 					nodeHasTemplateParams(node.name),
 			);
 
-		const allNodeTypes: Record<string, string> = {};
+		const nodeNameToType: Record<string, string> = {};
 		for (const node of sourceNodes.value) {
-			allNodeTypes[node.name] = node.type;
+			nodeNameToType[node.name] = node.type;
 		}
 
 		return sortNodesByExecutionOrder(
-			nodesForSetup,
+			filteredNodes,
 			workflowDocumentStore.value?.connectionsBySourceNode ?? {},
 			workflowDocumentStore.value?.connectionsByDestinationNode ?? {},
-			allNodeTypes,
+			nodeNameToType,
 		);
 	});
 
@@ -540,9 +540,9 @@ export const useWorkflowSetupState = (
 		const result: NodeSetupState[] = [];
 
 		// --- Parameter-only nodes (no credentials) ---
-		for (const entry of nodesWithMissingParameters.value) {
-			if (entry.credentialTypes.length > 0) continue;
-			const { node, parameterIssues, isTrigger } = entry;
+		for (const setupEntry of nodesWithMissingParameters.value) {
+			if (setupEntry.credentialTypes.length > 0) continue;
+			const { node, parameterIssues, isTrigger } = setupEntry;
 
 			const state: NodeSetupState = {
 				node,
@@ -558,7 +558,8 @@ export const useWorkflowSetupState = (
 		// --- Credential+parameter nodes ---
 		// Build maps: all nodes per cred type + nodes with params per cred type
 		const credTypeToAllNodes = new Map<string, INodeUi[]>();
-		const credTypeToEntries = new Map<
+		const credTypeNodeIds = new Map<string, Set<string>>();
+		const credTypeToNodesWithParams = new Map<
 			string,
 			Array<{
 				node: INodeUi;
@@ -568,16 +569,20 @@ export const useWorkflowSetupState = (
 			}>
 		>();
 
-		for (const entry of nodesRequiringSetup.value) {
-			const { node, credentialTypes, parameterIssues } = entry;
+		for (const setupEntry of nodesRequiringSetup.value) {
+			const { node, credentialTypes, parameterIssues } = setupEntry;
 			if (credentialTypes.length === 0) continue;
 
 			for (const credType of credentialTypes) {
 				if (!perNodeCredTypes.value.has(credType)) continue;
 
-				if (!credTypeToAllNodes.has(credType)) credTypeToAllNodes.set(credType, []);
+				if (!credTypeToAllNodes.has(credType)) {
+					credTypeToAllNodes.set(credType, []);
+					credTypeNodeIds.set(credType, new Set());
+				}
 
-				if (!credTypeToAllNodes.get(credType)!.some((n) => n.id === node.id)) {
+				if (!credTypeNodeIds.get(credType)!.has(node.id)) {
+					credTypeNodeIds.get(credType)!.add(node.id);
 					credTypeToAllNodes.get(credType)!.push(node);
 				}
 
@@ -587,35 +592,104 @@ export const useWorkflowSetupState = (
 				const alreadySeen = stickyNodeCredentials.value.has(combinationKey);
 
 				if (hasParameters || hasTemplateParams || alreadySeen) {
-					if (!credTypeToEntries.has(credType)) credTypeToEntries.set(credType, []);
-					credTypeToEntries.get(credType)!.push(entry);
+					if (!credTypeToNodesWithParams.has(credType)) credTypeToNodesWithParams.set(credType, []);
+					credTypeToNodesWithParams.get(credType)!.push(setupEntry);
 				}
 			}
 		}
 
 		const seenCombinations = new Set<string>();
 
-		for (const [credType, entries] of credTypeToEntries) {
-			let isFirstNode = true;
-			const allNodesUsingCredential = credTypeToAllNodes.get(credType) ?? [];
+		function extractCredentialInfo(node: INodeUi, credType: string) {
+			const credValue = node.credentials?.[credType];
+			const selectedCredentialId =
+				typeof credValue === 'string' ? undefined : (credValue?.id ?? undefined);
+			const credentialIssues = node.issues?.credentials ?? {};
+			const issues = credentialIssues[credType];
+			const issueMessages = [issues ?? []].flat();
+			const isAutoApplied =
+				!!selectedCredentialId && autoAppliedCredentialIds.value.has(selectedCredentialId);
+			return { selectedCredentialId, issueMessages, isAutoApplied };
+		}
 
-			for (const entry of entries) {
-				const { node, parameterIssues, isTrigger } = entry;
+		// Precompute per-credType credTypeInfo data shared by both passes
+		const multiNodeCredTypeInfo = new Map<
+			string,
+			{ paramNodeIds: Set<string>; nonParamFollowers: INodeUi[] }
+		>();
+		for (const [credType, allNodes] of credTypeToAllNodes) {
+			if (allNodes.length <= 1) continue;
+			const paramNodeEntries = credTypeToNodesWithParams.get(credType);
+			const paramNodeIds = new Set(paramNodeEntries?.map((e) => e.node.id) ?? []);
+			const firstNode = allNodes[0];
+			const nonParamFollowers = allNodes.filter(
+				(n) => n.id !== firstNode.id && !paramNodeIds.has(n.id),
+			);
+			multiNodeCredTypeInfo.set(credType, { paramNodeIds, nonParamFollowers });
+		}
+
+		// Credential-only cards for first nodes without params
+		for (const [credType, allNodes] of credTypeToAllNodes) {
+			const credTypeInfo = multiNodeCredTypeInfo.get(credType);
+			if (!credTypeInfo) continue;
+			const nodesWithParams = credTypeToNodesWithParams.get(credType);
+			// if no nodes with params for that credential type, nodes will be handled by credentialTypeStates
+			if (!nodesWithParams || nodesWithParams.length === 0) continue;
+
+			const firstNode = allNodes[0];
+			if (credTypeInfo.paramNodeIds.has(firstNode.id)) continue;
+
+			const combinationKey = `${credType}:${firstNode.id}`;
+			if (seenCombinations.has(combinationKey)) continue;
+			seenCombinations.add(combinationKey);
+
+			const { selectedCredentialId, issueMessages, isAutoApplied } = extractCredentialInfo(
+				firstNode,
+				credType,
+			);
+
+			const state: NodeSetupState = {
+				node: firstNode,
+				credentialType: credType,
+				credentialDisplayName: getCredentialDisplayName(credType),
+				selectedCredentialId,
+				issues: issueMessages,
+				parameterIssues: {},
+				isTrigger: isTriggerNode(firstNode),
+				showCredentialPicker: true,
+				isComplete: false,
+				allNodesUsingCredential: [firstNode, ...credTypeInfo.nonParamFollowers],
+				isAutoApplied,
+			};
+
+			state.isComplete = isNodeSetupComplete(state, buildCompletionContext(credType));
+			result.push(state);
+		}
+
+		// Per-node cards with credential + parameter setup
+		for (const [credType, paramNodeEntries] of credTypeToNodesWithParams) {
+			const allNodes = credTypeToAllNodes.get(credType) ?? [];
+			const credTypeInfo = multiNodeCredTypeInfo.get(credType);
+			const isSharingCredential = !!credTypeInfo;
+
+			for (const setupEntry of paramNodeEntries) {
+				const { node, parameterIssues, isTrigger } = setupEntry;
 				const combinationKey = `${credType}:${node.id}`;
 
 				if (seenCombinations.has(combinationKey)) continue;
 				seenCombinations.add(combinationKey);
 
-				const credValue = node.credentials?.[credType];
-				const selectedCredentialId =
-					typeof credValue === 'string' ? undefined : (credValue?.id ?? undefined);
+				const { selectedCredentialId, issueMessages, isAutoApplied } = extractCredentialInfo(
+					node,
+					credType,
+				);
 
-				const credentialIssues = node.issues?.credentials ?? {};
-				const issues = credentialIssues[credType];
-				const issueMessages = [issues ?? []].flat();
-
-				const isAutoApplied =
-					!!selectedCredentialId && autoAppliedCredentialIds.value.has(selectedCredentialId);
+				const isFirstInOrder = node.id === allNodes[0]?.id;
+				const allNodesUsingCredential = isSharingCredential
+					? isFirstInOrder
+						? [node, ...credTypeInfo!.nonParamFollowers]
+						: [node]
+					: allNodes;
 
 				const state: NodeSetupState = {
 					node,
@@ -626,7 +700,7 @@ export const useWorkflowSetupState = (
 					parameterIssues,
 					additionalParameterNames: templateParametersByNode.value.get(node.name),
 					isTrigger,
-					showCredentialPicker: isFirstNode,
+					showCredentialPicker: true,
 					isComplete: false,
 					allNodesUsingCredential,
 					isAutoApplied,
@@ -635,8 +709,6 @@ export const useWorkflowSetupState = (
 				state.isComplete = isNodeSetupComplete(state, buildCompletionContext(credType));
 
 				result.push(state);
-
-				isFirstNode = false;
 			}
 		}
 
@@ -686,19 +758,23 @@ export const useWorkflowSetupState = (
 			isComplete: trigState.isComplete,
 		}));
 
-		const flatCards: SetupCardItem[] = [...credentialCards, ...triggerCards, ...nodeStates.value]
+		const ungroupedCards: SetupCardItem[] = [
+			...credentialCards,
+			...triggerCards,
+			...nodeStates.value,
+		]
 			.filter((state) => state.node.type !== MANUAL_TRIGGER_NODE_TYPE)
 			.map((state) => ({ state }));
 
 		const executionOrder = nodesRequiringSetup.value.map(({ node }) => node.name);
 
-		flatCards.sort(
+		ungroupedCards.sort(
 			(a, b) =>
 				executionOrder.indexOf(a.state!.node.name) - executionOrder.indexOf(b.state!.node.name),
 		);
 
 		return groupSetupCards(
-			flatCards,
+			ungroupedCards,
 			sourceNodes.value,
 			workflowsStore.connectionsByDestinationNode,
 			executionOrder,


### PR DESCRIPTION
## Summary
The credential type based grouping wasn't working well in the setup panel/builder setup in the following cases:
* 2 nodes sharing a credential and both having RLC param. If the user jumps straight to the second node card without filling the credential in the first they wouldn't be able to use the RLC (because credential is set in the first node)
* 2 nodes sharing a credential and only the second having a parameter to be filled. In that case with the old logic we'd show only credential picker for the second node (no card for the first) which means that if there is a node in between those two the execution would break if no credential is picked yet for the two nodes that are sharing

With the new grouping:
* First node(execution order) using a credential type always shows credential picker
* Following nodes having the same credential type
  * hidden if no other params than the credential
  * shows both independent credential picker and param inputs if there other params

## Test plan
Prompt to test - "Add two agents, one generates a joke, the second rates it. Both agents use openrouter with placeholders for the model values. Send the joke to telegram before it is being rated" 
