### PR TITLE
fix(Notion Node): Store lastTimeChecked as ISO string instead of moment object

### DIFF
--- a/packages/nodes-base/nodes/Notion/NotionTrigger.node.ts
+++ b/packages/nodes-base/nodes/Notion/NotionTrigger.node.ts
@@ -189,7 +189,7 @@ export class NotionTrigger implements INodeType {
 			: moment().set({ second: 0, millisecond: 0 }); // Notion timestamp accuracy is only down to the minute
 
 		// update lastTimeChecked to now
-		webhookData.lastTimeChecked = moment().set({ second: 0, millisecond: 0 });
+		webhookData.lastTimeChecked = moment().set({ second: 0, millisecond: 0 }).toISOString();
 
 		// because Notion timestamp accuracy is only down to the minute some duplicates can be fetch
 		const possibleDuplicates = (webhookData.possibleDuplicates as string[]) ?? [];

--- a/packages/nodes-base/nodes/Notion/test/NotionTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/NotionTrigger.node.test.ts
@@ -1,0 +1,75 @@
+import nock from 'nock';
+
+import type { IDataObject } from 'n8n-workflow';
+
+import { testPollingTriggerNode } from '@test/nodes/TriggerHelpers';
+
+import { NotionTrigger } from '../NotionTrigger.node';
+
+describe('NotionTrigger', () => {
+	const baseUrl = 'https://api.notion.com';
+
+	beforeAll(() => {
+		nock.disableNetConnect();
+	});
+
+	afterAll(() => {
+		nock.restore();
+	});
+
+	afterEach(() => {
+		nock.cleanAll();
+	});
+
+	describe('lastTimeChecked serialization', () => {
+		it('should store lastTimeChecked as an ISO string, not a moment object', async () => {
+			const staticData: IDataObject = {};
+
+			nock(baseUrl)
+				.post('/v1/databases/test-db-id/query')
+				.reply(200, { results: [], has_more: false, next_cursor: null });
+
+			await testPollingTriggerNode(NotionTrigger, {
+				node: {
+					parameters: {
+						event: 'pageAddedToDatabase',
+						databaseId: 'test-db-id',
+						simple: true,
+					},
+				},
+				workflowStaticData: staticData,
+			});
+
+			expect(staticData.lastTimeChecked).toBeDefined();
+			expect(typeof staticData.lastTimeChecked).toBe('string');
+			// Verify it's a valid ISO 8601 string
+			expect(new Date(staticData.lastTimeChecked as string).toISOString()).toBe(
+				staticData.lastTimeChecked,
+			);
+		});
+
+		it('should correctly read back a previously stored ISO string', async () => {
+			const previousTime = '2024-06-15T10:30:00.000Z';
+			const staticData: IDataObject = { lastTimeChecked: previousTime };
+
+			nock(baseUrl)
+				.post('/v1/databases/test-db-id/query')
+				.reply(200, { results: [], has_more: false, next_cursor: null });
+
+			await testPollingTriggerNode(NotionTrigger, {
+				node: {
+					parameters: {
+						event: 'pagedUpdatedInDatabase',
+						databaseId: 'test-db-id',
+						simple: true,
+					},
+				},
+				workflowStaticData: staticData,
+			});
+
+			// After poll, lastTimeChecked should be updated and still a string
+			expect(typeof staticData.lastTimeChecked).toBe('string');
+			expect(staticData.lastTimeChecked).not.toBe(previousTime);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

The `NotionTrigger` node's `poll()` method stores a raw moment.js object into `webhookData.lastTimeChecked`:

```ts
webhookData.lastTimeChecked = moment().set({ second: 0, millisecond: 0 });
```

`webhookData` is backed by the workflow's `staticData`, which TypeORM serializes on every mutation. During serialization, TypeORM calls native `Date.prototype` methods on the stored value. Since a moment.js object is not a native `Date` instance, this throws:

```
TypeError: this is not a Date object.
```

This error propagates up through `runPoll()` → `executeTrigger(true)` → `ActiveWorkflows.add()`, where it gets wrapped as a `WorkflowActivationError` — preventing any workflow with a Notion Trigger from activating.

The fix appends `.toISOString()` so that a plain string is stored instead. The read-back path already wraps the value with `moment()`, which parses ISO strings without issue, so no changes are needed there.

## Related Linear tickets, Github issues, and Community forum posts

Fixes https://github.com/n8n-io/n8n/issues/28445
https://linear.app/n8n/issue/GHC-7725

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)