### PR TITLE
feat(core): Add DB infrastructure for trusted keys and key sources (no-changelog)

### DIFF
--- a/packages/@n8n/backend-test-utils/src/test-db.ts
+++ b/packages/@n8n/backend-test-utils/src/test-db.ts
@@ -107,7 +107,9 @@ type EntityName =
 	| 'DynamicCredentialEntry'
 	| 'DynamicCredentialResolver'
 	| 'DynamicCredentialUserEntry'
-	| 'TokenExchangeJti';
+	| 'TokenExchangeJti'
+	| 'TrustedKeySourceEntity'
+	| 'TrustedKeyEntity';
 
 /**
  * Truncate specific DB tables in a test DB.

--- a/packages/@n8n/db/src/migrations/common/1776000000000-CreateTrustedKeyTables.ts
+++ b/packages/@n8n/db/src/migrations/common/1776000000000-CreateTrustedKeyTables.ts
@@ -1,0 +1,34 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+const sourceTable = 'trusted_key_source';
+const keyTable = 'trusted_key';
+
+export class CreateTrustedKeyTables1776000000000 implements ReversibleMigration {
+	async up({ schemaBuilder: { createTable, column } }: MigrationContext) {
+		await createTable(sourceTable).withColumns(
+			column('id').varchar(36).primary.notNull,
+			column('type').varchar(32).notNull,
+			column('config').text.notNull,
+			column('status').varchar(32).notNull.default("'pending'"),
+			column('lastError').text,
+			column('lastRefreshedAt').timestamp(),
+		).withTimestamps;
+
+		await createTable(keyTable)
+			.withColumns(
+				column('sourceId').varchar(36).primary.notNull,
+				column('kid').varchar(255).primary.notNull,
+				column('data').text.notNull,
+			)
+			.withForeignKey('sourceId', {
+				tableName: sourceTable,
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			}).withCreatedAt;
+	}
+
+	async down({ schemaBuilder: { dropTable } }: MigrationContext) {
+		await dropTable(keyTable);
+		await dropTable(sourceTable);
+	}
+}

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -158,6 +158,7 @@ import { AddRestoreFieldsToWorkflowBuilderSession1774280963551 } from '../common
 import { CreateInstanceVersionHistoryTable1774854660000 } from '../common/1774854660000-CreateInstanceVersionHistoryTable';
 import { CreateInstanceAiTables1775000000000 } from '../common/1775000000000-CreateInstanceAiTables';
 import { CreateTokenExchangeJtiTable1775116241000 } from '../common/1775116241000-CreateTokenExchangeJtiTable';
+import { CreateTrustedKeyTables1776000000000 } from '../common/1776000000000-CreateTrustedKeyTables';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -321,4 +322,5 @@ export const postgresMigrations: Migration[] = [
 	CreateInstanceVersionHistoryTable1774854660000,
 	CreateInstanceAiTables1775000000000,
 	CreateTokenExchangeJtiTable1775116241000,
+	CreateTrustedKeyTables1776000000000,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -152,6 +152,7 @@ import { AddRestoreFieldsToWorkflowBuilderSession1774280963551 } from '../common
 import { CreateInstanceVersionHistoryTable1774854660000 } from '../common/1774854660000-CreateInstanceVersionHistoryTable';
 import { CreateInstanceAiTables1775000000000 } from '../common/1775000000000-CreateInstanceAiTables';
 import { CreateTokenExchangeJtiTable1775116241000 } from '../common/1775116241000-CreateTokenExchangeJtiTable';
+import { CreateTrustedKeyTables1776000000000 } from '../common/1776000000000-CreateTrustedKeyTables';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -309,6 +310,7 @@ const sqliteMigrations: Migration[] = [
 	CreateInstanceVersionHistoryTable1774854660000,
 	CreateInstanceAiTables1775000000000,
 	CreateTokenExchangeJtiTable1775116241000,
+	CreateTrustedKeyTables1776000000000,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/modules/token-exchange/database/entities/trusted-key-source.entity.ts
+++ b/packages/cli/src/modules/token-exchange/database/entities/trusted-key-source.entity.ts
@@ -1,0 +1,25 @@
+import { DateTimeColumn, WithTimestamps } from '@n8n/db';
+import { Column, Entity, PrimaryColumn } from '@n8n/typeorm';
+
+import type { TrustedKeySourceStatus, TrustedKeySourceType } from '../../token-exchange.schemas';
+
+@Entity('trusted_key_source')
+export class TrustedKeySourceEntity extends WithTimestamps {
+	@PrimaryColumn('varchar', { length: 36 })
+	id: string;
+
+	@Column({ type: 'varchar', length: 32 })
+	type: TrustedKeySourceType;
+
+	@Column('text')
+	config: string;
+
+	@Column({ type: 'varchar', length: 32, default: 'pending' })
+	status: TrustedKeySourceStatus;
+
+	@Column({ type: 'text', nullable: true })
+	lastError: string | null;
+
+	@DateTimeColumn({ nullable: true })
+	lastRefreshedAt: Date | null;
+}

--- a/packages/cli/src/modules/token-exchange/database/entities/trusted-key.entity.ts
+++ b/packages/cli/src/modules/token-exchange/database/entities/trusted-key.entity.ts
@@ -1,0 +1,24 @@
+import { DateTimeColumn } from '@n8n/db';
+import type { Relation } from '@n8n/typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from '@n8n/typeorm';
+
+import { TrustedKeySourceEntity } from './trusted-key-source.entity';
+
+@Entity('trusted_key')
+export class TrustedKeyEntity {
+	@PrimaryColumn('varchar', { length: 36 })
+	sourceId: string;
+
+	@PrimaryColumn('varchar', { length: 255 })
+	kid: string;
+
+	@Column('text')
+	data: string;
+
+	@DateTimeColumn()
+	createdAt: Date;
+
+	@ManyToOne(() => TrustedKeySourceEntity, { onDelete: 'CASCADE' })
+	@JoinColumn({ name: 'sourceId' })
+	source: Relation<TrustedKeySourceEntity>;
+}

--- a/packages/cli/src/modules/token-exchange/database/repositories/trusted-key-source.repository.ts
+++ b/packages/cli/src/modules/token-exchange/database/repositories/trusted-key-source.repository.ts
@@ -1,0 +1,11 @@
+import { Service } from '@n8n/di';
+import { DataSource, Repository } from '@n8n/typeorm';
+
+import { TrustedKeySourceEntity } from '../entities/trusted-key-source.entity';
+
+@Service()
+export class TrustedKeySourceRepository extends Repository<TrustedKeySourceEntity> {
+	constructor(dataSource: DataSource) {
+		super(TrustedKeySourceEntity, dataSource.manager);
+	}
+}

--- a/packages/cli/src/modules/token-exchange/database/repositories/trusted-key.repository.ts
+++ b/packages/cli/src/modules/token-exchange/database/repositories/trusted-key.repository.ts
@@ -1,0 +1,19 @@
+import { Service } from '@n8n/di';
+import { DataSource, Repository } from '@n8n/typeorm';
+
+import { TrustedKeyEntity } from '../entities/trusted-key.entity';
+
+@Service()
+export class TrustedKeyRepository extends Repository<TrustedKeyEntity> {
+	constructor(dataSource: DataSource) {
+		super(TrustedKeyEntity, dataSource.manager);
+	}
+
+	async findBySourceAndKid(sourceId: string, kid: string): Promise<TrustedKeyEntity | null> {
+		return await this.findOneBy({ sourceId, kid });
+	}
+
+	async findAllByKid(kid: string): Promise<TrustedKeyEntity[]> {
+		return await this.findBy({ kid });
+	}
+}

--- a/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
@@ -81,6 +81,10 @@ export class TrustedKeyService {
 				this.logger.warn('JWKS key sources are not yet supported, skipping kid in source');
 				continue;
 			}
+			if (source.type === 'ui') {
+				this.logger.warn('UI key sources are not yet supported, skipping');
+				continue;
+			}
 			this.validateAndStoreStaticKey(source);
 		}
 

--- a/packages/cli/src/modules/token-exchange/token-exchange.config.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.config.ts
@@ -20,6 +20,10 @@ export class TokenExchangeConfig {
 	@Env('N8N_TOKEN_EXCHANGE_TRUSTED_KEYS')
 	trustedKeys: string = '';
 
+	/** Interval in seconds between trusted key refresh runs (leader only). */
+	@Env('N8N_TOKEN_EXCHANGE_KEY_REFRESH_INTERVAL_SECONDS')
+	keyRefreshIntervalSeconds: number = 300;
+
 	/** Interval in seconds between JTI cleanup runs. */
 	@Env('N8N_TOKEN_EXCHANGE_JTI_CLEANUP_INTERVAL_SECONDS')
 	jtiCleanupIntervalSeconds: number = 60;

