### PR TITLE
fix(core): Refresh the ai assistant token if it's about to expire (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/src/tracing/__tests__/langsmith-tracing.test.ts
+++ b/packages/@n8n/instance-ai/src/tracing/__tests__/langsmith-tracing.test.ts
@@ -705,6 +705,7 @@ describe('createInstanceAiTraceContext', () => {
 			input: { message: 'proxy test' },
 			proxyConfig: {
 				apiUrl: 'https://proxy.example.com/langsmith',
+				// eslint-disable-next-line @typescript-eslint/require-await
 				getAuthHeaders: async () => ({ Authorization: 'Bearer proxy-token' }),
 			},
 		});
@@ -723,6 +724,7 @@ describe('createInstanceAiTraceContext', () => {
 			input: { message: 'client test' },
 			proxyConfig: {
 				apiUrl: 'https://proxy.example.com/langsmith',
+				// eslint-disable-next-line @typescript-eslint/require-await
 				getAuthHeaders: async () => ({ Authorization: 'Bearer proxy-token' }),
 			},
 		});
@@ -764,6 +766,7 @@ describe('createInstanceAiTraceContext', () => {
 			input: { message: 'disabled test' },
 			proxyConfig: {
 				apiUrl: 'https://proxy.example.com/langsmith',
+				// eslint-disable-next-line @typescript-eslint/require-await
 				getAuthHeaders: async () => ({ Authorization: 'Bearer proxy-token' }),
 			},
 		});

--- a/packages/@n8n/instance-ai/src/tracing/__tests__/langsmith-tracing.test.ts
+++ b/packages/@n8n/instance-ai/src/tracing/__tests__/langsmith-tracing.test.ts
@@ -705,7 +705,7 @@ describe('createInstanceAiTraceContext', () => {
 			input: { message: 'proxy test' },
 			proxyConfig: {
 				apiUrl: 'https://proxy.example.com/langsmith',
-				headers: { Authorization: 'Bearer proxy-token' },
+				getAuthHeaders: async () => ({ Authorization: 'Bearer proxy-token' }),
 			},
 		});
 
@@ -723,7 +723,7 @@ describe('createInstanceAiTraceContext', () => {
 			input: { message: 'client test' },
 			proxyConfig: {
 				apiUrl: 'https://proxy.example.com/langsmith',
-				headers: { Authorization: 'Bearer proxy-token' },
+				getAuthHeaders: async () => ({ Authorization: 'Bearer proxy-token' }),
 			},
 		});
 
@@ -764,7 +764,7 @@ describe('createInstanceAiTraceContext', () => {
 			input: { message: 'disabled test' },
 			proxyConfig: {
 				apiUrl: 'https://proxy.example.com/langsmith',
-				headers: { Authorization: 'Bearer proxy-token' },
+				getAuthHeaders: async () => ({ Authorization: 'Bearer proxy-token' }),
 			},
 		});
 

--- a/packages/@n8n/instance-ai/src/tracing/langsmith-tracing.ts
+++ b/packages/@n8n/instance-ai/src/tracing/langsmith-tracing.ts
@@ -30,6 +30,13 @@ const traceParentOverrideStorage = new AsyncLocalStorage<{ current: RunTree | nu
 // Authorization header without any shared mutable state.
 const proxyHeaderStore = new AsyncLocalStorage<Record<string, string>>();
 
+/** Resolve proxy headers that may be a static object or an async function. */
+async function resolveProxyHeaders(
+	headers: Record<string, string> | (() => Promise<Record<string, string>>),
+): Promise<Record<string, string>> {
+	return typeof headers === 'function' ? await headers() : headers;
+}
+
 // Module-level map associating traceIds with proxy clients so that
 // hydrateRunTree() (which reconstructs RunTree from serialized state)
 // can use the correct proxy client for its HTTP calls.
@@ -743,10 +750,13 @@ function createTraceContext(
 	traceKind: InstanceAiTraceContext['traceKind'],
 	rootRun: InstanceAiTraceRun,
 	actorRun: InstanceAiTraceRun,
-	proxyHeaders?: Record<string, string>,
+	proxyHeaders?: Record<string, string> | (() => Promise<Record<string, string>>),
 ): InstanceAiTraceContext {
-	const withProxy = async <T>(fn: () => Promise<T>): Promise<T> =>
-		proxyHeaders ? await proxyHeaderStore.run(proxyHeaders, fn) : await fn();
+	const withProxy = async <T>(fn: () => Promise<T>): Promise<T> => {
+		if (!proxyHeaders) return await fn();
+		const resolved = typeof proxyHeaders === 'function' ? await proxyHeaders() : proxyHeaders;
+		return await proxyHeaderStore.run(resolved, fn);
+	};
 
 	const startChildRun = async (
 		parentRun: InstanceAiTraceRun,
@@ -1053,7 +1063,8 @@ export async function createInstanceAiTraceContext(
 	};
 
 	if (options.proxyConfig) {
-		return await proxyHeaderStore.run(options.proxyConfig.headers, createTraceRuns);
+		const resolved = await resolveProxyHeaders(options.proxyConfig.headers);
+		return await proxyHeaderStore.run(resolved, createTraceRuns);
 	}
 	return await createTraceRuns();
 }
@@ -1082,7 +1093,8 @@ export async function continueInstanceAiTraceContext(
 	};
 
 	if (options.proxyConfig) {
-		return await proxyHeaderStore.run(options.proxyConfig.headers, createContinuation);
+		const resolved = await resolveProxyHeaders(options.proxyConfig.headers);
+		return await proxyHeaderStore.run(resolved, createContinuation);
 	}
 	return await createContinuation();
 }
@@ -1133,7 +1145,8 @@ export async function createDetachedSubAgentTraceContext(
 	};
 
 	if (options.proxyConfig) {
-		return await proxyHeaderStore.run(options.proxyConfig.headers, createDetachedRuns);
+		const resolved = await resolveProxyHeaders(options.proxyConfig.headers);
+		return await proxyHeaderStore.run(resolved, createDetachedRuns);
 	}
 	return await createDetachedRuns();
 }

