### PR TITLE
fix(editor): Prevent setup wizard disappearing on requestId-driven remount

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -5175,6 +5175,7 @@
 	"instanceAi.workflowSetup.apply": "Apply",
 	"instanceAi.workflowSetup.applyCompleted": "Apply completed",
 	"instanceAi.workflowSetup.later": "Skip setup for now",
+	"instanceAi.workflowSetup.loading": "Loading setup…",
 	"instanceAi.workflowSetup.applying": "Applying changes…",
 	"instanceAi.workflowSetup.applied": "Workflow configured",
 	"instanceAi.workflowSetup.partiallyApplied": "Partially configured — some nodes skipped",

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowSetup.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowSetup.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
 import userEvent from '@testing-library/user-event';
+import { waitFor } from '@testing-library/vue';
 import { createComponentRenderer } from '@/__tests__/render';
 import type { InstanceAiWorkflowSetupNode } from '@n8n/api-types';
 import InstanceAiWorkflowSetup from '../components/InstanceAiWorkflowSetup.vue';
@@ -75,6 +76,18 @@ vi.mock('@/features/workflows/canvas/experimental/composables/useExpressionResol
 
 const renderComponent = createComponentRenderer(InstanceAiWorkflowSetup);
 
+/** Render the component and wait for the async onMounted to complete (isStoreReady = true). */
+async function renderAndWait(
+	...args: Parameters<typeof renderComponent>
+): ReturnType<typeof renderComponent> {
+	const result = renderComponent(...args);
+	// Wait for async onMounted (credential/workflow fetch) to complete so the wizard renders
+	await waitFor(() => {
+		expect(result.queryByText('instanceAi.workflowSetup.loading')).toBeNull();
+	});
+	return result;
+}
+
 function makeSetupNode(
 	overrides: Partial<InstanceAiWorkflowSetupNode> = {},
 ): InstanceAiWorkflowSetupNode {
@@ -143,7 +156,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				]),
 			];
 
-			const { getByTestId, getByText } = renderComponent({
+			const { getByTestId, getByText } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -177,7 +190,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				]),
 			];
 
-			const { getByTestId, getByText } = renderComponent({
+			const { getByTestId, getByText } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -208,7 +221,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				]),
 			];
 
-			const { getByTestId, getByText } = renderComponent({
+			const { getByTestId, getByText } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -243,7 +256,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				]),
 			];
 
-			const { getByTestId } = renderComponent({
+			const { getByTestId } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -281,7 +294,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				}),
 			];
 
-			const { getByTestId, getByText } = renderComponent({
+			const { getByTestId, getByText } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -312,7 +325,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				]),
 			];
 
