### PR TITLE
feat: Add multiple runs to instanceAI eval (no-changelog)

### DIFF
--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -114,11 +114,11 @@ jobs:
           # Build the full comment body with jq
           jq -r '
             "### Instance AI Workflow Eval Results\n\n" +
-            "**\(.summary.built)/\(.summary.testCases) built | \(.summary.scenariosPassed)/\(.summary.scenariosTotal) passed (\(.summary.passRate * 100 | floor)%)**\n\n" +
-            "| Workflow | Build | Passed |\n|---|---|---|\n" +
-            ([.testCases[] | "| \(.name) | \(if .built then "✅" else "❌" end) | \([.scenarios[] | select(.passed)] | length)/\(.scenarios | length) |"] | join("\n")) +
+            "**\(.summary.built)/\(.summary.testCases) built | \(.totalRuns) run(s) | pass@\(.totalRuns): \(.summary.passAtK * 100 | floor)% | pass^\(.totalRuns): \(.summary.passHatK * 100 | floor)%**\n\n" +
+            "| Workflow | Build | pass@\(.totalRuns) | pass^\(.totalRuns) |\n|---|---|---|---|\n" +
+            ([.testCases[] | "| \(.name) | \(.buildSuccessCount)/\(.totalRuns) | \([.scenarios[] | .passAtK] | add / (.scenarios | length) * 100 | floor)% | \([.scenarios[] | .passHatK] | add / (.scenarios | length) * 100 | floor)% |"] | join("\n")) +
             "\n\n<details><summary>Failure details</summary>\n\n" +
-            ([.testCases[].scenarios[] | select(.passed == false) | "**\(.name)** \(if .failureCategory then "[\(.failureCategory)]" else "" end)\n> \(.reasoning | .[0:200])\n"] | join("\n")) +
+            ([.testCases[] as $tc | $tc.scenarios[] | select(.passHatK < 1) | "**\($tc.name) / \(.name)** — \(.passCount)/\(.totalRuns) passed" + "\n" + ([.runs[] | select(.passed == false) | "> Run\(if .failureCategory then " [\(.failureCategory)]" else "" end): \(.reasoning | .[0:200])"] | join("\n"))] | join("\n\n")) +
             "\n</details>"
           ' "$RESULTS_FILE" > /tmp/eval-comment.md
 

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -92,6 +92,7 @@ jobs:
           pnpm eval:instance-ai
           --base-url http://localhost:5678
           --verbose
+          --runs 5
           ${{ inputs.filter && format('--filter "{0}"', inputs.filter) || '' }}
         env:
           N8N_INSTANCE_AI_MODEL_API_KEY: ${{ secrets.EVALS_ANTHROPIC_KEY }}

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -116,7 +116,7 @@ jobs:
             "### Instance AI Workflow Eval Results\n\n" +
             "**\(.summary.built)/\(.summary.testCases) built | \(.totalRuns) run(s) | pass@\(.totalRuns): \(.summary.passAtK * 100 | floor)% | pass^\(.totalRuns): \(.summary.passHatK * 100 | floor)%**\n\n" +
             "| Workflow | Build | pass@\(.totalRuns) | pass^\(.totalRuns) |\n|---|---|---|---|\n" +
-            ([.testCases[] | "| \(.name) | \(.buildSuccessCount)/\(.totalRuns) | \([.scenarios[] | .passAtK] | add / (.scenarios | length) * 100 | floor)% | \([.scenarios[] | .passHatK] | add / (.scenarios | length) * 100 | floor)% |"] | join("\n")) +
+            ([.testCases[] as $tc | "| \($tc.name) | \($tc.buildSuccessCount)/\($tc.totalRuns) | \(([$tc.scenarios[] | .passAtK] | add) / ($tc.scenarios | length) * 100 | floor)% | \(([$tc.scenarios[] | .passHatK] | add) / ($tc.scenarios | length) * 100 | floor)% |"] | join("\n")) +
             "\n\n<details><summary>Failure details</summary>\n\n" +
             ([.testCases[] as $tc | $tc.scenarios[] | select(.passHatK < 1) | "**\($tc.name) / \(.name)** — \(.passCount)/\(.totalRuns) passed" + "\n" + ([.runs[] | select(.passed == false) | "> Run\(if .failureCategory then " [\(.failureCategory)]" else "" end): \(.reasoning | .[0:200])"] | join("\n"))] | join("\n\n")) +
             "\n</details>"

