### PR TITLE
fix(HTTP Request Node): Fix multipart/form-data file upload with binary streams

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/axios-utils.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/axios-utils.test.ts
@@ -1,0 +1,95 @@
+import type { AxiosRequestConfig } from 'axios';
+import FormData from 'form-data';
+import { Readable } from 'stream';
+
+import { generateContentLengthHeader, isFormDataInstance } from '../request-helpers/axios-utils';
+
+describe('isFormDataInstance', () => {
+	it('should return true for a real FormData instance', () => {
+		const formData = new FormData();
+		expect(isFormDataInstance(formData)).toBe(true);
+	});
+
+	it('should return true for a duck-typed FormData (different module copy)', () => {
+		const fakeFormData = {
+			getHeaders: () => ({ 'content-type': 'multipart/form-data; boundary=---test' }),
+			append: () => {},
+		};
+		expect(isFormDataInstance(fakeFormData)).toBe(true);
+	});
+
+	it('should return false for null', () => {
+		expect(isFormDataInstance(null)).toBe(false);
+	});
+
+	it('should return false for undefined', () => {
+		expect(isFormDataInstance(undefined)).toBe(false);
+	});
+
+	it('should return false for a plain object', () => {
+		expect(isFormDataInstance({ key: 'value' })).toBe(false);
+	});
+
+	it('should return false for a string', () => {
+		expect(isFormDataInstance('form-data')).toBe(false);
+	});
+
+	it('should return false for an object with only getHeaders', () => {
+		expect(isFormDataInstance({ getHeaders: () => ({}) })).toBe(false);
+	});
+
+	it('should return false for an object with only append', () => {
+		expect(isFormDataInstance({ append: () => {} })).toBe(false);
+	});
+});
+
+describe('generateContentLengthHeader', () => {
+	it('should set content-length for FormData with buffer values', async () => {
+		const formData = new FormData();
+		formData.append('file', Buffer.from('test-content'), {
+			filename: 'test.txt',
+			contentType: 'text/plain',
+		});
+
+		const config: AxiosRequestConfig = { data: formData, headers: {} };
+		await generateContentLengthHeader(config);
+
+		expect(config.headers?.['content-length']).toBeGreaterThan(0);
+	});
+
+	it('should set content-length for FormData with stream and knownLength', async () => {
+		const formData = new FormData();
+		const stream = Readable.from(Buffer.from('test-content'));
+		formData.append('file', stream, {
+			filename: 'test.txt',
+			contentType: 'text/plain',
+			knownLength: 12,
+		});
+
+		const config: AxiosRequestConfig = { data: formData, headers: {} };
+		await generateContentLengthHeader(config);
+
+		expect(config.headers?.['content-length']).toBeGreaterThan(0);
+	});
+
+	it('should not throw for FormData with stream without knownLength', async () => {
+		const formData = new FormData();
+		const stream = Readable.from(Buffer.from('test-content'));
+		formData.append('file', stream, {
+			filename: 'test.txt',
+			contentType: 'text/plain',
+		});
+
+		const config: AxiosRequestConfig = { data: formData, headers: {} };
+		await generateContentLengthHeader(config);
+
+		expect(config.headers?.['content-length']).toBeUndefined();
+	});
+
+	it('should skip non-FormData data', async () => {
+		const config: AxiosRequestConfig = { data: 'plain string', headers: {} };
+		await generateContentLengthHeader(config);
+
+		expect(config.headers?.['content-length']).toBeUndefined();
+	});
+});

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
@@ -403,6 +403,40 @@ describe('Request Helper Functions', () => {
 			expect(axiosOptions.data).toBeInstanceOf(FormData);
 		});
 
