### PR TITLE
feat(core): Add 'verify' option to installPackage handler and update …

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/community-packages/__tests__/community-packages.handler.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/__tests__/community-packages.handler.test.ts
@@ -68,6 +68,23 @@ describe('CommunityPackages Handler', () => {
 			expect(mockResponse.json).toHaveBeenCalledWith(mapToCommunityPackage(mockInstalledPackage));
 		});
 
+		it('should forward verify:true to lifecycle when provided', async () => {
+			const req = {
+				body: { name: 'n8n-nodes-test', verify: true },
+				user: mockUser,
+			};
+
+			mockLifecycle.install.mockResolvedValue(mockInstalledPackage as InstalledPackages);
+
+			await handler.installPackage[handler.installPackage.length - 1](req, mockResponse);
+
+			expect(mockLifecycle.install).toHaveBeenCalledWith(
+				{ name: 'n8n-nodes-test', version: undefined, verify: true },
+				mockUser,
+				'publicApi',
+			);
+		});
+
 		it('should return 400 when name is missing', async () => {
 			const req = {
 				body: {},

--- a/packages/cli/src/public-api/v1/handlers/community-packages/community-packages.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/community-packages.handler.ts
@@ -16,14 +16,18 @@ export = {
 	installPackage: [
 		apiKeyHasScope('communityPackage:install'),
 		async (
-			req: AuthenticatedRequest<Record<string, never>, unknown, { name: string; version?: string }>,
+			req: AuthenticatedRequest<
+				Record<string, never>,
+				unknown,
+				{ name: string; version?: string; verify?: boolean }
+			>,
 			res: express.Response,
 		): Promise<express.Response> => {
 			const lifecycle = Container.get(CommunityPackagesLifecycleService);
 
 			try {
 				const installedPackage = await lifecycle.install(
-					{ name: req.body.name, version: req.body.version, verify: false },
+					{ name: req.body.name, version: req.body.version, verify: req.body.verify ?? false },
 					req.user,
 					'publicApi',
 				);

--- a/packages/cli/src/public-api/v1/handlers/community-packages/spec/schemas/installCommunityPackageRequest.yml
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/spec/schemas/installCommunityPackageRequest.yml
@@ -8,3 +8,8 @@ properties:
   version:
     type: string
     description: Specific semver version to install
+  verify:
+    type: boolean
+    description: >
+      Whether to verify the package against the n8n-vetted package list.
+      Required when the instance has N8N_UNVERIFIED_PACKAGES_ENABLED=false.


### PR DESCRIPTION
## Summary

The public API handler for installing community packages hardcoded `verify: false`, which meant it never fetched a checksum for the package being installed. On cloud, N8N_UNVERIFIED_PACKAGES_ENABLED=false requires a checksum to proceed, that's why installation on cloud failed.

The fix reads verify from the request body instead of hardcoding it, and adds it to the OpenAPI schema — matching how the UI controller already works, so cloud users can now pass "verify": true to install vetted packages via the public API.

## Related Linear tickets, Github issues, and Community forum posts

Fixes [LIGO-447](https://linear.app/n8n/issue/LIGO-447/community-packages-install-endpoint-doesnt-work-on-cloud)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
