### PR TITLE
fix(core): Handle git fetch failure during source control startup

### DIFF
--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-git.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-git.service.test.ts
@@ -78,7 +78,7 @@ describe('SourceControlGitService', () => {
 		});
 
 		describe('when fetch fails during remote tracking setup', () => {
-			it('should log warning and not throw', async () => {
+			it('should log warning and not throw when tracking fetch failures are tolerated', async () => {
 				const mockLogger = mock<any>();
 				const gitService = new SourceControlGitService(mockLogger, mock(), mock());
 				const prefs = mock<SourceControlPreferences>({ branchName: 'main' });
@@ -90,12 +90,32 @@ describe('SourceControlGitService', () => {
 				const fetchError = new Error('Authentication failed for HTTPS remote');
 				jest.spyOn(gitService, 'fetch').mockRejectedValue(fetchError);
 
-				await gitService.initRepository(prefs, user);
+				await gitService.initRepository(prefs, user, {
+					tolerateTrackingFetchFailure: true,
+				});
 
 				expect(mockLogger.warn).toHaveBeenCalledWith(
 					'Failed to fetch during remote tracking setup',
 					{ error: fetchError },
 				);
+			});
+
+			it('should throw when tracking fetch failures are NOT tolerated', async () => {
+				const gitService = new SourceControlGitService(mock(), mock(), mock());
+				const prefs = mock<SourceControlPreferences>({ branchName: 'main' });
+				const user = mock<User>();
+				const git = mock<SimpleGit>();
+				gitService.git = git;
+				jest.spyOn(gitService, 'setGitCommand').mockResolvedValue();
+
+				const fetchError = new Error('Authentication failed for HTTPS remote');
+				jest.spyOn(gitService, 'fetch').mockRejectedValue(fetchError);
+
+				await expect(
+					gitService.initRepository(prefs, user, {
+						tolerateTrackingFetchFailure: false,
+					}),
+				).rejects.toThrow(fetchError);
 			});
 		});
 
@@ -154,18 +174,18 @@ describe('SourceControlGitService', () => {
 				expect(addRemoteSpy).toHaveBeenCalledWith('origin', originUrl);
 			});
 
-			it('should log warning and not throw when HTTPS credentials are invalid during fetch', async () => {
+			it('should throw error when HTTPS connection type is specified but no credentials found', async () => {
 				const mockPreferencesService = mock<SourceControlPreferencesService>();
-				const mockLogger = mock<any>();
+				const errorMessage = 'Error';
 				mockPreferencesService.getDecryptedHttpsCredentials.mockRejectedValue(
-					new Error('Authentication failed'),
+					new Error(errorMessage),
 				);
 				mockPreferencesService.getPreferences.mockReturnValue({
 					connectionType: 'https',
 					repositoryUrl: 'https://github.com/user/repo.git',
 				} as never);
 
-				const gitService = new SourceControlGitService(mockLogger, mock(), mockPreferencesService);
+				const gitService = new SourceControlGitService(mock(), mock(), mockPreferencesService);
 				const prefs = mock<SourceControlPreferences>({
 					repositoryUrl: 'https://github.com/user/repo.git',
 					connectionType: 'https',
@@ -175,12 +195,7 @@ describe('SourceControlGitService', () => {
 				const git = mock<SimpleGit>();
 				gitService.git = git;
 
-				await gitService.initRepository(prefs, user);
-
-				expect(mockLogger.warn).toHaveBeenCalledWith(
-					'Failed to fetch during remote tracking setup',
-					expect.objectContaining({ error: expect.any(Error) }),
-				);
+				await expect(gitService.initRepository(prefs, user)).rejects.toThrow(errorMessage);
 				expect(mockPreferencesService.getDecryptedHttpsCredentials).toHaveBeenCalled();
 			});
 		});

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-git.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-git.service.test.ts
@@ -4,8 +4,8 @@ import { simpleGit } from 'simple-git';
 import type { SimpleGit } from 'simple-git';
 
 import { SourceControlGitService } from '../source-control-git.service.ee';
-import type { SourceControlPreferences } from '../types/source-control-preferences';
 import type { SourceControlPreferencesService } from '../source-control-preferences.service.ee';
+import type { SourceControlPreferences } from '../types/source-control-preferences';
 
 const MOCK_BRANCHES = {
 	all: ['origin/master', 'origin/feature/branch'],
@@ -77,6 +77,28 @@ describe('SourceControlGitService', () => {
 			});
 		});
 
+		describe('when fetch fails during remote tracking setup', () => {
+			it('should log warning and not throw', async () => {
+				const mockLogger = mock<any>();
+				const gitService = new SourceControlGitService(mockLogger, mock(), mock());
+				const prefs = mock<SourceControlPreferences>({ branchName: 'main' });
+				const user = mock<User>();
+				const git = mock<SimpleGit>();
+				gitService.git = git;
+				jest.spyOn(gitService, 'setGitCommand').mockResolvedValue();
+
+				const fetchError = new Error('Authentication failed for HTTPS remote');
+				jest.spyOn(gitService, 'fetch').mockRejectedValue(fetchError);
+
+				await gitService.initRepository(prefs, user);
+
+				expect(mockLogger.warn).toHaveBeenCalledWith(
+					'Failed to fetch during remote tracking setup',
+					{ error: fetchError },
+				);
+			});
+		});
+
 		describe('repository URL authorization', () => {
 			it('should set repositoryUrl URL for SSH connection type', async () => {
 				const mockPreferencesService = mock<SourceControlPreferencesService>();
@@ -132,18 +154,18 @@ describe('SourceControlGitService', () => {
 				expect(addRemoteSpy).toHaveBeenCalledWith('origin', originUrl);
 			});
 
-			it('should throw error when HTTPS connection type is specified but no credentials found', async () => {
+			it('should log warning and not throw when HTTPS credentials are invalid during fetch', async () => {
 				const mockPreferencesService = mock<SourceControlPreferencesService>();
-				const errorMessage = 'Error';
+				const mockLogger = mock<any>();
 				mockPreferencesService.getDecryptedHttpsCredentials.mockRejectedValue(
-					new Error(errorMessage),
+					new Error('Authentication failed'),
 				);
 				mockPreferencesService.getPreferences.mockReturnValue({
 					connectionType: 'https',
 					repositoryUrl: 'https://github.com/user/repo.git',
 				} as never);
 
-				const gitService = new SourceControlGitService(mock(), mock(), mockPreferencesService);
+				const gitService = new SourceControlGitService(mockLogger, mock(), mockPreferencesService);
 				const prefs = mock<SourceControlPreferences>({
 					repositoryUrl: 'https://github.com/user/repo.git',
 					connectionType: 'https',
@@ -153,7 +175,12 @@ describe('SourceControlGitService', () => {
 				const git = mock<SimpleGit>();
 				gitService.git = git;
 
-				await expect(gitService.initRepository(prefs, user)).rejects.toThrow(errorMessage);
+				await gitService.initRepository(prefs, user);
+
+				expect(mockLogger.warn).toHaveBeenCalledWith(
+					'Failed to fetch during remote tracking setup',
+					expect.objectContaining({ error: expect.any(Error) }),
+				);
 				expect(mockPreferencesService.getDecryptedHttpsCredentials).toHaveBeenCalled();
 			});
 		});

--- a/packages/cli/src/modules/source-control.ee/source-control-git.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-git.service.ee.ts
@@ -101,7 +101,9 @@ export class SourceControlGitService {
 		if (!(await this.hasRemote(sourceControlPreferences.repositoryUrl))) {
 			if (sourceControlPreferences.connected && sourceControlPreferences.repositoryUrl) {
 				const instanceOwner = await this.ownershipService.getInstanceOwner();
-				await this.initRepository(sourceControlPreferences, instanceOwner);
+				await this.initRepository(sourceControlPreferences, instanceOwner, {
+					tolerateTrackingFetchFailure: true,
+				});
 			}
 		}
 
@@ -222,6 +224,7 @@ export class SourceControlGitService {
 			'repositoryUrl' | 'branchName' | 'initRepo' | 'connectionType'
 		>,
 		user: User,
+		options?: { tolerateTrackingFetchFailure?: boolean },
 	): Promise<void> {
 		if (!this.git) {
 			throw new UnexpectedError('Git is not initialized (Promise)');
@@ -253,7 +256,7 @@ export class SourceControlGitService {
 			user.email ?? SOURCE_CONTROL_DEFAULT_EMAIL,
 		);
 
-		await this.trackRemoteIfReady(branchName);
+		await this.trackRemoteIfReady(branchName, options?.tolerateTrackingFetchFailure);
 
 		if (initRepo) {
 			try {
@@ -271,14 +274,17 @@ export class SourceControlGitService {
 	 * If this is a new local repository being set up after remote is ready,
 	 * then set this local to start tracking remote's target branch.
 	 */
-	private async trackRemoteIfReady(targetBranch: string) {
+	private async trackRemoteIfReady(targetBranch: string, tolerateFetchFailure: boolean = false) {
 		if (!this.git) return;
 
 		try {
 			await this.fetch();
 		} catch (error) {
+			if (!tolerateFetchFailure) {
+				throw error;
+			}
 			this.logger.warn('Failed to fetch during remote tracking setup', { error });
-			return; // Don't fail initialization, let sanityCheck handle errors
+			return; // Don't fail startup initialization for recoverable remote issues
 		}
 
 		const { currentBranch, branches: remoteBranches } = await this.getBranches();

--- a/packages/cli/src/modules/source-control.ee/source-control-git.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-git.service.ee.ts
@@ -274,7 +274,12 @@ export class SourceControlGitService {
 	private async trackRemoteIfReady(targetBranch: string) {
 		if (!this.git) return;
 
-		await this.fetch();
+		try {
+			await this.fetch();
+		} catch (error) {
+			this.logger.warn('Failed to fetch during remote tracking setup', { error });
+			return; // Don't fail initialization, let sanityCheck handle errors
+		}
 
 		const { currentBranch, branches: remoteBranches } = await this.getBranches();
 


### PR DESCRIPTION
## Summary

> [!IMPORTANT]  
> I'd like to get more hands on this, I cannot really reproduce the issue with the steps provided because if someone has their HTTPs with git, a git folder must be already there, the way I reproduced this differed a bit from the ticket which is why I need someone to validate this with me please after watching the video below 👇 

https://www.loom.com/share/c9844d430fb140188f1a1cfb91addc1a

When n8n starts with source control (Environments) configured over HTTPS and the local git folder is absent or incomplete (e.g. fresh pod, ephemeral filesystem, or manually deleted folder), it calls `initRepository()` → `trackRemoteIfReady()` → `fetch()`. If the HTTPS token is expired or revoked, the authentication error was unhandled and propagated all the way up, crashing the process on startup.

This created a recovery deadlock: the UI never became available, so users couldn't fix the credentials through the UI and had to edit the database directly.

**Root cause:** `trackRemoteIfReady()` called `fetch()` without a try-catch, unlike the sibling method `ensureBranchSetup()` which already handles fetch errors gracefully.

**Fix:** Wrap the `fetch()` call in `trackRemoteIfReady()` with the same try-catch pattern used in `ensureBranchSetup()` — log a warning and return early, letting `sanityCheck()` surface the error once the instance is up.

**How to reproduce:**
1. Configure source control with a GitHub HTTPS remote and token
2. Revoke the token
3. Delete the local git folder (`~/.n8n/gitFolder` or equivalent)
4. Restart n8n — observe startup crash
5. With this fix: n8n starts, logs a warning, and the user can fix credentials via the UI

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-453
closes https://github.com/n8n-io/n8n/issues/28311

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI