### PR TITLE
feat(Mailgun Node): Add reply-to, cc, bcc, custom headers, and tags

### DIFF
--- a/packages/nodes-base/nodes/Mailgun/Mailgun.node.ts
+++ b/packages/nodes-base/nodes/Mailgun/Mailgun.node.ts
@@ -54,16 +54,68 @@ export class Mailgun implements INodeType {
 				name: 'ccEmail',
 				type: 'string',
 				default: '',
-				placeholder: '',
-				description: 'Cc Email address of the recipient. Multiple ones can be separated by comma.',
+				placeholder: 'cc@example.com',
+				description: 'Cc recipient(s). Comma-separated for multiple. Aligns with Mailgun API.',
 			},
 			{
 				displayName: 'Bcc Email',
 				name: 'bccEmail',
 				type: 'string',
 				default: '',
-				placeholder: '',
-				description: 'Bcc Email address of the recipient. Multiple ones can be separated by comma.',
+				placeholder: 'bcc@example.com',
+				description: 'Bcc recipient(s). Comma-separated for multiple. Aligns with Mailgun API.',
+			},
+			{
+				displayName: 'Reply-To',
+				name: 'replyTo',
+				type: 'string',
+				default: '',
+				placeholder: 'reply@example.com',
+				description: 'Reply-To header. Recipients will use this address when replying.',
+			},
+			{
+				displayName: 'Custom Headers',
+				name: 'customHeaders',
+				type: 'fixedCollection',
+				typeOptions: {
+					multipleValues: true,
+				},
+				default: {},
+				placeholder: 'Add Header',
+				description:
+					'Arbitrary email headers sent as h:Header-Name (e.g. h:X-Custom-Header). Reply-To can also be set here if needed.',
+				options: [
+					{
+						name: 'headers',
+						displayName: 'Header',
+						values: [
+							{
+								displayName: 'Name',
+								name: 'name',
+								type: 'string',
+								default: '',
+								placeholder: 'X-Custom-Header',
+								description: 'Header name (without h: prefix; it is added automatically)',
+							},
+							{
+								displayName: 'Value',
+								name: 'value',
+								type: 'string',
+								default: '',
+								description: 'Header value',
+							},
+						],
+					},
+				],
+			},
+			{
+				displayName: 'Tags',
+				name: 'tags',
+				type: 'string',
+				default: '',
+				placeholder: 'tag1, tag2',
+				description:
+					'Tags for segmentation and analytics (comma-separated). Sent as o:tag. Matches Zapier tagging.',
 			},
 			{
 				displayName: 'Subject',
@@ -120,6 +172,11 @@ export class Mailgun implements INodeType {
 				const toEmail = this.getNodeParameter('toEmail', itemIndex) as string;
 				const ccEmail = this.getNodeParameter('ccEmail', itemIndex) as string;
 				const bccEmail = this.getNodeParameter('bccEmail', itemIndex) as string;
+				const replyTo = this.getNodeParameter('replyTo', itemIndex) as string;
+				const customHeaders = this.getNodeParameter('customHeaders', itemIndex) as {
+					headers?: Array<{ name: string; value: string }>;
+				};
+				const tagsParam = this.getNodeParameter('tags', itemIndex) as string;
 				const subject = this.getNodeParameter('subject', itemIndex) as string;
 				const text = this.getNodeParameter('text', itemIndex) as string;
 				const html = this.getNodeParameter('html', itemIndex) as string;
@@ -140,6 +197,24 @@ export class Mailgun implements INodeType {
 				}
 				if (bccEmail.length !== 0) {
 					formData.bcc = bccEmail;
+				}
+				if (replyTo.trim().length !== 0) {
+					formData['h:Reply-To'] = replyTo.trim();
+				}
+				const headerEntries = customHeaders?.headers ?? [];
+				for (const { name: headerName, value: headerValue } of headerEntries) {
+					if (headerName?.trim() && headerValue !== undefined) {
+						formData[`h:${headerName.trim()}`] = headerValue;
+					}
+				}
+				if (tagsParam.trim().length !== 0) {
+					const tagList = tagsParam
+						.split(',')
+						.map((t) => t.trim())
+						.filter(Boolean);
+					if (tagList.length) {
+						formData['o:tag'] = tagList;
+					}
 				}
 
 				if (attachmentPropertyString && item.binary) {

--- a/packages/nodes-base/nodes/Mailgun/test/Mailgun.node.test.ts
+++ b/packages/nodes-base/nodes/Mailgun/test/Mailgun.node.test.ts
@@ -59,6 +59,9 @@ describe('Test Mailgun node', () => {
 				.mockReturnValueOnce('to@example.com')
 				.mockReturnValueOnce('')
 				.mockReturnValueOnce('')
+				.mockReturnValueOnce('')
+				.mockReturnValueOnce({})
+				.mockReturnValueOnce('')
 				.mockReturnValueOnce('Test Subject')
 				.mockReturnValueOnce('Test text')
 				.mockReturnValueOnce('<p>Test HTML</p>')
@@ -119,6 +122,9 @@ describe('Test Mailgun node', () => {
 				.mockReturnValueOnce('to@example.com')
 				.mockReturnValueOnce('')
 				.mockReturnValueOnce('')
+				.mockReturnValueOnce('')
+				.mockReturnValueOnce({})
+				.mockReturnValueOnce('')
 				.mockReturnValueOnce('Test Subject')
 				.mockReturnValueOnce('Test text')
 				.mockReturnValueOnce('<p>Test HTML</p>')
@@ -177,6 +183,9 @@ describe('Test Mailgun node', () => {
 				.mockReturnValueOnce('from@example.com')
 				.mockReturnValueOnce('to@example.com')
 				.mockReturnValueOnce('')
+				.mockReturnValueOnce('')
+				.mockReturnValueOnce('')
+				.mockReturnValueOnce({})
 				.mockReturnValueOnce('')
 				.mockReturnValueOnce('Test Subject')
 				.mockReturnValueOnce('Test text')
@@ -239,6 +248,9 @@ describe('Test Mailgun node', () => {
 				.mockReturnValueOnce('from@example.com')
 				.mockReturnValueOnce('to@example.com')
 				.mockReturnValueOnce('')
+				.mockReturnValueOnce('')
+				.mockReturnValueOnce('')
+				.mockReturnValueOnce({})
 				.mockReturnValueOnce('')
 				.mockReturnValueOnce('Test Subject')
 				.mockReturnValueOnce('Test text')
@@ -324,6 +336,9 @@ describe('Test Mailgun node', () => {
 				.mockReturnValueOnce('to@example.com')
 				.mockReturnValueOnce('')
 				.mockReturnValueOnce('')
+				.mockReturnValueOnce('')
+				.mockReturnValueOnce({})
+				.mockReturnValueOnce('')
 				.mockReturnValueOnce('Test Subject')
 				.mockReturnValueOnce('Test text')
 				.mockReturnValueOnce('<p>Test HTML</p>')
@@ -391,6 +406,9 @@ describe('Test Mailgun node', () => {
 				.mockReturnValueOnce('to@example.com')
 				.mockReturnValueOnce('')
 				.mockReturnValueOnce('')
+				.mockReturnValueOnce('')
+				.mockReturnValueOnce({})
+				.mockReturnValueOnce('')
 				.mockReturnValueOnce('Test Subject')
 				.mockReturnValueOnce('Test text')
 				.mockReturnValueOnce('<p>Test HTML</p>')
@@ -455,6 +473,9 @@ describe('Test Mailgun node', () => {
 				.mockReturnValueOnce('to@example.com')
 				.mockReturnValueOnce('')
 				.mockReturnValueOnce('')
+				.mockReturnValueOnce('')
+				.mockReturnValueOnce({})
+				.mockReturnValueOnce('')
 				.mockReturnValueOnce('Test Subject')
 				.mockReturnValueOnce('Test text')
 				.mockReturnValueOnce('<p>Test HTML</p>')
@@ -491,6 +512,9 @@ describe('Test Mailgun node', () => {
 				.mockReturnValueOnce('to@example.com')
 				.mockReturnValueOnce('')
 				.mockReturnValueOnce('')
+				.mockReturnValueOnce('')
+				.mockReturnValueOnce({})
+				.mockReturnValueOnce('')
 				.mockReturnValueOnce('Test Subject')
 				.mockReturnValueOnce('Test text')
 				.mockReturnValueOnce('<p>Test HTML</p>')
@@ -507,6 +531,55 @@ describe('Test Mailgun node', () => {
 				expect.objectContaining({
 					formData: expect.not.objectContaining({
 						attachment: expect.anything(),
+					}),
+				}),
+			);
+		});
+	});
+
+	describe('Reply-To, custom headers, and tags', () => {
+		it('should send Reply-To, custom headers (h:), and tags (o:tag) in formData', async () => {
+			const items = [{ json: { data: 'test' } }];
+
+			mockExecuteFunctions.getInputData.mockReturnValue(items);
+			mockExecuteFunctions.getNode.mockReturnValue({ type: 'n8n-nodes-base.mailgun' } as any);
+			mockExecuteFunctions.getCredentials.mockResolvedValue({
+				apiDomain: 'api.mailgun.net',
+				emailDomain: 'example.com',
+			});
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('from@example.com')
+				.mockReturnValueOnce('to@example.com')
+				.mockReturnValueOnce('')
+				.mockReturnValueOnce('')
+				.mockReturnValueOnce('reply@example.com')
+				.mockReturnValueOnce({
+					headers: [
+						{ name: 'X-Custom-Header', value: 'custom-value' },
+						{ name: 'X-Another', value: 'another-value' },
+					],
+				})
+				.mockReturnValueOnce('tag1, tag2, tag3')
+				.mockReturnValueOnce('Test Subject')
+				.mockReturnValueOnce('Test text')
+				.mockReturnValueOnce('<p>Test HTML</p>')
+				.mockReturnValueOnce('');
+
+			mockRequestWithAuthentication.mockResolvedValue({ id: 'test-message-id' });
+			mockReturnJsonArray.mockImplementation((data: any) => [{ json: data }]);
+			mockConstructExecutionMetaData.mockImplementation((data: any) => data);
+
+			await mailgunNode.execute.call(mockExecuteFunctions);
+
+			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+				'mailgunApi',
+				expect.objectContaining({
+					formData: expect.objectContaining({
+						'h:Reply-To': 'reply@example.com',
+						'h:X-Custom-Header': 'custom-value',
+						'h:X-Another': 'another-value',
+						'o:tag': ['tag1', 'tag2', 'tag3'],
 					}),
 				}),
 			);


### PR DESCRIPTION
## Summary

Extends the **Mailgun** node’s send operation so workflows can set fields that the Mailgun Messages API already supports:

- **Cc** / **Bcc** — comma-separated recipients, mapped to `cc` / `bcc` in the multipart form.
- **Reply-To** — mapped to `h:Reply-To`.
- **Custom headers** — fixed collection (`name` / `value`); each entry is sent as `h:<Header-Name>` (the `h:` prefix is applied in code, not in the UI).
- **Tags** — comma-separated list, sent as `o:tag` for Mailgun analytics/segmentation.

**Tests:** `packages/nodes-base/nodes/Mailgun/test/Mailgun.node.test.ts` — includes coverage for Reply-To, custom headers, and tags in the outgoing `formData` (alongside existing attachment and send cases).

**How to test**

1. `cd packages/nodes-base && pnpm test Mailgun.node.test.ts` (use a Node version compatible with the repo’s `engines`, e.g. 22.x, if `isolated-vm` fails on other versions).
2. Manual: run n8n with Mailgun credentials, send a message using the new fields, then confirm in the received message (headers) and/or Mailgun logs (tags, recipients).

**Test results in UI**
1. Fields show in action: 
<img width="1478" height="735" alt="Pasted Graphic 20" src="https://github.com/user-attachments/assets/a3db79ab-dce0-4787-aa33-895d1b39380f" />

2. cc & header is functional in sending email: 
<img width="466" height="254" alt="To O Ziting Zhang" src="https://github.com/user-attachments/assets/cbab3a2a-6712-422f-950d-173dbb1e0a5e" />

3. Reply-to is working: 
<img width="461" height="426" alt="From" src="https://github.com/user-attachments/assets/71e0c971-68e1-4202-9119-11754c76886e" />

4. cc & bcc works as expected: 
<img width="1251" height="728" alt="Pasted Graphic 23" src="https://github.com/user-attachments/assets/6595601a-c19b-46ef-b5fd-9d5b6a742ff5" />

5. Tags successfully logged in Mailgun: 
<img width="705" height="126" alt="image" src="https://github.com/user-attachments/assets/41a7be68-58e8-4d37-bab8-e2db297ebd0f" />

