### PR TITLE
fix(core): Align VM expression engine error handler with legacy engine

### DIFF
--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -377,58 +377,34 @@ describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
 
 	it('should handle throw null without crashing', () => {
 		const data = { $json: {} };
-		let error: Error | undefined;
-		try {
-			evaluator.evaluate('{{ (() => { throw null })() }}', data, caller);
-		} catch (e) {
-			error = e as Error;
-		}
-		expect(error).toBeDefined();
-		expect(error?.message).not.toContain('Cannot read properties');
+		expect(evaluator.evaluate('{{ (() => { throw null })() }}', data, caller)).toBeUndefined();
 	});
 
 	it('should handle throw undefined without crashing', () => {
 		const data = { $json: {} };
-		let error: Error | undefined;
-		try {
-			evaluator.evaluate('{{ (() => { throw undefined })() }}', data, caller);
-		} catch (e) {
-			error = e as Error;
-		}
-		expect(error).toBeDefined();
-		expect(error?.message).not.toContain('Cannot read properties');
+		expect(evaluator.evaluate('{{ (() => { throw undefined })() }}', data, caller)).toBeUndefined();
 	});
 
 	it('should handle throw of null-prototype object with properties without crashing', () => {
 		const data = { $json: {} };
-		let error: Error | undefined;
-		try {
+		expect(
 			evaluator.evaluate(
 				'{{ (() => { var e = Object.create(null); e.foo = "bar"; throw e; })() }}',
 				data,
 				caller,
-			);
-		} catch (e) {
-			error = e as Error;
-		}
-		expect(error).toBeDefined();
-		expect(error?.message).not.toContain('hasOwnProperty is not a function');
+			),
+		).toBeUndefined();
 	});
 
 	it('should handle throw of object with hasOwnProperty shadowed by null without crashing', () => {
 		const data = { $json: {} };
-		let error: Error | undefined;
-		try {
+		expect(
 			evaluator.evaluate(
 				'{{ (() => { throw { hasOwnProperty: null, foo: "bar" }; })() }}',
 				data,
 				caller,
-			);
-		} catch (e) {
-			error = e as Error;
-		}
-		expect(error).toBeDefined();
-		expect(error?.message).not.toContain('hasOwnProperty is not a function');
+			),
+		).toBeUndefined();
 	});
 
 	it('should swallow TypeError and return undefined', () => {
@@ -445,19 +421,31 @@ describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
 		expect(result).toBeUndefined();
 	});
 
