### PR TITLE
feat(core): Add identity resolution for token exchange (no-changelog)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
     "start": "node ../../scripts/os-normalize.mjs --dir bin n8n",
     "test": "N8N_LOG_LEVEL=silent DB_SQLITE_POOL_SIZE=4 DB_TYPE=sqlite jest",
     "test:unit": "N8N_LOG_LEVEL=silent DB_SQLITE_POOL_SIZE=4 DB_TYPE=sqlite jest --config=jest.config.unit.js",
-    "test:integration": "N8N_LOG_LEVEL=silent DB_SQLITE_POOL_SIZE=4 DB_TYPE=sqlite jest --config=jest.config.integration.js",
+    "test:integration": "DB_SQLITE_POOL_SIZE=4 DB_TYPE=sqlite jest --config=jest.config.integration.js",
     "test:dev": "N8N_LOG_LEVEL=silent DB_SQLITE_POOL_SIZE=4 DB_TYPE=sqlite jest --watch",
     "test:sqlite": "N8N_LOG_LEVEL=silent DB_SQLITE_POOL_SIZE=4 DB_TYPE=sqlite jest --config=jest.config.integration.js --no-coverage",
     "test:sqlite:migrations": "N8N_LOG_LEVEL=silent DB_SQLITE_POOL_SIZE=4 DB_TYPE=sqlite jest --config=jest.config.migration.js --no-coverage",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
     "start": "node ../../scripts/os-normalize.mjs --dir bin n8n",
     "test": "N8N_LOG_LEVEL=silent DB_SQLITE_POOL_SIZE=4 DB_TYPE=sqlite jest",
     "test:unit": "N8N_LOG_LEVEL=silent DB_SQLITE_POOL_SIZE=4 DB_TYPE=sqlite jest --config=jest.config.unit.js",
-    "test:integration": "DB_SQLITE_POOL_SIZE=4 DB_TYPE=sqlite jest --config=jest.config.integration.js",
+    "test:integration": "N8N_LOG_LEVEL=silent DB_SQLITE_POOL_SIZE=4 DB_TYPE=sqlite jest --config=jest.config.integration.js",
     "test:dev": "N8N_LOG_LEVEL=silent DB_SQLITE_POOL_SIZE=4 DB_TYPE=sqlite jest --watch",
     "test:sqlite": "N8N_LOG_LEVEL=silent DB_SQLITE_POOL_SIZE=4 DB_TYPE=sqlite jest --config=jest.config.integration.js --no-coverage",
     "test:sqlite:migrations": "N8N_LOG_LEVEL=silent DB_SQLITE_POOL_SIZE=4 DB_TYPE=sqlite jest --config=jest.config.migration.js --no-coverage",

--- a/packages/cli/src/eventbus/event-message-classes/index.ts
+++ b/packages/cli/src/eventbus/event-message-classes/index.ts
@@ -109,6 +109,9 @@ export const eventNamesAudit = [
 	'n8n.audit.token-exchange.succeeded',
 	'n8n.audit.token-exchange.failed',
 	'n8n.audit.token-exchange.embed-login',
+	'n8n.audit.token-exchange.identity-linked',
+	'n8n.audit.token-exchange.user-provisioned',
+	'n8n.audit.token-exchange.role-updated',
 ] as const;
 
 export type EventNamesWorkflowType = (typeof eventNamesWorkflow)[number];

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -725,6 +725,8 @@ export type RelayEventMap = {
 		userId: string;
 		sub: string;
 		email: string;
+		kid: string;
+		issuer: string;
 	};
 
 	'token-exchange-user-provisioned': {
@@ -732,12 +734,16 @@ export type RelayEventMap = {
 		sub: string;
 		email: string;
 		role: string;
+		kid: string;
+		issuer: string;
 	};
 
 	'token-exchange-role-updated': {
 		userId: string;
 		previousRole: string;
 		newRole: string;
+		kid: string;
+		issuer: string;
 	};
 
 	// #endregion

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -721,6 +721,25 @@ export type RelayEventMap = {
 		clientIp: string;
 	};
 
+	'token-exchange-identity-linked': {
+		userId: string;
+		sub: string;
+		email: string;
+	};
+
+	'token-exchange-user-provisioned': {
+		userId: string;
+		sub: string;
+		email: string;
+		role: string;
+	};
+
+	'token-exchange-role-updated': {
+		userId: string;
+		previousRole: string;
+		newRole: string;
+	};
+
 	// #endregion
 
 	// #region runner

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -106,6 +106,9 @@ export class LogStreamingEventRelay extends EventRelay {
 			'instance-policies-updated': (event) => this.instancePoliciesUpdated(event),
 			'token-exchange-succeeded': (event) => this.tokenExchangeSucceeded(event),
 			'token-exchange-failed': (event) => this.tokenExchangeFailed(event),
+			'token-exchange-identity-linked': (event) => this.tokenExchangeIdentityLinked(event),
+			'token-exchange-user-provisioned': (event) => this.tokenExchangeUserProvisioned(event),
+			'token-exchange-role-updated': (event) => this.tokenExchangeRoleUpdated(event),
 			'embed-login': (event) => this.embedLogin(event),
 		});
 	}
