### PR TITLE
feat(MCP Client Node): Add session handling to MCP client tool

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -6,6 +6,7 @@ import { StructuredToolkit } from 'n8n-core';
 import {
 	type IDataObject,
 	type IExecuteFunctions,
+	type INode,
 	type INodeExecutionData,
 	NodeConnectionTypes,
 	NodeOperationError,
@@ -42,6 +43,7 @@ interface CachedClient {
 	client: Client;
 	mcpTools: McpTool[];
 	createdAt: number;
+	lastUsedAt: number;
 }
 
 /**
@@ -51,16 +53,27 @@ interface CachedClient {
  */
 export const activeClients = new Map<string, CachedClient>();
 
+/**
+ * In-flight connection promises to dedupe concurrent cache misses for the
+ * same key — prevents two parallel tool dispatches from racing to connect
+ * and orphaning one of the resulting clients.
+ */
+const pendingConnections = new Map<string, Promise<{ client: Client; mcpTools: McpTool[] }>>();
+
 function getCacheKey(executionId: string, nodeName: string): string {
 	return `${executionId}:${nodeName}`;
 }
 
-function closeAndRemove(key: string): void {
+type CloseLogger = Pick<IExecuteFunctions['logger'], 'warn' | 'debug'> | undefined;
+
+function closeAndRemove(key: string, logger?: CloseLogger): void {
 	const entry = activeClients.get(key);
-	if (entry) {
-		void entry.client.close().catch(() => {});
-		activeClients.delete(key);
-	}
+	if (!entry) return;
+
+	activeClients.delete(key);
+	void entry.client.close().catch((error) => {
+		logger?.warn('McpClientTool: failed to close cached client', { cacheKey: key, error });
+	});
 }
 
 let lastEvictionAt = 0;
@@ -71,15 +84,16 @@ export function resetEvictionTimer(): void {
 	lastEvictionAt = 0;
 }
 
-/** Evict stale entries (TTL) and enforce max cache size. */
-export function evictStaleClients(): void {
+/** Evict idle entries (TTL on lastUsedAt) and enforce max cache size. */
+export function evictStaleClients(logger?: CloseLogger): void {
 	const now = Date.now();
 	if (now - lastEvictionAt < EVICTION_INTERVAL_MS) return;
 	lastEvictionAt = now;
 
 	for (const [key, entry] of activeClients) {
-		if (now - entry.createdAt > N8N_MCP_CLIENT_CACHE_TTL_MS) {
-			closeAndRemove(key);
+		if (now - entry.lastUsedAt > N8N_MCP_CLIENT_CACHE_TTL_MS) {
+			logger?.debug('McpClientTool: evicting idle client', { cacheKey: key });
+			closeAndRemove(key, logger);
 		}
 	}
 
@@ -89,7 +103,8 @@ export function evictStaleClients(): void {
 		let excess = activeClients.size - N8N_MCP_CLIENT_CACHE_MAX_SIZE;
 		for (const [key] of activeClients) {
 			if (excess <= 0) break;
-			closeAndRemove(key);
+			logger?.debug('McpClientTool: evicting oldest client (max size)', { cacheKey: key });
+			closeAndRemove(key, logger);
 			excess--;
 		}
 	}
@@ -97,21 +112,150 @@ export function evictStaleClients(): void {
 
 /** Connect to MCP server and return client + tools, or throw on failure. */
 async function connectOrThrow(
-	ctx: IExecuteFunctions,
+	ctx: IExecuteFunctions | ISupplyDataFunctions,
+	itemIndex: number,
 ): Promise<{ client: Client; mcpTools: McpTool[] }> {
 	const node = ctx.getNode();
-	const config = getNodeConfig(ctx, 0);
+	const config = getNodeConfig(ctx, itemIndex);
 	const result = await connectAndGetTools(ctx, config);
 
 	if (result.error) {
-		throw new NodeOperationError(node, result.error.error, { itemIndex: 0 });
+		throw new NodeOperationError(node, result.error.error, { itemIndex });
 	}
 
 	if (!result.mcpTools?.length) {
-		throw new NodeOperationError(node, 'MCP Server returned no tools', { itemIndex: 0 });
+		throw new NodeOperationError(node, 'MCP Server returned no tools', { itemIndex });
 	}
 
 	return { client: result.client, mcpTools: result.mcpTools };
+}
+
+/**
+ * Wire transport-level lifecycle so cache evicts when server drops the
+ * connection or transport errors out — prevents handing dead clients
+ * back to subsequent tool calls.
+ */
+function attachTransportLifecycle(client: Client, cacheKey: string, logger: CloseLogger): void {
+	const prevOnClose = client.onclose;
+	client.onclose = () => {
+		logger?.debug('McpClientTool: transport closed, evicting cache entry', { cacheKey });
+		activeClients.delete(cacheKey);
+		prevOnClose?.();
+	};
+
+	const prevOnError = client.onerror;
+	client.onerror = (error: Error) => {
+		logger?.warn('McpClientTool: transport error, evicting cache entry', { cacheKey, error });
+		activeClients.delete(cacheKey);
+		prevOnError?.(error);
+	};
+}
+
+/**
+ * v1.3+ execute path: cache live Client across tool calls within an execution.
+ * Standalone (not method) so `this` binding works with mock test contexts.
+ */
+async function executeWithCache(
+	ctx: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[][]> {
+	const node = ctx.getNode();
+	const returnData: INodeExecutionData[] = [];
+	const logger: CloseLogger = ctx.logger;
+
+	evictStaleClients(logger);
+
+	const cacheKey = getCacheKey(ctx.getExecutionId(), node.name);
+	let cached = activeClients.get(cacheKey);
+
+	if (cached) {
+		logger?.debug?.('McpClientTool: cache hit', { cacheKey });
+		cached.lastUsedAt = Date.now();
+	} else {
+		// Dedupe concurrent cache misses for same key — prevents racing
+		// connects from leaking transports.
+		let pending = pendingConnections.get(cacheKey);
+		if (pending) {
+			logger?.debug?.('McpClientTool: awaiting in-flight connection', { cacheKey });
+			await pending;
+		} else {
+			logger?.debug?.('McpClientTool: cache miss, connecting', { cacheKey });
+			pending = connectOrThrow(ctx, 0);
+			pendingConnections.set(cacheKey, pending);
+			try {
+				const { client, mcpTools } = await pending;
+				const now = Date.now();
+				activeClients.set(cacheKey, { client, mcpTools, createdAt: now, lastUsedAt: now });
+				attachTransportLifecycle(client, cacheKey, logger);
+				ctx.onExecutionCancellation?.(() => closeAndRemove(cacheKey, logger));
+			} finally {
+				pendingConnections.delete(cacheKey);
+			}
+		}
+		cached = activeClients.get(cacheKey);
+		if (!cached) {
+			throw new NodeOperationError(node, 'Failed to populate MCP client cache', {
+				itemIndex: 0,
+			});
+		}
+	}
+
+	const { client, mcpTools } = cached;
+
+	for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+		const item = items[itemIndex];
+		const timeout = ctx.getNodeParameter('options.timeout', itemIndex, 60000) as number;
+		await appendToolResults(node, item, mcpTools, client, timeout, itemIndex, returnData);
+	}
+
+	// Refresh idle timer at end of each execute() — keeps long-running agents alive.
+	const stillCached = activeClients.get(cacheKey);
+	if (stillCached) stillCached.lastUsedAt = Date.now();
+
+	return [returnData];
+}
+
+/** Run matching tool from item.json.tool against the MCP client and push result. */
+async function appendToolResults(
+	node: INode,
+	item: INodeExecutionData,
+	mcpTools: McpTool[],
+	client: Client,
+	timeout: number,
+	itemIndex: number,
+	returnData: INodeExecutionData[],
+): Promise<void> {
+	for (const tool of mcpTools) {
+		if (!item.json.tool || typeof item.json.tool !== 'string') {
+			throw new NodeOperationError(node, 'Tool name not found in item.json.tool or item.tool', {
+				itemIndex,
+			});
+		}
+
+		const toolName = item.json.tool;
+		if (toolName === tool.name) {
+			const { tool: _, ...toolArguments } = item.json;
+			const schema: JSONSchema7 = tool.inputSchema;
+			const sanitizedToolArguments: IDataObject =
+				schema.additionalProperties !== true
+					? pick(toolArguments, Object.keys(schema.properties ?? {}))
+					: toolArguments;
+
+			const result = await client.callTool(
+				{ name: tool.name, arguments: sanitizedToolArguments },
+				CallToolResultSchema,
+				{ timeout },
+			);
+			returnData.push({
+				json: {
+					response: result.content as IDataObject,
+				},
+				pairedItem: {
+					item: itemIndex,
+				},
+			});
+		}
+	}
 }
 
 /**
@@ -483,72 +627,20 @@ export class McpClientTool implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const node = this.getNode();
 		const items = this.getInputData();
-		const returnData: INodeExecutionData[] = [];
 		const useClientCache = node.typeVersion >= 1.3;
 
-		let client: Client;
-		let mcpTools: McpTool[];
-
 		if (useClientCache) {
-			evictStaleClients();
-
-			const cacheKey = getCacheKey(this.getExecutionId(), node.name);
-			const cached = activeClients.get(cacheKey);
-
-			if (cached) {
-				client = cached.client;
-				mcpTools = cached.mcpTools;
-			} else {
-				({ client, mcpTools } = await connectOrThrow(this));
-
-				activeClients.set(cacheKey, { client, mcpTools, createdAt: Date.now() });
-
-				const cancelSignal = this.getExecutionCancelSignal();
-				if (cancelSignal) {
-					cancelSignal.addEventListener('abort', () => closeAndRemove(cacheKey), {
-						once: true,
-					});
-				}
-			}
-		} else {
-			({ client, mcpTools } = await connectOrThrow(this));
+			return await executeWithCache(this, items);
 		}
 
+		// v1.2 and below: per-item connection (preserves expression-based per-item config).
+		// Pre-existing behavior: client is left open after the loop (matches pre-1.3).
+		const returnData: INodeExecutionData[] = [];
 		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
 			const item = items[itemIndex];
+			const { client, mcpTools } = await connectOrThrow(this, itemIndex);
 			const timeout = this.getNodeParameter('options.timeout', itemIndex, 60000) as number;
-
-			for (const tool of mcpTools) {
-				if (!item.json.tool || typeof item.json.tool !== 'string') {
-					throw new NodeOperationError(node, 'Tool name not found in item.json.tool or item.tool', {
-						itemIndex,
-					});
-				}
-
-				const toolName = item.json.tool;
-				if (toolName === tool.name) {
-					const { tool: _, ...toolArguments } = item.json;
-					const schema: JSONSchema7 = tool.inputSchema;
-					const sanitizedToolArguments: IDataObject =
-						schema.additionalProperties !== true
-							? pick(toolArguments, Object.keys(schema.properties ?? {}))
-							: toolArguments;
-
-					const result = await client.callTool(
-						{ name: tool.name, arguments: sanitizedToolArguments },
-						CallToolResultSchema,
-						{ timeout },
-					);
-					returnData.push({
-						json: {
-							response: result.content as IDataObject,
-						},
-						pairedItem: {
-							item: itemIndex,
-						},
-					});
-				}
-			}
+			await appendToolResults(node, item, mcpTools, client, timeout, itemIndex, returnData);
 		}
 
 		return [returnData];

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -1,5 +1,6 @@
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
+import { Container } from '@n8n/di';
 import type { JSONSchema7 } from 'json-schema';
 import pick from 'lodash/pick';
 import { StructuredToolkit } from 'n8n-core';
@@ -22,6 +23,7 @@ import { getTools } from './loadOptions';
 import type { McpToolIncludeMode } from './types';
 import { createCallTool, getSelectedTools, mcpToolToDynamicTool } from './utils';
 import { credentials, transportSelect } from '../shared/descriptions';
+import { McpClientsManager, type McpCacheLogger } from '../shared/McpClientsManager';
 import type { McpAuthenticationOption, McpServerTransport, McpTool } from '../shared/types';
 import {
 	connectMcpClient,
@@ -31,91 +33,20 @@ import {
 	tryRefreshOAuth2Token,
 } from '../shared/utils';
 
-const DEFAULT_CACHE_TTL_MS = 300_000;
-const DEFAULT_CACHE_MAX_SIZE = 500;
-
-const N8N_MCP_CLIENT_CACHE_TTL_MS =
-	parseInt(process.env.N8N_MCP_CLIENT_CACHE_TTL_MS ?? '', 10) || DEFAULT_CACHE_TTL_MS;
-const N8N_MCP_CLIENT_CACHE_MAX_SIZE =
-	parseInt(process.env.N8N_MCP_CLIENT_CACHE_MAX_SIZE ?? '', 10) || DEFAULT_CACHE_MAX_SIZE;
-
-interface CachedClient {
-	client: Client;
-	mcpTools: McpTool[];
-	createdAt: number;
-	lastUsedAt: number;
-}
-
-/**
- * Cache of live MCP clients keyed by `executionId:nodeName`.
- * Keeps the transport alive between tool calls within the same execution,
- * which is required for stateful MCP servers (e.g. Playwright).
- */
-export const activeClients = new Map<string, CachedClient>();
-
-/**
- * In-flight connection promises to dedupe concurrent cache misses for the
- * same key — prevents two parallel tool dispatches from racing to connect
- * and orphaning one of the resulting clients.
- */
-const pendingConnections = new Map<string, Promise<{ client: Client; mcpTools: McpTool[] }>>();
-
 function getCacheKey(executionId: string, nodeName: string): string {
 	return `${executionId}:${nodeName}`;
 }
 
-type CloseLogger = Pick<IExecuteFunctions['logger'], 'warn' | 'debug'> | undefined;
-
-function closeAndRemove(key: string, logger?: CloseLogger): void {
-	const entry = activeClients.get(key);
-	if (!entry) return;
-
-	activeClients.delete(key);
-	void entry.client.close().catch((error) => {
-		logger?.warn('McpClientTool: failed to close cached client', { cacheKey: key, error });
-	});
-}
-
-let lastEvictionAt = 0;
-// Lazy time-gated sweep instead of setInterval — avoids pinning the event
-// loop and leaking timers in tests where there's no shutdown hook.
-const EVICTION_INTERVAL_MS = 30_000;
-
-/** Reset the eviction timer — exported for testing only. */
-export function resetEvictionTimer(): void {
-	lastEvictionAt = 0;
-}
-
-/** Evict idle entries (TTL on lastUsedAt) and enforce max cache size. */
-export function evictStaleClients(logger?: CloseLogger): void {
-	const now = Date.now();
-	if (now - lastEvictionAt < EVICTION_INTERVAL_MS) return;
-	lastEvictionAt = now;
-
-	let idleEvicted = 0;
-	for (const [key, entry] of activeClients) {
-		if (now - entry.lastUsedAt > N8N_MCP_CLIENT_CACHE_TTL_MS) {
-			closeAndRemove(key, logger);
-			idleEvicted++;
-		}
-	}
-	if (idleEvicted > 0) {
-		logger?.debug('McpClientTool: evicted idle clients', { count: idleEvicted });
-	}
-
-	// Map preserves insertion order, which matches createdAt order since
-	// entries are only inserted (never re-set) with Date.now() timestamps.
-	if (activeClients.size > N8N_MCP_CLIENT_CACHE_MAX_SIZE) {
-		let excess = activeClients.size - N8N_MCP_CLIENT_CACHE_MAX_SIZE;
-		let oldestEvicted = 0;
-		for (const [key] of activeClients) {
-			if (excess <= 0) break;
-			closeAndRemove(key, logger);
-			excess--;
-			oldestEvicted++;
-		}
-		logger?.debug('McpClientTool: evicted oldest clients (max size)', { count: oldestEvicted });
-	}
+/**
+ * Narrow to a real Logger only when both methods are callable —
+ * jest-mock-extended's `mock<any>` returns proxy values that are truthy
+ * but not callable, which would crash a naive `logger?.debug(...)`.
+ */
+function narrowLogger(ctx: IExecuteFunctions): McpCacheLogger | undefined {
+	const logger = ctx.logger;
+	return typeof logger?.debug === 'function' && typeof logger?.warn === 'function'
+		? logger
+		: undefined;
 }
 
 /** Connect to MCP server and return client + tools, or throw on failure. */
@@ -136,111 +67,6 @@ async function connectOrThrow(
 	}
 
 	return { client: result.client, mcpTools: result.mcpTools };
-}
-
-/**
- * Wire transport-level lifecycle so cache evicts when server drops the
- * connection or transport errors out — prevents handing dead clients
- * back to subsequent tool calls. The MCP SDK's Protocol class exposes
- * `onclose`/`onerror` as plain assignable fields (no setter side effects),
- * so chaining via captured `prev*` is safe.
- */
-function attachTransportLifecycle(client: Client, cacheKey: string, logger: CloseLogger): void {
-	const prevOnClose = client.onclose;
-	client.onclose = () => {
-		logger?.debug('McpClientTool: transport closed, evicting cache entry', { cacheKey });
-		// Transport already closed — no need to call client.close().
-		activeClients.delete(cacheKey);
-		try {
-			prevOnClose?.();
-		} catch (error) {
-			logger?.warn('McpClientTool: chained onclose threw', { error });
-		}
-	};
-
-	const prevOnError = client.onerror;
-	client.onerror = (error: Error) => {
-		logger?.warn('McpClientTool: transport error, evicting cache entry', { cacheKey, error });
-		// Transport errored — close path will follow; just drop from cache.
-		activeClients.delete(cacheKey);
-		try {
-			prevOnError?.(error);
-		} catch (chained) {
-			logger?.warn('McpClientTool: chained onerror threw', { error: chained });
-		}
-	};
-}
-
-/**
- * v1.3+ execute path: cache live Client across tool calls within an execution.
- * Standalone (not method) so `this` binding works with mock test contexts.
- */
-async function executeWithCache(
-	ctx: IExecuteFunctions,
-	items: INodeExecutionData[],
-): Promise<INodeExecutionData[][]> {
-	const node = ctx.getNode();
-	const returnData: INodeExecutionData[] = [];
-	// Narrow to a real Logger only when both methods are callable —
-	// jest-mock-extended's `mock<any>` returns proxy values that are truthy
-	// but not callable, which would crash a naive `logger?.debug(...)`.
-	const logger: CloseLogger =
-		typeof ctx.logger?.debug === 'function' && typeof ctx.logger?.warn === 'function'
-			? ctx.logger
-			: undefined;
-
-	evictStaleClients(logger);
-
-	const cacheKey = getCacheKey(ctx.getExecutionId(), node.name);
-	let client: Client;
-	let mcpTools: McpTool[];
-
-	const cached = activeClients.get(cacheKey);
-	if (cached) {
-		logger?.debug('McpClientTool: cache hit', { cacheKey });
-		({ client, mcpTools } = cached);
-	} else {
-		// Dedupe concurrent cache misses for same key — prevents racing
-		// connects from leaking transports.
-		let pending = pendingConnections.get(cacheKey);
-		if (pending) {
-			logger?.debug('McpClientTool: awaiting in-flight connection', { cacheKey });
-			({ client, mcpTools } = await pending);
-		} else {
-			logger?.debug('McpClientTool: cache miss, connecting', { cacheKey });
-			pending = connectOrThrow(ctx, 0);
-			pendingConnections.set(cacheKey, pending);
-			try {
-				({ client, mcpTools } = await pending);
-				const now = Date.now();
-				activeClients.set(cacheKey, { client, mcpTools, createdAt: now, lastUsedAt: now });
-				attachTransportLifecycle(client, cacheKey, logger);
-				ctx.onExecutionCancellation?.(() => closeAndRemove(cacheKey, logger));
-			} finally {
-				pendingConnections.delete(cacheKey);
-			}
-		}
-	}
-
-	for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
-		const timeout = ctx.getNodeParameter('options.timeout', itemIndex, 60000) as number;
-		await appendToolResults({
-			node,
-			item: items[itemIndex],
-			mcpTools,
-			client,
-			timeout,
-			itemIndex,
-			returnData,
-		});
-	}
-
-	// Refresh idle timer at end of each execute() — keeps long-running agents
-	// alive even when callTool() runs longer than EVICTION_INTERVAL_MS.
-	const stillCached = activeClients.get(cacheKey);
-	if (stillCached) stillCached.lastUsedAt = Date.now();
-
-	return [returnData];
 }
 
 interface AppendToolResultsOpts {
@@ -655,14 +481,42 @@ export class McpClientTool implements INodeType {
 		const node = this.getNode();
 		const items = this.getInputData();
 		const useClientCache = node.typeVersion >= 1.3;
+		const returnData: INodeExecutionData[] = [];
 
 		if (useClientCache) {
-			return await executeWithCache(this, items);
+			const logger = narrowLogger(this);
+			const cacheKey = getCacheKey(this.getExecutionId(), node.name);
+			const manager = Container.get(McpClientsManager);
+			const { client, mcpTools } = await manager.getOrConnect(
+				cacheKey,
+				async () => await connectOrThrow(this, 0),
+				{
+					logger,
+					onExecutionCancellation: this.onExecutionCancellation?.bind(this),
+				},
+			);
+
+			for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+				const timeout = this.getNodeParameter('options.timeout', itemIndex, 60000) as number;
+				await appendToolResults({
+					node,
+					item: items[itemIndex],
+					mcpTools,
+					client,
+					timeout,
+					itemIndex,
+					returnData,
+				});
+			}
+
+			// Refresh idle timer at end — keeps long-running agents alive even when
+			// callTool() runs longer than the eviction interval.
+			manager.refresh(cacheKey);
+			return [returnData];
 		}
 
 		// v1.2 and below: per-item connection (preserves expression-based per-item config).
 		// Pre-existing behavior: client is left open after the loop (matches pre-1.3).
-		const returnData: INodeExecutionData[] = [];
 		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
 			const { client, mcpTools } = await connectOrThrow(this, itemIndex);
 			const timeout = this.getNodeParameter('options.timeout', itemIndex, 60000) as number;

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -77,6 +77,8 @@ function closeAndRemove(key: string, logger?: CloseLogger): void {
 }
 
 let lastEvictionAt = 0;
+// Lazy time-gated sweep instead of setInterval — avoids pinning the event
+// loop and leaking timers in tests where there's no shutdown hook.
 const EVICTION_INTERVAL_MS = 30_000;
 
 /** Reset the eviction timer — exported for testing only. */
@@ -90,23 +92,29 @@ export function evictStaleClients(logger?: CloseLogger): void {
 	if (now - lastEvictionAt < EVICTION_INTERVAL_MS) return;
 	lastEvictionAt = now;
 
+	let idleEvicted = 0;
 	for (const [key, entry] of activeClients) {
 		if (now - entry.lastUsedAt > N8N_MCP_CLIENT_CACHE_TTL_MS) {
-			logger?.debug('McpClientTool: evicting idle client', { cacheKey: key });
 			closeAndRemove(key, logger);
+			idleEvicted++;
 		}
+	}
+	if (idleEvicted > 0) {
+		logger?.debug('McpClientTool: evicted idle clients', { count: idleEvicted });
 	}
 
 	// Map preserves insertion order, which matches createdAt order since
 	// entries are only inserted (never re-set) with Date.now() timestamps.
 	if (activeClients.size > N8N_MCP_CLIENT_CACHE_MAX_SIZE) {
 		let excess = activeClients.size - N8N_MCP_CLIENT_CACHE_MAX_SIZE;
+		let oldestEvicted = 0;
 		for (const [key] of activeClients) {
 			if (excess <= 0) break;
-			logger?.debug('McpClientTool: evicting oldest client (max size)', { cacheKey: key });
 			closeAndRemove(key, logger);
 			excess--;
+			oldestEvicted++;
 		}
+		logger?.debug('McpClientTool: evicted oldest clients (max size)', { count: oldestEvicted });
 	}
 }
 
@@ -133,21 +141,33 @@ async function connectOrThrow(
 /**
  * Wire transport-level lifecycle so cache evicts when server drops the
  * connection or transport errors out — prevents handing dead clients
- * back to subsequent tool calls.
+ * back to subsequent tool calls. The MCP SDK's Protocol class exposes
+ * `onclose`/`onerror` as plain assignable fields (no setter side effects),
+ * so chaining via captured `prev*` is safe.
  */
 function attachTransportLifecycle(client: Client, cacheKey: string, logger: CloseLogger): void {
 	const prevOnClose = client.onclose;
 	client.onclose = () => {
 		logger?.debug('McpClientTool: transport closed, evicting cache entry', { cacheKey });
+		// Transport already closed — no need to call client.close().
 		activeClients.delete(cacheKey);
-		prevOnClose?.();
+		try {
+			prevOnClose?.();
+		} catch (error) {
+			logger?.warn('McpClientTool: chained onclose threw', { error });
+		}
 	};
 
 	const prevOnError = client.onerror;
 	client.onerror = (error: Error) => {
 		logger?.warn('McpClientTool: transport error, evicting cache entry', { cacheKey, error });
+		// Transport errored — close path will follow; just drop from cache.
 		activeClients.delete(cacheKey);
-		prevOnError?.(error);
+		try {
+			prevOnError?.(error);
+		} catch (chained) {
+			logger?.warn('McpClientTool: chained onerror threw', { error: chained });
+		}
 	};
 }
 
@@ -161,29 +181,37 @@ async function executeWithCache(
 ): Promise<INodeExecutionData[][]> {
 	const node = ctx.getNode();
 	const returnData: INodeExecutionData[] = [];
-	const logger: CloseLogger = ctx.logger;
+	// Narrow to a real Logger only when both methods are callable —
+	// jest-mock-extended's `mock<any>` returns proxy values that are truthy
+	// but not callable, which would crash a naive `logger?.debug(...)`.
+	const logger: CloseLogger =
+		typeof ctx.logger?.debug === 'function' && typeof ctx.logger?.warn === 'function'
+			? ctx.logger
+			: undefined;
 
 	evictStaleClients(logger);
 
 	const cacheKey = getCacheKey(ctx.getExecutionId(), node.name);
-	let cached = activeClients.get(cacheKey);
+	let client: Client;
+	let mcpTools: McpTool[];
 
+	const cached = activeClients.get(cacheKey);
 	if (cached) {
-		logger?.debug?.('McpClientTool: cache hit', { cacheKey });
-		cached.lastUsedAt = Date.now();
+		logger?.debug('McpClientTool: cache hit', { cacheKey });
+		({ client, mcpTools } = cached);
 	} else {
 		// Dedupe concurrent cache misses for same key — prevents racing
 		// connects from leaking transports.
 		let pending = pendingConnections.get(cacheKey);
 		if (pending) {
-			logger?.debug?.('McpClientTool: awaiting in-flight connection', { cacheKey });
-			await pending;
+			logger?.debug('McpClientTool: awaiting in-flight connection', { cacheKey });
+			({ client, mcpTools } = await pending);
 		} else {
-			logger?.debug?.('McpClientTool: cache miss, connecting', { cacheKey });
+			logger?.debug('McpClientTool: cache miss, connecting', { cacheKey });
 			pending = connectOrThrow(ctx, 0);
 			pendingConnections.set(cacheKey, pending);
 			try {
-				const { client, mcpTools } = await pending;
+				({ client, mcpTools } = await pending);
 				const now = Date.now();
 				activeClients.set(cacheKey, { client, mcpTools, createdAt: now, lastUsedAt: now });
 				attachTransportLifecycle(client, cacheKey, logger);
@@ -192,70 +220,69 @@ async function executeWithCache(
 				pendingConnections.delete(cacheKey);
 			}
 		}
-		cached = activeClients.get(cacheKey);
-		if (!cached) {
-			throw new NodeOperationError(node, 'Failed to populate MCP client cache', {
-				itemIndex: 0,
-			});
-		}
 	}
-
-	const { client, mcpTools } = cached;
 
 	for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
-		const item = items[itemIndex];
 		const timeout = ctx.getNodeParameter('options.timeout', itemIndex, 60000) as number;
-		await appendToolResults(node, item, mcpTools, client, timeout, itemIndex, returnData);
+		await appendToolResults({
+			node,
+			item: items[itemIndex],
+			mcpTools,
+			client,
+			timeout,
+			itemIndex,
+			returnData,
+		});
 	}
 
-	// Refresh idle timer at end of each execute() — keeps long-running agents alive.
+	// Refresh idle timer at end of each execute() — keeps long-running agents
+	// alive even when callTool() runs longer than EVICTION_INTERVAL_MS.
 	const stillCached = activeClients.get(cacheKey);
 	if (stillCached) stillCached.lastUsedAt = Date.now();
 
 	return [returnData];
 }
 
+interface AppendToolResultsOpts {
+	node: INode;
+	item: INodeExecutionData;
+	mcpTools: McpTool[];
+	client: Client;
+	timeout: number;
+	itemIndex: number;
+	returnData: INodeExecutionData[];
+}
+
 /** Run matching tool from item.json.tool against the MCP client and push result. */
-async function appendToolResults(
-	node: INode,
-	item: INodeExecutionData,
-	mcpTools: McpTool[],
-	client: Client,
-	timeout: number,
-	itemIndex: number,
-	returnData: INodeExecutionData[],
-): Promise<void> {
-	for (const tool of mcpTools) {
-		if (!item.json.tool || typeof item.json.tool !== 'string') {
-			throw new NodeOperationError(node, 'Tool name not found in item.json.tool or item.tool', {
-				itemIndex,
-			});
-		}
+async function appendToolResults(opts: AppendToolResultsOpts): Promise<void> {
+	const { node, item, mcpTools, client, timeout, itemIndex, returnData } = opts;
 
-		const toolName = item.json.tool;
-		if (toolName === tool.name) {
-			const { tool: _, ...toolArguments } = item.json;
-			const schema: JSONSchema7 = tool.inputSchema;
-			const sanitizedToolArguments: IDataObject =
-				schema.additionalProperties !== true
-					? pick(toolArguments, Object.keys(schema.properties ?? {}))
-					: toolArguments;
-
-			const result = await client.callTool(
-				{ name: tool.name, arguments: sanitizedToolArguments },
-				CallToolResultSchema,
-				{ timeout },
-			);
-			returnData.push({
-				json: {
-					response: result.content as IDataObject,
-				},
-				pairedItem: {
-					item: itemIndex,
-				},
-			});
-		}
+	const toolName = item.json.tool;
+	if (typeof toolName !== 'string' || toolName.length === 0) {
+		throw new NodeOperationError(node, 'Tool name not found in item.json.tool or item.tool', {
+			itemIndex,
+		});
 	}
+
+	const tool = mcpTools.find((t) => t.name === toolName);
+	if (!tool) return;
+
+	const { tool: _, ...toolArguments } = item.json;
+	const schema: JSONSchema7 = tool.inputSchema;
+	const sanitizedToolArguments: IDataObject =
+		schema.additionalProperties !== true
+			? pick(toolArguments, Object.keys(schema.properties ?? {}))
+			: toolArguments;
+
+	const result = await client.callTool(
+		{ name: tool.name, arguments: sanitizedToolArguments },
+		CallToolResultSchema,
+		{ timeout },
+	);
+	returnData.push({
+		json: { response: result.content as IDataObject },
+		pairedItem: { item: itemIndex },
+	});
 }
 
 /**
@@ -637,10 +664,17 @@ export class McpClientTool implements INodeType {
 		// Pre-existing behavior: client is left open after the loop (matches pre-1.3).
 		const returnData: INodeExecutionData[] = [];
 		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
-			const item = items[itemIndex];
 			const { client, mcpTools } = await connectOrThrow(this, itemIndex);
 			const timeout = this.getNodeParameter('options.timeout', itemIndex, 60000) as number;
-			await appendToolResults(node, item, mcpTools, client, timeout, itemIndex, returnData);
+			await appendToolResults({
+				node,
+				item: items[itemIndex],
+				mcpTools,
+				client,
+				timeout,
+				itemIndex,
+				returnData,
+			});
 		}
 
 		return [returnData];

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -30,7 +30,8 @@ import {
 	tryRefreshOAuth2Token,
 } from '../shared/utils';
 
-const CLIENT_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const MCP_CLIENT_CACHE_TTL_MS = parseInt(process.env.MCP_CLIENT_CACHE_TTL_MS ?? '300000', 10);
+const MCP_CLIENT_CACHE_MAX_SIZE = parseInt(process.env.MCP_CLIENT_CACHE_MAX_SIZE ?? '500', 10);
 
 interface CachedClient {
 	client: Client;
@@ -49,17 +50,31 @@ function getCacheKey(executionId: string, nodeName: string): string {
 	return `${executionId}:${nodeName}`;
 }
 
-/** Remove cache entries older than CLIENT_CACHE_TTL_MS as a safety net against leaks. */
 let lastEvictionAt = 0;
 const EVICTION_INTERVAL_MS = 30_000;
 
-function evictStaleClients(): void {
+/** Reset the eviction timer — exported for testing only. */
+export function resetEvictionTimer(): void {
+	lastEvictionAt = 0;
+}
+
+/** Evict stale entries (TTL) and enforce max cache size. */
+export function evictStaleClients(): void {
 	const now = Date.now();
 	if (now - lastEvictionAt < EVICTION_INTERVAL_MS) return;
 	lastEvictionAt = now;
 
 	for (const [key, entry] of activeClients) {
-		if (now - entry.createdAt > CLIENT_CACHE_TTL_MS) {
+		if (now - entry.createdAt > MCP_CLIENT_CACHE_TTL_MS) {
+			void entry.client.close().catch(() => {});
+			activeClients.delete(key);
+		}
+	}
+
+	if (activeClients.size > MCP_CLIENT_CACHE_MAX_SIZE) {
+		const sorted = [...activeClients.entries()].sort((a, b) => a[1].createdAt - b[1].createdAt);
+		const toEvict = sorted.slice(0, activeClients.size - MCP_CLIENT_CACHE_MAX_SIZE);
+		for (const [key, entry] of toEvict) {
 			void entry.client.close().catch(() => {});
 			activeClients.delete(key);
 		}

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -1,4 +1,7 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
+import type { JSONSchema7 } from 'json-schema';
+import pick from 'lodash/pick';
 import { StructuredToolkit } from 'n8n-core';
 import {
 	type IDataObject,
@@ -18,7 +21,7 @@ import { getTools } from './loadOptions';
 import type { McpToolIncludeMode } from './types';
 import { createCallTool, getSelectedTools, mcpToolToDynamicTool } from './utils';
 import { credentials, transportSelect } from '../shared/descriptions';
-import type { McpAuthenticationOption, McpServerTransport } from '../shared/types';
+import type { McpAuthenticationOption, McpServerTransport, McpTool } from '../shared/types';
 import {
 	connectMcpClient,
 	getAllTools,
@@ -26,8 +29,36 @@ import {
 	mapToNodeOperationError,
 	tryRefreshOAuth2Token,
 } from '../shared/utils';
-import type { JSONSchema7 } from 'json-schema';
-import pick from 'lodash/pick';
+
+const CLIENT_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+interface CachedClient {
+	client: Client;
+	mcpTools: McpTool[];
+	createdAt: number;
+}
+
+/**
+ * Cache of live MCP clients keyed by `executionId:nodeName`.
+ * Keeps the transport alive between tool calls within the same execution,
+ * which is required for stateful MCP servers (e.g. Playwright).
+ */
+export const activeClients = new Map<string, CachedClient>();
+
+function getCacheKey(executionId: string, nodeName: string): string {
+	return `${executionId}:${nodeName}`;
+}
+
+/** Remove cache entries older than CLIENT_CACHE_TTL_MS as a safety net against leaks. */
+function evictStaleClients(): void {
+	const now = Date.now();
+	for (const [key, entry] of activeClients) {
+		if (now - entry.createdAt > CLIENT_CACHE_TTL_MS) {
+			void entry.client.close().catch(() => {});
+			activeClients.delete(key);
+		}
+	}
+}
 
 /**
  * Get node parameters for MCP client configuration
@@ -120,7 +151,7 @@ export class McpClientTool implements INodeType {
 			dark: 'file:../mcp.dark.svg',
 		},
 		group: ['output'],
-		version: [1, 1.1, 1.2],
+		version: [1, 1.1, 1.2, 1.3],
 		description: 'Connect tools from an MCP Server',
 		defaults: {
 			name: 'MCP Client',
@@ -399,24 +430,75 @@ export class McpClientTool implements INodeType {
 		const node = this.getNode();
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
+		const useClientCache = node.typeVersion >= 1.3;
+
+		let client: Client;
+		let mcpTools: McpTool[];
+
+		if (useClientCache) {
+			evictStaleClients();
+
+			const cacheKey = getCacheKey(this.getExecutionId(), node.name);
+			const cached = activeClients.get(cacheKey);
+
+			if (cached) {
+				client = cached.client;
+				mcpTools = cached.mcpTools;
+			} else {
+				const config = getNodeConfig(this, 0);
+				const result = await connectAndGetTools(this, config);
+
+				if (result.error) {
+					throw new NodeOperationError(node, result.error.error, { itemIndex: 0 });
+				}
+
+				if (!result.mcpTools?.length) {
+					throw new NodeOperationError(node, 'MCP Server returned no tools', { itemIndex: 0 });
+				}
+
+				client = result.client;
+				mcpTools = result.mcpTools;
+
+				activeClients.set(cacheKey, { client, mcpTools, createdAt: Date.now() });
+
+				// Clean up when the execution ends
+				const cancelSignal = this.getExecutionCancelSignal();
+				if (cancelSignal) {
+					cancelSignal.addEventListener(
+						'abort',
+						() => {
+							const entry = activeClients.get(cacheKey);
+							if (entry) {
+								void entry.client.close().catch(() => {});
+								activeClients.delete(cacheKey);
+							}
+						},
+						{ once: true },
+					);
+				}
+			}
+		} else {
+			// v1.2 and below: fresh connection per execute call (existing behavior)
+			const config = getNodeConfig(this, 0);
+			const result = await connectAndGetTools(this, config);
+
+			if (result.error) {
+				throw new NodeOperationError(node, result.error.error, { itemIndex: 0 });
+			}
+
+			if (!result.mcpTools?.length) {
+				throw new NodeOperationError(node, 'MCP Server returned no tools', { itemIndex: 0 });
+			}
+
+			client = result.client;
+			mcpTools = result.mcpTools;
+		}
 
 		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
 			const item = items[itemIndex];
 			const config = getNodeConfig(this, itemIndex);
 
-			const { client, mcpTools, error } = await connectAndGetTools(this, config);
-
-			if (error) {
-				throw new NodeOperationError(node, error.error, { itemIndex });
-			}
-
-			if (!mcpTools?.length) {
-				throw new NodeOperationError(node, 'MCP Server returned no tools', { itemIndex });
-			}
-
 			for (const tool of mcpTools) {
-				// Check for tool name in item.json.tool (for toolkit execution from agent)
-				// or item.tool (for direct execution)
 				if (!item.json.tool || typeof item.json.tool !== 'string') {
 					throw new NodeOperationError(node, 'Tool name not found in item.json.tool or item.tool', {
 						itemIndex,
@@ -425,11 +507,8 @@ export class McpClientTool implements INodeType {
 
 				const toolName = item.json.tool;
 				if (toolName === tool.name) {
-					// Extract the tool name from arguments before passing to MCP
 					const { tool: _, ...toolArguments } = item.json;
 					const schema: JSONSchema7 = tool.inputSchema;
-					// When additionalProperties is not explicitly true, filter to schema-defined properties.
-					// Otherwise, pass all arguments through
 					const sanitizedToolArguments: IDataObject =
 						schema.additionalProperties !== true
 							? pick(toolArguments, Object.keys(schema.properties ?? {}))

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -30,8 +30,13 @@ import {
 	tryRefreshOAuth2Token,
 } from '../shared/utils';
 
-const MCP_CLIENT_CACHE_TTL_MS = parseInt(process.env.MCP_CLIENT_CACHE_TTL_MS ?? '300000', 10);
-const MCP_CLIENT_CACHE_MAX_SIZE = parseInt(process.env.MCP_CLIENT_CACHE_MAX_SIZE ?? '500', 10);
+const DEFAULT_CACHE_TTL_MS = 300_000;
+const DEFAULT_CACHE_MAX_SIZE = 500;
+
+const MCP_CLIENT_CACHE_TTL_MS =
+	parseInt(process.env.MCP_CLIENT_CACHE_TTL_MS ?? '', 10) || DEFAULT_CACHE_TTL_MS;
+const MCP_CLIENT_CACHE_MAX_SIZE =
+	parseInt(process.env.MCP_CLIENT_CACHE_MAX_SIZE ?? '', 10) || DEFAULT_CACHE_MAX_SIZE;
 
 interface CachedClient {
 	client: Client;
@@ -50,6 +55,14 @@ function getCacheKey(executionId: string, nodeName: string): string {
 	return `${executionId}:${nodeName}`;
 }
 
+function closeAndRemove(key: string): void {
+	const entry = activeClients.get(key);
+	if (entry) {
+		void entry.client.close().catch(() => {});
+		activeClients.delete(key);
+	}
+}
+
 let lastEvictionAt = 0;
 const EVICTION_INTERVAL_MS = 30_000;
 
@@ -66,17 +79,18 @@ export function evictStaleClients(): void {
 
 	for (const [key, entry] of activeClients) {
 		if (now - entry.createdAt > MCP_CLIENT_CACHE_TTL_MS) {
-			void entry.client.close().catch(() => {});
-			activeClients.delete(key);
+			closeAndRemove(key);
 		}
 	}
 
+	// Map preserves insertion order, which matches createdAt order since
+	// entries are only inserted (never re-set) with Date.now() timestamps.
 	if (activeClients.size > MCP_CLIENT_CACHE_MAX_SIZE) {
-		const sorted = [...activeClients.entries()].sort((a, b) => a[1].createdAt - b[1].createdAt);
-		const toEvict = sorted.slice(0, activeClients.size - MCP_CLIENT_CACHE_MAX_SIZE);
-		for (const [key, entry] of toEvict) {
-			void entry.client.close().catch(() => {});
-			activeClients.delete(key);
+		let excess = activeClients.size - MCP_CLIENT_CACHE_MAX_SIZE;
+		for (const [key] of activeClients) {
+			if (excess <= 0) break;
+			closeAndRemove(key);
+			excess--;
 		}
 	}
 }
@@ -491,17 +505,9 @@ export class McpClientTool implements INodeType {
 
 				const cancelSignal = this.getExecutionCancelSignal();
 				if (cancelSignal) {
-					cancelSignal.addEventListener(
-						'abort',
-						() => {
-							const entry = activeClients.get(cacheKey);
-							if (entry) {
-								void entry.client.close().catch(() => {});
-								activeClients.delete(cacheKey);
-							}
-						},
-						{ once: true },
-					);
+					cancelSignal.addEventListener('abort', () => closeAndRemove(cacheKey), {
+						once: true,
+					});
 				}
 			}
 		} else {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -33,10 +33,10 @@ import {
 const DEFAULT_CACHE_TTL_MS = 300_000;
 const DEFAULT_CACHE_MAX_SIZE = 500;
 
-const MCP_CLIENT_CACHE_TTL_MS =
-	parseInt(process.env.MCP_CLIENT_CACHE_TTL_MS ?? '', 10) || DEFAULT_CACHE_TTL_MS;
-const MCP_CLIENT_CACHE_MAX_SIZE =
-	parseInt(process.env.MCP_CLIENT_CACHE_MAX_SIZE ?? '', 10) || DEFAULT_CACHE_MAX_SIZE;
+const N8N_MCP_CLIENT_CACHE_TTL_MS =
+	parseInt(process.env.N8N_MCP_CLIENT_CACHE_TTL_MS ?? '', 10) || DEFAULT_CACHE_TTL_MS;
+const N8N_MCP_CLIENT_CACHE_MAX_SIZE =
+	parseInt(process.env.N8N_MCP_CLIENT_CACHE_MAX_SIZE ?? '', 10) || DEFAULT_CACHE_MAX_SIZE;
 
 interface CachedClient {
 	client: Client;
@@ -78,15 +78,15 @@ export function evictStaleClients(): void {
 	lastEvictionAt = now;
 
 	for (const [key, entry] of activeClients) {
-		if (now - entry.createdAt > MCP_CLIENT_CACHE_TTL_MS) {
+		if (now - entry.createdAt > N8N_MCP_CLIENT_CACHE_TTL_MS) {
 			closeAndRemove(key);
 		}
 	}
 
 	// Map preserves insertion order, which matches createdAt order since
 	// entries are only inserted (never re-set) with Date.now() timestamps.
-	if (activeClients.size > MCP_CLIENT_CACHE_MAX_SIZE) {
-		let excess = activeClients.size - MCP_CLIENT_CACHE_MAX_SIZE;
+	if (activeClients.size > N8N_MCP_CLIENT_CACHE_MAX_SIZE) {
+		let excess = activeClients.size - N8N_MCP_CLIENT_CACHE_MAX_SIZE;
 		for (const [key] of activeClients) {
 			if (excess <= 0) break;
 			closeAndRemove(key);

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -50,14 +50,39 @@ function getCacheKey(executionId: string, nodeName: string): string {
 }
 
 /** Remove cache entries older than CLIENT_CACHE_TTL_MS as a safety net against leaks. */
+let lastEvictionAt = 0;
+const EVICTION_INTERVAL_MS = 30_000;
+
 function evictStaleClients(): void {
 	const now = Date.now();
+	if (now - lastEvictionAt < EVICTION_INTERVAL_MS) return;
+	lastEvictionAt = now;
+
 	for (const [key, entry] of activeClients) {
 		if (now - entry.createdAt > CLIENT_CACHE_TTL_MS) {
 			void entry.client.close().catch(() => {});
 			activeClients.delete(key);
 		}
 	}
+}
+
+/** Connect to MCP server and return client + tools, or throw on failure. */
+async function connectOrThrow(
+	ctx: IExecuteFunctions,
+): Promise<{ client: Client; mcpTools: McpTool[] }> {
+	const node = ctx.getNode();
+	const config = getNodeConfig(ctx, 0);
+	const result = await connectAndGetTools(ctx, config);
+
+	if (result.error) {
+		throw new NodeOperationError(node, result.error.error, { itemIndex: 0 });
+	}
+
+	if (!result.mcpTools?.length) {
+		throw new NodeOperationError(node, 'MCP Server returned no tools', { itemIndex: 0 });
+	}
+
+	return { client: result.client, mcpTools: result.mcpTools };
 }
 
 /**
@@ -445,23 +470,10 @@ export class McpClientTool implements INodeType {
 				client = cached.client;
 				mcpTools = cached.mcpTools;
 			} else {
-				const config = getNodeConfig(this, 0);
-				const result = await connectAndGetTools(this, config);
-
-				if (result.error) {
-					throw new NodeOperationError(node, result.error.error, { itemIndex: 0 });
-				}
-
-				if (!result.mcpTools?.length) {
-					throw new NodeOperationError(node, 'MCP Server returned no tools', { itemIndex: 0 });
-				}
-
-				client = result.client;
-				mcpTools = result.mcpTools;
+				({ client, mcpTools } = await connectOrThrow(this));
 
 				activeClients.set(cacheKey, { client, mcpTools, createdAt: Date.now() });
 
-				// Clean up when the execution ends
 				const cancelSignal = this.getExecutionCancelSignal();
 				if (cancelSignal) {
 					cancelSignal.addEventListener(
@@ -478,25 +490,12 @@ export class McpClientTool implements INodeType {
 				}
 			}
 		} else {
-			// v1.2 and below: fresh connection per execute call (existing behavior)
-			const config = getNodeConfig(this, 0);
-			const result = await connectAndGetTools(this, config);
-
-			if (result.error) {
-				throw new NodeOperationError(node, result.error.error, { itemIndex: 0 });
-			}
-
-			if (!result.mcpTools?.length) {
-				throw new NodeOperationError(node, 'MCP Server returned no tools', { itemIndex: 0 });
-			}
-
-			client = result.client;
-			mcpTools = result.mcpTools;
+			({ client, mcpTools } = await connectOrThrow(this));
 		}
 
 		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
 			const item = items[itemIndex];
-			const config = getNodeConfig(this, itemIndex);
+			const timeout = this.getNodeParameter('options.timeout', itemIndex, 60000) as number;
 
 			for (const tool of mcpTools) {
 				if (!item.json.tool || typeof item.json.tool !== 'string') {
@@ -514,16 +513,11 @@ export class McpClientTool implements INodeType {
 							? pick(toolArguments, Object.keys(schema.properties ?? {}))
 							: toolArguments;
 
-					const params: {
-						name: string;
-						arguments: IDataObject;
-					} = {
-						name: tool.name,
-						arguments: sanitizedToolArguments,
-					};
-					const result = await client.callTool(params, CallToolResultSchema, {
-						timeout: config.timeout,
-					});
+					const result = await client.callTool(
+						{ name: tool.name, arguments: sanitizedToolArguments },
+						CallToolResultSchema,
+						{ timeout },
+					);
 					returnData.push({
 						json: {
 							response: result.content as IDataObject,

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
@@ -12,15 +12,13 @@ import {
 	type ISupplyDataFunctions,
 } from 'n8n-workflow';
 
+import { Container } from '@n8n/di';
+
 import { proxyFetch } from '@n8n/ai-utilities';
 
 import { getTools } from '../loadOptions';
-import {
-	McpClientTool,
-	activeClients,
-	evictStaleClients,
-	resetEvictionTimer,
-} from '../McpClientTool.node';
+import { McpClientTool } from '../McpClientTool.node';
+import { McpClientsManager } from '../../shared/McpClientsManager';
 
 jest.mock('@modelcontextprotocol/sdk/client/sse.js');
 jest.mock('@modelcontextprotocol/sdk/client/index.js');
@@ -887,14 +885,7 @@ describe('McpClientTool', () => {
 				onExecutionCancellation: jest.fn((handler: () => void) => {
 					abortController.signal.addEventListener('abort', handler, { once: true });
 				}),
-				getInputData: jest.fn(() => [
-					{
-						json: {
-							tool: 'get_weather',
-							location: 'Berlin',
-						},
-					},
-				]),
+				getInputData: jest.fn(() => [{ json: { tool: 'get_weather', location: 'Berlin' } }]),
 				getNodeParameter: jest.fn((key) => {
 					const params: Record<string, unknown> = {
 						include: 'all',
@@ -914,7 +905,7 @@ describe('McpClientTool', () => {
 
 		beforeEach(() => {
 			jest.resetAllMocks();
-			activeClients.clear();
+			Container.get(McpClientsManager).clearForTests();
 		});
 
 		it('should cache client and reuse on subsequent execute calls', async () => {
@@ -932,14 +923,13 @@ describe('McpClientTool', () => {
 				],
 			});
 
+			const manager = Container.get(McpClientsManager);
 			const { mockExecuteFunctions } = createV13MockExecuteFunctions();
 
-			// First call: should connect and cache
 			await new McpClientTool().execute.call(mockExecuteFunctions);
 			expect(connectSpy).toHaveBeenCalledTimes(1);
-			expect(activeClients.size).toBe(1);
+			expect(manager.size).toBe(1);
 
-			// Second call: should reuse cached client, not connect again
 			await new McpClientTool().execute.call(mockExecuteFunctions);
 			expect(connectSpy).toHaveBeenCalledTimes(1);
 			expect(Client.prototype.callTool).toHaveBeenCalledTimes(2);
@@ -960,10 +950,10 @@ describe('McpClientTool', () => {
 				],
 			});
 
+			const manager = Container.get(McpClientsManager);
 			const { mockExecuteFunctions: exec1 } = createV13MockExecuteFunctions();
 			await new McpClientTool().execute.call(exec1);
 
-			// Different execution ID
 			const abortController2 = new AbortController();
 			const mockNode2 = mock<INode>({
 				typeVersion: 1.3,
@@ -974,6 +964,9 @@ describe('McpClientTool', () => {
 				getNode: jest.fn(() => mockNode2),
 				getExecutionId: jest.fn(() => 'different-execution-456'),
 				getExecutionCancelSignal: jest.fn(() => abortController2.signal),
+				onExecutionCancellation: jest.fn((handler: () => void) => {
+					abortController2.signal.addEventListener('abort', handler, { once: true });
+				}),
 				getInputData: jest.fn(() => [{ json: { tool: 'get_weather', location: 'London' } }]),
 				getNodeParameter: jest.fn((key) => {
 					const params: Record<string, unknown> = {
@@ -991,7 +984,7 @@ describe('McpClientTool', () => {
 
 			await new McpClientTool().execute.call(exec2);
 			expect(connectSpy).toHaveBeenCalledTimes(2);
-			expect(activeClients.size).toBe(2);
+			expect(manager.size).toBe(2);
 		});
 
 		it('should clean up cached client when execution is cancelled', async () => {
@@ -1010,83 +1003,31 @@ describe('McpClientTool', () => {
 				],
 			});
 
+			const manager = Container.get(McpClientsManager);
 			const { mockExecuteFunctions, abortController } = createV13MockExecuteFunctions();
 
 			await new McpClientTool().execute.call(mockExecuteFunctions);
-			expect(activeClients.size).toBe(1);
+			expect(manager.size).toBe(1);
 
-			// Simulate execution cancellation
 			abortController.abort();
 
 			expect(closeSpy).toHaveBeenCalledTimes(1);
-			expect(activeClients.size).toBe(0);
-		});
-
-		it('should evict oldest entries when cache exceeds max size', () => {
-			const closeSpy = jest.fn().mockResolvedValue(undefined);
-			const now = Date.now();
-
-			// Pre-populate cache with 502 entries (default max is 500)
-			// All entries are recent (within TTL) so only max-size eviction applies
-			for (let i = 0; i < 502; i++) {
-				activeClients.set(`exec-${i}:node`, {
-					client: { close: closeSpy } as unknown as Client,
-					mcpTools: [],
-					createdAt: now - 1000 + i, // all recent, oldest first
-					lastUsedAt: now - 1000 + i,
-				});
-			}
-
-			expect(activeClients.size).toBe(502);
-			resetEvictionTimer();
-			evictStaleClients();
-
-			// Should have evicted 2 oldest entries to get back to 500
-			expect(activeClients.size).toBe(500);
-			expect(activeClients.has('exec-0:node')).toBe(false);
-			expect(activeClients.has('exec-1:node')).toBe(false);
-			expect(activeClients.has('exec-2:node')).toBe(true);
-			expect(closeSpy).toHaveBeenCalledTimes(2);
-		});
-
-		it('should evict entries older than TTL', () => {
-			const closeSpy = jest.fn().mockResolvedValue(undefined);
-			const now = Date.now();
-
-			activeClients.set('old:node', {
-				client: { close: closeSpy } as unknown as Client,
-				mcpTools: [],
-				createdAt: now - 600_000,
-				lastUsedAt: now - 600_000, // idle 10 min, past 5 min default TTL
-			});
-			activeClients.set('recent:node', {
-				client: { close: closeSpy } as unknown as Client,
-				mcpTools: [],
-				createdAt: now - 600_000, // old by createdAt
-				lastUsedAt: now - 1000, // but idle only 1 sec
-			});
-
-			resetEvictionTimer();
-			evictStaleClients();
-
-			expect(activeClients.size).toBe(1);
-			expect(activeClients.has('old:node')).toBe(false);
-			expect(activeClients.has('recent:node')).toBe(true);
-			expect(closeSpy).toHaveBeenCalledTimes(1);
+			expect(manager.size).toBe(0);
 		});
 
 		it('should not cache client when connection fails on v1.3', async () => {
 			jest.spyOn(Client.prototype, 'connect').mockRejectedValue(new Error('Connection failed'));
 
+			const manager = Container.get(McpClientsManager);
 			const { mockExecuteFunctions } = createV13MockExecuteFunctions();
 
 			await expect(new McpClientTool().execute.call(mockExecuteFunctions)).rejects.toThrow(
 				NodeOperationError,
 			);
-			expect(activeClients.size).toBe(0);
+			expect(manager.size).toBe(0);
 		});
 
-		it('should refresh lastUsedAt on cache hit (idle TTL semantics)', async () => {
+		it('should refresh lastUsedAt on cache hit', async () => {
 			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
 			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({
 				content: [{ type: 'text', text: 'Sunny' }],
@@ -1101,49 +1042,19 @@ describe('McpClientTool', () => {
 				],
 			});
 
+			const manager = Container.get(McpClientsManager);
 			const { mockExecuteFunctions } = createV13MockExecuteFunctions();
 			await new McpClientTool().execute.call(mockExecuteFunctions);
 
 			const cacheKey = `${executionId}:${nodeName}`;
-			const entry = activeClients.get(cacheKey);
+			const entry = manager.getEntry(cacheKey);
 			expect(entry).toBeDefined();
 			const firstLastUsed = entry!.lastUsedAt;
 
 			await new Promise((resolve) => setTimeout(resolve, 5));
 			await new McpClientTool().execute.call(mockExecuteFunctions);
 
-			const updated = activeClients.get(cacheKey);
-			expect(updated!.lastUsedAt).toBeGreaterThan(firstLastUsed);
-		});
-
-		it('should evict cache entry when transport closes', async () => {
-			let onCloseHandler: (() => void) | undefined;
-			const mockClient = {
-				close: jest.fn().mockResolvedValue(undefined),
-				set onclose(handler: (() => void) | undefined) {
-					onCloseHandler = handler;
-				},
-				get onclose() {
-					return onCloseHandler as () => void;
-				},
-				onerror: undefined,
-			} as unknown as Client;
-
-			activeClients.set('exec-x:node', {
-				client: mockClient,
-				mcpTools: [],
-				createdAt: Date.now(),
-				lastUsedAt: Date.now(),
-			});
-
-			// Simulate attaching lifecycle then transport closing
-			const cacheKey = 'exec-x:node';
-			(mockClient as { onclose?: () => void }).onclose = () => {
-				activeClients.delete(cacheKey);
-			};
-			(mockClient as { onclose?: () => void }).onclose!();
-
-			expect(activeClients.has('exec-x:node')).toBe(false);
+			expect(manager.getEntry(cacheKey)!.lastUsedAt).toBeGreaterThan(firstLastUsed);
 		});
 
 		it('should throw NodeOperationError on v1.2 connection failure', async () => {
@@ -1187,6 +1098,7 @@ describe('McpClientTool', () => {
 				],
 			});
 
+			const manager = Container.get(McpClientsManager);
 			const mockNode = mock<INode>({ typeVersion: 1.2, type: 'mcpClientTool', name: nodeName });
 			const mockExecuteFunctions = mock<any>({
 				getNode: jest.fn(() => mockNode),
@@ -1205,11 +1117,10 @@ describe('McpClientTool', () => {
 				}),
 			});
 
-			// Call twice - should connect each time (no caching)
 			await new McpClientTool().execute.call(mockExecuteFunctions);
 			await new McpClientTool().execute.call(mockExecuteFunctions);
 			expect(connectSpy).toHaveBeenCalledTimes(2);
-			expect(activeClients.size).toBe(0);
+			expect(manager.size).toBe(0);
 		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
@@ -884,6 +884,9 @@ describe('McpClientTool', () => {
 				getNode: jest.fn(() => mockNode),
 				getExecutionId: jest.fn(() => executionId),
 				getExecutionCancelSignal: jest.fn(() => abortController.signal),
+				onExecutionCancellation: jest.fn((handler: () => void) => {
+					abortController.signal.addEventListener('abort', handler, { once: true });
+				}),
 				getInputData: jest.fn(() => [
 					{
 						json: {
@@ -1030,6 +1033,7 @@ describe('McpClientTool', () => {
 					client: { close: closeSpy } as unknown as Client,
 					mcpTools: [],
 					createdAt: now - 1000 + i, // all recent, oldest first
+					lastUsedAt: now - 1000 + i,
 				});
 			}
 
@@ -1052,12 +1056,14 @@ describe('McpClientTool', () => {
 			activeClients.set('old:node', {
 				client: { close: closeSpy } as unknown as Client,
 				mcpTools: [],
-				createdAt: now - 600_000, // 10 min ago, well past 5 min default TTL
+				createdAt: now - 600_000,
+				lastUsedAt: now - 600_000, // idle 10 min, past 5 min default TTL
 			});
 			activeClients.set('recent:node', {
 				client: { close: closeSpy } as unknown as Client,
 				mcpTools: [],
-				createdAt: now - 1000, // 1 second ago, within TTL
+				createdAt: now - 600_000, // old by createdAt
+				lastUsedAt: now - 1000, // but idle only 1 sec
 			});
 
 			resetEvictionTimer();
@@ -1078,6 +1084,92 @@ describe('McpClientTool', () => {
 				NodeOperationError,
 			);
 			expect(activeClients.size).toBe(0);
+		});
+
+		it('should refresh lastUsedAt on cache hit (idle TTL semantics)', async () => {
+			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({
+				content: [{ type: 'text', text: 'Sunny' }],
+			});
+			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+				tools: [
+					{
+						name: 'get_weather',
+						description: 'Gets the weather',
+						inputSchema: { type: 'object', properties: { location: { type: 'string' } } },
+					},
+				],
+			});
+
+			const { mockExecuteFunctions } = createV13MockExecuteFunctions();
+			await new McpClientTool().execute.call(mockExecuteFunctions);
+
+			const cacheKey = `${executionId}:${nodeName}`;
+			const entry = activeClients.get(cacheKey);
+			expect(entry).toBeDefined();
+			const firstLastUsed = entry!.lastUsedAt;
+
+			await new Promise((resolve) => setTimeout(resolve, 5));
+			await new McpClientTool().execute.call(mockExecuteFunctions);
+
+			const updated = activeClients.get(cacheKey);
+			expect(updated!.lastUsedAt).toBeGreaterThan(firstLastUsed);
+		});
+
+		it('should evict cache entry when transport closes', async () => {
+			let onCloseHandler: (() => void) | undefined;
+			const mockClient = {
+				close: jest.fn().mockResolvedValue(undefined),
+				set onclose(handler: () => void) {
+					onCloseHandler = handler;
+				},
+				get onclose() {
+					return onCloseHandler;
+				},
+				onerror: undefined,
+			} as unknown as Client;
+
+			activeClients.set('exec-x:node', {
+				client: mockClient,
+				mcpTools: [],
+				createdAt: Date.now(),
+				lastUsedAt: Date.now(),
+			});
+
+			// Simulate attaching lifecycle then transport closing
+			const cacheKey = 'exec-x:node';
+			(mockClient as { onclose?: () => void }).onclose = () => {
+				activeClients.delete(cacheKey);
+			};
+			(mockClient as { onclose?: () => void }).onclose!();
+
+			expect(activeClients.has('exec-x:node')).toBe(false);
+		});
+
+		it('should throw NodeOperationError on v1.2 connection failure', async () => {
+			jest.spyOn(Client.prototype, 'connect').mockRejectedValue(new Error('Connection failed'));
+
+			const mockNode = mock<INode>({ typeVersion: 1.2, type: 'mcpClientTool', name: nodeName });
+			const mockExecuteFunctions = mock<any>({
+				getNode: jest.fn(() => mockNode),
+				getInputData: jest.fn(() => [{ json: { tool: 'get_weather', location: 'Berlin' } }]),
+				getNodeParameter: jest.fn((key) => {
+					const params: Record<string, unknown> = {
+						include: 'all',
+						includeTools: [],
+						excludeTools: [],
+						authentication: 'none',
+						serverTransport: 'httpStreamable',
+						endpointUrl: 'https://test.com/mcp',
+						'options.timeout': 60000,
+					};
+					return params[key as string];
+				}),
+			});
+
+			await expect(new McpClientTool().execute.call(mockExecuteFunctions)).rejects.toThrow(
+				NodeOperationError,
+			);
 		});
 
 		it('should not use client cache for v1.2 nodes', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
@@ -1120,11 +1120,11 @@ describe('McpClientTool', () => {
 			let onCloseHandler: (() => void) | undefined;
 			const mockClient = {
 				close: jest.fn().mockResolvedValue(undefined),
-				set onclose(handler: () => void) {
+				set onclose(handler: (() => void) | undefined) {
 					onCloseHandler = handler;
 				},
 				get onclose() {
-					return onCloseHandler;
+					return onCloseHandler as () => void;
 				},
 				onerror: undefined,
 			} as unknown as Client;

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
@@ -15,7 +15,12 @@ import {
 import { proxyFetch } from '@n8n/ai-utilities';
 
 import { getTools } from '../loadOptions';
-import { McpClientTool, activeClients } from '../McpClientTool.node';
+import {
+	McpClientTool,
+	activeClients,
+	evictStaleClients,
+	resetEvictionTimer,
+} from '../McpClientTool.node';
 
 jest.mock('@modelcontextprotocol/sdk/client/sse.js');
 jest.mock('@modelcontextprotocol/sdk/client/index.js');
@@ -1012,6 +1017,32 @@ describe('McpClientTool', () => {
 
 			expect(closeSpy).toHaveBeenCalledTimes(1);
 			expect(activeClients.size).toBe(0);
+		});
+
+		it('should evict oldest entries when cache exceeds max size', () => {
+			const closeSpy = jest.fn().mockResolvedValue(undefined);
+			const now = Date.now();
+
+			// Pre-populate cache with 502 entries (default max is 500)
+			// All entries are recent (within TTL) so only max-size eviction applies
+			for (let i = 0; i < 502; i++) {
+				activeClients.set(`exec-${i}:node`, {
+					client: { close: closeSpy } as unknown as Client,
+					mcpTools: [],
+					createdAt: now - 1000 + i, // all recent, oldest first
+				});
+			}
+
+			expect(activeClients.size).toBe(502);
+			resetEvictionTimer();
+			evictStaleClients();
+
+			// Should have evicted 2 oldest entries to get back to 500
+			expect(activeClients.size).toBe(500);
+			expect(activeClients.has('exec-0:node')).toBe(false);
+			expect(activeClients.has('exec-1:node')).toBe(false);
+			expect(activeClients.has('exec-2:node')).toBe(true);
+			expect(closeSpy).toHaveBeenCalledTimes(2);
 		});
 
 		it('should not use client cache for v1.2 nodes', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
@@ -1045,6 +1045,41 @@ describe('McpClientTool', () => {
 			expect(closeSpy).toHaveBeenCalledTimes(2);
 		});
 
+		it('should evict entries older than TTL', () => {
+			const closeSpy = jest.fn().mockResolvedValue(undefined);
+			const now = Date.now();
+
+			activeClients.set('old:node', {
+				client: { close: closeSpy } as unknown as Client,
+				mcpTools: [],
+				createdAt: now - 600_000, // 10 min ago, well past 5 min default TTL
+			});
+			activeClients.set('recent:node', {
+				client: { close: closeSpy } as unknown as Client,
+				mcpTools: [],
+				createdAt: now - 1000, // 1 second ago, within TTL
+			});
+
+			resetEvictionTimer();
+			evictStaleClients();
+
+			expect(activeClients.size).toBe(1);
+			expect(activeClients.has('old:node')).toBe(false);
+			expect(activeClients.has('recent:node')).toBe(true);
+			expect(closeSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('should not cache client when connection fails on v1.3', async () => {
+			jest.spyOn(Client.prototype, 'connect').mockRejectedValue(new Error('Connection failed'));
+
+			const { mockExecuteFunctions } = createV13MockExecuteFunctions();
+
+			await expect(new McpClientTool().execute.call(mockExecuteFunctions)).rejects.toThrow(
+				NodeOperationError,
+			);
+			expect(activeClients.size).toBe(0);
+		});
+
 		it('should not use client cache for v1.2 nodes', async () => {
 			const connectSpy = jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
 			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
@@ -15,7 +15,7 @@ import {
 import { proxyFetch } from '@n8n/ai-utilities';
 
 import { getTools } from '../loadOptions';
-import { McpClientTool } from '../McpClientTool.node';
+import { McpClientTool, activeClients } from '../McpClientTool.node';
 
 jest.mock('@modelcontextprotocol/sdk/client/sse.js');
 jest.mock('@modelcontextprotocol/sdk/client/index.js');
@@ -861,6 +861,197 @@ describe('McpClientTool', () => {
 				CallToolResultSchema,
 				{ timeout: 12345 },
 			);
+		});
+	});
+
+	describe('execute v1.3 (client caching)', () => {
+		const executionId = 'test-execution-123';
+		const nodeName = 'MCP Client';
+
+		function createV13MockExecuteFunctions(overrides: Record<string, unknown> = {}) {
+			const abortController = new AbortController();
+			const mockNode = mock<INode>({
+				typeVersion: 1.3,
+				type: 'mcpClientTool',
+				name: nodeName,
+			});
+			const mockExecuteFunctions = mock<any>({
+				getNode: jest.fn(() => mockNode),
+				getExecutionId: jest.fn(() => executionId),
+				getExecutionCancelSignal: jest.fn(() => abortController.signal),
+				getInputData: jest.fn(() => [
+					{
+						json: {
+							tool: 'get_weather',
+							location: 'Berlin',
+						},
+					},
+				]),
+				getNodeParameter: jest.fn((key) => {
+					const params: Record<string, unknown> = {
+						include: 'all',
+						includeTools: [],
+						excludeTools: [],
+						authentication: 'none',
+						serverTransport: 'httpStreamable',
+						endpointUrl: 'https://test.com/mcp',
+						'options.timeout': 60000,
+						...overrides,
+					};
+					return params[key as string];
+				}),
+			});
+			return { mockExecuteFunctions, abortController, mockNode };
+		}
+
+		beforeEach(() => {
+			jest.resetAllMocks();
+			activeClients.clear();
+		});
+
+		it('should cache client and reuse on subsequent execute calls', async () => {
+			const connectSpy = jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({
+				content: [{ type: 'text', text: 'Sunny' }],
+			});
+			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+				tools: [
+					{
+						name: 'get_weather',
+						description: 'Gets the weather',
+						inputSchema: { type: 'object', properties: { location: { type: 'string' } } },
+					},
+				],
+			});
+
+			const { mockExecuteFunctions } = createV13MockExecuteFunctions();
+
+			// First call: should connect and cache
+			await new McpClientTool().execute.call(mockExecuteFunctions);
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+			expect(activeClients.size).toBe(1);
+
+			// Second call: should reuse cached client, not connect again
+			await new McpClientTool().execute.call(mockExecuteFunctions);
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+			expect(Client.prototype.callTool).toHaveBeenCalledTimes(2);
+		});
+
+		it('should not share cache across different executions', async () => {
+			const connectSpy = jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({
+				content: [{ type: 'text', text: 'Sunny' }],
+			});
+			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+				tools: [
+					{
+						name: 'get_weather',
+						description: 'Gets the weather',
+						inputSchema: { type: 'object', properties: { location: { type: 'string' } } },
+					},
+				],
+			});
+
+			const { mockExecuteFunctions: exec1 } = createV13MockExecuteFunctions();
+			await new McpClientTool().execute.call(exec1);
+
+			// Different execution ID
+			const abortController2 = new AbortController();
+			const mockNode2 = mock<INode>({
+				typeVersion: 1.3,
+				type: 'mcpClientTool',
+				name: nodeName,
+			});
+			const exec2 = mock<any>({
+				getNode: jest.fn(() => mockNode2),
+				getExecutionId: jest.fn(() => 'different-execution-456'),
+				getExecutionCancelSignal: jest.fn(() => abortController2.signal),
+				getInputData: jest.fn(() => [{ json: { tool: 'get_weather', location: 'London' } }]),
+				getNodeParameter: jest.fn((key) => {
+					const params: Record<string, unknown> = {
+						include: 'all',
+						includeTools: [],
+						excludeTools: [],
+						authentication: 'none',
+						serverTransport: 'httpStreamable',
+						endpointUrl: 'https://test.com/mcp',
+						'options.timeout': 60000,
+					};
+					return params[key as string];
+				}),
+			});
+
+			await new McpClientTool().execute.call(exec2);
+			expect(connectSpy).toHaveBeenCalledTimes(2);
+			expect(activeClients.size).toBe(2);
+		});
+
+		it('should clean up cached client when execution is cancelled', async () => {
+			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			const closeSpy = jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({
+				content: [{ type: 'text', text: 'Sunny' }],
+			});
+			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+				tools: [
+					{
+						name: 'get_weather',
+						description: 'Gets the weather',
+						inputSchema: { type: 'object', properties: { location: { type: 'string' } } },
+					},
+				],
+			});
+
+			const { mockExecuteFunctions, abortController } = createV13MockExecuteFunctions();
+
+			await new McpClientTool().execute.call(mockExecuteFunctions);
+			expect(activeClients.size).toBe(1);
+
+			// Simulate execution cancellation
+			abortController.abort();
+
+			expect(closeSpy).toHaveBeenCalledTimes(1);
+			expect(activeClients.size).toBe(0);
+		});
+
+		it('should not use client cache for v1.2 nodes', async () => {
+			const connectSpy = jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({
+				content: [{ type: 'text', text: 'Sunny' }],
+			});
+			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+				tools: [
+					{
+						name: 'get_weather',
+						description: 'Gets the weather',
+						inputSchema: { type: 'object', properties: { location: { type: 'string' } } },
+					},
+				],
+			});
+
+			const mockNode = mock<INode>({ typeVersion: 1.2, type: 'mcpClientTool', name: nodeName });
+			const mockExecuteFunctions = mock<any>({
+				getNode: jest.fn(() => mockNode),
+				getInputData: jest.fn(() => [{ json: { tool: 'get_weather', location: 'Berlin' } }]),
+				getNodeParameter: jest.fn((key) => {
+					const params: Record<string, unknown> = {
+						include: 'all',
+						includeTools: [],
+						excludeTools: [],
+						authentication: 'none',
+						serverTransport: 'httpStreamable',
+						endpointUrl: 'https://test.com/mcp',
+						'options.timeout': 60000,
+					};
+					return params[key as string];
+				}),
+			});
+
+			// Call twice - should connect each time (no caching)
+			await new McpClientTool().execute.call(mockExecuteFunctions);
+			await new McpClientTool().execute.call(mockExecuteFunctions);
+			expect(connectSpy).toHaveBeenCalledTimes(2);
+			expect(activeClients.size).toBe(0);
 		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/McpClientsManager.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/McpClientsManager.ts
@@ -1,0 +1,208 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { Service } from '@n8n/di';
+
+import type { McpTool } from './types';
+
+const DEFAULT_CACHE_TTL_MS = 300_000;
+const DEFAULT_CACHE_MAX_SIZE = 500;
+const EVICTION_INTERVAL_MS = 30_000;
+
+const ttlMs = parseInt(process.env.N8N_MCP_CLIENT_CACHE_TTL_MS ?? '', 10) || DEFAULT_CACHE_TTL_MS;
+const maxSize =
+	parseInt(process.env.N8N_MCP_CLIENT_CACHE_MAX_SIZE ?? '', 10) || DEFAULT_CACHE_MAX_SIZE;
+
+export interface McpCacheLogger {
+	warn(message: string, meta?: object): void;
+	debug(message: string, meta?: object): void;
+}
+
+interface CachedClient {
+	client: Client;
+	mcpTools: McpTool[];
+	createdAt: number;
+	lastUsedAt: number;
+}
+
+interface GetOrConnectOpts {
+	logger?: McpCacheLogger;
+	cancelSignal?: AbortSignal;
+	onExecutionCancellation?: (handler: () => void) => void;
+}
+
+/**
+ * Cache of live MCP clients across tool calls within a single execution.
+ * Required for stateful MCP servers (e.g. Playwright) — keeping the
+ * transport open between Agent V3 tool calls preserves the server-side
+ * session that would otherwise be torn down per call.
+ *
+ * Lifecycle:
+ *   - `getOrConnect` returns a cached entry or runs the factory once
+ *     (with concurrent-miss dedup via in-flight Promise map).
+ *   - Transport `onclose`/`onerror` evict the entry automatically.
+ *   - Idle entries (older than TTL on `lastUsedAt`) and overflow entries
+ *     (beyond max size) are swept periodically.
+ *   - On process exit, all live transports are closed.
+ */
+@Service()
+export class McpClientsManager {
+	private readonly activeClients = new Map<string, CachedClient>();
+
+	private readonly pendingConnections = new Map<
+		string,
+		Promise<{ client: Client; mcpTools: McpTool[] }>
+	>();
+
+	private cleanupTimer: NodeJS.Timeout;
+
+	constructor() {
+		this.cleanupTimer = setInterval(() => this.evictStale(), EVICTION_INTERVAL_MS);
+		this.cleanupTimer.unref();
+		process.on('exit', () => this.shutdown());
+	}
+
+	/** Test-only: total entries currently held. */
+	get size(): number {
+		return this.activeClients.size;
+	}
+
+	/** Test-only: peek a cached entry. */
+	getEntry(key: string): CachedClient | undefined {
+		return this.activeClients.get(key);
+	}
+
+	/** Test-only: drop all entries without closing (caller responsibility). */
+	clearForTests(): void {
+		this.activeClients.clear();
+		this.pendingConnections.clear();
+	}
+
+	async getOrConnect(
+		key: string,
+		factory: () => Promise<{ client: Client; mcpTools: McpTool[] }>,
+		opts: GetOrConnectOpts = {},
+	): Promise<{ client: Client; mcpTools: McpTool[] }> {
+		this.evictStale(opts.logger);
+
+		const cached = this.activeClients.get(key);
+		if (cached) {
+			opts.logger?.debug('McpClientsManager: cache hit', { cacheKey: key });
+			cached.lastUsedAt = Date.now();
+			return { client: cached.client, mcpTools: cached.mcpTools };
+		}
+
+		const inFlight = this.pendingConnections.get(key);
+		if (inFlight) {
+			opts.logger?.debug('McpClientsManager: awaiting in-flight connection', { cacheKey: key });
+			return await inFlight;
+		}
+
+		opts.logger?.debug('McpClientsManager: cache miss, connecting', { cacheKey: key });
+		const pending = factory();
+		this.pendingConnections.set(key, pending);
+		try {
+			const result = await pending;
+			const now = Date.now();
+			this.activeClients.set(key, {
+				client: result.client,
+				mcpTools: result.mcpTools,
+				createdAt: now,
+				lastUsedAt: now,
+			});
+			this.attachTransportLifecycle(result.client, key, opts.logger);
+			opts.onExecutionCancellation?.(() => this.remove(key, opts.logger));
+			return result;
+		} finally {
+			this.pendingConnections.delete(key);
+		}
+	}
+
+	/** Refresh idle timer for an entry — call after long-running tool calls. */
+	refresh(key: string): void {
+		const entry = this.activeClients.get(key);
+		if (entry) entry.lastUsedAt = Date.now();
+	}
+
+	/** Close + remove cache entry. Safe to call multiple times. */
+	remove(key: string, logger?: McpCacheLogger): void {
+		const entry = this.activeClients.get(key);
+		if (!entry) return;
+
+		this.activeClients.delete(key);
+		void entry.client.close().catch((error) => {
+			logger?.warn('McpClientsManager: failed to close cached client', { cacheKey: key, error });
+		});
+	}
+
+	/** Evict idle entries (TTL on lastUsedAt) and enforce max cache size. */
+	evictStale(logger?: McpCacheLogger): void {
+		const now = Date.now();
+
+		let idleEvicted = 0;
+		for (const [key, entry] of this.activeClients) {
+			if (now - entry.lastUsedAt > ttlMs) {
+				this.remove(key, logger);
+				idleEvicted++;
+			}
+		}
+		if (idleEvicted > 0) {
+			logger?.debug('McpClientsManager: evicted idle clients', { count: idleEvicted });
+		}
+
+		// Map preserves insertion order, which matches createdAt order since
+		// entries are only inserted (never re-set) with Date.now() timestamps.
+		if (this.activeClients.size > maxSize) {
+			let excess = this.activeClients.size - maxSize;
+			let oldestEvicted = 0;
+			for (const [key] of this.activeClients) {
+				if (excess <= 0) break;
+				this.remove(key, logger);
+				excess--;
+				oldestEvicted++;
+			}
+			logger?.debug('McpClientsManager: evicted oldest clients (max size)', {
+				count: oldestEvicted,
+			});
+		}
+	}
+
+	/**
+	 * Wire transport-level lifecycle so cache evicts when the server drops
+	 * the connection or transport errors out — prevents handing dead clients
+	 * back to subsequent tool calls. The MCP SDK's Protocol class exposes
+	 * `onclose`/`onerror` as plain assignable fields (no setter side effects),
+	 * so chaining via captured `prev*` is safe.
+	 */
+	private attachTransportLifecycle(client: Client, key: string, logger?: McpCacheLogger): void {
+		const prevOnClose = client.onclose;
+		client.onclose = () => {
+			logger?.debug('McpClientsManager: transport closed, evicting cache entry', { cacheKey: key });
+			this.activeClients.delete(key);
+			try {
+				prevOnClose?.();
+			} catch (error) {
+				logger?.warn('McpClientsManager: chained onclose threw', { error });
+			}
+		};
+
+		const prevOnError = client.onerror;
+		client.onerror = (error: Error) => {
+			logger?.warn('McpClientsManager: transport error, evicting cache entry', {
+				cacheKey: key,
+				error,
+			});
+			this.activeClients.delete(key);
+			try {
+				prevOnError?.(error);
+			} catch (chained) {
+				logger?.warn('McpClientsManager: chained onerror threw', { error: chained });
+			}
+		};
+	}
+
+	shutdown(): void {
+		clearInterval(this.cleanupTimer);
+		for (const key of this.activeClients.keys()) {
+			this.remove(key);
+		}
+	}
+}

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/McpClientsManager.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/McpClientsManager.ts
@@ -54,10 +54,12 @@ export class McpClientsManager {
 
 	private cleanupTimer: NodeJS.Timeout;
 
+	private readonly exitHandler = () => this.shutdown();
+
 	constructor() {
 		this.cleanupTimer = setInterval(() => this.evictStale(), EVICTION_INTERVAL_MS);
 		this.cleanupTimer.unref();
-		process.on('exit', () => this.shutdown());
+		process.on('exit', this.exitHandler);
 	}
 
 	/** Test-only: total entries currently held. */
@@ -81,8 +83,6 @@ export class McpClientsManager {
 		factory: () => Promise<{ client: Client; mcpTools: McpTool[] }>,
 		opts: GetOrConnectOpts = {},
 	): Promise<{ client: Client; mcpTools: McpTool[] }> {
-		this.evictStale(opts.logger);
-
 		const cached = this.activeClients.get(key);
 		if (cached) {
 			opts.logger?.debug('McpClientsManager: cache hit', { cacheKey: key });
@@ -135,6 +135,7 @@ export class McpClientsManager {
 
 	/** Evict idle entries (TTL on lastUsedAt) and enforce max cache size. */
 	evictStale(logger?: McpCacheLogger): void {
+		if (this.activeClients.size === 0) return;
 		const now = Date.now();
 
 		let idleEvicted = 0;
@@ -201,7 +202,8 @@ export class McpClientsManager {
 
 	shutdown(): void {
 		clearInterval(this.cleanupTimer);
-		for (const key of this.activeClients.keys()) {
+		process.off('exit', this.exitHandler);
+		for (const key of [...this.activeClients.keys()]) {
 			this.remove(key);
 		}
 	}

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/__test__/McpClientsManager.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/__test__/McpClientsManager.test.ts
@@ -1,0 +1,197 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+import { McpClientsManager } from '../McpClientsManager';
+import type { McpTool } from '../types';
+
+const noopTools: McpTool[] = [];
+
+function makeMockClient(closeSpy: jest.Mock): Client {
+	let onCloseHandler: (() => void) | undefined;
+	let onErrorHandler: ((err: Error) => void) | undefined;
+	return {
+		close: closeSpy,
+		set onclose(handler: (() => void) | undefined) {
+			onCloseHandler = handler;
+		},
+		get onclose() {
+			return onCloseHandler as () => void;
+		},
+		set onerror(handler: ((err: Error) => void) | undefined) {
+			onErrorHandler = handler;
+		},
+		get onerror() {
+			return onErrorHandler as (err: Error) => void;
+		},
+	} as unknown as Client;
+}
+
+describe('McpClientsManager', () => {
+	let manager: McpClientsManager;
+
+	beforeEach(() => {
+		manager = new McpClientsManager();
+	});
+
+	afterEach(() => {
+		manager.shutdown();
+	});
+
+	describe('getOrConnect', () => {
+		it('caches client and returns same instance on second call', async () => {
+			const closeSpy = jest.fn().mockResolvedValue(undefined);
+			const client = makeMockClient(closeSpy);
+			const factory = jest.fn().mockResolvedValue({ client, mcpTools: noopTools });
+
+			const first = await manager.getOrConnect('key1', factory);
+			const second = await manager.getOrConnect('key1', factory);
+
+			expect(factory).toHaveBeenCalledTimes(1);
+			expect(first.client).toBe(second.client);
+			expect(manager.size).toBe(1);
+		});
+
+		it('dedupes concurrent cache misses for same key', async () => {
+			const closeSpy = jest.fn().mockResolvedValue(undefined);
+			const client = makeMockClient(closeSpy);
+			let resolveFactory: (value: { client: Client; mcpTools: McpTool[] }) => void;
+			const factory = jest.fn().mockImplementation(
+				async () =>
+					await new Promise((resolve) => {
+						resolveFactory = resolve;
+					}),
+			);
+
+			const p1 = manager.getOrConnect('key1', factory);
+			const p2 = manager.getOrConnect('key1', factory);
+
+			resolveFactory!({ client, mcpTools: noopTools });
+			const [r1, r2] = await Promise.all([p1, p2]);
+
+			expect(factory).toHaveBeenCalledTimes(1);
+			expect(r1.client).toBe(r2.client);
+		});
+
+		it('does not cache on factory rejection', async () => {
+			const factory = jest.fn().mockRejectedValue(new Error('fail'));
+
+			await expect(manager.getOrConnect('key1', factory)).rejects.toThrow('fail');
+			expect(manager.size).toBe(0);
+		});
+
+		it('registers cancellation handler that closes the client', async () => {
+			const closeSpy = jest.fn().mockResolvedValue(undefined);
+			const client = makeMockClient(closeSpy);
+			const factory = jest.fn().mockResolvedValue({ client, mcpTools: noopTools });
+			let cancelHandler: (() => void) | undefined;
+			const onExecutionCancellation = (handler: () => void) => {
+				cancelHandler = handler;
+			};
+
+			await manager.getOrConnect('key1', factory, { onExecutionCancellation });
+			expect(manager.size).toBe(1);
+
+			cancelHandler!();
+			expect(closeSpy).toHaveBeenCalledTimes(1);
+			expect(manager.size).toBe(0);
+		});
+	});
+
+	describe('evictStale', () => {
+		it('evicts entries older than TTL by lastUsedAt', () => {
+			const closeSpy = jest.fn().mockResolvedValue(undefined);
+			const recent = makeMockClient(closeSpy);
+			const old = makeMockClient(closeSpy);
+			const now = Date.now();
+
+			(manager as any).activeClients.set('old', {
+				client: old,
+				mcpTools: noopTools,
+				createdAt: now - 600_000,
+				lastUsedAt: now - 600_000,
+			});
+			(manager as any).activeClients.set('recent', {
+				client: recent,
+				mcpTools: noopTools,
+				createdAt: now - 600_000,
+				lastUsedAt: now - 1000,
+			});
+
+			manager.evictStale();
+
+			expect(manager.size).toBe(1);
+			expect(manager.getEntry('old')).toBeUndefined();
+			expect(manager.getEntry('recent')).toBeDefined();
+			expect(closeSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('enforces max cache size by evicting oldest entries', () => {
+			const closeSpy = jest.fn().mockResolvedValue(undefined);
+			const now = Date.now();
+
+			for (let i = 0; i < 502; i++) {
+				(manager as any).activeClients.set(`exec-${i}`, {
+					client: makeMockClient(closeSpy),
+					mcpTools: noopTools,
+					createdAt: now - 1000 + i,
+					lastUsedAt: now - 1000 + i,
+				});
+			}
+
+			expect(manager.size).toBe(502);
+			manager.evictStale();
+
+			expect(manager.size).toBe(500);
+			expect(manager.getEntry('exec-0')).toBeUndefined();
+			expect(manager.getEntry('exec-1')).toBeUndefined();
+			expect(manager.getEntry('exec-2')).toBeDefined();
+		});
+	});
+
+	describe('transport lifecycle', () => {
+		it('evicts cache entry when transport closes', async () => {
+			const closeSpy = jest.fn().mockResolvedValue(undefined);
+			const client = makeMockClient(closeSpy);
+			const factory = jest.fn().mockResolvedValue({ client, mcpTools: noopTools });
+
+			await manager.getOrConnect('key1', factory);
+			expect(manager.size).toBe(1);
+
+			(client as { onclose?: () => void }).onclose!();
+			expect(manager.size).toBe(0);
+		});
+
+		it('evicts cache entry when transport errors', async () => {
+			const closeSpy = jest.fn().mockResolvedValue(undefined);
+			const client = makeMockClient(closeSpy);
+			const factory = jest.fn().mockResolvedValue({ client, mcpTools: noopTools });
+
+			await manager.getOrConnect('key1', factory);
+			expect(manager.size).toBe(1);
+
+			(client as { onerror?: (err: Error) => void }).onerror!(new Error('transport down'));
+			expect(manager.size).toBe(0);
+		});
+	});
+
+	describe('shutdown', () => {
+		it('closes all cached clients', async () => {
+			const closeSpy = jest.fn().mockResolvedValue(undefined);
+			const client = makeMockClient(closeSpy);
+			const factory = jest.fn().mockResolvedValue({ client, mcpTools: noopTools });
+
+			await manager.getOrConnect('key1', factory);
+			await manager.getOrConnect(
+				'key2',
+				factory.mockResolvedValue({
+					client: makeMockClient(closeSpy),
+					mcpTools: noopTools,
+				}),
+			);
+			expect(manager.size).toBe(2);
+
+			manager.shutdown();
+			expect(manager.size).toBe(0);
+			expect(closeSpy).toHaveBeenCalledTimes(2);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

**Check plan in Linear**

Fixes a regression where Agent V3 MCP tool calls each create a fresh HTTP session, breaking stateful MCP servers (e.g. Playwright MCP).

**Root cause:** In Agent V3, each tool call dispatches `execute()` independently on the MCP Client Tool node, creating a new `connectMcpClient()` → new transport → new server session. In Agent V2, `supplyData()` was called once and tools shared a single connection.

**Fix:** Cache live MCP `Client` instances in a module-level `Map` keyed by `executionId:nodeName`. When `execute()` is called for a subsequent tool call within the same execution, the cached client (and its transport) is reused, keeping the server session alive.

Key details:
- Gated behind new node version **1.3** — existing v1.2 nodes keep current behavior
- Cleanup on execution cancellation via `getExecutionCancelSignal()` abort event
- TTL-based eviction (10 min) as a safety net against memory leaks
- Tool calls within an Agent V3 execution always stay on the same worker (EngineRequest is processed in the same execution loop), so a module-level cache works for all deployment modes including multi-main

### How to test

1. Create Agent V3 workflow with MCP Client Tool (v1.3) connected to a stateful MCP server (e.g. Playwright MCP)
2. Issue multiple sequential tool calls (e.g. `browser_navigate` → `browser_click`)
3. Verify the second tool call operates on the same browser context (not a fresh `about:blank` page)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4274
closes #21642

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)