### PR TITLE
feat(core): Add in-process mutex for SQLite advisory lock parity

### DIFF
--- a/packages/@n8n/db/src/services/__tests__/db-lock.service.test.ts
+++ b/packages/@n8n/db/src/services/__tests__/db-lock.service.test.ts
@@ -149,4 +149,221 @@ describe('DbLockService', () => {
 			expect(fn).toHaveBeenCalledWith(mockTx);
 		});
 	});
+
+	describe('SQLite in-process mutex', () => {
+		beforeEach(() => {
+			databaseConfig.type = 'sqlite';
+		});
+
+		afterEach(() => {
+			jest.useRealTimers();
+		});
+
+		it('should serialize concurrent withLock calls for the same lockId', async () => {
+			const executionOrder: string[] = [];
+			let resolveFirst!: () => void;
+			const firstBlocking = new Promise<void>((r) => {
+				resolveFirst = r;
+			});
+
+			const fn1 = jest.fn(async () => {
+				executionOrder.push('fn1-start');
+				await firstBlocking;
+				executionOrder.push('fn1-end');
+				return 'first';
+			});
+			const fn2 = jest.fn(async () => {
+				executionOrder.push('fn2-start');
+				return 'second';
+			});
+
+			const p1 = service.withLock(1001, fn1);
+			const p2 = service.withLock(1001, fn2);
+
+			// fn1 has started but fn2 should not have
+			await new Promise((r) => setImmediate(r));
+			expect(fn1).toHaveBeenCalled();
+			expect(fn2).not.toHaveBeenCalled();
+
+			resolveFirst();
+			const [r1, r2] = await Promise.all([p1, p2]);
+
+			expect(r1).toBe('first');
+			expect(r2).toBe('second');
+			expect(executionOrder).toEqual(['fn1-start', 'fn1-end', 'fn2-start']);
+		});
+
+		it('should not block different lockIds', async () => {
+			let resolveFirst!: () => void;
+			const firstBlocking = new Promise<void>((r) => {
+				resolveFirst = r;
+			});
+
+			const fn1 = jest.fn(async () => {
+				await firstBlocking;
+				return 'first';
+			});
+			const fn2 = jest.fn(async () => 'second');
+
+			const p1 = service.withLock(1001, fn1);
+			const p2 = service.withLock(9999, fn2);
+
+			// Both should start since they use different lockIds
+			await new Promise((r) => setImmediate(r));
+			expect(fn1).toHaveBeenCalled();
+			expect(fn2).toHaveBeenCalled();
+
+			resolveFirst();
+			const [r1, r2] = await Promise.all([p1, p2]);
+			expect(r1).toBe('first');
+			expect(r2).toBe('second');
+		});
+
+		it('should reject with OperationalError when withLock timeout expires', async () => {
+			jest.useFakeTimers();
+
+			let resolveFirst!: () => void;
+			const firstBlocking = new Promise<void>((r) => {
+				resolveFirst = r;
+			});
+
+			const fn1 = jest.fn(async () => {
+				await firstBlocking;
+				return 'first';
+			});
+			const fn2 = jest.fn().mockResolvedValue('second');
+
+			const p1 = service.withLock(1001, fn1);
+			const p2 = service.withLock(1001, fn2, { timeoutMs: 100 });
+
+			jest.advanceTimersByTime(100);
+
+			await expect(p2).rejects.toThrow(OperationalError);
+			await expect(p2).rejects.toThrow(/Timed out waiting for DbLock 1001 after 100ms/);
+			expect(fn2).not.toHaveBeenCalled();
+
+			resolveFirst();
+			await p1;
+		});
+
+		it('should fail tryWithLock immediately when lock is held', async () => {
+			let resolveFirst!: () => void;
+			const firstBlocking = new Promise<void>((r) => {
+				resolveFirst = r;
+			});
+
+			const fn1 = jest.fn(async () => {
+				await firstBlocking;
+				return 'first';
+			});
+			const fn2 = jest.fn().mockResolvedValue('second');
+
+			const p1 = service.withLock(1001, fn1);
+
+			// Wait for fn1 to start (lock is held)
+			await new Promise((r) => setImmediate(r));
+
+			await expect(service.tryWithLock(1001, fn2)).rejects.toThrow(
+				/DbLock 1001 is already held by another process/,
+			);
+			expect(fn2).not.toHaveBeenCalled();
+
+			resolveFirst();
+			await p1;
+		});
+
+		it('should release lock when fn throws in withLock', async () => {
+			const fn1 = jest.fn().mockRejectedValue(new Error('fn1 failed'));
+			const fn2 = jest.fn().mockResolvedValue('second');
+
+			await expect(service.withLock(1001, fn1)).rejects.toThrow('fn1 failed');
+
+			const result = await service.withLock(1001, fn2);
+			expect(result).toBe('second');
+		});
+
+		it('should release lock when fn throws in tryWithLock', async () => {
+			const fn1 = jest.fn().mockRejectedValue(new Error('fn1 failed'));
+			const fn2 = jest.fn().mockResolvedValue('second');
+
+			await expect(service.tryWithLock(1001, fn1)).rejects.toThrow('fn1 failed');
+
+			const result = await service.tryWithLock(1001, fn2);
+			expect(result).toBe('second');
+		});
+
+		it('should treat double-release as a safe no-op', async () => {
+			let resolveFirst!: () => void;
+			const firstBlocking = new Promise<void>((r) => {
+				resolveFirst = r;
+			});
+
+			const fn1 = jest.fn(async () => {
+				await firstBlocking;
+				return 'first';
+			});
+			const fn2 = jest.fn().mockResolvedValue('second');
+			const fn3 = jest.fn().mockResolvedValue('third');
+
+			const p1 = service.withLock(1001, fn1);
+			const p2 = service.withLock(1001, fn2);
+
+			await new Promise((r) => setImmediate(r));
+
+			// fn1 holds the lock, fn2 is queued
+			resolveFirst();
+			await Promise.all([p1, p2]);
+
+			// The internal release for p1 already fired once (via finally).
+			// If double-release corrupted state, fn3 would fail or deadlock.
+			const result = await service.withLock(1001, fn3);
+			expect(result).toBe('third');
+		});
+
+		it('should execute 3+ waiters in FIFO order', async () => {
+			const executionOrder: string[] = [];
+			let resolve1!: () => void;
+			let resolve2!: () => void;
+			const blocking1 = new Promise<void>((r) => {
+				resolve1 = r;
+			});
+			const blocking2 = new Promise<void>((r) => {
+				resolve2 = r;
+			});
+
+			const fn1 = jest.fn(async () => {
+				executionOrder.push('fn1');
+				await blocking1;
+				return 'first';
+			});
+			const fn2 = jest.fn(async () => {
+				executionOrder.push('fn2');
+				await blocking2;
+				return 'second';
+			});
+			const fn3 = jest.fn(async () => {
+				executionOrder.push('fn3');
+				return 'third';
+			});
+
+			const p1 = service.withLock(1001, fn1);
+			const p2 = service.withLock(1001, fn2);
+			const p3 = service.withLock(1001, fn3);
+
+			await new Promise((r) => setImmediate(r));
+			expect(executionOrder).toEqual(['fn1']);
+
+			resolve1();
+			await p1;
+			await new Promise((r) => setImmediate(r));
+			expect(executionOrder).toEqual(['fn1', 'fn2']);
+
+			resolve2();
+			const [r2, r3] = await Promise.all([p2, p3]);
+
+			expect(r2).toBe('second');
+			expect(r3).toBe('third');
+			expect(executionOrder).toEqual(['fn1', 'fn2', 'fn3']);
+		});
+	});
 });

