### PR TITLE
fix(Google Drive Node): Fix infinite pagination loop in v1 API request

### DIFF
--- a/packages/nodes-base/nodes/Google/Drive/test/v1/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v1/GenericFunctions.test.ts
@@ -1,0 +1,67 @@
+import { mockDeep } from 'jest-mock-extended';
+import type { IDataObject, IPollFunctions } from 'n8n-workflow';
+
+import { googleApiRequestAllItems } from '../../v1/GenericFunctions';
+
+describe('googleApiRequestAllItems', () => {
+	let mockContext: jest.Mocked<IPollFunctions>;
+
+	beforeEach(() => {
+		mockContext = mockDeep<IPollFunctions>();
+		mockContext.getNodeParameter.mockReturnValue('oAuth2');
+	});
+
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it('should advance pageToken across pages and terminate when nextPageToken is absent', async () => {
+		const pageTokensReceived: Array<string | undefined> = [];
+
+		(mockContext.helpers.requestOAuth2 as jest.Mock).mockImplementation(
+			async (_cred: string, opts: IDataObject) => {
+				const qs = opts.qs as IDataObject;
+				pageTokensReceived.push(qs.pageToken as string | undefined);
+
+				if (pageTokensReceived.length === 1) {
+					return { files: [{ id: '1' }, { id: '2' }], nextPageToken: 'token-page-2' };
+				}
+				if (pageTokensReceived.length === 2) {
+					return { files: [{ id: '3' }], nextPageToken: 'token-page-3' };
+				}
+				return { files: [{ id: '4' }] };
+			},
+		);
+
+		const result = await googleApiRequestAllItems.call(
+			mockContext,
+			'files',
+			'GET',
+			'/drive/v3/files',
+			{},
+			{},
+		);
+
+		expect(result).toEqual([{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }]);
+		expect(mockContext.helpers.requestOAuth2).toHaveBeenCalledTimes(3);
+		expect(pageTokensReceived).toEqual([undefined, 'token-page-2', 'token-page-3']);
+	});
+
+	it('should handle single page (no nextPageToken)', async () => {
+		(mockContext.helpers.requestOAuth2 as jest.Mock).mockResolvedValueOnce({
+			files: [{ id: '1' }],
+		});
+
+		const result = await googleApiRequestAllItems.call(
+			mockContext,
+			'files',
+			'GET',
+			'/drive/v3/files',
+			{},
+			{},
+		);
+
+		expect(result).toEqual([{ id: '1' }]);
+		expect(mockContext.helpers.requestOAuth2).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/nodes-base/nodes/Google/Drive/v1/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Drive/v1/GenericFunctions.ts
@@ -81,6 +81,10 @@ export async function googleApiRequestAllItems(
 	do {
 		responseData = await googleApiRequest.call(this, method, endpoint, body, query);
 		returnData.push.apply(returnData, responseData[propertyName] as IDataObject[]);
+
+		if (responseData.nextPageToken) {
+			query.pageToken = responseData.nextPageToken as string;
+		}
 	} while (responseData.nextPageToken !== undefined && responseData.nextPageToken !== '');
 
 	return returnData;


### PR DESCRIPTION
## Summary

Fixes a memory leak in the Google Drive trigger node caused by an infinite pagination loop in the v1 `googleApiRequestAllItems` function.

The function's `do-while` loop checked `responseData.nextPageToken` to decide whether to continue paginating, but never assigned `query.pageToken = responseData.nextPageToken` to advance to the next page. When the Google Drive API returned more than 100 results (one page), the same first page was re-fetched indefinitely, pushing ~100 items into an array per iteration until OOM.

This bug only affects the **v1 transport** used by `GoogleDriveTrigger.node.ts`. The v2 transport (used by the main Google Drive node) already had the correct implementation. Every other Google API pagination function in the codebase (Gmail, Calendar, Sheets, YouTube, etc.) also includes this assignment — the v1 Drive function was the only one missing it.

**Impact:** Instances with active Google Drive trigger workflows polling accounts with >100 modified files experienced unbounded memory growth and repeated OOM crashes, even when no workflow executions were triggered.

### How to test

1. Set up a Google Drive trigger node in `specificFile` mode polling a Google account with many files
2. Verify the trigger polls correctly without memory growth
3. Run the new unit test: `cd packages/nodes-base && pnpm test nodes/Google/Drive/test/v1/GenericFunctions.test.ts`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4565

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)