### PR TITLE
refactor(editor): Migrate Workflow class usages in Vue props and function arguments

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
@@ -51,6 +51,7 @@ import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
+import type { WorkflowObjectAccessors } from '../types';
 
 declare namespace HttpRequestNode {
 	namespace V2 {
@@ -775,7 +776,7 @@ export function useNodeHelpers() {
 	function getNodeSubtitle(
 		data: INode,
 		nodeType: INodeTypeDescription,
-		workflow: Workflow,
+		workflow: WorkflowObjectAccessors,
 	): string | undefined {
 		if (!data) {
 			return undefined;
@@ -966,7 +967,7 @@ export function useNodeHelpers() {
 	}
 
 	function getNodeHints(
-		workflow: Workflow,
+		workflow: WorkflowObjectAccessors,
 		node: INode,
 		nodeTypeData: INodeTypeDescription,
 		nodeInputData?: {

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
@@ -416,6 +416,11 @@ describe('useRunWorkflow({ router })', () => {
 					[parentNodeName]: createTestNode({ name: parentNodeName }),
 					[destinationNodeName]: createTestNode({ name: destinationNodeName }),
 				},
+				getNode: (name: string) => {
+					if (name === parentNodeName) return createTestNode({ name: parentNodeName });
+					if (name === destinationNodeName) return createTestNode({ name: destinationNodeName });
+					return null;
+				},
 			} as unknown as Workflow;
 
 			vi.mocked(pushConnectionStore).isConnected = true;
@@ -496,6 +501,10 @@ describe('useRunWorkflow({ router })', () => {
 				name: 'Test Workflow',
 				getParentNodes: () => [parentName],
 				nodes: { [parentName]: {} },
+				getNode: (name: string) => {
+					if (name === parentName) return {};
+					return null;
+				},
 			} as unknown as Workflow;
 			vi.mocked(workflowHelpers).getWorkflowDataToSave.mockResolvedValue({
 				nodes: [],
@@ -1074,6 +1083,7 @@ describe('useRunWorkflow({ router })', () => {
 			const workflowMock = {
 				getParentNodes: vi.fn(),
 				nodes: {},
+				getNode: () => null,
 			} as unknown as Workflow;
 
 			const result = consolidateRunDataAndStartNodes([], null, undefined, workflowMock);
@@ -1099,6 +1109,12 @@ describe('useRunWorkflow({ router })', () => {
 					node1: { disabled: false },
 					node2: { disabled: false },
 					node3: { disabled: true },
+				},
+				getNode: (name: string) => {
+					if (name === 'node1') return { disabled: false };
+					if (name === 'node2') return { disabled: false };
+					if (name === 'node3') return { disabled: true };
+					return null;
 				},
 			} as unknown as Workflow;
 
@@ -1129,6 +1145,10 @@ describe('useRunWorkflow({ router })', () => {
 			const workflowMock = {
 				getParentNodes: vi.fn().mockReturnValue([]),
 				nodes: { node1: { disabled: false } },
+				getNode: (name: string) => {
+					if (name === 'node1') return { disabled: false };
+					return null;
+				},
 			} as unknown as Workflow;
 
 			const result = consolidateRunDataAndStartNodes(
@@ -1157,6 +1177,11 @@ describe('useRunWorkflow({ router })', () => {
 				nodes: {
 					node1: { disabled: false },
 					node2: { disabled: false },
+				},
+				getNode: (name: string) => {
+					if (name === 'node1') return { disabled: false };
+					if (name === 'node2') return { disabled: false };
+					return null;
 				},
 			} as unknown as Workflow;
 
@@ -1207,6 +1232,10 @@ describe('useRunWorkflow({ router })', () => {
 			vi.mocked(workflowsStore).workflowObject = {
 				id: 'workflowId',
 				nodes: { [chatTrigger.name]: chatTrigger },
+				getNode: (name: string) => {
+					if (name === chatTrigger.name) return chatTrigger;
+					return null;
+				},
 			} as unknown as Workflow;
 			vi.mocked(workflowsStore).selectedTriggerNodeName = undefined;
 			vi.mocked(workflowHelpers).getWorkflowDataToSave.mockResolvedValue({
@@ -1242,6 +1271,11 @@ describe('useRunWorkflow({ router })', () => {
 				nodes: {
 					[chatTrigger.name]: chatTrigger,
 					[manualTrigger.name]: manualTrigger,
+				},
+				getNode: (name: string) => {
+					if (name === chatTrigger.name) return chatTrigger;
+					if (name === manualTrigger.name) return manualTrigger;
+					return null;
 				},
 			} as unknown as Workflow;
 			vi.mocked(workflowsStore).selectedTriggerNodeName = undefined;

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
@@ -63,6 +63,7 @@ import { computed } from 'vue';
 import { injectWorkflowState, type WorkflowState } from '@/app/composables/useWorkflowState';
 import { useDocumentTitle } from './useDocumentTitle';
 import { useChat } from '@n8n/chat/composables';
+import type { WorkflowObjectAccessors } from '../types';
 
 export function useRunWorkflow(useRunWorkflowOpts: {
 	router: ReturnType<typeof useRouter>;
@@ -462,7 +463,7 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 		directParentNodes: string[],
 		runData: IRunData | null,
 		pinData: IPinData | undefined,
-		workflow: Workflow,
+		workflow: WorkflowObjectAccessors,
 	): { runData: IRunData | undefined; startNodeNames: string[] } {
 		const startNodeNames = new Set<string>();
 		let newRunData: IRunData | undefined;
@@ -476,7 +477,7 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 				const parentNodes = workflow.getParentNodes(directParentNode, NodeConnectionTypes.Main);
 
 				// Add also the enabled direct parent to be checked
-				if (workflow.nodes[directParentNode].disabled) continue;
+				if (workflow.getNode(directParentNode)?.disabled) continue;
 
 				parentNodes.push(directParentNode);
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -63,6 +63,7 @@ import {
 	createWorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
 import { computed } from 'vue';
+import type { WorkflowObjectAccessors } from '../types';
 
 export type ResolveParameterOptions = {
 	targetItem?: TargetItem;
@@ -117,7 +118,7 @@ export async function resolveParameter<T = IDataObject>(
 // TODO: move to separate file
 function resolveParameterImpl<T = IDataObject>(
 	parameter: NodeParameterValue | INodeParameters | NodeParameterValue[] | INodeParameters[],
-	workflowObject: Workflow,
+	workflowObject: WorkflowObjectAccessors,
 	connections: IConnections,
 	envVars: Record<string, string | boolean | number>,
 	ndvActiveNode: INodeUi | null,
@@ -332,7 +333,7 @@ export async function resolveRequiredParameters(
 
 function getConnectedNodes(
 	direction: 'upstream' | 'downstream',
-	workflow: Workflow,
+	workflow: WorkflowObjectAccessors,
 	nodeName: string,
 ): string[] {
 	let checkNodes: string[];

--- a/packages/frontend/editor-ui/src/app/stores/nodeTypes.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/nodeTypes.store.ts
@@ -21,7 +21,6 @@ import type {
 	INodeOutputConfiguration,
 	INodeTypeDescription,
 	INodeTypeNameVersion,
-	Workflow,
 	NodeConnectionType,
 } from 'n8n-workflow';
 import { NodeConnectionTypes, NodeHelpers } from 'n8n-workflow';
@@ -34,6 +33,7 @@ import { computed, ref } from 'vue';
 import { useActionsGenerator } from '@/features/shared/nodeCreator/composables/useActionsGeneration';
 import { removePreviewToken } from '@/features/shared/nodeCreator/nodeCreator.utils';
 import { useSettingsStore } from '@/app/stores/settings.store';
+import type { WorkflowObjectAccessors } from '../types';
 
 export type NodeTypesStore = ReturnType<typeof useNodeTypesStore>;
 
@@ -155,8 +155,8 @@ export const useNodeTypesStore = defineStore(STORES.NODE_TYPES, () => {
 	});
 
 	const isConfigNode = computed(() => {
-		return (workflow: Workflow, node: INode, nodeTypeName: string): boolean => {
-			if (!workflow.nodes[node.name]) {
+		return (workflow: WorkflowObjectAccessors, node: INode, nodeTypeName: string): boolean => {
+			if (!workflow.getNode(node.name)) {
 				return false;
 			}
 			const nodeType =
@@ -299,7 +299,7 @@ export const useNodeTypesStore = defineStore(STORES.NODE_TYPES, () => {
 
 	const isConfigurableNode = computed(() => {
 		return (
-			workflow: Workflow,
+			workflow: WorkflowObjectAccessors,
 			node: INode,
 			nodeTypeName: string,
 			nodeTypeVersion?: number,

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentExpression.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentExpression.ts
@@ -1,4 +1,5 @@
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import type { WorkflowExpression } from 'n8n-workflow';
 
 // --- Composable ---
 
@@ -13,8 +14,8 @@ export function useWorkflowDocumentExpression() {
 	// Expression resolution
 	// -----------------------------------------------------------------------
 
-	function getExpressionHandler() {
-		return workflowsStore.workflowObject.expression;
+	function getExpressionHandler(): WorkflowExpression {
+		return workflowsStore.workflowObject.expression as WorkflowExpression;
 	}
 
 	return {

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -1718,6 +1718,9 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		getNodeTypes,
 		getNodes,
 		convertTemplateNodeToNodeUi,
+		/**
+		 * @deprecated
+		 */
 		workflowObject,
 		createWorkflowObject,
 		cloneWorkflowObject,

--- a/packages/frontend/editor-ui/src/app/types/expressions.ts
+++ b/packages/frontend/editor-ui/src/app/types/expressions.ts
@@ -1,6 +1,7 @@
 import type { Basic } from '@/Interface';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
-import type { IConnections, IWorkflowDataProxyAdditionalKeys, Workflow } from 'n8n-workflow';
+import type { IConnections, IWorkflowDataProxyAdditionalKeys } from 'n8n-workflow';
+import type { WorkflowObjectAccessors } from './workflow';
 
 type Range = { from: number; to: number };
 
@@ -40,7 +41,7 @@ export interface ExpressionLocalResolveContext {
 	localResolve: true;
 	envVars: Record<string, Basic>;
 	additionalKeys: IWorkflowDataProxyAdditionalKeys;
-	workflow: Workflow;
+	workflow: WorkflowObjectAccessors;
 	connections: IConnections;
 	execution: IExecutionResponse | null;
 	nodeName: string;

--- a/packages/frontend/editor-ui/src/app/types/index.ts
+++ b/packages/frontend/editor-ui/src/app/types/index.ts
@@ -1,2 +1,3 @@
 export type * from './externalHooks';
 export type * from './pushConnection';
+export type * from './workflow';

--- a/packages/frontend/editor-ui/src/app/types/workflow.ts
+++ b/packages/frontend/editor-ui/src/app/types/workflow.ts
@@ -1,0 +1,19 @@
+import type { Workflow } from 'n8n-workflow';
+
+/**
+ * Temporary interface describing the subset of the Workflow class used across the frontend.
+ * Will be removed when workflowsStore.workflowObject migration is complete.
+ */
+export type WorkflowObjectAccessors = Pick<
+	Workflow,
+	| 'id'
+	| 'connectionsBySourceNode'
+	| 'expression'
+	| 'pinData'
+	| 'getNode'
+	| 'getChildNodes'
+	| 'getParentNodes'
+	| 'getParentNodesByDepth'
+	| 'getNodeConnectionIndexes'
+	| 'getParentMainInputNode'
+>;

--- a/packages/frontend/editor-ui/src/app/utils/nodeViewUtils.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodeViewUtils.test.ts
@@ -66,7 +66,7 @@ describe('getGenericHints', () => {
 			nodeOutputData: mockNodeOutputData,
 			hasMultipleInputItems,
 			hasNodeRun,
-			nodes: {},
+			getNodeByName: () => null,
 			connections: {},
 		});
 
@@ -92,7 +92,7 @@ describe('getGenericHints', () => {
 			nodeOutputData: mockNodeOutputData,
 			hasMultipleInputItems,
 			hasNodeRun,
-			nodes: {},
+			getNodeByName: () => null,
 			connections: {},
 		});
 
@@ -131,7 +131,7 @@ describe('getGenericHints', () => {
 			nodeOutputData: mockNodeOutputData,
 			hasMultipleInputItems,
 			hasNodeRun,
-			nodes: {},
+			getNodeByName: () => null,
 			connections: {},
 		});
 
@@ -156,7 +156,7 @@ describe('getGenericHints', () => {
 			nodeOutputData: mockNodeOutputData,
 			hasMultipleInputItems,
 			hasNodeRun,
-			nodes: {},
+			getNodeByName: () => null,
 			connections: {},
 		});
 
@@ -181,7 +181,7 @@ describe('getGenericHints', () => {
 			nodeOutputData: mockNodeOutputData,
 			hasMultipleInputItems,
 			hasNodeRun,
-			nodes: {},
+			getNodeByName: () => null,
 			connections: {},
 		});
 
@@ -207,7 +207,7 @@ describe('getGenericHints', () => {
 			nodeOutputData: mockNodeOutputData,
 			hasMultipleInputItems,
 			hasNodeRun,
-			nodes: {},
+			getNodeByName: () => null,
 			connections: {},
 		});
 

--- a/packages/frontend/editor-ui/src/app/utils/nodeViewUtils.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodeViewUtils.ts
@@ -14,7 +14,6 @@ import type {
 	IConnections,
 	INode,
 	INodeExecutionData,
-	INodes,
 	INodeTypeDescription,
 	NodeHint,
 } from 'n8n-workflow';
@@ -388,7 +387,7 @@ export function getGenericHints({
 	nodeType,
 	nodeOutputData,
 	hasMultipleInputItems,
-	nodes,
+	getNodeByName,
 	connections,
 	hasNodeRun,
 }: {
@@ -397,7 +396,7 @@ export function getGenericHints({
 	nodeType: INodeTypeDescription;
 	nodeOutputData: INodeExecutionData[];
 	hasMultipleInputItems: boolean;
-	nodes: INodes;
+	getNodeByName: (name: string) => INode | null;
 	connections: IConnections;
 	hasNodeRun: boolean;
 }) {
@@ -436,7 +435,7 @@ export function getGenericHints({
 		hasMultipleInputItems &&
 		LIST_LIKE_NODE_OPERATIONS.includes((workflowNode.parameters.operation as string) || '')
 	) {
-		const executeOnce = workflowUtils.getNodeByName(nodes, node.name)?.executeOnce;
+		const executeOnce = getNodeByName(node.name)?.executeOnce;
 		if (!executeOnce) {
 			nodeHints.push({
 				message:
@@ -448,7 +447,7 @@ export function getGenericHints({
 
 	// add sendAndWait hint
 	if (hasMultipleInputItems && workflowNode.parameters.operation === SEND_AND_WAIT_OPERATION) {
-		const executeOnce = workflowUtils.getNodeByName(nodes, node.name)?.executeOnce;
+		const executeOnce = getNodeByName(node.name)?.executeOnce;
 		if (!executeOnce) {
 			nodeHints.push({
 				message: 'This action will run only once, for the first input item',

--- a/packages/frontend/editor-ui/src/features/execution/executions/executions.utils.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/executions.utils.ts
@@ -13,10 +13,10 @@ import type {
 	ExecutionError,
 	INodeTypeBaseDescription,
 	INodeExecutionData,
-	Workflow,
 	IWorkflowDataProxyAdditionalKeys,
 } from 'n8n-workflow';
 import type { INodeUi, IWorkflowDb } from '@/Interface';
+import type { WorkflowObjectAccessors } from '@/app/types/workflow';
 import type {
 	ExecutionFilterType,
 	ExecutionPreviewNodeSchema,
@@ -187,7 +187,7 @@ export async function displayForm({
 
 export const waitingNodeTooltip = (
 	node: INodeUi | null | undefined,
-	workflow?: Workflow,
+	workflow?: WorkflowObjectAccessors,
 	metadata?: { resumeUrl?: string; resumeFormUrl?: string },
 ) => {
 	if (!node) return '';

--- a/packages/frontend/editor-ui/src/features/execution/logs/logs.types.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/logs.types.ts
@@ -1,9 +1,10 @@
+import type { WorkflowObjectAccessors } from '@/app/types';
 import type {
 	LOG_DETAILS_PANEL_STATE,
 	LOGS_PANEL_STATE,
 } from '@/features/execution/logs/logs.constants';
 import type { INodeUi, LlmTokenUsageData } from '@/Interface';
-import type { IRunExecutionData, ITaskData, Workflow } from 'n8n-workflow';
+import type { IRunExecutionData, ITaskData } from 'n8n-workflow';
 
 export type LogEntry = {
 	parent?: LogEntry;
@@ -13,7 +14,7 @@ export type LogEntry = {
 	runIndex: number;
 	runData: ITaskData | undefined;
 	consumedTokens: LlmTokenUsageData;
-	workflow: Workflow;
+	workflow: WorkflowObjectAccessors;
 	executionId: string;
 	execution: IRunExecutionData;
 	isSubExecution: boolean;
@@ -22,10 +23,10 @@ export type LogEntry = {
 export interface LogTreeCreationContext {
 	parent: LogEntry | undefined;
 	ancestorRunIndexes: number[];
-	workflow: Workflow;
+	workflow: WorkflowObjectAccessors;
 	executionId: string;
 	data: IRunExecutionData;
-	workflows: Record<string, Workflow>;
+	workflows: Record<string, WorkflowObjectAccessors>;
 	subWorkflowData: Record<string, IRunExecutionData>;
 	isSubExecution: boolean;
 }

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/InputNodeSelect.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/InputNodeSelect.vue
@@ -4,7 +4,7 @@ import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { isPresent } from '@/app/utils/typesUtils';
-import type { IConnectedNode, Workflow } from 'n8n-workflow';
+import type { IConnectedNode } from 'n8n-workflow';
 import { computed } from 'vue';
 import NodeIcon from '@/app/components/NodeIcon.vue';
 import { truncate } from '@n8n/utils/string/truncate';
@@ -12,7 +12,6 @@ import { truncate } from '@n8n/utils/string/truncate';
 import { N8nOption, N8nSelect } from '@n8n/design-system';
 type Props = {
 	nodes: IConnectedNode[];
-	workflow: Workflow;
 	modelValue: string | null;
 };
 

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/InputPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/InputPanel.vue
@@ -18,11 +18,11 @@ import uniqBy from 'lodash/uniqBy';
 import {
 	type INodeInputConfiguration,
 	type INodeOutputConfiguration,
-	type Workflow,
 	type NodeConnectionType,
 	NodeConnectionTypes,
 	NodeHelpers,
 } from 'n8n-workflow';
+import type { WorkflowObjectAccessors } from '@/app/types/workflow';
 import { computed, ref, watch } from 'vue';
 import InputNodeSelect from './InputNodeSelect.vue';
 import NodeExecuteButton from '@/app/components/NodeExecuteButton.vue';
@@ -42,7 +42,7 @@ type MappingMode = 'debugging' | 'mapping';
 
 export type Props = {
 	runIndex: number;
-	workflowObject: Workflow;
+	workflowObject: WorkflowObjectAccessors;
 	pushRef: string;
 	activeNodeName: string;
 	currentNodeName?: string;
@@ -463,7 +463,6 @@ function handleChangeCollapsingColumn(columnName: string | null) {
 			<InputNodeSelect
 				v-if="parentNodes.length && currentNodeName"
 				:model-value="currentNodeName"
-				:workflow="workflowObject"
 				:nodes="parentNodes"
 				@update:model-value="onInputNodeChange"
 			/>
@@ -477,7 +476,6 @@ function handleChangeCollapsingColumn(columnName: string | null) {
 			<div :class="$style.mappedNode">
 				<InputNodeSelect
 					:model-value="mappedNode"
-					:workflow="workflowObject"
 					:nodes="rootNodesParents"
 					@update:model-value="onMappedNodeSelected"
 				/>

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/OutputPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/OutputPanel.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue';
-import { NodeConnectionTypes, type IRunData, type Workflow } from 'n8n-workflow';
+import { NodeConnectionTypes, type IRunData } from 'n8n-workflow';
 import RunData from '@/features/ndv/runData/components/RunData.vue';
 import RunInfo from '@/features/ndv/runData/components/RunInfo.vue';
 import { storeToRefs } from 'pinia';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import type { WorkflowObjectAccessors } from '@/app/types/workflow';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import RunDataAi from '@/features/ndv/runData/components/ai/RunDataAi.vue';
 import { useNodeType } from '@/app/composables/useNodeType';
@@ -42,7 +43,7 @@ type OutputTypeKey = keyof typeof OUTPUT_TYPE;
 type OutputType = (typeof OUTPUT_TYPE)[OutputTypeKey];
 
 type Props = {
-	workflowObject: Workflow;
+	workflowObject: WorkflowObjectAccessors;
 	runIndex: number;
 	isReadOnly?: boolean;
 	linkedRuns?: boolean;

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
@@ -874,7 +874,7 @@ const nodeHints = computed<NodeHint[]>(() => {
 					node: node.value,
 					nodeType: nodeType.value,
 					nodeOutputData,
-					getNodeByName: props.workflowObject.getNode,
+					getNodeByName: (name) => props.workflowObject.getNode(name),
 					connections: props.workflowObject.connectionsBySourceNode,
 					hasNodeRun: hasNodeRun.value,
 					hasMultipleInputItems,

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
@@ -12,7 +12,6 @@ import type {
 	ITaskMetadata,
 	NodeError,
 	NodeHint,
-	Workflow,
 	NodeConnectionType,
 } from 'n8n-workflow';
 import { parseErrorMetadata, NodeConnectionTypes, NodeHelpers } from 'n8n-workflow';
@@ -21,6 +20,7 @@ import { computed, defineAsyncComponent, onBeforeUnmount, onMounted, ref, toRef,
 import type { INodeUi, IRunDataDisplayMode, ITab } from '@/Interface';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
 import type { NodePanelType } from '@/features/ndv/shared/ndv.types';
+import type { WorkflowObjectAccessors } from '@/app/types/workflow';
 
 import {
 	CORE_NODES_CATEGORY,
@@ -111,7 +111,7 @@ export type EnterEditModeArgs = {
 };
 
 type Props = {
-	workflowObject: Workflow;
+	workflowObject: WorkflowObjectAccessors;
 	workflowExecution?: IRunExecutionData;
 	runIndex: number;
 	executingMessage: string;
@@ -874,7 +874,7 @@ const nodeHints = computed<NodeHint[]>(() => {
 					node: node.value,
 					nodeType: nodeType.value,
 					nodeOutputData,
-					nodes: props.workflowObject.nodes,
+					getNodeByName: props.workflowObject.getNode,
 					connections: props.workflowObject.connectionsBySourceNode,
 					hasNodeRun: hasNodeRun.value,
 					hasMultipleInputItems,

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount, computed, watch } from 'vue';
 import { createEventBus } from '@n8n/utils/event-bus';
-import type { IRunData, Workflow, NodeConnectionType, IConnectedNode } from 'n8n-workflow';
+import type { IRunData, NodeConnectionType, IConnectedNode } from 'n8n-workflow';
 import { jsonParse, NodeHelpers, NodeConnectionTypes } from 'n8n-workflow';
 import type { IRunDataDisplayMode, IUpdateInformation, TargetItem } from '@/Interface';
 import type { NodePanelType } from '@/features/ndv/shared/ndv.types';
+import type { WorkflowObjectAccessors } from '@/app/types/workflow';
 
 import NodeSettings from '@/features/ndv/settings/components/NodeSettings.vue';
 import NDVDraggablePanels from '../../panel/components/NDVDraggablePanels.vue';
@@ -53,7 +54,7 @@ const emit = defineEmits<{
 
 const props = withDefaults(
 	defineProps<{
-		workflowObject: Workflow;
+		workflowObject: WorkflowObjectAccessors;
 		readOnly?: boolean;
 		renaming?: boolean;
 		isProductionExecutionPreview?: boolean;

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import type { IRunDataDisplayMode, IUpdateInformation, TargetItem } from '@/Interface';
 import type { MainPanelType, NodePanelType } from '../ndv.types';
+import type { WorkflowObjectAccessors } from '@/app/types/workflow';
 import { createEventBus } from '@n8n/utils/event-bus';
-import type { IRunData, NodeConnectionType, Workflow } from 'n8n-workflow';
+import type { IRunData, NodeConnectionType } from 'n8n-workflow';
 import { jsonParse, NodeConnectionTypes, NodeHelpers } from 'n8n-workflow';
 import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue';
 
@@ -55,7 +56,7 @@ const emit = defineEmits<{
 
 const props = withDefaults(
 	defineProps<{
-		workflowObject: Workflow;
+		workflowObject: WorkflowObjectAccessors;
 		readOnly?: boolean;
 		isProductionExecutionPreview?: boolean;
 	}>(),

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.vue
@@ -6,11 +6,11 @@ import { createEventBus } from '@n8n/utils/event-bus';
 import type { ViewportTransform } from '@vue-flow/core';
 import { getRectOfNodes, useVueFlow } from '@vue-flow/core';
 import { throttledRef } from '@vueuse/core';
-import type { Workflow } from 'n8n-workflow';
 import { computed, ref, toRef, useCssModule, useTemplateRef } from 'vue';
 import type { CanvasEventBusEvents } from '../canvas.types';
 import { useCanvasMapping } from '../composables/useCanvasMapping';
 import Canvas from './Canvas.vue';
+import type { WorkflowObjectAccessors } from '@/app/types';
 
 defineOptions({
 	inheritAttrs: false,
@@ -20,7 +20,7 @@ const props = withDefaults(
 	defineProps<{
 		id?: string;
 		workflow: IWorkflowDb;
-		workflowObject: Workflow;
+		workflowObject: WorkflowObjectAccessors;
 		fallbackNodes?: IWorkflowDb['nodes'];
 		showFallbackNodes?: boolean;
 		eventBus?: EventBus<CanvasEventBusEvents>;

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
@@ -40,7 +40,6 @@ import type {
 	INodeExecutionData,
 	INodeTypeDescription,
 	ITaskData,
-	Workflow,
 } from 'n8n-workflow';
 import {
 	NodeConnectionTypes,
@@ -67,6 +66,7 @@ import { getNodeIconSource } from '@/app/utils/nodeIcon';
 import * as workflowUtils from 'n8n-workflow/common';
 import { throttledWatch } from '@vueuse/core';
 import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import type { WorkflowObjectAccessors } from '@/app/types';
 
 export function useCanvasMapping({
 	nodes,
@@ -75,7 +75,7 @@ export function useCanvasMapping({
 }: {
 	nodes: Ref<INodeUi[]>;
 	connections: Ref<IConnections>;
-	workflowObject: Ref<Workflow>;
+	workflowObject: Ref<WorkflowObjectAccessors>;
 }) {
 	const i18n = useI18n();
 	const workflowsStore = useWorkflowsStore();

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalEmbeddedNdvMapper.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalEmbeddedNdvMapper.vue
@@ -2,7 +2,6 @@
 import InputPanel from '@/features/ndv/panel/components/InputPanel.vue';
 import type { INodeUi } from '@/Interface';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
-import type { Workflow } from 'n8n-workflow';
 import { onBeforeUnmount, watch, computed, ref, useTemplateRef } from 'vue';
 import { useStyles } from '@/app/composables/useStyles';
 import {
@@ -15,6 +14,7 @@ import { useExperimentalNdvStore } from '../experimentalNdv.store';
 import { isEventTargetContainedBy } from '@/app/utils/htmlUtils';
 
 import { N8nPopover } from '@n8n/design-system';
+import type { WorkflowObjectAccessors } from '@/app/types';
 type MapperState = { isOpen: true; closeOnMouseLeave: boolean } | { isOpen: false };
 
 const hoverOptions: UseElementHoverOptions = {
@@ -27,7 +27,7 @@ const {
 	reference,
 	visibleOnHover = false,
 } = defineProps<{
-	workflow: Workflow;
+	workflow: WorkflowObjectAccessors;
 	node: INodeUi;
 	inputNodeName: string;
 	visibleOnHover?: boolean;

--- a/packages/workflow/src/node-helpers.ts
+++ b/packages/workflow/src/node-helpers.ts
@@ -52,7 +52,10 @@ import {
 } from './type-guards';
 import { validateFieldType } from './type-validation';
 import { deepCopy } from './utils';
-import type { Workflow } from './workflow';
+import type { Workflow } from '.';
+
+// To facilitate frontend refactoring, make some helper functions work without full workflow object
+type WorkflowForNodeHelpers = Pick<Workflow, 'expression'>;
 
 export const cronNodeOptions: INodePropertyCollection[] = [
 	{
@@ -1148,7 +1151,7 @@ export function getConnectionTypes(
 }
 
 export function getNodeInputs(
-	workflow: Workflow,
+	workflow: WorkflowForNodeHelpers,
 	node: INode,
 	nodeTypeData: INodeTypeDescription,
 ): Array<NodeConnectionType | INodeInputConfiguration> {
@@ -1171,7 +1174,7 @@ export function getNodeInputs(
 }
 
 export function getNodeOutputs(
-	workflow: Workflow,
+	workflow: WorkflowForNodeHelpers,
 	node: INode,
 	nodeTypeData: INodeTypeDescription,
 ): Array<NodeConnectionType | INodeOutputConfiguration> {
@@ -1705,7 +1708,11 @@ export function isTriggerNode(nodeTypeData: INodeTypeDescription) {
 	return nodeTypeData.group.includes('trigger');
 }
 
-export function isExecutable(workflow: Workflow, node: INode, nodeTypeData: INodeTypeDescription) {
+export function isExecutable(
+	workflow: WorkflowForNodeHelpers,
+	node: INode,
+	nodeTypeData: INodeTypeDescription,
+) {
 	if (!nodeTypeData) {
 		return false;
 	}


### PR DESCRIPTION
## Summary

As part of the groundwork for introducing CRDT, this PR replaces `Workflow` class usages in Vue component props and utility function arguments with temporary `WorkflowObjectAccessors` and `WorkflowForNodeHelpers` type which exposes a subset of methods and fields of Workflow class. This allows us to finish migrating all usages of `workflowsStore.workflowObject` (in subsequent PRs).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2797/migrate-workflow-class-usages-in-component-props-and-function


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
