### PR TITLE
fix(MCP Server Trigger Node): Propagate tool errors with isError flag in MCP responses

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
@@ -303,7 +303,10 @@ export class McpServer {
 						`SSE queue mode: sending response directly via transport for session ${sessionId}`,
 					);
 
-					const formattedResult = MessageFormatter.formatToolResult(result);
+					const formattedResult = MessageFormatter.formatToolResult(
+						result,
+						MessageFormatter.isErrorResult(result),
+					);
 					const response: JSONRPCMessage = {
 						jsonrpc: '2.0',
 						id: messageId,
@@ -489,7 +492,7 @@ export class McpServer {
 						messageId: requestId,
 					});
 
-					return MessageFormatter.formatToolResult(result);
+					return MessageFormatter.formatToolResult(result, MessageFormatter.isErrorResult(result));
 				}
 
 				const result = await this.executionCoordinator.executeTool(requestedTool, toolArguments, {
@@ -503,7 +506,7 @@ export class McpServer {
 					this.logger.warn(`No resolve function found for ${callId}`);
 				}
 
-				return MessageFormatter.formatToolResult(result);
+				return MessageFormatter.formatToolResult(result, MessageFormatter.isErrorResult(result));
 			} catch (error) {
 				this.logger.error(
 					`Error while executing Tool ${toolName}: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__tests__/McpServer.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__tests__/McpServer.test.ts
@@ -319,6 +319,91 @@ describe('McpServer', () => {
 	});
 
 	describe('handleWorkerResponse', () => {
+		it('should set isError on error results sent via SSE transport', async () => {
+			const sessionId = 'test-session';
+			const transport = createMockTransport(sessionId, 'sse');
+			const server = createMockServer();
+
+			const sessionManager = (
+				mcpServer as unknown as {
+					sessionManager: {
+						registerSession: (
+							s: string,
+							srv: unknown,
+							tr: unknown,
+							tools?: unknown[],
+						) => Promise<void>;
+					};
+				}
+			).sessionManager;
+			await sessionManager.registerSession(sessionId, server, transport, [
+				createMockTool('test-tool'),
+			]);
+
+			// Set up queue mode so handleWorkerResponse uses SSE fallback path
+			const queuedStrategy = new QueuedExecutionStrategy(mcpServer.getPendingCallsManager());
+			mcpServer.setExecutionStrategy(queuedStrategy);
+
+			// Worker returns an error result (queue mode error format)
+			const errorResult = { error: { message: 'Bad request', name: 'NodeApiError' } };
+			mcpServer.handleWorkerResponse(sessionId, 'msg-1', errorResult);
+
+			expect(transport.send).toHaveBeenCalledWith(
+				expect.objectContaining({
+					jsonrpc: '2.0',
+					id: 'msg-1',
+					result: expect.objectContaining({
+						isError: true,
+						content: [{ type: 'text', text: JSON.stringify(errorResult) }],
+					}),
+				}),
+			);
+		});
+
+		it('should not set isError on successful results sent via SSE transport', async () => {
+			const sessionId = 'test-session';
+			const transport = createMockTransport(sessionId, 'sse');
+			const server = createMockServer();
+
+			const sessionManager = (
+				mcpServer as unknown as {
+					sessionManager: {
+						registerSession: (
+							s: string,
+							srv: unknown,
+							tr: unknown,
+							tools?: unknown[],
+						) => Promise<void>;
+					};
+				}
+			).sessionManager;
+			await sessionManager.registerSession(sessionId, server, transport, [
+				createMockTool('test-tool'),
+			]);
+
+			const queuedStrategy = new QueuedExecutionStrategy(mcpServer.getPendingCallsManager());
+			mcpServer.setExecutionStrategy(queuedStrategy);
+
+			// Worker returns a successful result
+			const successResult = { data: 'value', count: 42 };
+			mcpServer.handleWorkerResponse(sessionId, 'msg-1', successResult);
+
+			expect(transport.send).toHaveBeenCalledWith(
+				expect.objectContaining({
+					jsonrpc: '2.0',
+					id: 'msg-1',
+					result: expect.objectContaining({
+						content: [{ type: 'text', text: JSON.stringify(successResult) }],
+					}),
+				}),
+			);
+			// Verify isError is NOT present
+			const sentMessage = (transport.send as jest.Mock).mock.calls[0][0] as {
+				result: { isError?: boolean };
+			};
+			expect(sentMessage.result.isError).toBeUndefined();
+		});
+
 		it('should handle list tools request marker', async () => {
 			const sessionId = 'test-session';
 			const transport = createMockTransport(sessionId, 'sse');

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__tests__/McpServer.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__tests__/McpServer.test.ts
@@ -398,7 +398,7 @@ describe('McpServer', () => {
 				}),
 			);
 			// Verify isError is NOT present
-			const sentMessage = (transport.send as jest.Mock).mock.calls[0][0] as {
+			const sentMessage = transport.send.mock.calls[0][0] as unknown as {
 				result: { isError?: boolean };
 			};
 			expect(sentMessage.result.isError).toBeUndefined();

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/protocol/MessageFormatter.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/protocol/MessageFormatter.ts
@@ -1,25 +1,48 @@
 import type { McpToolResult } from './types';
 
 export class MessageFormatter {
-	static formatToolResult(result: unknown): McpToolResult {
+	static formatToolResult(result: unknown, isError = false): McpToolResult {
+		let content: McpToolResult['content'];
+
 		if (typeof result === 'object' && result !== null) {
-			return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+			content = [{ type: 'text', text: JSON.stringify(result) }];
+		} else if (typeof result === 'string') {
+			content = [{ type: 'text', text: result }];
+		} else if (result === null || result === undefined) {
+			content = [{ type: 'text', text: String(result) }];
+		} else if (
+			typeof result === 'number' ||
+			typeof result === 'boolean' ||
+			typeof result === 'bigint'
+		) {
+			content = [{ type: 'text', text: result.toString() }];
+		} else {
+			// Remaining types: symbol, function - convert to string representation
+			content = [
+				{ type: 'text', text: String(result as symbol | ((...args: unknown[]) => unknown)) },
+			];
+		}
+
+		return isError ? { isError: true, content } : { content };
+	}
+
+	/**
+	 * Detect whether a tool result represents an error.
+	 *
+	 * In direct mode, N8nTool catches errors and returns `e.toString()` producing
+	 * strings like `"NodeApiError: Bad request"`. ToolHttpRequest catches HTTP errors
+	 * and returns `"There was an error: \"...\"" or `"HTTP 401 There was an error: \"...\""`.
+	 *
+	 * In queue mode, the job processor wraps errors as `{ error: { message, name } }`.
+	 */
+	static isErrorResult(result: unknown): boolean {
+		if (typeof result === 'object' && result !== null && 'error' in result) {
+			return true;
 		}
 		if (typeof result === 'string') {
-			return { content: [{ type: 'text', text: result }] };
+			return /^(\w+Error: |HTTP \d{3} There was an error: |There was an error: )/.test(result);
 		}
-		if (result === null || result === undefined) {
-			return { content: [{ type: 'text', text: String(result) }] };
-		}
-		if (typeof result === 'number' || typeof result === 'boolean' || typeof result === 'bigint') {
-			return { content: [{ type: 'text', text: result.toString() }] };
-		}
-		// Remaining types: symbol, function - convert to string representation
-		return {
-			content: [
-				{ type: 'text', text: String(result as symbol | ((...args: unknown[]) => unknown)) },
-			],
-		};
+		return false;
 	}
 
 	static formatError(error: Error): McpToolResult {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/protocol/MessageFormatter.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/protocol/MessageFormatter.ts
@@ -37,7 +37,13 @@ export class MessageFormatter {
 	 */
 	static isErrorResult(result: unknown): boolean {
 		if (typeof result === 'object' && result !== null && 'error' in result) {
-			return true;
+			const { error } = result as { error: unknown };
+			return (
+				typeof error === 'object' &&
+				error !== null &&
+				'message' in error &&
+				typeof (error as { message: unknown }).message === 'string'
+			);
 		}
 		if (typeof result === 'string') {
 			return /^(\w+Error: |HTTP \d{3} There was an error: |There was an error: )/.test(result);

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/protocol/__tests__/MessageFormatter.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/protocol/__tests__/MessageFormatter.test.ts
@@ -113,6 +113,86 @@ describe('MessageFormatter', () => {
 		});
 	});
 
+	describe('isErrorResult', () => {
+		it('should detect queue mode error objects with error.message', () => {
+			expect(
+				MessageFormatter.isErrorResult({ error: { message: 'Bad request', name: 'NodeApiError' } }),
+			).toBe(true);
+		});
+
+		it('should detect queue mode error objects with just error.message', () => {
+			expect(MessageFormatter.isErrorResult({ error: { message: 'something failed' } })).toBe(true);
+		});
+
+		it('should detect direct mode error strings from N8nTool toString()', () => {
+			expect(
+				MessageFormatter.isErrorResult('NodeApiError: Bad request - please check your parameters'),
+			).toBe(true);
+		});
+
+		it('should detect HTTP error strings from ToolHttpRequest', () => {
+			expect(MessageFormatter.isErrorResult('HTTP 401 There was an error: "Unauthorized"')).toBe(
+				true,
+			);
+		});
+
+		it('should detect generic error strings from ToolHttpRequest', () => {
+			expect(MessageFormatter.isErrorResult('There was an error: "Token not found"')).toBe(true);
+		});
+
+		it('should detect TypeError strings', () => {
+			expect(MessageFormatter.isErrorResult('TypeError: Cannot read property of undefined')).toBe(
+				true,
+			);
+		});
+
+		it('should not flag normal string results as errors', () => {
+			expect(MessageFormatter.isErrorResult('Hello world')).toBe(false);
+		});
+
+		it('should not flag normal object results as errors', () => {
+			expect(MessageFormatter.isErrorResult({ data: 'value', count: 42 })).toBe(false);
+		});
+
+		it('should not flag null/undefined as errors', () => {
+			expect(MessageFormatter.isErrorResult(null)).toBe(false);
+			expect(MessageFormatter.isErrorResult(undefined)).toBe(false);
+		});
+
+		it('should not flag numbers as errors', () => {
+			expect(MessageFormatter.isErrorResult(42)).toBe(false);
+		});
+
+		it('should not flag empty string as error', () => {
+			expect(MessageFormatter.isErrorResult('')).toBe(false);
+		});
+	});
+
+	describe('formatToolResult with isError flag', () => {
+		it('should set isError when flag is true', () => {
+			const result = MessageFormatter.formatToolResult('There was an error: "Unauthorized"', true);
+			expect(result.isError).toBe(true);
+			expect(result.content[0].text).toBe('There was an error: "Unauthorized"');
+		});
+
+		it('should not set isError when flag is false', () => {
+			const result = MessageFormatter.formatToolResult('hello world', false);
+			expect(result.isError).toBeUndefined();
+		});
+
+		it('should not set isError by default', () => {
+			const result = MessageFormatter.formatToolResult('hello world');
+			expect(result.isError).toBeUndefined();
+		});
+
+		it('should set isError for object results', () => {
+			const errorObj = { error: { message: 'Bad request', name: 'NodeApiError' } };
+			const result = MessageFormatter.formatToolResult(errorObj, true);
+			expect(result.isError).toBe(true);
+			expect(result.content[0].text).toBe(JSON.stringify(errorObj));
+		});
+	});
+
 	describe('formatError', () => {
 		it('should format error with isError flag set to true', () => {
 			const error = new Error('Something went wrong');

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/protocol/__tests__/MessageFormatter.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/protocol/__tests__/MessageFormatter.test.ts
@@ -154,6 +154,15 @@ describe('MessageFormatter', () => {
 			expect(MessageFormatter.isErrorResult({ data: 'value', count: 42 })).toBe(false);
 		});
 
+		it('should not flag tool outputs with a non-envelope error field as errors', () => {
+			expect(MessageFormatter.isErrorResult({ error: 'no errors found' })).toBe(false);
+			expect(MessageFormatter.isErrorResult({ error: false })).toBe(false);
+			expect(MessageFormatter.isErrorResult({ error: 0 })).toBe(false);
+			expect(MessageFormatter.isErrorResult({ error: null })).toBe(false);
+			expect(MessageFormatter.isErrorResult({ error: { code: 500 } })).toBe(false);
+			expect(MessageFormatter.isErrorResult({ error: { message: 42 } })).toBe(false);
+		});
+
 		it('should not flag null/undefined as errors', () => {
 			expect(MessageFormatter.isErrorResult(null)).toBe(false);
 			expect(MessageFormatter.isErrorResult(undefined)).toBe(false);


### PR DESCRIPTION
## Summary
  - When a tool execution fails (e.g. expired OAuth2 token returning HTTP 401), the MCP Server Trigger was returning the error as a
  normal successful text response without isError: true, making it impossible for MCP clients to distinguish tool errors from
  successful results
  - Add MessageFormatter.isErrorResult() to detect error results from both queue mode (error objects from worker: { error: {
  message, name } }) and direct mode (error strings like "NodeApiError: ..." or "There was an error: ...")
  - Pass the isError flag through formatToolResult at all three call sites in McpServer.ts so the MCP protocol response correctly
  signals errors to clients

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-2278


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
