### PR TITLE
fix(core): Strip credentials from binary data response URLs

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/binary-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/binary-helper-functions.test.ts
@@ -1363,6 +1363,16 @@ describe('prepareBinaryData', () => {
 		expect(result.mimeType).toBe('text/plain');
 	});
 
+	it('strips basic auth credentials from responseUrl in directory field', async () => {
+		const incomingMessage = bufferToIncomingMessage(buffer);
+		incomingMessage.responseUrl = 'http://user:password@example.com/path/file.txt';
+
+		const result = await prepareBinaryData(incomingMessage, executionId, workflowId);
+
+		expect(result.directory).toBe('http://example.com/path/file.txt');
+		expect(result.fileName).toBe('file.txt');
+	});
+
 	it('handles buffer with no detectable mime type', async () => {
 		const buffer = Buffer.from([0x00, 0x01, 0x02, 0x03]);
 

--- a/packages/core/src/execution-engine/node-execution-context/utils/binary-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/binary-helper-functions.ts
@@ -269,7 +269,12 @@ export async function prepareBinaryData(
 				filePath =
 					binaryData.contentDisposition?.filename ??
 					((responseUrl && new URL(responseUrl).pathname) ?? binaryData.req?.path)?.slice(1);
-				fullUrl = responseUrl;
+				if (responseUrl) {
+					const url = new URL(responseUrl);
+					url.username = '';
+					url.password = '';
+					fullUrl = url.toString();
+				}
 			} catch {}
 		}
 		if (!mimeType) {

--- a/packages/nodes-base/nodes/HttpRequest/V3/utils/binaryData.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/utils/binaryData.ts
@@ -11,7 +11,8 @@ export const setFilename = (
 		typeof requestOptions.uri === 'string' &&
 		requestOptions.uri.endsWith(preparedBinaryData.fileExtension)
 	) {
-		return requestOptions.uri.split('/').pop();
+		const url = new URL(requestOptions.uri);
+		return url.pathname.split('/').pop();
 	}
 
 	if (!preparedBinaryData.fileName && preparedBinaryData.fileExtension) {

--- a/packages/nodes-base/nodes/HttpRequest/test/utils/binaryData.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/utils/binaryData.test.ts
@@ -26,4 +26,12 @@ describe('setFilename', () => {
 		const requestOptions = { uri: 'https://example.com/file.pdf' } as IRequestOptions;
 		expect(setFilename(preparedBinaryData, requestOptions, 'response')).toBe('myfile.pdf');
 	});
+
+	it('does not include basic auth credentials in extracted filename', () => {
+		const preparedBinaryData = { fileExtension: 'png' } as IBinaryData;
+		const requestOptions = {
+			uri: 'https://user:password@example.com/image.png',
+		} as IRequestOptions;
+		expect(setFilename(preparedBinaryData, requestOptions, undefined)).toBe('image.png');
+	});
 });


### PR DESCRIPTION
## Summary

When using basic auth in an HTTP Request node, the response binary data `directory` field contained the full URL including `username:password` credentials. This strips auth credentials from URLs before storing them in binary data metadata.

**Changes:**
- `prepareBinaryData()` in core now sanitizes `responseUrl` by clearing `username` and `password` via `URL` API before storing in `directory`
- `setFilename()` in HttpRequest V3 now extracts filename from `url.pathname` instead of splitting the raw URI, avoiding any credential leakage
- Tests added for both fixes

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4649

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)