### PR TITLE
fix(Gmail Trigger Node): Add maxResults limit to prevent OOM on large inboxes

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -23,7 +23,9 @@ import type {
 	GmailWorkflowStaticData,
 	GmailWorkflowStaticDataDictionary,
 	Label,
+	ListMessage,
 	Message,
+	MessageBookkeeping,
 	MessageListResponse,
 } from './types';
 
@@ -33,7 +35,7 @@ export class GmailTrigger implements INodeType {
 		name: 'gmailTrigger',
 		icon: 'file:gmail.svg',
 		group: ['trigger'],
-		version: [1, 1.1, 1.2, 1.3],
+		version: [1, 1.1, 1.2, 1.3, 1.4],
 		description:
 			'Fetches emails from Gmail and starts the workflow on specified polling intervals.',
 		subtitle: '={{"Gmail Trigger"}}',
@@ -112,6 +114,23 @@ export class GmailTrigger implements INodeType {
 				builderHint: {
 					message:
 						'Set to false when the email body is needed for AI analysis, summarization, or content processing. When true, only returns snippet (preview text). When false, returns full email with {id, threadId, labelIds, headers, html, text, textAsHtml, subject, date, to, from, messageId, replyTo}.',
+				},
+			},
+			{
+				displayName: 'Max Emails per Poll',
+				name: 'maxResults',
+				type: 'number',
+				default: 10,
+				typeOptions: {
+					minValue: 1,
+					maxValue: 50,
+				},
+				description:
+					'Maximum number of emails to fetch each time the node polls for new messages. If more emails arrive between polls, the remaining ones will be picked up in subsequent polls.',
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gte: 1.4 } }],
+					},
 				},
 			},
 			{
@@ -285,11 +304,133 @@ export class GmailTrigger implements INodeType {
 
 		const options = this.getNodeParameter('options', {}) as GmailTriggerOptions;
 		const filters = this.getNodeParameter('filters', {}) as GmailTriggerFilters;
+		const simple = this.getNodeParameter('simple') as boolean;
+
+		const shouldLimitMessages = node.typeVersion >= 1.4 && this.getMode() !== 'manual';
+		const maxResults = shouldLimitMessages
+			? (this.getNodeParameter('maxResults', 10) as number)
+			: Infinity;
 
 		let responseData: INodeExecutionData[] = [];
-		const allFetchedMessages: Message[] = [];
+		const allFetchedMessages: MessageBookkeeping[] = [];
+
+		const getEmailDateAsSeconds = (email: Message): number => {
+			let date;
+
+			if (email.internalDate) {
+				date = +email.internalDate / 1000;
+			} else if (email.date) {
+				date = +DateTime.fromJSDate(new Date(email.date)).toSeconds();
+			} else if (email.headers?.date) {
+				date = +DateTime.fromJSDate(new Date(email.headers.date)).toSeconds();
+			}
+
+			if (!date || isNaN(date)) {
+				return +startDate;
+			}
+
+			return date;
+		};
+
+		const buildFetchQs = (): IDataObject => {
+			const qs: IDataObject = {};
+			if (simple) {
+				qs.format = 'metadata';
+				qs.metadataHeaders = ['From', 'To', 'Cc', 'Bcc', 'Subject'];
+			} else {
+				qs.format = 'raw';
+			}
+			return qs;
+		};
+
+		let includeDrafts = false;
+		if (node.typeVersion > 1.1) {
+			includeDrafts = filters.includeDrafts ?? false;
+		} else {
+			includeDrafts = filters.includeDrafts ?? true;
+		}
+
+		const fetchAndProcessMessage = async (
+			messageId: string,
+			fetchQs: IDataObject,
+		): Promise<void> => {
+			const fullMessage = (await googleApiRequest.call(
+				this,
+				'GET',
+				`/gmail/v1/users/me/messages/${messageId}`,
+				{},
+				fetchQs,
+			)) as Message;
+
+			allFetchedMessages.push({
+				id: fullMessage.id,
+				date: getEmailDateAsSeconds(fullMessage),
+			});
+
+			if (!includeDrafts && fullMessage.labelIds?.includes('DRAFT')) {
+				return;
+			}
+			if (
+				node.typeVersion > 1.2 &&
+				fullMessage.labelIds?.includes('SENT') &&
+				!fullMessage.labelIds?.includes('INBOX')
+			) {
+				return;
+			}
+
+			if (!simple) {
+				const dataPropertyNameDownload = options.dataPropertyAttachmentsPrefixName || 'attachment_';
+				const parsed = await parseRawEmail.call(this, fullMessage, dataPropertyNameDownload);
+				responseData.push(parsed);
+			} else {
+				responseData.push({ json: fullMessage });
+			}
+		};
 
 		try {
+			let budget = maxResults;
+
+			// Process pending messages from previous poll first.
+			// These are IDs that were listed but not fetched last time due to maxResults.
+			const pendingIds = nodeStaticData.pendingMessageIds ?? [];
+			if (shouldLimitMessages && pendingIds.length > 0) {
+				const idsToFetch = pendingIds.slice(0, budget);
+				nodeStaticData.pendingMessageIds = pendingIds.slice(budget);
+				const fetchQs = buildFetchQs();
+
+				for (const id of idsToFetch) {
+					await fetchAndProcessMessage(id, fetchQs);
+				}
+
+				budget -= idsToFetch.length;
+
+				// Record drained IDs in possibleDuplicates so Gmail's boundary-inclusive
+				// `after:` query can't re-list a message we just emitted and push it back
+				// into pendingMessageIds as overflow. Also covers the early-return path,
+				// where the state update at the end of poll() is skipped.
+				if (allFetchedMessages.length > 0) {
+					const merged = new Set([
+						...(nodeStaticData.possibleDuplicates ?? []),
+						...allFetchedMessages.map((m) => m.id),
+					]);
+					nodeStaticData.possibleDuplicates = Array.from(merged);
+				}
+
+				// If we still have pending IDs, don't list new messages yet.
+				if (nodeStaticData.pendingMessageIds.length > 0) {
+					if (simple && responseData.length > 0) {
+						responseData = this.helpers.returnJsonArray(
+							await simplifyOutput.call(
+								this,
+								responseData.map((item) => item.json),
+							),
+						);
+					}
+					return responseData.length > 0 ? [responseData] : null;
+				}
+			}
+
+			// List new messages from Gmail.
 			const qs: IDataObject = {};
 			const allFilters: GmailTriggerFilters = { ...filters, receivedAfter: startDate };
 
@@ -308,66 +449,44 @@ export class GmailTrigger implements INodeType {
 				qs,
 			);
 
-			const messages = messagesResponse.messages ?? [];
+			let messages: ListMessage[] = messagesResponse.messages ?? [];
 
-			if (!messages.length) {
+			if (!messages.length && !allFetchedMessages.length) {
 				return null;
 			}
 
-			const simple = this.getNodeParameter('simple') as boolean;
-
-			if (simple) {
-				qs.format = 'metadata';
-				qs.metadataHeaders = ['From', 'To', 'Cc', 'Bcc', 'Subject'];
-			} else {
-				qs.format = 'raw';
-			}
-
-			let includeDrafts = false;
-			if (node.typeVersion > 1.1) {
-				includeDrafts = filters.includeDrafts ?? false;
-			} else {
-				includeDrafts = filters.includeDrafts ?? true;
-			}
-
-			delete qs.includeDrafts;
-
-			for (const message of messages) {
-				const fullMessage = (await googleApiRequest.call(
-					this,
-					'GET',
-					`/gmail/v1/users/me/messages/${message.id}`,
-					{},
-					qs,
-				)) as Message;
-
-				allFetchedMessages.push(fullMessage);
-
-				if (!includeDrafts) {
-					if (fullMessage.labelIds?.includes('DRAFT')) {
-						continue;
-					}
-				}
-				if (
-					node.typeVersion > 1.2 &&
-					fullMessage.labelIds?.includes('SENT') &&
-					!fullMessage.labelIds?.includes('INBOX')
-				) {
-					continue;
+			// For v1.4+, filter out boundary duplicates before fetching to save API calls.
+			// Gmail's `after:` query is inclusive at the second boundary, so messages at
+			// the lastTimeChecked timestamp can reappear.
+			if (shouldLimitMessages) {
+				const possibleDuplicates = new Set(nodeStaticData.possibleDuplicates ?? []);
+				if (possibleDuplicates.size > 0) {
+					messages = messages.filter((m) => !possibleDuplicates.has(m.id));
 				}
 
-				if (!simple) {
-					const dataPropertyNameDownload =
-						options.dataPropertyAttachmentsPrefixName || 'attachment_';
-
-					const parsed = await parseRawEmail.call(this, fullMessage, dataPropertyNameDownload);
-					responseData.push(parsed);
-				} else {
-					responseData.push({ json: fullMessage });
+				if (!messages.length && !allFetchedMessages.length) {
+					return null;
 				}
 			}
 
-			if (simple) {
+			// Take only what fits in the remaining budget, store the rest as pending.
+			let messagesToProcess = messages;
+			if (shouldLimitMessages && messages.length > budget) {
+				messagesToProcess = messages.slice(0, budget);
+				nodeStaticData.pendingMessageIds = messages.slice(budget).map((m) => m.id);
+			}
+
+			if (messagesToProcess.length > 0) {
+				const fetchQs = buildFetchQs();
+				Object.assign(fetchQs, options);
+				delete fetchQs.includeDrafts;
+
+				for (const message of messagesToProcess) {
+					await fetchAndProcessMessage(message.id, fetchQs);
+				}
+			}
+
+			if (simple && responseData.length > 0) {
 				responseData = this.helpers.returnJsonArray(
 					await simplifyOutput.call(
 						this,
@@ -394,47 +513,36 @@ export class GmailTrigger implements INodeType {
 			return null;
 		}
 
-		const emailsWithInvalidDate = new Set<string>();
+		const lastEmailDate = allFetchedMessages.reduce(
+			(lastDate, message) => (message.date > lastDate ? message.date : lastDate),
+			0,
+		);
 
-		const getEmailDateAsSeconds = (email: Message): number => {
-			let date;
+		const nextPollPossibleDuplicates = allFetchedMessages.map((m) => m.id);
 
-			if (email.internalDate) {
-				date = +email.internalDate / 1000;
-			} else if (email.date) {
-				date = +DateTime.fromJSDate(new Date(email.date)).toSeconds();
-			} else if (email.headers?.date) {
-				date = +DateTime.fromJSDate(new Date(email.headers.date)).toSeconds();
+		// For older versions, filter at the response level since the pre-fetch filter
+		// above is gated to v1.4+. v1.4+ already skipped these before fetching.
+		if (!shouldLimitMessages) {
+			const prevDuplicates = new Set(nodeStaticData.possibleDuplicates ?? []);
+			if (prevDuplicates.size > 0) {
+				responseData = responseData.filter(({ json }) => {
+					if (!json || typeof json.id !== 'string') return false;
+					return !prevDuplicates.has(json.id);
+				});
 			}
-
-			if (!date || isNaN(date)) {
-				emailsWithInvalidDate.add(email.id);
-				return +startDate;
-			}
-
-			return date;
-		};
-
-		const lastEmailDate = allFetchedMessages.reduce((lastDate, message) => {
-			const emailDate = getEmailDateAsSeconds(message);
-			return emailDate > lastDate ? emailDate : lastDate;
-		}, 0);
-
-		const nextPollPossibleDuplicates = allFetchedMessages.reduce((duplicates, message) => {
-			const emailDate = getEmailDateAsSeconds(message);
-			return emailDate <= lastEmailDate ? duplicates.concat(message.id) : duplicates;
-		}, Array.from(emailsWithInvalidDate));
-
-		const possibleDuplicates = new Set(nodeStaticData.possibleDuplicates ?? []);
-		if (possibleDuplicates.size > 0) {
-			responseData = responseData.filter(({ json }) => {
-				if (!json || typeof json.id !== 'string') return false;
-				return !possibleDuplicates.has(json.id);
-			});
 		}
 
-		nodeStaticData.possibleDuplicates = nextPollPossibleDuplicates;
-		nodeStaticData.lastTimeChecked = lastEmailDate ?? +startDate;
+		const effectiveLastTimeChecked = Math.floor(Math.max(lastEmailDate, +startDate)) || +startDate;
+
+		// When lastTimeChecked didn't advance (e.g., only older pending messages were processed),
+		// preserve existing possibleDuplicates — they're still at the query boundary.
+		if (effectiveLastTimeChecked === +startDate && nodeStaticData.possibleDuplicates?.length) {
+			const merged = new Set([...nodeStaticData.possibleDuplicates, ...nextPollPossibleDuplicates]);
+			nodeStaticData.possibleDuplicates = Array.from(merged);
+		} else {
+			nodeStaticData.possibleDuplicates = nextPollPossibleDuplicates;
+		}
+		nodeStaticData.lastTimeChecked = effectiveLastTimeChecked;
 
 		if (Array.isArray(responseData) && responseData.length) {
 			return [responseData];

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -77,7 +77,9 @@ describe('GmailTrigger', () => {
 			.get(new RegExp('/gmail/v1/users/me/messages/2?.*'))
 			.reply(200, createMessage({ id: '2' }));
 
-		const { response } = await testPollingTriggerNode(GmailTrigger);
+		const { response } = await testPollingTriggerNode(GmailTrigger, {
+			node: { typeVersion: 1.3 },
+		});
 
 		expect(response).toEqual([
 			[
@@ -144,7 +146,7 @@ describe('GmailTrigger', () => {
 			.reply(200, createMessage({ id: '2' }));
 
 		const { response } = await testPollingTriggerNode(GmailTrigger, {
-			node: { parameters: { simple: true } },
+			node: { typeVersion: 1.3, parameters: { simple: true } },
 		});
 
 		expect(response).toEqual([
@@ -204,7 +206,7 @@ describe('GmailTrigger', () => {
 		nock(baseUrl).get(new RegExp('/gmail/v1/users/me/messages?.*')).reply(200, messageListResponse);
 
 		const { response } = await testPollingTriggerNode(GmailTrigger, {
-			node: { parameters: { simple: true } },
+			node: { typeVersion: 1.3, parameters: { simple: true } },
 			workflowStaticData: {
 				'Gmail Trigger': { lastTimeChecked: new Date('2024-10-31').getTime() / 1000 },
 			},
@@ -260,7 +262,7 @@ describe('GmailTrigger', () => {
 		nock(baseUrl).get(new RegExp('/gmail/v1/users/me/messages/5?.*')).reply(200, {});
 
 		const { response } = await testPollingTriggerNode(GmailTrigger, {
-			node: { parameters: { simple: true } },
+			node: { typeVersion: 1.3, parameters: { simple: true } },
 			workflowStaticData: {
 				'Gmail Trigger': {
 					lastTimeChecked: new Date('2024-10-31').getTime() / 1000,
@@ -294,7 +296,7 @@ describe('GmailTrigger', () => {
 			.reply(200, createMessage({ id: '2', labelIds: ['INBOX'] }));
 
 		const { response } = await testPollingTriggerNode(GmailTrigger, {
-			node: { parameters: { filters: { includeDrafts: false } } },
+			node: { typeVersion: 1.3, parameters: { filters: { includeDrafts: false } } },
 		});
 
 		expect(response).toEqual([
@@ -348,7 +350,9 @@ describe('GmailTrigger', () => {
 			.get(new RegExp('/gmail/v1/users/me/messages/2?.*'))
 			.reply(200, createMessage({ id: '2', labelIds: ['SENT'] }));
 
-		const { response } = await testPollingTriggerNode(GmailTrigger);
+		const { response } = await testPollingTriggerNode(GmailTrigger, {
+			node: { typeVersion: 1.3 },
+		});
 
 		expect(response).toEqual([
 			[
@@ -401,7 +405,9 @@ describe('GmailTrigger', () => {
 			.get(new RegExp('/gmail/v1/users/me/messages/2?.*'))
 			.reply(200, createMessage({ id: '2', labelIds: ['SENT'] }));
 
-		const { response } = await testPollingTriggerNode(GmailTrigger);
+		const { response } = await testPollingTriggerNode(GmailTrigger, {
+			node: { typeVersion: 1.3 },
+		});
 		expect(response).toEqual([
 			[
 				{
@@ -457,7 +463,7 @@ describe('GmailTrigger', () => {
 			.reply(200, createMessage({ id: '3', internalDate: timestamp }));
 
 		const { response } = await testPollingTriggerNode(GmailTrigger, {
-			node: { parameters: { simple: true } },
+			node: { typeVersion: 1.3, parameters: { simple: true } },
 			workflowStaticData: {
 				'Gmail Trigger': {
 					lastTimeChecked: Number(timestamp) / 1000,
@@ -485,7 +491,7 @@ describe('GmailTrigger', () => {
 			.reply(200, createMessage({ id: '1', internalDate: emailTimestamp }));
 
 		const { response } = await testPollingTriggerNode(GmailTrigger, {
-			node: { parameters: { simple: true } },
+			node: { typeVersion: 1.3, parameters: { simple: true } },
 			workflowStaticData: {
 				'Gmail Trigger': { lastTimeChecked: initialTimestamp },
 			},
@@ -518,7 +524,7 @@ describe('GmailTrigger', () => {
 			);
 
 		const { response } = await testPollingTriggerNode(GmailTrigger, {
-			node: { parameters: { filters: { includeDrafts: false } } },
+			node: { typeVersion: 1.3, parameters: { filters: { includeDrafts: false } } },
 			workflowStaticData: {
 				'Gmail Trigger': { lastTimeChecked: initialTimestamp },
 			},
@@ -543,7 +549,7 @@ describe('GmailTrigger', () => {
 			.reply(200, createMessage({ id: '1', internalDate: undefined }));
 
 		const { response } = await testPollingTriggerNode(GmailTrigger, {
-			node: { parameters: { simple: true } },
+			node: { typeVersion: 1.3, parameters: { simple: true } },
 			workflowStaticData: {
 				'Gmail Trigger': { lastTimeChecked: initialTimestamp },
 			},
@@ -584,7 +590,7 @@ describe('GmailTrigger', () => {
 			.reply(200, createMessage({ id: '3', internalDate: timestamp, labelIds: ['INBOX'] }));
 
 		const { response } = await testPollingTriggerNode(GmailTrigger, {
-			node: { parameters: { filters: { includeDrafts: false } } },
+			node: { typeVersion: 1.3, parameters: { filters: { includeDrafts: false } } },
 			workflowStaticData: {
 				'Gmail Trigger': {
 					lastTimeChecked: Number(timestamp) / 1000 - 1,
@@ -597,5 +603,957 @@ describe('GmailTrigger', () => {
 		expect(response?.[0]).toHaveLength(2);
 		expect(response?.[0]?.[0]?.json?.id).toBe('1');
 		expect(response?.[0]?.[1]?.json?.id).toBe('3');
+	});
+
+	describe('v1.4 - maxResults limit', () => {
+		it('should fetch only maxResults messages from a larger list', async () => {
+			// Gmail list returns 3 IDs, but maxResults=2 so only 2 full messages are fetched
+			const messageListResponse: MessageListResponse = {
+				messages: [
+					createListMessage({ id: '3' }),
+					createListMessage({ id: '2' }),
+					createListMessage({ id: '1' }),
+				],
+				resultSizeEstimate: 3,
+			};
+
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, messageListResponse);
+			// Only first 2 messages are fetched (3 and 2)
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/3?.*'))
+				.reply(200, createMessage({ id: '3', internalDate: '3000000000000' }));
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/2?.*'))
+				.reply(200, createMessage({ id: '2', internalDate: '2000000000000' }));
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+			});
+
+			expect(response).toHaveLength(1);
+			expect(response?.[0]).toHaveLength(2);
+			expect(response?.[0]?.[0]?.json?.id).toBe('3');
+			expect(response?.[0]?.[1]?.json?.id).toBe('2');
+		});
+
+		it('should store pending IDs and advance lastTimeChecked when more messages remain', async () => {
+			const initialTimestamp = 1000000;
+			const messageListResponse: MessageListResponse = {
+				messages: [
+					createListMessage({ id: '3' }),
+					createListMessage({ id: '2' }),
+					createListMessage({ id: '1' }),
+				],
+				resultSizeEstimate: 3,
+			};
+
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, messageListResponse);
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/3?.*'))
+				.reply(200, createMessage({ id: '3', internalDate: '3000000000000' }));
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/2?.*'))
+				.reply(200, createMessage({ id: '2', internalDate: '2000000000000' }));
+
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: initialTimestamp },
+			};
+
+			await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			// lastTimeChecked advances to the max date of fetched messages
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(3000000000);
+			// Remaining unfetched message ID stored as pending
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['1']);
+		});
+
+		it('should pick up pending messages on subsequent poll', async () => {
+			// Simulates poll 2: pending IDs from previous poll are fetched directly,
+			// then new messages are listed.
+			const newMessageListResponse: MessageListResponse = {
+				messages: [],
+				resultSizeEstimate: 0,
+			};
+
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			// Pending message fetched by ID
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/1?.*'))
+				.reply(200, createMessage({ id: '1', internalDate: '1000000000000' }));
+			// Then list for new messages (returns nothing)
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, newMessageListResponse);
+
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: 3000000000,
+					pendingMessageIds: ['1'],
+				},
+			};
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(response).toHaveLength(1);
+			expect(response?.[0]).toHaveLength(1);
+			expect(response?.[0]?.[0]?.json?.id).toBe('1');
+			// Pending cleared
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual([]);
+			// lastTimeChecked must NOT regress — pending message 1 has an older date (1s)
+			// than the already-advanced lastTimeChecked (3s) from poll 1
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(3000000000);
+		});
+
+		it('should process pending and new messages in one poll when budget allows', async () => {
+			const newMessageListResponse: MessageListResponse = {
+				messages: [createListMessage({ id: '4' })],
+				resultSizeEstimate: 1,
+			};
+
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			// Pending message fetched by ID
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/1?.*'))
+				.reply(200, createMessage({ id: '1', internalDate: '1000000000000' }));
+			// New messages listed
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, newMessageListResponse);
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/4?.*'))
+				.reply(200, createMessage({ id: '4', internalDate: '4000000000000' }));
+
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: 3000000000,
+					pendingMessageIds: ['1'],
+				},
+			};
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+				workflowStaticData,
+			});
+
+			expect(response).toHaveLength(1);
+			expect(response?.[0]).toHaveLength(2);
+			expect(response?.[0]?.[0]?.json?.id).toBe('1');
+			expect(response?.[0]?.[1]?.json?.id).toBe('4');
+			// lastTimeChecked advances to newest message
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(4000000000);
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual([]);
+		});
+
+		it('should advance lastTimeChecked when all messages fit within limit', async () => {
+			const initialTimestamp = 1000000;
+			const messageListResponse: MessageListResponse = {
+				messages: [createListMessage({ id: '1' })],
+				resultSizeEstimate: 1,
+			};
+
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, messageListResponse);
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/1?.*'))
+				.reply(200, createMessage({ id: '1', internalDate: '2000000000000' }));
+
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: initialTimestamp },
+			};
+
+			await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+				workflowStaticData,
+			});
+
+			// 1 message with maxResults=5, all fetched — advance normally
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(2000000000);
+			// No pending messages
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toBeUndefined();
+		});
+
+		it('should not produce duplicates across a 3-poll pending drain cycle', async () => {
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: 1000000 },
+			};
+
+			// Poll 1: 3 messages arrive, maxResults=2 → fetch 3,2; pending=['1']
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, {
+					messages: [
+						createListMessage({ id: '3' }),
+						createListMessage({ id: '2' }),
+						createListMessage({ id: '1' }),
+					],
+					resultSizeEstimate: 3,
+				} satisfies MessageListResponse);
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/3?.*'))
+				.reply(200, createMessage({ id: '3', internalDate: '3000000000000' }));
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/2?.*'))
+				.reply(200, createMessage({ id: '2', internalDate: '2000000000000' }));
+
+			const poll1 = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(poll1.response?.[0]).toHaveLength(2);
+			expect(poll1.response?.[0]?.[0]?.json?.id).toBe('3');
+			expect(poll1.response?.[0]?.[1]?.json?.id).toBe('2');
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['1']);
+
+			// Poll 2: drain pending msg 1, no new messages
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/1?.*'))
+				.reply(200, createMessage({ id: '1', internalDate: '1000000000000' }));
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, { messages: [], resultSizeEstimate: 0 } satisfies MessageListResponse);
+
+			const poll2 = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(poll2.response?.[0]).toHaveLength(1);
+			expect(poll2.response?.[0]?.[0]?.json?.id).toBe('1');
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(3000000000);
+
+			// Poll 3: Gmail returns msg 3 again (boundary inclusive) → should be filtered
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, {
+					messages: [createListMessage({ id: '3' })],
+					resultSizeEstimate: 1,
+				} satisfies MessageListResponse);
+			// No fetch mock for msg 3 — it's filtered at ID level by possibleDuplicates
+
+			const poll3 = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			// No duplicates — msg 3 was already returned in poll 1
+			expect(poll3.response).toBeNull();
+		});
+
+		it('should reset possibleDuplicates when lastTimeChecked advances after a merge', async () => {
+			// Verifies that the possibleDuplicates merge from pending drain is temporary —
+			// once a newer message arrives and advances lastTimeChecked, duplicates reset.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: 1000000 },
+			};
+
+			// Poll 1: 3 messages, maxResults=2 → fetch 3,2; pending=['1']
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, {
+					messages: [
+						createListMessage({ id: '3' }),
+						createListMessage({ id: '2' }),
+						createListMessage({ id: '1' }),
+					],
+					resultSizeEstimate: 3,
+				} satisfies MessageListResponse);
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/3?.*'))
+				.reply(200, createMessage({ id: '3', internalDate: '3000000000000' }));
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/2?.*'))
+				.reply(200, createMessage({ id: '2', internalDate: '2000000000000' }));
+
+			await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			// Poll 2: drain pending msg 1, no new messages → merge happens
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/1?.*'))
+				.reply(200, createMessage({ id: '1', internalDate: '1000000000000' }));
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, { messages: [], resultSizeEstimate: 0 } satisfies MessageListResponse);
+
+			await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			// After merge: possibleDuplicates should include all three
+			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(
+				expect.arrayContaining(['1', '2', '3']),
+			);
+
+			// Poll 3: new message 4 at a newer timestamp → lastTimeChecked advances
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, {
+					messages: [createListMessage({ id: '4' })],
+					resultSizeEstimate: 1,
+				} satisfies MessageListResponse);
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/4?.*'))
+				.reply(200, createMessage({ id: '4', internalDate: '5000000000000' }));
+
+			const poll3 = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(poll3.response?.[0]).toHaveLength(1);
+			expect(poll3.response?.[0]?.[0]?.json?.id).toBe('4');
+			// possibleDuplicates reset to only msg 4 — old IDs purged
+			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(['4']);
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(5000000000);
+		});
+
+		it('should not re-emit a drained pending message when a newer message arrived in the same poll', async () => {
+			// Reviewer's scenario from PR #28470:
+			//   Poll 1: msgs 1,2,3 exist → fetch [3,2], pending=['1']
+			//   Between polls: msg 4 arrives
+			//   Poll 2: drain pending 1 + fetch new 4 → output [1,4], pending=[]
+			//   Poll 3: no new mail → must be null (msg 1 must NOT reappear)
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: 1000000 },
+			};
+
+			// Poll 1 — msgs 1,2,3 present, maxResults=2 → keep [3,2], pending=['1']
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, {
+					messages: [
+						createListMessage({ id: '3' }),
+						createListMessage({ id: '2' }),
+						createListMessage({ id: '1' }),
+					],
+					resultSizeEstimate: 3,
+				} satisfies MessageListResponse);
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/3?.*'))
+				.reply(200, createMessage({ id: '3', internalDate: '3000000000000' }));
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/2?.*'))
+				.reply(200, createMessage({ id: '2', internalDate: '2000000000000' }));
+
+			const poll1 = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(poll1.response?.[0]).toHaveLength(2);
+			expect(poll1.response?.[0]?.[0]?.json?.id).toBe('3');
+			expect(poll1.response?.[0]?.[1]?.json?.id).toBe('2');
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['1']);
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(3000000000);
+
+			// Poll 2 — drain pending 1, list also returns new msg 4 (+ msg 3 at inclusive boundary)
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/1?.*'))
+				.reply(200, createMessage({ id: '1', internalDate: '1000000000000' }));
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, {
+					messages: [createListMessage({ id: '4' }), createListMessage({ id: '3' })],
+					resultSizeEstimate: 2,
+				} satisfies MessageListResponse);
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/4?.*'))
+				.reply(200, createMessage({ id: '4', internalDate: '4000000000000' }));
+
+			const poll2 = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(poll2.response?.[0]).toHaveLength(2);
+			expect(poll2.response?.[0]?.[0]?.json?.id).toBe('1');
+			expect(poll2.response?.[0]?.[1]?.json?.id).toBe('4');
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds ?? []).toEqual([]);
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(4000000000);
+
+			// Poll 3 — no new mail; Gmail returns msg 4 again (inclusive boundary)
+			// Intentionally NO fetch mock for msg 1 — if code re-fetches it,
+			// nock will throw an unmatched-request error, pinpointing the bug.
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, {
+					messages: [createListMessage({ id: '4' })],
+					resultSizeEstimate: 1,
+				} satisfies MessageListResponse);
+
+			const poll3 = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(poll3.response).toBeNull();
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(4000000000);
+		});
+
+		it('should not re-emit a drained pending message when a newer message arrived in the same poll (simple=false)', async () => {
+			// Same reviewer scenario as above, but with simple=false (raw format).
+			// parseRawEmail path + mailparser may produce a different output shape,
+			// but the dedupe state machine should still prevent re-emitting msg 1 on poll 3.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: 1000000 },
+			};
+
+			// Poll 1
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, {
+					messages: [
+						createListMessage({ id: '3' }),
+						createListMessage({ id: '2' }),
+						createListMessage({ id: '1' }),
+					],
+					resultSizeEstimate: 3,
+				} satisfies MessageListResponse);
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/3?.*'))
+				.reply(200, createMessage({ id: '3', internalDate: '3000000000000' }));
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/2?.*'))
+				.reply(200, createMessage({ id: '2', internalDate: '2000000000000' }));
+
+			const poll1 = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: false, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(poll1.response?.[0]).toHaveLength(2);
+			expect(poll1.response?.[0]?.[0]?.json?.id).toBe('3');
+			expect(poll1.response?.[0]?.[1]?.json?.id).toBe('2');
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['1']);
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(3000000000);
+
+			// Poll 2 — drain pending 1 + new msg 4 (list also returns msg 3 at boundary)
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/1?.*'))
+				.reply(200, createMessage({ id: '1', internalDate: '1000000000000' }));
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, {
+					messages: [createListMessage({ id: '4' }), createListMessage({ id: '3' })],
+					resultSizeEstimate: 2,
+				} satisfies MessageListResponse);
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/4?.*'))
+				.reply(200, createMessage({ id: '4', internalDate: '4000000000000' }));
+
+			const poll2 = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: false, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(poll2.response?.[0]).toHaveLength(2);
+			expect(poll2.response?.[0]?.[0]?.json?.id).toBe('1');
+			expect(poll2.response?.[0]?.[1]?.json?.id).toBe('4');
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds ?? []).toEqual([]);
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(4000000000);
+
+			// Poll 3 — no new mail; deliberately no /messages/1 fetch mock
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, {
+					messages: [createListMessage({ id: '4' })],
+					resultSizeEstimate: 1,
+				} satisfies MessageListResponse);
+
+			const poll3 = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: false, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(poll3.response).toBeNull();
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(4000000000);
+		});
+
+		it('should handle same-timestamp messages split across pending boundary', async () => {
+			// 3 messages all at t=3000s, maxResults=2 → fetch 2, pending 1.
+			// After drain, all 3 should be in possibleDuplicates.
+			const ts = '3000000000000';
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: 1000000 },
+			};
+
+			// Poll 1: fetch msgs A and B, pending=['C']
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, {
+					messages: [
+						createListMessage({ id: 'A' }),
+						createListMessage({ id: 'B' }),
+						createListMessage({ id: 'C' }),
+					],
+					resultSizeEstimate: 3,
+				} satisfies MessageListResponse);
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/A?.*'))
+				.reply(200, createMessage({ id: 'A', internalDate: ts }));
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/B?.*'))
+				.reply(200, createMessage({ id: 'B', internalDate: ts }));
+
+			await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(
+				expect.arrayContaining(['A', 'B']),
+			);
+
+			// Poll 2: drain pending C, no new messages
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/C?.*'))
+				.reply(200, createMessage({ id: 'C', internalDate: ts }));
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, { messages: [], resultSizeEstimate: 0 } satisfies MessageListResponse);
+
+			const poll2 = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(poll2.response?.[0]).toHaveLength(1);
+			expect(poll2.response?.[0]?.[0]?.json?.id).toBe('C');
+			// All three same-timestamp messages tracked as possible duplicates
+			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(
+				expect.arrayContaining(['A', 'B', 'C']),
+			);
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(3000000000);
+		});
+
+		it('should advance lastTimeChecked when all fetched messages are filtered as drafts', async () => {
+			const initialTimestamp = 1000000;
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: initialTimestamp },
+			};
+
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'DRAFT', name: 'DRAFT' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, {
+					messages: [createListMessage({ id: '1' }), createListMessage({ id: '2' })],
+					resultSizeEstimate: 2,
+				} satisfies MessageListResponse);
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/1?.*'))
+				.reply(200, createMessage({ id: '1', internalDate: '5000000000000', labelIds: ['DRAFT'] }));
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/2?.*'))
+				.reply(200, createMessage({ id: '2', internalDate: '4000000000000', labelIds: ['DRAFT'] }));
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: {
+					typeVersion: 1.4,
+					parameters: { simple: true, maxResults: 5, filters: { includeDrafts: false } },
+				},
+				workflowStaticData,
+			});
+
+			// No output — both messages are drafts
+			expect(response).toBeNull();
+			// But lastTimeChecked still advances (prevents infinite re-fetch)
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(5000000000);
+		});
+
+		it('should pick up new messages in the same poll after draining pending', async () => {
+			// Poll 1: 5 messages, maxResults=2 → fetch [5,4], pending=[3,2,1]
+			// Poll 2: drain [3,2], pending=[1], early return (budget exhausted)
+			// Poll 3: drain [1], budget left=1, list returns new msg 6 → fetch it
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: 1000000 },
+			};
+
+			// Poll 1
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, {
+					messages: [
+						createListMessage({ id: '5' }),
+						createListMessage({ id: '4' }),
+						createListMessage({ id: '3' }),
+						createListMessage({ id: '2' }),
+						createListMessage({ id: '1' }),
+					],
+					resultSizeEstimate: 5,
+				} satisfies MessageListResponse);
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/5?.*'))
+				.reply(200, createMessage({ id: '5', internalDate: '5000000000000' }));
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/4?.*'))
+				.reply(200, createMessage({ id: '4', internalDate: '4000000000000' }));
+
+			await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['3', '2', '1']);
+
+			// Poll 2: drain [3,2], budget exhausted, pending=[1], early return
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/3?.*'))
+				.reply(200, createMessage({ id: '3', internalDate: '3000000000000' }));
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/2?.*'))
+				.reply(200, createMessage({ id: '2', internalDate: '2000000000000' }));
+
+			const poll2 = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(poll2.response?.[0]).toHaveLength(2);
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['1']);
+
+			// Poll 3: drain [1] (budget=2, uses 1), then list returns new msg 6
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/1?.*'))
+				.reply(200, createMessage({ id: '1', internalDate: '1000000000000' }));
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, {
+					messages: [createListMessage({ id: '6' })],
+					resultSizeEstimate: 1,
+				} satisfies MessageListResponse);
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/6?.*'))
+				.reply(200, createMessage({ id: '6', internalDate: '6000000000000' }));
+
+			const poll3 = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			// Both pending msg 1 and new msg 6 returned in one poll
+			expect(poll3.response?.[0]).toHaveLength(2);
+			expect(poll3.response?.[0]?.[0]?.json?.id).toBe('1');
+			expect(poll3.response?.[0]?.[1]?.json?.id).toBe('6');
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(6000000000);
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual([]);
+		});
+
+		it('should early-return when budget is fully consumed by pending messages', async () => {
+			// maxResults=2, pending has 3 IDs → fetch 2, keep 1 pending, no listing
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/A?.*'))
+				.reply(200, createMessage({ id: 'A', internalDate: '1000000000000' }));
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/B?.*'))
+				.reply(200, createMessage({ id: 'B', internalDate: '2000000000000' }));
+			// No list mock — listing should NOT happen because budget is exhausted
+
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: 5000000000,
+					pendingMessageIds: ['A', 'B', 'C'],
+					possibleDuplicates: ['X', 'Y'],
+				},
+			};
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(response?.[0]).toHaveLength(2);
+			expect(response?.[0]?.[0]?.json?.id).toBe('A');
+			expect(response?.[0]?.[1]?.json?.id).toBe('B');
+			// One pending ID remains
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['C']);
+			// possibleDuplicates includes the pre-existing entries plus drained IDs so
+			// the next poll's boundary-inclusive `after:` list can't re-queue A or B.
+			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(['X', 'Y', 'A', 'B']);
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(5000000000);
+		});
+
+		it('should not re-overflow a drained pending message sharing a same-second boundary', async () => {
+			// Reproduces Roman's duplicate-emission observation when messages sent in
+			// rapid succession share an integer-second floor.
+			//
+			// Setup: emails 1, 2, 3 all arrive within the same floor-second
+			// (e.g. 3000000000.050s / .100s / .500s), maxResults=2.
+			//
+			// Poll 1: list [3,2,1] → emit [3,2], pending=['1'], lastTimeChecked=3000000000.
+			// Poll 2: drain '1', then list after:3000000000 is boundary-inclusive and
+			//   returns [4,3,2,1]. The pre-fetch filter at GmailTrigger.node.ts:450 only
+			//   knows about possibleDuplicates={3,2}, so '1' falls through to overflow
+			//   and is re-added to pendingMessageIds — even though '1' was just drained.
+			// Poll 3 would then drain '1' again → the observed duplicate.
+			//
+			// The critical assertion is AFTER poll 2: pendingMessageIds must not contain
+			// a message we already emitted this poll.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: 1000000 },
+			};
+
+			// --- Poll 1: msgs 1/2/3 all in same integer-second ---
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, {
+					messages: [
+						createListMessage({ id: '3' }),
+						createListMessage({ id: '2' }),
+						createListMessage({ id: '1' }),
+					],
+					resultSizeEstimate: 3,
+				} satisfies MessageListResponse);
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/3?.*'))
+				.reply(200, createMessage({ id: '3', internalDate: '3000000000500' }));
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/2?.*'))
+				.reply(200, createMessage({ id: '2', internalDate: '3000000000100' }));
+
+			const poll1 = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+			expect(poll1.response?.[0]).toHaveLength(2);
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['1']);
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(3000000000);
+
+			// --- Poll 2: msg 4 arrives, drain '1' + list returns all 4 at boundary ---
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/1?.*'))
+				.reply(200, createMessage({ id: '1', internalDate: '3000000000050' }));
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, {
+					// Gmail's `after:3000000000` is inclusive at the second boundary, so all
+					// three same-second msgs come back alongside the new msg 4.
+					messages: [
+						createListMessage({ id: '4' }),
+						createListMessage({ id: '3' }),
+						createListMessage({ id: '2' }),
+						createListMessage({ id: '1' }),
+					],
+					resultSizeEstimate: 4,
+				} satisfies MessageListResponse);
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/4?.*'))
+				.reply(200, createMessage({ id: '4', internalDate: '4000000000000' }));
+
+			const poll2 = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(poll2.response?.[0]).toHaveLength(2);
+			const poll2Ids = (poll2.response?.[0] ?? []).map((item) => item.json?.id);
+			expect(poll2Ids).toEqual(['1', '4']);
+			// Msg 1 was just drained this poll — it must not be queued again as pending.
+			// The pre-fetch filter must include IDs drained during the current poll.
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds ?? []).toEqual([]);
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(4000000000);
+		});
+
+		it('should not re-emit pending messages drained during an early-return poll', async () => {
+			// Alternative failure path: with maxResults=1 and several same-second msgs,
+			// poll 2 early-returns at GmailTrigger.node.ts:417 because pending is still
+			// non-empty. The early-return skips the state update at lines 504-533, so
+			// possibleDuplicates never records emails drained in poll 2. Poll 3's list
+			// call then finds those same-second emails unchanged in possibleDuplicates
+			// and they get re-queued as pending — causing duplicate emission later.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: 1000000 },
+			};
+
+			// --- Poll 1: emit '3', pending=['2','1'] ---
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, {
+					messages: [
+						createListMessage({ id: '3' }),
+						createListMessage({ id: '2' }),
+						createListMessage({ id: '1' }),
+					],
+					resultSizeEstimate: 3,
+				} satisfies MessageListResponse);
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/3?.*'))
+				.reply(200, createMessage({ id: '3', internalDate: '3000000000500' }));
+
+			const poll1 = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 1 } },
+				workflowStaticData,
+			});
+			expect(poll1.response?.[0]).toHaveLength(1);
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['2', '1']);
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(3000000000);
+
+			// --- Poll 2: drain '2', pending=['1'] still non-empty → early return ---
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/2?.*'))
+				.reply(200, createMessage({ id: '2', internalDate: '3000000000100' }));
+
+			const poll2 = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 1 } },
+				workflowStaticData,
+			});
+			expect(poll2.response?.[0]).toHaveLength(1);
+			expect(poll2.response?.[0]?.[0]?.json?.id).toBe('2');
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['1']);
+
+			// --- Poll 3: drain '1', pending=[], then list after:3000000000 boundary-returns
+			// all 3 same-second msgs. Pre-fetch filter knows only {3}. Msgs [2,1] remain.
+			// Budget=0 → messagesToProcess=[], but pendingMessageIds=['2','1'] (BUG: '2'
+			// was already emitted in poll 2, and '1' was just drained this poll).
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/1?.*'))
+				.reply(200, createMessage({ id: '1', internalDate: '3000000000050' }));
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, {
+					messages: [
+						createListMessage({ id: '3' }),
+						createListMessage({ id: '2' }),
+						createListMessage({ id: '1' }),
+					],
+					resultSizeEstimate: 3,
+				} satisfies MessageListResponse);
+
+			const poll3 = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 1 } },
+				workflowStaticData,
+			});
+			expect(poll3.response?.[0]).toHaveLength(1);
+			expect(poll3.response?.[0]?.[0]?.json?.id).toBe('1');
+
+			// After poll 3, pendingMessageIds must not contain IDs already emitted:
+			// '2' was emitted in poll 2 and '1' in this poll.
+			const pending = (workflowStaticData['Gmail Trigger'].pendingMessageIds ?? []) as string[];
+			expect(pending).not.toContain('2');
+			expect(pending).not.toContain('1');
+		});
+
+		it('should not apply limit in manual mode', async () => {
+			const messageListResponse: MessageListResponse = {
+				messages: [createListMessage({ id: '1' })],
+				resultSizeEstimate: 1,
+			};
+
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
+				.reply(200, messageListResponse);
+			nock(baseUrl)
+				.get(new RegExp('/gmail/v1/users/me/messages/1?.*'))
+				.reply(200, createMessage({ id: '1' }));
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				mode: 'manual',
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+			});
+
+			expect(response).toHaveLength(1);
+			expect(response?.[0]?.[0]?.json?.id).toBe('1');
+		});
 	});
 });

