### PR TITLE
fix: Truncate long custom role names and add hover tooltip

### DIFF
--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMembersRoleCell.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMembersRoleCell.vue
@@ -6,6 +6,7 @@ import {
 	N8nSelect2,
 	N8nSelect2Item,
 	N8nText,
+	N8nTooltip,
 } from '@n8n/design-system';
 import type { AllRolesMap, Role } from '@n8n/permissions';
 import { computed, ref, watch } from 'vue';
@@ -178,9 +179,15 @@ const onAddCustomRoleClick = () => {
 		>
 			<!-- Custom trigger to match original styling -->
 			<template #default>
-				<span :class="$style.triggerContent">
-					{{ selectedRole?.displayName }}
-				</span>
+				<N8nTooltip
+					:content="selectedRole?.displayName"
+					:disabled="!selectedRole || dropdownOpen"
+					placement="top"
+				>
+					<span :class="$style.triggerContent">
+						{{ selectedRole?.displayName }}
+					</span>
+				</N8nTooltip>
 			</template>
 
 			<!-- Search input header -->

--- a/packages/frontend/editor-ui/src/features/project-roles/ProjectRoleView.test.ts
+++ b/packages/frontend/editor-ui/src/features/project-roles/ProjectRoleView.test.ts
@@ -245,7 +245,11 @@ describe('ProjectRoleView', () => {
 			});
 
 			await waitFor(() => {
-				expect(getByText('Role "Test Role"')).toBeInTheDocument();
+				expect(
+					getByText(
+						(_, el) => el?.tagName === 'H1' && (el.textContent ?? '').includes('Role "Test Role"'),
+					),
+				).toBeInTheDocument();
 				expect(getByRole('button', { name: 'Save' })).toBeInTheDocument();
 				expect(getByDisplayValue('Test Role')).toBeInTheDocument();
 				expect(getByDisplayValue('A test role for testing')).toBeInTheDocument();

--- a/packages/frontend/editor-ui/src/features/project-roles/ProjectRoleView.vue
+++ b/packages/frontend/editor-ui/src/features/project-roles/ProjectRoleView.vue
@@ -358,9 +358,16 @@ const displayNameValidationRules = [
 			{{ backButtonText }}
 		</N8nButton>
 		<div class="mb-xl" :class="$style.headerContainer">
-			<N8nHeading tag="h1" size="2xlarge">
-				{{ roleSlug ? `Role "${form.displayName}"` : i18n.baseText('projectRoles.newRole') }}
-			</N8nHeading>
+			<div :class="$style.headingContainer">
+				<N8nHeading tag="h1" size="2xlarge" :class="$style.heading">
+					<template v-if="roleSlug"
+						>Role "<N8nTooltip :content="form.displayName" placement="bottom"
+							><span>{{ form.displayName }}</span></N8nTooltip
+						>"</template
+					>
+					<template v-else>{{ i18n.baseText('projectRoles.newRole') }}</template>
+				</N8nHeading>
+			</div>
 			<div v-if="initialState && !isReadOnly && !isLoading" :class="$style.headerActions">
 				<N8nButton variant="subtle" :disabled="!hasUnsavedChanges" @click="resetForm(initialState)">
 					{{ i18n.baseText('projectRoles.discardChanges') }}
@@ -562,6 +569,16 @@ const displayNameValidationRules = [
 	justify-content: space-between;
 	align-items: flex-start;
 	gap: var(--spacing--sm);
+}
+
+.headingContainer {
+	min-width: 0;
+}
+
+.heading {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .headerActions {


### PR DESCRIPTION
## Summary

Fixes layout and UX issues in the role selector and role settings page when custom roles have long display names.

**Role settings page (save/discard buttons wrapping)**

The heading `Role "…"` had no width constraint in the flex row, so a long role name would grow unboundedly and push the save/discard buttons onto a new line.

- Added `min-width: 0` to the heading container (flex child) so the heading can shrink
- Applied `overflow: hidden; text-overflow: ellipsis; white-space: nowrap` to the heading element so long names truncate with `…`
- Wrapped the role name part of the heading in `N8nTooltip` so the full name is always visible on hover

**Role selector (project member role cell)**

The trigger already had CSS truncation but no way to see the full name once it was cut off.

- Added `N8nTooltip` to the selector trigger — shows the full role name on hover/focus, disabled while the dropdown is open

<img width="1850" height="931" alt="image" src="https://github.com/user-attachments/assets/748bfaa7-9d88-4d6a-a63c-4410c97d59b2" />

<img width="1850" height="931" alt="image" src="https://github.com/user-attachments/assets/65ed166d-52cb-44ae-a0dc-f5b0bc663784" />


## Related Linear tickets

https://linear.app/n8n/issue/IAM-19

## Manual testing

### Prerequisites

Create a custom role with a long name, e.g. **"Super Long Custom Role Name That Definitely Overflows"** (Settings → Project Roles → New Role).

---

### 1. Role settings page — heading truncation & button alignment

1. Navigate to **Settings → Project Roles** and open the long-named role.
2. **Verify:** The heading `Role "Super Long Custom Role Name…"` truncates with `…` — it does **not** wrap onto multiple lines.
3. **Verify:** The **Discard changes** and **Save** buttons remain on the same line as the heading, right-aligned, without wrapping.
4. Hover over the truncated heading text.
5. **Verify:** A tooltip appears showing the full role name.

---

### 2. Role selector — truncation & tooltip

1. Open a project → go to **Project settings → Members**.
2. Click the role dropdown for any member.
3. Select the long-named custom role.
4. **Verify:** The trigger (closed dropdown) shows the role name truncated on a single line with `…` — it does **not** wrap or overflow.
5. **Verify:** The role name is left-aligned within the trigger.
6. Hover over the trigger (without opening the dropdown).
7. **Verify:** A tooltip appears showing the full role name.
8. Open the dropdown again.
9. **Verify:** No tooltip appears while the dropdown is open.

---

### 3. Short role names (regression)

1. Assign a short built-in role (e.g. **Editor**) via the role selector.
2. **Verify:** The trigger shows the name without truncation or visual issues.
3. Open the long-named role in settings.
4. **Verify:** Discard/Save buttons are still present and functional (save is disabled until a change is made).

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


