### PR TITLE
chore(n8n Node): Add insights summary endpoint to API coverage manifest (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -41,6 +41,9 @@
 		"GET /discover": {
 			"status": "gap"
 		},
+		"GET /insights/summary": {
+			"status": "gap"
+		},
 		"GET /executions": {
 			"status": "covered",
 			"nodeOperation": "execution:getAll"

--- a/packages/nodes-base/nodes/N8n/test/N8n.api-coverage.test.ts
+++ b/packages/nodes-base/nodes/N8n/test/N8n.api-coverage.test.ts
@@ -27,6 +27,8 @@ const MANIFEST_RELATIVE = 'packages/nodes-base/nodes/N8n/n8n-api-coverage.json';
 
 const HTTP_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete', 'head', 'options']);
 
+// This test reads OpenAPI files from packages/cli. Keep Turbo inputs for
+// n8n-nodes-base#test in sync (see turbo.json) so CLI spec changes invalidate cache.
 // Matches path entries in openapi.yml: "  /some/path:\n    $ref: './relative/file.yml'"
 const PATH_REF_PATTERN = /^ {2}(\/\S+):\s*\n\s+\$ref:\s*'([^']+)'/gm;
 

--- a/turbo.json
+++ b/turbo.json
@@ -26,6 +26,9 @@
 			"dependsOn": ["^build", "build"],
 			"outputs": ["coverage/**", "*.xml"]
 		},
+		"n8n-nodes-base#test": {
+			"inputs": ["$TURBO_DEFAULT$", "../cli/src/public-api/v1/**/*.yml"]
+		},
 		"test:unit": {
 			"dependsOn": ["^build", "build"],
 			"outputs": ["coverage/**", "*.xml"]


### PR DESCRIPTION
## Summary

Add missing insights summary endpoint to coverage manifest
This also fixes turbo invalidation for CLI and nodes-base packages being dependent on each other :)

https://www.loom.com/share/82cf2be1ca4a4800abe3985f46a75a80

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
