### PR TITLE
feat(core): Make token exchange rate limits configurable via env vars (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/dto/auth/embed-login-body.dto.ts
+++ b/packages/@n8n/api-types/src/dto/auth/embed-login-body.dto.ts
@@ -4,4 +4,5 @@ import { Z } from '../../zod-class';
 
 export class EmbedLoginBodyDto extends Z.class({
 	token: z.string().min(1),
+	redirectTo: z.string().optional(),
 }) {}

--- a/packages/@n8n/api-types/src/dto/auth/embed-login-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/auth/embed-login-query.dto.ts
@@ -4,4 +4,5 @@ import { Z } from '../../zod-class';
 
 export class EmbedLoginQueryDto extends Z.class({
 	token: z.string().min(1),
+	redirectTo: z.string().optional(),
 }) {}

--- a/packages/cli/src/modules/sso-saml/saml.controller.ee.ts
+++ b/packages/cli/src/modules/sso-saml/saml.controller.ee.ts
@@ -13,6 +13,7 @@ import { EventService } from '@/events/event.service';
 import { AuthlessRequest } from '@/requests';
 import { sendErrorResponse } from '@/response-helper';
 import { UrlService } from '@/services/url.service';
+import { validateRedirectUrl } from '@/utils/validate-redirect-url';
 import { isSamlLicensedAndEnabled } from '@/sso.ee/sso-helpers';
 
 import {
@@ -141,7 +142,7 @@ export class SamlController {
 						return res.redirect(this.urlService.getInstanceBaseUrl() + '/saml/onboarding');
 					} else {
 						const safeRedirectUrl = payload.RelayState
-							? this.validateRedirectUrl(payload.RelayState)
+							? validateRedirectUrl(payload.RelayState)
 							: '/';
 						return res.redirect(this.urlService.getInstanceBaseUrl() + safeRedirectUrl);
 					}
@@ -193,7 +194,7 @@ export class SamlController {
 			// ignore
 		}
 
-		return await this.handleInitSSO(res, this.validateRedirectUrl(redirectUrl));
+		return await this.handleInitSSO(res, validateRedirectUrl(redirectUrl));
 	}
 
 	/**
@@ -231,25 +232,4 @@ export class SamlController {
 		}
 	}
 
-	/**
-	 * Validates that a redirect URL is safe (relative path only, no external redirects)
-	 */
-	private validateRedirectUrl(redirectUrl: string): string {
-		if (typeof redirectUrl !== 'string' || redirectUrl.trim() === '') {
-			return '/';
-		}
-
-		const trimmed = redirectUrl.trim();
-
-		// Only allow paths starting with /
-		if (!trimmed.startsWith('/')) {
-			return '/';
-		}
-		// Reject protocol-relative URLs (//example.com)
-		if (trimmed.startsWith('//')) {
-			return '/';
-		}
-
-		return trimmed;
-	}
 }

--- a/packages/cli/src/modules/sso-saml/saml.controller.ee.ts
+++ b/packages/cli/src/modules/sso-saml/saml.controller.ee.ts
@@ -231,5 +231,4 @@ export class SamlController {
 			throw new AuthError('SAML redirect failed, please check your SAML configuration.');
 		}
 	}
-
 }

--- a/packages/cli/src/modules/token-exchange/controllers/__tests__/embed-auth.controller.test.ts
+++ b/packages/cli/src/modules/token-exchange/controllers/__tests__/embed-auth.controller.test.ts
@@ -134,6 +134,56 @@ describe('EmbedAuthController', () => {
 		});
 	});
 
