### PR TITLE
fix(editor): Improve setup wizard placeholder detection and card completion scoping

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/setup-workflow.service.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/setup-workflow.service.test.ts
@@ -356,6 +356,69 @@ describe('buildSetupRequests', () => {
 		// list should only be called once due to caching
 		expect(context.credentialService.list).toHaveBeenCalledTimes(1);
 	});
+
+	it('treats placeholder values as parameter issues', async () => {
+		(context.nodeService.getDescription as jest.Mock).mockResolvedValue({
+			group: [],
+			credentials: [],
+			properties: [{ name: 'email', displayName: 'Email', type: 'string' }],
+		});
+
+		const node = makeNode({
+			parameters: { email: '<__PLACEHOLDER_VALUE__your_email__>' },
+		});
+		const result = await buildSetupRequests(context, node);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].parameterIssues).toBeDefined();
+		expect(result[0].parameterIssues!.email).toEqual(
+			expect.arrayContaining([expect.stringContaining('your_email')]),
+		);
+	});
+
+	it('adds placeholder issue even when param already has validation issues', async () => {
+		(context.nodeService.getDescription as jest.Mock).mockResolvedValue({
+			group: [],
+			credentials: [],
+			properties: [{ name: 'email', displayName: 'Email', type: 'string', required: true }],
+		});
+		(context.nodeService as Record<string, unknown>).getParameterIssues = jest
+			.fn()
+			.mockResolvedValue({ email: ['Parameter "Email" is required'] });
+
+		const node = makeNode({
+			parameters: { email: '<__PLACEHOLDER_VALUE__your_email__>' },
+		});
+		const result = await buildSetupRequests(context, node);
+
+		expect(result).toHaveLength(1);
+		const issues = result[0].parameterIssues!.email;
+		expect(issues).toHaveLength(2);
+		expect(issues).toEqual(
+			expect.arrayContaining([
+				'Parameter "Email" is required',
+				expect.stringContaining('your_email'),
+			]),
+		);
+	});
+
+	it('uses generic message when placeholder has no label', async () => {
+		(context.nodeService.getDescription as jest.Mock).mockResolvedValue({
+			group: [],
+			credentials: [],
+			properties: [{ name: 'value', displayName: 'Value', type: 'string' }],
+		});
+
+		const node = makeNode({
+			parameters: { value: '<__PLACEHOLDER_VALUE____>' },
+		});
+		const result = await buildSetupRequests(context, node);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].parameterIssues!.value).toEqual([
+			'Contains a placeholder value — please provide the real value',
+		]);
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/setup-workflow.service.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/setup-workflow.service.test.ts
@@ -382,7 +382,7 @@ describe('buildSetupRequests', () => {
 			credentials: [],
 			properties: [{ name: 'email', displayName: 'Email', type: 'string', required: true }],
 		});
-		(context.nodeService as Record<string, unknown>).getParameterIssues = jest
+		(context.nodeService as unknown as Record<string, unknown>).getParameterIssues = jest
 			.fn()
 			.mockResolvedValue({ email: ['Parameter "Email" is required'] });
 

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/setup-workflow.service.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/setup-workflow.service.test.ts
@@ -401,24 +401,6 @@ describe('buildSetupRequests', () => {
 			]),
 		);
 	});
