### PR TITLE
chore: Migrate @n8n/json-schema-to-zod from Jest to Vitest

### DIFF
--- a/packages/@n8n/json-schema-to-zod/jest.config.js
+++ b/packages/@n8n/json-schema-to-zod/jest.config.js
@@ -1,5 +1,0 @@
-/** @type {import('jest').Config} */
-module.exports = {
-	...require('../../../jest.config'),
-	setupFilesAfterEnv: ['<rootDir>/test/extend-expect.ts'],
-};

--- a/packages/@n8n/json-schema-to-zod/package.json
+++ b/packages/@n8n/json-schema-to-zod/package.json
@@ -28,9 +28,9 @@
     "build:esm": "tsc -p tsconfig.esm.json && node postesm.cjs",
     "build": "rimraf ./dist && pnpm run build:types && pnpm run build:cjs && pnpm run build:esm",
     "dry": "pnpm run build && pnpm pub --dry-run",
-    "test": "jest",
-    "test:unit": "jest",
-    "test:watch": "jest --watch"
+    "test": "vitest run",
+    "test:unit": "vitest run",
+    "test:dev": "vitest --silent=false"
   },
   "keywords": [
     "zod",
@@ -65,6 +65,10 @@
   "devDependencies": {
     "@n8n/typescript-config": "workspace:*",
     "@types/json-schema": "^7.0.15",
-    "zod": "catalog:"
+    "zod": "catalog:",
+    "@n8n/vitest-config": "workspace:*",
+    "@vitest/coverage-v8": "catalog:",
+    "vitest": "catalog:",
+    "vitest-mock-extended": "catalog:"
   }
 }

