### PR TITLE
feat(Salesforce Node): Add HasOptedOutOfEmail field to contact resource

### DIFF
--- a/packages/nodes-base/nodes/Salesforce/ContactDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/ContactDescription.ts
@@ -259,6 +259,14 @@ export const contactFields: INodeProperties[] = [
 				default: '',
 				description: 'First name of the contact. Maximum size is 40 characters.',
 			},
+ 			{
+ 				displayName: 'Has Opted Out of Email',
+ 				name: 'hasOptedOutOfEmail',
+ 				type: 'boolean',
+ 				default: false,
+ 				description:
+ 					'Whether the contact doesn’t want to receive email from Salesforce (true) or does (false). Label is Email Opt Out.',
+ 			},
 			{
 				displayName: 'Home Phone',
 				name: 'homePhone',
@@ -559,6 +567,14 @@ export const contactFields: INodeProperties[] = [
 				default: '',
 				description: 'First name of the contact. Maximum size is 40 characters.',
 			},
+			{
+ 				displayName: 'Has Opted Out of Email',
+ 				name: 'hasOptedOutOfEmail',
+ 				type: 'boolean',
+ 				default: false,
+ 				description:
+ 					'Whether the contact doesn’t want to receive email from Salesforce (true) or does (false). Label is Email Opt Out.',
+ 			},
 			{
 				displayName: 'Home Phone',
 				name: 'homePhone',

--- a/packages/nodes-base/nodes/Salesforce/ContactInterface.ts
+++ b/packages/nodes-base/nodes/Salesforce/ContactInterface.ts
@@ -3,6 +3,7 @@ export interface IContact {
 	LastName?: string;
 	Fax?: string;
 	Email?: string;
+	HasOptedOutOfEmail?: boolean;
 	Phone?: string;
 	Title?: string;
 	Jigsaw?: string;

--- a/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
+++ b/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
@@ -1378,6 +1378,9 @@ export class Salesforce implements INodeType {
 						if (additionalFields.fax !== undefined) {
 							body.Fax = additionalFields.fax as string;
 						}
+ 						if (additionalFields.hasOptedOutOfEmail !== undefined) {
+ 							body.HasOptedOutOfEmail = additionalFields.hasOptedOutOfEmail as boolean;
+ 						}
 						if (additionalFields.email !== undefined) {
 							body.Email = additionalFields.email as string;
 						}
@@ -1511,6 +1514,9 @@ export class Salesforce implements INodeType {
 						if (updateFields.email !== undefined) {
 							body.Email = updateFields.email as string;
 						}
+ 						if (updateFields.hasOptedOutOfEmail !== undefined) {
+ 							body.HasOptedOutOfEmail = updateFields.hasOptedOutOfEmail as boolean;
+ 						}
 						if (updateFields.recordTypeId !== undefined) {
 							body.RecordTypeId = updateFields.recordTypeId as string;
 						}

--- a/packages/nodes-base/nodes/Salesforce/__schema__/v1.0.0/contact/get.json
+++ b/packages/nodes-base/nodes/Salesforce/__schema__/v1.0.0/contact/get.json
@@ -18,6 +18,9 @@
         "CreatedDate": {
             "type": "string"
         },
+        "HasOptedOutOfEmail": {
+            "type": "boolean"
+        },
         "HomePhone": {
             "type": "null"
         },

--- a/packages/nodes-base/nodes/Salesforce/__test__/Salesforce.node.test.ts
+++ b/packages/nodes-base/nodes/Salesforce/__test__/Salesforce.node.test.ts
@@ -1942,6 +1942,7 @@ describe('Salesforce', () => {
 						additionalFields: {
 							fax: '1234567890',
 							email: 'contact@example.com',
+							hasOptedOutOfEmail: true,
 							phone: '+1234567890',
 							title: 'Director',
 							jigsaw: 'JIGSAW456',
@@ -1992,6 +1993,7 @@ describe('Salesforce', () => {
 						LastName: 'Smith',
 						Fax: '1234567890',
 						Email: 'contact@example.com',
+						HasOptedOutOfEmail: true,
 						Phone: '+1234567890',
 						Title: 'Director',
 						Jigsaw: 'JIGSAW456',
@@ -2080,6 +2082,7 @@ describe('Salesforce', () => {
 							lastName: 'Updated Contact',
 							fax: '9876543210',
 							email: 'updated@contact.com',
+							hasOptedOutOfEmail: false,
 							recordTypeId: 'rt999',
 							phone: '+1999999999',
 							title: 'Updated Director',


### PR DESCRIPTION
## Summary

In a previous pull request from 2023 the HasOptedOutOfEmail field has been added to the Lead Object since it was missing, but it was still missing on the Contact Object.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/pull/5235/
https://community.n8n.io/t/there-is-no-email-opt-out-field-in-the-saleforce-create-lead/18616/9

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. _(Not required here I would say?)_
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
