### PR TITLE
fix(nodes): migrate Todoist Move task from Sync API v9 to REST API v2

### DIFF
--- a/packages/nodes-base/nodes/Todoist/v2/OperationHandler.ts
+++ b/packages/nodes-base/nodes/Todoist/v2/OperationHandler.ts
@@ -435,7 +435,7 @@ export class UpdateHandler implements OperationHandler {
 
 export class MoveHandler implements OperationHandler {
 	async handleOperation(ctx: Context, itemIndex: number): Promise<TodoistResponse> {
-		//https://api.todoist.com/sync/v9/sync
+		//https://developer.todoist.com/rest/v2/#update-a-task
 		const taskId = ctx.getNodeParameter('taskId', itemIndex);
 		assertValidTodoistId('taskId', taskId, ctx.getNode());
 
@@ -445,29 +445,13 @@ export class MoveHandler implements OperationHandler {
 		assertValidTodoistId('project', projectId, ctx.getNode());
 		const nodeVersion = ctx.getNode().typeVersion;
 
-		const body: SyncRequest = {
-			commands: [
-				{
-					type: CommandTypes.ITEM_MOVE,
-					uuid: uuid(),
-					args: {
-						id: taskId,
-						// Set section_id only if node version is below 2.1
-						...(nodeVersion < 2.1
-							? {
-									section_id: (() => {
-										const section = ctx.getNodeParameter('section', itemIndex);
-										assertValidTodoistId('section', section, ctx.getNode());
-										return section;
-									})(),
-								}
-							: {}),
-					},
-				},
-			],
-		};
+		const body: IDataObject = {};
 
-		if (nodeVersion >= 2.1) {
+		if (nodeVersion < 2.1) {
+			const section = ctx.getNodeParameter('section', itemIndex);
+			assertValidTodoistId('section', section, ctx.getNode());
+			body.section_id = section;
+		} else {
 			const options = ctx.getNodeParameter('options', itemIndex, {}) as IDataObject;
 			validateNodeParameters(
 				options,
@@ -480,15 +464,15 @@ export class MoveHandler implements OperationHandler {
 
 			// Only one of parent_id, section_id, or project_id must be set to move the task
 			if (options.parent) {
-				body.commands[0].args.parent_id = options.parent;
+				body.parent_id = options.parent;
 			} else if (options.section) {
-				body.commands[0].args.section_id = options.section;
+				body.section_id = options.section;
 			} else {
-				body.commands[0].args.project_id = projectId;
+				body.project_id = projectId;
 			}
 		}
 
-		await todoistSyncRequest.call(ctx, body);
+		await todoistApiRequest.call(ctx, 'POST', `/tasks/${taskId}`, body);
 		return { success: true };
 	}
 }

--- a/packages/nodes-base/nodes/Todoist/v2/test/OperationHandler.test.ts
+++ b/packages/nodes-base/nodes/Todoist/v2/test/OperationHandler.test.ts
@@ -352,7 +352,7 @@ describe('OperationHandler', () => {
 		});
 
 		describe('MoveHandler', () => {
-			it('should move a task successfully', async () => {
+			it('should move a task to a project successfully', async () => {
 				const handler = new MoveHandler();
 				const mockCtx = createMockContext({
 					taskId: '123456',
@@ -360,22 +360,15 @@ describe('OperationHandler', () => {
 					options: {},
 				});
 
-				mockTodoistSyncRequest.mockResolvedValue(undefined);
+				mockTodoistApiRequest.mockResolvedValue(undefined);
 
 				const result = await handler.handleOperation(mockCtx, 0);
 
-				expect(mockTodoistSyncRequest).toHaveBeenCalledWith(
+				expect(mockTodoistApiRequest).toHaveBeenCalledWith(
+					'POST',
+					'/tasks/123456',
 					expect.objectContaining({
-						commands: [
-							expect.objectContaining({
-								type: 'item_move',
-								uuid: 'mock-uuid-123',
-								args: expect.objectContaining({
-									id: '123456',
-									project_id: '789',
-								}),
-							}),
-						],
+						project_id: '789',
 					}),
 				);
 				expect(result).toEqual({ success: true });
@@ -391,20 +384,38 @@ describe('OperationHandler', () => {
 					},
 				});
 
-				mockTodoistSyncRequest.mockResolvedValue(undefined);
+				mockTodoistApiRequest.mockResolvedValue(undefined);
 
 				await handler.handleOperation(mockCtx, 0);
 
-				expect(mockTodoistSyncRequest).toHaveBeenCalledWith(
+				expect(mockTodoistApiRequest).toHaveBeenCalledWith(
+					'POST',
+					'/tasks/123456',
 					expect.objectContaining({
-						commands: [
-							expect.objectContaining({
-								args: expect.objectContaining({
-									id: '123456',
-									section_id: '456',
-								}),
-							}),
-						],
+						section_id: '456',
+					}),
+				);
+			});
+
+			it('should move a task to a parent task', async () => {
+				const handler = new MoveHandler();
+				const mockCtx = createMockContext({
+					taskId: '123456',
+					project: '789',
+					options: {
+						parent: '999',
+					},
+				});
+
+				mockTodoistApiRequest.mockResolvedValue(undefined);
+
+				await handler.handleOperation(mockCtx, 0);
+
+				expect(mockTodoistApiRequest).toHaveBeenCalledWith(
+					'POST',
+					'/tasks/123456',
+					expect.objectContaining({
+						parent_id: '999',
 					}),
 				);
 			});

--- a/packages/nodes-base/nodes/Todoist/v2/test/TodoistV2.node.test.ts
+++ b/packages/nodes-base/nodes/Todoist/v2/test/TodoistV2.node.test.ts
@@ -281,9 +281,6 @@ describe('Execute TodoistV2 Node', () => {
 		todoistNock.delete('/rest/v2/tasks/8888999900').reply(200, successResponse);
 		todoistNock.get('/rest/v2/tasks').query(true).reply(200, tasksListData);
 
-		// Move task uses sync API
-		todoistNock.post('/sync/v9/sync').reply(200, { sync_status: { '8888999900': 'ok' } });
-
 		// Label operations
 		todoistNock.post('/rest/v2/labels').reply(200, labelData);
 		todoistNock.get('/rest/v2/labels/1111222233').reply(200, labelData);


### PR DESCRIPTION
## Summary

The Todoist Sync API v9 endpoint used by the Move task handler is deprecated. This PR replaces the sync-based `item_move` command with a REST API v2 `POST /tasks/{id}` call.

Fixes #26450

## Changes

- Replace `todoistSyncRequest` with `todoistApiRequest` `POST /tasks/{taskId}` in `MoveHandler`
- Flatten the nested `commands[0].args` structure into a simple request body with `project_id`, `section_id`, or `parent_id`
- Preserve version-gated behavior: v2.0 uses `section_id`, v2.1+ supports all three move targets
- Update unit tests to assert against REST endpoint instead of sync request
- Remove obsolete sync API mock from integration test
- Add test case for moving a task to a parent task

## Testing

- All existing MoveHandler tests updated and passing
- New test added for parent_id move path
- Integration test mock updated from sync to REST endpoint

---
*Built autonomously by [islo.dev](https://islo.dev)*