-	it('should propagate errors thrown when reading a property across the isolate boundary', () => {
+	it('should re-throw ExpressionError from host-side callbacks', () => {
+		const json = {
+			get brokenProp() {
+				const err = new Error('paired item failed');
+				err.name = 'ExpressionError';
+				throw err;
+			},
+		};
+
+		expect(() => evaluator.evaluate('{{ $json.brokenProp }}', { $json: json }, caller)).toThrow(
+			expect.objectContaining({ name: 'ExpressionError', message: 'paired item failed' }),
+		);
+	});
+
+	it('should swallow generic errors thrown when reading a property across the isolate boundary', () => {
 		const json = {
 			get brokenProp() {
 				throw new Error('property access failed');
 			},
 		};
 
-		expect(() => evaluator.evaluate('{{ $json.brokenProp }}', { $json: json }, caller)).toThrow(
-			'property access failed',
-		);
+		expect(evaluator.evaluate('{{ $json.brokenProp }}', { $json: json }, caller)).toBeUndefined();
 	});
 
-	it('should propagate errors thrown by functions accessed via the lazy proxy', () => {
+	it('should swallow generic errors thrown by functions accessed via the lazy proxy', () => {
 		const data = {
 			$json: {
 				myFn() {
@@ -466,22 +454,20 @@ describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
 			},
 		};
 
-		expect(() => evaluator.evaluate('{{ $json.myFn() }}', data, caller)).toThrow('function threw');
+		expect(evaluator.evaluate('{{ $json.myFn() }}', data, caller)).toBeUndefined();
 	});
 
-	it('should propagate errors from $items() when result properties are accessed', () => {
+	it('should swallow generic errors from $items() when result properties are accessed', () => {
 		const data = {
 			$items() {
 				throw new Error('items failed');
 			},
 		};
 
-		// Without throwIfErrorSentinel in the $items wrapper, the sentinel is
-		// returned as a value and .length reads undefined on it — silently swallowed
-		expect(() => evaluator.evaluate('{{ $items().length }}', data, caller)).toThrow('items failed');
+		expect(evaluator.evaluate('{{ $items().length }}', data, caller)).toBeUndefined();
 	});
 
-	it('should propagate errors thrown during array element access across the isolate boundary', () => {
+	it('should swallow generic errors thrown during array element access across the isolate boundary', () => {
 		const items = [1, 2, 3];
 		Object.defineProperty(items, '0', {
 			get() {
@@ -493,12 +479,10 @@ describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
 
 		const data = { $json: { items } };
 
-		expect(() => evaluator.evaluate('{{ $json.items[0] }}', data, caller)).toThrow(
-			'element access failed',
-		);
+		expect(evaluator.evaluate('{{ $json.items[0] }}', data, caller)).toBeUndefined();
 	});
 
-	it('should propagate errors thrown during an "in" operator check across the isolate boundary', () => {
+	it('should swallow generic errors thrown during an "in" operator check across the isolate boundary', () => {
 		const json = {
 			get brokenProp() {
 				throw new Error('in-check access failed');
@@ -507,11 +491,9 @@ describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
 
 		// The 'in' operator triggers the has trap on $json proxy.
 		// The bridge calls __getValueAtPath(['$json', 'brokenProp']) which throws.
-		// Without throwIfErrorSentinel in the has trap, the sentinel is returned
-		// as a non-undefined value so 'brokenProp' in $json incorrectly returns true.
-		expect(() =>
+		expect(
 			evaluator.evaluate('{{ "brokenProp" in $json }}', { $json: json }, caller),
-		).toThrow('in-check access failed');
+		).toBeUndefined();
 	});
 });
 

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -435,6 +435,23 @@ describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
 		);
 	});
 
+	it('should re-throw ExpressionExtensionError from host-side callbacks', () => {
+		const json = {
+			get brokenProp() {
+				const err = new Error('extension failed');
+				err.name = 'ExpressionExtensionError';
+				throw err;
+			},
+		};
+
+		expect(() => evaluator.evaluate('{{ $json.brokenProp }}', { $json: json }, caller)).toThrow(
+			expect.objectContaining({
+				name: 'ExpressionExtensionError',
+				message: 'extension failed',
+			}),
+		);
+	});
+
 	it('should swallow generic errors thrown when reading a property across the isolate boundary', () => {
 		const json = {
 			get brokenProp() {

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -252,11 +252,18 @@ export class IsolatedVmBridge implements RuntimeBridge {
 	/**
 	 * Inject the E() error handler into the isolate context.
 	 *
-	 * Tournament wraps expressions with try-catch that calls E(error, this).
-	 * This handler must match the legacy engine's behavior (set in
-	 * expression.ts via setErrorHandler):
-	 * - Re-throw ExpressionError / ExpressionExtensionError
-	 * - Swallow everything else (TypeErrors, generic Errors, etc.)
+	 * There are two exception-handling layers inside the isolate:
+	 *
+	 * 1. **Inner layer (this handler, `E()`)** — Tournament wraps each
+	 *    expression with try-catch that calls `E(error, this)`. This handler
+	 *    must match the legacy engine's behavior (set in expression.ts via
+	 *    setErrorHandler):
+	 *    - Re-throw ExpressionError / ExpressionExtensionError
+	 *    - Swallow everything else (TypeErrors, generic Errors, etc.)
+	 *
+	 * 2. **Outer layer (`wrappedCode` try-catch in `execute()`)** — Catches
+	 *    anything that escaped `E()` (e.g. re-thrown ExpressionErrors) and
+	 *    serializes it into a sentinel object so the host can reconstruct it.
 	 *
 	 * Inside the isolate, errors from host callbacks arrive as sentinel
 	 * objects ({ __isError, name, message, ... }) rather than class instances,

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -256,7 +256,6 @@ export class IsolatedVmBridge implements RuntimeBridge {
 	 * This handler must match the legacy engine's behavior (set in
 	 * expression.ts via setErrorHandler):
 	 * - Re-throw ExpressionError / ExpressionExtensionError
-	 * - Re-throw security violations from __sanitize
 	 * - Swallow everything else (TypeErrors, generic Errors, etc.)
 	 *
 	 * Inside the isolate, errors from host callbacks arrive as sentinel
@@ -274,14 +273,10 @@ export class IsolatedVmBridge implements RuntimeBridge {
 		await this.context.eval(`
 			if (typeof E === 'undefined') {
 				globalThis.E = function(error, _context) {
-					// Re-throw security violations from __sanitize
-					if (error && error.message && error.message.includes('due to security concerns')) {
-						throw error;
-					}
 					// Re-throw ExpressionError / ExpressionExtensionError to match
 					// the legacy handler in expression.ts. Errors from host callbacks
 					// arrive as sentinels (not class instances), so check by name.
-					var name = error && error.name;
+					const name = error?.name;
 					if (name === 'ExpressionError' || name === 'ExpressionExtensionError') {
 						throw error;
 					}

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -253,10 +253,15 @@ export class IsolatedVmBridge implements RuntimeBridge {
 	 * Inject the E() error handler into the isolate context.
 	 *
 	 * Tournament wraps expressions with try-catch that calls E(error, this).
-	 * This handler:
-	 * - Re-throws security violations from __sanitize
-	 * - Swallows TypeErrors (failed attack attempts return undefined)
-	 * - Re-throws all other errors
+	 * This handler must match the legacy engine's behavior (set in
+	 * expression.ts via setErrorHandler):
+	 * - Re-throw ExpressionError / ExpressionExtensionError
+	 * - Re-throw security violations from __sanitize
+	 * - Swallow everything else (TypeErrors, generic Errors, etc.)
+	 *
+	 * Inside the isolate, errors from host callbacks arrive as sentinel
+	 * objects ({ __isError, name, message, ... }) rather than class instances,
+	 * so we match by name instead of instanceof.
 	 *
 	 * @private
 	 * @throws {Error} If context not initialized
@@ -273,11 +278,15 @@ export class IsolatedVmBridge implements RuntimeBridge {
 					if (error && error.message && error.message.includes('due to security concerns')) {
 						throw error;
 					}
-					// Swallow TypeErrors (failed attack attempts return undefined)
-					if (error instanceof TypeError) {
-						return undefined;
+					// Re-throw ExpressionError / ExpressionExtensionError to match
+					// the legacy handler in expression.ts. Errors from host callbacks
+					// arrive as sentinels (not class instances), so check by name.
+					var name = error && error.name;
+					if (name === 'ExpressionError' || name === 'ExpressionExtensionError') {
+						throw error;
 					}
-					throw error;
+					// Swallow everything else (TypeErrors, generic Errors, etc.)
+					return undefined;
 				};
 			}
 		`);

--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -190,6 +190,9 @@
 		"DELETE /data-tables/{dataTableId}/rows/delete": {
 			"status": "gap"
 		},
+		"GET /insights/summary": {
+			"status": "gap"
+		},
 		"POST /projects": {
 			"status": "gap"
 		},

--- a/packages/workflow/test/expression.test.ts
+++ b/packages/workflow/test/expression.test.ts
@@ -935,7 +935,7 @@ describe('Expression', () => {
 				nodes: [
 					{
 						id: 'source-id',
-						name: 'Source',
+						name: 'source',
 						type: 'n8n-nodes-base.set',
 						typeVersion: 1,
 						position: [0, 0],
@@ -943,7 +943,7 @@ describe('Expression', () => {
 					},
 					{
 						id: 'consumer-id',
-						name: 'Consumer',
+						name: 'consumer',
 						type: 'n8n-nodes-base.set',
 						typeVersion: 1,
 						position: [200, 0],
@@ -951,7 +951,7 @@ describe('Expression', () => {
 					},
 				],
 				connections: connected
-					? { Source: { main: [[{ node: 'Consumer', type: 'main' as any, index: 0 }]] } }
+					? { source: { main: [[{ node: 'consumer', type: 'main', index: 0 }]] } }
 					: {},
 				active: false,
 				nodeTypes,
@@ -961,7 +961,7 @@ describe('Expression', () => {
 		const runExecutionData = createRunExecutionData({
 			resultData: {
 				runData: {
-					Source: [
+					source: [
 						{
 							startTime: 1,
 							executionTime: 1,
@@ -976,25 +976,25 @@ describe('Expression', () => {
 			},
 		});
 
-		it("should resolve $('Source').item.json.city", async () => {
+		it("should resolve $('source').item.json.city", async () => {
 			const testWorkflow = createTestWorkflow(true);
 
 			await testWorkflow.expression.acquireIsolate();
 			try {
 				const result = testWorkflow.expression.getParameterValue(
-					"={{ $('Source').item.json.city }}",
+					"={{ $('source').item.json.city }}",
 					runExecutionData,
 					0,
 					0,
-					'Consumer',
+					'consumer',
 					[{ json: { city: 'Prague' }, pairedItem: { item: 0 } }],
 					'manual',
 					{},
 					{
-						node: testWorkflow.getNode('Consumer')!,
+						node: testWorkflow.getNode('consumer')!,
 						data: {},
 						source: {
-							main: [{ previousNode: 'Source', previousNodeOutput: 0, previousNodeRun: 0 }],
+							main: [{ previousNode: 'source', previousNodeOutput: 0, previousNodeRun: 0 }],
 						},
 					},
 				);
@@ -1012,11 +1012,11 @@ describe('Expression', () => {
 			try {
 				expect(() =>
 					testWorkflow.expression.getParameterValue(
-						"={{ $('Source').item.json.city }}",
+						"={{ $('source').item.json.city }}",
 						runExecutionData,
 						0,
 						0,
-						'Consumer',
+						'consumer',
 						[{ json: {} }],
 						'manual',
 						{},

--- a/packages/workflow/test/expression.test.ts
+++ b/packages/workflow/test/expression.test.ts
@@ -10,6 +10,7 @@ import { ExpressionReservedVariableError } from '../src/errors/expression-reserv
 import { ExpressionError } from '../src/errors/expression.error';
 import { Expression } from '../src/expression';
 import { extendSyntax } from '../src/extensions/expression-extension';
+import { createRunExecutionData } from '../src';
 import type { INodeExecutionData } from '../src/interfaces';
 import { Workflow } from '../src/workflow';
 import { WorkflowDataProxy } from '../src/workflow-data-proxy';
@@ -921,6 +922,109 @@ describe('Expression', () => {
 			);
 			expect(expression.resolveSimpleParameterValue(123, data, false)).toBe(123);
 			expect(expression.resolveSimpleParameterValue(true, data, false)).toBe(true);
+		});
+	});
+
+	describe('$() node reference through expression engine', () => {
+		const nodeTypes = Helpers.NodeTypes();
+
+		function createTestWorkflow(connected: boolean) {
+			return new Workflow({
+				id: 'test-dollar-ref',
+				name: 'Test',
+				nodes: [
+					{
+						id: 'source-id',
+						name: 'Source',
+						type: 'n8n-nodes-base.set',
+						typeVersion: 1,
+						position: [0, 0],
+						parameters: {},
+					},
+					{
+						id: 'consumer-id',
+						name: 'Consumer',
+						type: 'n8n-nodes-base.set',
+						typeVersion: 1,
+						position: [200, 0],
+						parameters: {},
+					},
+				],
+				connections: connected
+					? { Source: { main: [[{ node: 'Consumer', type: 'main' as any, index: 0 }]] } }
+					: {},
+				active: false,
+				nodeTypes,
+			});
+		}
+
+		const runExecutionData = createRunExecutionData({
+			resultData: {
+				runData: {
+					Source: [
+						{
+							startTime: 1,
+							executionTime: 1,
+							executionIndex: 0,
+							source: [],
+							data: {
+								main: [[{ json: { city: 'Prague' }, pairedItem: { item: 0 } }]],
+							},
+						},
+					],
+				},
+			},
+		});
+
+		it("should resolve $('Source').item.json.city", async () => {
+			const testWorkflow = createTestWorkflow(true);
+
+			await testWorkflow.expression.acquireIsolate();
+			try {
+				const result = testWorkflow.expression.getParameterValue(
+					"={{ $('Source').item.json.city }}",
+					runExecutionData,
+					0,
+					0,
+					'Consumer',
+					[{ json: { city: 'Prague' }, pairedItem: { item: 0 } }],
+					'manual',
+					{},
+					{
+						node: testWorkflow.getNode('Consumer')!,
+						data: {},
+						source: {
+							main: [{ previousNode: 'Source', previousNodeOutput: 0, previousNodeRun: 0 }],
+						},
+					},
+				);
+
+				expect(result).toBe('Prague');
+			} finally {
+				await testWorkflow.expression.releaseIsolate();
+			}
+		});
+
+		it('should throw ExpressionError when nodes are not connected', async () => {
+			const testWorkflow = createTestWorkflow(false);
+
+			await testWorkflow.expression.acquireIsolate();
+			try {
+				expect(() =>
+					testWorkflow.expression.getParameterValue(
+						"={{ $('Source').item.json.city }}",
+						runExecutionData,
+						0,
+						0,
+						'Consumer',
+						[{ json: {} }],
+						'manual',
+						{},
+					),
+				).toThrow(ExpressionError);
+			} finally {
+				await testWorkflow.expression.releaseIsolate();
+			}
 		});
 	});
 


### PR DESCRIPTION
## Summary

The new expression engine's `tournament` error handler `E()` had different behavior than the legacy engine, causing many tests in the [VM expression E2E nightly job](https://github.com/n8n-io/n8n/actions/runs/24118384091) to fail.

For context, `tournament` wraps every expression with `try { return ...; } catch(e) { E(e, this); }`. The legacy `E()` handler (set via `setErrorHandler` in `expression.ts`) re-throws `ExpressionError` and `ExpressionExtensionError` and silently swallows everything else. The VM `E()` handler was re-throwing all non-`TypeError` errors, causing expressions that fail during paired-item resolution to crash in VM mode, where those silently return `undefined` in legacy mode.

Importantly, this means that paired-item resolution in this context (sub-nodes referencing main-flow nodes across AI connections) is apparently not supported. The legacy engine masks this by swallowing the error. Unclear if this is intentionally unsupported or an oversight.

> [!note]
> This fixes [many but not all](https://github.com/n8n-io/n8n/actions/runs/24128951449/job/70401107284) e2e issues.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2775

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
