### PR TITLE
feat: Add `require-continue-on-fail` ESLint rule for community nodes (no-changelog)

### DIFF
--- a/packages/@n8n/eslint-plugin-community-nodes/README.md
+++ b/packages/@n8n/eslint-plugin-community-nodes/README.md
@@ -62,6 +62,7 @@ export default [
 | [node-usable-as-tool](docs/rules/node-usable-as-tool.md)                                 | Ensure node classes have usableAsTool property                                                                                              | ✅ ☑️ |      | 🔧 |    |
 | [options-sorted-alphabetically](docs/rules/options-sorted-alphabetically.md)             | Enforce alphabetical ordering of options arrays in n8n node properties                                                                      |      | ✅ ☑️ |    |    |
 | [package-name-convention](docs/rules/package-name-convention.md)                         | Enforce correct package naming convention for n8n community nodes                                                                           | ✅ ☑️ |      |    | 💡 |
+| [require-continue-on-fail](docs/rules/require-continue-on-fail.md)                       | Require continueOnFail() handling in execute() methods of node classes                                                                      | ✅ ☑️ |      |    |    |
 | [resource-operation-pattern](docs/rules/resource-operation-pattern.md)                   | Enforce proper resource/operation pattern for better UX in n8n nodes                                                                        |      | ✅ ☑️ |    |    |
 
 <!-- end auto-generated rules list -->

--- a/packages/@n8n/eslint-plugin-community-nodes/docs/rules/require-continue-on-fail.md
+++ b/packages/@n8n/eslint-plugin-community-nodes/docs/rules/require-continue-on-fail.md
@@ -1,0 +1,56 @@
+# Require continueOnFail() handling in execute() methods of node classes (`@n8n/community-nodes/require-continue-on-fail`)
+
+💼 This rule is enabled in the following configs: ✅ `recommended`, ☑️ `recommendedWithoutN8nCloudSupport`.
+
+<!-- end auto-generated rule header -->
+
+## Rule Details
+
+Ensures that `execute()` methods in node classes include a `this.continueOnFail()` check. Without this, a single item error will abort the entire workflow instead of allowing execution to continue past the failing item.
+
+## Examples
+
+### ❌ Incorrect
+
+```typescript
+export class MyNode implements INodeType {
+  description: INodeTypeDescription = { /* ... */ };
+
+  async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+    const items = this.getInputData();
+    const returnData: INodeExecutionData[] = [];
+    for (let i = 0; i < items.length; i++) {
+      // No error handling — one bad item kills the whole workflow
+      const result = await someApiCall(items[i]);
+      returnData.push({ json: result });
+    }
+    return [returnData];
+  }
+}
+```
+
+### ✅ Correct
+
+```typescript
+export class MyNode implements INodeType {
+  description: INodeTypeDescription = { /* ... */ };
+
+  async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+    const items = this.getInputData();
+    const returnData: INodeExecutionData[] = [];
+    for (let i = 0; i < items.length; i++) {
+      try {
+        const result = await someApiCall(items[i]);
+        returnData.push({ json: result });
+      } catch (error) {
+        if (this.continueOnFail()) {
+          returnData.push({ json: { error: error.message }, pairedItem: { item: i } });
+          continue;
+        }
+        throw error;
+      }
+    }
+    return [returnData];
+  }
+}
+```

--- a/packages/@n8n/eslint-plugin-community-nodes/src/plugin.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/plugin.ts
@@ -38,6 +38,7 @@ const configs = {
 			'@n8n/community-nodes/cred-class-field-icon-missing': 'error',
 			'@n8n/community-nodes/node-connection-type-literal': 'error',
 			'@n8n/community-nodes/missing-paired-item': 'error',
+			'@n8n/community-nodes/require-continue-on-fail': 'error',
 		},
 	},
 	recommendedWithoutN8nCloudSupport: {
@@ -62,6 +63,7 @@ const configs = {
 			'@n8n/community-nodes/cred-class-field-icon-missing': 'error',
 			'@n8n/community-nodes/node-connection-type-literal': 'error',
 			'@n8n/community-nodes/missing-paired-item': 'error',
+			'@n8n/community-nodes/require-continue-on-fail': 'error',
 		},
 	},
 } satisfies Record<string, Linter.Config>;

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/index.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/index.ts
@@ -17,6 +17,7 @@ import { NodeConnectionTypeLiteralRule } from './node-connection-type-literal.js
 import { NodeUsableAsToolRule } from './node-usable-as-tool.js';
 import { OptionsSortedAlphabeticallyRule } from './options-sorted-alphabetically.js';
 import { PackageNameConventionRule } from './package-name-convention.js';
