### PR TITLE
fix(nodes-langchain): remove stack trace from MCP tool error responses

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/protocol/MessageFormatter.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/protocol/MessageFormatter.ts
@@ -23,13 +23,9 @@ export class MessageFormatter {
 	}
 
 	static formatError(error: Error): McpToolResult {
-		const errorDetails = [`${error.name}: ${error.message}`];
-		if (error.stack) {
-			errorDetails.push(error.stack);
-		}
 		return {
 			isError: true,
-			content: [{ type: 'text', text: errorDetails.join('\n') }],
+			content: [{ type: 'text', text: `${error.name}: ${error.message}` }],
 		};
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/protocol/__tests__/MessageFormatter.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/protocol/__tests__/MessageFormatter.test.ts
@@ -169,12 +169,15 @@ describe('MessageFormatter', () => {
 			expect(result.content[0].text).toContain('CustomError: Custom error message');
 		});
 
-		it('should include stack trace when available', () => {
+		it('should not include stack trace in the response', () => {
 			const error = new Error('Test error');
+			error.stack =
+				'Error: Test error\n    at Context.<anonymous> (test.ts:1:1)\n    at /internal/path/node.js:100:5';
 			const result = MessageFormatter.formatError(error);
 
-			expect(result.content[0].text).toContain('Error: Test error');
-			expect(result.content[0].text).toContain('at ');
+			expect(result.content[0].text).toBe('Error: Test error');
+			expect(result.content[0].text).not.toContain('at ');
+			expect(result.content[0].text).not.toContain('internal/path');
 		});
 	});
 });


### PR DESCRIPTION
## Summary

`MessageFormatter.formatError()` was appending the full `error.stack` to the MCP JSON-RPC response body sent to clients. Stack traces expose internal file paths, line numbers, and function names that should not leave the server.

- Remove `error.stack` from client-facing error content
- Keep error name and message (sufficient for clients to understand what went wrong)
- Server-side logging at the call site in `McpServer.ts` is unchanged — full details remain available for debugging

## Related Linear tickets, Github issues, and Community forum posts

Fixes https://github.com/n8n-io/n8n/issues/28414

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.