### PR TITLE
feat(core): Add JWKS resolver for fetching and parsing JWK Set URLs (no-changelog)

### DIFF
--- a/packages/cli/src/modules/token-exchange/services/__tests__/jwks-resolver.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/jwks-resolver.test.ts
@@ -1,0 +1,281 @@
+import { generateKeyPairSync } from 'node:crypto';
+
+import { OperationalError } from 'n8n-workflow';
+
+import type { JwksKeySource } from '../../token-exchange.schemas';
+import { resolveJwksKeys } from '../jwks-resolver';
+
+// ──────────────────────────────────────────────────────────────────────
+// Test key fixtures — generated once, reused across tests
+// ──────────────────────────────────────────────────────────────────────
+
+const rsaKeyPair = generateKeyPairSync('rsa', { modulusLength: 2048 });
+const rsaJwk = rsaKeyPair.publicKey.export({ format: 'jwk' });
+
+const ecKeyPair = generateKeyPairSync('ec', { namedCurve: 'P-256' });
+const ecJwk = ecKeyPair.publicKey.export({ format: 'jwk' });
+
+const ed25519KeyPair = generateKeyPairSync('ed25519');
+const ed25519Jwk = ed25519KeyPair.publicKey.export({ format: 'jwk' });
+
+// ──────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────
+
+const DEFAULT_SOURCE: JwksKeySource = {
+	type: 'jwks',
+	url: 'https://idp.example.com/.well-known/jwks.json',
+	issuer: 'https://idp.example.com',
+};
+
+function mockFetchResponse(
+	keys: unknown[],
+	options?: { status?: number; cacheControl?: string },
+): typeof fetch {
+	const status = options?.status ?? 200;
+	const headers = new Headers();
+	if (options?.cacheControl) {
+		headers.set('cache-control', options.cacheControl);
+	}
+	return jest.fn().mockResolvedValue({
+		ok: status >= 200 && status < 300,
+		status,
+		headers,
+		json: async () => ({ keys }),
+	});
+}
+
+function mockFetchError(error: Error): typeof fetch {
+	return jest.fn().mockRejectedValue(error);
+}
+
+function mockFetchInvalidJson(): typeof fetch {
+	return jest.fn().mockResolvedValue({
+		ok: true,
+		status: 200,
+		headers: new Headers(),
+		json: async () => {
+			throw new SyntaxError('Unexpected token');
+		},
+	});
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────────
+
+describe('resolveJwksKeys', () => {
+	describe('happy path', () => {
+		it('should resolve RSA JWK with explicit alg', async () => {
+			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256', use: 'sig' }]);
+
+			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+
+			expect(result.keys).toHaveLength(1);
+			expect(result.keys[0].kid).toBe('rsa-1');
+			expect(result.keys[0].algorithms).toEqual(['RS256']);
+			expect(result.keys[0].issuer).toBe('https://idp.example.com');
+			expect(result.keys[0].key).toBeDefined();
+		});
+
+		it('should infer ES256 from EC P-256 JWK without alg', async () => {
+			const fetcher = mockFetchResponse([{ ...ecJwk, kid: 'ec-1' }]);
+
+			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+
+			expect(result.keys).toHaveLength(1);
+			expect(result.keys[0].kid).toBe('ec-1');
+			expect(result.keys[0].algorithms).toEqual(['ES256']);
+		});
+
+		it('should resolve multiple keys from one JWKS', async () => {
+			const fetcher = mockFetchResponse([
+				{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' },
+				{ ...ecJwk, kid: 'ec-1' },
+			]);
+
+			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+
+			expect(result.keys).toHaveLength(2);
+			expect(result.keys.map((k) => k.kid)).toEqual(['rsa-1', 'ec-1']);
+		});
+
+		it('should resolve Ed25519 OKP JWK to EdDSA', async () => {
+			const fetcher = mockFetchResponse([{ ...ed25519Jwk, kid: 'ed-1' }]);
+
+			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+
+			expect(result.keys).toHaveLength(1);
+			expect(result.keys[0].algorithms).toEqual(['EdDSA']);
+		});
+
+		it('should propagate expectedAudience and allowedRoles from source', async () => {
+			const source: JwksKeySource = {
+				...DEFAULT_SOURCE,
+				expectedAudience: 'https://n8n.example.com',
+				allowedRoles: ['admin'],
+			};
+			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }]);
+
+			const result = await resolveJwksKeys(source, { fetcher });
+
+			expect(result.keys[0].expectedAudience).toBe('https://n8n.example.com');
+			expect(result.keys[0].allowedRoles).toEqual(['admin']);
+		});
+	});
+
+	describe('filtering', () => {
+		it('should skip keys without kid', async () => {
+			const fetcher = mockFetchResponse([
+				{ ...rsaJwk, alg: 'RS256' }, // no kid
+				{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' },
+			]);
+
+			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+
+			expect(result.keys).toHaveLength(1);
+			expect(result.keys[0].kid).toBe('rsa-1');
+		});
+
+		it('should skip keys with use: enc', async () => {
+			const fetcher = mockFetchResponse([
+				{ ...rsaJwk, kid: 'enc-key', alg: 'RS256', use: 'enc' },
+				{ ...rsaJwk, kid: 'sig-key', alg: 'RS256', use: 'sig' },
+			]);
+
+			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+
+			expect(result.keys).toHaveLength(1);
+			expect(result.keys[0].kid).toBe('sig-key');
+		});
+
+		it('should skip symmetric keys (kty: oct)', async () => {
+			const fetcher = mockFetchResponse([
+				{ kid: 'hmac-key', kty: 'oct', alg: 'HS256', k: 'c2VjcmV0' },
+				{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' },
+			]);
+
+			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+
+			expect(result.keys).toHaveLength(1);
+			expect(result.keys[0].kid).toBe('rsa-1');
+		});
+
+		it('should include keys with use: sig and keys without use field', async () => {
+			const fetcher = mockFetchResponse([
+				{ ...rsaJwk, kid: 'explicit-sig', alg: 'RS256', use: 'sig' },
+				{ ...ecJwk, kid: 'no-use' }, // no use field — included
+			]);
+
+			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+
+			expect(result.keys).toHaveLength(2);
+			expect(result.keys.map((k) => k.kid)).toEqual(['explicit-sig', 'no-use']);
+		});
+	});
+
+	describe('TTL / Cache-Control', () => {
+		it('should parse Cache-Control max-age for expiresAt', async () => {
+			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }], {
+				cacheControl: 'public, max-age=600',
+			});
+			const before = Date.now();
+
+			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+
+			const after = Date.now();
+			const expectedMin = before + 600 * 1000;
+			const expectedMax = after + 600 * 1000;
+			expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(expectedMin);
+			expect(result.expiresAt.getTime()).toBeLessThanOrEqual(expectedMax);
+		});
+
+		it('should fall back to source cacheTtlSeconds when no Cache-Control', async () => {
+			const source: JwksKeySource = { ...DEFAULT_SOURCE, cacheTtlSeconds: 120 };
+			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }]);
+			const before = Date.now();
+
+			const result = await resolveJwksKeys(source, { fetcher });
+
+			const expectedMin = before + 120 * 1000;
+			expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(expectedMin);
+		});
+
+		it('should fall back to default TTL (3600s) when no Cache-Control and no cacheTtlSeconds', async () => {
+			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }]);
+			const before = Date.now();
+
+			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+
+			const expectedMin = before + 3600 * 1000;
+			expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(expectedMin);
+		});
+	});
+
+	describe('error handling', () => {
+		it('should throw OperationalError on network failure', async () => {
+			const fetcher = mockFetchError(new Error('ECONNREFUSED'));
+
+			await expect(resolveJwksKeys(DEFAULT_SOURCE, { fetcher })).rejects.toThrow(OperationalError);
+			await expect(resolveJwksKeys(DEFAULT_SOURCE, { fetcher })).rejects.toThrow(
+				/JWKS fetch failed.*ECONNREFUSED/,
+			);
+		});
+
+		it('should throw OperationalError on non-200 response', async () => {
+			const fetcher = mockFetchResponse([], { status: 500 });
+
+			await expect(resolveJwksKeys(DEFAULT_SOURCE, { fetcher })).rejects.toThrow(OperationalError);
+			await expect(resolveJwksKeys(DEFAULT_SOURCE, { fetcher })).rejects.toThrow(/HTTP 500/);
+		});
+
+		it('should throw OperationalError on invalid JSON', async () => {
+			const fetcher = mockFetchInvalidJson();
+
+			await expect(resolveJwksKeys(DEFAULT_SOURCE, { fetcher })).rejects.toThrow(OperationalError);
+			await expect(resolveJwksKeys(DEFAULT_SOURCE, { fetcher })).rejects.toThrow(/not valid JSON/);
+		});
+
+		it('should throw OperationalError on empty keys array', async () => {
+			const fetcher = mockFetchResponse([]);
+
+			await expect(resolveJwksKeys(DEFAULT_SOURCE, { fetcher })).rejects.toThrow(OperationalError);
+			await expect(resolveJwksKeys(DEFAULT_SOURCE, { fetcher })).rejects.toThrow(/no keys/);
+		});
+
+		it('should throw OperationalError when all keys are filtered out', async () => {
+			const fetcher = mockFetchResponse([{ kid: 'enc-only', kty: 'RSA', use: 'enc', ...rsaJwk }]);
+
+			await expect(resolveJwksKeys(DEFAULT_SOURCE, { fetcher })).rejects.toThrow(OperationalError);
+			await expect(resolveJwksKeys(DEFAULT_SOURCE, { fetcher })).rejects.toThrow(
+				/no usable signing keys/,
+			);
+		});
+	});
+
+	describe('edge cases', () => {
+		it('should skip keys with unrecognized kty/crv and return valid keys', async () => {
+			const fetcher = mockFetchResponse([
+				{ kid: 'unknown-curve', kty: 'EC', crv: 'brainpoolP256r1', x: 'x', y: 'y' },
+				{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' },
+			]);
+
+			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+
+			expect(result.keys).toHaveLength(1);
+			expect(result.keys[0].kid).toBe('rsa-1');
+		});
+
+		it('should skip keys that fail createPublicKey and return valid keys', async () => {
+			const fetcher = mockFetchResponse([
+				{ kid: 'bad-key', kty: 'EC', crv: 'P-256', x: '!!!', y: '!!!' },
+				{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' },
+			]);
+
+			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+
+			expect(result.keys).toHaveLength(1);
+			expect(result.keys[0].kid).toBe('rsa-1');
+		});
+	});
+});