--- a/packages/@n8n/instance-ai/evaluations/cli/aggregator.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/aggregator.ts
@@ -1,0 +1,99 @@
+import type {
+	WorkflowTestCaseResult,
+	MultiRunEvaluation,
+	TestCaseAggregation,
+	ScenarioAggregation,
+} from '../types';
+
+/**
+ * Binomial coefficient C(n, k). Returns 0 when k > n.
+ */
+function combinations(n: number, k: number): number {
+	if (k > n || k < 0) return 0;
+	if (k === 0 || k === n) return 1;
+	let result = 1;
+	for (let i = 0; i < k; i++) {
+		result = (result * (n - i)) / (i + 1);
+	}
+	return Math.round(result);
+}
+
+/**
+ * pass@k = 1 - C(n - c, k) / C(n, k)
+ * Probability that at least 1 of k randomly chosen samples passes,
+ * given n total samples of which c passed.
+ */
+function passAtK(n: number, c: number, k: number): number {
+	if (k > n) return 0;
+	const denominator = combinations(n, k);
+	if (denominator === 0) return 0;
+	return 1 - combinations(n - c, k) / denominator;
+}
+
+/**
+ * pass^k = (c/n)^k
+ * Probability that all k independent attempts pass,
+ * given observed success rate p = c/n.
+ */
+function passHatK(n: number, c: number, k: number): number {
+	if (n === 0) return 0;
+	return Math.pow(c / n, k);
+}
+
+function computePassMetrics(
+	n: number,
+	c: number,
+): { passAtKValues: number[]; passHatKValues: number[] } {
+	const passAtKValues: number[] = [];
+	const passHatKValues: number[] = [];
+	for (let k = 1; k <= n; k++) {
+		passAtKValues.push(passAtK(n, c, k));
+		passHatKValues.push(passHatK(n, c, k));
+	}
+	return { passAtKValues, passHatKValues };
+}
+
+export function aggregateResults(
+	allRunResults: WorkflowTestCaseResult[][],
+	totalRuns: number,
+): MultiRunEvaluation {
+	const testCaseCount = allRunResults[0].length;
+	const testCases: TestCaseAggregation[] = [];
+
+	for (let tcIdx = 0; tcIdx < testCaseCount; tcIdx++) {
+		const runs = allRunResults.map((runResults) => runResults[tcIdx]);
+		const testCase = runs[0].testCase;
+		const buildSuccessCount = runs.filter((r) => r.workflowBuildSuccess).length;
+
+		const scenarioCount = testCase.scenarios.length;
+		const scenarios: ScenarioAggregation[] = [];
+
+		for (let sIdx = 0; sIdx < scenarioCount; sIdx++) {
+			const scenario = testCase.scenarios[sIdx];
+			const scenarioRuns = runs.map(
+				(r) =>
+					r.scenarioResults[sIdx] ?? {
+						scenario,
+						success: false,
+						score: 0,
+						reasoning: 'Build failed — scenario not executed',
+					},
+			);
+			const passCount = scenarioRuns.filter((sr) => sr.success).length;
+			const { passAtKValues, passHatKValues } = computePassMetrics(totalRuns, passCount);
+
+			scenarios.push({
+				scenario,
+				runs: scenarioRuns,
+				passCount,
+				passRate: totalRuns > 0 ? passCount / totalRuns : 0,
+				passAtK: passAtKValues,
+				passHatK: passHatKValues,
+			});
+		}
+
+		testCases.push({ testCase, runs, buildSuccessCount, scenarios });
+	}
+
+	return { totalRuns, testCases };
+}

