### PR TITLE
feat(ai-builder): Add --keep-workflows flag and fix eval execution errors (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/cli/args.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/args.ts
@@ -19,6 +19,8 @@ export interface CliArgs {
 	verbose: boolean;
 	/** Filter workflow test cases by filename substring (e.g. "contact-form") */
 	filter?: string;
+	/** Keep built workflows after evaluation instead of deleting them */
+	keepWorkflows: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -32,6 +34,7 @@ const cliArgsSchema = z.object({
 	password: z.string().optional(),
 	verbose: z.boolean().default(false),
 	filter: z.string().optional(),
+	keepWorkflows: z.boolean().default(false),
 });
 
 // ---------------------------------------------------------------------------
@@ -49,6 +52,7 @@ export function parseCliArgs(argv: string[]): CliArgs {
 		password: validated.password,
 		verbose: validated.verbose,
 		filter: validated.filter,
+		keepWorkflows: validated.keepWorkflows,
 	};
 }
 
@@ -63,6 +67,7 @@ interface RawArgs {
 	password?: string;
 	verbose: boolean;
 	filter?: string;
+	keepWorkflows: boolean;
 }
 
 function parseRawArgs(argv: string[]): RawArgs {
@@ -70,6 +75,7 @@ function parseRawArgs(argv: string[]): RawArgs {
 		timeoutMs: 600_000,
 		baseUrl: 'http://localhost:5678',
 		verbose: false,
+		keepWorkflows: false,
 	};
 
 	for (let i = 0; i < argv.length; i++) {
@@ -103,6 +109,10 @@ function parseRawArgs(argv: string[]): RawArgs {
 			case '--filter':
 				result.filter = nextArg(argv, i, '--filter');
 				i++;
+				break;
+
+			case '--keep-workflows':
+				result.keepWorkflows = true;
 				break;
 
 			default:

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -55,6 +55,7 @@ async function main(): Promise<void> {
 					preRunWorkflowIds,
 					claimedWorkflowIds,
 					logger,
+					keepWorkflows: args.keepWorkflows,
 				}),
 			MAX_CONCURRENT_TEST_CASES,
 		);

--- a/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
+++ b/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
@@ -289,10 +289,19 @@ export class N8nClient {
 	}
 
 	/**
-	 * Delete a workflow by ID.
+	 * Archive a workflow (soft-delete). Required before hard-deleting.
+	 * POST /rest/workflows/:id/archive
+	 */
+	async archiveWorkflow(id: string): Promise<void> {
+		await this.fetch(`/rest/workflows/${id}/archive`, { method: 'POST' });
+	}
+
+	/**
+	 * Delete a workflow by ID. The workflow must be archived first.
 	 * DELETE /rest/workflows/:id
 	 */
 	async deleteWorkflow(id: string): Promise<void> {
+		await this.archiveWorkflow(id);
 		await this.fetch(`/rest/workflows/${id}`, { method: 'DELETE' });
 	}
 

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/daily-slack-summary.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/daily-slack-summary.json
@@ -1,5 +1,5 @@
 {
-	"prompt": "Every day, get the posts made in the past day on 3 different Slack channels (#general, #engineering, #product), summarize them using AI, and post the summary on #daily-digest. Configure all nodes as completely as possible and don't ask me for credentials, I'll set them up later.",
+	"prompt": "Every day, get the posts made in the past day on 3 different Slack channels: #general (C04GENERAL01), #engineering (C04ENGINEER1), and #product (C04PRODUCT01). Summarize them using AI, and post the summary on #daily-digest (C04DAILYDG01). Configure all nodes as completely as possible and don't ask me for credentials, I'll set them up later.",
 	"complexity": "medium",
 	"tags": ["build", "slack", "ai", "schedule"],
 	"triggerType": "schedule",

--- a/packages/@n8n/instance-ai/evaluations/harness/runner.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/runner.ts
@@ -51,6 +51,7 @@ interface WorkflowTestCaseConfig {
 	preRunWorkflowIds: Set<string>;
 	claimedWorkflowIds: Set<string>;
 	logger: EvalLogger;
+	keepWorkflows: boolean;
 }
 
 export async function runWorkflowTestCase(
@@ -199,12 +200,14 @@ export async function runWorkflowTestCase(
 			MAX_CONCURRENT_SCENARIOS,
 		);
 
-		// 4. Cleanup — delete workflows created during build
-		for (const wf of outcome.workflowsCreated) {
-			try {
-				await client.deleteWorkflow(wf.id);
-			} catch {
-				// Best-effort cleanup
+		// 4. Cleanup — delete workflows created during build (unless --keep-workflows)
+		if (!config.keepWorkflows) {
+			for (const wf of outcome.workflowsCreated) {
+				try {
+					await client.deleteWorkflow(wf.id);
+				} catch {
+					// Best-effort cleanup
+				}
 			}
 		}
 

--- a/packages/cli/src/modules/instance-ai/eval/execution.service.ts
+++ b/packages/cli/src/modules/instance-ai/eval/execution.service.ts
@@ -137,6 +137,7 @@ export class EvalExecutionService {
 				workflowEntity,
 				bypassNodeNames,
 				hints.globalContext,
+				scenarioHints,
 			);
 			this.logger.debug(
 				`[EvalMock] Phase 1.5 result — pinned nodes: ${Object.keys(hints.bypassPinData).join(', ') || 'none'}`,
@@ -157,14 +158,16 @@ export class EvalExecutionService {
 		workflowEntity: IWorkflowBase,
 		bypassNodeNames: string[],
 		globalContext: string,
+		scenarioHints?: string,
 	): Promise<IPinData> {
 		if (bypassNodeNames.length === 0) return {};
 
 		try {
+			const dataDescription = [globalContext, scenarioHints].filter(Boolean).join('\n\n');
 			const result = await generatePinData({
 				workflow: workflowEntity as unknown as WorkflowJSON,
 				nodeNames: bypassNodeNames,
-				instructions: globalContext ? { dataDescription: globalContext } : undefined,
+				instructions: dataDescription ? { dataDescription } : undefined,
 			});
 
 			return normalizePinData(result as unknown as IPinData);


### PR DESCRIPTION
## Summary
- Add `--keep-workflows` CLI flag to preserve built workflows after evaluation for debugging
- Fix workflow cleanup: n8n now requires archiving before deletion — `deleteWorkflow` archives first
- Catch workflow execution errors in `EvalExecutionService` and return proper eval results instead of 500s
- Pass scenario hints to bypass pin data generation so AI/LangChain node mocks reflect the scenario
- Add Slack channel IDs to daily-slack-summary test case prompt for better builder node configuration

## Related Linear ticket
https://linear.app/n8n/issue/TRUST-32

## Test plan
- [x] `pnpm typecheck` — both `cli` and `instance-ai` clean
- [x] `pnpm lint` — both packages clean
- [x] CLI tests: 261 passed (13 suites)
- [x] eval-mock-helpers tests: 20 passed
- [x] Manual workflow eval run: build + scenarios + archive + delete working end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)