### PR TITLE
fix(core): Make it possible to run workflows with event based triggers on instance AI (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -207,7 +207,7 @@ Always pass \`conversationContext\` when spawning background agents (\`build-wor
 
 - **Check before creating** — list existing workflows/credentials first.
 - **Test credentials** before referencing them in workflows.
-- **Call execution tools directly** — \`run-workflow\`, \`get-execution\`, \`debug-execution\`, \`get-node-output\`, \`list-executions\`, \`stop-execution\`.
+- **Call execution tools directly** — \`run-workflow\`, \`get-execution\`, \`debug-execution\`, \`get-node-output\`, \`list-executions\`, \`stop-execution\`. To test workflows with event-based triggers (Linear, GitHub, Slack, etc.), use \`run-workflow\` with \`inputData\` matching the trigger's output shape — do NOT rebuild the workflow with a Manual Trigger.
 - **Prefer tool calls over advice** — if you can do it, do it.
 - **Always include entity names** — when a tool accepts an optional name parameter (e.g. \`workflowName\`, \`folderName\`, \`credentialName\`), always pass it. The name is shown to the user in confirmation dialogs.
 - **Data tables**: read directly (\`list-data-tables\`, \`get-data-table-schema\`, \`query-data-table-rows\`); for creates/updates/deletes, use \`plan\` or \`create-tasks\` with \`manage-data-tables\` tasks. When building workflows that need tables, describe table requirements in the \`build-workflow\` task spec — the builder creates them.

--- a/packages/@n8n/instance-ai/src/tools/executions/run-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/executions/run-workflow.tool.ts
@@ -14,10 +14,11 @@ export const runWorkflowInputSchema = z.object({
 		.record(z.unknown())
 		.optional()
 		.describe(
-			'Input data passed to the workflow trigger. ' +
-				'For webhook-triggered workflows, inputData IS the request body — ' +
-				'do NOT wrap it in { body: ... }. ' +
-				'Example: to send { title: "Hello" } as POST body, pass inputData: { title: "Hello" }.',
+			'Input data passed to the workflow trigger. Works for ANY trigger type — ' +
+				'the system injects inputData as the trigger node output, bypassing the need for a real event. ' +
+				'For webhook triggers, inputData is the request body (do NOT wrap in { body: ... }). ' +
+				'For event-based triggers (e.g. Linear, GitHub, Slack), pass inputData matching ' +
+				'the shape the trigger would emit (e.g. { action: "create", data: { ... } }).',
 		),
 	timeout: z
 		.number()

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.prompt.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.prompt.ts
@@ -677,6 +677,7 @@ Supported input types: \`string\`, \`number\`, \`boolean\`, \`array\`, \`object\
    - Sub-workflows with \`executeWorkflowTrigger\` can be tested immediately via \`run-workflow\` without publishing. However, they must be **published** via \`publish-workflow\` before the parent workflow can call them in production (trigger-based) executions.
 2. Run the chunk: \`run-workflow\` with \`inputData\` matching the trigger schema.
    - **Webhook workflows**: \`inputData\` IS the request body — do NOT wrap it in \`{ body: ... }\`. The system automatically places \`inputData\` into \`{ headers, query, body: inputData }\`. So to test a webhook expecting \`{ title: "Hello" }\`, pass \`inputData: { title: "Hello" }\`. Inside the workflow, the data arrives at \`$json.body.title\`.
+   - **Event-based triggers** (e.g. Linear Trigger, GitHub Trigger, Slack Trigger): pass \`inputData\` matching what the trigger would normally emit. The system injects it as the trigger node's output — e.g. \`inputData: { action: "create", data: { id: "123", title: "Test issue" } }\` for a Linear Trigger. No need to rebuild the workflow with a Manual Trigger.
 3. If it fails, use \`debug-execution\` to investigate, fix, and re-submit.
 
 ### Step 3: Compose chunks in the main workflow

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
@@ -125,7 +125,7 @@ The system tracks file hashes. If you edit the code and then call run-workflow o
 ### Verification
 
 - If submit-workflow returned mocked credentials, call verify-built-workflow with the workItemId
-- Otherwise call run-workflow to test (skip for trigger-only workflows)
+- Otherwise call run-workflow to test (skip for trigger-only workflows). For event-based triggers (Linear, GitHub, Slack, etc.), pass \`inputData\` with sample data matching the trigger's expected output shape — the system injects it as the trigger node's output.
 - If verification fails, call debug-execution, fix the code, re-submit, and retry once
 - If the same failure signature repeats, stop and explain the block
 


### PR DESCRIPTION
## Summary

Make the agent know that it can run workflows with event-based triggers by just passing it the inputData to unblock the happy path.

We might still want to revisit how our workflow execution tools work (and to have a separate `test_workflow` tool or similar, but this should help things for now. Using this I was able to test workflows with Slack and Telegram triggers, doing something like basically testing Telegram bot echoing messages back even though I never messaged it first by having this mock the trigger call.

## Related Linear tickets, Github issues, and Community forum posts

https://www.notion.so/n8n/aef5b6e0c94f82159cc58164aa417607?v=7965b6e0c94f823c918f88516500cb86&p=33d5b6e0c94f80faaf6cd8e89b821305&pm=s

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
