### PR TITLE
fix(Pushover Node): Replace duplicate Timestamp field with TTL parameter

### DIFF
--- a/packages/nodes-base/nodes/Pushover/Pushover.node.ts
+++ b/packages/nodes-base/nodes/Pushover/Pushover.node.ts
@@ -252,12 +252,15 @@ export class Pushover implements INodeType {
 						description: "Your message's title, otherwise your app's name is used",
 					},
 					{
-						displayName: 'Timestamp',
-						name: 'timestamp',
-						type: 'dateTime',
-						default: '',
+						displayName: 'TTL (Seconds)',
+						name: 'ttl',
+						type: 'number',
+						typeOptions: {
+							minValue: 1,
+						},
+						default: 0,
 						description:
-							"A Unix timestamp of your message's date and time to display to the user, rather than the time your message is received by our API",
+							'The number of seconds before the message is automatically deleted from the user\'s devices. Messages with emergency priority ignore this parameter.',
 					},
 					{
 						displayName: 'URL',


### PR DESCRIPTION
## Summary

The Pushover node's **Additional Fields** collection contains a duplicate `Timestamp` entry — the field appears twice in the dropdown, which is confusing for users. This PR removes the duplicate and replaces it with the missing **TTL (Time to Live)** parameter from the [Pushover API](https://pushover.net/api#ttl).

**Changes:**
- Removed the second, duplicate `Timestamp` field definition (the first one remains)
- Added a new `TTL (Seconds)` field — an integer specifying how many seconds before the message is automatically deleted from the user's devices (as documented in the Pushover API)

**How to test:**
1. Add a Pushover node to a workflow
2. Open Additional Fields → Add Field
3. Verify `Timestamp` appears only once (previously appeared twice)
4. Verify the new `TTL (Seconds)` field is available
5. Configure TTL with a positive integer and send a test message

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4606
Fixes https://github.com/n8n-io/n8n/issues/10984
Supersedes https://github.com/n8n-io/n8n/pull/11287
Supersedes https://github.com/n8n-io/n8n/pull/27027

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)