--- a/packages/cli/src/modules/token-exchange/token-exchange.module.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.module.ts
@@ -15,7 +15,11 @@ function isFeatureFlagEnabled(): boolean {
 export class TokenExchangeModule implements ModuleInterface {
 	async entities() {
 		const { TokenExchangeJti } = await import('./database/entities/token-exchange-jti.entity');
-		return [TokenExchangeJti] as never;
+		const { TrustedKeySourceEntity } = await import(
+			'./database/entities/trusted-key-source.entity'
+		);
+		const { TrustedKeyEntity } = await import('./database/entities/trusted-key.entity');
+		return [TokenExchangeJti, TrustedKeySourceEntity, TrustedKeyEntity] as never;
 	}
 
 	async init() {

--- a/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
@@ -65,11 +65,44 @@ export const TrustedKeySourceSchema = z.discriminatedUnion('type', [
 		allowedRoles: z.array(z.string()).optional(),
 		cacheTtlSeconds: z.number().int().positive().optional(),
 	}),
+	z.object({
+		type: z.literal('ui'),
+	}),
 ]);
 
 export type TrustedKeySource = z.infer<typeof TrustedKeySourceSchema>;
 export type StaticKeySource = Extract<TrustedKeySource, { type: 'static' }>;
 export type JwksKeySource = Extract<TrustedKeySource, { type: 'jwks' }>;
+export type UiKeySource = Extract<TrustedKeySource, { type: 'ui' }>;
+
+export type JwtAlgorithm = z.infer<typeof JwtAlgorithmSchema>;
+export type TrustedKeySourceType = 'static' | 'jwks' | 'ui';
+export type TrustedKeySourceStatus = 'pending' | 'healthy' | 'error';
+
+/**
+ * Serializable representation of a trusted key stored in the `trusted_key.data`
+ * JSON column. Unlike `ResolvedTrustedKey`, this holds the raw PEM string
+ * instead of a live `crypto.KeyObject`.
+ */
+export interface TrustedKeyData {
+	/** Allowed signing algorithms for tokens using this key. */
+	algorithms: JwtAlgorithm[];
+
+	/** PEM-encoded public key material. */
+	keyMaterial: string;
+
+	/** Expected `iss` claim value for tokens signed with this key. */
+	issuer: string;
+
+	/** Expected `aud` claim value, if restricted. */
+	expectedAudience?: string;
+
+	/** Roles allowed for tokens signed with this key, if restricted. */
+	allowedRoles?: string[];
+
+	/** ISO 8601 expiry — used by JWKS sources for key rotation. */
+	expiresAt?: string;
+}
 
 /**
  * A trusted key that has been normalized and resolved to an in-memory

--- a/packages/cli/test/integration/token-exchange/trusted-key.repository.integration.test.ts
+++ b/packages/cli/test/integration/token-exchange/trusted-key.repository.integration.test.ts
@@ -1,0 +1,365 @@
+import { testDb, testModules } from '@n8n/backend-test-utils';
+import { Container } from '@n8n/di';
+
+import type {
+	TrustedKeyData,
+	TrustedKeySourceStatus,
+	TrustedKeySourceType,
+} from '@/modules/token-exchange/token-exchange.schemas';
+import { TrustedKeyRepository } from '@/modules/token-exchange/database/repositories/trusted-key.repository';
+import { TrustedKeySourceRepository } from '@/modules/token-exchange/database/repositories/trusted-key-source.repository';
+
+const makeSource = (
+	overrides: Partial<{
+		id: string;
+		type: TrustedKeySourceType;
+		config: string;
+		status: TrustedKeySourceStatus;
+		lastError: string | null;
+		lastRefreshedAt: Date | null;
+	}> = {},
+) => ({
+	id: 'source-1',
+	type: 'static' as const,
+	config: JSON.stringify({ kid: 'key-1', algorithms: ['RS256'] }),
+	status: 'pending' as const,
+	lastError: null,
+	lastRefreshedAt: null,
+	...overrides,
+});
+
+const makeKeyData = (overrides: Partial<TrustedKeyData> = {}): TrustedKeyData => ({
+	algorithms: ['RS256'],
+	keyMaterial: '-----BEGIN PUBLIC KEY-----\ntest\n-----END PUBLIC KEY-----',
+	issuer: 'https://issuer.example.com',
+	...overrides,
+});
+
+const serializeKeyData = (overrides: Partial<TrustedKeyData> = {}): string =>
+	JSON.stringify(makeKeyData(overrides));
+
+describe('TrustedKeySourceRepository & TrustedKeyRepository', () => {
+	let sourceRepo: TrustedKeySourceRepository;
+	let keyRepo: TrustedKeyRepository;
+
+	beforeAll(async () => {
+		await testModules.loadModules(['token-exchange']);
+		await testDb.init();
+		sourceRepo = Container.get(TrustedKeySourceRepository);
+		keyRepo = Container.get(TrustedKeyRepository);
+	});
+
+	afterEach(async () => {
+		// Child table first to respect FK constraints
+		await testDb.truncate(['TrustedKeyEntity', 'TrustedKeySourceEntity']);
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	describe('TrustedKeySourceRepository', () => {
+		it('should insert and retrieve a source', async () => {
+			const source = makeSource();
+			await sourceRepo.save(sourceRepo.create(source));
+
+			const found = await sourceRepo.findOneBy({ id: source.id });
+
+			expect(found).not.toBeNull();
+			expect(found!.id).toBe('source-1');
+			expect(found!.type).toBe('static');
+			expect(found!.status).toBe('pending');
+			expect(found!.config).toBe(source.config);
+		});
+
+		it('should update source status and lastError', async () => {
+			await sourceRepo.save(sourceRepo.create(makeSource()));
+
+			await sourceRepo.update('source-1', {
+				status: 'error',
+				lastError: 'connection refused',
+				lastRefreshedAt: new Date(),
+			});
+
+			const found = await sourceRepo.findOneBy({ id: 'source-1' });
+			expect(found!.status).toBe('error');
+			expect(found!.lastError).toBe('connection refused');
+			expect(found!.lastRefreshedAt).not.toBeNull();
+		});
+
+		it('should update source status to healthy', async () => {
+			await sourceRepo.save(sourceRepo.create(makeSource()));
+
+			await sourceRepo.update('source-1', {
+				status: 'healthy',
+				lastError: null,
+				lastRefreshedAt: new Date(),
+			});
+
+			const found = await sourceRepo.findOneBy({ id: 'source-1' });
+			expect(found!.status).toBe('healthy');
+			expect(found!.lastError).toBeNull();
+		});
+
+		it('should return all sources', async () => {
+			await sourceRepo.save([
+				sourceRepo.create(makeSource({ id: 'src-a' })),
+				sourceRepo.create(makeSource({ id: 'src-b', type: 'jwks' })),
+			]);
+
+			const all = await sourceRepo.find();
+			expect(all).toHaveLength(2);
+		});
+	});
+
+	describe('TrustedKeyRepository', () => {
+		it('should insert a key and retrieve it by source and kid', async () => {
+			await sourceRepo.save(sourceRepo.create(makeSource()));
+
+			await keyRepo.save(
+				keyRepo.create({
+					kid: 'key-1',
+					sourceId: 'source-1',
+					data: serializeKeyData(),
+					createdAt: new Date(),
+				}),
+			);
+
+			const found = await keyRepo.findBySourceAndKid('source-1', 'key-1');
+
+			expect(found).not.toBeNull();
+			expect(found!.kid).toBe('key-1');
+			expect(found!.sourceId).toBe('source-1');
+
+			const data = JSON.parse(found!.data) as TrustedKeyData;
+			expect(data.algorithms).toEqual(['RS256']);
+			expect(data.keyMaterial).toContain('BEGIN PUBLIC KEY');
+		});
+
+		it('should return null for unknown kid', async () => {
+			const found = await keyRepo.findBySourceAndKid('source-1', 'nonexistent');
+			expect(found).toBeNull();
+		});
+
+		it('should support multiple keys per source', async () => {
+			await sourceRepo.save(sourceRepo.create(makeSource()));
+
+			await keyRepo.save([
+				keyRepo.create({
+					kid: 'key-a',
+					sourceId: 'source-1',
+					data: serializeKeyData(),
+					createdAt: new Date(),
+				}),
+				keyRepo.create({
+					kid: 'key-b',
+					sourceId: 'source-1',
+					data: serializeKeyData({ issuer: 'https://other.example.com' }),
+					createdAt: new Date(),
+				}),
+			]);
+
+			const keys = await keyRepo.findBy({ sourceId: 'source-1' });
+			expect(keys).toHaveLength(2);
+		});
+
+		it('should enforce uniqueness within the same source', async () => {
+			await sourceRepo.save(sourceRepo.create(makeSource()));
+
+			await keyRepo.save(
+				keyRepo.create({
+					kid: 'dup-kid',
+					sourceId: 'source-1',
+					data: serializeKeyData(),
+					createdAt: new Date(),
+				}),
+			);
+
+			await expect(
+				keyRepo.insert({
+					kid: 'dup-kid',
+					sourceId: 'source-1',
+					data: serializeKeyData({ issuer: 'https://other.example.com' }),
+					createdAt: new Date(),
+				}),
+			).rejects.toThrow();
+		});
+
+		it('should allow the same kid across different sources', async () => {
+			await sourceRepo.save([
+				sourceRepo.create(makeSource({ id: 'src-a' })),
+				sourceRepo.create(makeSource({ id: 'src-b' })),
+			]);
+
+			await keyRepo.save([
+				keyRepo.create({
+					kid: 'shared-kid',
+					sourceId: 'src-a',
+					data: serializeKeyData({ issuer: 'https://provider-a.example.com' }),
+					createdAt: new Date(),
+				}),
+				keyRepo.create({
+					kid: 'shared-kid',
+					sourceId: 'src-b',
+					data: serializeKeyData({ issuer: 'https://provider-b.example.com' }),
+					createdAt: new Date(),
+				}),
+			]);
+
+			const fromA = await keyRepo.findBySourceAndKid('src-a', 'shared-kid');
+			const fromB = await keyRepo.findBySourceAndKid('src-b', 'shared-kid');
+
+			expect(fromA).not.toBeNull();
+			expect(fromB).not.toBeNull();
+
+			const dataA = JSON.parse(fromA!.data) as TrustedKeyData;
+			const dataB = JSON.parse(fromB!.data) as TrustedKeyData;
+			expect(dataA.issuer).toBe('https://provider-a.example.com');
+			expect(dataB.issuer).toBe('https://provider-b.example.com');
+		});
+
+		it('should return all keys matching a kid via findAllByKid', async () => {
+			await sourceRepo.save([
+				sourceRepo.create(makeSource({ id: 'src-a' })),
+				sourceRepo.create(makeSource({ id: 'src-b' })),
+			]);
+
+			await keyRepo.save([
+				keyRepo.create({
+					kid: 'shared-kid',
+					sourceId: 'src-a',
+					data: serializeKeyData({ issuer: 'https://provider-a.example.com' }),
+					createdAt: new Date(),
+				}),
+				keyRepo.create({
+					kid: 'shared-kid',
+					sourceId: 'src-b',
+					data: serializeKeyData({ issuer: 'https://provider-b.example.com' }),
+					createdAt: new Date(),
+				}),
+				keyRepo.create({
+					kid: 'other-kid',
+					sourceId: 'src-a',
+					data: serializeKeyData(),
+					createdAt: new Date(),
+				}),
+			]);
+
+			const matches = await keyRepo.findAllByKid('shared-kid');
+			expect(matches).toHaveLength(2);
+		});
+
+		it('should reject key with non-existent sourceId', async () => {
+			await expect(
+				keyRepo.insert({
+					kid: 'orphan-key',
+					sourceId: 'does-not-exist',
+					data: serializeKeyData(),
+					createdAt: new Date(),
+				}),
+			).rejects.toThrow();
+		});
+
+		it('should round-trip all optional TrustedKeyData fields', async () => {
+			await sourceRepo.save(sourceRepo.create(makeSource()));
+
+			const fullData = serializeKeyData({
+				expectedAudience: 'https://n8n.example.com',
+				allowedRoles: ['admin', 'editor'],
+				expiresAt: '2026-12-31T23:59:59.000Z',
+			});
+
+			await keyRepo.save(
+				keyRepo.create({
+					kid: 'full-key',
+					sourceId: 'source-1',
+					data: fullData,
+					createdAt: new Date(),
+				}),
+			);
+
+			const found = await keyRepo.findBySourceAndKid('source-1', 'full-key');
+
+			expect(found).not.toBeNull();
+			const data = JSON.parse(found!.data) as TrustedKeyData;
+			expect(data.expectedAudience).toBe('https://n8n.example.com');
+			expect(data.allowedRoles).toEqual(['admin', 'editor']);
+			expect(data.expiresAt).toBe('2026-12-31T23:59:59.000Z');
+		});
+
+		it('should persist and return createdAt as a Date', async () => {
+			await sourceRepo.save(sourceRepo.create(makeSource()));
+
+			const now = new Date();
+			await keyRepo.save(
+				keyRepo.create({
+					kid: 'ts-key',
+					sourceId: 'source-1',
+					data: serializeKeyData(),
+					createdAt: now,
+				}),
+			);
+
+			const found = await keyRepo.findBySourceAndKid('source-1', 'ts-key');
+
+			expect(found).not.toBeNull();
+			expect(found!.createdAt).toBeInstanceOf(Date);
+			expect(found!.createdAt.getTime()).toBe(now.getTime());
+		});
+	});
+
+	describe('FK CASCADE', () => {
+		it('should delete keys when source is deleted', async () => {
+			await sourceRepo.save(sourceRepo.create(makeSource()));
+
+			await keyRepo.save([
+				keyRepo.create({
+					kid: 'cascade-1',
+					sourceId: 'source-1',
+					data: serializeKeyData(),
+					createdAt: new Date(),
+				}),
+				keyRepo.create({
+					kid: 'cascade-2',
+					sourceId: 'source-1',
+					data: serializeKeyData(),
+					createdAt: new Date(),
+				}),
+			]);
+
+			expect(await keyRepo.count()).toBe(2);
+
+			await sourceRepo.delete('source-1');
+
+			expect(await keyRepo.count()).toBe(0);
+		});
+
+		it('should not affect keys from other sources', async () => {
+			await sourceRepo.save([
+				sourceRepo.create(makeSource({ id: 'src-keep' })),
+				sourceRepo.create(makeSource({ id: 'src-delete' })),
+			]);
+
+			await keyRepo.save([
+				keyRepo.create({
+					kid: 'key-keep',
+					sourceId: 'src-keep',
+					data: serializeKeyData(),
+					createdAt: new Date(),
+				}),
+				keyRepo.create({
+					kid: 'key-delete',
+					sourceId: 'src-delete',
+					data: serializeKeyData(),
+					createdAt: new Date(),
+				}),
+			]);
+
+			await sourceRepo.delete('src-delete');
+
+			expect(await keyRepo.count()).toBe(1);
+			expect(await keyRepo.findBySourceAndKid('src-keep', 'key-keep')).not.toBeNull();
+			expect(await keyRepo.findBySourceAndKid('src-delete', 'key-delete')).toBeNull();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

This PR adds the database layer for persisting trusted keys and their sources in the token exchange module. Currently, trusted keys are loaded from environment variables at startup and held only in memory. This change introduces two new tables (`trusted_key_source` and `trusted_key`) with TypeORM entities, repositories, and a reversible migration, laying the groundwork for dynamic key management (e.g., JWKS rotation and UI-managed keys).

**What's included:**
- **Migration** (`1776000000000-CreateTrustedKeyTables`): Creates `trusted_key_source` (with status tracking, config, and refresh metadata) and `trusted_key` (composite PK on `sourceId` + `kid`, FK cascade to source) for both PostgreSQL and SQLite.
- **Entities**: `TrustedKeySourceEntity` and `TrustedKeyEntity` with proper TypeORM decorators and relations.
- **Repositories**: `TrustedKeySourceRepository` and `TrustedKeyRepository` (with `findBySourceAndKid` and `findAllByKid` query methods).
- **Schema additions**: New `ui` source type in the Zod discriminated union, `TrustedKeyData` interface for the serialized JSON column, and exported type aliases (`TrustedKeySourceType`, `TrustedKeySourceStatus`).
- **Config**: `keyRefreshIntervalSeconds` env var for future leader-only refresh scheduling.
- **Module registration**: Entities lazy-loaded in `TokenExchangeModule.entities()`.

**Key design decisions:**
- Composite primary key (`sourceId`, `kid`) on `trusted_key` allows the same `kid` across different sources while enforcing uniqueness within a source.
- `trusted_key.data` is a JSON text column storing `TrustedKeyData` (algorithms, PEM, issuer, audience, roles, expiry) — keeps the schema stable as key metadata evolves.
- `trusted_key_source.status` tracks source health (`pending` → `healthy` | `error`) for observability of JWKS refresh cycles.
- `ui` source type is recognized in the schema but explicitly skipped during initialization (not yet supported).

### How to test manually

1. Start n8n with the token exchange feature flag enabled
2. Verify the migration runs without errors on a fresh database (check startup logs)
3. Confirm both tables exist: `SELECT * FROM trusted_key_source; SELECT * FROM trusted_key;`

### Related tickets

closes https://linear.app/n8n/issue/IAM-523/2a31-trustedkeystore-db-tables-entities-and-repositories

## Review checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   - Integration tests cover: CRUD operations, FK cascade deletes, composite PK uniqueness, cross-source kid sharing, `findAllByKid` queries, optional field round-tripping, and orphan key rejection.