### PR TITLE
fix(core): Scope deferred tool processors per run

### DIFF
--- a/packages/@n8n/instance-ai/src/agent/__tests__/instance-agent.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/instance-agent.test.ts
@@ -1,0 +1,111 @@
+jest.mock('@mastra/core/agent', () => ({
+	Agent: jest.fn().mockImplementation(function Agent(
+		this: { __registerMastra?: jest.Mock } & Record<string, unknown>,
+		config: Record<string, unknown>,
+	) {
+		Object.assign(this, config);
+		this.__registerMastra = jest.fn();
+	}),
+}));
+
+jest.mock('@mastra/core/mastra', () => ({
+	Mastra: jest.fn().mockImplementation(function Mastra() {}),
+}));
+
+jest.mock('@mastra/core/processors', () => ({
+	ToolSearchProcessor: jest.fn().mockImplementation(function ToolSearchProcessor(
+		this: Record<string, unknown>,
+		config: Record<string, unknown>,
+	) {
+		Object.assign(this, config);
+	}),
+}));
+
+jest.mock('@mastra/mcp', () => ({
+	MCPClient: jest.fn().mockImplementation(() => ({
+		listTools: jest.fn().mockResolvedValue({}),
+	})),
+}));
+
+jest.mock('../../memory/memory-config', () => ({
+	createMemory: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../../tools', () => ({
+	createAllTools: jest.fn((context: { runLabel?: string }) => ({
+		'list-workflows': { id: `list-${context.runLabel ?? 'unknown'}` },
+	})),
+	createOrchestrationTools: jest.fn((context: { runId: string }) => ({
+		plan: { id: `plan-${context.runId}` },
+		'build-workflow-with-agent': { id: `build-${context.runId}` },
+	})),
+}));
+
+jest.mock('../../tools/filesystem/create-tools-from-mcp-server', () => ({
+	createToolsFromLocalMcpServer: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../../tracing/langsmith-tracing', () => ({
+	buildAgentTraceInputs: jest.fn().mockReturnValue({}),
+	mergeTraceRunInputs: jest.fn(),
+}));
+
+jest.mock('../sanitize-mcp-schemas', () => ({
+	sanitizeMcpToolSchemas: jest.fn((tools: Record<string, unknown>) => tools),
+}));
+
+jest.mock('../system-prompt', () => ({
+	getSystemPrompt: jest.fn().mockReturnValue('system prompt'),
+}));
+
+jest.mock('../tool-access', () => ({
+	getOrchestratorDomainTools: jest.fn((tools: Record<string, unknown>) => tools),
+}));
+
+const { createInstanceAgent } =
+	// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
+	require('../instance-agent') as typeof import('../instance-agent');
+const { ToolSearchProcessor } =
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	require('@mastra/core/processors') as {
+		ToolSearchProcessor: jest.Mock;
+	};
+
+describe('createInstanceAgent', () => {
+	it('creates a fresh deferred tool processor for each run-scoped toolset', async () => {
+		const memoryConfig = {
+			storage: { id: 'memory-store' },
+		} as never;
+
+		const createOptions = (runId: string) =>
+			({
+				modelId: 'test-model',
+				context: {
+					runLabel: runId,
+					localGatewayStatus: undefined,
+					licenseHints: undefined,
+					localMcpServer: undefined,
+					filesystemService: undefined,
+				},
+				orchestrationContext: {
+					runId,
+					browserMcpConfig: undefined,
+				},
+				memoryConfig,
+			}) as never;
+
+		await createInstanceAgent(createOptions('run-1'));
+		await createInstanceAgent(createOptions('run-2'));
+
+		expect(ToolSearchProcessor).toHaveBeenCalledTimes(2);
+		const toolSearchCalls = ToolSearchProcessor.mock.calls as Array<
+			[{ tools: Record<string, { id: string }> }]
+		>;
+		expect(toolSearchCalls[0]?.[0]?.tools).toMatchObject({
+			'build-workflow-with-agent': { id: 'build-run-1' },
+		});
+		expect(toolSearchCalls[1]?.[0]?.tools).toMatchObject({
+			'build-workflow-with-agent': { id: 'build-run-2' },
+		});
+	});
+});

