### PR TITLE
chore: Suppress warning from style lint

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/AgentActivityTree.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/AgentActivityTree.vue
@@ -109,6 +109,7 @@ function resolveArtifactName(artifact: ArtifactInfo): string {
 
 <style lang="scss" module>
 .reasoningTrigger {
+	/* stylelint-disable-next-line @n8n/css-var-naming -- design-system token */
 	color: var(--text-color--subtler);
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/ArtifactCard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/ArtifactCard.vue
@@ -83,6 +83,7 @@ function handleClick(e: MouseEvent) {
 }
 
 .metadata {
+	/* stylelint-disable-next-line @n8n/css-var-naming -- design-system token */
 	color: var(--text-color--subtler);
 	overflow: hidden;
 	text-overflow: ellipsis;


### PR DESCRIPTION
## Summary

Our style linter doesn't like `--text-color--subtler`, but it's a token in our design system currently anyways 🤔 
Suppress the error from those lints for now, as it runs on commit hook and blocks commits without `--no-verify`.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
