### PR TITLE
fix(core): Unblock builder agent when correction arrives during HITL confirmation (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/src/runtime/__tests__/background-task-manager.test.ts
+++ b/packages/@n8n/instance-ai/src/runtime/__tests__/background-task-manager.test.ts
@@ -209,6 +209,68 @@ describe('BackgroundTaskManager', () => {
 
 			expect(drainedCorrections[0]).toEqual([]);
 		});
+
+		it('notifies waitForCorrection when a correction is queued', async () => {
+			let waitForCorrection: (() => Promise<void>) | undefined;
+			const { promise, resolve } = createDeferred<string>();
+
+			manager.spawn(
+				makeSpawnOptions({
+					run: async (_signal, _drain, waitFn) => {
+						waitForCorrection = waitFn;
+						return await promise;
+					},
+				}),
+			);
+
+			await flushPromises();
+
+			const correctionPromise = waitForCorrection!();
+			let resolved = false;
+			void correctionPromise.then(() => {
+				resolved = true;
+			});
+
+			await flushPromises();
+			expect(resolved).toBe(false);
+
+			manager.queueCorrection('thread-1', 'task-1', 'use openrouter node');
+			await flushPromises();
+
+			expect(resolved).toBe(true);
+
+			resolve('done');
+			await flushPromises();
+		});
+
+		it('resolves waitForCorrection immediately when corrections are already queued', async () => {
+			let waitForCorrection: (() => Promise<void>) | undefined;
+			const { promise, resolve } = createDeferred<string>();
+
+			manager.spawn(
+				makeSpawnOptions({
+					run: async (_signal, _drain, waitFn) => {
+						waitForCorrection = waitFn;
+						return await promise;
+					},
+				}),
+			);
+
+			await flushPromises();
+
+			manager.queueCorrection('thread-1', 'task-1', 'pending correction');
+			const correctionPromise = waitForCorrection!();
+			let resolved = false;
+			void correctionPromise.then(() => {
+				resolved = true;
+			});
+
+			await flushPromises();
+			expect(resolved).toBe(true);
+
+			resolve('done');
+			await flushPromises();
+		});
 	});
 
 	describe('cancelTask', () => {

--- a/packages/@n8n/instance-ai/src/runtime/background-task-manager.ts
+++ b/packages/@n8n/instance-ai/src/runtime/background-task-manager.ts
@@ -75,9 +75,9 @@ export class BackgroundTaskManager {
 		if (task.status !== 'running') return 'task-completed';
 		task.corrections.push(correction);
 		if (task.onCorrectionQueued) {
-			const callback = task.onCorrectionQueued;
+			const notify = task.onCorrectionQueued;
 			task.onCorrectionQueued = undefined;
-			callback();
+			notify();
 		}
 		return 'queued';
 	}
@@ -154,8 +154,8 @@ export class BackgroundTaskManager {
 			return pending;
 		};
 
-		const waitForCorrection = (): Promise<void> =>
-			new Promise<void>((resolve) => {
+		const waitForCorrection = async (): Promise<void> =>
+			await new Promise<void>((resolve) => {
 				if (task.corrections.length > 0) {
 					resolve();
 					return;

--- a/packages/@n8n/instance-ai/src/runtime/background-task-manager.ts
+++ b/packages/@n8n/instance-ai/src/runtime/background-task-manager.ts
@@ -14,6 +14,8 @@ export interface ManagedBackgroundTask {
 	startedAt: number;
 	abortController: AbortController;
 	corrections: string[];
+	/** Callback resolved when a new correction is queued. Re-created by the consumer after each notification. */
+	onCorrectionQueued?: () => void;
 	messageGroupId?: string;
 	outcome?: Record<string, unknown>;
 	plannedTaskId?: string;
@@ -34,6 +36,7 @@ export interface SpawnManagedBackgroundTaskOptions {
 	run: (
 		signal: AbortSignal,
 		drainCorrections: () => string[],
+		waitForCorrection: () => Promise<void>,
 	) => Promise<string | BackgroundTaskResult>;
 	onLimitReached?: (errorMessage: string) => void;
 	onCompleted?: (task: ManagedBackgroundTask) => void | Promise<void>;
@@ -71,6 +74,11 @@ export class BackgroundTaskManager {
 		if (!task || task.threadId !== threadId) return 'task-not-found';
 		if (task.status !== 'running') return 'task-completed';
 		task.corrections.push(correction);
+		if (task.onCorrectionQueued) {
+			const callback = task.onCorrectionQueued;
+			task.onCorrectionQueued = undefined;
+			callback();
+		}
 		return 'queued';
 	}
 
@@ -146,8 +154,21 @@ export class BackgroundTaskManager {
 			return pending;
 		};
 
+		const waitForCorrection = (): Promise<void> =>
+			new Promise<void>((resolve) => {
+				if (task.corrections.length > 0) {
+					resolve();
+					return;
+				}
+				task.onCorrectionQueued = resolve;
+			});
+
 		try {
-			const raw = await options.run(task.abortController.signal, drainCorrections);
+			const raw = await options.run(
+				task.abortController.signal,
+				drainCorrections,
+				waitForCorrection,
+			);
 			task.status = 'completed';
 			task.result = typeof raw === 'string' ? raw : raw.text;
 			task.outcome = typeof raw === 'string' ? undefined : raw.outcome;

--- a/packages/@n8n/instance-ai/src/runtime/resumable-stream-executor.ts
+++ b/packages/@n8n/instance-ai/src/runtime/resumable-stream-executor.ts
@@ -40,6 +40,9 @@ export interface AutoResumeControl {
 	mode: 'auto';
 	waitForConfirmation: (requestId: string) => Promise<Record<string, unknown>>;
 	drainCorrections?: () => string[];
+	/** Returns a promise that resolves when a new user correction is queued. Used to unblock
+	 *  HITL suspensions so the builder can incorporate the correction instead of waiting forever. */
+	waitForCorrection?: () => Promise<void>;
 	onSuspension?: (suspension: SuspensionInfo) => void;
 	buildResumeOptions?: (input: {
 		mastraRunId: string;
@@ -2062,9 +2065,13 @@ export async function executeResumableStream(
 			};
 		}
 
-		const resumeData = await waitForConfirmation(
+		const confirmationPromise =
+			pendingConfirmation ?? options.control.waitForConfirmation(suspension.requestId);
+		const resumeData = await waitForConfirmationOrCorrection(
 			options.context.signal,
-			pendingConfirmation ?? options.control.waitForConfirmation(suspension.requestId),
+			confirmationPromise,
+			options.control,
+			options.context,
 		);
 		const resumeOptions = options.control.buildResumeOptions?.({
 			mastraRunId: activeMastraRunId,
@@ -2147,6 +2154,44 @@ async function waitForConfirmation(
 			signal.removeEventListener('abort', abortHandler);
 		}
 	}
+}
+
+/**
+ * Race the HITL confirmation promise against an incoming user correction.
+ * When a correction arrives first, auto-confirm the suspended tool call with
+ * override data so the builder can resume and incorporate the correction.
+ */
+async function waitForConfirmationOrCorrection(
+	signal: AbortSignal,
+	confirmationPromise: Promise<Record<string, unknown>>,
+	control: AutoResumeControl,
+	context: ResumableStreamContext,
+): Promise<Record<string, unknown>> {
+	if (!control.waitForCorrection) {
+		return await waitForConfirmation(signal, confirmationPromise);
+	}
+
+	const correctionSentinel = Object.freeze({ __correctionOverride: true });
+	const raced = Promise.race([
+		confirmationPromise,
+		control.waitForCorrection().then(() => correctionSentinel as Record<string, unknown>),
+	]);
+
+	const result = await waitForConfirmation(signal, raced);
+
+	if (result === correctionSentinel) {
+		const corrections = control.drainCorrections?.() ?? [];
+		publishCorrections(context, corrections);
+		return {
+			__correctionOverride: true,
+			message:
+				'The user sent a correction while this tool was waiting for confirmation. ' +
+				'The confirmation has been skipped. Apply the correction and continue.',
+			corrections,
+		};
+	}
+
+	return result;
 }
 
 function isSameSuspension(left: SuspensionInfo, right: SuspensionInfo): boolean {

--- a/packages/@n8n/instance-ai/src/stream/consume-with-hitl.ts
+++ b/packages/@n8n/instance-ai/src/stream/consume-with-hitl.ts
@@ -20,6 +20,9 @@ export interface ConsumeWithHitlOptions {
 	waitForConfirmation?: (requestId: string) => Promise<Record<string, unknown>>;
 	/** Drain queued user corrections (mid-flight steering for background tasks). */
 	drainCorrections?: () => string[];
+	/** Returns a promise that resolves when a new user correction is queued.
+	 *  Used to unblock HITL suspensions when a correction arrives mid-confirmation. */
+	waitForCorrection?: () => Promise<void>;
 	llmStepTraceHooks?: LlmStepTraceHooks;
 	workingMemoryEnabled?: boolean;
 	/** Max steps for the agent — passed to resumeStream so resumed streams keep the same limit. */
@@ -61,6 +64,7 @@ export async function consumeStreamWithHitl(
 			mode: 'auto',
 			waitForConfirmation: options.waitForConfirmation,
 			drainCorrections: options.drainCorrections,
+			waitForCorrection: options.waitForCorrection,
 			...(options.maxSteps
 				? {
 						buildResumeOptions: ({ mastraRunId, suspension }) => ({

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
@@ -340,7 +340,7 @@ export async function startBuildWorkflowAgentTask(
 		traceContext,
 		plannedTaskId: input.plannedTaskId,
 		workItemId,
-		run: async (signal, drainCorrections): Promise<BackgroundTaskResult> =>
+		run: async (signal, drainCorrections, waitForCorrection): Promise<BackgroundTaskResult> =>
 			await withTraceContextActor(traceContext, async () => {
 				let builderWs: BuilderWorkspace | undefined;
 				const submitAttempts = new Map<string, SubmitWorkflowAttempt>();
@@ -462,6 +462,7 @@ export async function startBuildWorkflowAgentTask(
 								abortSignal: signal,
 								waitForConfirmation: context.waitForConfirmation,
 								drainCorrections,
+								waitForCorrection,
 								llmStepTraceHooks,
 								workingMemoryEnabled: false,
 							});
@@ -595,6 +596,7 @@ export async function startBuildWorkflowAgentTask(
 							abortSignal: signal,
 							waitForConfirmation: context.waitForConfirmation,
 							drainCorrections,
+							waitForCorrection,
 							llmStepTraceHooks,
 							workingMemoryEnabled: false,
 						});

--- a/packages/@n8n/instance-ai/src/tools/orchestration/data-table-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/data-table-agent.tool.ts
@@ -120,7 +120,7 @@ export async function startDataTableAgentTask(
 		role: 'data-table-manager',
 		traceContext,
 		plannedTaskId: input.plannedTaskId,
-		run: async (signal, _drainCorrections) => {
+		run: async (signal, _drainCorrections, _waitForCorrection) => {
 			return await withTraceContextActor(traceContext, async () => {
 				const subAgent = new Agent({
 					id: subAgentId,

--- a/packages/@n8n/instance-ai/src/tools/orchestration/delegate.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/delegate.tool.ts
@@ -181,7 +181,7 @@ export async function startDetachedDelegateTask(
 		role,
 		traceContext,
 		plannedTaskId: input.plannedTaskId,
-		run: async (signal, drainCorrections) => {
+		run: async (signal, drainCorrections, waitForCorrection) => {
 			return await withTraceContextActor(traceContext, async () => {
 				const subAgent = createSubAgent({
 					agentId: subAgentId,
@@ -232,6 +232,7 @@ export async function startDetachedDelegateTask(
 						abortSignal: signal,
 						waitForConfirmation: context.waitForConfirmation,
 						drainCorrections,
+						waitForCorrection,
 						llmStepTraceHooks,
 						workingMemoryEnabled: false,
 					});

--- a/packages/@n8n/instance-ai/src/tools/orchestration/research-with-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/research-with-agent.tool.ts
@@ -112,7 +112,7 @@ export async function startResearchAgentTask(
 		role: 'web-researcher',
 		traceContext,
 		plannedTaskId: input.plannedTaskId,
-		run: async (signal, drainCorrections) => {
+		run: async (signal, drainCorrections, waitForCorrection) => {
 			return await withTraceContextActor(traceContext, async () => {
 				const subAgent = new Agent({
 					id: subAgentId,
@@ -161,6 +161,7 @@ export async function startResearchAgentTask(
 						abortSignal: signal,
 						waitForConfirmation: context.waitForConfirmation,
 						drainCorrections,
+						waitForCorrection,
 						llmStepTraceHooks,
 					});
 

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -799,6 +799,7 @@ export interface SpawnBackgroundTaskOptions {
 	run: (
 		signal: AbortSignal,
 		drainCorrections: () => string[],
+		waitForCorrection: () => Promise<void>,
 	) => Promise<string | BackgroundTaskResult>;
 }
 


### PR DESCRIPTION
## Summary

Fixes a deadlock where the AI builder agent gets stuck forever when a user sends a correction while the builder is waiting for HITL confirmation (e.g. `setup-credentials`).

**Root cause:** `drainCorrections()` is only called inside the stream chunk loop (`for await (const chunk of activeStream)`). Once the stream ends and the builder hits `await waitForConfirmation()`, no more chunks are produced, so corrections queued via `correct-background-task` are never processed... the builder blocks forever.

**Fix:** Add a `waitForCorrection` signal that races against `waitForConfirmation` in `resumable-stream-executor.ts`. When a correction arrives first, auto-confirm the suspended tool call with override data so the builder can resume and incorporate the correction.
## Related Linear tickets, Github issues, and Community forum posts

- https://www.notion.so/n8n/Stuck-after-asking-for-correction-on-the-wf-33c5b6e0c94f8064a56bd218cc42e165