### PR TITLE
ci: Replace docker/login-action with retry-wrapped docker login for DockerHub

### DIFF
--- a/.github/actions/docker-registry-login/action.yml
+++ b/.github/actions/docker-registry-login/action.yml
@@ -39,10 +39,13 @@ runs:
 
     - name: Login to DockerHub
       if: inputs.login-dockerhub == 'true'
-      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-      with:
-        username: ${{ inputs.dockerhub-username }}
-        password: ${{ inputs.dockerhub-password }}
+      shell: bash
+      env:
+        DOCKER_USER: ${{ inputs.dockerhub-username }}
+        DOCKER_PASS: ${{ inputs.dockerhub-password }}
+      run: |
+        node .github/scripts/retry.mjs --attempts 3 --delay 10 \
+          'echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin'
 
     - name: Login to DHI Registry
       if: inputs.login-dhi == 'true'


### PR DESCRIPTION
## Summary

Replaces the third-party `docker/login-action` composite action step for DockerHub login with a direct `docker login` bash command, consistent with how the GHCR login step is already implemented in this action.

The new step wraps the login in `retry.mjs` (3 attempts, 10s delay) to handle transient DockerHub rate limits or network hiccups — the same retry pattern used for GHCR login.

**Verification:**
- `docker/login-action` without a `registry:` input defaults to `docker.io` — identical to `docker login` with no registry argument
- Both write credentials to `~/.docker/config.json`; the action does not use credential helpers or any storage mechanism beyond the standard Docker CLI
- Composite action steps share the runner environment with the calling workflow, so login sessions are equally visible to downstream steps

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2808

Hopefully fixes flakiness present in e.g. the Release process https://github.com/n8n-io/n8n/actions/runs/24347179771/job/71091395195#step:6:59

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

---
🤖 PR Summary generated by AI