### PR TITLE
fix(nodes-langchain): clear timer on PendingCallsManager.remove() and expand test coverage

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/execution/PendingCallsManager.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/execution/PendingCallsManager.ts
@@ -63,6 +63,10 @@ export class PendingCallsManager {
 	}
 
 	remove(callId: string): void {
+		const pending = this.pendingCalls[callId];
+		if (pending) {
+			clearTimeout(pending.timer);
+		}
 		delete this.pendingCalls[callId];
 	}
 

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/execution/__tests__/PendingCallsManager.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/execution/__tests__/PendingCallsManager.test.ts
@@ -247,5 +247,31 @@ describe('PendingCallsManager', () => {
 		it('should handle removing non-existent call', () => {
 			expect(() => manager.remove('non-existent')).not.toThrow();
 		});
+
+		it('should clear the timer when removing a pending call', async () => {
+			const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+
+			const promise = manager.waitForResult('call-1', 'tool', {}, 1000);
+			manager.remove('call-1');
+
+			expect(clearTimeoutSpy).toHaveBeenCalled();
+
+			clearTimeoutSpy.mockRestore();
+			// Drain the hanging promise to avoid open handles
+			await Promise.race([promise.catch(() => {}), Promise.resolve()]);
+		});
+
+		it('should not reject the promise when the timeout fires after removal', async () => {
+			const settled = { value: false };
+			const promise = manager.waitForResult('call-1', 'tool', {}, 500);
+			promise.then(() => (settled.value = true)).catch(() => (settled.value = true));
+
+			manager.remove('call-1');
+			jest.advanceTimersByTime(600);
+
+			await Promise.resolve();
+
+			expect(settled.value).toBe(false);
+		});
 	});
 });


### PR DESCRIPTION
## Summary

`PendingCallsManager.remove()` was deleting the pending call entry without first clearing its timeout timer. This meant the timer could still fire after removal and invoke `this.reject(callId, ...)` — a no-op since the entry was already deleted, but wasteful and semantically incorrect.

**Fix:** Call `clearTimeout(pending.timer)` before deletion, consistent with how `resolve()` and `reject()` already handle cleanup.

**Tests added:**
- Verifies `clearTimeout` is called when a pending call is removed
- Verifies the promise never settles (neither resolves nor rejects) after removal, even when the original timeout elapses

## Related Linear tickets, Github issues, and Community forum posts

<!-- No Linear ticket for this fix -->

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.