### PR TITLE
chore: Enable n8n plugin in Claude GitHub Actions workflows (no-changelog)

### DIFF
--- a/.github/workflows/util-claude-task.yml
+++ b/.github/workflows/util-claude-task.yml
@@ -149,6 +149,17 @@ jobs:
                   "mcp__linear__*",
                   "mcp__notion__*"
                 ]
+              },
+              "extraKnownMarketplaces": {
+                "n8n": {
+                  "source": {
+                    "source": "directory",
+                    "path": "./.claude/plugins/n8n"
+                  }
+                }
+              },
+              "enabledPlugins": {
+                "n8n@n8n": true
               }
             }
           claude_args: |

--- a/.github/workflows/util-claude.yml
+++ b/.github/workflows/util-claude.yml
@@ -36,6 +36,20 @@ jobs:
           # Or use OAuth token instead:
           # claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           timeout_minutes: '60'
+          settings: |
+            {
+              "extraKnownMarketplaces": {
+                "n8n": {
+                  "source": {
+                    "source": "directory",
+                    "path": "./.claude/plugins/n8n"
+                  }
+                }
+              },
+              "enabledPlugins": {
+                "n8n@n8n": true
+              }
+            }
           # mode: tag  # Default: responds to @claude mentions
           # Optional: Restrict network access to specific domains only
           # experimental_allowed_domains: |


### PR DESCRIPTION
## Summary

- Adds `extraKnownMarketplaces` and `enabledPlugins` to the `settings` block in both Claude GitHub Actions workflows so the n8n plugin (skills, agents, commands) is automatically loaded in CI without manual `/plugin` installation
- Applied to `util-claude-task.yml` (task runner) and `util-claude.yml` (PR/issue comment responder)

The n8n plugin lives at `./.claude/plugins/n8n` in the repo, so no download is needed — just registration via settings.

## Test plan

- [X] Trigger `util-claude-task.yml` and verify n8n skills are available to Claude
- [X] Trigger `util-claude.yml` via an `@claude` comment and verify n8n skills are available

Test run: https://github.com/n8n-io/n8n/actions/runs/24197561464/job/70631804492

https://linear.app/n8n/issue/NODE-4812/update-claude-github-actions-to-use-n8n-plugin-skills