--- a/packages/@n8n/instance-ai/evaluations/cli/args.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/args.ts
@@ -12,6 +12,7 @@ import { z } from 'zod';
 // ---------------------------------------------------------------------------
 
 export interface CliArgs {
+	/** TimeoutMs is defined per run, not as the total timeout for all the runs */
 	timeoutMs: number;
 	baseUrl: string;
 	email?: string;
@@ -23,6 +24,8 @@ export interface CliArgs {
 	keepWorkflows: boolean;
 	/** Directory to write eval-results.json (defaults to cwd) */
 	outputDir?: string;
+	/** Number of times to run each test case (default: 1) */
+	runs: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -38,6 +41,7 @@ const cliArgsSchema = z.object({
 	filter: z.string().optional(),
 	keepWorkflows: z.boolean().default(false),
 	outputDir: z.string().optional(),
+	runs: z.number().int().positive().default(1),
 });
 
 // ---------------------------------------------------------------------------
@@ -57,6 +61,7 @@ export function parseCliArgs(argv: string[]): CliArgs {
 		filter: validated.filter,
 		keepWorkflows: validated.keepWorkflows,
 		outputDir: validated.outputDir,
+		runs: validated.runs,
 	};
 }
 
@@ -73,6 +78,7 @@ interface RawArgs {
 	filter?: string;
 	keepWorkflows: boolean;
 	outputDir?: string;
+	runs: number;
 }
 
 function parseRawArgs(argv: string[]): RawArgs {
@@ -82,6 +88,7 @@ function parseRawArgs(argv: string[]): RawArgs {
 		verbose: false,
 		keepWorkflows: false,
 		outputDir: undefined,
+		runs: 1,
 	};
 
 	for (let i = 0; i < argv.length; i++) {
@@ -123,6 +130,10 @@ function parseRawArgs(argv: string[]): RawArgs {
 
 			case '--output-dir':
 				result.outputDir = nextArg(argv, i, '--output-dir');
+				break;
+
+			case '--runs':
+				result.runs = parseIntArg(argv, i, '--runs');
 				i++;
 				break;
 

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -97,11 +97,11 @@ function writeEvalResults(
 	const allScenarios = testCases.flatMap((tc) => tc.scenarios);
 	const totalScenariosCount = allScenarios.length;
 
-	const passAtNCount =
+	const passAtKCount =
 		totalScenariosCount > 0
 			? allScenarios.reduce((sum, s) => sum + (s.passAtK[totalRuns - 1] ?? 0), 0)
 			: 0;
-	const passHatNCount =
+	const passHatKCount =
 		totalScenariosCount > 0
 			? allScenarios.reduce((sum, s) => sum + (s.passHatK[totalRuns - 1] ?? 0), 0)
 			: 0;
@@ -114,8 +114,8 @@ function writeEvalResults(
 			testCases: testCases.length,
 			built: testCases.filter((tc) => tc.buildSuccessCount > 0).length,
 			scenariosTotal: totalScenariosCount,
-			passAtN: totalScenariosCount > 0 ? passAtNCount / totalScenariosCount : 0,
-			passHatN: totalScenariosCount > 0 ? passHatNCount / totalScenariosCount : 0,
+			passAtK: totalScenariosCount > 0 ? passAtKCount / totalScenariosCount : 0,
+			passHatK: totalScenariosCount > 0 ? passHatKCount / totalScenariosCount : 0,
 		},
 		testCases: testCases.map((tc) => ({
 			name: tc.testCase.prompt.slice(0, 70),
@@ -125,8 +125,8 @@ function writeEvalResults(
 				name: sa.scenario.name,
 				passCount: sa.passCount,
 				totalRuns,
-				passAtN: sa.passAtK[totalRuns - 1] ?? 0,
-				passHatN: sa.passHatK[totalRuns - 1] ?? 0,
+				passAtK: sa.passAtK[totalRuns - 1] ?? 0,
+				passHatK: sa.passHatK[totalRuns - 1] ?? 0,
 				runs: sa.runs.map((sr) => ({
 					passed: sr.success,
 					score: sr.score,
@@ -166,11 +166,11 @@ function printSummary(evaluation: MultiRunEvaluation): void {
 
 		for (const sa of tc.scenarios) {
 			if (multiRun) {
-				const passAtN = Math.round((sa.passAtK[totalRuns - 1] ?? 0) * 100);
-				const passHatN = Math.round((sa.passHatK[totalRuns - 1] ?? 0) * 100);
+				const passAtK = Math.round((sa.passAtK[totalRuns - 1] ?? 0) * 100);
+				const passHatK = Math.round((sa.passHatK[totalRuns - 1] ?? 0) * 100);
 				console.log(
 					`  ${sa.scenario.name}: ${String(sa.passCount)}/${String(totalRuns)} passed` +
-						` | pass@${String(totalRuns)}: ${String(passAtN)}% | pass^${String(totalRuns)}: ${String(passHatN)}%`,
+						` | pass@${String(totalRuns)}: ${String(passAtK)}% | pass^${String(totalRuns)}: ${String(passHatK)}%`,
 				);
 			} else {
 				const sr = sa.runs[0];
@@ -189,26 +189,24 @@ function printSummary(evaluation: MultiRunEvaluation): void {
 	if (multiRun) {
 		const allScenarios = testCases.flatMap((tc) => tc.scenarios);
 		const total = allScenarios.length;
-		const avgPassAtN =
+		const avgPassAtK =
 			total > 0
 				? Math.round(
-						(allScenarios.reduce((sum, s) => sum + (s.passAtK[totalRuns - 1] ?? 0), 0) /
-							total) *
+						(allScenarios.reduce((sum, s) => sum + (s.passAtK[totalRuns - 1] ?? 0), 0) / total) *
 							100,
 					)
 				: 0;
-		const avgPassHatN =
+		const avgPassHatK =
 			total > 0
 				? Math.round(
-						(allScenarios.reduce((sum, s) => sum + (s.passHatK[totalRuns - 1] ?? 0), 0) /
-							total) *
+						(allScenarios.reduce((sum, s) => sum + (s.passHatK[totalRuns - 1] ?? 0), 0) / total) *
 							100,
 					)
 				: 0;
 
 		console.log('\n=== Aggregate Metrics ===\n');
-		console.log(`  pass@${String(totalRuns)}: ${String(avgPassAtN)}%`);
-		console.log(`  pass^${String(totalRuns)}: ${String(avgPassHatN)}%`);
+		console.log(`  pass@${String(totalRuns)}: ${String(avgPassAtK)}%`);
+		console.log(`  pass^${String(totalRuns)}: ${String(avgPassHatK)}%`);
 	}
 
 	// Totals

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -2,6 +2,7 @@
 import { mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
+import { aggregateResults } from './aggregator';
 import { parseCliArgs } from './args';
 import { N8nClient } from '../clients/n8n-client';
 import { seedCredentials, cleanupCredentials } from '../credentials/seeder';
@@ -9,7 +10,7 @@ import { loadWorkflowTestCases } from '../data/workflows';
 import { createLogger } from '../harness/logger';
 import { runWorkflowTestCase, runWithConcurrency } from '../harness/runner';
 import { snapshotWorkflowIds } from '../outcome/workflow-discovery';
-import type { WorkflowTestCaseResult } from '../types';
+import type { MultiRunEvaluation, WorkflowTestCaseResult } from '../types';
 
 async function main(): Promise<void> {
 	const args = parseCliArgs(process.argv.slice(2));
@@ -22,7 +23,7 @@ async function main(): Promise<void> {
 
 	const totalScenarios = testCases.reduce((sum, tc) => sum + tc.scenarios.length, 0);
 	console.log(
-		`Running ${String(testCases.length)} workflow test case(s) with ${String(totalScenarios)} scenario(s)\n`,
+		`Running ${String(testCases.length)} workflow test case(s) with ${String(totalScenarios)} scenario(s) x ${String(args.runs)} runs\n`,
 	);
 
 	const logger = createLogger(args.verbose);
@@ -37,77 +38,102 @@ async function main(): Promise<void> {
 	const seedResult = await seedCredentials(client, undefined, logger);
 	logger.info(`Seeded ${String(seedResult.credentialIds.length)} credential(s)`);
 
-	const preRunWorkflowIds = await snapshotWorkflowIds(client);
-	const claimedWorkflowIds = new Set<string>();
-
 	// Run test cases with bounded concurrency.
 	// Each test case builds a workflow (uses n8n's agent) then runs scenarios
 	// (uses our Anthropic key for Phase 1 + Phase 2 mock generation).
 	const MAX_CONCURRENT_TEST_CASES = 4;
 	const startTime = Date.now();
-	let results;
+	const allRunResults: WorkflowTestCaseResult[][] = [];
+
 	try {
-		results = await runWithConcurrency(
-			testCases,
-			async (testCase) =>
-				await runWorkflowTestCase({
-					client,
-					testCase,
-					timeoutMs: args.timeoutMs,
-					seededCredentialTypes: seedResult.seededTypes,
-					preRunWorkflowIds,
-					claimedWorkflowIds,
-					logger,
-					keepWorkflows: args.keepWorkflows,
-				}),
-			MAX_CONCURRENT_TEST_CASES,
-		);
+		for (let run = 0; run < args.runs; run++) {
+			if (args.runs > 1) {
+				console.log(`\n--- Run #${String(run + 1)}/${String(args.runs)} ---\n`);
+			}
+
+			const preRunWorkflowIds = await snapshotWorkflowIds(client);
+			const claimedWorkflowIds = new Set<string>();
+
+			const results = await runWithConcurrency(
+				testCases,
+				async (testCase) =>
+					await runWorkflowTestCase({
+						client,
+						testCase,
+						timeoutMs: args.timeoutMs,
+						seededCredentialTypes: seedResult.seededTypes,
+						preRunWorkflowIds,
+						claimedWorkflowIds,
+						logger,
+						keepWorkflows: args.keepWorkflows,
+					}),
+				MAX_CONCURRENT_TEST_CASES,
+			);
+
+			allRunResults.push(results);
+		}
 	} finally {
-		// Cleanup credentials even if test execution fails
 		await cleanupCredentials(client, seedResult.credentialIds).catch(() => {});
 	}
 
 	const totalDuration = Date.now() - startTime;
+	const aggregatedResults = aggregateResults(allRunResults, args.runs);
 
 	// Write eval-results.json for CI consumption (PR comments, artifacts)
-	const outputPath = writeEvalResults(results, totalDuration, args.outputDir);
+	const outputPath = writeEvalResults(aggregatedResults, totalDuration, args.outputDir);
 	console.log(`Results: ${outputPath}`);
 
 	// Print console summary
-	printSummary(results);
+	printSummary(aggregatedResults);
 }
 
 /** Write structured JSON results for CI (PR comments, artifact upload). */
 function writeEvalResults(
-	results: WorkflowTestCaseResult[],
+	evaluation: MultiRunEvaluation,
 	duration: number,
 	outputDir?: string,
 ): string {
-	const allScenarios = results.flatMap((r) => r.scenarioResults);
-	const passed = allScenarios.filter((s) => s.success).length;
+	const { totalRuns, testCases } = evaluation;
+	const allScenarios = testCases.flatMap((tc) => tc.scenarios);
+	const totalScenariosCount = allScenarios.length;
+
+	const passAtNCount =
+		totalScenariosCount > 0
+			? allScenarios.reduce((sum, s) => sum + (s.passAtK[totalRuns - 1] ?? 0), 0)
+			: 0;
+	const passHatNCount =
+		totalScenariosCount > 0
+			? allScenarios.reduce((sum, s) => sum + (s.passHatK[totalRuns - 1] ?? 0), 0)
+			: 0;
 
 	const report = {
 		timestamp: new Date().toISOString(),
 		duration,
+		totalRuns,
 		summary: {
-			testCases: results.length,
-			built: results.filter((r) => r.workflowBuildSuccess).length,
-			scenariosTotal: allScenarios.length,
-			scenariosPassed: passed,
-			passRate: allScenarios.length > 0 ? passed / allScenarios.length : 0,
+			testCases: testCases.length,
+			built: testCases.filter((tc) => tc.buildSuccessCount > 0).length,
+			scenariosTotal: totalScenariosCount,
+			passAtN: totalScenariosCount > 0 ? passAtNCount / totalScenariosCount : 0,
+			passHatN: totalScenariosCount > 0 ? passHatNCount / totalScenariosCount : 0,
 		},
-		testCases: results.map((r) => ({
-			name: r.testCase.prompt.slice(0, 70),
-			built: r.workflowBuildSuccess,
-			buildError: r.buildError,
-			workflowId: r.workflowId,
-			scenarios: r.scenarioResults.map((sr) => ({
-				name: sr.scenario.name,
-				passed: sr.success,
-				score: sr.score,
-				reasoning: sr.reasoning,
-				failureCategory: sr.failureCategory,
-				rootCause: sr.rootCause,
+		testCases: testCases.map((tc) => ({
+			name: tc.testCase.prompt.slice(0, 70),
+			buildSuccessCount: tc.buildSuccessCount,
+			totalRuns,
+			scenarios: tc.scenarios.map((sa) => ({
+				name: sa.scenario.name,
+				passCount: sa.passCount,
+				totalRuns,
+				passAtN: sa.passAtK[totalRuns - 1] ?? 0,
+				passHatN: sa.passHatK[totalRuns - 1] ?? 0,
+				runs: sa.runs.map((sr) => ({
+					passed: sr.success,
+					score: sr.score,
+					reasoning: sr.reasoning,
+					failureCategory: sr.failureCategory,
+					rootCause: sr.rootCause,
+				})),
 			})),
 		})),
 	};
@@ -119,34 +145,83 @@ function writeEvalResults(
 	return outputPath;
 }
 
-function printSummary(results: WorkflowTestCaseResult[]): void {
-	console.log('\n=== Workflow Eval Results ===\n');
-	for (const r of results) {
-		const buildStatus = r.workflowBuildSuccess ? 'BUILT' : 'BUILD FAILED';
-		console.log(`${r.testCase.prompt.slice(0, 70)}...`);
-		console.log(`  Workflow: ${buildStatus}${r.workflowId ? ` (${r.workflowId})` : ''}`);
-		if (r.buildError) {
-			console.log(`  Error: ${r.buildError.slice(0, 200)}`);
-		}
+function printSummary(evaluation: MultiRunEvaluation): void {
+	const { totalRuns, testCases } = evaluation;
+	const multiRun = totalRuns > 1;
 
-		for (const sr of r.scenarioResults) {
-			const icon = sr.success ? '\u2713' : '\u2717';
-			console.log(
-				`  ${icon} ${sr.scenario.name}: ${sr.success ? 'PASS' : 'FAIL'} (${String(sr.score * 100)}%)`,
-			);
-			if (!sr.success) {
-				console.log(`    ${sr.reasoning.slice(0, 120)}`);
+	console.log('\n=== Workflow Eval Results ===\n');
+	for (const tc of testCases) {
+		console.log(`${tc.testCase.prompt.slice(0, 70)}...`);
+
+		if (multiRun) {
+			console.log(`  Build: ${String(tc.buildSuccessCount)}/${String(totalRuns)} runs`);
+		} else {
+			const r = tc.runs[0];
+			const buildStatus = r.workflowBuildSuccess ? 'BUILT' : 'BUILD FAILED';
+			console.log(`  Workflow: ${buildStatus}${r.workflowId ? ` (${r.workflowId})` : ''}`);
+			if (r.buildError) {
+				console.log(`  Error: ${r.buildError.slice(0, 200)}`);
 			}
 		}
-		console.log('');
+
+		for (const sa of tc.scenarios) {
+			if (multiRun) {
+				const passAtN = Math.round((sa.passAtK[totalRuns - 1] ?? 0) * 100);
+				const passHatN = Math.round((sa.passHatK[totalRuns - 1] ?? 0) * 100);
+				console.log(
+					`  ${sa.scenario.name}: ${String(sa.passCount)}/${String(totalRuns)} passed` +
+						` | pass@${String(totalRuns)}: ${String(passAtN)}% | pass^${String(totalRuns)}: ${String(passHatN)}%`,
+				);
+			} else {
+				const sr = sa.runs[0];
+				const icon = sr.success ? '✓' : '✗';
+				console.log(
+					`  ${icon} ${sr.scenario.name}: ${sr.success ? 'PASS' : 'FAIL'} (${String(sr.score * 100)}%)`,
+				);
+				if (!sr.success) {
+					console.log(`    ${sr.reasoning.slice(0, 120)}`);
+				}
+			}
+		}
+	}
+
+	// Aggregate metrics for multi-run
+	if (multiRun) {
+		const allScenarios = testCases.flatMap((tc) => tc.scenarios);
+		const total = allScenarios.length;
+		const avgPassAtN =
+			total > 0
+				? Math.round(
+						(allScenarios.reduce((sum, s) => sum + (s.passAtK[totalRuns - 1] ?? 0), 0) /
+							total) *
+							100,
+					)
+				: 0;
+		const avgPassHatN =
+			total > 0
+				? Math.round(
+						(allScenarios.reduce((sum, s) => sum + (s.passHatK[totalRuns - 1] ?? 0), 0) /
+							total) *
+							100,
+					)
+				: 0;
+
+		console.log('\n=== Aggregate Metrics ===\n');
+		console.log(`  pass@${String(totalRuns)}: ${String(avgPassAtN)}%`);
+		console.log(`  pass^${String(totalRuns)}: ${String(avgPassHatN)}%`);
 	}
 
 	// Totals
-	const allScenarios = results.flatMap((r) => r.scenarioResults);
-	const passed = allScenarios.filter((s) => s.success).length;
-	const built = results.filter((r) => r.workflowBuildSuccess).length;
+	const allScenarios = testCases.flatMap((tc) => tc.scenarios);
+	const total = allScenarios.length;
+	const built = testCases.filter((tc) => tc.buildSuccessCount > 0).length;
+	const passedTotal = multiRun
+		? allScenarios.reduce((sum, s) => sum + s.passCount, 0)
+		: allScenarios.filter((s) => s.runs[0]?.success).length;
+	const totalAttempts = multiRun ? total * totalRuns : total;
+
 	console.log(
-		`${String(built)}/${String(results.length)} built | ${String(passed)}/${String(allScenarios.length)} passed (${String(allScenarios.length > 0 ? Math.round((passed / allScenarios.length) * 100) : 0)}%)`,
+		`\n${String(built)}/${String(testCases.length)} built | ${String(passedTotal)}/${String(totalAttempts)} passed (${String(totalAttempts > 0 ? Math.round((passedTotal / totalAttempts) * 100) : 0)}%)`,
 	);
 }
 

--- a/packages/@n8n/instance-ai/evaluations/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/types.ts
@@ -169,3 +169,30 @@ export interface WorkflowTestCaseResult {
 	/** The built workflow JSON — saved for debugging and cross-run comparison */
 	workflowJson?: WorkflowResponse;
 }
+
+// ---------------------------------------------------------------------------
+// Multi-run aggregation
+// ---------------------------------------------------------------------------
+
+export interface ScenarioAggregation {
+	scenario: TestScenario;
+	runs: ScenarioResult[];
+	passCount: number;
+	passRate: number;
+	/** probability at least 1 of k attempts passes */
+	passAtK: number[];
+	/** probability all k attempts pass */
+	passHatK: number[];
+}
+
+export interface TestCaseAggregation {
+	testCase: WorkflowTestCase;
+	runs: WorkflowTestCaseResult[];
+	buildSuccessCount: number;
+	scenarios: ScenarioAggregation[];
+}
+
+export interface MultiRunEvaluation {
+	totalRuns: number;
+	testCases: TestCaseAggregation[];
+}


### PR DESCRIPTION
## Summary

Implements multiple runs & pass@k/pass^k in instanceAI evals

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
