### PR TITLE
fix(core): Mark tool calls cancelled when cancelling main agent on instance AI (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/schemas/__tests__/agent-run-reducer.test.ts
+++ b/packages/@n8n/api-types/src/schemas/__tests__/agent-run-reducer.test.ts
@@ -222,6 +222,38 @@ describe('agent-run-reducer', () => {
 			expect(state.agentsById['root'].status).toBe('error');
 		});
 
+		it('run-finish(cancelled) clears isLoading on all tool calls', () => {
+			const state = stateWithRun('run-1', 'root');
+			reduceEvent(state, makeToolCall('run-1', 'root', 'tc-1', 'publish-workflow'));
+			reduceEvent(state, makeConfirmationRequest('run-1', 'root', 'tc-1'));
+
+			expect(state.toolCallsById['tc-1'].isLoading).toBe(true);
+
+			reduceEvent(state, makeRunFinish('run-1', 'root', 'cancelled'));
+
+			expect(state.toolCallsById['tc-1'].isLoading).toBe(false);
+		});
+
+		it('run-finish(error) clears isLoading on all tool calls', () => {
+			const state = stateWithRun('run-1', 'root');
+			reduceEvent(state, makeToolCall('run-1', 'root', 'tc-1', 'some-tool'));
+
+			reduceEvent(state, makeRunFinish('run-1', 'root', 'error'));
+
+			expect(state.toolCallsById['tc-1'].isLoading).toBe(false);
+		});
+
+		it('run-finish(completed) does not clear isLoading on tool calls', () => {
+			const state = stateWithRun('run-1', 'root');
+			reduceEvent(state, makeAgentSpawned('run-1', 'sub-1', 'root'));
+			reduceEvent(state, makeToolCall('run-1', 'sub-1', 'tc-1', 'background-tool'));
+
+			reduceEvent(state, makeRunFinish('run-1', 'root', 'completed'));
+
+			// A completed run may still have background tasks with in-flight tool calls
+			expect(state.toolCallsById['tc-1'].isLoading).toBe(true);
+		});
+
 		it('run-start with unsafe agentId is ignored', () => {
 			const state = createInitialState();
 
@@ -392,6 +424,32 @@ describe('agent-run-reducer', () => {
 
 			expect(state.agentsById['sub-1'].status).toBe('error');
 			expect(state.agentsById['sub-1'].error).toBe('failed');
+		});
+
+		it('agent-completed clears isLoading on agent tool calls', () => {
+			const state = stateWithRun('run-1', 'root');
+			reduceEvent(state, makeAgentSpawned('run-1', 'sub-1', 'root'));
+			reduceEvent(state, makeToolCall('run-1', 'sub-1', 'tc-1', 'some-tool'));
+			reduceEvent(state, makeConfirmationRequest('run-1', 'sub-1', 'tc-1'));
+
+			expect(state.toolCallsById['tc-1'].isLoading).toBe(true);
+
+			reduceEvent(state, makeAgentCompleted('run-1', 'sub-1', '', 'Cancelled by user'));
+
+			expect(state.toolCallsById['tc-1'].isLoading).toBe(false);
+		});
+
+		it('agent-completed does not clear tool calls of other agents', () => {
+			const state = stateWithRun('run-1', 'root');
+			reduceEvent(state, makeAgentSpawned('run-1', 'sub-1', 'root'));
+			reduceEvent(state, makeAgentSpawned('run-1', 'sub-2', 'root'));
+			reduceEvent(state, makeToolCall('run-1', 'sub-1', 'tc-1', 'tool-a'));
+			reduceEvent(state, makeToolCall('run-1', 'sub-2', 'tc-2', 'tool-b'));
+
+			reduceEvent(state, makeAgentCompleted('run-1', 'sub-1', '', 'Cancelled by user'));
+
+			expect(state.toolCallsById['tc-1'].isLoading).toBe(false);
+			expect(state.toolCallsById['tc-2'].isLoading).toBe(true);
 		});
 
 		it('agent-spawned with unsafe ids is ignored', () => {

--- a/packages/@n8n/api-types/src/schemas/agent-run-reducer.ts
+++ b/packages/@n8n/api-types/src/schemas/agent-run-reducer.ts
@@ -293,6 +293,17 @@ export function reduceEvent(state: AgentRunState, event: InstanceAiEvent): Agent
 				agent.result = event.payload.result;
 				agent.error = event.payload.error;
 			}
+			// A completed/errored agent can't have tool calls still in-flight.
+			// Clear isLoading so persisted snapshots don't show stale confirmations.
+			const agentToolCallIds = state.toolCallIdsByAgentId[event.agentId];
+			if (agentToolCallIds) {
+				for (const tcId of agentToolCallIds) {
+					const tc = state.toolCallsById[tcId];
+					if (tc?.isLoading) {
+						tc.isLoading = false;
+					}
+				}
+			}
 			break;
 		}
 
@@ -365,6 +376,15 @@ export function reduceEvent(state: AgentRunState, event: InstanceAiEvent): Agent
 			const root = state.agentsById[state.rootAgentId];
 			if (root) {
 				root.status = state.status;
+			}
+			// A terminated run can't have tool calls still in-flight.
+			// Clear isLoading so persisted snapshots don't show stale confirmations.
+			if (state.status === 'cancelled' || state.status === 'error') {
+				for (const tc of Object.values(state.toolCallsById)) {
+					if (tc.isLoading) {
+						tc.isLoading = false;
+					}
+				}
 			}
 			break;
 		}

--- a/packages/@n8n/api-types/src/schemas/agent-run-reducer.ts
+++ b/packages/@n8n/api-types/src/schemas/agent-run-reducer.ts
@@ -295,6 +295,7 @@ export function reduceEvent(state: AgentRunState, event: InstanceAiEvent): Agent
 			}
 			// A completed/errored agent can't have tool calls still in-flight.
 			// Clear isLoading so persisted snapshots don't show stale confirmations.
+			if (!isSafeObjectKey(event.agentId)) break;
 			const agentToolCallIds = state.toolCallIdsByAgentId[event.agentId];
 			if (agentToolCallIds) {
 				for (const tcId of agentToolCallIds) {

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -767,6 +767,9 @@ export class InstanceAiService {
 				agentId: ORCHESTRATOR_AGENT_ID,
 				payload: { status: 'cancelled', reason: 'user_cancelled' },
 			});
+			// Persist the snapshot so the run-finish event (which clears
+			// in-flight tool calls) is reflected in the stored tree.
+			void this.saveAgentTreeSnapshot(threadId, suspended.runId, this.dbSnapshotStorage, true);
 			if (suspended.mastraRunId) {
 				void this.cleanupMastraSnapshots(suspended.mastraRunId);
 			}


### PR DESCRIPTION
## Summary

If you cancel the message generation while there's a HITL prompt (or other tool call) in progress we don't mark the tool calls cancelled, meaning they remain there visible as if they could be approved, even after reload.

This also fixes that.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
