### PR TITLE
test: Add simple baseline instance AI memory test

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -249,5 +249,5 @@ jobs:
     if: always()
     uses: ./.github/workflows/util-qa-metrics-comment-reusable.yml
     with:
-      metrics: memory-heap-used-baseline,docker-image-size-n8n,docker-image-size-runners
+      metrics: memory-heap-used-baseline,memory-rss-baseline,instance-ai-heap-used-baseline,instance-ai-rss-baseline,docker-image-size-n8n,docker-image-size-runners
     secrets: inherit

--- a/packages/testing/playwright/tests/performance/memory-consumption-instance-ai.spec.ts
+++ b/packages/testing/playwright/tests/performance/memory-consumption-instance-ai.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '../../fixtures/base';
+import { attachMetric, getStableHeap } from '../../utils/performance-helper';
+
+test.use({
+	capability: {
+		resourceQuota: { memory: 0.75, cpu: 0.5 },
+		services: ['victoriaLogs', 'victoriaMetrics', 'vector'],
+		env: {
+			N8N_ENABLED_MODULES: 'instance-ai',
+			N8N_INSTANCE_AI_MODEL: 'anthropic/claude-sonnet-4-6',
+			N8N_INSTANCE_AI_MODEL_API_KEY: 'fake-key',
+		},
+	},
+});
+
+test.describe(
+	'Instance AI Memory Consumption @capability:observability',
+	{
+		annotation: [{ type: 'owner', description: 'Catalysts' }],
+	},
+	() => {
+		test('Idle baseline with Instance AI module loaded', async ({
+			n8nContainer,
+			services,
+		}, testInfo) => {
+			const obs = services.observability;
+
+			const result = await getStableHeap(n8nContainer.baseUrl, obs.metrics);
+
+			await attachMetric(testInfo, 'instance-ai-heap-used-baseline', result.heapUsedMB, 'MB');
+			await attachMetric(testInfo, 'instance-ai-heap-total-baseline', result.heapTotalMB, 'MB');
+			await attachMetric(testInfo, 'instance-ai-rss-baseline', result.rssMB, 'MB');
+			await attachMetric(testInfo, 'instance-ai-pss-baseline', result.pssMB ?? 0, 'MB');
+			await attachMetric(
+				testInfo,
+				'instance-ai-non-heap-overhead-baseline',
+				result.nonHeapOverheadMB,
+				'MB',
+			);
+
+			expect(result.heapUsedMB).toBeGreaterThan(0);
+			expect(result.heapTotalMB).toBeGreaterThan(0);
+			expect(result.rssMB).toBeGreaterThan(0);
+
+			console.log(
+				`[INSTANCE AI IDLE] Heap used: ${result.heapUsedMB.toFixed(1)} MB | ` +
+					`Heap total: ${result.heapTotalMB.toFixed(1)} MB | ` +
+					`RSS: ${result.rssMB.toFixed(1)} MB | ` +
+					`Non-heap overhead: ${result.nonHeapOverheadMB.toFixed(1)} MB`,
+			);
+		});
+	},
+);


### PR DESCRIPTION
## Summary

Introduces a Playwright performance test to measure the idle memory consumption of the Instance AI module. This establishes a baseline for its resource usage (heap, RSS, PSS) and integrates these metrics into CI for ongoing monitoring.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
