### PR TITLE
fix(core): Use upsert for MCP OAuth user consent to allow re-authorization

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/mcp-oauth-consent.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp-oauth-consent.service.test.ts
@@ -151,7 +151,7 @@ describe('McpOAuthConsentService', () => {
 				clientId: 'client-123',
 				userId: 'user-123',
 			});
-			expect(userConsentRepository.insert).not.toHaveBeenCalled();
+			expect(userConsentRepository.upsert).not.toHaveBeenCalled();
 		});
 
 		it('should handle user approval and generate authorization code', async () => {
@@ -166,18 +166,21 @@ describe('McpOAuthConsentService', () => {
 			const authCode = 'generated-auth-code';
 
 			oauthSessionService.verifySession.mockReturnValue(sessionPayload);
-			userConsentRepository.insert.mockResolvedValue(mock());
+			userConsentRepository.upsert.mockResolvedValue(mock());
 			authorizationCodeService.createAuthorizationCode.mockResolvedValue(authCode);
 
 			const result = await service.handleConsentDecision(sessionToken, userId, true);
 
 			expect(result.redirectUrl).toContain('code=generated-auth-code');
 			expect(result.redirectUrl).toContain('state=state-xyz');
-			expect(userConsentRepository.insert).toHaveBeenCalledWith({
-				userId: 'user-123',
-				clientId: 'client-123',
-				grantedAt: expect.any(Number),
-			});
+			expect(userConsentRepository.upsert).toHaveBeenCalledWith(
+				{
+					userId: 'user-123',
+					clientId: 'client-123',
+					grantedAt: expect.any(Number),
+				},
+				['userId', 'clientId'],
+			);
 			expect(authorizationCodeService.createAuthorizationCode).toHaveBeenCalledWith(
 				'client-123',
 				'user-123',
@@ -203,7 +206,7 @@ describe('McpOAuthConsentService', () => {
 			const authCode = 'generated-auth-code';
 
 			oauthSessionService.verifySession.mockReturnValue(sessionPayload);
-			userConsentRepository.insert.mockResolvedValue(mock());
+			userConsentRepository.upsert.mockResolvedValue(mock());
 			authorizationCodeService.createAuthorizationCode.mockResolvedValue(authCode);
 
 			const result = await service.handleConsentDecision(sessionToken, userId, true);
@@ -222,6 +225,38 @@ describe('McpOAuthConsentService', () => {
 
 			await expect(service.handleConsentDecision(sessionToken, userId, true)).rejects.toThrow(
 				'Invalid or expired session',
+			);
+		});
+
+		it('should handle re-authorization for same user and client via upsert', async () => {
+			const sessionToken = 'valid-session-token';
+			const userId = 'user-123';
+			const sessionPayload = {
+				clientId: 'client-123',
+				redirectUri: 'https://example.com/callback',
+				codeChallenge: 'challenge-abc',
+				state: 'state-xyz',
+			};
+			const authCode = 'generated-auth-code';
+
+			oauthSessionService.verifySession.mockReturnValue(sessionPayload);
+			userConsentRepository.upsert.mockResolvedValue(mock());
+			authorizationCodeService.createAuthorizationCode.mockResolvedValue(authCode);
+
+			// First authorization
+			await service.handleConsentDecision(sessionToken, userId, true);
+			// Second authorization (re-authorization) — should not throw
+			const result = await service.handleConsentDecision(sessionToken, userId, true);
+
+			expect(result.redirectUrl).toContain('code=generated-auth-code');
+			expect(userConsentRepository.upsert).toHaveBeenCalledTimes(2);
+			expect(userConsentRepository.upsert).toHaveBeenCalledWith(
+				{
+					userId: 'user-123',
+					clientId: 'client-123',
+					grantedAt: expect.any(Number),
+				},
+				['userId', 'clientId'],
 			);
 		});
 

--- a/packages/cli/src/modules/mcp/mcp-oauth-consent.service.ts
+++ b/packages/cli/src/modules/mcp/mcp-oauth-consent.service.ts
@@ -83,11 +83,14 @@ export class McpOAuthConsentService {
 			return { redirectUrl };
 		}
 
-		await this.userConsentRepository.insert({
-			userId,
-			clientId: sessionPayload.clientId,
-			grantedAt: Date.now(),
-		});
+		await this.userConsentRepository.upsert(
+			{
+				userId,
+				clientId: sessionPayload.clientId,
+				grantedAt: Date.now(),
+			},
+			['userId', 'clientId'],
+		);
 
 		const code = await this.authorizationCodeService.createAuthorizationCode(
 			sessionPayload.clientId,


### PR DESCRIPTION
## Summary

Replace `insert()` with `upsert()` in `McpOAuthConsentService.handleConsentDecision()` to fix re-authorization failure for MCP OAuth clients.

When a user who has already consented to an MCP OAuth client goes through the authorization flow again (e.g., after token expiry or reconnecting from an MCP client like Claude.ai), the plain `insert()` call violates the `UNIQUE("userId", "clientId")` constraint on `oauth_user_consents`, throwing:

duplicate key value violates unique constraint "UQ_083721d99ce8db4033e2958ebb4"

The fix uses `upsert()` with conflict target `['userId', 'clientId']`, which updates `grantedAt` on re-authorization instead of throwing a duplicate key error.

## Related Linear tickets, Github issues, and Community forum posts

- Fixes #28496
- Linear: [GHC-7735](https://linear.app/n8n/issue/GHC-7735)

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
