### PR TITLE
chore: Add scoped JWT strategy for public API (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/entities/types-db.ts
+++ b/packages/@n8n/db/src/entities/types-db.ts
@@ -419,9 +419,9 @@ export type AuthenticationInformation = {
  * actor:    Actor identity for delegation — present when the token carries an `act` claim.
  */
 export interface TokenGrant {
-	roles?: string[];
 	scopes: string[];
-	actor?: { userId: string };
+	actor?: User;
+	subject: User;
 }
 
 export type AuthenticatedRequest<

--- a/packages/cli/src/modules/token-exchange/services/__tests__/scoped-jwt.strategy.integration.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/scoped-jwt.strategy.integration.test.ts
@@ -1,0 +1,152 @@
+import { testDb } from '@n8n/backend-test-utils';
+import type { AuthenticatedRequest } from '@n8n/db';
+import { UserRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { mock } from 'jest-mock-extended';
+import type { InstanceSettings } from 'n8n-core';
+
+import { createMember, createOwner } from '@test-integration/db/users';
+
+import { JwtService } from '@/services/jwt.service';
+
+import { TOKEN_EXCHANGE_ISSUER } from '../../token-exchange.types';
+import { ScopedJwtStrategy } from '../scoped-jwt.strategy';
+
+const instanceSettings = mock<InstanceSettings>({ encryptionKey: 'test-key' });
+const jwtService = new JwtService(instanceSettings, mock());
+
+function makeBearerReq(token: string): AuthenticatedRequest {
+	const req = mock<AuthenticatedRequest>();
+	req.headers = { authorization: `Bearer ${token}` } as AuthenticatedRequest['headers'];
+	return req;
+}
+
+function makeApiKeyReq(token: string): AuthenticatedRequest {
+	const req = mock<AuthenticatedRequest>();
+	req.headers = { 'x-n8n-api-key': token } as AuthenticatedRequest['headers'];
+	return req;
+}
+
+function makeScopedJwt(sub: string, actSub?: string): string {
+	return jwtService.sign({
+		iss: TOKEN_EXCHANGE_ISSUER,
+		sub,
+		...(actSub && { act: { sub: actSub } }),
+		iat: Math.floor(Date.now() / 1000),
+		exp: Math.floor(Date.now() / 1000) + 3600,
+		jti: 'test-jti',
+	});
+}
+
+describe('ScopedJwtStrategy (integration)', () => {
+	let strategy: ScopedJwtStrategy;
+
+	beforeAll(async () => {
+		await testDb.init();
+		strategy = new ScopedJwtStrategy(jwtService, Container.get(UserRepository));
+	});
+
+	beforeEach(async () => {
+		await testDb.truncate(['User']);
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	it('returns null for a token with a non-token-exchange issuer', async () => {
+		const token = jwtService.sign({ iss: 'n8n', sub: '123' });
+		expect(await strategy.authenticate(makeBearerReq(token))).toBeNull();
+	});
+
+	it('returns false when subject user does not exist in DB', async () => {
+		const token = makeScopedJwt('non-existent-id');
+		expect(await strategy.authenticate(makeBearerReq(token))).toBe(false);
+	});
+
+	it('sets req.user to subject and loads subject role scopes when no act claim', async () => {
+		const owner = await createOwner();
+		const ownerWithRole = await Container.get(UserRepository).findOne({
+			where: { id: owner.id },
+			relations: { role: true },
+		});
+		const expectedScopes = ownerWithRole!.role.scopes.map((s) => s.slug);
+
+		const token = makeScopedJwt(owner.id);
+		const req = makeBearerReq(token);
+
+		expect(await strategy.authenticate(req)).toBe(true);
+
+		expect(req.user.id).toBe(owner.id);
+		expect(req.tokenGrant?.subject.id).toBe(owner.id);
+		expect(req.tokenGrant?.actor).toBeUndefined();
+		expect(req.tokenGrant?.scopes).toEqual(expect.arrayContaining(expectedScopes));
+		expect(req.tokenGrant?.scopes).toHaveLength(expectedScopes.length);
+	});
+
+	it('sets req.user to actor and uses actor scopes when act claim resolves', async () => {
+		const subject = await createOwner();
+		const actor = await createMember();
+		const token = makeScopedJwt(subject.id, actor.id);
+		const req = makeBearerReq(token);
+
+		expect(await strategy.authenticate(req)).toBe(true);
+
+		expect(req.user.id).toBe(actor.id);
+		expect(req.tokenGrant?.subject.id).toBe(subject.id);
+		expect(req.tokenGrant?.actor?.id).toBe(actor.id);
+
+		const actorWithRole = await Container.get(UserRepository).findOne({
+			where: { id: actor.id },
+			relations: { role: true },
+		});
+		const actorScopes = actorWithRole!.role.scopes.map((s) => s.slug);
+		expect(req.tokenGrant?.scopes).toEqual(expect.arrayContaining(actorScopes));
+		expect(req.tokenGrant?.scopes).toHaveLength(actorScopes.length);
+	});
+
+	it('continues without actor and uses subject scopes when actor ID is not in DB', async () => {
+		const subject = await createOwner();
+		const token = makeScopedJwt(subject.id, 'non-existent-actor');
+		const req = makeBearerReq(token);
+
+		expect(await strategy.authenticate(req)).toBe(true);
+
+		expect(req.user.id).toBe(subject.id);
+		expect(req.tokenGrant?.actor).toBeUndefined();
+
+		const subjectWithRole = await Container.get(UserRepository).findOne({
+			where: { id: subject.id },
+			relations: { role: true },
+		});
+		const subjectScopes = subjectWithRole!.role.scopes.map((s) => s.slug);
+		expect(req.tokenGrant?.scopes).toEqual(expect.arrayContaining(subjectScopes));
+		expect(req.tokenGrant?.scopes).toHaveLength(subjectScopes.length);
+	});
+
+	it('accepts token from x-n8n-api-key header', async () => {
+		const owner = await createOwner();
+		const token = makeScopedJwt(owner.id);
+		const req = makeApiKeyReq(token);
+
+		expect(await strategy.authenticate(req)).toBe(true);
+		expect(req.user.id).toBe(owner.id);
+	});
+
+	it('returns false when subject is disabled', async () => {
+		const owner = await createOwner();
+		await Container.get(UserRepository).update({ id: owner.id }, { disabled: true });
+		const token = makeScopedJwt(owner.id);
+
+		expect(await strategy.authenticate(makeBearerReq(token))).toBe(false);
+	});
+
+	it('returns false when actor is disabled', async () => {
+		const subject = await createOwner();
+		const actor = await createMember();
+		await Container.get(UserRepository).update({ id: actor.id }, { disabled: true });
+		const token = makeScopedJwt(subject.id, actor.id);
+
+		expect(await strategy.authenticate(makeBearerReq(token))).toBe(false);
+	});
+});

--- a/packages/cli/src/modules/token-exchange/services/__tests__/scoped-jwt.strategy.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/scoped-jwt.strategy.test.ts
@@ -1,0 +1,203 @@
+import type { AuthenticatedRequest, User } from '@n8n/db';
+import { UserRepository } from '@n8n/db';
+import type { Scope as ScopeType } from '@n8n/permissions';
+import { mock } from 'jest-mock-extended';
+import type { InstanceSettings } from 'n8n-core';
+
+import { JwtService } from '@/services/jwt.service';
+
+import { TOKEN_EXCHANGE_ISSUER, type IssuedJwtPayload } from '../../token-exchange.types';
+import { ScopedJwtStrategy } from '../scoped-jwt.strategy';
+
+const instanceSettings = mock<InstanceSettings>({ encryptionKey: 'test-key' });
+const jwtService = new JwtService(instanceSettings, mock());
+const otherJwtService = new JwtService(
+	mock<InstanceSettings>({ encryptionKey: 'different-key' }),
+	mock(),
+);
+
+/** Create a mock user with role.scopes pre-populated for scope assertions. */
+function makeUser(id: string, scopeSlugs: string[] = [], disabled = false): User {
+	return {
+		...mock<User>(),
+		id,
+		disabled,
+		role: {
+			...mock<User['role']>(),
+			scopes: scopeSlugs.map((slug) => ({ ...mock(), slug: slug as ScopeType })),
+		},
+	};
+}
+
+function makeTokenExchangeJwt(payload: Partial<IssuedJwtPayload> = {}): string {
+	return jwtService.sign({
+		iss: TOKEN_EXCHANGE_ISSUER,
+		sub: 'subject-id',
+		iat: Math.floor(Date.now() / 1000),
+		exp: Math.floor(Date.now() / 1000) + 3600,
+		jti: 'test-jti',
+		...payload,
+	});
+}
+
+function makeBearerReq(token: string): AuthenticatedRequest {
+	const req = mock<AuthenticatedRequest>();
+	req.headers = { authorization: `Bearer ${token}` } as AuthenticatedRequest['headers'];
+	return req;
+}
+
+function makeApiKeyReq(token: string): AuthenticatedRequest {
+	const req = mock<AuthenticatedRequest>();
+	req.headers = { 'x-n8n-api-key': token } as unknown as AuthenticatedRequest['headers'];
+	return req;
+}
+
+function makeEmptyReq(): AuthenticatedRequest {
+	const req = mock<AuthenticatedRequest>();
+	req.headers = {} as AuthenticatedRequest['headers'];
+	return req;
+}
+
+describe('ScopedJwtStrategy', () => {
+	let strategy: ScopedJwtStrategy;
+	let userRepository: jest.Mocked<UserRepository>;
+
+	beforeEach(() => {
+		userRepository = mock<UserRepository>();
+		strategy = new ScopedJwtStrategy(jwtService, userRepository);
+	});
+
+	describe('token extraction', () => {
+		it('returns null when neither Authorization nor x-n8n-api-key header is present', async () => {
+			expect(await strategy.authenticate(makeEmptyReq())).toBeNull();
+		});
+
+		it('returns null for non-Bearer Authorization header', async () => {
+			const req = mock<AuthenticatedRequest>();
+			req.headers = { authorization: 'Basic dXNlcjpwYXNz' } as AuthenticatedRequest['headers'];
+			expect(await strategy.authenticate(req)).toBeNull();
+		});
+
+		it('accepts token from x-n8n-api-key header', async () => {
+			const subject = makeUser('subject-id', ['workflow:read']);
+			userRepository.findOne.mockResolvedValue(subject);
+
+			const token = makeTokenExchangeJwt();
+			expect(await strategy.authenticate(makeApiKeyReq(token))).toBe(true);
+		});
+	});
+
+	describe('issuer check', () => {
+		it('returns null for a JWT with a non-token-exchange issuer', async () => {
+			const foreignToken = jwtService.sign({ iss: 'https://idp.example.com', sub: '123' });
+			expect(await strategy.authenticate(makeBearerReq(foreignToken))).toBeNull();
+		});
+
+		it('returns null for a JWT with the API key issuer', async () => {
+			const apiKeyToken = jwtService.sign({ iss: 'n8n', sub: '123' });
+			expect(await strategy.authenticate(makeBearerReq(apiKeyToken))).toBeNull();
+		});
+	});
+
+	describe('signature and expiry', () => {
+		it('returns false for an expired token-exchange JWT', async () => {
+			const expiredToken = jwtService.sign({
+				iss: TOKEN_EXCHANGE_ISSUER,
+				sub: 'subject-id',
+				iat: Math.floor(Date.now() / 1000) - 7200,
+				exp: Math.floor(Date.now() / 1000) - 1,
+				jti: 'test-jti',
+			});
+			expect(await strategy.authenticate(makeBearerReq(expiredToken))).toBe(false);
+		});
+
+		it('returns false for a token signed with a different key', async () => {
+			const badToken = otherJwtService.sign({
+				iss: TOKEN_EXCHANGE_ISSUER,
+				sub: 'subject-id',
+				iat: Math.floor(Date.now() / 1000),
+				exp: Math.floor(Date.now() / 1000) + 3600,
+				jti: 'test-jti',
+			});
+			expect(await strategy.authenticate(makeBearerReq(badToken))).toBe(false);
+		});
+	});
+
+	describe('user resolution', () => {
+		it('returns false when subject is not found in DB', async () => {
+			userRepository.findOne.mockResolvedValue(null);
+			expect(await strategy.authenticate(makeBearerReq(makeTokenExchangeJwt()))).toBe(false);
+		});
+
+		it('returns false when subject is disabled', async () => {
+			userRepository.findOne.mockResolvedValue(makeUser('subject-id', [], true));
+			expect(await strategy.authenticate(makeBearerReq(makeTokenExchangeJwt()))).toBe(false);
+		});
+
+		it('continues without actor when act is present but actor not found in DB', async () => {
+			const subject = makeUser('subject-id', ['workflow:read']);
+			userRepository.findOne
+				.mockResolvedValueOnce(subject) // subject lookup
+				.mockResolvedValueOnce(null); // actor not found
+
+			const token = makeTokenExchangeJwt({ act: { sub: 'unknown-actor' } });
+			const req = makeBearerReq(token);
+
+			expect(await strategy.authenticate(req)).toBe(true);
+			expect(req.user).toBe(subject);
+			expect(req.tokenGrant?.actor).toBeUndefined();
+		});
+
+		it('returns false when actor is found but disabled', async () => {
+			const subject = makeUser('subject-id', ['workflow:read']);
+			const actor = makeUser('actor-id', [], true); // disabled
+			userRepository.findOne.mockResolvedValueOnce(subject).mockResolvedValueOnce(actor);
+
+			const token = makeTokenExchangeJwt({ act: { sub: 'actor-id' } });
+			expect(await strategy.authenticate(makeBearerReq(token))).toBe(false);
+		});
+	});
+
+	describe('successful authentication', () => {
+		it('sets req.user to subject and uses subject scopes when no act claim', async () => {
+			const subject = makeUser('subject-id', ['workflow:read', 'workflow:create']);
+			userRepository.findOne.mockResolvedValue(subject);
+
+			const req = makeBearerReq(makeTokenExchangeJwt({ sub: 'subject-id' }));
+
+			expect(await strategy.authenticate(req)).toBe(true);
+			expect(req.user).toBe(subject);
+			expect(req.tokenGrant?.subject).toBe(subject);
+			expect(req.tokenGrant?.actor).toBeUndefined();
+			expect(req.tokenGrant?.scopes).toEqual(['workflow:read', 'workflow:create']);
+		});
+
+		it('sets req.user to actor and uses actor scopes when act claim is present', async () => {
+			const subject = makeUser('subject-id', ['workflow:read']);
+			const actor = makeUser('actor-id', ['credential:read', 'credential:create']);
+			userRepository.findOne.mockResolvedValueOnce(subject).mockResolvedValueOnce(actor);
+
+			const token = makeTokenExchangeJwt({ sub: 'subject-id', act: { sub: 'actor-id' } });
+			const req = makeBearerReq(token);
+
+			expect(await strategy.authenticate(req)).toBe(true);
+			expect(req.user).toBe(actor);
+			expect(req.tokenGrant?.subject).toBe(subject);
+			expect(req.tokenGrant?.actor).toBe(actor);
+			expect(req.tokenGrant?.scopes).toEqual(['credential:read', 'credential:create']);
+		});
+
+		it('uses subject scopes when act is present but actor not found', async () => {
+			const subject = makeUser('subject-id', ['workflow:read']);
+			userRepository.findOne.mockResolvedValueOnce(subject).mockResolvedValueOnce(null); // actor not found
+
+			const token = makeTokenExchangeJwt({ sub: 'subject-id', act: { sub: 'missing' } });
+			const req = makeBearerReq(token);
+
+			await strategy.authenticate(req);
+
+			expect(req.tokenGrant?.scopes).toEqual(['workflow:read']);
+			expect(req.user).toBe(subject);
+		});
+	});
+});

--- a/packages/cli/src/modules/token-exchange/services/scoped-jwt.strategy.ts
+++ b/packages/cli/src/modules/token-exchange/services/scoped-jwt.strategy.ts
@@ -1,0 +1,94 @@
+import type { AuthenticatedRequest, User } from '@n8n/db';
+import { UserRepository } from '@n8n/db';
+import { Service } from '@n8n/di';
+import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken';
+
+import type { AuthStrategy } from '@/services/auth-strategy.types';
+import { JwtService } from '@/services/jwt.service';
+
+import { TOKEN_EXCHANGE_ISSUER, type IssuedJwtPayload } from '../token-exchange.types';
+
+const BEARER_PREFIX = 'Bearer ';
+const API_KEY_HEADER = 'x-n8n-api-key';
+
+@Service()
+export class ScopedJwtStrategy implements AuthStrategy {
+	constructor(
+		private readonly jwtService: JwtService,
+		private readonly userRepository: UserRepository,
+	) {}
+
+	async authenticate(req: AuthenticatedRequest): Promise<boolean | null> {
+		// 1. Extract token from Authorization: Bearer or x-n8n-api-key header
+		const token = this.extractToken(req);
+		if (!token) return null;
+
+		// 2. Decode (unverified) — check iss before expensive signature verification
+		const decoded = this.jwtService.decode<IssuedJwtPayload>(token);
+		if (!decoded || decoded.iss !== TOKEN_EXCHANGE_ISSUER) {
+			return null; // Not a token-exchange JWT — pass to next strategy
+		}
+
+		// 3. Verify signature + expiry
+		let payload: IssuedJwtPayload;
+		try {
+			payload = this.jwtService.verify<IssuedJwtPayload>(token, {
+				issuer: TOKEN_EXCHANGE_ISSUER,
+			});
+		} catch (error) {
+			if (error instanceof TokenExpiredError || error instanceof JsonWebTokenError) {
+				return false;
+			}
+			throw error;
+		}
+
+		// 4. Resolve subject (sub claim)
+		const subject = await this.findUser(payload.sub);
+		if (!subject || subject.disabled) return false;
+
+		// 5. Resolve actor (act.sub claim) if present — actor is optional;
+		//    a missing actor is not an error, but a disabled actor is.
+		let actor: User | undefined;
+		if (payload.act) {
+			const found = await this.findUser(payload.act.sub);
+			if (found?.disabled) return false;
+			actor = found ?? undefined;
+		}
+
+		// 6. Acting principal: actor (if resolved) or subject
+		const actingUser = actor ?? subject;
+
+		// 7. Scopes come from the acting user's role (role.scopes is eager: true)
+		req.tokenGrant = {
+			scopes: actingUser.role.scopes.map((s) => s.slug),
+			subject,
+			...(actor && { actor }),
+		};
+
+		req.user = actingUser;
+
+		return true;
+	}
+
+	private async findUser(id: string) {
+		return await this.userRepository.findOne({
+			where: { id },
+			relations: { role: true }, // role.scopes is eager: true, auto-loaded
+		});
+	}
+
+	private extractToken(req: AuthenticatedRequest): string | null {
+		const authHeader = req.headers.authorization;
+		if (typeof authHeader === 'string' && authHeader.startsWith(BEARER_PREFIX)) {
+			const token = authHeader.slice(BEARER_PREFIX.length).trim();
+			if (token) return token;
+		}
+
+		const apiKeyHeader = req.headers[API_KEY_HEADER];
+		if (typeof apiKeyHeader === 'string' && apiKeyHeader) {
+			return apiKeyHeader;
+		}
+
+		return null;
+	}
+}

--- a/packages/cli/src/modules/token-exchange/token-exchange.module.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.module.ts
@@ -35,5 +35,11 @@ export class TokenExchangeModule implements ModuleInterface {
 
 		const { JtiCleanupService } = await import('./services/jti-cleanup.service');
 		Container.get(JtiCleanupService).init();
+
+		// Register the scoped JWT auth strategy into the public API auth chain.
+		// ScopedJwtStrategy runs after ApiKeyAuthStrategy (which abstains for token-exchange JWTs).
+		const { ScopedJwtStrategy } = await import('./services/scoped-jwt.strategy');
+		const { AuthStrategyRegistry } = await import('@/services/auth-strategy.registry');
+		Container.get(AuthStrategyRegistry).register(Container.get(ScopedJwtStrategy));
 	}
 }

--- a/packages/cli/src/modules/token-exchange/token-exchange.service.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.service.ts
@@ -10,12 +10,14 @@ import {
 	type ExternalTokenClaims,
 	type TokenExchangeRequest,
 } from './token-exchange.schemas';
-import type { IssuedJwtPayload, IssuedTokenResult } from './token-exchange.types';
+import {
+	TOKEN_EXCHANGE_ISSUER,
+	type IssuedJwtPayload,
+	type IssuedTokenResult,
+} from './token-exchange.types';
 
 @Service()
 export class TokenExchangeService {
-	private static readonly ISSUER = 'n8n';
-
 	private readonly jwtService = Container.get(JwtService);
 
 	private readonly config = Container.get(TokenExchangeConfig);
@@ -41,7 +43,7 @@ export class TokenExchangeService {
 		const scopes = request.scope?.split(' ').filter(Boolean);
 
 		const payload: IssuedJwtPayload = {
-			iss: TokenExchangeService.ISSUER,
+			iss: TOKEN_EXCHANGE_ISSUER,
 			sub: subjectClaims.sub,
 			...(actorClaims && { act: { sub: actorClaims.sub } }),
 			...(scopes?.length && { scope: scopes }),

--- a/packages/cli/src/modules/token-exchange/token-exchange.types.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.types.ts
@@ -19,6 +19,8 @@ export interface IssuedJwtPayload {
 	jti: string;
 }
 
+export const TOKEN_EXCHANGE_ISSUER = 'n8n-token-exchange';
+
 export type TokenExchangeAuditEvent =
 	| {
 			event: 'token_exchange_success';

--- a/packages/cli/src/public-api/v1/__tests__/global.middleware.test.ts
+++ b/packages/cli/src/public-api/v1/__tests__/global.middleware.test.ts
@@ -1,6 +1,6 @@
-import type { AuthenticatedRequest, TokenGrant } from '@n8n/db';
+import type { AuthenticatedRequest, TokenGrant, User } from '@n8n/db';
 import type { ApiKeyScope } from '@n8n/permissions';
-import { mockDeep } from 'jest-mock-extended';
+import { mock, mockDeep } from 'jest-mock-extended';
 import type { NextFunction, Response } from 'express';
 
 import * as middlewares from '../shared/middlewares/global.middleware';
@@ -37,7 +37,7 @@ describe('publicApiScope', () => {
 	});
 
 	it('calls next() when the required scope is present in tokenGrant.scopes', async () => {
-		const grant: TokenGrant = { scopes: ['workflow:read'] };
+		const grant: TokenGrant = { scopes: ['workflow:read'], subject: mock<User>() };
 		await middlewares.publicApiScope('workflow:read' as ApiKeyScope)(
 			buildReq(grant) as any,
 			res,
@@ -47,7 +47,7 @@ describe('publicApiScope', () => {
 	});
 
 	it('returns 403 when the required scope is not in tokenGrant.scopes', async () => {
-		const grant: TokenGrant = { scopes: ['workflow:read'] };
+		const grant: TokenGrant = { scopes: ['workflow:read'], subject: mock<User>() };
 		await middlewares.publicApiScope('workflow:create' as ApiKeyScope)(
 			buildReq(grant) as any,
 			res,
@@ -59,7 +59,7 @@ describe('publicApiScope', () => {
 	});
 
 	it('returns 403 when tokenGrant.scopes is empty', async () => {
-		const grant: TokenGrant = { scopes: [] };
+		const grant: TokenGrant = { scopes: [], subject: mock<User>() };
 		await middlewares.publicApiScope('workflow:read' as ApiKeyScope)(
 			buildReq(grant) as any,
 			res,

--- a/packages/cli/src/services/__tests__/api-key-auth.strategy.integration.test.ts
+++ b/packages/cli/src/services/__tests__/api-key-auth.strategy.integration.test.ts
@@ -11,6 +11,8 @@ import { createOwnerWithApiKey } from '@test-integration/db/users';
 
 import { ApiKeyAuthStrategy } from '../api-key-auth.strategy';
 import { JwtService } from '../jwt.service';
+import { TOKEN_EXCHANGE_ISSUER } from '@/modules/token-exchange/token-exchange.types';
+import { API_KEY_ISSUER } from '../public-api-key.service';
 
 const mockReqWith = (apiKey: string, path: string, method: string): AuthenticatedRequest =>
 	mock<AuthenticatedRequest>({
@@ -62,7 +64,7 @@ describe('ApiKeyAuthStrategy', () => {
 	});
 
 	it('should return false if valid api key is not in database', async () => {
-		const apiKey = jwtService.sign({ sub: '123' });
+		const apiKey = jwtService.sign({ sub: '123', iss: API_KEY_ISSUER });
 		const req = mockReqWith(apiKey, '/test', 'GET');
 		expect(await strategy.authenticate(req)).toBe(false);
 	});
@@ -142,5 +144,23 @@ describe('ApiKeyAuthStrategy', () => {
 		const req = mockReqWith(apiKey, '/test', 'GET');
 
 		expect(await strategy.authenticate(req)).toBe(false);
+	});
+
+	it('should set req.tokenGrant.subject to the API key owner', async () => {
+		const owner = await createOwnerWithApiKey();
+		const [{ apiKey }] = owner.apiKeys;
+		const req = mockReqWith(apiKey, '/test', 'GET');
+
+		await strategy.authenticate(req);
+
+		expect(req.tokenGrant?.subject).toBeDefined();
+		expect(req.tokenGrant?.subject.id).toBe(owner.id);
+	});
+
+	it('should return null when x-n8n-api-key contains a token-exchange JWT', async () => {
+		const tokenExchangeJwt = jwtService.sign({ iss: TOKEN_EXCHANGE_ISSUER, sub: '123' });
+		const req = mockReqWith(tokenExchangeJwt, '/test', 'GET');
+
+		expect(await strategy.authenticate(req)).toBeNull();
 	});
 });

--- a/packages/cli/src/services/api-key-auth.strategy.ts
+++ b/packages/cli/src/services/api-key-auth.strategy.ts
@@ -21,6 +21,16 @@ export class ApiKeyAuthStrategy implements AuthStrategy {
 
 		if (typeof providedApiKey !== 'string' || !providedApiKey) return null;
 
+		// Abstain from non-API-key JWTs so other strategies (e.g. ScopedJwtStrategy) can handle them.
+		// Legacy keys (PREFIX_LEGACY_API_KEY prefix) are never JWTs — skip the decode for them.
+		// A null decode means the string is not a structurally valid JWT — reject authentication.
+		if (!providedApiKey.startsWith(PREFIX_LEGACY_API_KEY)) {
+			const decoded = this.jwtService.decode<{ iss?: string }>(providedApiKey);
+			// Note: JwtService.decode casts its return as T, but jwt.decode() can still return null at runtime.
+			if (decoded === null) return false;
+			if (decoded.iss !== API_KEY_ISSUER) return null;
+		}
+
 		const apiKeyRecord = await this.apiKeyRepository.findOne({
 			where: { apiKey: providedApiKey, audience: API_KEY_AUDIENCE },
 			relations: { user: { role: true } },
@@ -43,7 +53,10 @@ export class ApiKeyAuthStrategy implements AuthStrategy {
 		}
 
 		req.user = apiKeyRecord.user;
-		req.tokenGrant = { scopes: apiKeyRecord.scopes ?? [] };
+		req.tokenGrant = {
+			scopes: apiKeyRecord.scopes ?? [],
+			subject: apiKeyRecord.user,
+		};
 
 		return true;
 	}


### PR DESCRIPTION
## PR Summary

https://linear.app/n8n/issue/IAM-469

### What this PR does

Implements `ScopedJwtStrategy` — the auth strategy that validates scoped JWTs issued by the token exchange endpoint and authenticates public API requests with them.

Scoped JWTs can be presented in either `Authorization: Bearer <token>` or `x-n8n-api-key` headers. The strategy identifies them by their issuer (`n8n-token-exchange`) and is registered into `AuthStrategyRegistry` by `TokenExchangeModule` on startup, making it the second strategy after `ApiKeyAuthStrategy`.

### Changes

**`ScopedJwtStrategy` (new)**
- Extracts tokens from both `Authorization: Bearer` and `x-n8n-api-key` headers
- Performs a cheap `decode()` + issuer check before the expensive `verify()` call, so non-token-exchange JWTs pass through as `null` without signature overhead
- Resolves `sub` → `subject` and optionally `act.sub` → `actor` from the DB
- Loads scopes from the acting user's role (`actor ?? subject`) — not from the JWT payload — so permission changes take effect immediately without re-issuing tokens
- Sets `req.user` to the acting principal (actor if delegation is present, subject otherwise)
- Sets `req.tokenGrant = { scopes, subject, actor? }`

**`ApiKeyAuthStrategy` (updated)**
- Added `subject: apiKeyRecord.user` to `req.tokenGrant` — `TokenGrant.subject` is now required
- Added early-exit before the DB lookup: if the value in `x-n8n-api-key` is a JWT with an issuer other than `API_KEY_ISSUER`, the strategy returns `null` (abstain) instead of `false` (fail-fast). Without this, a token-exchange JWT in `x-n8n-api-key` would short-circuit the auth chain before `ScopedJwtStrategy` runs

**`TokenExchangeModule` (updated)**
- Registers `ScopedJwtStrategy` into `AuthStrategyRegistry` at the end of `init()`, behind the existing feature flag guard

### Key decisions

**Scopes from role, not JWT payload.** Scopes are resolved at request time from the acting user's `role.scopes` rather than from the `scope` claim embedded in the JWT. This means permission changes take effect immediately and the JWT itself only needs to carry identity claims (`sub`, `act`).

**Actor is optional.** If the JWT carries an `act` claim but the actor user ID is not found in the DB (e.g. the account was deleted after the token was issued), authentication continues with the subject acting as principal. Only if the actor is found *and* disabled does authentication fail. This keeps token-exchange tokens usable across user lifecycle events.

**`ApiKeyAuthStrategy` abstains on non-API-key JWTs.** The issuer check (`decoded.iss !== API_KEY_ISSUER`) is placed before the DB lookup so a token-exchange JWT in `x-n8n-api-key` gets `null` (pass through) rather than `false` (block). A null decode (non-JWT string) still returns `false` to preserve existing rejection behaviour for garbage values.

**Module self-registration (Option B).** `ScopedJwtStrategy` is registered by `TokenExchangeModule.init()` rather than in the public API bootstrap. This keeps the token-exchange module self-contained and ensures the strategy is only active when the module is enabled.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
