### PR TITLE
feat(editor): Enable workflow execution from read-only preview canvas

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2159,6 +2159,7 @@
 	"nodeView.runButtonText.executingWorkflow": "Executing workflow",
 	"nodeView.runButtonText.waitingForTriggerEvent": "Waiting for trigger event",
 	"nodeView.runButtonText.from": "from {nodeName}",
+	"nodeView.runButtonText.chatTriggerOnly": "This workflow uses a Chat Trigger and must be executed via the chat panel",
 	"nodeView.showError.workflowError": "Workflow execution had an error",
 	"nodeView.showError.getWorkflowDataFromUrl.title": "Problem loading workflow",
 	"nodeView.showError.importWorkflowData.title": "Problem importing workflow",

--- a/packages/frontend/@n8n/stores/src/useRootStore.ts
+++ b/packages/frontend/@n8n/stores/src/useRootStore.ts
@@ -212,6 +212,10 @@ export const useRootStore = defineStore(STORES.ROOT, () => {
 		state.value.binaryDataMode = value;
 	};
 
+	const setPushRef = (value: string) => {
+		state.value.pushRef = value;
+	};
+
 	// #endregion
 
 	return {
@@ -255,5 +259,6 @@ export const useRootStore = defineStore(STORES.ROOT, () => {
 		setN8nMetadata,
 		setDefaultLocale,
 		setBinaryDataMode,
+		setPushRef,
 	};
 });

--- a/packages/frontend/editor-ui/src/app/components/WorkflowPreview.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowPreview.test.ts
@@ -335,6 +335,47 @@ describe('WorkflowPreview', () => {
 		});
 	});
 
