### PR TITLE
fix(core): Preserve config credential properties in eval mock layer (no-changelog)

### DIFF
--- a/packages/core/src/execution-engine/__tests__/eval-mock-helpers.test.ts
+++ b/packages/core/src/execution-engine/__tests__/eval-mock-helpers.test.ts
@@ -1,28 +1,171 @@
 import { mock } from 'jest-mock-extended';
-import type { IHttpRequestOptions, INode, IRequestOptions } from 'n8n-workflow';
+import type { IHttpRequestOptions, INode, INodeProperties, IRequestOptions } from 'n8n-workflow';
 
 import {
 	buildEvalMockCredentials,
 	callEvalMockHandler,
+	isSecretCredentialProperty,
 	normalizeLegacyRequest,
 	serializeMockToHttpResponse,
 } from '../eval-mock-helpers';
 import type { EvalLlmMockHandler, EvalMockHttpResponse } from '../index';
 
+// ---------------------------------------------------------------------------
+// Helper to build a minimal INodeProperties with sensible defaults
+// ---------------------------------------------------------------------------
+function credProp(overrides: Partial<INodeProperties> & { name: string }): INodeProperties {
+	return {
+		displayName: overrides.name,
+		type: 'string',
+		default: '',
+		...overrides,
+	};
+}
+
 describe('eval-mock-helpers', () => {
+	// -----------------------------------------------------------------------
+	// isSecretCredentialProperty
+	// -----------------------------------------------------------------------
+	describe('isSecretCredentialProperty', () => {
+		it('should classify typeOptions.password as secret', () => {
+			expect(
+				isSecretCredentialProperty(
+					credProp({ name: 'someField', typeOptions: { password: true } }),
+				),
+			).toBe(true);
+		});
+
+		it('should classify secret name patterns as secret', () => {
+			const secretNames = [
+				'apiKey',
+				'secretAccessKey',
+				'accessToken',
+				'password',
+				'credentials',
+				'authHeader',
+				'connectionString',
+			];
+			for (const name of secretNames) {
+				expect(isSecretCredentialProperty(credProp({ name }))).toBe(true);
+			}
+		});
+
+		it('should classify boolean, number, and options types as config', () => {
+			expect(
+				isSecretCredentialProperty(credProp({ name: 'useTls', type: 'boolean', default: false })),
+			).toBe(false);
+			expect(
+				isSecretCredentialProperty(credProp({ name: 'port', type: 'number', default: 5432 })),
+			).toBe(false);
+			expect(
+				isSecretCredentialProperty(
+					credProp({
+						name: 'region',
+						type: 'options',
+						default: 'us-east-1',
+						options: [{ name: 'US East', value: 'us-east-1' }],
+					}),
+				),
+			).toBe(false);
+		});
+
+		it('should classify config name patterns as config', () => {
+			const configNames = [
+				'baseUrl',
+				'hostname',
+				'region',
+				'endpoint',
+				'subdomain',
+				'domain',
+				'server',
+				'namespace',
+				'workspace',
+				'database',
+			];
+			for (const name of configNames) {
+				expect(isSecretCredentialProperty(credProp({ name }))).toBe(false);
+			}
+		});
+
+		it('should fall back to secret for ambiguous string properties', () => {
+			expect(isSecretCredentialProperty(credProp({ name: 'customField' }))).toBe(true);
+		});
+
+		it('should treat secret name patterns as secret even when type is non-string', () => {
+			// Secret name patterns take priority over type-based classification
+			expect(
+				isSecretCredentialProperty(credProp({ name: 'apiKey', type: 'number', default: 0 })),
+			).toBe(true);
+		});
+	});
+
 	// -----------------------------------------------------------------------
 	// buildEvalMockCredentials
 	// -----------------------------------------------------------------------
 	describe('buildEvalMockCredentials', () => {
-		it('should populate each property with eval-mock-value', () => {
-			const result = buildEvalMockCredentials([{ name: 'apiKey' }, { name: 'domain' }]);
+		it('should mock secret properties with descriptive placeholders', () => {
+			const result = buildEvalMockCredentials([
+				credProp({ name: 'apiKey', typeOptions: { password: true } }),
+				credProp({ name: 'secretAccessKey' }),
+			]);
 
-			expect(result.apiKey).toBe('eval-mock-value');
-			expect(result.domain).toBe('eval-mock-value');
+			expect(result.apiKey).toBe('<api-key>');
+			expect(result.secretAccessKey).toBe('<secret-access-key>');
+		});
+
+		it('should preserve default values for config properties', () => {
+			const result = buildEvalMockCredentials([
+				credProp({ name: 'baseUrl', default: 'https://api.example.com' }),
+				credProp({ name: 'region', type: 'options', default: 'eu-west-1' }),
+				credProp({ name: 'port', type: 'number', default: 443 }),
+				credProp({ name: 'useTls', type: 'boolean', default: true }),
+			]);
+
+			expect(result.baseUrl).toBe('https://api.example.com');
+			expect(result.region).toBe('eu-west-1');
+			expect(result.port).toBe(443);
+			expect(result.useTls).toBe(true);
+		});
+
+		it('should fall back to placeholder for config properties with no default', () => {
+			const result = buildEvalMockCredentials([
+				credProp({ name: 'endpoint', default: undefined as unknown as string }),
+			]);
+
+			expect(result.endpoint).toBe('<endpoint>');
+		});
+
+		it('should handle a realistic credential with mixed secret and config properties', () => {
+			const result = buildEvalMockCredentials([
+				credProp({ name: 'accessKeyId' }),
+				credProp({
+					name: 'secretAccessKey',
+					typeOptions: { password: true },
+				}),
+				credProp({
+					name: 'region',
+					type: 'options',
+					default: 'us-east-1',
+					options: [
+						{ name: 'US East', value: 'us-east-1' },
+						{ name: 'EU West', value: 'eu-west-1' },
+					],
+				}),
+				credProp({ name: 'customEndpoint', default: 'https://s3.amazonaws.com' }),
+			]);
+
+			// Secrets
+			expect(result.accessKeyId).toBe('<access-key-id>');
+			expect(result.secretAccessKey).toBe('<secret-access-key>');
+			// Config
+			expect(result.region).toBe('us-east-1');
+			expect(result.customEndpoint).toBe('https://s3.amazonaws.com');
 		});
 
 		it('should always include oauthTokenData with access_token, token_type, and refresh_token', () => {
-			const result = buildEvalMockCredentials([{ name: 'apiKey' }]);
+			const result = buildEvalMockCredentials([
+				credProp({ name: 'apiKey', typeOptions: { password: true } }),
+			]);
 
 			expect(result.oauthTokenData).toEqual({
 				access_token: 'eval-mock-access-token',
@@ -32,7 +175,9 @@ describe('eval-mock-helpers', () => {
 		});
 
 		it('should always include a privateKey containing an RSA key', () => {
-			const result = buildEvalMockCredentials([{ name: 'apiKey' }]);
+			const result = buildEvalMockCredentials([
+				credProp({ name: 'apiKey', typeOptions: { password: true } }),
+			]);
 
 			expect(result.privateKey).toEqual(expect.stringContaining('BEGIN RSA PRIVATE KEY'));
 			expect(result.privateKey).toEqual(expect.stringContaining('END RSA PRIVATE KEY'));

--- a/packages/core/src/execution-engine/eval-mock-helpers.ts
+++ b/packages/core/src/execution-engine/eval-mock-helpers.ts
@@ -7,7 +7,7 @@
  * type definitions in index.ts (module augmentation).
  */
 
-import type { IHttpRequestOptions, INode, IRequestOptions } from 'n8n-workflow';
+import type { IHttpRequestOptions, INode, INodeProperties, IRequestOptions } from 'n8n-workflow';
 
 import type { EvalLlmMockHandler, EvalMockHttpResponse } from './index';
 
@@ -38,17 +38,62 @@ const EVAL_MOCK_RSA_KEY =
 	'1RGx/w0Q3n5FVjMP3oG3UcUx9EB7GD8NMo74J/lEJ2UsBnIP3ggOb3AE+pWHNE0K\n' +
 	'-----END RSA PRIVATE KEY-----';
 
+// Name patterns that indicate a property holds a secret value (case-insensitive).
+const SECRET_NAME_PATTERNS =
+	/key|secret|token|password|credential|auth|connectionString|apiToken|accessCode/i;
+
+// Name patterns that indicate a property holds configuration (case-insensitive).
+const CONFIG_NAME_PATTERNS =
+	/url|host|region|endpoint|domain|subdomain|port|base|zone|server|namespace|org|project|team|site|instance|tenant|account(?!.*key)|workspace|bucket|database|schema|cluster|version/i;
+
+/**
+ * Determine whether a credential property is a secret that must be masked,
+ * or a config value whose default should be preserved for the LLM mock layer.
+ *
+ * Classification order:
+ * 1. `typeOptions.password` — explicit secret marker by credential authors
+ * 2. Secret name patterns — catches unmarked keys/tokens/passwords
+ * 3. Non-string types (boolean, number, options) — always config
+ * 4. Config name patterns — URLs, regions, hosts, etc.
+ * 5. Fallback — treat as secret (safe default: never leak to LLM)
+ */
+export function isSecretCredentialProperty(prop: INodeProperties): boolean {
+	if (prop.typeOptions?.password === true) return true;
+	if (SECRET_NAME_PATTERNS.test(prop.name)) return true;
+
+	if (prop.type === 'boolean' || prop.type === 'number' || prop.type === 'options') return false;
+	if (CONFIG_NAME_PATTERNS.test(prop.name)) return false;
+
+	return true;
+}
+
+/** Format a property name into a descriptive placeholder, e.g. `secretAccessKey` → `<secret-access-key>`. */
+function toPlaceholder(name: string): string {
+	const kebab = name.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+	return `<${kebab}>`;
+}
+
 /**
  * Build mock credentials for eval mode from the credential type's property definitions.
- * Includes auth-related fields (OAuth tokens, RSA keys) that nodes need beyond
- * the UI properties — nodes pick what they need and ignore the rest.
+ *
+ * Secret properties (API keys, passwords, tokens) are replaced with a
+ * descriptive placeholder like `<api-key>` so identifying credentials never
+ * reach the LLM, while the placeholder makes it obvious the value was mocked.
+ * Config properties (URLs, regions, hosts) keep their schema default values
+ * so the LLM mock handler sees realistic request URLs and can generate
+ * accurate responses.
+ *
+ * Also includes auth-related fields (OAuth tokens, RSA keys) that nodes need
+ * beyond the UI properties — nodes pick what they need and ignore the rest.
  */
-export function buildEvalMockCredentials(
-	properties: Array<{ name: string }>,
-): Record<string, unknown> {
+export function buildEvalMockCredentials(properties: INodeProperties[]): Record<string, unknown> {
 	const mockCredentials: Record<string, unknown> = {};
 	for (const prop of properties) {
-		mockCredentials[prop.name] = 'eval-mock-value';
+		if (isSecretCredentialProperty(prop)) {
+			mockCredentials[prop.name] = toPlaceholder(prop.name);
+		} else {
+			mockCredentials[prop.name] = prop.default ?? toPlaceholder(prop.name);
+		}
 	}
 	mockCredentials.oauthTokenData = {
 		access_token: 'eval-mock-access-token',


### PR DESCRIPTION
## Summary

- Credential properties used as config (URL, region, endpoint, host) were blindly replaced with a generic placeholder, misleading the LLM mock handler into generating inaccurate responses
- Now classifies each credential property as **secret** vs **config** using schema metadata (`typeOptions.password`, property type, name patterns) and preserves schema defaults for config properties
- Secret properties get descriptive placeholders like `<api-key>`, `<secret-access-key>` instead of the opaque `eval-mock-value`

## Related Linear ticket

https://linear.app/n8n/issue/TRUST-18

## Review / Merge checklist

- [x] Tests pass — 29 tests (6 new for `isSecretCredentialProperty`, 4 updated for `buildEvalMockCredentials`)
- [x] Typecheck clean
- [x] Lint clean

> **Note:** This is a clean reimplementation of #27908, rebased onto current master to avoid the merge conflicts from the `feature/instance-ai-evals-v2` base branch.