### PR TITLE
feat(editor): Improve agent builder UX with integrations, one-shot build, and config sync (no-changelog)

### DIFF
--- a/packages/cli/src/modules/agents/__tests__/agents-service-sync.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-service-sync.test.ts
@@ -16,7 +16,6 @@ import { AgentsService } from '../agents.service';
 import type { AgentRepository } from '../repositories/agent.repository';
 import type { N8NCheckpointStorage } from '../integrations/n8n-checkpoint-storage';
 import type { AgentSecureRuntime } from '../runtime/agent-secure-runtime';
-import type { NullableJsonColumn } from '@n8n/db';
 import type { Agent } from '../entities/agent.entity';
 import type { AgentJsonConfig } from '../json-config/agent-json-config';
 import type { N8nMemory } from '../integrations/n8n-memory';
@@ -94,7 +93,7 @@ describe('AgentsService — updateName / updateDescription schema sync', () => {
 		});
 
 		it('handles agent with null schema', async () => {
-			const agent = makeAgent({ schema: null as unknown as NullableJsonColumn<AgentJsonConfig> });
+			const agent = makeAgent({ schema: null } as unknown as Partial<Agent>);
 			agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
 
 			const result = await service.updateName('agent-1', 'project-1', 'New Name');
@@ -136,7 +135,7 @@ describe('AgentsService — updateName / updateDescription schema sync', () => {
 		});
 
 		it('handles agent with null schema', async () => {
-			const agent = makeAgent({ schema: null as unknown as NullableJsonColumn<AgentJsonConfig> });
+			const agent = makeAgent({ schema: null } as unknown as Partial<Agent>);
 			agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
 
 			const result = await service.updateDescription('agent-1', 'project-1', 'New desc');

--- a/packages/cli/src/modules/agents/__tests__/agents-service-sync.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-service-sync.test.ts
@@ -1,0 +1,149 @@
+import { mock } from 'jest-mock-extended';
+import type { Logger } from '@n8n/backend-common';
+import type {
+	ExecutionRepository,
+	ProjectRelationRepository,
+	UserRepository,
+	WorkflowRepository,
+} from '@n8n/db';
+import type { ActiveExecutions } from '@/active-executions';
+import type { UrlService } from '@/services/url.service';
+import type { WorkflowRunner } from '@/workflow-runner';
+import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+import type { EphemeralNodeExecutor } from '@/node-execution';
+
+import { AgentsService } from '../agents.service';
+import type { AgentRepository } from '../repositories/agent.repository';
+import type { N8NCheckpointStorage } from '../integrations/n8n-checkpoint-storage';
+import type { AgentSecureRuntime } from '../runtime/agent-secure-runtime';
+import type { NullableJsonColumn } from '@n8n/db';
+import type { Agent } from '../entities/agent.entity';
+import type { AgentJsonConfig } from '../json-config/agent-json-config';
+import type { N8nMemory } from '../integrations/n8n-memory';
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+	return {
+		id: 'agent-1',
+		name: 'Old Name',
+		description: 'Old description',
+		projectId: 'project-1',
+		credentialId: null,
+		provider: null,
+		model: null,
+		schema: {
+			name: 'Old Name',
+			model: 'anthropic/claude-sonnet-4-5',
+			credential: 'cred-1',
+			instructions: 'Be helpful',
+		} as AgentJsonConfig,
+		integrations: [],
+		tools: {},
+		createdAt: new Date('2026-01-01'),
+		updatedAt: new Date('2026-01-01'),
+		...overrides,
+	} as Agent;
+}
+
+describe('AgentsService — updateName / updateDescription schema sync', () => {
+	let service: AgentsService;
+	let agentRepository: ReturnType<typeof mock<AgentRepository>>;
+
+	beforeEach(() => {
+		agentRepository = mock<AgentRepository>();
+		agentRepository.save.mockImplementation(async (entity) => entity as Agent);
+
+		service = new AgentsService(
+			mock<Logger>(),
+			agentRepository,
+			mock<ProjectRelationRepository>(),
+			mock<WorkflowRunner>(),
+			mock<ActiveExecutions>(),
+			mock<ExecutionRepository>(),
+			mock<WorkflowRepository>(),
+			mock<UserRepository>(),
+			mock<WorkflowFinderService>(),
+			mock<UrlService>(),
+			mock<N8NCheckpointStorage>(),
+			mock<AgentSecureRuntime>(),
+			mock<EphemeralNodeExecutor>(),
+			mock<N8nMemory>(),
+		);
+	});
+
+	describe('updateName', () => {
+		it('updates entity name and schema name together', async () => {
+			const agent = makeAgent();
+			agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
+
+			const result = await service.updateName('agent-1', 'project-1', 'New Name');
+
+			expect(result).not.toBeNull();
+			expect(result!.name).toBe('New Name');
+			expect(result!.schema!.name).toBe('New Name');
+		});
+
+		it('preserves other schema fields when updating name', async () => {
+			const agent = makeAgent();
+			agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
+
+			const result = await service.updateName('agent-1', 'project-1', 'New Name');
+
+			expect(result!.schema!.model).toBe('anthropic/claude-sonnet-4-5');
+			expect(result!.schema!.credential).toBe('cred-1');
+			expect(result!.schema!.instructions).toBe('Be helpful');
+		});
+
+		it('handles agent with null schema', async () => {
+			const agent = makeAgent({ schema: null as unknown as NullableJsonColumn<AgentJsonConfig> });
+			agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
+
+			const result = await service.updateName('agent-1', 'project-1', 'New Name');
+
+			expect(result).not.toBeNull();
+			expect(result!.name).toBe('New Name');
+			expect(result!.schema).toBeNull();
+		});
+
+		it('returns null for non-existent agent', async () => {
+			agentRepository.findByIdAndProjectId.mockResolvedValue(null);
+
+			const result = await service.updateName('missing', 'project-1', 'Name');
+
+			expect(result).toBeNull();
+		});
+	});
+
+	describe('updateDescription', () => {
+		it('updates entity description and schema description together', async () => {
+			const agent = makeAgent();
+			agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
+
+			const result = await service.updateDescription('agent-1', 'project-1', 'New desc');
+
+			expect(result).not.toBeNull();
+			expect(result!.description).toBe('New desc');
+			expect(result!.schema!.description).toBe('New desc');
+		});
+
+		it('preserves other schema fields when updating description', async () => {
+			const agent = makeAgent();
+			agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
+
+			const result = await service.updateDescription('agent-1', 'project-1', 'New desc');
+
+			expect(result!.schema!.name).toBe('Old Name');
+			expect(result!.schema!.model).toBe('anthropic/claude-sonnet-4-5');
+		});
+
+		it('handles agent with null schema', async () => {
+			const agent = makeAgent({ schema: null as unknown as NullableJsonColumn<AgentJsonConfig> });
+			agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
+
+			const result = await service.updateDescription('agent-1', 'project-1', 'New desc');
+
+			expect(result).not.toBeNull();
+			expect(result!.description).toBe('New desc');
+			expect(result!.schema).toBeNull();
+		});
+	});
+});

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -135,6 +135,11 @@ export class AgentsService {
 		}
 
 		agent.name = name;
+		// Keep the JSON config name in sync so a subsequent config save doesn't
+		// revert the entity name back to the stale config value.
+		if (agent.schema) {
+			agent.schema = { ...agent.schema, name };
+		}
 		const saved = await this.agentRepository.save(agent);
 		this.logger.debug('Updated SDK agent name', { agentId, projectId, name });
 		return saved;
@@ -157,6 +162,9 @@ export class AgentsService {
 		}
 
 		agent.description = description;
+		if (agent.schema) {
+			agent.schema = { ...agent.schema, description };
+		}
 		const saved = await this.agentRepository.save(agent);
 		this.logger.debug('Updated SDK agent description', { agentId, projectId });
 		return saved;

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -5446,6 +5446,7 @@
 	"agents.settings.unsavedChanges": "Unsaved changes",
 	"agents.settings.triggers": "Triggers",
 	"agents.settings.triggers.placeholder": "Trigger configuration will be available soon.",
+	"agents.settings.integrations": "Integrations",
 	"agents.settings.tools": "Tools",
 	"agents.settings.advanced": "Advanced",
 	"agents.settings.code": "Code",

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentHomeContent.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentHomeContent.test.ts
@@ -116,4 +116,28 @@ describe('AgentHomeContent', () => {
 		const wrapper = await renderComponent();
 		expect(wrapper.find('[data-testid="icon-picker-stub"]').exists()).toBe(true);
 	});
+
+	it('emits send-message when submitMessage is called with text', async () => {
+		const wrapper = await renderComponent();
+		const vm = wrapper.vm as unknown as { inputText: string; submitMessage: () => void };
+		vm.inputText = 'Build me an SEO agent';
+		vm.submitMessage();
+		expect(wrapper.emitted('send-message')?.[0]).toEqual(['Build me an SEO agent']);
+	});
+
+	it('does not emit send-message when input is empty', async () => {
+		const wrapper = await renderComponent();
+		const vm = wrapper.vm as unknown as { inputText: string; submitMessage: () => void };
+		vm.inputText = '   ';
+		vm.submitMessage();
+		expect(wrapper.emitted('send-message')).toBeUndefined();
+	});
+
+	it('clears input after submitting message', async () => {
+		const wrapper = await renderComponent();
+		const vm = wrapper.vm as unknown as { inputText: string; submitMessage: () => void };
+		vm.inputText = 'Hello';
+		vm.submitMessage();
+		expect(vm.inputText).toBe('');
+	});
 });

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentSettingsSidebar.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentSettingsSidebar.test.ts
@@ -108,6 +108,9 @@ describe('AgentSettingsSidebar', () => {
 			props: {
 				config: mockConfig,
 				agentTools: {},
+				projectId: 'test-project',
+				agentId: 'test-agent',
+				agentName: 'Test Agent',
 				updatedAt: '2026-04-09T00:00:00Z',
 				isDirty: false,
 				...props,

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentSettingsSidebar.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentSettingsSidebar.test.ts
@@ -120,6 +120,7 @@ describe('AgentSettingsSidebar', () => {
 					ModelSelector: { template: '<div data-testid="model-selector-stub" />' },
 					AgentToolsPanel: { template: '<div data-testid="tools-panel-stub" />' },
 					AgentMemoryPanel: { template: '<div data-testid="memory-panel-stub" />' },
+					AgentIntegrationsPanel: { template: '<div data-testid="integrations-panel-stub" />' },
 					AgentCodeEditor: { template: '<div data-testid="code-editor-stub" />' },
 					N8nButton: {
 						template:
@@ -217,5 +218,31 @@ describe('AgentSettingsSidebar', () => {
 		const codeHeader = wrapper.findAll('button').find((b) => b.text().includes('Code'));
 		await codeHeader?.trigger('click');
 		expect(wrapper.find('[data-testid="code-editor-stub"]').exists()).toBe(true);
+	});
+
+	it('auto-expands Code section when building prop becomes true', async () => {
+		const wrapper = await renderComponent({ building: false });
+		expect(wrapper.find('[data-testid="code-editor-stub"]').exists()).toBe(false);
+
+		await wrapper.setProps({ building: true });
+		expect(wrapper.find('[data-testid="code-editor-stub"]').exists()).toBe(true);
+	});
+
+	it('expands Triggers section to show integrations panel', async () => {
+		const wrapper = await renderComponent();
+		expect(wrapper.find('[data-testid="integrations-panel-stub"]').exists()).toBe(false);
+
+		const triggersHeader = wrapper.findAll('button').find((b) => b.text().includes('Triggers'));
+		await triggersHeader?.trigger('click');
+		expect(wrapper.find('[data-testid="integrations-panel-stub"]').exists()).toBe(true);
+	});
+
+	it('expands Advanced section to show memory panel', async () => {
+		const wrapper = await renderComponent();
+		expect(wrapper.find('[data-testid="memory-panel-stub"]').exists()).toBe(false);
+
+		const advancedHeader = wrapper.findAll('button').find((b) => b.text().includes('Advanced'));
+		await advancedHeader?.trigger('click');
+		expect(wrapper.find('[data-testid="memory-panel-stub"]').exists()).toBe(true);
 	});
 });

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentSettingsSidebar.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentSettingsSidebar.test.ts
@@ -228,6 +228,11 @@ describe('AgentSettingsSidebar', () => {
 		expect(wrapper.find('[data-testid="code-editor-stub"]').exists()).toBe(true);
 	});
 
+	it('auto-expands Code section when mounted with building already true', async () => {
+		const wrapper = await renderComponent({ building: true });
+		expect(wrapper.find('[data-testid="code-editor-stub"]').exists()).toBe(true);
+	});
+
 	it('expands Triggers section to show integrations panel', async () => {
 		const wrapper = await renderComponent();
 		expect(wrapper.find('[data-testid="integrations-panel-stub"]').exists()).toBe(false);

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChatPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChatPanel.vue
@@ -39,7 +39,7 @@ interface ChatMessage {
 	status?: 'streaming' | 'success' | 'error';
 }
 
-const activeTab = ref<'test' | 'builder'>(props.mode === 'inline' ? 'builder' : 'test');
+const activeTab = ref<'test' | 'builder'>('test');
 const messages = ref<ChatMessage[]>([]);
 const builderMessages = ref<ChatMessage[]>([]);
 const inputText = ref('');

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentIntegrationsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentIntegrationsPanel.vue
@@ -263,6 +263,7 @@ onMounted(async () => {
 								type="tertiary"
 								size="small"
 								icon="pen"
+								aria-label="Edit credential"
 								data-testid="slack-edit-credential"
 								@click="onEditCredential"
 							/>

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentIntegrationsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentIntegrationsPanel.vue
@@ -1,18 +1,22 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
-import { N8nButton, N8nCard, N8nIcon, N8nText } from '@n8n/design-system';
+import { ref, computed, onMounted, watch } from 'vue';
+import { N8nButton, N8nCard, N8nDialog, N8nIcon, N8nText } from '@n8n/design-system';
 import N8nSelect from '@n8n/design-system/components/N8nSelect';
 import N8nOption from '@n8n/design-system/components/N8nOption';
 import { useRootStore } from '@n8n/stores/useRootStore';
+import { useUIStore } from '@/app/stores/ui.store';
+import { CREDENTIAL_EDIT_MODAL_KEY } from '@/features/credentials/credentials.constants';
 import { makeRestApiRequest } from '@n8n/rest-api-client';
 import { connectSlack, disconnectSlack, getSlackStatus } from '../composables/useAgentApi';
 
 const props = defineProps<{
 	projectId: string;
 	agentId: string;
+	agentName: string;
 }>();
 
 const rootStore = useRootStore();
+const uiStore = useUIStore();
 
 interface CredentialOption {
 	id: string;
@@ -23,14 +27,95 @@ const slackStatus = ref('disconnected');
 const connectedCredentialId = ref('');
 const selectedCredentialId = ref('');
 const loading = ref(false);
+const errorMessage = ref('');
 const credentials = ref<CredentialOption[]>([]);
 const credentialsLoading = ref(false);
+const copied = ref(false);
+const showManifest = ref(false);
+
+const hasCredentials = computed(() => credentials.value.length > 0);
+const hasError = computed(() => errorMessage.value.length > 0);
+
+const webhookUrl = computed(() => {
+	const base = rootStore.urlBaseEditor;
+	return `${base}rest/projects/${props.projectId}/agents/v2/${props.agentId}/webhooks/slack`;
+});
+
+const oauthCallbackUrl = computed(
+	() => (rootStore.OAuthCallbackUrls as { oauth2?: string }).oauth2 ?? '',
+);
+
+const slackAppManifest = computed(() =>
+	JSON.stringify(
+		{
+			display_information: {
+				name: props.agentName || 'n8n Agent',
+			},
+			features: {
+				app_home: {
+					home_tab_enabled: true,
+					messages_tab_enabled: false,
+					messages_tab_read_only_enabled: false,
+				},
+				bot_user: {
+					display_name: props.agentName || 'n8n Agent',
+					always_online: true,
+				},
+			},
+			oauth_config: {
+				redirect_urls: [oauthCallbackUrl.value],
+				scopes: {
+					bot: [
+						'app_mentions:read',
+						'assistant:write',
+						'channels:join',
+						'channels:manage',
+						'channels:read',
+						'chat:write',
+						'chat:write.customize',
+						'files:read',
+						'files:write',
+						'im:history',
+						'im:read',
+						'im:write',
+						'mpim:read',
+						'mpim:write',
+						'users:read',
+					],
+				},
+				pkce_enabled: false,
+			},
+			settings: {
+				event_subscriptions: {
+					request_url: webhookUrl.value,
+					bot_events: ['app_mention', 'assistant_thread_context_changed', 'message.im'],
+				},
+				interactivity: {
+					is_enabled: true,
+					request_url: webhookUrl.value,
+				},
+				org_deploy_enabled: false,
+				socket_mode_enabled: false,
+				token_rotation_enabled: false,
+			},
+		},
+		null,
+		2,
+	),
+);
+
+async function copyManifest() {
+	await navigator.clipboard.writeText(slackAppManifest.value);
+	copied.value = true;
+	setTimeout(() => {
+		copied.value = false;
+	}, 2000);
+}
 
 async function fetchSlackStatus() {
 	try {
 		const result = await getSlackStatus(rootStore.restApiContext, props.projectId, props.agentId);
 		slackStatus.value = result.status;
-		// Track which credential is connected so disconnect can use it
 		const slackIntegration = (result.integrations ?? []).find(
 			(i: { type: string }) => i.type === 'slack',
 		);
@@ -64,6 +149,7 @@ async function fetchCredentials() {
 async function onConnect() {
 	if (!selectedCredentialId.value) return;
 	loading.value = true;
+	errorMessage.value = '';
 	try {
 		await connectSlack(
 			rootStore.restApiContext,
@@ -72,6 +158,14 @@ async function onConnect() {
 			selectedCredentialId.value,
 		);
 		await fetchSlackStatus();
+	} catch (e: unknown) {
+		const msg =
+			e instanceof Error
+				? e.message
+				: typeof e === 'object' && e !== null && 'message' in e
+					? String((e as { message: unknown }).message)
+					: 'Failed to connect';
+		errorMessage.value = msg;
 	} finally {
 		loading.value = false;
 	}
@@ -90,6 +184,27 @@ async function onDisconnect() {
 	}
 }
 
+function onCreateCredential() {
+	uiStore.openNewCredential('slackApi');
+}
+
+function onEditCredential() {
+	if (selectedCredentialId.value) {
+		uiStore.openExistingCredential(selectedCredentialId.value);
+	}
+}
+
+// Re-fetch credentials when the credential edit modal closes
+const credentialModalOpen = computed(
+	() => uiStore.isModalActiveById[CREDENTIAL_EDIT_MODAL_KEY] ?? false,
+);
+
+watch(credentialModalOpen, (isOpen, wasOpen) => {
+	if (wasOpen && !isOpen) {
+		void fetchCredentials();
+	}
+});
+
 onMounted(async () => {
 	await Promise.all([fetchSlackStatus(), fetchCredentials()]);
 });
@@ -97,8 +212,6 @@ onMounted(async () => {
 
 <template>
 	<div :class="$style.panel">
-		<N8nText :class="$style.heading" tag="h3" bold>Integrations</N8nText>
-
 		<N8nCard :class="$style.card">
 			<template #header>
 				<div :class="$style.cardHeader">
@@ -124,49 +237,104 @@ onMounted(async () => {
 				</N8nText>
 
 				<div v-if="slackStatus !== 'connected'" :class="$style.connectForm">
-					<label :class="$style.label">
-						<N8nText size="small" bold>Slack Credential</N8nText>
-					</label>
-					<N8nSelect
-						v-model="selectedCredentialId"
-						:class="$style.select"
-						placeholder="Select a credential..."
-						:loading="credentialsLoading"
-						:disabled="loading"
-						size="medium"
-						data-testid="slack-credential-select"
-					>
-						<N8nOption
-							v-for="cred in credentials"
-							:key="cred.id"
-							:value="cred.id"
-							:label="cred.name"
-						/>
-					</N8nSelect>
-					<N8nText v-if="credentials.length === 0 && !credentialsLoading" size="small">
-						No Slack API credentials found. Create a Slack API or Slack OAuth2 API credential in the
-						Credentials page.
+					<template v-if="hasCredentials">
+						<label :class="$style.label">
+							<N8nText size="small" bold>Slack Credential</N8nText>
+						</label>
+						<div :class="$style.selectRow">
+							<N8nSelect
+								v-model="selectedCredentialId"
+								:class="$style.select"
+								placeholder="Select a credential..."
+								:loading="credentialsLoading"
+								:disabled="loading"
+								size="medium"
+								data-testid="slack-credential-select"
+							>
+								<N8nOption
+									v-for="cred in credentials"
+									:key="cred.id"
+									:value="cred.id"
+									:label="cred.name"
+								/>
+							</N8nSelect>
+							<N8nButton
+								v-if="selectedCredentialId"
+								type="tertiary"
+								size="small"
+								icon="pen"
+								data-testid="slack-edit-credential"
+								@click="onEditCredential"
+							/>
+						</div>
+					</template>
+
+					<div v-else-if="!credentialsLoading" :class="$style.emptyCredentials">
+						<N8nText size="small"> No Slack credentials found. </N8nText>
+						<N8nButton
+							size="small"
+							data-testid="slack-create-credential"
+							@click="onCreateCredential"
+						>
+							<N8nIcon icon="plus" :size="14" />
+							Add Slack credential
+						</N8nButton>
+					</div>
+
+					<N8nText v-if="hasError" :class="$style.errorText" size="small">
+						{{ errorMessage }}
+						<a
+							v-if="selectedCredentialId"
+							:class="$style.link"
+							href="#"
+							@click.prevent="onEditCredential"
+							>Edit credential</a
+						>
 					</N8nText>
-					<N8nButton
-						:class="$style.actionButton"
-						:disabled="!selectedCredentialId || loading"
-						:loading="loading"
-						size="small"
-						data-testid="slack-connect-button"
-						@click="onConnect"
-					>
-						<N8nIcon icon="plug" :size="14" />
-						Connect
-					</N8nButton>
+
+					<div :class="$style.actions">
+						<N8nButton
+							:disabled="!selectedCredentialId || loading"
+							:loading="loading"
+							size="small"
+							data-testid="slack-connect-button"
+							@click="onConnect"
+						>
+							<N8nIcon icon="plug" :size="14" />
+							Connect
+						</N8nButton>
+						<N8nButton
+							v-if="hasCredentials"
+							type="tertiary"
+							size="small"
+							data-testid="slack-create-another-credential"
+							@click="onCreateCredential"
+						>
+							<N8nIcon icon="plus" :size="14" />
+							New credential
+						</N8nButton>
+					</div>
 				</div>
 
-				<div v-else :class="$style.disconnectSection">
+				<div v-else :class="$style.connectedSection">
 					<N8nText size="small">
 						Your agent is connected to Slack and can receive messages.
 					</N8nText>
+
+					<!-- Slack App Manifest -->
+					<N8nText :class="$style.manifestHint" size="small">
+						Copy the app manifest and paste it into your Slack app's settings to configure events,
+						scopes, and interactivity.
+						<a :class="$style.link" href="#" @click.prevent="showManifest = true">View JSON</a>
+					</N8nText>
+					<N8nButton variant="outline" size="small" @click="copyManifest">
+						<N8nIcon :icon="copied ? 'check' : 'copy'" :size="14" />
+						{{ copied ? 'Copied' : 'Copy manifest' }}
+					</N8nButton>
+
 					<N8nButton
 						:class="$style.actionButton"
-						type="tertiary"
+						variant="destructive"
 						:loading="loading"
 						size="small"
 						data-testid="slack-disconnect-button"
@@ -175,6 +343,16 @@ onMounted(async () => {
 						<N8nIcon icon="unlink" :size="14" />
 						Disconnect
 					</N8nButton>
+
+					<!-- Manifest modal -->
+					<N8nDialog
+						:open="showManifest"
+						header="Slack App Manifest"
+						size="medium"
+						@update:open="showManifest = $event"
+					>
+						<pre :class="$style.manifestCode">{{ slackAppManifest }}</pre>
+					</N8nDialog>
 				</div>
 			</div>
 		</N8nCard>
@@ -183,17 +361,11 @@ onMounted(async () => {
 
 <style module>
 .panel {
-	padding: var(--spacing--lg);
 	overflow-y: auto;
-	height: 100%;
-}
-
-.heading {
-	margin-bottom: var(--spacing--sm);
 }
 
 .card {
-	max-width: 480px;
+	width: 100%;
 }
 
 .cardHeader {
@@ -247,14 +419,64 @@ onMounted(async () => {
 	display: block;
 }
 
-.select {
-	width: 100%;
+.selectRow {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing--4xs);
 }
 
-.disconnectSection {
+.select {
+	flex: 1;
+	min-width: 0;
+}
+
+.emptyCredentials {
 	display: flex;
 	flex-direction: column;
 	gap: var(--spacing--xs);
+	align-items: flex-start;
+}
+
+.actions {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing--2xs);
+}
+
+.connectedSection {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--sm);
+}
+
+.manifestHint {
+	color: var(--color--text--tint-1);
+}
+
+.manifestCode {
+	margin: 0;
+	padding: var(--spacing--xs);
+	background-color: var(--color--foreground--tint-2);
+	border-radius: var(--radius);
+	font-size: var(--font-size--2xs);
+	line-height: var(--line-height--xl);
+	overflow-x: auto;
+	max-height: 300px;
+	overflow-y: auto;
+	white-space: pre;
+	font-family: monospace;
+	color: var(--color--text);
+}
+
+.errorText {
+	color: var(--color--danger);
+}
+
+.link {
+	color: var(--color--primary);
+	text-decoration: underline;
+	cursor: pointer;
+	margin-left: var(--spacing--4xs);
 }
 
 .actionButton {

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentSettingsSidebar.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentSettingsSidebar.vue
@@ -13,6 +13,7 @@ import type { CustomToolEntry } from '../agent.types';
 import { CHATHUB_TO_CATALOG, CATALOG_TO_CHATHUB } from '../provider-mapping';
 import AgentToolsPanel from './AgentToolsPanel.vue';
 import AgentMemoryPanel from './AgentMemoryPanel.vue';
+import AgentIntegrationsPanel from './AgentIntegrationsPanel.vue';
 import AgentCodeEditor from './AgentCodeEditor.vue';
 
 const locale = useI18n();
@@ -22,8 +23,12 @@ const chatStore = useChatStore();
 const props = defineProps<{
 	config: AgentJsonConfig | null;
 	agentTools: Record<string, CustomToolEntry>;
+	projectId: string;
+	agentId: string;
+	agentName: string;
 	updatedAt: string;
 	isDirty: boolean;
+	building?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -134,6 +139,16 @@ function toggleSection(section: string) {
 	expandedSections.value[section] = !expandedSections.value[section];
 }
 
+// Auto-expand code section when building starts
+watch(
+	() => props.building,
+	(building) => {
+		if (building) {
+			expandedSections.value.code = true;
+		}
+	},
+);
+
 // --- Resizable width ---
 const sidebarWidth = ref(480);
 const MIN_WIDTH = 360;
@@ -242,9 +257,11 @@ function onResizeStart(event: MouseEvent) {
 					</span>
 				</button>
 				<div v-if="expandedSections.triggers" :class="$style.sectionContent">
-					<N8nText size="small" color="text-light">
-						{{ locale.baseText('agents.settings.triggers.placeholder') }}
-					</N8nText>
+					<AgentIntegrationsPanel
+						:project-id="projectId"
+						:agent-id="agentId"
+						:agent-name="agentName"
+					/>
 				</div>
 			</div>
 
@@ -302,6 +319,7 @@ function onResizeStart(event: MouseEvent) {
 						<N8nText tag="span" bold size="small">{{
 							locale.baseText('agents.settings.code')
 						}}</N8nText>
+						<N8nIcon v-if="building" icon="spinner" :size="14" spin />
 					</div>
 				</button>
 				<div v-if="expandedSections.code" :class="$style.codeSection">
@@ -397,7 +415,6 @@ function onResizeStart(event: MouseEvent) {
 	flex-direction: column;
 	gap: var(--spacing--2xs);
 	padding: var(--spacing--sm);
-	border-bottom: var(--border-width) var(--border-style) var(--color--foreground);
 }
 
 .modelSection {
@@ -413,7 +430,7 @@ function onResizeStart(event: MouseEvent) {
 }
 
 .section {
-	border-bottom: var(--border-width) var(--border-style) var(--color--foreground);
+	border-top: var(--border-width) var(--border-style) var(--color--foreground);
 }
 
 .sectionHeader {

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentSettingsSidebar.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentSettingsSidebar.vue
@@ -147,6 +147,7 @@ watch(
 			expandedSections.value.code = true;
 		}
 	},
+	{ immediate: true },
 );
 
 // --- Resizable width ---

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -35,6 +35,7 @@ const agentId = computed(() => route.params.agentId as string);
 // UI state
 const chatActive = ref(false);
 const settingsVisible = ref(true);
+const isBuilding = ref(false);
 const agentName = ref('');
 const agentDescription = ref<string | null>(null);
 const agentIcon = ref<IconOrEmoji>({ type: 'icon', value: 'robot' });
@@ -93,10 +94,57 @@ async function updateDescription(description: string) {
 	}
 }
 
-function startChat(msg: string) {
-	initialPrompt.value = msg;
-	chatActive.value = true;
-	telemetry.track('User started agent chat', { agent_id: agentId.value });
+async function buildFromPrompt(msg: string) {
+	if (isBuilding.value) return;
+
+	isBuilding.value = true;
+	settingsVisible.value = true;
+	telemetry.track('User started agent build', { agent_id: agentId.value });
+
+	try {
+		const { baseUrl } = rootStore.restApiContext;
+		const browserId = localStorage.getItem('n8n-browserId') ?? '';
+		const url = `${baseUrl}/projects/${projectId.value}/agents/v2/${agentId.value}/build`;
+
+		const response = await fetch(url, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', 'browser-id': browserId },
+			credentials: 'include',
+			body: JSON.stringify({ message: msg }),
+		});
+
+		if (!response.ok || !response.body) return;
+
+		const reader = response.body.getReader();
+		const decoder = new TextDecoder();
+		let buffer = '';
+
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+
+			buffer += decoder.decode(value, { stream: true });
+			const lines = buffer.split('\n');
+			buffer = lines.pop() ?? '';
+
+			for (const line of lines) {
+				if (!line.startsWith('data: ')) continue;
+				try {
+					const data = JSON.parse(line.slice(6)) as Record<string, unknown>;
+					if (data.configUpdated !== undefined || data.toolUpdated !== undefined) {
+						await onConfigUpdated();
+					}
+				} catch {
+					// skip malformed JSON
+				}
+			}
+		}
+
+		// Final refresh after stream ends
+		await onConfigUpdated();
+	} finally {
+		isBuilding.value = false;
+	}
 }
 
 function onConfigFieldUpdate(updates: Partial<AgentJsonConfig>) {
@@ -144,6 +192,7 @@ async function onHeaderAction(action: string) {
 async function initialize() {
 	agent.value = null;
 	chatActive.value = false;
+	isBuilding.value = false;
 	agentIcon.value = { type: 'icon', value: 'robot' };
 	initialPrompt.value = undefined;
 	localConfig.value = null;
@@ -156,7 +205,7 @@ async function initialize() {
 	const prompt = route.query.prompt as string | undefined;
 	if (prompt) {
 		void router.replace({ query: { ...route.query, prompt: undefined } });
-		startChat(prompt);
+		void buildFromPrompt(prompt);
 	}
 }
 
@@ -206,7 +255,7 @@ watch(agentId, initialize, { immediate: true });
 					:agent-icon="agentIcon"
 					:project-id="projectId"
 					:agent-id="agentId"
-					@send-message="startChat"
+					@send-message="buildFromPrompt"
 					@update:name="updateName"
 					@update:description="updateDescription"
 					@update:icon="agentIcon = $event"
@@ -227,8 +276,12 @@ watch(agentId, initialize, { immediate: true });
 			v-if="settingsVisible"
 			:config="localConfig"
 			:agent-tools="agent?.tools ?? {}"
+			:project-id="projectId"
+			:agent-id="agentId"
+			:agent-name="agentName"
 			:updated-at="updatedAt"
 			:is-dirty="isDirty"
+			:building="isBuilding"
 			@update:config="onConfigFieldUpdate"
 			@save="saveConfig"
 			@cancel="cancelConfig"

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -79,6 +79,10 @@ async function updateName(name: string) {
 		agent.value = updated;
 		agentName.value = updated.name;
 		updatedAt.value = updated.updatedAt;
+		// Keep config name in sync so it persists on next config save
+		if (localConfig.value) {
+			localConfig.value.name = updated.name;
+		}
 		agentsEventBus.emit('agentUpdated');
 	}
 }

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -82,6 +82,8 @@ async function updateName(name: string) {
 		// Keep config name in sync so it persists on next config save
 		if (localConfig.value) {
 			localConfig.value.name = updated.name;
+			// Update the dirty-state baseline so the rename alone doesn't mark config as dirty
+			originalConfigJson.value = JSON.stringify(localConfig.value);
 		}
 		agentsEventBus.emit('agentUpdated');
 	}
@@ -98,23 +100,34 @@ async function updateDescription(description: string) {
 	}
 }
 
+let buildAbortController: AbortController | null = null;
+
 async function buildFromPrompt(msg: string) {
 	if (isBuilding.value) return;
 
+	// Capture IDs at call time so in-flight callbacks never act on a stale agent
+	const capturedProjectId = projectId.value;
+	const capturedAgentId = agentId.value;
+
+	buildAbortController?.abort();
+	const abortController = new AbortController();
+	buildAbortController = abortController;
+
 	isBuilding.value = true;
 	settingsVisible.value = true;
-	telemetry.track('User started agent build', { agent_id: agentId.value });
+	telemetry.track('User started agent build', { agent_id: capturedAgentId });
 
 	try {
 		const { baseUrl } = rootStore.restApiContext;
 		const browserId = localStorage.getItem('n8n-browserId') ?? '';
-		const url = `${baseUrl}/projects/${projectId.value}/agents/v2/${agentId.value}/build`;
+		const url = `${baseUrl}/projects/${capturedProjectId}/agents/v2/${capturedAgentId}/build`;
 
 		const response = await fetch(url, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json', 'browser-id': browserId },
 			credentials: 'include',
 			body: JSON.stringify({ message: msg }),
+			signal: abortController.signal,
 		});
 
 		if (!response.ok || !response.body) return;
@@ -124,6 +137,7 @@ async function buildFromPrompt(msg: string) {
 		let buffer = '';
 
 		while (true) {
+			if (abortController.signal.aborted) break;
 			const { done, value } = await reader.read();
 			if (done) break;
 
@@ -136,7 +150,8 @@ async function buildFromPrompt(msg: string) {
 				try {
 					const data = JSON.parse(line.slice(6)) as Record<string, unknown>;
 					if (data.configUpdated !== undefined || data.toolUpdated !== undefined) {
-						await onConfigUpdated();
+						if (abortController.signal.aborted) break;
+						await onConfigUpdated(capturedProjectId, capturedAgentId);
 					}
 				} catch {
 					// skip malformed JSON
@@ -145,8 +160,16 @@ async function buildFromPrompt(msg: string) {
 		}
 
 		// Final refresh after stream ends
-		await onConfigUpdated();
+		if (!abortController.signal.aborted) {
+			await onConfigUpdated(capturedProjectId, capturedAgentId);
+		}
+	} catch (e) {
+		if (e instanceof DOMException && e.name === 'AbortError') return;
+		throw e;
 	} finally {
+		if (buildAbortController === abortController) {
+			buildAbortController = null;
+		}
 		isBuilding.value = false;
 	}
 }
@@ -173,8 +196,12 @@ function cancelConfig() {
 	}
 }
 
-async function onConfigUpdated() {
-	await Promise.all([fetchAgent(), fetchConfig(projectId.value, agentId.value)]);
+async function onConfigUpdated(forProjectId?: string, forAgentId?: string) {
+	const pid = forProjectId ?? projectId.value;
+	const aid = forAgentId ?? agentId.value;
+	// Skip if the agent is no longer the one being viewed (stale callback)
+	if (pid !== projectId.value || aid !== agentId.value) return;
+	await Promise.all([fetchAgent(), fetchConfig(pid, aid)]);
 	isDirty.value = false;
 }
 
@@ -194,6 +221,8 @@ async function onHeaderAction(action: string) {
 }
 
 async function initialize() {
+	buildAbortController?.abort();
+	buildAbortController = null;
 	agent.value = null;
 	chatActive.value = false;
 	isBuilding.value = false;

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectNavigation.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectNavigation.test.ts
@@ -276,5 +276,23 @@ describe('ProjectsNavigation', () => {
 
 			expect(queryByTestId('new-agent-menu-item')).not.toBeInTheDocument();
 		});
+
+		it('should refresh agents list when agentUpdated event is emitted', async () => {
+			settingsStore.isModuleActive = vi.fn((module: string) => module === 'agents');
+
+			const { listAllAgents } = await import('@/features/agents/composables/useAgentApi');
+			const { agentsEventBus } = await import('@/features/agents/agents.eventBus');
+
+			renderComponent({ props: { collapsed: false } });
+			await flushPromises();
+
+			// Reset call count after initial mount fetch
+			vi.mocked(listAllAgents).mockClear();
+
+			agentsEventBus.emit('agentUpdated');
+			await flushPromises();
+
+			expect(listAllAgents).toHaveBeenCalledTimes(1);
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Improves the agent builder UI/UX with several fixes and features built on top of the n8n-agents merge:

- **Integrations panel**: Restored Slack integration panel inside the Settings sidebar (Triggers section). Added credential create/edit buttons using existing `uiStore.openNewCredential`/`openExistingCredential`, inline error display for connection failures (e.g. missing signing secret), and a Slack App Manifest (copy button + View JSON modal) shown after successful connection.
- **One-shot builder**: The initial message from AgentHomeContent now fires a one-shot `/build` request instead of opening a chat thread. The settings sidebar slides in with the Code section auto-expanded and a spinner while the builder configures the agent. Subsequent chats test the agent via `/chat`.
- **Name/description sync**: `updateName` and `updateDescription` now update both the entity column and `agent.schema` (JSON config) so names persist across config saves and page refreshes. Frontend also syncs `localConfig.name` and emits `agentUpdated` to refresh the sidebar nav.
- **Chat panel builder tabs**: Added test/builder tab switching with persistent builder message history to AgentChatPanel, with `configUpdated` event handling for real-time sidebar refresh.
- **AgentSettingsSidebar tests**: Updated to pass new `projectId`, `agentId`, `agentName` props and config-based mock data.

### How to test

1. Create a new agent, type an initial description → sidebar should open with Code section expanded and spinner while builder runs
2. After build completes, edit agent name → should persist after refresh and update in sidebar nav
3. Open Triggers section → Slack integration panel with create/edit credential flow
4. Connect Slack credential → manifest shown with Copy button and View JSON modal
5. Open chat → messages should go to `/chat` (test tab), not builder

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AGENT-1
- https://linear.app/n8n/issue/AGENT-16

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)