### PR TITLE
fix(core): Make workflow preview refresh after setup completes (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/WorkflowPreview.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowPreview.vue
@@ -216,6 +216,19 @@ watch(
 );
 
 watch(
+	() => props.mode,
+	() => {
+		if (showPreview.value) {
+			if (props.mode === 'workflow') {
+				loadWorkflow();
+			} else if (props.mode === 'execution') {
+				loadExecution();
+			}
+		}
+	},
+);
+
+watch(
 	() => props.executionId,
 	() => {
 		if (props.mode === 'execution' && props.executionId) {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/canvasPreview.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/canvasPreview.utils.ts
@@ -13,6 +13,12 @@ export interface BuildResult {
 	toolCallId: string;
 }
 
+export interface WorkflowSetupResult {
+	workflowId: string;
+	/** Unique per operation — changes even when the same workflow is set up again. */
+	toolCallId: string;
+}
+
 export interface DataTableResult {
 	dataTableId: string;
 	/** Unique per operation — changes even when the same table is modified again. */
@@ -39,6 +45,39 @@ export function getLatestBuildResult(node: InstanceAiAgentNode): BuildResult | u
 			const result = tc.result as Record<string, unknown>;
 			if (result.success === true && typeof result.workflowId === 'string') {
 				return { workflowId: result.workflowId, toolCallId: tc.toolCallId };
+			}
+		}
+	}
+	return undefined;
+}
+
+const WORKFLOW_SETUP_TOOLS = new Set(['setup-workflow', 'apply-workflow-credentials']);
+
+/**
+ * Walks an agent tree depth-first (most recent last) and returns the workflowId
+ * (from args) and toolCallId from the latest successful setup-workflow /
+ * apply-workflow-credentials tool result. These tools modify the workflow
+ * (credentials, parameters) but don't return workflowId in the result.
+ */
+export function getLatestWorkflowSetupResult(
+	node: InstanceAiAgentNode,
+): WorkflowSetupResult | undefined {
+	for (let i = node.children.length - 1; i >= 0; i--) {
+		const childResult = getLatestWorkflowSetupResult(node.children[i]);
+		if (childResult) return childResult;
+	}
+	for (let i = node.toolCalls.length - 1; i >= 0; i--) {
+		const tc = node.toolCalls[i];
+		if (
+			WORKFLOW_SETUP_TOOLS.has(tc.toolName) &&
+			!tc.isLoading &&
+			tc.result &&
+			typeof tc.result === 'object'
+		) {
+			const result = tc.result as Record<string, unknown>;
+			const args = tc.args as Record<string, unknown> | undefined;
+			if (result.success === true && typeof args?.workflowId === 'string') {
+				return { workflowId: args.workflowId, toolCallId: tc.toolCallId };
 			}
 		}
 	}

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/useCanvasPreview.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/useCanvasPreview.ts
@@ -4,6 +4,7 @@ import type { RouteLocationNormalizedLoadedGeneric } from 'vue-router';
 import type { IconName } from '@n8n/design-system';
 import {
 	getLatestBuildResult,
+	getLatestWorkflowSetupResult,
 	getLatestExecutionId,
 	getLatestDataTableResult,
 	getLatestDeletedDataTableId,
@@ -282,6 +283,35 @@ export function useCanvasPreview({ store, route, workflowExecutions }: UseCanvas
 			activeExecutionId.value = null;
 			activeTabId.value = targetId;
 			workflowRefreshKey.value++;
+		},
+	);
+
+	// --- Refresh preview when setup-workflow / apply-workflow-credentials completes ---
+	// These tools modify the workflow (credentials, parameters) but aren't detected
+	// by getLatestBuildResult. Refresh the preview so the iframe shows the latest state.
+
+	const latestSetupResult = computed(() => {
+		for (let i = store.messages.length - 1; i >= 0; i--) {
+			const msg = store.messages[i];
+			if (msg.agentTree) {
+				const result = getLatestWorkflowSetupResult(msg.agentTree);
+				if (result) return result;
+			}
+		}
+		return null;
+	});
+
+	watch(
+		() => latestSetupResult.value?.toolCallId,
+		(toolCallId) => {
+			if (!toolCallId || !latestSetupResult.value) return;
+
+			const targetId = latestSetupResult.value.workflowId;
+
+			// Only refresh if the setup targeted the currently active workflow tab
+			if (activeTabId.value === targetId) {
+				workflowRefreshKey.value++;
+			}
 		},
 	);
 


### PR DESCRIPTION
## Summary

It seems like we weren't refreshing the workflow preview properly after setup completes / if the mode changes, this should hopefully fix some of the reported preview problems

## Related Linear tickets, Github issues, and Community forum posts

[Artefact did not update](https://www.notion.so/n8n/aef5b6e0c94f82159cc58164aa417607?v=7965b6e0c94f823c918f88516500cb86&p=3415b6e0c94f80599b24ff05f3ba1828&pm=s)

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
