### PR TITLE
feat(ai-builder): Add a binary check to validate node references (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/checks/__tests__/deterministic-checks.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/checks/__tests__/deterministic-checks.test.ts
@@ -8,6 +8,7 @@ import { noCodeImports } from '../no-code-imports';
 import { noEmptySetNodes } from '../no-empty-set-nodes';
 import { noUnnecessaryCodeNodes } from '../no-unnecessary-code-nodes';
 import { noUnreachableNodes } from '../no-unreachable-nodes';
+import { referencesReachableNodes } from '../references-reachable-nodes';
 import {
 	hasNodes,
 	hasTrigger,
@@ -1289,5 +1290,340 @@ describe('no_code_imports', () => {
 	it('passes for empty workflow', async () => {
 		const result = await noCodeImports.run(makeWorkflow({ nodes: [] }), makeCtx());
 		expect(result.pass).toBe(true);
+	});
+});
+
+describe('references_reachable_nodes', () => {
+	it('passes for empty workflow', async () => {
+		const result = await referencesReachableNodes.run(makeWorkflow({ nodes: [] }), makeCtx());
+		expect(result.pass).toBe(true);
+	});
+
+	it('passes when referencing an upstream node', async () => {
+		const result = await referencesReachableNodes.run(
+			makeWorkflow({
+				nodes: [
+					{
+						name: 'Trigger',
+						type: 'n8n-nodes-base.manualTrigger',
+						typeVersion: 1,
+						position: [0, 0],
+					},
+					{
+						name: 'Set',
+						type: 'n8n-nodes-base.set',
+						typeVersion: 3,
+						position: [200, 0],
+						parameters: {
+							assignments: {
+								assignments: [
+									{ name: 'val', value: "={{ $('Trigger').first().json.data }}", type: 'string' },
+								],
+							},
+						},
+					},
+				],
+				connections: {
+					['Trigger']: { main: [[{ node: 'Set', type: 'main', index: 0 }]] },
+				},
+			}),
+			makeCtx(),
+		);
+		expect(result.pass).toBe(true);
+	});
+
+	it('fails when referencing a non-existent node', async () => {
+		const result = await referencesReachableNodes.run(
+			makeWorkflow({
+				nodes: [
+					{
+						name: 'Set',
+						type: 'n8n-nodes-base.set',
+						typeVersion: 3,
+						position: [0, 0],
+						parameters: {
+							assignments: {
+								assignments: [
+									{ name: 'val', value: "={{ $('Ghost').first().json.data }}", type: 'string' },
+								],
+							},
+						},
+					},
+				],
+			}),
+			makeCtx(),
+		);
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('Set');
+	});
+
+	it('fails when referencing a downstream node', async () => {
+		const result = await referencesReachableNodes.run(
+			makeWorkflow({
+				nodes: [
+					{
+						name: 'Trigger',
+						type: 'n8n-nodes-base.manualTrigger',
+						typeVersion: 1,
+						position: [0, 0],
+					},
+					{
+						name: 'SetA',
+						type: 'n8n-nodes-base.set',
+						typeVersion: 3,
+						position: [200, 0],
+						parameters: {
+							assignments: {
+								assignments: [
+									{ name: 'val', value: "={{ $('SetB').first().json.data }}", type: 'string' },
+								],
+							},
+						},
+					},
+					{ name: 'SetB', type: 'n8n-nodes-base.set', typeVersion: 3, position: [400, 0] },
+				],
+				connections: {
+					['Trigger']: { main: [[{ node: 'SetA', type: 'main', index: 0 }]] },
+					['SetA']: { main: [[{ node: 'SetB', type: 'main', index: 0 }]] },
+				},
+			}),
+			makeCtx(),
+		);
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('SetA');
+	});
+
+	it('fails when referencing a transitive downstream node', async () => {
+		const result = await referencesReachableNodes.run(
+			makeWorkflow({
+				nodes: [
+					{
+						name: 'Trigger',
+						type: 'n8n-nodes-base.manualTrigger',
+						typeVersion: 1,
+						position: [0, 0],
+					},
+					{
+						name: 'SetA',
+						type: 'n8n-nodes-base.set',
+						typeVersion: 3,
+						position: [200, 0],
+						parameters: {
+							assignments: {
+								assignments: [
+									{ name: 'val', value: "={{ $('SetC').first().json.data }}", type: 'string' },
+								],
+							},
+						},
+					},
+					{ name: 'SetB', type: 'n8n-nodes-base.set', typeVersion: 3, position: [400, 0] },
+					{ name: 'SetC', type: 'n8n-nodes-base.set', typeVersion: 3, position: [600, 0] },
+				],
+				connections: {
+					['Trigger']: { main: [[{ node: 'SetA', type: 'main', index: 0 }]] },
+					['SetA']: { main: [[{ node: 'SetB', type: 'main', index: 0 }]] },
+					['SetB']: { main: [[{ node: 'SetC', type: 'main', index: 0 }]] },
+				},
+			}),
+			makeCtx(),
+		);
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('SetA');
+	});
+
+	it('fails when referencing a node on a parallel IF branch', async () => {
+		// TrueNode references FalseNode — FalseNode is not an ancestor of TrueNode
+		const result = await referencesReachableNodes.run(
+			makeWorkflow({
+				nodes: [
+					{
+						name: 'Trigger',
+						type: 'n8n-nodes-base.manualTrigger',
+						typeVersion: 1,
+						position: [0, 0],
+					},
+					{ name: 'IF', type: 'n8n-nodes-base.if', typeVersion: 1, position: [200, 0] },
+					{
+						name: 'TrueNode',
+						type: 'n8n-nodes-base.set',
+						typeVersion: 3,
+						position: [400, -100],
+						parameters: {
+							assignments: {
+								assignments: [
+									{ name: 'val', value: "={{ $('FalseNode').first().json.data }}", type: 'string' },
+								],
+							},
+						},
+					},
+					{ name: 'FalseNode', type: 'n8n-nodes-base.set', typeVersion: 3, position: [400, 100] },
+				],
+				connections: {
+					['Trigger']: { main: [[{ node: 'IF', type: 'main', index: 0 }]] },
+					IF: {
+						main: [
+							[{ node: 'TrueNode', type: 'main', index: 0 }],
+							[{ node: 'FalseNode', type: 'main', index: 0 }],
+						],
+					},
+				},
+			}),
+			makeCtx(),
+		);
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('TrueNode');
+	});
+
+	it('fails when referencing a node on a different unconnected chain', async () => {
+		const result = await referencesReachableNodes.run(
+			makeWorkflow({
+				nodes: [
+					{
+						name: 'Trigger1',
+						type: 'n8n-nodes-base.manualTrigger',
+						typeVersion: 1,
+						position: [0, 0],
+					},
+					{
+						name: 'NodeA',
+						type: 'n8n-nodes-base.set',
+						typeVersion: 3,
+						position: [200, 0],
+						parameters: {
+							assignments: {
+								assignments: [
+									{ name: 'val', value: "={{ $('NodeB').first().json.data }}", type: 'string' },
+								],
+							},
+						},
+					},
+					{
+						name: 'Trigger2',
+						type: 'n8n-nodes-base.manualTrigger',
+						typeVersion: 1,
+						position: [0, 200],
+					},
+					{ name: 'NodeB', type: 'n8n-nodes-base.set', typeVersion: 3, position: [200, 200] },
+				],
+				connections: {
+					['Trigger1']: { main: [[{ node: 'NodeA', type: 'main', index: 0 }]] },
+					['Trigger2']: { main: [[{ node: 'NodeB', type: 'main', index: 0 }]] },
+				},
+			}),
+			makeCtx(),
+		);
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('NodeA');
+	});
+
+	it('passes when no expressions are present', async () => {
+		const result = await referencesReachableNodes.run(
+			makeWorkflow({
+				nodes: [
+					{
+						name: 'Set',
+						type: 'n8n-nodes-base.set',
+						typeVersion: 3,
+						position: [0, 0],
+						parameters: { mode: 'manual' },
+					},
+				],
+			}),
+			makeCtx(),
+		);
+		expect(result.pass).toBe(true);
+	});
+
+	it('passes when node has no parameters', async () => {
+		const result = await referencesReachableNodes.run(
+			makeWorkflow({
+				nodes: [{ name: 'Set', type: 'n8n-nodes-base.set', typeVersion: 3, position: [0, 0] }],
+			}),
+			makeCtx(),
+		);
+		expect(result.pass).toBe(true);
+	});
+
+	it('passes when referencing a node upstream through a merge', async () => {
+		const result = await referencesReachableNodes.run(
+			makeWorkflow({
+				nodes: [
+					{
+						name: 'Trigger',
+						type: 'n8n-nodes-base.manualTrigger',
+						typeVersion: 1,
+						position: [0, 0],
+					},
+					{ name: 'FetchA', type: 'n8n-nodes-base.set', typeVersion: 3, position: [200, -100] },
+					{ name: 'FetchB', type: 'n8n-nodes-base.set', typeVersion: 3, position: [200, 100] },
+					{ name: 'Merge', type: 'n8n-nodes-base.merge', typeVersion: 1, position: [400, 0] },
+					{
+						name: 'Consumer',
+						type: 'n8n-nodes-base.set',
+						typeVersion: 3,
+						position: [600, 0],
+						parameters: {
+							assignments: {
+								assignments: [
+									{ name: 'val', value: "={{ $('FetchA').first().json.data }}", type: 'string' },
+								],
+							},
+						},
+					},
+				],
+				connections: {
+					['Trigger']: {
+						main: [
+							[
+								{ node: 'FetchA', type: 'main', index: 0 },
+								{ node: 'FetchB', type: 'main', index: 0 },
+							],
+						],
+					},
+					['FetchA']: { main: [[{ node: 'Merge', type: 'main', index: 0 }]] },
+					['FetchB']: { main: [[{ node: 'Merge', type: 'main', index: 1 }]] },
+					['Merge']: { main: [[{ node: 'Consumer', type: 'main', index: 0 }]] },
+				},
+			}),
+			makeCtx(),
+		);
+		expect(result.pass).toBe(true);
+	});
+
+	it('reports both non-existent and non-ancestor in the same node', async () => {
+		const result = await referencesReachableNodes.run(
+			makeWorkflow({
+				nodes: [
+					{
+						name: 'Trigger',
+						type: 'n8n-nodes-base.manualTrigger',
+						typeVersion: 1,
+						position: [0, 0],
+					},
+					{
+						name: 'SetA',
+						type: 'n8n-nodes-base.set',
+						typeVersion: 3,
+						position: [200, 0],
+						parameters: {
+							assignments: {
+								assignments: [
+									{ name: 'a', value: "={{ $('Ghost').first().json }}", type: 'string' },
+									{ name: 'b', value: "={{ $('SetB').first().json }}", type: 'string' },
+								],
+							},
+						},
+					},
+					{ name: 'SetB', type: 'n8n-nodes-base.set', typeVersion: 3, position: [400, 0] },
+				],
+				connections: {
+					['Trigger']: { main: [[{ node: 'SetA', type: 'main', index: 0 }]] },
+					['SetA']: { main: [[{ node: 'SetB', type: 'main', index: 0 }]] },
+				},
+			}),
+			makeCtx(),
+		);
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('SetA');
 	});
 });

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/checks/__tests__/deterministic-checks.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/checks/__tests__/deterministic-checks.test.ts
@@ -144,7 +144,7 @@ describe('all_nodes_connected', () => {
 					{ name: 'Set', type: 'n8n-nodes-base.set', typeVersion: 3, position: [200, 0] },
 				],
 				connections: {
-					Trigger: { main: [[{ node: 'Set', type: 'main', index: 0 }]] },
+					['Trigger']: { main: [[{ node: 'Set', type: 'main', index: 0 }]] },
 				},
 			}),
 			makeCtx(),
@@ -171,7 +171,7 @@ describe('all_nodes_connected', () => {
 					},
 				],
 				connections: {
-					Trigger: { main: [[{ node: 'Set', type: 'main', index: 0 }]] },
+					['Trigger']: { main: [[{ node: 'Set', type: 'main', index: 0 }]] },
 				},
 			}),
 			makeCtx(),