-			const { getByTestId, getByText } = renderComponent({
+			const { getByTestId, getByText } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -330,7 +343,7 @@ describe('InstanceAiWorkflowSetup', () => {
 			expect(getByText('1 of 2')).toBeTruthy();
 		});
 
-		it('disables apply button when no card is completed', () => {
+		it('disables apply button when no card is completed', async () => {
 			const requests = [
 				makeSetupNodeWithCredentials('slackApi', [
 					{ id: 'cred-1', name: 'Slack' },
@@ -338,7 +351,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				]),
 			];
 
-			const { getByTestId } = renderComponent({
+			const { getByTestId } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -395,7 +408,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				),
 			];
 
-			const { getByText } = renderComponent({
+			const { getByText } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -419,7 +432,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				]),
 			];
 
-			const { getByTestId } = renderComponent({
+			const { getByTestId } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -437,7 +450,7 @@ describe('InstanceAiWorkflowSetup', () => {
 	});
 
 	describe('credential testing', () => {
-		it('renders card for auto-applied testable credential type', () => {
+		it('renders card for auto-applied testable credential type', async () => {
 			const credentialsStore = useCredentialsStore();
 			// @ts-expect-error Known pinia issue when spying on store getters
 			vi.spyOn(credentialsStore, 'getCredentialTypeByName', 'get').mockReturnValue(() => ({
@@ -452,7 +465,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				}),
 			];
 
-			const { getByTestId } = renderComponent({
+			const { getByTestId } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -465,7 +478,7 @@ describe('InstanceAiWorkflowSetup', () => {
 			expect(getByTestId('instance-ai-workflow-setup-card')).toBeTruthy();
 		});
 
-		it('backend-tested credential remains complete when selection unchanged', () => {
+		it('backend-tested credential remains complete when selection unchanged', async () => {
 			const requests = [
 				makeSetupNodeWithCredentials('headerAuth', [{ id: 'cred-1', name: 'Header Auth' }], {
 					isAutoApplied: true,
@@ -482,7 +495,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				}),
 			];
 
-			const { getByTestId } = renderComponent({
+			const { getByTestId } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -536,7 +549,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				}),
 			];
 
-			const { getByTestId } = renderComponent({
+			const { getByTestId } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -565,14 +578,14 @@ describe('InstanceAiWorkflowSetup', () => {
 	});
 
 	describe('confirm mode', () => {
-		it('shows confirm card when all items are pre-resolved', () => {
+		it('shows confirm card when all items are pre-resolved', async () => {
 			const requests = [
 				makeSetupNodeWithCredentials('slackApi', [{ id: 'cred-1', name: 'Slack' }], {
 					needsAction: false,
 				}),
 			];
 
-			const { getByTestId } = renderComponent({
+			const { getByTestId } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -591,7 +604,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				}),
 			];
 
-			const { getByTestId, queryByTestId } = renderComponent({
+			const { getByTestId, queryByTestId } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -629,7 +642,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				),
 			];
 
-			const { getByTestId, getByText } = renderComponent({
+			const { getByTestId, getByText } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowSetup.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowSetup.test.ts
@@ -79,7 +79,7 @@ const renderComponent = createComponentRenderer(InstanceAiWorkflowSetup);
 /** Render the component and wait for the async onMounted to complete (isStoreReady = true). */
 async function renderAndWait(
 	...args: Parameters<typeof renderComponent>
-): ReturnType<typeof renderComponent> {
+): Promise<ReturnType<typeof renderComponent>> {
 	const result = renderComponent(...args);
 	// Wait for async onMounted (credential/workflow fetch) to complete so the wizard renders
 	await waitFor(() => {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowSetup.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowSetup.vue
@@ -216,6 +216,7 @@ const ExpressionContextProvider = defineComponent({
 // ---------------------------------------------------------------------------
 
 let previousWorkflow: IWorkflowDb | null = null;
+let isMounted = true;
 
 // ---------------------------------------------------------------------------
 // Trigger test result + disabled helpers
@@ -339,6 +340,7 @@ const stopCreateListener = credentialsStore.$onAction(({ name, after }) => {
 // ---------------------------------------------------------------------------
 
 onUnmounted(() => {
+	isMounted = false;
 	stopDeleteListener();
 	stopCreateListener();
 	if (previousWorkflow) {
@@ -364,13 +366,18 @@ onMounted(async () => {
 		console.warn('Failed to preload credentials/node types for Instance AI workflow setup', error);
 	}
 
+	if (!isMounted) return;
+
 	try {
 		const workflowData = await fetchWorkflowApi(rootStore.restApiContext, props.workflowId);
+		if (!isMounted) return;
 		previousWorkflow = { ...workflowsStore.workflow };
 		workflowsStore.setWorkflow(workflowData);
 	} catch (error) {
 		console.warn('Failed to fetch workflow for Instance AI setup', error);
 	}
+
+	if (!isMounted) return;
 
 	isStoreReady.value = true;
 
@@ -451,7 +458,11 @@ const nodeNamesTooltip = computed(() => nodeNames.value.join(', '));
 
 <template>
 	<div>
-		<template v-if="!isSubmitted && !isApplying">
+		<div v-if="!isStoreReady" :class="$style.submitted">
+			<N8nIcon icon="spinner" color="primary" spin size="small" :class="$style.loading" />
+			<span>{{ i18n.baseText('instanceAi.workflowSetup.loading' as BaseTextKey) }}</span>
+		</div>
+		<template v-else-if="!isSubmitted && !isApplying">
 			<!-- Streamlined confirm mode: all items pre-resolved by AI -->
 			<div
 				v-if="allPreResolved && !showFullWizard"


### PR DESCRIPTION
## Summary

- Add unmount guard to `InstanceAiWorkflowSetup` so async mount work (`fetchWorkflowApi`, credential preloading) bails out when the component has already been destroyed by a `requestId` change — prevents the dead instance from overwriting the workflow store
- Show a loading spinner while async setup is in flight, preventing a blank gap during the unmount→remount transition

## How this fixes the disappearing setup wizard

The setup wizard component is keyed by `requestId` in the parent panel. When the backend re-suspends with a new `requestId` (e.g. after re-analysis), Vue destroys the old component instance and creates a new one.

The problem is that `onMounted` performs async work — it fetches credentials and the workflow via API — but never checks whether the component was unmounted while those fetches were in flight. This creates a race condition:

1. **Component A** mounts, starts `fetchWorkflowApi` (async)
2. Backend sends a new `requestId` → **Component A unmounts** (restores `previousWorkflow` to the store), **Component B mounts**
3. **Component A's fetch resolves** → calls `workflowsStore.setWorkflow()` with stale data, **clobbering Component B's state**
4. The wizard appears empty or disappears entirely

The fix adds an `isMounted` flag that is set to `false` in `onUnmounted`. After each `await` in `onMounted`, we check `if (!isMounted) return` to bail out early — the dead component instance never touches the workflow store.

Additionally, the template now shows a loading spinner (`"Loading setup…"`) while the async initialization is running, so the user sees feedback during the unmount→remount gap instead of a blank space.

## Related Linear ticket

https://linear.app/n8n/issue/AI-2364/fix-setup-wizard-component-disappears-due-to-requestid-driven-remount

- [x] I have seen this code, I have run this code, and I take responsibility for this code.