### PR TITLE
fix(editor): Show saved credentials for HTTP Request dynamic auth types

### DIFF
--- a/packages/frontend/editor-ui/src/app/utils/nodes/getNodeTypeDisplayableCredentials.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodes/getNodeTypeDisplayableCredentials.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { INodeTypeDescription } from 'n8n-workflow';
+import { HTTP_REQUEST_NODE_TYPE, HTTP_REQUEST_TOOL_LANGCHAIN_NODE_TYPE } from 'n8n-workflow';
+
+import { HTTP_REQUEST_TOOL_NODE_TYPE } from '@/app/constants/nodeTypes';
+
+vi.mock('@/app/stores/nodeTypes.store', () => ({
+	useNodeTypesStore: vi.fn(() => ({
+		getNodeType: vi.fn(),
+	})),
+}));
+
+import { getNodeTypeDisplayableCredentials } from './nodeTransforms';
+
+/**
+ * Minimal HTTP Request–shaped description so NodeHelpers.getNodeParameters can resolve
+ * defaults and displayParameter for SSL + dynamic credential parameters.
+ */
+function minimalHttpRequestNodeType(): INodeTypeDescription {
+	return {
+		name: 'httpRequest',
+		displayName: 'HTTP Request',
+		version: [4.2],
+		defaults: { name: 'HTTP Request' },
+		inputs: ['main'],
+		outputs: ['main'],
+		group: ['transform'],
+		description: '',
+		credentials: [
+			{
+				name: 'httpSslAuth',
+				required: true,
+				displayOptions: {
+					show: {
+						provideSslCertificates: [true],
+					},
+				},
+			},
+		],
+		properties: [
+			{
+				displayName: 'Provide SSL',
+				name: 'provideSslCertificates',
+				type: 'boolean',
+				default: false,
+			},
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				noDataExpression: true,
+				options: [
+					{ name: 'None', value: 'none' },
+					{ name: 'Predefined', value: 'predefinedCredentialType' },
+					{ name: 'Generic', value: 'genericCredentialType' },
+				],
+				default: 'none',
+			},
+			{
+				displayName: 'Credential Type',
+				name: 'nodeCredentialType',
+				type: 'string',
+				default: '',
+				displayOptions: {
+					show: {
+						authentication: ['predefinedCredentialType'],
+					},
+				},
+			},
+			{
+				displayName: 'Generic Auth Type',
+				name: 'genericAuthType',
+				type: 'string',
+				default: '',
+				displayOptions: {
+					show: {
+						authentication: ['genericCredentialType'],
+					},
+				},
+			},
+		],
+	};
+}
+
+describe('getNodeTypeDisplayableCredentials (HTTP Request dynamic auth)', () => {
+	const nodeType = minimalHttpRequestNodeType();
+	const nodeTypeProvider = { getNodeType: () => nodeType };
+
+	it('includes nodeCredentialType when authentication is predefinedCredentialType', () => {
+		const result = getNodeTypeDisplayableCredentials(nodeTypeProvider, {
+			type: HTTP_REQUEST_NODE_TYPE,
+			typeVersion: 4.2,
+			parameters: {
+				authentication: 'predefinedCredentialType',
+				nodeCredentialType: 'anthropicApi',
+				provideSslCertificates: false,
+			},
+		});
+
+		expect(result.map((c) => c.name)).toContain('anthropicApi');
+		expect(result.map((c) => c.name)).not.toContain('httpSslAuth');
+	});
+
+	it('includes genericAuthType when authentication is genericCredentialType', () => {
+		const result = getNodeTypeDisplayableCredentials(nodeTypeProvider, {
+			type: HTTP_REQUEST_NODE_TYPE,
+			typeVersion: 4.2,
+			parameters: {
+				authentication: 'genericCredentialType',
+				genericAuthType: 'httpHeaderAuth',
+				provideSslCertificates: false,
+			},
+		});
+
+		expect(result.map((c) => c.name)).toEqual(['httpHeaderAuth']);
+	});
+
+	it('does not duplicate a credential type already present from static credentials', () => {
+		const result = getNodeTypeDisplayableCredentials(nodeTypeProvider, {
+			type: HTTP_REQUEST_NODE_TYPE,
+			typeVersion: 4.2,
+			parameters: {
+				authentication: 'predefinedCredentialType',
+				nodeCredentialType: 'httpSslAuth',
+				provideSslCertificates: true,
+			},
+		});
+
+		expect(result.filter((c) => c.name === 'httpSslAuth')).toHaveLength(1);
+	});
+
+	it('applies to HTTP Request Tool node types', () => {
+		for (const type of [HTTP_REQUEST_TOOL_NODE_TYPE, HTTP_REQUEST_TOOL_LANGCHAIN_NODE_TYPE]) {
+			const result = getNodeTypeDisplayableCredentials(nodeTypeProvider, {
+				type,
+				typeVersion: 1,
+				parameters: {
+					authentication: 'predefinedCredentialType',
+					nodeCredentialType: 'anthropicApi',
+					provideSslCertificates: false,
+				},
+			});
+			expect(result.map((c) => c.name)).toContain('anthropicApi');
+		}
+	});
+});

