### PR TITLE
fix(nodes): add 'to' field to Zammad ticket article for email recipients

### DIFF
--- a/packages/nodes-base/nodes/Zammad/descriptions/TicketDescription.ts
+++ b/packages/nodes-base/nodes/Zammad/descriptions/TicketDescription.ts
@@ -253,6 +253,14 @@ export const ticketDescription: INodeProperties[] = [
 						default: 'note',
 					},
 					{
+						displayName: 'To',
+						name: 'to',
+						type: 'string',
+						default: '',
+						placeholder: 'recipient@example.com',
+						description: 'Recipient of the article (required for email type tickets)',
+					},
+					{
 						displayName: 'Reply To',
 						name: 'reply_to',
 						type: 'string',

--- a/packages/nodes-base/nodes/Zammad/types.ts
+++ b/packages/nodes-base/nodes/Zammad/types.ts
@@ -90,6 +90,7 @@ export declare namespace Zammad {
 			body: string;
 			sender: 'Agent' | 'Customer' | 'System';
 			type: 'chat' | 'email' | 'fax' | 'note' | 'phone' | 'sms';
+			to?: string;
 			reply_to: string;
 		};
 	};


### PR DESCRIPTION
Fixes #27952

## Problem

When creating an email ticket in the Zammad node, there is no "To" field available in the article configuration. This makes it impossible to specify email recipients for email-type tickets, since the Zammad API requires a `to` field for email articles.

The [Zammad API](https://docs.zammad.org/en/latest/api/ticket/articles.html) supports a `to` field to specify the recipient(s) of the article, which is required for email article types.

## Solution

Added a "To" field to the ticket article description in the Zammad node. The field:
- Is placed after the "Article Type" dropdown and before the "Reply To" field for logical ordering
- Has a placeholder showing the expected format (`recipient@example.com`)
- Has a clear description indicating it is required for email type tickets
- Is passed through to the Zammad API via the existing `...rest` spread in the article body

Also updated the `Article` TypeScript type definition to include the `to?: string` field.

## Testing

- Configure a Zammad node with ticket resource and create operation
- Select "Email" as the article type
- Fill in the "To" field with a recipient email address
- Verify the ticket is created with the email recipient set correctly in Zammad