### PR TITLE
fix(nodes-langchain): strip internal stack traces from MCP trigger error responses

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/protocol/MessageFormatter.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/protocol/MessageFormatter.ts
@@ -23,13 +23,13 @@ export class MessageFormatter {
 	}
 
 	static formatError(error: Error): McpToolResult {
-		const errorDetails = [`${error.name}: ${error.message}`];
-		if (error.stack) {
-			errorDetails.push(error.stack);
-		}
+		// Only include the error name and message in the client-facing JSON-RPC
+		// response. Stack traces are internal implementation details and should
+		// stay in server-side logs (the call site in McpServer.ts already logs
+		// the full error there for debugging).
 		return {
 			isError: true,
-			content: [{ type: 'text', text: errorDetails.join('\n') }],
+			content: [{ type: 'text', text: `${error.name}: ${error.message}` }],
 		};
 	}
 }


### PR DESCRIPTION
Per #28414, `MessageFormatter.formatError()` in the MCP Trigger node appends the full server-side stack trace to the tool error response that gets sent back to the MCP client over JSON-RPC. Stack traces are internal implementation details and should not leak to clients.

This PR returns only `name: message` in the response. The existing call site in `McpServer.ts` already logs the full error server-side for debugging, so no observability is lost.

Closes #28414