+		test('should handle FormData from a different module copy (duck-typing)', async () => {
+			// Simulate a FormData created by a different copy of the form-data package.
+			// instanceof FormData would return false, but duck-type check should pass.
+			const realFormData = new FormData();
+			realFormData.append('key', 'value');
+
+			// Create a wrapper that breaks instanceof but preserves the interface
+			const foreignFormData: Record<string, unknown> = Object.create(null);
+			for (const prop of Object.getOwnPropertyNames(Object.getPrototypeOf(realFormData))) {
+				const value = (realFormData as unknown as Record<string, unknown>)[prop];
+				if (typeof value === 'function') {
+					foreignFormData[prop] = value.bind(realFormData);
+				}
+			}
+			for (const prop of Object.getOwnPropertyNames(realFormData)) {
+				foreignFormData[prop] = (realFormData as unknown as Record<string, unknown>)[prop];
+			}
+
+			// Verify it's NOT an instanceof FormData
+			expect(foreignFormData instanceof FormData).toBe(false);
+
+			const axiosOptions = await parseRequestObject({
+				url: 'https://example.com',
+				formData: foreignFormData as unknown as FormData,
+				headers: {
+					'content-type': 'multipart/form-data',
+				},
+			});
+
+			expect(axiosOptions.headers).toMatchObject({
+				'content-type': expect.stringMatching(/^multipart\/form-data; boundary=/),
+			});
+		});
+
 		test('should not use Host header for SNI', async () => {
 			const axiosOptions = await parseRequestObject({
 				url: 'https://example.de/foo/bar',

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
@@ -19,7 +19,7 @@ import { Container } from '@n8n/di';
 import type { AxiosError, AxiosHeaders, AxiosRequestConfig } from 'axios';
 import axios from 'axios';
 import crypto, { createHmac } from 'crypto';
-import FormData from 'form-data';
+import type FormData from 'form-data';
 import { IncomingMessage } from 'http';
 import { type AgentOptions } from 'https';
 import get from 'lodash/get';
@@ -81,6 +81,7 @@ import {
 	generateContentLengthHeader,
 	getBeforeRedirectFn,
 	getHostFromRequestObject,
+	isFormDataInstance,
 	isIgnoreStatusErrorConfig,
 	searchForHeader,
 	setAxiosAgents,
@@ -158,7 +159,7 @@ export async function parseRequestObject(requestObject: IRequestOptions, ssrfBri
 			}
 		}
 	} else if (contentType?.includes('multipart/form-data')) {
-		if (requestObject.formData !== undefined && requestObject.formData instanceof FormData) {
+		if (requestObject.formData !== undefined && isFormDataInstance(requestObject.formData)) {
 			axiosConfig.data = requestObject.formData;
 		} else {
 			const allData: Partial<FormData> = {
@@ -206,7 +207,7 @@ export async function parseRequestObject(requestObject: IRequestOptions, ssrfBri
 				});
 			}
 
-			if (requestObject.formData instanceof FormData) {
+			if (isFormDataInstance(requestObject.formData)) {
 				axiosConfig.data = requestObject.formData;
 			} else {
 				axiosConfig.data = createFormDataObject(requestObject.formData as Record<string, unknown>);
@@ -573,7 +574,7 @@ export function convertN8nRequestToAxios(
 			axiosRequest.headers = axiosRequest.headers || {};
 			// We are only setting content type headers if the user did
 			// not set it already manually. We're not overriding, even if it's wrong.
-			if (body instanceof FormData) {
+			if (isFormDataInstance(body)) {
 				axiosRequest.headers = {
 					...axiosRequest.headers,
 					...body.getHeaders(),

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/axios-utils.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/axios-utils.ts
@@ -212,9 +212,27 @@ export const createFormDataObject = (data: Record<string, unknown>) => {
 	return formData;
 };
 
+/**
+ * Duck-type check for FormData instances. Using `instanceof` fails when
+ * multiple copies of the `form-data` package are installed
+ * (e.g. one instance in one package, another in another package),
+ * because each copy has its own constructor reference.
+ */
+export function isFormDataInstance(data: unknown): data is FormData {
+	return (
+		data instanceof FormData ||
+		(typeof data === 'object' &&
+			data !== null &&
+			'getHeaders' in data &&
+			typeof (data as { getHeaders: unknown }).getHeaders === 'function' &&
+			'append' in data &&
+			typeof (data as { append: unknown }).append === 'function')
+	);
+}
+
 /** Sets the `content-length` header by measuring the FormData stream length. */
 export async function generateContentLengthHeader(config: AxiosRequestConfig) {
-	if (!(config.data instanceof FormData)) {
+	if (!isFormDataInstance(config.data)) {
 		return;
 	}
 

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/index.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/index.ts
@@ -4,6 +4,7 @@ export {
 	generateContentLengthHeader,
 	getBeforeRedirectFn,
 	getHostFromRequestObject,
+	isFormDataInstance,
 	isIgnoreStatusErrorConfig,
 	searchForHeader,
 	tryParseUrl,

--- a/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
@@ -1,5 +1,6 @@
 import FormData from 'form-data';
 import get from 'lodash/get';
+import type { Readable } from 'stream';
 import isPlainObject from 'lodash/isPlainObject';
 import set from 'lodash/set';
 import {
@@ -263,7 +264,7 @@ export const prepareRequestBody = async (
 			if (parameter.parameterType === 'formBinaryData') {
 				const entry = await defaultReducer({}, parameter);
 				const key = Object.keys(entry)[0];
-				const data = entry[key] as { value: Buffer; options: FormData.AppendOptions };
+				const data = entry[key] as { value: Buffer | Readable; options: FormData.AppendOptions };
 				formData.append(key, data.value, data.options);
 				continue;
 			}

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -382,9 +382,12 @@ export class HttpRequestV3 implements INodeType {
 						if (!cur.inputDataFieldName) return accumulator;
 						const binaryData = this.helpers.assertBinaryData(itemIndex, cur.inputDataFieldName);
 						let uploadData: Buffer | Readable;
+						let knownLength: number | undefined;
 
 						if (binaryData.id) {
 							uploadData = await this.helpers.getBinaryStream(binaryData.id);
+							const metadata = await this.helpers.getBinaryMetadata(binaryData.id);
+							knownLength = metadata.fileSize;
 						} else {
 							uploadData = Buffer.from(binaryData.data, BINARY_ENCODING);
 						}
@@ -394,6 +397,7 @@ export class HttpRequestV3 implements INodeType {
 							options: {
 								filename: binaryData.fileName,
 								contentType: binaryData.mimeType,
+								...(knownLength !== undefined && { knownLength }),
 							},
 						};
 						return accumulator;

--- a/packages/nodes-base/nodes/HttpRequest/test/utils/utils.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/utils/utils.test.ts
@@ -1,3 +1,5 @@
+import FormData from 'form-data';
+import { Readable } from 'stream';
 import type {
 	ICredentialDataDecryptedObject,
 	INodeExecutionData,
@@ -29,6 +31,48 @@ describe('HTTP Node Utils', () => {
 
 			expect(defaultReducer).toBeCalledTimes(1);
 			expect(defaultReducer).toBeCalledWith({}, { name: 'foo.bar', value: 'baz' });
+		});
+
+		it('should create FormData with knownLength for stream binary data', async () => {
+			const streamContent = Buffer.from('test-binary-content');
+			const bodyParameters: BodyParameter[] = [
+				{
+					name: 'File',
+					value: '',
+					parameterType: 'formBinaryData',
+				},
+				{
+					name: 'Folder',
+					value: '/uploads',
+				},
+			];
+
+			const mockReducer: BodyParametersReducer = jest.fn().mockResolvedValue({
+				File: {
+					value: Readable.from(streamContent),
+					options: {
+						filename: 'test.pdf',
+						contentType: 'application/pdf',
+						knownLength: streamContent.length,
+					},
+				},
+			});
+
+			const result = await prepareRequestBody(
+				bodyParameters,
+				'multipart-form-data',
+				4.2,
+				mockReducer,
+			);
+
+			expect(result).toBeInstanceOf(FormData);
+			const formData = result as FormData;
+
+			// Verify FormData can calculate its total length (fails without knownLength)
+			const length = await new Promise<number>((resolve, reject) => {
+				formData.getLength((err, len) => (err ? reject(err) : resolve(len)));
+			});
+			expect(length).toBeGreaterThan(0);
 		});
 
 		it('should call process dot notations', async () => {


### PR DESCRIPTION
## Summary

Fixes multipart/form-data file uploads failing when binary data is stored in filesystem mode (the default for production n8n). Two root causes:

1. **`instanceof FormData` fails across packages** — When `packages/core` and `packages/nodes-base` resolve separate copies of the `form-data` module (common with npm/npx installs), `instanceof` returns `false`. The code then destroys the FormData by spreading it as a plain object and re-creating it, losing all stream data. Fixed by adding `isFormDataInstance()` — a duck-type check with an `instanceof` fast path. This is the root cause for the differing behavior between `npx n8n` and a local dev build: pnpm deduplicates to a single shared copy of `form-data`, so `instanceof` succeeds locally.

2. **Missing `knownLength` for binary streams** — `getBinaryStream()` returns a `Readable` stream whose length the `form-data` package cannot measure, causing `content-length` calculation to fail silently. Servers that require `content-length` then reject or time out the request. Fixed by calling `getBinaryMetadata()` to obtain the file size and passing it as `knownLength` when appending streams to FormData.

### How to test

1. Create an empty folder and initialise it with `npm init -y`
2. Install n8n: `npm install --save n8n` and add a run script `"n8n": "n8n"` to `package.json`
3. Start n8n: `npm run n8n` (reproduces the same dependency layout as `npx n8n`)
4. Create a workflow: **Manual Trigger → Read Binary File → HTTP Request** (POST, body type Form-Data, with an `n8n Binary File` parameter)
5. Verify the upload completes without "Unable to calculate form data length" errors and that `content-length` is set correctly — use [RequestBin](https://requestbin.com) or a similar tool to inspect the incoming request headers and boundary values

## Related Linear tickets, GitHub issues, and community forum posts

- https://linear.app/n8n/issue/NODE-4730
- https://linear.app/n8n/issue/N8N-9861
- Fixes https://github.com/n8n-io/n8n/issues/27533
- Supersedes https://github.com/n8n-io/n8n/pull/28047

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)