### PR TITLE
docs: fix package README links

### DIFF
--- a/packages/@n8n/expression-runtime/README.md
+++ b/packages/@n8n/expression-runtime/README.md
@@ -296,7 +296,7 @@ See the main n8n repository for contribution guidelines.
 
 ## License
 
-See [LICENSE.md](../../LICENSE.md) in the n8n repository root.
+See [LICENSE.md](../../../LICENSE.md) in the n8n repository root.
 
 ## Related
 

--- a/packages/@n8n/utils/README.md
+++ b/packages/@n8n/utils/README.md
@@ -18,8 +18,8 @@ A collection of utility functions that provide common functionality for both Fro
 
 ## Contributing
 
-For more details, please read our [CONTRIBUTING.md](CONTRIBUTING.md).
+For more details, please read our [CONTRIBUTING.md](../../../CONTRIBUTING.md).
 
 ## License
 
-For more details, please read our [LICENSE.md](LICENSE.md).
+For more details, please read our [LICENSE.md](../../../LICENSE.md).

--- a/packages/frontend/@n8n/composables/README.md
+++ b/packages/frontend/@n8n/composables/README.md
@@ -17,8 +17,8 @@ A collection of Vue composables that provide common functionality across n8n's F
 
 ## Contributing
 
-For more details, please read our [CONTRIBUTING.md](CONTRIBUTING.md).
+For more details, please read our [CONTRIBUTING.md](../../../../CONTRIBUTING.md).
 
 ## License
 
-For more details, please read our [LICENSE.md](LICENSE.md).
+For more details, please read our [LICENSE.md](../../../../LICENSE.md).

--- a/packages/frontend/@n8n/i18n/README.md
+++ b/packages/frontend/@n8n/i18n/README.md
@@ -20,8 +20,8 @@ A package for managing internationalization (i18n) in n8n's Frontend codebase. I
 
 ## Contributing
 
-For more details, please read our [CONTRIBUTING.md](CONTRIBUTING.md).
+For more details, please read our [CONTRIBUTING.md](../../../../CONTRIBUTING.md).
 
 ## License
 
-For more details, please read our [LICENSE.md](LICENSE.md).
+For more details, please read our [LICENSE.md](../../../../LICENSE.md).

--- a/packages/frontend/@n8n/rest-api-client/README.md
+++ b/packages/frontend/@n8n/rest-api-client/README.md
@@ -15,8 +15,8 @@ This package contains the REST API calls for n8n.
 
 ## Contributing
 
-For more details, please read our [CONTRIBUTING.md](CONTRIBUTING.md).
+For more details, please read our [CONTRIBUTING.md](../../../../CONTRIBUTING.md).
 
 ## License
 
-For more details, please read our [LICENSE.md](LICENSE.md).
+For more details, please read our [LICENSE.md](../../../../LICENSE.md).

--- a/packages/frontend/@n8n/stores/README.md
+++ b/packages/frontend/@n8n/stores/README.md
@@ -17,8 +17,8 @@ A collection of Pinia stores that provide common data-related functionality acro
 
 ## Contributing
 
-For more details, please read our [CONTRIBUTING.md](CONTRIBUTING.md).
+For more details, please read our [CONTRIBUTING.md](../../../../CONTRIBUTING.md).
 
 ## License
 
-For more details, please read our [LICENSE.md](LICENSE.md).
+For more details, please read our [LICENSE.md](../../../../LICENSE.md).


### PR DESCRIPTION
## Summary
- fix broken CONTRIBUTING and LICENSE links in several package READMEs
- point frontend package READMEs back to the repo-root docs
- fix the expression-runtime README license link to the actual repo-root file

## Testing
- not run (docs-only link fix)