### PR TITLE
fix(editor): Center sub-node icons and refresh triggers panel icons

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/ItemTypes/NodeItem.vue
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/ItemTypes/NodeItem.vue
@@ -194,13 +194,15 @@ function onCommunityNodeTooltipClick(event: MouseEvent) {
 		@dragend="onDragEnd"
 	>
 		<template #icon>
-			<div v-if="isSubNodeType" :class="$style.subNodeBackground"></div>
-			<NodeIcon
-				:class="$style.nodeIcon"
-				:node-type="nodeType"
-				:size="nodeListIconSize"
-				color-default="var(--color--foreground--shade-2)"
-			/>
+			<div :class="$style.iconWrapper">
+				<div v-if="isSubNodeType" :class="$style.subNodeBackground"></div>
+				<NodeIcon
+					:class="$style.nodeIcon"
+					:node-type="nodeType"
+					:size="nodeListIconSize"
+					color-default="var(--color--foreground--shade-2)"
+				/>
+			</div>
 		</template>
 
 		<template v-if="isOfficial" #extraDetails>
@@ -264,6 +266,13 @@ function onCommunityNodeTooltipClick(event: MouseEvent) {
 	user-select: none;
 }
 
+.iconWrapper {
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
 .nodeIcon {
 	z-index: 2;
 }
@@ -272,9 +281,11 @@ function onCommunityNodeTooltipClick(event: MouseEvent) {
 	background-color: var(--node-type--supplemental--color--background);
 	border-radius: 50%;
 	height: 40px;
-	position: absolute;
-	transform: translate(-7px, -7px);
 	width: 40px;
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
 	z-index: 1;
 }
 

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/viewsData.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/viewsData.ts
@@ -427,7 +427,7 @@ export function TriggerView() {
 					name: WEBHOOK_NODE_TYPE,
 					displayName: i18n.baseText('nodeCreator.triggerHelperPanel.webhookTriggerDisplayName'),
 					description: i18n.baseText('nodeCreator.triggerHelperPanel.webhookTriggerDescription'),
-					iconData: { type: 'icon', icon: 'webhook' },
+					icon: 'node:webhook',
 				},
 			},
 			{

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/viewsData.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/viewsData.ts
@@ -439,7 +439,7 @@ export function TriggerView() {
 					name: FORM_TRIGGER_NODE_TYPE,
 					displayName: i18n.baseText('nodeCreator.triggerHelperPanel.formTriggerDisplayName'),
 					description: i18n.baseText('nodeCreator.triggerHelperPanel.formTriggerDescription'),
-					iconData: { type: 'icon', icon: 'form' },
+					icon: 'node:form-trigger',
 				},
 			},
 			{


### PR DESCRIPTION
## Summary

Fixes icon rendering issues in the node creator panel that surfaced after #28104 introduced variable-size node icons (24px for new SVGs, 20px for old file icons).

### 1. Sub-node icons misaligned in the Language Models / sub-node list

The 40×40 supplemental background circle was positioned via `transform: translate(-7px, -7px)` — that offset was designed for a 26px icon (so the icon center landed at (13, 13), matching the circle center). After icon sizes became variable, the circle no longer centered on the icon:

- 20px icons (e.g. Vercel AI Gateway, xAI Grok) → icon center at (10, 10) vs circle center at (13, 13) → **3px offset toward top-left**
- 24px icons (e.g. Lemonade, Ollama) → 1px subtle vertical/horizontal drift

Fix: wrap the slot contents in a relatively-positioned flex container and center the circle via `top: 50%; left: 50%; transform: translate(-50%, -50%)` so it aligns with any icon size.

### 2. Form Trigger and Webhook nodes used stale icons in the triggers panel

The triggers panel in `viewsData.ts` hardcoded old icon overrides via `iconData: { type: 'icon', icon: 'form' | 'webhook' }`, pointing at the old Lucide-style icons instead of the new `node:form-trigger` / `node:webhook` SVGs used on canvas. Switched to `icon: 'node:form-trigger'` / `icon: 'node:webhook'` — the node-type store fallback in `getNodeIconSource` picks up the correct icon color (teal / magenta) from the real node type.

### How to test

1. Open an AI Agent node on the canvas, click the + near "Model" — all icons in the Language Models panel should be centered within their circular containers.
2. Open the trigger node creator panel — "On form submission" and "On webhook call" entries should show the same SVG + color as their respective nodes on the canvas.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DS-521

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)