+	describe('redirect parameter', () => {
+		it('should redirect to the specified local path via GET', async () => {
+			const req = mock<AuthlessRequest>({ browserId: 'browser-id-123' });
+			const res = mock<Response>();
+			const query = new EmbedLoginQueryDto({ token: 'subject-token', redirectTo: '/workflow/123' });
+			tokenExchangeService.embedLogin.mockResolvedValue(mockUser);
+
+			await controller.getLogin(req, res, query);
+
+			expect(res.redirect).toHaveBeenCalledWith('http://localhost:5678/workflow/123');
+		});
+
+		it('should redirect to the specified local path via POST', async () => {
+			const req = mock<AuthlessRequest>({ browserId: 'browser-id-456' });
+			const res = mock<Response>();
+			const body = new EmbedLoginBodyDto({ token: 'subject-token', redirectTo: '/credentials' });
+			tokenExchangeService.embedLogin.mockResolvedValue(mockUser);
+
+			await controller.postLogin(req, res, body);
+
+			expect(res.redirect).toHaveBeenCalledWith('http://localhost:5678/credentials');
+		});
+
+		it.each([
+			['https://evil.com/phishing'],
+			['//evil.com/phishing'],
+			['javascript:alert(1)'],
+		])('should reject external redirect %s and default to /', async (maliciousUrl) => {
+			const req = mock<AuthlessRequest>({ browserId: 'browser-id-123' });
+			const res = mock<Response>();
+			const query = new EmbedLoginQueryDto({ token: 'subject-token', redirectTo: maliciousUrl });
+			tokenExchangeService.embedLogin.mockResolvedValue(mockUser);
+
+			await controller.getLogin(req, res, query);
+
+			expect(res.redirect).toHaveBeenCalledWith('http://localhost:5678/');
+		});
+
+		it('should default to / when redirect is empty', async () => {
+			const req = mock<AuthlessRequest>({ browserId: 'browser-id-123' });
+			const res = mock<Response>();
+			const query = new EmbedLoginQueryDto({ token: 'subject-token', redirectTo: '' });
+			tokenExchangeService.embedLogin.mockResolvedValue(mockUser);
+
+			await controller.getLogin(req, res, query);
+
+			expect(res.redirect).toHaveBeenCalledWith('http://localhost:5678/');
+		});
+	});
+
 	describe('error propagation', () => {
 		it('should not emit audit event or issue cookie on failure', async () => {
 			const req = mock<AuthlessRequest>({ browserId: 'browser-id-789' });

--- a/packages/cli/src/modules/token-exchange/controllers/__tests__/embed-auth.controller.test.ts
+++ b/packages/cli/src/modules/token-exchange/controllers/__tests__/embed-auth.controller.test.ts
@@ -157,20 +157,19 @@ describe('EmbedAuthController', () => {
 			expect(res.redirect).toHaveBeenCalledWith('http://localhost:5678/credentials');
 		});
 
-		it.each([
-			['https://evil.com/phishing'],
-			['//evil.com/phishing'],
-			['javascript:alert(1)'],
-		])('should reject external redirect %s and default to /', async (maliciousUrl) => {
-			const req = mock<AuthlessRequest>({ browserId: 'browser-id-123' });
-			const res = mock<Response>();
-			const query = new EmbedLoginQueryDto({ token: 'subject-token', redirectTo: maliciousUrl });
-			tokenExchangeService.embedLogin.mockResolvedValue(mockUser);
+		it.each([['https://evil.com/phishing'], ['//evil.com/phishing'], ['javascript:alert(1)']])(
+			'should reject external redirect %s and default to /',
+			async (maliciousUrl) => {
+				const req = mock<AuthlessRequest>({ browserId: 'browser-id-123' });
+				const res = mock<Response>();
+				const query = new EmbedLoginQueryDto({ token: 'subject-token', redirectTo: maliciousUrl });
+				tokenExchangeService.embedLogin.mockResolvedValue(mockUser);
 
-			await controller.getLogin(req, res, query);
+				await controller.getLogin(req, res, query);
 
-			expect(res.redirect).toHaveBeenCalledWith('http://localhost:5678/');
-		});
+				expect(res.redirect).toHaveBeenCalledWith('http://localhost:5678/');
+			},
+		);
 
 		it('should default to / when redirect is empty', async () => {
 			const req = mock<AuthlessRequest>({ browserId: 'browser-id-123' });

--- a/packages/cli/src/modules/token-exchange/controllers/__tests__/embed-auth.controller.test.ts
+++ b/packages/cli/src/modules/token-exchange/controllers/__tests__/embed-auth.controller.test.ts
@@ -139,7 +139,7 @@ describe('EmbedAuthController', () => {
 			const req = mock<AuthlessRequest>({ browserId: 'browser-id-123' });
 			const res = mock<Response>();
 			const query = new EmbedLoginQueryDto({ token: 'subject-token', redirectTo: '/workflow/123' });
-			tokenExchangeService.embedLogin.mockResolvedValue(mockUser);
+			tokenExchangeService.embedLogin.mockResolvedValue(embedLoginResult);
 
 			await controller.getLogin(req, res, query);
 
@@ -150,7 +150,7 @@ describe('EmbedAuthController', () => {
 			const req = mock<AuthlessRequest>({ browserId: 'browser-id-456' });
 			const res = mock<Response>();
 			const body = new EmbedLoginBodyDto({ token: 'subject-token', redirectTo: '/credentials' });
-			tokenExchangeService.embedLogin.mockResolvedValue(mockUser);
+			tokenExchangeService.embedLogin.mockResolvedValue(embedLoginResult);
 
 			await controller.postLogin(req, res, body);
 
@@ -163,7 +163,7 @@ describe('EmbedAuthController', () => {
 				const req = mock<AuthlessRequest>({ browserId: 'browser-id-123' });
 				const res = mock<Response>();
 				const query = new EmbedLoginQueryDto({ token: 'subject-token', redirectTo: maliciousUrl });
-				tokenExchangeService.embedLogin.mockResolvedValue(mockUser);
+				tokenExchangeService.embedLogin.mockResolvedValue(embedLoginResult);
 
 				await controller.getLogin(req, res, query);
 
@@ -175,7 +175,7 @@ describe('EmbedAuthController', () => {
 			const req = mock<AuthlessRequest>({ browserId: 'browser-id-123' });
 			const res = mock<Response>();
 			const query = new EmbedLoginQueryDto({ token: 'subject-token', redirectTo: '' });
-			tokenExchangeService.embedLogin.mockResolvedValue(mockUser);
+			tokenExchangeService.embedLogin.mockResolvedValue(embedLoginResult);
 
 			await controller.getLogin(req, res, query);
 

--- a/packages/cli/src/modules/token-exchange/controllers/embed-auth.controller.ts
+++ b/packages/cli/src/modules/token-exchange/controllers/embed-auth.controller.ts
@@ -10,6 +10,9 @@ import { UrlService } from '@/services/url.service';
 
 import { TokenExchangeService } from '../services/token-exchange.service';
 import { TokenExchangeConfig } from '../token-exchange.config';
+import { Container } from '@n8n/di';
+
+const configService = Container.get(TokenExchangeConfig);
 
 @RestController('/auth/embed')
 export class EmbedAuthController {
@@ -23,7 +26,10 @@ export class EmbedAuthController {
 
 	@Get('/', {
 		skipAuth: true,
-		ipRateLimit: { limit: 20, windowMs: 1 * Time.minutes.toMilliseconds },
+		ipRateLimit: {
+			limit: configService.rateLimitEmbedLogin,
+			windowMs: 1 * Time.minutes.toMilliseconds,
+		},
 	})
 	async getLogin(req: AuthlessRequest, res: Response, @Query query: EmbedLoginQueryDto) {
 		if (!this.config.embedEnabled) {
@@ -38,7 +44,10 @@ export class EmbedAuthController {
 
 	@Post('/', {
 		skipAuth: true,
-		ipRateLimit: { limit: 20, windowMs: 1 * Time.minutes.toMilliseconds },
+		ipRateLimit: {
+			limit: configService.rateLimitEmbedLogin,
+			windowMs: 1 * Time.minutes.toMilliseconds,
+		},
 	})
 	async postLogin(req: AuthlessRequest, res: Response, @Body body: EmbedLoginBodyDto) {
 		if (!this.config.embedEnabled) {

--- a/packages/cli/src/modules/token-exchange/controllers/embed-auth.controller.ts
+++ b/packages/cli/src/modules/token-exchange/controllers/embed-auth.controller.ts
@@ -7,6 +7,7 @@ import { AuthService } from '@/auth/auth.service';
 import { EventService } from '@/events/event.service';
 import { AuthlessRequest } from '@/requests';
 import { UrlService } from '@/services/url.service';
+import { validateRedirectUrl } from '@/utils/validate-redirect-url';
 
 import { TokenExchangeService } from '../services/token-exchange.service';
 import { TokenExchangeConfig } from '../token-exchange.config';
@@ -39,7 +40,7 @@ export class EmbedAuthController {
 			});
 			return;
 		}
-		return await this.handleLogin(query.token, req, res);
+		return await this.handleLogin(query.token, req, res, query.redirectTo);
 	}
 
 	@Post('/', {
@@ -57,10 +58,15 @@ export class EmbedAuthController {
 			});
 			return;
 		}
-		return await this.handleLogin(body.token, req, res);
+		return await this.handleLogin(body.token, req, res, body.redirectTo);
 	}
 
-	private async handleLogin(subjectToken: string, req: AuthlessRequest, res: Response) {
+	private async handleLogin(
+		subjectToken: string,
+		req: AuthlessRequest,
+		res: Response,
+		redirect?: string,
+	) {
 		const { user, subject, issuer, kid } = await this.tokenExchangeService.embedLogin(subjectToken);
 
 		this.authService.issueCookie(res, user, true, req.browserId, true, {
@@ -75,6 +81,7 @@ export class EmbedAuthController {
 			clientIp: req.ip ?? 'unknown',
 		});
 
-		res.redirect(this.urlService.getInstanceBaseUrl() + '/');
+		const safePath = validateRedirectUrl(redirect ?? '');
+		res.redirect(this.urlService.getInstanceBaseUrl() + safePath);
 	}
 }

--- a/packages/cli/src/modules/token-exchange/controllers/token-exchange.controller.ts
+++ b/packages/cli/src/modules/token-exchange/controllers/token-exchange.controller.ts
@@ -14,6 +14,8 @@ import { TokenExchangeService } from '../services/token-exchange.service';
 import { TokenExchangeConfig } from '../token-exchange.config';
 import { TOKEN_EXCHANGE_GRANT_TYPE, TokenExchangeRequestSchema } from '../token-exchange.schemas';
 
+const configService = Container.get(TokenExchangeConfig);
+
 @RestController('/auth/oauth')
 export class TokenExchangeController {
 	private readonly config = Container.get(TokenExchangeConfig);
@@ -31,7 +33,10 @@ export class TokenExchangeController {
 	 */
 	@Post('/token', {
 		skipAuth: true,
-		ipRateLimit: { limit: 20, windowMs: 1 * Time.minutes.toMilliseconds },
+		ipRateLimit: {
+			limit: configService.rateLimitTokenExchange,
+			windowMs: 1 * Time.minutes.toMilliseconds,
+		},
 	})
 	async exchangeToken(req: AuthlessRequest, res: Response): Promise<void> {
 		if (!this.config.enabled) {

--- a/packages/cli/src/modules/token-exchange/token-exchange.config.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.config.ts
@@ -35,4 +35,12 @@ export class TokenExchangeConfig {
 	/** Maximum number of expired JTI rows to delete per cleanup run. */
 	@Env('N8N_TOKEN_EXCHANGE_JTI_CLEANUP_BATCH_SIZE')
 	jtiCleanupBatchSize: number = 1000;
+
+	/** Maximum number of embed logins per ip per minute. */
+	@Env('N8N_TOKEN_EXCHANGE_EMBED_LOGIN_PER_MINUTE')
+	rateLimitEmbedLogin: number = 20;
+
+	/** Maximum number of token exchanges per ip per minute. */
+	@Env('N8N_TOKEN_EXCHANGE_TOKEN_EXCHANGE_PER_MINUTE')
+	rateLimitTokenExchange: number = 20;
 }

--- a/packages/cli/src/utils/__tests__/validate-redirect-url.test.ts
+++ b/packages/cli/src/utils/__tests__/validate-redirect-url.test.ts
@@ -1,0 +1,33 @@
+import { validateRedirectUrl } from '../validate-redirect-url';
+
+describe('validateRedirectUrl', () => {
+	it.each([
+		['/workflow/123', '/workflow/123'],
+		['/workflows', '/workflows'],
+		['/', '/'],
+		['/path?query=1', '/path?query=1'],
+		['/path#fragment', '/path#fragment'],
+		['  /trimmed  ', '/trimmed'],
+	])('allows valid relative path %s → %s', (input, expected) => {
+		expect(validateRedirectUrl(input)).toBe(expected);
+	});
+
+	it.each([
+		['', '/'],
+		['   ', '/'],
+		['https://evil.com/phishing', '/'],
+		['//evil.com/phishing', '/'],
+		['javascript:alert(1)', '/'],
+		['%2F%2Fevil.com/phishing', '/'],
+		['workflows/123', '/'],
+		['data:text/html,<h1>hi</h1>', '/'],
+	])('rejects unsafe redirect %s → %s', (input, expected) => {
+		expect(validateRedirectUrl(input)).toBe(expected);
+	});
+
+	it('returns / for non-string input', () => {
+		expect(validateRedirectUrl(undefined as unknown as string)).toBe('/');
+		expect(validateRedirectUrl(null as unknown as string)).toBe('/');
+		expect(validateRedirectUrl(123 as unknown as string)).toBe('/');
+	});
+});

--- a/packages/cli/src/utils/validate-redirect-url.ts
+++ b/packages/cli/src/utils/validate-redirect-url.ts
@@ -1,0 +1,22 @@
+/**
+ * Validates that a redirect URL is safe (relative path only, no external redirects).
+ * Returns '/' if the URL is invalid or unsafe.
+ */
+export function validateRedirectUrl(redirectUrl: string): string {
+	if (typeof redirectUrl !== 'string' || redirectUrl.trim() === '') {
+		return '/';
+	}
+
+	const trimmed = redirectUrl.trim();
+
+	// Only allow paths starting with /
+	if (!trimmed.startsWith('/')) {
+		return '/';
+	}
+	// Reject protocol-relative URLs (//example.com)
+	if (trimmed.startsWith('//')) {
+		return '/';
+	}
+
+	return trimmed;
+}


### PR DESCRIPTION
## Summary

Makes rate limits on the token exchange authentication endpoints (`POST /auth/oauth/token` and `GET/POST /auth/embed`) configurable via environment variables instead of hardcoded values. Also adds a `redirectTo` parameter to the embed login endpoints so callers can specify where the user lands after authentication, and extracts the redirect URL validation logic from the SAML controller into a shared utility.

**New env vars:**
- `N8N_TOKEN_EXCHANGE_EMBED_LOGIN_PER_MINUTE` (default: `20`) — IP rate limit for `GET/POST /auth/embed`
- `N8N_TOKEN_EXCHANGE_TOKEN_EXCHANGE_PER_MINUTE` (default: `20`) — IP rate limit for `POST /auth/oauth/token`


This is part of the Phase 4 (Hardening) milestone for the OAuth 2.0 Token Exchange project. These endpoints are authentication surfaces, so configurable rate limiting allows operators to tune protection against brute-force attempts for their deployment profile without code changes.

### Key implementation decisions

- Rate limit values are read from `TokenExchangeConfig` at module load time via `Container.get()` at the top level, since decorator arguments must be static. This is consistent with how the config is used elsewhere.
- Extracted `validateRedirectUrl` from `SamlController` into `@/utils/validate-redirect-url` so both SAML and embed login share the same open-redirect protection.


## Related tickets

- https://linear.app/n8n/issue/IAM-474

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