@@ -193,7 +193,7 @@ describe('all_nodes_connected', () => {
 					{ name: 'Orphan', type: 'n8n-nodes-base.set', typeVersion: 3, position: [400, 0] },
 				],
 				connections: {
-					Trigger: { main: [[{ node: 'Set', type: 'main', index: 0 }]] },
+					['Trigger']: { main: [[{ node: 'Set', type: 'main', index: 0 }]] },
 				},
 			}),
 			makeCtx(),
@@ -233,7 +233,7 @@ describe('no_unreachable_nodes', () => {
 					{ name: 'Set', type: 'n8n-nodes-base.set', typeVersion: 3, position: [200, 0] },
 				],
 				connections: {
-					Trigger: { main: [[{ node: 'Set', type: 'main', index: 0 }]] },
+					['Trigger']: { main: [[{ node: 'Set', type: 'main', index: 0 }]] },
 				},
 			}),
 			makeCtx(),
@@ -255,7 +255,7 @@ describe('no_unreachable_nodes', () => {
 					{ name: 'Orphan', type: 'n8n-nodes-base.set', typeVersion: 3, position: [400, 0] },
 				],
 				connections: {
-					Trigger: { main: [[{ node: 'Set', type: 'main', index: 0 }]] },
+					['Trigger']: { main: [[{ node: 'Set', type: 'main', index: 0 }]] },
 				},
 			}),
 			makeCtx(),
