### PR TITLE
test: Harden polling trigger test helper against flaky OAuth2 failures (no-changelog)

### DIFF
--- a/packages/nodes-base/test/nodes/TriggerHelpers.ts
+++ b/packages/nodes-base/test/nodes/TriggerHelpers.ts
@@ -250,35 +250,46 @@ export async function testPollingTriggerNode(
 	});
 	const mode = options.mode ?? 'trigger';
 
-	const pollContext = new PollContext(
-		workflow,
-		node,
-		mock<IWorkflowExecuteAdditionalData>({
-			currentNodeParameters: node.parameters,
-			credentialsHelper: mock<IWorkflowExecuteAdditionalData['credentialsHelper']>({
-				getParentTypes: () => [],
-				authenticate: async (_creds, _type, options) => {
-					set(options, 'headers.authorization', 'mockAuth');
-					return options as IHttpRequestOptions;
-				},
-			}),
-			hooks: mock<ExecutionLifecycleHooks>(),
-			ssrfBridge: {
-				validateIp: jest.fn().mockReturnValue({ ok: true, result: undefined }),
-				validateUrl: jest.fn().mockResolvedValue({ ok: true, result: undefined }),
-				validateRedirectSync: jest.fn(),
-				createSecureLookup: jest.fn().mockReturnValue(jest.fn()),
-			} as SsrfBridge,
+	const additionalData = mock<IWorkflowExecuteAdditionalData>({
+		currentNodeParameters: node.parameters,
+		credentialsHelper: mock<IWorkflowExecuteAdditionalData['credentialsHelper']>({
+			getParentTypes: () => [],
+			authenticate: async (_creds, _type, options) => {
+				set(options, 'headers.authorization', 'mockAuth');
+				return options as IHttpRequestOptions;
+			},
 		}),
-		mode,
-		'init',
-	);
+		hooks: mock<ExecutionLifecycleHooks>(),
+		ssrfBridge: {
+			validateIp: jest.fn().mockReturnValue({ ok: true, result: undefined }),
+			validateUrl: jest.fn().mockResolvedValue({ ok: true, result: undefined }),
+			validateRedirectSync: jest.fn(),
+			createSecureLookup: jest.fn().mockReturnValue(jest.fn()),
+		} as SsrfBridge,
+	});
+	// Prevent the auto-mocked property from being truthy so request helpers
+	// don't take the eval-mock code path.
+	(additionalData as unknown as Record<string, unknown>).evalLlmMockHandler = undefined;
+
+	const pollContext = new PollContext(workflow, node, additionalData, mode, 'init');
 
 	pollContext.getNode = () => node;
 	pollContext.getCredentials = async <T extends object = ICredentialDataDecryptedObject>() =>
 		(options.credential ?? {}) as T;
 	pollContext.getNodeParameter = (parameterName, fallback) =>
 		get(node.parameters, parameterName) ?? fallback;
+
+	// Override OAuth helpers so tests don't flow through the real OAuth2
+	// signing/token logic (which is fragile with mocked credentials).
+	const originalRequest = pollContext.helpers.request.bind(pollContext.helpers);
+	pollContext.helpers.requestOAuth2 = async function (_credentialsType, requestOptions) {
+		set(requestOptions, 'headers.authorization', 'mockAuth');
+		return await originalRequest(requestOptions);
+	};
+	pollContext.helpers.requestOAuth1 = async function (_credentialsType, requestOptions) {
+		set(requestOptions, 'headers.authorization', 'mockAuth');
+		return await originalRequest(requestOptions);
+	};
 
 	const response = await trigger.poll?.call(pollContext);
 


### PR DESCRIPTION
## Summary

Fixes flaky CI failures in polling trigger tests (e.g. `GoogleSheetsTrigger.test.ts` failing with `Cannot read properties of undefined (reading 'map')`).

The `testPollingTriggerNode` helper in `TriggerHelpers.ts` created a real `PollContext` whose request helpers flowed through the full OAuth2 signing/token pipeline with `jest-mock-extended` deep-mock credentials. This was fragile — deep-mock proxies interacting with `ClientOAuth2` string operations, date math, and object spreading caused intermittent failures.

**Two fixes:**

1. **Override `requestOAuth2`/`requestOAuth1`** on the `PollContext` to skip the real OAuth2 flow entirely and forward directly to the base `request` helper (which `nock` can intercept cleanly).

2. **Explicitly null out `evalLlmMockHandler`** on the mocked `additionalData` so `jest-mock-extended`'s auto-mock doesn't create a truthy proxy that diverts every request through the eval-mock code path.

## Related Linear tickets, Github issues, and Community forum posts

Addresses flaky CI observed in https://github.com/n8n-io/n8n/actions/runs/24182041829/job/70577629267

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

Made with [Cursor](https://cursor.com)