### PR TITLE
chore: Make scripts in local-gateway platform-agnostic

### DIFF
--- a/packages/@n8n/local-gateway/eslint.config.mjs
+++ b/packages/@n8n/local-gateway/eslint.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig, globalIgnores } from 'eslint/config';
 import { nodeConfig } from '@n8n/eslint-config/node';
 
 export default defineConfig(
-	globalIgnores(['electron-builder.config.js']),
+	globalIgnores(['electron-builder.config.js','scripts/**']),
 	nodeConfig,
 	{
 		rules: {

--- a/packages/@n8n/local-gateway/package.json
+++ b/packages/@n8n/local-gateway/package.json
@@ -5,9 +5,10 @@
   "private": true,
   "main": "dist/main/index.js",
   "scripts": {
-    "build": "tsc -p tsconfig.renderer.json && tsc -p tsconfig.build.json && pnpm copy:renderer && cp -r ./assets ./dist/main",
+    "build": "tsc -p tsconfig.renderer.json && tsc -p tsconfig.build.json && pnpm copy:renderer && pnpm copy:assets",
+    "copy:assets": "node -e \"const fs=require('fs');fs.mkdirSync('./dist/main',{recursive:true});fs.cpSync('./assets','./dist/main/assets',{recursive:true})\"",
     "copy:renderer": "node -e \"const fs=require('fs');['index.html','styles.css'].forEach(f=>fs.copyFileSync('src/renderer/'+f,'dist/renderer/'+f));\"",
-    "dev": "cp -r ./assets ./dist/main && pnpm copy:renderer && tsc -p tsconfig.renderer.json --watch & tsc -p tsconfig.build.json --watch ",
+    "dev": "pnpm copy:assets && pnpm copy:renderer && concurrently \"tsc -p tsconfig.renderer.json --watch\" \"tsc -p tsconfig.build.json --watch\"",
     "start": "electron dist/main/index.js",
     "dist:mac": "pnpm build && electron-builder --mac --config electron-builder.config.js",
     "dist:win": "pnpm build && electron-builder --win --config electron-builder.config.js",
@@ -30,6 +31,7 @@
     "@n8n/eslint-config": "workspace:*",
     "@n8n/typescript-config": "workspace:*",
     "@types/node": "catalog:",
+    "concurrently": "^8.2.0",
     "electron": "^36.0.0",
     "electron-builder": "^25.0.0",
     "rimraf": "catalog:"

--- a/packages/@n8n/local-gateway/package.json
+++ b/packages/@n8n/local-gateway/package.json
@@ -6,8 +6,8 @@
   "main": "dist/main/index.js",
   "scripts": {
     "build": "tsc -p tsconfig.renderer.json && tsc -p tsconfig.build.json && pnpm copy:renderer && pnpm copy:assets",
-    "copy:assets": "node -e \"const fs=require('fs');fs.mkdirSync('./dist/main',{recursive:true});fs.cpSync('./assets','./dist/main/assets',{recursive:true})\"",
-    "copy:renderer": "node -e \"const fs=require('fs');['index.html','styles.css'].forEach(f=>fs.copyFileSync('src/renderer/'+f,'dist/renderer/'+f));\"",
+    "copy:assets": "node scripts/copy-assets.js",
+    "copy:renderer": "node scripts/copy-renderer.js",
     "dev": "pnpm copy:assets && pnpm copy:renderer && concurrently \"tsc -p tsconfig.renderer.json --watch\" \"tsc -p tsconfig.build.json --watch\"",
     "start": "electron dist/main/index.js",
     "dist:mac": "pnpm build && electron-builder --mac --config electron-builder.config.js",

--- a/packages/@n8n/local-gateway/scripts/copy-assets.js
+++ b/packages/@n8n/local-gateway/scripts/copy-assets.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+
+function main() {
+	fs.mkdirSync('./dist/main', { recursive: true });
+	fs.cpSync('./assets', './dist/main/assets', { recursive: true });
+}
+
+main();

--- a/packages/@n8n/local-gateway/scripts/copy-renderer.js
+++ b/packages/@n8n/local-gateway/scripts/copy-renderer.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+
+function main() {
+	['index.html', 'styles.css'].forEach((f) =>
+		fs.copyFileSync('src/renderer/' + f, 'dist/renderer/' + f),
+	);
+}
+
+main();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1658,6 +1658,9 @@ importers:
       '@types/node':
         specifier: ^20.17.50
         version: 20.19.21
+      concurrently:
+        specifier: ^8.2.0
+        version: 8.2.0
       electron:
         specifier: ^36.0.0
         version: 36.9.5


### PR DESCRIPTION
## Summary

Small fix to make the scripts work on windows, replaced `cp` with nodejs script

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
