### PR TITLE
fix(editor): Surface configured minimum password length in UI

### DIFF
--- a/packages/@n8n/api-types/src/frontend-settings.ts
+++ b/packages/@n8n/api-types/src/frontend-settings.ts
@@ -35,6 +35,7 @@ export interface IUserManagementSettings {
 	showSetupOnFirstLoad?: boolean;
 	smtpSetup: boolean;
 	authenticationMethod: AuthenticationMethod;
+	passwordMinLength: number;
 }
 
 export interface IEnterpriseSettings {

--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -63,6 +63,9 @@ describe('FrontendService', () => {
 		credentials: {
 			overwrite: { skipTypes: [] },
 		},
+		userManagement: {
+			password: { minLength: 8 },
+		},
 	});
 
 	const instanceSettings = mock<InstanceSettings>({
@@ -229,6 +232,7 @@ describe('FrontendService', () => {
 					smtpSetup: false,
 					showSetupOnFirstLoad: true,
 					authenticationMethod: 'email',
+					passwordMinLength: 8,
 				},
 				sso: {
 					saml: { loginEnabled: false },
@@ -258,6 +262,7 @@ describe('FrontendService', () => {
 					smtpSetup: false,
 					showSetupOnFirstLoad: true,
 					authenticationMethod: 'email',
+					passwordMinLength: 8,
 				},
 				sso: {
 					saml: { loginEnabled: false },
@@ -281,6 +286,21 @@ describe('FrontendService', () => {
 			const settings = await service.getPublicSettings(true);
 
 			expect(settings).toEqual(expectedPublicSettings);
+		});
+
+		it('should expose configured passwordMinLength in settings', async () => {
+			(globalConfig as any).userManagement = { password: { minLength: 12 } };
+
+			const { service } = createMockService();
+			const settings = await service.getSettings();
+
+			expect(settings.userManagement.passwordMinLength).toBe(12);
+
+			const publicSettings = await service.getPublicSettings(false);
+			expect(publicSettings.userManagement.passwordMinLength).toBe(12);
+
+			// Restore default
+			(globalConfig as any).userManagement = { password: { minLength: 8 } };
 		});
 
 		it('should set showSetupOnFirstLoad to false in preview mode', async () => {

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -59,6 +59,9 @@ export type PublicFrontendSettings = {
 
 		/** Determines forgot password page UX */
 		smtpSetup: FrontendSettings['userManagement']['smtpSetup'];
+
+		/** Configurable minimum password length for password requirement display */
+		passwordMinLength: FrontendSettings['userManagement']['passwordMinLength'];
 	};
 
 	enterprise: {
@@ -249,6 +252,7 @@ export class FrontendService {
 				showSetupOnFirstLoad: await this.getShowSetupOnFirstLoad(),
 				smtpSetup: this.mailer.isEmailSetUp,
 				authenticationMethod: getCurrentAuthenticationMethod(),
+				passwordMinLength: this.globalConfig.userManagement.password.minLength,
 			},
 			sso: {
 				managedByEnv: this.globalConfig.instanceSettingsLoader.ssoManagedByEnv,
@@ -569,7 +573,7 @@ export class FrontendService {
 		// Get full settings to ensure all required properties are initialized
 		const {
 			defaultLocale,
-			userManagement: { authenticationMethod, showSetupOnFirstLoad, smtpSetup },
+			userManagement: { authenticationMethod, showSetupOnFirstLoad, smtpSetup, passwordMinLength },
 			sso: { saml: ssoSaml, ldap: ssoLdap, oidc: ssoOidc },
 			authCookie,
 			previewMode,
@@ -584,6 +588,7 @@ export class FrontendService {
 				authenticationMethod,
 				showSetupOnFirstLoad,
 				smtpSetup,
+				passwordMinLength,
 			},
 			sso: {
 				saml: {

--- a/packages/frontend/@n8n/design-system/src/components/N8nFormInput/validators.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nFormInput/validators.test.ts
@@ -1,0 +1,79 @@
+import {
+	createPasswordRules,
+	defaultPasswordRules,
+	getValidationError,
+	VALIDATORS,
+} from './validators';
+import type { IValidator, RuleGroup } from '../../types';
+
+const validators = VALIDATORS as unknown as Record<string, IValidator | RuleGroup>;
+
+describe('createPasswordRules', () => {
+	it('should create rules with the specified minimum length', () => {
+		const rules = createPasswordRules(12);
+		const innerGroup = rules.rules[0] as RuleGroup;
+		const minLengthRule = innerGroup.rules[0] as { name: string; config: { minimum: number } };
+
+		expect(minLengthRule.name).toBe('MIN_LENGTH');
+		expect(minLengthRule.config.minimum).toBe(12);
+	});
+
+	it('should include the minimum in defaultError options', () => {
+		const rules = createPasswordRules(15);
+		const innerGroup = rules.rules[0] as RuleGroup;
+
+		expect(innerGroup.defaultError).toEqual({
+			messageKey: 'formInput.validator.defaultPasswordRequirements',
+			options: { minimum: 15 },
+		});
+	});
+
+	it('should default to 8 when no argument is provided', () => {
+		const rules = createPasswordRules();
+		const innerGroup = rules.rules[0] as RuleGroup;
+		const minLengthRule = innerGroup.rules[0] as { name: string; config: { minimum: number } };
+
+		expect(minLengthRule.config.minimum).toBe(8);
+		expect(innerGroup.defaultError?.options).toEqual({ minimum: 8 });
+	});
+
+	it('defaultPasswordRules should use minimum of 8', () => {
+		const innerGroup = defaultPasswordRules.rules[0] as RuleGroup;
+		const minLengthRule = innerGroup.rules[0] as { name: string; config: { minimum: number } };
+
+		expect(minLengthRule.config.minimum).toBe(8);
+	});
+});
+
+describe('password validation with custom min length', () => {
+	it('should reject passwords shorter than the custom minimum', () => {
+		const rules = createPasswordRules(12);
+		const error = getValidationError('Short1Pass', validators, rules);
+
+		expect(error).toBeTruthy();
+		expect(error).toHaveProperty('messageKey', 'formInput.validator.defaultPasswordRequirements');
+	});
+
+	it('should accept passwords meeting the custom minimum', () => {
+		const rules = createPasswordRules(12);
+		const error = getValidationError('LongEnough1Pass', validators, rules);
+
+		expect(error).toBeFalsy();
+	});
+
+	it('should reject passwords missing uppercase with custom min length', () => {
+		const rules = createPasswordRules(8);
+		const error = getValidationError('alllowercase1', validators, rules);
+
+		expect(error).toBeTruthy();
+		expect(error).toHaveProperty('messageKey', 'formInput.validator.defaultPasswordRequirements');
+	});
+
+	it('should reject passwords missing numbers with custom min length', () => {
+		const rules = createPasswordRules(8);
+		const error = getValidationError('NoNumbersHere', validators, rules);
+
+		expect(error).toBeTruthy();
+		expect(error).toHaveProperty('messageKey', 'formInput.validator.defaultPasswordRequirements');
+	});
+});

--- a/packages/frontend/@n8n/design-system/src/components/N8nFormInput/validators.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nFormInput/validators.ts
@@ -106,21 +106,24 @@ export const matchRegex: IValidator<{ regex: RegExp; message: string }> = {
 	},
 };
 
-export const defaultPasswordRules: RuleGroup = {
+export const createPasswordRules = (minLength = 8): RuleGroup => ({
 	rules: [
 		{
 			rules: [
-				{ name: 'MIN_LENGTH', config: { minimum: 8 } },
+				{ name: 'MIN_LENGTH', config: { minimum: minLength } },
 				{ name: 'CONTAINS_NUMBER', config: { minimum: 1 } },
 				{ name: 'CONTAINS_UPPERCASE', config: { minimum: 1 } },
 			],
 			defaultError: {
 				messageKey: 'formInput.validator.defaultPasswordRequirements',
+				options: { minimum: minLength },
 			},
 		},
 		{ name: 'MAX_LENGTH', config: { maximum: 64 } },
 	],
-};
+});
+
+export const defaultPasswordRules: RuleGroup = createPasswordRules(8);
 
 export const VALIDATORS = {
 	REQUIRED: requiredValidator,

--- a/packages/frontend/@n8n/design-system/src/index.ts
+++ b/packages/frontend/@n8n/design-system/src/index.ts
@@ -22,4 +22,5 @@ export { default as N8nDropdownMenu } from './v2/components/DropdownMenu/Dropdow
 export type * from './v2/components/DropdownMenu/DropdownMenu.types';
 export { default as N8nSwitch2 } from './v2/components/Switch/Switch.vue';
 export type * from './v2/components/Switch/Switch.types';
+export { createPasswordRules } from './components/N8nFormInput/validators';
 export { locale };

--- a/packages/frontend/@n8n/design-system/src/locale/lang/en.ts
+++ b/packages/frontend/@n8n/design-system/src/locale/lang/en.ts
@@ -23,7 +23,7 @@ export default {
 	'formInput.validator.uppercaseCharsRequired': (config: { minimum: number }) =>
 		`Must have at least ${config.minimum} uppercase character${config.minimum > 1 ? 's' : ''}`,
 	'formInput.validator.defaultPasswordRequirements':
-		'8+ characters, at least 1 number and 1 capital letter',
+		'{minimum}+ characters, at least 1 number and 1 capital letter',
 	'sticky.markdownHint':
 		'You can style with <a href="https://docs.n8n.io/workflows/components/sticky-notes/" target="_blank">Markdown</a>',
 	'tags.showMore': (count: number) => `+${count} more`,

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -219,7 +219,7 @@
 	"auth.confirmPassword": "Confirm password",
 	"auth.confirmPassword.currentPassword": "Current password",
 	"auth.confirmPassword.confirmPasswordToChangeEmail": "Please confirm your password in order to change your email address.",
-	"auth.defaultPasswordRequirements": "8+ characters, at least 1 number and 1 capital letter",
+	"auth.defaultPasswordRequirements": "{minimum}+ characters, at least 1 number and 1 capital letter",
 	"auth.validation.missingParameters": "Missing token or user id",
 	"auth.email": "Email",
 	"auth.firstName": "First Name",

--- a/packages/frontend/editor-ui/src/__tests__/defaults.ts
+++ b/packages/frontend/editor-ui/src/__tests__/defaults.ts
@@ -108,6 +108,7 @@ export const defaultSettings: FrontendSettings = {
 		smtpSetup: true,
 		authenticationMethod: 'email',
 		quota: 10,
+		passwordMinLength: 8,
 	},
 	versionCli: '',
 	nodeJsVersion: '',

--- a/packages/frontend/editor-ui/src/__tests__/utils.ts
+++ b/packages/frontend/editor-ui/src/__tests__/utils.ts
@@ -47,6 +47,7 @@ export const SETTINGS_STORE_DEFAULT_STATE: ISettingsState = {
 		smtpSetup: false,
 		authenticationMethod: UserManagementAuthenticationMethod.Email,
 		quota: defaultSettings.userManagement.quota,
+		passwordMinLength: 8,
 	},
 	templatesEndpointHealthy: false,
 	api: {

--- a/packages/frontend/editor-ui/src/app/stores/settings.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/settings.store.ts
@@ -28,6 +28,7 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 		showSetupOnFirstLoad: false,
 		smtpSetup: false,
 		authenticationMethod: UserManagementAuthenticationMethod.Email,
+		passwordMinLength: 8,
 	});
 	const templatesEndpointHealthy = ref(false);
 	const api = ref({

--- a/packages/frontend/editor-ui/src/features/core/auth/components/ChangePasswordModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/components/ChangePasswordModal.test.ts
@@ -34,6 +34,9 @@ describe('ChangePasswordModal', () => {
 	});
 
 	it('should default to 8-character minimum when passwordMinLength is not configured', () => {
+		const settingsStore = mockedStore(useSettingsStore);
+		delete (settingsStore.userManagement as { passwordMinLength?: number }).passwordMinLength;
+
 		renderComponent({ pinia });
 
 		expect(createPasswordRules).toHaveBeenCalledWith(8);

--- a/packages/frontend/editor-ui/src/features/core/auth/components/ChangePasswordModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/components/ChangePasswordModal.test.ts
@@ -33,6 +33,12 @@ describe('ChangePasswordModal', () => {
 		expect(wrapper.html()).toMatchSnapshot();
 	});
 
+	it('should default to 8-character minimum when passwordMinLength is not configured', () => {
+		renderComponent({ pinia });
+
+		expect(createPasswordRules).toHaveBeenCalledWith(8);
+	});
+
 	it('should pass configured passwordMinLength to createPasswordRules', () => {
 		const settingsStore = mockedStore(useSettingsStore);
 		settingsStore.userManagement.passwordMinLength = 12;

--- a/packages/frontend/editor-ui/src/features/core/auth/components/ChangePasswordModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/components/ChangePasswordModal.test.ts
@@ -7,7 +7,7 @@ import { useSettingsStore } from '@/app/stores/settings.store';
 import { createPasswordRules } from '@n8n/design-system';
 
 vi.mock('@n8n/design-system', async () => {
-	const actual = await vi.importActual('@n8n/design-system');
+	const actual = await vi.importActual<typeof import('@n8n/design-system')>('@n8n/design-system');
 	return {
 		...actual,
 		createPasswordRules: vi.fn(actual.createPasswordRules),

--- a/packages/frontend/editor-ui/src/features/core/auth/components/ChangePasswordModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/components/ChangePasswordModal.test.ts
@@ -7,10 +7,13 @@ import { useSettingsStore } from '@/app/stores/settings.store';
 import { createPasswordRules } from '@n8n/design-system';
 
 vi.mock('@n8n/design-system', async () => {
-	const actual = await vi.importActual<typeof import('@n8n/design-system')>('@n8n/design-system');
+	const actual = await vi.importActual('@n8n/design-system');
+	const { createPasswordRules: originalCreatePasswordRules } = actual as {
+		createPasswordRules: typeof createPasswordRules;
+	};
 	return {
 		...actual,
-		createPasswordRules: vi.fn(actual.createPasswordRules),
+		createPasswordRules: vi.fn(originalCreatePasswordRules),
 	};
 });
 

--- a/packages/frontend/editor-ui/src/features/core/auth/components/ChangePasswordModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/components/ChangePasswordModal.test.ts
@@ -4,6 +4,15 @@ import type { createPinia } from 'pinia';
 import { createComponentRenderer } from '@/__tests__/render';
 import { mockedStore } from '@/__tests__/utils';
 import { useSettingsStore } from '@/app/stores/settings.store';
+import { createPasswordRules } from '@n8n/design-system';
+
+vi.mock('@n8n/design-system', async () => {
+	const actual = await vi.importActual('@n8n/design-system');
+	return {
+		...actual,
+		createPasswordRules: vi.fn(actual.createPasswordRules),
+	};
+});
 
 const renderComponent = createComponentRenderer(ChangePasswordModal);
 
@@ -12,6 +21,7 @@ describe('ChangePasswordModal', () => {
 
 	beforeEach(() => {
 		pinia = createTestingPinia({});
+		vi.mocked(createPasswordRules).mockClear();
 	});
 
 	it('should render correctly', () => {
@@ -20,12 +30,12 @@ describe('ChangePasswordModal', () => {
 		expect(wrapper.html()).toMatchSnapshot();
 	});
 
-	it('should use passwordMinLength from settings store', () => {
+	it('should pass configured passwordMinLength to createPasswordRules', () => {
 		const settingsStore = mockedStore(useSettingsStore);
 		settingsStore.userManagement.passwordMinLength = 12;
 
-		const wrapper = renderComponent({ pinia });
+		renderComponent({ pinia });
 
-		expect(wrapper.html()).toBeDefined();
+		expect(createPasswordRules).toHaveBeenCalledWith(12);
 	});
 });

--- a/packages/frontend/editor-ui/src/features/core/auth/components/ChangePasswordModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/components/ChangePasswordModal.test.ts
@@ -2,6 +2,8 @@ import { createTestingPinia } from '@pinia/testing';
 import ChangePasswordModal from './ChangePasswordModal.vue';
 import type { createPinia } from 'pinia';
 import { createComponentRenderer } from '@/__tests__/render';
+import { mockedStore } from '@/__tests__/utils';
+import { useSettingsStore } from '@/app/stores/settings.store';
 
 const renderComponent = createComponentRenderer(ChangePasswordModal);
 
@@ -16,5 +18,14 @@ describe('ChangePasswordModal', () => {
 		const wrapper = renderComponent({ pinia });
 
 		expect(wrapper.html()).toMatchSnapshot();
+	});
+
+	it('should use passwordMinLength from settings store', () => {
+		const settingsStore = mockedStore(useSettingsStore);
+		settingsStore.userManagement.passwordMinLength = 12;
+
+		const wrapper = renderComponent({ pinia });
+
+		expect(wrapper.html()).toBeDefined();
 	});
 });

--- a/packages/frontend/editor-ui/src/features/core/auth/components/ChangePasswordModal.vue
+++ b/packages/frontend/editor-ui/src/features/core/auth/components/ChangePasswordModal.vue
@@ -8,8 +8,9 @@ import { createFormEventBus } from '@n8n/design-system/utils';
 import { createEventBus } from '@n8n/utils/event-bus';
 import type { IFormInputs, IFormInput, FormFieldValueUpdate, FormValues } from '@/Interface';
 import { useI18n } from '@n8n/i18n';
+import { useSettingsStore } from '@/app/stores/settings.store';
 
-import { N8nButton, N8nFormInputs } from '@n8n/design-system';
+import { N8nButton, N8nFormInputs, createPasswordRules } from '@n8n/design-system';
 const config = ref<IFormInputs | null>(null);
 const formBus = createFormEventBus();
 const modalBus = createEventBus();
@@ -19,6 +20,8 @@ const loading = ref(false);
 const i18n = useI18n();
 const { showMessage, showError } = useToast();
 const usersStore = useUsersStore();
+const settingsStore = useSettingsStore();
+const passwordMinLength = settingsStore.userManagement.passwordMinLength ?? 8;
 
 const passwordsMatch = (value: string | number | boolean | null | undefined) => {
 	if (typeof value !== 'string') {
@@ -96,8 +99,10 @@ onMounted(() => {
 				label: i18n.baseText('auth.newPassword'),
 				type: 'password',
 				required: true,
-				validationRules: [{ name: 'DEFAULT_PASSWORD_RULES' }],
-				infoText: i18n.baseText('auth.defaultPasswordRequirements'),
+				validationRules: [createPasswordRules(passwordMinLength)],
+				infoText: i18n.baseText('auth.defaultPasswordRequirements', {
+					interpolate: { minimum: passwordMinLength },
+				}),
 				autocomplete: 'new-password',
 				capitalize: true,
 			},

--- a/packages/frontend/editor-ui/src/features/core/auth/views/ChangePasswordView.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/ChangePasswordView.test.ts
@@ -41,13 +41,13 @@ describe('ChangePasswordView', () => {
 		expect(() => renderComponent()).not.toThrow();
 	});
 
-	it('should use passwordMinLength from settings store', () => {
+	it('should reflect configured passwordMinLength in password hint text', async () => {
 		const pinia = createTestingPinia();
 		const settingsStore = mockedStore(useSettingsStore);
 		settingsStore.userManagement.passwordMinLength = 12;
 
-		const { container } = renderComponent({ pinia });
+		const { findByText } = renderComponent({ pinia });
 
-		expect(container.querySelector('[data-test-id]')).toBeDefined();
+		expect(await findByText(/12\+ characters/)).toBeInTheDocument();
 	});
 });

--- a/packages/frontend/editor-ui/src/features/core/auth/views/ChangePasswordView.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/ChangePasswordView.test.ts
@@ -1,0 +1,53 @@
+import { createComponentRenderer } from '@/__tests__/render';
+import { mockedStore } from '@/__tests__/utils';
+import { createTestingPinia } from '@pinia/testing';
+import ChangePasswordView from './ChangePasswordView.vue';
+import { useSettingsStore } from '@/app/stores/settings.store';
+
+vi.mock('vue-router', () => {
+	const push = vi.fn();
+	const replace = vi.fn();
+	return {
+		useRouter: () => ({
+			push,
+			replace,
+			currentRoute: { value: { query: { token: 'test-token' } } },
+		}),
+		useRoute: () => ({
+			query: { token: 'test-token' },
+		}),
+		RouterLink: {
+			template: '<a><slot /></a>',
+		},
+	};
+});
+
+vi.mock('@/app/composables/useToast', () => {
+	const showError = vi.fn();
+	const showMessage = vi.fn();
+	return {
+		useToast: () => ({
+			showError,
+			showMessage,
+		}),
+	};
+});
+
+const renderComponent = createComponentRenderer(ChangePasswordView);
+
+describe('ChangePasswordView', () => {
+	it('should render correctly', () => {
+		createTestingPinia();
+		expect(() => renderComponent()).not.toThrow();
+	});
+
+	it('should use passwordMinLength from settings store', () => {
+		const pinia = createTestingPinia();
+		const settingsStore = mockedStore(useSettingsStore);
+		settingsStore.userManagement.passwordMinLength = 12;
+
+		const { container } = renderComponent({ pinia });
+
+		expect(container.querySelector('[data-test-id]')).toBeDefined();
+	});
+});

--- a/packages/frontend/editor-ui/src/features/core/auth/views/ChangePasswordView.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/ChangePasswordView.test.ts
@@ -41,6 +41,14 @@ describe('ChangePasswordView', () => {
 		expect(() => renderComponent()).not.toThrow();
 	});
 
+	it('should default to 8-character minimum when passwordMinLength is not configured', async () => {
+		const pinia = createTestingPinia();
+
+		const { findByText } = renderComponent({ pinia });
+
+		expect(await findByText(/8\+ characters/)).toBeInTheDocument();
+	});
+
 	it('should reflect configured passwordMinLength in password hint text', async () => {
 		const pinia = createTestingPinia();
 		const settingsStore = mockedStore(useSettingsStore);

--- a/packages/frontend/editor-ui/src/features/core/auth/views/ChangePasswordView.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/ChangePasswordView.test.ts
@@ -43,6 +43,8 @@ describe('ChangePasswordView', () => {
 
 	it('should default to 8-character minimum when passwordMinLength is not configured', async () => {
 		const pinia = createTestingPinia();
+		const settingsStore = mockedStore(useSettingsStore);
+		delete (settingsStore.userManagement as { passwordMinLength?: number }).passwordMinLength;
 
 		const { findByText } = renderComponent({ pinia });
 

--- a/packages/frontend/editor-ui/src/features/core/auth/views/ChangePasswordView.vue
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/ChangePasswordView.vue
@@ -5,17 +5,21 @@ import { useRouter } from 'vue-router';
 import AuthView from './AuthView.vue';
 
 import { useI18n } from '@n8n/i18n';
+import { createPasswordRules } from '@n8n/design-system';
 import { useToast } from '@/app/composables/useToast';
+import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
 
 import type { FormFieldValueUpdate, IFormBoxConfig } from '@/Interface';
 import { MFA_AUTHENTICATION_CODE_INPUT_MAX_LENGTH, VIEWS } from '@/app/constants';
 
 const usersStore = useUsersStore();
+const settingsStore = useSettingsStore();
 
 const locale = useI18n();
 const toast = useToast();
 const router = useRouter();
+const passwordMinLength = settingsStore.userManagement.passwordMinLength ?? 8;
 
 const password = ref('');
 const loading = ref(false);
@@ -99,8 +103,10 @@ onMounted(async () => {
 					label: locale.baseText('auth.newPassword'),
 					type: 'password',
 					required: true,
-					validationRules: [{ name: 'DEFAULT_PASSWORD_RULES' }],
-					infoText: locale.baseText('auth.defaultPasswordRequirements'),
+					validationRules: [createPasswordRules(passwordMinLength)],
+					infoText: locale.baseText('auth.defaultPasswordRequirements', {
+						interpolate: { minimum: passwordMinLength },
+					}),
 					autocomplete: 'new-password',
 					capitalize: true,
 				},

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SetupView.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SetupView.test.ts
@@ -40,13 +40,13 @@ describe('SetupView', () => {
 		expect(() => renderComponent()).not.toThrow();
 	});
 
-	it('should use passwordMinLength from settings store', () => {
+	it('should reflect configured passwordMinLength in password hint text', () => {
 		const pinia = createTestingPinia();
 		const settingsStore = mockedStore(useSettingsStore);
 		settingsStore.userManagement.passwordMinLength = 12;
 
-		const { container } = renderComponent({ pinia });
+		const { getByText } = renderComponent({ pinia });
 
-		expect(container.querySelector('[data-test-id="setup-form"]')).toBeDefined();
+		expect(getByText(/12\+ characters/)).toBeInTheDocument();
 	});
 });

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SetupView.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SetupView.test.ts
@@ -40,6 +40,14 @@ describe('SetupView', () => {
 		expect(() => renderComponent()).not.toThrow();
 	});
 
+	it('should default to 8-character minimum when passwordMinLength is not configured', () => {
+		const pinia = createTestingPinia();
+
+		const { getByText } = renderComponent({ pinia });
+
+		expect(getByText(/8\+ characters/)).toBeInTheDocument();
+	});
+
 	it('should reflect configured passwordMinLength in password hint text', () => {
 		const pinia = createTestingPinia();
 		const settingsStore = mockedStore(useSettingsStore);

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SetupView.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SetupView.test.ts
@@ -42,6 +42,8 @@ describe('SetupView', () => {
 
 	it('should default to 8-character minimum when passwordMinLength is not configured', () => {
 		const pinia = createTestingPinia();
+		const settingsStore = mockedStore(useSettingsStore);
+		delete (settingsStore.userManagement as { passwordMinLength?: number }).passwordMinLength;
 
 		const { getByText } = renderComponent({ pinia });
 

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SetupView.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SetupView.test.ts
@@ -1,0 +1,52 @@
+import { createComponentRenderer } from '@/__tests__/render';
+import { mockedStore } from '@/__tests__/utils';
+import { createTestingPinia } from '@pinia/testing';
+import SetupView from './SetupView.vue';
+import { useSettingsStore } from '@/app/stores/settings.store';
+
+vi.mock('vue-router', () => {
+	const push = vi.fn();
+	const replace = vi.fn();
+	return {
+		useRouter: () => ({
+			push,
+			replace,
+		}),
+		useRoute: () => ({
+			query: {},
+		}),
+		RouterLink: {
+			template: '<a><slot /></a>',
+		},
+	};
+});
+
+vi.mock('@/app/composables/useToast', () => {
+	const showError = vi.fn();
+	const showMessage = vi.fn();
+	return {
+		useToast: () => ({
+			showError,
+			showMessage,
+		}),
+	};
+});
+
+const renderComponent = createComponentRenderer(SetupView);
+
+describe('SetupView', () => {
+	it('should render correctly', () => {
+		createTestingPinia();
+		expect(() => renderComponent()).not.toThrow();
+	});
+
+	it('should use passwordMinLength from settings store', () => {
+		const pinia = createTestingPinia();
+		const settingsStore = mockedStore(useSettingsStore);
+		settingsStore.userManagement.passwordMinLength = 12;
+
+		const { container } = renderComponent({ pinia });
+
+		expect(container.querySelector('[data-test-id="setup-form"]')).toBeDefined();
+	});
+});

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SetupView.vue
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SetupView.vue
@@ -4,6 +4,7 @@ import { useRouter } from 'vue-router';
 
 import { useToast } from '@/app/composables/useToast';
 import { useI18n } from '@n8n/i18n';
+import { createPasswordRules } from '@n8n/design-system';
 
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
@@ -20,6 +21,7 @@ const toast = useToast();
 const locale = useI18n();
 const router = useRouter();
 
+const passwordMinLength = settingsStore.userManagement.passwordMinLength ?? 8;
 const loading = ref(false);
 const formConfig: IFormBoxConfig = reactive({
 	title: locale.baseText('auth.setup.setupOwner'),
@@ -62,8 +64,10 @@ const formConfig: IFormBoxConfig = reactive({
 				label: locale.baseText('auth.password'),
 				type: 'password',
 				required: true,
-				validationRules: [{ name: 'DEFAULT_PASSWORD_RULES' }],
-				infoText: locale.baseText('auth.defaultPasswordRequirements'),
+				validationRules: [createPasswordRules(passwordMinLength)],
+				infoText: locale.baseText('auth.defaultPasswordRequirements', {
+					interpolate: { minimum: passwordMinLength },
+				}),
 				autocomplete: 'new-password',
 				capitalize: true,
 			},

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SignupView.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SignupView.test.ts
@@ -197,6 +197,12 @@ describe('SignupView', () => {
 		expect(payload).not.toHaveProperty('inviteeId');
 	});
 
+	it('should default to 8-character minimum when passwordMinLength is not configured', () => {
+		const { getByText } = renderComponent();
+
+		expect(getByText(/8\+ characters/)).toBeInTheDocument();
+	});
+
 	it('should reflect configured passwordMinLength in password hint text', () => {
 		const settingsStore = mockedStore(useSettingsStore);
 		settingsStore.userManagement.passwordMinLength = 12;

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SignupView.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SignupView.test.ts
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { useToast } from '@/app/composables/useToast';
 import SignupView from './SignupView.vue';
 import { VIEWS } from '@/app/constants';
+import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { mockedStore } from '@/__tests__/utils';
 
@@ -194,6 +195,13 @@ describe('SignupView', () => {
 		// IAM-403: invite acceptance is token-only; must not send legacy params
 		expect(payload).not.toHaveProperty('inviterId');
 		expect(payload).not.toHaveProperty('inviteeId');
+	});
+
+	it('should use passwordMinLength from settings store', () => {
+		const settingsStore = mockedStore(useSettingsStore);
+		settingsStore.userManagement.passwordMinLength = 12;
+
+		expect(() => renderComponent()).not.toThrow();
 	});
 
 	it('should show error and redirect when URL has inviterId but no token', async () => {

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SignupView.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SignupView.test.ts
@@ -198,6 +198,9 @@ describe('SignupView', () => {
 	});
 
 	it('should default to 8-character minimum when passwordMinLength is not configured', () => {
+		const settingsStore = mockedStore(useSettingsStore);
+		delete (settingsStore.userManagement as { passwordMinLength?: number }).passwordMinLength;
+
 		const { getByText } = renderComponent();
 
 		expect(getByText(/8\+ characters/)).toBeInTheDocument();

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SignupView.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SignupView.test.ts
@@ -197,11 +197,13 @@ describe('SignupView', () => {
 		expect(payload).not.toHaveProperty('inviteeId');
 	});
 
-	it('should use passwordMinLength from settings store', () => {
+	it('should reflect configured passwordMinLength in password hint text', () => {
 		const settingsStore = mockedStore(useSettingsStore);
 		settingsStore.userManagement.passwordMinLength = 12;
 
-		expect(() => renderComponent()).not.toThrow();
+		const { getByText } = renderComponent();
+
+		expect(getByText(/12\+ characters/)).toBeInTheDocument();
 	});
 
 	it('should show error and redirect when URL has inviterId but no token', async () => {

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SignupView.vue
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SignupView.vue
@@ -5,16 +5,20 @@ import { useToast } from '@/app/composables/useToast';
 import { computed, onMounted, ref } from 'vue';
 import type { IFormBoxConfig } from '@/Interface';
 import { VIEWS } from '@/app/constants';
+import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { useI18n } from '@n8n/i18n';
+import { createPasswordRules } from '@n8n/design-system';
 import { useRoute, useRouter } from 'vue-router';
 
 const usersStore = useUsersStore();
+const settingsStore = useSettingsStore();
 
 const toast = useToast();
 const i18n = useI18n();
 const router = useRouter();
 const route = useRoute();
+const passwordMinLength = settingsStore.userManagement.passwordMinLength ?? 8;
 
 const FORM_CONFIG: IFormBoxConfig = {
 	title: i18n.baseText('auth.signup.setupYourAccount'),
@@ -46,9 +50,11 @@ const FORM_CONFIG: IFormBoxConfig = {
 			properties: {
 				label: i18n.baseText('auth.password'),
 				type: 'password',
-				validationRules: [{ name: 'DEFAULT_PASSWORD_RULES' }],
+				validationRules: [createPasswordRules(passwordMinLength)],
 				required: true,
-				infoText: i18n.baseText('auth.defaultPasswordRequirements'),
+				infoText: i18n.baseText('auth.defaultPasswordRequirements', {
+					interpolate: { minimum: passwordMinLength },
+				}),
 				autocomplete: 'new-password',
 				capitalize: true,
 			},


### PR DESCRIPTION
## Summary
- Expose the server-configured `N8N_PASSWORD_MIN_LENGTH` to the frontend via `IUserManagementSettings.passwordMinLength`
- Refactor `defaultPasswordRules` into a `createPasswordRules(minLength)` factory function in the design system
- Update all password form views (Setup, Signup, ChangePassword, ChangePasswordModal) to use the configured value for validation and hint text interpolation

## Test plan
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] Run `N8N_PASSWORD_MIN_LENGTH=12 pnpm dev` and verify hint text shows "12+ characters" on setup/signup/change-password views
- [x] Verify passwords shorter than configured minimum are rejected
- [x] Run backend service tests: `pushd packages/cli && pnpm test src/services/__tests__/frontend.service.test.ts`
- [x] Run validator unit tests: `pushd packages/frontend/@n8n/design-system && pnpm test src/components/N8nFormInput/validators.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)