### PR TITLE
fix(core): update default User-Agent to include version and support N…

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
@@ -437,6 +437,16 @@ export async function proxyRequestToAxios(
 	axiosConfig = Object.assign(axiosConfig, await parseRequestObject(configObject, ssrfBridge));
 	throwIfDomainNotAllowed(axiosConfig, configObject.allowedDomains);
 
+	const userAgentHeader = searchForHeader(axiosConfig, 'user-agent');
+	if (!userAgentHeader) {
+		const version = process.env.N8N_VERSION;
+		const defaultUserAgent = `n8n${version ? `/${version}` : ''}`;
+		axiosConfig.headers = {
+			...axiosConfig.headers,
+			'User-Agent': process.env.N8N_USER_AGENT ?? defaultUserAgent,
+		};
+	}
+
 	try {
 		const response = await invokeAxios(axiosConfig, configObject.auth);
 		let body = response.data;
@@ -611,9 +621,11 @@ export function convertN8nRequestToAxios(
 	// If key exists, then the user has set both accept
 	// header and the json flag. Header should take precedence.
 	if (!userAgentHeader) {
+		const version = process.env.N8N_VERSION;
+		const defaultUserAgent = `n8n${version ? `/${version}` : ''}`;
 		axiosRequest.headers = {
 			...axiosRequest.headers,
-			'User-Agent': 'n8n',
+			'User-Agent': process.env.N8N_USER_AGENT ?? defaultUserAgent,
 		};
 	}
 


### PR DESCRIPTION
…8N_USER_AGENT override #28280

## Summary

This PR resolves the issue where n8n sends a bare `n8n` string as the default User-Agent for outbound HTTP requests. This format is often flagged by Web Application Firewalls (WAFs) as a "Bad User-Agent," leading to 403 Forbidden errors for nodes such as WooCommerce, WordPress, and GitHub.

#### Changes Implemented:
- **RFC-Compliant Default:** Modified `@n8n/core` to set the default User-Agent to `n8n/${version}` (e.g., `n8n/1.23.0`).
- **Environment Variable Override:** Introduced `N8N_USER_AGENT`, allowing users to provide a custom string (e.g., a Chrome/Mozilla identity) for environments with extremely strict security policies.
- **Legacy & Modern Support:** Applied the logic to both `convertN8nRequestToAxios` and `proxyRequestToAxios` within `request-helper-functions.ts`.
- **Unit Tests:** Updated `request-helper-functions.test.ts` to verify both the new default versioning and the environment variable override.

### How to test:
1. Run n8n locally: `pnpm dev`.
2. Use a **WooCommerce** node (or an HTTP Request node) and point it to a local listener (e.g., `nc -l 8080`).
3. Execute the node and verify the `User-Agent` header in the terminal output.
4. Restart n8n with `export N8N_USER_AGENT="CustomAgent/1.0"` and verify the header updates accordingly.

## Related Linear tickets, Github issues, and Community forum posts

- Fixes #28280
- Internal Linear: GHC-7673

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated (Will create follow-up for the new N8N_USER_AGENT variable).
- [x] Tests included.
