### PR TITLE
fix(core): Switch to latest artifact when it updates / new one is created (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/composableIntegration.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/composableIntegration.test.ts
@@ -63,7 +63,7 @@ describe('composable integration', () => {
 	// 2. Tab auto-switches to executed workflow
 	// -----------------------------------------------------------------------
 	describe('tab auto-switch on execution', () => {
-		test('does not switch tab when viewing a different artifact', async () => {
+		test('switches to latest artifact when execution completes on different workflow', async () => {
 			h.registerWorkflow('wf-1', 'Workflow A');
 			h.registerWorkflow('wf-2', 'Workflow B');
 			h.selectTab('wf-2');
@@ -74,8 +74,8 @@ describe('composable integration', () => {
 			h.addExecutionResult('wf-1', 'exec-1');
 			await h.flush();
 
-			// Should stay on wf-2 — user chose that tab
-			expect(h.activeTabId.value).toBe('wf-2');
+			// Should switch to the workflow that was just built and executed
+			expect(h.activeTabId.value).toBe('wf-1');
 		});
 
 		test('auto-opens preview when streaming and build result appears', async () => {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/useCanvasPreview.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/useCanvasPreview.test.ts
@@ -486,7 +486,7 @@ describe('useCanvasPreview', () => {
 			expect(ctx.isPreviewVisible.value).toBe(false);
 		});
 
-		test('does not switch tab when viewing a different artifact', async () => {
+		test('switches to latest artifact when a new workflow is built while viewing different artifact', async () => {
 			const ctx = setup();
 			registerDataTable(ctx.store, 'dt-1', 'Table', 'proj-1');
 			registerWorkflow(ctx.store, 'wf-1');
@@ -508,9 +508,9 @@ describe('useCanvasPreview', () => {
 			];
 			await nextTick();
 
-			// Should stay on data table — user chose that tab
-			expect(ctx.activeDataTableId.value).toBe('dt-1');
-			expect(ctx.activeWorkflowId.value).toBeNull();
+			// Should switch to the newly built workflow
+			expect(ctx.activeTabId.value).toBe('wf-1');
+			expect(ctx.activeWorkflowId.value).toBe('wf-1');
 		});
 
 		test('increments workflowRefreshKey on each build', async () => {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/useCanvasPreview.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/useCanvasPreview.ts
@@ -251,8 +251,7 @@ export function useCanvasPreview({ store, route, workflowExecutions }: UseCanvas
 	// Watch the toolCallId — it changes even when the same workflow is rebuilt.
 	// Auto-open logic:
 	//   - Preview closed + live build/user message: auto-open to this workflow
-	//   - Preview open on same workflow: refresh it (workflowRefreshKey++)
-	//   - Preview open on different artifact: don't switch — user chose that tab
+	//   - Preview open: switch to this workflow and refresh (workflowRefreshKey++)
 	//   - Thread switch with canvas open: restore canvas with new thread's workflow
 	//   - Thread switch with canvas closed: stay closed
 	watch(
@@ -277,12 +276,6 @@ export function useCanvasPreview({ store, route, workflowExecutions }: UseCanvas
 				const next = new Map(workflowExecutions.value);
 				next.delete(targetId);
 				workflowExecutions.value = next;
-			}
-
-			// If preview is already open on a different artifact, don't switch
-			if (isPreviewVisible.value && activeTabId.value !== null && activeTabId.value !== targetId) {
-				workflowRefreshKey.value++;
-				return;
 			}
 
 			wasCanvasOpenBeforeSwitch.value = false;
@@ -312,15 +305,6 @@ export function useCanvasPreview({ store, route, workflowExecutions }: UseCanvas
 			if (!exec) return;
 
 			if (!isPreviewVisible.value && !store.isStreaming && !userSentMessage.value) return;
-
-			// If preview is already open on a different artifact, don't switch
-			if (
-				isPreviewVisible.value &&
-				activeTabId.value !== null &&
-				activeTabId.value !== exec.workflowId
-			) {
-				return;
-			}
 
 			activeExecutionId.value = exec.executionId;
 			activeTabId.value = exec.workflowId;
@@ -356,12 +340,6 @@ export function useCanvasPreview({ store, route, workflowExecutions }: UseCanvas
 				!userSentMessage.value &&
 				!wasCanvasOpenBeforeSwitch.value
 			) {
-				return;
-			}
-
-			// If preview is already open on a different artifact, don't switch
-			if (isPreviewVisible.value && activeTabId.value !== null && activeTabId.value !== targetId) {
-				dataTableRefreshKey.value++;
 				return;
 			}
 


### PR DESCRIPTION
## Summary

Make us switch to the latest artifact when new ones are created / old ones are updated.

## Related Linear tickets, Github issues, and Community forum posts

[We don’t show the new artifact when one was built already](https://www.notion.so/n8n/aef5b6e0c94f82159cc58164aa417607?v=7965b6e0c94f823c918f88516500cb86&p=33d5b6e0c94f80e0af68fead835198da&pm=s)

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
