### PR TITLE
fix(core): Use RFC-style default outbound User-Agent

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/outbound-user-agent.integration.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/outbound-user-agent.integration.test.ts
@@ -1,0 +1,33 @@
+import nock from 'nock';
+
+import { getDefaultN8nOutboundUserAgent } from '../outbound-user-agent';
+import { httpRequest } from '../request-helper-functions';
+
+/** Exercises the full httpRequest → axios path for the default User-Agent. */
+describe('Outbound User-Agent (httpRequest integration)', () => {
+	const baseUrl = 'https://example.com';
+
+	beforeEach(() => {
+		nock.cleanAll();
+	});
+
+	afterEach(() => {
+		nock.cleanAll();
+	});
+
+	it('sends RFC-style default User-Agent when none is provided', async () => {
+		const scope = nock(baseUrl, {
+			reqheaders: {
+				'user-agent': getDefaultN8nOutboundUserAgent(),
+			},
+		})
+			.get('/outbound-user-agent-integration')
+			.reply(200, { success: true });
+
+		await expect(
+			httpRequest({ method: 'GET', url: `${baseUrl}/outbound-user-agent-integration` }),
+		).resolves.toEqual({ success: true });
+
+		scope.done();
+	});
+});

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/outbound-user-agent.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/outbound-user-agent.test.ts
@@ -1,0 +1,30 @@
+import {
+	buildDefaultN8nOutboundUserAgent,
+	getDefaultN8nOutboundUserAgent,
+} from '../outbound-user-agent';
+
+describe('outbound-user-agent', () => {
+	it('buildDefaultN8nOutboundUserAgent uses a conventional product token', () => {
+		expect(buildDefaultN8nOutboundUserAgent('1.2.3')).toBe(
+			'Mozilla/5.0 (compatible; n8n/1.2.3; +https://n8n.io/)',
+		);
+	});
+
+	it('getDefaultN8nOutboundUserAgent returns a non-empty string', () => {
+		const ua = getDefaultN8nOutboundUserAgent();
+		expect(ua).toMatch(/^Mozilla\/5\.0 \(compatible; n8n\/.+; \+https:\/\/n8n\.io\/\)$/);
+	});
+
+	it('getDefaultN8nOutboundUserAgent falls back to 0.0.0 when package.json cannot be read', () => {
+		let ua: string | undefined;
+		jest.isolateModules(() => {
+			jest.mock('../../../../../package.json', () => {
+				throw new Error('Module not found');
+			});
+			// eslint-disable-next-line @typescript-eslint/no-require-imports
+			const mod = require('../outbound-user-agent') as typeof import('../outbound-user-agent');
+			ua = mod.getDefaultN8nOutboundUserAgent();
+		});
+		expect(ua).toBe('Mozilla/5.0 (compatible; n8n/0.0.0; +https://n8n.io/)');
+	});
+});

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
@@ -19,6 +19,7 @@ import type { SecureContextOptions } from 'tls';
 import type { SsrfBridge } from '@/execution-engine';
 import type { ExecutionLifecycleHooks } from '@/execution-engine/execution-lifecycle-hooks';
 
+import { getDefaultN8nOutboundUserAgent } from '../outbound-user-agent';
 import {
 	applyPaginationRequestData,
 	convertN8nRequestToAxios,
@@ -543,7 +544,7 @@ describe('Request Helper Functions', () => {
 					url: 'https://example.com',
 					headers: expect.objectContaining({
 						'Custom-Header': 'test',
-						'User-Agent': 'n8n',
+						'User-Agent': getDefaultN8nOutboundUserAgent(),
 					}),
 					params: { param1: 'value1' },
 				}),
@@ -589,7 +590,7 @@ describe('Request Helper Functions', () => {
 					data: formData,
 					headers: expect.objectContaining({
 						...formData.getHeaders(),
-						'User-Agent': 'n8n',
+						'User-Agent': getDefaultN8nOutboundUserAgent(),
 					}),
 				}),
 			);
@@ -953,29 +954,11 @@ describe('Request Helper Functions', () => {
 			scope.done();
 		});
 
