### PR TITLE
Add Codex CLI plugin manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "n8n",
+  "version": "0.1.0",
+  "description": "Fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.",
+  "author": {
+    "name": "n8n-io",
+    "url": "https://github.com/n8n-io"
+  },
+  "homepage": "https://github.com/n8n-io/n8n",
+  "repository": "https://github.com/n8n-io/n8n",
+  "keywords": [
+    "mcp",
+    "codex"
+  ],
+  "mcpServers": "./.mcp.json"
+}

--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -1,0 +1,26 @@
+name: Codex Plugin Quality Gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: codex-plugin-scanner-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Codex plugin scanner
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@e83708a91ae4812872aa2905b99ad559a55c74ab
+        with:
+          plugin_dir: "."
+          mode: scan
+          fail_on_severity: critical

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "n8n": {
+      "command": "npx",
+      "args": [
+        "n8n-io-n8n"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This adds a small metadata pass so the repo is easier to wire into Codex without touching runtime code.

I targeted this repo because it already exposes:
- Want to shape the future of automation? Check out our job posts and join our team!

It adds `.codex-plugin/plugin.json`, a starter `.mcp.json`, and the scanner workflow.
Permissions: read-only. No secrets. No publish. No runtime changes.
If you want different command wiring or metadata values, I can adjust the branch.