### PR TITLE
fix(core): Avoid markdown in instance AI titles (no-changelog)

### DIFF
--- a/packages/@n8n/agents/src/runtime/title-generation.ts
+++ b/packages/@n8n/agents/src/runtime/title-generation.ts
@@ -10,10 +10,11 @@ const logger = createFilteredLogger();
 
 const DEFAULT_TITLE_INSTRUCTIONS = [
 	'- you will generate a short title based on the first message a user begins a conversation with',
-	'- ensure it is not more than 80 characters long',
 	"- the title should be a summary of the user's message",
-	'- do not use quotes or colons',
-	'- the entire text you return will be used as the title',
+	'- 1 to 5 words, no more than 80 characters',
+	'- use sentence case (e.g. "Conversation title" instead of "Conversation Title")',
+	'- do not use quotes, colons, or markdown formatting',
+	'- the entire text you return will be used directly as the title, so respond with the title only',
 ].join('\n');
 
 /**
@@ -63,6 +64,13 @@ export async function generateThreadTitle(opts: {
 
 		// Strip <think>...</think> blocks (e.g. from DeepSeek R1)
 		title = title.replace(/<think>[\s\S]*?<\/think>/g, '').trim();
+		if (!title) return;
+
+		// Strip markdown heading prefixes and inline formatting
+		title = title
+			.replace(/^#{1,6}\s+/, '')
+			.replace(/\*+/g, '')
+			.trim();
 		if (!title) return;
 
 		await opts.memory.saveThread({


### PR DESCRIPTION
## Summary

Avoid titles like `# Lorem Ipsum *dolor sit* amet` -> `Lorem ipsum dolor sit amet` with both a bit more accurate system prompt & sanitization just in case something slips through.

## Related Linear tickets, Github issues, and Community forum posts

https://www.notion.so/n8n/aef5b6e0c94f82159cc58164aa417607?v=7965b6e0c94f823c918f88516500cb86&p=3345b6e0c94f80d7a4aede7bf06b8fbb&pm=s

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
