### PR TITLE
feat(core): Add DB-backed TrustedKeyService with leader refresh and crypto cache (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/services/db-lock.service.ts
+++ b/packages/@n8n/db/src/services/db-lock.service.ts
@@ -11,6 +11,7 @@ import { OperationalError } from 'n8n-workflow';
  */
 export const enum DbLock {
 	AUTH_ROLES_SYNC = 1001,
+	TRUSTED_KEY_REFRESH = 1002,
 	/** Reserved for integration tests — never use in production code */
 	TEST = 9999,
 }

--- a/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
@@ -65,14 +65,17 @@ describe('TokenExchangeService', () => {
 			jest
 				.spyOn(jwt, 'verify')
 				.mockReturnValue(validClaims as unknown as ReturnType<typeof jwt.verify>);
-			trustedKeyStore.getByKid.mockResolvedValue(resolvedKey);
+			trustedKeyStore.getByKidAndIss.mockResolvedValue(resolvedKey);
 			jtiStore.consume.mockResolvedValue(true);
 			identityResolutionService.resolve.mockResolvedValue(mockUser);
 
 			const result = await service.embedLogin('valid-token');
 
 			expect(result).toBe(mockUser);
-			expect(trustedKeyStore.getByKid).toHaveBeenCalledWith('test-kid');
+			expect(trustedKeyStore.getByKidAndIss).toHaveBeenCalledWith(
+				'test-kid',
+				'https://issuer.example.com',
+			);
 			expect(jtiStore.consume).toHaveBeenCalledWith(
 				'unique-jti-1',
 				new Date(validClaims.exp * 1000),
@@ -100,13 +103,24 @@ describe('TokenExchangeService', () => {
 			await expect(service.embedLogin('no-kid-token')).rejects.toThrow(BadRequestError);
 		});
 
+		it('should throw when iss is missing from JWT payload', async () => {
+			const { iss: _, ...claimsWithoutIss } = validClaims;
+			jest.spyOn(jwt, 'decode').mockReturnValue({
+				header: { alg: 'RS256', kid: 'test-kid' },
+				payload: claimsWithoutIss,
+				signature: 'sig',
+			} as unknown as ReturnType<typeof jwt.decode>);
+
+			await expect(service.embedLogin('no-iss-token')).rejects.toThrow(BadRequestError);
+		});
+
 		it('should throw when kid is unknown', async () => {
 			jest.spyOn(jwt, 'decode').mockReturnValue({
 				header: { alg: 'RS256', kid: 'unknown-kid' },
 				payload: validClaims,
 				signature: 'sig',
 			} as unknown as ReturnType<typeof jwt.decode>);
-			trustedKeyStore.getByKid.mockResolvedValue(undefined);
+			trustedKeyStore.getByKidAndIss.mockResolvedValue(undefined);
 
 			await expect(service.embedLogin('unknown-kid-token')).rejects.toThrow(AuthError);
 		});
@@ -120,7 +134,7 @@ describe('TokenExchangeService', () => {
 			jest
 				.spyOn(jwt, 'verify')
 				.mockReturnValue('string-payload' as unknown as ReturnType<typeof jwt.verify>);
-			trustedKeyStore.getByKid.mockResolvedValue(resolvedKey);
+			trustedKeyStore.getByKidAndIss.mockResolvedValue(resolvedKey);
 
 			await expect(service.embedLogin('string-payload-token')).rejects.toThrow(AuthError);
 		});
@@ -134,7 +148,7 @@ describe('TokenExchangeService', () => {
 			jest.spyOn(jwt, 'verify').mockImplementation(() => {
 				throw new Error('invalid signature');
 			});
-			trustedKeyStore.getByKid.mockResolvedValue(resolvedKey);
+			trustedKeyStore.getByKidAndIss.mockResolvedValue(resolvedKey);
 
 			await expect(service.embedLogin('bad-sig-token')).rejects.toThrow(AuthError);
 		});
@@ -149,7 +163,7 @@ describe('TokenExchangeService', () => {
 			jest
 				.spyOn(jwt, 'verify')
 				.mockReturnValue(invalidClaims as unknown as ReturnType<typeof jwt.verify>);
-			trustedKeyStore.getByKid.mockResolvedValue(resolvedKey);
+			trustedKeyStore.getByKidAndIss.mockResolvedValue(resolvedKey);
 
 			await expect(service.embedLogin('invalid-claims-token')).rejects.toThrow();
 		});
@@ -164,7 +178,7 @@ describe('TokenExchangeService', () => {
 			jest
 				.spyOn(jwt, 'verify')
 				.mockReturnValue(longLivedClaims as unknown as ReturnType<typeof jwt.verify>);
-			trustedKeyStore.getByKid.mockResolvedValue(resolvedKey);
+			trustedKeyStore.getByKidAndIss.mockResolvedValue(resolvedKey);
 
 			await expect(service.embedLogin('long-lived-token')).rejects.toThrow(AuthError);
 		});
@@ -178,7 +192,7 @@ describe('TokenExchangeService', () => {
 			jest
 				.spyOn(jwt, 'verify')
 				.mockReturnValue(validClaims as unknown as ReturnType<typeof jwt.verify>);
-			trustedKeyStore.getByKid.mockResolvedValue(resolvedKey);
+			trustedKeyStore.getByKidAndIss.mockResolvedValue(resolvedKey);
 			jtiStore.consume.mockResolvedValue(false);
 
 			await expect(service.embedLogin('replayed-token')).rejects.toThrow(AuthError);
@@ -193,7 +207,7 @@ describe('TokenExchangeService', () => {
 			jest
 				.spyOn(jwt, 'verify')
 				.mockReturnValue(validClaims as unknown as ReturnType<typeof jwt.verify>);
-			trustedKeyStore.getByKid.mockResolvedValue(resolvedKey);
+			trustedKeyStore.getByKidAndIss.mockResolvedValue(resolvedKey);
 			jtiStore.consume.mockResolvedValue(true);
 			identityResolutionService.resolve.mockRejectedValue(new Error('User not found'));
 

--- a/packages/cli/src/modules/token-exchange/services/__tests__/trusted-key.service.integration.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/trusted-key.service.integration.test.ts
@@ -1,0 +1,434 @@
+import { mockInstance, testDb, testModules } from '@n8n/backend-test-utils';
+import { Container } from '@n8n/di';
+import { InstanceSettings } from 'n8n-core';
+import type { KeyObject } from 'node:crypto';
+
+import type { TrustedKeySourceEntity } from '../../database/entities/trusted-key-source.entity';
+import { TrustedKeyEntity } from '../../database/entities/trusted-key.entity';
+import { TrustedKeySourceRepository } from '../../database/repositories/trusted-key-source.repository';
+import { TrustedKeyRepository } from '../../database/repositories/trusted-key.repository';
+import { TokenExchangeConfig } from '../../token-exchange.config';
+import type { TrustedKeyData } from '../../token-exchange.schemas';
+import { TrustedKeyService } from '../trusted-key.service';
+
+// ──────────────────────────────────────────────────────────────────────
+// Pre-generated PEM public keys (test-only, no secrets)
+// ──────────────────────────────────────────────────────────────────────
+
+const RSA_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1A5I3JA3ylWxNFZcNqp9
+qo3dhhO/7wAKUVH73Ryc/UWeHQPon5K+cVchPG2td4yg9llV6LDqurdI5wO1b1tg
+XZjky3Brbh6LISZNjQJr0YvhCVW7NU6jjqgrLqNVrPeAGP51h9ozSIHUm1UyWm2J
+wquhuvVhFlgaeHwA5HtBrYuwihEHJBJueIn9CiGYGwTModwT+WrhK5SxuXhtkD9w
+6SJrbXZIdOnTtAFxH0bn+OYriRD7SgEn5UWiVpXyaRNkKhiFpozK2U1MqtKLrWgC
+o6LNz3KqejtBEOT+/IbnbgIShhWcTuh8Ehw0EUtkOXdqykqoXuEtcoLj3c4efQ/n
+dQIDAQAB
+-----END PUBLIC KEY-----`;
+
+const EC_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpCuPN2BHQ7G0A2qD2Bd27bwwUB9M
+Npzv5WS/ygt55l8y2X+Vfm5TQFRMNkqEx+/GXaPIU/hDmtnBdCxAUIRM9g==
+-----END PUBLIC KEY-----`;
+
+const ED25519_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAPBUxurC3wGyi/yXTTjNwTzgHjSioAIa4Qx6nyOqof0U=
+-----END PUBLIC KEY-----`;
+
+// ──────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────
+
+function staticKeyEntry(
+	overrides: Partial<{
+		kid: string;
+		algorithms: string[];
+		key: string;
+		issuer: string;
+		expectedAudience: string;
+		allowedRoles: string[];
+	}> = {},
+) {
+	return {
+		type: 'static' as const,
+		kid: 'test-kid',
+		algorithms: ['RS256'],
+		key: RSA_PUBLIC_KEY,
+		issuer: 'https://issuer.example.com',
+		...overrides,
+	};
+}
+
+function makeTrustedKeyData(overrides: Partial<TrustedKeyData> = {}): TrustedKeyData {
+	return {
+		algorithms: ['RS256'],
+		keyMaterial: RSA_PUBLIC_KEY,
+		issuer: 'https://issuer.example.com',
+		...overrides,
+	};
+}
+
+async function insertSource(
+	overrides: Partial<TrustedKeySourceEntity> = {},
+): Promise<TrustedKeySourceEntity> {
+	const sourceRepo = Container.get(TrustedKeySourceRepository);
+	return await sourceRepo.save({
+		id: 'static',
+		type: 'static' as const,
+		config: JSON.stringify([staticKeyEntry()]),
+		status: 'pending' as const,
+		lastError: null,
+		lastRefreshedAt: null,
+		...overrides,
+	});
+}
+
+async function insertKey(
+	overrides: Partial<{ sourceId: string; kid: string; data: TrustedKeyData }> = {},
+): Promise<TrustedKeyEntity> {
+	const keyRepo = Container.get(TrustedKeyRepository);
+	const entity = new TrustedKeyEntity();
+	entity.sourceId = overrides.sourceId ?? 'static';
+	entity.kid = overrides.kid ?? 'test-kid';
+	entity.data = JSON.stringify(overrides.data ?? makeTrustedKeyData());
+	entity.createdAt = new Date();
+	return await keyRepo.save(entity);
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Setup / Teardown
+// ──────────────────────────────────────────────────────────────────────
+
+const config = mockInstance(TokenExchangeConfig, {
+	trustedKeys: '',
+	keyRefreshIntervalSeconds: 300,
+});
+
+let service: TrustedKeyService;
+let sourceRepo: TrustedKeySourceRepository;
+let keyRepo: TrustedKeyRepository;
+let instanceSettings: InstanceSettings;
+
+beforeAll(async () => {
+	await testModules.loadModules(['token-exchange']);
+	await testDb.init();
+
+	instanceSettings = Container.get(InstanceSettings);
+	service = Container.get(TrustedKeyService);
+	sourceRepo = Container.get(TrustedKeySourceRepository);
+	keyRepo = Container.get(TrustedKeyRepository);
+});
+
+beforeEach(async () => {
+	await testDb.truncate(['TrustedKeyEntity', 'TrustedKeySourceEntity']);
+	// Reset config defaults
+	config.trustedKeys = '';
+	config.keyRefreshIntervalSeconds = 300;
+	// Default to leader
+	Object.defineProperty(instanceSettings, 'isLeader', { value: true, configurable: true });
+});
+
+afterEach(() => {
+	service.stopRefresh();
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────────
+
+describe('TrustedKeyService (integration)', () => {
+	describe('initialize', () => {
+		it('should sync sources to DB, refresh keys to healthy, and persist key data', async () => {
+			config.trustedKeys = JSON.stringify([
+				staticKeyEntry({ kid: 'key-1' }),
+				staticKeyEntry({ kid: 'key-2', issuer: 'https://issuer-2.example.com' }),
+			]);
+
+			await service.initialize();
+
+			const sources = await sourceRepo.find();
+			expect(sources).toHaveLength(1);
+			expect(sources[0]).toMatchObject({
+				id: 'static',
+				type: 'static',
+				status: 'healthy',
+			});
+			expect(sources[0].lastRefreshedAt).toBeDefined();
+
+			const keys = await keyRepo.find();
+			expect(keys).toHaveLength(2);
+
+			const key1 = keys.find((k) => k.kid === 'key-1')!;
+			const key1Data = JSON.parse(key1.data) as TrustedKeyData;
+			expect(key1Data.algorithms).toEqual(['RS256']);
+			expect(key1Data.issuer).toBe('https://issuer.example.com');
+			expect(key1Data.keyMaterial).toBe(RSA_PUBLIC_KEY);
+
+			const key2 = keys.find((k) => k.kid === 'key-2')!;
+			const key2Data = JSON.parse(key2.data) as TrustedKeyData;
+			expect(key2Data.issuer).toBe('https://issuer-2.example.com');
+		});
+
+		it('should not create any sources or keys with empty config', async () => {
+			config.trustedKeys = '';
+
+			await service.initialize();
+
+			expect(await sourceRepo.find()).toHaveLength(0);
+			expect(await keyRepo.find()).toHaveLength(0);
+		});
+
+		it.each([
+			{ name: 'invalid JSON', trustedKeys: 'not-json', error: 'Failed to parse trusted keys JSON' },
+			{
+				name: 'invalid schema',
+				trustedKeys: JSON.stringify([{ type: 'invalid' }]),
+				error: 'Trusted keys JSON has invalid format',
+			},
+		])('should throw on $name config', async ({ trustedKeys, error }) => {
+			config.trustedKeys = trustedKeys;
+			await expect(service.initialize()).rejects.toThrow(error);
+		});
+
+		it('should remove orphaned sources but preserve UI sources', async () => {
+			await insertSource({ id: 'old-source', type: 'static', config: '[]' });
+			await insertSource({ id: 'ui-source', type: 'ui', config: '{}' });
+
+			config.trustedKeys = JSON.stringify([staticKeyEntry({ kid: 'new-key' })]);
+
+			await service.initialize();
+
+			const sources = await sourceRepo.find();
+			const sourceIds = sources.map((s) => s.id);
+
+			expect(sourceIds).toContain('static');
+			expect(sourceIds).toContain('ui-source');
+			expect(sourceIds).not.toContain('old-source');
+		});
+
+		it('should skip everything as worker', async () => {
+			Object.defineProperty(instanceSettings, 'isLeader', { value: false, configurable: true });
+			config.trustedKeys = JSON.stringify([staticKeyEntry()]);
+
+			await service.initialize();
+
+			expect(await sourceRepo.find()).toHaveLength(0);
+			expect(await keyRepo.find()).toHaveLength(0);
+		});
+	});
+
+	describe('getByKidAndIss', () => {
+		it('should find matching key, return undefined for wrong issuer and unknown kid', async () => {
+			await insertSource();
+			await insertKey();
+
+			// Matching kid + issuer
+			const result = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
+			expect(result).toBeDefined();
+			expect(result!.kid).toBe('test-kid');
+			expect(result!.algorithms).toEqual(['RS256']);
+			expect(result!.issuer).toBe('https://issuer.example.com');
+			expect(result!.key).toBeDefined();
+			expect((result!.key as KeyObject).type).toBe('public');
+
+			// Wrong issuer
+			expect(
+				await service.getByKidAndIss('test-kid', 'https://other-issuer.example.com'),
+			).toBeUndefined();
+
+			// Unknown kid
+			expect(
+				await service.getByKidAndIss('unknown-kid', 'https://issuer.example.com'),
+			).toBeUndefined();
+		});
+
+		it('should skip corrupted entities and still resolve valid ones', async () => {
+			await insertSource();
+
+			// Corrupted JSON
+			const corruptedJson = new TrustedKeyEntity();
+			corruptedJson.sourceId = 'static';
+			corruptedJson.kid = 'bad-json-kid';
+			corruptedJson.data = 'not-valid-json';
+			corruptedJson.createdAt = new Date();
+			await keyRepo.save(corruptedJson);
+
+			// Invalid PEM
+			await insertKey({
+				kid: 'bad-pem-kid',
+				data: makeTrustedKeyData({ keyMaterial: 'not-a-pem' }),
+			});
+
+			// Valid key
+			await insertKey({ kid: 'good-kid' });
+
+			expect(
+				await service.getByKidAndIss('bad-json-kid', 'https://issuer.example.com'),
+			).toBeUndefined();
+			expect(
+				await service.getByKidAndIss('bad-pem-kid', 'https://issuer.example.com'),
+			).toBeUndefined();
+
+			const valid = await service.getByKidAndIss('good-kid', 'https://issuer.example.com');
+			expect(valid).toBeDefined();
+			expect(valid!.kid).toBe('good-kid');
+		});
+
+		it('should select the entity matching the requested issuer', async () => {
+			await insertSource({ id: 'source-a' });
+			await insertSource({ id: 'source-b' });
+			await insertKey({
+				sourceId: 'source-a',
+				kid: 'shared-kid',
+				data: makeTrustedKeyData({ issuer: 'https://issuer-a.com' }),
+			});
+			await insertKey({
+				sourceId: 'source-b',
+				kid: 'shared-kid',
+				data: makeTrustedKeyData({ issuer: 'https://issuer-b.com' }),
+			});
+
+			const result = await service.getByKidAndIss('shared-kid', 'https://issuer-b.com');
+			expect(result).toBeDefined();
+			expect(result!.issuer).toBe('https://issuer-b.com');
+		});
+	});
+
+	describe('refreshSource', () => {
+		it('should refresh keys and replace them on subsequent refresh', async () => {
+			const initialConfig = [staticKeyEntry({ kid: 'key-v1' }), staticKeyEntry({ kid: 'key-v2' })];
+			await insertSource({ config: JSON.stringify(initialConfig) });
+
+			await service.refreshSource('static');
+
+			// First refresh: source healthy, both keys exist
+			const source = await sourceRepo.findOneBy({ id: 'static' });
+			expect(source!.status).toBe('healthy');
+			expect(source!.lastError).toBeNull();
+			expect(source!.lastRefreshedAt).toBeDefined();
+			expect(await keyRepo.find()).toHaveLength(2);
+
+			// Update config to a single different key
+			await sourceRepo.update('static', {
+				config: JSON.stringify([staticKeyEntry({ kid: 'key-v3' })]),
+			});
+
+			await service.refreshSource('static');
+
+			// Second refresh: only new key remains
+			const keys = await keyRepo.find();
+			expect(keys).toHaveLength(1);
+			expect(keys[0].kid).toBe('key-v3');
+		});
+
+		it('should mark source as error and preserve existing keys on failure', async () => {
+			await insertSource({ config: JSON.stringify([staticKeyEntry({ kid: 'preserved-key' })]) });
+			await service.refreshSource('static');
+
+			expect(await keyRepo.find()).toHaveLength(1);
+
+			// Corrupt config
+			await sourceRepo.update('static', { config: 'invalid-json' });
+			await service.refreshSource('static');
+
+			const source = await sourceRepo.findOneBy({ id: 'static' });
+			expect(source!.status).toBe('error');
+			expect(source!.lastError).toBeDefined();
+
+			// Key from prior successful refresh should be preserved
+			const keys = await keyRepo.find();
+			expect(keys).toHaveLength(1);
+			expect(keys[0].kid).toBe('preserved-key');
+		});
+
+		it('should throw when source not found', async () => {
+			await expect(service.refreshSource('nonexistent')).rejects.toThrow(
+				'Trusted key source not found',
+			);
+		});
+
+		it.each([
+			{
+				type: 'jwks' as const,
+				config: JSON.stringify({
+					type: 'jwks',
+					url: 'https://example.com/jwks',
+					issuer: 'https://example.com',
+				}),
+			},
+			{ type: 'ui' as const, config: JSON.stringify({ type: 'ui' }) },
+		])('should skip $type sources without writing keys', async ({ type, config: sourceConfig }) => {
+			await insertSource({ id: `${type}-source`, type, config: sourceConfig });
+
+			await service.refreshSource(`${type}-source`);
+
+			expect(await keyRepo.find()).toHaveLength(0);
+		});
+	});
+
+	describe('algorithm validation and key compatibility', () => {
+		it.each([
+			{ name: 'RSA key with RS256', kid: 'rsa-key', algorithms: ['RS256'], key: RSA_PUBLIC_KEY },
+			{ name: 'EC key with ES256', kid: 'ec-key', algorithms: ['ES256'], key: EC_PUBLIC_KEY },
+			{
+				name: 'Ed25519 key with EdDSA',
+				kid: 'ed-key',
+				algorithms: ['EdDSA'],
+				key: ED25519_PUBLIC_KEY,
+			},
+		])('should accept $name', async ({ kid, algorithms, key }) => {
+			await insertSource({
+				config: JSON.stringify([staticKeyEntry({ kid, algorithms, key })]),
+			});
+
+			await service.refreshSource('static');
+
+			const source = await sourceRepo.findOneBy({ id: 'static' });
+			expect(source!.status).toBe('healthy');
+
+			const keys = await keyRepo.find();
+			expect(keys).toHaveLength(1);
+			expect(keys[0].kid).toBe(kid);
+		});
+
+		it.each([
+			{
+				name: 'cross-family algorithm mixing',
+				entries: [staticKeyEntry({ kid: 'mixed', algorithms: ['RS256', 'ES256'] })],
+			},
+			{
+				name: 'EC key with RSA algorithm',
+				entries: [staticKeyEntry({ kid: 'ec-rsa', algorithms: ['RS256'], key: EC_PUBLIC_KEY })],
+			},
+			{
+				name: 'duplicate kid',
+				entries: [staticKeyEntry({ kid: 'dup' }), staticKeyEntry({ kid: 'dup' })],
+			},
+		])('should reject $name', async ({ entries }) => {
+			await insertSource({ config: JSON.stringify(entries) });
+
+			await service.refreshSource('static');
+
+			const source = await sourceRepo.findOneBy({ id: 'static' });
+			expect(source!.status).toBe('error');
+			expect(source!.lastError).toBeDefined();
+			expect(await keyRepo.find()).toHaveLength(0);
+		});
+	});
+
+	describe('listAll and listSources', () => {
+		it('should return all entities from the database', async () => {
+			await insertSource({ id: 'source-1' });
+			await insertSource({ id: 'source-2' });
+			await insertKey({ sourceId: 'source-1', kid: 'kid-1' });
+			await insertKey({ sourceId: 'source-1', kid: 'kid-2' });
+			await insertKey({ sourceId: 'source-2', kid: 'kid-3' });
+
+			expect(await service.listSources()).toHaveLength(2);
+			expect(await service.listAll()).toHaveLength(3);
+		});
+	});
+});

--- a/packages/cli/src/modules/token-exchange/services/__tests__/trusted-key.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/trusted-key.service.test.ts
@@ -1,11 +1,9 @@
 import type { Logger } from '@n8n/backend-common';
 import type { DbLockService } from '@n8n/db';
-import { DbLock } from '@n8n/db';
 import type { EntityManager } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
 
-import type { TrustedKeySourceEntity } from '../../database/entities/trusted-key-source.entity';
 import { TrustedKeyEntity } from '../../database/entities/trusted-key.entity';
 import type { TrustedKeySourceRepository } from '../../database/repositories/trusted-key-source.repository';
 import type { TrustedKeyRepository } from '../../database/repositories/trusted-key.repository';
@@ -32,35 +30,11 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpCuPN2BHQ7G0A2qD2Bd27bwwUB9M
 Npzv5WS/ygt55l8y2X+Vfm5TQFRMNkqEx+/GXaPIU/hDmtnBdCxAUIRM9g==
 -----END PUBLIC KEY-----`;
 
-const ED25519_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
-MCowBQYDK2VwAyEAPBUxurC3wGyi/yXTTjNwTzgHjSioAIa4Qx6nyOqof0U=
------END PUBLIC KEY-----`;
-
 // ──────────────────────────────────────────────────────────────────────
 // Helpers
 // ──────────────────────────────────────────────────────────────────────
 
 const mockLogger = mock<Logger>({ scoped: jest.fn().mockReturnThis() });
-
-function staticKeyEntry(
-	overrides: Partial<{
-		kid: string;
-		algorithms: string[];
-		key: string;
-		issuer: string;
-		expectedAudience: string;
-		allowedRoles: string[];
-	}> = {},
-) {
-	return {
-		type: 'static' as const,
-		kid: 'test-kid',
-		algorithms: ['RS256'],
-		key: RSA_PUBLIC_KEY,
-		issuer: 'https://issuer.example.com',
-		...overrides,
-	};
-}
 
 function makeTrustedKeyData(overrides: Partial<TrustedKeyData> = {}): TrustedKeyData {
 	return {
@@ -82,28 +56,23 @@ function makeTrustedKeyEntity(
 	return entity;
 }
 
-function createMocks(opts: { isLeader?: boolean; trustedKeys?: string } = {}) {
+function createMocks() {
 	const config = mock<TokenExchangeConfig>({
-		trustedKeys: opts.trustedKeys ?? '',
+		trustedKeys: '',
 		keyRefreshIntervalSeconds: 300,
 	});
 	const sourceRepo = mock<TrustedKeySourceRepository>();
 	const keyRepo = mock<TrustedKeyRepository>();
-	const instanceSettings = mock<InstanceSettings>({ isLeader: opts.isLeader ?? true });
-	const entityManager = mock<EntityManager>();
+	const instanceSettings = mock<InstanceSettings>({ isLeader: true });
 	const dbLockService = mock<DbLockService>();
 
-	// DbLockService.withLock mock — executes the callback with the entityManager
 	dbLockService.withLock.mockImplementation(
 		async (_lockId: unknown, fn: (tx: EntityManager) => Promise<unknown>) => {
-			return await fn(entityManager);
+			return await fn(mock<EntityManager>());
 		},
 	);
 
-	// Default: no existing sources (clean state)
 	sourceRepo.find.mockResolvedValue([]);
-	// Default: no cross-source conflicts during refresh
-	entityManager.findBy.mockResolvedValue([]);
 
 	const service = new TrustedKeyService(
 		mockLogger,
@@ -114,7 +83,7 @@ function createMocks(opts: { isLeader?: boolean; trustedKeys?: string } = {}) {
 		dbLockService,
 	);
 
-	return { service, config, sourceRepo, keyRepo, instanceSettings, entityManager, dbLockService };
+	return { service, keyRepo };
 }
 
 // ──────────────────────────────────────────────────────────────────────
@@ -129,244 +98,6 @@ describe('TrustedKeyService', () => {
 
 	afterEach(() => {
 		jest.useRealTimers();
-	});
-
-	describe('initialize', () => {
-		describe('as leader', () => {
-			it('should parse config, sync sources, refresh all, and start interval', async () => {
-				const entries = [staticKeyEntry({ kid: 'key-1' })];
-				const { service, sourceRepo, entityManager } = createMocks({
-					isLeader: true,
-					trustedKeys: JSON.stringify(entries),
-				});
-
-				// syncSourcesToDb uses entityManager (via withLock) — return empty for orphan check
-				entityManager.find.mockResolvedValue([]);
-
-				// After syncSourcesToDb, refreshAllSources queries sources
-				sourceRepo.find.mockResolvedValue([
-					{
-						id: 'static',
-						type: 'static',
-						config: JSON.stringify(entries),
-						status: 'pending',
-						lastError: null,
-						lastRefreshedAt: null,
-					} as TrustedKeySourceEntity,
-				]);
-
-				await service.initialize();
-
-				// Source was synced to DB via transaction
-				expect(entityManager.save).toHaveBeenCalledWith(
-					expect.anything(),
-					expect.objectContaining({ id: 'static', type: 'static' }),
-				);
-
-				// Refresh used advisory lock
-				expect(entityManager.delete).toHaveBeenCalled();
-				expect(entityManager.update).toHaveBeenCalledWith(
-					expect.anything(),
-					'static',
-					expect.objectContaining({ status: 'healthy' }),
-				);
-			});
-
-			it('should handle empty config', async () => {
-				const { service, entityManager } = createMocks({ isLeader: true, trustedKeys: '' });
-
-				// syncSourcesToDb uses tx.find for orphan cleanup
-				entityManager.find.mockResolvedValue([]);
-
-				await service.initialize();
-
-				// No sources saved (only orphan cleanup ran)
-				expect(entityManager.save).not.toHaveBeenCalled();
-			});
-
-			it('should throw on invalid JSON', async () => {
-				const { service } = createMocks({ isLeader: true, trustedKeys: 'not-json' });
-
-				await expect(service.initialize()).rejects.toThrow('Failed to parse trusted keys JSON');
-			});
-
-			it('should throw on invalid schema', async () => {
-				const { service } = createMocks({
-					isLeader: true,
-					trustedKeys: JSON.stringify([{ type: 'invalid' }]),
-				});
-
-				await expect(service.initialize()).rejects.toThrow('Trusted keys JSON has invalid format');
-			});
-
-			it('should remove orphaned sources not in config', async () => {
-				const { service, sourceRepo, entityManager } = createMocks({
-					isLeader: true,
-					trustedKeys: JSON.stringify([staticKeyEntry()]),
-				});
-
-				// syncSourcesToDb orphan check returns an orphaned source
-				entityManager.find.mockResolvedValueOnce([
-					{ id: 'orphaned-source', type: 'jwks' } as TrustedKeySourceEntity,
-				]);
-				// For refreshAllSources
-				sourceRepo.find.mockResolvedValueOnce([
-					{
-						id: 'static',
-						type: 'static',
-						config: JSON.stringify([staticKeyEntry()]),
-						status: 'pending',
-					} as TrustedKeySourceEntity,
-				]);
-
-				await service.initialize();
-
-				expect(entityManager.delete).toHaveBeenCalledWith(expect.anything(), 'orphaned-source');
-			});
-
-			it('should not remove UI sources during orphan cleanup', async () => {
-				const { service, sourceRepo, entityManager } = createMocks({
-					isLeader: true,
-					trustedKeys: JSON.stringify([staticKeyEntry()]),
-				});
-
-				// syncSourcesToDb orphan check returns a UI source
-				entityManager.find.mockResolvedValueOnce([
-					{ id: 'ui-source-uuid', type: 'ui' } as TrustedKeySourceEntity,
-				]);
-				// For refreshAllSources
-				sourceRepo.find.mockResolvedValueOnce([
-					{
-						id: 'static',
-						type: 'static',
-						config: JSON.stringify([staticKeyEntry()]),
-						status: 'pending',
-					} as TrustedKeySourceEntity,
-				]);
-
-				await service.initialize();
-
-				// UI source should not be deleted — only config-managed sources are orphan-cleaned
-				expect(entityManager.delete).not.toHaveBeenCalledWith(expect.anything(), 'ui-source-uuid');
-			});
-		});
-
-		describe('as worker', () => {
-			it('should not sync sources or start refresh', async () => {
-				const { service, sourceRepo } = createMocks({
-					isLeader: false,
-					trustedKeys: JSON.stringify([staticKeyEntry()]),
-				});
-
-				await service.initialize();
-
-				expect(sourceRepo.save).not.toHaveBeenCalled();
-				expect(sourceRepo.find).not.toHaveBeenCalled();
-			});
-		});
-	});
-
-	describe('getByKidAndIss', () => {
-		it('should return resolved key for matching kid and issuer', async () => {
-			const { service, keyRepo } = createMocks();
-
-			keyRepo.findAllByKid.mockResolvedValue([makeTrustedKeyEntity()]);
-
-			const result = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
-
-			expect(result).toBeDefined();
-			expect(result!.kid).toBe('test-kid');
-			expect(result!.algorithms).toEqual(['RS256']);
-			expect(result!.issuer).toBe('https://issuer.example.com');
-			expect(result!.key).toBeDefined();
-		});
-
-		it('should return undefined for unknown kid', async () => {
-			const { service, keyRepo } = createMocks();
-
-			keyRepo.findAllByKid.mockResolvedValue([]);
-
-			const result = await service.getByKidAndIss('unknown', 'https://issuer.example.com');
-
-			expect(result).toBeUndefined();
-		});
-
-		it('should return undefined when kid matches but issuer does not', async () => {
-			const { service, keyRepo } = createMocks();
-
-			keyRepo.findAllByKid.mockResolvedValue([makeTrustedKeyEntity()]);
-
-			const result = await service.getByKidAndIss('test-kid', 'https://other-issuer.example.com');
-
-			expect(result).toBeUndefined();
-		});
-
-		it('should skip entity with corrupted JSON data and return undefined', async () => {
-			const { service, keyRepo } = createMocks();
-
-			const entity = makeTrustedKeyEntity();
-			entity.data = 'not-valid-json';
-			keyRepo.findAllByKid.mockResolvedValue([entity]);
-
-			const result = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
-
-			expect(result).toBeUndefined();
-			expect(mockLogger.warn).toHaveBeenCalledWith(
-				'Skipping corrupted trusted key entity',
-				expect.objectContaining({ kid: 'test-kid', sourceId: 'static' }),
-			);
-		});
-
-		it('should skip entity with invalid schema and continue to next', async () => {
-			const { service, keyRepo } = createMocks();
-
-			const corruptedEntity = makeTrustedKeyEntity();
-			corruptedEntity.data = JSON.stringify({ algorithms: [], keyMaterial: '', issuer: '' });
-			const validEntity = makeTrustedKeyEntity({
-				data: makeTrustedKeyData({ issuer: 'https://issuer.example.com' }),
-			});
-			keyRepo.findAllByKid.mockResolvedValue([corruptedEntity, validEntity]);
-
-			const result = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
-
-			expect(result).toBeDefined();
-			expect(result!.issuer).toBe('https://issuer.example.com');
-		});
-
-		it('should skip entity with corrupted PEM key material', async () => {
-			const { service, keyRepo } = createMocks();
-
-			const entity = makeTrustedKeyEntity({
-				data: makeTrustedKeyData({ keyMaterial: 'not-a-pem' }),
-			});
-			keyRepo.findAllByKid.mockResolvedValue([entity]);
-
-			const result = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
-
-			expect(result).toBeUndefined();
-			expect(mockLogger.warn).toHaveBeenCalledWith(
-				'Failed to parse key material from DB',
-				expect.objectContaining({ kid: 'test-kid' }),
-			);
-		});
-
-		it('should select the entity matching the issuer from multiple results', async () => {
-			const { service, keyRepo } = createMocks();
-
-			keyRepo.findAllByKid.mockResolvedValue([
-				makeTrustedKeyEntity({
-					data: makeTrustedKeyData({ issuer: 'https://issuer-a.com' }),
-				}),
-				makeTrustedKeyEntity({
-					data: makeTrustedKeyData({ issuer: 'https://issuer-b.com' }),
-				}),
-			]);
-
-			const result = await service.getByKidAndIss('test-kid', 'https://issuer-b.com');
-
-			expect(result).toBeDefined();
-			expect(result!.issuer).toBe('https://issuer-b.com');
-		});
 	});
 
 	describe('crypto cache', () => {
@@ -406,281 +137,6 @@ describe('TrustedKeyService', () => {
 
 			// Different KeyObject (cache miss due to hash mismatch)
 			expect(result1!.key).not.toBe(result2!.key);
-		});
-	});
-
-	describe('refreshSourceInternal (via refreshSource)', () => {
-		it('should execute transactional refresh for static source', async () => {
-			const entries = [staticKeyEntry({ kid: 'key-1' })];
-			const { service, sourceRepo, entityManager, dbLockService } = createMocks();
-
-			sourceRepo.findOneBy.mockResolvedValue({
-				id: 'static',
-				type: 'static',
-				config: JSON.stringify(entries),
-				status: 'pending',
-			} as TrustedKeySourceEntity);
-
-			// No cross-source conflicts
-			entityManager.findBy.mockResolvedValue([]);
-
-			await service.refreshSource('static');
-
-			// Advisory lock was used
-			expect(dbLockService.withLock).toHaveBeenCalledWith(
-				DbLock.TRUSTED_KEY_REFRESH,
-				expect.any(Function),
-			);
-
-			// Old keys deleted
-			expect(entityManager.delete).toHaveBeenCalledWith(TrustedKeyEntity, {
-				sourceId: 'static',
-			});
-
-			// New key inserted
-			expect(entityManager.save).toHaveBeenCalledWith(
-				TrustedKeyEntity,
-				expect.objectContaining({ sourceId: 'static', kid: 'key-1' }),
-			);
-
-			// Source marked healthy
-			expect(entityManager.update).toHaveBeenCalledWith(
-				expect.anything(),
-				'static',
-				expect.objectContaining({ status: 'healthy', lastError: null }),
-			);
-		});
-
-		it('should mark source as error on failure and preserve existing keys', async () => {
-			const { service, sourceRepo, dbLockService } = createMocks();
-
-			sourceRepo.findOneBy.mockResolvedValue({
-				id: 'static',
-				type: 'static',
-				config: 'invalid-json',
-				status: 'healthy',
-			} as TrustedKeySourceEntity);
-
-			// Make the lock callback throw (simulating parse failure inside txn)
-			dbLockService.withLock.mockRejectedValue(new Error('Unexpected token'));
-
-			await service.refreshSource('static');
-
-			// Source updated with error status (outside txn — keys preserved)
-			expect(sourceRepo.update).toHaveBeenCalledWith('static', {
-				status: 'error',
-				lastError: 'Unexpected token',
-				lastRefreshedAt: expect.any(Date),
-			});
-		});
-
-		it('should throw when source not found', async () => {
-			const { service, sourceRepo } = createMocks();
-			sourceRepo.findOneBy.mockResolvedValue(null);
-
-			await expect(service.refreshSource('nonexistent')).rejects.toThrow(
-				'Trusted key source not found',
-			);
-		});
-
-		it('should skip JWKS sources with warning', async () => {
-			const { service, sourceRepo, entityManager } = createMocks();
-
-			sourceRepo.findOneBy.mockResolvedValue({
-				id: 'jwks-source',
-				type: 'jwks',
-				config: JSON.stringify({
-					type: 'jwks',
-					url: 'https://example.com/jwks',
-					issuer: 'https://example.com',
-				}),
-				status: 'pending',
-			} as TrustedKeySourceEntity);
-
-			await service.refreshSource('jwks-source');
-
-			expect(mockLogger.warn).toHaveBeenCalledWith(
-				'JWKS key sources are not yet supported, skipping',
-				expect.objectContaining({ sourceId: 'jwks-source' }),
-			);
-			expect(entityManager.save).not.toHaveBeenCalled();
-		});
-
-		it('should skip UI sources with warning', async () => {
-			const { service, sourceRepo, entityManager } = createMocks();
-
-			sourceRepo.findOneBy.mockResolvedValue({
-				id: 'ui-source',
-				type: 'ui',
-				config: JSON.stringify({ type: 'ui' }),
-				status: 'pending',
-			} as TrustedKeySourceEntity);
-
-			await service.refreshSource('ui-source');
-
-			expect(mockLogger.warn).toHaveBeenCalledWith(
-				'UI key sources are not yet supported, skipping',
-				expect.objectContaining({ sourceId: 'ui-source' }),
-			);
-			expect(entityManager.save).not.toHaveBeenCalled();
-		});
-	});
-
-	describe('kid conflict resolution', () => {
-		it('should delete cross-source conflicts and log warning', async () => {
-			const entries = [staticKeyEntry({ kid: 'conflicting-kid' })];
-			const { service, sourceRepo, entityManager } = createMocks();
-
-			sourceRepo.findOneBy.mockResolvedValue({
-				id: 'static',
-				type: 'static',
-				config: JSON.stringify(entries),
-				status: 'pending',
-			} as TrustedKeySourceEntity);
-
-			// Cross-source conflict: another source has the same kid
-			entityManager.findBy.mockResolvedValue([
-				{ sourceId: 'other-source', kid: 'conflicting-kid' } as TrustedKeyEntity,
-			]);
-
-			await service.refreshSource('static');
-
-			// Warning logged about conflict
-			expect(mockLogger.warn).toHaveBeenCalledWith(
-				'Kid conflict: overwriting key from another source',
-				expect.objectContaining({
-					kid: 'conflicting-kid',
-					existingSourceId: 'other-source',
-					newSourceId: 'static',
-				}),
-			);
-
-			// Conflicting keys deleted
-			expect(entityManager.delete).toHaveBeenCalledWith(TrustedKeyEntity, {
-				kid: 'conflicting-kid',
-			});
-		});
-	});
-
-	describe('algorithm validation (write path)', () => {
-		it('should reject cross-family algorithm mixing', async () => {
-			const entries = [
-				staticKeyEntry({
-					kid: 'mixed',
-					algorithms: ['RS256', 'ES256'],
-					key: RSA_PUBLIC_KEY,
-				}),
-			];
-			const { service, sourceRepo } = createMocks();
-
-			sourceRepo.findOneBy.mockResolvedValue({
-				id: 'static',
-				type: 'static',
-				config: JSON.stringify(entries),
-				status: 'pending',
-			} as TrustedKeySourceEntity);
-
-			await service.refreshSource('static');
-
-			expect(sourceRepo.update).toHaveBeenCalledWith(
-				'static',
-				expect.objectContaining({ status: 'error' }),
-			);
-		});
-
-		it('should reject EC key with RSA algorithm', async () => {
-			const entries = [
-				staticKeyEntry({ kid: 'ec-rsa', algorithms: ['RS256'], key: EC_PUBLIC_KEY }),
-			];
-			const { service, sourceRepo } = createMocks();
-
-			sourceRepo.findOneBy.mockResolvedValue({
-				id: 'static',
-				type: 'static',
-				config: JSON.stringify(entries),
-				status: 'pending',
-			} as TrustedKeySourceEntity);
-
-			await service.refreshSource('static');
-
-			expect(sourceRepo.update).toHaveBeenCalledWith(
-				'static',
-				expect.objectContaining({ status: 'error' }),
-			);
-		});
-
-		it('should reject duplicate kid within same source', async () => {
-			const entries = [staticKeyEntry({ kid: 'dup-kid' }), staticKeyEntry({ kid: 'dup-kid' })];
-			const { service, sourceRepo } = createMocks();
-
-			sourceRepo.findOneBy.mockResolvedValue({
-				id: 'static',
-				type: 'static',
-				config: JSON.stringify(entries),
-				status: 'pending',
-			} as TrustedKeySourceEntity);
-
-			await service.refreshSource('static');
-
-			expect(sourceRepo.update).toHaveBeenCalledWith(
-				'static',
-				expect.objectContaining({ status: 'error' }),
-			);
-		});
-	});
-
-	describe('key-algorithm compatibility (write path)', () => {
-		it.each([
-			{ name: 'RSA key with RS256', kid: 'rsa-key', algorithms: ['RS256'], key: RSA_PUBLIC_KEY },
-			{ name: 'EC key with ES256', kid: 'ec-key', algorithms: ['ES256'], key: EC_PUBLIC_KEY },
-			{
-				name: 'Ed25519 key with EdDSA',
-				kid: 'ed-key',
-				algorithms: ['EdDSA'],
-				key: ED25519_PUBLIC_KEY,
-			},
-		])('should accept $name during refresh', async ({ kid, algorithms, key }) => {
-			const entries = [staticKeyEntry({ kid, algorithms, key })];
-			const { service, sourceRepo, entityManager } = createMocks();
-
-			sourceRepo.findOneBy.mockResolvedValue({
-				id: 'static',
-				type: 'static',
-				config: JSON.stringify(entries),
-				status: 'pending',
-			} as TrustedKeySourceEntity);
-			entityManager.findBy.mockResolvedValue([]);
-
-			await service.refreshSource('static');
-
-			expect(entityManager.save).toHaveBeenCalledWith(
-				TrustedKeyEntity,
-				expect.objectContaining({ kid }),
-			);
-		});
-	});
-
-	describe('listAll', () => {
-		it('should delegate to repository', async () => {
-			const { service, keyRepo } = createMocks();
-			const entities = [makeTrustedKeyEntity()];
-			keyRepo.find.mockResolvedValue(entities);
-
-			const result = await service.listAll();
-
-			expect(result).toBe(entities);
-		});
-	});
-
-	describe('listSources', () => {
-		it('should delegate to repository', async () => {
-			const { service, sourceRepo } = createMocks();
-			const sources = [{ id: 'static', type: 'static' } as TrustedKeySourceEntity];
-			sourceRepo.find.mockResolvedValue(sources);
-
-			const result = await service.listSources();
-
-			expect(result).toBe(sources);
 		});
 	});
 

--- a/packages/cli/src/modules/token-exchange/services/__tests__/trusted-key.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/trusted-key.service.test.ts
@@ -4,6 +4,7 @@ import type { EntityManager } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
 
+import { TrustedKeySourceEntity } from '../../database/entities/trusted-key-source.entity';
 import { TrustedKeyEntity } from '../../database/entities/trusted-key.entity';
 import type { TrustedKeySourceRepository } from '../../database/repositories/trusted-key-source.repository';
 import type { TrustedKeyRepository } from '../../database/repositories/trusted-key.repository';
@@ -83,7 +84,7 @@ function createMocks() {
 		dbLockService,
 	);
 
-	return { service, keyRepo };
+	return { service, keyRepo, sourceRepo, dbLockService };
 }
 
 // ──────────────────────────────────────────────────────────────────────
@@ -141,14 +142,14 @@ describe('TrustedKeyService', () => {
 	});
 
 	describe('leader lifecycle', () => {
-		it('should start refresh interval on leader takeover', () => {
+		it('should start refresh poll interval on leader takeover', () => {
 			const { service } = createMocks();
 			const setIntervalSpy = jest.spyOn(global, 'setInterval');
 
 			service.startRefresh();
 
 			expect(setIntervalSpy).toHaveBeenCalledTimes(1);
-			expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 300_000);
+			expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 30_000);
 
 			service.stopRefresh();
 			setIntervalSpy.mockRestore();
@@ -208,6 +209,72 @@ describe('TrustedKeyService', () => {
 			expect(setIntervalSpy).toHaveBeenCalledTimes(1);
 
 			setIntervalSpy.mockRestore();
+		});
+	});
+
+	describe('refreshDueSources', () => {
+		it('should skip sources that were recently refreshed', async () => {
+			const { service, sourceRepo, dbLockService } = createMocks();
+
+			const recentSource = Object.assign(new TrustedKeySourceEntity(), {
+				id: 'static',
+				type: 'static' as const,
+				config: JSON.stringify([]),
+				status: 'healthy' as const,
+				lastError: null,
+				lastRefreshedAt: new Date(), // just refreshed
+			});
+
+			sourceRepo.find.mockResolvedValue([recentSource]);
+
+			service.startRefresh();
+			await jest.advanceTimersByTimeAsync(30_000);
+			service.stopRefresh();
+
+			// Source was recently refreshed — should not trigger a refresh
+			expect(dbLockService.withLock).not.toHaveBeenCalled();
+		});
+
+		it('should refresh sources whose lastRefreshedAt exceeds the interval', async () => {
+			const { service, sourceRepo, dbLockService } = createMocks();
+
+			const staleSource = Object.assign(new TrustedKeySourceEntity(), {
+				id: 'static',
+				type: 'static' as const,
+				config: JSON.stringify([]),
+				status: 'healthy' as const,
+				lastError: null,
+				lastRefreshedAt: new Date(Date.now() - 400_000), // 400s ago, interval is 300s
+			});
+
+			sourceRepo.find.mockResolvedValue([staleSource]);
+
+			service.startRefresh();
+			await jest.advanceTimersByTimeAsync(30_000);
+			service.stopRefresh();
+
+			expect(dbLockService.withLock).toHaveBeenCalled();
+		});
+
+		it('should refresh sources that have never been refreshed', async () => {
+			const { service, sourceRepo, dbLockService } = createMocks();
+
+			const newSource = Object.assign(new TrustedKeySourceEntity(), {
+				id: 'static',
+				type: 'static' as const,
+				config: JSON.stringify([]),
+				status: 'pending' as const,
+				lastError: null,
+				lastRefreshedAt: null,
+			});
+
+			sourceRepo.find.mockResolvedValue([newSource]);
+
+			service.startRefresh();
+			await jest.advanceTimersByTimeAsync(30_000);
+			service.stopRefresh();
+
+			expect(dbLockService.withLock).toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/cli/src/modules/token-exchange/services/__tests__/trusted-key.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/trusted-key.service.test.ts
@@ -140,6 +140,9 @@ describe('TrustedKeyService', () => {
 					trustedKeys: JSON.stringify(entries),
 				});
 
+				// syncSourcesToDb uses entityManager (via withLock) — return empty for orphan check
+				entityManager.find.mockResolvedValue([]);
+
 				// After syncSourcesToDb, refreshAllSources queries sources
 				sourceRepo.find.mockResolvedValue([
 					{
@@ -154,14 +157,14 @@ describe('TrustedKeyService', () => {
 
 				await service.initialize();
 
-				// Source was synced to DB
-				expect(sourceRepo.save).toHaveBeenCalledWith(
+				// Source was synced to DB via transaction
+				expect(entityManager.save).toHaveBeenCalledWith(
+					expect.anything(),
 					expect.objectContaining({ id: 'static', type: 'static' }),
 				);
 
 				// Refresh used advisory lock
 				expect(entityManager.delete).toHaveBeenCalled();
-				expect(entityManager.save).toHaveBeenCalled();
 				expect(entityManager.update).toHaveBeenCalledWith(
 					expect.anything(),
 					'static',
@@ -170,11 +173,15 @@ describe('TrustedKeyService', () => {
 			});
 
 			it('should handle empty config', async () => {
-				const { service, sourceRepo } = createMocks({ isLeader: true, trustedKeys: '' });
+				const { service, entityManager } = createMocks({ isLeader: true, trustedKeys: '' });
+
+				// syncSourcesToDb uses tx.find for orphan cleanup
+				entityManager.find.mockResolvedValue([]);
 
 				await service.initialize();
 
-				expect(sourceRepo.save).not.toHaveBeenCalled();
+				// No sources saved (only orphan cleanup ran)
+				expect(entityManager.save).not.toHaveBeenCalled();
 			});
 
 			it('should throw on invalid JSON', async () => {
@@ -193,13 +200,13 @@ describe('TrustedKeyService', () => {
 			});
 
 			it('should remove orphaned sources not in config', async () => {
-				const { service, sourceRepo } = createMocks({
+				const { service, sourceRepo, entityManager } = createMocks({
 					isLeader: true,
 					trustedKeys: JSON.stringify([staticKeyEntry()]),
 				});
 
-				// Existing orphaned source in DB
-				sourceRepo.find.mockResolvedValueOnce([
+				// syncSourcesToDb orphan check returns an orphaned source
+				entityManager.find.mockResolvedValueOnce([
 					{ id: 'orphaned-source', type: 'jwks' } as TrustedKeySourceEntity,
 				]);
 				// For refreshAllSources
@@ -214,18 +221,20 @@ describe('TrustedKeyService', () => {
 
 				await service.initialize();
 
-				expect(sourceRepo.delete).toHaveBeenCalledWith('orphaned-source');
+				expect(entityManager.delete).toHaveBeenCalledWith(expect.anything(), 'orphaned-source');
 			});
 
 			it('should not remove UI sources during orphan cleanup', async () => {
-				const { service, sourceRepo } = createMocks({
+				const { service, sourceRepo, entityManager } = createMocks({
 					isLeader: true,
 					trustedKeys: JSON.stringify([staticKeyEntry()]),
 				});
 
-				sourceRepo.find.mockResolvedValueOnce([
+				// syncSourcesToDb orphan check returns a UI source
+				entityManager.find.mockResolvedValueOnce([
 					{ id: 'ui-source-uuid', type: 'ui' } as TrustedKeySourceEntity,
 				]);
+				// For refreshAllSources
 				sourceRepo.find.mockResolvedValueOnce([
 					{
 						id: 'static',
@@ -237,7 +246,8 @@ describe('TrustedKeyService', () => {
 
 				await service.initialize();
 
-				expect(sourceRepo.delete).not.toHaveBeenCalledWith('ui-source-uuid');
+				// UI source should not be deleted — only config-managed sources are orphan-cleaned
+				expect(entityManager.delete).not.toHaveBeenCalledWith(expect.anything(), 'ui-source-uuid');
 			});
 		});
 
@@ -289,6 +299,55 @@ describe('TrustedKeyService', () => {
 			const result = await service.getByKidAndIss('test-kid', 'https://other-issuer.example.com');
 
 			expect(result).toBeUndefined();
+		});
+
+		it('should skip entity with corrupted JSON data and return undefined', async () => {
+			const { service, keyRepo } = createMocks();
+
+			const entity = makeTrustedKeyEntity();
+			entity.data = 'not-valid-json';
+			keyRepo.findAllByKid.mockResolvedValue([entity]);
+
+			const result = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
+
+			expect(result).toBeUndefined();
+			expect(mockLogger.warn).toHaveBeenCalledWith(
+				'Skipping corrupted trusted key entity',
+				expect.objectContaining({ kid: 'test-kid', sourceId: 'static' }),
+			);
+		});
+
+		it('should skip entity with invalid schema and continue to next', async () => {
+			const { service, keyRepo } = createMocks();
+
+			const corruptedEntity = makeTrustedKeyEntity();
+			corruptedEntity.data = JSON.stringify({ algorithms: [], keyMaterial: '', issuer: '' });
+			const validEntity = makeTrustedKeyEntity({
+				data: makeTrustedKeyData({ issuer: 'https://issuer.example.com' }),
+			});
+			keyRepo.findAllByKid.mockResolvedValue([corruptedEntity, validEntity]);
+
+			const result = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
+
+			expect(result).toBeDefined();
+			expect(result!.issuer).toBe('https://issuer.example.com');
+		});
+
+		it('should skip entity with corrupted PEM key material', async () => {
+			const { service, keyRepo } = createMocks();
+
+			const entity = makeTrustedKeyEntity({
+				data: makeTrustedKeyData({ keyMaterial: 'not-a-pem' }),
+			});
+			keyRepo.findAllByKid.mockResolvedValue([entity]);
+
+			const result = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
+
+			expect(result).toBeUndefined();
+			expect(mockLogger.warn).toHaveBeenCalledWith(
+				'Failed to parse key material from DB',
+				expect.objectContaining({ kid: 'test-kid' }),
+			);
 		});
 
 		it('should select the entity matching the issuer from multiple results', async () => {
@@ -633,6 +692,19 @@ describe('TrustedKeyService', () => {
 
 			// Verify interval was set (check that stopRefresh clears it)
 			service.stopRefresh();
+		});
+
+		it('should not create duplicate interval on repeated startRefresh calls', () => {
+			const { service } = createMocks();
+			const setIntervalSpy = jest.spyOn(global, 'setInterval');
+
+			service.startRefresh();
+			service.startRefresh();
+
+			expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+
+			service.stopRefresh();
+			setIntervalSpy.mockRestore();
 		});
 
 		it('should not start refresh if shutting down', () => {

--- a/packages/cli/src/modules/token-exchange/services/__tests__/trusted-key.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/trusted-key.service.test.ts
@@ -143,11 +143,15 @@ describe('TrustedKeyService', () => {
 	describe('leader lifecycle', () => {
 		it('should start refresh interval on leader takeover', () => {
 			const { service } = createMocks();
+			const setIntervalSpy = jest.spyOn(global, 'setInterval');
 
 			service.startRefresh();
 
-			// Verify interval was set (check that stopRefresh clears it)
+			expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+			expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 300_000);
+
 			service.stopRefresh();
+			setIntervalSpy.mockRestore();
 		});
 
 		it('should not create duplicate interval on repeated startRefresh calls', () => {
@@ -165,32 +169,45 @@ describe('TrustedKeyService', () => {
 
 		it('should not start refresh if shutting down', () => {
 			const { service } = createMocks();
+			const setIntervalSpy = jest.spyOn(global, 'setInterval');
 
 			service.shutdown();
 			service.startRefresh();
 
-			// No interval to clear — this just verifies no error thrown
-			service.stopRefresh();
+			expect(setIntervalSpy).not.toHaveBeenCalled();
+
+			setIntervalSpy.mockRestore();
 		});
 
 		it('should clear interval on leader stepdown', () => {
 			const { service } = createMocks();
+			const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
 
 			service.startRefresh();
 			service.stopRefresh();
 
-			// Call again to verify idempotency
+			expect(clearIntervalSpy).toHaveBeenCalled();
+
+			// Call again to verify idempotency — should not throw
 			service.stopRefresh();
+
+			clearIntervalSpy.mockRestore();
 		});
 
 		it('should stop refresh on shutdown', () => {
 			const { service } = createMocks();
+			const setIntervalSpy = jest.spyOn(global, 'setInterval');
 
 			service.startRefresh();
+			expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+
 			service.shutdown();
-
-			// Verify startRefresh after shutdown is a no-op
 			service.startRefresh();
+
+			// Still only 1 call — post-shutdown startRefresh is a no-op
+			expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+
+			setIntervalSpy.mockRestore();
 		});
 	});
 });

--- a/packages/cli/src/modules/token-exchange/services/__tests__/trusted-key.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/trusted-key.service.test.ts
@@ -1,7 +1,16 @@
 import type { Logger } from '@n8n/backend-common';
+import type { DbLockService } from '@n8n/db';
+import { DbLock } from '@n8n/db';
+import type { EntityManager } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
+import type { InstanceSettings } from 'n8n-core';
 
+import type { TrustedKeySourceEntity } from '../../database/entities/trusted-key-source.entity';
+import { TrustedKeyEntity } from '../../database/entities/trusted-key.entity';
+import type { TrustedKeySourceRepository } from '../../database/repositories/trusted-key-source.repository';
+import type { TrustedKeyRepository } from '../../database/repositories/trusted-key.repository';
 import type { TokenExchangeConfig } from '../../token-exchange.config';
+import type { TrustedKeyData } from '../../token-exchange.schemas';
 import { TrustedKeyService } from '../trusted-key.service';
 
 // ──────────────────────────────────────────────────────────────────────
@@ -33,14 +42,6 @@ MCowBQYDK2VwAyEAPBUxurC3wGyi/yXTTjNwTzgHjSioAIa4Qx6nyOqof0U=
 
 const mockLogger = mock<Logger>({ scoped: jest.fn().mockReturnThis() });
 
-function createService(trustedKeysJson: string): TrustedKeyService {
-	const tokenExchangeConfig = mock<TokenExchangeConfig>({
-		trustedKeys: trustedKeysJson,
-		enabled: true,
-	});
-	return new TrustedKeyService(mockLogger, tokenExchangeConfig);
-}
-
 function staticKeyEntry(
 	overrides: Partial<{
 		kid: string;
@@ -61,10 +62,59 @@ function staticKeyEntry(
 	};
 }
 
-async function initWithEntries(entries: unknown[]): Promise<TrustedKeyService> {
-	const service = createService(JSON.stringify(entries));
-	await service.initialize();
-	return service;
+function makeTrustedKeyData(overrides: Partial<TrustedKeyData> = {}): TrustedKeyData {
+	return {
+		algorithms: ['RS256'],
+		keyMaterial: RSA_PUBLIC_KEY,
+		issuer: 'https://issuer.example.com',
+		...overrides,
+	};
+}
+
+function makeTrustedKeyEntity(
+	overrides: Partial<{ sourceId: string; kid: string; data: TrustedKeyData }> = {},
+): TrustedKeyEntity {
+	const entity = new TrustedKeyEntity();
+	entity.sourceId = overrides.sourceId ?? 'static';
+	entity.kid = overrides.kid ?? 'test-kid';
+	entity.data = JSON.stringify(overrides.data ?? makeTrustedKeyData());
+	entity.createdAt = new Date();
+	return entity;
+}
+
+function createMocks(opts: { isLeader?: boolean; trustedKeys?: string } = {}) {
+	const config = mock<TokenExchangeConfig>({
+		trustedKeys: opts.trustedKeys ?? '',
+		keyRefreshIntervalSeconds: 300,
+	});
+	const sourceRepo = mock<TrustedKeySourceRepository>();
+	const keyRepo = mock<TrustedKeyRepository>();
+	const instanceSettings = mock<InstanceSettings>({ isLeader: opts.isLeader ?? true });
+	const entityManager = mock<EntityManager>();
+	const dbLockService = mock<DbLockService>();
+
+	// DbLockService.withLock mock — executes the callback with the entityManager
+	dbLockService.withLock.mockImplementation(
+		async (_lockId: unknown, fn: (tx: EntityManager) => Promise<unknown>) => {
+			return await fn(entityManager);
+		},
+	);
+
+	// Default: no existing sources (clean state)
+	sourceRepo.find.mockResolvedValue([]);
+	// Default: no cross-source conflicts during refresh
+	entityManager.findBy.mockResolvedValue([]);
+
+	const service = new TrustedKeyService(
+		mockLogger,
+		config,
+		sourceRepo,
+		keyRepo,
+		instanceSettings,
+		dbLockService,
+	);
+
+	return { service, config, sourceRepo, keyRepo, instanceSettings, entityManager, dbLockService };
 }
 
 // ──────────────────────────────────────────────────────────────────────
@@ -74,179 +124,545 @@ async function initWithEntries(entries: unknown[]): Promise<TrustedKeyService> {
 describe('TrustedKeyService', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
+		jest.useFakeTimers();
 	});
 
-	describe('configuration loading', () => {
-		it('should load keys from trustedKeys config', async () => {
-			const service = await initWithEntries([staticKeyEntry()]);
-			expect(service.size).toBe(1);
-		});
-
-		it('should succeed with empty config', async () => {
-			const service = createService('');
-			await service.initialize();
-			expect(service.size).toBe(0);
-		});
-
-		it('should throw on invalid JSON', async () => {
-			const service = createService('not-json');
-			await expect(service.initialize()).rejects.toThrow('Failed to parse trusted keys JSON');
-		});
-
-		it('should throw when parsed value is not an array', async () => {
-			const service = createService(JSON.stringify({ type: 'static' }));
-			await expect(service.initialize()).rejects.toThrow();
-		});
+	afterEach(() => {
+		jest.useRealTimers();
 	});
 
-	describe('algorithm validation', () => {
-		it('should reject none algorithm', async () => {
-			// 'none' is not in JwtAlgorithmSchema, so Zod rejects it at parse time
-			await expect(
-				initWithEntries([staticKeyEntry({ algorithms: ['none' as 'RS256'] })]),
-			).rejects.toThrow();
+	describe('initialize', () => {
+		describe('as leader', () => {
+			it('should parse config, sync sources, refresh all, and start interval', async () => {
+				const entries = [staticKeyEntry({ kid: 'key-1' })];
+				const { service, sourceRepo, entityManager } = createMocks({
+					isLeader: true,
+					trustedKeys: JSON.stringify(entries),
+				});
+
+				// After syncSourcesToDb, refreshAllSources queries sources
+				sourceRepo.find.mockResolvedValue([
+					{
+						id: 'static',
+						type: 'static',
+						config: JSON.stringify(entries),
+						status: 'pending',
+						lastError: null,
+						lastRefreshedAt: null,
+					} as TrustedKeySourceEntity,
+				]);
+
+				await service.initialize();
+
+				// Source was synced to DB
+				expect(sourceRepo.save).toHaveBeenCalledWith(
+					expect.objectContaining({ id: 'static', type: 'static' }),
+				);
+
+				// Refresh used advisory lock
+				expect(entityManager.delete).toHaveBeenCalled();
+				expect(entityManager.save).toHaveBeenCalled();
+				expect(entityManager.update).toHaveBeenCalledWith(
+					expect.anything(),
+					'static',
+					expect.objectContaining({ status: 'healthy' }),
+				);
+			});
+
+			it('should handle empty config', async () => {
+				const { service, sourceRepo } = createMocks({ isLeader: true, trustedKeys: '' });
+
+				await service.initialize();
+
+				expect(sourceRepo.save).not.toHaveBeenCalled();
+			});
+
+			it('should throw on invalid JSON', async () => {
+				const { service } = createMocks({ isLeader: true, trustedKeys: 'not-json' });
+
+				await expect(service.initialize()).rejects.toThrow('Failed to parse trusted keys JSON');
+			});
+
+			it('should throw on invalid schema', async () => {
+				const { service } = createMocks({
+					isLeader: true,
+					trustedKeys: JSON.stringify([{ type: 'invalid' }]),
+				});
+
+				await expect(service.initialize()).rejects.toThrow('Trusted keys JSON has invalid format');
+			});
+
+			it('should remove orphaned sources not in config', async () => {
+				const { service, sourceRepo } = createMocks({
+					isLeader: true,
+					trustedKeys: JSON.stringify([staticKeyEntry()]),
+				});
+
+				// Existing orphaned source in DB
+				sourceRepo.find.mockResolvedValueOnce([
+					{ id: 'orphaned-source', type: 'jwks' } as TrustedKeySourceEntity,
+				]);
+				// For refreshAllSources
+				sourceRepo.find.mockResolvedValueOnce([
+					{
+						id: 'static',
+						type: 'static',
+						config: JSON.stringify([staticKeyEntry()]),
+						status: 'pending',
+					} as TrustedKeySourceEntity,
+				]);
+
+				await service.initialize();
+
+				expect(sourceRepo.delete).toHaveBeenCalledWith('orphaned-source');
+			});
+
+			it('should not remove UI sources during orphan cleanup', async () => {
+				const { service, sourceRepo } = createMocks({
+					isLeader: true,
+					trustedKeys: JSON.stringify([staticKeyEntry()]),
+				});
+
+				sourceRepo.find.mockResolvedValueOnce([
+					{ id: 'ui-source-uuid', type: 'ui' } as TrustedKeySourceEntity,
+				]);
+				sourceRepo.find.mockResolvedValueOnce([
+					{
+						id: 'static',
+						type: 'static',
+						config: JSON.stringify([staticKeyEntry()]),
+						status: 'pending',
+					} as TrustedKeySourceEntity,
+				]);
+
+				await service.initialize();
+
+				expect(sourceRepo.delete).not.toHaveBeenCalledWith('ui-source-uuid');
+			});
 		});
 
-		it.each(['HS256', 'HS384', 'HS512'])('should reject HMAC algorithm %s', async (alg) => {
-			await expect(
-				initWithEntries([staticKeyEntry({ algorithms: [alg as 'RS256'] })]),
-			).rejects.toThrow();
-		});
+		describe('as worker', () => {
+			it('should not sync sources or start refresh', async () => {
+				const { service, sourceRepo } = createMocks({
+					isLeader: false,
+					trustedKeys: JSON.stringify([staticKeyEntry()]),
+				});
 
-		it('should reject unknown algorithm', async () => {
-			await expect(
-				initWithEntries([staticKeyEntry({ algorithms: ['FAKE256' as 'RS256'] })]),
-			).rejects.toThrow();
-		});
+				await service.initialize();
 
-		it('should reject cross-family mixing (RS256 + ES256)', async () => {
-			await expect(
-				initWithEntries([staticKeyEntry({ algorithms: ['RS256', 'ES256'], key: RSA_PUBLIC_KEY })]),
-			).rejects.toThrow('same family');
-		});
-
-		it('should accept multiple same-family algorithms (RS256 + PS256)', async () => {
-			const service = await initWithEntries([
-				staticKeyEntry({ algorithms: ['RS256', 'PS256'], key: RSA_PUBLIC_KEY }),
-			]);
-			expect(service.size).toBe(1);
-		});
-	});
-
-	describe('key-algorithm compatibility', () => {
-		it('should accept RSA key with RS256', async () => {
-			const service = await initWithEntries([
-				staticKeyEntry({ kid: 'rsa-key', algorithms: ['RS256'], key: RSA_PUBLIC_KEY }),
-			]);
-			expect(service.size).toBe(1);
-		});
-
-		it('should accept EC key with ES256', async () => {
-			const service = await initWithEntries([
-				staticKeyEntry({ kid: 'ec-key', algorithms: ['ES256'], key: EC_PUBLIC_KEY }),
-			]);
-			expect(service.size).toBe(1);
-		});
-
-		it('should accept Ed25519 key with EdDSA', async () => {
-			const service = await initWithEntries([
-				staticKeyEntry({
-					kid: 'ed-key',
-					algorithms: ['EdDSA'],
-					key: ED25519_PUBLIC_KEY,
-				}),
-			]);
-			expect(service.size).toBe(1);
-		});
-
-		it('should reject EC key with RSA algorithm', async () => {
-			await expect(
-				initWithEntries([
-					staticKeyEntry({ kid: 'ec-rsa', algorithms: ['RS256'], key: EC_PUBLIC_KEY }),
-				]),
-			).rejects.toThrow('does not match algorithm family');
-		});
-
-		it('should reject RSA key with EC algorithm', async () => {
-			await expect(
-				initWithEntries([
-					staticKeyEntry({ kid: 'rsa-ec', algorithms: ['ES256'], key: RSA_PUBLIC_KEY }),
-				]),
-			).rejects.toThrow('does not match algorithm family');
-		});
-
-		it('should reject invalid PEM string', async () => {
-			await expect(
-				initWithEntries([
-					staticKeyEntry({ kid: 'bad-pem', algorithms: ['RS256'], key: 'not-a-pem' }),
-				]),
-			).rejects.toThrow('failed to parse public key');
-		});
-	});
-
-	describe('duplicate detection', () => {
-		it('should reject duplicate kid values', async () => {
-			await expect(
-				initWithEntries([
-					staticKeyEntry({ kid: 'same-kid', key: RSA_PUBLIC_KEY }),
-					staticKeyEntry({ kid: 'same-kid', key: RSA_PUBLIC_KEY }),
-				]),
-			).rejects.toThrow('duplicate kid');
-		});
-	});
-
-	describe('JWKS handling', () => {
-		it('should log warning and skip JWKS sources', async () => {
-			const service = await initWithEntries([
-				{
-					type: 'jwks',
-					url: 'https://example.com/.well-known/jwks.json',
-					issuer: 'https://example.com',
-				},
-			]);
-			expect(service.size).toBe(0);
-			expect(mockLogger.warn).toHaveBeenCalledWith(
-				expect.stringContaining('JWKS key sources are not yet supported'),
-			);
-		});
-
-		it('should load static keys alongside skipped JWKS sources', async () => {
-			const service = await initWithEntries([
-				staticKeyEntry({ kid: 'static-1' }),
-				{
-					type: 'jwks',
-					url: 'https://example.com/.well-known/jwks.json',
-					issuer: 'https://example.com',
-				},
-			]);
-			expect(service.size).toBe(1);
-			expect(await service.getByKid('static-1')).toBeDefined();
+				expect(sourceRepo.save).not.toHaveBeenCalled();
+				expect(sourceRepo.find).not.toHaveBeenCalled();
+			});
 		});
 	});
 
-	describe('getByKid', () => {
-		it('should return correct ResolvedTrustedKey for known kid', async () => {
-			const service = await initWithEntries([
-				staticKeyEntry({
-					kid: 'my-key',
-					algorithms: ['RS256'],
-					key: RSA_PUBLIC_KEY,
-					issuer: 'https://issuer.example.com',
-				}),
-			]);
+	describe('getByKidAndIss', () => {
+		it('should return resolved key for matching kid and issuer', async () => {
+			const { service, keyRepo } = createMocks();
 
-			const result = await service.getByKid('my-key');
+			keyRepo.findAllByKid.mockResolvedValue([makeTrustedKeyEntity()]);
+
+			const result = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
+
 			expect(result).toBeDefined();
-			expect(result!.kid).toBe('my-key');
+			expect(result!.kid).toBe('test-kid');
 			expect(result!.algorithms).toEqual(['RS256']);
 			expect(result!.issuer).toBe('https://issuer.example.com');
 			expect(result!.key).toBeDefined();
 		});
 
 		it('should return undefined for unknown kid', async () => {
-			const service = await initWithEntries([staticKeyEntry({ kid: 'known' })]);
-			const result = await service.getByKid('unknown');
+			const { service, keyRepo } = createMocks();
+
+			keyRepo.findAllByKid.mockResolvedValue([]);
+
+			const result = await service.getByKidAndIss('unknown', 'https://issuer.example.com');
+
 			expect(result).toBeUndefined();
+		});
+
+		it('should return undefined when kid matches but issuer does not', async () => {
+			const { service, keyRepo } = createMocks();
+
+			keyRepo.findAllByKid.mockResolvedValue([makeTrustedKeyEntity()]);
+
+			const result = await service.getByKidAndIss('test-kid', 'https://other-issuer.example.com');
+
+			expect(result).toBeUndefined();
+		});
+
+		it('should select the entity matching the issuer from multiple results', async () => {
+			const { service, keyRepo } = createMocks();
+
+			keyRepo.findAllByKid.mockResolvedValue([
+				makeTrustedKeyEntity({
+					data: makeTrustedKeyData({ issuer: 'https://issuer-a.com' }),
+				}),
+				makeTrustedKeyEntity({
+					data: makeTrustedKeyData({ issuer: 'https://issuer-b.com' }),
+				}),
+			]);
+
+			const result = await service.getByKidAndIss('test-kid', 'https://issuer-b.com');
+
+			expect(result).toBeDefined();
+			expect(result!.issuer).toBe('https://issuer-b.com');
+		});
+	});
+
+	describe('crypto cache', () => {
+		it('should reuse cached crypto key when keyMaterial is unchanged', async () => {
+			const { service, keyRepo } = createMocks();
+
+			const entity = makeTrustedKeyEntity();
+			keyRepo.findAllByKid.mockResolvedValue([entity]);
+
+			const result1 = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
+			const result2 = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
+
+			// Same KeyObject instance (from cache)
+			expect(result1!.key).toBe(result2!.key);
+		});
+
+		it('should create new crypto key when keyMaterial changes', async () => {
+			const { service, keyRepo } = createMocks();
+
+			const entity1 = makeTrustedKeyEntity({
+				data: makeTrustedKeyData({ keyMaterial: RSA_PUBLIC_KEY }),
+			});
+			keyRepo.findAllByKid.mockResolvedValueOnce([entity1]);
+
+			const result1 = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
+
+			// Change key material to EC key
+			const entity2 = makeTrustedKeyEntity({
+				data: makeTrustedKeyData({
+					keyMaterial: EC_PUBLIC_KEY,
+					algorithms: ['ES256'],
+				}),
+			});
+			keyRepo.findAllByKid.mockResolvedValueOnce([entity2]);
+
+			const result2 = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
+
+			// Different KeyObject (cache miss due to hash mismatch)
+			expect(result1!.key).not.toBe(result2!.key);
+		});
+	});
+
+	describe('refreshSourceInternal (via refreshSource)', () => {
+		it('should execute transactional refresh for static source', async () => {
+			const entries = [staticKeyEntry({ kid: 'key-1' })];
+			const { service, sourceRepo, entityManager, dbLockService } = createMocks();
+
+			sourceRepo.findOneBy.mockResolvedValue({
+				id: 'static',
+				type: 'static',
+				config: JSON.stringify(entries),
+				status: 'pending',
+			} as TrustedKeySourceEntity);
+
+			// No cross-source conflicts
+			entityManager.findBy.mockResolvedValue([]);
+
+			await service.refreshSource('static');
+
+			// Advisory lock was used
+			expect(dbLockService.withLock).toHaveBeenCalledWith(
+				DbLock.TRUSTED_KEY_REFRESH,
+				expect.any(Function),
+			);
+
+			// Old keys deleted
+			expect(entityManager.delete).toHaveBeenCalledWith(TrustedKeyEntity, {
+				sourceId: 'static',
+			});
+
+			// New key inserted
+			expect(entityManager.save).toHaveBeenCalledWith(
+				TrustedKeyEntity,
+				expect.objectContaining({ sourceId: 'static', kid: 'key-1' }),
+			);
+
+			// Source marked healthy
+			expect(entityManager.update).toHaveBeenCalledWith(
+				expect.anything(),
+				'static',
+				expect.objectContaining({ status: 'healthy', lastError: null }),
+			);
+		});
+
+		it('should mark source as error on failure and preserve existing keys', async () => {
+			const { service, sourceRepo, dbLockService } = createMocks();
+
+			sourceRepo.findOneBy.mockResolvedValue({
+				id: 'static',
+				type: 'static',
+				config: 'invalid-json',
+				status: 'healthy',
+			} as TrustedKeySourceEntity);
+
+			// Make the lock callback throw (simulating parse failure inside txn)
+			dbLockService.withLock.mockRejectedValue(new Error('Unexpected token'));
+
+			await service.refreshSource('static');
+
+			// Source updated with error status (outside txn — keys preserved)
+			expect(sourceRepo.update).toHaveBeenCalledWith('static', {
+				status: 'error',
+				lastError: 'Unexpected token',
+				lastRefreshedAt: expect.any(Date),
+			});
+		});
+
+		it('should throw when source not found', async () => {
+			const { service, sourceRepo } = createMocks();
+			sourceRepo.findOneBy.mockResolvedValue(null);
+
+			await expect(service.refreshSource('nonexistent')).rejects.toThrow(
+				'Trusted key source not found',
+			);
+		});
+
+		it('should skip JWKS sources with warning', async () => {
+			const { service, sourceRepo, entityManager } = createMocks();
+
+			sourceRepo.findOneBy.mockResolvedValue({
+				id: 'jwks-source',
+				type: 'jwks',
+				config: JSON.stringify({
+					type: 'jwks',
+					url: 'https://example.com/jwks',
+					issuer: 'https://example.com',
+				}),
+				status: 'pending',
+			} as TrustedKeySourceEntity);
+
+			await service.refreshSource('jwks-source');
+
+			expect(mockLogger.warn).toHaveBeenCalledWith(
+				'JWKS key sources are not yet supported, skipping',
+				expect.objectContaining({ sourceId: 'jwks-source' }),
+			);
+			expect(entityManager.save).not.toHaveBeenCalled();
+		});
+
+		it('should skip UI sources with warning', async () => {
+			const { service, sourceRepo, entityManager } = createMocks();
+
+			sourceRepo.findOneBy.mockResolvedValue({
+				id: 'ui-source',
+				type: 'ui',
+				config: JSON.stringify({ type: 'ui' }),
+				status: 'pending',
+			} as TrustedKeySourceEntity);
+
+			await service.refreshSource('ui-source');
+
+			expect(mockLogger.warn).toHaveBeenCalledWith(
+				'UI key sources are not yet supported, skipping',
+				expect.objectContaining({ sourceId: 'ui-source' }),
+			);
+			expect(entityManager.save).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('kid conflict resolution', () => {
+		it('should delete cross-source conflicts and log warning', async () => {
+			const entries = [staticKeyEntry({ kid: 'conflicting-kid' })];
+			const { service, sourceRepo, entityManager } = createMocks();
+
+			sourceRepo.findOneBy.mockResolvedValue({
+				id: 'static',
+				type: 'static',
+				config: JSON.stringify(entries),
+				status: 'pending',
+			} as TrustedKeySourceEntity);
+
+			// Cross-source conflict: another source has the same kid
+			entityManager.findBy.mockResolvedValue([
+				{ sourceId: 'other-source', kid: 'conflicting-kid' } as TrustedKeyEntity,
+			]);
+
+			await service.refreshSource('static');
+
+			// Warning logged about conflict
+			expect(mockLogger.warn).toHaveBeenCalledWith(
+				'Kid conflict: overwriting key from another source',
+				expect.objectContaining({
+					kid: 'conflicting-kid',
+					existingSourceId: 'other-source',
+					newSourceId: 'static',
+				}),
+			);
+
+			// Conflicting keys deleted
+			expect(entityManager.delete).toHaveBeenCalledWith(TrustedKeyEntity, {
+				kid: 'conflicting-kid',
+			});
+		});
+	});
+
+	describe('algorithm validation (write path)', () => {
+		it('should reject cross-family algorithm mixing', async () => {
+			const entries = [
+				staticKeyEntry({
+					kid: 'mixed',
+					algorithms: ['RS256', 'ES256'],
+					key: RSA_PUBLIC_KEY,
+				}),
+			];
+			const { service, sourceRepo } = createMocks();
+
+			sourceRepo.findOneBy.mockResolvedValue({
+				id: 'static',
+				type: 'static',
+				config: JSON.stringify(entries),
+				status: 'pending',
+			} as TrustedKeySourceEntity);
+
+			await service.refreshSource('static');
+
+			expect(sourceRepo.update).toHaveBeenCalledWith(
+				'static',
+				expect.objectContaining({ status: 'error' }),
+			);
+		});
+
+		it('should reject EC key with RSA algorithm', async () => {
+			const entries = [
+				staticKeyEntry({ kid: 'ec-rsa', algorithms: ['RS256'], key: EC_PUBLIC_KEY }),
+			];
+			const { service, sourceRepo } = createMocks();
+
+			sourceRepo.findOneBy.mockResolvedValue({
+				id: 'static',
+				type: 'static',
+				config: JSON.stringify(entries),
+				status: 'pending',
+			} as TrustedKeySourceEntity);
+
+			await service.refreshSource('static');
+
+			expect(sourceRepo.update).toHaveBeenCalledWith(
+				'static',
+				expect.objectContaining({ status: 'error' }),
+			);
+		});
+
+		it('should reject duplicate kid within same source', async () => {
+			const entries = [staticKeyEntry({ kid: 'dup-kid' }), staticKeyEntry({ kid: 'dup-kid' })];
+			const { service, sourceRepo } = createMocks();
+
+			sourceRepo.findOneBy.mockResolvedValue({
+				id: 'static',
+				type: 'static',
+				config: JSON.stringify(entries),
+				status: 'pending',
+			} as TrustedKeySourceEntity);
+
+			await service.refreshSource('static');
+
+			expect(sourceRepo.update).toHaveBeenCalledWith(
+				'static',
+				expect.objectContaining({ status: 'error' }),
+			);
+		});
+	});
+
+	describe('key-algorithm compatibility (write path)', () => {
+		it.each([
+			{ name: 'RSA key with RS256', kid: 'rsa-key', algorithms: ['RS256'], key: RSA_PUBLIC_KEY },
+			{ name: 'EC key with ES256', kid: 'ec-key', algorithms: ['ES256'], key: EC_PUBLIC_KEY },
+			{
+				name: 'Ed25519 key with EdDSA',
+				kid: 'ed-key',
+				algorithms: ['EdDSA'],
+				key: ED25519_PUBLIC_KEY,
+			},
+		])('should accept $name during refresh', async ({ kid, algorithms, key }) => {
+			const entries = [staticKeyEntry({ kid, algorithms, key })];
+			const { service, sourceRepo, entityManager } = createMocks();
+
+			sourceRepo.findOneBy.mockResolvedValue({
+				id: 'static',
+				type: 'static',
+				config: JSON.stringify(entries),
+				status: 'pending',
+			} as TrustedKeySourceEntity);
+			entityManager.findBy.mockResolvedValue([]);
+
+			await service.refreshSource('static');
+
+			expect(entityManager.save).toHaveBeenCalledWith(
+				TrustedKeyEntity,
+				expect.objectContaining({ kid }),
+			);
+		});
+	});
+
+	describe('listAll', () => {
+		it('should delegate to repository', async () => {
+			const { service, keyRepo } = createMocks();
+			const entities = [makeTrustedKeyEntity()];
+			keyRepo.find.mockResolvedValue(entities);
+
+			const result = await service.listAll();
+
+			expect(result).toBe(entities);
+		});
+	});
+
+	describe('listSources', () => {
+		it('should delegate to repository', async () => {
+			const { service, sourceRepo } = createMocks();
+			const sources = [{ id: 'static', type: 'static' } as TrustedKeySourceEntity];
+			sourceRepo.find.mockResolvedValue(sources);
+
+			const result = await service.listSources();
+
+			expect(result).toBe(sources);
+		});
+	});
+
+	describe('leader lifecycle', () => {
+		it('should start refresh interval on leader takeover', () => {
+			const { service } = createMocks();
+
+			service.startRefresh();
+
+			// Verify interval was set (check that stopRefresh clears it)
+			service.stopRefresh();
+		});
+
+		it('should not start refresh if shutting down', () => {
+			const { service } = createMocks();
+
+			service.shutdown();
+			service.startRefresh();
+
+			// No interval to clear — this just verifies no error thrown
+			service.stopRefresh();
+		});
+
+		it('should clear interval on leader stepdown', () => {
+			const { service } = createMocks();
+
+			service.startRefresh();
+			service.stopRefresh();
+
+			// Call again to verify idempotency
+			service.stopRefresh();
+		});
+
+		it('should stop refresh on shutdown', () => {
+			const { service } = createMocks();
+
+			service.startRefresh();
+			service.shutdown();
+
+			// Verify startRefresh after shutdown is a no-op
+			service.startRefresh();
 		});
 	});
 });

--- a/packages/cli/src/modules/token-exchange/services/jti-cleanup.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/jti-cleanup.service.ts
@@ -30,7 +30,7 @@ export class JtiCleanupService {
 
 	@OnLeaderTakeover()
 	startCleanup() {
-		if (this.isShuttingDown) return;
+		if (this.isShuttingDown || this.cleanupInterval) return;
 
 		const intervalMs = this.config.jtiCleanupIntervalSeconds * Time.seconds.toMilliseconds;
 		this.cleanupInterval = setInterval(async () => await this.cleanup(), intervalMs);

--- a/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
@@ -52,7 +52,16 @@ export class TokenExchangeService {
 			throw new BadRequestError('Token header missing kid');
 		}
 
-		const resolvedKey = await this.trustedKeyStore.getByKid(kid);
+		const decodedPayload = decoded.payload;
+		const iss =
+			typeof decodedPayload === 'object' && decodedPayload !== null
+				? (decodedPayload as Record<string, unknown>).iss
+				: undefined;
+		if (typeof iss !== 'string' || !iss) {
+			throw new BadRequestError('Token payload missing iss');
+		}
+
+		const resolvedKey = await this.trustedKeyStore.getByKidAndIss(kid, iss);
 		if (!resolvedKey) {
 			throw new AuthError('Unknown key id');
 		}

--- a/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
@@ -55,7 +55,7 @@ export class TokenExchangeService {
 		const decodedPayload = decoded.payload;
 		const iss =
 			typeof decodedPayload === 'object' && decodedPayload !== null
-				? (decodedPayload as Record<string, unknown>).iss
+				? decodedPayload.iss
 				: undefined;
 		if (typeof iss !== 'string' || !iss) {
 			throw new BadRequestError('Token payload missing iss');

--- a/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
@@ -69,7 +69,8 @@ export class TokenExchangeService {
 		let payload: jwt.JwtPayload;
 		try {
 			const result = jwt.verify(subjectToken, resolvedKey.key, {
-				algorithms: resolvedKey.algorithms,
+				// EdDSA is valid at runtime but missing from @types/jsonwebtoken
+				algorithms: resolvedKey.algorithms as jwt.Algorithm[],
 				issuer: resolvedKey.issuer,
 				audience: resolvedKey.expectedAudience,
 			});

--- a/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
@@ -7,6 +7,7 @@ import { DbLock, DbLockService } from '@n8n/db';
 import { OnLeaderStepdown, OnLeaderTakeover, OnShutdown } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import type { EntityManager } from '@n8n/typeorm';
+import { In, Not } from '@n8n/typeorm';
 import type { Algorithm } from 'jsonwebtoken';
 import { InstanceSettings } from 'n8n-core';
 import { UnexpectedError } from 'n8n-workflow';
@@ -269,14 +270,11 @@ export class TrustedKeyService {
 			}
 
 			// Remove orphaned config-managed sources (not UI sources)
-			const existingSources = await tx.find(TrustedKeySourceEntity);
-			for (const existing of existingSources) {
-				if (existing.type !== 'ui' && !expectedSourceIds.has(existing.id)) {
-					await tx.delete(TrustedKeySourceEntity, existing.id);
-					this.logger.info('Removed orphaned trusted key source', {
-						sourceId: existing.id,
-					});
-				}
+			if (expectedSourceIds.size > 0) {
+				await tx.delete(TrustedKeySourceEntity, {
+					id: Not(In([...expectedSourceIds])),
+					type: Not('ui'),
+				});
 			}
 		});
 	}
@@ -326,54 +324,14 @@ export class TrustedKeyService {
 		source: TrustedKeySourceEntity,
 		tx: EntityManager,
 	): Promise<void> {
-		let resolvedKeys: Array<{ kid: string; data: TrustedKeyData }>;
-
-		if (source.type === 'static') {
-			let rawConfig: unknown;
-			try {
-				rawConfig = JSON.parse(source.config);
-			} catch {
-				throw new UnexpectedError('Invalid static source config: malformed JSON');
-			}
-			const configResult = z.array(TrustedKeySourceSchema).safeParse(rawConfig);
-			if (!configResult.success) {
-				throw new UnexpectedError(`Invalid static source config: ${configResult.error.message}`);
-			}
-			const staticConfigs = configResult.data.filter(
-				(s): s is StaticKeySource => s.type === 'static',
-			);
-			resolvedKeys = this.resolveStaticKeys(staticConfigs);
-		} else if (source.type === 'jwks') {
-			this.logger.warn('JWKS key sources are not yet supported, skipping', {
-				sourceId: source.id,
-			});
-			return;
-		} else {
-			// 'ui' — skip for now
-			this.logger.warn('UI key sources are not yet supported, skipping', {
-				sourceId: source.id,
-			});
-			return;
-		}
+		const resolvedKeys = this.resolveKeysForSource(source);
+		if (!resolvedKeys) return;
 
 		// 1. DELETE old keys for this source
 		await tx.delete(TrustedKeyEntity, { sourceId: source.id });
 
-		// 2. For each resolved key, handle cross-source kid conflicts (last-writer-wins)
+		// 2. INSERT new keys
 		for (const key of resolvedKeys) {
-			const conflicting = await tx.findBy(TrustedKeyEntity, { kid: key.kid });
-			if (conflicting.length > 0) {
-				for (const conflict of conflicting) {
-					this.logger.warn('Kid conflict: overwriting key from another source', {
-						kid: key.kid,
-						existingSourceId: conflict.sourceId,
-						newSourceId: source.id,
-					});
-				}
-				await tx.delete(TrustedKeyEntity, { kid: key.kid });
-			}
-
-			// 3. INSERT new key
 			await tx.save(TrustedKeyEntity, {
 				sourceId: source.id,
 				kid: key.kid,
@@ -382,12 +340,60 @@ export class TrustedKeyService {
 			});
 		}
 
-		// 4. UPDATE source status
+		// 3. UPDATE source status
 		await tx.update(TrustedKeySourceEntity, source.id, {
 			status: 'healthy',
 			lastError: null,
 			lastRefreshedAt: new Date(),
 		});
+	}
+
+	/**
+	 * Resolve keys for a source by type. Returns `undefined` for
+	 * unsupported types (signalling the caller should skip).
+	 */
+	private resolveKeysForSource(
+		source: TrustedKeySourceEntity,
+	): Array<{ kid: string; data: TrustedKeyData }> | undefined {
+		switch (source.type) {
+			case 'static':
+				return this.resolveKeysForStaticSource(source);
+			case 'jwks':
+				this.logger.warn('JWKS key sources are not yet supported, skipping', {
+					sourceId: source.id,
+				});
+				return undefined;
+			case 'ui':
+				this.logger.warn('UI key sources are not yet supported, skipping', {
+					sourceId: source.id,
+				});
+				return undefined;
+			default:
+				this.logger.warn('Unknown key source type, skipping', {
+					sourceId: source.id,
+					type: source.type,
+				});
+				return undefined;
+		}
+	}
+
+	private resolveKeysForStaticSource(
+		source: TrustedKeySourceEntity,
+	): Array<{ kid: string; data: TrustedKeyData }> {
+		let rawConfig: unknown;
+		try {
+			rawConfig = JSON.parse(source.config);
+		} catch {
+			throw new UnexpectedError('Invalid static source config: malformed JSON');
+		}
+		const configResult = z.array(TrustedKeySourceSchema).safeParse(rawConfig);
+		if (!configResult.success) {
+			throw new UnexpectedError(`Invalid static source config: ${configResult.error.message}`);
+		}
+		const staticConfigs = configResult.data.filter(
+			(s): s is StaticKeySource => s.type === 'static',
+		);
+		return this.resolveStaticKeys(staticConfigs);
 	}
 
 	// ─── Private: key resolution ───────────────────────────────────────

--- a/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
@@ -93,13 +93,21 @@ export class TrustedKeyService {
 			return;
 		}
 
+		await this.initializeAsLeader();
+	}
+
+	@OnLeaderTakeover()
+	async onLeaderTakeover() {
+		await this.initializeAsLeader();
+	}
+
+	private async initializeAsLeader(): Promise<void> {
 		const sources = this.parseConfigSources();
 		await this.syncSourcesToDb(sources);
 		await this.refreshAllSources();
 		this.startRefresh();
 	}
 
-	@OnLeaderTakeover()
 	startRefresh() {
 		if (this.isShuttingDown || this.refreshInterval) return;
 
@@ -273,6 +281,8 @@ export class TrustedKeyService {
 				await tx.delete(TrustedKeySourceEntity, {
 					id: Not(In([...expectedSourceIds])),
 				});
+			} else {
+				await tx.delete(TrustedKeySourceEntity, {});
 			}
 		});
 	}

--- a/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
@@ -8,7 +8,6 @@ import { OnLeaderStepdown, OnLeaderTakeover, OnShutdown } from '@n8n/decorators'
 import { Service } from '@n8n/di';
 import type { EntityManager } from '@n8n/typeorm';
 import { In, Not } from '@n8n/typeorm';
-import type { Algorithm } from 'jsonwebtoken';
 import { InstanceSettings } from 'n8n-core';
 import { UnexpectedError } from 'n8n-workflow';
 import { z } from 'zod';
@@ -168,12 +167,12 @@ export class TrustedKeyService {
 
 			if (data.issuer !== issuer) continue;
 
-			const cryptoKey = this.resolveCryptoKey(kid, data.keyMaterial);
+			const cryptoKey = this.resolveCryptoKey(`${entity.sourceId}:${kid}`, data.keyMaterial);
 			if (!cryptoKey) continue;
 
 			return {
 				kid,
-				algorithms: data.algorithms as Algorithm[],
+				algorithms: data.algorithms,
 				key: cryptoKey,
 				issuer: data.issuer,
 				expectedAudience: data.expectedAudience,
@@ -347,7 +346,9 @@ export class TrustedKeyService {
 	private async refreshSourceInternal(source: TrustedKeySourceEntity): Promise<void> {
 		try {
 			await this.dbLockService.withLock(DbLock.TRUSTED_KEY_REFRESH, async (tx) => {
-				await this.refreshSourceWithinTransaction(source, tx);
+				const freshSource = await tx.findOneBy(TrustedKeySourceEntity, { id: source.id });
+				if (!freshSource) return;
+				await this.refreshSourceWithinTransaction(freshSource, tx);
 			});
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
@@ -514,9 +515,9 @@ export class TrustedKeyService {
 
 	// ─── Private: crypto cache ─────────────────────────────────────────
 
-	private resolveCryptoKey(kid: string, keyMaterial: string): KeyObject | undefined {
+	private resolveCryptoKey(cacheKey: string, keyMaterial: string): KeyObject | undefined {
 		const hash = createHash('sha256').update(keyMaterial).digest('hex');
-		const cached = this.cryptoCache.get(kid);
+		const cached = this.cryptoCache.get(cacheKey);
 
 		if (cached && cached.keyMaterialHash === hash) {
 			return cached.cryptoKey;
@@ -524,11 +525,11 @@ export class TrustedKeyService {
 
 		try {
 			const cryptoKey = createPublicKey(keyMaterial);
-			this.cryptoCache.set(kid, { keyMaterialHash: hash, cryptoKey });
+			this.cryptoCache.set(cacheKey, { keyMaterialHash: hash, cryptoKey });
 			return cryptoKey;
 		} catch (error) {
 			this.logger.warn('Failed to parse key material from DB', {
-				kid,
+				cacheKey,
 				error: error instanceof Error ? error.message : String(error),
 			});
 			return undefined;

--- a/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
@@ -1,13 +1,28 @@
-import { createPublicKey } from 'node:crypto';
+import { createHash, createPublicKey } from 'node:crypto';
+import type { KeyObject } from 'node:crypto';
 
 import { Logger } from '@n8n/backend-common';
+import { Time } from '@n8n/constants';
+import { DbLock, DbLockService } from '@n8n/db';
+import { OnLeaderStepdown, OnLeaderTakeover, OnShutdown } from '@n8n/decorators';
 import { Service } from '@n8n/di';
+import type { EntityManager } from '@n8n/typeorm';
 import type { Algorithm } from 'jsonwebtoken';
-import { UnexpectedError } from 'n8n-workflow';
+import { InstanceSettings } from 'n8n-core';
+import { jsonParse, UnexpectedError } from 'n8n-workflow';
 import { z } from 'zod';
 
+import { TrustedKeySourceEntity } from '../database/entities/trusted-key-source.entity';
+import { TrustedKeyEntity } from '../database/entities/trusted-key.entity';
+import { TrustedKeySourceRepository } from '../database/repositories/trusted-key-source.repository';
+import { TrustedKeyRepository } from '../database/repositories/trusted-key.repository';
 import { TokenExchangeConfig } from '../token-exchange.config';
-import type { ResolvedTrustedKey, StaticKeySource } from '../token-exchange.schemas';
+import type {
+	ResolvedTrustedKey,
+	StaticKeySource,
+	TrustedKeyData,
+	TrustedKeySource,
+} from '../token-exchange.schemas';
 import { TrustedKeySourceSchema } from '../token-exchange.schemas';
 
 type AlgorithmFamily = 'RSA' | 'EC' | 'EdDSA';
@@ -25,38 +40,147 @@ const ALGORITHM_FAMILY: Record<string, AlgorithmFamily> = {
 	EdDSA: 'EdDSA',
 };
 
+const STATIC_SOURCE_ID = 'static';
+
 /**
- * Loads and validates trusted public keys at startup, then serves
- * them by Key ID (`kid`) for JWT signature verification.
+ * Manages trusted public keys for JWT signature verification.
  *
- * Keys are loaded from the `N8N_TOKEN_EXCHANGE_TRUSTED_KEYS` config
- * (or `_FILE` variant) and stored in-process. JWKS sources are
- * recognised but not yet supported — they log a warning and are skipped.
+ * The leader resolves all configured key sources (env-var static keys,
+ * future JWKS endpoints) and writes them to the database on startup and
+ * on a periodic refresh interval. All instances read keys from the
+ * database on every lookup, ensuring multi-instance consistency.
+ *
+ * A local crypto-primitive cache avoids repeated `createPublicKey()`
+ * calls when the underlying key material has not changed.
  */
 @Service()
 export class TrustedKeyService {
 	private readonly logger: Logger;
 
-	private readonly keys = new Map<string, ResolvedTrustedKey>();
+	private refreshInterval: NodeJS.Timeout | undefined;
+
+	private isShuttingDown = false;
+
+	private readonly cryptoCache = new Map<
+		string,
+		{ keyMaterialHash: string; cryptoKey: KeyObject }
+	>();
 
 	constructor(
 		logger: Logger,
-		private readonly tokenExchangeConfig: TokenExchangeConfig,
+		private readonly config: TokenExchangeConfig,
+		private readonly trustedKeySourceRepository: TrustedKeySourceRepository,
+		private readonly trustedKeyRepository: TrustedKeyRepository,
+		private readonly instanceSettings: InstanceSettings,
+		private readonly dbLockService: DbLockService,
 	) {
 		this.logger = logger.scoped('token-exchange');
 	}
 
+	// ─── Public lifecycle ──────────────────────────────────────────────
+
 	/**
-	 * Parse, validate, and store all configured trusted key sources.
-	 * Must be called once during module initialisation — validation
-	 * failures throw and prevent startup.
+	 * Leader: parse config → sync sources to DB → refresh all → start interval.
+	 * Worker: no-op (reads from DB on demand via `getByKidAndIss`).
 	 */
 	async initialize(): Promise<void> {
-		const raw = this.tokenExchangeConfig.trustedKeys;
+		if (!this.instanceSettings.isLeader) {
+			this.logger.debug('Worker instance — skipping trusted key initialization');
+			return;
+		}
+
+		const sources = this.parseConfigSources();
+		await this.syncSourcesToDb(sources);
+		await this.refreshAllSources();
+		this.startRefresh();
+	}
+
+	@OnLeaderTakeover()
+	startRefresh() {
+		if (this.isShuttingDown) return;
+
+		const intervalMs = this.config.keyRefreshIntervalSeconds * Time.seconds.toMilliseconds;
+		this.refreshInterval = setInterval(async () => await this.refreshAllSources(), intervalMs);
+
+		this.logger.debug(
+			`Trusted key refresh scheduled every ${this.config.keyRefreshIntervalSeconds}s`,
+		);
+	}
+
+	@OnLeaderStepdown()
+	stopRefresh() {
+		clearInterval(this.refreshInterval);
+		this.refreshInterval = undefined;
+	}
+
+	@OnShutdown()
+	shutdown() {
+		this.isShuttingDown = true;
+		this.stopRefresh();
+	}
+
+	// ─── Public read path ──────────────────────────────────────────────
+
+	/**
+	 * Look up a resolved trusted key by its `kid` and `issuer`.
+	 *
+	 * Queries the database on every call (no stale reads). The local
+	 * crypto cache avoids repeated `createPublicKey()` calls when the
+	 * key material has not changed.
+	 */
+	async getByKidAndIss(kid: string, issuer: string): Promise<ResolvedTrustedKey | undefined> {
+		const entities = await this.trustedKeyRepository.findAllByKid(kid);
+		if (entities.length === 0) return undefined;
+
+		for (const entity of entities) {
+			const data = jsonParse<TrustedKeyData>(entity.data);
+			if (data.issuer !== issuer) continue;
+
+			const cryptoKey = this.resolveCryptoKey(kid, data.keyMaterial);
+
+			return {
+				kid,
+				algorithms: data.algorithms as Algorithm[],
+				key: cryptoKey,
+				issuer: data.issuer,
+				expectedAudience: data.expectedAudience,
+				allowedRoles: data.allowedRoles,
+			};
+		}
+
+		return undefined;
+	}
+
+	// ─── Public admin/diagnostic methods ───────────────────────────────
+
+	/**
+	 * Force-refresh a single source. Can be called from any instance —
+	 * uses an advisory lock for distributed mutual exclusion.
+	 */
+	async refreshSource(sourceId: string): Promise<void> {
+		const source = await this.trustedKeySourceRepository.findOneBy({ id: sourceId });
+		if (!source) {
+			throw new UnexpectedError(`Trusted key source not found: ${sourceId}`);
+		}
+		await this.refreshSourceInternal(source);
+	}
+
+	async listAll(): Promise<TrustedKeyEntity[]> {
+		return await this.trustedKeyRepository.find();
+	}
+
+	async listSources(): Promise<TrustedKeySourceEntity[]> {
+		return await this.trustedKeySourceRepository.find();
+	}
+
+	// ─── Private: config parsing ───────────────────────────────────────
+
+	private parseConfigSources(): TrustedKeySource[] {
+		const raw = this.config.trustedKeys;
 
 		if (!raw) {
 			this.logger.info('No trusted keys configured');
-			return;
+			return [];
 		}
 
 		let parsed: unknown;
@@ -67,52 +191,202 @@ export class TrustedKeyService {
 			throw new UnexpectedError('Failed to parse trusted keys JSON');
 		}
 
-		const sourcesResult = z.array(TrustedKeySourceSchema).safeParse(parsed);
+		const result = z.array(TrustedKeySourceSchema).safeParse(parsed);
 
-		if (!sourcesResult.success) {
-			this.logger.error('Trusted keys JSON has invalid format', { error: sourcesResult.error });
+		if (!result.success) {
+			this.logger.error('Trusted keys JSON has invalid format', { error: result.error });
 			throw new UnexpectedError('Trusted keys JSON has invalid format');
 		}
 
-		const sources = sourcesResult.data;
+		return result.data;
+	}
 
-		for (const source of sources) {
-			if (source.type === 'jwks') {
-				this.logger.warn('JWKS key sources are not yet supported, skipping kid in source');
-				continue;
-			}
-			if (source.type === 'ui') {
-				this.logger.warn('UI key sources are not yet supported, skipping');
-				continue;
-			}
-			this.validateAndStoreStaticKey(source);
+	// ─── Private: source sync ──────────────────────────────────────────
+
+	private generateSourceId(source: TrustedKeySource): string {
+		if (source.type === 'static') return STATIC_SOURCE_ID;
+		if (source.type === 'jwks') {
+			return createHash('sha256').update(source.url).digest('hex').slice(0, 36);
 		}
-
-		this.logger.info(`Loaded ${this.keys.size} trusted key(s)`);
+		// 'ui' sources use DB-generated IDs — should not reach here
+		return createHash('sha256').update('ui').digest('hex').slice(0, 36);
 	}
 
 	/**
-	 * Look up a resolved trusted key by its `kid`.
-	 * @returns the resolved key, or `undefined` if the kid is unknown.
+	 * Upsert source rows to DB and remove orphaned sources whose IDs
+	 * are no longer in the current config.
 	 */
-	async getByKid(kid: string): Promise<ResolvedTrustedKey | undefined> {
-		return this.keys.get(kid);
-	}
+	private async syncSourcesToDb(sources: TrustedKeySource[]): Promise<void> {
+		const staticSources = sources.filter((s): s is StaticKeySource => s.type === 'static');
+		const jwksSources = sources.filter((s) => s.type === 'jwks');
 
-	/** Number of loaded keys — useful for diagnostics and tests. */
-	get size(): number {
-		return this.keys.size;
-	}
+		const expectedSourceIds = new Set<string>();
 
-	private validateAndStoreStaticKey(source: StaticKeySource): void {
-		const { kid, algorithms, key: pemString, issuer, expectedAudience, allowedRoles } = source;
-
-		// 1. Reject duplicate kid
-		if (this.keys.has(kid)) {
-			throw new UnexpectedError(`Trusted key "${kid}": duplicate kid`);
+		// Group all static keys under a single source
+		if (staticSources.length > 0) {
+			const sourceId = STATIC_SOURCE_ID;
+			expectedSourceIds.add(sourceId);
+			await this.trustedKeySourceRepository.save({
+				id: sourceId,
+				type: 'static' as const,
+				config: JSON.stringify(staticSources),
+				status: 'pending' as const,
+			});
 		}
 
-		// 2. Resolve and validate algorithm families
+		// Each JWKS URL is a separate source
+		for (const jwks of jwksSources) {
+			const sourceId = this.generateSourceId(jwks);
+			expectedSourceIds.add(sourceId);
+			await this.trustedKeySourceRepository.save({
+				id: sourceId,
+				type: 'jwks' as const,
+				config: JSON.stringify(jwks),
+				status: 'pending' as const,
+			});
+		}
+
+		// UI sources are skipped — they are DB-generated via future UI
+
+		// Remove orphaned sources no longer in config
+		const existingSources = await this.trustedKeySourceRepository.find();
+		for (const existing of existingSources) {
+			// Only clean up config-managed sources (static/jwks), not UI sources
+			if (existing.type !== 'ui' && !expectedSourceIds.has(existing.id)) {
+				await this.trustedKeySourceRepository.delete(existing.id);
+				this.logger.info('Removed orphaned trusted key source', { sourceId: existing.id });
+			}
+		}
+	}
+
+	// ─── Private: refresh ──────────────────────────────────────────────
+
+	private async refreshAllSources(): Promise<void> {
+		const sources = await this.trustedKeySourceRepository.find();
+		for (const source of sources) {
+			await this.refreshSourceInternal(source);
+		}
+	}
+
+	/**
+	 * Per-source transactional refresh, serialized by an advisory lock.
+	 *
+	 * On success: old keys deleted, conflicts resolved, new keys inserted,
+	 * source marked healthy.
+	 *
+	 * On error: transaction rolls back (preserving existing keys), source
+	 * marked with `status = 'error'` and `lastError` outside the transaction.
+	 */
+	private async refreshSourceInternal(source: TrustedKeySourceEntity): Promise<void> {
+		try {
+			await this.dbLockService.withLock(DbLock.TRUSTED_KEY_REFRESH, async (tx) => {
+				await this.refreshSourceWithinTransaction(source, tx);
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			this.logger.error('Failed to refresh trusted key source', {
+				sourceId: source.id,
+				error: message,
+			});
+			await this.trustedKeySourceRepository.update(source.id, {
+				status: 'error',
+				lastError: message,
+				lastRefreshedAt: new Date(),
+			});
+		}
+	}
+
+	private async refreshSourceWithinTransaction(
+		source: TrustedKeySourceEntity,
+		tx: EntityManager,
+	): Promise<void> {
+		let resolvedKeys: Array<{ kid: string; data: TrustedKeyData }>;
+
+		if (source.type === 'static') {
+			const staticConfigs = jsonParse<StaticKeySource[]>(source.config);
+			resolvedKeys = this.resolveStaticKeys(staticConfigs);
+		} else if (source.type === 'jwks') {
+			this.logger.warn('JWKS key sources are not yet supported, skipping', {
+				sourceId: source.id,
+			});
+			return;
+		} else {
+			// 'ui' — skip for now
+			this.logger.warn('UI key sources are not yet supported, skipping', {
+				sourceId: source.id,
+			});
+			return;
+		}
+
+		// 1. DELETE old keys for this source
+		await tx.delete(TrustedKeyEntity, { sourceId: source.id });
+
+		// 2. For each resolved key, handle cross-source kid conflicts (last-writer-wins)
+		for (const key of resolvedKeys) {
+			const conflicting = await tx.findBy(TrustedKeyEntity, { kid: key.kid });
+			if (conflicting.length > 0) {
+				for (const conflict of conflicting) {
+					this.logger.warn('Kid conflict: overwriting key from another source', {
+						kid: key.kid,
+						existingSourceId: conflict.sourceId,
+						newSourceId: source.id,
+					});
+				}
+				await tx.delete(TrustedKeyEntity, { kid: key.kid });
+			}
+
+			// 3. INSERT new key
+			await tx.save(TrustedKeyEntity, {
+				sourceId: source.id,
+				kid: key.kid,
+				data: JSON.stringify(key.data),
+				createdAt: new Date(),
+			});
+		}
+
+		// 4. UPDATE source status
+		await tx.update(TrustedKeySourceEntity, source.id, {
+			status: 'healthy',
+			lastError: null,
+			lastRefreshedAt: new Date(),
+		});
+	}
+
+	// ─── Private: key resolution ───────────────────────────────────────
+
+	private resolveStaticKeys(
+		configs: StaticKeySource[],
+	): Array<{ kid: string; data: TrustedKeyData }> {
+		const result: Array<{ kid: string; data: TrustedKeyData }> = [];
+		const seenKids = new Set<string>();
+
+		for (const config of configs) {
+			const { kid, algorithms, key: pemString, issuer, expectedAudience, allowedRoles } = config;
+
+			if (seenKids.has(kid)) {
+				throw new UnexpectedError(`Trusted key "${kid}": duplicate kid`);
+			}
+			seenKids.add(kid);
+
+			this.validateKeyMaterial(kid, algorithms, pemString);
+
+			result.push({
+				kid,
+				data: {
+					algorithms,
+					keyMaterial: pemString,
+					issuer,
+					expectedAudience,
+					allowedRoles,
+				},
+			});
+		}
+
+		return result;
+	}
+
+	private validateKeyMaterial(kid: string, algorithms: string[], pemString: string): void {
+		// 1. Resolve and validate algorithm families
 		const families = new Set<AlgorithmFamily>();
 		for (const alg of algorithms) {
 			const family = ALGORITHM_FAMILY[alg];
@@ -122,7 +396,7 @@ export class TrustedKeyService {
 			families.add(family);
 		}
 
-		// 3. Reject cross-family mixing
+		// 2. Reject cross-family mixing
 		if (families.size > 1) {
 			throw new UnexpectedError(
 				`Trusted key "${kid}": algorithms must belong to the same family, got ${[...families].join(', ')}`,
@@ -131,7 +405,7 @@ export class TrustedKeyService {
 
 		const family = [...families][0];
 
-		// 4. Parse PEM
+		// 3. Parse PEM
 		let keyObject: ReturnType<typeof createPublicKey>;
 		try {
 			keyObject = createPublicKey(pemString);
@@ -140,7 +414,7 @@ export class TrustedKeyService {
 			throw new UnexpectedError(`Trusted key "${kid}": failed to parse public key — ${message}`);
 		}
 
-		// 5. Validate key type matches algorithm family
+		// 4. Validate key type matches algorithm family
 		const keyType = keyObject.asymmetricKeyType;
 		const expectedTypes: Record<AlgorithmFamily, string[]> = {
 			RSA: ['rsa'],
@@ -153,15 +427,20 @@ export class TrustedKeyService {
 				`Trusted key "${kid}": key type "${keyType}" does not match algorithm family "${family}"`,
 			);
 		}
+	}
 
-		// 6. Store resolved key
-		this.keys.set(kid, {
-			kid,
-			algorithms: algorithms as Algorithm[],
-			key: keyObject,
-			issuer,
-			expectedAudience,
-			allowedRoles,
-		});
+	// ─── Private: crypto cache ─────────────────────────────────────────
+
+	private resolveCryptoKey(kid: string, keyMaterial: string): KeyObject {
+		const hash = createHash('sha256').update(keyMaterial).digest('hex');
+		const cached = this.cryptoCache.get(kid);
+
+		if (cached && cached.keyMaterialHash === hash) {
+			return cached.cryptoKey;
+		}
+
+		const cryptoKey = createPublicKey(keyMaterial);
+		this.cryptoCache.set(kid, { keyMaterialHash: hash, cryptoKey });
+		return cryptoKey;
 	}
 }

--- a/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
@@ -247,6 +247,7 @@ export class TrustedKeyService {
 	 */
 	private async syncSourcesToDb(sources: TrustedKeySource[]): Promise<void> {
 		await this.dbLockService.withLock(DbLock.TRUSTED_KEY_REFRESH, async (tx) => {
+			this.logger.debug('Syncing sources to the database', { sources });
 			const staticSources = sources.filter((s): s is StaticKeySource => s.type === 'static');
 			const jwksSources = sources.filter((s) => s.type === 'jwks');
 
@@ -310,6 +311,7 @@ export class TrustedKeyService {
 	 */
 	private async refreshDueSources(): Promise<void> {
 		try {
+			this.logger.debug('Refreshing due sources');
 			const sources = await this.trustedKeySourceRepository.find();
 			const now = Date.now();
 			for (const source of sources) {
@@ -365,6 +367,7 @@ export class TrustedKeyService {
 		source: TrustedKeySourceEntity,
 		tx: EntityManager,
 	): Promise<void> {
+		this.logger.debug('Refreshing source', { source });
 		const resolvedKeys = this.resolveKeysForSource(source);
 		if (!resolvedKeys) return;
 

--- a/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
@@ -43,6 +43,9 @@ const ALGORITHM_FAMILY: Record<string, AlgorithmFamily> = {
 
 const STATIC_SOURCE_ID = 'static';
 
+/** How often the leader polls sources to check if any are due for refresh. */
+const REFRESH_POLL_INTERVAL_MS = 30 * Time.seconds.toMilliseconds;
+
 /**
  * Manages trusted public keys for JWT signature verification.
  *
@@ -100,12 +103,12 @@ export class TrustedKeyService {
 	startRefresh() {
 		if (this.isShuttingDown || this.refreshInterval) return;
 
-		const intervalMs = this.config.keyRefreshIntervalSeconds * Time.seconds.toMilliseconds;
-		this.refreshInterval = setInterval(async () => await this.refreshAllSources(), intervalMs);
-
-		this.logger.debug(
-			`Trusted key refresh scheduled every ${this.config.keyRefreshIntervalSeconds}s`,
+		this.refreshInterval = setInterval(
+			async () => await this.refreshDueSources(),
+			REFRESH_POLL_INTERVAL_MS,
 		);
+
+		this.logger.debug('Trusted key refresh poller started');
 	}
 
 	@OnLeaderStepdown()
@@ -227,11 +230,7 @@ export class TrustedKeyService {
 
 	private generateSourceId(source: TrustedKeySource): string {
 		if (source.type === 'static') return STATIC_SOURCE_ID;
-		if (source.type === 'jwks') {
-			return createHash('sha256').update(source.url).digest('hex').slice(0, 36);
-		}
-		// 'ui' sources use DB-generated IDs — should not reach here
-		return createHash('sha256').update('ui').digest('hex').slice(0, 36);
+		return createHash('sha256').update(source.url).digest('hex').slice(0, 36);
 	}
 
 	/**
@@ -269,11 +268,10 @@ export class TrustedKeyService {
 				});
 			}
 
-			// Remove orphaned config-managed sources (not UI sources)
+			// Remove orphaned config-managed sources
 			if (expectedSourceIds.size > 0) {
 				await tx.delete(TrustedKeySourceEntity, {
 					id: Not(In([...expectedSourceIds])),
-					type: Not('ui'),
 				});
 			}
 		});
@@ -281,6 +279,10 @@ export class TrustedKeyService {
 
 	// ─── Private: refresh ──────────────────────────────────────────────
 
+	/**
+	 * Initial refresh: refreshes all sources unconditionally.
+	 * Called once during `initialize` before the poll loop starts.
+	 */
 	private async refreshAllSources(): Promise<void> {
 		try {
 			const sources = await this.trustedKeySourceRepository.find();
@@ -289,6 +291,35 @@ export class TrustedKeyService {
 			}
 		} catch (error) {
 			this.logger.error('Failed to run trusted key refresh cycle', { error });
+		}
+	}
+
+	/**
+	 * Poll-driven refresh: only refreshes sources whose `lastRefreshedAt`
+	 * is older than their configured refresh interval.
+	 */
+	private async refreshDueSources(): Promise<void> {
+		try {
+			const sources = await this.trustedKeySourceRepository.find();
+			const now = Date.now();
+			for (const source of sources) {
+				const intervalMs = this.getRefreshIntervalMs(source);
+				const lastRefresh = source.lastRefreshedAt?.getTime() ?? 0;
+				if (now - lastRefresh >= intervalMs) {
+					await this.refreshSourceInternal(source);
+				}
+			}
+		} catch (error) {
+			this.logger.error('Failed to run trusted key refresh cycle', { error });
+		}
+	}
+
+	private getRefreshIntervalMs(source: TrustedKeySourceEntity): number {
+		switch (source.type) {
+			case 'static':
+			case 'jwks':
+			default:
+				return this.config.keyRefreshIntervalSeconds * Time.seconds.toMilliseconds;
 		}
 	}
 
@@ -360,11 +391,6 @@ export class TrustedKeyService {
 				return this.resolveKeysForStaticSource(source);
 			case 'jwks':
 				this.logger.warn('JWKS key sources are not yet supported, skipping', {
-					sourceId: source.id,
-				});
-				return undefined;
-			case 'ui':
-				this.logger.warn('UI key sources are not yet supported, skipping', {
 					sourceId: source.id,
 				});
 				return undefined;

--- a/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
@@ -9,7 +9,7 @@ import { Service } from '@n8n/di';
 import type { EntityManager } from '@n8n/typeorm';
 import type { Algorithm } from 'jsonwebtoken';
 import { InstanceSettings } from 'n8n-core';
-import { jsonParse, UnexpectedError } from 'n8n-workflow';
+import { UnexpectedError } from 'n8n-workflow';
 import { z } from 'zod';
 
 import { TrustedKeySourceEntity } from '../database/entities/trusted-key-source.entity';
@@ -23,7 +23,7 @@ import type {
 	TrustedKeyData,
 	TrustedKeySource,
 } from '../token-exchange.schemas';
-import { TrustedKeySourceSchema } from '../token-exchange.schemas';
+import { TrustedKeyDataSchema, TrustedKeySourceSchema } from '../token-exchange.schemas';
 
 type AlgorithmFamily = 'RSA' | 'EC' | 'EdDSA';
 
@@ -97,7 +97,7 @@ export class TrustedKeyService {
 
 	@OnLeaderTakeover()
 	startRefresh() {
-		if (this.isShuttingDown) return;
+		if (this.isShuttingDown || this.refreshInterval) return;
 
 		const intervalMs = this.config.keyRefreshIntervalSeconds * Time.seconds.toMilliseconds;
 		this.refreshInterval = setInterval(async () => await this.refreshAllSources(), intervalMs);
@@ -133,10 +133,31 @@ export class TrustedKeyService {
 		if (entities.length === 0) return undefined;
 
 		for (const entity of entities) {
-			const data = jsonParse<TrustedKeyData>(entity.data);
+			let data: TrustedKeyData;
+			try {
+				const parsed = TrustedKeyDataSchema.safeParse(JSON.parse(entity.data));
+				if (!parsed.success) {
+					this.logger.warn('Skipping corrupted trusted key entity', {
+						kid,
+						sourceId: entity.sourceId,
+						error: parsed.error.message,
+					});
+					continue;
+				}
+				data = parsed.data;
+			} catch {
+				this.logger.warn('Skipping corrupted trusted key entity', {
+					kid,
+					sourceId: entity.sourceId,
+					error: 'invalid JSON',
+				});
+				continue;
+			}
+
 			if (data.issuer !== issuer) continue;
 
 			const cryptoKey = this.resolveCryptoKey(kid, data.keyMaterial);
+			if (!cryptoKey) continue;
 
 			return {
 				kid,
@@ -217,54 +238,59 @@ export class TrustedKeyService {
 	 * are no longer in the current config.
 	 */
 	private async syncSourcesToDb(sources: TrustedKeySource[]): Promise<void> {
-		const staticSources = sources.filter((s): s is StaticKeySource => s.type === 'static');
-		const jwksSources = sources.filter((s) => s.type === 'jwks');
+		await this.dbLockService.withLock(DbLock.TRUSTED_KEY_REFRESH, async (tx) => {
+			const staticSources = sources.filter((s): s is StaticKeySource => s.type === 'static');
+			const jwksSources = sources.filter((s) => s.type === 'jwks');
 
-		const expectedSourceIds = new Set<string>();
+			const expectedSourceIds = new Set<string>();
 
-		// Group all static keys under a single source
-		if (staticSources.length > 0) {
-			const sourceId = STATIC_SOURCE_ID;
-			expectedSourceIds.add(sourceId);
-			await this.trustedKeySourceRepository.save({
-				id: sourceId,
-				type: 'static' as const,
-				config: JSON.stringify(staticSources),
-				status: 'pending' as const,
-			});
-		}
-
-		// Each JWKS URL is a separate source
-		for (const jwks of jwksSources) {
-			const sourceId = this.generateSourceId(jwks);
-			expectedSourceIds.add(sourceId);
-			await this.trustedKeySourceRepository.save({
-				id: sourceId,
-				type: 'jwks' as const,
-				config: JSON.stringify(jwks),
-				status: 'pending' as const,
-			});
-		}
-
-		// UI sources are skipped — they are DB-generated via future UI
-
-		// Remove orphaned sources no longer in config
-		const existingSources = await this.trustedKeySourceRepository.find();
-		for (const existing of existingSources) {
-			// Only clean up config-managed sources (static/jwks), not UI sources
-			if (existing.type !== 'ui' && !expectedSourceIds.has(existing.id)) {
-				await this.trustedKeySourceRepository.delete(existing.id);
-				this.logger.info('Removed orphaned trusted key source', { sourceId: existing.id });
+			// Group all static keys under a single source
+			if (staticSources.length > 0) {
+				const sourceId = STATIC_SOURCE_ID;
+				expectedSourceIds.add(sourceId);
+				await tx.save(TrustedKeySourceEntity, {
+					id: sourceId,
+					type: 'static' as const,
+					config: JSON.stringify(staticSources),
+					status: 'pending' as const,
+				});
 			}
-		}
+
+			// Each JWKS URL is a separate source
+			for (const jwks of jwksSources) {
+				const sourceId = this.generateSourceId(jwks);
+				expectedSourceIds.add(sourceId);
+				await tx.save(TrustedKeySourceEntity, {
+					id: sourceId,
+					type: 'jwks' as const,
+					config: JSON.stringify(jwks),
+					status: 'pending' as const,
+				});
+			}
+
+			// Remove orphaned config-managed sources (not UI sources)
+			const existingSources = await tx.find(TrustedKeySourceEntity);
+			for (const existing of existingSources) {
+				if (existing.type !== 'ui' && !expectedSourceIds.has(existing.id)) {
+					await tx.delete(TrustedKeySourceEntity, existing.id);
+					this.logger.info('Removed orphaned trusted key source', {
+						sourceId: existing.id,
+					});
+				}
+			}
+		});
 	}
 
 	// ─── Private: refresh ──────────────────────────────────────────────
 
 	private async refreshAllSources(): Promise<void> {
-		const sources = await this.trustedKeySourceRepository.find();
-		for (const source of sources) {
-			await this.refreshSourceInternal(source);
+		try {
+			const sources = await this.trustedKeySourceRepository.find();
+			for (const source of sources) {
+				await this.refreshSourceInternal(source);
+			}
+		} catch (error) {
+			this.logger.error('Failed to run trusted key refresh cycle', { error });
 		}
 	}
 
@@ -303,7 +329,19 @@ export class TrustedKeyService {
 		let resolvedKeys: Array<{ kid: string; data: TrustedKeyData }>;
 
 		if (source.type === 'static') {
-			const staticConfigs = jsonParse<StaticKeySource[]>(source.config);
+			let rawConfig: unknown;
+			try {
+				rawConfig = JSON.parse(source.config);
+			} catch {
+				throw new UnexpectedError('Invalid static source config: malformed JSON');
+			}
+			const configResult = z.array(TrustedKeySourceSchema).safeParse(rawConfig);
+			if (!configResult.success) {
+				throw new UnexpectedError(`Invalid static source config: ${configResult.error.message}`);
+			}
+			const staticConfigs = configResult.data.filter(
+				(s): s is StaticKeySource => s.type === 'static',
+			);
 			resolvedKeys = this.resolveStaticKeys(staticConfigs);
 		} else if (source.type === 'jwks') {
 			this.logger.warn('JWKS key sources are not yet supported, skipping', {
@@ -431,7 +469,7 @@ export class TrustedKeyService {
 
 	// ─── Private: crypto cache ─────────────────────────────────────────
 
-	private resolveCryptoKey(kid: string, keyMaterial: string): KeyObject {
+	private resolveCryptoKey(kid: string, keyMaterial: string): KeyObject | undefined {
 		const hash = createHash('sha256').update(keyMaterial).digest('hex');
 		const cached = this.cryptoCache.get(kid);
 
@@ -439,8 +477,16 @@ export class TrustedKeyService {
 			return cached.cryptoKey;
 		}
 
-		const cryptoKey = createPublicKey(keyMaterial);
-		this.cryptoCache.set(kid, { keyMaterialHash: hash, cryptoKey });
-		return cryptoKey;
+		try {
+			const cryptoKey = createPublicKey(keyMaterial);
+			this.cryptoCache.set(kid, { keyMaterialHash: hash, cryptoKey });
+			return cryptoKey;
+		} catch (error) {
+			this.logger.warn('Failed to parse key material from DB', {
+				kid,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return undefined;
+		}
 	}
 }

--- a/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
@@ -370,7 +370,15 @@ export class TrustedKeyService {
 	): Promise<void> {
 		this.logger.debug('Refreshing source', { source });
 		const resolvedKeys = this.resolveKeysForSource(source);
-		if (!resolvedKeys) return;
+		if (!resolvedKeys) {
+			// Mark as refreshed so the source is skipped until the next interval,
+			// even though no keys were resolved (e.g. unsupported source type).
+			await tx.update(TrustedKeySourceEntity, source.id, {
+				status: 'healthy',
+				lastRefreshedAt: new Date(),
+			});
+			return;
+		}
 
 		// 1. DELETE old keys for this source
 		await tx.delete(TrustedKeyEntity, { sourceId: source.id });

--- a/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
@@ -1,4 +1,4 @@
-import type { Algorithm, Secret } from 'jsonwebtoken';
+import type { Secret } from 'jsonwebtoken';
 import { z } from 'zod';
 
 /** RFC 8693 grant type URN for token exchange */
@@ -102,7 +102,7 @@ export interface ResolvedTrustedKey {
 	kid: string;
 
 	/** Allowed signing algorithms for tokens using this key. */
-	algorithms: Algorithm[];
+	algorithms: JwtAlgorithm[];
 
 	/** The resolved key material, ready to pass to `jwt.verify()`. */
 	key: Secret;

--- a/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
@@ -84,25 +84,16 @@ export type TrustedKeySourceStatus = 'pending' | 'healthy' | 'error';
  * JSON column. Unlike `ResolvedTrustedKey`, this holds the raw PEM string
  * instead of a live `crypto.KeyObject`.
  */
-export interface TrustedKeyData {
-	/** Allowed signing algorithms for tokens using this key. */
-	algorithms: JwtAlgorithm[];
+export const TrustedKeyDataSchema = z.object({
+	algorithms: z.array(JwtAlgorithmSchema).min(1),
+	keyMaterial: z.string().min(1),
+	issuer: z.string().min(1),
+	expectedAudience: z.string().optional(),
+	allowedRoles: z.array(z.string()).optional(),
+	expiresAt: z.string().optional(),
+});
 
-	/** PEM-encoded public key material. */
-	keyMaterial: string;
-
-	/** Expected `iss` claim value for tokens signed with this key. */
-	issuer: string;
-
-	/** Expected `aud` claim value, if restricted. */
-	expectedAudience?: string;
-
-	/** Roles allowed for tokens signed with this key, if restricted. */
-	allowedRoles?: string[];
-
-	/** ISO 8601 expiry — used by JWKS sources for key rotation. */
-	expiresAt?: string;
-}
+export type TrustedKeyData = z.infer<typeof TrustedKeyDataSchema>;
 
 /**
  * A trusted key that has been normalized and resolved to an in-memory

--- a/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
@@ -65,18 +65,14 @@ export const TrustedKeySourceSchema = z.discriminatedUnion('type', [
 		allowedRoles: z.array(z.string()).optional(),
 		cacheTtlSeconds: z.number().int().positive().optional(),
 	}),
-	z.object({
-		type: z.literal('ui'),
-	}),
 ]);
 
 export type TrustedKeySource = z.infer<typeof TrustedKeySourceSchema>;
 export type StaticKeySource = Extract<TrustedKeySource, { type: 'static' }>;
 export type JwksKeySource = Extract<TrustedKeySource, { type: 'jwks' }>;
-export type UiKeySource = Extract<TrustedKeySource, { type: 'ui' }>;
 
 export type JwtAlgorithm = z.infer<typeof JwtAlgorithmSchema>;
-export type TrustedKeySourceType = 'static' | 'jwks' | 'ui';
+export type TrustedKeySourceType = 'static' | 'jwks';
 export type TrustedKeySourceStatus = 'pending' | 'healthy' | 'error';
 
 /**

--- a/packages/cli/test/integration/token-exchange/trusted-key.service.integration.test.ts
+++ b/packages/cli/test/integration/token-exchange/trusted-key.service.integration.test.ts
@@ -383,7 +383,7 @@ describe('TrustedKeyService (integration)', () => {
 			);
 		});
 
-		it('should skip jwks sources without writing keys', async () => {
+		it('should skip jwks sources without writing keys but update lastRefreshedAt', async () => {
 			await insertSource({
 				id: 'jwks-source',
 				type: 'jwks',
@@ -397,6 +397,10 @@ describe('TrustedKeyService (integration)', () => {
 			await service.refreshSource('jwks-source');
 
 			expect(await keyRepo.find()).toHaveLength(0);
+
+			const source = await sourceRepo.findOneBy({ id: 'jwks-source' });
+			expect(source!.status).toBe('healthy');
+			expect(source!.lastRefreshedAt).toBeDefined();
 		});
 	});
 

--- a/packages/cli/test/integration/token-exchange/trusted-key.service.integration.test.ts
+++ b/packages/cli/test/integration/token-exchange/trusted-key.service.integration.test.ts
@@ -3,13 +3,13 @@ import { Container } from '@n8n/di';
 import { InstanceSettings } from 'n8n-core';
 import type { KeyObject } from 'node:crypto';
 
-import type { TrustedKeySourceEntity } from '../../database/entities/trusted-key-source.entity';
-import { TrustedKeyEntity } from '../../database/entities/trusted-key.entity';
-import { TrustedKeySourceRepository } from '../../database/repositories/trusted-key-source.repository';
-import { TrustedKeyRepository } from '../../database/repositories/trusted-key.repository';
-import { TokenExchangeConfig } from '../../token-exchange.config';
-import type { TrustedKeyData } from '../../token-exchange.schemas';
-import { TrustedKeyService } from '../trusted-key.service';
+import type { TrustedKeySourceEntity } from '@/modules/token-exchange/database/entities/trusted-key-source.entity';
+import { TrustedKeyEntity } from '@/modules/token-exchange/database/entities/trusted-key.entity';
+import { TrustedKeySourceRepository } from '@/modules/token-exchange/database/repositories/trusted-key-source.repository';
+import { TrustedKeyRepository } from '@/modules/token-exchange/database/repositories/trusted-key.repository';
+import { TrustedKeyService } from '@/modules/token-exchange/services/trusted-key.service';
+import { TokenExchangeConfig } from '@/modules/token-exchange/token-exchange.config';
+import type { TrustedKeyData } from '@/modules/token-exchange/token-exchange.schemas';
 
 // ──────────────────────────────────────────────────────────────────────
 // Pre-generated PEM public keys (test-only, no secrets)

--- a/packages/cli/test/integration/token-exchange/trusted-key.service.integration.test.ts
+++ b/packages/cli/test/integration/token-exchange/trusted-key.service.integration.test.ts
@@ -216,6 +216,41 @@ describe('TrustedKeyService (integration)', () => {
 			expect(await sourceRepo.find()).toHaveLength(0);
 			expect(await keyRepo.find()).toHaveLength(0);
 		});
+
+		it('should remove all sources and keys when config becomes empty', async () => {
+			config.trustedKeys = JSON.stringify([staticKeyEntry({ kid: 'old-key' })]);
+			await service.initialize();
+
+			expect(await sourceRepo.find()).toHaveLength(1);
+			expect(await keyRepo.find()).toHaveLength(1);
+
+			config.trustedKeys = '';
+			await service.initialize();
+
+			expect(await sourceRepo.find()).toHaveLength(0);
+			expect(await keyRepo.find()).toHaveLength(0);
+		});
+	});
+
+	describe('onLeaderTakeover', () => {
+		it('should sync sources and refresh keys on leader takeover', async () => {
+			Object.defineProperty(instanceSettings, 'isLeader', { value: false, configurable: true });
+			config.trustedKeys = JSON.stringify([staticKeyEntry({ kid: 'takeover-key' })]);
+			await service.initialize();
+
+			expect(await sourceRepo.find()).toHaveLength(0);
+
+			Object.defineProperty(instanceSettings, 'isLeader', { value: true, configurable: true });
+			await service.onLeaderTakeover();
+
+			const sources = await sourceRepo.find();
+			expect(sources).toHaveLength(1);
+			expect(sources[0].status).toBe('healthy');
+
+			const keys = await keyRepo.find();
+			expect(keys).toHaveLength(1);
+			expect(keys[0].kid).toBe('takeover-key');
+		});
 	});
 
 	describe('getByKidAndIss', () => {

--- a/packages/cli/test/integration/token-exchange/trusted-key.service.integration.test.ts
+++ b/packages/cli/test/integration/token-exchange/trusted-key.service.integration.test.ts
@@ -193,9 +193,8 @@ describe('TrustedKeyService (integration)', () => {
 			await expect(service.initialize()).rejects.toThrow(error);
 		});
 
-		it('should remove orphaned sources but preserve UI sources', async () => {
+		it('should remove orphaned sources on config change', async () => {
 			await insertSource({ id: 'old-source', type: 'static', config: '[]' });
-			await insertSource({ id: 'ui-source', type: 'ui', config: '{}' });
 
 			config.trustedKeys = JSON.stringify([staticKeyEntry({ kid: 'new-key' })]);
 
@@ -205,7 +204,6 @@ describe('TrustedKeyService (integration)', () => {
 			const sourceIds = sources.map((s) => s.id);
 
 			expect(sourceIds).toContain('static');
-			expect(sourceIds).toContain('ui-source');
 			expect(sourceIds).not.toContain('old-source');
 		});
 
@@ -350,20 +348,18 @@ describe('TrustedKeyService (integration)', () => {
 			);
 		});
 
-		it.each([
-			{
-				type: 'jwks' as const,
+		it('should skip jwks sources without writing keys', async () => {
+			await insertSource({
+				id: 'jwks-source',
+				type: 'jwks',
 				config: JSON.stringify({
 					type: 'jwks',
 					url: 'https://example.com/jwks',
 					issuer: 'https://example.com',
 				}),
-			},
-			{ type: 'ui' as const, config: JSON.stringify({ type: 'ui' }) },
-		])('should skip $type sources without writing keys', async ({ type, config: sourceConfig }) => {
-			await insertSource({ id: `${type}-source`, type, config: sourceConfig });
+			});
 
-			await service.refreshSource(`${type}-source`);
+			await service.refreshSource('jwks-source');
 
 			expect(await keyRepo.find()).toHaveLength(0);
 		});


### PR DESCRIPTION
## Summary

Refactors `TrustedKeyService` from an in-process `Map` to a DB-backed service with leader/worker separation. The leader resolves all configured key sources (static keys from env-var config) and writes them to the database on startup and on a periodic refresh interval. All instances — including workers — read keys from the database on every `getByKidAndIss` call, ensuring multi-instance consistency without stale reads.

This is part of the **Embed auth flow** (Phase 2a). The previous PR (IAM-523) added the DB tables, entities, and repositories for trusted keys and key sources. This PR wires the service layer to use them, completing the storage tier. The next step (IAM-472) will add a health-check endpoint for trusted key configuration.

**Key implementation decisions:**

- **Leader lifecycle** follows the `JtiCleanupService` pattern: `initialize()` + `@OnLeaderTakeover` / `@OnLeaderStepdown` / `@OnShutdown` decorators
- **Per-source transactional refresh** with advisory lock (`DbLock.TRUSTED_KEY_REFRESH`): DELETE old keys → resolve cross-source kid conflicts (last-writer-wins) → INSERT new keys → UPDATE source status
- **Crypto cache**: local `Map<kid, { keyMaterialHash, cryptoKey }>` — DB is always queried, cache only avoids repeated `createPublicKey()` calls when key material is unchanged
- **Issuer-scoped lookup**: `getByKid` → `getByKidAndIss` — token exchange now validates `iss` claim and uses it for key resolution, preventing cross-tenant key confusion
- **Orphan cleanup**: on startup, config-managed sources (static/jwks) not in the current config are removed; UI sources are preserved
- **Zod validation on read path**: `TrustedKeyData` is now a Zod schema, and entities are validated when read from DB to guard against corrupted data
- **JWKS/UI sources**: recognized and persisted but skipped at refresh time with a warning (JWKS resolution is IAM-518)

### How to test manually

1. Configure `N8N_TOKEN_EXCHANGE_TRUSTED_KEYS` with a static key JSON array

```
export N8N_ENV_FEAT_TOKEN_EXCHANGE=true
export N8N_TOKEN_EXCHANGE_ENABLED=true
export N8N_TOKEN_EXCHANGE_KEY_REFRESH_INTERVAL_SECONDS=30
export N8N_TOKEN_EXCHANGE_TRUSTED_KEYS='[{"type":"static","kid":"test-key-1","algorithms":["RS256"],"key":"-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAw6jZKAsZVTVLAB9cc7xT\nEqBq3/OvO2bw90RAaZYF2erBxNkOs92Ed/NvmhM2jGLR5Ov8tBbQ3sbxzPf3Tv30\n4zP+SpFVqGkXibRQoB6F+7rW2Zm3b8mPqUTJa4bMmc//G3YFSCIddym0LYMED5Xa\nzSvhXTCKfEsSBOr8wKGCV5gbsbl3UZ3HZTA3gqSpE83Pf7l6QDU7ytuVSuV9elIb\njTyrUtL6i6oUgjgCyrxVgnHFjESLRI+NCGeBmua3uvWp8xCiJ+9jMc054M4ltFV1\n+NSFJE9nFYuh7IRkYz+onZtMIi5y84QHVPhRBKdTKbOL8u6Lfyuij2KGNPD08g+b\nSQIDAQAB\n-----END PUBLIC KEY-----","issuer":"https://test-issuer.example.com","expectedAudience":"https://n8n.example.com"}]'
```

These are example envvars

2. Start n8n — verify leader logs show source sync, refresh, and "healthy" status
3. Query the `trusted_key` and `trusted_key_source` tables — verify keys and source rows are present
4. Stop/restart — verify keys are re-synced from config

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-524
closes https://linear.app/n8n/issue/IAM-466/2a3-trustedkeystore-db-backed-storage-and-multi-instance-sync

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)