### PR TITLE
fix(core): Fix duplicate task request on runner defer

### DIFF
--- a/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
+++ b/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
@@ -359,6 +359,78 @@ describe('TaskBroker', () => {
 			expect(remainingRequests[0]).toEqual(request);
 		});
 
+		it('should not create duplicate request when runner defers', async () => {
+			const runnerId = 'runner1';
+			const runner = mock<TaskRunner>({ id: runnerId });
+
+			// Simulate a launcher-like runner that defers tasks on acceptance
+			const messageCallback = jest.fn().mockImplementation(async (message) => {
+				if (message.type === 'broker:taskofferaccept') {
+					taskBroker.handleRunnerDeferred(message.taskId);
+				}
+			});
+
+			taskBroker.registerRunner(runner, messageCallback);
+
+			const offer: TaskOffer = {
+				offerId: 'offer1',
+				runnerId,
+				taskType: 'taskType1',
+				validFor: -1,
+				validUntil: 0n,
+			};
+
+			const request: TaskRequest = {
+				requestId: 'request1',
+				requesterId: 'requester1',
+				taskType: 'taskType1',
+			};
+
+			taskBroker.setPendingTaskOffers([offer]);
+			taskBroker.setPendingTaskRequests([request]);
+
+			taskBroker.settleTasks();
+
+			// Let the async acceptOffer complete
+			await new Promise(setImmediate);
+
+			const requests = taskBroker.getPendingTaskRequests();
+			expect(requests).toHaveLength(1);
+			expect(requests[0].requestId).toBe('request1');
+			expect(requests[0].acceptInProgress).toBe(false);
+		});
+
+		it('should log warning when offers exist but none match request type', () => {
+			const loggerMock = mock<Logger>();
+			taskBroker = new TaskBroker(loggerMock, mock(), mock(), mock());
+
+			const offer: TaskOffer = {
+				offerId: 'offer1',
+				runnerId: 'runner1',
+				taskType: 'python',
+				validFor: -1,
+				validUntil: 0n,
+			};
+
+			const request: TaskRequest = {
+				requestId: 'request1',
+				requesterId: 'requester1',
+				taskType: 'javascript',
+				acceptInProgress: false,
+			};
+
+			taskBroker.setPendingTaskOffers([offer]);
+			taskBroker.setPendingTaskRequests([request]);
+
+			jest.spyOn(taskBroker, 'acceptOffer').mockResolvedValue();
+
+			taskBroker.settleTasks();
+
+			expect(loggerMock.warn).toHaveBeenCalledWith(
+				expect.stringMatching(/No matching task offer.*request1.*javascript.*python/),
+			);
+		});
+
 		it('should expire tasks before settling', () => {
 			const validOffer: TaskOffer = {
 				offerId: 'valid',
@@ -1064,9 +1136,9 @@ describe('TaskBroker', () => {
 			const handleTimeoutSpy = jest.spyOn(taskBroker as any, 'handleRequestTimeout');
 
 			jest.spyOn(taskBroker, 'acceptOffer').mockImplementation(async (_offer, request) => {
+				request.acceptInProgress = false;
 				clearTimeout(request.timeout);
 				request.timeout = taskBroker['createRequestTimeout'](request.requestId);
-				taskBroker.setPendingTaskRequests([request]);
 			});
 
 			taskBroker.settleTasks();

--- a/packages/cli/src/task-runners/task-broker/task-broker.service.ts
+++ b/packages/cli/src/task-runners/task-broker/task-broker.service.ts
@@ -91,6 +91,9 @@ export class TaskBroker {
 
 	private pendingTaskRequests: TaskRequest[] = [];
 
+	/** Request IDs that have already logged a task-type mismatch warning */
+	private mismatchWarned = new Set<string>();
+
 	constructor(
 		private readonly logger: Logger,
 		private readonly taskRunnersConfig: TaskRunnersConfig,
@@ -114,6 +117,7 @@ export class TaskBroker {
 
 		const request = this.pendingTaskRequests[requestIndex];
 		this.pendingTaskRequests.splice(requestIndex, 1);
+		this.mismatchWarned.delete(requestId);
 
 		clearTimeout(request.timeout);
 
@@ -567,7 +571,6 @@ export class TaskBroker {
 				this.logger.debug(`Task (${taskId}) deferred until runner is ready`);
 				clearTimeout(request.timeout);
 				request.timeout = this.createRequestTimeout(request.requestId);
-				this.pendingTaskRequests.push(request); // will settle on receiving task offer from runner
 				return;
 			}
 			if (e instanceof TaskRunnerAcceptTimeoutError) {
@@ -651,15 +654,28 @@ export class TaskBroker {
 			}
 			const offerIndex = this.pendingTaskOffers.findIndex((o) => o.taskType === request.taskType);
 			if (offerIndex === -1) {
+				this.warnOnTaskTypeMismatch(request);
 				continue;
 			}
 			const offer = this.pendingTaskOffers[offerIndex];
 
 			request.acceptInProgress = true;
 			this.pendingTaskOffers.splice(offerIndex, 1);
+			this.mismatchWarned.delete(request.requestId);
 
 			void this.acceptOffer(offer, request);
 		}
+	}
+
+	private warnOnTaskTypeMismatch(request: TaskRequest) {
+		if (this.pendingTaskOffers.length === 0) return;
+		if (this.mismatchWarned.has(request.requestId)) return;
+
+		const offerTypes = [...new Set(this.pendingTaskOffers.map((o) => o.taskType))];
+		this.logger.warn(
+			`No matching task offer for request "${request.requestId}" (type "${request.taskType}"). Available offer types: [${offerTypes.join(', ')}]`,
+		);
+		this.mismatchWarned.add(request.requestId);
 	}
 
 	taskRequested(request: TaskRequest) {


### PR DESCRIPTION
## Summary

When the launcher [defers](https://github.com/n8n-io/task-runner-launcher/blob/main/docs/lifecycle.md) a task, the broker's `acceptOffer` catch block was pushing the request back into `pendingTaskRequests` but `settleTasks` never removes requests from that array in the first place, only sets `acceptInProgress = true`. This created a duplicate entry on every defer cycle.

This PR fixes the duplication and also adds a warning log when the broker has pending offers but none match a request's task type. My suspicion is after a worker restart, since only one launcher type reconnects, requests for the other type sit with no match until they time out.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2706

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