@@ -283,7 +283,7 @@ describe('no_unreachable_nodes', () => {
 					},
 				],
 				connections: {
-					Trigger: { main: [[{ node: 'Set', type: 'main', index: 0 }]] },
+					['Trigger']: { main: [[{ node: 'Set', type: 'main', index: 0 }]] },
 				},
 			}),
 			makeCtx(),
@@ -334,13 +334,13 @@ describe('no_unreachable_nodes', () => {
 					},
 				],
 				connections: {
-					Trigger: { main: [[{ node: 'Agent', type: 'main', index: 0 }]] },
-					LLM: { ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 0 }]] },
-					SubAgent: { ai_tool: [[{ node: 'Agent', type: 'ai_tool', index: 0 }]] },
-					SubLLM: {
-						ai_languageModel: [[{ node: 'SubAgent', type: 'ai_languageModel', index: 0 }]],
+					['Trigger']: { main: [[{ node: 'Agent', type: 'main', index: 0 }]] },
+					LLM: { ['ai_languageModel']: [[{ node: 'Agent', type: 'ai_languageModel', index: 0 }]] },
+					['SubAgent']: { ai_tool: [[{ node: 'Agent', type: 'ai_tool', index: 0 }]] },
+					['SubLLM']: {
+						['ai_languageModel']: [[{ node: 'SubAgent', type: 'ai_languageModel', index: 0 }]],
 					},
-					SearchTool: { ai_tool: [[{ node: 'SubAgent', type: 'ai_tool', index: 0 }]] },
+					['SearchTool']: { ai_tool: [[{ node: 'SubAgent', type: 'ai_tool', index: 0 }]] },
 				},
 			}),
 			makeCtx(),