+	describe('canExecute prop', () => {
+		it('should include canExecute=true in iframe src when canExecute prop is true', () => {
+			const { container } = renderComponent({
+				pinia,
+				props: {
+					canExecute: true,
+				},
+			});
+
+			const iframe = container.querySelector('iframe');
+			expect(iframe?.getAttribute('src')).toContain('canExecute=true');
+		});
+
+		it('should not include canExecute param when canExecute prop is false', () => {
+			const { container } = renderComponent({
+				pinia,
+				props: {
+					canExecute: false,
+				},
+			});
+
+			const iframe = container.querySelector('iframe');
+			expect(iframe?.getAttribute('src')).not.toContain('canExecute');
+		});
+
+		it('should include both hideControls and canExecute when both are true', () => {
+			const { container } = renderComponent({
+				pinia,
+				props: {
+					hideControls: true,
+					canExecute: true,
+				},
+			});
+
+			const iframe = container.querySelector('iframe');
+			const src = iframe?.getAttribute('src') ?? '';
+			expect(src).toContain('hideControls=true');
+			expect(src).toContain('canExecute=true');
+		});
+	});
+
 	describe('ready event', () => {
 		it('should emit ready event when iframe sends n8nReady command', async () => {
 			const { emitted } = renderComponent({

--- a/packages/frontend/editor-ui/src/app/components/WorkflowPreview.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowPreview.vue
@@ -22,6 +22,7 @@ const props = withDefaults(
 		focusOnLoad?: boolean;
 		hideControls?: boolean;
 		suppressNotifications?: boolean;
+		canExecute?: boolean;
 	}>(),
 	{
 		loading: false,
@@ -36,6 +37,7 @@ const props = withDefaults(
 		focusOnLoad: true,
 		hideControls: false,
 		suppressNotifications: false,
+		canExecute: false,
 	},
 );
 
@@ -58,10 +60,15 @@ const scrollY = ref(0);
 
 const iframeSrc = computed(() => {
 	const basePath = `${window.BASE_PATH ?? '/'}workflows/demo`;
+	const params = new URLSearchParams();
 	if (props.hideControls) {
-		return `${basePath}?hideControls=true`;
+		params.set('hideControls', 'true');
 	}
-	return basePath;
+	if (props.canExecute) {
+		params.set('canExecute', 'true');
+	}
+	const qs = params.toString();
+	return qs ? `${basePath}?${qs}` : basePath;
 });
 
 const showPreview = computed(() => {

--- a/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.test.ts
@@ -72,11 +72,15 @@ vi.mock('@/features/execution/executions/executions.utils', async (importOrigina
 	};
 });
 
+const mockRoute = vi.hoisted(() => ({
+	name: 'workflow' as string,
+	query: {} as Record<string, string>,
+}));
 vi.mock('vue-router', async (importOriginal) => {
 	const actual = (await importOriginal()) as object;
 	return {
 		...actual,
-		useRoute: vi.fn(() => ({ name: 'workflow' })),
+		useRoute: vi.fn(() => mockRoute),
 	};
 });
 
@@ -93,6 +97,8 @@ describe('usePostMessageHandler', () => {
 		vi.clearAllMocks();
 		setActivePinia(createTestingPinia());
 		mockIsProductionExecutionPreview.value = false;
+		mockRoute.name = 'workflow';
+		mockRoute.query = {};
 		workflowState = createMockWorkflowState();
 	});
 
@@ -183,6 +189,66 @@ describe('usePostMessageHandler', () => {
 			});
 
 			cleanup();
+		});
+
+		it('should override workflow id to "demo" in iframe context when canExecute is not set', async () => {
+			// Simulate iframe context
+			const originalParent = Object.getOwnPropertyDescriptor(window, 'parent');
+			Object.defineProperty(window, 'parent', { value: { postMessage: vi.fn() }, writable: true });
+
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: shallowRef(null),
+			});
+			setup();
+
+			const workflow = { id: 'real-wf-id', nodes: [], connections: {} };
+			const messageEvent = new MessageEvent('message', {
+				data: JSON.stringify({ command: 'openWorkflow', workflow }),
+			});
+			window.dispatchEvent(messageEvent);
+
+			await vi.waitFor(() => {
+				expect(mockImportWorkflowExact).toHaveBeenCalledWith(
+					expect.objectContaining({ workflow: expect.objectContaining({ id: 'demo' }) }),
+				);
+			});
+
+			cleanup();
+			if (originalParent) {
+				Object.defineProperty(window, 'parent', originalParent);
+			}
+		});
+
+		it('should preserve real workflow id in iframe context when canExecute is true', async () => {
+			mockRoute.query = { canExecute: 'true' };
+
+			// Simulate iframe context
+			const originalParent = Object.getOwnPropertyDescriptor(window, 'parent');
+			Object.defineProperty(window, 'parent', { value: { postMessage: vi.fn() }, writable: true });
+
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: shallowRef(null),
+			});
+			setup();
+
+			const workflow = { id: 'real-wf-id', nodes: [], connections: {} };
+			const messageEvent = new MessageEvent('message', {
+				data: JSON.stringify({ command: 'openWorkflow', workflow }),
+			});
+			window.dispatchEvent(messageEvent);
+
+			await vi.waitFor(() => {
+				expect(mockImportWorkflowExact).toHaveBeenCalledWith(
+					expect.objectContaining({ workflow: expect.objectContaining({ id: 'real-wf-id' }) }),
+				);
+			});
+
+			cleanup();
+			if (originalParent) {
+				Object.defineProperty(window, 'parent', originalParent);
+			}
 		});
 
 		it('should emit tidyUp event when tidyUp is true', async () => {
@@ -344,6 +410,50 @@ describe('usePostMessageHandler', () => {
 			expect(mockSetPinData).toHaveBeenCalledWith({});
 
 			cleanup();
+		});
+
+		it('should always override workflow id to "demo" in iframe context', async () => {
+			mockRoute.query = { canExecute: 'true' };
+
+			// Simulate iframe context
+			const originalParent = Object.getOwnPropertyDescriptor(window, 'parent');
+			Object.defineProperty(window, 'parent', { value: { postMessage: vi.fn() }, writable: true });
+
+			const mockSetPinData = vi.fn();
+			const storeRef = shallowRef({ setPinData: mockSetPinData } as never);
+
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: storeRef,
+			});
+			setup();
+
+			const messageEvent = new MessageEvent('message', {
+				data: JSON.stringify({
+					command: 'openExecutionPreview',
+					workflow: {
+						id: 'real-wf-id',
+						nodes: [{ name: 'Node1' }],
+						connections: {},
+					},
+					nodeExecutionSchema: {},
+					executionStatus: 'success',
+				}),
+			});
+			window.dispatchEvent(messageEvent);
+
+			await vi.waitFor(() => {
+				expect(mockImportWorkflowExact).toHaveBeenCalledWith(
+					expect.objectContaining({
+						workflow: expect.objectContaining({ id: 'demo' }),
+					}),
+				);
+			});
+
+			cleanup();
+			if (originalParent) {
+				Object.defineProperty(window, 'parent', originalParent);
+			}
 		});
 
 		it('should throw if workflow has no nodes', async () => {

--- a/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.ts
@@ -1,5 +1,6 @@
 import { nextTick, type ShallowRef } from 'vue';
 import { useI18n } from '@n8n/i18n';
+import { useRoute } from 'vue-router';
 import type { ExecutionStatus, ExecutionSummary } from 'n8n-workflow';
 import { useToast } from '@/app/composables/useToast';
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
@@ -45,6 +46,7 @@ export function usePostMessageHandler({
 	const telemetry = useTelemetry();
 	const nodeHelpers = useNodeHelpers();
 
+	const route = useRoute();
 	const workflowsStore = useWorkflowsStore();
 	const { resetWorkspace, openExecution, fitView } = useCanvasOperations();
 	const { importWorkflowExact } = useWorkflowImport(currentWorkflowDocumentStore);
@@ -81,6 +83,14 @@ export function usePostMessageHandler({
 		if (json.projectId) {
 			await projectsStore.fetchAndSetProject(json.projectId);
 		}
+
+		// On the demo route, override the workflow ID to 'demo' so the iframe
+		// doesn't reference a real workflow — unless canExecute is enabled,
+		// in which case the real ID is needed for execution API calls.
+		if (window !== window.parent && route.query.canExecute !== 'true') {
+			json.workflow.id = 'demo';
+		}
+
 		await importWorkflowExact(json);
 
 		// importWorkflowExact → resetWorkspace resets activeExecutionId to undefined,
@@ -160,6 +170,12 @@ export function usePostMessageHandler({
 		if (!workflow?.nodes || !workflow?.connections) {
 			canvasStore.stopLoading();
 			throw new Error('Invalid workflow object');
+		}
+
+		// Execution previews always use 'demo' ID — they display pre-computed
+		// results and never need real execution API calls.
+		if (window !== window.parent) {
+			json.workflow.id = 'demo';
 		}
 
 		if (json.projectId) {

--- a/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.ts
@@ -94,9 +94,13 @@ export function usePostMessageHandler({
 		await importWorkflowExact(json);
 
 		// importWorkflowExact → resetWorkspace resets activeExecutionId to undefined,
-		// which causes the iframe to reject push execution events. Re-set to null so
-		// the iframe stays receptive to incoming execution push events.
-		if (window !== window.parent) {
+		// which causes the iframe to reject push execution events relayed from the
+		// parent. Re-set to null so the iframe stays receptive — but only when
+		// canExecute is disabled. When canExecute is enabled, leave it as undefined
+		// so the run button isn't disabled (isWorkflowRunning treats null as
+		// "execution starting"). The user-triggered execution flow will handle
+		// activeExecutionId itself.
+		if (window !== window.parent && route.query.canExecute !== 'true') {
 			workflowState.setActiveExecutionId(null);
 		}
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowImport.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowImport.test.ts
@@ -118,14 +118,16 @@ describe('useWorkflowImport', () => {
 		);
 	});
 
-	it('should use "demo" id on demo routes', async () => {
+	it('should pass through workflow id as-is on demo routes', async () => {
 		mockRoute.name = VIEWS.DEMO;
 
 		const storeRef = shallowRef(null);
 		const { importWorkflowExact } = useWorkflowImport(storeRef);
 
-		await importWorkflowExact({ workflow: createWorkflowData({ id: 'ignored-id' }) });
+		await importWorkflowExact({ workflow: createWorkflowData({ id: 'real-workflow-id' }) });
 
-		expect(mockInitializeWorkspace).toHaveBeenCalledWith(expect.objectContaining({ id: 'demo' }));
+		expect(mockInitializeWorkspace).toHaveBeenCalledWith(
+			expect.objectContaining({ id: 'real-workflow-id' }),
+		);
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowImport.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowImport.ts
@@ -31,7 +31,6 @@ export function useWorkflowImport(
 
 		const { workflowDocumentStore } = await initializeWorkspace({
 			...workflowData,
-			id: isDemoRoute.value ? 'demo' : workflowData.id,
 			nodes: getNodesWithNormalizedPosition<INodeUi>(workflowData.nodes),
 		} as IWorkflowDb);
 

--- a/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import { provide, onBeforeMount, onBeforeUnmount, onMounted } from 'vue';
-import { useRouter } from 'vue-router';
+import { computed, provide, onBeforeMount, onBeforeUnmount, onMounted } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
 import BaseLayout from './BaseLayout.vue';
 import DemoFooter from '@/features/execution/logs/components/DemoFooter.vue';
 import { WorkflowStateKey, WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
@@ -9,6 +9,10 @@ import { useWorkflowState } from '@/app/composables/useWorkflowState';
 import { useWorkflowInitialization } from '@/app/composables/useWorkflowInitialization';
 import { usePostMessageHandler } from '@/app/composables/usePostMessageHandler';
 import { usePushConnection } from '@/app/composables/usePushConnection/usePushConnection';
+import { usePushConnectionStore } from '@/app/stores/pushConnection.store';
+
+const route = useRoute();
+const canExecute = computed(() => route.query.canExecute === 'true');
 
 const workflowState = useWorkflowState();
 provide(WorkflowStateKey, workflowState);
@@ -29,8 +33,10 @@ const { setup: setupPostMessages, cleanup: cleanupPostMessages } = usePostMessag
 
 // Initialize push event handlers so relayed execution events (via postMessage
 // from the parent) are processed for node highlighting, execution state, etc.
-// No pushConnect() — the parent owns the WebSocket and relays events to us.
+// When canExecute is enabled, the iframe also establishes its own WebSocket
+// connection for user-triggered executions (pushConnect below).
 const pushConnection = usePushConnection({ router: useRouter(), workflowState });
+const pushConnectionStore = usePushConnectionStore();
 
 // Set activeExecutionId to null (not undefined) eagerly so the iframe accepts
 // incoming execution push events relayed from the parent via postMessage.
@@ -43,9 +49,18 @@ onBeforeMount(() => {
 onMounted(async () => {
 	await initializeData();
 	pushConnection.initialize();
+
+	// When canExecute is enabled, establish a real WebSocket/SSE connection
+	// so the iframe can trigger and receive its own execution events directly.
+	if (canExecute.value) {
+		pushConnectionStore.pushConnect();
+	}
 });
 
 onBeforeUnmount(() => {
+	if (canExecute.value) {
+		pushConnectionStore.pushDisconnect();
+	}
 	pushConnection.terminate();
 	cleanupPostMessages();
 	cleanupInitialization();

--- a/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
@@ -10,9 +10,19 @@ import { useWorkflowInitialization } from '@/app/composables/useWorkflowInitiali
 import { usePostMessageHandler } from '@/app/composables/usePostMessageHandler';
 import { usePushConnection } from '@/app/composables/usePushConnection/usePushConnection';
 import { usePushConnectionStore } from '@/app/stores/pushConnection.store';
+import { useRootStore } from '@n8n/stores/useRootStore';
+import { randomString } from 'n8n-workflow';
 
 const route = useRoute();
 const canExecute = computed(() => route.query.canExecute === 'true');
+
+// The iframe shares sessionStorage with the parent page (same origin), so both
+// get the same pushRef by default. This causes the backend to replace one
+// push connection with the other. Generate a unique pushRef for this iframe
+// so it can have its own independent push connection.
+if (window !== window.parent) {
+	useRootStore().setPushRef(randomString(10).toLowerCase());
+}
 
 const workflowState = useWorkflowState();
 provide(WorkflowStateKey, workflowState);
@@ -38,9 +48,14 @@ const { setup: setupPostMessages, cleanup: cleanupPostMessages } = usePostMessag
 const pushConnection = usePushConnection({ router: useRouter(), workflowState });
 const pushConnectionStore = usePushConnectionStore();
 
-// Set activeExecutionId to null (not undefined) eagerly so the iframe accepts
-// incoming execution push events relayed from the parent via postMessage.
-workflowState.setActiveExecutionId(null);
+// When canExecute is disabled (read-only preview), set activeExecutionId to null
+// so the iframe accepts incoming execution push events relayed from the parent
+// via postMessage. When canExecute is enabled, leave it as undefined so the run
+// button is not disabled — the normal execution flow will set it to null when
+// the user actually starts an execution.
+if (!canExecute.value) {
+	workflowState.setActiveExecutionId(null);
+}
 
 onBeforeMount(() => {
 	setupPostMessages();

--- a/packages/frontend/editor-ui/src/app/stores/pushConnection.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/pushConnection.store.ts
@@ -82,12 +82,12 @@ export const usePushConnectionStore = defineStore(STORES.PUSH, () => {
 		});
 	}
 
-	const url = getConnectionUrl();
+	const url = computed(() => getConnectionUrl());
 
 	const client = computed(() =>
 		useWebSockets.value
-			? useWebSocketClient({ url, onMessage })
-			: useEventSourceClient({ url, onMessage }),
+			? useWebSocketClient({ url: url.value, onMessage })
+			: useEventSourceClient({ url: url.value, onMessage }),
 	);
 
 	function serializeAndSend(message: unknown) {

--- a/packages/frontend/editor-ui/src/app/types/nodeSettings.ts
+++ b/packages/frontend/editor-ui/src/app/types/nodeSettings.ts
@@ -4,4 +4,5 @@ export type NodeSettingsTab =
 	| 'communityNode'
 	| 'docs'
 	| 'action'
-	| 'credential';
+	| 'credential'
+	| 'output';

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -301,7 +301,9 @@ const isCanvasReadOnly = computed(() => {
 });
 
 const canExecuteOnCanvas = computed(() => {
-	if (isDemoRoute.value) return false;
+	if (isDemoRoute.value) {
+		return route.query.canExecute === 'true';
+	}
 	if (editableWorkflow.value.isArchived) return false;
 	if (builderStore.streaming) return false;
 	return !!(workflowPermissions.value.execute ?? projectPermissions.value.workflow.execute);
@@ -1782,6 +1784,7 @@ onBeforeUnmount(() => {
 			:show-fallback-nodes="showFallbackNodes"
 			:event-bus="canvasEventBus"
 			:read-only="isCanvasReadOnly"
+			:can-execute="canExecuteOnCanvas"
 			:executing="isWorkflowRunning"
 			:key-bindings="keyBindingsEnabled"
 			:suppress-interaction="experimentalNdvStore.isMapperOpen"

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -1041,8 +1041,24 @@ const isExecutionDisabled = computed(() => {
 });
 
 const isRunWorkflowButtonVisible = computed(
-	() => !isOnlyChatTriggerNodeActive.value || chatTriggerNodePinnedData.value,
+	() =>
+		!isOnlyChatTriggerNodeActive.value ||
+		chatTriggerNodePinnedData.value ||
+		(isDemoRoute.value && canExecuteOnCanvas.value),
 );
+
+const executionDisabledReason = computed(() => {
+	if (
+		isDemoRoute.value &&
+		canExecuteOnCanvas.value &&
+		containsChatTriggerNodes.value &&
+		isOnlyChatTriggerNodeActive.value &&
+		!chatTriggerNodePinnedData.value
+	) {
+		return i18n.baseText('nodeView.runButtonText.chatTriggerOnly');
+	}
+	return undefined;
+});
 const isStopExecutionButtonVisible = computed(
 	() => isWorkflowRunning.value && !isExecutionWaitingForWebhook.value,
 );
@@ -1843,6 +1859,7 @@ onBeforeUnmount(() => {
 					v-if="isRunWorkflowButtonVisible"
 					:waiting-for-webhook="isExecutionWaitingForWebhook"
 					:disabled="isExecutionDisabled"
+					:disabled-reason="executionDisabledReason"
 					:executing="isWorkflowRunning"
 					:trigger-nodes="triggerNodes"
 					:get-node-type="nodeTypesStore.getNodeType"

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowPreview.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowPreview.vue
@@ -118,6 +118,7 @@ defineExpose({ relayPushEvent });
 			:workflow="workflow"
 			:execution-id="props.executionId ?? undefined"
 			:can-open-ndv="true"
+			:can-execute="true"
 			:hide-controls="false"
 			:suppress-notifications="true"
 			loader-type="spinner"

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
@@ -148,7 +148,11 @@ if (props.isEmbeddedInCanvas) {
 }
 
 const nodeValid = ref(true);
-const openPanel = ref<NodeSettingsTab>('params');
+
+const initialNode = props.activeNode ?? ndvStore.activeNode;
+const hasExecutionData =
+	!!initialNode && !!workflowsStore.getWorkflowRunData?.[initialNode.name]?.length;
+const openPanel = ref<NodeSettingsTab>(props.readOnly && hasExecutionData ? 'output' : 'params');
 
 // Used to prevent nodeValues from being overwritten by defaults on reopening ndv
 const nodeValuesInitialized = ref(false);

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
@@ -1109,6 +1109,7 @@ defineExpose({
 					v-bind="nodeProps"
 					:data="nodeDataById[nodeProps.id]"
 					:read-only="readOnly"
+					:can-execute="canExecute"
 					:event-bus="eventBus"
 					:hovered="nodesHoveredById[nodeProps.id]"
 					:nearby-hovered="nodeProps.id === hoveredTriggerNode.id.value"

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
@@ -141,6 +141,7 @@ const props = withDefaults(
 		controlsPosition?: PanelPosition;
 		eventBus?: EventBus<CanvasEventBusEvents>;
 		readOnly?: boolean;
+		canExecute?: boolean;
 		executing?: boolean;
 		keyBindings?: boolean;
 		loading?: boolean;
@@ -155,6 +156,7 @@ const props = withDefaults(
 		controlsPosition: PanelPosition.BottomLeft,
 		eventBus: () => createEventBus(),
 		readOnly: false,
+		canExecute: false,
 		executing: false,
 		keyBindings: true,
 		loading: false,
@@ -359,6 +361,9 @@ const keyMap = computed(() => {
 		z: onToggleZoomMode,
 	};
 
+	if (props.readOnly && props.canExecute) {
+		return { ...readOnlyKeymap, ctrl_enter: () => emit('run:workflow') };
+	}
 	if (props.readOnly) return readOnlyKeymap;
 
 	const fullKeymap: KeyMap = {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.vue
@@ -25,6 +25,7 @@ const props = withDefaults(
 		showFallbackNodes?: boolean;
 		eventBus?: EventBus<CanvasEventBusEvents>;
 		readOnly?: boolean;
+		canExecute?: boolean;
 		executing?: boolean;
 		suppressInteraction?: boolean;
 		initialViewport?: ViewportTransform | null;
@@ -154,6 +155,7 @@ defineExpose({
 				:connections="executing ? mappedConnectionsThrottled : mappedConnections"
 				:event-bus="eventBus"
 				:read-only="readOnly"
+				:can-execute="canExecute"
 				:executing="executing"
 				:suppress-interaction="suppressInteraction"
 				:initial-viewport="initialViewport"

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasRunWorkflowButton.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasRunWorkflowButton.test.ts
@@ -135,6 +135,40 @@ describe('CanvasRunWorkflowButton', () => {
 		expect(menuItems[3]).toHaveTextContent('from A');
 	});
 
+	it('should show disabled reason tooltip when disabled with a reason', async () => {
+		const wrapper = renderComponent({
+			props: {
+				disabled: true,
+				disabledReason: 'Chat Trigger only',
+				triggerNodes: [createTestNode({ type: MANUAL_TRIGGER_NODE_TYPE })],
+			},
+		});
+
+		const button = wrapper.getByRole('button');
+		expect(button).toBeDisabled();
+
+		await hoverTooltipTrigger(button);
+		await new Promise((r) => setTimeout(r, 600));
+		await waitFor(() => expect(getTooltip()).toHaveTextContent('Chat Trigger only'));
+	});
+
+	it('should show keyboard shortcut tooltip when disabled without a reason', async () => {
+		const wrapper = renderComponent({
+			props: {
+				disabled: true,
+				triggerNodes: [createTestNode({ type: MANUAL_TRIGGER_NODE_TYPE })],
+			},
+		});
+
+		const button = wrapper.getByRole('button');
+		expect(button).toBeDisabled();
+
+		// Should show the keyboard shortcut tooltip, not a disabled reason
+		await hoverTooltipTrigger(button);
+		await new Promise((r) => setTimeout(r, 600));
+		await waitFor(() => expect(getTooltip()).toHaveTextContent('Execute workflow'));
+	});
+
 	it('should allow to select and execute a different trigger', async () => {
 		const wrapper = renderComponent({
 			props: {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasRunWorkflowButton.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasRunWorkflowButton.vue
@@ -9,7 +9,13 @@ import { computed } from 'vue';
 import { isChatNode } from '@/app/utils/aiUtils';
 import { I18nT } from 'vue-i18n';
 
-import { N8nActionDropdown, N8nButton, N8nText, type ActionDropdownItem } from '@n8n/design-system';
+import {
+	N8nActionDropdown,
+	N8nButton,
+	N8nText,
+	N8nTooltip,
+	type ActionDropdownItem,
+} from '@n8n/design-system';
 const emit = defineEmits<{
 	mouseenter: [event: MouseEvent];
 	mouseleave: [event: MouseEvent];
@@ -23,6 +29,7 @@ const props = defineProps<{
 	waitingForWebhook?: boolean;
 	executing?: boolean;
 	disabled?: boolean;
+	disabledReason?: string;
 	hideTooltip?: boolean;
 	label?: string;
 	size?: 'small' | 'medium' | 'large';
@@ -81,7 +88,23 @@ function getNodeTypeByName(name: string): INodeTypeDescription | null {
 
 <template>
 	<div :class="[$style.component, isSplitButton ? $style.split : '']">
+		<N8nTooltip v-if="disabled && disabledReason" :content="disabledReason" placement="top">
+			<N8nButton
+				variant="solid"
+				:class="$style.button"
+				:aria-label="i18n.baseText('nodeView.runButtonText.executeWorkflow')"
+				:disabled="true"
+				:size="size ?? 'large'"
+				icon="flask-conical"
+				data-test-id="execute-workflow-button"
+			>
+				<span :class="$style.buttonContent">
+					{{ label }}
+				</span>
+			</N8nButton>
+		</N8nTooltip>
 		<KeyboardShortcutTooltip
+			v-else
 			:label="label"
 			:shortcut="{ metaKey: true, keys: ['↵'] }"
 			:disabled="executing || hideTooltip"

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.vue
@@ -38,6 +38,7 @@ import { CONFIGURATION_NODE_RADIUS, GRID_SIZE } from '@/app/utils/nodeViewUtils'
 
 type Props = NodeProps<CanvasNodeData> & {
 	readOnly?: boolean;
+	canExecute?: boolean;
 	eventBus?: EventBus<CanvasEventBusEvents>;
 	hovered?: boolean;
 	nearbyHovered?: boolean;
@@ -412,6 +413,7 @@ onBeforeUnmount(() => {
 			v-else-if="hasToolbar"
 			data-test-id="canvas-node-toolbar"
 			:read-only="readOnly"
+			:can-execute="canExecute"
 			:class="$style.canvasNodeToolbar"
 			:show-status-icons="isExperimentalNdvActive"
 			:items-class="$style.canvasNodeToolbarItems"

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.test.ts
@@ -186,6 +186,67 @@ describe('CanvasNodeToolbar', () => {
 		expect(emitted('update')[0]).toEqual([{ color: 1 }]);
 	});
 
+	it('should show execute button when readOnly is true and canExecute is true', () => {
+		const { getByTestId } = renderComponent({
+			pinia,
+			props: {
+				readOnly: true,
+				canExecute: true,
+				showStatusIcons: false,
+				itemsClass: '',
+			},
+			global: {
+				provide: {
+					...createCanvasNodeProvide(),
+					...createCanvasProvide(),
+				},
+			},
+		});
+
+		expect(getByTestId('execute-node-button')).toBeInTheDocument();
+	});
+
+	it('should hide execute button when readOnly is true and canExecute is false', () => {
+		const { queryByTestId } = renderComponent({
+			pinia,
+			props: {
+				readOnly: true,
+				canExecute: false,
+				showStatusIcons: false,
+				itemsClass: '',
+			},
+			global: {
+				provide: {
+					...createCanvasNodeProvide(),
+					...createCanvasProvide(),
+				},
+			},
+		});
+
+		expect(queryByTestId('execute-node-button')).not.toBeInTheDocument();
+	});
+
+	it('should hide delete and disable buttons when readOnly is true regardless of canExecute', () => {
+		const { queryByTestId } = renderComponent({
+			pinia,
+			props: {
+				readOnly: true,
+				canExecute: true,
+				showStatusIcons: false,
+				itemsClass: '',
+			},
+			global: {
+				provide: {
+					...createCanvasNodeProvide(),
+					...createCanvasProvide(),
+				},
+			},
+		});
+
+		expect(queryByTestId('delete-node-button')).not.toBeInTheDocument();
+		expect(queryByTestId('disable-node-button')).not.toBeInTheDocument();
+	});
+
 	it('should have "forceVisible" class when hovered', async () => {
 		const { getByTestId } = renderComponent({
 			pinia,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.vue
@@ -23,11 +23,17 @@ const emit = defineEmits<{
 	'add:ai': [id: string];
 }>();
 
-const props = defineProps<{
-	readOnly?: boolean;
-	showStatusIcons: boolean;
-	itemsClass: string;
-}>();
+const props = withDefaults(
+	defineProps<{
+		readOnly?: boolean;
+		canExecute?: boolean;
+		showStatusIcons: boolean;
+		itemsClass: string;
+	}>(),
+	{
+		canExecute: false,
+	},
+);
 
 const $style = useCssModule();
 const i18n = useI18n();
@@ -61,7 +67,7 @@ const classes = computed(() => ({
 
 const isExecuteNodeVisible = computed(() => {
 	return (
-		!props.readOnly &&
+		(!props.readOnly || props.canExecute) &&
 		render.value.type === CanvasNodeRenderType.Default &&
 		'configuration' in render.value.options &&
 		(!render.value.options.configuration || isToolNode.value)


### PR DESCRIPTION
## Summary

Enables users to execute workflows directly from a read-only preview canvas (iframe with `canExecute=true`), as used by the instance AI preview and similar embedded preview contexts.

<img width="3216" height="1344" alt="image" src="https://github.com/user-attachments/assets/76635fa9-4a6a-4ae4-a538-2ad710c53f57" />


**Feature**
- New \`canExecute\` prop on \`WorkflowPreview\` — when enabled, the iframe URL gets \`?canExecute=true\` and the iframe establishes its own WebSocket push connection.
- \`canExecuteOnCanvas\` returns true on the demo route when \`canExecute=true\`, so the Run button, per-node run buttons, and the ⌘+↵ keyboard shortcut all light up in the read-only layout.
- Per-node run buttons render in the canvas node toolbar when \`readOnly && canExecute\`. Delete/disable/other toolbar buttons stay hidden.
- Chat Trigger-only workflows show the Run button in a disabled-with-tooltip state in preview.
- NDV auto-selects the Output tab when opening a node that has execution data (read-only mode), avoiding a flash of disabled parameters.

**Fixes required for the feature to work end-to-end**
- Generate a unique \`pushRef\` per iframe instance so parent and child don't overwrite each other's push connection (they share sessionStorage on the same origin).
- Make the pushConnection store URL reactive so post-mount \`pushRef\` changes take effect.
- Only reset \`activeExecutionId\` to \`null\` in read-only *relay* mode — not when \`canExecute\` is on — otherwise \`isWorkflowRunning\` treats it as "execution starting" and the Run button renders disabled with a loading spinner.
- Apply the same guard in the post-import handler so loading a workflow into the iframe doesn't re-disable the button.

**How to test**
1. Embed \`<WorkflowPreview :workflow=\"wf\" :can-execute=\"true\" />\`.
2. The canvas Run button and per-node run buttons should be visible and enabled.
3. Click Run or ⌘+↵ — the workflow executes, node badges update, Run button shows loading state, then success indicators appear.
4. Double-click a successful node — NDV opens on the Output tab with the node's run data.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Link to Linear ticket: https://linear.app/n8n/issue/[TICKET-ID] -->

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with \`release/backport\` (if the PR is an urgent fix that needs to be backported)