### PR TITLE
fix(core): Prevent Redis connection recovery from being missed

### DIFF
--- a/packages/cli/src/services/__tests__/redis-client.service.test.ts
+++ b/packages/cli/src/services/__tests__/redis-client.service.test.ts
@@ -5,6 +5,8 @@ import Redis from 'ioredis';
 
 import { RedisClientService } from '@/services/redis-client.service';
 
+type EventHandler = (...args: unknown[]) => void;
+
 jest.mock('ioredis', () => {
 	return jest.fn().mockImplementation(() => {
 		return {
@@ -32,6 +34,9 @@ describe('RedisClientService', () => {
 		},
 	});
 
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any The ioRedis constructor overloads prevent jest.mocked() from typing calls correctly
+	const mockedRedis = Redis as unknown as jest.Mock;
+
 	beforeEach(() => {
 		jest.clearAllMocks();
 	});
@@ -50,7 +55,7 @@ describe('RedisClientService', () => {
 			}),
 		);
 
-		const callArgs = (Redis as unknown as jest.Mock).mock.calls[0][0];
+		const callArgs = mockedRedis.mock.calls[0][0];
 		expect(callArgs).not.toHaveProperty('keepAlive');
 	});
 
@@ -81,5 +86,41 @@ describe('RedisClientService', () => {
 				reconnectOnError: expect.any(Function),
 			}),
 		);
+	});
+
+	describe('connection recovery', () => {
+		it('should set lostConnection synchronously in retryStrategy', () => {
+			const service = new RedisClientService(logger, globalConfig);
+			service.createClient({ type: 'client(bull)' });
+
+			expect(service.isConnected()).toBe(true);
+
+			const callArgs = mockedRedis.mock.calls[0][0];
+			const retryStrategy = callArgs.retryStrategy as () => number;
+
+			retryStrategy();
+
+			expect(service.isConnected()).toBe(false);
+		});
+
+		it('should recover when ready fires after retryStrategy', () => {
+			const service = new RedisClientService(logger, globalConfig);
+			service.createClient({ type: 'client(bull)' });
+
+			const mockClient = mockedRedis.mock.results[0].value;
+			const handlers = new Map<string, EventHandler>();
+			jest.mocked(mockClient.on).mock.calls.forEach(([event, handler]: [string, EventHandler]) => {
+				handlers.set(event, handler);
+			});
+
+			const callArgs = mockedRedis.mock.calls[0][0];
+			const retryStrategy = callArgs.retryStrategy as () => number;
+
+			retryStrategy();
+			expect(service.isConnected()).toBe(false);
+
+			handlers.get('ready')!();
+			expect(service.isConnected()).toBe(true);
+		});
 	});
 });

--- a/packages/cli/src/services/__tests__/redis-client.service.test.ts
+++ b/packages/cli/src/services/__tests__/redis-client.service.test.ts
@@ -34,7 +34,7 @@ describe('RedisClientService', () => {
 		},
 	});
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any The ioRedis constructor overloads prevent jest.mocked() from typing calls correctly
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ioRedis constructor overloads prevent jest.mocked() from typing calls correctly
 	const mockedRedis = Redis as unknown as jest.Mock;
 
 	beforeEach(() => {

--- a/packages/cli/src/services/redis-client.service.ts
+++ b/packages/cli/src/services/redis-client.service.ts
@@ -240,6 +240,7 @@ export class RedisClientService extends TypedEmitter<RedisEventMap> {
 				}
 			}
 
+			this.lostConnection = true;
 			this.emit('connection-lost', cumulativeTimeout);
 
 			return this.config.retryInterval;
@@ -276,8 +277,6 @@ export class RedisClientService extends TypedEmitter<RedisEventMap> {
 			const timeoutDetails = `${cumulativeTimeout}/${maxTimeout}`;
 
 			this.logger.warn(`Lost Redis connection. ${reconnectionMsg} (${timeoutDetails})`);
-
-			this.lostConnection = true;
 		});
 
 		this.on('connection-recovered', () => {


### PR DESCRIPTION
## Summary

`RedisClientService` debounces all event emissions by 1s, and the reconnection retry interval is also 1s. When a connection drops, `retryStrategy` queues a debounced `connection-lost` event. Meanwhile, `ioRedis` waits 1s and reconnects. So the debounce timer and the `ready` event race each other. Typically the debounce wins and sets `lostConnection = true` before `ready` checks it, but under load `ready` can fire first, so it finds `lostConnection` still as `false` and skips recovery, then the late `connection-lost` flips the flag to `true`, where it stays forever.

This PR sets `lostConnection = true` synchronously in `retryStrategy` to bypass the debounce. The debounced listener now only logs.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2721
Closes #27753


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
