### PR TITLE
chore: Add new entries to .gitignore (no-changelog)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,5 +58,8 @@ packages/cli/src/commands/export/outputs
 .claude/settings.local.json
 .claude/plans/
 .cursor/plans/
+.superset
+.conductor
+.n8n
 lefthook-local.yml
 .playwright-mcp


### PR DESCRIPTION
Exclude Superset and Conductor folders, also exclude .n8n in case it's created inside the worktree root for testing.
