### PR TITLE
fix(editor): use ClipboardItem for Safari-compatible async clipboard writes

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useClipboard.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useClipboard.ts
@@ -21,15 +21,32 @@ export function useClipboard({
 
 	// Find the correct navigator at copy-time so it works even when the
 	// pop-out window opens after the composable was created.
-	async function copy(value: string) {
+	async function copy(value: string | Promise<string>) {
 		const nav = popOutWindow?.value?.navigator;
-		if (nav?.clipboard) {
+		const targetClipboard = (nav?.clipboard ?? navigator?.clipboard) as Clipboard | undefined;
+
+		// Use ClipboardItem with Promise support for Safari compatibility.
+		// navigator.clipboard.writeText() fails in Safari when called after an async
+		// operation (e.g. a fetch). ClipboardItem accepts a Promise as content, so the
+		// clipboard-write permission is requested synchronously within the user gesture
+		// while the actual text is resolved asynchronously.
+		if (targetClipboard && typeof ClipboardItem !== 'undefined') {
 			try {
-				await nav.clipboard.writeText(value);
+				const textPromise = value instanceof Promise ? value : Promise.resolve(value);
+				await targetClipboard.write([new ClipboardItem({ 'text/plain': textPromise })]);
 				return;
 			} catch {}
 		}
-		await coreCopy(value);
+
+		// Legacy fallback for environments without ClipboardItem support.
+		const text = await Promise.resolve(value);
+		if (nav?.clipboard) {
+			try {
+				await nav.clipboard.writeText(text);
+				return;
+			} catch {}
+		}
+		await coreCopy(text);
 	}
 
 	const ignoreClasses = ['el-messsage-box', 'ignore-key-press-canvas'];

--- a/packages/frontend/editor-ui/src/features/settings/users/views/SettingsUsersView.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/views/SettingsUsersView.test.ts
@@ -551,8 +551,10 @@ describe('SettingsUsersView', () => {
 			emitters.settingsUsersTable.emit('action', { action: 'generateInviteLink', userId: '3' });
 
 			expect(usersStore.generateInviteLink).toHaveBeenCalledWith({ id: '3' });
-			await waitFor(() => {
-				expect(mockClipboard.copy).toHaveBeenCalledWith(
+			await waitFor(async () => {
+				expect(mockClipboard.copy).toHaveBeenCalled();
+				const copyArg = mockClipboard.copy.mock.calls[0]?.[0] as unknown;
+				expect(await Promise.resolve(copyArg)).toBe(
 					'https://example.com/signup?token=generated-token',
 				);
 				expect(mockToast.showToast).toHaveBeenCalledWith({
@@ -596,8 +598,10 @@ describe('SettingsUsersView', () => {
 			emitters.settingsUsersTable.emit('action', { action: 'copyPasswordResetLink', userId: '2' });
 
 			expect(usersStore.getUserPasswordResetLink).toHaveBeenCalledWith(mockUsersList.items[1]);
-			await waitFor(() => {
-				expect(mockClipboard.copy).toHaveBeenCalledWith('https://example.com/reset/123');
+			await waitFor(async () => {
+				expect(mockClipboard.copy).toHaveBeenCalled();
+				const copyArg = mockClipboard.copy.mock.calls[0]?.[0] as unknown;
+				expect(await Promise.resolve(copyArg)).toBe('https://example.com/reset/123');
 				expect(mockToast.showToast).toHaveBeenCalledWith({
 					type: 'success',
 					title: expect.any(String),

--- a/packages/frontend/editor-ui/src/features/settings/users/views/SettingsUsersView.vue
+++ b/packages/frontend/editor-ui/src/features/settings/users/views/SettingsUsersView.vue
@@ -241,8 +241,12 @@ async function onGenerateInviteLink(userId: string) {
 	try {
 		const user = usersStore.usersList.state.items.find((u) => u.id === userId);
 		if (user) {
-			const url = await usersStore.generateInviteLink({ id: userId });
-			void clipboard.copy(url.link);
+			// Start the API call but pass its result as a Promise to clipboard.copy so
+			// that the clipboard-write permission is requested synchronously within the
+			// user-gesture context. This is required for Safari compatibility.
+			const urlPromise = usersStore.generateInviteLink({ id: userId });
+			void clipboard.copy(urlPromise.then((url) => url.link));
+			await urlPromise;
 
 			showToast({
 				type: 'success',
@@ -258,8 +262,9 @@ async function onCopyPasswordResetLink(userId: string) {
 	try {
 		const user = usersStore.usersList.state.items.find((u) => u.id === userId);
 		if (user) {
-			const url = await usersStore.getUserPasswordResetLink(user);
-			void clipboard.copy(url.link);
+			const urlPromise = usersStore.getUserPasswordResetLink(user);
+			void clipboard.copy(urlPromise.then((url) => url.link));
+			await urlPromise;
 
 			showToast({
 				type: 'success',


### PR DESCRIPTION
Fixes #28058

## Problem

In Safari, `navigator.clipboard.writeText()` must be called synchronously within a user-gesture context. When clicking **"Generate Invite Link"** or **"Copy Password Reset Link"** in Settings → Users, n8n first makes an async API call to fetch the URL, then attempts to write to the clipboard in the `.then()` callback. Safari blocks this because the clipboard write is no longer in the direct user-gesture context, leaving the clipboard empty despite the toast saying "Invite link copied".

## Solution

Use `ClipboardItem` with `navigator.clipboard.write()` instead of `writeText()`.

`ClipboardItem` accepts a `Promise` as content — this allows the clipboard-write permission to be requested synchronously within the user gesture, while the actual text content (the fetched URL) resolves asynchronously.

Changes:
- **`useClipboard.ts`**: Updated `copy()` to accept `string | Promise<string>`. When `ClipboardItem` is available (Chrome 84+, Safari 16.1+), it uses `clipboard.write([new ClipboardItem({ 'text/plain': textPromise })])`. Falls back to the previous `writeText` / `execCommand` legacy path for older environments (e.g. Firefox which doesn't support `ClipboardItem`).
- **`SettingsUsersView.vue`**: Updated `onGenerateInviteLink` and `onCopyPasswordResetLink` to pass the API-call promise (`.then(url => url.link)`) directly to `clipboard.copy()`, so the ClipboardItem is created synchronously in the user gesture.
- **`SettingsUsersView.test.ts`**: Updated assertions to resolve the Promise argument before comparing.

## Testing

- Manually test in Safari: Settings → Users → Generate Invite Link should now copy the URL correctly
- Chrome/Firefox behavior is unchanged (falls through the same code path via `ClipboardItem` or legacy fallback)
- Unit tests updated to verify the Promise resolves to the correct URL