### PR TITLE
fix: Correct typo in proxy error message: not value -> not valid

### DIFF
--- a/packages/core/src/execution-engine/routing-node.ts
+++ b/packages/core/src/execution-engine/routing-node.ts
@@ -183,7 +183,7 @@ export class RoutingNode {
 						!(property in proxyParsed) ||
 						proxyParsed[property as keyof typeof proxyParsed] === null
 					) {
-						throw new NodeOperationError(node, 'The proxy is not value', {
+						throw new NodeOperationError(node, 'The proxy is not valid', {
 							runIndex,
 							itemIndex,
 							description: `The proxy URL does not contain a valid value for "${property}"`,


### PR DESCRIPTION
## Summary
Correct typo in proxy error message: changed `not value` to `not valid`.

Closes #15773

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] Documentation updated or not required
- [x] Tests included or not required