### PR TITLE
fix(core): Add strict input validation for `workflow()` (no-changelog)

### DIFF
--- a/packages/@n8n/workflow-sdk/src/workflow-builder.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.test.ts
@@ -2800,4 +2800,68 @@ describe('Workflow Builder', () => {
 			expect(() => wf.to(current)).toThrow(/Maximum branch depth/);
 		});
 	});
+
+	describe('invalid input handling', () => {
+		it('should throw descriptive TypeError when name is an array', () => {
+			expect(() => {
+				// @ts-expect-error intentional misuse
+				workflow('Test', [trigger({ type: 'n8n-nodes-base.webhook', version: 2, config: {} })]);
+			}).toThrow(
+				expect.objectContaining({
+					name: 'TypeError',
+					message: expect.stringMatching(/workflow\(\) requires \(id: string, name: string\)/),
+				}),
+			);
+		});
+
+		it('should throw descriptive TypeError when id is not a string', () => {
+			expect(() => {
+				// @ts-expect-error intentional misuse
+				workflow(123, 'Test');
+			}).toThrow(
+				expect.objectContaining({
+					name: 'TypeError',
+					message: expect.stringMatching(/workflow\(\) requires \(id: string, name: string\)/),
+				}),
+			);
+		});
+
+		it('should throw when nodes are passed in the options argument', () => {
+			const t = trigger({ type: 'n8n-nodes-base.manualTrigger', version: 1, config: {} });
+			expect(() => {
+				// @ts-expect-error intentional misuse
+				workflow('id', 'Test', { nodes: [t] });
+			}).toThrow(
+				expect.objectContaining({
+					name: 'TypeError',
+					message: expect.stringMatching(/Do not pass nodes or connections here/),
+				}),
+			);
+		});
+
+		it('should throw when connections are passed in the options argument', () => {
+			expect(() => {
+				// @ts-expect-error intentional misuse
+				workflow('id', 'Test', { connections: { 'Node 1': { main: [[]] } } });
+			}).toThrow(
+				expect.objectContaining({
+					name: 'TypeError',
+					message: expect.stringMatching(/use \.add\(\) and \.to\(\)/),
+				}),
+			);
+		});
+
+		it('should throw when an array of nodes is passed as the options argument', () => {
+			const t = trigger({ type: 'n8n-nodes-base.manualTrigger', version: 1, config: {} });
+			expect(() => {
+				// @ts-expect-error intentional misuse
+				workflow('id', 'Test', [t]);
+			}).toThrow(
+				expect.objectContaining({
+					name: 'TypeError',
+					message: expect.stringMatching(/Do not pass nodes or connections here/),
+				}),
+			);
+		});
+	});
 });

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.test.ts
@@ -2806,49 +2806,27 @@ describe('Workflow Builder', () => {
 			expect(() => {
 				// @ts-expect-error intentional misuse
 				workflow('Test', [trigger({ type: 'n8n-nodes-base.webhook', version: 2, config: {} })]);
-			}).toThrow(
-				expect.objectContaining({
-					name: 'TypeError',
-					message: expect.stringMatching(/workflow\(\) requires \(id: string, name: string\)/),
-				}),
-			);
+			}).toThrow(/workflow\(\) requires \(id: string, name: string\)/);
 		});
 
 		it('should throw descriptive TypeError when id is not a string', () => {
 			expect(() => {
 				// @ts-expect-error intentional misuse
 				workflow(123, 'Test');
-			}).toThrow(
-				expect.objectContaining({
-					name: 'TypeError',
-					message: expect.stringMatching(/workflow\(\) requires \(id: string, name: string\)/),
-				}),
-			);
+			}).toThrow(/workflow\(\) requires \(id: string, name: string\)/);
 		});
 
 		it('should throw when nodes are passed in the options argument', () => {
 			const t = trigger({ type: 'n8n-nodes-base.manualTrigger', version: 1, config: {} });
 			expect(() => {
-				// @ts-expect-error intentional misuse
 				workflow('id', 'Test', { nodes: [t] });
-			}).toThrow(
-				expect.objectContaining({
-					name: 'TypeError',
-					message: expect.stringMatching(/Do not pass nodes or connections here/),
-				}),
-			);
+			}).toThrow(/Do not pass nodes or connections here/);
 		});
 
 		it('should throw when connections are passed in the options argument', () => {
 			expect(() => {
-				// @ts-expect-error intentional misuse
 				workflow('id', 'Test', { connections: { 'Node 1': { main: [[]] } } });
-			}).toThrow(
-				expect.objectContaining({
-					name: 'TypeError',
-					message: expect.stringMatching(/use \.add\(\) and \.to\(\)/),
-				}),
-			);
+			}).toThrow(/use \.add\(\) and \.to\(\)/);
 		});
 
 		it('should throw when an array of nodes is passed as the options argument', () => {
@@ -2856,12 +2834,7 @@ describe('Workflow Builder', () => {
 			expect(() => {
 				// @ts-expect-error intentional misuse
 				workflow('id', 'Test', [t]);
-			}).toThrow(
-				expect.objectContaining({
-					name: 'TypeError',
-					message: expect.stringMatching(/Do not pass nodes or connections here/),
-				}),
-			);
+			}).toThrow(/Do not pass nodes or connections here/);
 		});
 	});
 });

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.ts
@@ -1186,8 +1186,9 @@ function createWorkflow(
 		const receivedId = Array.isArray(id) ? 'an array' : typeof id;
 		const receivedName = Array.isArray(name) ? 'an array' : typeof name;
 		throw new TypeError(
+			// eslint-disable-next-line n8n-local-rules/no-interpolation-in-regular-string
 			`workflow() requires (id: string, name: string), but received (${receivedId}, ${receivedName}). ` +
-				`Example: workflow('my-workflow-id', 'My Workflow Name')`,
+				"Example: workflow('my-workflow-id', 'My Workflow Name')",
 		);
 	}
 	if (
@@ -1198,9 +1199,9 @@ function createWorkflow(
 				('nodes' in options || 'connections' in options)))
 	) {
 		throw new TypeError(
-			`workflow() third argument is settings, not workflow structure. ` +
-				`Do not pass nodes or connections here — use .add() and .to() to build the workflow. ` +
-				`Example: workflow('id', 'Name').add(trigger({...})).to(node({...}))`,
+			'workflow() third argument is settings, not workflow structure. ' +
+				'Do not pass nodes or connections here — use .add() and .to() to build the workflow. ' +
+				"Example: workflow('id', 'Name').add(trigger({...})).to(node({...}))",
 		);
 	}
 	if (isWorkflowBuilderOptions(options)) {

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.ts
@@ -1182,6 +1182,27 @@ function createWorkflow(
 	name: string,
 	options?: WorkflowSettings | WorkflowBuilderOptions,
 ): WorkflowBuilder {
+	if (typeof id !== 'string' || typeof name !== 'string') {
+		const receivedId = Array.isArray(id) ? 'an array' : typeof id;
+		const receivedName = Array.isArray(name) ? 'an array' : typeof name;
+		throw new TypeError(
+			`workflow() requires (id: string, name: string), but received (${receivedId}, ${receivedName}). ` +
+				`Example: workflow('my-workflow-id', 'My Workflow Name')`,
+		);
+	}
+	if (
+		options !== undefined &&
+		(Array.isArray(options) ||
+			(typeof options === 'object' &&
+				options !== null &&
+				('nodes' in options || 'connections' in options)))
+	) {
+		throw new TypeError(
+			`workflow() third argument is settings, not workflow structure. ` +
+				`Do not pass nodes or connections here — use .add() and .to() to build the workflow. ` +
+				`Example: workflow('id', 'Name').add(trigger({...})).to(node({...}))`,
+		);
+	}
 	if (isWorkflowBuilderOptions(options)) {
 		return new WorkflowBuilderImpl(
 			id,


### PR DESCRIPTION
## Summary
Tightening up input validation for workflow builder SDK function that should prevent wrong usage (e.g. by LLM agents hallucinating the syntax) from successfully creating invalid workflows.

## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-5029
Fixes [28046](https://github.com/n8n-io/n8n/issues/28046)


## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
