### PR TITLE
feat: support context caching in Google Vertex model

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/LmChatGoogleVertex.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/LmChatGoogleVertex.node.ts
@@ -1,9 +1,15 @@
 import { ProjectsClient } from '@google-cloud/resource-manager';
 import type { GoogleAISafetySetting } from '@langchain/google-common';
 import { ChatVertexAI, type ChatVertexAIInput } from '@langchain/google-vertexai';
+import {
+	makeN8nLlmFailedAttemptHandler,
+	N8nLlmTracing,
+	getConnectionHintNoticeField,
+} from '@n8n/ai-utilities';
 import { formatPrivateKey } from 'n8n-nodes-base/dist/utils/utilities';
 import {
 	NodeConnectionTypes,
+	type INode,
 	type INodeType,
 	type INodeTypeDescription,
 	type ISupplyDataFunctions,
@@ -15,12 +21,13 @@ import {
 } from 'n8n-workflow';
 
 import { makeErrorFromStatus } from './error-handling';
-import { getAdditionalOptions } from '../gemini-common/additional-options';
+import { applyVertexAutoContextCachePatch } from './context-caching/auto/auto-cache';
+import { applyPredefinedVertexContextCachePatch } from './context-caching/predefined/predefined-context-cache-patch';
 import {
-	makeN8nLlmFailedAttemptHandler,
-	N8nLlmTracing,
-	getConnectionHintNoticeField,
-} from '@n8n/ai-utilities';
+	buildVertexContextCacheRedisBaseKey,
+	RedisContextCacheMetadataStorage,
+} from './context-caching/auto/storage/redis';
+import { getAdditionalOptions } from '../gemini-common/additional-options';
 
 export class LmChatGoogleVertex implements INodeType {
 	description: INodeTypeDescription = {
@@ -58,6 +65,16 @@ export class LmChatGoogleVertex implements INodeType {
 				name: 'googleApi',
 				required: true,
 			},
+			{
+				displayName: 'Redis (auto-cache metadata)',
+				name: 'redis',
+				required: true,
+				displayOptions: {
+					show: {
+						contextCacheStrategy: ['auto'],
+					},
+				},
+			},
 		],
 		properties: [
 			getConnectionHintNoticeField([NodeConnectionTypes.AiChain, NodeConnectionTypes.AiAgent]),
@@ -92,7 +109,88 @@ export class LmChatGoogleVertex implements INodeType {
 					'The model which will generate the completion. <a href="https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models">Learn more</a>.',
 				default: 'gemini-2.5-flash',
 			},
-			getAdditionalOptions({ supportsThinkingBudget: true }),
+			{
+				displayName: 'Context Caching Strategy',
+				name: 'contextCacheStrategy',
+				type: 'options',
+				default: 'none',
+				options: [
+					{ name: 'None', value: 'none' },
+					{ name: 'Auto-caching', value: 'auto' },
+					{ name: 'Predefined cache', value: 'predefined' },
+				],
+				description: 'Select how this node should use Vertex context caching.',
+			},
+			{
+				displayName:
+					'With Predefined cache, system instructions from your workflow and tool definitions from the AI Agent are not sent to the model. The Vertex context cache resource you configure replaces that context. If the cache does not match what the agent expects, behavior can be inconsistent or incorrect.',
+				name: 'vertexPredefinedCacheContextNotice',
+				type: 'notice',
+				default: '',
+				displayOptions: {
+					show: {
+						contextCacheStrategy: ['predefined'],
+					},
+				},
+			},
+			{
+				displayName: 'Context Cache TTL (Seconds)',
+				name: 'contextCacheTtlSeconds',
+				type: 'number',
+				default: 86400,
+				required: true,
+				typeOptions: { minValue: 300, numberPrecision: 0 },
+				displayOptions: {
+					show: {
+						contextCacheStrategy: ['auto'],
+					},
+				},
+				description:
+					'How long new Vertex cached contents remain valid (TTL sent to Google). After expiry, the next run recreates the cache.',
+			},
+			{
+				displayName:
+					'Connect Redis in the credentials tab. It stores small metadata records so n8n can reuse automatically created Vertex context caches when using Auto-caching. Cached prompts and tools still live in Google Cloud - Redis is only for coordination.',
+				name: 'vertexAutoCacheRedisHelpNotice',
+				type: 'notice',
+				default: '',
+				displayOptions: {
+					show: {
+						contextCacheStrategy: ['auto'],
+					},
+				},
+			},
+			{
+				displayName: 'Context Cache Storage Prefix',
+				name: 'vertexContextCacheRedisKeyPrefix',
+				type: 'string',
+				default: 'n8n:vertexCtx',
+				required: true,
+				displayOptions: {
+					show: {
+						contextCacheStrategy: ['auto'],
+					},
+				},
+				description:
+					'Prefix for keys in Redis where this workflow stores auto-cache metadata. Use a unique value if several n8n instances or environments share the same Redis. Allowed characters: letters, numbers, underscores, hyphens, colons, and dots (max 200 characters).',
+			},
+			{
+				displayName: 'Context Cache Name',
+				name: 'contextCacheName',
+				type: 'string',
+				default: '',
+				required: true,
+				displayOptions: {
+					show: {
+						contextCacheStrategy: ['predefined'],
+					},
+				},
+				description:
+					'Full Vertex AI context cache resource name passed as cachedContent to generateContent, for example projects/PROJECT_NUMBER/locations/LOCATION/cachedContents/CACHE_ID. <a href="https://cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-use">Learn more</a>.',
+			},
+			getAdditionalOptions({
+				supportsThinkingBudget: true,
+			}),
 		],
 	};
 
@@ -147,6 +245,12 @@ export class LmChatGoogleVertex implements INodeType {
 			topP: 0.9,
 		});
 
+		const contextCacheStrategy = this.getNodeParameter(
+			'contextCacheStrategy',
+			itemIndex,
+			'none',
+		) as string;
+
 		// Validate options parameter
 		validateNodeParameters(
 			options,
@@ -159,6 +263,59 @@ export class LmChatGoogleVertex implements INodeType {
 			},
 			this.getNode(),
 		);
