### PR TITLE
fix(core): Fix public API package update process

### DIFF
--- a/packages/cli/src/modules/community-packages/__tests__/community-node-types.service.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-node-types.service.test.ts
@@ -313,8 +313,8 @@ describe('CommunityNodeTypesService', () => {
 			(service as any).updateCommunityNodeTypes(mockNodeTypes);
 		});
 
-		it('should return the correct package when exact packageName match is found', () => {
-			const result = service.findVetted('n8n-nodes-air');
+		it('should return the correct package when exact packageName match is found', async () => {
+			const result = await service.findVetted('n8n-nodes-air');
 
 			expect(result).toBeDefined();
 			expect(result?.packageName).toBe('n8n-nodes-air');
@@ -322,14 +322,14 @@ describe('CommunityNodeTypesService', () => {
 			expect(result?.npmVersion).toBe('1.0.0');
 		});
 
-		it('should return undefined when package is not found', () => {
-			const result = service.findVetted('n8n-nodes-nonexistent');
+		it('should return undefined when package is not found', async () => {
+			const result = await service.findVetted('n8n-nodes-nonexistent');
 
 			expect(result).toBeUndefined();
 		});
 
-		it('should not match similar package names with substring matching', () => {
-			const result = service.findVetted('n8n-nodes-air');
+		it('should not match similar package names with substring matching', async () => {
+			const result = await service.findVetted('n8n-nodes-air');
 
 			expect(result).toBeDefined();
 			expect(result?.packageName).toBe('n8n-nodes-air');
@@ -337,9 +337,9 @@ describe('CommunityNodeTypesService', () => {
 			expect(result?.packageName).not.toBe('n8n-nodes-airparser');
 		});
 
-		it('should return the correct package from multiple similar names', () => {
-			const airResult = service.findVetted('n8n-nodes-air');
-			const airparserResult = service.findVetted('n8n-nodes-airparser');
+		it('should return the correct package from multiple similar names', async () => {
+			const airResult = await service.findVetted('n8n-nodes-air');
+			const airparserResult = await service.findVetted('n8n-nodes-airparser');
 
 			expect(airResult?.packageName).toBe('n8n-nodes-air');
 			expect(airResult?.checksum).toBe('checksum-air');
@@ -348,15 +348,15 @@ describe('CommunityNodeTypesService', () => {
 			expect(airparserResult?.checksum).toBe('checksum-airparser');
 		});
 
-		it('should return undefined when communityNodeTypes is empty', () => {
+		it('should return undefined when communityNodeTypes is empty', async () => {
 			(service as any).communityNodeTypes.clear();
 
-			const result = service.findVetted('n8n-nodes-air');
+			const result = await service.findVetted('n8n-nodes-air');
 
 			expect(result).toBeUndefined();
 		});
 
-		it('should handle packages with similar prefixes correctly', () => {
+		it('should handle packages with similar prefixes correctly', async () => {
 			const mockNodeTypes = [
 				{
 					name: 'n8n-nodes-test.test',
@@ -380,9 +380,9 @@ describe('CommunityNodeTypesService', () => {
 
 			(service as any).updateCommunityNodeTypes(mockNodeTypes);
 
-			const testResult = service.findVetted('n8n-nodes-test');
-			const testingResult = service.findVetted('n8n-nodes-testing');
-			const testerResult = service.findVetted('n8n-nodes-tester');
+			const testResult = await service.findVetted('n8n-nodes-test');
+			const testingResult = await service.findVetted('n8n-nodes-testing');
+			const testerResult = await service.findVetted('n8n-nodes-tester');
 
 			expect(testResult?.packageName).toBe('n8n-nodes-test');
 			expect(testingResult?.packageName).toBe('n8n-nodes-testing');

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.controller.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.controller.test.ts
@@ -43,7 +43,7 @@ describe('CommunityPackagesController', () => {
 				user: { id: 'user123' },
 				body: { name: 'n8n-nodes-test', verify: true, version: '1.0.0' },
 			});
-			communityNodeTypesService.findVetted.mockReturnValue(undefined);
+			communityNodeTypesService.findVetted.mockResolvedValue(undefined);
 			await expect(controller.installPackage(request)).rejects.toThrow(
 				'Package n8n-nodes-test is not vetted for installation',
 			);
@@ -67,7 +67,7 @@ describe('CommunityPackagesController', () => {
 				user: { id: 'user123' },
 				body: { name: 'n8n-nodes-test', verify: true, version: '1.0.0' },
 			});
-			communityNodeTypesService.findVetted.mockReturnValue(
+			communityNodeTypesService.findVetted.mockResolvedValue(
 				mock<CommunityNodeType>({
 					checksum: 'checksum',
 				}),

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.lifecycle.service.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.lifecycle.service.test.ts
@@ -32,18 +32,28 @@ describe('CommunityPackagesLifecycleService', () => {
 
 	const user = { id: 'user123' };
 
+	const mockPackage = (installedVersion: string) =>
+		mock<InstalledPackages>({
+			installedNodes: [{ type: 'testNode', latestVersion: 1, name: 'testNode' }],
+			installedVersion,
+			authorName: 'Author',
+			authorEmail: 'author@example.com',
+		});
+
 	beforeEach(() => {
 		jest.clearAllMocks();
 	});
 
 	describe('install', () => {
 		it('should throw error if verify in options but no checksum', async () => {
+			communityNodeTypesService.getCommunityNodeTypes.mockResolvedValue([]);
 			communityNodeTypesService.findVetted.mockReturnValue(undefined);
 
 			await expect(
 				lifecycle.install({ name: 'n8n-nodes-test', verify: true, version: '1.0.0' }, user, 'ui'),
 			).rejects.toThrow('Package n8n-nodes-test is not vetted for installation');
 
+			expect(communityNodeTypesService.getCommunityNodeTypes).toHaveBeenCalled();
 			expect(communityNodeTypesService.findVetted).toHaveBeenCalledWith('n8n-nodes-test');
 		});
 
@@ -57,6 +67,7 @@ describe('CommunityPackagesLifecycleService', () => {
 		);
 
 		it('should install with checksum when verify is true', async () => {
+			communityNodeTypesService.getCommunityNodeTypes.mockResolvedValue([]);
 			communityNodeTypesService.findVetted.mockReturnValue(
 				mock<CommunityNodeType>({
 					checksum: 'checksum',
@@ -100,18 +111,8 @@ describe('CommunityPackagesLifecycleService', () => {
 
 	describe('update', () => {
 		it('should use the version from the request when updating a package', async () => {
-			const previouslyInstalledPackage = mock<InstalledPackages>({
-				installedNodes: [{ type: 'testNode', latestVersion: 1, name: 'testNode' }],
-				installedVersion: '1.0.0',
-				authorName: 'Author',
-				authorEmail: 'author@example.com',
-			});
-			const newInstalledPackage = mock<InstalledPackages>({
-				installedNodes: [{ type: 'testNode', latestVersion: 1, name: 'testNode' }],
-				installedVersion: '2.0.0',
-				authorName: 'Author',
-				authorEmail: 'author@example.com',
-			});
+			const previouslyInstalledPackage = mockPackage('1.0.0');
+			const newInstalledPackage = mockPackage('2.0.0');
 
 			communityPackagesService.findInstalledPackage.mockResolvedValue(previouslyInstalledPackage);
 			communityPackagesService.updatePackage.mockResolvedValue(newInstalledPackage);
@@ -153,6 +154,85 @@ describe('CommunityPackagesLifecycleService', () => {
 				).rejects.toThrow(`Invalid version: ${version}`);
 			},
 		);
+
+		it('should throw error if verify is true but package is not vetted', async () => {
+			communityNodeTypesService.getCommunityNodeTypes.mockResolvedValue([]);
+			communityNodeTypesService.findVetted.mockReturnValue(undefined);
+
+			await expect(
+				lifecycle.update(
+					{ name: 'n8n-nodes-test', version: '2.0.0', verify: true },
+					user,
+					'badRequest',
+				),
+			).rejects.toThrow('Package n8n-nodes-test is not vetted for installation');
+		});
+
+		it('should update with checksum when verify is true and version matches latest', async () => {
+			communityNodeTypesService.getCommunityNodeTypes.mockResolvedValue([]);
+			communityNodeTypesService.findVetted.mockReturnValue(
+				mock<CommunityNodeType>({
+					checksum: 'vetted-checksum',
+					npmVersion: '2.0.0',
+					nodeVersions: [],
+				}),
+			);
+			const previouslyInstalledPackage = mockPackage('1.0.0');
+			const newInstalledPackage = mockPackage('2.0.0');
+			communityPackagesService.findInstalledPackage.mockResolvedValue(previouslyInstalledPackage);
+			communityPackagesService.updatePackage.mockResolvedValue(newInstalledPackage);
+			communityPackagesService.parseNpmPackageName.mockReturnValue({
+				rawString: 'n8n-nodes-test',
+				packageName: 'n8n-nodes-test',
+				version: undefined,
+			});
+
+			await lifecycle.update(
+				{ name: 'n8n-nodes-test', version: '2.0.0', verify: true },
+				user,
+				'badRequest',
+			);
+
+			expect(communityPackagesService.updatePackage).toHaveBeenCalledWith(
+				'n8n-nodes-test',
+				previouslyInstalledPackage,
+				'2.0.0',
+				'vetted-checksum',
+			);
+		});
+
+		it('should use version-specific checksum from nodeVersions when targeting older version', async () => {
+			communityNodeTypesService.getCommunityNodeTypes.mockResolvedValue([]);
+			communityNodeTypesService.findVetted.mockReturnValue(
+				mock<CommunityNodeType>({
+					checksum: 'latest-checksum',
+					npmVersion: '2.0.0',
+					nodeVersions: [{ npmVersion: '1.0.0', checksum: 'v1-checksum' }],
+				}),
+			);
+			const previouslyInstalledPackage = mockPackage('0.5.0');
+			const newInstalledPackage = mockPackage('1.0.0');
+			communityPackagesService.findInstalledPackage.mockResolvedValue(previouslyInstalledPackage);
+			communityPackagesService.updatePackage.mockResolvedValue(newInstalledPackage);
+			communityPackagesService.parseNpmPackageName.mockReturnValue({
+				rawString: 'n8n-nodes-test',
+				packageName: 'n8n-nodes-test',
+				version: undefined,
+			});
+
+			await lifecycle.update(
+				{ name: 'n8n-nodes-test', version: '1.0.0', verify: true },
+				user,
+				'badRequest',
+			);
+
+			expect(communityPackagesService.updatePackage).toHaveBeenCalledWith(
+				'n8n-nodes-test',
+				previouslyInstalledPackage,
+				'1.0.0',
+				'v1-checksum',
+			);
+		});
 
 		it('should throw NotFoundError when package missing and whenMissing is notFound', async () => {
 			communityPackagesService.findInstalledPackage.mockResolvedValue(null);

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.lifecycle.service.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.lifecycle.service.test.ts
@@ -46,14 +46,12 @@ describe('CommunityPackagesLifecycleService', () => {
 
 	describe('install', () => {
 		it('should throw error if verify in options but no checksum', async () => {
-			communityNodeTypesService.getCommunityNodeTypes.mockResolvedValue([]);
-			communityNodeTypesService.findVetted.mockReturnValue(undefined);
+			communityNodeTypesService.findVetted.mockResolvedValue(undefined);
 
 			await expect(
 				lifecycle.install({ name: 'n8n-nodes-test', verify: true, version: '1.0.0' }, user, 'ui'),
 			).rejects.toThrow('Package n8n-nodes-test is not vetted for installation');
 
-			expect(communityNodeTypesService.getCommunityNodeTypes).toHaveBeenCalled();
 			expect(communityNodeTypesService.findVetted).toHaveBeenCalledWith('n8n-nodes-test');
 		});
 
@@ -67,8 +65,7 @@ describe('CommunityPackagesLifecycleService', () => {
 		);
 
 		it('should install with checksum when verify is true', async () => {
-			communityNodeTypesService.getCommunityNodeTypes.mockResolvedValue([]);
-			communityNodeTypesService.findVetted.mockReturnValue(
+			communityNodeTypesService.findVetted.mockResolvedValue(
 				mock<CommunityNodeType>({
 					checksum: 'checksum',
 				}),
@@ -156,8 +153,7 @@ describe('CommunityPackagesLifecycleService', () => {
 		);
 
 		it('should throw error if verify is true but package is not vetted', async () => {
-			communityNodeTypesService.getCommunityNodeTypes.mockResolvedValue([]);
-			communityNodeTypesService.findVetted.mockReturnValue(undefined);
+			communityNodeTypesService.findVetted.mockResolvedValue(undefined);
 
 			await expect(
 				lifecycle.update(
@@ -169,8 +165,7 @@ describe('CommunityPackagesLifecycleService', () => {
 		});
 
 		it('should update with checksum when verify is true and version matches latest', async () => {
-			communityNodeTypesService.getCommunityNodeTypes.mockResolvedValue([]);
-			communityNodeTypesService.findVetted.mockReturnValue(
+			communityNodeTypesService.findVetted.mockResolvedValue(
 				mock<CommunityNodeType>({
 					checksum: 'vetted-checksum',
 					npmVersion: '2.0.0',
@@ -202,8 +197,7 @@ describe('CommunityPackagesLifecycleService', () => {
 		});
 
 		it('should use version-specific checksum from nodeVersions when targeting older version', async () => {
-			communityNodeTypesService.getCommunityNodeTypes.mockResolvedValue([]);
-			communityNodeTypesService.findVetted.mockReturnValue(
+			communityNodeTypesService.findVetted.mockResolvedValue(
 				mock<CommunityNodeType>({
 					checksum: 'latest-checksum',
 					npmVersion: '2.0.0',

--- a/packages/cli/src/modules/community-packages/community-node-types.service.ts
+++ b/packages/cli/src/modules/community-packages/community-node-types.service.ts
@@ -223,7 +223,10 @@ export class CommunityNodeTypesService {
 		return { ...nodeType, isInstalled: isInstalled(nodeType.name) };
 	}
 
-	findVetted(packageName: string) {
+	async findVetted(packageName: string) {
+		if (this.updateRequired()) {
+			await this.fetchNodeTypes();
+		}
 		const vettedTypes = Array.from(this.communityNodeTypes.values());
 		return vettedTypes.find((nodeType) => nodeType.packageName === packageName);
 	}

--- a/packages/cli/src/modules/community-packages/community-packages.lifecycle.service.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.lifecycle.service.ts
@@ -107,6 +107,7 @@ export class CommunityPackagesLifecycleService {
 		let checksum: string | undefined;
 
 		if (verify) {
+			await this.communityNodeTypesService.getCommunityNodeTypes();
 			checksum = this.communityNodeTypesService.findVetted(name)?.checksum;
 			if (!checksum) {
 				throw new BadRequestError(`Package ${name} is not vetted for installation`);
@@ -212,11 +213,31 @@ export class CommunityPackagesLifecycleService {
 	}
 
 	async update(
-		args: { name: string | undefined; version?: string; checksum?: string },
+		args: { name: string | undefined; version?: string; checksum?: string; verify?: boolean },
 		user: UserLike,
 		whenMissing: MissingInstalledPackageBehavior,
 	): Promise<InstalledPackages> {
-		const { name, version, checksum } = args;
+		const { name, version, verify } = args;
+
+		let checksum = args.checksum;
+
+		if (verify) {
+			await this.communityNodeTypesService.getCommunityNodeTypes();
+			const vettedPackage = this.communityNodeTypesService.findVetted(name ?? '');
+			if (!vettedPackage) {
+				throw new BadRequestError(`Package ${name} is not vetted for installation`);
+			}
+			if (!version || version === vettedPackage.npmVersion) {
+				checksum = vettedPackage.checksum;
+			} else {
+				checksum = vettedPackage.nodeVersions?.find((v) => v.npmVersion === version)?.checksum;
+			}
+			if (!checksum) {
+				throw new BadRequestError(
+					`Version ${version} of ${name} is not verified by n8n. Latest verified version is ${vettedPackage.npmVersion}`,
+				);
+			}
+		}
 
 		if (!name) {
 			throw new BadRequestError(PACKAGE_NAME_NOT_PROVIDED);

--- a/packages/cli/src/modules/community-packages/community-packages.lifecycle.service.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.lifecycle.service.ts
@@ -107,8 +107,7 @@ export class CommunityPackagesLifecycleService {
 		let checksum: string | undefined;
 
 		if (verify) {
-			await this.communityNodeTypesService.getCommunityNodeTypes();
-			checksum = this.communityNodeTypesService.findVetted(name)?.checksum;
+			checksum = (await this.communityNodeTypesService.findVetted(name))?.checksum;
 			if (!checksum) {
 				throw new BadRequestError(`Package ${name} is not vetted for installation`);
 			}
@@ -222,8 +221,7 @@ export class CommunityPackagesLifecycleService {
 		let checksum = args.checksum;
 
 		if (verify) {
-			await this.communityNodeTypesService.getCommunityNodeTypes();
-			const vettedPackage = this.communityNodeTypesService.findVetted(name ?? '');
+			const vettedPackage = await this.communityNodeTypesService.findVetted(name ?? '');
 			if (!vettedPackage) {
 				throw new BadRequestError(`Package ${name} is not vetted for installation`);
 			}

--- a/packages/cli/src/public-api/v1/handlers/community-packages/__tests__/community-packages.handler.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/__tests__/community-packages.handler.test.ts
@@ -164,7 +164,7 @@ describe('CommunityPackages Handler', () => {
 			await handler.updatePackage[handler.updatePackage.length - 1](req, mockResponse);
 
 			expect(mockLifecycle.update).toHaveBeenCalledWith(
-				{ name: 'n8n-nodes-test', version: undefined },
+				{ name: 'n8n-nodes-test', version: undefined, verify: false },
 				mockUser,
 				'notFound',
 			);

--- a/packages/cli/src/public-api/v1/handlers/community-packages/__tests__/community-packages.handler.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/__tests__/community-packages.handler.test.ts
@@ -61,16 +61,16 @@ describe('CommunityPackages Handler', () => {
 			await handler.installPackage[handler.installPackage.length - 1](req, mockResponse);
 
 			expect(mockLifecycle.install).toHaveBeenCalledWith(
-				{ name: 'n8n-nodes-test', version: undefined, verify: false },
+				{ name: 'n8n-nodes-test', version: undefined, verify: true },
 				mockUser,
 				'publicApi',
 			);
 			expect(mockResponse.json).toHaveBeenCalledWith(mapToCommunityPackage(mockInstalledPackage));
 		});
 
-		it('should forward verify:true to lifecycle when provided', async () => {
+		it('should forward verify:false to lifecycle when explicitly provided', async () => {
 			const req = {
-				body: { name: 'n8n-nodes-test', verify: true },
+				body: { name: 'n8n-nodes-test', verify: false },
 				user: mockUser,
 			};
 
@@ -79,7 +79,7 @@ describe('CommunityPackages Handler', () => {
 			await handler.installPackage[handler.installPackage.length - 1](req, mockResponse);
 
 			expect(mockLifecycle.install).toHaveBeenCalledWith(
-				{ name: 'n8n-nodes-test', version: undefined, verify: true },
+				{ name: 'n8n-nodes-test', version: undefined, verify: false },
 				mockUser,
 				'publicApi',
 			);
@@ -164,7 +164,7 @@ describe('CommunityPackages Handler', () => {
 			await handler.updatePackage[handler.updatePackage.length - 1](req, mockResponse);
 
 			expect(mockLifecycle.update).toHaveBeenCalledWith(
-				{ name: 'n8n-nodes-test', version: undefined, verify: false },
+				{ name: 'n8n-nodes-test', version: undefined, verify: true },
 				mockUser,
 				'notFound',
 			);

--- a/packages/cli/src/public-api/v1/handlers/community-packages/community-packages.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/community-packages.handler.ts
@@ -56,7 +56,11 @@ export = {
 	updatePackage: [
 		publicApiScope('communityPackage:update'),
 		async (
-			req: AuthenticatedRequest<{ name: string }, Record<string, never>, { version?: string }>,
+			req: AuthenticatedRequest<
+				{ name: string },
+				Record<string, never>,
+				{ version?: string; verify?: boolean }
+			>,
 			res: express.Response,
 		): Promise<express.Response> => {
 			const lifecycle = Container.get(CommunityPackagesLifecycleService);
@@ -66,6 +70,7 @@ export = {
 					{
 						name: req.params.name,
 						version: req.body?.version,
+						verify: req.body?.verify ?? false,
 					},
 					req.user,
 					'notFound',

--- a/packages/cli/src/public-api/v1/handlers/community-packages/community-packages.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/community-packages.handler.ts
@@ -27,7 +27,7 @@ export = {
 
 			try {
 				const installedPackage = await lifecycle.install(
-					{ name: req.body.name, version: req.body.version, verify: req.body.verify ?? false },
+					{ name: req.body.name, version: req.body.version, verify: req.body.verify ?? true },
 					req.user,
 					'publicApi',
 				);
@@ -70,7 +70,7 @@ export = {
 					{
 						name: req.params.name,
 						version: req.body?.version,
-						verify: req.body?.verify ?? false,
+						verify: req.body?.verify ?? true,
 					},
 					req.user,
 					'notFound',

--- a/packages/cli/src/public-api/v1/handlers/community-packages/spec/paths/community-packages.packageName.yml
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/spec/paths/community-packages.packageName.yml
@@ -27,7 +27,8 @@ patch:
               type: boolean
               description: >
                 Whether to verify the package against the n8n-vetted package list.
-                Required when the instance has N8N_UNVERIFIED_PACKAGES_ENABLED=false.
+                Setting to false will allow installing or updating to an unverified version.
+                Default is true.
   responses:
     '200':
       description: Package updated successfully.

--- a/packages/cli/src/public-api/v1/handlers/community-packages/spec/paths/community-packages.packageName.yml
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/spec/paths/community-packages.packageName.yml
@@ -23,6 +23,11 @@ patch:
             version:
               type: string
               description: Specific semver version to update to
+            verify:
+              type: boolean
+              description: >
+                Whether to verify the package against the n8n-vetted package list.
+                Required when the instance has N8N_UNVERIFIED_PACKAGES_ENABLED=false.
   responses:
     '200':
       description: Package updated successfully.

--- a/packages/cli/test/integration/public-api/community-packages.test.ts
+++ b/packages/cli/test/integration/public-api/community-packages.test.ts
@@ -1,15 +1,19 @@
 jest.mock('@/modules/community-packages/npm-utils', () => ({
 	...jest.requireActual('@/modules/community-packages/npm-utils'),
 	executeNpmCommand: jest.fn(),
+	verifyIntegrity: jest.fn(),
 }));
 
 import { mockInstance, testDb } from '@n8n/backend-test-utils';
+import type { CommunityNodeType } from '@n8n/api-types';
 import type { User } from '@n8n/db';
 import type { ApiKeyScope } from '@n8n/permissions';
 import { OWNER_API_KEY_SCOPES } from '@n8n/permissions';
+import { mock } from 'jest-mock-extended';
 import path from 'node:path';
 
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
+import { CommunityNodeTypesService } from '@/modules/community-packages/community-node-types.service';
 import { CommunityPackagesService } from '@/modules/community-packages/community-packages.service';
 import { executeNpmCommand } from '@/modules/community-packages/npm-utils';
 
@@ -29,8 +33,15 @@ const communityPackagesService = mockInstance(CommunityPackagesService, {
 	missingPackages: [],
 	hasMissingPackages: false,
 });
+const communityNodeTypesService = mockInstance(CommunityNodeTypesService);
 const mockedExecuteNpmCommand = jest.mocked(executeNpmCommand);
 mockInstance(LoadNodesAndCredentials);
+
+const mockedVettedPackage = mock<CommunityNodeType>({
+	checksum: 'test-checksum',
+	npmVersion: COMMUNITY_PACKAGE_VERSION.UPDATED,
+	nodeVersions: [],
+});
 
 const testServer = setupTestServer({
 	endpointGroups: ['publicApi'],
@@ -51,6 +62,7 @@ describe('Community packages (Public API)', () => {
 
 	beforeEach(async () => {
 		jest.resetAllMocks();
+		communityNodeTypesService.findVetted.mockResolvedValue(mockedVettedPackage);
 		await testDb.truncate(['User']);
 		const ownerUser = await createOwner();
 		const scopes = [
@@ -188,7 +200,24 @@ describe('Community packages (Public API)', () => {
 
 			expect(response.status).toBe(200);
 			expect(response.body.packageName).toBe(pkg.packageName);
-			expect(communityPackagesService.installPackage).toHaveBeenCalledTimes(1);
+			expect(communityPackagesService.installPackage).toHaveBeenCalledWith(
+				parsedNpmPackageName.packageName,
+				undefined,
+				mockedVettedPackage.checksum,
+			);
+		});
+
+		it('should return 400 when package is not vetted', async () => {
+			communityNodeTypesService.findVetted.mockResolvedValue(undefined);
+			communityPackagesService.parseNpmPackageName.mockReturnValue(parsedNpmPackageName);
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/community-packages')
+				.send({ name: mockPackageName() });
+
+			expect(response.status).toBe(400);
+			expect(response.body.message).toContain('not vetted');
 		});
 
 		it('should return 400 when package is banned', async () => {
@@ -228,7 +257,12 @@ describe('Community packages (Public API)', () => {
 
 			expect(response.status).toBe(200);
 			expect(response.body.packageName).toBe(pkg.packageName);
-			expect(communityPackagesService.updatePackage).toHaveBeenCalledTimes(1);
+			expect(communityPackagesService.updatePackage).toHaveBeenCalledWith(
+				pkg.packageName,
+				pkg,
+				COMMUNITY_PACKAGE_VERSION.UPDATED,
+				mockedVettedPackage.checksum,
+			);
 		});
 
 		it('should return 404 when package is not installed', async () => {


### PR DESCRIPTION
- Updated the update method to include verification for community packages. Makes sure to retrieve the checksum for the respective version
- Improved error messages to clarify when a package is not verified.

<img width="701" height="255" alt="Screenshot 2026-04-14 at 14 22 07" src="https://github.com/user-attachments/assets/9e3f120d-9fea-4c0a-94b7-b4e53961ec05" />


<img width="696" height="447" alt="Screenshot 2026-04-14 at 14 25 27" src="https://github.com/user-attachments/assets/6c741e46-73a6-4c0f-91bd-a0a1b6a8e964" />



## Related Linear tickets, Github issues, and Community forum posts

Fixes [LIGO-447](https://linear.app/n8n/issue/LIGO-447/community-packages-install-endpoint-doesnt-work-on-cloud)


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
