### PR TITLE
test: Fix flaky unit tests across three packages (no-changelog)

### DIFF
--- a/packages/cli/src/executions/__tests__/execution-persistence.test.ts
+++ b/packages/cli/src/executions/__tests__/execution-persistence.test.ts
@@ -215,22 +215,21 @@ describe('ExecutionPersistence', () => {
 		const target = { workflowId: 'wf-1', executionId: 'exec-1', storedAt: 'db' as const };
 
 		it('should soft-delete with backdated `deletedAt` when pruning is enabled', async () => {
+			jest.useFakeTimers();
+			const now = Date.now();
+
 			executionsConfig.pruneData = true;
 			executionsConfig.pruneDataHardDeleteBuffer = 1;
 			const executionPersistence = createPersistenceService('db');
 
 			await executionPersistence.deleteInFlightExecution(target);
-			const after = Date.now();
 
 			expect(executionRepository.update).toHaveBeenCalledWith('exec-1', {
-				deletedAt: expect.any(Date),
+				deletedAt: new Date(now - 3600_000),
 			});
-
-			const { deletedAt } = executionRepository.update.mock.calls[0][1] as { deletedAt: Date };
-			// deletedAt should be backdated by ~1 hour (the buffer)
-			// Use `after` to tolerate clock progression between before/after snapshots
-			expect(deletedAt.getTime()).toBeLessThanOrEqual(after - 3600_000);
 			expect(executionRepository.deleteByIds).not.toHaveBeenCalled();
+
+			jest.useRealTimers();
 		});
 
 		it('should hard-delete immediately when pruning is disabled', async () => {

--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/typescript/worker/typescript.worker.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/typescript/worker/typescript.worker.test.ts
@@ -5,6 +5,15 @@ import { mock } from 'vitest-mock-extended';
 import type { WorkerInitOptions } from '../types';
 import { worker } from './typescript.worker';
 
+vi.mock('@/app/plugins/cache', () => ({
+	indexedDbCache: async () => ({
+		getItem: () => '{}',
+		setItem: () => {},
+		removeItem: () => {},
+		clear: () => {},
+		getAllWithPrefix: async () => ({}),
+	}),
+}));
 vi.mock('@typescript/vfs');
 vi.mock('typescript', async (importOriginal) => {
 	return await importOriginal();

--- a/packages/nodes-base/nodes/Google/Sheet/test/GoogleSheetsTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/GoogleSheetsTrigger.test.ts
@@ -8,6 +8,18 @@ import { GoogleSheetsTrigger } from '../GoogleSheetsTrigger.node';
 describe('GoogleSheetsTrigger', () => {
 	const baseUrl = 'https://sheets.googleapis.com';
 
+	beforeAll(() => {
+		nock.disableNetConnect();
+	});
+
+	afterAll(() => {
+		nock.enableNetConnect();
+	});
+
+	afterEach(() => {
+		nock.cleanAll();
+	});
+
 	describe('rowAdded event', () => {
 		it('should return rows without header', async () => {
 			const scope = nock(baseUrl);


### PR DESCRIPTION
## Summary

Fix three flaky unit tests that accounted for **~200 CI failures across 40+ branches** in the last 7 days (data from Codecov test analytics).

### 1. `ExecutionPersistence` — timestamp off-by-one (15 failures / 15 branches)
The test captured `Date.now()` **after** calling the function under test, then asserted the backdated `deletedAt` was `<=` that value minus the buffer. When the clock ticked by 1ms between the implementation's and the test's `Date.now()` calls, the assertion failed. Fixed by using **Jest fake timers** so `Date.now()` is deterministic.

### 2. `TypeScript Worker` — CDN fetch timeout (8 failures / 8 branches)
The test didn't mock `indexedDbCache`, so it opened real IndexedDB via `fake-indexeddb`. When the luxon type cache missed, the worker tried to **fetch types from `cdn.jsdelivr.net`**, which timed out under CI network constraints. Fixed by **mocking the cache module** with a cache hit, eliminating both IndexedDB and network overhead (tests now run in 9ms vs timing out at 5000ms).

### 3. `GoogleSheetsTrigger` — missing nock isolation (23 failures each × 5 tests / 8 branches)
The test file was missing `nock.disableNetConnect()`. While `globalSetup.ts` calls it, Jest runs global setup in a separate context from test workers. Without it, unmatched requests could leak to the real Google Sheets API. Fixed by adding proper **nock lifecycle hooks** (`disableNetConnect`, `cleanAll`, `enableNetConnect`).

## Related Linear tickets, Github issues, and Community forum posts

N/A — identified via Codecov test analytics API flaky test analysis.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created.
- [x] Tests included.