### PR TITLE
fix(core): Retry queued execution lookup in worker

### DIFF
--- a/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
@@ -6,6 +6,7 @@ import { mock } from 'jest-mock-extended';
 import type { WorkflowExecute as ActualWorkflowExecute, InstanceSettings } from 'n8n-core';
 import { ExternalSecretsProxy } from 'n8n-core';
 import { mockInstance } from 'n8n-core/test/utils';
+import * as n8nWorkflow from 'n8n-workflow';
 import {
 	type IPinData,
 	type ITaskData,
@@ -87,6 +88,85 @@ describe('JobProcessor', () => {
 		const result = await jobProcessor.processJob(mock<Job>());
 
 		expect(result).toEqual({ success: false });
+	});
+
+	it('should retry loading execution data when the initial lookup misses', async () => {
+		const sleepSpy = jest.spyOn(n8nWorkflow, 'sleep').mockResolvedValue();
+		sleepSpy.mockClear();
+		const executionRepository = mock<ExecutionRepository>();
+		executionRepository.findSingleExecution
+			.mockResolvedValueOnce(undefined)
+			.mockResolvedValueOnce(
+				mock<IExecutionResponse>({
+					mode: 'manual',
+					workflowData: { id: 'workflow-id', nodes: [] },
+					data: mock<IRunExecutionData>({
+						executionData: undefined,
+						resultData: { runData: {} },
+					}),
+				}),
+			)
+			.mockResolvedValueOnce(
+				mock<IExecutionResponse>({
+					status: 'success',
+					startedAt: new Date(),
+					stoppedAt: new Date(),
+					data: mock<IRunExecutionData>({
+						resultData: { runData: {} },
+					}),
+				}),
+			);
+
+		const jobProcessor = new JobProcessor(
+			logger,
+			executionRepository,
+			mock(),
+			mock(),
+			mock(),
+			mock(),
+			executionsConfig,
+			mock(),
+		);
+
+		await jobProcessor.processJob(
+			mock<Job>({
+				id: 'job-id',
+				data: { executionId: 'execution-id', loadStaticData: false },
+			}),
+		);
+
+		expect(executionRepository.findSingleExecution).toHaveBeenCalledTimes(3);
+		expect(sleepSpy).toHaveBeenCalledTimes(1);
+		expect(sleepSpy).toHaveBeenCalledWith(100);
+	});
+
+	it('should throw when execution data is still missing after retries', async () => {
+		const sleepSpy = jest.spyOn(n8nWorkflow, 'sleep').mockResolvedValue();
+		sleepSpy.mockClear();
+		const executionRepository = mock<ExecutionRepository>();
+		executionRepository.findSingleExecution.mockResolvedValue(undefined);
+		const jobProcessor = new JobProcessor(
+			logger,
+			executionRepository,
+			mock(),
+			mock(),
+			mock(),
+			mock(),
+			executionsConfig,
+			mock(),
+		);
+
+		await expect(
+			jobProcessor.processJob(
+				mock<Job>({
+					id: 'job-id',
+					data: { executionId: 'execution-id', loadStaticData: false },
+				}),
+			),
+		).rejects.toThrow('Worker failed to find data for execution execution-id (job job-id)');
+
+		expect(executionRepository.findSingleExecution).toHaveBeenCalledTimes(5);
+		expect(sleepSpy).toHaveBeenCalledTimes(4);
 	});
 
 	it.each(['manual', 'evaluation'] satisfies WorkflowExecuteMode[])(

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -28,6 +28,7 @@ import {
 	Workflow,
 	UnexpectedError,
 	createRunExecutionData,
+	sleep,
 } from 'n8n-workflow';
 import type PCancelable from 'p-cancelable';
 
@@ -49,6 +50,9 @@ import type {
 	RunningJob,
 	SendChunkMessage,
 } from './scaling.types';
+
+const MAX_EXECUTION_LOOKUP_ATTEMPTS = 5;
+const EXECUTION_LOOKUP_RETRY_DELAY_MS = 100;
 
 /**
  * Responsible for processing jobs from the queue, i.e. running enqueued executions.
@@ -73,10 +77,7 @@ export class JobProcessor {
 	async processJob(job: Job): Promise<JobResult> {
 		const { executionId, loadStaticData } = job.data;
 
-		const execution = await this.executionRepository.findSingleExecution(executionId, {
-			includeData: true,
-			unflattenData: true,
-		});
+		const execution = await this.findQueuedExecution(executionId, job.id);
 
 		if (!execution) {
 			throw new UnexpectedError(
@@ -381,6 +382,36 @@ export class JobProcessor {
 		 */
 
 		return { success: true };
+	}
+
+	private async findQueuedExecution(executionId: string, jobId: JobId) {
+		for (let attempt = 1; attempt <= MAX_EXECUTION_LOOKUP_ATTEMPTS; attempt++) {
+			const execution = await this.executionRepository.findSingleExecution(executionId, {
+				includeData: true,
+				unflattenData: true,
+			});
+
+			if (execution) {
+				if (attempt > 1) {
+					this.logger.warn(
+						`Worker found data for execution ${executionId} after ${attempt} attempts (job ${jobId})`,
+						{
+							executionId,
+							jobId,
+							attempts: attempt,
+						},
+					);
+				}
+
+				return execution;
+			}
+
+			if (attempt < MAX_EXECUTION_LOOKUP_ATTEMPTS) {
+				await sleep(EXECUTION_LOOKUP_RETRY_DELAY_MS);
+			}
+		}
+
+		return undefined;
 	}
 
 	private deriveJobFinishedProps(run: IRun, startedAt: Date): JobFinishedProps {


### PR DESCRIPTION
## Summary
Queue workers currently perform a single execution lookup before failing. In queue mode, that lookup can intermittently miss even though the execution becomes available a short moment later.

This change adds a short retry window around the worker's initial `findSingleExecution()` lookup before aborting the job.

## Changes
- retry the initial queued execution lookup up to 5 attempts with a 100ms delay
- preserve the existing error if the execution is still missing after the retry window
- add unit coverage for both the recovered and exhausted-retry cases

## Validation
- `cd packages/cli && pnpm test:unit -- src/scaling/__tests__/job-processor.service.test.ts`
- `pnpm exec biome check packages/cli/src/scaling/job-processor.ts packages/cli/src/scaling/__tests__/job-processor.service.test.ts`

Related to #12535
Related to #20262
Related to #24274
