### PR TITLE
fix(core): Increase timing delays in workflow publish history tests

### DIFF
--- a/packages/cli/test/integration/database/repositories/workflow-publish-history.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/workflow-publish-history.repository.test.ts
@@ -98,7 +98,7 @@ describe('WorkflowPublishHistoryRepository', () => {
 				userId: null,
 			});
 
-			await new Promise((resolve) => setTimeout(resolve, 1));
+			await new Promise((resolve) => setTimeout(resolve, 5));
 
 			await repository.addRecord({
 				workflowId: workflow.id,
@@ -107,7 +107,7 @@ describe('WorkflowPublishHistoryRepository', () => {
 				userId: null,
 			});
 
-			await new Promise((resolve) => setTimeout(resolve, 1));
+			await new Promise((resolve) => setTimeout(resolve, 5));
 
 			await repository.addRecord({
 				workflowId: workflow.id,
@@ -151,7 +151,7 @@ describe('WorkflowPublishHistoryRepository', () => {
 				userId: user1.id,
 			});
 
-			await new Promise((resolve) => setTimeout(resolve, 1));
+			await new Promise((resolve) => setTimeout(resolve, 5));
 
 			await repository.addRecord({
 				workflowId: workflow.id,


### PR DESCRIPTION
## Summary

I saw this flake recently, so bumping the time a bit. This is obviously not great, but relatively common in our codebase.

Increases `setTimeout` delays from 1ms to 5ms in `WorkflowPublishHistoryRepository` integration tests to fix flaky failures caused by insufficient timing gaps between record insertions.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)