--- a/packages/cli/src/modules/token-exchange/services/__tests__/jwks-resolver.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/jwks-resolver.test.ts
@@ -15,6 +15,12 @@ const rsaJwk = rsaKeyPair.publicKey.export({ format: 'jwk' });
 const ecKeyPair = generateKeyPairSync('ec', { namedCurve: 'P-256' });
 const ecJwk = ecKeyPair.publicKey.export({ format: 'jwk' });
 
+const ecP384KeyPair = generateKeyPairSync('ec', { namedCurve: 'P-384' });
+const ecP384Jwk = ecP384KeyPair.publicKey.export({ format: 'jwk' });
+
+const ecP521KeyPair = generateKeyPairSync('ec', { namedCurve: 'P-521' });
+const ecP521Jwk = ecP521KeyPair.publicKey.export({ format: 'jwk' });
+
 const ed25519KeyPair = generateKeyPairSync('ed25519');
 const ed25519Jwk = ed25519KeyPair.publicKey.export({ format: 'jwk' });
 
@@ -109,6 +115,28 @@ describe('resolveJwksKeys', () => {
 			expect(result.keys[0].algorithms).toEqual(['EdDSA']);
 		});
 
+		it('should infer RS256 from RSA JWK without explicit alg', async () => {
+			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-no-alg' }]);
+
+			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+
+			expect(result.keys).toHaveLength(1);
+			expect(result.keys[0].kid).toBe('rsa-no-alg');
+			expect(result.keys[0].algorithms).toEqual(['RS256']);
+		});
+
+		it.each([
+			{ curve: 'P-384', jwk: ecP384Jwk, expectedAlg: 'ES384' },
+			{ curve: 'P-521', jwk: ecP521Jwk, expectedAlg: 'ES512' },
+		])('should infer $expectedAlg from EC $curve JWK', async ({ jwk, expectedAlg }) => {
+			const fetcher = mockFetchResponse([{ ...jwk, kid: 'ec-curve' }]);
+
+			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+
+			expect(result.keys).toHaveLength(1);
+			expect(result.keys[0].algorithms).toEqual([expectedAlg]);
+		});
+
 		it('should propagate expectedAudience and allowedRoles from source', async () => {
 			const source: JwksKeySource = {
 				...DEFAULT_SOURCE,
@@ -161,6 +189,21 @@ describe('resolveJwksKeys', () => {
 			expect(result.keys[0].kid).toBe('rsa-1');
 		});
 
+		it('should skip keys with unsupported explicit alg', async () => {
+			const fetcher = mockFetchResponse([
+				{ ...rsaJwk, kid: 'hmac-key', alg: 'HS256' },
+				{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' },
+			]);
+
+			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+
+			expect(result.keys).toHaveLength(1);
+			expect(result.keys[0].kid).toBe('rsa-1');
+			expect(result.skipped).toEqual(
+				expect.arrayContaining([expect.objectContaining({ kid: 'hmac-key' })]),
+			);
+		});
+
 		it('should include keys with use: sig and keys without use field', async () => {
 			const fetcher = mockFetchResponse([
 				{ ...rsaJwk, kid: 'explicit-sig', alg: 'RS256', use: 'sig' },
@@ -210,46 +253,102 @@ describe('resolveJwksKeys', () => {
 			const expectedMin = before + 3600 * 1000;
 			expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(expectedMin);
 		});
+
+		it('should clamp max-age=0 to minimum TTL (60s)', async () => {
+			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }], {
+				cacheControl: 'max-age=0',
+			});
+			const before = Date.now();
+
+			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+
+			const expectedMin = before + 60 * 1000;
+			expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(expectedMin);
+		});
+
+		it('should clamp very large max-age to maximum TTL (86400s)', async () => {
+			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }], {
+				cacheControl: 'max-age=999999999',
+			});
+			const before = Date.now();
+
+			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+
+			const after = Date.now();
+			const expectedMax = after + 86_400 * 1000;
+			expect(result.expiresAt.getTime()).toBeLessThanOrEqual(expectedMax);
+			expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(before + 86_400 * 1000);
+		});
+
+		it('should prefer Cache-Control max-age over source cacheTtlSeconds', async () => {
+			const source: JwksKeySource = { ...DEFAULT_SOURCE, cacheTtlSeconds: 120 };
+			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }], {
+				cacheControl: 'max-age=600',
+			});
+			const before = Date.now();
+
+			const result = await resolveJwksKeys(source, { fetcher });
+
+			const expectedMin = before + 600 * 1000;
+			expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(expectedMin);
+		});
+
+		it('should use custom defaultTtlSeconds when no Cache-Control and no cacheTtlSeconds', async () => {
+			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }]);
+			const before = Date.now();
+
+			const result = await resolveJwksKeys(DEFAULT_SOURCE, {
+				fetcher,
+				defaultTtlSeconds: 300,
+			});
+
+			const after = Date.now();
+			const expectedMin = before + 300 * 1000;
+			const expectedMax = after + 300 * 1000;
+			expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(expectedMin);
+			expect(result.expiresAt.getTime()).toBeLessThanOrEqual(expectedMax);
+		});
 	});
 
 	describe('error handling', () => {
 		it('should throw OperationalError on network failure', async () => {
 			const fetcher = mockFetchError(new Error('ECONNREFUSED'));
 
-			await expect(resolveJwksKeys(DEFAULT_SOURCE, { fetcher })).rejects.toThrow(OperationalError);
-			await expect(resolveJwksKeys(DEFAULT_SOURCE, { fetcher })).rejects.toThrow(
-				/JWKS fetch failed.*ECONNREFUSED/,
-			);
+			const error = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher }).catch((e) => e);
+			expect(error).toBeInstanceOf(OperationalError);
+			expect(error.message).toMatch(/JWKS fetch failed.*ECONNREFUSED/);
 		});
 
 		it('should throw OperationalError on non-200 response', async () => {
 			const fetcher = mockFetchResponse([], { status: 500 });
 
-			await expect(resolveJwksKeys(DEFAULT_SOURCE, { fetcher })).rejects.toThrow(OperationalError);
-			await expect(resolveJwksKeys(DEFAULT_SOURCE, { fetcher })).rejects.toThrow(/HTTP 500/);
+			const error = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher }).catch((e) => e);
+			expect(error).toBeInstanceOf(OperationalError);
+			expect(error.message).toMatch(/HTTP 500/);
 		});
 
 		it('should throw OperationalError on invalid JSON', async () => {
 			const fetcher = mockFetchInvalidJson();
 
-			await expect(resolveJwksKeys(DEFAULT_SOURCE, { fetcher })).rejects.toThrow(OperationalError);
-			await expect(resolveJwksKeys(DEFAULT_SOURCE, { fetcher })).rejects.toThrow(/not valid JSON/);
+			const error = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher }).catch((e) => e);
+			expect(error).toBeInstanceOf(OperationalError);
+			expect(error.message).toMatch(/not valid JSON/);
 		});
 
 		it('should throw OperationalError on empty keys array', async () => {
 			const fetcher = mockFetchResponse([]);
 
-			await expect(resolveJwksKeys(DEFAULT_SOURCE, { fetcher })).rejects.toThrow(OperationalError);
-			await expect(resolveJwksKeys(DEFAULT_SOURCE, { fetcher })).rejects.toThrow(/no keys/);
+			const error = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher }).catch((e) => e);
+			expect(error).toBeInstanceOf(OperationalError);
+			expect(error.message).toMatch(/no keys/);
 		});
 
 		it('should throw OperationalError when all keys are filtered out', async () => {
 			const fetcher = mockFetchResponse([{ kid: 'enc-only', kty: 'RSA', use: 'enc', ...rsaJwk }]);
 
-			await expect(resolveJwksKeys(DEFAULT_SOURCE, { fetcher })).rejects.toThrow(OperationalError);
-			await expect(resolveJwksKeys(DEFAULT_SOURCE, { fetcher })).rejects.toThrow(
-				/no usable signing keys/,
-			);
+			const error = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher }).catch((e) => e);
+			expect(error).toBeInstanceOf(OperationalError);
+			expect(error.message).toMatch(/no usable signing keys/);
 		});
 	});
 
@@ -276,6 +375,40 @@ describe('resolveJwksKeys', () => {
 
 			expect(result.keys).toHaveLength(1);
 			expect(result.keys[0].kid).toBe('rsa-1');
+		});
+
+		it('should return skipped key diagnostics alongside resolved keys', async () => {
+			const fetcher = mockFetchResponse([
+				{ ...rsaJwk, alg: 'RS256' }, // no kid → schema validation failure
+				{ kid: 'unsupported', kty: 'EC', crv: 'brainpoolP256r1', x: 'x', y: 'y' }, // unsupported curve
+				{ kid: 'bad-material', kty: 'EC', crv: 'P-256', x: '!!!', y: '!!!' }, // invalid key material
+				{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }, // valid
+			]);
+
+			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+
+			expect(result.keys).toHaveLength(1);
+			expect(result.skipped).toHaveLength(3);
+			expect(result.skipped).toEqual([
+				expect.objectContaining({ reason: 'failed schema validation' }),
+				expect.objectContaining({
+					kid: 'unsupported',
+					reason: expect.stringContaining('unsupported algorithm'),
+				}),
+				expect.objectContaining({
+					kid: 'bad-material',
+					reason: expect.stringContaining('failed to create public key'),
+				}),
+			]);
+		});
+
+		it('should return empty skipped array when all keys are valid', async () => {
+			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }]);
+
+			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+
+			expect(result.keys).toHaveLength(1);
+			expect(result.skipped).toEqual([]);
 		});
 	});
 });

