### PR TITLE
fix(core): Resolver settings page is only visible to authorized users (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/router.test.ts
+++ b/packages/frontend/editor-ui/src/app/router.test.ts
@@ -142,6 +142,42 @@ describe('router', () => {
 		10000,
 	);
 
+	test.each<[string, RouteRecordName, Scope[]]>([
+		['/settings/resolvers', VIEWS.WORKFLOWS, []],
+		[
+			'/settings/resolvers',
+			VIEWS.WORKFLOWS,
+			['credentialResolver:read', 'credentialResolver:list'],
+		],
+		[
+			'/settings/resolvers',
+			VIEWS.RESOLVERS,
+			[
+				'credentialResolver:read',
+				'credentialResolver:list',
+				'credentialResolver:create',
+				'credentialResolver:update',
+				'credentialResolver:delete',
+			],
+		],
+	])(
+		'should resolve %s to %s with %s user permissions (resolvers)',
+		async (path, name, scopes) => {
+			const rbacStore = useRBACStore();
+
+			settingsStore.settings.activeModules = ['dynamic-credentials'];
+			settingsStore.settings.envFeatureFlags = {
+				N8N_ENV_FEAT_DYNAMIC_CREDENTIALS: true,
+			} as typeof settingsStore.settings.envFeatureFlags;
+			rbacStore.setGlobalScopes(scopes);
+
+			await router.push(path);
+			expect(initializeAuthenticatedFeaturesSpy).toHaveBeenCalled();
+			expect(router.currentRoute.value.name).toBe(name);
+		},
+		10000,
+	);
+
 	test.each([
 		[VIEWS.PERSONAL_SETTINGS, true],
 		[VIEWS.USAGE, false],

--- a/packages/frontend/editor-ui/src/app/router.ts
+++ b/packages/frontend/editor-ui/src/app/router.ts
@@ -719,6 +719,7 @@ export const routes: RouteRecordRaw[] = [
 								'credentialResolver:update',
 								'credentialResolver:delete',
 							],
+							options: { mode: 'allOf' },
 						},
 						custom: () => {
 							const { isEnabled } = useDynamicCredentials();


### PR DESCRIPTION


## Summary
settings page was visible to users with role `member` but editing resulted in errors as they do not have the correct permissions

## Related Linear tickets, Github issues, and Community forum posts

none

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