--- a/packages/@n8n/instance-ai/src/tracing/langsmith-tracing.ts
+++ b/packages/@n8n/instance-ai/src/tracing/langsmith-tracing.ts
@@ -30,13 +30,6 @@ const traceParentOverrideStorage = new AsyncLocalStorage<{ current: RunTree | nu
 // Authorization header without any shared mutable state.
 const proxyHeaderStore = new AsyncLocalStorage<Record<string, string>>();
 
-/** Resolve proxy headers that may be a static object or an async function. */
-async function resolveProxyHeaders(
-	headers: Record<string, string> | (() => Promise<Record<string, string>>),
-): Promise<Record<string, string>> {
-	return typeof headers === 'function' ? await headers() : headers;
-}
-
 // Module-level map associating traceIds with proxy clients so that
 // hydrateRunTree() (which reconstructs RunTree from serialized state)
 // can use the correct proxy client for its HTTP calls.
@@ -750,12 +743,12 @@ function createTraceContext(
 	traceKind: InstanceAiTraceContext['traceKind'],
 	rootRun: InstanceAiTraceRun,
 	actorRun: InstanceAiTraceRun,
-	proxyHeaders?: Record<string, string> | (() => Promise<Record<string, string>>),
+	getProxyHeaders?: () => Promise<Record<string, string>>,
 ): InstanceAiTraceContext {
 	const withProxy = async <T>(fn: () => Promise<T>): Promise<T> => {
-		if (!proxyHeaders) return await fn();
-		const resolved = typeof proxyHeaders === 'function' ? await proxyHeaders() : proxyHeaders;
-		return await proxyHeaderStore.run(resolved, fn);
+		if (!getProxyHeaders) return await fn();
+		const headers = await getProxyHeaders();
+		return await proxyHeaderStore.run(headers, fn);
 	};
 
 	const startChildRun = async (
@@ -1058,13 +1051,13 @@ export async function createInstanceAiTraceContext(
 			'message_turn',
 			messageRun,
 			orchestratorRun,
-			options.proxyConfig?.headers,
+			options.proxyConfig?.getAuthHeaders,
 		);
 	};
 
 	if (options.proxyConfig) {
-		const resolved = await resolveProxyHeaders(options.proxyConfig.headers);
-		return await proxyHeaderStore.run(resolved, createTraceRuns);
+		const headers = await options.proxyConfig.getAuthHeaders();
+		return await proxyHeaderStore.run(headers, createTraceRuns);
 	}
 	return await createTraceRuns();
 }
@@ -1088,13 +1081,13 @@ export async function continueInstanceAiTraceContext(
 			'message_turn',
 			existingContext.rootRun,
 			orchestratorRun,
-			options.proxyConfig?.headers,
+			options.proxyConfig?.getAuthHeaders,
 		);
 	};
 
 	if (options.proxyConfig) {
-		const resolved = await resolveProxyHeaders(options.proxyConfig.headers);
-		return await proxyHeaderStore.run(resolved, createContinuation);
+		const headers = await options.proxyConfig.getAuthHeaders();
+		return await proxyHeaderStore.run(headers, createContinuation);
 	}
 	return await createContinuation();
 }
@@ -1140,13 +1133,13 @@ export async function createDetachedSubAgentTraceContext(
 			'detached_subagent',
 			rootRun,
 			rootRun,
-			options.proxyConfig?.headers,
+			options.proxyConfig?.getAuthHeaders,
 		);
 	};
 
 	if (options.proxyConfig) {
-		const resolved = await resolveProxyHeaders(options.proxyConfig.headers);
-		return await proxyHeaderStore.run(resolved, createDetachedRuns);
+		const headers = await options.proxyConfig.getAuthHeaders();
+		return await proxyHeaderStore.run(headers, createDetachedRuns);
 	}
 	return await createDetachedRuns();
 }

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -648,8 +648,14 @@ export type ModelConfig =
 export interface ServiceProxyConfig {
 	/** Proxy endpoint, e.g. '{baseUrl}/langsmith' or '{baseUrl}/brave-search' */
 	apiUrl: string;
-	/** Auth headers to include in proxied requests */
-	headers: Record<string, string>;
+	/**
+	 * Auth headers to include in proxied requests.
+	 *
+	 * Can be a static object or a function that returns fresh headers on each
+	 * call.  The function form allows transparent token refresh during
+	 * long-running agent turns so that short-lived proxy tokens do not expire.
+	 */
+	headers: Record<string, string> | (() => Promise<Record<string, string>>);
 }
 
 // ── LangSmith tracing ────────────────────────────────────────────────────────

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -649,13 +649,12 @@ export interface ServiceProxyConfig {
 	/** Proxy endpoint, e.g. '{baseUrl}/langsmith' or '{baseUrl}/brave-search' */
 	apiUrl: string;
 	/**
-	 * Auth headers to include in proxied requests.
+	 * Returns fresh auth headers for proxied requests.
 	 *
-	 * Can be a static object or a function that returns fresh headers on each
-	 * call.  The function form allows transparent token refresh during
-	 * long-running agent turns so that short-lived proxy tokens do not expire.
+	 * Called on each outbound request so that short-lived proxy tokens are
+	 * transparently refreshed during long-running agent turns.
 	 */
-	headers: Record<string, string> | (() => Promise<Record<string, string>>);
+	getAuthHeaders: () => Promise<Record<string, string>>;
 }
 
 // ── LangSmith tracing ────────────────────────────────────────────────────────