-		test('should set default user agent', async () => {
-			const scope = nock(baseUrl, {
-				reqheaders: {
-					'user-agent': 'n8n',
-				},
-			})
-				.get('/test')
-				.reply(200, { success: true });
-
-			const response = await httpRequest({
-				method: 'GET',
-				url: `${baseUrl}/test`,
-			});
-
-			expect(response).toEqual({ success: true });
-			scope.done();
-		});
-
 		test('should respect custom headers', async () => {
 			const scope = nock(baseUrl, {
 				reqheaders: {
 					'X-Custom-Header': 'custom-value',
-					'user-agent': 'n8n',
+					'user-agent': getDefaultN8nOutboundUserAgent(),
 				},
 			})
 				.get('/test')

--- a/packages/core/src/execution-engine/node-execution-context/utils/outbound-user-agent.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/outbound-user-agent.ts
@@ -1,0 +1,31 @@
+import { join } from 'node:path';
+
+const N8N_PRODUCT_URL = 'https://n8n.io/';
+
+function readN8nVersion(): string {
+	try {
+		// require self-caches, so repeated calls are cheap
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		const pkg = require(join(__dirname, '../../../../package.json')) as { version: string };
+		return pkg.version;
+	} catch {
+		return '0.0.0';
+	}
+}
+
+/**
+ * Builds the default User-Agent for n8n-initiated HTTP requests when none is set.
+ * Uses a conventional browser-style token so strict WAFs accept the value.
+ *
+ * @see https://github.com/n8n-io/n8n/issues/28280
+ */
+export function buildDefaultN8nOutboundUserAgent(version: string): string {
+	return `Mozilla/5.0 (compatible; n8n/${version}; +${N8N_PRODUCT_URL})`;
+}
+
+/**
+ * Default User-Agent for n8n outbound HTTP requests (e.g. native integration nodes).
+ */
+export function getDefaultN8nOutboundUserAgent(): string {
+	return buildDefaultN8nOutboundUserAgent(readN8nVersion());
+}

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
@@ -71,6 +71,7 @@ import { callEvalMockHandler, normalizeLegacyRequest } from '@/execution-engine/
 import type { IResponseError } from '@/interfaces';
 
 import { binaryToString } from './binary-helper-functions';
+import { getDefaultN8nOutboundUserAgent } from './outbound-user-agent';
 import { parseIncomingMessage } from './parse-incoming-message';
 // Imported for side effects: sets axios defaults and registers the request interceptor
 import './request-helpers/axios-config';
@@ -613,7 +614,7 @@ export function convertN8nRequestToAxios(
 	if (!userAgentHeader) {
 		axiosRequest.headers = {
 			...axiosRequest.headers,
-			'User-Agent': 'n8n',
+			'User-Agent': getDefaultN8nOutboundUserAgent(),
 		};
 	}
 

--- a/packages/nodes-base/credentials/DropcontactApi.credentials.ts
+++ b/packages/nodes-base/credentials/DropcontactApi.credentials.ts
@@ -26,7 +26,6 @@ export class DropcontactApi implements ICredentialType {
 		type: 'generic',
 		properties: {
 			headers: {
-				'user-agent': 'n8n',
 				'X-Access-Token': '={{$credentials.apiKey}}',
 			},
 		},

--- a/packages/nodes-base/credentials/PerplexityApi.credentials.ts
+++ b/packages/nodes-base/credentials/PerplexityApi.credentials.ts
@@ -29,7 +29,6 @@ export class PerplexityApi implements ICredentialType {
 		properties: {
 			headers: {
 				Authorization: '=Bearer {{$credentials.apiKey}}',
-				'User-Agent': 'n8n',
 				'X-Source': 'n8n',
 			},
 		},

--- a/packages/nodes-base/credentials/RundeckApi.credentials.ts
+++ b/packages/nodes-base/credentials/RundeckApi.credentials.ts
@@ -33,7 +33,6 @@ export class RundeckApi implements ICredentialType {
 		type: 'generic',
 		properties: {
 			headers: {
-				'user-agent': 'n8n',
 				'X-Rundeck-Auth-Token': '={{$credentials?.token}}',
 			},
 		},

--- a/packages/nodes-base/nodes/ApiTemplateIo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ApiTemplateIo/GenericFunctions.ts
@@ -16,7 +16,6 @@ export async function apiTemplateIoApiRequest(
 ) {
 	const options: IRequestOptions = {
 		headers: {
-			'user-agent': 'n8n',
 			Accept: 'application/json',
 		},
 		uri: `https://api.apitemplate.io/v1${endpoint}`,

--- a/packages/nodes-base/nodes/Bitwarden/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Bitwarden/GenericFunctions.ts
@@ -43,7 +43,6 @@ export async function bitwardenApiRequest(
 	const baseUrl = await getBaseUrl.call(this);
 	const options: IRequestOptions = {
 		headers: {
-			'user-agent': 'n8n',
 			Authorization: `Bearer ${token}`,
 			'Content-Type': 'application/json',
 		},

--- a/packages/nodes-base/nodes/Bubble/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Bubble/GenericFunctions.ts
@@ -32,7 +32,6 @@ export async function bubbleApiRequest(
 
 	const options: IRequestOptions = {
 		headers: {
-			'user-agent': 'n8n',
 			Authorization: `Bearer ${apiToken}`,
 		},
 		method,

--- a/packages/nodes-base/nodes/Coda/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Coda/GenericFunctions.ts
@@ -23,7 +23,6 @@ export async function codaApiRequest(
 	let options: IRequestOptions = {
 		headers: {
 			Authorization: `Bearer ${credentials.accessToken}`,
-			'User-Agent': 'n8n',
 		},
 		method,
 		qs,

--- a/packages/nodes-base/nodes/Github/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Github/GenericFunctions.ts
@@ -23,9 +23,6 @@ export async function githubApiRequest(
 ): Promise<any> {
 	const options: IRequestOptions = {
 		method,
-		headers: {
-			'User-Agent': 'n8n',
-		},
 		body,
 		qs: query,
 		uri: '',

--- a/packages/nodes-base/nodes/Github/__tests__/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Github/__tests__/GenericFunctions.test.ts
@@ -53,7 +53,6 @@ describe('GenericFunctions', () => {
 				'githubApi',
 				{
 					method: 'GET',
-					headers: { 'User-Agent': 'n8n' },
 					body: {},
 					qs: undefined,
 					uri: 'https://api.github.com/repos/test-owner/test-repo',
@@ -103,7 +102,6 @@ describe('GenericFunctions', () => {
 				'githubApi',
 				{
 					method: 'GET',
-					headers: { 'User-Agent': 'n8n' },
 					body: {},
 					qs: { ref: 'main' },
 					uri: 'https://api.github.com/repos/test-owner/test-repo/contents/README.md',

--- a/packages/nodes-base/nodes/Github/__tests__/node/Github.node.test.ts
+++ b/packages/nodes-base/nodes/Github/__tests__/node/Github.node.test.ts
@@ -120,7 +120,6 @@ describe('Test Github Node', () => {
 					'githubOAuth2Api',
 					{
 						body: {},
-						headers: { 'User-Agent': 'n8n' },
 						json: true,
 						method: 'GET',
 						qs: {},

--- a/packages/nodes-base/nodes/GoToWebinar/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/GoToWebinar/GenericFunctions.ts
@@ -36,7 +36,6 @@ export async function goToWebinarApiRequest(
 
 	const options: IRequestOptions = {
 		headers: {
-			'user-agent': 'n8n',
 			Accept: 'application/json',
 			'Content-Type': 'application/json',
 		},

--- a/packages/nodes-base/nodes/Odoo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Odoo/GenericFunctions.ts
@@ -110,7 +110,6 @@ export async function odooJSONRPCRequest(
 	try {
 		const options: IRequestOptions = {
 			headers: {
-				'User-Agent': 'n8n',
 				Connection: 'keep-alive',
 				Accept: '*/*',
 				'Content-Type': 'application/json',

--- a/packages/nodes-base/nodes/Odoo/Odoo.node.ts
+++ b/packages/nodes-base/nodes/Odoo/Odoo.node.ts
@@ -248,7 +248,6 @@ export class Odoo implements INodeType {
 
 					const options: IRequestOptions = {
 						headers: {
-							'User-Agent': 'n8n',
 							Connection: 'keep-alive',
 							Accept: '*/*',
 							'Content-Type': 'application/json',

--- a/packages/nodes-base/nodes/QuickBase/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/QuickBase/GenericFunctions.ts
@@ -33,7 +33,6 @@ export async function quickbaseApiRequest(
 		const options: IRequestOptions = {
 			headers: {
 				'QB-Realm-Hostname': credentials.hostname,
-				'User-Agent': 'n8n',
 				Authorization: `QB-USER-TOKEN ${credentials.userToken}`,
 				'Content-Type': 'application/json',
 			},

--- a/packages/nodes-base/nodes/QuickBooks/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/QuickBooks/GenericFunctions.ts
@@ -43,9 +43,6 @@ export async function quickBooksApiRequest(
 	const credentials = await this.getCredentials<QuickBooksOAuth2Credentials>('quickBooksOAuth2Api');
 
 	const options: IRequestOptions = {
-		headers: {
-			'user-agent': 'n8n',
-		},
 		method,
 		uri: `${credentials.environment === 'sandbox' ? sandboxUrl : productionUrl}${endpoint}`,
 		qs,

--- a/packages/nodes-base/nodes/Raindrop/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Raindrop/GenericFunctions.ts
@@ -22,7 +22,6 @@ export async function raindropApiRequest(
 ) {
 	const options: IRequestOptions = {
 		headers: {
-			'user-agent': 'n8n',
 			'Content-Type': 'application/json',
 		},
 		method,

--- a/packages/nodes-base/nodes/Reddit/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Reddit/GenericFunctions.ts
@@ -24,9 +24,6 @@ export async function redditApiRequest(
 	qs.api_type = 'json';
 
 	const options: IRequestOptions = {
-		headers: {
-			'user-agent': 'n8n',
-		},
 		method,
 		uri: authRequired
 			? `https://oauth.reddit.com/${endpoint}`

--- a/packages/nodes-base/nodes/Spotify/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Spotify/GenericFunctions.ts
@@ -24,7 +24,6 @@ export async function spotifyApiRequest(
 	const options: IHttpRequestOptions = {
 		method,
 		headers: {
-			'User-Agent': 'n8n',
 			'Content-Type': 'text/plain',
 			Accept: ' application/json',
 		},

--- a/packages/nodes-base/nodes/Spotify/__tests__/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Spotify/__tests__/GenericFunctions.test.ts
@@ -31,7 +31,6 @@ describe('Spotify -> GenericFunctions', () => {
 			{
 				method,
 				headers: {
-					'User-Agent': 'n8n',
 					'Content-Type': 'text/plain',
 					Accept: ' application/json',
 				},

--- a/packages/nodes-base/nodes/UrlScanIo/descriptions/ScanDescription.ts
+++ b/packages/nodes-base/nodes/UrlScanIo/descriptions/ScanDescription.ts
@@ -142,7 +142,7 @@ export const scanFields: INodeProperties[] = [
 				displayName: 'Custom Agent',
 				name: 'customAgent',
 				description:
-					'<code>User-Agent</code> header to set for this scan. Defaults to <code>n8n</code>',
+					'<code>User-Agent</code> header to set for this scan. Defaults to n8n standard outbound User-Agent.',
 				type: 'string',
 				default: '',
 			},

--- a/packages/nodes-base/nodes/Wise/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Wise/GenericFunctions.ts
@@ -33,7 +33,6 @@ export async function wiseApiRequest(
 
 	const options: IHttpRequestOptions = {
 		headers: {
-			'user-agent': 'n8n',
 			Authorization: `Bearer ${apiToken}`,
 		},
 		method,

--- a/packages/nodes-base/nodes/Wordpress/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Wordpress/GenericFunctions.ts
@@ -46,7 +46,6 @@ export async function wordpressApiRequest(
 		headers: {
 			Accept: 'application/json',
 			'Content-Type': 'application/json',
-			'User-Agent': 'n8n',
 		},
 		method,
 		qs,


### PR DESCRIPTION
## Summary
- replace the default outbound `User-Agent` from bare `n8n` to a WAF-friendly RFC-style token (`Mozilla/5.0 (compatible; n8n/<version>; +https://n8n.io/)`)
- add a dedicated utility to resolve n8n version for outbound headers while preserving explicit user overrides
- add unit and integration tests covering user-agent generation and runtime request behavior
- implemented from a Cursor-assisted workflow

## Related Linear tickets, Github issues, and Community forum posts
- Fixes #28280
- https://github.com/n8n-io/n8n/issues/28280

## Test plan
- `cd packages/core && pnpm exec jest src/execution-engine/node-execution-context/utils/__tests__/outbound-user-agent.test.ts src/execution-engine/node-execution-context/utils/__tests__/outbound-user-agent.integration.test.ts src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts --no-cache`

## Review / Merge checklist
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if needed)