--- a/packages/@n8n/instance-ai/src/agent/__tests__/tool-access.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/tool-access.test.ts
@@ -1,0 +1,25 @@
+import type { ToolsInput } from '@mastra/core/agent';
+
+import { getOrchestratorDomainTools } from '../tool-access';
+
+describe('getOrchestratorDomainTools', () => {
+	it('keeps user-facing template search but excludes builder-only template tools', () => {
+		const tools = {
+			'search-workflow-templates': { id: 'search-workflow-templates' },
+			'search-template-structures': { id: 'search-template-structures' },
+			'search-template-parameters': { id: 'search-template-parameters' },
+			'build-workflow': { id: 'build-workflow' },
+			'query-data-table-rows': { id: 'query-data-table-rows' },
+			'create-data-table': { id: 'create-data-table' },
+		} as unknown as ToolsInput;
+
+		const result = getOrchestratorDomainTools(tools);
+
+		expect(result['search-workflow-templates']).toBeDefined();
+		expect(result['query-data-table-rows']).toBeDefined();
+		expect(result['search-template-structures']).toBeUndefined();
+		expect(result['search-template-parameters']).toBeUndefined();
+		expect(result['build-workflow']).toBeUndefined();
+		expect(result['create-data-table']).toBeUndefined();
+	});
+});

--- a/packages/@n8n/instance-ai/src/agent/instance-agent.ts
+++ b/packages/@n8n/instance-ai/src/agent/instance-agent.ts
@@ -13,6 +13,7 @@ import { buildAgentTraceInputs, mergeTraceRunInputs } from '../tracing/langsmith
 import type { CreateInstanceAgentOptions, McpServerConfig } from '../types';
 import { sanitizeMcpToolSchemas } from './sanitize-mcp-schemas';
 import { getSystemPrompt } from './system-prompt';