--- a/packages/cli/src/modules/instance-ai/__tests__/proxy-token-manager.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/proxy-token-manager.test.ts
@@ -1,0 +1,166 @@
+import { ProxyTokenManager } from '../proxy-token-manager';
+
+/** Build a minimal JWT with the given `exp` (seconds since epoch). */
+function makeJwt(exp: number): string {
+	const header = Buffer.from(JSON.stringify({ alg: 'HS256' })).toString('base64url');
+	const payload = Buffer.from(JSON.stringify({ sub: 'test', exp })).toString('base64url');
+	return `${header}.${payload}.fake-sig`;
+}
+
+/** Build a token response whose JWT expires at `expMs` (absolute ms). */
+function tokenExpiringAt(expMs: number) {
+	return { accessToken: makeJwt(expMs / 1000), tokenType: 'Bearer' };
+}
+
+describe('ProxyTokenManager', () => {
+	const THRESHOLD = 0.8;
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('should return auth headers on first call', async () => {
+		const now = Date.now();
+		const fetchToken = jest.fn().mockResolvedValue(tokenExpiringAt(now + 600_000));
+		const mgr = new ProxyTokenManager(fetchToken, THRESHOLD);
+
+		const headers = await mgr.getAuthHeaders();
+
+		expect(headers.Authorization).toMatch(/^Bearer /);
+		expect(fetchToken).toHaveBeenCalledTimes(1);
+	});
+
+	it('should cache the token within the TTL threshold', async () => {
+		const now = Date.now();
+		const ttlMs = 600_000; // 10 min
+		const fetchToken = jest.fn().mockResolvedValue(tokenExpiringAt(now + ttlMs));
+		const mgr = new ProxyTokenManager(fetchToken, THRESHOLD);
+
+		await mgr.getAuthHeaders();
+		// Advance to 50% of TTL — well within the 80% threshold
+		jest.advanceTimersByTime(ttlMs * 0.5);
+		await mgr.getAuthHeaders();
+
+		expect(fetchToken).toHaveBeenCalledTimes(1);
+	});
+
+	it('should refresh the token when past the TTL threshold', async () => {
+		const now = Date.now();
+		const ttlMs = 600_000;
+		const fetchToken = jest
+			.fn()
+			.mockResolvedValueOnce(tokenExpiringAt(now + ttlMs))
+			.mockResolvedValueOnce(tokenExpiringAt(now + ttlMs * 2));
+		const mgr = new ProxyTokenManager(fetchToken, THRESHOLD);
+
+		await mgr.getAuthHeaders();
+
+		// Advance past the 80% threshold
+		jest.advanceTimersByTime(ttlMs * 0.85);
+		await mgr.getAuthHeaders();
+
+		expect(fetchToken).toHaveBeenCalledTimes(2);
+	});
+
+	it('should derive TTL from the JWT exp claim', async () => {
+		const now = Date.now();
+		const shortTtlMs = 60_000; // 1 min token
+		const fetchToken = jest.fn().mockResolvedValue(tokenExpiringAt(now + shortTtlMs));
+		const mgr = new ProxyTokenManager(fetchToken, THRESHOLD);
+
+		await mgr.getAuthHeaders();
+		// At 70% of 1 min — still within threshold
+		jest.advanceTimersByTime(shortTtlMs * 0.7);
+		await mgr.getAuthHeaders();
+		expect(fetchToken).toHaveBeenCalledTimes(1);
+
+		// At 85% of 1 min — past the 80% threshold → refresh
+		jest.advanceTimersByTime(shortTtlMs * 0.15);
+		await mgr.getAuthHeaders();
+		expect(fetchToken).toHaveBeenCalledTimes(2);
+	});
+
+	it('should fall back to default TTL when JWT has no exp', async () => {
+		const header = Buffer.from(JSON.stringify({ alg: 'HS256' })).toString('base64url');
+		const payload = Buffer.from(JSON.stringify({ sub: 'no-exp' })).toString('base64url');
+		const noExpJwt = `${header}.${payload}.fake-sig`;
+
+		const fetchToken = jest.fn().mockResolvedValue({ accessToken: noExpJwt, tokenType: 'Bearer' });
+		const mgr = new ProxyTokenManager(fetchToken, THRESHOLD);
+
+		await mgr.getAuthHeaders();
+		// At 50% of default 10 min — should still be cached
+		jest.advanceTimersByTime(5 * 60 * 1000);
+		await mgr.getAuthHeaders();
+		expect(fetchToken).toHaveBeenCalledTimes(1);
+
+		// At 85% of default 10 min — should refresh
+		jest.advanceTimersByTime(3.5 * 60 * 1000);
+		await mgr.getAuthHeaders();
+		expect(fetchToken).toHaveBeenCalledTimes(2);
+	});
+
+	it('should deduplicate concurrent refresh calls (single-flight)', async () => {
+		const now = Date.now();
+		const fetchToken = jest.fn().mockImplementation(
+			async () =>
+				await new Promise((resolve) => {
+					setTimeout(() => resolve(tokenExpiringAt(now + 600_000)), 100);
+				}),
+		);
+		const mgr = new ProxyTokenManager(fetchToken, THRESHOLD);
+
+		const p1 = mgr.getAuthHeaders();
+		const p2 = mgr.getAuthHeaders();
+		const p3 = mgr.getAuthHeaders();
+
+		jest.advanceTimersByTime(100);
+
+		const [h1, h2, h3] = await Promise.all([p1, p2, p3]);
+
+		expect(h1).toEqual(h2);
+		expect(h2).toEqual(h3);
+		expect(fetchToken).toHaveBeenCalledTimes(1);
+	});
+
+	it('should allow a new refresh after a previous one completes', async () => {
+		const now = Date.now();
+		const ttlMs = 1000;
+		const fetchToken = jest
+			.fn()
+			.mockResolvedValueOnce(tokenExpiringAt(now + ttlMs))
+			.mockResolvedValueOnce(tokenExpiringAt(now + ttlMs * 2));
+		const mgr = new ProxyTokenManager(fetchToken, THRESHOLD);
+
+		await mgr.getAuthHeaders();
+		jest.advanceTimersByTime(ttlMs);
+		await mgr.getAuthHeaders();
+
+		expect(fetchToken).toHaveBeenCalledTimes(2);
+	});
+
+	it('should propagate fetch errors', async () => {
+		const fetchToken = jest.fn().mockRejectedValue(new Error('network error'));
+		const mgr = new ProxyTokenManager(fetchToken, THRESHOLD);
+
+		await expect(mgr.getAuthHeaders()).rejects.toThrow('network error');
+	});
+
+	it('should retry after a failed refresh', async () => {
+		const now = Date.now();
+		const fetchToken = jest
+			.fn()
+			.mockRejectedValueOnce(new Error('transient'))
+			.mockResolvedValueOnce(tokenExpiringAt(now + 600_000));
+		const mgr = new ProxyTokenManager(fetchToken, THRESHOLD);
+
+		await expect(mgr.getAuthHeaders()).rejects.toThrow('transient');
+		const headers = await mgr.getAuthHeaders();
+		expect(headers.Authorization).toMatch(/^Bearer /);
+		expect(fetchToken).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/cli/src/modules/instance-ai/__tests__/proxy-token-manager.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/proxy-token-manager.test.ts
@@ -84,7 +84,7 @@ describe('ProxyTokenManager', () => {
 		expect(fetchToken).toHaveBeenCalledTimes(2);
 	});
 
-	it('should fall back to default TTL when JWT has no exp', async () => {
+	it('should throw when JWT has no exp claim', async () => {
 		const header = Buffer.from(JSON.stringify({ alg: 'HS256' })).toString('base64url');
 		const payload = Buffer.from(JSON.stringify({ sub: 'no-exp' })).toString('base64url');
 		const noExpJwt = `${header}.${payload}.fake-sig`;
@@ -92,16 +92,7 @@ describe('ProxyTokenManager', () => {
 		const fetchToken = jest.fn().mockResolvedValue({ accessToken: noExpJwt, tokenType: 'Bearer' });
 		const mgr = new ProxyTokenManager(fetchToken, THRESHOLD);
 
-		await mgr.getAuthHeaders();
-		// At 50% of default 10 min — should still be cached
-		jest.advanceTimersByTime(5 * 60 * 1000);
-		await mgr.getAuthHeaders();
-		expect(fetchToken).toHaveBeenCalledTimes(1);
-
-		// At 85% of default 10 min — should refresh
-		jest.advanceTimersByTime(3.5 * 60 * 1000);
-		await mgr.getAuthHeaders();
-		expect(fetchToken).toHaveBeenCalledTimes(2);
+		await expect(mgr.getAuthHeaders()).rejects.toThrow('Proxy token JWT is missing the exp claim');
 	});
 
 	it('should deduplicate concurrent refresh calls (single-flight)', async () => {

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -362,23 +362,6 @@ export class InstanceAiService {
 	}
 
 	/**
-	 * Create a ProxyTokenManager that lazily fetches and caches proxy auth
-	 * tokens for a given user.  One manager is shared across the Anthropic
-	 * model, Brave Search, and LangSmith tracing configs within a single
-	 * orchestration run so every outbound request gets a valid token.
-	 */
-	private async createProxyTokenManager(user: User): Promise<{
-		client: Awaited<ReturnType<AiService['getClient']>>;
-		tokenManager: ProxyTokenManager;
-	}> {
-		const client = await this.aiService.getClient();
-		const tokenManager = new ProxyTokenManager(async () => {
-			return await client.getBuilderApiProxyToken({ id: user.id }, { userMessageId: nanoid() });
-		});
-		return { client, tokenManager };
-	}
-
-	/**
 	 * Build model config. When the AI service proxy is enabled, returns a native
 	 * Anthropic LanguageModelV2 instance pointing at the proxy.
 	 *
@@ -392,55 +375,26 @@ export class InstanceAiService {
 	 * request gets a fresh-or-cached token from the ProxyTokenManager,
 	 * avoiding 401s on long-running agent turns.
 	 */
-	private async resolveModel(user: User, tokenManager?: ProxyTokenManager): Promise<ModelConfig> {
-		if (this.aiService.isProxyEnabled()) {
-			const client = await this.aiService.getClient();
-			const mgr = tokenManager ?? (await this.createProxyTokenManager(user)).tokenManager;
-			const modelName = await this.settingsService.resolveModelName(user);
-			const { createAnthropic } = await import('@ai-sdk/anthropic');
-			const provider = createAnthropic({
-				baseURL: client.getApiProxyBaseUrl() + '/anthropic/v1',
-				apiKey: 'proxy-managed',
-				fetch: async (input, init) => {
-					const headers = new Headers(init?.headers);
-					const auth = await mgr.getAuthHeaders();
-					for (const [k, v] of Object.entries(auth)) {
-						headers.set(k, v);
-					}
-					return await globalThis.fetch(input, { ...init, headers });
-				},
-			});
-			return provider(modelName);
-		}
-		return await this.settingsService.resolveModelConfig(user);
-	}
-
-	/** Build search proxy config when proxy is enabled. */
-	private async resolveSearchProxyConfig(
+	private async resolveProxyModel(
 		user: User,
-		tokenManager?: ProxyTokenManager,
-	): Promise<ServiceProxyConfig | undefined> {
-		if (!this.aiService.isProxyEnabled()) return undefined;
-		const client = await this.aiService.getClient();
-		const mgr = tokenManager ?? (await this.createProxyTokenManager(user)).tokenManager;
-		return {
-			apiUrl: client.getApiProxyBaseUrl() + '/brave-search',
-			headers: async () => await mgr.getAuthHeaders(),
-		};
-	}
-
-	/** Build tracing proxy config when proxy is enabled. */
-	private async resolveTracingProxyConfig(
-		user: User,
-		tokenManager?: ProxyTokenManager,
-	): Promise<ServiceProxyConfig | undefined> {
-		if (!this.aiService.isProxyEnabled()) return undefined;
-		const client = await this.aiService.getClient();
-		const mgr = tokenManager ?? (await this.createProxyTokenManager(user)).tokenManager;
-		return {
-			apiUrl: client.getApiProxyBaseUrl() + '/langsmith',
-			headers: async () => await mgr.getAuthHeaders(),
-		};
+		proxyBaseUrl: string,
+		tokenManager: ProxyTokenManager,
+	): Promise<ModelConfig> {
+		const modelName = await this.settingsService.resolveModelName(user);
+		const { createAnthropic } = await import('@ai-sdk/anthropic');
+		const provider = createAnthropic({
+			baseURL: proxyBaseUrl + '/anthropic/v1',
+			apiKey: 'proxy-managed',
+			fetch: async (input, init) => {
+				const headers = new Headers(init?.headers);
+				const auth = await tokenManager.getAuthHeaders();
+				for (const [k, v] of Object.entries(auth)) {
+					headers.set(k, v);
+				}
+				return await globalThis.fetch(input, { ...init, headers });
+			},
+		});
+		return provider(modelName);
 	}
 
 	/**
@@ -1121,13 +1075,31 @@ export class InstanceAiService {
 	) {
 		const localGatewayDisabled = this.settingsService.isLocalGatewayDisabled();
 		const userGateway = this.gatewayRegistry.findGateway(user.id);
-		// Share a single ProxyTokenManager across all proxy configs so that the
-		// cached token is reused while valid and refreshed transparently on expiry.
-		const tokenManager = this.aiService.isProxyEnabled()
-			? (await this.createProxyTokenManager(user)).tokenManager
-			: undefined;
-		const searchProxyConfig = await this.resolveSearchProxyConfig(user, tokenManager);
-		const tracingProxyConfig = await this.resolveTracingProxyConfig(user, tokenManager);
+
+		// When the proxy is enabled, create a single ProxyTokenManager and
+		// AiAssistantClient that are shared across model, search, and tracing
+		// configs.  The token manager caches the JWT and refreshes it
+		// transparently before it expires.
+		let searchProxyConfig: ServiceProxyConfig | undefined;
+		let tracingProxyConfig: ServiceProxyConfig | undefined;
+		let tokenManager: ProxyTokenManager | undefined;
+		let proxyBaseUrl: string | undefined;
+		if (this.aiService.isProxyEnabled()) {
+			const client = await this.aiService.getClient();
+			proxyBaseUrl = client.getApiProxyBaseUrl();
+			tokenManager = new ProxyTokenManager(async () => {
+				return await client.getBuilderApiProxyToken({ id: user.id }, { userMessageId: nanoid() });
+			});
+			searchProxyConfig = {
+				apiUrl: proxyBaseUrl + '/brave-search',
+				headers: async () => await tokenManager!.getAuthHeaders(),
+			};
+			tracingProxyConfig = {
+				apiUrl: proxyBaseUrl + '/langsmith',
+				headers: async () => await tokenManager!.getAuthHeaders(),
+			};
+		}
+
 		const context = this.adapterService.createContext(user, {
 			searchProxyConfig,
 			pushRef,
@@ -1162,7 +1134,10 @@ export class InstanceAiService {
 			};
 		}
 
-		const modelId = await this.resolveModel(user, tokenManager);
+		const modelId =
+			proxyBaseUrl && tokenManager
+				? await this.resolveProxyModel(user, proxyBaseUrl, tokenManager)
+				: await this.settingsService.resolveModelConfig(user);
 		const memory = createMemory(this.createMemoryConfig());
 		await this.ensureThreadExists(memory, threadId, user.id);
 

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -79,6 +79,7 @@ import type { TypeORMWorkflowsStorage } from './storage/typeorm-workflows-storag
 import { DbSnapshotStorage } from './storage/db-snapshot-storage';
 import { DbIterationLogStorage } from './storage/db-iteration-log-storage';
 import { InstanceAiCompactionService } from './compaction.service';
+import { ProxyTokenManager } from './proxy-token-manager';
 import { InstanceAiThreadRepository } from './repositories/instance-ai-thread.repository';
 
 function getErrorMessage(error: unknown): string {
@@ -361,6 +362,23 @@ export class InstanceAiService {
 	}
 
 	/**
+	 * Create a ProxyTokenManager that lazily fetches and caches proxy auth
+	 * tokens for a given user.  One manager is shared across the Anthropic
+	 * model, Brave Search, and LangSmith tracing configs within a single
+	 * orchestration run so every outbound request gets a valid token.
+	 */
+	private async createProxyTokenManager(user: User): Promise<{
+		client: Awaited<ReturnType<AiService['getClient']>>;
+		tokenManager: ProxyTokenManager;
+	}> {
+		const client = await this.aiService.getClient();
+		const tokenManager = new ProxyTokenManager(async () => {
+			return await client.getBuilderApiProxyToken({ id: user.id }, { userMessageId: nanoid() });
+		});
+		return { client, tokenManager };
+	}
+
+	/**
 	 * Build model config. When the AI service proxy is enabled, returns a native
 	 * Anthropic LanguageModelV2 instance pointing at the proxy.
 	 *
@@ -369,16 +387,28 @@ export class InstanceAiService {
 	 * `createOpenAICompatible`, which sends requests to `/chat/completions`.
 	 * The proxy may forward to Vertex AI, which only supports the native Anthropic
 	 * Messages API (`/v1/messages`), not the OpenAI-compatible endpoint.
+	 *
+	 * Auth headers are injected via a custom `fetch` wrapper so that each
+	 * request gets a fresh-or-cached token from the ProxyTokenManager,
+	 * avoiding 401s on long-running agent turns.
 	 */
-	private async resolveModel(user: User): Promise<ModelConfig> {
+	private async resolveModel(user: User, tokenManager?: ProxyTokenManager): Promise<ModelConfig> {
 		if (this.aiService.isProxyEnabled()) {
-			const { client, headers } = await this.getProxyAuth(user);
+			const client = await this.aiService.getClient();
+			const mgr = tokenManager ?? (await this.createProxyTokenManager(user)).tokenManager;
 			const modelName = await this.settingsService.resolveModelName(user);
 			const { createAnthropic } = await import('@ai-sdk/anthropic');
 			const provider = createAnthropic({
 				baseURL: client.getApiProxyBaseUrl() + '/anthropic/v1',
 				apiKey: 'proxy-managed',
-				headers,
+				fetch: async (input, init) => {
+					const headers = new Headers(init?.headers);
+					const auth = await mgr.getAuthHeaders();
+					for (const [k, v] of Object.entries(auth)) {
+						headers.set(k, v);
+					}
+					return await globalThis.fetch(input, { ...init, headers });
+				},
 			});
 			return provider(modelName);
 		}
@@ -386,17 +416,31 @@ export class InstanceAiService {
 	}
 
 	/** Build search proxy config when proxy is enabled. */
-	private async resolveSearchProxyConfig(user: User): Promise<ServiceProxyConfig | undefined> {
+	private async resolveSearchProxyConfig(
+		user: User,
+		tokenManager?: ProxyTokenManager,
+	): Promise<ServiceProxyConfig | undefined> {
 		if (!this.aiService.isProxyEnabled()) return undefined;
-		const { client, headers } = await this.getProxyAuth(user);
-		return { apiUrl: client.getApiProxyBaseUrl() + '/brave-search', headers };
+		const client = await this.aiService.getClient();
+		const mgr = tokenManager ?? (await this.createProxyTokenManager(user)).tokenManager;
+		return {
+			apiUrl: client.getApiProxyBaseUrl() + '/brave-search',
+			headers: async () => await mgr.getAuthHeaders(),
+		};
 	}
 
 	/** Build tracing proxy config when proxy is enabled. */
-	private async resolveTracingProxyConfig(user: User): Promise<ServiceProxyConfig | undefined> {
+	private async resolveTracingProxyConfig(
+		user: User,
+		tokenManager?: ProxyTokenManager,
+	): Promise<ServiceProxyConfig | undefined> {
 		if (!this.aiService.isProxyEnabled()) return undefined;
-		const { client, headers } = await this.getProxyAuth(user);
-		return { apiUrl: client.getApiProxyBaseUrl() + '/langsmith', headers };
+		const client = await this.aiService.getClient();
+		const mgr = tokenManager ?? (await this.createProxyTokenManager(user)).tokenManager;
+		return {
+			apiUrl: client.getApiProxyBaseUrl() + '/langsmith',
+			headers: async () => await mgr.getAuthHeaders(),
+		};
 	}
 
 	/**
@@ -1077,9 +1121,13 @@ export class InstanceAiService {
 	) {
 		const localGatewayDisabled = this.settingsService.isLocalGatewayDisabled();
 		const userGateway = this.gatewayRegistry.findGateway(user.id);
-		// Each resolve*() call fetches a separate proxy token for audit tracking (see getProxyAuth)
-		const searchProxyConfig = await this.resolveSearchProxyConfig(user);
-		const tracingProxyConfig = await this.resolveTracingProxyConfig(user);
+		// Share a single ProxyTokenManager across all proxy configs so that the
+		// cached token is reused while valid and refreshed transparently on expiry.
+		const tokenManager = this.aiService.isProxyEnabled()
+			? (await this.createProxyTokenManager(user)).tokenManager
+			: undefined;
+		const searchProxyConfig = await this.resolveSearchProxyConfig(user, tokenManager);
+		const tracingProxyConfig = await this.resolveTracingProxyConfig(user, tokenManager);
 		const context = this.adapterService.createContext(user, {
 			searchProxyConfig,
 			pushRef,
@@ -1114,7 +1162,7 @@ export class InstanceAiService {
 			};
 		}
 
-		const modelId = await this.resolveModel(user); // separate proxy token — see getProxyAuth
+		const modelId = await this.resolveModel(user, tokenManager);
 		const memory = createMemory(this.createMemoryConfig());
 		await this.ensureThreadExists(memory, threadId, user.id);
 

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -1087,16 +1087,17 @@ export class InstanceAiService {
 		if (this.aiService.isProxyEnabled()) {
 			const client = await this.aiService.getClient();
 			proxyBaseUrl = client.getApiProxyBaseUrl();
-			tokenManager = new ProxyTokenManager(async () => {
+			const manager = new ProxyTokenManager(async () => {
 				return await client.getBuilderApiProxyToken({ id: user.id }, { userMessageId: nanoid() });
 			});
+			tokenManager = manager;
 			searchProxyConfig = {
 				apiUrl: proxyBaseUrl + '/brave-search',
-				getAuthHeaders: async () => await tokenManager!.getAuthHeaders(),
+				getAuthHeaders: async () => await manager.getAuthHeaders(),
 			};
 			tracingProxyConfig = {
 				apiUrl: proxyBaseUrl + '/langsmith',
-				getAuthHeaders: async () => await tokenManager!.getAuthHeaders(),
+				getAuthHeaders: async () => await manager.getAuthHeaders(),
 			};
 		}
 

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -1092,11 +1092,11 @@ export class InstanceAiService {
 			});
 			searchProxyConfig = {
 				apiUrl: proxyBaseUrl + '/brave-search',
-				headers: async () => await tokenManager!.getAuthHeaders(),
+				getAuthHeaders: async () => await tokenManager!.getAuthHeaders(),
 			};
 			tracingProxyConfig = {
 				apiUrl: proxyBaseUrl + '/langsmith',
-				headers: async () => await tokenManager!.getAuthHeaders(),
+				getAuthHeaders: async () => await tokenManager!.getAuthHeaders(),
 			};
 		}
 

--- a/packages/cli/src/modules/instance-ai/proxy-token-manager.ts
+++ b/packages/cli/src/modules/instance-ai/proxy-token-manager.ts
@@ -1,0 +1,92 @@
+const DEFAULT_TTL_MS = 10 * 60 * 1000; // 10 min — fallback if JWT has no exp
+
+interface CachedToken {
+	accessToken: string;
+	tokenType: string;
+	/** Absolute timestamp (ms) after which we should proactively refresh. */
+	refreshAfter: number;
+}
+
+/**
+ * Decode the payload of a JWT without verifying the signature.
+ * Returns the `exp` claim (seconds since epoch) or undefined.
+ */
+function getJwtExpiry(jwt: string): number | undefined {
+	const parts = jwt.split('.');
+	if (parts.length !== 3) return undefined;
+	try {
+		const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString()) as {
+			exp?: number;
+		};
+		return typeof payload.exp === 'number' ? payload.exp : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Caches a proxy auth token and transparently refreshes it before expiry.
+ *
+ * The AI assistant service issues short-lived JWTs (default 10 min).
+ * During a single orchestration run the same token is reused across the
+ * orchestrator, all sub-agents, and potential HITL resume flows.  Without
+ * proactive refresh the token can expire mid-run, causing 401 errors.
+ *
+ * The TTL is derived from the JWT `exp` claim so the client automatically
+ * adapts when the server changes its token lifetime.
+ *
+ * One instance is created per `createExecutionEnvironment()` call and
+ * shared by the Anthropic model, Brave Search proxy, and LangSmith
+ * tracing proxy.
+ */
+export class ProxyTokenManager {
+	private cached: CachedToken | null = null;
+
+	private refreshPromise: Promise<CachedToken> | null = null;
+
+	constructor(
+		private readonly fetchToken: () => Promise<{
+			accessToken: string;
+			tokenType: string;
+		}>,
+		private readonly refreshThreshold: number = 0.8,
+	) {}
+
+	async getAuthHeaders(): Promise<Record<string, string>> {
+		const token = await this.getValidToken();
+		return { Authorization: `${token.tokenType} ${token.accessToken}` };
+	}
+
+	private async getValidToken(): Promise<CachedToken> {
+		if (this.cached && !this.isExpiringSoon()) return this.cached;
+		return await this.refresh();
+	}
+
+	private isExpiringSoon(): boolean {
+		if (!this.cached) return true;
+		return Date.now() >= this.cached.refreshAfter;
+	}
+
+	private async refresh(): Promise<CachedToken> {
+		if (this.refreshPromise) return await this.refreshPromise;
+		this.refreshPromise = this.doRefresh();
+		try {
+			return await this.refreshPromise;
+		} finally {
+			this.refreshPromise = null;
+		}
+	}
+
+	private async doRefresh(): Promise<CachedToken> {
+		const result = await this.fetchToken();
+		const now = Date.now();
+		const exp = getJwtExpiry(result.accessToken);
+		const expiresAt = exp ? exp * 1000 : now + DEFAULT_TTL_MS;
+		const ttl = expiresAt - now;
+		this.cached = {
+			...result,
+			refreshAfter: now + ttl * this.refreshThreshold,
+		};
+		return this.cached;
+	}
+}

--- a/packages/cli/src/modules/instance-ai/proxy-token-manager.ts
+++ b/packages/cli/src/modules/instance-ai/proxy-token-manager.ts
@@ -1,4 +1,4 @@
-const DEFAULT_TTL_MS = 10 * 60 * 1000; // 10 min — fallback if JWT has no exp
+import { UnexpectedError } from 'n8n-workflow';
 
 interface CachedToken {
 	accessToken: string;
@@ -81,8 +81,8 @@ export class ProxyTokenManager {
 		const result = await this.fetchToken();
 		const now = Date.now();
 		const exp = getJwtExpiry(result.accessToken);
-		const expiresAt = exp ? exp * 1000 : now + DEFAULT_TTL_MS;
-		const ttl = expiresAt - now;
+		if (!exp) throw new UnexpectedError('Proxy token JWT is missing the exp claim');
+		const ttl = exp * 1000 - now;
 		this.cached = {
 			...result,
 			refreshAfter: now + ttl * this.refreshThreshold,

--- a/packages/cli/src/modules/instance-ai/web-research/__tests__/brave-search.test.ts
+++ b/packages/cli/src/modules/instance-ai/web-research/__tests__/brave-search.test.ts
@@ -159,7 +159,7 @@ describe('braveSearch', () => {
 	describe('proxy mode', () => {
 		const proxyConfig = {
 			apiUrl: 'https://proxy.example.com/brave-search',
-			headers: { Authorization: 'Bearer proxy-token' },
+			getAuthHeaders: async () => ({ Authorization: 'Bearer proxy-token' }),
 		};
 
 		it('uses proxy URL and auth headers when proxyConfig is provided', async () => {

--- a/packages/cli/src/modules/instance-ai/web-research/brave-search.ts
+++ b/packages/cli/src/modules/instance-ai/web-research/brave-search.ts
@@ -30,7 +30,10 @@ export async function braveSearch(
 		maxResults?: number;
 		includeDomains?: string[];
 		excludeDomains?: string[];
-		proxyConfig?: { apiUrl: string; headers: Record<string, string> };
+		proxyConfig?: {
+			apiUrl: string;
+			headers: Record<string, string> | (() => Promise<Record<string, string>>);
+		};
 	},
 ): Promise<WebSearchResponse> {
 	let searchQuery = query;
@@ -53,10 +56,15 @@ export async function braveSearch(
 	const baseUrl = useProxy
 		? `${options.proxyConfig!.apiUrl}${BRAVE_SEARCH_PATH}`
 		: BRAVE_SEARCH_URL;
+	const proxyHeaders = useProxy
+		? typeof options.proxyConfig!.headers === 'function'
+			? await options.proxyConfig!.headers()
+			: options.proxyConfig!.headers
+		: undefined;
 	const headers: Record<string, string> = {
 		Accept: 'application/json',
 		'Accept-Encoding': 'gzip',
-		...(useProxy ? options.proxyConfig!.headers : { 'X-Subscription-Token': apiKey }),
+		...(proxyHeaders ?? { 'X-Subscription-Token': apiKey }),
 	};
 
 	const response = await fetch(`${baseUrl}?${params}`, { headers });

--- a/packages/cli/src/modules/instance-ai/web-research/brave-search.ts
+++ b/packages/cli/src/modules/instance-ai/web-research/brave-search.ts
@@ -32,7 +32,7 @@ export async function braveSearch(
 		excludeDomains?: string[];
 		proxyConfig?: {
 			apiUrl: string;
-			headers: Record<string, string> | (() => Promise<Record<string, string>>);
+			getAuthHeaders: () => Promise<Record<string, string>>;
 		};
 	},
 ): Promise<WebSearchResponse> {
@@ -56,11 +56,7 @@ export async function braveSearch(
 	const baseUrl = useProxy
 		? `${options.proxyConfig!.apiUrl}${BRAVE_SEARCH_PATH}`
 		: BRAVE_SEARCH_URL;
-	const proxyHeaders = useProxy
-		? typeof options.proxyConfig!.headers === 'function'
-			? await options.proxyConfig!.headers()
-			: options.proxyConfig!.headers
-		: undefined;
+	const proxyHeaders = useProxy ? await options.proxyConfig!.getAuthHeaders() : undefined;
 	const headers: Record<string, string> = {
 		Accept: 'application/json',
 		'Accept-Encoding': 'gzip',


### PR DESCRIPTION
## Summary

We were requesting a new token from AI assistant each turn, but as a single turn can take a while and as the tokens only have 10min TTL at production they could expire, leading into "Unauthorized" errors seen on the agent.

Daytona proxy always gets a new token already with a lazy get function for the token, and I implemented something similar here, but as I didn't want every interaction with the proxy endpoints (for instance the anthropic one gets called a lot) to result in a new token call I made us reuse the same token during the turn until its expiration time is near.

This complicates things a bit but should make it so that the token no longer expires during a long response turn / if user leaves the agent waiting on a HITL suspension for a while.

## Related Linear tickets, Github issues, and Community forum posts

https://www.notion.so/n8n/aef5b6e0c94f82159cc58164aa417607?v=7965b6e0c94f823c918f88516500cb86&p=33e5b6e0c94f8080ae24ff196877207f&pm=s

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
