### PR TITLE
fix: Generate unique pushRef per tab to prevent WebSocket disconnect loop

### DIFF
--- a/packages/frontend/@n8n/stores/src/useRootStore.ts
+++ b/packages/frontend/@n8n/stores/src/useRootStore.ts
@@ -35,17 +35,11 @@ export type RootStoreState = {
 };
 
 export const useRootStore = defineStore(STORES.ROOT, () => {
-	// Generate or retrieve client ID from sessionStorage
-	const getClientId = (): string => {
-		const storageKey = 'n8n-client-id';
-		const existingId = sessionStorage.getItem(storageKey);
-		if (existingId) {
-			return existingId;
-		}
-		const newId = randomString(10).toLowerCase();
-		sessionStorage.setItem(storageKey, newId);
-		return newId;
-	};
+	// Generate a unique client ID per tab. Must NOT be cached in sessionStorage
+	// because duplicating a browser tab copies sessionStorage, causing two tabs
+	// to share the same pushRef. The server enforces one connection per pushRef,
+	// so a shared ID triggers an infinite WebSocket disconnect/reconnect loop.
+	const getClientId = (): string => randomString(10).toLowerCase();
 
 	const state = ref<RootStoreState>({
 		baseUrl: VUE_APP_URL_BASE_API ?? window.BASE_PATH,


### PR DESCRIPTION
## Summary

Opening a second browser tab on n8n cloud triggers an immediate WebSocket disconnection loop in the first tab, flooding the console with `Connection lost, code=1005` errors and preventing the session from recovering.

**Root cause:** `getClientId()` cached the `pushRef` in `sessionStorage`. When a user duplicates a tab (right-click → Duplicate), the browser clones `sessionStorage`, giving both tabs the **same `pushRef`**. The server's `AbstractPush.add()` enforces one WebSocket connection per `pushRef` — when the second tab connects, it closes the first tab's connection. The first tab then reconnects (same `pushRef`), closing the second tab's connection, creating an infinite disconnect/reconnect loop.

**Fix:** Remove `sessionStorage` caching from `getClientId()` so each tab generates a fresh, unique `pushRef` on initialization. The `pushRef` doesn't need to persist across reloads — a reload creates a new WebSocket connection regardless, and the server has no message buffering tied to `pushRef` persistence.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5056
fixes #28514

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)