### PR TITLE
fix(Google Cloud Firestore Node): fix empty array type coercion in jsonToDocument

### DIFF
--- a/packages/cli/src/modules/mcp/mcp.controller.ts
+++ b/packages/cli/src/modules/mcp/mcp.controller.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@n8n/backend-common';
 import { AuthenticatedRequest } from '@n8n/db';
-import { Head, Post, RootLevelController } from '@n8n/decorators';
+import { Get, Head, Post, RootLevelController } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 import type { Request, Response } from 'express';
 import { ErrorReporter } from 'n8n-core';
@@ -65,6 +65,54 @@ export class McpController {
 		this.setCorsHeaders(res);
 		res.header('WWW-Authenticate', 'Bearer realm="n8n MCP Server"');
 		res.status(401).end();
+	}
+
+	/**
+	 * GET endpoint for SSE stream connections
+	 * Some MCP clients (e.g. Gemini CLI) use GET requests to establish SSE streams
+	 * for server-initiated messages per the MCP Streamable HTTP transport spec.
+	 */
+	@Get('/http', {
+		middlewares: [getAuthMiddleware()],
+		skipAuth: true,
+		usesTemplates: true,
+	})
+	async stream(req: AuthenticatedRequest, res: FlushableResponse) {
+		this.setCorsHeaders(res);
+
+		const enabled = await this.mcpSettingsService.getEnabled();
+		if (!enabled) {
+			res.status(403).json({ message: MCP_ACCESS_DISABLED_ERROR_MESSAGE });
+			return;
+		}
+
+		try {
+			const { StreamableHTTPServerTransport } = await import(
+				'@modelcontextprotocol/sdk/server/streamableHttp.js'
+			);
+			const server = await this.mcpService.getServer(req.user);
+			const transport = new StreamableHTTPServerTransport({
+				sessionIdGenerator: undefined,
+			});
+			res.on('close', () => {
+				void transport.close();
+				void server.close();
+			});
+			await server.connect(transport);
+			await transport.handleRequest(req, res);
+		} catch (error) {
+			this.errorReporter.error(error);
+			if (!res.headersSent) {
+				res.status(500).json({
+					jsonrpc: '2.0',
+					error: {
+						code: -32603,
+						message: INTERNAL_SERVER_ERROR_MESSAGE,
+					},
+					id: null,
+				});
+			}
+		}
 	}
 
 	@Post('/http', {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/utils/fromAIOverride.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/utils/fromAIOverride.utils.test.ts
@@ -112,6 +112,17 @@ describe('makeOverrideValue', () => {
 		expect(makeOverrideValue(context, nodeType)).toBeNull();
 	});
 
+	it('should create an fromAI override for a field named "name"', () => {
+		getNodeType.mockReturnValue(AI_NODE_TYPE);
+		const result = makeOverrideValue(
+			makeContext('', 'parameters.name'),
+			mockNodeFromType(AI_NODE_TYPE),
+		);
+
+		expect(result).not.toBeNull();
+		expect(result?.type).toEqual('fromAI');
+	});
+
 	it('should create an fromAI override', () => {
 		getNodeType.mockReturnValue(AI_NODE_TYPE);
 		const result = makeOverrideValue(

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/utils/fromAIOverride.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/utils/fromAIOverride.utils.ts
@@ -54,7 +54,6 @@ const NODE_DENYLIST = [
 ] as const;
 
 const PATH_DENYLIST = [
-	'parameters.name',
 	// this is used in vector store tools
 	'parameters.toolName',
 	'parameters.description',

--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GenericFunctions.ts
@@ -90,7 +90,7 @@ export function jsonToDocument(value: string | number | IDataObject | IDataObjec
 		return { booleanValue: value };
 	} else if (value === null) {
 		return { nullValue: null };
-	} else if (value !== '' && !isNaN(value as number)) {
+	} else if (value !== '' && !Array.isArray(value) && !isNaN(value as number)) {
 		if (value.toString().indexOf('.') !== -1) {
 			return { doubleValue: value };
 		} else {

--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/__test__/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/__test__/GenericFunctions.test.ts
@@ -284,6 +284,16 @@ describe('GoogleFirebaseCloudFirestore > GenericFunctions', () => {
 			});
 		});
 
+		it('should convert empty arrays to arrayValue, not integerValue', () => {
+			const result = jsonToDocument([] as any);
+			expect(result).toEqual({ arrayValue: { values: [] } });
+		});
+
+		it('should convert single-element numeric arrays to arrayValue', () => {
+			const result = jsonToDocument([42] as any);
+			expect(result).toEqual({ arrayValue: { values: [{ integerValue: 42 }] } });
+		});
+
 		it('should convert objects', () => {
 			const obj = {
 				name: 'John',

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -1,3 +1,4 @@
+import FormData from 'form-data';
 import { lookup } from 'mime-types';
 import type {
 	IExecuteFunctions,
@@ -2158,23 +2159,55 @@ export class Telegram implements INodeType {
 						uploadData = Buffer.from(itemBinaryData.data, BINARY_ENCODING);
 					}
 
-					const formData = {
-						...body,
-						[propertyName]: {
-							value: uploadData,
-							options: {
-								filename,
-								contentType: itemBinaryData.mimeType,
-							},
-						},
-					};
+					// Serialize reply_markup before building form data
+					if (body.reply_markup) {
+						body.reply_markup = JSON.stringify(body.reply_markup);
+					}
 
-					if (formData.reply_markup) {
-						formData.reply_markup = JSON.stringify(formData.reply_markup);
+					let formData: IDataObject | FormData;
+
+					// Use RFC 5987 encoding (filename*=UTF-8'') for filenames containing
+					// non-ASCII characters (e.g. Chinese punctuation). Raw UTF-8 bytes in
+					// Content-Disposition headers are technically non-standard and some
+					// servers (including Telegram's API) may strip or corrupt them.
+					if (filename && /[^\x00-\x7F]/.test(filename)) {
+						const fd = new FormData();
+
+						for (const [key, value] of Object.entries(body)) {
+							if (value !== undefined && value !== null) {
+								fd.append(key, String(value));
+							}
+						}
+
+						const boundary = fd.getBoundary();
+						// ASCII-safe fallback for servers that don't support filename*
+						const asciiFilename = filename.replace(/[^\x00-\x7F]/g, '_');
+						const encodedFilename = encodeURIComponent(filename);
+						const customHeader = [
+							`--${boundary}`,
+							`Content-Disposition: form-data; name="${propertyName}"; filename="${asciiFilename}"; filename*=UTF-8''${encodedFilename}`,
+							`Content-Type: ${itemBinaryData.mimeType}`,
+							'',
+							'',
+						].join('\r\n');
+
+						fd.append(propertyName, uploadData, { header: customHeader });
+						formData = fd;
+					} else {
+						formData = {
+							...body,
+							[propertyName]: {
+								value: uploadData,
+								options: {
+									filename,
+									contentType: itemBinaryData.mimeType,
+								},
+							},
+						};
 					}
 
 					responseData = await apiRequest.call(this, requestMethod, endpoint, {}, qs, {
-						formData,
+						formData: formData as IDataObject,
 					});
 				} else {
 					responseData = await apiRequest.call(this, requestMethod, endpoint, body, qs);

--- a/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
@@ -1,3 +1,4 @@
+import FormData from 'form-data';
 import { mockDeep } from 'jest-mock-extended';
 import type {
 	IExecuteFunctions,
@@ -748,6 +749,93 @@ describe('Telegram node', () => {
 			expectChatId(1, 'chat-id-0');
 			expectChatId(2, 'chat-id-1');
 			expectChatId(3, 'chat-id-2');
+		});
+	});
+
+	describe('message:sendDocument with non-ASCII filenames', () => {
+		const setupSendDocument = (fileName: string) => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((paramName) => {
+				switch (paramName) {
+					case 'resource':
+						return 'message';
+					case 'operation':
+						return 'sendDocument';
+					case 'binaryData':
+						return true;
+					case 'chatId':
+						return 'chat-id';
+					case 'binaryPropertyName':
+						return 'data';
+					case 'additionalFields.fileName':
+						return fileName;
+					case 'additionalFields':
+						return {};
+					default:
+						return undefined;
+				}
+			});
+
+			executeFunctionsMock.getInputData.mockReturnValue([
+				{
+					json: {},
+					binary: {
+						data: {
+							data: 'dGVzdA==',
+							mimeType: 'text/markdown',
+							fileName,
+						},
+					},
+				},
+			]);
+
+			executeFunctionsMock.helpers.assertBinaryData.mockReturnValue({
+				data: 'dGVzdA==',
+				mimeType: 'text/markdown',
+				fileName,
+			});
+
+			apiRequestSpy.mockResolvedValue([{ result: { document: { file_name: fileName } } }]);
+		};
+
+		it('should use a FormData instance with RFC 5987 encoding for filenames with non-ASCII characters', async () => {
+			const nonAsciiFilename = '认知天性【标题已矫正】.md';
+			setupSendDocument(nonAsciiFilename);
+
+			await node.execute.call(executeFunctionsMock);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				'POST',
+				'sendDocument',
+				{},
+				{},
+				expect.objectContaining({
+					formData: expect.any(FormData),
+				}),
+			);
+		});
+
+		it('should use a plain object for filenames with only ASCII characters', async () => {
+			const asciiFilename = 'document.md';
+			setupSendDocument(asciiFilename);
+
+			await node.execute.call(executeFunctionsMock);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				'POST',
+				'sendDocument',
+				{},
+				{},
+				expect.objectContaining({
+					formData: expect.objectContaining({
+						document: expect.objectContaining({
+							options: expect.objectContaining({
+								filename: asciiFilename,
+								contentType: 'text/markdown',
+							}),
+						}),
+					}),
+				}),
+			);
 		});
 	});
 });


### PR DESCRIPTION
Fixes #28212

## Problem

Empty arrays (e.g., `[]`) in Firestore documents fail with:

```
Invalid JSON payload received. Unknown name "integerValue" at 'writes[0].update.fields[x].value': Proto field is not repeating, cannot start list.
```

The root cause is a JavaScript type coercion quirk: `Number([])` evaluates to `0` (not `NaN`), so the numeric type check in `jsonToDocument` incorrectly handles empty arrays before the array check is reached. The function returns `{ integerValue: [] }` instead of `{ arrayValue: { values: [] } }`.

The same coercion bug also affects single-element numeric arrays (e.g., `[0]` → `Number([0]) === 0`).

## Solution

Add `!Array.isArray(value)` to the numeric guard so arrays of all sizes bypass the numeric check and correctly fall through to the `arrayValue` branch.

```diff
-} else if (value !== '' && !isNaN(value as number)) {
+} else if (value !== '' && !Array.isArray(value) && !isNaN(value as number)) {
```

## Testing

Added two unit tests to `GenericFunctions.test.ts`:
- `should convert empty arrays to arrayValue, not integerValue` — verifies `[]` → `{ arrayValue: { values: [] } }`
- `should convert single-element numeric arrays to arrayValue` — verifies `[42]` → `{ arrayValue: { values: [{ integerValue: 42 }] } }`