### PR TITLE
ci: Allow only bundles to 1.x

### DIFF
--- a/.github/workflows/ci-restrict-private-merges.yml
+++ b/.github/workflows/ci-restrict-private-merges.yml
@@ -47,7 +47,7 @@ jobs:
               `${marker}\n` +
               `🚫 **Merge blocked**: PRs into \`${base}\` are only allowed from branches named \`bundle/*\`.\n\n` +
               `Current source branch: \`${head}\`\n\n` +
-              `Merge your developments into a bundle branch instead of directly merging to master.`;
+              `Merge your developments into a bundle branch instead of directly merging to master or 1.x.`;
 
             // Find an existing marker comment (to update instead of spamming)
             const { data: comments } = await github.rest.issues.listComments({
@@ -80,7 +80,7 @@ jobs:
         env:
           HEAD_REF: ${{ github.head_ref }}
         run: |
-          echo "::error::You can only merge to master from a bundle/* branch. Got '$HEAD_REF'."
+          echo "::error::You can only merge to master and 1.x from a bundle/* branch. Got '$HEAD_REF'."
           exit 1
 
       - name: Allowed

--- a/.github/workflows/ci-restrict-private-merges.yml
+++ b/.github/workflows/ci-restrict-private-merges.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - 1.x
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Summary

Same rules that we do on master branch on bundle merges should also apply to the 1.x branch.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
