### PR TITLE
fix(core): Skip disabled Azure Key Vault secrets and handle partial fetch failures

### DIFF
--- a/packages/cli/src/modules/external-secrets.ee/providers/__tests__/azure-key-vault.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/__tests__/azure-key-vault.test.ts
@@ -1,6 +1,7 @@
 import { SecretClient } from '@azure/keyvault-secrets';
 import type { KeyVaultSecret } from '@azure/keyvault-secrets';
 import { mock } from 'jest-mock-extended';
+import { UnexpectedError } from 'n8n-workflow';
 
 import { AzureKeyVault } from '../azure-key-vault/azure-key-vault';
 import type { AzureKeyVaultContext } from '../azure-key-vault/types';
@@ -167,7 +168,19 @@ describe('AzureKeyVault', () => {
 			throw new Error('Key Vault unavailable');
 		});
 
-		await expect(azureKeyVault.update()).rejects.toThrow('Key Vault unavailable');
+		let thrown: unknown;
+		try {
+			await azureKeyVault.update();
+		} catch (error: unknown) {
+			thrown = error;
+		}
+
+		expect(thrown).toBeDefined();
+		expect(thrown).toBeInstanceOf(UnexpectedError);
+		if (thrown instanceof UnexpectedError) {
+			expect(thrown.message).toBe('Could not read any secrets from Azure Key Vault');
+			expect(thrown.cause).toEqual(expect.objectContaining({ message: 'Key Vault unavailable' }));
+		}
 		expect(azureKeyVault.getSecret('only-secret')).toBe('cached-value');
 	});
 });

--- a/packages/cli/src/modules/external-secrets.ee/providers/__tests__/azure-key-vault.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/__tests__/azure-key-vault.test.ts
@@ -65,4 +65,109 @@ describe('AzureKeyVault', () => {
 		expect(azureKeyVault.getSecret('secret2')).toBe('value2');
 		expect(azureKeyVault.getSecret('secret3')).toBeUndefined(); // no value
 	});
+
+	it('should skip disabled secrets without calling getSecret', async () => {
+		await azureKeyVault.init(
+			mock<AzureKeyVaultContext>({
+				settings: {
+					vaultName: 'my-vault',
+					tenantId: 'my-tenant-id',
+					clientId: 'my-client-id',
+					clientSecret: 'my-client-secret',
+				},
+			}),
+		);
+
+		const listSpy = jest
+			.spyOn(SecretClient.prototype, 'listPropertiesOfSecrets')
+			// @ts-expect-error Partial mock
+			.mockImplementation(() => ({
+				async *[Symbol.asyncIterator]() {
+					yield { name: 'enabled-secret', enabled: true };
+					yield { name: 'disabled-secret', enabled: false };
+				},
+			}));
+
+		const getSpy = jest
+			.spyOn(SecretClient.prototype, 'getSecret')
+			.mockResolvedValue(mock<KeyVaultSecret>({ value: 'ok' }));
+
+		await azureKeyVault.connect();
+		await azureKeyVault.update();
+
+		expect(listSpy).toHaveBeenCalled();
+		expect(getSpy).toHaveBeenCalledTimes(1);
+		expect(getSpy).toHaveBeenCalledWith('enabled-secret');
+		expect(azureKeyVault.getSecret('enabled-secret')).toBe('ok');
+		expect(azureKeyVault.hasSecret('disabled-secret')).toBe(false);
+	});
+
+	it('should still load other secrets when one getSecret fails', async () => {
+		await azureKeyVault.init(
+			mock<AzureKeyVaultContext>({
+				settings: {
+					vaultName: 'my-vault',
+					tenantId: 'my-tenant-id',
+					clientId: 'my-client-id',
+					clientSecret: 'my-client-secret',
+				},
+			}),
+		);
+
+		// @ts-expect-error Partial mock
+		jest.spyOn(SecretClient.prototype, 'listPropertiesOfSecrets').mockImplementation(() => ({
+			async *[Symbol.asyncIterator]() {
+				yield { name: 'good', enabled: true };
+				yield { name: 'bad', enabled: true };
+			},
+		}));
+
+		jest.spyOn(SecretClient.prototype, 'getSecret').mockImplementation(async (name: string) => {
+			if (name === 'bad') {
+				throw new Error('Forbidden');
+			}
+			return mock<KeyVaultSecret>({ value: 'fine' });
+		});
+
+		await azureKeyVault.connect();
+		await azureKeyVault.update();
+
+		expect(azureKeyVault.getSecret('good')).toBe('fine');
+		expect(azureKeyVault.hasSecret('bad')).toBe(false);
+	});
+
+	it('should throw when every getSecret fails and leave the previous cache unchanged', async () => {
+		await azureKeyVault.init(
+			mock<AzureKeyVaultContext>({
+				settings: {
+					vaultName: 'my-vault',
+					tenantId: 'my-tenant-id',
+					clientId: 'my-client-id',
+					clientSecret: 'my-client-secret',
+				},
+			}),
+		);
+
+		// @ts-expect-error Partial mock
+		jest.spyOn(SecretClient.prototype, 'listPropertiesOfSecrets').mockImplementation(() => ({
+			async *[Symbol.asyncIterator]() {
+				yield { name: 'only-secret', enabled: true };
+			},
+		}));
+
+		const getSpy = jest
+			.spyOn(SecretClient.prototype, 'getSecret')
+			.mockResolvedValue(mock<KeyVaultSecret>({ value: 'cached-value' }));
+
+		await azureKeyVault.connect();
+		await azureKeyVault.update();
+		expect(azureKeyVault.getSecret('only-secret')).toBe('cached-value');
+
+		getSpy.mockImplementation(async () => {
+			throw new Error('Key Vault unavailable');
+		});
+
+		await expect(azureKeyVault.update()).rejects.toThrow('Key Vault unavailable');
+		expect(azureKeyVault.getSecret('only-secret')).toBe('cached-value');
+	});
 });

