### PR TITLE
feat(core): Add telemetry for data redaction settings and reveal data

### DIFF
--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -1222,6 +1222,7 @@ describe('TelemetryEventRelay', () => {
 				credential_edited: false,
 				ai_builder_assisted: false,
 				identity_extractor_changed: false,
+				redaction_policy: undefined,
 			});
 		});
 
@@ -1238,7 +1239,7 @@ describe('TelemetryEventRelay', () => {
 					id: 'workflow123',
 					name: 'Test Workflow',
 					nodes: [],
-					settings: { credentialResolverId: 'resolver-123' },
+					settings: { credentialResolverId: 'resolver-123', redactionPolicy: undefined },
 				}),
 				publicApi: false,
 				settingsChanged: {
@@ -1269,6 +1270,69 @@ describe('TelemetryEventRelay', () => {
 				ai_builder_assisted: false,
 				credential_resolver_id: 'resolver-123',
 				identity_extractor_changed: false,
+				redaction_policy: undefined,
+			});
+		});
+
+		it('should track redaction policy when it changes', async () => {
+			const event: RelayEventMap['workflow-saved'] = {
+				user: {
+					id: 'user123',
+					email: 'user@example.com',
+					firstName: 'John',
+					lastName: 'Doe',
+					role: { slug: GLOBAL_OWNER_ROLE.slug },
+				},
+				workflow: mock<IWorkflowDb>({
+					id: 'workflow123',
+					name: 'Test Workflow',
+					nodes: [],
+					settings: { redactionPolicy: 'all' },
+				}),
+				publicApi: false,
+				settingsChanged: {
+					redactionPolicy: {
+						from: 'none',
+						to: 'all',
+					},
+				},
+			};
+
+			eventService.emit('workflow-saved', event);
+
+			await flushPromises();
+
+			expect(telemetry.track).toHaveBeenCalledWith(
+				'User saved workflow',
+				expect.objectContaining({
+					redaction_policy: 'all',
+				}),
+			);
+		});
+
+		it('should track on `execution-data-revealed` event', () => {
+			const event: RelayEventMap['execution-data-revealed'] = {
+				user: {
+					id: 'user123',
+					email: 'user@example.com',
+					firstName: 'John',
+					lastName: 'Doe',
+					role: { slug: GLOBAL_OWNER_ROLE.slug },
+				},
+				executionId: 'exec123',
+				workflowId: 'workflow123',
+				ipAddress: '127.0.0.1',
+				userAgent: 'test-agent',
+				redactionPolicy: 'all',
+			};
+
+			eventService.emit('execution-data-revealed', event);
+
+			expect(telemetry.track).toHaveBeenCalledWith('User confirmed reveal data', {
+				user_id: 'user123',
+				execution_id: 'exec123',
+				workflow_id: 'workflow123',
+				redaction_policy: 'all',
 			});
 		});
 

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -151,6 +151,7 @@ export class TelemetryEventRelay extends EventRelay {
 			'user-password-reset-request-click': (event) => this.userPasswordResetRequestClick(event),
 			'history-compacted': (event) => this.historyCompacted(event),
 			'instance-policies-updated': (event) => this.instancePoliciesUpdated(event),
+			'execution-data-revealed': (event) => this.executionDataRevealed(event),
 		});
 	}
 
@@ -775,6 +776,12 @@ export class TelemetryEventRelay extends EventRelay {
 			credentialResolverId = settingsChanged.credentialResolverId.to;
 		}
 
+		let redactionPolicy: JsonValue | undefined = undefined;
+
+		if (settingsChanged?.redactionPolicy) {
+			redactionPolicy = settingsChanged.redactionPolicy.to;
+		}
+
 		const identityExtractorChanged = this.detectIdentityExtractorChanges(
 			previousWorkflow,
 			workflow,
@@ -796,6 +803,7 @@ export class TelemetryEventRelay extends EventRelay {
 			ai_builder_assisted: aiBuilderAssisted ?? false,
 			credential_resolver_id: credentialResolverId,
 			identity_extractor_changed: identityExtractorChanged,
+			redaction_policy: redactionPolicy,
 		});
 	}
 
@@ -1579,6 +1587,20 @@ export class TelemetryEventRelay extends EventRelay {
 		this.telemetry.track('User updated instance policies', {
 			user_id: user.id,
 			[settingName]: value,
+		});
+	}
+
+	private executionDataRevealed({
+		user,
+		executionId,
+		workflowId,
+		redactionPolicy,
+	}: RelayEventMap['execution-data-revealed']) {
+		this.telemetry.track('User confirmed reveal data', {
+			user_id: user.id,
+			execution_id: executionId,
+			workflow_id: workflowId,
+			redaction_policy: redactionPolicy,
 		});
 	}
 

--- a/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionRedaction.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionRedaction.ts
@@ -1,6 +1,7 @@
 import { computed, h } from 'vue';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useMessage } from '@/app/composables/useMessage';
+import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useToast } from '@/app/composables/useToast';
 import { useI18n } from '@n8n/i18n';
 import { MODAL_CONFIRM } from '@/app/constants/modals';
@@ -9,6 +10,7 @@ import RevealDataWarning from '../components/RevealDataWarning.vue';
 export function useExecutionRedaction() {
 	const workflowsStore = useWorkflowsStore();
 	const message = useMessage();
+	const telemetry = useTelemetry();
 	const { showError } = useToast();
 	const i18n = useI18n();
 
@@ -23,6 +25,11 @@ export function useExecutionRedaction() {
 	);
 
 	async function revealData() {
+		telemetry.track('User clicked reveal data', {
+			workflow_id: workflowsStore.workflowId,
+			execution_id: workflowsStore.getWorkflowExecution?.id,
+		});
+
 		const warningContent = h(RevealDataWarning, {
 			warning: i18n.baseText('ndv.redacted.revealModal.warning'),
 			logged: i18n.baseText('ndv.redacted.revealModal.logged'),


### PR DESCRIPTION
## Summary

Adds telemetry tracking for workflow data redaction settings and the reveal data flow:
- **`User saved workflow`** now includes `redaction_policy` when the setting changes (same pattern as `credential_resolver_id`)
- **`User confirmed reveal data`** backend telemetry event on successful execution data reveal (mapped from `execution-data-revealed`)
- **`User clicked reveal data`** frontend telemetry event when the user clicks the reveal button (before the confirm modal)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-540

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)