### PR TITLE
fix(core): Declare credentialType on MCP workflow-builder autoAssignedCredentials schema

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
@@ -1,6 +1,7 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import { ProjectRepository, User, WorkflowEntity } from '@n8n/db';
 import type { INode } from 'n8n-workflow';
+import { z } from 'zod';
 
 import { createCreateWorkflowFromCodeTool } from '../tools/workflow-builder/create-workflow-from-code.tool';
 
@@ -10,6 +11,14 @@ import { UrlService } from '@/services/url.service';
 import { Telemetry } from '@/telemetry';
 import { WorkflowCreationService } from '@/workflows/workflow-creation.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+
+// Mock credentials auto-assign
+const mockAutoPopulateNodeCredentials = jest.fn();
+jest.mock('../tools/workflow-builder/credentials-auto-assign', () => ({
+	autoPopulateNodeCredentials: (...args: unknown[]) =>
+		mockAutoPopulateNodeCredentials(...args) as unknown,
+	stripNullCredentialStubs: jest.fn(),
+}));
 
 // Mock dynamic imports
 const mockParseAndValidate = jest.fn();
@@ -93,6 +102,7 @@ describe('create-workflow-from-code MCP tool', () => {
 
 		mockParseAndValidate.mockResolvedValue({ workflow: mockWorkflowJson });
 		mockStripImportStatements.mockImplementation((code: string) => code);
+		mockAutoPopulateNodeCredentials.mockResolvedValue({ assignments: [], skippedHttpNodes: [] });
 	});
 
 	const credentialsService = mockInstance(CredentialsService, {
@@ -351,6 +361,35 @@ describe('create-workflow-from-code MCP tool', () => {
 					}),
 				}),
 			);
+		});
+
+		test('structuredContent conforms to declared outputSchema under strict validation', async () => {
+			// Regression for #28274: MCP publishes outputSchema with additionalProperties: false,
+			// so any field returned by the handler but missing from the schema breaks strict clients.
+			mockAutoPopulateNodeCredentials.mockResolvedValue({
+				assignments: [
+					{ nodeName: 'Webhook', credentialName: 'My Cred', credentialType: 'webhookAuth' },
+				],
+				skippedHttpNodes: [],
+			});
+
+			const tool = createTool();
+			const result = (await tool.handler({ code: 'const wf = ...' } as never, {} as never)) as {
+				structuredContent: unknown;
+			};
+
+			const envelopeShape = tool.config.outputSchema as z.ZodRawShape;
+			const itemsField = envelopeShape.autoAssignedCredentials as z.ZodArray<
+				z.ZodObject<z.ZodRawShape>
+			>;
+			const strictSchema = z
+				.object({
+					...envelopeShape,
+					autoAssignedCredentials: z.array(itemsField.element.strict()),
+				})
+				.strict();
+
+			expect(() => strictSchema.parse(result.structuredContent)).not.toThrow();
 		});
 	});
 });

--- a/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
@@ -1,6 +1,7 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import { SharedWorkflowRepository, User, WorkflowEntity } from '@n8n/db';
 import type { INode } from 'n8n-workflow';
+import { z } from 'zod';
 
 import { createUpdateWorkflowTool } from '../tools/workflow-builder/update-workflow.tool';
 
@@ -399,6 +400,36 @@ describe('update-workflow MCP tool', () => {
 				{ nodeName: 'Webhook', credentialName: 'My Cred', credentialType: 'webhookAuth' },
 			]);
 			expect(response.note).toBeUndefined();
+		});
+
+		test('structuredContent conforms to declared outputSchema under strict validation', async () => {
+			// Regression for #28274: MCP publishes outputSchema with additionalProperties: false,
+			// so any field returned by the handler but missing from the schema breaks strict clients.
+			mockAutoPopulateNodeCredentials.mockResolvedValue({
+				assignments: [
+					{ nodeName: 'Webhook', credentialName: 'My Cred', credentialType: 'webhookAuth' },
+				],
+				skippedHttpNodes: [],
+			});
+
+			const tool = createTool();
+			const result = (await tool.handler(
+				{ workflowId: 'wf-1', code: 'const wf = ...' } as never,
+				{} as never,
+			)) as { structuredContent: unknown };
+
+			const envelopeShape = tool.config.outputSchema as z.ZodRawShape;
+			const itemsField = envelopeShape.autoAssignedCredentials as z.ZodArray<
+				z.ZodObject<z.ZodRawShape>
+			>;
+			const strictSchema = z
+				.object({
+					...envelopeShape,
+					autoAssignedCredentials: z.array(itemsField.element.strict()),
+				})
+				.strict();
+
+			expect(() => strictSchema.parse(result.structuredContent)).not.toThrow();
 		});
 
 		test('includes note about skipped HTTP nodes', async () => {

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
@@ -58,6 +58,7 @@ const outputSchema = {
 			z.object({
 				nodeName: z.string().describe('The name of the node that had credentials auto-assigned'),
 				credentialName: z.string().describe('The name of the credential that was auto-assigned'),
+				credentialType: z.string().describe('The credential type that was auto-assigned'),
 			}),
 		)
 		.describe('List of credentials that were automatically assigned to nodes'),

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -49,6 +49,7 @@ const outputSchema = {
 			z.object({
 				nodeName: z.string().describe('The name of the node that had credentials auto-assigned'),
 				credentialName: z.string().describe('The name of the credential that was auto-assigned'),
+				credentialType: z.string().describe('The credential type that was auto-assigned'),
 			}),
 		)
 		.describe('List of credentials that were automatically assigned to nodes'),


### PR DESCRIPTION
## Summary

The `create_workflow_from_code` and `update_workflow` MCP tools each declare an `outputSchema` for `autoAssignedCredentials` items containing only `nodeName` and `credentialName`. But the handlers return a third field, `credentialType`, that comes from `CredentialAssignment` in `credentials-auto-assign.ts`.

MCP publishes that schema to clients with `additionalProperties: false` (via `toJsonSchemaCompat`), so strict MCP clients — OpenCode was the one reported in the issue — reject the tool response even though the handler is working correctly.

The existing test at `update-workflow.tool.test.ts` already asserts `credentialType` is present in the response, which shows the field was meant to be exposed; the Zod schema simply wasn't updated to match.

This PR:

- Adds `credentialType` to the Zod `outputSchema` in both `create-workflow-from-code.tool.ts` and `update-workflow.tool.ts` so the published schema matches the actual handler output.
- Adds a regression test in each test file that invokes the handler with a non-empty assignment and parses `structuredContent` through a reconstructed strict version of the declared schema. Both tests fail on `master` and pass with the fix applied.

### How I tested

```
cd packages/cli
pnpm exec jest src/modules/mcp/__tests__/update-workflow.tool.test.ts \
               src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
# → 39 passed (both new tests green)

# Regression check: stash the fix, rerun → both new tests FAIL as expected.
pnpm exec eslint <the 4 files>           # clean
pnpm exec biome check <the 4 files>      # clean
```

## Related Linear tickets, Github issues, and Community forum posts

Fixes #28274

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. <!-- n/a — internal schema only -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)