### PR TITLE
ci: Make PR metrics comment non-blocking (no-changelog)

### DIFF
--- a/.github/scripts/post-qa-metrics-comment.mjs
+++ b/.github/scripts/post-qa-metrics-comment.mjs
@@ -60,23 +60,30 @@ if (user && pass) {
 
 console.log(`PR #${pr}: fetching ${metrics.join(', ')} (${baselineDays}-day baseline)`);
 
-const res = await fetch(webhookUrl, {
-	method: 'POST',
-	headers,
-	body: JSON.stringify({
-		pr_number: pr,
-		github_repo: repo,
-		git_sha: sha,
-		baseline_days: baselineDays,
-		metric_names: metrics,
-	}),
-	signal: AbortSignal.timeout(60_000),
-});
+let res;
+try {
+	res = await fetch(webhookUrl, {
+		method: 'POST',
+		headers,
+		body: JSON.stringify({
+			pr_number: pr,
+			github_repo: repo,
+			git_sha: sha,
+			baseline_days: baselineDays,
+			metric_names: metrics,
+		}),
+		signal: AbortSignal.timeout(60_000),
+	});
+} catch (err) {
+	console.warn(`Webhook unreachable, skipping metrics comment: ${err.message}`);
+	process.exit(0);
+}
 
 if (!res.ok) {
 	const text = await res.text().catch(() => '');
-	console.error(`Webhook failed: ${res.status} ${res.statusText}\n${text}`);
-	process.exit(1);
+	console.warn(`Webhook failed: ${res.status} ${res.statusText}\n${text}`);
+	console.warn('Skipping metrics comment.');
+	process.exit(0);
 }
 
 const { markdown, has_data } = await res.json();


### PR DESCRIPTION
## Summary
- The QA metrics webhook can return 500 or be unreachable (e.g. internal n8n instance is down), which previously caused the CI step to `exit 1` and show as a failed check on PRs
- Wrapped the webhook fetch in try/catch to handle network errors (timeouts, DNS, connection refused)
- Changed non-ok HTTP responses from `exit 1` to `exit 0` with a warning log

## Test plan
- [ ] Verify the script exits 0 when the webhook returns 500
- [ ] Verify the script exits 0 when the webhook is unreachable (network error)
- [ ] Verify normal operation is unaffected when the webhook is healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)