### PR TITLE
fix(GraphQL Node): Improve error response handling

### DIFF
--- a/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
+++ b/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
@@ -552,9 +552,15 @@ export class GraphQL implements INodeType {
 				}
 				// throw from response object.errors[]
 				if (typeof response === 'object' && response.errors) {
-					const message =
-						response.errors?.map((error: IDataObject) => error.message).join(', ') ||
-						'Unexpected error';
+					let message = 'Unexpected error';
+					if (Array.isArray(response.errors)) {
+						message = (response.errors as IDataObject[])
+							.map((error) => error.message ?? error)
+							.join(', ');
+					} else if (typeof response.errors === 'string') {
+						message = response.errors;
+					}
+
 					throw new NodeApiError(this.getNode(), response.errors as JsonObject, { message });
 				}
 			} catch (error) {

--- a/packages/nodes-base/nodes/GraphQL/test/GraphQL.node.test.ts
+++ b/packages/nodes-base/nodes/GraphQL/test/GraphQL.node.test.ts
@@ -1,5 +1,11 @@
 import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import { mockDeep } from 'jest-mock-extended';
+import get from 'lodash/get';
+import { constructExecutionMetaData, returnJsonArray } from 'n8n-core';
+import type { IDataObject, IExecuteFunctions } from 'n8n-workflow';
 import nock from 'nock';
+
+import { GraphQL } from '../GraphQL.node';
 
 describe('GraphQL Node', () => {
 	describe('valid request', () => {
@@ -108,6 +114,77 @@ describe('GraphQL Node', () => {
 		new NodeTestHarness().setupTests({
 			workflowFiles: ['workflow.refresh_token.json'],
 			credentials,
+		});
+	});
+
+	describe('error response', () => {
+		const createMockExecuteFunctions = (parameters: IDataObject) => {
+			const mockExecuteFunctions = mockDeep<IExecuteFunctions>();
+			mockExecuteFunctions.getNodeParameter.mockImplementation((parameter, _idx, fallbackValue) => {
+				return get(parameters, parameter) ?? fallbackValue;
+			});
+			mockExecuteFunctions.getInputData.mockReturnValue([{ json: {} }]);
+			mockExecuteFunctions.helpers.returnJsonArray.mockImplementation(returnJsonArray);
+			mockExecuteFunctions.helpers.constructExecutionMetaData.mockImplementation(
+				constructExecutionMetaData,
+			);
+			return mockExecuteFunctions;
+		};
+
+		beforeEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it('should format error response if response.errors is an array with objects', async () => {
+			const mockExecuteFunctions = createMockExecuteFunctions({
+				query: 'query { foo }',
+			});
+			mockExecuteFunctions.helpers.request.mockResolvedValue({
+				errors: [{ message: 'Bad format 1' }, { message: 'Bad format 2' }],
+			});
+			const node = new GraphQL();
+
+			await expect(node.execute.call(mockExecuteFunctions)).rejects.toThrow(
+				'Bad format 1, Bad format 2',
+			);
+		});
+
+		it('should format error response if response.errors is an array with strings', async () => {
+			const mockExecuteFunctions = createMockExecuteFunctions({
+				query: 'query { foo }',
+			});
+			mockExecuteFunctions.helpers.request.mockResolvedValue({
+				errors: ['Bad format 1', 'Bad format 2'],
+			});
+			const node = new GraphQL();
+
+			await expect(node.execute.call(mockExecuteFunctions)).rejects.toThrow(
+				'Bad format 1, Bad format 2',
+			);
+		});
+
+		it('should format error response if response.errors is a string', async () => {
+			const mockExecuteFunctions = createMockExecuteFunctions({
+				query: 'query { foo }',
+			});
+			mockExecuteFunctions.helpers.request.mockResolvedValue({
+				errors: 'Bad format',
+			});
+			const node = new GraphQL();
+
+			await expect(node.execute.call(mockExecuteFunctions)).rejects.toThrow('Bad format');
+		});
+
+		it('should fallback to unexpected error if response.errors is not an array or string', async () => {
+			const mockExecuteFunctions = createMockExecuteFunctions({
+				query: 'query { foo }',
+			});
+			mockExecuteFunctions.helpers.request.mockResolvedValue({
+				errors: 123,
+			});
+			const node = new GraphQL();
+
+			await expect(node.execute.call(mockExecuteFunctions)).rejects.toThrow('Unexpected error');
 		});
 	});
 });


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

If a GraphQL returns an error response where `.errors` is not an array of objects with `message` property, it would fail or produce an invalid message. This PR fixes that by handling more error formats with a fallback error message

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-4737/community-issue-graphql-node-issue-parsing-responseerrorsmap-is-not-a
Closes #27601

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
