### PR TITLE
ci: Install script dependencies before detecting new packages

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -58,6 +58,9 @@ jobs:
           N8N_FAIL_ON_POPULARITY_FETCH_ERROR: true
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
+      - name: Install script dependencies
+        run: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
+
       - name: Check for new unpublished packages
         run: node .github/scripts/detect-new-packages.mjs
 


### PR DESCRIPTION
## Summary

There was a missing step in the workflow files checking for new npm packages. This was not caught in master due to `@codecov/vite-plugin` installing them to the monorepo and transiently allowing us to utilize them.

However since this plugin isn't present in 1.x, it causes crashes there.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/actions/runs/24073164984/job/70215011912

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
