### PR TITLE
fix(Gitlab Node): Handle binary data in all storage modes

### DIFF
--- a/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
@@ -1623,12 +1623,12 @@ export class Gitlab implements INodeType {
 						}
 
 						if (this.getNodeParameter('binaryData', i)) {
-							// Currently internally n8n uses base64 and also GitLab expects it base64 encoded.
-							// If that ever changes the data has to get converted here.
+							// GitLab expects base64 encoded content.
+							// Use getBinaryDataBuffer to correctly resolve the binary content
+							// regardless of the binary data storage mode (memory or filesystem).
 							const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
-							const binaryData = this.helpers.assertBinaryData(i, binaryPropertyName);
-							// TODO: Does this work with filesystem mode
-							body.content = binaryData.data;
+							const buffer = await this.helpers.getBinaryDataBuffer(i, binaryPropertyName);
+							body.content = buffer.toString('base64');
 							body.encoding = 'base64';
 						} else {
 							// Is text file

--- a/packages/nodes-base/nodes/Gitlab/__tests__/Gitlab.file.create.test.ts
+++ b/packages/nodes-base/nodes/Gitlab/__tests__/Gitlab.file.create.test.ts
@@ -1,0 +1,236 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+import { Gitlab } from '../Gitlab.node';
+import * as GenericFunctions from '../GenericFunctions';
+
+jest.mock('../GenericFunctions', () => ({
+	...jest.requireActual('../GenericFunctions'),
+	gitlabApiRequest: jest.fn(),
+}));
+
+describe('Gitlab Node - File Create/Edit Operations', () => {
+	let gitlab: Gitlab;
+	let mockExecuteFunctions: jest.Mocked<IExecuteFunctions>;
+
+	beforeEach(() => {
+		gitlab = new Gitlab();
+		jest.clearAllMocks();
+
+		mockExecuteFunctions = {
+			getNodeParameter: jest.fn(),
+			getInputData: jest.fn().mockReturnValue([{ json: {} }]),
+			getNode: jest.fn().mockReturnValue({
+				id: 'test-node-id',
+				name: 'Gitlab',
+				type: 'n8n-nodes-base.gitlab',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			}),
+			helpers: {
+				assertBinaryData: jest.fn(),
+				getBinaryDataBuffer: jest.fn(),
+				requestWithAuthentication: jest.fn(),
+				returnJsonArray: jest.fn((data) => (Array.isArray(data) ? data : [data])),
+				constructExecutionMetaData: jest.fn((data) => data),
+			},
+			getCredentials: jest.fn().mockResolvedValue({
+				accessToken: 'test-token',
+				server: 'https://gitlab.example.com',
+			}),
+			continueOnFail: jest.fn().mockReturnValue(false),
+		} as unknown as jest.Mocked<IExecuteFunctions>;
+	});
+
+	describe('File Create - Binary Data', () => {
+		it('should use getBinaryDataBuffer to correctly resolve binary content', async () => {
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockImplementation(
+				(paramName: string, _itemIndex: number, fallback?: unknown) => {
+					const params: Record<string, unknown> = {
+						authentication: 'accessToken',
+						resource: 'file',
+						operation: 'create',
+						owner: 'test-owner',
+						repository: 'test-repo',
+						filePath: 'test/file.txt',
+						branch: 'main',
+						commitMessage: 'Add test file',
+						binaryData: true,
+						binaryPropertyName: 'data',
+						additionalParameters: {},
+					};
+					return params[paramName] ?? fallback;
+				},
+			);
+
+			const expectedBuffer = Buffer.from('test binary content');
+			(mockExecuteFunctions.helpers.getBinaryDataBuffer as jest.Mock).mockResolvedValue(
+				expectedBuffer,
+			);
+
+			(GenericFunctions.gitlabApiRequest as jest.Mock).mockResolvedValue({
+				file_path: 'test/file.txt',
+				branch: 'main',
+			});
+
+			const result = await gitlab.execute.call(mockExecuteFunctions);
+
+			expect(mockExecuteFunctions.helpers.getBinaryDataBuffer).toHaveBeenCalledWith(0, 'data');
+
+			expect(GenericFunctions.gitlabApiRequest).toHaveBeenCalledWith(
+				'POST',
+				expect.stringContaining('/repository/files/'),
+				expect.objectContaining({
+					content: expectedBuffer.toString('base64'),
+					encoding: 'base64',
+					commit_message: 'Add test file',
+					branch: 'main',
+				}),
+				{},
+			);
+
+			expect(result).toBeDefined();
+			expect(result.length).toBeGreaterThan(0);
+		});
+	});
+
+	describe('File Edit - Binary Data', () => {
+		it('should use getBinaryDataBuffer for edit operations with binary data', async () => {
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockImplementation(
+				(paramName: string, _itemIndex: number, fallback?: unknown) => {
+					const params: Record<string, unknown> = {
+						authentication: 'accessToken',
+						resource: 'file',
+						operation: 'edit',
+						owner: 'test-owner',
+						repository: 'test-repo',
+						filePath: 'test/file.txt',
+						branch: 'main',
+						commitMessage: 'Update test file',
+						binaryData: true,
+						binaryPropertyName: 'data',
+						additionalParameters: {},
+					};
+					return params[paramName] ?? fallback;
+				},
+			);
+
+			const expectedBuffer = Buffer.from('updated binary content');
+			(mockExecuteFunctions.helpers.getBinaryDataBuffer as jest.Mock).mockResolvedValue(
+				expectedBuffer,
+			);
+
+			(GenericFunctions.gitlabApiRequest as jest.Mock).mockResolvedValue({
+				file_path: 'test/file.txt',
+				branch: 'main',
+			});
+
+			const result = await gitlab.execute.call(mockExecuteFunctions);
+
+			expect(mockExecuteFunctions.helpers.getBinaryDataBuffer).toHaveBeenCalledWith(0, 'data');
+
+			expect(GenericFunctions.gitlabApiRequest).toHaveBeenCalledWith(
+				'PUT',
+				expect.stringContaining('/repository/files/'),
+				expect.objectContaining({
+					content: expectedBuffer.toString('base64'),
+					encoding: 'base64',
+					commit_message: 'Update test file',
+					branch: 'main',
+				}),
+				{},
+			);
+
+			expect(result).toBeDefined();
+			expect(result.length).toBeGreaterThan(0);
+		});
+	});
+
+	describe('File Create - Text Content', () => {
+		it('should encode text content as base64 when encoding is set to base64', async () => {
+			const fileContent = 'Hello, World!';
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockImplementation(
+				(paramName: string, _itemIndex: number, fallback?: unknown) => {
+					const params: Record<string, unknown> = {
+						authentication: 'accessToken',
+						resource: 'file',
+						operation: 'create',
+						owner: 'test-owner',
+						repository: 'test-repo',
+						filePath: 'test/file.txt',
+						branch: 'main',
+						commitMessage: 'Add text file',
+						binaryData: false,
+						fileContent,
+						additionalParameters: { encoding: 'base64' },
+					};
+					return params[paramName] ?? fallback;
+				},
+			);
+
+			(GenericFunctions.gitlabApiRequest as jest.Mock).mockResolvedValue({
+				file_path: 'test/file.txt',
+				branch: 'main',
+			});
+
+			const result = await gitlab.execute.call(mockExecuteFunctions);
+
+			expect(GenericFunctions.gitlabApiRequest).toHaveBeenCalledWith(
+				'POST',
+				expect.stringContaining('/repository/files/'),
+				expect.objectContaining({
+					content: Buffer.from(fileContent).toString('base64'),
+					commit_message: 'Add text file',
+					branch: 'main',
+				}),
+				{},
+			);
+
+			expect(result).toBeDefined();
+			expect(result.length).toBeGreaterThan(0);
+		});
+
+		it('should send text content as-is when encoding is not base64', async () => {
+			const fileContent = 'Hello, World!';
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockImplementation(
+				(paramName: string, _itemIndex: number, fallback?: unknown) => {
+					const params: Record<string, unknown> = {
+						authentication: 'accessToken',
+						resource: 'file',
+						operation: 'create',
+						owner: 'test-owner',
+						repository: 'test-repo',
+						filePath: 'test/file.txt',
+						branch: 'main',
+						commitMessage: 'Add text file',
+						binaryData: false,
+						fileContent,
+						additionalParameters: {},
+					};
+					return params[paramName] ?? fallback;
+				},
+			);
+
+			(GenericFunctions.gitlabApiRequest as jest.Mock).mockResolvedValue({
+				file_path: 'test/file.txt',
+				branch: 'main',
+			});
+
+			const result = await gitlab.execute.call(mockExecuteFunctions);
+
+			expect(GenericFunctions.gitlabApiRequest).toHaveBeenCalledWith(
+				'POST',
+				expect.stringContaining('/repository/files/'),
+				expect.objectContaining({
+					content: fileContent,
+					commit_message: 'Add text file',
+					branch: 'main',
+				}),
+				{},
+			);
+
+			expect(result).toBeDefined();
+			expect(result.length).toBeGreaterThan(0);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Fix binary file upload in the GitLab node when using filesystem-based binary data storage (`N8N_DEFAULT_BINARY_DATA_MODE=filesystem`).

**The bug:** When uploading binary files via the GitLab node (File → Create or Edit with binary data), the node sent `binaryData.data` directly — which in filesystem mode contains a storage metadata reference (~7 bytes) instead of the actual file content.

**The fix:** Use `getBinaryDataBuffer()` to correctly resolve the binary content regardless of storage mode, then convert to base64. This is the same fix applied to the GitHub node in [PR #23497](https://github.com/n8n-io/n8n/pull/23497).

**How to test:**
1. Set `N8N_DEFAULT_BINARY_DATA_MODE=filesystem`
2. Create a workflow: Read File → GitLab (File → Create, binary data mode)
3. Upload a binary file to a GitLab repository
4. Verify the uploaded file has the correct content and size (not ~7 bytes)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4255
Fixes #24809

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)