### PR TITLE
fix(AWS DynamoDB Node): Use typeof check for number detection in PutItem

### DIFF
--- a/packages/nodes-base/nodes/Aws/DynamoDB/__test__/utils.test.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/__test__/utils.test.ts
@@ -1,0 +1,64 @@
+import { adjustPutItem } from '../utils';
+import type { PutItemUi } from '../types';
+
+describe('adjustPutItem', () => {
+	it('should classify actual JS numbers as DynamoDB N type', () => {
+		const result = adjustPutItem({ age: 34 } as unknown as PutItemUi);
+		expect(result).toEqual({ age: { N: '34' } });
+	});
+
+	it('should classify numeric strings as DynamoDB S type', () => {
+		const result = adjustPutItem({ id: '34' } as unknown as PutItemUi);
+		expect(result).toEqual({ id: { S: '34' } });
+	});
+
+	it('should classify regular strings as DynamoDB S type', () => {
+		const result = adjustPutItem({ name: 'hello' } as unknown as PutItemUi);
+		expect(result).toEqual({ name: { S: 'hello' } });
+	});
+
+	it('should classify booleans as DynamoDB BOOL type', () => {
+		const result = adjustPutItem({ active: true } as unknown as PutItemUi);
+		expect(result).toEqual({ active: { BOOL: 'true' } });
+	});
+
+	it('should classify plain objects as DynamoDB M type', () => {
+		const result = adjustPutItem({ meta: { foo: 'bar' } } as unknown as PutItemUi);
+		expect(result).toEqual({ meta: { M: '[object Object]' } });
+	});
+
+	it('should handle zero as a number', () => {
+		const result = adjustPutItem({ count: 0 } as unknown as PutItemUi);
+		expect(result).toEqual({ count: { N: '0' } });
+	});
+
+	it('should handle string "0" as a string', () => {
+		const result = adjustPutItem({ code: '0' } as unknown as PutItemUi);
+		expect(result).toEqual({ code: { S: '0' } });
+	});
+
+	it('should handle floating point numbers', () => {
+		const result = adjustPutItem({ price: 3.14 } as unknown as PutItemUi);
+		expect(result).toEqual({ price: { N: '3.14' } });
+	});
+
+	it('should handle string that looks like a float as a string', () => {
+		const result = adjustPutItem({ version: '3.14' } as unknown as PutItemUi);
+		expect(result).toEqual({ version: { S: '3.14' } });
+	});
+
+	it('should handle multiple attributes with mixed types', () => {
+		const result = adjustPutItem({
+			id: '34',
+			count: 5,
+			name: 'test',
+			active: false,
+		} as unknown as PutItemUi);
+		expect(result).toEqual({
+			id: { S: '34' },
+			count: { N: '5' },
+			name: { S: 'test' },
+			active: { BOOL: 'false' },
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Aws/DynamoDB/utils.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/utils.ts
@@ -47,10 +47,10 @@ export function adjustPutItem(putItemUi: PutItemUi) {
 			type = 'BOOL';
 		} else if (typeof value === 'object' && !Array.isArray(value) && value !== null) {
 			type = 'M';
-		} else if (isNaN(Number(value))) {
-			type = 'S';
-		} else {
+		} else if (typeof value === 'number') {
 			type = 'N';
+		} else {
+			type = 'S';
 		}
 
 		adjustedPutItem[attribute] = { [type]: value.toString() };


### PR DESCRIPTION
## Summary

Fixes a bug where numeric strings (e.g. `'34'`) were incorrectly classified as DynamoDB `N` (number) type in PutItem operations. The old logic used `isNaN(Number(value))`, which returns `false` for numeric strings, causing them to be stored as numbers instead of strings.

The fix switches to `typeof value === 'number'` so only actual JavaScript numbers are classified as `N` type. Strings — even those that look like numbers — are now correctly classified as `S` type.

### How to test

1. Create a DynamoDB PutItem operation with a string field containing a numeric value like `'34'`
2. Verify the item is stored with type `S` (string), not `N` (number)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4576

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)