### PR TITLE
fix(core): Fix retry activation in multi-main bypassing exponential backoff

### DIFF
--- a/packages/cli/src/active-workflow-manager.ts
+++ b/packages/cli/src/active-workflow-manager.ts
@@ -571,6 +571,7 @@ export class ActiveWorkflowManager {
 	@OnLeaderStepdown()
 	@OnShutdown()
 	async removeAllTriggerAndPollerBasedWorkflows() {
+		this.removeAllQueuedWorkflowActivations();
 		await this.activeWorkflows.removeAllTriggerAndPollerBasedWorkflows();
 	}
 
@@ -838,7 +839,7 @@ export class ActiveWorkflowManager {
 				workflowName,
 			});
 			try {
-				await this.add(workflowId, activationMode, workflowData);
+				await this.add(workflowId, activationMode, workflowData, { shouldPublish: false });
 			} catch (error) {
 				this.errorReporter.error(error);
 				let lastTimeout = this.queuedActivations[workflowId].lastTimeout;


### PR DESCRIPTION
## Summary

On multi-main, when a workflow fails to activate on startup, we are supposed to keep retrying activation with exponential backoff. Instead, on retry we currently call `this.add()` _without_ passing `{ shouldPublish: false }`, so `shouldPublish` defaults to `true`, which causes the leader to publish a pubsub message to itself and return successfully without actually activating the workflow. The retry loop sees no error and stops, thinking it succeeded. If the leader then fails to activate the workflow when handling its own pubsub message, we permanently deactivate with no further retries, bypassing the exponential backoff mechanism.

This PR fixes the above and also clears queued activation timers on leader stepdown, preventing a former leader from firing stale retries.

## Testing

Workflow activation is ancient and in dire need of refactoring. Mocking `setTimeout`, `publisher`, `instanceSettings.isMultiMain`, etc. just to assert `add` was called with the right 4th arg would be restating the implementation in test form, which doesn't really prove anything. We could find some way to orchestrate this in e2e, but I think it's pragmatic to go ahead as-is until we streamline workflow publication. Please let me know if you disagree.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
