### PR TITLE
fix(editor): Gracefully handle expired confirmations in setup wizard

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
@@ -281,7 +281,13 @@ async function handleContinue() {
 
 	const success = await store.confirmAction(props.requestId, true, undefined, credentials);
 	if (success) {
-		store.resolveConfirmation(props.requestId, 'approved');
+		if (store.isConfirmationGone(props.requestId)) {
+			// Run was swept/cancelled — show deferred state instead of approved
+			isDeferred.value = true;
+			store.resolveConfirmation(props.requestId, 'deferred');
+		} else {
+			store.resolveConfirmation(props.requestId, 'approved');
+		}
 	} else {
 		isSubmitted.value = false;
 	}

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
@@ -279,15 +279,13 @@ async function handleContinue() {
 
 	isSubmitted.value = true;
 
-	const success = await store.confirmAction(props.requestId, true, undefined, credentials);
-	if (success) {
-		if (store.isConfirmationGone(props.requestId)) {
-			// Run was swept/cancelled — show deferred state instead of approved
-			isDeferred.value = true;
-			store.resolveConfirmation(props.requestId, 'deferred');
-		} else {
-			store.resolveConfirmation(props.requestId, 'approved');
-		}
+	const result = await store.confirmAction(props.requestId, true, undefined, credentials);
+	if (result === 'expired') {
+		// Run was swept/cancelled — show deferred state instead of approved
+		isDeferred.value = true;
+		store.resolveConfirmation(props.requestId, 'deferred');
+	} else if (result) {
+		store.resolveConfirmation(props.requestId, 'approved');
 	} else {
 		isSubmitted.value = false;
 	}

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useSetupActions.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useSetupActions.ts
@@ -167,7 +167,7 @@ export function useSetupActions(deps: {
 		isApplying.value = true;
 		applyError.value = null;
 
-		const postSuccess = await deps.store.confirmAction(
+		const postResult = await deps.store.confirmAction(
 			deps.requestId.value,
 			true,
 			undefined,
@@ -182,15 +182,15 @@ export function useSetupActions(deps: {
 			},
 		);
 
-		if (!postSuccess) {
+		if (!postResult) {
 			isApplying.value = false;
 			applyError.value = 'Failed to send confirmation. Try again.';
 			return;
 		}
 
-		// If the run was already cancelled/expired (e.g. 404 returned as success),
-		// don't wait for a tool result that will never arrive — gracefully dismiss.
-		if (deps.store.isConfirmationGone(deps.requestId.value)) {
+		// The run was already cancelled/expired (404) —
+		// don't wait for a tool result that will never arrive.
+		if (postResult === 'expired') {
 			isApplying.value = false;
 			isSubmitted.value = true;
 			isDeferred.value = true;
@@ -224,7 +224,7 @@ export function useSetupActions(deps: {
 
 		applyError.value = null;
 
-		const postSuccess = await deps.store.confirmAction(
+		const postResult = await deps.store.confirmAction(
 			deps.requestId.value,
 			true,
 			undefined,
@@ -240,13 +240,13 @@ export function useSetupActions(deps: {
 			},
 		);
 
-		if (!postSuccess) {
+		if (!postResult) {
 			applyError.value = 'Failed to send trigger test request. Try again.';
 			return;
 		}
 
-		// If the run was already cancelled/expired, don't wait for a tool result.
-		if (deps.store.isConfirmationGone(deps.requestId.value)) {
+		// The run was already cancelled/expired (404) — don't wait for a tool result.
+		if (postResult === 'expired') {
 			isSubmitted.value = true;
 			isDeferred.value = true;
 			deps.store.resolveConfirmation(deps.requestId.value, 'deferred');

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useSetupActions.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useSetupActions.ts
@@ -188,6 +188,16 @@ export function useSetupActions(deps: {
 			return;
 		}
 
+		// If the run was already cancelled/expired (e.g. 404 returned as success),
+		// don't wait for a tool result that will never arrive — gracefully dismiss.
+		if (deps.store.isConfirmationGone(deps.requestId.value)) {
+			isApplying.value = false;
+			isSubmitted.value = true;
+			isDeferred.value = true;
+			deps.store.resolveConfirmation(deps.requestId.value, 'deferred');
+			return;
+		}
+
 		const { promise, cancel } = waitForToolResult(deps.requestId.value);
 		cancelApplyWait = cancel;
 		const toolResult = await promise;
@@ -232,6 +242,14 @@ export function useSetupActions(deps: {
 
 		if (!postSuccess) {
 			applyError.value = 'Failed to send trigger test request. Try again.';
+			return;
+		}
+
+		// If the run was already cancelled/expired, don't wait for a tool result.
+		if (deps.store.isConfirmationGone(deps.requestId.value)) {
+			isSubmitted.value = true;
+			isDeferred.value = true;
+			deps.store.resolveConfirmation(deps.requestId.value, 'deferred');
 			return;
 		}
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.store.ts
@@ -294,12 +294,6 @@ export const useInstanceAiStore = defineStore('instanceAi', () => {
 		return undefined;
 	}
 
-	/** Check whether the run behind a confirmation has already been cancelled or completed. */
-	function isConfirmationGone(requestId: string): boolean {
-		const tc = findToolCallByRequestId(requestId);
-		return !tc || !tc.isLoading;
-	}
-
 	// --- Event reducer (delegated to pure module) ---
 
 	// --- SSE lifecycle ---
@@ -856,7 +850,7 @@ export const useInstanceAiStore = defineStore('instanceAi', () => {
 		},
 		answers?: InstanceAiConfirmResponse['answers'],
 		resourceDecision?: string,
-	): Promise<boolean> {
+	): Promise<boolean | 'expired'> {
 		try {
 			await postConfirmation(
 				rootStore.restApiContext,
@@ -874,9 +868,9 @@ export const useInstanceAiStore = defineStore('instanceAi', () => {
 			return true;
 		} catch (error) {
 			if (error instanceof ResponseError && error.httpStatusCode === 404) {
-				// The run was already swept/cancelled — treat as handled so callers
-				// proceed with their cleanup path instead of getting stuck.
-				return true;
+				// The run was already swept/cancelled — signal callers so they can
+				// show a deferred/dismissed state instead of getting stuck.
+				return 'expired';
 			}
 			toast.showError(new Error('Failed to send confirmation. Try again.'), 'Confirmation failed');
 			return false;
@@ -1072,7 +1066,6 @@ export const useInstanceAiStore = defineStore('instanceAi', () => {
 		confirmResourceDecision,
 		resolveConfirmation,
 		findToolCallByRequestId,
-		isConfirmationGone,
 		copyFullTrace,
 		submitFeedback,
 		fetchCredits,

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.store.ts
@@ -294,6 +294,12 @@ export const useInstanceAiStore = defineStore('instanceAi', () => {
 		return undefined;
 	}
 
+	/** Check whether the run behind a confirmation has already been cancelled or completed. */
+	function isConfirmationGone(requestId: string): boolean {
+		const tc = findToolCallByRequestId(requestId);
+		return !tc || !tc.isLoading;
+	}
+
 	// --- Event reducer (delegated to pure module) ---
 
 	// --- SSE lifecycle ---
@@ -866,7 +872,12 @@ export const useInstanceAiStore = defineStore('instanceAi', () => {
 				resourceDecision,
 			);
 			return true;
-		} catch {
+		} catch (error) {
+			if (error instanceof ResponseError && error.httpStatusCode === 404) {
+				// The run was already swept/cancelled — treat as handled so callers
+				// proceed with their cleanup path instead of getting stuck.
+				return true;
+			}
 			toast.showError(new Error('Failed to send confirmation. Try again.'), 'Confirmation failed');
 			return false;
 		}
@@ -1061,6 +1072,7 @@ export const useInstanceAiStore = defineStore('instanceAi', () => {
 		confirmResourceDecision,
 		resolveConfirmation,
 		findToolCallByRequestId,
+		isConfirmationGone,
 		copyFullTrace,
 		submitFeedback,
 		fetchCredits,


### PR DESCRIPTION
## Summary

When the Instance AI setup wizard has been open for >10 minutes, the backend sweeps the suspended run (confirmation timeout). If the user then clicks "Later" or "Continue":

- **Before:** POST returns 404 → `confirmAction()` catches it generically → shows cryptic "Confirmation failed" toast → UI stays permanently stuck (buttons do nothing)
- **After:** 404 is detected as "run already gone" → wizard gracefully dismisses with "Deferred" status → no stuck UI

### What changed

- **`confirmAction()` in `instanceAi.store.ts`**: Detect `ResponseError` with `httpStatusCode === 404` and return `true` instead of `false` (suppressing the error toast). This lets callers proceed with their cleanup path. Uses the same `error instanceof ResponseError` pattern already established in `sendMessage()` (line 787).
- **New `isConfirmationGone()` helper**: Checks if a tool call's `isLoading` is `false` (meaning the run was already cancelled via the SSE `run-finish` event). This prevents `handleApply()` and `handleTestTrigger()` from waiting 60 seconds for a tool result that will never arrive from a cancelled run.
- **Guards in `useSetupActions.ts`**: `handleApply()` and `handleTestTrigger()` check `isConfirmationGone()` after `confirmAction` returns `true`, and gracefully dismiss instead of entering the dead wait.
- **Guard in `InstanceAiCredentialSetup.vue`**: `handleContinue()` checks `isConfirmationGone()` and shows "Deferred" state instead of "Approved" when the run was swept.

### Why this works

The backend already sends a `run-finish` SSE event with `status: 'cancelled'` when it sweeps an expired run. The frontend reducer sets `tc.isLoading = false`, which removes the confirmation from the panel. The bug only occurs in the race where the user clicks **before** the SSE event arrives — this fix handles that race by treating the 404 as "effectively handled."

## Linear tickets

- Fixes https://linear.app/n8n/issue/AI-2367 — "Later" doesn't work after waiting
- Fixes https://linear.app/n8n/issue/AI-2371 — Cryptic "Confirmation failed" error on Continue


- [x] I have seen this code, I have run this code, and I take responsibility for this code.