-
-	it('uses generic message when placeholder has no label', async () => {
-		(context.nodeService.getDescription as jest.Mock).mockResolvedValue({
-			group: [],
-			credentials: [],
-			properties: [{ name: 'value', displayName: 'Value', type: 'string' }],
-		});
-
-		const node = makeNode({
-			parameters: { value: '<__PLACEHOLDER_VALUE____>' },
-		});
-		const result = await buildSetupRequests(context, node);
-
-		expect(result).toHaveLength(1);
-		expect(result[0].parameterIssues!.value).toEqual([
-			'Contains a placeholder value — please provide the real value',
-		]);
-	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/@n8n/instance-ai/src/tools/workflows/setup-workflow.service.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/setup-workflow.service.ts
@@ -5,7 +5,7 @@
  * Separated from the tool definition so the tool stays a thin suspend/resume
  * state machine, and this logic is testable independently.
  */
-import { hasPlaceholderDeep, extractPlaceholderLabel } from '@n8n/utils';
+import { findPlaceholderDetails } from '@n8n/utils';
 import type { IDataObject, NodeJSON, DisplayOptions } from '@n8n/workflow-sdk';
 import { matchesDisplayOptions } from '@n8n/workflow-sdk';
 import { nanoid } from 'nanoid';
@@ -70,11 +70,9 @@ export async function buildSetupRequests(
 
 	// Also treat placeholder values as parameter issues so the setup wizard surfaces them
 	for (const [paramName, paramValue] of Object.entries(parameters)) {
-		if (hasPlaceholderDeep(paramValue)) {
-			const label = extractPlaceholderLabel(paramValue);
-			const message = label
-				? `Placeholder "${label}" — please provide the real value`
-				: 'Contains a placeholder value — please provide the real value';
+		const details = findPlaceholderDetails(paramValue);
+		if (details.length > 0) {
+			const message = `Placeholder "${details[0].label}" — please provide the real value`;
 			if (parameterIssues[paramName]) {
 				parameterIssues[paramName].push(message);
 			} else {

--- a/packages/@n8n/instance-ai/src/tools/workflows/setup-workflow.service.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/setup-workflow.service.ts
@@ -5,7 +5,7 @@
  * Separated from the tool definition so the tool stays a thin suspend/resume
  * state machine, and this logic is testable independently.
  */
-import { hasPlaceholderDeep } from '@n8n/utils';
+import { hasPlaceholderDeep, extractPlaceholderLabel } from '@n8n/utils';
 import type { IDataObject, NodeJSON, DisplayOptions } from '@n8n/workflow-sdk';
 import { matchesDisplayOptions } from '@n8n/workflow-sdk';
 import { nanoid } from 'nanoid';
@@ -70,8 +70,16 @@ export async function buildSetupRequests(
 
 	// Also treat placeholder values as parameter issues so the setup wizard surfaces them
 	for (const [paramName, paramValue] of Object.entries(parameters)) {
-		if (!parameterIssues[paramName] && hasPlaceholderDeep(paramValue)) {
-			parameterIssues[paramName] = ['Contains a placeholder value - please provide the real value'];
+		if (hasPlaceholderDeep(paramValue)) {
+			const label = extractPlaceholderLabel(paramValue);
+			const message = label
+				? `Placeholder "${label}" — please provide the real value`
+				: 'Contains a placeholder value — please provide the real value';
+			if (parameterIssues[paramName]) {
+				parameterIssues[paramName].push(message);
+			} else {
+				parameterIssues[paramName] = [message];
+			}
 		}
 	}
 

--- a/packages/@n8n/utils/src/placeholder.test.ts
+++ b/packages/@n8n/utils/src/placeholder.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isPlaceholderString, hasPlaceholderDeep } from './placeholder';
+import { isPlaceholderString, hasPlaceholderDeep, extractPlaceholderLabel } from './placeholder';
 
 describe('isPlaceholderString', () => {
 	it('returns true for a valid placeholder sentinel', () => {
@@ -52,5 +52,59 @@ describe('hasPlaceholderDeep', () => {
 	it('returns false for null and undefined', () => {
 		expect(hasPlaceholderDeep(null)).toBe(false);
 		expect(hasPlaceholderDeep(undefined)).toBe(false);
+	});
+});
+
+describe('extractPlaceholderLabel', () => {
+	it('extracts label from PLACEHOLDER_VALUE format', () => {
+		expect(extractPlaceholderLabel('<__PLACEHOLDER_VALUE__Your email address__>')).toBe(
+			'Your email address',
+		);
+	});
+
+	it('extracts label from PLACEHOLDER__: format', () => {
+		expect(extractPlaceholderLabel('<__PLACEHOLDER__: some hint__>')).toBe('some hint');
+	});
+
+	it('extracts label from PLACEHOLDER__ format', () => {
+		expect(extractPlaceholderLabel('<__PLACEHOLDER__api_key__>')).toBe('api_key');
+	});
+
+	it('returns undefined for non-placeholder strings', () => {
+		expect(extractPlaceholderLabel('user@example.com')).toBeUndefined();
+		expect(extractPlaceholderLabel('hello')).toBeUndefined();
+	});
+
+	it('returns undefined for non-string values', () => {
+		expect(extractPlaceholderLabel(42)).toBeUndefined();
+		expect(extractPlaceholderLabel(null)).toBeUndefined();
+		expect(extractPlaceholderLabel(undefined)).toBeUndefined();
+	});
+
+	it('returns undefined for placeholder with empty label', () => {
+		expect(extractPlaceholderLabel('<__PLACEHOLDER_VALUE____>')).toBeUndefined();
+	});
+
+	it('extracts label from nested object', () => {
+		expect(extractPlaceholderLabel({ config: { key: '<__PLACEHOLDER_VALUE__api_key__>' } })).toBe(
+			'api_key',
+		);
+	});
+
+	it('extracts label from nested array', () => {
+		expect(extractPlaceholderLabel(['a', '<__PLACEHOLDER_VALUE__email__>'])).toBe('email');
+	});
+
+	it('returns first label from deeply nested structure', () => {
+		expect(
+			extractPlaceholderLabel({
+				a: { b: [{ c: '<__PLACEHOLDER_VALUE__first__>' }] },
+				d: '<__PLACEHOLDER_VALUE__second__>',
+			}),
+		).toBe('first');
+	});
+
+	it('returns undefined when no placeholders in nested structure', () => {
+		expect(extractPlaceholderLabel({ a: { b: [1, 'hello'] } })).toBeUndefined();
 	});
 });

--- a/packages/@n8n/utils/src/placeholder.test.ts
+++ b/packages/@n8n/utils/src/placeholder.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { isPlaceholderString, hasPlaceholderDeep, extractPlaceholderLabel } from './placeholder';
+import {
+	isPlaceholderString,
+	hasPlaceholderDeep,
+	isPlaceholderValue,
+	extractPlaceholderLabels,
+	findPlaceholderDetails,
+	formatPlaceholderPath,
+} from './placeholder';
 
 describe('isPlaceholderString', () => {
 	it('returns true for a valid placeholder sentinel', () => {
@@ -55,56 +62,105 @@ describe('hasPlaceholderDeep', () => {
 	});
 });
 
-describe('extractPlaceholderLabel', () => {
+describe('isPlaceholderValue', () => {
+	it('returns true for a placeholder string', () => {
+		expect(isPlaceholderValue('<__PLACEHOLDER_VALUE__hint__>')).toBe(true);
+	});
+
+	it('returns true for alternative placeholder format', () => {
+		expect(isPlaceholderValue('<__PLACEHOLDER__api_key__>')).toBe(true);
+	});
+
+	it('returns false for regular strings', () => {
+		expect(isPlaceholderValue('hello')).toBe(false);
+	});
+
+	it('returns false for non-string values', () => {
+		expect(isPlaceholderValue(42)).toBe(false);
+		expect(isPlaceholderValue(null)).toBe(false);
+	});
+});
+
+describe('extractPlaceholderLabels', () => {
 	it('extracts label from PLACEHOLDER_VALUE format', () => {
-		expect(extractPlaceholderLabel('<__PLACEHOLDER_VALUE__Your email address__>')).toBe(
+		expect(extractPlaceholderLabels('<__PLACEHOLDER_VALUE__Your email address__>')).toEqual([
 			'Your email address',
-		);
+		]);
 	});
 
 	it('extracts label from PLACEHOLDER__: format', () => {
-		expect(extractPlaceholderLabel('<__PLACEHOLDER__: some hint__>')).toBe('some hint');
+		expect(extractPlaceholderLabels('<__PLACEHOLDER__: some hint__>')).toEqual(['some hint']);
 	});
 
 	it('extracts label from PLACEHOLDER__ format', () => {
-		expect(extractPlaceholderLabel('<__PLACEHOLDER__api_key__>')).toBe('api_key');
+		expect(extractPlaceholderLabels('<__PLACEHOLDER__api_key__>')).toEqual(['api_key']);
 	});
 
-	it('returns undefined for non-placeholder strings', () => {
-		expect(extractPlaceholderLabel('user@example.com')).toBeUndefined();
-		expect(extractPlaceholderLabel('hello')).toBeUndefined();
+	it('returns empty array for non-placeholder strings', () => {
+		expect(extractPlaceholderLabels('user@example.com')).toEqual([]);
 	});
 
-	it('returns undefined for non-string values', () => {
-		expect(extractPlaceholderLabel(42)).toBeUndefined();
-		expect(extractPlaceholderLabel(null)).toBeUndefined();
-		expect(extractPlaceholderLabel(undefined)).toBeUndefined();
+	it('returns empty array for non-string values', () => {
+		expect(extractPlaceholderLabels(42)).toEqual([]);
+		expect(extractPlaceholderLabels(null)).toEqual([]);
 	});
 
-	it('returns undefined for placeholder with empty label', () => {
-		expect(extractPlaceholderLabel('<__PLACEHOLDER_VALUE____>')).toBeUndefined();
+	it('returns empty array for placeholder with empty label', () => {
+		expect(extractPlaceholderLabels('<__PLACEHOLDER_VALUE____>')).toEqual([]);
 	});
 
-	it('extracts label from nested object', () => {
-		expect(extractPlaceholderLabel({ config: { key: '<__PLACEHOLDER_VALUE__api_key__>' } })).toBe(
-			'api_key',
+	it('extracts multiple labels from embedded placeholders', () => {
+		const code =
+			'const key = "<__PLACEHOLDER_VALUE__api_key__>"; const url = "<__PLACEHOLDER_VALUE__base_url__>";';
+		expect(extractPlaceholderLabels(code)).toEqual(['api_key', 'base_url']);
+	});
+});
+
+describe('findPlaceholderDetails', () => {
+	it('finds placeholder in a flat string', () => {
+		expect(findPlaceholderDetails('<__PLACEHOLDER_VALUE__email__>')).toEqual([
+			{ path: [], label: 'email' },
+		]);
+	});
+
+	it('finds placeholder nested in an object', () => {
+		expect(findPlaceholderDetails({ config: { key: '<__PLACEHOLDER_VALUE__api_key__>' } })).toEqual(
+			[{ path: ['config', 'key'], label: 'api_key' }],
 		);
 	});
 
-	it('extracts label from nested array', () => {
-		expect(extractPlaceholderLabel(['a', '<__PLACEHOLDER_VALUE__email__>'])).toBe('email');
+	it('finds placeholder nested in an array', () => {
+		expect(findPlaceholderDetails(['a', '<__PLACEHOLDER_VALUE__email__>'])).toEqual([
+			{ path: ['[1]'], label: 'email' },
+		]);
 	});
 
-	it('returns first label from deeply nested structure', () => {
-		expect(
-			extractPlaceholderLabel({
-				a: { b: [{ c: '<__PLACEHOLDER_VALUE__first__>' }] },
-				d: '<__PLACEHOLDER_VALUE__second__>',
-			}),
-		).toBe('first');
+	it('finds multiple placeholders in deeply nested structure', () => {
+		const result = findPlaceholderDetails({
+			a: { b: [{ c: '<__PLACEHOLDER_VALUE__first__>' }] },
+			d: '<__PLACEHOLDER_VALUE__second__>',
+		});
+		expect(result).toEqual([
+			{ path: ['a', 'b', '[0]', 'c'], label: 'first' },
+			{ path: ['d'], label: 'second' },
+		]);
 	});
 
-	it('returns undefined when no placeholders in nested structure', () => {
-		expect(extractPlaceholderLabel({ a: { b: [1, 'hello'] } })).toBeUndefined();
+	it('returns empty array when no placeholders exist', () => {
+		expect(findPlaceholderDetails({ a: { b: [1, 'hello'] } })).toEqual([]);
+	});
+});
+
+describe('formatPlaceholderPath', () => {
+	it('returns "parameters" for empty path', () => {
+		expect(formatPlaceholderPath([])).toBe('parameters');
+	});
+
+	it('formats simple path', () => {
+		expect(formatPlaceholderPath(['config', 'key'])).toBe('config.key');
+	});
+
+	it('preserves array indices', () => {
+		expect(formatPlaceholderPath(['items', '[0]', 'value'])).toBe('items[0].value');
 	});
 });

--- a/packages/@n8n/utils/src/placeholder.ts
+++ b/packages/@n8n/utils/src/placeholder.ts
@@ -1,11 +1,14 @@
-const PLACEHOLDER_PREFIX = '<__PLACEHOLDER_VALUE__';
+const PLACEHOLDER_PREFIX = '<__PLACEHOLDER';
 const PLACEHOLDER_SUFFIX = '__>';
+const PLACEHOLDER_VALUE_PREFIX = '<__PLACEHOLDER_VALUE__';
+
+const PLACEHOLDER_REGEX = /<__PLACEHOLDER.*?__>/;
 
 /** Check if a value is a placeholder sentinel string (format: `<__PLACEHOLDER_VALUE__hint__>`). */
 export function isPlaceholderString(value: unknown): boolean {
 	return (
 		typeof value === 'string' &&
-		value.startsWith(PLACEHOLDER_PREFIX) &&
+		value.startsWith(PLACEHOLDER_VALUE_PREFIX) &&
 		value.endsWith(PLACEHOLDER_SUFFIX)
 	);
 }
@@ -18,4 +21,47 @@ export function hasPlaceholderDeep(value: unknown): boolean {
 		return Object.values(value as Record<string, unknown>).some(hasPlaceholderDeep);
 	}
 	return false;
+}
+
+/**
+ * Extract the human-readable hint label from the first placeholder sentinel found in a value.
+ * Handles both direct string placeholders and nested objects/arrays (recurses to find the first match).
+ * Returns `undefined` if no placeholder is found or the label is empty.
+ */
+export function extractPlaceholderLabel(value: unknown): string | undefined {
+	if (typeof value === 'string') {
+		const match = value.match(PLACEHOLDER_REGEX);
+		if (!match) return undefined;
+
+		let label = match[0].slice(PLACEHOLDER_PREFIX.length, -PLACEHOLDER_SUFFIX.length);
+
+		if (label.startsWith('_VALUE__')) {
+			label = label.slice('_VALUE__'.length);
+		} else if (label.startsWith('__:')) {
+			label = label.slice('__:'.length);
+		} else if (label.startsWith('__')) {
+			label = label.slice('__'.length);
+		}
+
+		label = label.trim();
+		return label.length > 0 ? label : undefined;
+	}
+
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			const result = extractPlaceholderLabel(item);
+			if (result) return result;
+		}
+		return undefined;
+	}
+
+	if (value !== null && typeof value === 'object') {
+		for (const nested of Object.values(value as Record<string, unknown>)) {
+			const result = extractPlaceholderLabel(nested);
+			if (result) return result;
+		}
+		return undefined;
+	}
+
+	return undefined;
 }

--- a/packages/@n8n/utils/src/placeholder.ts
+++ b/packages/@n8n/utils/src/placeholder.ts
@@ -4,6 +4,11 @@ const PLACEHOLDER_VALUE_PREFIX = '<__PLACEHOLDER_VALUE__';
 
 const PLACEHOLDER_REGEX = /<__PLACEHOLDER.*?__>/;
 
+export interface PlaceholderDetail {
+	path: string[];
+	label: string;
+}
+
 /** Check if a value is a placeholder sentinel string (format: `<__PLACEHOLDER_VALUE__hint__>`). */
 export function isPlaceholderString(value: unknown): boolean {
 	return (
@@ -23,45 +28,86 @@ export function hasPlaceholderDeep(value: unknown): boolean {
 	return false;
 }
 
+/** Checks if a value is a placeholder value (matches the placeholder regex pattern). */
+export function isPlaceholderValue(value: unknown): boolean {
+	if (typeof value !== 'string') return false;
+	return !!value.match(PLACEHOLDER_REGEX);
+}
+
 /**
- * Extract the human-readable hint label from the first placeholder sentinel found in a value.
- * Handles both direct string placeholders and nested objects/arrays (recurses to find the first match).
- * Returns `undefined` if no placeholder is found or the label is empty.
+ * Extracts the label from a single placeholder string.
+ * Handles formats like:
+ * - <__PLACEHOLDER_VALUE__label__>
+ * - <__PLACEHOLDER__: label__>
  */
-export function extractPlaceholderLabel(value: unknown): string | undefined {
-	if (typeof value === 'string') {
-		const match = value.match(PLACEHOLDER_REGEX);
-		if (!match) return undefined;
+function extractLabelFromPlaceholder(placeholder: string): string {
+	let label = placeholder.slice(PLACEHOLDER_PREFIX.length, -PLACEHOLDER_SUFFIX.length);
 
-		let label = match[0].slice(PLACEHOLDER_PREFIX.length, -PLACEHOLDER_SUFFIX.length);
+	if (label.startsWith('_VALUE__')) {
+		label = label.slice('_VALUE__'.length);
+	} else if (label.startsWith('__:')) {
+		label = label.slice('__:'.length);
+	} else if (label.startsWith('__')) {
+		label = label.slice('__'.length);
+	}
 
-		if (label.startsWith('_VALUE__')) {
-			label = label.slice('_VALUE__'.length);
-		} else if (label.startsWith('__:')) {
-			label = label.slice('__:'.length);
-		} else if (label.startsWith('__')) {
-			label = label.slice('__'.length);
+	return label.trim();
+}
+
+/**
+ * Extracts all placeholder labels from a string value.
+ * Handles both cases where the entire value is a placeholder and where
+ * placeholders are embedded within code (e.g., Code node).
+ * Returns an array of labels found.
+ */
+export function extractPlaceholderLabels(value: unknown): string[] {
+	if (typeof value !== 'string') return [];
+
+	const labels: string[] = [];
+	const regex = new RegExp(PLACEHOLDER_REGEX.source, 'g');
+	let match;
+
+	while ((match = regex.exec(value)) !== null) {
+		const label = extractLabelFromPlaceholder(match[0]);
+		if (label.length > 0) {
+			labels.push(label);
 		}
+	}
 
-		label = label.trim();
-		return label.length > 0 ? label : undefined;
+	return labels;
+}
+
+/**
+ * Recursively searches through a value (object, array, or primitive) to find
+ * all placeholder values and their paths.
+ */
+export function findPlaceholderDetails(value: unknown, path: string[] = []): PlaceholderDetail[] {
+	if (typeof value === 'string') {
+		const labels = extractPlaceholderLabels(value);
+		return labels.map((label) => ({ path, label }));
 	}
 
 	if (Array.isArray(value)) {
-		for (const item of value) {
-			const result = extractPlaceholderLabel(item);
-			if (result) return result;
-		}
-		return undefined;
+		return value.flatMap((item, index) => findPlaceholderDetails(item, [...path, `[${index}]`]));
 	}
 
 	if (value !== null && typeof value === 'object') {
-		for (const nested of Object.values(value as Record<string, unknown>)) {
-			const result = extractPlaceholderLabel(nested);
-			if (result) return result;
-		}
-		return undefined;
+		return Object.entries(value).flatMap(([key, nested]) =>
+			findPlaceholderDetails(nested, [...path, key]),
+		);
 	}
 
-	return undefined;
+	return [];
+}
+
+/**
+ * Formats a path array into a dot-notation string for display.
+ * Array indices are preserved as [N] without leading dots.
+ */
+export function formatPlaceholderPath(path: string[]): string {
+	if (path.length === 0) return 'parameters';
+
+	return path
+		.map((segment, index) => (segment.startsWith('[') || index === 0 ? segment : `.${segment}`))
+		.join('');
 }

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useBuilderTodos.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useBuilderTodos.ts
@@ -6,15 +6,21 @@ import {
 	createWorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
 import type { WorkflowValidationIssue } from '@/Interface';
+import {
+	extractPlaceholderLabels,
+	findPlaceholderDetails,
+	formatPlaceholderPath,
+	isPlaceholderValue,
+	type PlaceholderDetail,
+} from '@n8n/utils';
 
-const PLACEHOLDER_PREFIX = '<__PLACEHOLDER';
-const PLACEHOLDER_SUFFIX = '__>';
-const PLACEHOLDER_REGEX = /<__PLACEHOLDER.*?__>/g;
-
-export interface PlaceholderDetail {
-	path: string[];
-	label: string;
-}
+export {
+	extractPlaceholderLabels,
+	findPlaceholderDetails,
+	formatPlaceholderPath,
+	isPlaceholderValue,
+	type PlaceholderDetail,
+};
 
 export interface TodoTrackingItem {
 	type: string;
@@ -26,99 +32,6 @@ export interface TodosTrackingPayload {
 	credentials_todo_count: number;
 	placeholders_todo_count: number;
 	todos: TodoTrackingItem[];
-}
-
-/**
- * Extracts the label from a single placeholder string.
- * Handles formats like:
- * - <__PLACEHOLDER_VALUE__label__>
- * - <__PLACEHOLDER__: label__>
- */
-function extractLabelFromPlaceholder(placeholder: string): string {
-	// Remove the prefix and suffix
-	let label = placeholder.slice(PLACEHOLDER_PREFIX.length, -PLACEHOLDER_SUFFIX.length);
-
-	// Handle _VALUE__ prefix if present
-	if (label.startsWith('_VALUE__')) {
-		label = label.slice('_VALUE__'.length);
-	}
-	// Handle __: prefix if present
-	else if (label.startsWith('__:')) {
-		label = label.slice('__:'.length);
-	}
-	// Handle __ prefix for other variations
-	else if (label.startsWith('__')) {
-		label = label.slice('__'.length);
-	}
-
-	return label.trim();
-}
-
-/**
- * Extracts all placeholder labels from a string value.
- * Handles both cases where the entire value is a placeholder and where
- * placeholders are embedded within code (e.g., Code node).
- * Returns an array of labels found.
- */
-export function extractPlaceholderLabels(value: unknown): string[] {
-	if (typeof value !== 'string') return [];
-
-	const labels: string[] = [];
-	const regex = new RegExp(PLACEHOLDER_REGEX.source, 'g');
-	let match;
-
-	while ((match = regex.exec(value)) !== null) {
-		const label = extractLabelFromPlaceholder(match[0]);
-		if (label.length > 0) {
-			labels.push(label);
-		}
-	}
-
-	return labels;
-}
-
-/**
- * Recursively searches through a value (object, array, or primitive) to find
- * all placeholder values and their paths.
- */
-export function findPlaceholderDetails(value: unknown, path: string[] = []): PlaceholderDetail[] {
-	// Check for placeholders in strings (handles both full placeholders and embedded ones)
-	if (typeof value === 'string') {
-		const labels = extractPlaceholderLabels(value);
-		return labels.map((label) => ({ path, label }));
-	}
-
-	if (Array.isArray(value)) {
-		return value.flatMap((item, index) => findPlaceholderDetails(item, [...path, `[${index}]`]));
-	}
-
-	if (value !== null && typeof value === 'object') {
-		return Object.entries(value).flatMap(([key, nested]) =>
-			findPlaceholderDetails(nested, [...path, key]),
-		);
-	}
-
-	return [];
-}
-
-/**
- * Formats a path array into a dot-notation string for display.
- * Array indices are preserved as [N] without leading dots.
- */
-export function formatPlaceholderPath(path: string[]): string {
-	if (path.length === 0) return 'parameters';
-
-	return path
-		.map((segment, index) => (segment.startsWith('[') || index === 0 ? segment : `.${segment}`))
-		.join('');
-}
-
-/**
- * Checks if a value is a placeholder value
- */
-export function isPlaceholderValue(value: unknown): boolean {
-	if (typeof value !== 'string') return false;
-	return !!value.match(PLACEHOLDER_REGEX);
 }
 
 /**

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowSetup.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowSetup.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
 import userEvent from '@testing-library/user-event';
-import { waitFor } from '@testing-library/vue';
 import { createComponentRenderer } from '@/__tests__/render';
 import type { InstanceAiWorkflowSetupNode } from '@n8n/api-types';
 import InstanceAiWorkflowSetup from '../components/InstanceAiWorkflowSetup.vue';
@@ -76,18 +75,6 @@ vi.mock('@/features/workflows/canvas/experimental/composables/useExpressionResol
 
 const renderComponent = createComponentRenderer(InstanceAiWorkflowSetup);
 
-/** Render the component and wait for the async onMounted to complete (isStoreReady = true). */
-async function renderAndWait(
-	...args: Parameters<typeof renderComponent>
-): Promise<ReturnType<typeof renderComponent>> {
-	const result = renderComponent(...args);
-	// Wait for async onMounted (credential/workflow fetch) to complete so the wizard renders
-	await waitFor(() => {
-		expect(result.queryByText('instanceAi.workflowSetup.loading')).toBeNull();
-	});
-	return result;
-}
-
 function makeSetupNode(
 	overrides: Partial<InstanceAiWorkflowSetupNode> = {},
 ): InstanceAiWorkflowSetupNode {
@@ -156,7 +143,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				]),
 			];
 
-			const { getByTestId, getByText } = await renderAndWait({
+			const { getByTestId, getByText } = renderComponent({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -190,7 +177,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				]),
 			];
 
-			const { getByTestId, getByText } = await renderAndWait({
+			const { getByTestId, getByText } = renderComponent({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -221,7 +208,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				]),
 			];
 
-			const { getByTestId, getByText } = await renderAndWait({
+			const { getByTestId, getByText } = renderComponent({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -256,7 +243,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				]),
 			];
 
-			const { getByTestId } = await renderAndWait({
+			const { getByTestId } = renderComponent({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -294,7 +281,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				}),
 			];
 
-			const { getByTestId, getByText } = await renderAndWait({
+			const { getByTestId, getByText } = renderComponent({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -325,7 +312,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				]),
 			];
 
-			const { getByTestId, getByText } = await renderAndWait({
+			const { getByTestId, getByText } = renderComponent({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -343,7 +330,7 @@ describe('InstanceAiWorkflowSetup', () => {
 			expect(getByText('1 of 2')).toBeTruthy();
 		});
 
-		it('disables apply button when no card is completed', async () => {
+		it('disables apply button when no card is completed', () => {
 			const requests = [
 				makeSetupNodeWithCredentials('slackApi', [
 					{ id: 'cred-1', name: 'Slack' },
@@ -351,7 +338,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				]),
 			];
 
-			const { getByTestId } = await renderAndWait({
+			const { getByTestId } = renderComponent({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -408,7 +395,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				),
 			];
 
-			const { getByText } = await renderAndWait({
+			const { getByText } = renderComponent({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -432,7 +419,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				]),
 			];
 
-			const { getByTestId } = await renderAndWait({
+			const { getByTestId } = renderComponent({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -450,7 +437,7 @@ describe('InstanceAiWorkflowSetup', () => {
 	});
 
 	describe('credential testing', () => {
-		it('renders card for auto-applied testable credential type', async () => {
+		it('renders card for auto-applied testable credential type', () => {
 			const credentialsStore = useCredentialsStore();
 			// @ts-expect-error Known pinia issue when spying on store getters
 			vi.spyOn(credentialsStore, 'getCredentialTypeByName', 'get').mockReturnValue(() => ({
@@ -465,7 +452,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				}),
 			];
 
-			const { getByTestId } = await renderAndWait({
+			const { getByTestId } = renderComponent({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -478,7 +465,7 @@ describe('InstanceAiWorkflowSetup', () => {
 			expect(getByTestId('instance-ai-workflow-setup-card')).toBeTruthy();
 		});
 
-		it('backend-tested credential remains complete when selection unchanged', async () => {
+		it('backend-tested credential remains complete when selection unchanged', () => {
 			const requests = [
 				makeSetupNodeWithCredentials('headerAuth', [{ id: 'cred-1', name: 'Header Auth' }], {
 					isAutoApplied: true,
@@ -495,7 +482,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				}),
 			];
 
-			const { getByTestId } = await renderAndWait({
+			const { getByTestId } = renderComponent({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -549,7 +536,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				}),
 			];
 
-			const { getByTestId } = await renderAndWait({
+			const { getByTestId } = renderComponent({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -578,14 +565,14 @@ describe('InstanceAiWorkflowSetup', () => {
 	});
 
 	describe('confirm mode', () => {
-		it('shows confirm card when all items are pre-resolved', async () => {
+		it('shows confirm card when all items are pre-resolved', () => {
 			const requests = [
 				makeSetupNodeWithCredentials('slackApi', [{ id: 'cred-1', name: 'Slack' }], {
 					needsAction: false,
 				}),
 			];
 
-			const { getByTestId } = await renderAndWait({
+			const { getByTestId } = renderComponent({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -604,7 +591,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				}),
 			];
 
-			const { getByTestId, queryByTestId } = await renderAndWait({
+			const { getByTestId, queryByTestId } = renderComponent({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -642,7 +629,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				),
 			];
 
-			const { getByTestId, getByText } = await renderAndWait({
+			const { getByTestId, getByText } = renderComponent({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowSetup.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowSetup.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
 import userEvent from '@testing-library/user-event';
+import { waitFor } from '@testing-library/vue';
 import { createComponentRenderer } from '@/__tests__/render';
 import type { InstanceAiWorkflowSetupNode } from '@n8n/api-types';
 import InstanceAiWorkflowSetup from '../components/InstanceAiWorkflowSetup.vue';
@@ -75,6 +76,18 @@ vi.mock('@/features/workflows/canvas/experimental/composables/useExpressionResol
 
 const renderComponent = createComponentRenderer(InstanceAiWorkflowSetup);
 
+/** Render the component and wait for the async onMounted to complete (isStoreReady = true). */
+async function renderAndWait(
+	...args: Parameters<typeof renderComponent>
+): ReturnType<typeof renderComponent> {
+	const result = renderComponent(...args);
+	// Wait for async onMounted (credential/workflow fetch) to complete so the wizard renders
+	await waitFor(() => {
+		expect(result.queryByText('instanceAi.workflowSetup.loading')).toBeNull();
+	});
+	return result;
+}
+
 function makeSetupNode(
 	overrides: Partial<InstanceAiWorkflowSetupNode> = {},
 ): InstanceAiWorkflowSetupNode {
@@ -143,7 +156,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				]),
 			];
 
-			const { getByTestId, getByText } = renderComponent({
+			const { getByTestId, getByText } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -177,7 +190,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				]),
 			];
 
-			const { getByTestId, getByText } = renderComponent({
+			const { getByTestId, getByText } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -208,7 +221,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				]),
 			];
 
-			const { getByTestId, getByText } = renderComponent({
+			const { getByTestId, getByText } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -243,7 +256,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				]),
 			];
 
-			const { getByTestId } = renderComponent({
+			const { getByTestId } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -281,7 +294,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				}),
 			];
 
-			const { getByTestId, getByText } = renderComponent({
+			const { getByTestId, getByText } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -312,7 +325,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				]),
 			];
 
-			const { getByTestId, getByText } = renderComponent({
+			const { getByTestId, getByText } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -330,7 +343,7 @@ describe('InstanceAiWorkflowSetup', () => {
 			expect(getByText('1 of 2')).toBeTruthy();
 		});
 
-		it('disables apply button when no card is completed', () => {
+		it('disables apply button when no card is completed', async () => {
 			const requests = [
 				makeSetupNodeWithCredentials('slackApi', [
 					{ id: 'cred-1', name: 'Slack' },
@@ -338,7 +351,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				]),
 			];
 
-			const { getByTestId } = renderComponent({
+			const { getByTestId } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -395,7 +408,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				),
 			];
 
-			const { getByText } = renderComponent({
+			const { getByText } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -419,7 +432,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				]),
 			];
 
-			const { getByTestId } = renderComponent({
+			const { getByTestId } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -437,7 +450,7 @@ describe('InstanceAiWorkflowSetup', () => {
 	});
 
 	describe('credential testing', () => {
-		it('renders card for auto-applied testable credential type', () => {
+		it('renders card for auto-applied testable credential type', async () => {
 			const credentialsStore = useCredentialsStore();
 			// @ts-expect-error Known pinia issue when spying on store getters
 			vi.spyOn(credentialsStore, 'getCredentialTypeByName', 'get').mockReturnValue(() => ({
@@ -452,7 +465,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				}),
 			];
 
-			const { getByTestId } = renderComponent({
+			const { getByTestId } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -465,7 +478,7 @@ describe('InstanceAiWorkflowSetup', () => {
 			expect(getByTestId('instance-ai-workflow-setup-card')).toBeTruthy();
 		});
 
-		it('backend-tested credential remains complete when selection unchanged', () => {
+		it('backend-tested credential remains complete when selection unchanged', async () => {
 			const requests = [
 				makeSetupNodeWithCredentials('headerAuth', [{ id: 'cred-1', name: 'Header Auth' }], {
 					isAutoApplied: true,
@@ -482,7 +495,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				}),
 			];
 
-			const { getByTestId } = renderComponent({
+			const { getByTestId } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -536,7 +549,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				}),
 			];
 
-			const { getByTestId } = renderComponent({
+			const { getByTestId } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -565,14 +578,14 @@ describe('InstanceAiWorkflowSetup', () => {
 	});
 
 	describe('confirm mode', () => {
-		it('shows confirm card when all items are pre-resolved', () => {
+		it('shows confirm card when all items are pre-resolved', async () => {
 			const requests = [
 				makeSetupNodeWithCredentials('slackApi', [{ id: 'cred-1', name: 'Slack' }], {
 					needsAction: false,
 				}),
 			];
 
-			const { getByTestId } = renderComponent({
+			const { getByTestId } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -591,7 +604,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				}),
 			];
 
-			const { getByTestId, queryByTestId } = renderComponent({
+			const { getByTestId, queryByTestId } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,
@@ -629,7 +642,7 @@ describe('InstanceAiWorkflowSetup', () => {
 				),
 			];
 
-			const { getByTestId, getByText } = renderComponent({
+			const { getByTestId, getByText } = await renderAndWait({
 				props: {
 					requestId: 'req-1',
 					setupRequests: requests,

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowSetup.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowSetup.test.ts
@@ -79,7 +79,7 @@ const renderComponent = createComponentRenderer(InstanceAiWorkflowSetup);
 /** Render the component and wait for the async onMounted to complete (isStoreReady = true). */
 async function renderAndWait(
 	...args: Parameters<typeof renderComponent>
-): ReturnType<typeof renderComponent> {
+): Promise<ReturnType<typeof renderComponent>> {
 	const result = renderComponent(...args);
 	// Wait for async onMounted (credential/workflow fetch) to complete so the wizard renders
 	await waitFor(() => {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useSetupCards.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useSetupCards.ts
@@ -310,8 +310,13 @@ export function useSetupCards(
 				if (storeNode) {
 					const liveIssues = getNodeParametersIssues(nodeTypesStore, storeNode);
 					if (Object.keys(liveIssues).length > 0) return false;
-					// Also check for remaining placeholder values in node parameters
-					if (hasPlaceholderDeep(storeNode.parameters)) return false;
+					// Check for remaining placeholder values only in tracked parameters
+					const tracked = trackedParamNames.value.get(req.node.name);
+					if (tracked) {
+						for (const paramName of tracked) {
+							if (hasPlaceholderDeep(storeNode.parameters[paramName])) return false;
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

- Scope `isCardComplete()` placeholder check to only `trackedParamNames` instead of the entire node parameters, so hidden placeholders in un-rendered params don't block card completion
- Improve backend `buildSetupRequests()` placeholder detection to always surface placeholders (even when param already has validation issues) and include the hint label in error messages
- Add `extractPlaceholderLabel()` utility to `@n8n/utils` for extracting human-readable hints from placeholder sentinels

## Related Linear tickets

- https://linear.app/n8n/issue/AI-2344/setup-workflow-no-placeholder-detection-for-ai-inserted-placeholder

- [x] I have seen this code, I have run this code, and I take responsibility for this code.