--- a/packages/cli/src/modules/token-exchange/services/__tests__/jwks-resolver.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/jwks-resolver.test.ts
@@ -353,6 +353,25 @@ describe('resolveJwksKeys', () => {
 	});
 
 	describe('edge cases', () => {
+		it('should skip null and non-object entries in keys array', async () => {
+			const fetcher = mockFetchResponse([
+				null,
+				'not-an-object',
+				42,
+				{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' },
+			]);
+
+			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+
+			expect(result.keys).toHaveLength(1);
+			expect(result.keys[0].kid).toBe('rsa-1');
+			expect(result.skipped).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ kid: undefined, reason: 'not an object' }),
+				]),
+			);
+		});
+
 		it('should skip keys with unrecognized kty/crv and return valid keys', async () => {
 			const fetcher = mockFetchResponse([
 				{ kid: 'unknown-curve', kty: 'EC', crv: 'brainpoolP256r1', x: 'x', y: 'y' },

--- a/packages/cli/src/modules/token-exchange/services/__tests__/jwks-resolver.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/jwks-resolver.test.ts
@@ -81,7 +81,7 @@ describe('resolveJwksKeys', () => {
 			expect(result.keys[0].kid).toBe('rsa-1');
 			expect(result.keys[0].algorithms).toEqual(['RS256']);
 			expect(result.keys[0].issuer).toBe('https://idp.example.com');
-			expect(result.keys[0].key).toBeDefined();
+			expect(result.keys[0].keyMaterial).toContain('BEGIN PUBLIC KEY');
 		});
 
 		it('should infer ES256 from EC P-256 JWK without alg', async () => {
@@ -218,66 +218,51 @@ describe('resolveJwksKeys', () => {
 	});
 
 	describe('TTL / Cache-Control', () => {
-		it('should parse Cache-Control max-age for expiresAt', async () => {
+		it('should parse Cache-Control max-age into ttlSeconds', async () => {
 			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }], {
 				cacheControl: 'public, max-age=600',
 			});
-			const before = Date.now();
 
 			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
 
-			const after = Date.now();
-			const expectedMin = before + 600 * 1000;
-			const expectedMax = after + 600 * 1000;
-			expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(expectedMin);
-			expect(result.expiresAt.getTime()).toBeLessThanOrEqual(expectedMax);
+			expect(result.ttlSeconds).toBe(600);
 		});
 
 		it('should fall back to source cacheTtlSeconds when no Cache-Control', async () => {
 			const source: JwksKeySource = { ...DEFAULT_SOURCE, cacheTtlSeconds: 120 };
 			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }]);
-			const before = Date.now();
 
 			const result = await resolveJwksKeys(source, { fetcher });
 
-			const expectedMin = before + 120 * 1000;
-			expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(expectedMin);
+			expect(result.ttlSeconds).toBe(120);
 		});
 
 		it('should fall back to default TTL (3600s) when no Cache-Control and no cacheTtlSeconds', async () => {
 			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }]);
-			const before = Date.now();
 
 			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
 
-			const expectedMin = before + 3600 * 1000;
-			expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(expectedMin);
+			expect(result.ttlSeconds).toBe(3600);
 		});
 
 		it('should clamp max-age=0 to minimum TTL (60s)', async () => {
 			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }], {
 				cacheControl: 'max-age=0',
 			});
-			const before = Date.now();
 
 			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
 
-			const expectedMin = before + 60 * 1000;
-			expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(expectedMin);
+			expect(result.ttlSeconds).toBe(60);
 		});
 
 		it('should clamp very large max-age to maximum TTL (86400s)', async () => {
 			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }], {
 				cacheControl: 'max-age=999999999',
 			});
-			const before = Date.now();
 
 			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
 
-			const after = Date.now();
-			const expectedMax = after + 86_400 * 1000;
-			expect(result.expiresAt.getTime()).toBeLessThanOrEqual(expectedMax);
-			expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(before + 86_400 * 1000);
+			expect(result.ttlSeconds).toBe(86_400);
 		});
 
 		it('should prefer Cache-Control max-age over source cacheTtlSeconds', async () => {
@@ -285,28 +270,21 @@ describe('resolveJwksKeys', () => {
 			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }], {
 				cacheControl: 'max-age=600',
 			});
-			const before = Date.now();
 
 			const result = await resolveJwksKeys(source, { fetcher });
 
-			const expectedMin = before + 600 * 1000;
-			expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(expectedMin);
+			expect(result.ttlSeconds).toBe(600);
 		});
 
 		it('should use custom defaultTtlSeconds when no Cache-Control and no cacheTtlSeconds', async () => {
 			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }]);
-			const before = Date.now();
 
 			const result = await resolveJwksKeys(DEFAULT_SOURCE, {
 				fetcher,
 				defaultTtlSeconds: 300,
 			});
 
-			const after = Date.now();
-			const expectedMin = before + 300 * 1000;
-			const expectedMax = after + 300 * 1000;
-			expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(expectedMin);
-			expect(result.expiresAt.getTime()).toBeLessThanOrEqual(expectedMax);
+			expect(result.ttlSeconds).toBe(300);
 		});
 	});
 

--- a/packages/cli/src/modules/token-exchange/services/__tests__/jwks-resolver.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/jwks-resolver.test.ts
@@ -1,9 +1,11 @@
 import { generateKeyPairSync } from 'node:crypto';
 
+import type { Logger } from '@n8n/backend-common';
+import { mock } from 'jest-mock-extended';
 import { OperationalError } from 'n8n-workflow';
 
 import type { JwksKeySource } from '../../token-exchange.schemas';
-import { resolveJwksKeys } from '../jwks-resolver';
+import { JwksResolverService } from '../jwks-resolver';
 
 // ──────────────────────────────────────────────────────────────────────
 // Test key fixtures — generated once, reused across tests
