### PR TITLE
fix(core): Drain webhook close functions to prevent MCP connection leaks

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -375,6 +375,7 @@ export class McpClientTool implements INodeType {
 		this.logger.debug('McpClientTool: Successfully connected to MCP Server');
 
 		if (!mcpTools?.length) {
+			await client.close();
 			return setError(
 				new NodeOperationError(node, 'MCP Server returned no tools', {
 					itemIndex,
@@ -384,34 +385,39 @@ export class McpClientTool implements INodeType {
 			);
 		}
 
-		const tools = mcpTools.map((tool) => {
-			const prefixedName = buildMcpToolName(node.name, tool.name);
-			return logWrapper(
-				mcpToolToDynamicTool(
-					{ ...tool, name: prefixedName },
-					createCallTool(
-						tool.name,
-						client,
-						config.timeout,
-						(errorMessage) => {
-							const error = new NodeOperationError(node, errorMessage, { itemIndex });
-							void this.addOutputData(NodeConnectionTypes.AiTool, itemIndex, error);
-							this.logger.error(`McpClientTool: Tool "${tool.name}" failed to execute`, {
-								error,
-							});
-						},
-						() => this.getExecutionCancelSignal(),
+		try {
+			const tools = mcpTools.map((tool) => {
+				const prefixedName = buildMcpToolName(node.name, tool.name);
+				return logWrapper(
+					mcpToolToDynamicTool(
+						{ ...tool, name: prefixedName },
+						createCallTool(
+							tool.name,
+							client,
+							config.timeout,
+							(errorMessage) => {
+								const error = new NodeOperationError(node, errorMessage, { itemIndex });
+								void this.addOutputData(NodeConnectionTypes.AiTool, itemIndex, error);
+								this.logger.error(`McpClientTool: Tool "${tool.name}" failed to execute`, {
+									error,
+								});
+							},
+							() => this.getExecutionCancelSignal(),
+						),
 					),
-				),
-				this,
-			);
-		});
+					this,
+				);
+			});
 
-		this.logger.debug(`McpClientTool: Connected to MCP Server with ${tools.length} tools`);
+			this.logger.debug(`McpClientTool: Connected to MCP Server with ${tools.length} tools`);
 
-		const toolkit = new StructuredToolkit(tools);
+			const toolkit = new StructuredToolkit(tools);
 
-		return { response: toolkit, closeFunction: async () => await client.close() };
+			return { response: toolkit, closeFunction: async () => await client.close() };
+		} catch (e) {
+			await client.close();
+			throw e;
+		}
 	}
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
@@ -546,6 +546,26 @@ describe('McpClientTool', () => {
 			);
 		});
 
+		it('should close client when MCP server returns no tools', async () => {
+			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [] });
+			const closeSpy = jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+
+			await expect(
+				new McpClientTool().supplyData.call(
+					mock<ISupplyDataFunctions>({
+						getNode: jest.fn(() => mock<INode>({ typeVersion: 1, name: 'MCP Client' })),
+						logger: { debug: jest.fn(), error: jest.fn() },
+						addInputData: jest.fn(() => ({ index: 0 })),
+						addOutputData: jest.fn(),
+					}),
+					0,
+				),
+			).rejects.toThrow('MCP Server returned no tools');
+
+			expect(closeSpy).toHaveBeenCalledTimes(1);
+		});
+
 		it('should call client.close() when closeFunction is invoked', async () => {
 			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
 			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({

--- a/packages/cli/src/webhooks/__tests__/webhook.service.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook.service.test.ts
@@ -513,6 +513,38 @@ describe('WebhookService', () => {
 			expect(result).toEqual(responseData);
 			expect(nodeType.webhook).toHaveBeenCalled();
 		});
+
+		test('should run close functions after webhook completes', async () => {
+			const closeFunction = jest.fn().mockResolvedValue(undefined);
+			const nodeType = mock<INodeType>({
+				webhook: jest.fn().mockImplementation(async function (this: any) {
+					this.closeFunctions.push(closeFunction);
+					return responseData;
+				}),
+			});
+			nodeTypes.getByNameAndVersion.mockReturnValue(nodeType);
+
+			await webhookService.runWebhook(workflow, webhookData, node, additionalData, 'trigger', null);
+
+			expect(closeFunction).toHaveBeenCalledTimes(1);
+		});
+
+		test('should run close functions even when webhook throws', async () => {
+			const closeFunction = jest.fn().mockResolvedValue(undefined);
+			const nodeType = mock<INodeType>({
+				webhook: jest.fn().mockImplementation(async function (this: any) {
+					this.closeFunctions.push(closeFunction);
+					throw new Error('webhook failed');
+				}),
+			});
+			nodeTypes.getByNameAndVersion.mockReturnValue(nodeType);
+
+			await expect(
+				webhookService.runWebhook(workflow, webhookData, node, additionalData, 'trigger', null),
+			).rejects.toThrow('webhook failed');
+
+			expect(closeFunction).toHaveBeenCalledTimes(1);
+		});
 	});
 
 	describe('findCached()', () => {

--- a/packages/cli/src/webhooks/webhook.service.ts
+++ b/packages/cli/src/webhooks/webhook.service.ts
@@ -449,18 +449,32 @@ export class WebhookService {
 			});
 		}
 
+		const closeFunctions: Array<() => Promise<void>> = [];
 		const context = new WebhookContext(
 			workflow,
 			node,
 			additionalData,
 			mode,
 			webhookData,
-			[],
+			closeFunctions,
 			runExecutionData ?? null,
 		);
 
-		return nodeType instanceof Node
-			? await nodeType.webhook(context)
-			: ((await nodeType.webhook.call(context)) as IWebhookResponseData);
+		try {
+			return nodeType instanceof Node
+				? await nodeType.webhook(context)
+				: ((await nodeType.webhook.call(context)) as IWebhookResponseData);
+		} finally {
+			const settledResults = await Promise.allSettled(closeFunctions.map(async (fn) => await fn()));
+			for (const result of settledResults) {
+				if (result.status === 'rejected') {
+					this.logger.error('Failed to run webhook close function', {
+						error: ensureError(result.reason),
+						nodeName: node.name,
+						nodeType: node.type,
+					});
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary

`WebhookService.runWebhook()` passed an empty `closeFunctions` array to `WebhookContext` but never executed the accumulated callbacks after the webhook handler returned. This caused MCP Client Tool connections opened via McpTrigger webhooks to leak on every request — each request opened a new outbound SSE/HTTP connection that was never closed.

This PR:
1. **Drains `closeFunctions`** in a `try/finally` block after `runWebhook()` completes (success or error)
2. **Closes the MCP client in `supplyData`** when the server returns no tools (previously the client was left open)
3. **Wraps `supplyData` tool construction in try/catch** to close the client if any error occurs after connection but before `closeFunction` is registered

## Related Linear tickets, Github issues, and Community forum posts

Fixes https://github.com/n8n-io/n8n/issues/25740

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.