### PR TITLE
refactor(editor): Migrate workflowObject usages in NDV store

### DIFF
--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.ts
@@ -5,8 +5,9 @@ import type {
 	INodeIssueObjectProperty,
 	INodeParameters,
 	INodeTypeDescription,
+	NodeConnectionType,
 } from 'n8n-workflow';
-import { NodeHelpers } from 'n8n-workflow';
+import { NodeConnectionTypes, NodeHelpers } from 'n8n-workflow';
 import type {
 	INodeUi,
 	INodeUpdatePropertiesInformation,
@@ -134,6 +135,14 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 
 	function findNodeByPartialId(partialId: string): INodeUi | undefined {
 		return workflowsStore.findNodeByPartialId(partialId);
+	}
+
+	function getParentNodes(
+		nodeName: string,
+		type: NodeConnectionType | 'ALL' | 'ALL_NON_MAIN' = NodeConnectionTypes.Main,
+		depth = -1,
+	): string[] {
+		return workflowsStore.workflowObject.getParentNodes(nodeName, type, depth);
 	}
 
 	function getNodesByIds(ids: string[]): INodeUi[] {
@@ -330,6 +339,7 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 		getNodes,
 		findNodeByPartialId,
 		getNodesByIds,
+		getParentNodes,
 
 		// Write
 		setNodes,

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.test.ts
@@ -12,6 +12,13 @@ import { fireEvent, waitFor } from '@testing-library/vue';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import * as workflowHelpers from '@/app/composables/useWorkflowHelpers';
 import { flushPromises } from '@vue/test-utils';
+import { shallowRef } from 'vue';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+
+vi.mock('@/app/stores/workflowDocument.store', async (importOriginal) => ({
+	...(await importOriginal()),
+	injectWorkflowDocumentStore: vi.fn(),
+}));
 
 // Mock i18n to return translation keys instead of translated strings
 vi.mock('@n8n/i18n', () => {
@@ -114,6 +121,15 @@ describe('ParameterInputList', () => {
 		createTestingPinia();
 		ndvStore = mockedStore(useNDVStore);
 		workflowStore = mockedStore(useWorkflowsStore);
+		vi.mocked(injectWorkflowDocumentStore).mockReturnValue(
+			shallowRef({
+				getChildNodes: (...args: Parameters<typeof workflowStore.workflowObject.getChildNodes>) =>
+					workflowStore.workflowObject.getChildNodes(...args),
+				getParentNodes: (...args: Parameters<typeof workflowStore.workflowObject.getParentNodes>) =>
+					workflowStore.workflowObject.getParentNodes(...args),
+				getNodeByName: (name: string) => workflowStore.workflowObject.getNode(name),
+			}) as ReturnType<typeof injectWorkflowDocumentStore>,
+		);
 	});
 
 	afterEach(async () => {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
@@ -388,11 +388,10 @@ function updateWaitParameters(parameters: INodeProperties[], nodeName: string) {
 }
 
 function updateFormParameters(parameters: INodeProperties[], nodeName: string) {
-	const workflowObject = workflowsStore.workflowObject;
-	const parentNodes = workflowObject.getParentNodes(nodeName);
+	const parentNodes = workflowDocumentStore?.value?.getParentNodes(nodeName) ?? [];
 
 	const formTriggerName = parentNodes.find(
-		(_node) => workflowObject.nodes[_node].type === FORM_TRIGGER_NODE_TYPE,
+		(_node) => workflowDocumentStore?.value?.getNodeByName(_node)?.type === FORM_TRIGGER_NODE_TYPE,
 	);
 
 	if (formTriggerName) return parameters.filter((parameter) => parameter.name !== 'triggerNotice');

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
@@ -40,7 +40,6 @@ import ResourceMapper from './ResourceMapper/ResourceMapper.vue';
 
 import { useCalloutHelpers } from '@/app/composables/useCalloutHelpers';
 import { useCollectionOverhaul } from '@/app/composables/useCollectionOverhaul';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
 	getParameterTypeOption,
 	type ParameterOptionsOverrides,
@@ -103,7 +102,6 @@ const emit = defineEmits<{
 
 const nodeTypesStore = useNodeTypesStore();
 const ndvStore = useNDVStore();
-const workflowsStore = useWorkflowsStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 
 const message = useMessage();

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
@@ -61,6 +61,7 @@ import {
 	N8nText,
 	N8nTooltip,
 } from '@n8n/design-system';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 const LazyFixedCollectionParameter = defineAsyncComponent(
 	async () => await import('./FixedCollection/FixedCollectionParameter.vue'),
 );
@@ -103,6 +104,7 @@ const emit = defineEmits<{
 const nodeTypesStore = useNodeTypesStore();
 const ndvStore = useNDVStore();
 const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 
 const message = useMessage();
 const nodeSettingsParameters = useNodeSettingsParameters();
@@ -304,11 +306,10 @@ const indexToShowSlotAt = computed(() => {
 });
 
 function updateFormTriggerParameters(parameters: INodeProperties[], triggerName: string) {
-	const workflowObject = workflowsStore.workflowObject;
-	const connectedNodes = workflowObject.getChildNodes(triggerName);
+	const connectedNodes = workflowDocumentStore?.value?.getChildNodes(triggerName);
 
-	const hasFormPage = connectedNodes.some((nodeName) => {
-		const _node = workflowObject.getNode(nodeName);
+	const hasFormPage = connectedNodes?.some((nodeName) => {
+		const _node = workflowDocumentStore?.value?.getNodeByName(nodeName);
 		return _node && _node.type === FORM_NODE_TYPE;
 	});
 
@@ -349,18 +350,17 @@ function updateFormTriggerParameters(parameters: INodeProperties[], triggerName:
 }
 
 function updateWaitParameters(parameters: INodeProperties[], nodeName: string) {
-	const workflowObject = workflowsStore.workflowObject;
-	const parentNodes = workflowObject.getParentNodes(nodeName);
+	const parentNodes = workflowDocumentStore?.value?.getParentNodes(nodeName);
 
-	const formTriggerName = parentNodes.find(
-		(_node) => workflowObject.nodes[_node].type === FORM_TRIGGER_NODE_TYPE,
+	const formTriggerName = parentNodes?.find(
+		(_node) => workflowDocumentStore?.value?.getNodeByName(_node)?.type === FORM_TRIGGER_NODE_TYPE,
 	);
 	if (!formTriggerName) return parameters;
 
-	const connectedNodes = workflowObject.getChildNodes(formTriggerName);
+	const connectedNodes = workflowDocumentStore?.value?.getChildNodes(formTriggerName);
 
-	const hasFormPage = connectedNodes.some((_nodeName) => {
-		const _node = workflowObject.getNode(_nodeName);
+	const hasFormPage = connectedNodes?.some((_nodeName) => {
+		const _node = workflowDocumentStore?.value?.getNodeByName(_nodeName);
 		return _node && _node.type === FORM_NODE_TYPE;
 	});
 

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
@@ -159,8 +159,8 @@ const subConnections = ref<InstanceType<typeof NDVSubConnections> | null>(null);
 const isDemoRoute = computed(() => route?.name === VIEWS.DEMO);
 const { isPreviewMode } = useSettingsStore();
 const isDemoPreview = computed(() => isDemoRoute.value && isPreviewMode);
-const currentWorkflow = computed(
-	() => workflowsListStore.getWorkflowById(workflowsStore.workflowObject.id), // @TODO check if we actually need workflowObject here
+const currentWorkflow = computed(() =>
+	workflowsListStore.getWorkflowById(workflowsStore.workflowId),
 );
 const hasForeignCredential = computed(() => props.foreignCredentials.length > 0);
 const isHomeProjectTeam = computed(

--- a/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.ts
@@ -187,12 +187,12 @@ export const useNDVStore = defineStore(STORES.NDV, () => {
 		if (!activeNode.value || !inputNodeName) {
 			return false;
 		}
-		const parentNodes = workflowsStore.workflowObject.getParentNodes(
+		const parentNodes = workflowDocumentStore.value?.getParentNodes(
 			activeNode.value.name,
 			NodeConnectionTypes.Main,
 			1,
 		);
-		return parentNodes.includes(inputNodeName);
+		return parentNodes?.includes(inputNodeName) ?? false;
 	});
 
 	const getHoveringItem = computed(() => {


### PR DESCRIPTION
## Summary

As part of the groundwork for introducing CRDT, this PR replaces direct `workflowObject` access in NDV store and remaining NDV components with `workflowDocumentStore` facade methods.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CAT-2693/migrate-ndv-stores-and-settings-from-workflowobject-to


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
