### PR TITLE
fix(editor): sanitize cURL URL placeholders when flags appear before URL

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useImportCurlCommand.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useImportCurlCommand.test.ts
@@ -648,6 +648,27 @@ describe('sanitizeCurlUrlPlaceholders', () => {
 		);
 	});
 
+	test('should sanitize placeholder in URL when curl has a method flag before it', () => {
+		const curl = 'curl -X POST https://api.openai.com/v1/agents/<AGENT_ID>/runs';
+		const result = sanitizeCurlUrlPlaceholders(curl);
+		expect(result).toBe('curl -X POST https://api.openai.com/v1/agents/{AGENT_ID}/runs');
+	});
+
+	test('should sanitize placeholder in URL when curl has multiple flags before it', () => {
+		const curl =
+			'curl -X GET https://api.example.com/<RESOURCE_ID>/data -H "Authorization: Bearer <TOKEN>"';
+		const result = sanitizeCurlUrlPlaceholders(curl);
+		expect(result).toBe(
+			'curl -X GET https://api.example.com/{RESOURCE_ID}/data -H "Authorization: Bearer <TOKEN>"',
+		);
+	});
+
+	test('should sanitize placeholder in quoted URL when curl has a method flag before it', () => {
+		const curl = "curl -X DELETE 'https://api.example.com/v1/users/<USER_ID>'";
+		const result = sanitizeCurlUrlPlaceholders(curl);
+		expect(result).toBe("curl -X DELETE 'https://api.example.com/v1/users/{USER_ID}'");
+	});
+
 	test('should parse cURL command with unknown content-type', () => {
 		const curl = `curl --request POST \
   --url https://example.com/api \

--- a/packages/frontend/editor-ui/src/app/composables/useImportCurlCommand.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useImportCurlCommand.ts
@@ -235,16 +235,22 @@ export const flattenObject = <T extends Record<string, unknown>>(obj: T, prefix 
 /**
  * Extracts and sanitizes the URL in a cURL command.
  * Converts invalid placeholder syntax like \<PLACEHOLDER\> → {PLACEHOLDER}
+ * Handles URLs that appear after curl flags (e.g., curl -X POST https://...)
  */
 export function sanitizeCurlUrlPlaceholders(curlCommand: string): string {
-	const CURL_URL_REGEX = /curl\s+(['"]?)(https?:\/\/[^\s'"]+)\1/;
+	// Match the first URL in the command (optionally quoted).
+	// The URL may appear after flags like -X POST or -H "..." rather than
+	// immediately after 'curl', so we don't anchor the match to 'curl'.
+	const URL_REGEX = /(['"]?)(https?:\/\/[^\s'"]+)\1/;
 	const PLACEHOLDER_REGEX = /<([A-Za-z0-9_-]+)>/g;
 
-	const urlMatch = curlCommand.match(CURL_URL_REGEX);
+	const urlMatch = curlCommand.match(URL_REGEX);
 	if (!urlMatch || !urlMatch[2]) return curlCommand;
 
 	const originalUrl = urlMatch[2];
 	const sanitizedUrl = originalUrl.replaceAll(PLACEHOLDER_REGEX, '{$1}');
+
+	if (originalUrl === sanitizedUrl) return curlCommand;
 
 	return curlCommand.replace(originalUrl, sanitizedUrl);
 }


### PR DESCRIPTION
## Summary

- `sanitizeCurlUrlPlaceholders` previously only matched URLs that appeared **immediately after `curl`**, missing the common case where method or header flags precede the URL
- As a result, angle-bracket placeholders like `<AGENT_ID>` were not converted to `{AGENT_ID}` when the curl command used flags first (e.g. `curl -X POST https://api.example.com/<AGENT_ID>/runs`)
- The URL would then be percent-encoded as `%3CAGENT_ID%3E` instead of the expected `{AGENT_ID}`

**Root cause:** The old regex `/curl\s+(['"]?)(https?:\/\/[^\s'"]+)\1/` required the URL to follow directly after `curl`. The fix removes the `curl` anchor so the first `https?://` URL in the command is matched regardless of preceding flags.

Fixes #28359

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.