@@ -988,6 +991,27 @@ export class LogStreamingEventRelay extends EventRelay {
 	private tokenExchangeFailed(event: RelayEventMap['token-exchange-failed']) {
 		void this.eventBus.sendAuditEvent({
 			eventName: 'n8n.audit.token-exchange.failed',
+			payload: event,
+		});
+	}
+
+	private tokenExchangeIdentityLinked(event: RelayEventMap['token-exchange-identity-linked']) {
+		void this.eventBus.sendAuditEvent({
+			eventName: 'n8n.audit.token-exchange.identity-linked',
+			payload: event,
+		});
+	}
+
+	private tokenExchangeUserProvisioned(event: RelayEventMap['token-exchange-user-provisioned']) {
+		void this.eventBus.sendAuditEvent({
+			eventName: 'n8n.audit.token-exchange.user-provisioned',
+			payload: event,
+		});
+	}
+
+	private tokenExchangeRoleUpdated(event: RelayEventMap['token-exchange-role-updated']) {
+		void this.eventBus.sendAuditEvent({
+			eventName: 'n8n.audit.token-exchange.role-updated',
 			payload: event,
 		});
 	}

--- a/packages/cli/src/modules/token-exchange/__tests__/token-exchange.schemas.test.ts
+++ b/packages/cli/src/modules/token-exchange/__tests__/token-exchange.schemas.test.ts
@@ -40,12 +40,12 @@ describe('token-exchange.schemas', () => {
 				expect(result.success).toBe(true);
 			});
 
-			test('accepts role as array', () => {
+			test('rejects role as array', () => {
 				const result = ExternalTokenClaimsSchema.safeParse({
 					...validClaims,
 					role: ['admin', 'viewer'],
 				});
-				expect(result.success).toBe(true);
+				expect(result.success).toBe(false);
 			});
 		});
 

--- a/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
@@ -79,6 +79,7 @@ describe('TokenExchangeService', () => {
 			expect(identityResolutionService.resolve).toHaveBeenCalledWith(
 				validClaims,
 				resolvedKey.allowedRoles,
+				{ kid: resolvedKey.kid, issuer: resolvedKey.issuer },
 			);
 		});
 

--- a/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
@@ -76,7 +76,10 @@ describe('TokenExchangeService', () => {
 				'unique-jti-1',
 				new Date(validClaims.exp * 1000),
 			);
-			expect(identityResolutionService.resolve).toHaveBeenCalledWith(validClaims);
+			expect(identityResolutionService.resolve).toHaveBeenCalledWith(
+				validClaims,
+				resolvedKey.allowedRoles,
+			);
 		});
 
 		it('should throw when token cannot be decoded', async () => {

--- a/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
@@ -29,6 +29,7 @@ const resolvedKey: ResolvedTrustedKey = {
 	algorithms: ['RS256'],
 	key: 'test-public-key',
 	issuer: 'https://issuer.example.com',
+	allowedRoles: ['global:member', 'global:admin'],
 };
 
 const mockUser = mock<User>({

--- a/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
@@ -1,22 +1,236 @@
-import type { User } from '@n8n/db';
+import { Logger } from '@n8n/backend-common';
+import {
+	AuthIdentity,
+	AuthIdentityRepository,
+	GLOBAL_MEMBER_ROLE,
+	GLOBAL_ROLES,
+	UserRepository,
+	type User,
+} from '@n8n/db';
 import { Service } from '@n8n/di';
 
-import { UserError } from 'n8n-workflow';
+import { AuthError } from '@/errors/response-errors/auth.error';
 
 import type { ExternalTokenClaims } from '../token-exchange.schemas';
 
 /**
- * Resolves validated external token claims to an n8n User.
- *
- * This is a skeleton service — the real implementation with user
- * lookup/creation logic will be provided in a follow-up ticket.
+ * Password placeholder for JIT-provisioned users. This is not a valid bcrypt
+ * hash, so it can never match any input — the user can only authenticate
+ * through token exchange.
  */
+const INVALID_PASSWORD_PLACEHOLDER = '!token-exchange-no-password';
+
+type GlobalRoleKey = keyof typeof GLOBAL_ROLES;
+
+function isGlobalRole(role: string): role is GlobalRoleKey {
+	return role in GLOBAL_ROLES;
+}
+
 @Service()
 export class IdentityResolutionService {
+	private readonly logger: Logger;
+
+	constructor(
+		logger: Logger,
+		private readonly userRepository: UserRepository,
+		private readonly authIdentityRepository: AuthIdentityRepository,
+	) {
+		this.logger = logger.scoped('token-exchange');
+	}
+
 	/**
 	 * Map external identity claims to a local n8n user, creating one if necessary.
+	 *
+	 * Resolution order:
+	 * 1. AuthIdentity lookup by sub + token-exchange provider
+	 * 2. Email fallback — link existing user to this sub
+	 * 3. JIT provision — create user + personal project + identity in a transaction
+	 *
+	 * Role handling: the role claim is only applied when it is both valid and
+	 * permitted by the key's allowedRoles. For existing users the current role
+	 * is preserved when the claimed role is disallowed or absent — login is
+	 * never blocked because of a role mismatch.
 	 */
-	async resolve(_claims: ExternalTokenClaims): Promise<User> {
-		throw new UserError('Identity resolution is not yet implemented');
+	async resolve(claims: ExternalTokenClaims, allowedRoles?: string[]): Promise<User> {
+		// Path 1: known sub
+		const identity = await this.authIdentityRepository.findOne({
+			where: { providerId: claims.sub, providerType: 'token-exchange' },
+			relations: { user: { role: true } },
+		});
+
+		if (identity) {
+			this.logger.debug('Resolved user by auth identity', { sub: claims.sub });
+			const resolvedRole = this.resolveRoleForExistingUser(
+				claims.role,
+				allowedRoles,
+				identity.user.role?.slug,
+			);
+			return await this.syncProfile(identity.user, claims, resolvedRole);
+		}
+
+		// Path 2: email fallback
+		if (claims.email) {
+			const existingUser = await this.userRepository.findOne({
+				where: { email: claims.email },
+				relations: ['authIdentities', 'role'],
+			});
+
+			if (existingUser) {
+				this.logger.debug('Linking external identity to existing user by email', {
+					sub: claims.sub,
+					email: claims.email,
+				});
+				await this.authIdentityRepository.save(
+					AuthIdentity.create(existingUser, claims.sub, 'token-exchange'),
+				);
+				const resolvedRole = this.resolveRoleForExistingUser(
+					claims.role,
+					allowedRoles,
+					existingUser.role?.slug,
+				);
+				return await this.syncProfile(existingUser, claims, resolvedRole);
+			}
+		}
+
+		// Path 3: JIT provisioning
+		if (!claims.email) {
+			throw new AuthError('Email claim is required for user provisioning');
+		}
+
+		this.logger.debug('JIT provisioning new user', {
+			sub: claims.sub,
+			email: claims.email,
+		});
+
+		const jitRole = this.resolveRoleForNewUser(claims.role, allowedRoles);
+		const targetRole = jitRole ? { slug: jitRole } : GLOBAL_MEMBER_ROLE;
+
+		return await this.userRepository.manager.transaction(async (trx) => {
+			const { user } = await this.userRepository.createUserWithProject(
+				{
+					email: claims.email,
+					firstName: claims.given_name ?? '',
+					lastName: claims.family_name ?? '',
+					role: targetRole,
+					password: INVALID_PASSWORD_PLACEHOLDER,
+				},
+				trx,
+			);
+
+			await trx.save(
+				trx.create(AuthIdentity, {
+					providerId: claims.sub,
+					providerType: 'token-exchange' as const,
+					userId: user.id,
+				}),
+			);
+
+			return user;
+		});
+	}
+
+	/**
+	 * Resolve the role claim for an existing user.
+	 *
+	 * Returns the role slug to sync to, or `undefined` to keep the current
+	 * role unchanged. Existing users are never blocked from logging in — if
+	 * the claimed role is invalid or not allowed, we simply skip the role
+	 * update and let them keep their current role.
+	 */
+	private resolveRoleForExistingUser(
+		roleClaim: ExternalTokenClaims['role'],
+		allowedRoles: string[] | undefined,
+		currentRole: string | undefined,
+	): GlobalRoleKey | undefined {
+		if (roleClaim === undefined) return undefined;
+
+		const role = Array.isArray(roleClaim) ? roleClaim[0] : roleClaim;
+
+		// Never change a user's role to global:owner via token exchange
+		if (role === 'global:owner') {
+			this.logger.warn('Ignoring global:owner role claim for existing user');
+			return undefined;
+		}
+
+		if (!isGlobalRole(role)) {
+			this.logger.warn('Unknown role claim ignored', { role });
+			return undefined;
+		}
+
+		// If the claimed role is not in the allowed list, skip the update
+		if (allowedRoles && allowedRoles.length > 0 && !allowedRoles.includes(role)) {
+			this.logger.debug('Role claim not in allowedRoles, keeping current role', {
+				claimed: role,
+				current: currentRole,
+			});
+			return undefined;
+		}
+
+		return role;
+	}
+
+	/**
+	 * Resolve the role claim for a new (JIT-provisioned) user.
+	 *
+	 * Returns the role slug to provision with, or `undefined` to default to
+	 * `global:member`. Unlike existing users, invalid or disallowed roles
+	 * throw because we have no fallback role to preserve.
+	 */
+	private resolveRoleForNewUser(
+		roleClaim: ExternalTokenClaims['role'],
+		allowedRoles: string[] | undefined,
+	): GlobalRoleKey | undefined {
+		if (roleClaim === undefined) return undefined;
+
+		const role = Array.isArray(roleClaim) ? roleClaim[0] : roleClaim;
+
+		if (role === 'global:owner') {
+			throw new AuthError('Cannot provision global:owner role via token exchange');
+		}
+
+		if (!isGlobalRole(role)) {
+			this.logger.warn('Unknown role claim ignored for new user', { role });
+			return undefined;
+		}
+
+		if (allowedRoles && allowedRoles.length > 0 && !allowedRoles.includes(role)) {
+			throw new AuthError(`Role '${role}' is not allowed for this token exchange key`);
+		}
+
+		return role;
+	}
+
+	/**
+	 * Sync profile fields from claims to user when present and changed.
+	 * Returns the user (potentially refreshed from the save operation).
+	 */
+	private async syncProfile(
+		user: User,
+		claims: ExternalTokenClaims,
+		resolvedRole?: GlobalRoleKey,
+	): Promise<User> {
+		const updates: Record<string, unknown> = {};
+
+		if (claims.given_name !== undefined && claims.given_name !== user.firstName) {
+			updates.firstName = claims.given_name;
+		}
+
+		if (claims.family_name !== undefined && claims.family_name !== user.lastName) {
+			updates.lastName = claims.family_name;
+		}
+
+		if (resolvedRole && resolvedRole !== user.role?.slug) {
+			updates.role = GLOBAL_ROLES[resolvedRole];
+		}
+
+		if (Object.keys(updates).length > 0) {
+			await this.userRepository.update(user.id, updates);
+			return await this.userRepository.findOneOrFail({
+				where: { id: user.id },
+				relations: ['role'],
+			});
+		}
+
+		return user;
 	}
 }

--- a/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
@@ -189,8 +189,7 @@ export class IdentityResolutionService {
 		}
 
 		if (!isGlobalRole(role)) {
-			this.logger.warn('Unknown role claim ignored for new user', { role });
-			return undefined;
+			throw new AuthError(`Unrecognized role '${role}' cannot be assigned to new user`);
 		}
 
 		if (allowedRoles && allowedRoles.length > 0 && !allowedRoles.includes(role)) {

--- a/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
@@ -11,6 +11,7 @@ import { Service } from '@n8n/di';
 
 import { AuthError } from '@/errors/response-errors/auth.error';
 import { EventService } from '@/events/event.service';
+import { UserService } from '@/services/user.service';
 
 import type { ExternalTokenClaims } from '../token-exchange.schemas';
 
@@ -43,6 +44,7 @@ export class IdentityResolutionService {
 		private readonly userRepository: UserRepository,
 		private readonly authIdentityRepository: AuthIdentityRepository,
 		private readonly eventService: EventService,
+		private readonly userService: UserService,
 	) {
 		this.logger = logger.scoped('token-exchange');
 	}
@@ -235,8 +237,9 @@ export class IdentityResolutionService {
 	}
 
 	/**
-	 * Sync profile fields from claims to user when present and changed.
-	 * Returns the user (potentially refreshed from the save operation).
+	 * Sync profile fields and role from claims to user when present and changed.
+	 * Uses `UserService.changeUserRole` for role changes to ensure side effects
+	 * (API key revocation, project relation cleanup, cache invalidation) are applied.
 	 */
 	private async syncProfile(
 		user: User,
@@ -244,40 +247,48 @@ export class IdentityResolutionService {
 		resolvedRole?: GlobalRoleKey,
 		tokenContext?: { kid: string; issuer: string },
 	): Promise<User> {
-		const updates: Partial<User> = {};
+		let needsReload = false;
+
+		// Sync profile fields (firstName, lastName)
+		const profileUpdates: Partial<User> = {};
 
 		if (claims.given_name !== undefined) {
 			const trimmed = trimName(claims.given_name);
 			if (trimmed !== user.firstName) {
-				updates.firstName = trimmed;
+				profileUpdates.firstName = trimmed;
 			}
 		}
 
 		if (claims.family_name !== undefined) {
 			const trimmed = trimName(claims.family_name);
 			if (trimmed !== user.lastName) {
-				updates.lastName = trimmed;
+				profileUpdates.lastName = trimmed;
 			}
 		}
 
-		const previousRole = user.role?.slug;
-		if (resolvedRole && resolvedRole !== previousRole) {
-			updates.role = GLOBAL_ROLES[resolvedRole];
+		if (Object.keys(profileUpdates).length > 0) {
+			await this.userRepository.update(user.id, profileUpdates);
+			needsReload = true;
 		}
 
-		if (Object.keys(updates).length > 0) {
-			await this.userRepository.update(user.id, updates);
+		// Sync role via UserService.changeUserRole for proper side effects
+		const previousRole = user.role?.slug;
+		if (resolvedRole && resolvedRole !== previousRole) {
+			await this.userService.changeUserRole(user, { newRoleName: resolvedRole });
+			needsReload = true;
 
-			if (updates.role && previousRole) {
+			if (previousRole) {
 				this.eventService.emit('token-exchange-role-updated', {
 					userId: user.id,
 					previousRole,
-					newRole: resolvedRole!,
+					newRole: resolvedRole,
 					kid: tokenContext?.kid ?? '',
 					issuer: tokenContext?.issuer ?? claims.iss,
 				});
 			}
+		}
 
+		if (needsReload) {
 			return await this.userRepository.findOneOrFail({
 				where: { id: user.id },
 				relations: ['role'],

--- a/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
@@ -10,6 +10,7 @@ import {
 import { Service } from '@n8n/di';
 
 import { AuthError } from '@/errors/response-errors/auth.error';
+import { EventService } from '@/events/event.service';
 
 import type { ExternalTokenClaims } from '../token-exchange.schemas';
 
@@ -20,10 +21,17 @@ import type { ExternalTokenClaims } from '../token-exchange.schemas';
  */
 const INVALID_PASSWORD_PLACEHOLDER = '!token-exchange-no-password';
 
+/** Maximum length for first/last name columns in the database. */
+const MAX_NAME_LENGTH = 32;
+
 type GlobalRoleKey = keyof typeof GLOBAL_ROLES;
 
 function isGlobalRole(role: string): role is GlobalRoleKey {
 	return role in GLOBAL_ROLES;
+}
+
+function trimName(value: string | undefined, fallback = ''): string {
+	return (value ?? fallback).slice(0, MAX_NAME_LENGTH);
 }
 
 @Service()
@@ -34,6 +42,7 @@ export class IdentityResolutionService {
 		logger: Logger,
 		private readonly userRepository: UserRepository,
 		private readonly authIdentityRepository: AuthIdentityRepository,
+		private readonly eventService: EventService,
 	) {
 		this.logger = logger.scoped('token-exchange');
 	}
@@ -52,6 +61,8 @@ export class IdentityResolutionService {
 	 * never blocked because of a role mismatch.
 	 */
 	async resolve(claims: ExternalTokenClaims, allowedRoles?: string[]): Promise<User> {
+		const email = claims.email?.toLowerCase();
+
 		// Path 1: known sub
 		const identity = await this.authIdentityRepository.findOne({
 			where: { providerId: claims.sub, providerType: 'token-exchange' },
@@ -69,20 +80,25 @@ export class IdentityResolutionService {
 		}
 
 		// Path 2: email fallback
-		if (claims.email) {
+		if (email) {
 			const existingUser = await this.userRepository.findOne({
-				where: { email: claims.email },
+				where: { email },
 				relations: ['authIdentities', 'role'],
 			});
 
 			if (existingUser) {
 				this.logger.debug('Linking external identity to existing user by email', {
 					sub: claims.sub,
-					email: claims.email,
+					email,
 				});
 				await this.authIdentityRepository.save(
 					AuthIdentity.create(existingUser, claims.sub, 'token-exchange'),
 				);
+				this.eventService.emit('token-exchange-identity-linked', {
+					userId: existingUser.id,
+					sub: claims.sub,
+					email,
+				});
 				const resolvedRole = this.resolveRoleForExistingUser(
 					claims.role,
 					allowedRoles,
@@ -93,24 +109,24 @@ export class IdentityResolutionService {
 		}
 
 		// Path 3: JIT provisioning
-		if (!claims.email) {
+		if (!email) {
 			throw new AuthError('Email claim is required for user provisioning');
 		}
 
 		this.logger.debug('JIT provisioning new user', {
 			sub: claims.sub,
-			email: claims.email,
+			email,
 		});
 
 		const jitRole = this.resolveRoleForNewUser(claims.role, allowedRoles);
 		const targetRole = jitRole ? { slug: jitRole } : GLOBAL_MEMBER_ROLE;
 
-		return await this.userRepository.manager.transaction(async (trx) => {
-			const { user } = await this.userRepository.createUserWithProject(
+		const user = await this.userRepository.manager.transaction(async (trx) => {
+			const { user: newUser } = await this.userRepository.createUserWithProject(
 				{
-					email: claims.email,
-					firstName: claims.given_name ?? '',
-					lastName: claims.family_name ?? '',
+					email,
+					firstName: trimName(claims.given_name),
+					lastName: trimName(claims.family_name),
 					role: targetRole,
 					password: INVALID_PASSWORD_PLACEHOLDER,
 				},
@@ -120,13 +136,22 @@ export class IdentityResolutionService {
 			await trx.save(
 				trx.create(AuthIdentity, {
 					providerId: claims.sub,
-					providerType: 'token-exchange' as const,
-					userId: user.id,
+					providerType: 'token-exchange',
+					userId: newUser.id,
 				}),
 			);
 
-			return user;
+			return newUser;
 		});
+
+		this.eventService.emit('token-exchange-user-provisioned', {
+			userId: user.id,
+			sub: claims.sub,
+			email,
+			role: targetRole.slug,
+		});
+
+		return user;
 	}
 
 	/**
@@ -143,6 +168,7 @@ export class IdentityResolutionService {
 		currentRole: string | undefined,
 	): GlobalRoleKey | undefined {
 		if (roleClaim === undefined) return undefined;
+		if (Array.isArray(roleClaim) && roleClaim.length === 0) return undefined;
 
 		const role = Array.isArray(roleClaim) ? roleClaim[0] : roleClaim;
 
@@ -181,6 +207,7 @@ export class IdentityResolutionService {
 		allowedRoles: string[] | undefined,
 	): GlobalRoleKey | undefined {
 		if (roleClaim === undefined) return undefined;
+		if (Array.isArray(roleClaim) && roleClaim.length === 0) return undefined;
 
 		const role = Array.isArray(roleClaim) ? roleClaim[0] : roleClaim;
 
@@ -208,22 +235,38 @@ export class IdentityResolutionService {
 		claims: ExternalTokenClaims,
 		resolvedRole?: GlobalRoleKey,
 	): Promise<User> {
-		const updates: Record<string, unknown> = {};
+		const updates: Partial<User> = {};
 
-		if (claims.given_name !== undefined && claims.given_name !== user.firstName) {
-			updates.firstName = claims.given_name;
+		if (claims.given_name !== undefined) {
+			const trimmed = trimName(claims.given_name);
+			if (trimmed !== user.firstName) {
+				updates.firstName = trimmed;
+			}
 		}
 
-		if (claims.family_name !== undefined && claims.family_name !== user.lastName) {
-			updates.lastName = claims.family_name;
+		if (claims.family_name !== undefined) {
+			const trimmed = trimName(claims.family_name);
+			if (trimmed !== user.lastName) {
+				updates.lastName = trimmed;
+			}
 		}
 
-		if (resolvedRole && resolvedRole !== user.role?.slug) {
+		const previousRole = user.role?.slug;
+		if (resolvedRole && resolvedRole !== previousRole) {
 			updates.role = GLOBAL_ROLES[resolvedRole];
 		}
 
 		if (Object.keys(updates).length > 0) {
 			await this.userRepository.update(user.id, updates);
+
+			if (updates.role && previousRole) {
+				this.eventService.emit('token-exchange-role-updated', {
+					userId: user.id,
+					previousRole,
+					newRole: resolvedRole!,
+				});
+			}
+
 			return await this.userRepository.findOneOrFail({
 				where: { id: user.id },
 				relations: ['role'],

--- a/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
@@ -60,7 +60,11 @@ export class IdentityResolutionService {
 	 * is preserved when the claimed role is disallowed or absent — login is
 	 * never blocked because of a role mismatch.
 	 */
-	async resolve(claims: ExternalTokenClaims, allowedRoles?: string[]): Promise<User> {
+	async resolve(
+		claims: ExternalTokenClaims,
+		allowedRoles?: string[],
+		tokenContext?: { kid: string; issuer: string },
+	): Promise<User> {
 		const email = claims.email?.toLowerCase();
 
 		// Path 1: known sub
@@ -76,7 +80,7 @@ export class IdentityResolutionService {
 				allowedRoles,
 				identity.user.role?.slug,
 			);
-			return await this.syncProfile(identity.user, claims, resolvedRole);
+			return await this.syncProfile(identity.user, claims, resolvedRole, tokenContext);
 		}
 
 		// Path 2: email fallback
@@ -98,13 +102,15 @@ export class IdentityResolutionService {
 					userId: existingUser.id,
 					sub: claims.sub,
 					email,
+					kid: tokenContext?.kid ?? '',
+					issuer: tokenContext?.issuer ?? claims.iss,
 				});
 				const resolvedRole = this.resolveRoleForExistingUser(
 					claims.role,
 					allowedRoles,
 					existingUser.role?.slug,
 				);
-				return await this.syncProfile(existingUser, claims, resolvedRole);
+				return await this.syncProfile(existingUser, claims, resolvedRole, tokenContext);
 			}
 		}
 
@@ -149,6 +155,8 @@ export class IdentityResolutionService {
 			sub: claims.sub,
 			email,
 			role: targetRole.slug,
+			kid: tokenContext?.kid ?? '',
+			issuer: tokenContext?.issuer ?? claims.iss,
 		});
 
 		return user;
@@ -234,6 +242,7 @@ export class IdentityResolutionService {
 		user: User,
 		claims: ExternalTokenClaims,
 		resolvedRole?: GlobalRoleKey,
+		tokenContext?: { kid: string; issuer: string },
 	): Promise<User> {
 		const updates: Partial<User> = {};
 
@@ -264,6 +273,8 @@ export class IdentityResolutionService {
 					userId: user.id,
 					previousRole,
 					newRole: resolvedRole!,
+					kid: tokenContext?.kid ?? '',
+					issuer: tokenContext?.issuer ?? claims.iss,
 				});
 			}
 

--- a/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
@@ -58,9 +58,8 @@ export class IdentityResolutionService {
 	 * 3. JIT provision — create user + personal project + identity in a transaction
 	 *
 	 * Role handling: the role claim is only applied when it is both valid and
-	 * permitted by the key's allowedRoles. For existing users the current role
-	 * is preserved when the claimed role is disallowed or absent — login is
-	 * never blocked because of a role mismatch.
+	 * permitted by the key's allowedRoles. A disallowed role claim throws —
+	 * OAuth flows are strict to avoid silent misconfiguration.
 	 */
 	async resolve(
 		claims: ExternalTokenClaims,
@@ -76,13 +75,7 @@ export class IdentityResolutionService {
 		});
 
 		if (identity) {
-			this.logger.debug('Resolved user by auth identity', { sub: claims.sub });
-			const resolvedRole = this.resolveRoleForExistingUser(
-				claims.role,
-				allowedRoles,
-				identity.user.role?.slug,
-			);
-			return await this.syncProfile(identity.user, claims, resolvedRole, tokenContext);
+			return await this.resolveByIdentity(claims, identity, allowedRoles, tokenContext);
 		}
 
 		// Path 2: email fallback
@@ -93,26 +86,7 @@ export class IdentityResolutionService {
 			});
 
 			if (existingUser) {
-				this.logger.debug('Linking external identity to existing user by email', {
-					sub: claims.sub,
-					email,
-				});
-				await this.authIdentityRepository.save(
-					AuthIdentity.create(existingUser, claims.sub, 'token-exchange'),
-				);
-				this.eventService.emit('token-exchange-identity-linked', {
-					userId: existingUser.id,
-					sub: claims.sub,
-					email,
-					kid: tokenContext?.kid ?? '',
-					issuer: tokenContext?.issuer ?? claims.iss,
-				});
-				const resolvedRole = this.resolveRoleForExistingUser(
-					claims.role,
-					allowedRoles,
-					existingUser.role?.slug,
-				);
-				return await this.syncProfile(existingUser, claims, resolvedRole, tokenContext);
+				return await this.resolveByEmail(claims, email, existingUser, allowedRoles, tokenContext);
 			}
 		}
 
@@ -121,10 +95,63 @@ export class IdentityResolutionService {
 			throw new AuthError('Email claim is required for user provisioning');
 		}
 
-		this.logger.debug('JIT provisioning new user', {
+		return await this.provisionUser(claims, email, allowedRoles, tokenContext);
+	}
+
+	/** Path 1: resolve an already-linked identity and sync profile/role. */
+	private async resolveByIdentity(
+		claims: ExternalTokenClaims,
+		identity: AuthIdentity,
+		allowedRoles: string[] | undefined,
+		tokenContext: { kid: string; issuer: string } | undefined,
+	): Promise<User> {
+		this.logger.debug('Resolved user by auth identity', { sub: claims.sub });
+		const resolvedRole = this.resolveRoleForExistingUser(
+			claims.role,
+			allowedRoles,
+			identity.user.role?.slug,
+		);
+		return await this.syncProfile(identity.user, claims, resolvedRole, tokenContext);
+	}
+
+	/** Path 2: link an external identity to an existing user found by email. */
+	private async resolveByEmail(
+		claims: ExternalTokenClaims,
+		email: string,
+		existingUser: User,
+		allowedRoles: string[] | undefined,
+		tokenContext: { kid: string; issuer: string } | undefined,
+	): Promise<User> {
+		this.logger.debug('Linking external identity to existing user by email', {
 			sub: claims.sub,
 			email,
 		});
+		await this.authIdentityRepository.save(
+			AuthIdentity.create(existingUser, claims.sub, 'token-exchange'),
+		);
+		this.eventService.emit('token-exchange-identity-linked', {
+			userId: existingUser.id,
+			sub: claims.sub,
+			email,
+			kid: tokenContext?.kid ?? '',
+			issuer: tokenContext?.issuer ?? claims.iss,
+		});
+		const resolvedRole = this.resolveRoleForExistingUser(
+			claims.role,
+			allowedRoles,
+			existingUser.role?.slug,
+		);
+		return await this.syncProfile(existingUser, claims, resolvedRole, tokenContext);
+	}
+
+	/** Path 3: JIT-provision a new user with a personal project and identity link. */
+	private async provisionUser(
+		claims: ExternalTokenClaims,
+		email: string,
+		allowedRoles: string[] | undefined,
+		tokenContext: { kid: string; issuer: string } | undefined,
+	): Promise<User> {
+		this.logger.debug('JIT provisioning new user', { sub: claims.sub, email });
 
 		const jitRole = this.resolveRoleForNewUser(claims.role, allowedRoles);
 		const targetRole = jitRole ? { slug: jitRole } : GLOBAL_MEMBER_ROLE;
@@ -168,9 +195,9 @@ export class IdentityResolutionService {
 	 * Resolve the role claim for an existing user.
 	 *
 	 * Returns the role slug to sync to, or `undefined` to keep the current
-	 * role unchanged. Existing users are never blocked from logging in — if
-	 * the claimed role is invalid or not allowed, we simply skip the role
-	 * update and let them keep their current role.
+	 * role unchanged. Throws when the claimed role is valid but not permitted
+	 * by the key's allowedRoles — OAuth flows must be strict to surface
+	 * misconfiguration early.
 	 */
 	private resolveRoleForExistingUser(
 		roleClaim: ExternalTokenClaims['role'],
@@ -178,7 +205,6 @@ export class IdentityResolutionService {
 		currentRole: string | undefined,
 	): GlobalRoleKey | undefined {
 		if (roleClaim === undefined) return undefined;
-		if (Array.isArray(roleClaim) && roleClaim.length === 0) return undefined;
 
 		// Never modify the role of an existing owner via token exchange
 		if (currentRole === 'global:owner') {
@@ -186,7 +212,7 @@ export class IdentityResolutionService {
 			return undefined;
 		}
 
-		const role = Array.isArray(roleClaim) ? roleClaim[0] : roleClaim;
+		const role = roleClaim;
 
 		// Never change a user's role to global:owner via token exchange
 		if (role === 'global:owner') {
@@ -199,13 +225,8 @@ export class IdentityResolutionService {
 			return undefined;
 		}
 
-		// If the claimed role is not in the allowed list, skip the update
 		if (allowedRoles && allowedRoles.length > 0 && !allowedRoles.includes(role)) {
-			this.logger.debug('Role claim not in allowedRoles, keeping current role', {
-				claimed: role,
-				current: currentRole,
-			});
-			return undefined;
+			throw new AuthError(`Role '${role}' is not allowed for this token exchange key`);
 		}
 
 		return role;
@@ -223,9 +244,8 @@ export class IdentityResolutionService {
 		allowedRoles: string[] | undefined,
 	): GlobalRoleKey | undefined {
 		if (roleClaim === undefined) return undefined;
-		if (Array.isArray(roleClaim) && roleClaim.length === 0) return undefined;
 
-		const role = Array.isArray(roleClaim) ? roleClaim[0] : roleClaim;
+		const role = roleClaim;
 
 		if (role === 'global:owner') {
 			throw new AuthError('Cannot provision global:owner role via token exchange');

--- a/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
@@ -126,6 +126,11 @@ export class IdentityResolutionService {
 			sub: claims.sub,
 			email,
 		});
+		const resolvedRole = this.resolveRoleForExistingUser(
+			claims.role,
+			allowedRoles,
+			existingUser.role?.slug,
+		);
 		await this.authIdentityRepository.save(
 			AuthIdentity.create(existingUser, claims.sub, 'token-exchange'),
 		);
@@ -136,11 +141,6 @@ export class IdentityResolutionService {
 			kid: tokenContext?.kid ?? '',
 			issuer: tokenContext?.issuer ?? claims.iss,
 		});
-		const resolvedRole = this.resolveRoleForExistingUser(
-			claims.role,
-			allowedRoles,
-			existingUser.role?.slug,
-		);
 		return await this.syncProfile(existingUser, claims, resolvedRole, tokenContext);
 	}
 

--- a/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
@@ -180,6 +180,12 @@ export class IdentityResolutionService {
 		if (roleClaim === undefined) return undefined;
 		if (Array.isArray(roleClaim) && roleClaim.length === 0) return undefined;
 
+		// Never modify the role of an existing owner via token exchange
+		if (currentRole === 'global:owner') {
+			this.logger.debug('Skipping role sync for existing owner');
+			return undefined;
+		}
+
 		const role = Array.isArray(roleClaim) ? roleClaim[0] : roleClaim;
 
 		// Never change a user's role to global:owner via token exchange

--- a/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
@@ -6,7 +6,7 @@ import jwt from 'jsonwebtoken';
 import { AuthError } from '@/errors/response-errors/auth.error';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 
-import type { ExternalTokenClaims } from '../token-exchange.schemas';
+import type { ExternalTokenClaims, ResolvedTrustedKey } from '../token-exchange.schemas';
 import { ExternalTokenClaimsSchema } from '../token-exchange.schemas';
 import { IdentityResolutionService } from './identity-resolution.service';
 import { JtiStoreService } from './jti-store.service';
@@ -41,7 +41,7 @@ export class TokenExchangeService {
 	async verifyToken(
 		subjectToken: string,
 		{ maxLifetimeSeconds }: { maxLifetimeSeconds?: number } = {},
-	): Promise<ExternalTokenClaims> {
+	): Promise<{ claims: ExternalTokenClaims; resolvedKey: ResolvedTrustedKey }> {
 		const decoded = jwt.decode(subjectToken, { complete: true });
 		if (!decoded || typeof decoded === 'string') {
 			throw new BadRequestError('Invalid token format');
@@ -89,13 +89,13 @@ export class TokenExchangeService {
 			throw new AuthError('Token has already been used');
 		}
 
-		return claims;
+		return { claims, resolvedKey };
 	}
 
 	async embedLogin(subjectToken: string): Promise<User> {
-		const claims = await this.verifyToken(subjectToken, {
+		const { claims, resolvedKey } = await this.verifyToken(subjectToken, {
 			maxLifetimeSeconds: MAX_TOKEN_LIFETIME_SECONDS,
 		});
-		return await this.identityResolutionService.resolve(claims);
+		return await this.identityResolutionService.resolve(claims, resolvedKey.allowedRoles);
 	}
 }

--- a/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
@@ -96,6 +96,9 @@ export class TokenExchangeService {
 		const { claims, resolvedKey } = await this.verifyToken(subjectToken, {
 			maxLifetimeSeconds: MAX_TOKEN_LIFETIME_SECONDS,
 		});
-		return await this.identityResolutionService.resolve(claims, resolvedKey.allowedRoles);
+		return await this.identityResolutionService.resolve(claims, resolvedKey.allowedRoles, {
+			kid: resolvedKey.kid,
+			issuer: resolvedKey.issuer,
+		});
 	}
 }

--- a/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
@@ -36,7 +36,7 @@ export const ExternalTokenClaimsSchema = z.object({
 	email: z.string().email().optional(),
 	given_name: z.string().optional(),
 	family_name: z.string().optional(),
-	role: z.union([z.string(), z.array(z.string())]).optional(),
+	role: z.string().optional(),
 });
 
 export type ExternalTokenClaims = z.infer<typeof ExternalTokenClaimsSchema>;

--- a/packages/cli/test/integration/token-exchange/identity-resolution.service.test.ts
+++ b/packages/cli/test/integration/token-exchange/identity-resolution.service.test.ts
@@ -112,6 +112,47 @@ describe('IdentityResolutionService (integration)', () => {
 			expect(secondResult.role).toBeDefined();
 			expect(secondResult.role.slug).toBe('global:member');
 		});
+
+		it('should update role when linking identity via email fallback', async () => {
+			const user = await createUser({ email: 'fallback-role@example.com' });
+
+			const result = await service.resolve(
+				{
+					...baseClaims,
+					sub: 'ext-fallback-role',
+					email: 'fallback-role@example.com',
+					role: 'global:admin',
+				},
+				['global:admin'],
+			);
+
+			expect(result.id).toBe(user.id);
+			expect(result.role.slug).toBe('global:admin');
+
+			const dbUser = await userRepository.findOne({
+				where: { id: user.id },
+				relations: ['role'],
+			});
+			expect(dbUser!.role.slug).toBe('global:admin');
+		});
+
+		it('should match existing user when email claim has different casing', async () => {
+			const user = await createUser({ email: 'casetest@example.com' });
+
+			const result = await service.resolve({
+				...baseClaims,
+				sub: 'ext-case',
+				email: 'CaseTest@Example.COM',
+			});
+
+			expect(result.id).toBe(user.id);
+
+			const identity = await authIdentityRepository.findOne({
+				where: { providerId: 'ext-case', providerType: 'token-exchange' },
+			});
+			expect(identity).toBeDefined();
+			expect(identity!.userId).toBe(user.id);
+		});
 	});
 
 	describe('Path 3 — JIT provisioning', () => {
@@ -187,6 +228,31 @@ describe('IdentityResolutionService (integration)', () => {
 					role: 'global:nonsense',
 				}),
 			).rejects.toThrow("Unrecognized role 'global:nonsense' cannot be assigned to new user");
+		});
+
+		it('should default to global:member when role claim is an empty array', async () => {
+			const result = await service.resolve({
+				...baseClaims,
+				sub: 'ext-jit-empty-role',
+				email: 'jit-empty-role@example.com',
+				role: [],
+			});
+
+			expect(result.role.slug).toBe('global:member');
+		});
+
+		it('should assign role from array claim when provisioning new user', async () => {
+			const result = await service.resolve(
+				{
+					...baseClaims,
+					sub: 'ext-jit-array-role',
+					email: 'jit-array-role@example.com',
+					role: ['global:admin'],
+				},
+				['global:admin'],
+			);
+
+			expect(result.role.slug).toBe('global:admin');
 		});
 
 		it('should assign role from allowedRoles when provisioning new user', async () => {
@@ -269,6 +335,43 @@ describe('IdentityResolutionService (integration)', () => {
 				sub: 'ext-unknown-role',
 				email: 'unknown-role@example.com',
 				role: 'global:nonsense',
+			});
+
+			expect(result.id).toBe(user.id);
+			expect(result.role.slug).toBe('global:member');
+		});
+
+		it('should preserve current role when role claim is an empty array', async () => {
+			const admin = await createUser({
+				email: 'empty-array-role@example.com',
+				role: GLOBAL_ADMIN_ROLE,
+			});
+			await authIdentityRepository.save(
+				AuthIdentity.create(admin, 'ext-empty-array', 'token-exchange'),
+			);
+
+			const result = await service.resolve({
+				...baseClaims,
+				sub: 'ext-empty-array',
+				email: 'empty-array-role@example.com',
+				role: [],
+			});
+
+			expect(result.id).toBe(admin.id);
+			expect(result.role.slug).toBe('global:admin');
+		});
+
+		it('should ignore global:owner role claim for non-owner user', async () => {
+			const user = await createUser({ email: 'escalation@example.com' });
+			await authIdentityRepository.save(
+				AuthIdentity.create(user, 'ext-escalation', 'token-exchange'),
+			);
+
+			const result = await service.resolve({
+				...baseClaims,
+				sub: 'ext-escalation',
+				email: 'escalation@example.com',
+				role: 'global:owner',
 			});
 
 			expect(result.id).toBe(user.id);

--- a/packages/cli/test/integration/token-exchange/identity-resolution.service.test.ts
+++ b/packages/cli/test/integration/token-exchange/identity-resolution.service.test.ts
@@ -3,13 +3,11 @@ import {
 	AuthIdentity,
 	AuthIdentityRepository,
 	GLOBAL_ADMIN_ROLE,
-	GLOBAL_OWNER_ROLE,
 	ProjectRepository,
 	UserRepository,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
 
-import { AuthError } from '@/errors/response-errors/auth.error';
 import type { ExternalTokenClaims } from '@/modules/token-exchange/token-exchange.schemas';
 import { IdentityResolutionService } from '@/modules/token-exchange/services/identity-resolution.service';
 

--- a/packages/cli/test/integration/token-exchange/identity-resolution.service.test.ts
+++ b/packages/cli/test/integration/token-exchange/identity-resolution.service.test.ts
@@ -178,15 +178,15 @@ describe('IdentityResolutionService (integration)', () => {
 			);
 		});
 
-		it('should ignore unknown role claim and default to global:member for new user', async () => {
-			const result = await service.resolve({
-				...baseClaims,
-				sub: 'ext-jit-unknown-role',
-				email: 'jit-unknown-role@example.com',
-				role: 'global:nonsense',
-			});
-
-			expect(result.role.slug).toBe('global:member');
+		it('should throw on unknown role claim for new user', async () => {
+			await expect(
+				service.resolve({
+					...baseClaims,
+					sub: 'ext-jit-unknown-role',
+					email: 'jit-unknown-role@example.com',
+					role: 'global:nonsense',
+				}),
+			).rejects.toThrow("Unrecognized role 'global:nonsense' cannot be assigned to new user");
 		});
 
 		it('should assign role from allowedRoles when provisioning new user', async () => {

--- a/packages/cli/test/integration/token-exchange/identity-resolution.service.test.ts
+++ b/packages/cli/test/integration/token-exchange/identity-resolution.service.test.ts
@@ -1,0 +1,339 @@
+import { testDb } from '@n8n/backend-test-utils';
+import {
+	AuthIdentity,
+	AuthIdentityRepository,
+	GLOBAL_ADMIN_ROLE,
+	GLOBAL_OWNER_ROLE,
+	ProjectRepository,
+	UserRepository,
+} from '@n8n/db';
+import { Container } from '@n8n/di';
+
+import { AuthError } from '@/errors/response-errors/auth.error';
+import type { ExternalTokenClaims } from '@/modules/token-exchange/token-exchange.schemas';
+import { IdentityResolutionService } from '@/modules/token-exchange/services/identity-resolution.service';
+
+import { createOwner, createUser } from '../shared/db/users';
+
+let service: IdentityResolutionService;
+let userRepository: UserRepository;
+let authIdentityRepository: AuthIdentityRepository;
+let projectRepository: ProjectRepository;
+
+beforeAll(async () => {
+	await testDb.init();
+
+	service = Container.get(IdentityResolutionService);
+	userRepository = Container.get(UserRepository);
+	authIdentityRepository = Container.get(AuthIdentityRepository);
+	projectRepository = Container.get(ProjectRepository);
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+beforeEach(async () => {
+	await testDb.truncate(['AuthIdentity', 'ProjectRelation', 'Project', 'User']);
+});
+
+const baseClaims: ExternalTokenClaims = {
+	sub: 'ext-sub-1',
+	iss: 'https://issuer.example.com',
+	aud: 'n8n',
+	iat: Math.floor(Date.now() / 1000),
+	exp: Math.floor(Date.now() / 1000) + 30,
+	jti: 'jti-1',
+	email: 'resolve-test@example.com',
+	given_name: 'Jane',
+	family_name: 'Doe',
+};
+
+describe('IdentityResolutionService (integration)', () => {
+	describe('Path 1 — known sub', () => {
+		it('should resolve user by auth identity and return role with scopes', async () => {
+			const user = await createUser({ email: 'known@example.com' });
+			await authIdentityRepository.save(AuthIdentity.create(user, 'ext-known', 'token-exchange'));
+
+			const result = await service.resolve({
+				...baseClaims,
+				sub: 'ext-known',
+				email: 'known@example.com',
+			});
+
+			expect(result.id).toBe(user.id);
+			expect(result.email).toBe('known@example.com');
+			expect(result.role).toBeDefined();
+			expect(result.role.slug).toBe('global:member');
+			expect(result.role.scopes.length).toBeGreaterThan(0);
+		});
+
+		it('should not update profile when given_name and family_name are unchanged', async () => {
+			const user = await createUser({
+				email: 'unchanged@example.com',
+				firstName: 'Same',
+				lastName: 'Name',
+			});
+			await authIdentityRepository.save(
+				AuthIdentity.create(user, 'ext-unchanged', 'token-exchange'),
+			);
+
+			const result = await service.resolve({
+				...baseClaims,
+				sub: 'ext-unchanged',
+				email: 'unchanged@example.com',
+				given_name: 'Same',
+				family_name: 'Name',
+			});
+
+			expect(result.id).toBe(user.id);
+
+			const dbUser = await userRepository.findOneBy({ id: user.id });
+			expect(dbUser!.firstName).toBe('Same');
+			expect(dbUser!.lastName).toBe('Name');
+		});
+	});
+
+	describe('Path 2 — email fallback', () => {
+		it('should link identity to existing user and resolve by sub on next call', async () => {
+			const user = await createUser({ email: 'fallback@example.com' });
+			const claims: ExternalTokenClaims = {
+				...baseClaims,
+				sub: 'ext-new-sub',
+				email: 'fallback@example.com',
+			};
+
+			// First call: email fallback creates the identity link
+			const result = await service.resolve(claims);
+			expect(result.id).toBe(user.id);
+
+			// Second call: should now resolve via Path 1 (known sub),
+			// proving the identity was correctly linked to the user
+			const secondResult = await service.resolve(claims);
+			expect(secondResult.id).toBe(user.id);
+			expect(secondResult.role).toBeDefined();
+			expect(secondResult.role.slug).toBe('global:member');
+		});
+	});
+
+	describe('Path 3 — JIT provisioning', () => {
+		it('should create user, personal project, and auth identity in a transaction', async () => {
+			const claims: ExternalTokenClaims = {
+				...baseClaims,
+				sub: 'ext-jit',
+				email: 'jit@example.com',
+				given_name: 'Jay',
+				family_name: 'Tee',
+			};
+
+			const result = await service.resolve(claims);
+
+			expect(result.email).toBe('jit@example.com');
+			expect(result.firstName).toBe('Jay');
+			expect(result.lastName).toBe('Tee');
+			expect(result.role.slug).toBe('global:member');
+			expect(result.role.scopes.length).toBeGreaterThan(0);
+
+			const dbUser = await userRepository.findOne({
+				where: { id: result.id },
+				select: ['id', 'password'],
+			});
+			expect(dbUser!.password).toBe('!token-exchange-no-password');
+
+			const identity = await authIdentityRepository.findOne({
+				where: { providerId: 'ext-jit', providerType: 'token-exchange' },
+			});
+			expect(identity).toBeDefined();
+			expect(identity!.userId).toBe(result.id);
+
+			const project = await projectRepository.getPersonalProjectForUser(result.id);
+			expect(project).toBeDefined();
+		});
+
+		it.each([
+			{
+				scenario: 'global:owner role',
+				role: 'global:owner',
+				allowedRoles: undefined,
+				errorMsg: 'Cannot provision global:owner role via token exchange',
+			},
+			{
+				scenario: 'role not in allowedRoles',
+				role: 'global:admin',
+				allowedRoles: ['global:member'],
+				errorMsg: "Role 'global:admin' is not allowed for this token exchange key",
+			},
+		])('should reject $scenario for new users', async ({ role, allowedRoles, errorMsg }) => {
+			await expect(
+				service.resolve(
+					{ ...baseClaims, sub: 'ext-rejected', email: 'rejected@example.com', role },
+					allowedRoles,
+				),
+			).rejects.toThrow(errorMsg);
+		});
+
+		it('should throw when email is missing and no identity match exists', async () => {
+			const claimsWithoutEmail = { ...baseClaims, sub: 'ext-no-email', email: undefined };
+
+			await expect(service.resolve(claimsWithoutEmail)).rejects.toThrow(
+				'Email claim is required for user provisioning',
+			);
+		});
+
+		it('should ignore unknown role claim and default to global:member for new user', async () => {
+			const result = await service.resolve({
+				...baseClaims,
+				sub: 'ext-jit-unknown-role',
+				email: 'jit-unknown-role@example.com',
+				role: 'global:nonsense',
+			});
+
+			expect(result.role.slug).toBe('global:member');
+		});
+
+		it('should assign role from allowedRoles when provisioning new user', async () => {
+			const result = await service.resolve(
+				{
+					...baseClaims,
+					sub: 'ext-jit-admin',
+					email: 'jit-admin@example.com',
+					role: 'global:admin',
+				},
+				['global:admin', 'global:member'],
+			);
+
+			expect(result.role.slug).toBe('global:admin');
+
+			const dbUser = await userRepository.findOne({
+				where: { id: result.id },
+				relations: ['role'],
+			});
+			expect(dbUser!.role.slug).toBe('global:admin');
+		});
+	});
+
+	describe('profile and role sync', () => {
+		it('should allow global:owner user to log in without changing their role', async () => {
+			const owner = await createOwner();
+			await authIdentityRepository.save(AuthIdentity.create(owner, 'ext-owner', 'token-exchange'));
+
+			const result = await service.resolve({
+				...baseClaims,
+				sub: 'ext-owner',
+				email: owner.email,
+				role: 'global:owner',
+			});
+
+			expect(result.id).toBe(owner.id);
+			expect(result.role.slug).toBe('global:owner');
+
+			const dbUser = await userRepository.findOne({
+				where: { id: owner.id },
+				relations: ['role'],
+			});
+			expect(dbUser!.role.slug).toBe('global:owner');
+		});
+
+		it('should keep current role when claimed role is not in allowedRoles', async () => {
+			const admin = await createUser({ email: 'admin-keep@example.com', role: GLOBAL_ADMIN_ROLE });
+			await authIdentityRepository.save(
+				AuthIdentity.create(admin, 'ext-admin-keep', 'token-exchange'),
+			);
+
+			const result = await service.resolve(
+				{
+					...baseClaims,
+					sub: 'ext-admin-keep',
+					email: 'admin-keep@example.com',
+					role: 'global:admin',
+				},
+				['global:member'],
+			);
+
+			expect(result.id).toBe(admin.id);
+			expect(result.role.slug).toBe('global:admin');
+
+			const dbUser = await userRepository.findOne({
+				where: { id: admin.id },
+				relations: ['role'],
+			});
+			expect(dbUser!.role.slug).toBe('global:admin');
+		});
+
+		it('should ignore unknown role claim for existing user', async () => {
+			const user = await createUser({ email: 'unknown-role@example.com' });
+			await authIdentityRepository.save(
+				AuthIdentity.create(user, 'ext-unknown-role', 'token-exchange'),
+			);
+
+			const result = await service.resolve({
+				...baseClaims,
+				sub: 'ext-unknown-role',
+				email: 'unknown-role@example.com',
+				role: 'global:nonsense',
+			});
+
+			expect(result.id).toBe(user.id);
+			expect(result.role.slug).toBe('global:member');
+		});
+
+		it('should use first element when role claim is an array', async () => {
+			const user = await createUser({ email: 'array-role@example.com' });
+			await authIdentityRepository.save(
+				AuthIdentity.create(user, 'ext-array-role', 'token-exchange'),
+			);
+
+			const result = await service.resolve(
+				{
+					...baseClaims,
+					sub: 'ext-array-role',
+					email: 'array-role@example.com',
+					role: ['global:admin', 'global:member'],
+				},
+				['global:admin'],
+			);
+
+			expect(result.role.slug).toBe('global:admin');
+
+			const dbUser = await userRepository.findOne({
+				where: { id: user.id },
+				relations: ['role'],
+			});
+			expect(dbUser!.role.slug).toBe('global:admin');
+		});
+
+		it('should update profile fields and role, persisting changes to the database', async () => {
+			const user = await createUser({
+				email: 'sync@example.com',
+				firstName: 'Old',
+				lastName: 'Name',
+			});
+			await authIdentityRepository.save(AuthIdentity.create(user, 'ext-sync', 'token-exchange'));
+
+			const result = await service.resolve(
+				{
+					...baseClaims,
+					sub: 'ext-sync',
+					email: 'sync@example.com',
+					given_name: 'New',
+					family_name: 'Last',
+					role: 'global:admin',
+				},
+				['global:admin'],
+			);
+
+			expect(result.firstName).toBe('New');
+			expect(result.lastName).toBe('Last');
+			expect(result.role).toEqual(expect.objectContaining({ slug: 'global:admin' }));
+
+			const dbUser = await userRepository.findOne({
+				where: { id: user.id },
+				relations: ['role'],
+			});
+			expect(dbUser!.firstName).toBe('New');
+			expect(dbUser!.lastName).toBe('Last');
+			expect(dbUser!.role.slug).toBe('global:admin');
+			expect(dbUser!.role.scopes.length).toBeGreaterThan(0);
+		});
+	});
+});

--- a/packages/cli/test/integration/token-exchange/identity-resolution.service.test.ts
+++ b/packages/cli/test/integration/token-exchange/identity-resolution.service.test.ts
@@ -403,6 +403,35 @@ describe('IdentityResolutionService (integration)', () => {
 			expect(dbUser!.role.slug).toBe('global:admin');
 		});
 
+		it('should downgrade admin to member when role claim is global:member', async () => {
+			const admin = await createUser({
+				email: 'downgrade@example.com',
+				role: GLOBAL_ADMIN_ROLE,
+			});
+			await authIdentityRepository.save(
+				AuthIdentity.create(admin, 'ext-downgrade', 'token-exchange'),
+			);
+
+			const result = await service.resolve(
+				{
+					...baseClaims,
+					sub: 'ext-downgrade',
+					email: 'downgrade@example.com',
+					role: 'global:member',
+				},
+				['global:admin', 'global:member'],
+			);
+
+			expect(result.id).toBe(admin.id);
+			expect(result.role.slug).toBe('global:member');
+
+			const dbUser = await userRepository.findOne({
+				where: { id: admin.id },
+				relations: ['role'],
+			});
+			expect(dbUser!.role.slug).toBe('global:member');
+		});
+
 		it('should update profile fields and role, persisting changes to the database', async () => {
 			const user = await createUser({
 				email: 'sync@example.com',

--- a/packages/cli/test/integration/token-exchange/identity-resolution.service.test.ts
+++ b/packages/cli/test/integration/token-exchange/identity-resolution.service.test.ts
@@ -306,6 +306,12 @@ describe('IdentityResolutionService (integration)', () => {
 					['global:member'],
 				),
 			).rejects.toThrow("Role 'global:admin' is not allowed for this token exchange key");
+
+			// Ensure no orphaned AuthIdentity was persisted before the role check
+			const orphanedIdentity = await authIdentityRepository.findOne({
+				where: { providerId: 'ext-admin-email', providerType: 'token-exchange' },
+			});
+			expect(orphanedIdentity).toBeNull();
 		});
 
 		it('should ignore unknown role claim for existing user', async () => {

--- a/packages/cli/test/integration/token-exchange/identity-resolution.service.test.ts
+++ b/packages/cli/test/integration/token-exchange/identity-resolution.service.test.ts
@@ -230,31 +230,6 @@ describe('IdentityResolutionService (integration)', () => {
 			).rejects.toThrow("Unrecognized role 'global:nonsense' cannot be assigned to new user");
 		});
 
-		it('should default to global:member when role claim is an empty array', async () => {
-			const result = await service.resolve({
-				...baseClaims,
-				sub: 'ext-jit-empty-role',
-				email: 'jit-empty-role@example.com',
-				role: [],
-			});
-
-			expect(result.role.slug).toBe('global:member');
-		});
-
-		it('should assign role from array claim when provisioning new user', async () => {
-			const result = await service.resolve(
-				{
-					...baseClaims,
-					sub: 'ext-jit-array-role',
-					email: 'jit-array-role@example.com',
-					role: ['global:admin'],
-				},
-				['global:admin'],
-			);
-
-			expect(result.role.slug).toBe('global:admin');
-		});
-
 		it('should assign role from allowedRoles when provisioning new user', async () => {
 			const result = await service.resolve(
 				{
@@ -298,30 +273,39 @@ describe('IdentityResolutionService (integration)', () => {
 			expect(dbUser!.role.slug).toBe('global:owner');
 		});
 
-		it('should keep current role when claimed role is not in allowedRoles', async () => {
+		it('should throw when claimed role is not in allowedRoles for known identity', async () => {
 			const admin = await createUser({ email: 'admin-keep@example.com', role: GLOBAL_ADMIN_ROLE });
 			await authIdentityRepository.save(
 				AuthIdentity.create(admin, 'ext-admin-keep', 'token-exchange'),
 			);
 
-			const result = await service.resolve(
-				{
-					...baseClaims,
-					sub: 'ext-admin-keep',
-					email: 'admin-keep@example.com',
-					role: 'global:admin',
-				},
-				['global:member'],
-			);
+			await expect(
+				service.resolve(
+					{
+						...baseClaims,
+						sub: 'ext-admin-keep',
+						email: 'admin-keep@example.com',
+						role: 'global:admin',
+					},
+					['global:member'],
+				),
+			).rejects.toThrow("Role 'global:admin' is not allowed for this token exchange key");
+		});
 
-			expect(result.id).toBe(admin.id);
-			expect(result.role.slug).toBe('global:admin');
+		it('should throw when claimed role is not in allowedRoles for email fallback', async () => {
+			await createUser({ email: 'admin-email@example.com', role: GLOBAL_ADMIN_ROLE });
 
-			const dbUser = await userRepository.findOne({
-				where: { id: admin.id },
-				relations: ['role'],
-			});
-			expect(dbUser!.role.slug).toBe('global:admin');
+			await expect(
+				service.resolve(
+					{
+						...baseClaims,
+						sub: 'ext-admin-email',
+						email: 'admin-email@example.com',
+						role: 'global:admin',
+					},
+					['global:member'],
+				),
+			).rejects.toThrow("Role 'global:admin' is not allowed for this token exchange key");
 		});
 
 		it('should ignore unknown role claim for existing user', async () => {
@@ -341,26 +325,6 @@ describe('IdentityResolutionService (integration)', () => {
 			expect(result.role.slug).toBe('global:member');
 		});
 
-		it('should preserve current role when role claim is an empty array', async () => {
-			const admin = await createUser({
-				email: 'empty-array-role@example.com',
-				role: GLOBAL_ADMIN_ROLE,
-			});
-			await authIdentityRepository.save(
-				AuthIdentity.create(admin, 'ext-empty-array', 'token-exchange'),
-			);
-
-			const result = await service.resolve({
-				...baseClaims,
-				sub: 'ext-empty-array',
-				email: 'empty-array-role@example.com',
-				role: [],
-			});
-
-			expect(result.id).toBe(admin.id);
-			expect(result.role.slug).toBe('global:admin');
-		});
-
 		it('should ignore global:owner role claim for non-owner user', async () => {
 			const user = await createUser({ email: 'escalation@example.com' });
 			await authIdentityRepository.save(
@@ -376,31 +340,6 @@ describe('IdentityResolutionService (integration)', () => {
 
 			expect(result.id).toBe(user.id);
 			expect(result.role.slug).toBe('global:member');
-		});
-
-		it('should use first element when role claim is an array', async () => {
-			const user = await createUser({ email: 'array-role@example.com' });
-			await authIdentityRepository.save(
-				AuthIdentity.create(user, 'ext-array-role', 'token-exchange'),
-			);
-
-			const result = await service.resolve(
-				{
-					...baseClaims,
-					sub: 'ext-array-role',
-					email: 'array-role@example.com',
-					role: ['global:admin', 'global:member'],
-				},
-				['global:admin'],
-			);
-
-			expect(result.role.slug).toBe('global:admin');
-
-			const dbUser = await userRepository.findOne({
-				where: { id: user.id },
-				relations: ['role'],
-			});
-			expect(dbUser!.role.slug).toBe('global:admin');
 		});
 
 		it('should downgrade admin to member when role claim is global:member', async () => {


### PR DESCRIPTION
## Summary

Implements `IdentityResolutionService` that resolves verified external token claims (`sub`) to an n8n user. This replaces the skeleton stub that previously threw "not implemented".

**Part of the OAuth 2.0 Token Exchange initiative** (Phase 2a — Embed flow). External systems identify users by their own IDs (`sub` claim). This service maps those to internal n8n users — linking on first encounter and keeping profiles in sync on subsequent exchanges.

### Resolution algorithm

1. **Known sub** — `AuthIdentity` lookup by `sub` + `token-exchange` provider → return linked user
2. **Email fallback** — no identity match but email matches existing user → create `AuthIdentity` link, return user
3. **JIT provision** — no match at all → create user + personal project + `AuthIdentity` in a single transaction

### Role handling

- Role claim validated against the key's `allowedRoles` whitelist
- `global:owner` can never be assigned via token exchange (existing owners keep their role, new users are rejected)
- Existing users keep their current role when the claimed role is invalid or not allowed — login is never blocked due to role mismatch
- New users get `global:member` by default when no role claim is present

### Other changes

- `TokenExchangeService.verifyToken` now returns `{ claims, resolvedKey }` so `embedLogin` can pass `allowedRoles` to identity resolution
- Three new audit events: `token-exchange-identity-linked`, `token-exchange-user-provisioned`, `token-exchange-role-updated`

### How to test manually

1. Configure a trusted key with `allowedRoles: ['global:member', 'global:admin']`
2. Generate a JWT with `sub`, `email`, and optional `role` claim signed by the trusted key
3. Call `POST /rest/auth/embed` with `{ "token": "<jwt>" }`
4. Verify:
   - First call with a new `sub` + known email links the identity and returns the existing user
   - First call with a new `sub` + unknown email creates a new user with personal project
   - Subsequent calls with the same `sub` resolve via identity lookup (Path 1)
   - Role updates are applied when the claim is in `allowedRoles`
   - `global:owner` role claim is silently ignored for existing users and rejected for new users
5. Check audit events are emitted for linking, provisioning, and role changes

## Related tickets

- https://linear.app/n8n/issue/IAM-462

## Review checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)