+import { RequireContinueOnFailRule } from './require-continue-on-fail.js';
 import { ResourceOperationPatternRule } from './resource-operation-pattern.js';
 
 export const rules = {
@@ -38,4 +39,5 @@ export const rules = {
 	'cred-class-field-icon-missing': CredClassFieldIconMissingRule,
 	'node-connection-type-literal': NodeConnectionTypeLiteralRule,
 	'missing-paired-item': MissingPairedItemRule,
+	'require-continue-on-fail': RequireContinueOnFailRule,
 } satisfies Record<string, AnyRuleModule>;

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/require-continue-on-fail.test.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/require-continue-on-fail.test.ts
@@ -1,0 +1,129 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+import { RequireContinueOnFailRule } from './require-continue-on-fail.js';
+
+const ruleTester = new RuleTester();
+
+function createNodeWithExecute(executeBody: string): string {
+	return `
+import type { INodeType, INodeTypeDescription, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+
+export class TestNode implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Test Node',
+		name: 'testNode',
+		group: ['input'],
+		version: 1,
+		description: 'A test node',
+		defaults: { name: 'Test Node' },
+		inputs: ['main'],
+		outputs: ['main'],
+		properties: [],
+	};
+
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		${executeBody}
+	}
+}`;
+}
+
+ruleTester.run('require-continue-on-fail', RequireContinueOnFailRule, {
+	valid: [
+		{
+			name: 'node with continueOnFail in catch block',
+			code: createNodeWithExecute(`
+				const items = this.getInputData();
+				const returnData: INodeExecutionData[] = [];
+				for (let i = 0; i < items.length; i++) {
+					try {
+						returnData.push({ json: { result: true } });
+					} catch (error) {
+						if (this.continueOnFail()) {
+							returnData.push({ json: { error: error.message } });
+							continue;
+						}
+						throw error;
+					}
+				}
+				return [returnData];
+			`),
+		},
+		{
+			name: 'non-node class with execute method (should be ignored)',
+			code: `
+export class RegularClass {
+	async execute() {
+		return [[]];
+	}
+}`,
+		},
+		{
+			name: 'node class without execute method (should be ignored)',
+			code: `
+import type { INodeType, INodeTypeDescription } from 'n8n-workflow';
+
+export class TestNode implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Test Node',
+		name: 'testNode',
+		group: ['input'],
+		version: 1,
+		description: 'A test node',
+		defaults: { name: 'Test Node' },
+		inputs: ['main'],
+		outputs: ['main'],
+		properties: [],
+	};
+}`,
+		},
+		{
+			name: 'node extending Node base class with continueOnFail',
+			code: `
+import { Node } from 'n8n-workflow';
+
+export class TestNode extends Node {
+	async execute() {
+		try {
+			// do work
+		} catch (error) {
+			if (this.continueOnFail()) {
+				return [[]];
+			}
+			throw error;
+		}
+		return [[]];
+	}
+}`,
+		},
+	],
+	invalid: [
+		{
+			name: 'node with execute but no continueOnFail',
+			code: createNodeWithExecute(`
+				const items = this.getInputData();
+				const returnData: INodeExecutionData[] = [];
+				for (let i = 0; i < items.length; i++) {
+					returnData.push({ json: { result: true } });
+				}
+				return [returnData];
+			`),
+			errors: [{ messageId: 'missingContinueOnFail' }],
+		},
+		{
+			name: 'node with try/catch but no continueOnFail check',
+			code: createNodeWithExecute(`
+				const items = this.getInputData();
+				const returnData: INodeExecutionData[] = [];
+				for (let i = 0; i < items.length; i++) {
+					try {
+						returnData.push({ json: { result: true } });
+					} catch (error) {
+						throw error;
+					}
+				}
+				return [returnData];
+			`),
+			errors: [{ messageId: 'missingContinueOnFail' }],
+		},
+	],
+});

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/require-continue-on-fail.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/require-continue-on-fail.ts
@@ -1,0 +1,88 @@
+import { AST_NODE_TYPES, type TSESTree } from '@typescript-eslint/utils';
+
+import { isNodeTypeClass } from '../utils/index.js';
+import { createRule } from '../utils/rule-creator.js';
+
+/** Keys that are not child AST nodes (back-references, metadata). */
+const NON_CHILD_KEYS = new Set(['parent', 'loc', 'range', 'start', 'end', 'tokens', 'comments']);
+
+/**
+ * Recursively checks whether any descendant of the given AST node is a
+ * `this.continueOnFail()` call expression.
+ */
+function containsContinueOnFailCall(node: TSESTree.Node): boolean {
+	if (
+		node.type === AST_NODE_TYPES.CallExpression &&
+		node.callee.type === AST_NODE_TYPES.MemberExpression &&
+		node.callee.object.type === AST_NODE_TYPES.ThisExpression &&
+		node.callee.property.type === AST_NODE_TYPES.Identifier &&
+		node.callee.property.name === 'continueOnFail'
+	) {
+		return true;
+	}
+
+	for (const key of Object.keys(node)) {
+		if (NON_CHILD_KEYS.has(key)) continue;
+
+		const value = (node as unknown as Record<string, unknown>)[key];
+
+		if (Array.isArray(value)) {
+			for (const child of value) {
+				if (child && typeof child === 'object' && 'type' in child) {
+					if (containsContinueOnFailCall(child as TSESTree.Node)) {
+						return true;
+					}
+				}
+			}
+		} else if (value && typeof value === 'object' && 'type' in value) {
+			if (containsContinueOnFailCall(value as TSESTree.Node)) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+export const RequireContinueOnFailRule = createRule({
+	name: 'require-continue-on-fail',
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Require continueOnFail() handling in execute() methods of node classes',
+		},
+		messages: {
+			missingContinueOnFail:
+				'execute() method must handle this.continueOnFail() for proper error handling. ' +
+				'Wrap item processing in a try/catch and check this.continueOnFail() in the catch block.',
+		},
+		schema: [],
+	},
+	defaultOptions: [],
+	create(context) {
+		return {
+			ClassDeclaration(node) {
+				if (!isNodeTypeClass(node)) {
+					return;
+				}
+
+				for (const member of node.body.body) {
+					if (
+						member.type !== AST_NODE_TYPES.MethodDefinition ||
+						member.key.type !== AST_NODE_TYPES.Identifier ||
+						member.key.name !== 'execute'
+					) {
+						continue;
+					}
+
+					if (member.value.body && !containsContinueOnFailCall(member.value.body)) {
+						context.report({
+							node: member.key,
+							messageId: 'missingContinueOnFail',
+						});
+					}
+				}
+			},
+		};
+	},
+});

--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -216,9 +216,6 @@
 		},
 		"PATCH /projects/{projectId}/users/{userId}": {
 			"status": "gap"
-		},
-		"GET /insights/summary": {
-			"status": "gap"
 		}
 	}
 }

