### PR TITLE
fix(core): Ensure SSE is connected on initial instance AI message (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAi.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAi.store.test.ts
@@ -485,6 +485,23 @@ describe('useInstanceAiStore - onSSEMessage', () => {
 			undefined,
 		);
 	});
+
+	test('sendMessage reconnects SSE when connection was closed', async () => {
+		mockPostMessage.mockResolvedValue({ runId: 'run-1' });
+
+		// SSE is connected after beforeEach setup. Close it to simulate
+		// Suspense unmount killing the connection during layout transition.
+		store.closeSSE();
+		expect(store.sseState).toBe('disconnected');
+
+		mockClose.mockClear();
+
+		await store.sendMessage('hello');
+
+		// sendMessage should have re-opened an EventSource before posting
+		expect(capturedInstance).not.toBeNull();
+		expect(mockPostMessage).toHaveBeenCalled();
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAi.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAi.store.test.ts
@@ -494,7 +494,8 @@ describe('useInstanceAiStore - onSSEMessage', () => {
 		store.closeSSE();
 		expect(store.sseState).toBe('disconnected');
 
-		mockClose.mockClear();
+		// Clear capturedInstance so we can verify a *new* EventSource is created
+		capturedInstance = null;
 
 		await store.sendMessage('hello');
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.store.ts
@@ -445,7 +445,9 @@ export const useInstanceAiStore = defineStore('instanceAi', () => {
 
 		eventSource.onmessage = (ev: MessageEvent) => {
 			// Guard: discard events from stale connections or wrong threads
-			if (gen !== sseGeneration || capturedThreadId !== currentThreadId.value) return;
+			if (gen !== sseGeneration || capturedThreadId !== currentThreadId.value) {
+				return;
+			}
 			onSSEMessage(ev);
 		};
 
@@ -689,6 +691,15 @@ export const useInstanceAiStore = defineStore('instanceAi', () => {
 	): Promise<void> {
 		// Clear amend context on new message
 		amendContext.value = null;
+
+		// Ensure SSE is connected before sending. Vue's Suspense boundary can
+		// unmount → remount InstanceAiView during layout transitions, which closes
+		// the SSE connection via onUnmounted. If the user sends a message before
+		// the remounted component's async connectSSE() fires, the response events
+		// would be lost. Re-establish the connection here as a safety net.
+		if (sseState.value === 'disconnected') {
+			connectSSE();
+		}
 
 		try {
 			await syncThread(currentThreadId.value);


### PR DESCRIPTION
## Summary

If user navigated to /instance-ai from another page for the first time and sent a message they wouldn't see the reply backend tried to send to it. The reply got generated, but user had to refresh the page or something to see it. This happened every time if you first loaded the app on home page, navigated to /instance-ai and sent a message to the prompt without loading any older threads.

This was caused by Vue's <Suspense> in AppLayout.vue causing InstanceAiView to mount -> unmount -> remount during navigation, causing SSE to end up closed.

Ensure SSE is in connected state with a guard to fix this.

## Related Linear tickets, Github issues, and Community forum posts

https://www.notion.so/n8n/Instance-AI-issues-reported-3285b6e0c94f802ca27cd2d2e067c5d7?p=33b5b6e0c94f803fb946cae61a95e823&pm=s

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
