### PR TITLE
test: Fix flaky e2e tests in CI shards 2, 5, and 7 (no-changelog)

### DIFF
--- a/packages/testing/playwright/tests/e2e/node-creator/categories.spec.ts
+++ b/packages/testing/playwright/tests/e2e/node-creator/categories.spec.ts
@@ -1,6 +1,8 @@
 import { MANUAL_TRIGGER_NODE_DISPLAY_NAME } from '../../../config/constants';
 import { test, expect } from '../../../fixtures/base';
 
+test.use({ capability: { env: { TEST_ISOLATION: 'node-creator-categories' } } });
+
 test.describe(
 	'Node Creator Categories',
 	{

--- a/packages/testing/playwright/tests/e2e/sentry/sentry-baseline.spec.ts
+++ b/packages/testing/playwright/tests/e2e/sentry/sentry-baseline.spec.ts
@@ -7,7 +7,7 @@ test.beforeEach(async ({ n8nContainer }) => {
 });
 
 test.describe(
-	'Sentry baseline',
+	'Sentry baseline @capability:kent',
 	{
 		annotation: [{ type: 'owner', description: 'Catalysts' }],
 	},

--- a/packages/testing/playwright/tests/e2e/workflows/editor/execution/logs.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/execution/logs.spec.ts
@@ -39,7 +39,6 @@ test.describe(
 				n8n.canvas.logsPanel.getOverviewStatus().filter({ hasText: 'Running' }),
 			).toBeVisible();
 
-			await expect(n8n.canvas.logsPanel.getLogEntries()).toHaveCount(4);
 			await expect(n8n.canvas.logsPanel.getLogEntries().nth(0)).toContainText(NODES.MANUAL_TRIGGER);
 			await expect(n8n.canvas.logsPanel.getLogEntries().nth(1)).toContainText(NODES.CODE);
 			await expect(n8n.canvas.logsPanel.getLogEntries().nth(2)).toContainText(
@@ -47,13 +46,11 @@ test.describe(
 			);
 			await expect(n8n.canvas.logsPanel.getLogEntries().nth(3)).toContainText(NODES.WAIT);
 
-			await expect(n8n.canvas.logsPanel.getLogEntries()).toHaveCount(6);
 			await expect(n8n.canvas.logsPanel.getLogEntries().nth(4)).toContainText(
 				NODES.LOOP_OVER_ITEMS,
 			);
 			await expect(n8n.canvas.logsPanel.getLogEntries().nth(5)).toContainText(NODES.WAIT);
 
-			await expect(n8n.canvas.logsPanel.getLogEntries()).toHaveCount(8);
 			await expect(n8n.canvas.logsPanel.getLogEntries().nth(6)).toContainText(
 				NODES.LOOP_OVER_ITEMS,
 			);


### PR DESCRIPTION
## Summary

Fixes 3 flaky e2e test failures observed in PR #27793 CI:

- **Shard 2 — Activation callout not found** (`categories.spec.ts`): Added `TEST_ISOLATION` worker isolation so the file gets a fresh DB where no user has been activated by other tests.
- **Shard 5 — Brittle intermediate log counts** (`logs.spec.ts`): Removed 3 intermediate `toHaveCount(4/6/8)` assertions that race against async log batching. The `.nth(N).toContainText()` assertions already auto-wait, and the final `toHaveCount(10)` validates completeness.
- **Shard 7 — n8nContainer null crash** (`sentry-baseline.spec.ts`): Added missing `@capability:kent` tag to the describe title so the `grepInvert` filter properly excludes this container-only test in local mode.

### CI failure evidence (from [PR #27793 run](https://github.com/n8n-io/n8n/actions/runs/24134447677))

- [Shard 2](https://github.com/n8n-io/n8n/actions/runs/24134447677/job/70419621799) — `categories.spec.ts:82` "should show intro callout if user has not made a production execution" failed 3× (test + 2 retries)
- [Shard 5](https://github.com/n8n-io/n8n/actions/runs/24134447677/job/70419621798) — `logs.spec.ts:56` `toHaveCount(8)` failed with 6 elements (async log batching race)
- [Shard 7](https://github.com/n8n-io/n8n/actions/runs/24134447677/job/70419621811) — `sentry-baseline.spec.ts:6` `n8nContainer.services` crashed (null reference, all 3 sentry tests failed 3× each)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/GHC-7520

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)