--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -216,6 +216,9 @@
 		},
 		"PATCH /projects/{projectId}/users/{userId}": {
 			"status": "gap"
+		},
+		"GET /insights/summary": {
+			"status": "gap"
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Add a new ESLint rule `require-continue-on-fail` to `@n8n/eslint-plugin-community-nodes` that ensures `execute()` methods in node classes include a `this.continueOnFail()` check.

Without this check, a single item error aborts the entire workflow instead of allowing execution to continue past the failing item. This was flagged as CRITICAL severity in a real community node review (CNOC-59).

**What the rule does:**
- Visits `ClassDeclaration` nodes that implement `INodeType` (or extend `Node`)
- Finds `execute()` methods on those classes
- Reports an error if `this.continueOnFail()` is not called anywhere in the method body
- Not auto-fixable (try/catch pattern is too varied to auto-insert)

**Files added/modified:**
- `require-continue-on-fail.ts` — rule implementation
- `require-continue-on-fail.test.ts` — 6 tests (4 valid, 2 invalid)
- `index.ts` — rule registration
- `plugin.ts` — added to `recommended` and `recommendedWithoutN8nCloudSupport` configs as `error`
- `docs/rules/require-continue-on-fail.md` — rule documentation
- `README.md` — auto-updated rules table

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CE-739

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.