### PR TITLE
fix(IMAP Node): Fix out-of-memory crash after ECONNRESET on reconnect

### DIFF
--- a/packages/@n8n/imap/src/imap-simple.test.ts
+++ b/packages/@n8n/imap/src/imap-simple.test.ts
@@ -57,17 +57,19 @@ describe('ImapSimple', () => {
 			expect(onMail).toHaveBeenCalledWith(3);
 		});
 
-		it('should suppress ECONNRESET errors if ending', () => {
+		it('should suppress errors after end() by removing forwarding listeners', () => {
 			const { imapSimple, mockImap } = createImap();
 			const onError = vi.fn();
 			imapSimple.on('error', onError);
 			imapSimple.end();
 
+			// After end(), forwarding listeners are removed so errors
+			// on the raw imap no longer propagate to imapSimple
 			mockImap.emit('error', { message: 'reset', code: 'ECONNRESET' });
 			expect(onError).not.toHaveBeenCalled();
 		});
 
-		it('should forward ECONNRESET errors if not ending', () => {
+		it('should forward all errors before end() is called', () => {
 			const { imapSimple, mockImap } = createImap();
 			const onError = vi.fn();
 			imapSimple.on('error', onError);
@@ -75,6 +77,49 @@ describe('ImapSimple', () => {
 			const error = { message: 'reset', code: 'ECONNRESET' };
 			mockImap.emit('error', error);
 			expect(onError).toHaveBeenCalledWith(error);
+		});
+	});
+
+	describe('event listener cleanup', () => {
+		it('should remove forwarding listeners and keep only close+error on end()', () => {
+			const { imapSimple, mockImap } = createImap();
+
+			// Verify listeners were added by ImapSimple constructor
+			expect(mockImap.listenerCount('mail')).toBe(1);
+			expect(mockImap.listenerCount('error')).toBe(1);
+
+			imapSimple.end();
+
+			// All forwarding listeners should be removed
+			expect(mockImap.listenerCount('mail')).toBe(0);
+			expect(mockImap.listenerCount('alert')).toBe(0);
+
+			// A no-op error handler suppresses errors during disconnect
+			expect(mockImap.listenerCount('error')).toBe(1);
+
+			// A once-close handler forwards the final close event
+			expect(mockImap.listenerCount('close')).toBe(1);
+		});
+
+		it('should still forward the close event after end()', () => {
+			const { imapSimple, mockImap } = createImap();
+			const onClose = vi.fn();
+			imapSimple.on('close', onClose);
+
+			imapSimple.end();
+			mockImap.emit('close', false);
+
+			expect(onClose).toHaveBeenCalledWith(false);
+		});
+
+		it('should auto-remove the close handler after it fires once', () => {
+			const { imapSimple, mockImap } = createImap();
+
+			imapSimple.end();
+			mockImap.emit('close', false);
+
+			// once handler auto-removed after firing
+			expect(mockImap.listenerCount('close')).toBe(0);
 		});
 	});
 

--- a/packages/@n8n/imap/src/imap-simple.ts
+++ b/packages/@n8n/imap/src/imap-simple.ts
@@ -9,9 +9,6 @@ import type { Message, MessagePart, SearchCriteria } from './types';
 const IMAP_EVENTS = ['alert', 'mail', 'expunge', 'uidvalidity', 'update', 'close', 'end'] as const;
 
 export class ImapSimple extends EventEmitter {
-	/** flag to determine whether we should suppress ECONNRESET from bubbling up to listener */
-	private ending = false;
-
 	constructor(private readonly imap: Imap) {
 		super();
 
@@ -20,30 +17,26 @@ export class ImapSimple extends EventEmitter {
 			this.imap.on(event, this.emit.bind(this, event));
 		});
 
-		// special handling for `error` event
-		this.imap.on('error', (e: Error & { code?: string }) => {
-			// if .end() has been called and an 'ECONNRESET' error is received, don't bubble
-			if (e && this.ending && e.code?.toUpperCase() === 'ECONNRESET') {
-				return;
-			}
+		// forward error events from the underlying connection
+		this.imap.on('error', (e: Error) => {
 			this.emit('error', e);
 		});
 	}
 
 	/** disconnect from the imap server */
 	end(): void {
-		// set state flag to suppress 'ECONNRESET' errors that are triggered when .end() is called.
-		// it is a known issue that has no known fix. This just temporarily ignores that error.
+		// Remove all forwarding listeners to prevent leaks on reconnect
+		this.imap.removeAllListeners();
+
+		// Suppress errors emitted during disconnect (e.g. ECONNRESET).
+		// This is a known node-imap issue with no upstream fix:
 		// https://github.com/mscdex/node-imap/issues/391
 		// https://github.com/mscdex/node-imap/issues/395
-		this.ending = true;
+		this.imap.on('error', () => {});
 
-		// using 'close' event to unbind ECONNRESET error handler, because the node-imap
-		// maintainer claims it is the more reliable event between 'end' and 'close'.
-		// https://github.com/mscdex/node-imap/issues/394
-		this.imap.once('close', () => {
-			this.ending = false;
-		});
+		// Forward the final 'close' event so callers can still react
+		// (e.g. EmailReadImapV2 logs reconnect/shutdown status on close)
+		this.imap.once('close', (...args: unknown[]) => this.emit('close', ...args));
 
 		this.imap.end();
 	}

--- a/packages/nodes-base/nodes/EmailReadImap/test/v2/econnresetHandling.test.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/test/v2/econnresetHandling.test.ts
@@ -1,0 +1,136 @@
+import { EventEmitter } from 'events';
+import { mock } from 'jest-mock-extended';
+import type { INode, INodeTypeBaseDescription, ITriggerFunctions, IDataObject } from 'n8n-workflow';
+
+import { type ICredentialsDataImap } from '@credentials/Imap.credentials';
+
+import { EmailReadImapV2 } from '../../v2/EmailReadImapV2.node';
+
+const mockConnection = Object.assign(new EventEmitter(), {
+	openBox: jest.fn().mockResolvedValue({}),
+	closeBox: jest.fn().mockResolvedValue(undefined),
+	end: jest.fn(),
+	search: jest.fn().mockResolvedValue([]),
+	getPartData: jest.fn(),
+	addFlags: jest.fn().mockResolvedValue(undefined),
+});
+
+jest.mock('@n8n/imap', () => ({
+	connect: jest.fn().mockImplementation(async () => mockConnection),
+}));
+
+jest.mock('../../v2/utils', () => ({
+	getNewEmails: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('ECONNRESET error handling', () => {
+	const staticData: IDataObject = {};
+
+	const triggerFunctions = mock<ITriggerFunctions>({
+		helpers: {
+			createDeferredPromise: jest.fn().mockImplementation(() => {
+				let resolve: () => void;
+				let reject: (e: Error) => void;
+				const promise = new Promise<void>((res, rej) => {
+					resolve = res;
+					reject = rej;
+				});
+				return { promise, resolve: resolve!, reject: reject! };
+			}),
+		},
+	});
+
+	const credentials: ICredentialsDataImap = {
+		host: 'imap.test.com',
+		port: 993,
+		user: 'user',
+		password: 'password',
+		secure: false,
+		allowUnauthorizedCerts: false,
+	};
+
+	const baseDescription: INodeTypeBaseDescription = {
+		displayName: 'EmailReadImapV2',
+		name: 'emailReadImapV2',
+		icon: 'file:removeDuplicates.svg',
+		group: ['transform'],
+		description: 'Test',
+	};
+
+	beforeEach(() => {
+		mockConnection.removeAllListeners();
+		Object.keys(staticData).forEach((key) => delete staticData[key]);
+
+		triggerFunctions.getCredentials.calledWith('imap').mockResolvedValue(credentials);
+		triggerFunctions.getNode.mockReturnValue(mock<INode>({ typeVersion: 2.1 }));
+		triggerFunctions.getNodeParameter.mockImplementation(((param: string) => {
+			const values: Record<string, unknown> = {
+				mailbox: 'INBOX',
+				postProcessAction: 'nothing',
+				options: {},
+			};
+			return values[param];
+		}) as typeof triggerFunctions.getNodeParameter);
+		triggerFunctions.getWorkflowStaticData.calledWith('node').mockReturnValue(staticData);
+		triggerFunctions.logger.debug = jest.fn();
+		triggerFunctions.logger.error = jest.fn();
+		(triggerFunctions as { emitError: jest.Mock }).emitError = jest.fn();
+	});
+
+	afterEach(() => jest.clearAllMocks());
+
+	it('should call emitError when ECONNRESET error is received', async () => {
+		const node = new EmailReadImapV2(baseDescription);
+		await node.trigger.call(triggerFunctions);
+
+		// Simulate ECONNRESET from node-imap
+		const error = Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' });
+		mockConnection.emit('error', error);
+
+		expect(triggerFunctions.emitError).toHaveBeenCalledWith(error);
+	});
+
+	it('should call emitError on unexpected close (when not reconnecting or shutting down)', async () => {
+		const node = new EmailReadImapV2(baseDescription);
+		await node.trigger.call(triggerFunctions);
+
+		// Simulate unexpected close without prior error
+		mockConnection.emit('close', false);
+
+		expect(triggerFunctions.emitError).toHaveBeenCalledWith(
+			expect.objectContaining({ message: 'Imap connection closed unexpectedly' }),
+		);
+	});
+
+	it('should call emitError only once when ECONNRESET is followed by close', async () => {
+		const node = new EmailReadImapV2(baseDescription);
+		await node.trigger.call(triggerFunctions);
+
+		// node-imap fires 'error' then 'close' on ECONNRESET
+		const error = Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' });
+		mockConnection.emit('error', error);
+		mockConnection.emit('close', true);
+
+		// emitError should only be called once — the close handler should
+		// not double-fire when the error handler already reported the failure
+		expect(triggerFunctions.emitError).toHaveBeenCalledTimes(1);
+	});
+
+	it('should remove listeners from connection after close', async () => {
+		const node = new EmailReadImapV2(baseDescription);
+		await node.trigger.call(triggerFunctions);
+
+		// Listeners were registered during establishConnection
+		expect(mockConnection.listenerCount('close')).toBeGreaterThanOrEqual(1);
+		expect(mockConnection.listenerCount('error')).toBeGreaterThanOrEqual(1);
+
+		// Simulate ECONNRESET + close
+		const error = Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' });
+		mockConnection.emit('error', error);
+		mockConnection.emit('close', true);
+
+		// Listeners should be cleaned up after the connection dies
+		expect(mockConnection.listenerCount('close')).toBe(0);
+		expect(mockConnection.listenerCount('error')).toBe(0);
+	});
+});

--- a/packages/nodes-base/nodes/EmailReadImap/test/v2/searchCriteriaLeak.test.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/test/v2/searchCriteriaLeak.test.ts
@@ -1,0 +1,130 @@
+import { EventEmitter } from 'events';
+import { mock } from 'jest-mock-extended';
+import type { INode, INodeTypeBaseDescription, ITriggerFunctions, IDataObject } from 'n8n-workflow';
+
+import { type ICredentialsDataImap } from '@credentials/Imap.credentials';
+
+import { EmailReadImapV2 } from '../../v2/EmailReadImapV2.node';
+
+let capturedOnMail: ((numEmails: number) => Promise<void>) | undefined;
+let capturedSearchCriteria: unknown[][] = [];
+
+const mockConnection = Object.assign(new EventEmitter(), {
+	openBox: jest.fn().mockResolvedValue({}),
+	closeBox: jest.fn().mockResolvedValue(undefined),
+	end: jest.fn(),
+	search: jest.fn().mockResolvedValue([]),
+	getPartData: jest.fn(),
+	addFlags: jest.fn().mockResolvedValue(undefined),
+});
+
+jest.mock('@n8n/imap', () => ({
+	connect: jest
+		.fn()
+		.mockImplementation(async (config: { onMail?: (n: number) => Promise<void> }) => {
+			capturedOnMail = config.onMail;
+			return mockConnection;
+		}),
+}));
+
+jest.mock('../../v2/utils', () => ({
+	getNewEmails: jest.fn().mockImplementation(async function (
+		this: ITriggerFunctions,
+		opts: { searchCriteria: unknown[] },
+	) {
+		// Record the searchCriteria for assertion
+		capturedSearchCriteria.push([...opts.searchCriteria]);
+
+		// Simulate processing: update lastMessageUid so subsequent onMail calls
+		// take the UID push path (line 398-411 in EmailReadImapV2.node.ts)
+		const staticData = this.getWorkflowStaticData('node');
+		staticData.lastMessageUid = ((staticData.lastMessageUid as number) ?? 0) + 1;
+	}),
+}));
+
+describe('searchCriteria leak on repeated onMail calls', () => {
+	const staticData: IDataObject = {};
+
+	const triggerFunctions = mock<ITriggerFunctions>({
+		helpers: {
+			createDeferredPromise: jest.fn().mockImplementation(() => {
+				let resolve: () => void;
+				let reject: (e: Error) => void;
+				const promise = new Promise<void>((res, rej) => {
+					resolve = res;
+					reject = rej;
+				});
+				return { promise, resolve: resolve!, reject: reject! };
+			}),
+		},
+	});
+
+	const credentials: ICredentialsDataImap = {
+		host: 'imap.test.com',
+		port: 993,
+		user: 'user',
+		password: 'password',
+		secure: false,
+		allowUnauthorizedCerts: false,
+	};
+
+	const baseDescription: INodeTypeBaseDescription = {
+		displayName: 'EmailReadImapV2',
+		name: 'emailReadImapV2',
+		icon: 'file:removeDuplicates.svg',
+		group: ['transform'],
+		description: 'Test',
+	};
+
+	beforeEach(() => {
+		capturedOnMail = undefined;
+		capturedSearchCriteria = [];
+		Object.keys(staticData).forEach((key) => delete staticData[key]);
+
+		triggerFunctions.getCredentials.calledWith('imap').mockResolvedValue(credentials);
+		triggerFunctions.getNode.mockReturnValue(mock<INode>({ typeVersion: 2.1 }));
+		triggerFunctions.getNodeParameter.mockImplementation(((param: string) => {
+			const values: Record<string, unknown> = {
+				mailbox: 'INBOX',
+				postProcessAction: 'nothing',
+				options: { trackLastMessageId: true },
+			};
+			return values[param];
+		}) as typeof triggerFunctions.getNodeParameter);
+		triggerFunctions.getWorkflowStaticData.calledWith('node').mockReturnValue(staticData);
+		triggerFunctions.logger.debug = jest.fn();
+		triggerFunctions.logger.error = jest.fn();
+	});
+
+	afterEach(() => jest.clearAllMocks());
+
+	it('should not accumulate UID entries in searchCriteria across onMail calls', async () => {
+		const node = new EmailReadImapV2(baseDescription);
+		await node.trigger.call(triggerFunctions);
+
+		expect(capturedOnMail).toBeDefined();
+
+		// Simulate the first onMail — lastMessageUid is undefined,
+		// so it takes the SINCE path, not the UID push path
+		await capturedOnMail!(1);
+		expect(capturedSearchCriteria).toHaveLength(1);
+		// After first call, the mock sets lastMessageUid = 1
+
+		// Now fire onMail 10 more times
+		for (let i = 0; i < 10; i++) {
+			await capturedOnMail!(1);
+		}
+
+		expect(capturedSearchCriteria).toHaveLength(11);
+
+		// Each onMail call should pass a fresh searchCriteria with at most
+		// 2 entries: UNSEEN + one UID filter for the current lastMessageUid.
+		// UID entries must NOT accumulate across calls.
+		const lastCriteria = capturedSearchCriteria[capturedSearchCriteria.length - 1];
+
+		const uidEntries = lastCriteria.filter((c) => Array.isArray(c) && c[0] === 'UID');
+
+		// Before the fix the UID Entries would accumulate (length > 1) and then lead to a slow memory leak
+		expect(uidEntries).toHaveLength(1);
+	});
+});

--- a/packages/nodes-base/nodes/EmailReadImap/v2/EmailReadImapV2.node.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/v2/EmailReadImapV2.node.ts
@@ -387,6 +387,9 @@ export class EmailReadImapV2 implements INodeType {
 					});
 
 					if (connection) {
+						// Create a fresh copy to avoid accumulating filters across calls
+						const currentSearchCriteria = [...searchCriteria];
+
 						/**
 						 * Only process new emails:
 						 * - If we've seen emails before (lastMessageUid is set), fetch messages higher UID.
@@ -408,19 +411,19 @@ export class EmailReadImapV2 implements INodeType {
 							 * - You can check if UIDs changed in the above example
 							 * by checking UIDValidity.
 							 */
-							searchCriteria.push(['UID', `${staticData.lastMessageUid as number}:*`]);
+							currentSearchCriteria.push(['UID', `${staticData.lastMessageUid as number}:*`]);
 						} else if (node.typeVersion > 2 && options.trackLastMessageId !== false) {
-							searchCriteria.push(['SINCE', activatedAt.toFormat('dd-LLL-yyyy')]);
+							currentSearchCriteria.push(['SINCE', activatedAt.toFormat('dd-LLL-yyyy')]);
 						}
 
 						this.logger.debug('Querying for new messages on node "EmailReadImap"', {
-							searchCriteria,
+							searchCriteria: currentSearchCriteria,
 						});
 
 						try {
 							await getNewEmails.call(this, {
 								imapConnection: connection,
-								searchCriteria,
+								searchCriteria: currentSearchCriteria,
 								postProcessAction,
 								getText,
 								getAttachment,
@@ -464,21 +467,26 @@ export class EmailReadImapV2 implements INodeType {
 			// Connect to the IMAP server and open the mailbox
 			// that we get informed whenever a new email arrives
 			return await imapConnect(config).then((conn) => {
+				let errorReported = false;
+
 				conn.on('close', (_hadError: boolean) => {
 					if (isCurrentlyReconnecting) {
 						this.logger.debug('Email Read Imap: Connected closed for forced reconnecting');
 					} else if (closeFunctionWasCalled) {
 						this.logger.debug('Email Read Imap: Shutting down workflow - connected closed');
-					} else {
+					} else if (!errorReported) {
 						this.logger.error('Email Read Imap: Connected closed unexpectedly');
 						this.emitError(new Error('Imap connection closed unexpectedly'));
 					}
+					conn.removeAllListeners();
 				});
 				conn.on('error', (error) => {
-					const errorCode = ((error as JsonObject).code as string).toUpperCase();
+					const errorCode =
+						((error as JsonObject).code as string | undefined)?.toUpperCase() ?? 'UNKNOWN';
 					this.logger.debug(`IMAP connection experienced an error: (${errorCode})`, {
 						error: error as Error,
 					});
+					errorReported = true;
 					this.emitError(error as Error);
 				});
 				return conn;


### PR DESCRIPTION
## Summary

Fixes an out-of-memory crash in the IMAP trigger node that occurred after an ECONNRESET. Three compounding issues caused the OOM:

1. **searchCriteria mutation leak** — The `searchCriteria` array was mutated on every `onMail` call, accumulating UID filter entries indefinitely. Fixed by creating a shallow copy per invocation.
2. **Event listener leak** — Listeners on the ImapSimple wrapper were never cleaned up on reconnect. Fixed by calling `removeAllListeners()` in `ImapSimple.end()` and in the connection close handler.
3. **Duplicate error reporting** — ECONNRESET fired both `error` and `close` events, causing duplicate `emitError` calls. Fixed with a per-connection `errorReported` flag.

## Testing

I used the following workflow for testing: [IMAP Test.json](https://github.com/user-attachments/files/26623768/IMAP.Test.json)
and used a local IMAP/SMTP Server using Greenmail via
`docker run -p 3143:3143 -p 3025:3025 -p 8080:8080 greenmail/standalone`

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-4710
- closes https://github.com/n8n-io/n8n/issues/26226

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
- [x] I have seen this code, I have run this code, and I take responsibility for this code.