@@ -70,12 +72,20 @@ function mockFetchInvalidJson(): typeof fetch {
 // Tests
 // ──────────────────────────────────────────────────────────────────────
 
-describe('resolveJwksKeys', () => {
+const mockLogger = mock<Logger>({ scoped: jest.fn().mockReturnThis() });
+
+describe('JwksResolverService', () => {
+	let service: JwksResolverService;
+
+	beforeEach(() => {
+		service = new JwksResolverService(mockLogger);
+	});
+
 	describe('happy path', () => {
 		it('should resolve RSA JWK with explicit alg', async () => {
 			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256', use: 'sig' }]);
 
-			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+			const result = await service.resolveKeys(DEFAULT_SOURCE, { fetcher });
 
 			expect(result.keys).toHaveLength(1);
 			expect(result.keys[0].kid).toBe('rsa-1');
@@ -87,7 +97,7 @@ describe('resolveJwksKeys', () => {
 		it('should infer ES256 from EC P-256 JWK without alg', async () => {
 			const fetcher = mockFetchResponse([{ ...ecJwk, kid: 'ec-1' }]);
 
-			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+			const result = await service.resolveKeys(DEFAULT_SOURCE, { fetcher });
 
 			expect(result.keys).toHaveLength(1);
 			expect(result.keys[0].kid).toBe('ec-1');
@@ -100,7 +110,7 @@ describe('resolveJwksKeys', () => {
 				{ ...ecJwk, kid: 'ec-1' },
 			]);
 
-			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+			const result = await service.resolveKeys(DEFAULT_SOURCE, { fetcher });
 
 			expect(result.keys).toHaveLength(2);
 			expect(result.keys.map((k) => k.kid)).toEqual(['rsa-1', 'ec-1']);
@@ -109,7 +119,7 @@ describe('resolveJwksKeys', () => {
 		it('should resolve Ed25519 OKP JWK to EdDSA', async () => {
 			const fetcher = mockFetchResponse([{ ...ed25519Jwk, kid: 'ed-1' }]);
 
-			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+			const result = await service.resolveKeys(DEFAULT_SOURCE, { fetcher });
 
 			expect(result.keys).toHaveLength(1);
 			expect(result.keys[0].algorithms).toEqual(['EdDSA']);
@@ -118,7 +128,7 @@ describe('resolveJwksKeys', () => {
 		it('should infer RS256 from RSA JWK without explicit alg', async () => {
 			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-no-alg' }]);
 
-			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+			const result = await service.resolveKeys(DEFAULT_SOURCE, { fetcher });
 
 			expect(result.keys).toHaveLength(1);
 			expect(result.keys[0].kid).toBe('rsa-no-alg');
@@ -131,7 +141,7 @@ describe('resolveJwksKeys', () => {
 		])('should infer $expectedAlg from EC $curve JWK', async ({ jwk, expectedAlg }) => {
 			const fetcher = mockFetchResponse([{ ...jwk, kid: 'ec-curve' }]);
 
-			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+			const result = await service.resolveKeys(DEFAULT_SOURCE, { fetcher });
 
 			expect(result.keys).toHaveLength(1);
 			expect(result.keys[0].algorithms).toEqual([expectedAlg]);
@@ -145,7 +155,7 @@ describe('resolveJwksKeys', () => {
 			};
 			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }]);
 
-			const result = await resolveJwksKeys(source, { fetcher });
+			const result = await service.resolveKeys(source, { fetcher });
 
 			expect(result.keys[0].expectedAudience).toBe('https://n8n.example.com');
 			expect(result.keys[0].allowedRoles).toEqual(['admin']);
@@ -159,7 +169,7 @@ describe('resolveJwksKeys', () => {
 				{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' },
 			]);
 
-			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+			const result = await service.resolveKeys(DEFAULT_SOURCE, { fetcher });
 
 			expect(result.keys).toHaveLength(1);
 			expect(result.keys[0].kid).toBe('rsa-1');
@@ -171,7 +181,7 @@ describe('resolveJwksKeys', () => {
 				{ ...rsaJwk, kid: 'sig-key', alg: 'RS256', use: 'sig' },
 			]);
 
-			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+			const result = await service.resolveKeys(DEFAULT_SOURCE, { fetcher });
 
 			expect(result.keys).toHaveLength(1);
 			expect(result.keys[0].kid).toBe('sig-key');
@@ -183,7 +193,7 @@ describe('resolveJwksKeys', () => {
 				{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' },
 			]);
 
-			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+			const result = await service.resolveKeys(DEFAULT_SOURCE, { fetcher });
 
 			expect(result.keys).toHaveLength(1);
 			expect(result.keys[0].kid).toBe('rsa-1');
@@ -195,7 +205,7 @@ describe('resolveJwksKeys', () => {
 				{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' },
 			]);
 
-			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+			const result = await service.resolveKeys(DEFAULT_SOURCE, { fetcher });
 
 			expect(result.keys).toHaveLength(1);
 			expect(result.keys[0].kid).toBe('rsa-1');
@@ -210,7 +220,7 @@ describe('resolveJwksKeys', () => {
 				{ ...ecJwk, kid: 'no-use' }, // no use field — included
 			]);
 
-			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+			const result = await service.resolveKeys(DEFAULT_SOURCE, { fetcher });
 
 			expect(result.keys).toHaveLength(2);
 			expect(result.keys.map((k) => k.kid)).toEqual(['explicit-sig', 'no-use']);
@@ -223,7 +233,7 @@ describe('resolveJwksKeys', () => {
 				cacheControl: 'public, max-age=600',
 			});
 
-			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+			const result = await service.resolveKeys(DEFAULT_SOURCE, { fetcher });
 
 			expect(result.ttlSeconds).toBe(600);
 		});
@@ -232,7 +242,7 @@ describe('resolveJwksKeys', () => {
 			const source: JwksKeySource = { ...DEFAULT_SOURCE, cacheTtlSeconds: 120 };
 			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }]);
 
-			const result = await resolveJwksKeys(source, { fetcher });
+			const result = await service.resolveKeys(source, { fetcher });
 
 			expect(result.ttlSeconds).toBe(120);
 		});
@@ -240,7 +250,7 @@ describe('resolveJwksKeys', () => {
 		it('should fall back to default TTL (3600s) when no Cache-Control and no cacheTtlSeconds', async () => {
 			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }]);
 
-			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+			const result = await service.resolveKeys(DEFAULT_SOURCE, { fetcher });
 
 			expect(result.ttlSeconds).toBe(3600);
 		});
@@ -250,7 +260,7 @@ describe('resolveJwksKeys', () => {
 				cacheControl: 'max-age=0',
 			});
 
-			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+			const result = await service.resolveKeys(DEFAULT_SOURCE, { fetcher });
 
 			expect(result.ttlSeconds).toBe(60);
 		});
@@ -260,7 +270,7 @@ describe('resolveJwksKeys', () => {
 				cacheControl: 'max-age=999999999',
 			});
 
-			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+			const result = await service.resolveKeys(DEFAULT_SOURCE, { fetcher });
 
 			expect(result.ttlSeconds).toBe(86_400);
 		});
@@ -271,7 +281,7 @@ describe('resolveJwksKeys', () => {
 				cacheControl: 'max-age=600',
 			});
 
-			const result = await resolveJwksKeys(source, { fetcher });
+			const result = await service.resolveKeys(source, { fetcher });
 
 			expect(result.ttlSeconds).toBe(600);
 		});
@@ -279,7 +289,7 @@ describe('resolveJwksKeys', () => {
 		it('should use custom defaultTtlSeconds when no Cache-Control and no cacheTtlSeconds', async () => {
 			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }]);
 
-			const result = await resolveJwksKeys(DEFAULT_SOURCE, {
+			const result = await service.resolveKeys(DEFAULT_SOURCE, {
 				fetcher,
 				defaultTtlSeconds: 300,
 			});
@@ -292,7 +302,7 @@ describe('resolveJwksKeys', () => {
 		it('should throw OperationalError on network failure', async () => {
 			const fetcher = mockFetchError(new Error('ECONNREFUSED'));
 
-			const error = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher }).catch((e) => e);
+			const error = await service.resolveKeys(DEFAULT_SOURCE, { fetcher }).catch((e) => e);
 			expect(error).toBeInstanceOf(OperationalError);
 			expect(error.message).toMatch(/JWKS fetch failed.*ECONNREFUSED/);
 		});
@@ -300,7 +310,7 @@ describe('resolveJwksKeys', () => {
 		it('should throw OperationalError on non-200 response', async () => {
 			const fetcher = mockFetchResponse([], { status: 500 });
 
-			const error = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher }).catch((e) => e);
+			const error = await service.resolveKeys(DEFAULT_SOURCE, { fetcher }).catch((e) => e);
 			expect(error).toBeInstanceOf(OperationalError);
 			expect(error.message).toMatch(/HTTP 500/);
 		});
@@ -308,7 +318,7 @@ describe('resolveJwksKeys', () => {
 		it('should throw OperationalError on invalid JSON', async () => {
 			const fetcher = mockFetchInvalidJson();
 
-			const error = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher }).catch((e) => e);
+			const error = await service.resolveKeys(DEFAULT_SOURCE, { fetcher }).catch((e) => e);
 			expect(error).toBeInstanceOf(OperationalError);
 			expect(error.message).toMatch(/not valid JSON/);
 		});
@@ -316,7 +326,7 @@ describe('resolveJwksKeys', () => {
 		it('should throw OperationalError on empty keys array', async () => {
 			const fetcher = mockFetchResponse([]);
 
-			const error = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher }).catch((e) => e);
+			const error = await service.resolveKeys(DEFAULT_SOURCE, { fetcher }).catch((e) => e);
 			expect(error).toBeInstanceOf(OperationalError);
 			expect(error.message).toMatch(/no keys/);
 		});
@@ -324,7 +334,7 @@ describe('resolveJwksKeys', () => {
 		it('should throw OperationalError when all keys are filtered out', async () => {
 			const fetcher = mockFetchResponse([{ kid: 'enc-only', kty: 'RSA', use: 'enc', ...rsaJwk }]);
 
-			const error = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher }).catch((e) => e);
+			const error = await service.resolveKeys(DEFAULT_SOURCE, { fetcher }).catch((e) => e);
 			expect(error).toBeInstanceOf(OperationalError);
 			expect(error.message).toMatch(/no usable signing keys/);
 		});
@@ -339,7 +349,7 @@ describe('resolveJwksKeys', () => {
 				{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' },
 			]);
 
-			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+			const result = await service.resolveKeys(DEFAULT_SOURCE, { fetcher });
 
 			expect(result.keys).toHaveLength(1);
 			expect(result.keys[0].kid).toBe('rsa-1');
@@ -356,7 +366,7 @@ describe('resolveJwksKeys', () => {
 				{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' },
 			]);
 
-			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+			const result = await service.resolveKeys(DEFAULT_SOURCE, { fetcher });
 
 			expect(result.keys).toHaveLength(1);
 			expect(result.keys[0].kid).toBe('rsa-1');
@@ -368,7 +378,7 @@ describe('resolveJwksKeys', () => {
 				{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' },
 			]);
 
-			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+			const result = await service.resolveKeys(DEFAULT_SOURCE, { fetcher });
 
 			expect(result.keys).toHaveLength(1);
 			expect(result.keys[0].kid).toBe('rsa-1');
@@ -382,7 +392,7 @@ describe('resolveJwksKeys', () => {
 				{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }, // valid
 			]);
 
-			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+			const result = await service.resolveKeys(DEFAULT_SOURCE, { fetcher });
 
 			expect(result.keys).toHaveLength(1);
 			expect(result.skipped).toHaveLength(3);
@@ -402,7 +412,7 @@ describe('resolveJwksKeys', () => {
 		it('should return empty skipped array when all keys are valid', async () => {
 			const fetcher = mockFetchResponse([{ ...rsaJwk, kid: 'rsa-1', alg: 'RS256' }]);
 
-			const result = await resolveJwksKeys(DEFAULT_SOURCE, { fetcher });
+			const result = await service.resolveKeys(DEFAULT_SOURCE, { fetcher });
 
 			expect(result.keys).toHaveLength(1);
 			expect(result.skipped).toEqual([]);

--- a/packages/cli/src/modules/token-exchange/services/__tests__/trusted-key.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/trusted-key.service.test.ts
@@ -10,6 +10,7 @@ import type { TrustedKeySourceRepository } from '../../database/repositories/tru
 import type { TrustedKeyRepository } from '../../database/repositories/trusted-key.repository';
 import type { TokenExchangeConfig } from '../../token-exchange.config';
 import type { TrustedKeyData } from '../../token-exchange.schemas';
+import type { JwksResolverService } from '../jwks-resolver';
 import { TrustedKeyService } from '../trusted-key.service';
 
 // ──────────────────────────────────────────────────────────────────────
@@ -66,6 +67,7 @@ function createMocks() {
 	const keyRepo = mock<TrustedKeyRepository>();
 	const instanceSettings = mock<InstanceSettings>({ isLeader: true });
 	const dbLockService = mock<DbLockService>();
+	const jwksResolverService = mock<JwksResolverService>();
 
 	dbLockService.withLock.mockImplementation(
 		async (_lockId: unknown, fn: (tx: EntityManager) => Promise<unknown>) => {
@@ -82,6 +84,7 @@ function createMocks() {
 		keyRepo,
 		instanceSettings,
 		dbLockService,
+		jwksResolverService,
 	);
 
 	return { service, keyRepo, sourceRepo, dbLockService };

--- a/packages/cli/src/modules/token-exchange/services/jwks-resolver.ts
+++ b/packages/cli/src/modules/token-exchange/services/jwks-resolver.ts
@@ -156,6 +156,11 @@ export async function resolveJwksKeys(
 	const skipped: SkippedKey[] = [];
 
 	for (const rawJwk of jwkSetResult.data.keys) {
+		if (rawJwk === null || typeof rawJwk !== 'object') {
+			skipped.push({ kid: undefined, reason: 'not an object' });
+			continue;
+		}
+
 		const jwkResult = SigningJwkSchema.safeParse(rawJwk);
 		if (!jwkResult.success) {
 			const raw = rawJwk as Record<string, unknown>;

--- a/packages/cli/src/modules/token-exchange/services/jwks-resolver.ts
+++ b/packages/cli/src/modules/token-exchange/services/jwks-resolver.ts
@@ -17,10 +17,18 @@ type SupportedAlgorithm = Algorithm | 'EdDSA';
 
 const FETCH_TIMEOUT_MS = 10_000;
 const DEFAULT_TTL_SECONDS = 3600;
+const MIN_TTL_SECONDS = 60;
+const MAX_TTL_SECONDS = 86_400;
+
+export interface SkippedKey {
+	kid?: string;
+	reason: string;
+}
 
 export interface JwksResolverResult {
 	keys: ResolvedTrustedKey[];
 	expiresAt: Date;
+	skipped: SkippedKey[];
 }
 
 // ──────────────────────────────────────────────────────────────────────
@@ -86,7 +94,9 @@ function inferAlgorithm(jwk: SigningJwk): SupportedAlgorithm | undefined {
 function parseMaxAge(cacheControl: string | null): number | undefined {
 	if (!cacheControl) return undefined;
 	const match = /max-age=(\d+)/.exec(cacheControl);
-	return match ? parseInt(match[1], 10) : undefined;
+	if (!match) return undefined;
+	const value = parseInt(match[1], 10);
+	return Number.isNaN(value) ? undefined : value;
 }
 
 // ──────────────────────────────────────────────────────────────────────
@@ -113,6 +123,7 @@ export async function resolveJwksKeys(
 		response = await doFetch(url, {
 			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
 			headers: { Accept: 'application/json' },
+			redirect: 'error',
 		});
 	} catch (error) {
 		const message = error instanceof Error ? error.message : 'unknown error';
@@ -135,26 +146,42 @@ export async function resolveJwksKeys(
 		throw new OperationalError(`JWKS response has no keys for "${url}"`);
 	}
 
-	// Compute TTL: Cache-Control max-age > source.cacheTtlSeconds > default
+	// Compute TTL: Cache-Control max-age > source.cacheTtlSeconds > default, clamped to [60s, 24h]
 	const maxAge = parseMaxAge(response.headers.get('cache-control'));
-	const ttlSeconds = maxAge ?? source.cacheTtlSeconds ?? defaultTtl;
+	const rawTtl = maxAge ?? source.cacheTtlSeconds ?? defaultTtl;
+	const ttlSeconds = Math.max(MIN_TTL_SECONDS, Math.min(rawTtl, MAX_TTL_SECONDS));
 	const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
 
 	const keys: ResolvedTrustedKey[] = [];
+	const skipped: SkippedKey[] = [];
 
 	for (const rawJwk of jwkSetResult.data.keys) {
 		const jwkResult = SigningJwkSchema.safeParse(rawJwk);
-		if (!jwkResult.success) continue;
+		if (!jwkResult.success) {
+			const raw = rawJwk as Record<string, unknown>;
+			skipped.push({
+				kid: typeof raw.kid === 'string' ? raw.kid : undefined,
+				reason: 'failed schema validation',
+			});
+			continue;
+		}
 
 		const jwk = jwkResult.data;
 
 		const algorithm = inferAlgorithm(jwk);
-		if (!algorithm) continue;
+		if (!algorithm) {
+			skipped.push({
+				kid: jwk.kid,
+				reason: `unsupported algorithm or key type (kty=${jwk.kty}, alg=${jwk.alg ?? 'none'}, crv=${jwk.crv ?? 'none'})`,
+			});
+			continue;
+		}
 
 		let keyObject: ReturnType<typeof createPublicKey>;
 		try {
 			keyObject = createPublicKey({ format: 'jwk', key: jwk } as crypto.JsonWebKeyInput);
 		} catch {
+			skipped.push({ kid: jwk.kid, reason: 'failed to create public key from JWK material' });
 			continue;
 		}
 
@@ -170,8 +197,11 @@ export async function resolveJwksKeys(
 	}
 
 	if (keys.length === 0) {
-		throw new OperationalError(`JWKS response has no usable signing keys for "${url}"`);
+		const reasons = skipped.map((s) => `${s.kid ?? 'unknown'}: ${s.reason}`).join('; ');
+		throw new OperationalError(
+			`JWKS response has no usable signing keys for "${url}" (${reasons})`,
+		);
 	}
 
-	return { keys, expiresAt };
+	return { keys, expiresAt, skipped };
 }

--- a/packages/cli/src/modules/token-exchange/services/jwks-resolver.ts
+++ b/packages/cli/src/modules/token-exchange/services/jwks-resolver.ts
@@ -6,6 +6,7 @@ import { OperationalError } from 'n8n-workflow';
 import { z } from 'zod';
 
 import type { JwksKeySource, ResolvedTrustedKey } from '../token-exchange.schemas';
+import { JwtAlgorithmSchema } from '../token-exchange.schemas';
 
 /**
  * Superset of jsonwebtoken's Algorithm that includes EdDSA.
@@ -26,20 +27,7 @@ export interface JwksResolverResult {
 // JWK Set Zod schemas
 // ──────────────────────────────────────────────────────────────────────
 
-const SUPPORTED_ALGORITHMS = [
-	'RS256',
-	'RS384',
-	'RS512',
-	'PS256',
-	'PS384',
-	'PS512',
-	'ES256',
-	'ES384',
-	'ES512',
-	'EdDSA',
-] as const;
-
-const supportedAlgorithmSet = new Set<string>(SUPPORTED_ALGORITHMS);
+const supportedAlgorithmSet = new Set<string>(JwtAlgorithmSchema.options);
 
 /** Schema for a single JWK that we consider usable as a signing key. */
 const SigningJwkSchema = z

--- a/packages/cli/src/modules/token-exchange/services/jwks-resolver.ts
+++ b/packages/cli/src/modules/token-exchange/services/jwks-resolver.ts
@@ -1,0 +1,189 @@
+import type crypto from 'node:crypto';
+import { createPublicKey } from 'node:crypto';
+
+import type { Algorithm } from 'jsonwebtoken';
+import { OperationalError } from 'n8n-workflow';
+import { z } from 'zod';
+
+import type { JwksKeySource, ResolvedTrustedKey } from '../token-exchange.schemas';
+
+/**
+ * Superset of jsonwebtoken's Algorithm that includes EdDSA.
+ * The `@types/jsonwebtoken` definition omits EdDSA, but jsonwebtoken
+ * handles it at runtime and the JwtAlgorithmSchema accepts it.
+ */
+type SupportedAlgorithm = Algorithm | 'EdDSA';
+
+const FETCH_TIMEOUT_MS = 10_000;
+const DEFAULT_TTL_SECONDS = 3600;
+
+export interface JwksResolverResult {
+	keys: ResolvedTrustedKey[];
+	expiresAt: Date;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// JWK Set Zod schemas
+// ──────────────────────────────────────────────────────────────────────
+
+const SUPPORTED_ALGORITHMS = [
+	'RS256',
+	'RS384',
+	'RS512',
+	'PS256',
+	'PS384',
+	'PS512',
+	'ES256',
+	'ES384',
+	'ES512',
+	'EdDSA',
+] as const;
+
+const supportedAlgorithmSet = new Set<string>(SUPPORTED_ALGORITHMS);
+
+/** Schema for a single JWK that we consider usable as a signing key. */
+const SigningJwkSchema = z
+	.object({
+		kid: z.string().min(1),
+		kty: z.enum(['RSA', 'EC', 'OKP']),
+		alg: z.string().optional(),
+		use: z
+			.string()
+			.optional()
+			.refine((use) => use === undefined || use === 'sig', {
+				message: 'Only signing keys (use: "sig" or absent) are accepted',
+			}),
+		crv: z.string().optional(),
+	})
+	.passthrough();
+
+type SigningJwk = z.infer<typeof SigningJwkSchema>;
+
+/** Schema for the full JWK Set response from a JWKS endpoint. */
+const JwkSetSchema = z.object({
+	keys: z.array(z.unknown()).min(1),
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// Algorithm inference
+// ──────────────────────────────────────────────────────────────────────
+
+const CURVE_TO_ALGORITHM: Record<string, SupportedAlgorithm> = {
+	'P-256': 'ES256',
+	'P-384': 'ES384',
+	'P-521': 'ES512',
+	Ed25519: 'EdDSA',
+};
+
+function inferAlgorithm(jwk: SigningJwk): SupportedAlgorithm | undefined {
+	if (jwk.alg) {
+		return supportedAlgorithmSet.has(jwk.alg) ? (jwk.alg as SupportedAlgorithm) : undefined;
+	}
+
+	switch (jwk.kty) {
+		case 'RSA':
+			return 'RS256';
+		case 'EC':
+		case 'OKP':
+			return jwk.crv ? CURVE_TO_ALGORITHM[jwk.crv] : undefined;
+		default:
+			return undefined;
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Cache-Control parsing
+// ──────────────────────────────────────────────────────────────────────
+
+function parseMaxAge(cacheControl: string | null): number | undefined {
+	if (!cacheControl) return undefined;
+	const match = /max-age=(\d+)/.exec(cacheControl);
+	return match ? parseInt(match[1], 10) : undefined;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Resolver
+// ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Fetches a JWKS endpoint, converts signing keys to ResolvedTrustedKey[],
+ * and determines cache expiry from Cache-Control or fallback TTL.
+ */
+export async function resolveJwksKeys(
+	source: JwksKeySource,
+	options?: {
+		fetcher?: typeof fetch;
+		defaultTtlSeconds?: number;
+	},
+): Promise<JwksResolverResult> {
+	const doFetch = options?.fetcher ?? globalThis.fetch;
+	const defaultTtl = options?.defaultTtlSeconds ?? DEFAULT_TTL_SECONDS;
+	const { url } = source;
+
+	let response: Response;
+	try {
+		response = await doFetch(url, {
+			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+			headers: { Accept: 'application/json' },
+		});
+	} catch (error) {
+		const message = error instanceof Error ? error.message : 'unknown error';
+		throw new OperationalError(`JWKS fetch failed for "${url}": ${message}`);
+	}
+
+	if (!response.ok) {
+		throw new OperationalError(`JWKS fetch failed for "${url}": HTTP ${response.status}`);
+	}
+
+	let body: unknown;
+	try {
+		body = await response.json();
+	} catch {
+		throw new OperationalError(`JWKS response is not valid JSON for "${url}"`);
+	}
+
+	const jwkSetResult = JwkSetSchema.safeParse(body);
+	if (!jwkSetResult.success) {
+		throw new OperationalError(`JWKS response has no keys for "${url}"`);
+	}
+
+	// Compute TTL: Cache-Control max-age > source.cacheTtlSeconds > default
+	const maxAge = parseMaxAge(response.headers.get('cache-control'));
+	const ttlSeconds = maxAge ?? source.cacheTtlSeconds ?? defaultTtl;
+	const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
+
+	const keys: ResolvedTrustedKey[] = [];
+
+	for (const rawJwk of jwkSetResult.data.keys) {
+		const jwkResult = SigningJwkSchema.safeParse(rawJwk);
+		if (!jwkResult.success) continue;
+
+		const jwk = jwkResult.data;
+
+		const algorithm = inferAlgorithm(jwk);
+		if (!algorithm) continue;
+
+		let keyObject: ReturnType<typeof createPublicKey>;
+		try {
+			keyObject = createPublicKey({ format: 'jwk', key: jwk } as crypto.JsonWebKeyInput);
+		} catch {
+			continue;
+		}
+
+		keys.push({
+			kid: jwk.kid,
+			algorithms: [algorithm] as Algorithm[],
+			key: keyObject,
+			issuer: source.issuer,
+			expectedAudience: source.expectedAudience,
+			allowedRoles: source.allowedRoles,
+			expiresAt,
+		});
+	}
+
+	if (keys.length === 0) {
+		throw new OperationalError(`JWKS response has no usable signing keys for "${url}"`);
+	}
+
+	return { keys, expiresAt };
+}

--- a/packages/cli/src/modules/token-exchange/services/jwks-resolver.ts
+++ b/packages/cli/src/modules/token-exchange/services/jwks-resolver.ts
@@ -5,7 +5,7 @@ import type { Algorithm } from 'jsonwebtoken';
 import { OperationalError } from 'n8n-workflow';
 import { z } from 'zod';
 
-import type { JwksKeySource, ResolvedTrustedKey } from '../token-exchange.schemas';
+import type { JwksKeySource } from '../token-exchange.schemas';
 import { JwtAlgorithmSchema } from '../token-exchange.schemas';
 
 /**
@@ -25,9 +25,19 @@ export interface SkippedKey {
 	reason: string;
 }
 
+/** A resolved JWKS key with PEM-encoded key material, ready for DB persistence. */
+export interface JwksResolvedKey {
+	kid: string;
+	algorithms: string[];
+	keyMaterial: string;
+	issuer: string;
+	expectedAudience?: string;
+	allowedRoles?: string[];
+}
+
 export interface JwksResolverResult {
-	keys: ResolvedTrustedKey[];
-	expiresAt: Date;
+	keys: JwksResolvedKey[];
+	ttlSeconds: number;
 	skipped: SkippedKey[];
 }
 
@@ -150,9 +160,8 @@ export async function resolveJwksKeys(
 	const maxAge = parseMaxAge(response.headers.get('cache-control'));
 	const rawTtl = maxAge ?? source.cacheTtlSeconds ?? defaultTtl;
 	const ttlSeconds = Math.max(MIN_TTL_SECONDS, Math.min(rawTtl, MAX_TTL_SECONDS));
-	const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
 
-	const keys: ResolvedTrustedKey[] = [];
+	const keys: JwksResolvedKey[] = [];
 	const skipped: SkippedKey[] = [];
 
 	for (const rawJwk of jwkSetResult.data.keys) {
@@ -192,12 +201,11 @@ export async function resolveJwksKeys(
 
 		keys.push({
 			kid: jwk.kid,
-			algorithms: [algorithm] as Algorithm[],
-			key: keyObject,
+			algorithms: [algorithm],
+			keyMaterial: keyObject.export({ type: 'spki', format: 'pem' }) as string,
 			issuer: source.issuer,
 			expectedAudience: source.expectedAudience,
 			allowedRoles: source.allowedRoles,
-			expiresAt,
 		});
 	}
 
@@ -208,5 +216,5 @@ export async function resolveJwksKeys(
 		);
 	}
 
-	return { keys, expiresAt, skipped };
+	return { keys, ttlSeconds, skipped };
 }

--- a/packages/cli/src/modules/token-exchange/services/jwks-resolver.ts
+++ b/packages/cli/src/modules/token-exchange/services/jwks-resolver.ts
@@ -1,6 +1,8 @@
 import type crypto from 'node:crypto';
 import { createPublicKey } from 'node:crypto';
 
+import { Logger } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
 import type { Algorithm } from 'jsonwebtoken';
 import { OperationalError } from 'n8n-workflow';
 import { z } from 'zod';
@@ -110,111 +112,167 @@ function parseMaxAge(cacheControl: string | null): number | undefined {
 }
 
 // ──────────────────────────────────────────────────────────────────────
-// Resolver
+// Service
 // ──────────────────────────────────────────────────────────────────────
 
 /**
- * Fetches a JWKS endpoint, converts signing keys to ResolvedTrustedKey[],
+ * Fetches JWKS endpoints, converts signing keys to PEM-encoded material,
  * and determines cache expiry from Cache-Control or fallback TTL.
  */
-export async function resolveJwksKeys(
-	source: JwksKeySource,
-	options?: {
-		fetcher?: typeof fetch;
-		defaultTtlSeconds?: number;
-	},
-): Promise<JwksResolverResult> {
-	const doFetch = options?.fetcher ?? globalThis.fetch;
-	const defaultTtl = options?.defaultTtlSeconds ?? DEFAULT_TTL_SECONDS;
-	const { url } = source;
+@Service()
+export class JwksResolverService {
+	private readonly logger: Logger;
 
-	let response: Response;
-	try {
-		response = await doFetch(url, {
-			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-			headers: { Accept: 'application/json' },
-			redirect: 'error',
+	constructor(logger: Logger) {
+		this.logger = logger.scoped('token-exchange');
+	}
+
+	async resolveKeys(
+		source: JwksKeySource,
+		options?: {
+			fetcher?: typeof fetch;
+			defaultTtlSeconds?: number;
+		},
+	): Promise<JwksResolverResult> {
+		const fetcher = options?.fetcher ?? globalThis.fetch;
+		const defaultTtl = options?.defaultTtlSeconds ?? DEFAULT_TTL_SECONDS;
+		const { url } = source;
+
+		this.logger.debug(`Fetching JWKS from "${url}"`);
+
+		const { rawKeys, cacheControl } = await this.fetchJwkSet(url, fetcher);
+		const ttlSeconds = this.computeTtl(cacheControl, source, defaultTtl);
+
+		const keys: JwksResolvedKey[] = [];
+		const skipped: SkippedKey[] = [];
+
+		for (const rawJwk of rawKeys) {
+			const result = this.parseJwk(rawJwk, source);
+			if ('resolved' in result) {
+				keys.push(result.resolved);
+			} else {
+				skipped.push(result.skipped);
+			}
+		}
+
+		if (keys.length === 0) {
+			const reasons = skipped.map((s) => `${s.kid ?? 'unknown'}: ${s.reason}`).join('; ');
+			throw new OperationalError(
+				`JWKS response has no usable signing keys for "${url}" (${reasons})`,
+			);
+		}
+
+		this.logger.debug(`Resolved ${keys.length} key(s) from "${url}"`, {
+			resolved: keys.length,
+			skipped: skipped.length,
+			ttlSeconds,
 		});
-	} catch (error) {
-		const message = error instanceof Error ? error.message : 'unknown error';
-		throw new OperationalError(`JWKS fetch failed for "${url}": ${message}`);
+
+		return { keys, ttlSeconds, skipped };
 	}
 
-	if (!response.ok) {
-		throw new OperationalError(`JWKS fetch failed for "${url}": HTTP ${response.status}`);
+	// ─── Private helpers ──────────────────────────────────────────────
+
+	/** Fetch the JWKS endpoint, validate the response, and return raw keys. */
+	private async fetchJwkSet(
+		url: string,
+		fetcher: typeof fetch,
+	): Promise<{ rawKeys: unknown[]; cacheControl: string | null }> {
+		let response: Response;
+		try {
+			response = await fetcher(url, {
+				signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+				headers: { Accept: 'application/json' },
+				redirect: 'error',
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : 'unknown error';
+			throw new OperationalError(`JWKS fetch failed for "${url}": ${message}`);
+		}
+
+		if (!response.ok) {
+			throw new OperationalError(`JWKS fetch failed for "${url}": HTTP ${response.status}`);
+		}
+
+		let body: unknown;
+		try {
+			body = await response.json();
+		} catch {
+			throw new OperationalError(`JWKS response is not valid JSON for "${url}"`);
+		}
+
+		const jwkSetResult = JwkSetSchema.safeParse(body);
+		if (!jwkSetResult.success) {
+			throw new OperationalError(`JWKS response has no keys for "${url}"`);
+		}
+
+		return {
+			rawKeys: jwkSetResult.data.keys,
+			cacheControl: response.headers.get('cache-control'),
+		};
 	}
 
-	let body: unknown;
-	try {
-		body = await response.json();
-	} catch {
-		throw new OperationalError(`JWKS response is not valid JSON for "${url}"`);
-	}
-
-	const jwkSetResult = JwkSetSchema.safeParse(body);
-	if (!jwkSetResult.success) {
-		throw new OperationalError(`JWKS response has no keys for "${url}"`);
-	}
-
-	// Compute TTL: Cache-Control max-age > source.cacheTtlSeconds > default, clamped to [60s, 24h]
-	const maxAge = parseMaxAge(response.headers.get('cache-control'));
-	const rawTtl = maxAge ?? source.cacheTtlSeconds ?? defaultTtl;
-	const ttlSeconds = Math.max(MIN_TTL_SECONDS, Math.min(rawTtl, MAX_TTL_SECONDS));
-
-	const keys: JwksResolvedKey[] = [];
-	const skipped: SkippedKey[] = [];
-
-	for (const rawJwk of jwkSetResult.data.keys) {
+	/** Parse and validate a single raw JWK entry from the key set. */
+	private parseJwk(
+		rawJwk: unknown,
+		source: JwksKeySource,
+	): { resolved: JwksResolvedKey } | { skipped: SkippedKey } {
 		if (rawJwk === null || typeof rawJwk !== 'object') {
-			skipped.push({ kid: undefined, reason: 'not an object' });
-			continue;
+			return { skipped: { kid: undefined, reason: 'not an object' } };
 		}
 
 		const jwkResult = SigningJwkSchema.safeParse(rawJwk);
 		if (!jwkResult.success) {
 			const raw = rawJwk as Record<string, unknown>;
-			skipped.push({
-				kid: typeof raw.kid === 'string' ? raw.kid : undefined,
-				reason: 'failed schema validation',
-			});
-			continue;
+			return {
+				skipped: {
+					kid: typeof raw.kid === 'string' ? raw.kid : undefined,
+					reason: 'failed schema validation',
+				},
+			};
 		}
 
 		const jwk = jwkResult.data;
 
 		const algorithm = inferAlgorithm(jwk);
 		if (!algorithm) {
-			skipped.push({
-				kid: jwk.kid,
-				reason: `unsupported algorithm or key type (kty=${jwk.kty}, alg=${jwk.alg ?? 'none'}, crv=${jwk.crv ?? 'none'})`,
-			});
-			continue;
+			return {
+				skipped: {
+					kid: jwk.kid,
+					reason: `unsupported algorithm or key type (kty=${jwk.kty}, alg=${jwk.alg ?? 'none'}, crv=${jwk.crv ?? 'none'})`,
+				},
+			};
 		}
 
 		let keyObject: ReturnType<typeof createPublicKey>;
 		try {
 			keyObject = createPublicKey({ format: 'jwk', key: jwk } as crypto.JsonWebKeyInput);
 		} catch {
-			skipped.push({ kid: jwk.kid, reason: 'failed to create public key from JWK material' });
-			continue;
+			return {
+				skipped: { kid: jwk.kid, reason: 'failed to create public key from JWK material' },
+			};
 		}
 
-		keys.push({
-			kid: jwk.kid,
-			algorithms: [algorithm],
-			keyMaterial: keyObject.export({ type: 'spki', format: 'pem' }) as string,
-			issuer: source.issuer,
-			expectedAudience: source.expectedAudience,
-			allowedRoles: source.allowedRoles,
-		});
+		return {
+			resolved: {
+				kid: jwk.kid,
+				algorithms: [algorithm],
+				keyMaterial: keyObject.export({ type: 'spki', format: 'pem' }) as string,
+				issuer: source.issuer,
+				expectedAudience: source.expectedAudience,
+				allowedRoles: source.allowedRoles,
+			},
+		};
 	}
 
-	if (keys.length === 0) {
-		const reasons = skipped.map((s) => `${s.kid ?? 'unknown'}: ${s.reason}`).join('; ');
-		throw new OperationalError(
-			`JWKS response has no usable signing keys for "${url}" (${reasons})`,
-		);
+	/** Compute TTL: Cache-Control max-age > source.cacheTtlSeconds > default, clamped to [60s, 24h]. */
+	private computeTtl(
+		cacheControl: string | null,
+		source: JwksKeySource,
+		defaultTtl: number,
+	): number {
+		const maxAge = parseMaxAge(cacheControl);
+		const rawTtl = maxAge ?? source.cacheTtlSeconds ?? defaultTtl;
+		return Math.max(MIN_TTL_SECONDS, Math.min(rawTtl, MAX_TTL_SECONDS));
 	}
-
-	return { keys, ttlSeconds, skipped };
 }

--- a/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
@@ -26,7 +26,7 @@ import type {
 	TrustedKeySource,
 } from '../token-exchange.schemas';
 import { TrustedKeyDataSchema, TrustedKeySourceSchema } from '../token-exchange.schemas';
-import { resolveJwksKeys } from './jwks-resolver';
+import { JwksResolverService } from './jwks-resolver';
 
 type AlgorithmFamily = 'RSA' | 'EC' | 'EdDSA';
 
@@ -79,6 +79,7 @@ export class TrustedKeyService {
 		private readonly trustedKeyRepository: TrustedKeyRepository,
 		private readonly instanceSettings: InstanceSettings,
 		private readonly dbLockService: DbLockService,
+		private readonly jwksResolverService: JwksResolverService,
 	) {
 		this.logger = logger.scoped('token-exchange');
 	}
@@ -456,7 +457,7 @@ export class TrustedKeyService {
 			throw new UnexpectedError('Invalid JWKS source config: malformed JSON');
 		}
 
-		const result = await resolveJwksKeys(jwksConfig);
+		const result = await this.jwksResolverService.resolveKeys(jwksConfig);
 
 		if (result.skipped.length > 0) {
 			this.logger.debug(`JWKS "${jwksConfig.url}": skipped ${result.skipped.length} key(s)`, {

--- a/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
@@ -338,7 +338,7 @@ export class TrustedKeyService {
 			} catch (e) {
 				this.logger.warn('Failed to parse source configuration for jwks source', {
 					id: source.id,
-					error: e
+					error: e,
 				});
 			}
 		}
@@ -430,8 +430,7 @@ export class TrustedKeyService {
 	private async resolveKeysForSource(
 		source: TrustedKeySourceEntity,
 	): Promise<
-		{ keys: Array<{ kid: string; data: TrustedKeyData }>; cacheTtlSeconds?: number }
-		| undefined
+		{ keys: Array<{ kid: string; data: TrustedKeyData }>; cacheTtlSeconds?: number } | undefined
 	> {
 		switch (source.type) {
 			case 'static':
@@ -481,9 +480,10 @@ export class TrustedKeyService {
 		};
 	}
 
-	private resolveKeysForStaticSource(
-		source: TrustedKeySourceEntity,
-	): { keys: Array<{ kid: string; data: TrustedKeyData }>; cacheTtlSeconds?: number } {
+	private resolveKeysForStaticSource(source: TrustedKeySourceEntity): {
+		keys: Array<{ kid: string; data: TrustedKeyData }>;
+		cacheTtlSeconds?: number;
+	} {
 		let rawConfig: unknown;
 		try {
 			rawConfig = JSON.parse(source.config);
@@ -498,8 +498,8 @@ export class TrustedKeyService {
 			(s): s is StaticKeySource => s.type === 'static',
 		);
 		return {
-			keys: this.resolveStaticKeys(staticConfigs)
-		}
+			keys: this.resolveStaticKeys(staticConfigs),
+		};
 	}
 
 	// ─── Private: key resolution ───────────────────────────────────────

--- a/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
@@ -9,7 +9,7 @@ import { Service } from '@n8n/di';
 import type { EntityManager } from '@n8n/typeorm';
 import { In, Not } from '@n8n/typeorm';
 import { InstanceSettings } from 'n8n-core';
-import { UnexpectedError } from 'n8n-workflow';
+import { UnexpectedError, jsonParse } from 'n8n-workflow';
 import { z } from 'zod';
 
 import { TrustedKeySourceEntity } from '../database/entities/trusted-key-source.entity';
@@ -18,12 +18,15 @@ import { TrustedKeySourceRepository } from '../database/repositories/trusted-key
 import { TrustedKeyRepository } from '../database/repositories/trusted-key.repository';
 import { TokenExchangeConfig } from '../token-exchange.config';
 import type {
+	JwksKeySource,
+	JwtAlgorithm,
 	ResolvedTrustedKey,
 	StaticKeySource,
 	TrustedKeyData,
 	TrustedKeySource,
 } from '../token-exchange.schemas';
 import { TrustedKeyDataSchema, TrustedKeySourceSchema } from '../token-exchange.schemas';
+import { resolveJwksKeys } from './jwks-resolver';
 
 type AlgorithmFamily = 'RSA' | 'EC' | 'EdDSA';
 
@@ -326,12 +329,20 @@ export class TrustedKeyService {
 	}
 
 	private getRefreshIntervalMs(source: TrustedKeySourceEntity): number {
-		switch (source.type) {
-			case 'static':
-			case 'jwks':
-			default:
-				return this.config.keyRefreshIntervalSeconds * Time.seconds.toMilliseconds;
+		if (source.type === 'jwks') {
+			try {
+				const config = jsonParse<Record<string, unknown>>(source.config);
+				if (typeof config.cacheTtlSeconds === 'number' && config.cacheTtlSeconds > 0) {
+					return config.cacheTtlSeconds * Time.seconds.toMilliseconds;
+				}
+			} catch (e) {
+				this.logger.warn('Failed to parse source configuration for jwks source', {
+					id: source.id,
+					error: e
+				});
+			}
 		}
+		return this.config.keyRefreshIntervalSeconds * Time.seconds.toMilliseconds;
 	}
 
 	/**
@@ -368,9 +379,8 @@ export class TrustedKeyService {
 		source: TrustedKeySourceEntity,
 		tx: EntityManager,
 	): Promise<void> {
-		this.logger.debug('Refreshing source', { source });
-		const resolvedKeys = this.resolveKeysForSource(source);
-		if (!resolvedKeys) {
+		const result = await this.resolveKeysForSource(source);
+		if (!result) {
 			// Mark as refreshed so the source is skipped until the next interval,
 			// even though no keys were resolved (e.g. unsupported source type).
 			await tx.update(TrustedKeySourceEntity, source.id, {
@@ -380,11 +390,14 @@ export class TrustedKeyService {
 			return;
 		}
 
+		const keys = result.keys;
+		const cacheTtlSeconds = result.cacheTtlSeconds;
+
 		// 1. DELETE old keys for this source
 		await tx.delete(TrustedKeyEntity, { sourceId: source.id });
 
 		// 2. INSERT new keys
-		for (const key of resolvedKeys) {
+		for (const key of keys) {
 			await tx.save(TrustedKeyEntity, {
 				sourceId: source.id,
 				kid: key.kid,
@@ -393,29 +406,38 @@ export class TrustedKeyService {
 			});
 		}
 
-		// 3. UPDATE source status
-		await tx.update(TrustedKeySourceEntity, source.id, {
-			status: 'healthy',
+		// 3. UPDATE source status, and persist observed cache TTL for refresh scheduling
+		const updatePayload: Partial<TrustedKeySourceEntity> = {
+			status: 'healthy' as const,
 			lastError: null,
 			lastRefreshedAt: new Date(),
-		});
+		};
+		if (cacheTtlSeconds !== undefined) {
+			const config = jsonParse<Record<string, unknown>>(source.config);
+			config.cacheTtlSeconds = cacheTtlSeconds;
+			updatePayload.config = JSON.stringify(config);
+		}
+		await tx.update(TrustedKeySourceEntity, source.id, updatePayload);
 	}
 
 	/**
 	 * Resolve keys for a source by type. Returns `undefined` for
 	 * unsupported types (signalling the caller should skip).
+	 *
+	 * Static sources return a plain array. JWKS sources return an object
+	 * with keys and observed cache TTL for refresh scheduling.
 	 */
-	private resolveKeysForSource(
+	private async resolveKeysForSource(
 		source: TrustedKeySourceEntity,
-	): Array<{ kid: string; data: TrustedKeyData }> | undefined {
+	): Promise<
+		{ keys: Array<{ kid: string; data: TrustedKeyData }>; cacheTtlSeconds?: number }
+		| undefined
+	> {
 		switch (source.type) {
 			case 'static':
 				return this.resolveKeysForStaticSource(source);
 			case 'jwks':
-				this.logger.warn('JWKS key sources are not yet supported, skipping', {
-					sourceId: source.id,
-				});
-				return undefined;
+				return await this.resolveKeysForJwksSource(source);
 			default:
 				this.logger.warn('Unknown key source type, skipping', {
 					sourceId: source.id,
@@ -425,9 +447,43 @@ export class TrustedKeyService {
 		}
 	}
 
+	private async resolveKeysForJwksSource(
+		source: TrustedKeySourceEntity,
+	): Promise<{ keys: Array<{ kid: string; data: TrustedKeyData }>; cacheTtlSeconds: number }> {
+		let jwksConfig: JwksKeySource;
+		try {
+			jwksConfig = jsonParse<JwksKeySource>(source.config);
+		} catch {
+			throw new UnexpectedError('Invalid JWKS source config: malformed JSON');
+		}
+
+		const result = await resolveJwksKeys(jwksConfig);
+
+		if (result.skipped.length > 0) {
+			this.logger.debug(`JWKS "${jwksConfig.url}": skipped ${result.skipped.length} key(s)`, {
+				skipped: result.skipped,
+			});
+		}
+
+		return {
+			keys: result.keys.map((key) => ({
+				kid: key.kid,
+				data: {
+					algorithms: key.algorithms as JwtAlgorithm[],
+					keyMaterial: key.keyMaterial,
+					issuer: key.issuer,
+					expectedAudience: key.expectedAudience,
+					allowedRoles: key.allowedRoles,
+					expiresAt: new Date(Date.now() + result.ttlSeconds * 1000).toISOString(),
+				},
+			})),
+			cacheTtlSeconds: result.ttlSeconds,
+		};
+	}
+
 	private resolveKeysForStaticSource(
 		source: TrustedKeySourceEntity,
-	): Array<{ kid: string; data: TrustedKeyData }> {
+	): { keys: Array<{ kid: string; data: TrustedKeyData }>; cacheTtlSeconds?: number } {
 		let rawConfig: unknown;
 		try {
 			rawConfig = JSON.parse(source.config);
@@ -441,7 +497,9 @@ export class TrustedKeyService {
 		const staticConfigs = configResult.data.filter(
 			(s): s is StaticKeySource => s.type === 'static',
 		);
-		return this.resolveStaticKeys(staticConfigs);
+		return {
+			keys: this.resolveStaticKeys(staticConfigs)
+		}
 	}
 
 	// ─── Private: key resolution ───────────────────────────────────────

--- a/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
@@ -8,7 +8,7 @@ export const TOKEN_EXCHANGE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:token
  * Asymmetric-only JWT algorithms accepted for trusted key sources.
  * Symmetric (HMAC) and 'none' are excluded by design.
  */
-const JwtAlgorithmSchema = z.enum([
+export const JwtAlgorithmSchema = z.enum([
 	'RS256',
 	'RS384',
 	'RS512',

--- a/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
@@ -115,6 +115,9 @@ export interface ResolvedTrustedKey {
 
 	/** Roles allowed for tokens signed with this key, if restricted. */
 	allowedRoles?: string[];
+
+	/** When this key expires (JWKS cache TTL). Undefined for static keys. */
+	expiresAt?: Date;
 }
 
 /**

--- a/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
@@ -115,9 +115,6 @@ export interface ResolvedTrustedKey {
 
 	/** Roles allowed for tokens signed with this key, if restricted. */
 	allowedRoles?: string[];
-
-	/** When this key expires (JWKS cache TTL). Undefined for static keys. */
-	expiresAt?: Date;
 }
 
 /**

--- a/packages/cli/test/integration/token-exchange/trusted-key.service.integration.test.ts
+++ b/packages/cli/test/integration/token-exchange/trusted-key.service.integration.test.ts
@@ -382,26 +382,6 @@ describe('TrustedKeyService (integration)', () => {
 				'Trusted key source not found',
 			);
 		});
-
-		it('should skip jwks sources without writing keys but update lastRefreshedAt', async () => {
-			await insertSource({
-				id: 'jwks-source',
-				type: 'jwks',
-				config: JSON.stringify({
-					type: 'jwks',
-					url: 'https://example.com/jwks',
-					issuer: 'https://example.com',
-				}),
-			});
-
-			await service.refreshSource('jwks-source');
-
-			expect(await keyRepo.find()).toHaveLength(0);
-
-			const source = await sourceRepo.findOneBy({ id: 'jwks-source' });
-			expect(source!.status).toBe('healthy');
-			expect(source!.lastRefreshedAt).toBeDefined();
-		});
 	});
 
 	describe('algorithm validation and key compatibility', () => {


### PR DESCRIPTION
## Summary

Adds a `JwksResolverService` that fetches JWKS endpoints, validates and filters signing keys, converts them to PEM-encoded key material, and determines cache TTL from `Cache-Control` headers. This is the bridge between external identity provider JWKS URLs and n8n's internal `TrustedKeyData` format used by the `trusted_key` table.

This is part of the **OAuth 2.0 Token Exchange** initiative (Phase 2a — Embed flow). The previous PRs added the DB infrastructure for trusted keys (#28097) and the DB-backed `TrustedKeyService` with leader refresh (#28136). This PR implements the JWKS resolution layer so that `jwks`-type key sources are no longer skipped during refresh — they now fetch, parse, and persist keys from remote JWKS endpoints.

### Key implementation decisions

- **`JwksResolverService`** is a standalone `@n8n/di` service with a `resolveKeys()` method that accepts a `JwksKeySource` config and returns resolved keys + TTL + skipped key diagnostics.
- **Algorithm inference**: When a JWK lacks an explicit `alg` field, the service infers it from `kty`/`crv` (RSA → RS256, EC P-256 → ES256, EC P-384 → ES384, EC P-521 → ES512, OKP Ed25519 → EdDSA).
- **Key filtering**: Skips keys without `kid`, encryption-only keys (`use: "enc"`), symmetric keys (`kty: "oct"`), and keys with unsupported algorithms. Returns detailed skip diagnostics for observability.
- **TTL computation**: `Cache-Control max-age` > `source.cacheTtlSeconds` > default (3600s), clamped to [60s, 24h]. The observed TTL is persisted back to the source config so refresh scheduling respects it.
- **`TrustedKeyService` integration**: `resolveKeysForSource()` is now async, dispatches to `resolveKeysForJwksSource()` for JWKS sources, and persists the observed `cacheTtlSeconds` on the source entity for future refresh interval computation.
- **`JwtAlgorithmSchema` exported** from `token-exchange.schemas.ts` so the resolver can validate algorithms against the canonical set.
- Removed the old integration test that asserted JWKS sources are skipped (they are now fully supported).

### How to test manually

To test end-to-end with a real JWKS endpoint (requires a running instance):
1. Configure a `jwks`-type trusted key source pointing to an IdP's `/.well-known/jwks.json`

For example:
```
export N8N_ENV_FEAT_TOKEN_EXCHANGE=true
export N8N_TOKEN_EXCHANGE_TRUSTED_KEYS='[{"type": "jwks","url": "https://dev-3nz2ealgrt07hg24.eu.auth0.com/.well-known/jwks.json","issuer": "https://dev-3nz2ealgrt07hg24.eu.auth0.com"}]'
```
2. Start n8n with the give envvars
3. Verify keys appear in the `trusted_key` table with correct PEM material and algorithm and the jwks source in the `trusted_key_source` table is correct.

## Related tickets

closes https://linear.app/n8n/issue/IAM-518
closes 

## Review checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] I have seen this code, I have run this code, and I take responsibility for this code.