@@ -510,7 +510,7 @@ describe('has_start_node', () => {
 					{ name: 'Set', type: 'n8n-nodes-base.set', typeVersion: 3, position: [200, 0] },
 				],
 				connections: {
-					Trigger: { main: [[{ node: 'Set', type: 'main', index: 0 }]] },
+					['Trigger']: { main: [[{ node: 'Set', type: 'main', index: 0 }]] },
 				},
 			}),
 			makeCtx(),
@@ -563,7 +563,7 @@ describe('expressions_reference_existing_nodes', () => {
 					},
 				],
 				connections: {
-					Trigger: { main: [[{ node: 'Set', type: 'main', index: 0 }]] },
+					['Trigger']: { main: [[{ node: 'Set', type: 'main', index: 0 }]] },
 				},
 			}),
 			makeCtx(),

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/checks/expressions-reference-existing-nodes.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/checks/expressions-reference-existing-nodes.ts
@@ -26,7 +26,7 @@ function collectMatches(pattern: RegExp, text: string, groupIndex: number): stri
 }
 
 /** Extract all referenced node names from an expression string. */
-function extractNodeNamesFromExpression(expression: string): string[] {
+export function extractNodeNamesFromExpression(expression: string): string[] {
 	const names: string[] = [];
 
 	for (const pattern of QUOTED_NODE_REFS) {
@@ -44,7 +44,7 @@ function extractNodeNamesFromExpression(expression: string): string[] {
 }
 
 /** Recursively extract all expression strings from node parameters. */
-function extractExpressionsFromParams(value: unknown, key?: string): string[] {
+export function extractExpressionsFromParams(value: unknown, key?: string): string[] {
 	if (typeof value === 'string') {
 		// Expressions start with '=', jsCode fields are also expressions
 		if (value.charAt(0) === '=' || key === 'jsCode') {

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/checks/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/checks/index.ts
@@ -6,6 +6,7 @@ import { noCodeImports } from './no-code-imports';
 import { noEmptySetNodes } from './no-empty-set-nodes';
 import { noUnnecessaryCodeNodes } from './no-unnecessary-code-nodes';
 import { noUnreachableNodes } from './no-unreachable-nodes';
+import { referencesReachableNodes } from './references-reachable-nodes';
 import {
 	agentHasDynamicPrompt,
 	agentHasLanguageModel,
@@ -35,6 +36,7 @@ export const DETERMINISTIC_CHECKS: BinaryCheck[] = [
 	noUnnecessaryCodeNodes,
 	noCodeImports,
 	expressionsReferenceExistingNodes,
+	referencesReachableNodes,
 	validRequiredParameters,
 	validOptionsValues,
 	noInvalidFromAi,

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/checks/references-reachable-nodes.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/checks/references-reachable-nodes.ts
@@ -1,0 +1,63 @@
+import { getParentNodes, mapConnectionsByDestination } from 'n8n-workflow';
+import type { IConnections, INode } from 'n8n-workflow';
+
+import type { BinaryCheck, SimpleWorkflow } from '../types';
+import {
+	extractExpressionsFromParams,
+	extractNodeNamesFromExpression,
+} from './expressions-reference-existing-nodes';
+
+function nodeReferenceIsInvalid(parents: Set<string>, nodeReference: string): boolean {
+	return !parents.has(nodeReference);
+}
+
+function nodeIsInvalid(connectionsByDest: IConnections, node: INode): boolean {
+	if (!node.parameters) return false;
+
+	const expressions = extractExpressionsFromParams(node.parameters);
+	const referencedNames = expressions.flatMap((expr: string) =>
+		extractNodeNamesFromExpression(expr),
+	);
+	const uniqReferencedNames = new Set<string>(referencedNames);
+
+	if (uniqReferencedNames.size === 0) return false;
+
+	const parents = new Set(getParentNodes(connectionsByDest, node.name, 'main', -1));
+	const invalidReferences = [...uniqReferencedNames].filter((nodeRef) =>
+		nodeReferenceIsInvalid(parents, nodeRef),
+	);
+	return invalidReferences.length > 0;
+}
+
+/**
+ * This deterministic check checks that every time a node references
+ * another node by name that node must be an ancestor, i.e. it must
+ * be reachable by following the parent chain upstream, using the same
+ * logic that the frontend implements currently in `workflow-data-proxy.ts`
+ *
+ * Fails when:
+ * 1. The referenced node does not exist in the workflow. (this actually
+ * makes "expressions_reference_existing_nodes" redundant)
+ * 2. The referenced node is not an ancestor of the current node.
+ */
+export const referencesReachableNodes: BinaryCheck = {
+	name: 'references_reachable_nodes',
+	kind: 'deterministic',
+	async run(workflow: SimpleWorkflow) {
+		if (!workflow.nodes || workflow.nodes.length === 0) {
+			return { pass: true };
+		}
+
+		const connections = workflow.connections ?? {};
+		const connectionsByDest = mapConnectionsByDestination(connections);
+
+		const allInvalidNodes = workflow.nodes.filter((node) => nodeIsInvalid(connectionsByDest, node));
+		const unique = [...new Set(allInvalidNodes)];
+		const uniqueNames = unique.map((node) => node.name);
+
+		return {
+			pass: unique.length === 0,
+			...(uniqueNames.length > 0 ? { comment: `Broken nodes: ${uniqueNames.join('; ')}` } : {}),
+		};
+	},
+};


### PR DESCRIPTION
## Summary

This PR adds a binary check that validates that all node references refer to nodes upstream.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.