--- a/packages/@n8n/json-schema-to-zod/test/extend-expect.ts
+++ b/packages/@n8n/json-schema-to-zod/test/extend-expect.ts
@@ -1,7 +1,8 @@
+import { expect, type MatcherState } from 'vitest';
 import type { z } from 'zod';
 
 expect.extend({
-	toMatchZod(this: jest.MatcherContext, actual: z.ZodTypeAny, expected: z.ZodTypeAny) {
+	toMatchZod(this: MatcherState, actual: z.ZodTypeAny, expected: z.ZodTypeAny) {
 		const actualSerialized = JSON.stringify(actual._def, null, 2);
 		const expectedSerialized = JSON.stringify(expected._def, null, 2);
 		const pass = this.equals(actualSerialized, expectedSerialized);

--- a/packages/@n8n/json-schema-to-zod/test/parsers/parse-object.test.ts
+++ b/packages/@n8n/json-schema-to-zod/test/parsers/parse-object.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable n8n-local-rules/no-skipped-tests */
 import type { JSONSchema7 } from 'json-schema';
-import { z, ZodError } from 'zod';
+import { z } from 'zod';
 
 import { parseObject } from '../../src/parsers/parse-object';
 
@@ -432,24 +432,26 @@ describe('parseObject', () => {
 			},
 		});
 
-		expect(run(result, { b: 'hello', x: true })).toEqual({
+		expect(run(result, { b: 'hello', x: true })).toMatchObject({
 			success: false,
-			error: new ZodError([
-				{
-					code: 'invalid_type',
-					expected: 'string',
-					received: 'undefined',
-					path: ['a'],
-					message: 'Required',
-				},
-				{
-					code: 'invalid_type',
-					expected: 'number',
-					received: 'string',
-					path: ['b'],
-					message: 'Expected number, received string',
-				},
-			]),
+			error: expect.objectContaining({
+				issues: [
+					{
+						code: 'invalid_type',
+						expected: 'string',
+						received: 'undefined',
+						path: ['a'],
+						message: 'Required',
+					},
+					{
+						code: 'invalid_type',
+						expected: 'number',
+						received: 'string',
+						path: ['b'],
+						message: 'Expected number, received string',
+					},
+				],
+			}),
 		});
 	});
 
@@ -474,31 +476,33 @@ describe('parseObject', () => {
 
 		expect(result).toMatchZod(expected);
 
-		expect(run(result, { b: 'hello', x: 'true' })).toEqual({
+		expect(run(result, { b: 'hello', x: 'true' })).toMatchObject({
 			success: false,
-			error: new ZodError([
-				{
-					code: 'invalid_type',
-					expected: 'string',
-					received: 'undefined',
-					path: ['a'],
-					message: 'Required',
-				},
-				{
-					code: 'invalid_type',
-					expected: 'number',
-					received: 'string',
-					path: ['b'],
-					message: 'Expected number, received string',
-				},
-				{
-					code: 'invalid_type',
-					expected: 'boolean',
-					received: 'string',
-					path: ['x'],
-					message: 'Expected boolean, received string',
-				},
-			]),
+			error: expect.objectContaining({
+				issues: [
+					{
+						code: 'invalid_type',
+						expected: 'string',
+						received: 'undefined',
+						path: ['a'],
+						message: 'Required',
+					},
+					{
+						code: 'invalid_type',
+						expected: 'number',
+						received: 'string',
+						path: ['b'],
+						message: 'Expected number, received string',
+					},
+					{
+						code: 'invalid_type',
+						expected: 'boolean',
+						received: 'string',
+						path: ['x'],
+						message: 'Expected boolean, received string',
+					},
+				],
+			}),
 		});
 	});
 
@@ -549,17 +553,19 @@ describe('parseObject', () => {
 			data: { a: 'a', b: 2, '.': [] },
 		});
 
-		expect(run(result, { a: 'a', b: 2, '.': '[]' })).toEqual({
+		expect(run(result, { a: 'a', b: 2, '.': '[]' })).toMatchObject({
 			success: false,
-			error: new ZodError([
-				{
-					code: 'invalid_type',
-					expected: 'array',
-					received: 'string',
-					path: ['.'],
-					message: 'Expected array, received string',
-				},
-			]),
+			error: expect.objectContaining({
+				issues: [
+					{
+						code: 'invalid_type',
+						expected: 'array',
+						received: 'string',
+						path: ['.'],
+						message: 'Expected array, received string',
+					},
+				],
+			}),
 		});
 	});
 
@@ -713,28 +719,30 @@ describe('parseObject', () => {
 
 		expect(result).toMatchZod(expected);
 
-		expect(run(result, { x: true, '.': [], ',': [] })).toEqual({
+		expect(run(result, { x: true, '.': [], ',': [] })).toMatchObject({
 			success: false,
-			error: new ZodError([
-				{
-					path: [','],
-					code: 'custom',
-					message: 'Invalid input: Key matching regex /,/ must match schema',
-					params: {
-						issues: [
-							{
-								code: 'too_small',
-								minimum: 1,
-								type: 'array',
-								inclusive: true,
-								exact: false,
-								message: 'Array must contain at least 1 element(s)',
-								path: [],
-							},
-						],
+			error: expect.objectContaining({
+				issues: [
+					{
+						path: [','],
+						code: 'custom',
+						message: 'Invalid input: Key matching regex /,/ must match schema',
+						params: {
+							issues: [
+								{
+									code: 'too_small',
+									minimum: 1,
+									type: 'array',
+									inclusive: true,
+									exact: false,
+									message: 'Array must contain at least 1 element(s)',
+									path: [],
+								},
+							],
+						},
 					},
-				},
-			]),
+				],
+			}),
 		});
 	});
 
@@ -818,28 +826,30 @@ describe('parseObject', () => {
 			data: { '.': [] },
 		});
 
-		expect(run(result, { ',': [] })).toEqual({
+		expect(run(result, { ',': [] })).toMatchObject({
 			success: false,
-			error: new ZodError([
-				{
-					path: [','],
-					code: 'custom',
-					message: 'Invalid input: Key matching regex /,/ must match schema',
-					params: {
-						issues: [
-							{
-								code: 'too_small',
-								minimum: 1,
-								type: 'array',
-								inclusive: true,
-								exact: false,
-								message: 'Array must contain at least 1 element(s)',
-								path: [],
-							},
-						],
+			error: expect.objectContaining({
+				issues: [
+					{
+						path: [','],
+						code: 'custom',
+						message: 'Invalid input: Key matching regex /,/ must match schema',
+						params: {
+							issues: [
+								{
+									code: 'too_small',
+									minimum: 1,
+									type: 'array',
+									inclusive: true,
+									exact: false,
+									message: 'Array must contain at least 1 element(s)',
+									path: [],
+								},
+							],
+						},
 					},
-				},
-			]),
+				],
+			}),
 		});
 
 		expect(result).toMatchZod(expected);

--- a/packages/@n8n/json-schema-to-zod/tsconfig.json
+++ b/packages/@n8n/json-schema-to-zod/tsconfig.json
@@ -6,7 +6,8 @@
 		"strict": true,
 		"noEmit": true,
 		"skipLibCheck": true,
-		"esModuleInterop": true
+		"esModuleInterop": true,
+		"types": ["vitest/globals"]
 	},
 	"include": ["src/**/*.ts", "test/**/*.ts"]
 }

--- a/packages/@n8n/json-schema-to-zod/vite.config.ts
+++ b/packages/@n8n/json-schema-to-zod/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import { vitestConfig } from '@n8n/vitest-config/node';
+
+export default mergeConfig(
+	defineConfig({
+		test: {
+			setupFiles: ['./test/extend-expect.ts'],
+		},
+	}),
+	vitestConfig,
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1648,9 +1648,21 @@ importers:
       '@n8n/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+      '@n8n/vitest-config':
+        specifier: workspace:*
+        version: link:../vitest-config
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(@vitest/browser-playwright@4.0.16)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
+      vitest-mock-extended:
+        specifier: 'catalog:'
+        version: 3.1.0(typescript@6.0.2)(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       zod:
         specifier: 3.25.67
         version: 3.25.67
@@ -5427,11 +5439,6 @@ packages:
     resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.28.5':
-    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
@@ -6123,10 +6130,6 @@ packages:
 
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.28.5':
-    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
@@ -24034,8 +24037,8 @@ snapshots:
 
   '@babel/generator@7.28.5':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -24240,10 +24243,6 @@ snapshots:
     dependencies:
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-
-  '@babel/parser@7.28.5':
-    dependencies:
-      '@babel/types': 7.28.5
 
   '@babel/parser@7.29.2':
     dependencies:
@@ -25159,7 +25158,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
       esutils: 2.0.3
 
   '@babel/runtime@7.26.10':
@@ -25171,8 +25170,8 @@ snapshots:
   '@babel/template@7.26.9':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
 
   '@babel/template@7.27.2':
     dependencies:
@@ -25209,11 +25208,6 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.28.5':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.0':
     dependencies:
@@ -31078,7 +31072,7 @@ snapshots:
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@types/babel__template@7.4.1':
     dependencies:
@@ -32165,7 +32159,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.26':
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       '@vue/shared': 3.5.26
       entities: 7.0.0
       estree-walker: 2.0.2
@@ -32178,7 +32172,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.26':
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       '@vue/compiler-core': 3.5.26
       '@vue/compiler-dom': 3.5.26
       '@vue/compiler-ssr': 3.5.26
@@ -32825,7 +32819,7 @@ snapshots:
 
   ast-kit@2.2.0:
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       pathe: 2.0.3
 
   ast-module-types@6.0.1: {}
@@ -37405,7 +37399,7 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.28.4
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.7.3
@@ -41814,8 +41808,8 @@ snapshots:
   rolldown-plugin-dts@0.17.8(rolldown@1.0.0-beta.50)(typescript@6.0.2)(vue-tsc@2.2.8(patch_hash=e2aee939ccac8a57fe449bfd92bedd8117841579526217bc39aca26c6b8c317f)(typescript@6.0.2)):
     dependencies:
       '@babel/generator': 7.28.5
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       ast-kit: 2.2.0
       birpc: 2.8.0
       dts-resolver: 2.1.3
@@ -44308,8 +44302,8 @@ snapshots:
 
   vue-docgen-api@4.76.0(vue@3.5.26(typescript@6.0.2)):
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       '@vue/compiler-dom': 3.5.26
       '@vue/compiler-sfc': 3.5.26
       ast-types: 0.16.1


### PR DESCRIPTION
## Summary

Migrates the `@n8n/json-schema-to-zod` package from Jest to Vitest.

**Changes:**

- Fix 5 failing tests in `parse-object.test.ts` that broke under Vitest due to two compatibility issues:
  1. **`toEqual` + Zod lazy getter**: Zod 3.25 returns `safeParse` failures as an object with a `get error()` accessor that writes back a `_error` cache property on first access. Vitest's `toEqual` checks for unexpected extra keys *after* traversing the object (by which point `_error` is present), while Jest did that enumeration before accessing getters. Fix: use `toMatchObject`.
  2. **`ZodError` instance comparison**: when `toMatchObject` receives a class instance as the expected value it falls back to exact `equals` rather than subset-matching, causing mismatches on `addIssue`/`addIssues` arrow-function references and `message` getter serialization. Fix: use `expect.objectContaining({ issues: [...] })` for the nested ZodError shape.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2802

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI