### PR TITLE
fix: Handle normalization of JSON for SQLite / postgres

### DIFF
--- a/packages/cli/src/services/__tests__/import.service.test.ts
+++ b/packages/cli/src/services/__tests__/import.service.test.ts
@@ -772,6 +772,179 @@ describe('ImportService', () => {
 		});
 	});
 
+	describe('normalizeEntityJsonColumns', () => {
+		const metadata = {
+			columns: [
+				{ databaseName: 'id', type: 'varchar' },
+				{ databaseName: 'nodes', type: 'simple-json' },
+				{ databaseName: 'meta', type: 'json' },
+				{ databaseName: 'name', type: 'text' },
+			],
+		} as any;
+
+		it('should parse and re-serialise a SQLite string JSON array value', () => {
+			const entity = { id: '1', nodes: '[{"id":"abc"}]', name: 'test' };
+
+			// @ts-expect-error accessing private method for testing
+			const result = importService.normalizeEntityJsonColumns(entity, metadata);
+
+			expect(result.nodes).toBe(JSON.stringify([{ id: 'abc' }]));
+		});
+
+		it('should parse and re-serialise a SQLite string JSON object value', () => {
+			const entity = { id: '1', meta: '{"key":"value"}', name: 'test' };
+
+			// @ts-expect-error accessing private method for testing
+			const result = importService.normalizeEntityJsonColumns(entity, metadata);
+
+			expect(result.meta).toBe(JSON.stringify({ key: 'value' }));
+		});
+
+		it('should serialise a Postgres parsed object value to a JSON string', () => {
+			const entity = { id: '1', nodes: [{ id: 'abc' }], name: 'test' };
+
+			// @ts-expect-error accessing private method for testing
+			const result = importService.normalizeEntityJsonColumns(entity, metadata);
+
+			expect(result.nodes).toBe(JSON.stringify([{ id: 'abc' }]));
+		});
+
+		it('should serialise a Postgres parsed array value to a JSON string', () => {
+			const entity = { id: '1', meta: [1, 2, 3], name: 'test' };
+
+			// @ts-expect-error accessing private method for testing
+			const result = importService.normalizeEntityJsonColumns(entity, metadata);
+
+			expect(result.meta).toBe(JSON.stringify([1, 2, 3]));
+		});
+
+		it('should leave null json column values unchanged', () => {
+			const entity = { id: '1', nodes: null, meta: null };
+
+			// @ts-expect-error accessing private method for testing
+			const result = importService.normalizeEntityJsonColumns(entity, metadata);
+
+			expect(result.nodes).toBeNull();
+			expect(result.meta).toBeNull();
+		});
+
+		it('should not modify non-json columns', () => {
+			const entity = { id: '1', name: 'should-not-change', nodes: '[]' };
+
+			// @ts-expect-error accessing private method for testing
+			const result = importService.normalizeEntityJsonColumns(entity, metadata);
+
+			expect(result.id).toBe('1');
+			expect(result.name).toBe('should-not-change');
+		});
+
+		it('should leave an invalid JSON string unchanged', () => {
+			const entity = { id: '1', nodes: 'not-valid-json' };
+
+			// @ts-expect-error accessing private method for testing
+			const result = importService.normalizeEntityJsonColumns(entity, metadata);
+
+			expect(result.nodes).toBe('not-valid-json');
+		});
+
+		it('should only normalise json columns in a mixed entity', () => {
+			const entity = {
+				id: '1',
+				name: 'workflow',
+				nodes: '[{"id":"abc"}]',
+				meta: { key: 'value' },
+			};
+
+			// @ts-expect-error accessing private method for testing
+			const result = importService.normalizeEntityJsonColumns(entity, metadata);
+
+			expect(result.id).toBe('1');
+			expect(result.name).toBe('workflow');
+			expect(result.nodes).toBe(JSON.stringify([{ id: 'abc' }]));
+			expect(result.meta).toBe(JSON.stringify({ key: 'value' }));
+		});
+	});
+
+	describe('importEntitiesFromFiles — JSON column normalisation', () => {
+		it('should normalise SQLite string json column values before inserting into Postgres', async () => {
+			// @ts-expect-error Accessing private property for testing
+			mockDataSource.entityMetadatas = [
+				{
+					name: 'WorkflowEntity',
+					tableName: 'workflow_entity',
+					columns: [
+						{ databaseName: 'id', type: 'varchar' },
+						{ databaseName: 'nodes', type: 'simple-json' },
+					],
+				},
+			] as any;
+
+			// SQLite-origin: nodes is a serialised string, not an object
+			const sqliteEntity = { id: '1', nodes: '[{"id":"abc"}]' };
+			jest.mocked(readFile).mockResolvedValue(JSON.stringify(sqliteEntity));
+
+			const capturedParams: unknown[][] = [];
+			mockDataSource.driver.escapeQueryWithParameters = jest
+				.fn()
+				.mockImplementation((_query, params) => {
+					capturedParams.push(params);
+					return ['INSERT COMMAND', params];
+				});
+
+			await importService.importEntitiesFromFiles(
+				'/test/input',
+				mockEntityManager,
+				['workflowentity'],
+				{ workflowentity: ['/test/input/workflowentity.jsonl'] },
+			);
+
+			expect(capturedParams).toHaveLength(1);
+			// nodes must be a serialised JSON string, not the raw SQLite text
+			expect((capturedParams[0] as Record<string, unknown>).nodes).toBe(
+				JSON.stringify([{ id: 'abc' }]),
+			);
+		});
+
+		it('should normalise Postgres object json column values before inserting into SQLite', async () => {
+			// @ts-expect-error Accessing private property for testing
+			mockDataSource.entityMetadatas = [
+				{
+					name: 'WorkflowEntity',
+					tableName: 'workflow_entity',
+					columns: [
+						{ databaseName: 'id', type: 'varchar' },
+						{ databaseName: 'nodes', type: 'json' },
+					],
+				},
+			] as any;
+
+			// Postgres-origin: nodes is a parsed object in the JSONL
+			const postgresEntity = { id: '1', nodes: [{ id: 'abc' }] };
+			jest.mocked(readFile).mockResolvedValue(JSON.stringify(postgresEntity));
+
+			const capturedParams: unknown[][] = [];
+			mockDataSource.driver.escapeQueryWithParameters = jest
+				.fn()
+				.mockImplementation((_query, params) => {
+					capturedParams.push(params);
+					return ['INSERT COMMAND', params];
+				});
+
+			await importService.importEntitiesFromFiles(
+				'/test/input',
+				mockEntityManager,
+				['workflowentity'],
+				{ workflowentity: ['/test/input/workflowentity.jsonl'] },
+			);
+
+			expect(capturedParams).toHaveLength(1);
+			// nodes must be a JSON string, not the raw JS object
+			expect((capturedParams[0] as Record<string, unknown>).nodes).toBe(
+				JSON.stringify([{ id: 'abc' }]),
+			);
+		});
+	});
+
 	describe('decompressEntitiesZip', () => {
 		it('should decompress entities.zip successfully when file exists', async () => {
 			const inputDir = '/test/input';

--- a/packages/cli/src/services/__tests__/import.service.test.ts
+++ b/packages/cli/src/services/__tests__/import.service.test.ts
@@ -883,11 +883,11 @@ describe('ImportService', () => {
 			const sqliteEntity = { id: '1', nodes: '[{"id":"abc"}]' };
 			jest.mocked(readFile).mockResolvedValue(JSON.stringify(sqliteEntity));
 
-			const capturedParams: unknown[][] = [];
+			const capturedParams: Array<Record<string, unknown>> = [];
 			mockDataSource.driver.escapeQueryWithParameters = jest
 				.fn()
 				.mockImplementation((_query, params) => {
-					capturedParams.push(params);
+					capturedParams.push(params as Record<string, unknown>);
 					return ['INSERT COMMAND', params];
 				});
 
@@ -900,9 +900,7 @@ describe('ImportService', () => {
 
 			expect(capturedParams).toHaveLength(1);
 			// nodes must be a serialised JSON string, not the raw SQLite text
-			expect((capturedParams[0] as Record<string, unknown>).nodes).toBe(
-				JSON.stringify([{ id: 'abc' }]),
-			);
+			expect(capturedParams[0].nodes).toBe(JSON.stringify([{ id: 'abc' }]));
 		});
 
 		it('should normalise Postgres object json column values before inserting into SQLite', async () => {
@@ -922,11 +920,11 @@ describe('ImportService', () => {
 			const postgresEntity = { id: '1', nodes: [{ id: 'abc' }] };
 			jest.mocked(readFile).mockResolvedValue(JSON.stringify(postgresEntity));
 
-			const capturedParams: unknown[][] = [];
+			const capturedParams: Array<Record<string, unknown>> = [];
 			mockDataSource.driver.escapeQueryWithParameters = jest
 				.fn()
 				.mockImplementation((_query, params) => {
-					capturedParams.push(params);
+					capturedParams.push(params as Record<string, unknown>);
 					return ['INSERT COMMAND', params];
 				});
 
@@ -939,9 +937,7 @@ describe('ImportService', () => {
 
 			expect(capturedParams).toHaveLength(1);
 			// nodes must be a JSON string, not the raw JS object
-			expect((capturedParams[0] as Record<string, unknown>).nodes).toBe(
-				JSON.stringify([{ id: 'abc' }]),
-			);
+			expect(capturedParams[0].nodes).toBe(JSON.stringify([{ id: 'abc' }]));
 		});
 	});
 

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -11,7 +11,7 @@ import {
 	WorkflowPublishHistory,
 } from '@n8n/db';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
-import { DataSource, EntityManager, In } from '@n8n/typeorm';
+import { DataSource, EntityManager, In, type EntityMetadata } from '@n8n/typeorm';
 import { Service } from '@n8n/di';
 import { type INode, type INodeCredentialsDetails, type IWorkflowBase } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
@@ -512,13 +512,14 @@ export class ImportService {
 
 						await Promise.all(
 							entities.map(async (entity) => {
-								const columns = Object.keys(entity);
+								const normalizedEntity = this.normalizeEntityJsonColumns(entity, entityMetadata);
+								const columns = Object.keys(normalizedEntity);
 								const columnNames = columns.map(this.dataSource.driver.escape).join(', ');
 								const columnValues = columns.map((key) => `:${key}`).join(', ');
 
 								const [query, parameters] = this.dataSource.driver.escapeQueryWithParameters(
 									`INSERT INTO ${tableName} (${columnNames}) VALUES (${columnValues})`,
-									entity,
+									normalizedEntity,
 									{},
 								);
 
@@ -559,6 +560,50 @@ export class ImportService {
 
 			node.credentials[type] = nodeCredential;
 		}
+	}
+
+	/**
+	 * Normalise JSON column values to JSON strings before a raw INSERT.
+	 *
+	 * The export uses raw SQL (SELECT … FROM table) which bypasses TypeORM column
+	 * transformers entirely. As a result, json/simple-json column values differ by
+	 * source database:
+	 *   - SQLite  → stored as TEXT, so SELECT returns a plain string
+	 *   - Postgres → stored natively, so SELECT returns a parsed JS object/array
+	 *
+	 * Passing a raw string to a Postgres `json` column or a raw object to SQLite's
+	 * TEXT-backed column via a parameterised INSERT produces incorrect data. This
+	 * method normalises both cases to a JSON string, which both database drivers
+	 * accept correctly for json/simple-json columns.
+	 */
+	private normalizeEntityJsonColumns(
+		entity: Record<string, unknown>,
+		metadata: EntityMetadata,
+	): Record<string, unknown> {
+		const result = { ...entity };
+
+		for (const column of metadata.columns) {
+			const { databaseName, type } = column;
+			if (type !== 'json' && type !== 'simple-json') continue;
+
+			const value = result[databaseName];
+			if (value === null || value === undefined) continue;
+
+			if (typeof value === 'string') {
+				// SQLite exports json columns as serialised text — parse then re-serialise
+				// to canonical JSON so both SQLite and Postgres targets receive a valid string.
+				try {
+					result[databaseName] = JSON.stringify(JSON.parse(value));
+				} catch {
+					// Not a valid JSON string; leave as-is and let the DB validate on insert.
+				}
+			} else if (typeof value === 'object') {
+				// Postgres exports json columns as parsed objects — serialise for raw INSERT.
+				result[databaseName] = JSON.stringify(value);
+			}
+		}
+
+		return result;
 	}
 
 	async disableForeignKeyConstraints(transactionManager: EntityManager) {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR handles an issue where JSON exports from SQLite differ from Postgres, which causes issues on simple json and JSON fields. 

With this fix, data is normalized based on the shape of data before insertion

## Related Linear tickets, Github issues, and Community forum posts

IAM-529
fixes #26814

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
