### PR TITLE
feat: Enable security policy settings via env vars

### DIFF
--- a/packages/@n8n/api-types/src/dto/security-settings/security-settings.dto.ts
+++ b/packages/@n8n/api-types/src/dto/security-settings/security-settings.dto.ts
@@ -8,6 +8,7 @@ export class SecuritySettingsDto extends Z.class({
 	publishedPersonalWorkflowsCount: z.number(),
 	sharedPersonalWorkflowsCount: z.number(),
 	sharedPersonalCredentialsCount: z.number(),
+	managedByEnv: z.boolean(),
 }) {}
 
 export class UpdateSecuritySettingsDto extends Z.class({

--- a/packages/@n8n/config/src/configs/instance-settings-loader.config.ts
+++ b/packages/@n8n/config/src/configs/instance-settings-loader.config.ts
@@ -32,15 +32,15 @@ export class InstanceSettingsLoaderConfig {
 	 * On every startup the security policy will be overridden by env vars.
 	 * When false (default), security policy env vars are ignored even if set.
 	 */
-	@Env('N8N_SECURITY_POLICY_OVERRIDE')
-	securityPolicyOverride: boolean = false;
+	@Env('N8N_SECURITY_POLICY_MANAGED_BY_ENV')
+	securityPolicyManagedByEnv: boolean = false;
 
-	@Env('N8N_SECURITY_POLICY_MFA_ENFORCED')
-	securityPolicyMfaEnforced: boolean = false;
+	@Env('N8N_MFA_ENFORCED_ENABLED')
+	mfaEnforcedEnabled: boolean = false;
 
-	@Env('N8N_SECURITY_POLICY_PERSONAL_SPACE_PUBLISHING')
-	securityPolicyPersonalSpacePublishing: boolean = true;
+	@Env('N8N_PERSONAL_SPACE_PUBLISHING_ENABLED')
+	personalSpacePublishingEnabled: boolean = true;
 
-	@Env('N8N_SECURITY_POLICY_PERSONAL_SPACE_SHARING')
-	securityPolicyPersonalSpaceSharing: boolean = true;
+	@Env('N8N_PERSONAL_SPACE_SHARING_ENABLED')
+	personalSpaceSharingEnabled: boolean = true;
 }

--- a/packages/@n8n/config/src/configs/instance-settings-loader.config.ts
+++ b/packages/@n8n/config/src/configs/instance-settings-loader.config.ts
@@ -26,4 +26,21 @@ export class InstanceSettingsLoaderConfig {
 	 */
 	@Env('N8N_INSTANCE_OWNER_PASSWORD_HASH')
 	ownerPasswordHash: string = '';
+
+	/**
+	 * When true, security policy settings are managed via environment variables.
+	 * On every startup the security policy will be overridden by env vars.
+	 * When false (default), security policy env vars are ignored even if set.
+	 */
+	@Env('SECURITY_POLICY_OVERRIDE')
+	securityPolicyOverride: boolean = false;
+
+	@Env('SECURITY_POLICY_MFA_ENFORCED')
+	securityPolicyMfaEnforced: boolean = false;
+
+	@Env('SECURITY_POLICY_PERSONAL_SPACE_PUBLISHING')
+	securityPolicyPersonalSpacePublishing: boolean = true;
+
+	@Env('SECURITY_POLICY_PERSONAL_SPACE_SHARING')
+	securityPolicyPersonalSpaceSharing: boolean = true;
 }

--- a/packages/@n8n/config/src/configs/instance-settings-loader.config.ts
+++ b/packages/@n8n/config/src/configs/instance-settings-loader.config.ts
@@ -32,15 +32,15 @@ export class InstanceSettingsLoaderConfig {
 	 * On every startup the security policy will be overridden by env vars.
 	 * When false (default), security policy env vars are ignored even if set.
 	 */
-	@Env('SECURITY_POLICY_OVERRIDE')
+	@Env('N8N_SECURITY_POLICY_OVERRIDE')
 	securityPolicyOverride: boolean = false;
 
-	@Env('SECURITY_POLICY_MFA_ENFORCED')
+	@Env('N8N_SECURITY_POLICY_MFA_ENFORCED')
 	securityPolicyMfaEnforced: boolean = false;
 
-	@Env('SECURITY_POLICY_PERSONAL_SPACE_PUBLISHING')
+	@Env('N8N_SECURITY_POLICY_PERSONAL_SPACE_PUBLISHING')
 	securityPolicyPersonalSpacePublishing: boolean = true;
 
-	@Env('SECURITY_POLICY_PERSONAL_SPACE_SHARING')
+	@Env('N8N_SECURITY_POLICY_PERSONAL_SPACE_SHARING')
 	securityPolicyPersonalSpaceSharing: boolean = true;
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -503,6 +503,10 @@ describe('GlobalConfig', () => {
 			ownerFirstName: 'Instance',
 			ownerLastName: 'Owner',
 			ownerPasswordHash: '',
+			securityPolicyOverride: false,
+			securityPolicyMfaEnforced: false,
+			securityPolicyPersonalSpacePublishing: true,
+			securityPolicyPersonalSpaceSharing: true,
 		},
 	} satisfies GlobalConfigShape;
 

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -503,10 +503,10 @@ describe('GlobalConfig', () => {
 			ownerFirstName: 'Instance',
 			ownerLastName: 'Owner',
 			ownerPasswordHash: '',
-			securityPolicyOverride: false,
-			securityPolicyMfaEnforced: false,
-			securityPolicyPersonalSpacePublishing: true,
-			securityPolicyPersonalSpaceSharing: true,
+			securityPolicyManagedByEnv: false,
+			mfaEnforcedEnabled: false,
+			personalSpacePublishingEnabled: true,
+			personalSpaceSharingEnabled: true,
 		},
 	} satisfies GlobalConfigShape;
 

--- a/packages/cli/src/controllers/mfa.controller.ts
+++ b/packages/cli/src/controllers/mfa.controller.ts
@@ -1,3 +1,4 @@
+import { InstanceSettingsLoaderConfig } from '@n8n/config';
 import { AuthenticatedRequest, UserRepository } from '@n8n/db';
 import {
 	createUserKeyedRateLimiter,
@@ -10,6 +11,7 @@ import { Response } from 'express';
 
 import { AuthService } from '@/auth/auth.service';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { EventService } from '@/events/event.service';
 import { ExternalHooks } from '@/external-hooks';
 import { MfaService } from '@/mfa/mfa.service';
@@ -23,11 +25,18 @@ export class MFAController {
 		private authService: AuthService,
 		private userRepository: UserRepository,
 		private eventService: EventService,
+		private instanceSettingsLoaderConfig: InstanceSettingsLoaderConfig,
 	) {}
 
 	@Post('/enforce-mfa')
 	@GlobalScope('user:enforceMfa')
 	async enforceMFA(req: MFA.Enforce) {
+		if (this.instanceSettingsLoaderConfig.securityPolicyManagedByEnv) {
+			throw new ForbiddenError(
+				'MFA enforcement is managed via environment variables and cannot be updated through the API',
+			);
+		}
+
 		if (req.body.enforce && !(req.authInfo?.usedMfa ?? false)) {
 			// The current user tries to enforce MFA, but does not have
 			// MFA set up for them self. We are forbidding this, to

--- a/packages/cli/src/controllers/security-settings.controller.ts
+++ b/packages/cli/src/controllers/security-settings.controller.ts
@@ -1,4 +1,5 @@
 import { UpdateSecuritySettingsDto } from '@n8n/api-types';
+import { InstanceSettingsLoaderConfig } from '@n8n/config';
 import { type AuthenticatedRequest } from '@n8n/db';
 import { Body, Get, GlobalScope, Licensed, Post, RestController } from '@n8n/decorators';
 import {
@@ -7,6 +8,7 @@ import {
 } from '@n8n/permissions';
 import type { Response } from 'express';
 
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { EventService } from '@/events/event.service';
 import { SecuritySettingsService } from '@/services/security-settings.service';
 
@@ -15,6 +17,7 @@ export class SecuritySettingsController {
 	constructor(
 		private readonly securitySettingsService: SecuritySettingsService,
 		private readonly eventService: EventService,
+		private readonly instanceSettingsLoaderConfig: InstanceSettingsLoaderConfig,
 	) {}
 
 	@Licensed('feat:personalSpacePolicy')
@@ -37,6 +40,7 @@ export class SecuritySettingsController {
 			publishedPersonalWorkflowsCount,
 			sharedPersonalWorkflowsCount,
 			sharedPersonalCredentialsCount,
+			managedByEnv: this.instanceSettingsLoaderConfig.securityPolicyManagedByEnv,
 		};
 	}
 
@@ -48,6 +52,12 @@ export class SecuritySettingsController {
 		_res: Response,
 		@Body dto: UpdateSecuritySettingsDto,
 	) {
+		if (this.instanceSettingsLoaderConfig.securityPolicyManagedByEnv) {
+			throw new ForbiddenError(
+				'Security settings are managed via environment variables and cannot be updated through the API',
+			);
+		}
+
 		const updatedSettings: Record<string, boolean> = {};
 		if (dto.personalSpacePublishing !== undefined) {
 			await this.securitySettingsService.setPersonalSpaceSetting(

--- a/packages/cli/src/instance-settings-loader/__tests__/owner.instance-settings-loader.test.ts
+++ b/packages/cli/src/instance-settings-loader/__tests__/owner.instance-settings-loader.test.ts
@@ -41,31 +41,25 @@ describe('OwnerInstanceSettingsLoader', () => {
 			expect(logger.warn).not.toHaveBeenCalled();
 		});
 
-		it('should skip and warn when ownerEmail is set', async () => {
+		it('should skip when ownerEmail is set', async () => {
 			const loader = createLoader({ ownerEmail: 'admin@example.com' });
 
 			const result = await loader.run();
 
 			expect(result).toBe('skipped');
 			expect(ownershipService.setupOwner).not.toHaveBeenCalled();
-			expect(logger.warn).toHaveBeenCalledWith(
-				expect.stringContaining('N8N_INSTANCE_OWNER_MANAGED_BY_ENV is not enabled'),
-			);
 		});
 
-		it('should skip and warn when ownerPasswordHash is set', async () => {
+		it('should skip when ownerPasswordHash is set', async () => {
 			const loader = createLoader({ ownerPasswordHash: validBcryptHash });
 
 			const result = await loader.run();
 
 			expect(result).toBe('skipped');
 			expect(ownershipService.setupOwner).not.toHaveBeenCalled();
-			expect(logger.warn).toHaveBeenCalledWith(
-				expect.stringContaining('N8N_INSTANCE_OWNER_MANAGED_BY_ENV is not enabled'),
-			);
 		});
 
-		it('should skip and warn when both email and password are set', async () => {
+		it('should skip when both email and password are set', async () => {
 			const loader = createLoader({
 				ownerEmail: 'admin@example.com',
 				ownerPasswordHash: validBcryptHash,
@@ -75,7 +69,6 @@ describe('OwnerInstanceSettingsLoader', () => {
 
 			expect(result).toBe('skipped');
 			expect(ownershipService.setupOwner).not.toHaveBeenCalled();
-			expect(logger.warn).toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/instance-settings-loader/__tests__/security-policy.instance-settings-loader.test.ts
+++ b/packages/cli/src/instance-settings-loader/__tests__/security-policy.instance-settings-loader.test.ts
@@ -39,7 +39,7 @@ describe('SecurityPolicyInstanceSettingsLoader', () => {
 	});
 
 	describe('when N8N_SECURITY_POLICY_MANAGED_BY_ENV is false', () => {
-		it('should skip when no security env vars deviate from defaults', async () => {
+		it('should skip when securityPolicyManagedByEnv is false', async () => {
 			const loader = createLoader();
 
 			const result = await loader.run();
@@ -47,43 +47,39 @@ describe('SecurityPolicyInstanceSettingsLoader', () => {
 			expect(result).toBe('skipped');
 			expect(mfaService.enforceMFA).not.toHaveBeenCalled();
 			expect(securitySettingsService.setPersonalSpaceSetting).not.toHaveBeenCalled();
-			expect(logger.warn).not.toHaveBeenCalled();
+			expect(logger.debug).toHaveBeenCalledWith(
+				expect.stringContaining('not managed by environment variables'),
+			);
 		});
 
-		it('should skip and warn when mfaEnforcedEnabled is true', async () => {
+		it('should skip without applying when mfaEnforcedEnabled is true', async () => {
 			const loader = createLoader({ mfaEnforcedEnabled: true });
 
 			const result = await loader.run();
 
 			expect(result).toBe('skipped');
 			expect(mfaService.enforceMFA).not.toHaveBeenCalled();
-			expect(logger.warn).toHaveBeenCalledWith(
-				expect.stringContaining('N8N_SECURITY_POLICY_MANAGED_BY_ENV is not enabled'),
-			);
+			expect(securitySettingsService.setPersonalSpaceSetting).not.toHaveBeenCalled();
 		});
 
-		it('should skip and warn when personalSpacePublishingEnabled is false', async () => {
+		it('should skip without applying when personalSpacePublishingEnabled is false', async () => {
 			const loader = createLoader({ personalSpacePublishingEnabled: false });
 
 			const result = await loader.run();
 
 			expect(result).toBe('skipped');
+			expect(mfaService.enforceMFA).not.toHaveBeenCalled();
 			expect(securitySettingsService.setPersonalSpaceSetting).not.toHaveBeenCalled();
-			expect(logger.warn).toHaveBeenCalledWith(
-				expect.stringContaining('N8N_SECURITY_POLICY_MANAGED_BY_ENV is not enabled'),
-			);
 		});
 
-		it('should skip and warn when personalSpaceSharingEnabled is false', async () => {
+		it('should skip without applying when personalSpaceSharingEnabled is false', async () => {
 			const loader = createLoader({ personalSpaceSharingEnabled: false });
 
 			const result = await loader.run();
 
 			expect(result).toBe('skipped');
+			expect(mfaService.enforceMFA).not.toHaveBeenCalled();
 			expect(securitySettingsService.setPersonalSpaceSetting).not.toHaveBeenCalled();
-			expect(logger.warn).toHaveBeenCalledWith(
-				expect.stringContaining('N8N_SECURITY_POLICY_MANAGED_BY_ENV is not enabled'),
-			);
 		});
 	});
 

--- a/packages/cli/src/instance-settings-loader/__tests__/security-policy.instance-settings-loader.test.ts
+++ b/packages/cli/src/instance-settings-loader/__tests__/security-policy.instance-settings-loader.test.ts
@@ -1,0 +1,207 @@
+import { mock } from 'jest-mock-extended';
+import type { Logger } from '@n8n/backend-common';
+import type { InstanceSettingsLoaderConfig } from '@n8n/config';
+import {
+	PERSONAL_SPACE_PUBLISHING_SETTING,
+	PERSONAL_SPACE_SHARING_SETTING,
+} from '@n8n/permissions';
+
+import type { MfaService } from '@/mfa/mfa.service';
+import type { SecuritySettingsService } from '@/services/security-settings.service';
+
+import { SecurityPolicyInstanceSettingsLoader } from '../loaders/security-policy.instance-settings-loader';
+
+describe('SecurityPolicyInstanceSettingsLoader', () => {
+	const logger = mock<Logger>({ scoped: jest.fn().mockReturnThis() });
+	const mfaService = mock<MfaService>();
+	const securitySettingsService = mock<SecuritySettingsService>();
+
+	const createLoader = (configOverrides: Partial<InstanceSettingsLoaderConfig> = {}) => {
+		const config = {
+			securityPolicyOverride: false,
+			securityPolicyMfaEnforced: false,
+			securityPolicyPersonalSpacePublishing: true,
+			securityPolicyPersonalSpaceSharing: true,
+			...configOverrides,
+		} as InstanceSettingsLoaderConfig;
+
+		return new SecurityPolicyInstanceSettingsLoader(
+			config,
+			securitySettingsService,
+			mfaService,
+			logger,
+		);
+	};
+
+	beforeEach(() => {
+		jest.resetAllMocks();
+		logger.scoped.mockReturnThis();
+	});
+
+	describe('when SECURITY_POLICY_OVERRIDE is false', () => {
+		it('should skip when no security env vars deviate from defaults', async () => {
+			const loader = createLoader();
+
+			const result = await loader.run();
+
+			expect(result).toBe('skipped');
+			expect(mfaService.enforceMFA).not.toHaveBeenCalled();
+			expect(securitySettingsService.setPersonalSpaceSetting).not.toHaveBeenCalled();
+			expect(logger.warn).not.toHaveBeenCalled();
+		});
+
+		it('should skip and warn when securityPolicyMfaEnforced is true', async () => {
+			const loader = createLoader({ securityPolicyMfaEnforced: true });
+
+			const result = await loader.run();
+
+			expect(result).toBe('skipped');
+			expect(mfaService.enforceMFA).not.toHaveBeenCalled();
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('SECURITY_POLICY_OVERRIDE is not enabled'),
+			);
+		});
+
+		it('should skip and warn when securityPolicyPersonalSpacePublishing is false', async () => {
+			const loader = createLoader({ securityPolicyPersonalSpacePublishing: false });
+
+			const result = await loader.run();
+
+			expect(result).toBe('skipped');
+			expect(securitySettingsService.setPersonalSpaceSetting).not.toHaveBeenCalled();
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('SECURITY_POLICY_OVERRIDE is not enabled'),
+			);
+		});
+
+		it('should skip and warn when securityPolicyPersonalSpaceSharing is false', async () => {
+			const loader = createLoader({ securityPolicyPersonalSpaceSharing: false });
+
+			const result = await loader.run();
+
+			expect(result).toBe('skipped');
+			expect(securitySettingsService.setPersonalSpaceSetting).not.toHaveBeenCalled();
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('SECURITY_POLICY_OVERRIDE is not enabled'),
+			);
+		});
+	});
+
+	describe('when SECURITY_POLICY_OVERRIDE is true', () => {
+		it('should enforce MFA when securityPolicyMfaEnforced is true', async () => {
+			const loader = createLoader({
+				securityPolicyOverride: true,
+				securityPolicyMfaEnforced: true,
+			});
+
+			const result = await loader.run();
+
+			expect(result).toBe('created');
+			expect(mfaService.enforceMFA).toHaveBeenCalledWith(true);
+		});
+
+		it('should disable MFA enforcement when securityPolicyMfaEnforced is false', async () => {
+			const loader = createLoader({
+				securityPolicyOverride: true,
+				securityPolicyMfaEnforced: false,
+			});
+
+			const result = await loader.run();
+
+			expect(result).toBe('created');
+			expect(mfaService.enforceMFA).toHaveBeenCalledWith(false);
+		});
+
+		it('should enable personal space publishing when securityPolicyPersonalSpacePublishing is true', async () => {
+			const loader = createLoader({
+				securityPolicyOverride: true,
+				securityPolicyPersonalSpacePublishing: true,
+			});
+
+			const result = await loader.run();
+
+			expect(result).toBe('created');
+			expect(securitySettingsService.setPersonalSpaceSetting).toHaveBeenCalledWith(
+				PERSONAL_SPACE_PUBLISHING_SETTING,
+				true,
+			);
+		});
+
+		it('should disable personal space publishing when securityPolicyPersonalSpacePublishing is false', async () => {
+			const loader = createLoader({
+				securityPolicyOverride: true,
+				securityPolicyPersonalSpacePublishing: false,
+			});
+
+			const result = await loader.run();
+
+			expect(result).toBe('created');
+			expect(securitySettingsService.setPersonalSpaceSetting).toHaveBeenCalledWith(
+				PERSONAL_SPACE_PUBLISHING_SETTING,
+				false,
+			);
+		});
+
+		it('should enable personal space sharing when securityPolicyPersonalSpaceSharing is true', async () => {
+			const loader = createLoader({
+				securityPolicyOverride: true,
+				securityPolicyPersonalSpaceSharing: true,
+			});
+
+			const result = await loader.run();
+
+			expect(result).toBe('created');
+			expect(securitySettingsService.setPersonalSpaceSetting).toHaveBeenCalledWith(
+				PERSONAL_SPACE_SHARING_SETTING,
+				true,
+			);
+		});
+
+		it('should disable personal space sharing when securityPolicyPersonalSpaceSharing is false', async () => {
+			const loader = createLoader({
+				securityPolicyOverride: true,
+				securityPolicyPersonalSpaceSharing: false,
+			});
+
+			const result = await loader.run();
+
+			expect(result).toBe('created');
+			expect(securitySettingsService.setPersonalSpaceSetting).toHaveBeenCalledWith(
+				PERSONAL_SPACE_SHARING_SETTING,
+				false,
+			);
+		});
+
+		it('should log info message about override being enabled', async () => {
+			const loader = createLoader({ securityPolicyOverride: true });
+
+			await loader.run();
+
+			expect(logger.info).toHaveBeenCalledWith(
+				expect.stringContaining('SECURITY_POLICY_OVERRIDE is enabled'),
+			);
+		});
+
+		it('should apply all settings together', async () => {
+			const loader = createLoader({
+				securityPolicyOverride: true,
+				securityPolicyMfaEnforced: true,
+				securityPolicyPersonalSpacePublishing: false,
+				securityPolicyPersonalSpaceSharing: false,
+			});
+
+			const result = await loader.run();
+
+			expect(result).toBe('created');
+			expect(mfaService.enforceMFA).toHaveBeenCalledWith(true);
+			expect(securitySettingsService.setPersonalSpaceSetting).toHaveBeenCalledWith(
+				PERSONAL_SPACE_PUBLISHING_SETTING,
+				false,
+			);
+			expect(securitySettingsService.setPersonalSpaceSetting).toHaveBeenCalledWith(
+				PERSONAL_SPACE_SHARING_SETTING,
+				false,
+			);
+		});
+	});
+});

--- a/packages/cli/src/instance-settings-loader/__tests__/security-policy.instance-settings-loader.test.ts
+++ b/packages/cli/src/instance-settings-loader/__tests__/security-policy.instance-settings-loader.test.ts
@@ -38,7 +38,7 @@ describe('SecurityPolicyInstanceSettingsLoader', () => {
 		logger.scoped.mockReturnThis();
 	});
 
-	describe('when SECURITY_POLICY_OVERRIDE is false', () => {
+	describe('when N8N_SECURITY_POLICY_OVERRIDE is false', () => {
 		it('should skip when no security env vars deviate from defaults', async () => {
 			const loader = createLoader();
 
@@ -58,7 +58,7 @@ describe('SecurityPolicyInstanceSettingsLoader', () => {
 			expect(result).toBe('skipped');
 			expect(mfaService.enforceMFA).not.toHaveBeenCalled();
 			expect(logger.warn).toHaveBeenCalledWith(
-				expect.stringContaining('SECURITY_POLICY_OVERRIDE is not enabled'),
+				expect.stringContaining('N8N_SECURITY_POLICY_OVERRIDE is not enabled'),
 			);
 		});
 
@@ -70,7 +70,7 @@ describe('SecurityPolicyInstanceSettingsLoader', () => {
 			expect(result).toBe('skipped');
 			expect(securitySettingsService.setPersonalSpaceSetting).not.toHaveBeenCalled();
 			expect(logger.warn).toHaveBeenCalledWith(
-				expect.stringContaining('SECURITY_POLICY_OVERRIDE is not enabled'),
+				expect.stringContaining('N8N_SECURITY_POLICY_OVERRIDE is not enabled'),
 			);
 		});
 
@@ -82,12 +82,12 @@ describe('SecurityPolicyInstanceSettingsLoader', () => {
 			expect(result).toBe('skipped');
 			expect(securitySettingsService.setPersonalSpaceSetting).not.toHaveBeenCalled();
 			expect(logger.warn).toHaveBeenCalledWith(
-				expect.stringContaining('SECURITY_POLICY_OVERRIDE is not enabled'),
+				expect.stringContaining('N8N_SECURITY_POLICY_OVERRIDE is not enabled'),
 			);
 		});
 	});
 
-	describe('when SECURITY_POLICY_OVERRIDE is true', () => {
+	describe('when N8N_SECURITY_POLICY_OVERRIDE is true', () => {
 		it('should enforce MFA when securityPolicyMfaEnforced is true', async () => {
 			const loader = createLoader({
 				securityPolicyOverride: true,
@@ -178,7 +178,7 @@ describe('SecurityPolicyInstanceSettingsLoader', () => {
 			await loader.run();
 
 			expect(logger.info).toHaveBeenCalledWith(
-				expect.stringContaining('SECURITY_POLICY_OVERRIDE is enabled'),
+				expect.stringContaining('N8N_SECURITY_POLICY_OVERRIDE is enabled'),
 			);
 		});
 

--- a/packages/cli/src/instance-settings-loader/__tests__/security-policy.instance-settings-loader.test.ts
+++ b/packages/cli/src/instance-settings-loader/__tests__/security-policy.instance-settings-loader.test.ts
@@ -18,10 +18,10 @@ describe('SecurityPolicyInstanceSettingsLoader', () => {
 
 	const createLoader = (configOverrides: Partial<InstanceSettingsLoaderConfig> = {}) => {
 		const config = {
-			securityPolicyOverride: false,
-			securityPolicyMfaEnforced: false,
-			securityPolicyPersonalSpacePublishing: true,
-			securityPolicyPersonalSpaceSharing: true,
+			securityPolicyManagedByEnv: false,
+			mfaEnforcedEnabled: false,
+			personalSpacePublishingEnabled: true,
+			personalSpaceSharingEnabled: true,
 			...configOverrides,
 		} as InstanceSettingsLoaderConfig;
 
@@ -38,7 +38,7 @@ describe('SecurityPolicyInstanceSettingsLoader', () => {
 		logger.scoped.mockReturnThis();
 	});
 
-	describe('when N8N_SECURITY_POLICY_OVERRIDE is false', () => {
+	describe('when N8N_SECURITY_POLICY_MANAGED_BY_ENV is false', () => {
 		it('should skip when no security env vars deviate from defaults', async () => {
 			const loader = createLoader();
 
@@ -50,48 +50,48 @@ describe('SecurityPolicyInstanceSettingsLoader', () => {
 			expect(logger.warn).not.toHaveBeenCalled();
 		});
 
-		it('should skip and warn when securityPolicyMfaEnforced is true', async () => {
-			const loader = createLoader({ securityPolicyMfaEnforced: true });
+		it('should skip and warn when mfaEnforcedEnabled is true', async () => {
+			const loader = createLoader({ mfaEnforcedEnabled: true });
 
 			const result = await loader.run();
 
 			expect(result).toBe('skipped');
 			expect(mfaService.enforceMFA).not.toHaveBeenCalled();
 			expect(logger.warn).toHaveBeenCalledWith(
-				expect.stringContaining('N8N_SECURITY_POLICY_OVERRIDE is not enabled'),
+				expect.stringContaining('N8N_SECURITY_POLICY_MANAGED_BY_ENV is not enabled'),
 			);
 		});
 
-		it('should skip and warn when securityPolicyPersonalSpacePublishing is false', async () => {
-			const loader = createLoader({ securityPolicyPersonalSpacePublishing: false });
+		it('should skip and warn when personalSpacePublishingEnabled is false', async () => {
+			const loader = createLoader({ personalSpacePublishingEnabled: false });
 
 			const result = await loader.run();
 
 			expect(result).toBe('skipped');
 			expect(securitySettingsService.setPersonalSpaceSetting).not.toHaveBeenCalled();
 			expect(logger.warn).toHaveBeenCalledWith(
-				expect.stringContaining('N8N_SECURITY_POLICY_OVERRIDE is not enabled'),
+				expect.stringContaining('N8N_SECURITY_POLICY_MANAGED_BY_ENV is not enabled'),
 			);
 		});
 
-		it('should skip and warn when securityPolicyPersonalSpaceSharing is false', async () => {
-			const loader = createLoader({ securityPolicyPersonalSpaceSharing: false });
+		it('should skip and warn when personalSpaceSharingEnabled is false', async () => {
+			const loader = createLoader({ personalSpaceSharingEnabled: false });
 
 			const result = await loader.run();
 
 			expect(result).toBe('skipped');
 			expect(securitySettingsService.setPersonalSpaceSetting).not.toHaveBeenCalled();
 			expect(logger.warn).toHaveBeenCalledWith(
-				expect.stringContaining('N8N_SECURITY_POLICY_OVERRIDE is not enabled'),
+				expect.stringContaining('N8N_SECURITY_POLICY_MANAGED_BY_ENV is not enabled'),
 			);
 		});
 	});
 
-	describe('when N8N_SECURITY_POLICY_OVERRIDE is true', () => {
-		it('should enforce MFA when securityPolicyMfaEnforced is true', async () => {
+	describe('when N8N_SECURITY_POLICY_MANAGED_BY_ENV is true', () => {
+		it('should enforce MFA when mfaEnforcedEnabled is true', async () => {
 			const loader = createLoader({
-				securityPolicyOverride: true,
-				securityPolicyMfaEnforced: true,
+				securityPolicyManagedByEnv: true,
+				mfaEnforcedEnabled: true,
 			});
 
 			const result = await loader.run();
@@ -100,10 +100,10 @@ describe('SecurityPolicyInstanceSettingsLoader', () => {
 			expect(mfaService.enforceMFA).toHaveBeenCalledWith(true);
 		});
 
-		it('should disable MFA enforcement when securityPolicyMfaEnforced is false', async () => {
+		it('should disable MFA enforcement when mfaEnforcedEnabled is false', async () => {
 			const loader = createLoader({
-				securityPolicyOverride: true,
-				securityPolicyMfaEnforced: false,
+				securityPolicyManagedByEnv: true,
+				mfaEnforcedEnabled: false,
 			});
 
 			const result = await loader.run();
@@ -112,10 +112,10 @@ describe('SecurityPolicyInstanceSettingsLoader', () => {
 			expect(mfaService.enforceMFA).toHaveBeenCalledWith(false);
 		});
 
-		it('should enable personal space publishing when securityPolicyPersonalSpacePublishing is true', async () => {
+		it('should enable personal space publishing when personalSpacePublishingEnabled is true', async () => {
 			const loader = createLoader({
-				securityPolicyOverride: true,
-				securityPolicyPersonalSpacePublishing: true,
+				securityPolicyManagedByEnv: true,
+				personalSpacePublishingEnabled: true,
 			});
 
 			const result = await loader.run();
@@ -127,10 +127,10 @@ describe('SecurityPolicyInstanceSettingsLoader', () => {
 			);
 		});
 
-		it('should disable personal space publishing when securityPolicyPersonalSpacePublishing is false', async () => {
+		it('should disable personal space publishing when personalSpacePublishingEnabled is false', async () => {
 			const loader = createLoader({
-				securityPolicyOverride: true,
-				securityPolicyPersonalSpacePublishing: false,
+				securityPolicyManagedByEnv: true,
+				personalSpacePublishingEnabled: false,
 			});
 
 			const result = await loader.run();
@@ -142,10 +142,10 @@ describe('SecurityPolicyInstanceSettingsLoader', () => {
 			);
 		});
 
-		it('should enable personal space sharing when securityPolicyPersonalSpaceSharing is true', async () => {
+		it('should enable personal space sharing when personalSpaceSharingEnabled is true', async () => {
 			const loader = createLoader({
-				securityPolicyOverride: true,
-				securityPolicyPersonalSpaceSharing: true,
+				securityPolicyManagedByEnv: true,
+				personalSpaceSharingEnabled: true,
 			});
 
 			const result = await loader.run();
@@ -157,10 +157,10 @@ describe('SecurityPolicyInstanceSettingsLoader', () => {
 			);
 		});
 
-		it('should disable personal space sharing when securityPolicyPersonalSpaceSharing is false', async () => {
+		it('should disable personal space sharing when personalSpaceSharingEnabled is false', async () => {
 			const loader = createLoader({
-				securityPolicyOverride: true,
-				securityPolicyPersonalSpaceSharing: false,
+				securityPolicyManagedByEnv: true,
+				personalSpaceSharingEnabled: false,
 			});
 
 			const result = await loader.run();
@@ -173,21 +173,21 @@ describe('SecurityPolicyInstanceSettingsLoader', () => {
 		});
 
 		it('should log info message about override being enabled', async () => {
-			const loader = createLoader({ securityPolicyOverride: true });
+			const loader = createLoader({ securityPolicyManagedByEnv: true });
 
 			await loader.run();
 
 			expect(logger.info).toHaveBeenCalledWith(
-				expect.stringContaining('N8N_SECURITY_POLICY_OVERRIDE is enabled'),
+				expect.stringContaining('N8N_SECURITY_POLICY_MANAGED_BY_ENV is enabled'),
 			);
 		});
 
 		it('should apply all settings together', async () => {
 			const loader = createLoader({
-				securityPolicyOverride: true,
-				securityPolicyMfaEnforced: true,
-				securityPolicyPersonalSpacePublishing: false,
-				securityPolicyPersonalSpaceSharing: false,
+				securityPolicyManagedByEnv: true,
+				mfaEnforcedEnabled: true,
+				personalSpacePublishingEnabled: false,
+				personalSpaceSharingEnabled: false,
 			});
 
 			const result = await loader.run();

--- a/packages/cli/src/instance-settings-loader/instance-settings-loader.service.ts
+++ b/packages/cli/src/instance-settings-loader/instance-settings-loader.service.ts
@@ -2,6 +2,7 @@ import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
 
 import { OwnerInstanceSettingsLoader } from './loaders/owner.instance-settings-loader';
+import { SecurityPolicyInstanceSettingsLoader } from './loaders/security-policy.instance-settings-loader';
 
 type LoaderResult = 'created' | 'skipped';
 
@@ -10,12 +11,14 @@ export class InstanceSettingsLoaderService {
 	constructor(
 		private logger: Logger,
 		private readonly ownerLoader: OwnerInstanceSettingsLoader,
+		private readonly securityPolicyLoader: SecurityPolicyInstanceSettingsLoader,
 	) {
 		this.logger = this.logger.scoped('instance-settings-loader');
 	}
 
 	async init(): Promise<void> {
 		await this.run('owner', async () => await this.ownerLoader.run());
+		await this.run('security-policy', async () => await this.securityPolicyLoader.run());
 	}
 
 	private async run(name: string, fn: () => Promise<LoaderResult>): Promise<void> {

--- a/packages/cli/src/instance-settings-loader/loaders/owner.instance-settings-loader.ts
+++ b/packages/cli/src/instance-settings-loader/loaders/owner.instance-settings-loader.ts
@@ -51,14 +51,10 @@ export class OwnerInstanceSettingsLoader {
 	}
 
 	async run(): Promise<'created' | 'skipped'> {
-		const { ownerManagedByEnv, ownerEmail, ownerPasswordHash } = this.instanceSettingsLoaderConfig;
+		const { ownerManagedByEnv } = this.instanceSettingsLoaderConfig;
 
 		if (!ownerManagedByEnv) {
-			if (ownerEmail || ownerPasswordHash) {
-				this.logger.warn(
-					'N8N_INSTANCE_OWNER_EMAIL or N8N_INSTANCE_OWNER_PASSWORD_HASH is set but N8N_INSTANCE_OWNER_MANAGED_BY_ENV is not enabled — ignoring owner env vars',
-				);
-			}
+			this.logger.debug('Owner is not managed by environment variables, skipping');
 			return 'skipped';
 		}
 

--- a/packages/cli/src/instance-settings-loader/loaders/security-policy.instance-settings-loader.ts
+++ b/packages/cli/src/instance-settings-loader/loaders/security-policy.instance-settings-loader.ts
@@ -35,13 +35,13 @@ export class SecurityPolicyInstanceSettingsLoader {
 				!securityPolicyPersonalSpaceSharing
 			) {
 				this.logger.warn(
-					'Security policy env vars are set but SECURITY_POLICY_OVERRIDE is not enabled — ignoring security policy env vars',
+					'Security policy env vars are set but N8N_SECURITY_POLICY_OVERRIDE is not enabled — ignoring security policy env vars',
 				);
 			}
 			return 'skipped';
 		}
 
-		this.logger.info('SECURITY_POLICY_OVERRIDE is enabled — applying security policy env vars');
+		this.logger.info('N8N_SECURITY_POLICY_OVERRIDE is enabled — applying security policy env vars');
 
 		await this.mfaService.enforceMFA(securityPolicyMfaEnforced);
 

--- a/packages/cli/src/instance-settings-loader/loaders/security-policy.instance-settings-loader.ts
+++ b/packages/cli/src/instance-settings-loader/loaders/security-policy.instance-settings-loader.ts
@@ -1,0 +1,60 @@
+import { Logger } from '@n8n/backend-common';
+import { InstanceSettingsLoaderConfig } from '@n8n/config';
+import { Service } from '@n8n/di';
+import {
+	PERSONAL_SPACE_PUBLISHING_SETTING,
+	PERSONAL_SPACE_SHARING_SETTING,
+} from '@n8n/permissions';
+
+import { MfaService } from '@/mfa/mfa.service';
+import { SecuritySettingsService } from '@/services/security-settings.service';
+
+@Service()
+export class SecurityPolicyInstanceSettingsLoader {
+	constructor(
+		private readonly instanceSettingsLoaderConfig: InstanceSettingsLoaderConfig,
+		private readonly securitySettingsService: SecuritySettingsService,
+		private readonly mfaService: MfaService,
+		private logger: Logger,
+	) {
+		this.logger = this.logger.scoped('instance-settings-loader');
+	}
+
+	async run(): Promise<'created' | 'skipped'> {
+		const {
+			securityPolicyOverride,
+			securityPolicyMfaEnforced,
+			securityPolicyPersonalSpacePublishing,
+			securityPolicyPersonalSpaceSharing,
+		} = this.instanceSettingsLoaderConfig;
+
+		if (!securityPolicyOverride) {
+			if (
+				securityPolicyMfaEnforced ||
+				!securityPolicyPersonalSpacePublishing ||
+				!securityPolicyPersonalSpaceSharing
+			) {
+				this.logger.warn(
+					'Security policy env vars are set but SECURITY_POLICY_OVERRIDE is not enabled — ignoring security policy env vars',
+				);
+			}
+			return 'skipped';
+		}
+
+		this.logger.info('SECURITY_POLICY_OVERRIDE is enabled — applying security policy env vars');
+
+		await this.mfaService.enforceMFA(securityPolicyMfaEnforced);
+
+		await this.securitySettingsService.setPersonalSpaceSetting(
+			PERSONAL_SPACE_PUBLISHING_SETTING,
+			securityPolicyPersonalSpacePublishing,
+		);
+
+		await this.securitySettingsService.setPersonalSpaceSetting(
+			PERSONAL_SPACE_SHARING_SETTING,
+			securityPolicyPersonalSpaceSharing,
+		);
+
+		return 'created';
+	}
+}

--- a/packages/cli/src/instance-settings-loader/loaders/security-policy.instance-settings-loader.ts
+++ b/packages/cli/src/instance-settings-loader/loaders/security-policy.instance-settings-loader.ts
@@ -22,37 +22,35 @@ export class SecurityPolicyInstanceSettingsLoader {
 
 	async run(): Promise<'created' | 'skipped'> {
 		const {
-			securityPolicyOverride,
-			securityPolicyMfaEnforced,
-			securityPolicyPersonalSpacePublishing,
-			securityPolicyPersonalSpaceSharing,
+			securityPolicyManagedByEnv,
+			mfaEnforcedEnabled,
+			personalSpacePublishingEnabled,
+			personalSpaceSharingEnabled,
 		} = this.instanceSettingsLoaderConfig;
 
-		if (!securityPolicyOverride) {
-			if (
-				securityPolicyMfaEnforced ||
-				!securityPolicyPersonalSpacePublishing ||
-				!securityPolicyPersonalSpaceSharing
-			) {
+		if (!securityPolicyManagedByEnv) {
+			if (mfaEnforcedEnabled || !personalSpacePublishingEnabled || !personalSpaceSharingEnabled) {
 				this.logger.warn(
-					'Security policy env vars are set but N8N_SECURITY_POLICY_OVERRIDE is not enabled — ignoring security policy env vars',
+					'Security policy env vars are set but N8N_SECURITY_POLICY_MANAGED_BY_ENV is not enabled — ignoring security policy env vars',
 				);
 			}
 			return 'skipped';
 		}
 
-		this.logger.info('N8N_SECURITY_POLICY_OVERRIDE is enabled — applying security policy env vars');
+		this.logger.info(
+			'N8N_SECURITY_POLICY_MANAGED_BY_ENV is enabled — applying security policy env vars',
+		);
 
-		await this.mfaService.enforceMFA(securityPolicyMfaEnforced);
+		await this.mfaService.enforceMFA(mfaEnforcedEnabled);
 
 		await this.securitySettingsService.setPersonalSpaceSetting(
 			PERSONAL_SPACE_PUBLISHING_SETTING,
-			securityPolicyPersonalSpacePublishing,
+			personalSpacePublishingEnabled,
 		);
 
 		await this.securitySettingsService.setPersonalSpaceSetting(
 			PERSONAL_SPACE_SHARING_SETTING,
-			securityPolicyPersonalSpaceSharing,
+			personalSpaceSharingEnabled,
 		);
 
 		return 'created';

--- a/packages/cli/src/instance-settings-loader/loaders/security-policy.instance-settings-loader.ts
+++ b/packages/cli/src/instance-settings-loader/loaders/security-policy.instance-settings-loader.ts
@@ -29,11 +29,7 @@ export class SecurityPolicyInstanceSettingsLoader {
 		} = this.instanceSettingsLoaderConfig;
 
 		if (!securityPolicyManagedByEnv) {
-			if (mfaEnforcedEnabled || !personalSpacePublishingEnabled || !personalSpaceSharingEnabled) {
-				this.logger.warn(
-					'Security policy env vars are set but N8N_SECURITY_POLICY_MANAGED_BY_ENV is not enabled — ignoring security policy env vars',
-				);
-			}
+			this.logger.debug('Security policy is not managed by environment variables, skipping');
 			return 'skipped';
 		}
 

--- a/packages/cli/test/integration/controllers/security-settings.controller.test.ts
+++ b/packages/cli/test/integration/controllers/security-settings.controller.test.ts
@@ -1,4 +1,5 @@
 import { mockInstance } from '@n8n/backend-test-utils';
+import { InstanceSettingsLoaderConfig } from '@n8n/config';
 import {
 	PERSONAL_SPACE_PUBLISHING_SETTING,
 	PERSONAL_SPACE_SHARING_SETTING,
@@ -12,6 +13,9 @@ import { setupTestServer } from '../shared/utils';
 
 describe('SecuritySettingsController', () => {
 	const securitySettingsService = mockInstance(SecuritySettingsService);
+	const instanceSettingsLoaderConfig = mockInstance(InstanceSettingsLoaderConfig, {
+		securityPolicyManagedByEnv: false,
+	});
 
 	const testServer = setupTestServer({ endpointGroups: ['security-settings'] });
 	let ownerAgent: SuperAgentTest;
@@ -24,6 +28,7 @@ describe('SecuritySettingsController', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		testServer.license.enable('feat:personalSpacePolicy');
+		instanceSettingsLoaderConfig.securityPolicyManagedByEnv = false;
 	});
 
 	describe('GET /settings/security', () => {
@@ -50,6 +55,7 @@ describe('SecuritySettingsController', () => {
 					publishedPersonalWorkflowsCount: 5,
 					sharedPersonalWorkflowsCount: 12,
 					sharedPersonalCredentialsCount: 3,
+					managedByEnv: false,
 				},
 			});
 			expect(securitySettingsService.arePersonalSpaceSettingsEnabled).toHaveBeenCalledTimes(1);
@@ -170,6 +176,35 @@ describe('SecuritySettingsController', () => {
 				.post('/settings/security')
 				.send({ personalSpacePublishing: true })
 				.expect(500);
+		});
+	});
+
+	describe('when securityPolicyManagedByEnv is true', () => {
+		beforeEach(() => {
+			instanceSettingsLoaderConfig.securityPolicyManagedByEnv = true;
+		});
+
+		it('GET should return managedByEnv: true', async () => {
+			securitySettingsService.arePersonalSpaceSettingsEnabled.mockResolvedValue({
+				personalSpacePublishing: true,
+				personalSpaceSharing: true,
+			});
+			securitySettingsService.getPublishedPersonalWorkflowsCount.mockResolvedValue(0);
+			securitySettingsService.getSharedPersonalWorkflowsCount.mockResolvedValue(0);
+			securitySettingsService.getSharedPersonalCredentialsCount.mockResolvedValue(0);
+
+			const response = await ownerAgent.get('/settings/security').expect(200);
+
+			expect(response.body.data.managedByEnv).toBe(true);
+		});
+
+		it('POST should return 403 when settings are managed by env', async () => {
+			await ownerAgent
+				.post('/settings/security')
+				.send({ personalSpacePublishing: false })
+				.expect(403);
+
+			expect(securitySettingsService.setPersonalSpaceSetting).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/cli/test/integration/mfa/mfa.api.test.ts
+++ b/packages/cli/test/integration/mfa/mfa.api.test.ts
@@ -1,4 +1,5 @@
 import { randomValidPassword, uniqueId, testDb, mockInstance } from '@n8n/backend-test-utils';
+import { InstanceSettingsLoaderConfig } from '@n8n/config';
 import { LICENSE_FEATURES } from '@n8n/constants';
 import { SettingsRepository, UserRepository, type User } from '@n8n/db';
 import { Container } from '@n8n/di';
@@ -415,6 +416,21 @@ describe('Login', () => {
 });
 
 describe('Enforce MFA', () => {
+	test('should return 403 when security policy is managed by env', async () => {
+		const instanceSettingsLoaderConfig = Container.get(InstanceSettingsLoaderConfig);
+		instanceSettingsLoaderConfig.securityPolicyManagedByEnv = true;
+
+		owner.mfaEnabled = true;
+		await testServer
+			.authAgentFor(owner)
+			.post('/mfa/enforce-mfa')
+			.send({ enforce: true })
+			.expect(403);
+		owner.mfaEnabled = false;
+
+		instanceSettingsLoaderConfig.securityPolicyManagedByEnv = false;
+	});
+
 	test('Enforce MFA for the instance', async () => {
 		const settingsRepository = Container.get(SettingsRepository);
 		const cacheService = Container.get(CacheService);

--- a/packages/cli/test/integration/mfa/mfa.api.test.ts
+++ b/packages/cli/test/integration/mfa/mfa.api.test.ts
@@ -420,15 +420,17 @@ describe('Enforce MFA', () => {
 		const instanceSettingsLoaderConfig = Container.get(InstanceSettingsLoaderConfig);
 		instanceSettingsLoaderConfig.securityPolicyManagedByEnv = true;
 
-		owner.mfaEnabled = true;
-		await testServer
-			.authAgentFor(owner)
-			.post('/mfa/enforce-mfa')
-			.send({ enforce: true })
-			.expect(403);
-		owner.mfaEnabled = false;
-
-		instanceSettingsLoaderConfig.securityPolicyManagedByEnv = false;
+		try {
+			owner.mfaEnabled = true;
+			await testServer
+				.authAgentFor(owner)
+				.post('/mfa/enforce-mfa')
+				.send({ enforce: true })
+				.expect(403);
+		} finally {
+			owner.mfaEnabled = false;
+			instanceSettingsLoaderConfig.securityPolicyManagedByEnv = false;
+		}
 	});
 
 	test('Enforce MFA for the instance', async () => {

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4339,6 +4339,7 @@
 	"settings.ldap.section.synchronization.title": "Synchronization",
 	"settings.security": "Security & policies",
 	"settings.security.description": "Manage workspace security requirements. Enforce two-factor authentication and control personal space actions like publishing workflows and sharing resources.",
+	"settings.security.managedByEnv": "These security settings are configured via environment variables and cannot be changed here.",
 	"settings.security.personalSpace.title": "Personal Space",
 	"settings.security.personalSpace.publishing.title": "Workflow publishing",
 	"settings.security.personalSpace.publishing.description": "Publishing workflows in personal space. Changing the setting doesn't unpublish existing workflows.",

--- a/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.test.ts
@@ -43,6 +43,7 @@ describe('SecuritySettings', () => {
 		publishedPersonalWorkflowsCount: 14,
 		sharedPersonalWorkflowsCount: 12,
 		sharedPersonalCredentialsCount: 5,
+		managedByEnv: false,
 	};
 
 	let settingsStore: ReturnType<typeof mockedStore<typeof useSettingsStore>>;
@@ -368,6 +369,60 @@ describe('SecuritySettings', () => {
 		await waitFor(() => {
 			expect(queryByTestId('security-personal-space-sharing-toggle')).toBeInTheDocument();
 			expect(queryByTestId('security-personal-space-publishing-toggle')).toBeInTheDocument();
+		});
+	});
+
+	describe('when managed by environment variables', () => {
+		beforeEach(() => {
+			getSecuritySettings.mockResolvedValue({
+				...defaultSettings,
+				managedByEnv: true,
+			});
+		});
+
+		it('should show env-managed notice banner', async () => {
+			const { getByTestId } = renderView();
+
+			await waitFor(() => {
+				expect(getByTestId('security-managed-by-env-notice')).toBeInTheDocument();
+			});
+		});
+
+		it('should not show env-managed notice when managedByEnv is false', async () => {
+			getSecuritySettings.mockResolvedValue(defaultSettings);
+			const { queryByTestId } = renderView();
+
+			await waitFor(() => {
+				expect(queryByTestId('security-personal-space-sharing-toggle')).toBeInTheDocument();
+			});
+
+			expect(queryByTestId('security-managed-by-env-notice')).not.toBeInTheDocument();
+		});
+
+		it('should disable all toggles when managed by env', async () => {
+			const { getByTestId } = renderView();
+
+			await waitFor(() => {
+				expect(getByTestId('security-personal-space-sharing-toggle')).toBeInTheDocument();
+			});
+
+			expect(getByTestId('enable-force-mfa')).toHaveClass('is-disabled');
+			expect(getByTestId('security-personal-space-sharing-toggle')).toHaveClass('is-disabled');
+			expect(getByTestId('security-personal-space-publishing-toggle')).toHaveClass('is-disabled');
+		});
+
+		it('should not call update APIs when clicking disabled toggles', async () => {
+			const { getByTestId } = renderView();
+
+			await waitFor(() => {
+				expect(getByTestId('security-personal-space-sharing-toggle')).toBeInTheDocument();
+			});
+
+			await userEvent.click(getByTestId('security-personal-space-sharing-toggle'));
+			await userEvent.click(getByTestId('enable-force-mfa'));
+
+			expect(updateSecuritySettings).not.toHaveBeenCalled();
+			expect(usersStore.updateEnforceMfa).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.vue
+++ b/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.vue
@@ -178,7 +178,7 @@ const sharingCountText = computed(() => {
 
 		<N8nNotice
 			v-if="isManagedByEnv"
-			class="mb-lg"
+			class="mb-l"
 			:content="i18n.baseText('settings.security.managedByEnv')"
 			data-test-id="security-managed-by-env-notice"
 		/>

--- a/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.vue
+++ b/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.vue
@@ -3,7 +3,14 @@ import { computed, ref, useCssModule } from 'vue';
 import { useAsyncState } from '@vueuse/core';
 import { ElSwitch } from 'element-plus';
 import { I18nT } from 'vue-i18n';
-import { N8nAlertDialog, N8nBadge, N8nHeading, N8nText, N8nTooltip } from '@n8n/design-system';
+import {
+	N8nAlertDialog,
+	N8nBadge,
+	N8nHeading,
+	N8nNotice,
+	N8nText,
+	N8nTooltip,
+} from '@n8n/design-system';
 import { useI18n, type BaseTextKey } from '@n8n/i18n';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useToast } from '@/app/composables/useToast';
@@ -65,8 +72,11 @@ const { state } = useAsyncState(async () => {
 		publishedPersonalWorkflowsCount: settings.publishedPersonalWorkflowsCount,
 		sharedPersonalWorkflowsCount: settings.sharedPersonalWorkflowsCount,
 		sharedPersonalCredentialsCount: settings.sharedPersonalCredentialsCount,
+		managedByEnv: settings.managedByEnv,
 	};
 }, undefined);
+
+const isManagedByEnv = computed(() => state.value?.managedByEnv ?? false);
 
 async function updatePersonalSpaceSetting(
 	key: 'personalSpacePublishing' | 'personalSpaceSharing',
@@ -166,6 +176,13 @@ const sharingCountText = computed(() => {
 			</N8nText>
 		</div>
 
+		<N8nNotice
+			v-if="isManagedByEnv"
+			class="mb-lg"
+			:content="i18n.baseText('settings.security.managedByEnv')"
+			data-test-id="security-managed-by-env-notice"
+		/>
+
 		<N8nHeading tag="h2" size="large" class="mb-l">
 			{{ i18n.baseText('settings.personal.mfa.enforce.title') }}
 		</N8nHeading>
@@ -188,6 +205,7 @@ const sharingCountText = computed(() => {
 						<ElSwitch
 							:model-value="settingsStore.isMFAEnforced"
 							size="large"
+							:disabled="isManagedByEnv"
 							data-test-id="enable-force-mfa"
 							@update:model-value="onUpdateMfaEnforced"
 						/>
@@ -237,6 +255,7 @@ const sharingCountText = computed(() => {
 							v-if="state !== undefined"
 							v-model="personalSpaceSharing"
 							size="large"
+							:disabled="isManagedByEnv"
 							data-test-id="security-personal-space-sharing-toggle"
 						/>
 						<template #fallback>
@@ -293,6 +312,7 @@ const sharingCountText = computed(() => {
 							v-if="state !== undefined"
 							v-model="personalSpacePublishing"
 							size="large"
+							:disabled="isManagedByEnv"
 							data-test-id="security-personal-space-publishing-toggle"
 						/>
 						<template #fallback>


### PR DESCRIPTION
## Summary

Add environment variable support for security policy settings using the instance settings loader pattern. This allows MFA enforcement, personal space publishing, and personal space sharing to be pre-configured via env vars and applied on instance startup.

**New env vars:**
- `N8N_SECURITY_POLICY_MANAGED_BY_ENV` (boolean, default `false`) — master toggle; when false, all other security policy env vars are ignored
- `N8N_SECURITY_POLICY_MFA_ENFORCED` (boolean, default `false`) — enforce MFA for all users
- `N8N_SECURITY_POLICY_PERSONAL_SPACE_PUBLISHING` (boolean, default `true`) — allow personal space publishing
- `N8N_SECURITY_POLICY_PERSONAL_SPACE_SHARING` (boolean, default `true`) — allow personal space sharing

**How to test:**
1. Set `N8N_SECURITY_POLICY_MANAGED_BY_ENV=true` along with desired policy env vars
2. Start the instance
3. Verify security settings in UI match the env var values
4. Restart and confirm settings are re-applied on every startup

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-436

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)