### PR TITLE
fix(googleGemini): Guard tool call parsing when response parts contain undefined

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/GoogleGemini.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/GoogleGemini.node.test.ts
@@ -731,6 +731,94 @@ describe('GoogleGemini Node', () => {
 				);
 			});
 
+			it('should handle multi-iteration tool responses with Google Search enabled', async () => {
+				executeFunctionsMock.getNodeParameter.mockImplementation((parameter: string) => {
+					switch (parameter) {
+						case 'modelId':
+							return 'models/gemini-2.5-flash';
+						case 'messages.values':
+							return [{ role: 'user', content: 'Generate a tweet about PSG vs Liverpool' }];
+						case 'simplify':
+							return true;
+						case 'jsonOutput':
+							return false;
+						case 'builtInTools':
+							return {
+								googleSearch: true,
+							};
+						case 'options':
+							return {};
+						case 'options.maxToolsIterations':
+							return 15;
+						default:
+							return undefined;
+					}
+				});
+				executeFunctionsMock.getNodeInputs.mockReturnValue([{ type: 'main' }]);
+				apiRequestMock
+					.mockResolvedValueOnce({
+						candidates: [
+							{
+								content: {
+									parts: [
+										undefined,
+										{
+											functionCall: {
+												id: 'search-round-1',
+												name: 'googleSearch',
+												args: { query: 'PSG vs Liverpool latest updates' },
+											},
+										},
+										{
+											functionResponse: {
+												id: 'search-round-1',
+												name: 'googleSearch',
+												response: { result: 'search results' },
+											},
+										},
+									],
+									role: 'model',
+								},
+							},
+						],
+					})
+					.mockResolvedValueOnce({
+						candidates: [
+							{
+								content: {
+									parts: [{ text: 'PSG and Liverpool are trending after a dramatic match.' }],
+									role: 'model',
+								},
+							},
+						],
+					});
+
+				const result = await text.message.execute.call(executeFunctionsMock, 0);
+
+				expect(apiRequestMock).toHaveBeenCalledTimes(2);
+				expect(apiRequestMock).toHaveBeenNthCalledWith(
+					1,
+					'POST',
+					'/v1beta/models/gemini-2.5-flash:generateContent',
+					expect.objectContaining({
+						body: expect.objectContaining({
+							tools: expect.arrayContaining([{ googleSearch: {} }]),
+						}),
+					}),
+				);
+				expect(result).toEqual([
+					{
+						json: {
+							content: {
+								parts: [{ text: 'PSG and Liverpool are trending after a dramatic match.' }],
+								role: 'model',
+							},
+						},
+						pairedItem: { item: 0 },
+					},
+				]);
+			});
+
 			describe('includeMergedResponse', () => {
 				it('should include mergedResponse per candidate when enabled and simplify is true', async () => {
 					executeFunctionsMock.getNodeParameter.mockImplementation((parameter: string) => {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/text/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/text/message.operation.ts
@@ -341,8 +341,20 @@ const displayOptions = {
 
 export const description = updateDisplayOptions(displayOptions, properties);
 
+function isObject(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === 'object';
+}
+
+function hasFunctionCallPart(
+	part: unknown,
+): part is { functionCall: { id?: string; name: string; args?: IDataObject } } {
+	return isObject(part) && 'functionCall' in part && isObject(part.functionCall);
+}
+
 function getToolCalls(response: GenerateContentResponse) {
-	return response.candidates.flatMap((c) => c.content.parts).filter((p) => 'functionCall' in p);
+	return response.candidates
+		.flatMap((candidate) => candidate.content?.parts ?? [])
+		.filter(hasFunctionCallPart);
 }
 
 export async function execute(this: IExecuteFunctions, i: number): Promise<INodeExecutionData[]> {


### PR DESCRIPTION
## Summary

The Google Gemini node (text resource, **Message** operation) could throw `Cannot use 'in' operator to search for 'functionCall' in undefined` when Gemini returned `content.parts` with missing entries during multi-turn tool use (for example with built-in Google Search). This updates `getToolCalls` to use `content?.parts ?? []` and to only treat plain objects with a real `functionCall` payload as tool calls.

A unit test covers a multi-iteration response with an undefined part and Google Search enabled.

## How to test

```bash
cd packages/@n8n/nodes-langchain && pnpm test GoogleGemini.node.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

Fixes https://github.com/n8n-io/n8n/issues/28215

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created (not required for this bugfix).
- [x] Tests included.
- [ ] PR labeled for backport if needed.
