### PR TITLE
ci: Run test:local on community PR's

### DIFF
--- a/.github/workflows/test-e2e-ci-reusable.yml
+++ b/.github/workflows/test-e2e-ci-reusable.yml
@@ -144,7 +144,7 @@ jobs:
     with:
       branch: ${{ inputs.branch }}
       test-mode: local
-      test-command: pnpm --filter=n8n-playwright test:local:e2e-only
+      test-command: pnpm --filter=n8n-playwright test:local
       shards: 7
       runner: ubuntu-latest
       workers: '1'


### PR DESCRIPTION
## Summary

[A previous PR](https://github.com/n8n-io/n8n/pull/24962/changes#diff-c31bf53740e93c047301d7add64686430a3bd7bf41efd5307fd9536313002cddL8) cleaned up the scripts in `n8n-playwright`, but we still left the Community PR test suite to run on a removed npm script. 

Now uses `test:local` instead of the removed `test:local:e2e-only`. Contents are the same.

`N8N_BASE_URL=http://localhost:5680 RESET_E2E_DB=true playwright test --project=e2e`

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
