### PR TITLE
ci: Update minor and patch release schedules

### DIFF
--- a/.github/workflows/release-create-minor-pr.yml
+++ b/.github/workflows/release-create-minor-pr.yml
@@ -3,7 +3,7 @@ name: 'Release: Create Minor Release PR'
 on:
   workflow_dispatch:
   schedule:
-    - cron: 0 13 * * 1 # 2pm CET (UTC+1), Monday
+    - cron: 0 8 * * 2 # 9am CET (UTC+1), Tuesday
 
 jobs:
   create-release-pr:

--- a/.github/workflows/release-schedule-patch-prs.yml
+++ b/.github/workflows/release-schedule-patch-prs.yml
@@ -3,7 +3,7 @@ name: 'Release: Schedule Patch Release PRs'
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 8 * * 2-5' # 9am CET (UTC+1), Tuesday–Friday
+    - cron: '0 8 * * 3-5,1' # 9am CET (UTC+1), Wednesday - Friday and Monday. (Minor release on tuesday)
 
 jobs:
   create-patch-prs:


### PR DESCRIPTION
## Summary

Updates **minor** releases to happen on a schedule

```diff
- Monday at 2PM CET
+ Tuesday at 9AM CET
```

Updates **patch** releases to happen on a schedule

```diff
- Tuesday to Friday, 9AM CET
+ Wednesday to Friday and Monday (skipping weekend) at 9AM CET
```

These changes are made to align with office hours as GitHub schedules might skew multiple hours at worst, causing releases to run outside of office hours. 

Patch releases are modified to all workdays not including the minor release day.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
