### PR TITLE
fix(core): Run snapshot pruning correctly and adjust logs (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-ai/instance-ai.module.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.module.ts
@@ -28,8 +28,9 @@ export class InstanceAiModule implements ModuleInterface {
 			.cleanupExpiredThreads(async (threadId) => await aiService.clearThreadState(threadId))
 			.catch(() => undefined);
 
-		// Register snapshot pruning — lifecycle decorators handle start/stop
-		await import('./snapshot-pruning.service');
+		// Initialize snapshot pruning — lifecycle decorators handle multi-main start/stop
+		const { SnapshotPruningService } = await import('./snapshot-pruning.service');
+		Container.get(SnapshotPruningService).init();
 	}
 
 	async settings() {

--- a/packages/cli/src/modules/instance-ai/snapshot-pruning.service.ts
+++ b/packages/cli/src/modules/instance-ai/snapshot-pruning.service.ts
@@ -3,6 +3,7 @@ import { InstanceAiConfig } from '@n8n/config';
 import { OnLeaderStepdown, OnLeaderTakeover, OnShutdown } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import { LessThan } from '@n8n/typeorm';
+import { InstanceSettings } from 'n8n-core';
 
 import { InstanceAiWorkflowSnapshotRepository } from './repositories/instance-ai-workflow-snapshot.repository';
 
@@ -14,8 +15,13 @@ export class SnapshotPruningService {
 		private readonly logger: Logger,
 		private readonly config: InstanceAiConfig,
 		private readonly snapshotRepo: InstanceAiWorkflowSnapshotRepository,
+		private readonly instanceSettings: InstanceSettings,
 	) {
-		this.logger = this.logger.scoped('pruning');
+		this.logger = this.logger.scoped('instance-ai');
+	}
+
+	init() {
+		if (this.instanceSettings.isLeader) this.startPruning();
 	}
 
 	@OnLeaderTakeover()
@@ -26,7 +32,10 @@ export class SnapshotPruningService {
 			async () => await this.prune(),
 			this.config.snapshotPruneInterval,
 		);
-		this.logger.debug('Started snapshot pruning timer');
+		this.logger.debug('Started snapshot pruning timer', {
+			pruneIntervalMs: this.config.snapshotPruneInterval,
+			retentionMs: this.config.snapshotRetention,
+		});
 	}
 
 	@OnLeaderStepdown()
@@ -50,8 +59,11 @@ export class SnapshotPruningService {
 			updatedAt: LessThan(cutoff),
 		});
 
-		if (affected) {
-			this.logger.debug('Pruned stale workflow snapshots', { count: affected });
+		if (affected === 0) {
+			this.logger.debug('Found no workflow snapshots to prune');
+			return;
 		}
+
+		this.logger.debug('Pruned stale workflow snapshots', { count: affected });
 	}
 }


### PR DESCRIPTION
## Summary

Through refactoring we had broken our workflow snapshots pruning mechanism, and it wasn't started anymore.
I now made it work similar to executions pruning, and adjusted how it gets logged.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
