### PR TITLE
fix(API): Disable response compression on instance-ai SSE connections (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
@@ -174,7 +174,7 @@ export class InstanceAiController {
 		// of native memory for the lifetime of the connection.
 		(res as unknown as { compress: boolean }).compress = false;
 		res.setHeader('Content-Type', 'text/event-stream; charset=UTF-8');
-		res.setHeader('Cache-Control', 'no-cache');
+		res.setHeader('Cache-Control', 'no-cache, no-transform');
 		res.setHeader('Connection', 'keep-alive');
 		res.setHeader('X-Accel-Buffering', 'no');
 		res.flushHeaders();
@@ -594,7 +594,7 @@ export class InstanceAiController {
 
 		(res as unknown as { compress: boolean }).compress = false;
 		res.setHeader('Content-Type', 'text/event-stream; charset=UTF-8');
-		res.setHeader('Cache-Control', 'no-cache');
+		res.setHeader('Cache-Control', 'no-cache, no-transform');
 		res.setHeader('Connection', 'keep-alive');
 		res.setHeader('X-Accel-Buffering', 'no');
 		res.flushHeaders();


### PR DESCRIPTION
## Summary

Adds `no-transform` to `Cache-Control` on both instance-ai SSE endpoints (`/events/:threadId` and `/gateway/events`). This prevents the global `compression` middleware from allocating a zlibcompressor stream per connection. Each compressor holds native memory for the lifetime of the SSE connection. Behind load balancers, orphaned connections accumulate when browsers reconnect after network blips or tab backgrounding, the old connection's compressor stays alive until TCP timeout.

Before (delegation benchmark scenario ran 3x):
<img width="581" height="410" alt="CleanShot 2026-04-09 at 13 58 31" src="https://github.com/user-attachments/assets/d5e04a0e-d6d2-4c32-b962-e61698ff457b" />

After:
<img width="922" height="454" alt="CleanShot 2026-04-09 at 13 58 00" src="https://github.com/user-attachments/assets/78874c5a-ab66-4cc9-9dbf-8813fa3bec37" />

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
