### PR TITLE
chore: Bump n8n Claude Code plugin version to 0.2.0 (no-changelog)

### DIFF
--- a/.claude/plugins/n8n/.claude-plugin/plugin.json
+++ b/.claude/plugins/n8n/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
   "name": "n8n",
+  "version": "0.2.0",
   "description": "n8n Claude Code plugin — shared skills, commands, and agents for n8n development"
 }


### PR DESCRIPTION
## Summary
- Adds `version` field to the n8n Claude Code plugin manifest (`plugin.json`)
- This helps Claude Code detect plugin updates after `git pull` and trigger re-discovery of skills
- Fixes issue where teammates only see `setup-mcps` skill instead of all 14 plugin skills after the skill migration in #28020

## Context
After skills were moved from `.claude/skills/` to `.claude/plugins/n8n/skills/` in #28020, some teammates couldn't see the new skills. Claude Code cached the plugin state from the initial install (which only had `setup-mcps`) and never re-scanned. Adding a version field should help with future plugin updates.

**Workaround for affected users:** `/plugins` → uninstall n8n → install again, or `/reload-plugins`.

## Test plan
- [ ] Verify plugin loads with version field
- [ ] Verify all 14 skills appear in available skills list
- [ ] Teammate confirms skills appear after pull + restart