### PR TITLE
fix(Schedule Node): Avoid using 0 day of month

### DIFF
--- a/packages/nodes-base/nodes/Schedule/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Schedule/GenericFunctions.ts
@@ -103,7 +103,7 @@ export const toCronExpression = (interval: ScheduleInterval): CronExpression => 
 		return `${randomSecond} ${minute} ${hour} * * ${daysOfWeek}` as CronExpression;
 	}
 
-	const dayOfMonth = interval.triggerAtDayOfMonth ?? randomInt(0, 31);
+	const dayOfMonth = interval.triggerAtDayOfMonth ?? randomInt(1, 31);
 	return `${randomSecond} ${minute} ${hour} ${dayOfMonth} */${interval.monthsInterval} *`;
 };
 

--- a/packages/nodes-base/nodes/Schedule/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Schedule/test/GenericFunctions.test.ts
@@ -118,7 +118,7 @@ describe('toCronExpression', () => {
 			field: 'months',
 			monthsInterval: 3,
 		});
-		expect(result1).toEqual('30 30 12 15 */3 *');
+		expect(result1).toEqual('30 30 12 16 */3 *');
 	});
 });
 


### PR DESCRIPTION
## Summary

`0` is not a valid day-of-month in a cron expression: https://github.com/kelektiv/node-cron/blob/d5f870a937209720cae5b14312b91b73c1e325bf/tests/crontime.test.ts#L181-L188. This prevents using it with the randomly generated day in schedule node cron expressions.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