+
+		if (contextCacheStrategy === 'predefined') {
+			const contextCacheName = (
+				this.getNodeParameter('contextCacheName', itemIndex, '') as string
+			).trim();
+			if (contextCacheName === '') {
+				throw new NodeOperationError(this.getNode(), {
+					message: 'Context Cache Name is required',
+					description: 'Set Context Cache Name when using the Predefined cache strategy.',
+				});
+			}
+		}
+		if (contextCacheStrategy === 'auto') {
+			const ttlRaw = this.getNodeParameter('contextCacheTtlSeconds', itemIndex);
+			if (
+				ttlRaw === undefined ||
+				ttlRaw === null ||
+				typeof ttlRaw !== 'number' ||
+				!Number.isFinite(ttlRaw)
+			) {
+				throw new NodeOperationError(this.getNode(), {
+					message: 'Context Cache TTL is required',
+					description: 'Set Context Cache TTL (seconds) when using Auto-caching.',
+				});
+			}
+
+			const prefixRaw = this.getNodeParameter(
+				'vertexContextCacheRedisKeyPrefix',
+				itemIndex,
+				'',
+			) as string;
+			const prefix = prefixRaw.trim();
+			if (prefix === '') {
+				throw new NodeOperationError(this.getNode(), {
+					message: 'Context cache storage prefix is required',
+					description:
+						'Set Context Cache Storage Prefix when using Auto-caching, or keep the default.',
+				});
+			}
+			if (prefix.length > 200) {
+				throw new NodeOperationError(this.getNode(), {
+					message: 'Context cache storage prefix is too long',
+					description: 'Use at most 200 characters for the storage prefix.',
+				});
+			}
+			if (!/^[\w:.-]+$/.test(prefix)) {
+				throw new NodeOperationError(this.getNode(), {
+					message: 'Invalid context cache storage prefix',
+					description:
+						'The prefix may only contain letters, numbers, underscores, hyphens, colons, and dots.',
+				});
+			}
+		}
 
 		const safetySettings = this.getNodeParameter(
 			'options.safetySettings.values',
@@ -184,9 +341,9 @@ export class LmChatGoogleVertex implements INodeType {
 				safetySettings,
 				callbacks: [new N8nLlmTracing(this)],
 				// Handle ChatVertexAI invocation errors to provide better error messages
-				onFailedAttempt: makeN8nLlmFailedAttemptHandler(this, (error: any) => {
-					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-					const customError = makeErrorFromStatus(Number(error?.response?.status), {
+				onFailedAttempt: makeN8nLlmFailedAttemptHandler(this, (error: unknown) => {
+					const failure = error as { response?: { status?: unknown } };
+					const customError = makeErrorFromStatus(Number(failure.response?.status), {
 						modelName,
 					});
 
@@ -204,24 +361,77 @@ export class LmChatGoogleVertex implements INodeType {
 			}
 
 			const model = new ChatVertexAI(modelConfig);
+			const autoContextCache = contextCacheStrategy === 'auto';
+			const predefinedContextCache = contextCacheStrategy === 'predefined';
+			const ttlRaw =
+				contextCacheStrategy === 'auto'
+					? this.getNodeParameter('contextCacheTtlSeconds', itemIndex)
+					: undefined;
+			const contextCacheTtlSeconds =
+				typeof ttlRaw === 'number' && Number.isFinite(ttlRaw)
+					? Math.max(300, Math.floor(ttlRaw))
+					: 86400;
+
+			if (autoContextCache) {
+				const parentNode = (this as ISupplyDataFunctions & { parentNode?: INode }).parentNode;
+				const parentNodeId = parentNode?.id ?? this.getNode().id;
+				const workflowId = this.getWorkflow().id ?? 'unknown';
+				const redisCredentials = await this.getCredentials('redis');
+				const redisKeyPrefix = (
+					this.getNodeParameter('vertexContextCacheRedisKeyPrefix', itemIndex) as string
+				).trim();
+				const redisBaseKey = buildVertexContextCacheRedisBaseKey(
+					redisKeyPrefix,
+					workflowId,
+					parentNodeId,
+				);
+				const metadataStorage = new RedisContextCacheMetadataStorage(
+					redisCredentials,
+					this.getNode().typeVersion,
+					redisBaseKey,
+				);
+				applyVertexAutoContextCachePatch(model, this, {
+					metadataStorage,
+					contextCacheTtlSeconds,
+					credentials,
+					location: region,
+					modelName,
+					parentNodeId,
+					projectId,
+				});
+				return {
+					response: model,
+				};
+			}
+
+			const contextCacheName = predefinedContextCache
+				? (this.getNodeParameter('contextCacheName', itemIndex, '') as string).trim()
+				: '';
+			// LangChain's withConfig() returns RunnableBinding (lc_namespace: runnables), which fails
+			// n8n's Tools Agent check (isChatInstance + bindTools). Merge cachedContent via
+			// invocationParams instead so the instance stays a ChatVertexAI.
+			if (contextCacheName !== '') {
+				applyPredefinedVertexContextCachePatch(model, this, contextCacheName);
+			}
 
 			return {
 				response: model,
 			};
-		} catch (e) {
+		} catch (caught) {
 			// Catch model name validation error from LangChain (https://github.com/langchain-ai/langchainjs/blob/ef201d0ee85ee4049078270a0cfd7a1767e624f8/libs/langchain-google-common/src/utils/common.ts#L124)
 			// to show more helpful error message
-			if (e?.message?.startsWith('Unable to verify model params')) {
-				throw new NodeOperationError(this.getNode(), e as JsonObject, {
+			const message = caught instanceof Error ? caught.message : String(caught);
+			if (message.startsWith('Unable to verify model params')) {
+				throw new NodeOperationError(this.getNode(), caught as JsonObject, {
 					message: 'Unsupported model',
 					description: "Only models starting with 'gemini' are supported.",
 				});
 			}
 
 			// Assume all other exceptions while creating a new ChatVertexAI instance are parameter validation errors
-			throw new NodeOperationError(this.getNode(), e as JsonObject, {
+			throw new NodeOperationError(this.getNode(), caught as JsonObject, {
 				message: 'Invalid options',
-				description: e.message,
+				description: message,
 			});
 		}
 	}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/auto/auto-cache.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/auto/auto-cache.ts
@@ -1,0 +1,553 @@
+import type { BaseMessage } from '@langchain/core/messages';
+import type { ChatGenerationChunk, ChatResult } from '@langchain/core/outputs';
+import type { ChatVertexAI } from '@langchain/google-vertexai';
+import type {
+	IDataObject,
+	ISupplyDataFunctions,
+	Logger,
+	LogMetadata,
+	NodeExecutionHint,
+} from 'n8n-workflow';
+
+import {
+	CACHE_CREATE_LOG_TEXT_MAX,
+	CACHE_TOO_SHORT_ERROR_TTL,
+	CONTEXT_CACHE_PENDING_METADATA_TTL_SECONDS,
+} from './consts';
+import type { ContextCacheMetadata, PendingCache } from './context-cache-metadata';
+import { isExistingContextCache, isNotCacheable, isPendingCache } from './context-cache-metadata';
+import { computeRedisMetadataTtlSecondsForSuccess } from './compute-redis-metadata-ttl';
+import { computeConfigHash, type InvocationParamsForHash } from './config-hash';
+import {
+	CacheMinimumTokenCountError,
+	createGoogleContextCache,
+	GoogleContextCacheApiError,
+} from './google-context-cache-api';
+import {
+	vertexContextCacheCreateFailedHint,
+	vertexContextCacheHitHint,
+	vertexContextCacheTooShortFirstHitHint,
+	vertexContextCacheTooShortFromStoreHint,
+} from './hints';
+import type { ContextCacheMetadataStorage } from './storage/context-cache-metadata-storage';
+import {
+	getFirstSystemMessagePlainText,
+	parseExpireMs,
+	stripSystemMessages,
+	stripToolCallOptions,
+} from '../utils';
+
+export {
+	CACHE_TOO_SHORT_ERROR_TTL,
+	CONTEXT_CACHE_PENDING_METADATA_TTL_SECONDS,
+	VERTEX_CONTEXT_CACHE_REDIS_METADATA_SAFETY_BUFFER_SEC,
+} from './consts';
+
+export type { ContextCacheMetadataStorage } from './storage/context-cache-metadata-storage';
+
+export type { ContextCacheMetadata } from './context-cache-metadata';
+
+// --- Request body (Google cachedContents.create) -----------------------------------------------
+
+export type VertexContent = {
+	role: string;
+	parts: Array<{ text?: string }>;
+};
+
+function systemInstructionFromMessages(messages: BaseMessage[]): VertexContent | undefined {
+	const text = getFirstSystemMessagePlainText(messages);
+	if (!text) return undefined;
+	return { parts: [{ text }], role: 'system' };
+}
+
+function toolConfigFromParams(
+	params: InvocationParamsForHash,
+): Record<string, unknown> | undefined {
+	const choice = params.tool_choice;
+	if (choice === undefined || choice === null || typeof choice !== 'string') return undefined;
+	if (['auto', 'any', 'none'].includes(choice)) {
+		return {
+			functionCallingConfig: {
+				allowedFunctionNames: params.allowed_function_names as string[] | undefined,
+				mode: choice,
+			},
+		};
+	}
+	return {
+		functionCallingConfig: {
+			allowedFunctionNames: [choice],
+			mode: 'any',
+		},
+	};
+}
+
+function aiAgentHasCacheableContext(
+	systemInstruction: VertexContent | undefined,
+	tools: unknown,
+): boolean {
+	const hasTools = Array.isArray(tools) && tools.length > 0;
+	const hasSystemParts = (systemInstruction?.parts?.length ?? 0) > 0;
+	return hasSystemParts || hasTools;
+}
+
+function buildCachedContentRequestBody(input: {
+	messages: BaseMessage[];
+	modelResourceName: string;
+	params: InvocationParamsForHash;
+	ttlSeconds: number;
+	displayNameSuffix: string;
+}): Record<string, unknown> {
+	const systemInstruction = systemInstructionFromMessages(input.messages);
+	const tools = input.params.tools;
+	const toolConfig = toolConfigFromParams(input.params);
+	const body: Record<string, unknown> = {
+		displayName: `n8n-vertex-cache-${input.displayNameSuffix.slice(0, 32)}`,
+		model: input.modelResourceName,
+		ttl: `${input.ttlSeconds}s`,
+	};
+	if (systemInstruction) body.systemInstruction = systemInstruction;
+	if (Array.isArray(tools) && tools.length > 0) body.tools = tools;
+	if (toolConfig) body.toolConfig = toolConfig;
+	return body;
+}
+
+// --- Debug logging for cache create -------------------------------------------------------------
+
+function firstTextFromSystemInstructionBody(systemInstruction: unknown): string | undefined {
+	if (!systemInstruction || typeof systemInstruction !== 'object') return undefined;
+	const parts = (systemInstruction as { parts?: unknown }).parts;
+	if (!Array.isArray(parts)) return undefined;
+	for (const part of parts) {
+		if (part && typeof part === 'object' && 'text' in part) {
+			const text = (part as { text?: unknown }).text;
+			if (typeof text === 'string' && text.length > 0) return text;
+		}
+	}
+	return undefined;
+}
+
+function summarizeCachedContentCreateBody(body: Record<string, unknown>): LogMetadata {
+	const systemText = firstTextFromSystemInstructionBody(body.systemInstruction);
+	const tools = body.tools;
+	const toolsSummary =
+		!Array.isArray(tools) || tools.length === 0
+			? { present: false }
+			: {
+					present: true,
+					toolCount: tools.length,
+					tools: tools.map((tool, index) => {
+						if (tool && typeof tool === 'object' && 'functionDeclarations' in tool) {
+							const declarations = (tool as { functionDeclarations?: Array<{ name?: string }> })
+								.functionDeclarations;
+							return {
+								functionCount: declarations?.length ?? 0,
+								functionNames: declarations?.map((d) => d.name).filter(Boolean) ?? [],
+								index,
+							};
+						}
+						return { index, keys: Object.keys(tool as object) };
+					}),
+				};
+
+	const preview =
+		systemText === undefined
+			? undefined
+			: systemText.length <= CACHE_CREATE_LOG_TEXT_MAX
+				? systemText
+				: `${systemText.slice(0, CACHE_CREATE_LOG_TEXT_MAX)}… (${systemText.length} chars total)`;
+
+	return {
+		displayName: body.displayName,
+		model: body.model,
+		toolConfig: body.toolConfig,
+		ttl: body.ttl,
+		systemInstruction: {
+			inRequest: systemText !== undefined,
+			textPreview: preview,
+		},
+		tools: toolsSummary,
+	};
+}
+
+// --- Model patch (LangChain) -------------------------------------------------------------------
+
+type PatchDeps = {
+	contextCacheTtlSeconds: number;
+	credentials: IDataObject;
+	executionId: string;
+	location: string;
+	logger: Logger;
+	metadataStorage: ContextCacheMetadataStorage;
+	modelResourceName: string;
+	parentNodeId: string;
+	projectId: string;
+	workflowId: string;
+};
+
+type RunPlan =
+	| { cacheName: string; type: 'warm' }
+	| { executionHints?: NodeExecutionHint[]; type: 'cold_no_create' }
+	| { body: Record<string, unknown>; hash: string; type: 'cold_create' };
+
+async function resolveRunPlan(
+	model: ChatVertexAI,
+	messages: BaseMessage[],
+	options: object,
+	deps: PatchDeps,
+): Promise<RunPlan> {
+	const params = model.invocationParams(options as never) as InvocationParamsForHash;
+	const hash = computeConfigHash(messages, deps.location, params);
+
+	const initialMeta = await deps.metadataStorage.read(hash);
+	const nowMs = Date.now();
+	const metaBase = {
+		executionId: deps.executionId,
+		hashPrefix: hash.slice(0, 8),
+		parentNodeId: deps.parentNodeId,
+		workflowId: deps.workflowId,
+	};
+
+	let meta = initialMeta;
+
+	if (meta === null) {
+		deps.logger.debug('VertexContextCache: cache_miss (no stored metadata)', metaBase);
+	} else if (isPendingCache(meta)) {
+		deps.logger.debug('VertexContextCache: cache_skip (pending create)', metaBase);
+		return { type: 'cold_no_create' };
+	} else if (isNotCacheable(meta)) {
+		if (parseExpireMs(meta.retryNotBeforeIso) <= nowMs) {
+			await deps.metadataStorage.delete(hash);
+			meta = null;
+			deps.logger.debug('VertexContextCache: cache_miss (not_cacheable window expired)', metaBase);
+		} else {
+			deps.logger.debug('VertexContextCache: cache_skip (not_cacheable in store)', metaBase);
+			return {
+				type: 'cold_no_create',
+				executionHints: [vertexContextCacheTooShortFromStoreHint()],
+			};
+		}
+	} else if (isExistingContextCache(meta)) {
+		if (parseExpireMs(meta.expireTime) <= nowMs) {
+			await deps.metadataStorage.delete(hash);
+			meta = null;
+			deps.logger.debug('VertexContextCache: cache_miss (expired)', metaBase);
+		} else if (meta.location !== deps.location) {
+			const storedLocation = meta.location;
+			await deps.metadataStorage.delete(hash);
+			meta = null;
+			deps.logger.debug('VertexContextCache: cache_miss_binding (location mismatch)', {
+				...metaBase,
+				expectedLocation: deps.location,
+				storedLocation,
+			});
+		} else if (meta.model !== deps.modelResourceName) {
+			const storedModel = meta.model;
+			await deps.metadataStorage.delete(hash);
+			meta = null;
+			deps.logger.debug('VertexContextCache: cache_miss_binding (model mismatch)', {
+				...metaBase,
+				expectedModel: deps.modelResourceName,
+				storedModel,
+			});
+		} else {
+			deps.logger.debug('VertexContextCache: cache_hit', {
+				...metaBase,
+				cacheNameSuffix: meta.cacheName.split('/').pop(),
+			});
+			return { cacheName: meta.cacheName, type: 'warm' };
+		}
+	} else {
+		await deps.metadataStorage.delete(hash);
+		meta = null;
+		deps.logger.debug('VertexContextCache: cache_miss (invalid stored metadata)', metaBase);
+	}
+
+	const body = buildCachedContentRequestBody({
+		displayNameSuffix: hash,
+		messages,
+		modelResourceName: deps.modelResourceName,
+		params,
+		ttlSeconds: deps.contextCacheTtlSeconds,
+	});
+
+	if (
+		!aiAgentHasCacheableContext(body.systemInstruction as VertexContent | undefined, body.tools)
+	) {
+		deps.logger.debug(
+			'VertexContextCache: cold path without cacheable prefix (skip create)',
+			metaBase,
+		);
+		return { type: 'cold_no_create' };
+	}
+
+	return {
+		body,
+		hash,
+		type: 'cold_create',
+	};
+}
+
+function patchInvocationParamsForCachedContent(model: ChatVertexAI, cacheName: string): () => void {
+	const originalInvocationParams = model.invocationParams.bind(model);
+	model.invocationParams = (callOptions) => {
+		const merged = originalInvocationParams(callOptions) as Record<string, unknown>;
+		const next: Record<string, unknown> = { ...merged };
+		delete next.tools;
+		delete next.tool_choice;
+		delete next.allowed_function_names;
+		next.cachedContent = cacheName;
+		return next;
+	};
+	return () => {
+		model.invocationParams = originalInvocationParams;
+	};
+}
+
+async function withCachedContentBinding(
+	model: ChatVertexAI,
+	cacheName: string,
+	fn: () => Promise<ChatResult>,
+): Promise<ChatResult> {
+	const restore = patchInvocationParamsForCachedContent(model, cacheName);
+	try {
+		return await fn();
+	} finally {
+		restore();
+	}
+}
+
+async function* streamWithCachedContentBinding(
+	model: ChatVertexAI,
+	cacheName: string,
+	stream: AsyncGenerator<ChatGenerationChunk>,
+): AsyncGenerator<ChatGenerationChunk> {
+	const restore = patchInvocationParamsForCachedContent(model, cacheName);
+	try {
+		for await (const chunk of stream) {
+			yield chunk;
+		}
+	} finally {
+		restore();
+	}
+}
+
+async function writeExistingMetadata(
+	storage: ContextCacheMetadataStorage,
+	hash: string,
+	fields: {
+		cacheName: string;
+		expireTime: string;
+		location: string;
+		model: string;
+	},
+	createDurationMs: number,
+): Promise<void> {
+	const ttlSeconds = computeRedisMetadataTtlSecondsForSuccess({
+		createDurationMs,
+		expireTimeIso: fields.expireTime,
+	});
+	const metadata: ContextCacheMetadata = { kind: 'existing', ...fields };
+	await storage.write(hash, metadata, { ttlSeconds });
+}
+
+async function writeNotCacheableTooShort(
+	storage: ContextCacheMetadataStorage,
+	hash: string,
+): Promise<void> {
+	const retryNotBeforeIso = new Date(Date.now() + CACHE_TOO_SHORT_ERROR_TTL * 1000).toISOString();
+	await storage.write(
+		hash,
+		{
+			kind: 'not_cacheable',
+			reason: 'CACHE_TOO_SHORT',
+			retryNotBeforeIso,
+		},
+		{ ttlSeconds: CACHE_TOO_SHORT_ERROR_TTL },
+	);
+}
+
+/**
+ * Fire-and-forget: completes `cachedContents.create` and updates Redis metadata (or deletes on hard failure).
+ */
+function scheduleContextCacheCreate(
+	plan: Extract<RunPlan, { type: 'cold_create' }>,
+	ctx: ISupplyDataFunctions,
+	deps: PatchDeps,
+): void {
+	void (async () => {
+		deps.logger.debug('VertexContextCache: cache_create_start', {
+			cachedContentsRequest: summarizeCachedContentCreateBody(plan.body),
+			executionId: deps.executionId,
+			hashPrefix: plan.hash.slice(0, 8),
+			parentNodeId: deps.parentNodeId,
+			workflowId: deps.workflowId,
+		});
+		try {
+			const createStartedMs = Date.now();
+			const result = await createGoogleContextCache(ctx, deps.credentials, {
+				body: plan.body,
+				location: deps.location,
+				projectId: deps.projectId,
+			});
+			const createDurationMs = Date.now() - createStartedMs;
+			await writeExistingMetadata(
+				deps.metadataStorage,
+				plan.hash,
+				{
+					cacheName: result.name,
+					expireTime: result.expireTime,
+					location: deps.location,
+					model: deps.modelResourceName,
+				},
+				createDurationMs,
+			);
+			deps.logger.debug('VertexContextCache: cache_create_ok (metadata storage updated)', {
+				cacheNameSuffix: result.name.split('/').pop(),
+				executionId: deps.executionId,
+				hashPrefix: plan.hash.slice(0, 8),
+				parentNodeId: deps.parentNodeId,
+				workflowId: deps.workflowId,
+			});
+		} catch (caught) {
+			if (caught instanceof CacheMinimumTokenCountError) {
+				deps.logger.debug('VertexContextCache: cache_create_error', {
+					executionId: deps.executionId,
+					hashPrefix: plan.hash.slice(0, 8),
+					message: caught.message,
+					parentNodeId: deps.parentNodeId,
+					status: caught.status,
+					workflowId: deps.workflowId,
+				});
+				await writeNotCacheableTooShort(deps.metadataStorage, plan.hash);
+				ctx.addExecutionHints(vertexContextCacheTooShortFirstHitHint());
+			} else if (caught instanceof GoogleContextCacheApiError) {
+				deps.logger.debug('VertexContextCache: cache_create_error', {
+					executionId: deps.executionId,
+					hashPrefix: plan.hash.slice(0, 8),
+					message: caught.message,
+					parentNodeId: deps.parentNodeId,
+					status: caught.status,
+					workflowId: deps.workflowId,
+				});
+				await deps.metadataStorage.delete(plan.hash);
+				ctx.addExecutionHints(vertexContextCacheCreateFailedHint(caught.message));
+			} else {
+				const message =
+					caught instanceof Error && caught.message !== ''
+						? caught.message
+						: 'Vertex cachedContents create failed with an unexpected error';
+				deps.logger.debug('VertexContextCache: cache_create_error', {
+					executionId: deps.executionId,
+					hashPrefix: plan.hash.slice(0, 8),
+					message,
+					parentNodeId: deps.parentNodeId,
+					workflowId: deps.workflowId,
+				});
+				await deps.metadataStorage.delete(plan.hash);
+				ctx.addExecutionHints(vertexContextCacheCreateFailedHint(message));
+			}
+		}
+	})();
+}
+
+/**
+ * Patches {@link ChatVertexAI} so explicit context caches are created and reused per parent agent.
+ * Safe with {@link ChatVertexAI.bindTools} because the same instance is invoked by the bound runnable.
+ */
+export function applyVertexAutoContextCachePatch(
+	model: ChatVertexAI,
+	ctx: ISupplyDataFunctions,
+	deps: Omit<PatchDeps, 'executionId' | 'logger' | 'modelResourceName' | 'workflowId'> & {
+		modelName: string;
+	},
+): void {
+	const workflowId = ctx.getWorkflow().id ?? 'unknown';
+	const executionId = ctx.getExecutionId();
+	const modelResourceName = `projects/${deps.projectId}/locations/${deps.location}/publishers/google/models/${deps.modelName}`;
+
+	const fullDeps: PatchDeps = {
+		...deps,
+		executionId,
+		logger: ctx.logger,
+		modelResourceName,
+		workflowId,
+	};
+
+	const originalGenerate = model._generate.bind(model) as (
+		messages: BaseMessage[],
+		options: object,
+		runManager?: unknown,
+	) => Promise<ChatResult>;
+
+	const originalStream = model._streamResponseChunks.bind(model) as (
+		messages: BaseMessage[],
+		options: object,
+		runManager?: unknown,
+	) => AsyncGenerator<ChatGenerationChunk>;
+
+	model._generate = async (messages, options, runManager) => {
+		const plan = await resolveRunPlan(model, messages, options as object, fullDeps);
+		if (plan.type === 'warm') {
+			ctx.addExecutionHints(vertexContextCacheHitHint(plan.cacheName));
+			return await withCachedContentBinding(model, plan.cacheName, async () => {
+				return await originalGenerate(
+					stripSystemMessages(messages),
+					stripToolCallOptions(options as object),
+					runManager,
+				);
+			});
+		}
+		if (plan.type === 'cold_no_create') {
+			if (plan.executionHints?.length) ctx.addExecutionHints(...plan.executionHints);
+			return await originalGenerate(messages, options, runManager);
+		}
+
+		const pending: PendingCache = {
+			kind: 'pending',
+			startedAtIso: new Date().toISOString(),
+		};
+		const acquired = await fullDeps.metadataStorage.writeIfAbsent(plan.hash, pending, {
+			ttlSeconds: CONTEXT_CACHE_PENDING_METADATA_TTL_SECONDS,
+		});
+		if (acquired) {
+			scheduleContextCacheCreate(plan, ctx, fullDeps);
+		}
+
+		return await originalGenerate(messages, options, runManager);
+	};
+
+	model._streamResponseChunks = async function* (messages, options, runManager) {
+		const plan = await resolveRunPlan(model, messages, options as object, fullDeps);
+		if (plan.type === 'warm') {
+			ctx.addExecutionHints(vertexContextCacheHitHint(plan.cacheName));
+			yield* streamWithCachedContentBinding(
+				model,
+				plan.cacheName,
+				originalStream(
+					stripSystemMessages(messages),
+					stripToolCallOptions(options as object),
+					runManager,
+				),
+			);
+			return;
+		}
+		if (plan.type === 'cold_no_create') {
+			if (plan.executionHints?.length) ctx.addExecutionHints(...plan.executionHints);
+			yield* originalStream(messages, options, runManager);
+			return;
+		}
+
+		const pending: PendingCache = {
+			kind: 'pending',
+			startedAtIso: new Date().toISOString(),
+		};
+		const acquired = await fullDeps.metadataStorage.writeIfAbsent(plan.hash, pending, {
+			ttlSeconds: CONTEXT_CACHE_PENDING_METADATA_TTL_SECONDS,
+		});
+		if (acquired) {
+			scheduleContextCacheCreate(plan, ctx, fullDeps);
+		}
+
+		yield* originalStream(messages, options, runManager);
+	};
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/auto/compute-redis-metadata-ttl.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/auto/compute-redis-metadata-ttl.ts
@@ -1,0 +1,18 @@
+import { VERTEX_CONTEXT_CACHE_REDIS_METADATA_SAFETY_BUFFER_SEC } from './consts';
+import { parseExpireMs } from '../utils';
+
+/**
+ * Seconds until this Redis metadata key should expire: remaining Vertex cache life from "now",
+ * minus the create-request wall time (rounded up), minus {@link VERTEX_CONTEXT_CACHE_REDIS_METADATA_SAFETY_BUFFER_SEC}.
+ */
+export function computeRedisMetadataTtlSecondsForSuccess(input: {
+	createDurationMs: number;
+	expireTimeIso: string;
+}): number {
+	const expireMs = parseExpireMs(input.expireTimeIso);
+	const now = Date.now();
+	const remainingSec = Math.floor((expireMs - now) / 1000);
+	const createSec = Math.ceil(Math.max(0, input.createDurationMs) / 1000);
+	const raw = remainingSec - createSec - VERTEX_CONTEXT_CACHE_REDIS_METADATA_SAFETY_BUFFER_SEC;
+	return Math.max(1, raw);
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/auto/config-hash.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/auto/config-hash.ts
@@ -1,0 +1,35 @@
+import type { BaseMessage } from '@langchain/core/messages';
+import { createHash } from 'node:crypto';
+
+import { getFirstSystemMessagePlainText, stableStringify } from '../utils';
+
+export type InvocationParamsForHash = {
+	model?: string;
+	tools?: unknown;
+	tool_choice?: unknown;
+	allowed_function_names?: unknown;
+};
+
+export function buildHashPayload(
+	messages: BaseMessage[],
+	location: string,
+	params: InvocationParamsForHash,
+): Record<string, unknown> {
+	return {
+		allowed_function_names: params.allowed_function_names ?? null,
+		location,
+		model: params.model ?? '',
+		systemInstructionText: getFirstSystemMessagePlainText(messages),
+		tool_choice: params.tool_choice ?? null,
+		tools: params.tools ?? null,
+	};
+}
+
+export function computeConfigHash(
+	messages: BaseMessage[],
+	location: string,
+	params: InvocationParamsForHash,
+): string {
+	const payload = buildHashPayload(messages, location, params);
+	return createHash('sha256').update(stableStringify(payload)).digest('hex');
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/auto/consts.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/auto/consts.ts
@@ -1,0 +1,14 @@
+/** Shorter than Vertex cache expiry so Redis metadata is gone before the remote cache may be unusable. */
+export const VERTEX_CONTEXT_CACHE_REDIS_METADATA_SAFETY_BUFFER_SEC = 10;
+
+/** Redis TTL for `pending` metadata while `cachedContents.create` runs (cross-worker lock + stale cleanup). */
+export const CONTEXT_CACHE_PENDING_METADATA_TTL_SECONDS = 30;
+
+/** Skip automatic cache recreation for this hash until TTL elapses after CACHE_TOO_SHORT (seconds). */
+export const CACHE_TOO_SHORT_ERROR_TTL = 3600;
+
+/** Max chars for system-instruction preview in cache-create debug logs. */
+export const CACHE_CREATE_LOG_TEXT_MAX = 800;
+
+/** Max chars when logging API error response bodies. */
+export const GOOGLE_CONTEXT_CACHE_RESPONSE_PREVIEW_MAX_CHARS = 4000;

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/auto/context-cache-metadata.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/auto/context-cache-metadata.ts
@@ -1,0 +1,104 @@
+/**
+ * JSON document stored in Redis per config hash for Vertex auto context cache.
+ */
+
+export type ExistingContextCache = {
+	kind: 'existing';
+	cacheName: string;
+	/** Vertex cachedContents expiry (RFC3339). */
+	expireTime: string;
+	model: string;
+	location: string;
+};
+
+/** Context cannot be cached (e.g. Google minimum token count). */
+export type NotCacheable = {
+	kind: 'not_cacheable';
+	reason: 'CACHE_TOO_SHORT';
+	/** Do not retry cachedContents.create until this instant (ISO 8601). */
+	retryNotBeforeIso: string;
+};
+
+/** Another worker is creating cachedContents; callers must use uncached path. */
+export type PendingCache = {
+	kind: 'pending';
+	startedAtIso?: string;
+};
+
+export type ContextCacheMetadata = ExistingContextCache | NotCacheable | PendingCache;
+
+export function isExistingContextCache(m: ContextCacheMetadata): m is ExistingContextCache {
+	return m.kind === 'existing';
+}
+
+export function isNotCacheable(m: ContextCacheMetadata): m is NotCacheable {
+	return m.kind === 'not_cacheable';
+}
+
+export function isPendingCache(m: ContextCacheMetadata): m is PendingCache {
+	return m.kind === 'pending';
+}
+
+export function serializeContextCacheMetadata(meta: ContextCacheMetadata): string {
+	return JSON.stringify(meta);
+}
+
+/**
+ * Parses and validates a JSON string. Returns `null` if invalid or unknown shape.
+ */
+export function parseContextCacheMetadata(raw: string): ContextCacheMetadata | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw) as unknown;
+	} catch {
+		return null;
+	}
+
+	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+		return null;
+	}
+
+	const o = parsed as Record<string, unknown>;
+	const kind = o.kind;
+
+	if (kind === 'pending') {
+		if (o.startedAtIso !== undefined && typeof o.startedAtIso !== 'string') {
+			return null;
+		}
+		const out: PendingCache = { kind: 'pending' };
+		if (typeof o.startedAtIso === 'string') {
+			out.startedAtIso = o.startedAtIso;
+		}
+		return out;
+	}
+
+	if (kind === 'not_cacheable') {
+		if (o.reason !== 'CACHE_TOO_SHORT') return null;
+		if (typeof o.retryNotBeforeIso !== 'string') return null;
+		return {
+			kind: 'not_cacheable',
+			reason: 'CACHE_TOO_SHORT',
+			retryNotBeforeIso: o.retryNotBeforeIso,
+		};
+	}
+
+	if (kind === 'existing') {
+		if (
+			typeof o.cacheName !== 'string' ||
+			typeof o.expireTime !== 'string' ||
+			typeof o.model !== 'string' ||
+			typeof o.location !== 'string'
+		) {
+			return null;
+		}
+		return {
+			kind: 'existing',
+			cacheName: o.cacheName,
+			expireTime: o.expireTime,
+			model: o.model,
+			location: o.location,
+		};
+	}
+
+	return null;
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/auto/google-context-cache-api.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/auto/google-context-cache-api.ts
@@ -1,0 +1,169 @@
+import { getGoogleAccessToken } from 'n8n-nodes-base/dist/nodes/Google/GenericFunctions';
+import type {
+	IDataObject,
+	IHttpRequestMethods,
+	IRequestOptions,
+	ISupplyDataFunctions,
+	LogMetadata,
+} from 'n8n-workflow';
+
+import { GOOGLE_CONTEXT_CACHE_RESPONSE_PREVIEW_MAX_CHARS } from './consts';
+import { previewForLog } from '../utils';
+
+/** Base for Vertex `cachedContents.create` failures surfaced to callers. */
+export class GoogleContextCacheApiError extends Error {
+	readonly status?: number;
+
+	constructor(message: string, init?: { status?: number; cause?: unknown }) {
+		super(message, init?.cause !== undefined ? { cause: init.cause } : undefined);
+		this.name = 'GoogleContextCacheApiError';
+		this.status = init?.status;
+	}
+}
+
+/** Vertex returns 400 when cached payload is below the minimum token count for explicit caches. */
+export class CacheMinimumTokenCountError extends GoogleContextCacheApiError {
+	constructor(message: string, status = 400) {
+		super(message, { status });
+		this.name = 'CacheMinimumTokenCountError';
+	}
+}
+
+/** OAuth/access token missing before calling the cachedContents endpoint. */
+export class GoogleContextCacheAccessTokenMissingError extends GoogleContextCacheApiError {
+	constructor(message = 'Google access token missing for Vertex context cache create') {
+		super(message);
+		this.name = 'GoogleContextCacheAccessTokenMissingError';
+	}
+}
+
+/** API error response, unexpected body shape, or HTTP-layer failure (non–minimum-token cases). */
+export class GoogleContextCacheCreateRejectedError extends GoogleContextCacheApiError {
+	constructor(message: string, init?: { status?: number; cause?: unknown }) {
+		super(message, init);
+		this.name = 'GoogleContextCacheCreateRejectedError';
+	}
+}
+
+/** Local wait limit for cache creation so the model call is not blocked indefinitely. */
+export class GoogleContextCacheCreateTimeoutError extends GoogleContextCacheApiError {
+	constructor(message = 'Vertex context cache creation timed out; continuing without a cache.') {
+		super(message);
+		this.name = 'GoogleContextCacheCreateTimeoutError';
+	}
+}
+
+export type GoogleContextCacheCreateSuccess = { expireTime: string; name: string };
+
+function isVertexMinimumTokenCacheError(status: number | undefined, errorMessage: string): boolean {
+	if (status !== 400) return false;
+	return errorMessage.toLowerCase().includes('minimum token count');
+}
+
+function rejectFromStatusAndMessage(
+	status: number | undefined,
+	message: string,
+	cause?: unknown,
+): never {
+	if (isVertexMinimumTokenCacheError(status, message)) {
+		throw new CacheMinimumTokenCountError(message, status ?? 400);
+	}
+	throw new GoogleContextCacheCreateRejectedError(message, { status, cause });
+}
+
+function logGoogleContextCacheCreateFailure(
+	ctx: ISupplyDataFunctions,
+	meta: LogMetadata & { url: string },
+): void {
+	ctx.logger.debug('VertexContextCache: cachedContents create endpoint error', meta);
+}
+
+function googleContextCacheApiHost(location: string): string {
+	if (location === 'global') {
+		return 'aiplatform.googleapis.com';
+	}
+	return `${location}-aiplatform.googleapis.com`;
+}
+
+export async function createGoogleContextCache(
+	ctx: ISupplyDataFunctions,
+	credentials: IDataObject,
+	input: {
+		body: Record<string, unknown>;
+		location: string;
+		projectId: string;
+	},
+): Promise<GoogleContextCacheCreateSuccess> {
+	const host = googleContextCacheApiHost(input.location);
+	const url = `https://${host}/v1/projects/${input.projectId}/locations/${input.location}/cachedContents`;
+
+	const tokenResponse = await getGoogleAccessToken.call(ctx, credentials, 'vertex');
+	const accessToken = tokenResponse.access_token as string;
+	if (!accessToken) {
+		const errorMessage = 'Google access token missing for Vertex context cache create';
+		logGoogleContextCacheCreateFailure(ctx, { errorMessage, url });
+		throw new GoogleContextCacheAccessTokenMissingError(errorMessage);
+	}
+
+	const options: IRequestOptions = {
+		headers: {
+			Authorization: `Bearer ${accessToken}`,
+			'Content-Type': 'application/json',
+		},
+		json: true,
+		method: 'POST' as IHttpRequestMethods,
+		body: input.body,
+		uri: url,
+	};
+
+	try {
+		const response = (await ctx.helpers.request(options)) as {
+			name?: string;
+			expireTime?: string;
+			error?: { code?: number; message?: string; status?: string };
+		};
+
+		if (response?.name && response?.expireTime) {
+			return { expireTime: response.expireTime, name: response.name };
+		}
+
+		const msg =
+			response?.error?.message ??
+			'Vertex cachedContents create returned an unexpected response (missing name or expireTime)';
+		const status = typeof response?.error?.code === 'number' ? response.error.code : undefined;
+		logGoogleContextCacheCreateFailure(ctx, {
+			errorMessage: msg,
+			responsePreview: previewForLog(response, GOOGLE_CONTEXT_CACHE_RESPONSE_PREVIEW_MAX_CHARS),
+			status,
+			url,
+		});
+		rejectFromStatusAndMessage(status, msg);
+	} catch (caught) {
+		if (caught instanceof GoogleContextCacheApiError) {
+			throw caught;
+		}
+		const failure = caught as {
+			statusCode?: number;
+			message?: string;
+			error?: unknown;
+		};
+		const message =
+			typeof failure.error === 'object' &&
+			failure.error !== null &&
+			'message' in failure.error &&
+			typeof failure.error.message === 'string'
+				? (failure.error as { message: string }).message
+				: (failure.message ?? 'Vertex cachedContents create request failed');
+		const statusCode = failure.statusCode;
+		logGoogleContextCacheCreateFailure(ctx, {
+			errorMessage: message,
+			responsePreview: previewForLog(
+				failure.error,
+				GOOGLE_CONTEXT_CACHE_RESPONSE_PREVIEW_MAX_CHARS,
+			),
+			status: statusCode,
+			url,
+		});
+		rejectFromStatusAndMessage(statusCode, message, caught);
+	}
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/auto/hints.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/auto/hints.ts
@@ -1,0 +1,38 @@
+import type { NodeExecutionHint } from 'n8n-workflow';
+
+import { CACHE_TOO_SHORT_ERROR_TTL } from './consts';
+
+export function vertexContextCacheTooShortFirstHitHint(): NodeExecutionHint {
+	return {
+		location: 'outputPane',
+		message:
+			"Vertex context cache was not used: your system instruction and tool definitions are below Google's minimum token size for cached content. This execution continues without a content cache. Use a longer system message, richer tool schemas, or the Predefined cache strategy.",
+		type: 'warning',
+	};
+}
+
+export function vertexContextCacheTooShortFromStoreHint(): NodeExecutionHint {
+	const minutes = Math.max(1, Math.round(CACHE_TOO_SHORT_ERROR_TTL / 60));
+	return {
+		location: 'outputPane',
+		message: `Vertex context cache was not used for this configuration: it was too small to cache in a recent run. Automatic cache creation is paused for about ${minutes} minutes. This execution runs without a content cache. Use a longer system message or larger tool definitions, or use the Predefined cache strategy.`,
+		type: 'warning',
+	};
+}
+
+export function vertexContextCacheCreateFailedHint(errorMessage: string): NodeExecutionHint {
+	return {
+		location: 'outputPane',
+		message: `Vertex context cache could not be created (${errorMessage}). This execution continues without using a content cache.`,
+		type: 'warning',
+	};
+}
+
+/** @param cacheResourceName Full Vertex `cachedContents` resource name from Google (not displayName). */
+export function vertexContextCacheHitHint(cacheResourceName: string): NodeExecutionHint {
+	return {
+		location: 'outputPane',
+		message: `Vertex context cache was used for this execution (reused cached content from a previous run). Cached content resource: ${cacheResourceName}`,
+		type: 'info',
+	};
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/auto/storage/context-cache-metadata-storage.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/auto/storage/context-cache-metadata-storage.ts
@@ -1,0 +1,26 @@
+import type { ContextCacheMetadata } from '../context-cache-metadata';
+
+export type ContextCacheMetadataTtlOptions = {
+	ttlSeconds: number;
+};
+
+/**
+ * Persists {@link ContextCacheMetadata} per config hash (e.g. Redis key = prefix + hash).
+ */
+export interface ContextCacheMetadataStorage {
+	read(hash: string): Promise<ContextCacheMetadata | null>;
+	write(
+		hash: string,
+		metadata: ContextCacheMetadata,
+		options: ContextCacheMetadataTtlOptions,
+	): Promise<void>;
+	/**
+	 * Writes only if no value is present (`SET NX`). Returns whether this call installed the value.
+	 */
+	writeIfAbsent(
+		hash: string,
+		metadata: ContextCacheMetadata,
+		options: ContextCacheMetadataTtlOptions,
+	): Promise<boolean>;
+	delete(hash: string): Promise<void>;
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/auto/storage/redis.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/auto/storage/redis.ts
@@ -1,0 +1,151 @@
+import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
+import { createClient, type RedisClientOptions } from 'redis';
+
+import {
+	type ContextCacheMetadata,
+	parseContextCacheMetadata,
+	serializeContextCacheMetadata,
+} from '../context-cache-metadata';
+import type {
+	ContextCacheMetadataStorage,
+	ContextCacheMetadataTtlOptions,
+} from './context-cache-metadata-storage';
+
+/** Matches `createClient()` return type without pinning Redis module generics. */
+type RedisClientInstance = ReturnType<typeof createClient>;
+
+const REDIS_KEY_SEGMENT_MAX = 200;
+
+function sanitizeKeySegment(value: string, fallback: string): string {
+	const cleaned = value.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, REDIS_KEY_SEGMENT_MAX);
+	return cleaned.length > 0 ? cleaned : fallback;
+}
+
+function sanitizeHashSegment(hash: string): string {
+	const h = hash.replace(/[^a-fA-F0-9]/g, '').slice(0, 128);
+	return h.length > 0 ? h : 'invalid';
+}
+
+/**
+ * Namespace segment: `{userPrefix}:{workflowId}:{parentNodeId}`.
+ * Full Redis key: `{baseKey}:{hash}`.
+ */
+export function buildVertexContextCacheRedisBaseKey(
+	userPrefix: string,
+	workflowId: string,
+	parentNodeId: string,
+): string {
+	const p = userPrefix.trim();
+	const wf = sanitizeKeySegment(workflowId, 'unknown');
+	const par = sanitizeKeySegment(parentNodeId, 'unknown');
+	return `${p}:${wf}:${par}`;
+}
+
+function redisKeyForHash(baseKey: string, hash: string): string {
+	return `${baseKey}:${sanitizeHashSegment(hash)}`;
+}
+
+async function quitRedisClientSafely(client: RedisClientInstance): Promise<void> {
+	try {
+		await client.quit();
+	} catch {
+		await client.disconnect();
+	}
+}
+
+export async function connectRedisClientForVertexCache(
+	credentials: ICredentialDataDecryptedObject,
+	nodeTypeVersion: number,
+): Promise<RedisClientInstance> {
+	const options: RedisClientOptions = {
+		socket: {
+			host: credentials.host as string,
+			port: credentials.port as number,
+			tls: credentials.ssl === true,
+		},
+		database: credentials.database as number,
+	};
+
+	if (credentials.user && nodeTypeVersion >= 1.5) {
+		options.username = credentials.user as string;
+	}
+	if (credentials.password) {
+		options.password = credentials.password as string;
+	}
+
+	const client = createClient(options);
+	await client.connect();
+	return client;
+}
+
+/**
+ * Redis-backed {@link ContextCacheMetadataStorage}. Opens a connection per operation and closes it
+ * in `finally`, so metadata writes cannot race with supply teardown of a shared client.
+ */
+export class RedisContextCacheMetadataStorage implements ContextCacheMetadataStorage {
+	constructor(
+		private readonly credentials: ICredentialDataDecryptedObject,
+		private readonly nodeTypeVersion: number,
+		private readonly baseKey: string,
+	) {}
+
+	private key(hash: string): string {
+		return redisKeyForHash(this.baseKey, hash);
+	}
+
+	private async withClient<T>(fn: (client: RedisClientInstance) => Promise<T>): Promise<T> {
+		const client = await connectRedisClientForVertexCache(this.credentials, this.nodeTypeVersion);
+		try {
+			return await fn(client);
+		} finally {
+			await quitRedisClientSafely(client);
+		}
+	}
+
+	async delete(hash: string): Promise<void> {
+		await this.withClient(async (client) => {
+			await client.del(this.key(hash));
+		});
+	}
+
+	async read(hash: string): Promise<ContextCacheMetadata | null> {
+		return await this.withClient(async (client) => {
+			const raw = await client.get(this.key(hash));
+			if (raw === null) {
+				return null;
+			}
+			const meta = parseContextCacheMetadata(raw);
+			if (meta === null) {
+				await client.del(this.key(hash));
+				return null;
+			}
+			return meta;
+		});
+	}
+
+	async write(
+		hash: string,
+		metadata: import('../context-cache-metadata').ContextCacheMetadata,
+		options: ContextCacheMetadataTtlOptions,
+	): Promise<void> {
+		const ttl = Math.max(1, Math.floor(options.ttlSeconds));
+		await this.withClient(async (client) => {
+			await client.set(this.key(hash), serializeContextCacheMetadata(metadata), { EX: ttl });
+		});
+	}
+
+	async writeIfAbsent(
+		hash: string,
+		metadata: ContextCacheMetadata,
+		options: ContextCacheMetadataTtlOptions,
+	): Promise<boolean> {
+		const ttl = Math.max(1, Math.floor(options.ttlSeconds));
+		return await this.withClient(async (client) => {
+			const reply = await client.set(this.key(hash), serializeContextCacheMetadata(metadata), {
+				EX: ttl,
+				NX: true,
+			});
+			return reply !== null;
+		});
+	}
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/auto/vertex-context-cache.auto.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/auto/vertex-context-cache.auto.test.ts
@@ -1,0 +1,447 @@
+/**
+ * Vertex auto context cache — behaviour covered by this file:
+ * - Cold path creates metadata (TTL in Google body); fire-and-forget create.
+ * - Warm path reuses metadata (no second create).
+ * - Expired metadata dropped then create again.
+ * - CACHE_TOO_SHORT → not_cacheable; next run skips create until window expires.
+ * - Human-only cold path: no create, storage unchanged for that hash.
+ * - Create failure (non too-short): metadata key removed so next run can retry.
+ * - Parallel cold paths: at most one Google create (writeIfAbsent).
+ * - While pending, subsequent runs use uncached path without scheduling another create.
+ */
+import type { BaseMessage } from '@langchain/core/messages';
+import type { ChatVertexAI } from '@langchain/google-vertexai';
+import type { INode, ISupplyDataFunctions } from 'n8n-workflow';
+
+import { applyVertexAutoContextCachePatch } from './auto-cache';
+import { computeConfigHash, type InvocationParamsForHash } from './config-hash';
+import {
+	type ContextCacheMetadata,
+	parseContextCacheMetadata,
+	serializeContextCacheMetadata,
+} from './context-cache-metadata';
+import { CacheMinimumTokenCountError, createGoogleContextCache } from './google-context-cache-api';
+import type { ContextCacheMetadataStorage } from './storage/context-cache-metadata-storage';
+
+jest.mock('./google-context-cache-api', () => ({
+	...jest.requireActual<typeof import('./google-context-cache-api')>('./google-context-cache-api'),
+	createGoogleContextCache: jest.fn(),
+}));
+
+const mockedCreateGoogleContextCache = jest.mocked(createGoogleContextCache);
+
+/** Lets scheduled `void (async () => { ... create ... })()` finish in tests. */
+async function flushBackgroundWork(): Promise<void> {
+	await new Promise<void>((resolve) => {
+		setImmediate(resolve);
+	});
+	await new Promise<void>((resolve) => {
+		setImmediate(resolve);
+	});
+}
+
+function createInMemoryMetadataStorage(
+	initial?: Record<string, ContextCacheMetadata>,
+): ContextCacheMetadataStorage {
+	const map = new Map<string, { expiresAtMs: number; meta: ContextCacheMetadata }>();
+
+	if (initial) {
+		for (const [h, meta] of Object.entries(initial)) {
+			map.set(h, { expiresAtMs: Date.now() + 86_400_000, meta });
+		}
+	}
+
+	return {
+		async delete(hash: string) {
+			map.delete(hash);
+		},
+		async read(hash: string) {
+			const row = map.get(hash);
+			if (!row) return null;
+			if (Date.now() >= row.expiresAtMs) {
+				map.delete(hash);
+				return null;
+			}
+			return row.meta;
+		},
+		async write(hash: string, meta: ContextCacheMetadata, options: { ttlSeconds: number }) {
+			map.set(hash, {
+				expiresAtMs: Date.now() + Math.max(1, options.ttlSeconds) * 1000,
+				meta,
+			});
+		},
+		async writeIfAbsent(hash: string, meta: ContextCacheMetadata, options: { ttlSeconds: number }) {
+			const row = map.get(hash);
+			const now = Date.now();
+			if (row !== undefined && now < row.expiresAtMs) {
+				return false;
+			}
+			map.set(hash, {
+				expiresAtMs: now + Math.max(1, options.ttlSeconds) * 1000,
+				meta,
+			});
+			return true;
+		},
+	};
+}
+
+const mockNodeForCache: INode = {
+	id: 'vertex-model-node',
+	name: 'Google Vertex Chat Model',
+	type: 'n8n-nodes-langchain.lmChatGoogleVertex',
+	typeVersion: 1,
+	position: [0, 0],
+	parameters: {},
+};
+
+const parentNodeId = 'parent1';
+const projectId = 'p';
+const location = 'us-central1';
+const modelName = 'gemini-2.5-flash';
+const modelResourceName = `projects/${projectId}/locations/${location}/publishers/google/models/${modelName}`;
+
+const systemAndUserMessages = [
+	{ content: 'stable system prompt', type: 'system' },
+	{ content: 'hello', type: 'human' },
+] as unknown as BaseMessage[];
+
+const humanOnlyMessages = [{ content: 'hello', type: 'human' }] as unknown as BaseMessage[];
+
+const paramsWithTools: InvocationParamsForHash = {
+	allowed_function_names: ['math'],
+	model: modelResourceName,
+	tool_choice: 'auto',
+	tools: [{ functionDeclarations: [{ name: 'math' }] }],
+};
+
+const paramsNoTools: InvocationParamsForHash = {
+	model: modelResourceName,
+};
+
+type PatchedModel = ChatVertexAI & {
+	_generate: jest.Mock;
+	invocationParams: jest.Mock;
+};
+
+function createModel(
+	invocationParamsReturn: InvocationParamsForHash,
+	innerGenerate?: jest.Mock,
+): PatchedModel {
+	return {
+		_generate: innerGenerate ?? jest.fn().mockResolvedValue({ generations: [] }),
+		_streamResponseChunks: jest.fn(),
+		invocationParams: jest.fn().mockReturnValue(invocationParamsReturn),
+	} as unknown as PatchedModel;
+}
+
+function createContext(): jest.Mocked<ISupplyDataFunctions> {
+	return {
+		addExecutionHints: jest.fn(),
+		getExecutionId: jest.fn().mockReturnValue('exec-1'),
+		getNode: jest.fn().mockReturnValue(mockNodeForCache),
+		getWorkflow: jest.fn().mockReturnValue({ id: 'wf-1' }),
+		logger: { debug: jest.fn() },
+	} as unknown as jest.Mocked<ISupplyDataFunctions>;
+}
+
+function applyPatch(
+	model: PatchedModel,
+	ctx: jest.Mocked<ISupplyDataFunctions>,
+	metadataStorage: ContextCacheMetadataStorage,
+	ttl = 86400,
+) {
+	applyVertexAutoContextCachePatch(model, ctx, {
+		contextCacheTtlSeconds: ttl,
+		credentials: {},
+		location,
+		metadataStorage,
+		modelName,
+		parentNodeId,
+		projectId,
+	});
+}
+
+describe('context-cache-metadata JSON', () => {
+	it('round-trips existing / not_cacheable / pending', () => {
+		const samples: ContextCacheMetadata[] = [
+			{
+				kind: 'existing',
+				cacheName: 'projects/x/locations/y/cachedContents/z',
+				expireTime: '2099-01-01T00:00:00.000Z',
+				location: 'us-central1',
+				model: modelResourceName,
+			},
+			{
+				kind: 'not_cacheable',
+				reason: 'CACHE_TOO_SHORT',
+				retryNotBeforeIso: '2099-01-01T00:00:00.000Z',
+			},
+			{ kind: 'pending', startedAtIso: '2024-01-01T00:00:00.000Z' },
+			{ kind: 'pending' },
+		];
+		for (const s of samples) {
+			expect(parseContextCacheMetadata(serializeContextCacheMetadata(s))).toEqual(s);
+		}
+	});
+
+	it('rejects invalid JSON and unknown kinds', () => {
+		expect(parseContextCacheMetadata('')).toBeNull();
+		expect(parseContextCacheMetadata('{"kind":"nope"}')).toBeNull();
+		expect(parseContextCacheMetadata('{"kind":"not_cacheable"}')).toBeNull();
+	});
+});
+
+describe('Vertex auto context cache', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockedCreateGoogleContextCache.mockResolvedValue({
+			expireTime: '2099-01-01T00:00:00.000Z',
+			name: 'projects/p/locations/us-central1/cachedContents/new-cache',
+		});
+	});
+
+	describe('cold hash: create + persist with TTL in request body', () => {
+		it('calls Google create and stores existing metadata for the config hash', async () => {
+			const metadataStorage = createInMemoryMetadataStorage();
+			const ctx = createContext();
+			const ttl = 7200;
+			const model = createModel(paramsWithTools);
+			applyPatch(model, ctx, metadataStorage, ttl);
+
+			await model._generate(systemAndUserMessages, {
+				allowed_function_names: ['math'],
+				tool_choice: 'auto',
+				tools: paramsWithTools.tools,
+			});
+			await flushBackgroundWork();
+
+			expect(mockedCreateGoogleContextCache).toHaveBeenCalledTimes(1);
+			const body = mockedCreateGoogleContextCache.mock.calls[0][2].body;
+			expect(body.ttl).toBe(`${ttl}s`);
+
+			const hash = computeConfigHash(systemAndUserMessages, location, paramsWithTools);
+			const meta = await metadataStorage.read(hash);
+			expect(meta?.kind).toBe('existing');
+			if (meta?.kind === 'existing') {
+				expect(meta.cacheName).toContain('new-cache');
+			}
+		});
+	});
+
+	describe('warm: reuse stored cache, no new create', () => {
+		it('does not call create when a non-expired existing entry matches the hash', async () => {
+			const hash = computeConfigHash(systemAndUserMessages, location, paramsWithTools);
+			const warmName = 'projects/p/locations/us-central1/cachedContents/warm-cache';
+			const metadataStorage = createInMemoryMetadataStorage({
+				[hash]: {
+					kind: 'existing',
+					cacheName: warmName,
+					expireTime: '2099-01-01T00:00:00.000Z',
+					location,
+					model: modelResourceName,
+				},
+			});
+			const ctx = createContext();
+			const innerGenerate = jest.fn().mockResolvedValue({ generations: [] });
+			const model = createModel(paramsWithTools, innerGenerate);
+			applyPatch(model, ctx, metadataStorage);
+
+			await model._generate(systemAndUserMessages, {
+				allowed_function_names: ['math'],
+				tool_choice: 'auto',
+				tools: paramsWithTools.tools,
+			});
+
+			expect(mockedCreateGoogleContextCache).not.toHaveBeenCalled();
+			expect(innerGenerate).toHaveBeenCalledWith(
+				[{ content: 'hello', type: 'human' }],
+				{},
+				undefined,
+			);
+			expect(ctx.addExecutionHints).toHaveBeenCalledWith(
+				expect.objectContaining({
+					message: expect.stringContaining(warmName),
+					type: 'info',
+				}),
+			);
+		});
+	});
+
+	describe('expired success: create again', () => {
+		it('calls create after dropping an expired existing entry for the same hash', async () => {
+			const hash = computeConfigHash(systemAndUserMessages, location, paramsWithTools);
+			const metadataStorage = createInMemoryMetadataStorage({
+				[hash]: {
+					kind: 'existing',
+					cacheName: 'projects/p/locations/us-central1/cachedContents/old-cache',
+					expireTime: '2000-01-01T00:00:00.000Z',
+					location,
+					model: modelResourceName,
+				},
+			});
+			const ctx = createContext();
+			const model = createModel(paramsWithTools);
+			applyPatch(model, ctx, metadataStorage);
+
+			await model._generate(systemAndUserMessages, {
+				allowed_function_names: ['math'],
+				tool_choice: 'auto',
+				tools: paramsWithTools.tools,
+			});
+			await flushBackgroundWork();
+
+			expect(mockedCreateGoogleContextCache).toHaveBeenCalledTimes(1);
+			const meta = await metadataStorage.read(hash);
+			expect(meta?.kind).toBe('existing');
+			if (meta?.kind === 'existing') {
+				expect(meta.cacheName).toContain('new-cache');
+			}
+		});
+	});
+
+	describe('minimum token count: persist not_cacheable; later run skips create', () => {
+		it('stores not_cacheable per hash and avoids create on the next run', async () => {
+			const metadataStorage = createInMemoryMetadataStorage();
+			const ctx = createContext();
+			const model = createModel(paramsWithTools);
+			applyPatch(model, ctx, metadataStorage);
+
+			mockedCreateGoogleContextCache.mockRejectedValueOnce(
+				new CacheMinimumTokenCountError(
+					'The cached content is of 2 tokens. The minimum token count to start caching is 1024.',
+					400,
+				),
+			);
+
+			await model._generate(systemAndUserMessages, {
+				allowed_function_names: ['math'],
+				tool_choice: 'auto',
+				tools: paramsWithTools.tools,
+			});
+			await flushBackgroundWork();
+
+			const hash = computeConfigHash(systemAndUserMessages, location, paramsWithTools);
+			const meta = await metadataStorage.read(hash);
+			expect(meta?.kind).toBe('not_cacheable');
+
+			jest.clearAllMocks();
+			const innerGenerate = jest.fn().mockResolvedValue({ generations: [] });
+			const model2 = createModel(paramsWithTools, innerGenerate);
+			applyPatch(model2, ctx, metadataStorage);
+
+			await model2._generate(systemAndUserMessages, {
+				allowed_function_names: ['math'],
+				tool_choice: 'auto',
+				tools: paramsWithTools.tools,
+			});
+
+			expect(mockedCreateGoogleContextCache).not.toHaveBeenCalled();
+			expect(ctx.addExecutionHints).toHaveBeenCalled();
+			expect(innerGenerate).toHaveBeenCalledWith(
+				systemAndUserMessages,
+				expect.any(Object),
+				undefined,
+			);
+		});
+	});
+
+	describe('human-only cold path', () => {
+		it('does not call create when there is no cacheable context and storage is empty', async () => {
+			const metadataStorage = createInMemoryMetadataStorage();
+			const ctx = createContext();
+			const innerGenerate = jest.fn().mockResolvedValue({ generations: [] });
+			const model = createModel(paramsNoTools, innerGenerate);
+			applyPatch(model, ctx, metadataStorage);
+
+			await model._generate(humanOnlyMessages, {});
+
+			expect(mockedCreateGoogleContextCache).not.toHaveBeenCalled();
+			const hash = computeConfigHash(humanOnlyMessages, location, paramsNoTools);
+			expect(await metadataStorage.read(hash)).toBeNull();
+		});
+	});
+
+	describe('create failure: model still generates with full messages (no cache path)', () => {
+		it('runs original generate with full messages when create throws', async () => {
+			const metadataStorage = createInMemoryMetadataStorage();
+			const ctx = createContext();
+			mockedCreateGoogleContextCache.mockRejectedValue(new Error('network down'));
+			const innerGenerate = jest.fn().mockResolvedValue({ generations: [] });
+			const model = createModel(paramsWithTools, innerGenerate);
+			applyPatch(model, ctx, metadataStorage);
+
+			const options = {
+				allowed_function_names: ['math'],
+				tool_choice: 'auto',
+				tools: paramsWithTools.tools,
+			};
+			await model._generate(systemAndUserMessages, options);
+			await flushBackgroundWork();
+
+			expect(innerGenerate).toHaveBeenCalledWith(systemAndUserMessages, options, undefined);
+			expect(ctx.addExecutionHints).toHaveBeenCalled();
+		});
+	});
+
+	describe('parallel cold paths', () => {
+		it('runs at most one Google create for the same hash', async () => {
+			const metadataStorage = createInMemoryMetadataStorage();
+			const ctx = createContext();
+			let resolveCreate!: () => void;
+			const createGate = new Promise<void>((r) => {
+				resolveCreate = r;
+			});
+			mockedCreateGoogleContextCache.mockImplementation(() =>
+				createGate.then(() =>
+					Promise.resolve({
+						expireTime: '2099-01-01T00:00:00.000Z',
+						name: 'projects/p/locations/us-central1/cachedContents/shared',
+					}),
+				),
+			);
+
+			const inner = jest.fn().mockResolvedValue({ generations: [] });
+			const modelA = createModel(paramsWithTools, inner);
+			const modelB = createModel(paramsWithTools, inner);
+			applyPatch(modelA, ctx, metadataStorage);
+			applyPatch(modelB, ctx, metadataStorage);
+
+			const opts = {
+				allowed_function_names: ['math'] as string[],
+				tool_choice: 'auto',
+				tools: paramsWithTools.tools,
+			};
+			const g1 = modelA._generate(systemAndUserMessages, opts);
+			const g2 = modelB._generate(systemAndUserMessages, opts);
+			await Promise.all([g1, g2]);
+
+			expect(mockedCreateGoogleContextCache).toHaveBeenCalledTimes(1);
+
+			resolveCreate();
+			await flushBackgroundWork();
+
+			const hash = computeConfigHash(systemAndUserMessages, location, paramsWithTools);
+			expect((await metadataStorage.read(hash))?.kind).toBe('existing');
+		});
+	});
+
+	describe('pending metadata', () => {
+		it('skips scheduling another create while pending', async () => {
+			const hash = computeConfigHash(systemAndUserMessages, location, paramsWithTools);
+			const metadataStorage = createInMemoryMetadataStorage({
+				[hash]: { kind: 'pending' },
+			});
+			const ctx = createContext();
+			const model = createModel(paramsWithTools);
+			applyPatch(model, ctx, metadataStorage);
+
+			await model._generate(systemAndUserMessages, {
+				allowed_function_names: ['math'],
+				tool_choice: 'auto',
+				tools: paramsWithTools.tools,
+			});
+
+			expect(mockedCreateGoogleContextCache).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/predefined/consts.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/predefined/consts.ts
@@ -1,0 +1,3 @@
+/** User-visible message when predefined cache caused workflow system messages to be omitted. */
+export const PREDEFINED_CACHE_IGNORED_SYSTEM_MESSAGE =
+	'Predefined Vertex context cache is active: workflow system instructions were not sent to the model; the cached content supplies that context instead.';

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/predefined/hints.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/predefined/hints.ts
@@ -1,0 +1,11 @@
+import type { NodeExecutionHint } from 'n8n-workflow';
+
+import { PREDEFINED_CACHE_IGNORED_SYSTEM_MESSAGE } from './consts';
+
+export function vertexContextCachePredefinedIgnoredSystemHint(): NodeExecutionHint {
+	return {
+		location: 'outputPane',
+		message: PREDEFINED_CACHE_IGNORED_SYSTEM_MESSAGE,
+		type: 'warning',
+	};
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/predefined/predefined-context-cache-patch.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/predefined/predefined-context-cache-patch.ts
@@ -1,0 +1,71 @@
+import type { BaseMessage } from '@langchain/core/messages';
+import type { ChatGenerationChunk, ChatResult } from '@langchain/core/outputs';
+import type { ChatVertexAI } from '@langchain/google-vertexai';
+import type { ISupplyDataFunctions } from 'n8n-workflow';
+
+import { vertexContextCachePredefinedIgnoredSystemHint } from './hints';
+import { stripSystemMessages, stripToolCallOptions } from '../utils';
+
+function hasSystemMessage(messages: BaseMessage[]): boolean {
+	return messages.some((m) => m.type === 'system');
+}
+
+/**
+ * Merges `cachedContent`, strips tools from invocation params, and strips system messages from
+ * each generate/stream call (matching auto-cache warm behavior). Warns when workflow system
+ * messages would have been sent.
+ */
+export function applyPredefinedVertexContextCachePatch(
+	model: ChatVertexAI,
+	ctx: ISupplyDataFunctions,
+	cacheResourceName: string,
+): void {
+	const originalInvocationParams = model.invocationParams.bind(model);
+	model.invocationParams = (callOptions) => {
+		const merged = originalInvocationParams(callOptions) as Record<string, unknown>;
+		const next: Record<string, unknown> = { ...merged };
+		delete next.tools;
+		delete next.tool_choice;
+		delete next.allowed_function_names;
+		next.cachedContent = cacheResourceName;
+		return next;
+	};
+
+	const originalGenerate = model._generate?.bind(model) as
+		| ((messages: BaseMessage[], options: object, runManager?: unknown) => Promise<ChatResult>)
+		| undefined;
+
+	if (typeof originalGenerate === 'function') {
+		model._generate = async (messages, options, runManager) => {
+			if (hasSystemMessage(messages)) {
+				ctx.addExecutionHints(vertexContextCachePredefinedIgnoredSystemHint());
+			}
+			return await originalGenerate(
+				stripSystemMessages(messages),
+				stripToolCallOptions(options as object),
+				runManager,
+			);
+		};
+	}
+
+	const originalStream = model._streamResponseChunks?.bind(model) as
+		| ((
+				messages: BaseMessage[],
+				options: object,
+				runManager?: unknown,
+		  ) => AsyncGenerator<ChatGenerationChunk>)
+		| undefined;
+
+	if (typeof originalStream === 'function') {
+		model._streamResponseChunks = async function* (messages, options, runManager) {
+			if (hasSystemMessage(messages)) {
+				ctx.addExecutionHints(vertexContextCachePredefinedIgnoredSystemHint());
+			}
+			yield* originalStream(
+				stripSystemMessages(messages),
+				stripToolCallOptions(options as object),
+				runManager,
+			);
+		};
+	}
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/context-caching/utils.ts
@@ -1,0 +1,68 @@
+import type { BaseMessage } from '@langchain/core/messages';
+
+/**
+ * Deterministic JSON.stringify for hashing (sorted object keys recursively).
+ */
+export function stableStringify(value: unknown): string {
+	if (value === null || typeof value !== 'object') {
+		return JSON.stringify(value);
+	}
+	if (Array.isArray(value)) {
+		return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+	}
+	const obj = value as Record<string, unknown>;
+	const keys = Object.keys(obj).sort();
+	return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(',')}}`;
+}
+
+export function previewForLog(value: unknown, maxLength: number): string {
+	if (value === null || value === undefined) return '';
+	if (typeof value === 'string') {
+		return value.length <= maxLength ? value : `${value.slice(0, maxLength)}…`;
+	}
+	try {
+		const s = JSON.stringify(value);
+		return s.length <= maxLength ? s : `${s.slice(0, maxLength)}…`;
+	} catch {
+		return '[unserializable]';
+	}
+}
+
+export function stripSystemMessages(messages: BaseMessage[]): BaseMessage[] {
+	return messages.filter((m) => m.type !== 'system');
+}
+
+export function stripToolCallOptions<T extends object>(options: T): T {
+	const next = { ...options } as Record<string, unknown>;
+	delete next.tools;
+	delete next.tool_choice;
+	delete next.allowed_function_names;
+	return next as T;
+}
+
+export function parseExpireMs(expireTime: string): number {
+	const t = Date.parse(expireTime);
+	return Number.isFinite(t) ? t : 0;
+}
+
+/** Plain text from the first system message (for hashing and cache body building). */
+export function getFirstSystemMessagePlainText(messages: BaseMessage[]): string {
+	const systemMessage = messages.find((message) => message.type === 'system');
+	if (!systemMessage) {
+		return '';
+	}
+	if (typeof systemMessage.content === 'string') {
+		return systemMessage.content;
+	}
+	if (Array.isArray(systemMessage.content)) {
+		return systemMessage.content
+			.map((part) => {
+				if (part && typeof part === 'object' && 'text' in part) {
+					return String((part as { text?: string }).text ?? '');
+				}
+				return '';
+			})
+			.join('');
+	}
+	return JSON.stringify(systemMessage.content);
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/test/LmChatGoogleVertex.context-cache.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/test/LmChatGoogleVertex.context-cache.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Google Vertex Chat Model — predefined cache wiring & auto-cache supplyData:
+ * - Predefined: passes cache resource name into `cachedContent`; strips tools from invocationParams;
+ *   strips system messages in `_generate` with a warning hint when present.
+ * - Auto: applies auto-cache patch whenever strategy is auto (any execution mode).
+ */
+import { ChatVertexAI } from '@langchain/google-vertexai';
+import { makeN8nLlmFailedAttemptHandler, N8nLlmTracing } from '@n8n/ai-utilities';
+import { createMockExecuteFunction } from 'n8n-nodes-base/test/nodes/Helpers';
+import { NodeOperationError, type INode, type ISupplyDataFunctions } from 'n8n-workflow';
+
+import { applyVertexAutoContextCachePatch } from '../context-caching/auto/auto-cache';
+import { vertexContextCachePredefinedIgnoredSystemHint } from '../context-caching/predefined/hints';
+import { LmChatGoogleVertex } from '../LmChatGoogleVertex.node';
+
+jest.mock('@langchain/google-vertexai');
+jest.mock('@n8n/ai-utilities');
+jest.mock('redis', () => {
+	const connect = jest.fn().mockResolvedValue(undefined);
+	const quit = jest.fn().mockResolvedValue(undefined);
+	const disconnect = jest.fn().mockResolvedValue(undefined);
+	return {
+		createClient: jest.fn(() => ({
+			connect,
+			del: jest.fn().mockResolvedValue(0),
+			disconnect,
+			get: jest.fn().mockResolvedValue(null),
+			quit,
+			set: jest.fn().mockResolvedValue('OK'),
+		})),
+	};
+});
+jest.mock('../context-caching/auto/auto-cache', () => ({
+	...jest.requireActual<typeof import('../context-caching/auto/auto-cache')>(
+		'../context-caching/auto/auto-cache',
+	),
+	applyVertexAutoContextCachePatch: jest.fn(),
+}));
+jest.mock('n8n-nodes-base/dist/utils/utilities', () => ({
+	formatPrivateKey: jest.fn().mockImplementation((key: string) => key),
+}));
+
+const MockedChatVertexAI = jest.mocked(ChatVertexAI);
+const MockedN8nLlmTracing = jest.mocked(N8nLlmTracing);
+const mockedMakeN8nLlmFailedAttemptHandler = jest.mocked(makeN8nLlmFailedAttemptHandler);
+const mockedApplyVertexAutoContextCachePatch = jest.mocked(applyVertexAutoContextCachePatch);
+
+let lastMockedInvocationParams: jest.Mock;
+
+describe('LmChatGoogleVertex — context cache', () => {
+	let lmChatGoogleVertex: LmChatGoogleVertex;
+	let mockContext: jest.Mocked<ISupplyDataFunctions>;
+
+	const mockNode: INode = {
+		id: '1',
+		name: 'Google Vertex Chat Model',
+		typeVersion: 1,
+		type: 'n8n-nodes-langchain.lmChatGoogleVertex',
+		position: [0, 0],
+		parameters: {},
+	};
+
+	const setupMockContext = () => {
+		mockContext = createMockExecuteFunction<ISupplyDataFunctions>(
+			{},
+			mockNode,
+		) as jest.Mocked<ISupplyDataFunctions>;
+
+		mockContext.getCredentials = jest.fn().mockImplementation((type: string) => {
+			if (type === 'googleApi') {
+				return Promise.resolve({
+					privateKey: 'test-private-key',
+					email: 'test@n8n.io',
+					region: 'us-central1',
+				});
+			}
+			if (type === 'redis') {
+				return Promise.resolve({
+					database: 0,
+					host: 'localhost',
+					port: 6379,
+					password: '',
+					ssl: false,
+				});
+			}
+			return Promise.reject(new Error(`Unexpected credential: ${type}`));
+		});
+		mockContext.getNode = jest.fn().mockReturnValue(mockNode);
+		mockContext.getNodeParameter = jest.fn();
+		mockContext.addExecutionHints = jest.fn();
+		mockContext.getMode = jest.fn().mockReturnValue('trigger');
+		mockContext.logger = { debug: jest.fn(), error: jest.fn(), info: jest.fn(), warn: jest.fn() };
+
+		MockedN8nLlmTracing.mockImplementation(() => ({}) as unknown as N8nLlmTracing);
+		mockedMakeN8nLlmFailedAttemptHandler.mockReturnValue(jest.fn());
+
+		return mockContext;
+	};
+
+	beforeEach(() => {
+		lmChatGoogleVertex = new LmChatGoogleVertex();
+		jest.clearAllMocks();
+		MockedChatVertexAI.mockImplementation(() => {
+			lastMockedInvocationParams = jest.fn().mockReturnValue({ fromOriginal: true });
+			return {
+				invocationParams: lastMockedInvocationParams,
+			} as unknown as ChatVertexAI;
+		});
+	});
+
+	const baseOptions = {
+		maxOutputTokens: 2048,
+		temperature: 0.4,
+		topK: 40,
+		topP: 0.9,
+	};
+
+	describe('Manual / predefined cache', () => {
+		it('uses the trimmed cache resource name as cachedContent', async () => {
+			const ctx = setupMockContext();
+			const cacheResource = 'projects/123/locations/us-central1/cachedContents/my-cache';
+
+			ctx.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'modelName') return 'gemini-2.5-flash';
+				if (paramName === 'projectId') return 'test-project';
+				if (paramName === 'contextCacheStrategy') return 'predefined';
+				if (paramName === 'contextCacheName') return `  ${cacheResource}  `;
+				if (paramName === 'options') return baseOptions;
+				if (paramName === 'options.safetySettings.values') return null;
+				return undefined;
+			});
+
+			await lmChatGoogleVertex.supplyData.call(ctx, 0);
+
+			const modelInstance = MockedChatVertexAI.mock.results[0]?.value as {
+				invocationParams: (opts: { topP?: number }) => unknown;
+			};
+			lastMockedInvocationParams.mockReturnValue({
+				allowed_function_names: ['math'],
+				fromOriginal: true,
+				tool_choice: 'auto',
+				tools: [{ functionDeclarations: [{ name: 'math' }] }],
+			});
+			const out = modelInstance.invocationParams({ topP: 0.5 });
+			expect(out).toEqual({ fromOriginal: true, cachedContent: cacheResource });
+			expect(lastMockedInvocationParams).toHaveBeenCalledWith({ topP: 0.5 });
+		});
+
+		it('omits tools, tool_choice, and allowed_function_names when merging cachedContent', async () => {
+			const ctx = setupMockContext();
+			const cacheResource = 'projects/123/locations/us-central1/cachedContents/predef';
+
+			ctx.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'modelName') return 'gemini-2.5-flash';
+				if (paramName === 'projectId') return 'test-project';
+				if (paramName === 'contextCacheStrategy') return 'predefined';
+				if (paramName === 'contextCacheName') return cacheResource;
+				if (paramName === 'options') return baseOptions;
+				if (paramName === 'options.safetySettings.values') return null;
+				return undefined;
+			});
+
+			await lmChatGoogleVertex.supplyData.call(ctx, 0);
+
+			const modelInstance = MockedChatVertexAI.mock.results[0]?.value as {
+				invocationParams: () => unknown;
+			};
+			lastMockedInvocationParams.mockReturnValue({
+				allowed_function_names: ['a'],
+				tool_choice: 'auto',
+				tools: [{ functionDeclarations: [{ name: 'x' }] }],
+				topP: 1,
+			});
+			expect(modelInstance.invocationParams()).toEqual({
+				cachedContent: cacheResource,
+				topP: 1,
+			});
+		});
+
+		it('strips system messages in _generate and warns when system messages are present', async () => {
+			const innerGenerate = jest.fn().mockResolvedValue({ generations: [] });
+			MockedChatVertexAI.mockImplementation(() => {
+				lastMockedInvocationParams = jest.fn().mockReturnValue({ topP: 1 });
+				return {
+					_generate: innerGenerate,
+					invocationParams: lastMockedInvocationParams,
+				} as unknown as ChatVertexAI;
+			});
+
+			const ctx = setupMockContext();
+			const cacheResource = 'projects/123/locations/us-central1/cachedContents/predef-sys';
+
+			ctx.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'modelName') return 'gemini-2.5-flash';
+				if (paramName === 'projectId') return 'test-project';
+				if (paramName === 'contextCacheStrategy') return 'predefined';
+				if (paramName === 'contextCacheName') return cacheResource;
+				if (paramName === 'options') return baseOptions;
+				if (paramName === 'options.safetySettings.values') return null;
+				return undefined;
+			});
+
+			await lmChatGoogleVertex.supplyData.call(ctx, 0);
+
+			const modelInstance = MockedChatVertexAI.mock.results[0]?.value as {
+				_generate: (
+					msgs: Array<{ content: string; type: string }>,
+					opts: object,
+					rm?: unknown,
+				) => Promise<unknown>;
+			};
+
+			await modelInstance._generate(
+				[
+					{ content: 'System prompt', type: 'system' },
+					{ content: 'hello', type: 'human' },
+				],
+				{ allowed_function_names: ['x'], tool_choice: 'auto', tools: [{ x: 1 }] },
+				undefined,
+			);
+
+			expect(ctx.addExecutionHints).toHaveBeenCalledWith(
+				vertexContextCachePredefinedIgnoredSystemHint(),
+			);
+			expect(innerGenerate).toHaveBeenCalledWith(
+				[{ content: 'hello', type: 'human' }],
+				{},
+				undefined,
+			);
+		});
+
+		it('rejects empty Context Cache Name', async () => {
+			const ctx = setupMockContext();
+			ctx.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'modelName') return 'gemini-2.5-flash';
+				if (paramName === 'projectId') return 'test-project';
+				if (paramName === 'contextCacheStrategy') return 'predefined';
+				if (paramName === 'contextCacheName') return '   ';
+				if (paramName === 'options') return baseOptions;
+				if (paramName === 'options.safetySettings.values') return null;
+				return undefined;
+			});
+
+			await expect(lmChatGoogleVertex.supplyData.call(ctx, 0)).rejects.toThrow(NodeOperationError);
+			expect(MockedChatVertexAI).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('Auto-caching and execution mode', () => {
+		it('applies auto-cache patch when strategy is auto', async () => {
+			const ctx = setupMockContext();
+			ctx.getMode = jest.fn().mockReturnValue('trigger');
+
+			ctx.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'modelName') return 'gemini-2.5-flash';
+				if (paramName === 'projectId') return 'test-project';
+				if (paramName === 'contextCacheStrategy') return 'auto';
+				if (paramName === 'contextCacheTtlSeconds') return 900;
+				if (paramName === 'vertexContextCacheRedisKeyPrefix') return 'n8n:vertexCtx';
+				if (paramName === 'options') return baseOptions;
+				if (paramName === 'options.safetySettings.values') return null;
+				return undefined;
+			});
+
+			await lmChatGoogleVertex.supplyData.call(ctx, 0);
+			expect(mockedApplyVertexAutoContextCachePatch).toHaveBeenCalledTimes(1);
+			expect(mockedApplyVertexAutoContextCachePatch).toHaveBeenCalledWith(
+				expect.anything(),
+				ctx,
+				expect.objectContaining({
+					metadataStorage: expect.objectContaining({
+						delete: expect.any(Function),
+						read: expect.any(Function),
+						write: expect.any(Function),
+						writeIfAbsent: expect.any(Function),
+					}),
+				}),
+			);
+		});
+
+		it('applies auto-cache patch in manual execution mode as well', async () => {
+			const ctx = setupMockContext();
+			ctx.getMode = jest.fn().mockReturnValue('manual');
+
+			ctx.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'modelName') return 'gemini-2.5-flash';
+				if (paramName === 'projectId') return 'test-project';
+				if (paramName === 'contextCacheStrategy') return 'auto';
+				if (paramName === 'contextCacheTtlSeconds') return 900;
+				if (paramName === 'vertexContextCacheRedisKeyPrefix') return 'n8n:vertexCtx';
+				if (paramName === 'options') return baseOptions;
+				if (paramName === 'options.safetySettings.values') return null;
+				return undefined;
+			});
+
+			await lmChatGoogleVertex.supplyData.call(ctx, 0);
+			expect(mockedApplyVertexAutoContextCachePatch).toHaveBeenCalledTimes(1);
+			expect(ctx.addExecutionHints).not.toHaveBeenCalled();
+		});
+
+		it('rejects auto strategy when Context Cache TTL is missing', async () => {
+			const ctx = setupMockContext();
+			ctx.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'modelName') return 'gemini-2.5-flash';
+				if (paramName === 'projectId') return 'test-project';
+				if (paramName === 'contextCacheStrategy') return 'auto';
+				if (paramName === 'contextCacheTtlSeconds') return undefined;
+				if (paramName === 'options') return baseOptions;
+				if (paramName === 'options.safetySettings.values') return null;
+				return undefined;
+			});
+
+			await expect(lmChatGoogleVertex.supplyData.call(ctx, 0)).rejects.toThrow(NodeOperationError);
+			expect(MockedChatVertexAI).not.toHaveBeenCalled();
+		});
+
+		it('rejects auto strategy when context cache storage prefix is empty', async () => {
+			const ctx = setupMockContext();
+			ctx.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'modelName') return 'gemini-2.5-flash';
+				if (paramName === 'projectId') return 'test-project';
+				if (paramName === 'contextCacheStrategy') return 'auto';
+				if (paramName === 'contextCacheTtlSeconds') return 900;
+				if (paramName === 'vertexContextCacheRedisKeyPrefix') return '   ';
+				if (paramName === 'options') return baseOptions;
+				if (paramName === 'options.safetySettings.values') return null;
+				return undefined;
+			});
+
+			await expect(lmChatGoogleVertex.supplyData.call(ctx, 0)).rejects.toThrow(NodeOperationError);
+			expect(MockedChatVertexAI).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('None strategy', () => {
+		it('does not wrap invocationParams or apply auto-cache patch', async () => {
+			const ctx = setupMockContext();
+			ctx.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'modelName') return 'gemini-2.5-flash';
+				if (paramName === 'projectId') return 'test-project';
+				if (paramName === 'contextCacheStrategy') return 'none';
+				if (paramName === 'options') return baseOptions;
+				if (paramName === 'options.safetySettings.values') return null;
+				return undefined;
+			});
+
+			await lmChatGoogleVertex.supplyData.call(ctx, 0);
+			const modelInstance = MockedChatVertexAI.mock.results[0]?.value as {
+				invocationParams: jest.Mock;
+			};
+			expect(modelInstance.invocationParams).toBe(lastMockedInvocationParams);
+			expect(mockedApplyVertexAutoContextCachePatch).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/llms/gemini-common/additional-options.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/gemini-common/additional-options.ts
@@ -5,7 +5,9 @@ import { harmCategories, harmThresholds } from './safety-options';
 
 export function getAdditionalOptions({
 	supportsThinkingBudget,
-}: { supportsThinkingBudget: boolean }) {
+}: {
+	supportsThinkingBudget: boolean;
+}) {
 	const baseOptions: INodeProperties = {
 		displayName: 'Options',
 		name: 'options',


### PR DESCRIPTION
## Summary

Add optional [Vertex AI context caching](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-use) for the Google Vertex Chat Model: users can disable caching, use automatic cache creation with Redis-backed metadata, or reference a predefined `cachedContents` resource. Align request shaping with [Vertex expectations](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-use#context_cache_use_restrictions) (strip system messages and tool config when a cache applies), surface execution hints and UI notices where behavior diverges from the agent workflow, and avoid Redis races by using a short-lived connection per metadata operation.

<img width="424" height="787" alt="Auto-caching strategy setup" src="https://github.com/user-attachments/assets/65727bda-0c31-47fc-8870-9b334e5d60c0" />
<img width="455" height="662" alt="Predefined cache strategy setup" src="https://github.com/user-attachments/assets/5abc4586-f15b-4760-9941-95caca118808" />


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