--- a/packages/cli/src/modules/external-secrets.ee/providers/azure-key-vault/azure-key-vault.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/azure-key-vault/azure-key-vault.ts
@@ -1,7 +1,7 @@
 import type { SecretClient } from '@azure/keyvault-secrets';
 import { Logger } from '@n8n/backend-common';
 import { Container } from '@n8n/di';
-import type { INodeProperties } from 'n8n-workflow';
+import { ensureError, type INodeProperties } from 'n8n-workflow';
 
 import type { AzureKeyVaultContext } from './types';
 import { DOCS_HELP_NOTICE } from '../../constants';
@@ -103,24 +103,38 @@ export class AzureKeyVault extends SecretsProvider {
 
 	async update() {
 		const secretNames: string[] = [];
-
 		for await (const secret of this.client.listPropertiesOfSecrets()) {
+			if (secret.enabled === false) continue;
 			secretNames.push(secret.name);
 		}
 
-		const promises = secretNames.map(async (name) => {
-			const { value } = await this.client.getSecret(name);
-			return { name, value };
-		});
+		const promises = await Promise.allSettled(
+			secretNames.map(async (name) => {
+				const { value } = await this.client.getSecret(name);
+				return { name, value };
+			}),
+		);
 
-		const secrets = await Promise.all(promises);
+		const updated: Record<string, string> = {};
+		const readErrors: Error[] = [];
+		for (const [index, promiseResult] of promises.entries()) {
+			if (promiseResult.status === 'fulfilled') {
+				const { name, value } = promiseResult.value;
+				if (value !== undefined) updated[name] = value;
+			} else {
+				const error = ensureError(promiseResult.reason);
+				readErrors.push(error);
+				this.logger.warn(`Could not read Azure Key Vault secret "${secretNames[index]}"`, {
+					error,
+				});
+			}
+		}
 
-		this.cachedSecrets = secrets.reduce<Record<string, string>>((acc, cur) => {
-			if (cur.value === undefined) return acc;
-			acc[cur.name] = cur.value;
-			return acc;
-		}, {});
+		if (secretNames.length > 0 && Object.keys(updated).length === 0 && readErrors.length > 0) {
+			throw readErrors[0];
+		}
 
+		this.cachedSecrets = updated;
 		this.logger.debug('Azure Key Vault provider secrets updated');
 	}
 

--- a/packages/cli/src/modules/external-secrets.ee/providers/azure-key-vault/azure-key-vault.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/azure-key-vault/azure-key-vault.ts
@@ -1,7 +1,7 @@
 import type { SecretClient } from '@azure/keyvault-secrets';
 import { Logger } from '@n8n/backend-common';
 import { Container } from '@n8n/di';
-import { ensureError, type INodeProperties } from 'n8n-workflow';
+import { ensureError, type INodeProperties, UnexpectedError } from 'n8n-workflow';
 
 import type { AzureKeyVaultContext } from './types';
 import { DOCS_HELP_NOTICE } from '../../constants';
@@ -131,7 +131,9 @@ export class AzureKeyVault extends SecretsProvider {
 		}
 
 		if (secretNames.length > 0 && Object.keys(updated).length === 0 && readErrors.length > 0) {
-			throw readErrors[0];
+			throw new UnexpectedError('Could not read any secrets from Azure Key Vault', {
+				cause: readErrors[0],
+			});
 		}
 
 		this.cachedSecrets = updated;

--- a/packages/cli/test/integration/public-api/credentials.test.ts
+++ b/packages/cli/test/integration/public-api/credentials.test.ts
@@ -9,6 +9,7 @@ import {
 	type ICredentialDataDecryptedObject,
 	randomString,
 } from 'n8n-workflow';
+
 import { CredentialsService } from '@/credentials/credentials.service';
 
 import {
@@ -203,13 +204,13 @@ describe('GET /credentials', () => {
 			expect(Array.isArray((item as { shared: unknown }).shared)).toBe(true);
 			(
 				item as {
-					shared: {
+					shared: Array<{
 						id: string;
 						name: string;
 						role: string;
 						createdAt: string;
 						updatedAt: string;
-					}[];
+					}>;
 				}
 			).shared.forEach((entry) => {
 				expect(entry).toHaveProperty('id');


### PR DESCRIPTION
## Summary

- Skip secrets marked as disabled when listing Azure Key Vault secrets, avoiding unnecessary `getSecret` calls for secrets that cannot be retrieved.
- Switch from `Promise.all` to `Promise.allSettled` when fetching secret values so that a single inaccessible secret does not abort the entire reload — other secrets are still loaded and a warning is logged per failure.
- Only throw (and leave the cache unchanged) when every secret fetch fails, preserving the last known good state.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-449

- [x] I have seen this code, I have run this code, and I take responsibility for this code.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)