### PR TITLE
ci: Tag Docker images

### DIFF
--- a/.github/scripts/docker/docker-tags.mjs
+++ b/.github/scripts/docker/docker-tags.mjs
@@ -9,7 +9,7 @@ class TagGenerator {
 		this.githubOutput = process.env.GITHUB_OUTPUT || null;
 	}
 
-	generate({ image, version, platform, includeDockerHub = false }) {
+	generate({ image, version, platform, includeDockerHub = false, sha = '' }) {
 		let imageName = image;
 		let versionSuffix = '';
 
@@ -27,6 +27,21 @@ class TagGenerator {
 		};
 
 		tags.all = [...tags.ghcr, ...tags.docker];
+
+		// Generate additional SHA-based tags for immutable references
+		if (sha) {
+			const shaVersion = `${version}-${sha}`;
+			const shaPlatformTag = `${shaVersion}${versionSuffix}${platformSuffix}`;
+			const shaGhcr = [`ghcr.io/${this.githubOwner}/${imageName}:${shaPlatformTag}`];
+			const shaDocker = includeDockerHub
+				? [`${this.dockerUsername}/${imageName}:${shaPlatformTag}`]
+				: [];
+			tags.all = [...tags.all, ...shaGhcr, ...shaDocker];
+			tags.ghcr = [...tags.ghcr, ...shaGhcr];
+			tags.docker = [...tags.docker, ...shaDocker];
+			tags.shaPrimaryTag = shaGhcr[0].replace(/-amd64$|-arm64$/, '');
+		}
+
 		return tags;
 	}
 
@@ -40,18 +55,21 @@ class TagGenerator {
 				`${prefixStr}docker_tag=${tags.docker[0] || ''}`,
 				`${prefixStr}primary_tag=${primaryTag}`,
 			];
+			if (tags.shaPrimaryTag) {
+				outputs.push(`${prefixStr}sha_primary_tag=${tags.shaPrimaryTag}`);
+			}
 			appendFileSync(this.githubOutput, outputs.join('\n') + '\n');
 		} else {
 			console.log(JSON.stringify(tags, null, 2));
 		}
 	}
 
-	generateAll({ version, platform, includeDockerHub = false }) {
+	generateAll({ version, platform, includeDockerHub = false, sha = '' }) {
 		const images = ['n8n', 'runners', 'runners-distroless'];
 		const results = {};
 
 		for (const image of images) {
-			const tags = this.generate({ image, version, platform, includeDockerHub });
+			const tags = this.generate({ image, version, platform, includeDockerHub, sha });
 			const prefix = image.replace('-distroless', '_distroless');
 			results[prefix] = tags;
 
@@ -86,6 +104,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 				version,
 				platform: getArg('platform'),
 				includeDockerHub: hasFlag('include-docker'),
+				sha: getArg('sha') || '',
 			});
 			if (!generator.githubOutput) {
 				console.log(JSON.stringify(results, null, 2));
@@ -101,6 +120,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 				version,
 				platform: getArg('platform'),
 				includeDockerHub: hasFlag('include-docker'),
+				sha: getArg('sha') || '',
 			});
 			generator.output(tags);
 		}

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -79,6 +79,9 @@ jobs:
       primary_ghcr_manifest_tag: ${{ steps.determine-tags.outputs.n8n_primary_tag }}
       runners_primary_ghcr_manifest_tag: ${{ steps.determine-tags.outputs.runners_primary_tag }}
       runners_distroless_primary_ghcr_manifest_tag: ${{ steps.determine-tags.outputs.runners_distroless_primary_tag }}
+      n8n_sha_manifest_tag: ${{ steps.determine-tags.outputs.n8n_sha_primary_tag }}
+      runners_sha_manifest_tag: ${{ steps.determine-tags.outputs.runners_sha_primary_tag }}
+      runners_distroless_sha_manifest_tag: ${{ steps.determine-tags.outputs.runners_distroless_sha_primary_tag }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -101,6 +104,7 @@ jobs:
             --all \
             --version "${{ needs.determine-build-context.outputs.n8n_version }}" \
             --platform "${{ matrix.docker_platform }}" \
+            --sha "${GITHUB_SHA::7}" \
             ${{ needs.determine-build-context.outputs.push_to_docker == 'true' && '--include-docker' || '' }}
 
           echo "=== Generated Docker Tags ==="
@@ -228,6 +232,11 @@ jobs:
           create_manifest "runners" "${{ needs.build-and-push-docker.outputs.runners_primary_ghcr_manifest_tag }}"
           create_manifest "runners-distroless" "${{ needs.build-and-push-docker.outputs.runners_distroless_primary_ghcr_manifest_tag }}"
 
+          # Create SHA-tagged manifests (immutable references for deployments)
+          create_manifest "n8n (sha)" "${{ needs.build-and-push-docker.outputs.n8n_sha_manifest_tag }}"
+          create_manifest "runners (sha)" "${{ needs.build-and-push-docker.outputs.runners_sha_manifest_tag }}"
+          create_manifest "runners-distroless (sha)" "${{ needs.build-and-push-docker.outputs.runners_distroless_sha_manifest_tag }}"
+
       - name: Create Docker Hub manifests
         if: needs.determine-build-context.outputs.push_to_docker == 'true'
         run: |
@@ -241,6 +250,8 @@ jobs:
             ["runners-distroless"]="${VERSION}-distroless"
           )
 
+          SHORT_SHA="${GITHUB_SHA::7}"
+
           for image in "${!images[@]}"; do
             TAG_SUFFIX="${images[$image]}"
             IMAGE_NAME="${image//-distroless/}"  # Remove -distroless from image name
@@ -250,6 +261,20 @@ jobs:
               --tag "${DOCKER_BASE}/${IMAGE_NAME}:${TAG_SUFFIX}" \
               "${DOCKER_BASE}/${IMAGE_NAME}:${TAG_SUFFIX}-amd64" \
               "${DOCKER_BASE}/${IMAGE_NAME}:${TAG_SUFFIX}-arm64"
+
+            # Create SHA-tagged manifest (immutable reference)
+            # For distroless, insert SHA between version and -distroless suffix
+            # to match docker-tags.mjs format: nightly-abc1234-distroless (not nightly-distroless-abc1234)
+            if [[ "$image" == *"-distroless"* ]]; then
+              SHA_SUFFIX="${VERSION}-${SHORT_SHA}-distroless"
+            else
+              SHA_SUFFIX="${TAG_SUFFIX}-${SHORT_SHA}"
+            fi
+            echo "Creating Docker Hub SHA manifest for $image: ${SHA_SUFFIX}"
+            docker buildx imagetools create \
+              --tag "${DOCKER_BASE}/${IMAGE_NAME}:${SHA_SUFFIX}" \
+              "${DOCKER_BASE}/${IMAGE_NAME}:${SHA_SUFFIX}-amd64" \
+              "${DOCKER_BASE}/${IMAGE_NAME}:${SHA_SUFFIX}-arm64"
           done
 
       - name: Get manifest digests for attestation


### PR DESCRIPTION
## Summary

Adds the capability to generate and push Docker images and manifests tagged with the short Git SHA. This provides immutable references for each build, enhancing traceability and enabling more reliable deployments by linking a specific image to its exact commit.

Generates tags in the format `version-SHA` for all images (n8n, runners, runners-distroless) on both GHCR and Docker Hub.

## Related Linear tickets, Github issues, and Community forum posts

<img width="997" height="122" alt="image" src="https://github.com/user-attachments/assets/75aac373-d036-4c26-b753-c8f41218c8c1" />



## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
