### PR TITLE
ci: Defer Chromatic visual regression tests

### DIFF
--- a/.github/workflows/ci-pull-request-review.yml
+++ b/.github/workflows/ci-pull-request-review.yml
@@ -1,0 +1,66 @@
+name: 'CI: Pull Request Review'
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+concurrency:
+  group: ci-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  filter:
+    name: Check Changes
+    if: >-
+      github.event.review.state == 'approved' &&
+      github.repository == 'n8n-io/n8n'
+    runs-on: ubuntu-slim
+    outputs:
+      design_system: ${{ fromJSON(steps.ci-filter.outputs.results)['design-system'] == true }}
+      commit_sha: ${{ steps.commit-sha.outputs.sha }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - name: Capture commit SHA
+        id: commit-sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Check for relevant changes
+        uses: ./.github/actions/ci-filter
+        id: ci-filter
+        with:
+          mode: filter
+          filters: |
+            design-system:
+              packages/frontend/@n8n/design-system/**
+              packages/frontend/@n8n/storybook/**
+              .github/workflows/test-visual-chromatic.yml
+
+  chromatic:
+    name: Chromatic
+    needs: filter
+    if: needs.filter.outputs.design_system == 'true'
+    uses: ./.github/workflows/test-visual-chromatic.yml
+    with:
+      ref: ${{ needs.filter.outputs.commit_sha }}
+    secrets: inherit
+
+  # Required by GitHub branch protection rules.
+  # PRs cannot be merged unless this job passes.
+  required-review-checks:
+    name: Required Review Checks
+    needs: [filter, chromatic]
+    if: always()
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/ci-filter
+          sparse-checkout-cone-mode: false
+      - name: Validate required checks
+        uses: ./.github/actions/ci-filter
+        with:
+          mode: validate
+          job-results: ${{ toJSON(needs) }}

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -25,7 +25,6 @@ jobs:
       workflows: ${{ fromJSON(steps.ci-filter.outputs.results).workflows == true }}
       workflow_scripts: ${{ fromJSON(steps.ci-filter.outputs.results)['workflow-scripts'] == true }}
       db: ${{ fromJSON(steps.ci-filter.outputs.results).db == true }}
-      design_system: ${{ fromJSON(steps.ci-filter.outputs.results)['design-system'] == true }}
       performance: ${{ fromJSON(steps.ci-filter.outputs.results).performance == true }}
       e2e_performance: ${{ fromJSON(steps.ci-filter.outputs.results)['e2e-performance'] == true }}
       commit_sha: ${{ steps.commit-sha.outputs.sha }}
@@ -61,11 +60,6 @@ jobs:
               packages/testing/containers/**
             workflows: .github/**
             workflow-scripts: .github/scripts/**
-            design-system:
-              packages/frontend/@n8n/design-system/**
-              packages/frontend/@n8n/chat/**
-              packages/frontend/@n8n/storybook/**
-              .github/workflows/test-visual-chromatic.yml
             performance:
               packages/testing/performance/**
               packages/workflow/src/**
@@ -201,15 +195,6 @@ jobs:
       ref: ${{ needs.install-and-build.outputs.commit_sha }}
     secrets: inherit
 
-  chromatic:
-    name: Chromatic
-    needs: install-and-build
-    if: needs.install-and-build.outputs.design_system == 'true' && github.event_name == 'pull_request' && github.repository == 'n8n-io/n8n'
-    uses: ./.github/workflows/test-visual-chromatic.yml
-    with:
-      ref: ${{ needs.install-and-build.outputs.commit_sha }}
-    secrets: inherit
-
   # This job is required by GitHub branch protection rules.
   # PRs cannot be merged unless this job passes.
   required-checks:
@@ -226,7 +211,6 @@ jobs:
         performance,
         security-checks,
         workflow-scripts,
-        chromatic,
       ]
     if: always()
     runs-on: ubuntu-slim


### PR DESCRIPTION
## Summary

Moves Chromatic visual regression checks to a new workflow that triggers only upon an approved pull request review.

This change optimizes CI resource usage by executing these tests later in the PR lifecycle, specifically when changes are considered more stable and ready for a final visual review. The `ci-pull-requests` workflow no longer runs Chromatic or detects design system changes, offloading this to the new `ci-pull-request-review` workflow.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
