### PR TITLE
docs: Add migration timestamp guidance to @n8n/db AGENTS.md (no-changelog)

### DIFF
--- a/packages/@n8n/db/AGENTS.md
+++ b/packages/@n8n/db/AGENTS.md
@@ -2,6 +2,13 @@
 
 Extra information specific to the `@n8n/db` package.
 
+## Creating Migrations
+
+Migration files are named `{TIMESTAMP}-{DescriptiveName}.ts`. The timestamp
+must be the **exact** Unix millisecond timestamp at the time of creation — do
+not round or fabricate a value. Use `Date.now()` in a Node REPL or
+`date +%s000` in a shell to generate it.
+
 ## Migration DSL
 
 ### UUID Primary Keys

--- a/packages/@n8n/db/AGENTS.md
+++ b/packages/@n8n/db/AGENTS.md
@@ -7,7 +7,7 @@ Extra information specific to the `@n8n/db` package.
 Migration files are named `{TIMESTAMP}-{DescriptiveName}.ts`. The timestamp
 must be the **exact** Unix millisecond timestamp at the time of creation — do
 not round or fabricate a value. Use `Date.now()` in a Node REPL or
-`date +%s000` in a shell to generate it.
+`date +%s%3N` in a shell (GNU `date`) to generate it.
 
 ## Migration DSL
 


### PR DESCRIPTION
## Summary

I saw a migration on master use a rounded up "future" timestamp, which is mildly annoying if you add an exact timestamp one after and they seem out of order as a result

Adds a "Creating Migrations" section to `packages/@n8n/db/AGENTS.md` instructing developers and AI agents to use exact Unix millisecond timestamps (not rounded or fabricated values) when naming migration files.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)