--- a/packages/frontend/editor-ui/src/app/utils/nodes/nodeTransforms.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodes/nodeTransforms.ts
@@ -3,6 +3,7 @@ import {
 	AI_MCP_TOOL_NODE_TYPE,
 	WIKIPEDIA_TOOL_NODE_TYPE,
 } from '@/app/constants';
+import { HTTP_REQUEST_TOOL_NODE_TYPE } from '@/app/constants/nodeTypes';
 import type { INodeUi } from '@/Interface';
 import type { NodeTypeProvider } from '@/app/utils/nodeTypes/nodeTypeTransforms';
 import type {
@@ -10,8 +11,45 @@ import type {
 	FromAIArgument,
 	INodePropertyOptions,
 } from 'n8n-workflow';
-import { isHitlToolType, NodeHelpers, traverseNodeParameters } from 'n8n-workflow';
+import {
+	HTTP_REQUEST_NODE_TYPE,
+	HTTP_REQUEST_TOOL_LANGCHAIN_NODE_TYPE,
+	isHitlToolType,
+	NodeHelpers,
+	traverseNodeParameters,
+} from 'n8n-workflow';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+
+const HTTP_REQUEST_LIKE_NODE_TYPES: ReadonlySet<string> = new Set([
+	HTTP_REQUEST_NODE_TYPE,
+	HTTP_REQUEST_TOOL_NODE_TYPE,
+	HTTP_REQUEST_TOOL_LANGCHAIN_NODE_TYPE,
+]);
+
+function isHttpRequestLikeNodeType(nodeTypeName: string | undefined): boolean {
+	return nodeTypeName !== undefined && HTTP_REQUEST_LIKE_NODE_TYPES.has(nodeTypeName);
+}
+
+function appendDynamicHttpRequestCredentials(
+	displayable: INodeCredentialDescription[],
+	nodeParameters: Record<string, unknown>,
+): INodeCredentialDescription[] {
+	const authentication = nodeParameters.authentication;
+	let dynamicType = '';
+	if (authentication === 'predefinedCredentialType') {
+		const raw = nodeParameters.nodeCredentialType;
+		dynamicType = typeof raw === 'string' ? raw : '';
+	} else if (authentication === 'genericCredentialType') {
+		const raw = nodeParameters.genericAuthType;
+		dynamicType = typeof raw === 'string' ? raw : '';
+	}
+
+	if (dynamicType === '' || displayable.some((c) => c.name === dynamicType)) {
+		return displayable;
+	}
+
+	return [...displayable, { name: dynamicType }];
+}
 
 /**
  * Returns the credentials that are displayable for the given node.
@@ -41,9 +79,16 @@ export function getNodeTypeDisplayableCredentials(
 			nodeType,
 		) ?? node.parameters;
 
-	const displayableCredentials = nodeTypeCreds.filter((credentialTypeDescription) => {
+	let displayableCredentials = nodeTypeCreds.filter((credentialTypeDescription) => {
 		return NodeHelpers.displayParameter(nodeParameters, credentialTypeDescription, node, nodeType);
 	});
+
+	if (isHttpRequestLikeNodeType(node.type)) {
+		displayableCredentials = appendDynamicHttpRequestCredentials(
+			displayableCredentials,
+			nodeParameters as Record<string, unknown>,
+		);
+	}
 
 	return displayableCredentials;
 }

--- a/packages/frontend/editor-ui/src/features/credentials/__tests__/credentials.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/__tests__/credentials.store.test.ts
@@ -3,6 +3,7 @@ import { mock } from 'vitest-mock-extended';
 import type { ICredentialsResponse } from '../credentials.types';
 import * as credentialsApi from '../credentials.api';
 import { useCredentialsStore } from '../credentials.store';
+import type { ICredentialType, INodeTypeDescription } from 'n8n-workflow';
 
 const mockRootStore = {
 	restApiContext: { baseUrl: 'http://localhost:5678', sessionId: 'test-session' },
@@ -329,6 +330,50 @@ describe('credentials.store', () => {
 			});
 
 			expect(store.state.credentials['cred-1']?.sharedWithProjects).toEqual(newSharing);
+		});
+	});
+
+	describe('getCredentialTypesNodeDescriptions', () => {
+		it('returns a minimal descriptor when the credential type is not loaded in the store yet', () => {
+			const store = useCredentialsStore();
+			const httpNodeType = {
+				credentials: [
+					{
+						name: 'httpSslAuth',
+						displayOptions: { show: { provideSslCertificates: [true] } },
+					},
+				],
+			} as unknown as INodeTypeDescription;
+
+			const result = store.getCredentialTypesNodeDescriptions('anthropicApi', httpNodeType);
+
+			expect(result).toEqual([{ name: 'anthropicApi' }]);
+		});
+
+		it('returns static node credentials when override is an empty string', () => {
+			const store = useCredentialsStore();
+			const staticCred = { name: 'httpSslAuth' };
+			const httpNodeType = { credentials: [staticCred] } as unknown as INodeTypeDescription;
+
+			const result = store.getCredentialTypesNodeDescriptions('', httpNodeType);
+
+			expect(result).toEqual([staticCred]);
+		});
+
+		it('returns the registered credential type when it exists in the store', () => {
+			const store = useCredentialsStore();
+			const anthropic: ICredentialType = {
+				name: 'anthropicApi',
+				displayName: 'Anthropic',
+				documentationUrl: '',
+				properties: [],
+			};
+			store.setCredentialTypes([anthropic]);
+
+			const result = store.getCredentialTypesNodeDescriptions('anthropicApi', null);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].name).toBe('anthropicApi');
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/credentials/credentials.store.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/credentials.store.ts
@@ -337,11 +337,20 @@ export const useCredentialsStore = defineStore(STORES.CREDENTIALS, () => {
 	) => INodeCredentialDescription[] = (overrideCredType, nodeType) => {
 		if (typeof overrideCredType !== 'string') return [];
 
+		// Empty override: use the node type's static credentials (e.g. HTTP Request SSL cert).
+		if (overrideCredType === '') {
+			return nodeType?.credentials ? nodeType.credentials : [];
+		}
+
 		const credType = getCredentialTypeByName.value(overrideCredType);
 
 		if (credType) return [credType];
 
-		return nodeType?.credentials ? nodeType.credentials : [];
+		// Credential types can be absent from the store briefly (e.g. before fetchCredentialTypes
+		// completes). Falling back to node.credentials would only expose unrelated entries (e.g.
+		// httpSslAuth for HTTP Request) and breaks CredentialsSelect for dynamic types such as
+		// anthropicApi — see https://github.com/n8n-io/n8n/issues/28272
+		return [{ name: overrideCredType }];
 	};
 
 	const createNewCredential = async (


### PR DESCRIPTION
## Summary

The HTTP Request node stores the active auth mode in parameters (`predefinedCredentialType` + `nodeCredentialType`, or `genericCredentialType` + `genericAuthType`), not only in the node type’s static `credentials` list (which is effectively SSL-only for HTTP Request).

The credential picker could show no saved credentials (or target the wrong credential slot) because:

1. **`getCredentialTypesNodeDescriptions`**: When the selected credential type was not yet present in the credential-types store, the code fell back to the node’s static `credentials` array. For HTTP Request that did not reflect the active `nodeCredentialType`, so the UI could not list the right saved credentials.
2. **`getNodeTypeDisplayableCredentials`**: It only surfaced credentials from the node description. Dynamic HTTP Request auth types from parameters were omitted, which broke downstream helpers (for example setup flows that derive required credential types from displayable credentials).

This PR fixes both paths for HTTP Request and HTTP Request–like node types, and adds unit tests for the store helper and `getNodeTypeDisplayableCredentials`.

### How to test

1. Add an **HTTP Request** node, set **Authentication** to **Predefined Credential Type**, pick a service credential type (for example **Anthropic**), and open the credential selector: your saved credentials for that type should appear and remain selectable after saving and reloading the workflow.
2. Smoke-test **Generic Credential Type** and **SSL certificates** on HTTP Request to confirm no regression.

## Related Linear tickets, Github issues, and Community forum posts

Fixes https://github.com/n8n-io/n8n/issues/28272

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