--- a/packages/@n8n/db/src/services/db-lock.service.ts
+++ b/packages/@n8n/db/src/services/db-lock.service.ts
@@ -15,8 +15,71 @@ export const enum DbLock {
 	TEST = 9999,
 }
 
+type ReleaseFn = () => void;
+
+/**
+ * Opaque ownership token created on lock acquisition. The release function
+ * captures this token and only releases if it still matches `held`, which
+ * prevents a stale release (from acquisition A) from corrupting a later
+ * acquisition B's lock state.
+ */
+type OwnerToken = Record<string, never>;
+
+interface LockState {
+	held: OwnerToken | null;
+	queue: Array<(token: OwnerToken) => void>;
+}
+
+/**
+ * Provides serialized execution of critical sections across concurrent
+ * callers using database-level advisory locks (Postgres) or an in-process
+ * async mutex (SQLite).
+ *
+ * ## Postgres: transaction-scoped advisory locks
+ *
+ * This service uses `pg_advisory_xact_lock` / `pg_try_advisory_xact_lock`,
+ * which are **transaction-scoped**. These locks are automatically released
+ * when the transaction ends (COMMIT or ROLLBACK) and cannot be released
+ * manually. This is in contrast to session-scoped advisory locks
+ * (`pg_advisory_lock`) which are bound to the database connection and
+ * persist across transaction boundaries until explicitly unlocked.
+ *
+ * Transaction-scoped locks are the safer choice in connection-pooled
+ * environments (like TypeORM): a session-scoped lock that is not
+ * explicitly released before the connection returns to the pool would
+ * remain held when the pool hands that connection to the next caller,
+ * causing unexpected blocking or deadlocks.
+ *
+ * ## SQLite: in-process async mutex
+ *
+ * SQLite has no advisory lock mechanism. A database transaction alone is
+ * not sufficient because the protected function may be triggered
+ * concurrently within the same process by independent sources (API
+ * requests, timers, webhooks, etc.). Without an application-level lock,
+ * two async calls can interleave inside the critical section even though
+ * each runs in its own transaction.
+ *
+ * The in-process mutex serializes callers the same way
+ * `pg_advisory_xact_lock` does in Postgres: only one caller at a time
+ * may execute the protected function for a given lock ID.
+ *
+ * ## Ownership model
+ *
+ * Each acquisition creates an opaque ownership token. The returned release
+ * function captures that token and will only release the lock if the token
+ * still matches the current holder. This makes double-release a safe no-op
+ * and prevents a stale release from corrupting a subsequent acquisition.
+ *
+ * On release, if a waiter is queued, ownership transfers atomically: the
+ * new token is created and assigned to `held` before the waiter's promise
+ * resolves. This ensures `held` is never `null` while the lock is logically
+ * owned, eliminating a microtask-width window where a concurrent
+ * `tryAcquireLock` could bypass the queue.
+ */
 @Service()
 export class DbLockService {
+	private readonly locks = new Map<number, LockState>();
+
 	constructor(
 		private readonly dataSource: DataSource,
 		private readonly databaseConfig: DatabaseConfig,
@@ -24,8 +87,7 @@ export class DbLockService {
 
 	/**
 	 * Execute `fn` inside a database transaction, serialized by a
-	 * Postgres advisory lock. On SQLite the transaction alone provides
-	 * serialization (single-process only).
+	 * Postgres advisory lock or an in-process mutex (SQLite).
 	 *
 	 * The lock is automatically released when the transaction commits
 	 * or rolls back. Concurrent callers block until the lock is available.
@@ -38,24 +100,31 @@ export class DbLockService {
 		fn: (tx: EntityManager) => Promise<T>,
 		options?: { timeoutMs?: number },
 	): Promise<T> {
+		if (this.databaseConfig.type !== 'postgresdb') {
+			const release = await this.acquireLock(lockId, options?.timeoutMs);
+			try {
+				return await this.dataSource.manager.transaction(async (tx) => await fn(tx));
+			} finally {
+				release();
+			}
+		}
+
 		return await this.dataSource.manager.transaction(async (tx) => {
-			if (this.databaseConfig.type === 'postgresdb') {
-				if (options?.timeoutMs !== undefined) {
-					// SET doesn't support parameterized queries ($1) in Postgres.
-					// Number() coercion is safe here since timeoutMs is typed as number.
-					await tx.query(`SET LOCAL lock_timeout = '${Number(options.timeoutMs)}'`);
+			if (options?.timeoutMs !== undefined) {
+				// SET doesn't support parameterized queries ($1) in Postgres.
+				// Number() coercion is safe here since timeoutMs is typed as number.
+				await tx.query(`SET LOCAL lock_timeout = '${Number(options.timeoutMs)}'`);
+			}
+			try {
+				await tx.query('SELECT pg_advisory_xact_lock($1)', [lockId]);
+			} catch (error) {
+				if (error instanceof QueryFailedError && error.message.includes('lock timeout')) {
+					throw new OperationalError(
+						`Timed out waiting for DbLock ${lockId} after ${options?.timeoutMs}ms`,
+						{ cause: error },
+					);
 				}
-				try {
-					await tx.query('SELECT pg_advisory_xact_lock($1)', [lockId]);
-				} catch (error) {
-					if (error instanceof QueryFailedError && error.message.includes('lock timeout')) {
-						throw new OperationalError(
-							`Timed out waiting for DbLock ${lockId} after ${options?.timeoutMs}ms`,
-							{ cause: error },
-						);
-					}
-					throw error;
-				}
+				throw error;
 			}
 			return await fn(tx);
 		});
@@ -63,23 +132,131 @@ export class DbLockService {
 
 	/**
 	 * Execute `fn` inside a database transaction, but only if the advisory
-	 * lock can be acquired immediately. On SQLite the transaction alone
-	 * provides serialization.
+	 * lock (Postgres) or in-process mutex (SQLite) can be acquired immediately.
 	 *
 	 * @throws {OperationalError} if the lock is already held by another process
 	 */
 	async tryWithLock<T>(lockId: DbLock, fn: (tx: EntityManager) => Promise<T>): Promise<T> {
+		if (this.databaseConfig.type !== 'postgresdb') {
+			const release = this.tryAcquireLock(lockId);
+			try {
+				return await this.dataSource.manager.transaction(async (tx) => await fn(tx));
+			} finally {
+				release();
+			}
+		}
+
 		return await this.dataSource.manager.transaction(async (tx) => {
-			if (this.databaseConfig.type === 'postgresdb') {
-				const result: Array<{ pg_try_advisory_xact_lock: boolean }> = await tx.query(
-					'SELECT pg_try_advisory_xact_lock($1)',
-					[lockId],
-				);
-				if (!result[0].pg_try_advisory_xact_lock) {
-					throw new OperationalError(`DbLock ${lockId} is already held by another process`);
-				}
+			const result: Array<{ pg_try_advisory_xact_lock: boolean }> = await tx.query(
+				'SELECT pg_try_advisory_xact_lock($1)',
+				[lockId],
+			);
+			if (!result[0].pg_try_advisory_xact_lock) {
+				throw new OperationalError(`DbLock ${lockId} is already held by another process`);
 			}
 			return await fn(tx);
 		});
+	}
+
+	/**
+	 * Acquire the in-process lock, blocking until available.
+	 * Returns a one-shot release function bound to this specific acquisition.
+	 */
+	private async acquireLock(lockId: number, timeoutMs?: number): Promise<ReleaseFn> {
+		const lockState = this.getOrCreateLockState(lockId);
+
+		if (!lockState.held) {
+			const token: OwnerToken = {} as OwnerToken;
+			lockState.held = token;
+			return this.createReleaseFn(lockState, token);
+		}
+
+		// Race the lock-release signal against an optional timeout.
+		//
+		// Node.js is single-threaded: `resolver` (called by releaseLock) and
+		// the setTimeout callback each run to completion before the other can
+		// start. Only one of them will settle the Promise first; the second
+		// call to resolve/reject on an already-settled Promise is a no-op per
+		// the Promise spec. clearTimeout on an already-fired timer is likewise
+		// a harmless no-op.
+		const token = await new Promise<OwnerToken>((resolve, reject) => {
+			let timer: ReturnType<typeof setTimeout> | undefined;
+
+			const resolver = (ownerToken: OwnerToken) => {
+				if (timer !== undefined) clearTimeout(timer);
+				resolve(ownerToken);
+			};
+
+			lockState.queue.push(resolver);
+
+			if (timeoutMs !== undefined) {
+				timer = setTimeout(() => {
+					const idx = lockState.queue.indexOf(resolver);
+					if (idx !== -1) {
+						lockState.queue.splice(idx, 1);
+					}
+					reject(
+						new OperationalError(`Timed out waiting for DbLock ${lockId} after ${timeoutMs}ms`),
+					);
+				}, timeoutMs);
+			}
+		});
+
+		return this.createReleaseFn(lockState, token);
+	}
+
+	/**
+	 * Try to acquire the in-process lock without blocking.
+	 * Returns a one-shot release function bound to this specific acquisition.
+	 *
+	 * @throws {OperationalError} if the lock is already held
+	 */
+	private tryAcquireLock(lockId: number): ReleaseFn {
+		const lockState = this.getOrCreateLockState(lockId);
+
+		if (!lockState.held) {
+			const token: OwnerToken = {} as OwnerToken;
+			lockState.held = token;
+			return this.createReleaseFn(lockState, token);
+		}
+
+		throw new OperationalError(`DbLock ${lockId} is already held by another process`);
+	}
+
+	/**
+	 * Create a one-shot release function for the given lock state.
+	 *
+	 * The release function captures the ownership token and only acts if
+	 * it still matches the current holder. This ensures that:
+	 * - Double-release is a safe no-op (token no longer matches after first release).
+	 * - A stale release from a previous acquisition cannot corrupt a later one.
+	 */
+	private createReleaseFn(lockState: LockState, token: OwnerToken): ReleaseFn {
+		return () => {
+			if (lockState.held !== token) return;
+
+			const next = lockState.queue.shift();
+			if (next) {
+				// Transfer ownership atomically: set held to the new token
+				// *before* resolving the waiter's promise. This ensures held
+				// is never null while the lock is logically owned, preventing
+				// a concurrent tryAcquireLock from sneaking in during the
+				// microtask gap between resolve and the waiter's continuation.
+				const nextToken: OwnerToken = {} as OwnerToken;
+				lockState.held = nextToken;
+				next(nextToken);
+			} else {
+				lockState.held = null;
+			}
+		};
+	}
+
+	private getOrCreateLockState(lockId: number): LockState {
+		let lockState = this.locks.get(lockId);
+		if (!lockState) {
+			lockState = { held: null, queue: [] };
+			this.locks.set(lockId, lockState);
+		}
+		return lockState;
 	}
 }


### PR DESCRIPTION
## Summary

`DbLockService` previously relied solely on database transactions for SQLite serialization, which is insufficient — concurrent async callers within the same process can interleave inside the critical section even when each runs its own transaction. This PR adds an in-process async mutex for SQLite that provides the same serialization guarantees as Postgres advisory locks (`pg_advisory_xact_lock` / `pg_try_advisory_xact_lock`).

**What changed:**
- `withLock` and `tryWithLock` now acquire an in-process mutex before entering the transaction on SQLite, while Postgres continues to use advisory locks as before
- The mutex uses an ownership-token model: each acquisition creates an opaque token, and the release function only acts if its token still matches the current holder — making double-release a safe no-op
- Ownership transfers atomically on release (new token assigned to `held` before the waiter's promise resolves), eliminating a microtask-width window where `tryAcquireLock` could bypass the queue
- The Postgres code path is unchanged but slightly simplified by removing the now-unnecessary `if (type === 'postgresdb')` nesting inside the transaction callback

**Key implementation decisions:**
- The mutex is per-lock-ID (not global) so different lock IDs don't block each other
- FIFO ordering is maintained via a queue array
- Timeout support mirrors the Postgres `SET LOCAL lock_timeout` behavior with `setTimeout` + queue cleanup on expiry

## Related Links

<!-- Add Linear ticket link if applicable -->

## Review checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)