### PR TITLE
ci: Run lint:styles as a part of reusable linting workflow

### DIFF
--- a/.github/workflows/test-linting-reusable.yml
+++ b/.github/workflows/test-linting-reusable.yml
@@ -29,5 +29,5 @@ jobs:
       - name: Build and Test
         uses: ./.github/actions/setup-nodejs
         with:
-          build-command: pnpm lint
+          build-command: pnpm lint:ci
           node-version: ${{ inputs.nodeVersion }}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lint:styles:fix": "turbo run lint:styles:fix",
     "lint:affected": "turbo run lint --affected",
     "lint:fix": "turbo run lint:fix",
+    "lint:ci": "turbo run lint lint:styles",
     "optimize-svg": "find ./packages -name '*.svg' ! -name 'pipedrive.svg' -print0 | xargs -0 -P16 -L20 npx svgo",
     "generate:third-party-licenses": "node scripts/generate-third-party-licenses.mjs",
     "setup-backend-module": "node scripts/ensure-zx.mjs && zx scripts/backend-module/setup.mjs",


### PR DESCRIPTION
## Summary

`pnpm lint:styles` was never run in the CI, only on pre-commit hooks. Implement running them via new `lint:ci` command.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2810


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
