### PR TITLE
fix(core): Propagate formidable parse errors in Form Trigger

### DIFF
--- a/packages/cli/src/webhooks/__tests__/webhook-form-data.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-form-data.test.ts
@@ -164,20 +164,36 @@ describe('webhook-form-data', () => {
 			testServer.assertHasBeenCalled();
 		});
 
-		it('should ignore file that is too large', async () => {
+		it('should reject with an error when file exceeds maxFileSize', async () => {
 			const oneByteInMb = 1 / 1024 / 1024;
 			const parseFn = createMultiFormDataParser(oneByteInMb);
 
 			await testServer
 				.sendRequestToHandler(async (req) => {
-					const parsedData = await parseFn(req);
-
-					expect(parsedData).toStrictEqual({
-						data: {},
-						files: {},
-					});
+					await expect(parseFn(req)).rejects.toThrow(/maxFileSize/);
 				})
 				.attach('file', oneKbData, 'file.txt');
+
+			testServer.assertHasBeenCalled();
+		});
+
+		it('should reject with an error when total file size exceeds limit', async () => {
+			// Simulate the real-world scenario from #28069: a file upload that
+			// exceeds the configured limit should surface the actual formidable
+			// error instead of silently returning empty data.
+			const twoKbData = Buffer.alloc(2 * 1024, 'x');
+			const oneKbInMb = 1 / 1024;
+			const parseFn = createMultiFormDataParser(oneKbInMb);
+
+			await testServer
+				.sendRequestToHandler(async (req) => {
+					const rejection = parseFn(req);
+					await expect(rejection).rejects.toThrow();
+					await expect(rejection).rejects.toMatchObject({
+						httpCode: 413,
+					});
+				})
+				.attach('file', twoKbData, 'large-upload.bin');
 
 			testServer.assertHasBeenCalled();
 		});

--- a/packages/cli/src/webhooks/webhook-form-data.ts
+++ b/packages/cli/src/webhooks/webhook-form-data.ts
@@ -27,8 +27,12 @@ export const createMultiFormDataParser = (maxFormDataSizeInMb: number) => {
 			// TODO: pass a custom `fileWriteStreamHandler` to create binary data files directly
 		});
 
-		return await new Promise((resolve) => {
-			form.parse(req, async (_err, data, files) => {
+		return await new Promise((resolve, reject) => {
+			form.parse(req, (error, data, files) => {
+				if (error) {
+					reject(error);
+					return;
+				}
 				normalizeFormData(data);
 				normalizeFormData(files);
 				resolve({ data, files });


### PR DESCRIPTION
## Summary

The multipart form data parser in `createMultiFormDataParser` silently discards errors from formidable. The callback's error parameter is prefixed with `_` and never checked:

```typescript
form.parse(req, async (_err, data, files) => {
    // _err is ignored — any formidable error silently produces empty files
    normalizeFormData(data);
    normalizeFormData(files);
    resolve({ data, files });
});
```

When formidable encounters an error (e.g. file exceeding `maxFileSize`, corrupted multipart stream, or any internal parse failure), `data` and `files` are empty/undefined. The promise resolves with empty objects, causing the Form Trigger to emit items with no binary data. Downstream nodes then fail with misleading errors (e.g. "No uploaded audio files were found") instead of surfacing the actual upload failure.

This PR checks the error parameter and rejects the promise when formidable reports an error, so the real failure reason reaches the user.

**What changed:**
- `webhook-form-data.ts`: Check formidable's error callback; reject instead of silently resolving
- `webhook-form-data.test.ts`: Updated the "file too large" test to expect rejection; added a second test verifying the error contains useful info (message + HTTP 413 status)

### Verification

I verified the fix by running real HTTP multipart requests through formidable (v3.5.4) with a file size exceeding `maxFileSize`:

**Before (old code — silent swallow):**
```
Had error from formidable: true
Error message: options.maxTotalFileSize (1024 bytes) exceeded, received 2048 bytes of file data
Data keys: []
File keys: []
=> BUG: Error silently swallowed. User gets empty data.
```

Formidable *does* report the error in its callback, but the old code ignores it and resolves with empty objects. The Form Trigger then emits an item with no binary data, and downstream nodes throw confusing, unrelated errors.

**After (new code — error propagated):**
```
Error surfaced: options.maxTotalFileSize (1024 bytes) exceeded, received 2048 bytes of file data
HTTP code: 413
=> FIX: User sees the actual error instead of empty data.
```

The error now rejects the promise, propagates through `parseRequestBody` → `executeWebhook`'s outer catch (line 927 of `webhook-helpers.ts`), and surfaces to the user as an `OperationalError` with the real formidable error as the cause.

**Success path (no regression):**
```
Data keys: [ 'name' ]
File keys: [ 'file' ]
=> Success path still works correctly.
```

Files under the limit still parse and resolve normally.

Fixes #28069

## Related Linear tickets, Github issues, and Community forum posts

- Fixes #28069

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.