+import { getOrchestratorDomainTools } from './tool-access';
 
 function buildMcpServers(
 	configs: McpServerConfig[],
@@ -42,9 +43,6 @@ let cachedMcpServersKey = '';
 let cachedBrowserMcpTools: ToolsInput | null = null;
 let cachedBrowserMcpKey = '';
 
-let cachedToolSearchProcessor: ToolSearchProcessor | null = null;
-let cachedToolSearchKey = '';
-
 let cachedMastra: Mastra | null = null;
 let cachedMastraStorageKey = '';
 
@@ -54,15 +52,12 @@ let cachedMastraStorageKey = '';
 const ALWAYS_LOADED_TOOLS = new Set(['plan', 'delegate', 'ask-user', 'web-search', 'fetch-url']);
 
 function getOrCreateToolSearchProcessor(tools: ToolsInput): ToolSearchProcessor {
-	const key = JSON.stringify(Object.keys(tools).sort());
-	if (cachedToolSearchProcessor && cachedToolSearchKey === key) return cachedToolSearchProcessor;
-
-	cachedToolSearchProcessor = new ToolSearchProcessor({
+	// Deferred tools capture per-run closures via the orchestration context.
+	// Reusing a processor across runs can inject stale tool instances into a new agent.
+	return new ToolSearchProcessor({
 		tools: tools as ToolSearchProcessorOptions['tools'],
 		search: { topK: 5 },
 	});
-	cachedToolSearchKey = key;
-	return cachedToolSearchProcessor;
 }
 
 async function getMcpTools(mcpServers: McpServerConfig[]): Promise<ToolsInput> {
@@ -131,43 +126,7 @@ export async function createInstanceAgent(options: CreateInstanceAgentOptions): 
 	// Build native n8n domain tools (context captured via closures — per-run)
 	const domainTools = createAllTools(context);
 
-	// Tools that only the builder sub-agent should use (not the orchestrator).
-	// The orchestrator should submit planned build-workflow tasks instead.
-	const BUILDER_ONLY_TOOLS = new Set([
-		'search-nodes',
-		'list-nodes',
-		'get-node-type-definition',
-		'get-node-description',
-		'get-best-practices',
-		'search-template-structures',
-		'search-template-parameters',
-		'build-workflow',
-		'get-workflow-as-code',
-	]);
-
-	// Write/mutate data-table tools are not exposed directly to the orchestrator.
-	// Read tools (list, schema, query) remain directly available.
-	// Detached table changes should go through planned manage-data-tables tasks.
-	const DATA_TABLE_WRITE_TOOLS = new Set([
-		'create-data-table',
-		'delete-data-table',
-		'add-data-table-column',
-		'delete-data-table-column',
-		'rename-data-table-column',
-		'insert-data-table-rows',
-		'update-data-table-rows',
-		'delete-data-table-rows',
-	]);
-
-	// Orchestrator sees domain tools minus builder-only and data-table-write tools.
-	// Execution tools (run-workflow, get-execution, etc.) are now directly available
-	// with output truncation to prevent context bloat.
-	const orchestratorDomainTools: ToolsInput = {};
-	for (const [name, tool] of Object.entries(domainTools)) {
-		if (!BUILDER_ONLY_TOOLS.has(name) && !DATA_TABLE_WRITE_TOOLS.has(name)) {
-			orchestratorDomainTools[name] = tool;
-		}
-	}
+	const orchestratorDomainTools = getOrchestratorDomainTools(domainTools);
 
 	// Load MCP tools (cached — only spawns processes on first call or config change)
 	const mcpTools = await getMcpTools(mcpServers);

--- a/packages/@n8n/instance-ai/src/agent/tool-access.ts
+++ b/packages/@n8n/instance-ai/src/agent/tool-access.ts
@@ -1,0 +1,32 @@
+import type { ToolsInput } from '@mastra/core/agent';
+
+const BUILDER_ONLY_TOOLS = new Set([
+	'search-nodes',
+	'list-nodes',
+	'get-node-type-definition',
+	'get-node-description',
+	'get-best-practices',
+	'search-template-structures',
+	'search-template-parameters',
+	'build-workflow',
+	'get-workflow-as-code',
+]);
+
+const DATA_TABLE_WRITE_TOOLS = new Set([
+	'create-data-table',
+	'delete-data-table',
+	'add-data-table-column',
+	'delete-data-table-column',
+	'rename-data-table-column',
+	'insert-data-table-rows',
+	'update-data-table-rows',
+	'delete-data-table-rows',
+]);
+
+export function getOrchestratorDomainTools(domainTools: ToolsInput): ToolsInput {
+	return Object.fromEntries(
+		Object.entries(domainTools).filter(
+			([name]) => !BUILDER_ONLY_TOOLS.has(name) && !DATA_TABLE_WRITE_TOOLS.has(name),
+		),
+	);
+}

--- a/packages/@n8n/instance-ai/src/agent/tool-access.ts
+++ b/packages/@n8n/instance-ai/src/agent/tool-access.ts
@@ -1,5 +1,7 @@
 import type { ToolsInput } from '@mastra/core/agent';
 
+// Tools that only the builder sub-agent should use (not the orchestrator).
+// The orchestrator should submit planned build-workflow tasks instead.
 const BUILDER_ONLY_TOOLS = new Set([
 	'search-nodes',
 	'list-nodes',
@@ -12,6 +14,9 @@ const BUILDER_ONLY_TOOLS = new Set([
 	'get-workflow-as-code',
 ]);
 
+// Write/mutate data-table tools are not exposed directly to the orchestrator.
+// Read tools (list, schema, query) remain directly available.
+// Detached table changes should go through planned manage-data-tables tasks.
 const DATA_TABLE_WRITE_TOOLS = new Set([
 	'create-data-table',
 	'delete-data-table',
@@ -24,6 +29,9 @@ const DATA_TABLE_WRITE_TOOLS = new Set([
 ]);
 
 export function getOrchestratorDomainTools(domainTools: ToolsInput): ToolsInput {
+	// Orchestrator sees domain tools minus builder-only and data-table-write tools.
+	// Execution tools (run-workflow, get-execution, etc.) are now directly available
+	// with output truncation to prevent context bloat.
 	return Object.fromEntries(
 		Object.entries(domainTools).filter(
 			([name]) => !BUILDER_ONLY_TOOLS.has(name) && !DATA_TABLE_WRITE_TOOLS.has(name),


### PR DESCRIPTION
## Summary

- Scope deferred `ToolSearchProcessor` creation to each run so deferred tools do not reuse stale run-scoped closures.
- Extract the orchestrator domain-tool filtering into `tool-access.ts` without changing the existing builder-only or data-table-write exclusions.
- Add unit coverage for per-run processor creation and orchestrator tool filtering.

### How to test

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
