### PR TITLE
feat(API): Add insights summary endpoint to public API

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -153,6 +153,7 @@ export {
 } from './schemas/source-controlled-file.schema';
 
 export {
+	insightsSummarySchema,
 	type InsightsSummaryType,
 	type InsightsSummaryUnit,
 	type InsightsSummary,

--- a/packages/cli/src/public-api/types.ts
+++ b/packages/cli/src/public-api/types.ts
@@ -197,6 +197,19 @@ export declare namespace CredentialRequest {
 	type Transfer = AuthenticatedRequest<{ id: string }, {}, { destinationProjectId: string }>;
 }
 
+export declare namespace InsightsRequest {
+	type GetSummary = AuthenticatedRequest<
+		{},
+		{},
+		{},
+		{
+			startDate?: string;
+			endDate?: string;
+			projectId?: string;
+		}
+	>;
+}
+
 export type OperationID = 'getUsers' | 'getUser';
 
 type PaginationBase = { limit: number };

--- a/packages/cli/src/public-api/v1/handlers/insights/insights.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/insights/insights.handler.ts
@@ -1,0 +1,72 @@
+import { InsightsDateFilterDto } from '@n8n/api-types';
+import { Container } from '@n8n/di';
+import type express from 'express';
+import { DateTime } from 'luxon';
+import { UserError } from 'n8n-workflow';
+import { z } from 'zod';
+
+import { apiKeyHasScope } from '../../shared/middlewares/global.middleware';
+
+import { InsightsService } from '@/modules/insights/insights.service';
+import type { InsightsRequest } from '@/public-api/types';
+
+const dateFilterValidationSchema = z
+	.object({
+		startDate: z.coerce.date().optional(),
+		endDate: z.coerce.date().optional(),
+	})
+	.refine(
+		(data) => {
+			if (data.startDate && data.endDate) {
+				return data.startDate <= data.endDate;
+			}
+
+			return true;
+		},
+		{
+			message: 'endDate must be the same as or after startDate',
+			path: ['endDate'],
+		},
+	);
+
+export = {
+	getInsightsSummary: [
+		apiKeyHasScope('insights:read'),
+		async (req: InsightsRequest.GetSummary, res: express.Response): Promise<express.Response> => {
+			const query = InsightsDateFilterDto.safeParse(req.query);
+			if (!query.success) {
+				return res
+					.status(400)
+					.json({ message: query.error.errors.map(({ message }) => message).join(' ') });
+			}
+
+			const validation = dateFilterValidationSchema.safeParse(query.data);
+			if (!validation.success) {
+				return res
+					.status(400)
+					.json({ message: validation.error.errors.map(({ message }) => message).join(' ') });
+			}
+
+			const endDate = query.data.endDate ?? new Date();
+			const startDate = query.data.startDate ?? DateTime.now().minus({ days: 7 }).toJSDate();
+
+			try {
+				Container.get(InsightsService).validateDateFiltersLicense({ startDate, endDate });
+			} catch (error) {
+				if (error instanceof UserError) {
+					return res.status(403).json({ message: error.message });
+				}
+
+				throw error;
+			}
+
+			const summary = await Container.get(InsightsService).getInsightsSummary({
+				startDate,
+				endDate,
+				projectId: query.data.projectId,
+			});
+
+			return res.json(summary);
+		},
+	],
+};

--- a/packages/cli/src/public-api/v1/handlers/insights/insights.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/insights/insights.handler.ts
@@ -5,10 +5,12 @@ import { DateTime } from 'luxon';
 import { UserError } from 'n8n-workflow';
 import { z } from 'zod';
 
-import { apiKeyHasScope } from '../../shared/middlewares/global.middleware';
-
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { InsightsService } from '@/modules/insights/insights.service';
 import type { InsightsRequest } from '@/public-api/types';
+
+import { apiKeyHasScope } from '../../shared/middlewares/global.middleware';
 
 const dateFilterValidationSchema = z
 	.object({
@@ -35,16 +37,12 @@ export = {
 		async (req: InsightsRequest.GetSummary, res: express.Response): Promise<express.Response> => {
 			const query = InsightsDateFilterDto.safeParse(req.query);
 			if (!query.success) {
-				return res
-					.status(400)
-					.json({ message: query.error.errors.map(({ message }) => message).join(' ') });
+				throw new BadRequestError(query.error.errors.map(({ message }) => message).join('; '));
 			}
 
 			const validation = dateFilterValidationSchema.safeParse(query.data);
 			if (!validation.success) {
-				return res
-					.status(400)
-					.json({ message: validation.error.errors.map(({ message }) => message).join(' ') });
+				throw new BadRequestError(validation.error.errors.map(({ message }) => message).join('; '));
 			}
 
 			const endDate = query.data.endDate ?? new Date();
@@ -54,7 +52,7 @@ export = {
 				Container.get(InsightsService).validateDateFiltersLicense({ startDate, endDate });
 			} catch (error) {
 				if (error instanceof UserError) {
-					return res.status(403).json({ message: error.message });
+					throw new ForbiddenError(error.message);
 				}
 
 				throw error;

--- a/packages/cli/src/public-api/v1/handlers/insights/spec/paths/insights.yml
+++ b/packages/cli/src/public-api/v1/handlers/insights/spec/paths/insights.yml
@@ -34,6 +34,8 @@ get:
         application/json:
           schema:
             $ref: '../schemas/insights.yml'
+    '400':
+      $ref: '../../../../shared/spec/responses/badRequest.yml'
     '401':
       $ref: '../../../../shared/spec/responses/unauthorized.yml'
     '403':

--- a/packages/cli/src/public-api/v1/handlers/insights/spec/paths/insights.yml
+++ b/packages/cli/src/public-api/v1/handlers/insights/spec/paths/insights.yml
@@ -1,0 +1,40 @@
+get:
+  x-eov-operation-id: getInsightsSummary
+  x-eov-operation-handler: v1/handlers/insights/insights.handler
+  tags:
+    - Insights
+  summary: Retrieve insights summary
+  description: Retrieve the insights summary for the selected date range.
+  parameters:
+    - name: startDate
+      in: query
+      required: false
+      description: ISO 8601 start date. Defaults to 7 days ago.
+      schema:
+        type: string
+        format: date-time
+    - name: endDate
+      in: query
+      required: false
+      description: ISO 8601 end date. Defaults to now.
+      schema:
+        type: string
+        format: date-time
+    - name: projectId
+      in: query
+      required: false
+      description: Project identifier to filter insights by project.
+      schema:
+        type: string
+        example: VmwOO9HeTEj20kxM
+  responses:
+    '200':
+      description: Operation successful.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/insights.yml'
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
+    '403':
+      $ref: '../../../../shared/spec/responses/forbidden.yml'

--- a/packages/cli/src/public-api/v1/handlers/insights/spec/schemas/insights.yml
+++ b/packages/cli/src/public-api/v1/handlers/insights/spec/schemas/insights.yml
@@ -1,0 +1,83 @@
+type: object
+required:
+  - total
+  - failed
+  - failureRate
+  - timeSaved
+  - averageRunTime
+properties:
+  total:
+    type: object
+    required:
+      - value
+      - deviation
+      - unit
+    properties:
+      value:
+        type: number
+      deviation:
+        type: number
+        nullable: true
+      unit:
+        type: string
+        enum: ['count']
+  failed:
+    type: object
+    required:
+      - value
+      - deviation
+      - unit
+    properties:
+      value:
+        type: number
+      deviation:
+        type: number
+        nullable: true
+      unit:
+        type: string
+        enum: ['count']
+  failureRate:
+    type: object
+    required:
+      - value
+      - deviation
+      - unit
+    properties:
+      value:
+        type: number
+      deviation:
+        type: number
+        nullable: true
+      unit:
+        type: string
+        enum: ['ratio']
+  timeSaved:
+    type: object
+    required:
+      - value
+      - deviation
+      - unit
+    properties:
+      value:
+        type: number
+      deviation:
+        type: number
+        nullable: true
+      unit:
+        type: string
+        enum: ['minute']
+  averageRunTime:
+    type: object
+    required:
+      - value
+      - deviation
+      - unit
+    properties:
+      value:
+        type: number
+      deviation:
+        type: number
+        nullable: true
+      unit:
+        type: string
+        enum: ['millisecond']

--- a/packages/cli/src/public-api/v1/openapi.yml
+++ b/packages/cli/src/public-api/v1/openapi.yml
@@ -40,6 +40,8 @@ tags:
     description: Operations about community packages
   - name: Discover
     description: API capability discovery
+  - name: Insights
+    description: Operations about insights
 
 paths:
   /audit:
@@ -124,6 +126,8 @@ paths:
     $ref: './handlers/community-packages/spec/paths/community-packages.packageName.yml'
   /discover:
     $ref: './handlers/discover/spec/paths/discover.yml'
+  /insights/summary:
+    $ref: './handlers/insights/spec/paths/insights.yml'
 components:
   schemas:
     $ref: './shared/spec/schemas/_index.yml'

--- a/packages/cli/test/integration/public-api/insights.test.ts
+++ b/packages/cli/test/integration/public-api/insights.test.ts
@@ -1,13 +1,13 @@
+import { insightsSummarySchema } from '@n8n/api-types';
 import { createTeamProject, createWorkflow, testDb } from '@n8n/backend-test-utils';
 import { type User } from '@n8n/db';
-import { insightsSummarySchema } from '@n8n/api-types';
 import { DateTime } from 'luxon';
-
-import { createCompactedInsightsEvent } from '@/modules/insights/database/entities/__tests__/db-utils';
 
 import { createOwnerWithApiKey } from '../shared/db/users';
 import type { SuperAgentTest } from '../shared/types';
 import * as utils from '../shared/utils';
+
+import { createCompactedInsightsEvent } from '@/modules/insights/database/entities/__tests__/db-utils';
 
 const testServer = utils.setupTestServer({
 	endpointGroups: ['publicApi'],

--- a/packages/cli/test/integration/public-api/insights.test.ts
+++ b/packages/cli/test/integration/public-api/insights.test.ts
@@ -1,0 +1,177 @@
+import { createTeamProject, createWorkflow, testDb } from '@n8n/backend-test-utils';
+import { type User } from '@n8n/db';
+import { insightsSummarySchema } from '@n8n/api-types';
+import { DateTime } from 'luxon';
+
+import { createCompactedInsightsEvent } from '@/modules/insights/database/entities/__tests__/db-utils';
+
+import { createOwnerWithApiKey } from '../shared/db/users';
+import type { SuperAgentTest } from '../shared/types';
+import * as utils from '../shared/utils';
+
+const testServer = utils.setupTestServer({
+	endpointGroups: ['publicApi'],
+	enabledFeatures: ['feat:advancedPermissions', 'feat:insights:viewSummary'],
+	quotas: { 'quota:insights:maxHistoryDays': 365 },
+	modules: ['insights'],
+});
+
+let scopedOwner: User;
+let unscopedOwner: User;
+let authScopedAgent: SuperAgentTest;
+let authUnscopedAgent: SuperAgentTest;
+
+async function createSummaryMetrics(
+	workflow: Awaited<ReturnType<typeof createWorkflow>>,
+	values: { success?: number; failure?: number; runtimeMs?: number; timeSavedMin?: number },
+) {
+	const periodStart = DateTime.utc().minus({ days: 1 });
+	const periodUnit = 'day' as const;
+
+	if (values.success !== undefined) {
+		await createCompactedInsightsEvent(workflow, {
+			type: 'success',
+			value: values.success,
+			periodStart,
+			periodUnit,
+		});
+	}
+
+	if (values.failure !== undefined) {
+		await createCompactedInsightsEvent(workflow, {
+			type: 'failure',
+			value: values.failure,
+			periodStart,
+			periodUnit,
+		});
+	}
+
+	if (values.runtimeMs !== undefined) {
+		await createCompactedInsightsEvent(workflow, {
+			type: 'runtime_ms',
+			value: values.runtimeMs,
+			periodStart,
+			periodUnit,
+		});
+	}
+
+	if (values.timeSavedMin !== undefined) {
+		await createCompactedInsightsEvent(workflow, {
+			type: 'time_saved_min',
+			value: values.timeSavedMin,
+			periodStart,
+			periodUnit,
+		});
+	}
+}
+
+beforeAll(async () => {
+	scopedOwner = await createOwnerWithApiKey({ scopes: ['insights:read'] });
+	unscopedOwner = await createOwnerWithApiKey({ scopes: ['workflow:list'] });
+});
+
+beforeEach(async () => {
+	await testDb.truncate(['InsightsByPeriod', 'InsightsMetadata', 'InsightsRaw']);
+	authScopedAgent = testServer.publicApiAgentFor(scopedOwner);
+	authUnscopedAgent = testServer.publicApiAgentFor(unscopedOwner);
+});
+
+describe('GET /insights/summary', () => {
+	test('returns 401 without API key', async () => {
+		await testServer.publicApiAgentWithoutApiKey().get('/insights/summary').expect(401);
+	});
+
+	test('returns 403 without insights:read scope', async () => {
+		await authUnscopedAgent.get('/insights/summary').expect(403);
+	});
+
+	test('returns data matching InsightsSummary schema', async () => {
+		const project = await createTeamProject();
+		const workflow = await createWorkflow({}, project);
+
+		await createSummaryMetrics(workflow, {
+			success: 3,
+			failure: 1,
+			runtimeMs: 400,
+			timeSavedMin: 20,
+		});
+
+		const response = await authScopedAgent
+			.get('/insights/summary')
+			.query({
+				startDate: DateTime.utc().minus({ days: 2 }).toISO(),
+				endDate: DateTime.utc().plus({ days: 1 }).toISO(),
+			})
+			.expect(200);
+
+		const parsed = insightsSummarySchema.safeParse(response.body);
+		expect(parsed.success).toBe(true);
+		expect(response.body.total.value).toBe(4);
+		expect(response.body.failed.value).toBe(1);
+	});
+
+	test('respects startDate and endDate filters', async () => {
+		const project = await createTeamProject();
+		const workflow = await createWorkflow({}, project);
+
+		await createCompactedInsightsEvent(workflow, {
+			type: 'success',
+			value: 2,
+			periodUnit: 'day',
+			periodStart: DateTime.utc().minus({ days: 1 }),
+		});
+
+		await createCompactedInsightsEvent(workflow, {
+			type: 'success',
+			value: 9,
+			periodUnit: 'day',
+			periodStart: DateTime.utc().minus({ days: 10 }),
+		});
+
+		const response = await authScopedAgent
+			.get('/insights/summary')
+			.query({
+				startDate: DateTime.utc().minus({ days: 2 }).toISO(),
+				endDate: DateTime.utc().plus({ days: 1 }).toISO(),
+			})
+			.expect(200);
+
+		expect(response.body.total.value).toBe(2);
+	});
+
+	test('respects projectId filter', async () => {
+		const [firstProject, secondProject] = await Promise.all([
+			createTeamProject(),
+			createTeamProject(),
+		]);
+		const [firstWorkflow, secondWorkflow] = await Promise.all([
+			createWorkflow({}, firstProject),
+			createWorkflow({}, secondProject),
+		]);
+
+		await createSummaryMetrics(firstWorkflow, {
+			success: 3,
+			failure: 1,
+			runtimeMs: 400,
+			timeSavedMin: 20,
+		});
+		await createSummaryMetrics(secondWorkflow, {
+			success: 5,
+			failure: 0,
+			runtimeMs: 500,
+			timeSavedMin: 25,
+		});
+
+		const response = await authScopedAgent
+			.get('/insights/summary')
+			.query({
+				projectId: firstProject.id,
+				startDate: DateTime.utc().minus({ days: 2 }).toISO(),
+				endDate: DateTime.utc().plus({ days: 1 }).toISO(),
+			})
+			.expect(200);
+
+		expect(response.body.total.value).toBe(4);
+		expect(response.body.failed.value).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary

https://www.loom.com/share/fbac4a85fadd4bfda033b32a1941da21

Adds a `GET /insights/summary` endpoint to the n8n public API, allowing API consumers to retrieve workflow execution summary metrics (successes, failures, runtime, time saved) with optional date range and project filtering.

**Changes:**
- New `GET /v1/insights/summary` endpoint with `insights:read` scope requirement
- Query params: `startDate`, `endDate`, `projectId` (all optional; defaults to last 7 days)
- License validation — respects `feat:insights:viewSummary` and `quota:insights:maxHistoryDays`
- OpenAPI spec updated with paths and schema definitions
- Integration tests covering success cases, validation errors, scoping, and license gating

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-243

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)