### PR TITLE
fix(ci): use retain-on-failure for Playwright traces and videos

### DIFF
--- a/packages/testing/playwright/playwright.config.ts
+++ b/packages/testing/playwright/playwright.config.ts
@@ -97,9 +97,9 @@ export default defineConfig<CurrentsFixtures, CurrentsWorkerFixtures>({
 
 	use: {
 		baseURL: WEB_SERVER_URL,
-		trace: 'on',
-		video: 'on',
-		screenshot: 'on',
+		trace: IS_CI ? 'retain-on-failure' : 'on',
+		video: IS_CI ? 'retain-on-failure' : 'on',
+		screenshot: IS_CI ? 'only-on-failure' : 'on',
 		testIdAttribute: 'data-test-id',
 		headless: process.env.SHOW_BROWSER !== 'true',
 		viewport: MACBOOK_WINDOW_SIZE,


### PR DESCRIPTION
## Summary

- Switch Playwright trace, video, and screenshot capture from `'on'` to `'retain-on-failure'` / `'only-on-failure'` in CI
- Local dev keeps `'on'` for full debugging support

## Problem

The Playwright config at `packages/testing/playwright/playwright.config.ts` (lines 100-102) unconditionally records traces, videos, and screenshots for every test run. In CI, with 16 shards and 2 retries per test, this generates substantial I/O and artifact storage for passing tests that nobody inspects.

The `retain-on-failure` mode records artifacts during execution but only persists them when a test fails, which is the only case where they're needed for debugging.

## Fix

Changed the `use` block to conditionally apply `retain-on-failure` (trace/video) and `only-on-failure` (screenshot) when running in CI (`IS_CI` is already defined in the config). Local runs are unaffected.

```diff
-  trace: 'on',
-  video: 'on',
-  screenshot: 'on',
+  trace: IS_CI ? 'retain-on-failure' : 'on',
+  video: IS_CI ? 'retain-on-failure' : 'on',
+  screenshot: IS_CI ? 'only-on-failure' : 'on',
```

## Verification

1. E2E tests on this PR should pass with no behavior change for failing tests (artifacts still captured on failure).
2. Passing tests should produce fewer/no artifact files, reducing job I/O.
3. Compare E2E shard durations before and after to measure savings.

---

> [!NOTE]
> Created by [Mendral](https://mendral.com). Tag @mendral-agent with feedback or questions.