### PR TITLE
fix: Disable axios built-in proxy for OAuth2 token requests

### DIFF
--- a/packages/@n8n/client-oauth2/src/client-oauth2.ts
+++ b/packages/@n8n/client-oauth2/src/client-oauth2.ts
@@ -96,6 +96,10 @@ export class ClientOAuth2 {
 			// Axios rejects the promise by default for all status codes 4xx.
 			// We override this to reject promises only on 5xxs
 			validateStatus: (status) => status < 500,
+			// Disable axios's built-in proxy handling so requests are routed
+			// through n8n's global proxy agents (HttpProxyManager / HttpsProxyManager)
+			// instead of being double-proxied in corporate proxy-chain environments.
+			proxy: false,
 		};
 
 		if (options.ignoreSSLIssues) {

--- a/packages/@n8n/client-oauth2/test/client-oauth2.test.ts
+++ b/packages/@n8n/client-oauth2/test/client-oauth2.test.ts
@@ -71,6 +71,7 @@ describe('ClientOAuth2', () => {
 					url: config.accessTokenUri,
 					method: 'POST',
 					data: 'refresh_token=test&grant_type=refresh_token',
+					proxy: false,
 					headers: {
 						Authorization: authHeader,
 						Accept: 'application/json',


### PR DESCRIPTION
## Summary

OAuth2 token refresh fails in corporate proxy-chain environments with `Unsupported content type: text/html`. The proxy returns an HTML error page (`METHOD_NOT_ALLOWED`) instead of a JSON token response.

**Root cause:** Two proxy layers conflict:

1. `installGlobalProxyAgent()` replaces `http.globalAgent` / `https.globalAgent` with `HttpProxyManager` / `HttpsProxyManager` (in `packages/core/src/http-proxy.ts`). These use `proxy-from-env` to route requests through the configured proxy.
2. Axios's own built-in proxy handling also reads `HTTPS_PROXY` from the environment and attempts to proxy the request itself.

n8n already sets `axios.defaults.proxy = false` in `packages/core` to prevent this conflict for all regular workflow HTTP requests. However, `@n8n/client-oauth2` makes direct `axios.request()` calls without an explicit `proxy: false` in the per-request config, so it relies on that side-effect import being loaded first — a fragile dependency that breaks in proxy-chain environments.

**Fix:** Add `proxy: false` directly to the `requestConfig` object in `ClientOAuth2.accessTokenRequest()`. This makes the OAuth2 client self-contained and consistent with how every other outbound HTTP request in n8n disables axios's built-in proxy.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/IAM-530
- fixes https://github.com/n8n-io/n8n/issues/28225

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
