### PR TITLE
fix(ai-builder): Increase orchestrator max steps from default 5 to 60

### DIFF
--- a/packages/@n8n/instance-ai/src/constants/max-steps.ts
+++ b/packages/@n8n/instance-ai/src/constants/max-steps.ts
@@ -1,0 +1,24 @@
+/**
+ * Maximum LLM steps (inference rounds) for each agent role.
+ *
+ * Mastra's Agent.stream() defaults to stepCountIs(5) which is too low
+ * for most use cases. Each agent sets its own limit based on task complexity.
+ *
+ * @see https://github.com/mastra-ai/mastra/issues/2930
+ */
+export const MAX_STEPS = {
+	/** Main orchestrator — coordinates all other agents and handles direct tool calls. */
+	ORCHESTRATOR: 60,
+	/** Browser automation sub-agent — needs many steps for multi-page flows. */
+	BROWSER: 300,
+	/** Workflow builder sub-agent — complex multi-tool build/verify loops. */
+	BUILDER: 60,
+	/** Data table management sub-agent. */
+	DATA_TABLE: 35,
+	/** Planning sub-agent — breaks down multi-step tasks. */
+	PLANNER: 30,
+	/** Research sub-agent — web search and synthesis. */
+	RESEARCH: 25,
+	/** Generic delegate fallback when no specific limit is configured. */
+	DELEGATE_FALLBACK: 10,
+} as const;

--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -1,3 +1,4 @@
+export { MAX_STEPS } from './constants/max-steps';
 export { wrapUntrustedData } from './tools/web-research/sanitize-web-content';
 export type { Logger } from './logger';
 export { generateCompactionSummary } from './compaction';

--- a/packages/@n8n/instance-ai/src/tools/orchestration/browser-credential-setup.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/browser-credential-setup.tool.ts
@@ -13,6 +13,7 @@ import {
 	withTraceRun,
 } from './tracing-utils';
 import { registerWithMastra } from '../../agent/register-with-mastra';
