### PR TITLE
fix: Add credential auth and test for Twilio, Pipedrive, Asana, Freshdesk, Workable

### DIFF
--- a/packages/nodes-base/credentials/AsanaApi.credentials.ts
+++ b/packages/nodes-base/credentials/AsanaApi.credentials.ts
@@ -1,4 +1,9 @@
-import type { IAuthenticateGeneric, ICredentialType, INodeProperties } from 'n8n-workflow';
+import type {
+	IAuthenticateGeneric,
+	ICredentialTestRequest,
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
 
 export class AsanaApi implements ICredentialType {
 	name = 'asanaApi';
@@ -23,6 +28,13 @@ export class AsanaApi implements ICredentialType {
 			headers: {
 				Authorization: '=Bearer {{$credentials.accessToken}}',
 			},
+		},
+	};
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: 'https://app.asana.com/api/1.0',
+			url: '/users/me',
 		},
 	};
 }

--- a/packages/nodes-base/credentials/FreshdeskApi.credentials.ts
+++ b/packages/nodes-base/credentials/FreshdeskApi.credentials.ts
@@ -1,4 +1,9 @@
-import type { ICredentialType, INodeProperties } from 'n8n-workflow';
+import type {
+	IAuthenticateGeneric,
+	ICredentialTestRequest,
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
 
 export class FreshdeskApi implements ICredentialType {
 	name = 'freshdeskApi';
@@ -25,4 +30,21 @@ export class FreshdeskApi implements ICredentialType {
 			default: '',
 		},
 	];
+
+	authenticate: IAuthenticateGeneric = {
+		type: 'generic',
+		properties: {
+			auth: {
+				username: '={{$credentials.apiKey}}',
+				password: 'X',
+			},
+		},
+	};
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: '=https://{{$credentials.domain}}.freshdesk.com/api/v2',
+			url: '/agents/me',
+		},
+	};
 }

--- a/packages/nodes-base/credentials/PipedriveApi.credentials.ts
+++ b/packages/nodes-base/credentials/PipedriveApi.credentials.ts
@@ -1,4 +1,9 @@
-import type { IAuthenticateGeneric, ICredentialType, INodeProperties } from 'n8n-workflow';
+import type {
+	IAuthenticateGeneric,
+	ICredentialTestRequest,
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
 
 export class PipedriveApi implements ICredentialType {
 	name = 'pipedriveApi';
@@ -23,6 +28,13 @@ export class PipedriveApi implements ICredentialType {
 			qs: {
 				api_token: '={{$credentials.apiToken}}',
 			},
+		},
+	};
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: 'https://api.pipedrive.com/v1',
+			url: '/userSettings',
 		},
 	};
 }

--- a/packages/nodes-base/credentials/TwilioApi.credentials.ts
+++ b/packages/nodes-base/credentials/TwilioApi.credentials.ts
@@ -1,4 +1,9 @@
-import type { IAuthenticateGeneric, ICredentialType, INodeProperties } from 'n8n-workflow';
+import type {
+	IAuthenticateGeneric,
+	ICredentialTestRequest,
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
 
 export class TwilioApi implements ICredentialType {
 	name = 'twilioApi';
@@ -79,6 +84,12 @@ export class TwilioApi implements ICredentialType {
 				password:
 					'={{ $credentials.authType === "apiKey" ? $credentials.apiKeySecret : $credentials.authToken }}',
 			},
+		},
+	};
+
+	test: ICredentialTestRequest = {
+		request: {
+			url: '=https://api.twilio.com/2010-04-01/Accounts/{{$credentials.accountSid}}.json',
 		},
 	};
 }

--- a/packages/nodes-base/credentials/WorkableApi.credentials.ts
+++ b/packages/nodes-base/credentials/WorkableApi.credentials.ts
@@ -1,4 +1,9 @@
-import type { ICredentialType, INodeProperties } from 'n8n-workflow';
+import type {
+	IAuthenticateGeneric,
+	ICredentialTestRequest,
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
 
 export class WorkableApi implements ICredentialType {
 	name = 'workableApi';
@@ -22,4 +27,20 @@ export class WorkableApi implements ICredentialType {
 			default: '',
 		},
 	];
+
+	authenticate: IAuthenticateGeneric = {
+		type: 'generic',
+		properties: {
+			headers: {
+				Authorization: '=Bearer {{$credentials.accessToken}}',
+			},
+		},
+	};
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: '=https://{{$credentials.subdomain}}.workable.com/spi/v3',
+			url: '/jobs',
+		},
+	};
 }


### PR DESCRIPTION
## Summary

Add missing `authenticate` and/or `test` properties to 5 credential files as part of the ongoing credential auth/test updates (NODE-2621).

| Credential | Linear Issue | Auth Method | Test Endpoint | Needs |
|------------|-------------|-------------|---------------|-------|
| Twilio API | NODE-2740 | HTTP Basic Auth (AccountSID:AuthToken) | `GET /2010-04-01/Accounts/{accountSid}.json` | `test` only |
| Pipedrive API | NODE-2795 | Query string `api_token` | `GET /v1/userSettings` | `test` only |
| Asana API | NODE-2817 | Bearer token header | `GET /api/1.0/users/me` | `test` only |
| Freshdesk API | NODE-2706 | HTTP Basic Auth (apiKey:X) | `GET /api/v2/agents/me` | `authenticate` + `test` |
| Workable API | NODE-2810 | Bearer token header | `GET /spi/v3/jobs` | `authenticate` + `test` |

All auth patterns verified against both GenericFunctions and current API documentation.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4814
https://linear.app/n8n/issue/NODE-2621

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)