### PR TITLE
fix(mcp): add GET endpoint for SSE stream connections

### DIFF
--- a/packages/cli/src/modules/mcp/mcp.controller.ts
+++ b/packages/cli/src/modules/mcp/mcp.controller.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@n8n/backend-common';
 import { AuthenticatedRequest } from '@n8n/db';
-import { Head, Post, RootLevelController } from '@n8n/decorators';
+import { Get, Head, Post, RootLevelController } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 import type { Request, Response } from 'express';
 import { ErrorReporter } from 'n8n-core';
@@ -65,6 +65,54 @@ export class McpController {
 		this.setCorsHeaders(res);
 		res.header('WWW-Authenticate', 'Bearer realm="n8n MCP Server"');
 		res.status(401).end();
+	}
+
+	/**
+	 * GET endpoint for SSE stream connections
+	 * Some MCP clients (e.g. Gemini CLI) use GET requests to establish SSE streams
+	 * for server-initiated messages per the MCP Streamable HTTP transport spec.
+	 */
+	@Get('/http', {
+		middlewares: [getAuthMiddleware()],
+		skipAuth: true,
+		usesTemplates: true,
+	})
+	async stream(req: AuthenticatedRequest, res: FlushableResponse) {
+		this.setCorsHeaders(res);
+
+		const enabled = await this.mcpSettingsService.getEnabled();
+		if (!enabled) {
+			res.status(403).json({ message: MCP_ACCESS_DISABLED_ERROR_MESSAGE });
+			return;
+		}
+
+		try {
+			const { StreamableHTTPServerTransport } = await import(
+				'@modelcontextprotocol/sdk/server/streamableHttp.js'
+			);
+			const server = await this.mcpService.getServer(req.user);
+			const transport = new StreamableHTTPServerTransport({
+				sessionIdGenerator: undefined,
+			});
+			res.on('close', () => {
+				void transport.close();
+				void server.close();
+			});
+			await server.connect(transport);
+			await transport.handleRequest(req, res);
+		} catch (error) {
+			this.errorReporter.error(error);
+			if (!res.headersSent) {
+				res.status(500).json({
+					jsonrpc: '2.0',
+					error: {
+						code: -32603,
+						message: INTERNAL_SERVER_ERROR_MESSAGE,
+					},
+					id: null,
+				});
+			}
+		}
 	}
 
 	@Post('/http', {


### PR DESCRIPTION
## Summary

Some MCP clients (e.g. Gemini CLI) use `GET /mcp-server/http` to establish SSE streams for server-initiated messages, per the [MCP Streamable HTTP transport specification](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/transports/#streamable-http). Without a registered GET route, these requests returned `404 Not Found`.

This PR adds a `GET /mcp-server/http` endpoint that delegates to `StreamableHTTPServerTransport.handleRequest()`, following the same stateless pattern used by the existing POST handler (creates a new transport+server per request with `sessionIdGenerator: undefined` for isolation).

**Observed before fix:**
- `POST /mcp-server/http` → works correctly
- `GET /mcp-server/http` → `404 Not Found` (breaks Gemini CLI SSE handshake)

**After fix:**
- Both `GET` and `POST` requests are handled correctly

## Related Linear tickets, Github issues, and Community forum posts

Fixes #28137

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)