### PR TITLE
fix(core): Add required field validation to MCP OAuth client registration

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/mcp.oauth.controller.api.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.oauth.controller.api.test.ts
@@ -207,6 +207,33 @@ describe('POST /mcp-oauth/register', () => {
 		expect(response.statusCode).toBeGreaterThanOrEqual(400);
 	});
 
+	test('should reject registration when client_name is missing', async () => {
+		const response = await testServer.restlessAgent.post('/mcp-oauth/register').send({
+			redirect_uris: ['https://example.com/callback'],
+			grant_types: ['authorization_code'],
+		});
+
+		expect(response.statusCode).toBeGreaterThanOrEqual(400);
+	});
+
+	test('should reject registration when grant_types is missing', async () => {
+		const response = await testServer.restlessAgent.post('/mcp-oauth/register').send({
+			client_name: 'Test Client',
+			redirect_uris: ['https://example.com/callback'],
+		});
+
+		expect(response.statusCode).toBeGreaterThanOrEqual(400);
+	});
+
+	test('should reject registration when redirect_uris is missing', async () => {
+		const response = await testServer.restlessAgent.post('/mcp-oauth/register').send({
+			client_name: 'Test Client',
+			grant_types: ['authorization_code'],
+		});
+
+		expect(response.statusCode).toBeGreaterThanOrEqual(400);
+	});
+
 	test('should reject registration when MCP access is disabled', async () => {
 		await mcpSettingsService.setEnabled(false);
 

--- a/packages/cli/src/modules/mcp/mcp-oauth-service.ts
+++ b/packages/cli/src/modules/mcp/mcp-oauth-service.ts
@@ -106,17 +106,27 @@ export class McpOAuthService implements OAuthServerProvider {
 	}
 
 	private validateClientRegistration(client: OAuthClientInformationFull): void {
-		if (client.redirect_uris) {
-			if (client.redirect_uris.length > MAX_REDIRECT_URIS) {
-				throw new Error(`redirect_uris exceeds maximum count of ${MAX_REDIRECT_URIS}`);
-			}
+		if (!client.client_name) {
+			throw new Error('client_name is required');
+		}
 
-			for (const uri of client.redirect_uris) {
-				if (uri.length > MAX_REDIRECT_URI_LENGTH) {
-					throw new Error(
-						`redirect_uri exceeds maximum length of ${MAX_REDIRECT_URI_LENGTH} characters`,
-					);
-				}
+		if (!client.grant_types || client.grant_types.length === 0) {
+			throw new Error('grant_types is required');
+		}
+
+		if (!client.redirect_uris || client.redirect_uris.length === 0) {
+			throw new Error('redirect_uris is required');
+		}
+
+		if (client.redirect_uris.length > MAX_REDIRECT_URIS) {
+			throw new Error(`redirect_uris exceeds maximum count of ${MAX_REDIRECT_URIS}`);
+		}
+
+		for (const uri of client.redirect_uris) {
+			if (uri.length > MAX_REDIRECT_URI_LENGTH) {
+				throw new Error(
+					`redirect_uri exceeds maximum length of ${MAX_REDIRECT_URI_LENGTH} characters`,
+				);
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Add validation for `client_name`, `grant_types`, and `redirect_uris` in the MCP OAuth client registration endpoint (`/mcp-oauth/register`)
- Previously, requests with missing required fields silently succeeded but the DB insert failed on NOT NULL constraints, resulting in phantom `client_id`s that couldn't be used
- Add 3 test cases covering each missing field scenario

## Related Linear tickets, Github issues, and Community forum posts

closes https://github.com/n8n-io/n8n/issues/27293
Linear Reference: https://linear.app/n8n/issue/AI-2267

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included
- [x] I have seen this code, I have run this code, and I take responsibility for this code.