### PR TITLE
fix(core): Propagate form data parse errors instead of silently discarding them

### DIFF
--- a/packages/cli/src/webhooks/__tests__/webhook-form-data.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-form-data.test.ts
@@ -164,18 +164,13 @@ describe('webhook-form-data', () => {
 			testServer.assertHasBeenCalled();
 		});
 
-		it('should ignore file that is too large', async () => {
+		it('should reject when file exceeds max size', async () => {
 			const oneByteInMb = 1 / 1024 / 1024;
 			const parseFn = createMultiFormDataParser(oneByteInMb);
 
 			await testServer
 				.sendRequestToHandler(async (req) => {
-					const parsedData = await parseFn(req);
-
-					expect(parsedData).toStrictEqual({
-						data: {},
-						files: {},
-					});
+					await expect(parseFn(req)).rejects.toThrow();
 				})
 				.attach('file', oneKbData, 'file.txt');
 

--- a/packages/cli/src/webhooks/webhook-form-data.ts
+++ b/packages/cli/src/webhooks/webhook-form-data.ts
@@ -27,8 +27,9 @@ export const createMultiFormDataParser = (maxFormDataSizeInMb: number) => {
 			// TODO: pass a custom `fileWriteStreamHandler` to create binary data files directly
 		});
 
-		return await new Promise((resolve) => {
-			form.parse(req, async (_err, data, files) => {
+		return await new Promise((resolve, reject) => {
+			form.parse(req, async (err, data, files) => {
+				if (err) return reject(err);
 				normalizeFormData(data);
 				normalizeFormData(files);
 				resolve({ data, files });


### PR DESCRIPTION
## Summary

The `createMultiFormDataParser` was silently swallowing errors from `formidable`'s parse callback (the `err` parameter was ignored as `_err` and the promise always resolved). This meant file uploads exceeding `maxFileSize` would silently return empty data instead of surfacing the error.

This fix adds proper error propagation by using `reject` in the Promise constructor and checking for errors in the callback.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4820

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)