### PR TITLE
fix: Increase timeout for computer use tool calls to 60 seconds (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/local-gateway.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/local-gateway.test.ts
@@ -135,7 +135,7 @@ describe('LocalGateway', () => {
 			).rejects.toThrow('not connected');
 		});
 
-		it('should timeout after 30 seconds', async () => {
+		it('should timeout after 60 seconds', async () => {
 			jest.useFakeTimers();
 
 			gateway.init(EMPTY_CAPABILITIES);
@@ -145,7 +145,7 @@ describe('LocalGateway', () => {
 				arguments: { filePath: 'slow.ts' },
 			});
 
-			jest.advanceTimersByTime(30_001);
+			jest.advanceTimersByTime(60_001);
 
 			await expect(callPromise).rejects.toThrow('timed out');
 

--- a/packages/cli/src/modules/instance-ai/filesystem/local-gateway.ts
+++ b/packages/cli/src/modules/instance-ai/filesystem/local-gateway.ts
@@ -8,7 +8,7 @@ import type {
 	ToolCategory,
 } from '@n8n/api-types';
 
-const REQUEST_TIMEOUT_MS = 30_000;
+const REQUEST_TIMEOUT_MS = 60_000; // 1 minute — tool calls like browser automation and shell execution can be long-running
 
 // ── Internal types ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Increases the timeout for computer-use tool calls from 30 seconds to 60 seconds

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4800/insteas-tool-call-timeout-in-instance-ai


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