--- a/packages/nodes-base/nodes/Google/Gmail/types.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/types.ts
@@ -14,6 +14,11 @@ export type Message = {
 
 export type ListMessage = Pick<Message, 'id' | 'threadId'>;
 
+export type MessageBookkeeping = {
+	id: string;
+	date: number;
+};
+
 export type MessageListResponse = {
 	messages?: ListMessage[];
 	nextPageToken?: string;
@@ -51,6 +56,8 @@ export type Label = {
 export type GmailWorkflowStaticData = {
 	lastTimeChecked?: number;
 	possibleDuplicates?: string[];
+	/** v1.4+: Message IDs remaining from a previous poll that exceeded maxResults */
+	pendingMessageIds?: string[];
 };
 export type GmailWorkflowStaticDataDictionary = Record<string, GmailWorkflowStaticData>;
 


### PR DESCRIPTION
## Summary

The Gmail Trigger causes OOM on Cloud when polling many or large emails. Root causes:
1. Gmail list API can return up to 100 message IDs, then each is fetched as a full message (`format=raw` can be 10MB+ per email)
2. Full `Message` objects were kept in memory just for timestamp/duplicate detection
3. No user control over how many emails to fetch per poll

This PR adds **node version 1.4** with a configurable "Max Emails per Poll" field (default 10, max 50). The approach: list all IDs (cheap), limit full fetches (expensive), store unfetched IDs as `pendingMessageIds` for the next poll cycle.

### Key changes:
- **`maxResults` property** gated behind `@version >= 1.4`, disabled in manual mode
- **`MessageBookkeeping` type** — lightweight `{id, date}` for timestamp/dedup computation without retaining full message bodies
- **`pendingMessageIds` state** — unfetched IDs stored for next poll (when # of emails > maxResults), drained before listing new messages
- **Duplicate fix** — `possibleDuplicates` are now merged (not replaced) when `lastTimeChecked` doesn't advance during pending drain, preventing boundary duplicates from reappearing
- **Timestamp flooring** — `Math.floor()` on `lastTimeChecked` to prevent float precision issues in equality comparisons
- **24 tests** (12 existing pinned to 1.3, 12 new for 1.4) covering: budget limiting, pending drain, multi-poll cycles, same-timestamp edge cases, draft filtering, early-return paths

### How to test:
1. Create a Gmail Trigger v1.4 workflow with `maxResults=2`
2. Send 3+ emails to the monitored account
3. Verify: Poll 1 returns 2 emails, Poll 2 returns remaining, Poll 3 returns nothing (no duplicates)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4595

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)