+import { MAX_STEPS } from '../../constants/max-steps';
 import {
 	createLlmStepTraceHooks,
 	executeResumableStream,
@@ -23,7 +24,6 @@ import {
 	mergeTraceRunInputs,
 	withTraceParentContext,
 } from '../../tracing/langsmith-tracing';
-import { MAX_STEPS } from '../../constants/max-steps';
 import type { OrchestrationContext } from '../../types';
 import { createToolsFromLocalMcpServer } from '../filesystem/create-tools-from-mcp-server';
 import { createAskUserTool } from '../shared/ask-user.tool';

--- a/packages/@n8n/instance-ai/src/tools/orchestration/browser-credential-setup.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/browser-credential-setup.tool.ts
@@ -23,13 +23,12 @@ import {
 	mergeTraceRunInputs,
 	withTraceParentContext,
 } from '../../tracing/langsmith-tracing';
+import { MAX_STEPS } from '../../constants/max-steps';
 import type { OrchestrationContext } from '../../types';
 import { createToolsFromLocalMcpServer } from '../filesystem/create-tools-from-mcp-server';
 import { createAskUserTool } from '../shared/ask-user.tool';
 import { createFetchUrlTool } from '../web-research/fetch-url.tool';
 import { createWebSearchTool } from '../web-research/web-search.tool';
-
-const BROWSER_AGENT_MAX_STEPS = 300;
 
 type BrowserToolSource = 'gateway' | 'chrome-devtools-mcp';
 
@@ -430,7 +429,7 @@ export function createBrowserCredentialSetupTool(context: OrchestrationContext) 
 						// Stream the sub-agent
 						const llmStepTraceHooks = createLlmStepTraceHooks(traceParent);
 						const stream = await subAgent.stream(briefing, {
-							maxSteps: BROWSER_AGENT_MAX_STEPS,
+							maxSteps: MAX_STEPS.BROWSER,
 							abortSignal: context.abortSignal,
 							providerOptions: {
 								anthropic: { cacheControl: { type: 'ephemeral' } },
@@ -485,7 +484,7 @@ export function createBrowserCredentialSetupTool(context: OrchestrationContext) 
 								const nudge = await subAgent.stream(
 									'You stopped without confirming with the user. Call pause-for-user NOW to ask the user if they have the credential values (Client ID, Client Secret, API Key, etc.) copied and ready to paste into n8n.',
 									{
-										maxSteps: BROWSER_AGENT_MAX_STEPS,
+										maxSteps: MAX_STEPS.BROWSER,
 										abortSignal: context.abortSignal,
 										providerOptions: {
 											anthropic: { cacheControl: { type: 'ephemeral' } },

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
@@ -28,6 +28,7 @@ import {
 import { createVerifyBuiltWorkflowTool } from './verify-built-workflow.tool';
 import { registerWithMastra } from '../../agent/register-with-mastra';
 import { buildSubAgentBriefing } from '../../agent/sub-agent-briefing';
+import { MAX_STEPS } from '../../constants/max-steps';
 import { createLlmStepTraceHooks } from '../../runtime/resumable-stream-executor';
 import { consumeStreamWithHitl } from '../../stream/consume-with-hitl';
 import {
@@ -36,7 +37,6 @@ import {
 	mergeTraceRunInputs,
 	withTraceParentContext,
 } from '../../tracing/langsmith-tracing';
-import { MAX_STEPS } from '../../constants/max-steps';
 import type { BackgroundTaskResult, OrchestrationContext } from '../../types';
 import { SDK_IMPORT_STATEMENT } from '../../workflow-builder/extract-code';
 import type { TriggerType, WorkflowBuildOutcome } from '../../workflow-loop';

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
@@ -36,6 +36,7 @@ import {
 	mergeTraceRunInputs,
 	withTraceParentContext,
 } from '../../tracing/langsmith-tracing';
+import { MAX_STEPS } from '../../constants/max-steps';
 import type { BackgroundTaskResult, OrchestrationContext } from '../../types';
 import { SDK_IMPORT_STATEMENT } from '../../workflow-builder/extract-code';
 import type { TriggerType, WorkflowBuildOutcome } from '../../workflow-loop';
@@ -104,8 +105,6 @@ function buildOutcome(
 		summary: finalText,
 	};
 }
-
-const BUILDER_MAX_STEPS = 60;
 
 const DETACHED_BUILDER_REQUIREMENTS = `## Detached Task Contract
 
@@ -409,7 +408,7 @@ export async function startBuildWorkflowAgentTask(
 						const hitlResult = await withTraceParentContext(traceParent, async () => {
 							const llmStepTraceHooks = createLlmStepTraceHooks(traceParent);
 							const stream = await subAgent.stream(briefing, {
-								maxSteps: BUILDER_MAX_STEPS,
+								maxSteps: MAX_STEPS.BUILDER,
 								abortSignal: signal,
 								providerOptions: {
 									anthropic: { cacheControl: { type: 'ephemeral' } },
@@ -532,7 +531,7 @@ export async function startBuildWorkflowAgentTask(
 					const hitlResult = await withTraceParentContext(traceParent, async () => {
 						const llmStepTraceHooks = createLlmStepTraceHooks(traceParent);
 						const stream = await subAgent.stream(briefing, {
-							maxSteps: BUILDER_MAX_STEPS,
+							maxSteps: MAX_STEPS.BUILDER,
 							abortSignal: signal,
 							providerOptions: {
 								anthropic: { cacheControl: { type: 'ephemeral' } },

--- a/packages/@n8n/instance-ai/src/tools/orchestration/data-table-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/data-table-agent.tool.ts
@@ -21,6 +21,7 @@ import {
 } from './tracing-utils';
 import { registerWithMastra } from '../../agent/register-with-mastra';
 import { buildSubAgentBriefing } from '../../agent/sub-agent-briefing';
+import { MAX_STEPS } from '../../constants/max-steps';
 import { createLlmStepTraceHooks } from '../../runtime/resumable-stream-executor';
 import { consumeStreamWithHitl } from '../../stream/consume-with-hitl';
 import {
@@ -29,7 +30,6 @@ import {
 	mergeTraceRunInputs,
 	withTraceParentContext,
 } from '../../tracing/langsmith-tracing';
-import { MAX_STEPS } from '../../constants/max-steps';
 import type { OrchestrationContext } from '../../types';
 
 const DATA_TABLE_TOOL_NAMES = [

--- a/packages/@n8n/instance-ai/src/tools/orchestration/data-table-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/data-table-agent.tool.ts
@@ -29,9 +29,8 @@ import {
 	mergeTraceRunInputs,
 	withTraceParentContext,
 } from '../../tracing/langsmith-tracing';
+import { MAX_STEPS } from '../../constants/max-steps';
 import type { OrchestrationContext } from '../../types';
-
-const DATA_TABLE_MAX_STEPS = 35;
 
 const DATA_TABLE_TOOL_NAMES = [
 	'list-data-tables',
@@ -157,7 +156,7 @@ export async function startDataTableAgentTask(
 				return await withTraceParentContext(traceParent, async () => {
 					const llmStepTraceHooks = createLlmStepTraceHooks(traceParent);
 					const stream = await subAgent.stream(briefing, {
-						maxSteps: DATA_TABLE_MAX_STEPS,
+						maxSteps: MAX_STEPS.DATA_TABLE,
 						abortSignal: signal,
 						providerOptions: {
 							anthropic: { cacheControl: { type: 'ephemeral' } },

--- a/packages/@n8n/instance-ai/src/tools/orchestration/delegate.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/delegate.tool.ts
@@ -17,10 +17,10 @@ import { registerWithMastra } from '../../agent/register-with-mastra';
 import { buildSubAgentBriefing } from '../../agent/sub-agent-briefing';
 import { buildDebriefing } from '../../agent/sub-agent-debriefing';
 import { createSubAgent, SUB_AGENT_PROTOCOL } from '../../agent/sub-agent-factory';
+import { MAX_STEPS } from '../../constants/max-steps';
 import { createLlmStepTraceHooks } from '../../runtime/resumable-stream-executor';
 import { consumeStreamWithHitl } from '../../stream/consume-with-hitl';
 import { getTraceParentRun, withTraceParentContext } from '../../tracing/langsmith-tracing';
-import { MAX_STEPS } from '../../constants/max-steps';
 import type { OrchestrationContext } from '../../types';
 
 const FORBIDDEN_TOOL_NAMES = new Set(['plan', 'create-tasks', 'delegate']);

--- a/packages/@n8n/instance-ai/src/tools/orchestration/delegate.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/delegate.tool.ts
@@ -20,11 +20,10 @@ import { createSubAgent, SUB_AGENT_PROTOCOL } from '../../agent/sub-agent-factor
 import { createLlmStepTraceHooks } from '../../runtime/resumable-stream-executor';
 import { consumeStreamWithHitl } from '../../stream/consume-with-hitl';
 import { getTraceParentRun, withTraceParentContext } from '../../tracing/langsmith-tracing';
+import { MAX_STEPS } from '../../constants/max-steps';
 import type { OrchestrationContext } from '../../types';
 
 const FORBIDDEN_TOOL_NAMES = new Set(['plan', 'create-tasks', 'delegate']);
-
-const FALLBACK_MAX_STEPS = 10;
 
 function generateAgentId(): string {
 	return `agent-${nanoid(6)}`;
@@ -193,7 +192,7 @@ export async function startDetachedDelegateTask(
 				return await withTraceParentContext(traceParent, async () => {
 					const llmStepTraceHooks = createLlmStepTraceHooks(traceParent);
 					const stream = await subAgent.stream(briefingMessage, {
-						maxSteps: context.subAgentMaxSteps ?? FALLBACK_MAX_STEPS,
+						maxSteps: context.subAgentMaxSteps ?? MAX_STEPS.DELEGATE_FALLBACK,
 						abortSignal: signal,
 						providerOptions: {
 							anthropic: { cacheControl: { type: 'ephemeral' } },
@@ -312,7 +311,7 @@ export function createDelegateTool(context: OrchestrationContext) {
 					return await withTraceParentContext(traceParent, async () => {
 						const llmStepTraceHooks = createLlmStepTraceHooks(traceParent);
 						const stream = await subAgent.stream(briefingMessage, {
-							maxSteps: context.subAgentMaxSteps ?? FALLBACK_MAX_STEPS,
+							maxSteps: context.subAgentMaxSteps ?? MAX_STEPS.DELEGATE_FALLBACK,
 							abortSignal: context.abortSignal,
 							providerOptions: {
 								anthropic: { cacheControl: { type: 'ephemeral' } },

--- a/packages/@n8n/instance-ai/src/tools/orchestration/plan-with-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/plan-with-agent.tool.ts
@@ -31,10 +31,10 @@ import {
 	withTraceRun,
 } from './tracing-utils';
 import { registerWithMastra } from '../../agent/register-with-mastra';
+import { MAX_STEPS } from '../../constants/max-steps';
 import { createLlmStepTraceHooks } from '../../runtime/resumable-stream-executor';
 import { consumeStreamWithHitl } from '../../stream/consume-with-hitl';
 import { getTraceParentRun, withTraceParentContext } from '../../tracing/langsmith-tracing';
-import { MAX_STEPS } from '../../constants/max-steps';
 import type { OrchestrationContext } from '../../types';
 
 /** Number of recent thread messages to include as planner context. */

--- a/packages/@n8n/instance-ai/src/tools/orchestration/plan-with-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/plan-with-agent.tool.ts
@@ -34,9 +34,8 @@ import { registerWithMastra } from '../../agent/register-with-mastra';
 import { createLlmStepTraceHooks } from '../../runtime/resumable-stream-executor';
 import { consumeStreamWithHitl } from '../../stream/consume-with-hitl';
 import { getTraceParentRun, withTraceParentContext } from '../../tracing/langsmith-tracing';
+import { MAX_STEPS } from '../../constants/max-steps';
 import type { OrchestrationContext } from '../../types';
-
-const PLANNER_MAX_STEPS = 30;
 
 /** Number of recent thread messages to include as planner context. */
 const MESSAGE_HISTORY_COUNT = 5;
@@ -287,7 +286,7 @@ export function createPlanWithAgentTool(context: OrchestrationContext) {
 					return await withTraceParentContext(traceParent, async () => {
 						const llmStepTraceHooks = createLlmStepTraceHooks(traceParent);
 						const stream = await subAgent.stream(briefing, {
-							maxSteps: PLANNER_MAX_STEPS,
+							maxSteps: MAX_STEPS.PLANNER,
 							abortSignal: context.abortSignal,
 							providerOptions: {
 								anthropic: { cacheControl: { type: 'ephemeral' } },
@@ -310,7 +309,7 @@ export function createPlanWithAgentTool(context: OrchestrationContext) {
 							abortSignal: context.abortSignal,
 							waitForConfirmation: context.waitForConfirmation,
 							llmStepTraceHooks,
-							maxSteps: PLANNER_MAX_STEPS,
+							maxSteps: MAX_STEPS.PLANNER,
 						});
 
 						return await result.text;

--- a/packages/@n8n/instance-ai/src/tools/orchestration/research-with-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/research-with-agent.tool.ts
@@ -28,9 +28,8 @@ import {
 	mergeTraceRunInputs,
 	withTraceParentContext,
 } from '../../tracing/langsmith-tracing';
+import { MAX_STEPS } from '../../constants/max-steps';
 import type { OrchestrationContext } from '../../types';
-
-const RESEARCH_MAX_STEPS = 25;
 
 export interface StartResearchAgentInput {
 	goal: string;
@@ -143,7 +142,7 @@ export async function startResearchAgentTask(
 				return await withTraceParentContext(traceParent, async () => {
 					const llmStepTraceHooks = createLlmStepTraceHooks(traceParent);
 					const stream = await subAgent.stream(briefing, {
-						maxSteps: RESEARCH_MAX_STEPS,
+						maxSteps: MAX_STEPS.RESEARCH,
 						abortSignal: signal,
 						providerOptions: {
 							anthropic: { cacheControl: { type: 'ephemeral' } },

--- a/packages/@n8n/instance-ai/src/tools/orchestration/research-with-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/research-with-agent.tool.ts
@@ -20,6 +20,7 @@ import {
 } from './tracing-utils';
 import { registerWithMastra } from '../../agent/register-with-mastra';
 import { buildSubAgentBriefing } from '../../agent/sub-agent-briefing';
+import { MAX_STEPS } from '../../constants/max-steps';
 import { createLlmStepTraceHooks } from '../../runtime/resumable-stream-executor';
 import { consumeStreamWithHitl } from '../../stream/consume-with-hitl';
 import {
@@ -28,7 +29,6 @@ import {
 	mergeTraceRunInputs,
 	withTraceParentContext,
 } from '../../tracing/langsmith-tracing';
-import { MAX_STEPS } from '../../constants/max-steps';
 import type { OrchestrationContext } from '../../types';
 
 export interface StartResearchAgentInput {

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -1824,6 +1824,7 @@ export class InstanceAiService {
 							agent as StreamableAgent,
 							streamInput,
 							{
+								maxSteps: 60,
 								abortSignal: signal,
 								memory: {
 									resource: user.id,
@@ -1847,6 +1848,7 @@ export class InstanceAiService {
 						agent as StreamableAgent,
 						streamInput,
 						{
+							maxSteps: 60,
 							abortSignal: signal,
 							memory: {
 								resource: user.id,

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -17,6 +17,7 @@ import type { User } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { UrlService } from '@/services/url.service';
 import {
+	MAX_STEPS,
 	createInstanceAgent,
 	createAllTools,
 	createMemory,
@@ -1824,7 +1825,7 @@ export class InstanceAiService {
 							agent as StreamableAgent,
 							streamInput,
 							{
-								maxSteps: 60,
+								maxSteps: MAX_STEPS.ORCHESTRATOR,
 								abortSignal: signal,
 								memory: {
 									resource: user.id,
@@ -1848,7 +1849,7 @@ export class InstanceAiService {
 						agent as StreamableAgent,
 						streamInput,
 						{
-							maxSteps: 60,
+							maxSteps: MAX_STEPS.ORCHESTRATOR,
 							abortSignal: signal,
 							memory: {
 								resource: user.id,


### PR DESCRIPTION
## Summary

Mastra's `Agent.stream()` defaults to `stopWhen: stepCountIs(5)`, meaning the orchestrator stops after only 5 LLM steps per turn. This causes the AI to stop mid-task during multi-step operations like browser automation (computer use), forcing users to repeatedly say "continue" to make progress.

Every sub-agent already sets its own `maxSteps` (builder=60, browser=300, planner=30, etc.), but the orchestrator was left at the framework default of 5.

This fix:
- Passes `maxSteps: 60` in the `streamOptions` for both `streamAgentRun()` calls (tracing and non-tracing paths), matching the builder agent's limit.
- Centralizes all `maxSteps` constants into a single file (`packages/@n8n/instance-ai/src/constants/max-steps.ts`) so every agent's step limit is visible in one place.

## Related Linear tickets, Github issues, and Community forum posts

- https://www.notion.so/n8n/Instance-AI-with-Computer-Use-stopped-after-4-5-messages-with-no-understandable-reason-so-I-had--33d5b6e0c94f8046a735dcd33cf296cb
- https://github.com/mastra-ai/mastra/issues/2930 — upstream Mastra issue for the low default `maxSteps`

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)