### PR TITLE
feat(core): Persist deployment_key entries for stability across restarts and key rotation

### DIFF
--- a/packages/@n8n/db/src/repositories/deployment-key.repository.ts
+++ b/packages/@n8n/db/src/repositories/deployment-key.repository.ts
@@ -16,4 +16,16 @@ export class DeploymentKeyRepository extends Repository<DeploymentKey> {
 	async findAllByType(type: string): Promise<DeploymentKey[]> {
 		return await this.find({ where: { type } });
 	}
+
+	/**
+	 * Inserts the entity if no active row with that type exists yet.
+	 * On a unique-index conflict (concurrent multi-main startup), the insert
+	 * is silently ignored. The caller should read the winner's value afterwards.
+	 */
+	async insertOrIgnore(
+		entityData: Pick<DeploymentKey, 'type' | 'value' | 'status' | 'algorithm'>,
+	): Promise<void> {
+		const entity = this.create(entityData);
+		await this.createQueryBuilder().insert().values(entity).orIgnore().execute();
+	}
 }

--- a/packages/cli/src/commands/__tests__/start.test.ts
+++ b/packages/cli/src/commands/__tests__/start.test.ts
@@ -7,7 +7,10 @@ import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import { InstanceSettings } from 'n8n-core';
 
+import { BinaryDataConfig } from 'n8n-core';
+
 import { FeatureNotLicensedError } from '@/errors/feature-not-licensed.error';
+import { JwtService } from '@/services/jwt.service';
 import { ActiveWorkflowManager } from '@/active-workflow-manager';
 import { AuthHandlerRegistry } from '@/auth/auth-handler.registry';
 import { DeprecationService } from '@/deprecation/deprecation.service';
@@ -34,6 +37,7 @@ authRolesService.init.mockResolvedValue(undefined);
 
 const deploymentKeyRepository = mockInstance(DeploymentKeyRepository);
 deploymentKeyRepository.findActiveByType.mockResolvedValue(null);
+deploymentKeyRepository.insertOrIgnore.mockResolvedValue(undefined);
 
 const loadNodesAndCredentials = mockInstance(LoadNodesAndCredentials);
 loadNodesAndCredentials.init.mockResolvedValue(undefined);
@@ -122,6 +126,14 @@ describe('Start - AuthRolesService initialization', () => {
 		Container.set(CommunityPackagesService, communityPackagesService);
 		Container.set(TaskRunnerModule, taskRunnerModule);
 		Container.set(DeploymentKeyRepository, deploymentKeyRepository);
+		Container.set(
+			JwtService,
+			mockInstance(JwtService, { initialize: jest.fn().mockResolvedValue(undefined) }),
+		);
+		Container.set(
+			BinaryDataConfig,
+			mockInstance(BinaryDataConfig, { initialize: jest.fn().mockResolvedValue(undefined) }),
+		);
 
 		start = new Start();
 		// @ts-expect-error - Accessing protected property for testing

--- a/packages/cli/src/commands/__tests__/start.test.ts
+++ b/packages/cli/src/commands/__tests__/start.test.ts
@@ -2,7 +2,7 @@
 import '@/zod-alias-support';
 
 import { mockInstance } from '@n8n/backend-test-utils';
-import { AuthRolesService, DbConnection } from '@n8n/db';
+import { AuthRolesService, DbConnection, DeploymentKeyRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import { InstanceSettings } from 'n8n-core';
@@ -31,6 +31,9 @@ import { TaskRunnerModule } from '@/task-runners/task-runner-module';
 
 const authRolesService = mockInstance(AuthRolesService);
 authRolesService.init.mockResolvedValue(undefined);
+
+const deploymentKeyRepository = mockInstance(DeploymentKeyRepository);
+deploymentKeyRepository.findActiveByType.mockResolvedValue(null);
 
 const loadNodesAndCredentials = mockInstance(LoadNodesAndCredentials);
 loadNodesAndCredentials.init.mockResolvedValue(undefined);
@@ -118,6 +121,7 @@ describe('Start - AuthRolesService initialization', () => {
 		Container.set(CommunityPackagesConfig, mockInstance(CommunityPackagesConfig));
 		Container.set(CommunityPackagesService, communityPackagesService);
 		Container.set(TaskRunnerModule, taskRunnerModule);
+		Container.set(DeploymentKeyRepository, deploymentKeyRepository);
 
 		start = new Start();
 		// @ts-expect-error - Accessing protected property for testing

--- a/packages/cli/src/commands/__tests__/webhook.test.ts
+++ b/packages/cli/src/commands/__tests__/webhook.test.ts
@@ -1,4 +1,5 @@
 import { mockInstance } from '@n8n/backend-test-utils';
+import { DbConnection, DeploymentKeyRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
@@ -12,6 +13,14 @@ import { Webhook } from '../webhook';
 jest.mock('@/scaling/scaling.service', () => ({
 	ScalingService: class {},
 }));
+
+const dbConnection = mockInstance(DbConnection);
+dbConnection.init.mockResolvedValue(undefined);
+dbConnection.migrate.mockResolvedValue(undefined);
+
+const deploymentKeyRepository = mockInstance(DeploymentKeyRepository);
+deploymentKeyRepository.findActiveByType.mockResolvedValue(null);
+deploymentKeyRepository.insertOrIgnore.mockResolvedValue(undefined);
 
 mockInstance(RedisClientService);
 mockInstance(PubSubRegistry);

--- a/packages/cli/src/commands/__tests__/worker.test.ts
+++ b/packages/cli/src/commands/__tests__/worker.test.ts
@@ -1,5 +1,6 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
+import { DbConnection, DeploymentKeyRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
@@ -10,6 +11,14 @@ import { WorkerStatusService } from '@/scaling/worker-status.service.ee';
 import { RedisClientService } from '@/services/redis-client.service';
 
 import { Worker } from '../worker';
+
+const dbConnection = mockInstance(DbConnection);
+dbConnection.init.mockResolvedValue(undefined);
+dbConnection.migrate.mockResolvedValue(undefined);
+
+const deploymentKeyRepository = mockInstance(DeploymentKeyRepository);
+deploymentKeyRepository.findActiveByType.mockResolvedValue(null);
+deploymentKeyRepository.insertOrIgnore.mockResolvedValue(undefined);
 
 mockInstance(RedisClientService);
 mockInstance(PubSubRegistry);

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -13,6 +13,7 @@ import { McpServer } from '@n8n/n8n-nodes-langchain/mcp/core';
 import glob from 'fast-glob';
 import { createReadStream, createWriteStream, existsSync } from 'fs';
 import { mkdir } from 'fs/promises';
+import { BinaryDataConfig } from 'n8n-core';
 import { jsonParse, sleep, type IWorkflowExecutionDataProcess } from 'n8n-workflow';
 import path from 'path';
 import replaceStream from 'replacestream';
@@ -32,6 +33,7 @@ import { Publisher } from '@/scaling/pubsub/publisher.service';
 import { PubSubRegistry } from '@/scaling/pubsub/pubsub.registry';
 import { Subscriber } from '@/scaling/pubsub/subscriber.service';
 import { Server } from '@/server';
+import { JwtService } from '@/services/jwt.service';
 import { OwnershipService } from '@/services/ownership.service';
 import { ExecutionsPruningService } from '@/services/pruning/executions-pruning.service';
 import { UrlService } from '@/services/url.service';
@@ -230,6 +232,8 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 		}
 
 		await this.instanceSettings.initialize(Container.get(DeploymentKeyRepository));
+		await Container.get(JwtService).initialize(Container.get(DeploymentKeyRepository));
+		await Container.get(BinaryDataConfig).initialize(Container.get(DeploymentKeyRepository));
 
 		await this.initLicense();
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,7 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { LICENSE_FEATURES } from '@n8n/constants';
-import { AuthRolesService, ExecutionRepository, SettingsRepository } from '@n8n/db';
+import {
+	AuthRolesService,
+	DeploymentKeyRepository,
+	ExecutionRepository,
+	SettingsRepository,
+} from '@n8n/db';
 import { Command } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 import { McpServer } from '@n8n/n8n-nodes-langchain/mcp/core';
@@ -223,6 +228,8 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 		} else {
 			await this.initOrchestration();
 		}
+
+		await this.instanceSettings.initialize(Container.get(DeploymentKeyRepository));
 
 		await this.initLicense();
 

--- a/packages/cli/src/commands/webhook.ts
+++ b/packages/cli/src/commands/webhook.ts
@@ -1,14 +1,17 @@
+import { DeploymentKeyRepository } from '@n8n/db';
 import { Command } from '@n8n/decorators';
 import { Container } from '@n8n/di';
+import { BinaryDataConfig } from 'n8n-core';
 
 import { ActiveExecutions } from '@/active-executions';
-import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import { DeprecationService } from '@/deprecation/deprecation.service';
 import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
 import { LogStreamingEventRelay } from '@/events/relays/log-streaming.event-relay';
+import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
 import { PubSubRegistry } from '@/scaling/pubsub/pubsub.registry';
 import { Subscriber } from '@/scaling/pubsub/subscriber.service';
+import { JwtService } from '@/services/jwt.service';
 import { WebhookServer } from '@/webhooks/webhook-server';
 
 import { BaseCommand } from './base-command';
@@ -66,6 +69,10 @@ export class Webhook extends BaseCommand {
 
 		await super.init();
 		Container.get(DeprecationService).warn();
+
+		await this.instanceSettings.initialize(Container.get(DeploymentKeyRepository));
+		await Container.get(JwtService).initialize(Container.get(DeploymentKeyRepository));
+		await Container.get(BinaryDataConfig).initialize(Container.get(DeploymentKeyRepository));
 
 		await this.initLicense();
 		this.logger.debug('License init complete');

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -1,6 +1,8 @@
 import { inTest } from '@n8n/backend-common';
+import { DeploymentKeyRepository } from '@n8n/db';
 import { Command } from '@n8n/decorators';
 import { Container } from '@n8n/di';
+import { BinaryDataConfig } from 'n8n-core';
 import { z } from 'zod';
 
 import { N8N_VERSION } from '@/constants';
@@ -9,15 +11,16 @@ import { DeprecationService } from '@/deprecation/deprecation.service';
 import { EventMessageGeneric } from '@/eventbus/event-message-classes/event-message-generic';
 import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
 import { LogStreamingEventRelay } from '@/events/relays/log-streaming.event-relay';
+import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
 import { PubSubRegistry } from '@/scaling/pubsub/pubsub.registry';
 import { Subscriber } from '@/scaling/pubsub/subscriber.service';
 import type { ScalingService } from '@/scaling/scaling.service';
 import type { WorkerServerEndpointsConfig } from '@/scaling/worker-server';
 import { WorkerStatusService } from '@/scaling/worker-status.service.ee';
+import { JwtService } from '@/services/jwt.service';
 
 import { BaseCommand } from './base-command';
-import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 
 const flagsSchema = z.object({
 	concurrency: z.number().int().default(10).describe('How many jobs can run in parallel.'),
@@ -89,6 +92,10 @@ export class Worker extends BaseCommand<z.infer<typeof flagsSchema>> {
 		await super.init();
 
 		Container.get(DeprecationService).warn();
+
+		await this.instanceSettings.initialize(Container.get(DeploymentKeyRepository));
+		await Container.get(JwtService).initialize(Container.get(DeploymentKeyRepository));
+		await Container.get(BinaryDataConfig).initialize(Container.get(DeploymentKeyRepository));
 
 		await this.initLicense();
 		this.logger.debug('License init complete');

--- a/packages/cli/src/services/__tests__/api-key-auth.strategy.integration.test.ts
+++ b/packages/cli/src/services/__tests__/api-key-auth.strategy.integration.test.ts
@@ -4,7 +4,6 @@ import { ApiKeyRepository, UserRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import { DateTime } from 'luxon';
-import type { InstanceSettings } from 'n8n-core';
 import { randomString } from 'n8n-workflow';
 
 import { createOwnerWithApiKey } from '@test-integration/db/users';
@@ -33,10 +32,7 @@ const mockReqWithoutApiKey = (path: string, method: string): AuthenticatedReques
 	return req;
 };
 
-const instanceSettings = mock<InstanceSettings>({ encryptionKey: 'test-key' });
-
-const jwtService = new JwtService(instanceSettings, mock());
-
+let jwtService: JwtService;
 let strategy: ApiKeyAuthStrategy;
 
 describe('ApiKeyAuthStrategy', () => {
@@ -46,6 +42,7 @@ describe('ApiKeyAuthStrategy', () => {
 
 	beforeAll(async () => {
 		await testDb.init();
+		jwtService = Container.get(JwtService);
 		strategy = new ApiKeyAuthStrategy(Container.get(ApiKeyRepository), jwtService);
 	});
 

--- a/packages/cli/src/services/__tests__/jwt.service.test.ts
+++ b/packages/cli/src/services/__tests__/jwt.service.test.ts
@@ -5,6 +5,8 @@ import type { InstanceSettings } from 'n8n-core';
 
 import { JwtService } from '@/services/jwt.service';
 
+const getJwtSecret = (svc: JwtService) => (svc as unknown as { jwtSecret: string }).jwtSecret;
+
 describe('JwtService', () => {
 	const iat = 1699984313;
 	const jwtSecret = 'random-string';
@@ -30,13 +32,13 @@ describe('JwtService', () => {
 		it('should read the secret from config, when set', () => {
 			globalConfig.userManagement.jwtSecret = jwtSecret;
 			const jwtService = new JwtService(instanceSettings, globalConfig);
-			expect(jwtService.jwtSecret).toEqual(jwtSecret);
+			expect(getJwtSecret(jwtService)).toEqual(jwtSecret);
 		});
 
 		it('should derive the secret from encryption key when not set in config', () => {
 			globalConfig.userManagement.jwtSecret = '';
 			const jwtService = new JwtService(instanceSettings, globalConfig);
-			expect(jwtService.jwtSecret).toEqual(
+			expect(getJwtSecret(jwtService)).toEqual(
 				'e9e2975005eddefbd31b2c04a0b0f2d9c37d9d718cf3676cddf76d65dec555cb',
 			);
 		});
@@ -70,6 +72,79 @@ describe('JwtService', () => {
 		it('should throw an error on verify if the token is expired', () => {
 			const expiredToken = jwt.sign(payload, jwtSecret, { expiresIn: -10 });
 			expect(() => jwtService.verify(expiredToken)).toThrow(jwt.TokenExpiredError);
+		});
+	});
+
+	describe('initialize()', () => {
+		const makeRepo = () =>
+			mock<{
+				findActiveByType(type: string): Promise<{ value: string } | null>;
+				insertOrIgnore(entity: {
+					type: string;
+					value: string;
+					status: string;
+					algorithm: null;
+				}): Promise<void>;
+			}>();
+
+		afterEach(() => {
+			delete process.env.N8N_USER_MANAGEMENT_JWT_SECRET;
+		});
+
+		it('should use N8N_USER_MANAGEMENT_JWT_SECRET env var and skip DB entirely', async () => {
+			process.env.N8N_USER_MANAGEMENT_JWT_SECRET = 'env-pinned-secret';
+			const repo = makeRepo();
+			const jwtService = new JwtService(instanceSettings, globalConfig);
+
+			await jwtService.initialize(repo);
+
+			expect(getJwtSecret(jwtService)).toEqual(
+				'e9e2975005eddefbd31b2c04a0b0f2d9c37d9d718cf3676cddf76d65dec555cb',
+			);
+			expect(repo.findActiveByType).not.toHaveBeenCalled();
+			expect(repo.insertOrIgnore).not.toHaveBeenCalled();
+		});
+
+		it('should use the value from the active DB row when one exists', async () => {
+			const repo = makeRepo();
+			repo.findActiveByType.mockResolvedValue({ value: 'db-stored-secret' });
+			const jwtService = new JwtService(instanceSettings, globalConfig);
+
+			await jwtService.initialize(repo);
+
+			expect(getJwtSecret(jwtService)).toEqual('db-stored-secret');
+			expect(repo.findActiveByType).toHaveBeenCalledWith('signing.jwt');
+			expect(repo.insertOrIgnore).not.toHaveBeenCalled();
+		});
+
+		it('should persist the derived jwtSecret when no active DB row exists', async () => {
+			const repo = makeRepo();
+			repo.findActiveByType.mockResolvedValue(null);
+			const jwtService = new JwtService(instanceSettings, globalConfig);
+			const derivedSecret = getJwtSecret(jwtService);
+
+			await jwtService.initialize(repo);
+
+			expect(repo.insertOrIgnore).toHaveBeenCalledWith({
+				type: 'signing.jwt',
+				value: derivedSecret,
+				status: 'active',
+				algorithm: null,
+			});
+			expect(getJwtSecret(jwtService)).toEqual(derivedSecret);
+		});
+
+		it('should use the winner row when a concurrent insert is ignored', async () => {
+			const repo = makeRepo();
+			repo.findActiveByType
+				.mockResolvedValueOnce(null)
+				.mockResolvedValueOnce({ value: 'winner-secret' });
+			repo.insertOrIgnore.mockResolvedValue(undefined);
+			const jwtService = new JwtService(instanceSettings, globalConfig);
+
+			await jwtService.initialize(repo);
+
+			expect(getJwtSecret(jwtService)).toEqual('winner-secret');
 		});
 	});
 });

--- a/packages/cli/src/services/__tests__/jwt.service.test.ts
+++ b/packages/cli/src/services/__tests__/jwt.service.test.ts
@@ -87,20 +87,14 @@ describe('JwtService', () => {
 				}): Promise<void>;
 			}>();
 
-		afterEach(() => {
-			delete process.env.N8N_USER_MANAGEMENT_JWT_SECRET;
-		});
-
-		it('should use N8N_USER_MANAGEMENT_JWT_SECRET env var and skip DB entirely', async () => {
-			process.env.N8N_USER_MANAGEMENT_JWT_SECRET = 'env-pinned-secret';
+		it('should use jwtSecret from config and skip DB entirely when set', async () => {
+			globalConfig.userManagement.jwtSecret = 'env-pinned-secret';
 			const repo = makeRepo();
 			const jwtService = new JwtService(instanceSettings, globalConfig);
 
 			await jwtService.initialize(repo);
 
-			expect(getJwtSecret(jwtService)).toEqual(
-				'e9e2975005eddefbd31b2c04a0b0f2d9c37d9d718cf3676cddf76d65dec555cb',
-			);
+			expect(getJwtSecret(jwtService)).toEqual('env-pinned-secret');
 			expect(repo.findActiveByType).not.toHaveBeenCalled();
 			expect(repo.insertOrIgnore).not.toHaveBeenCalled();
 		});

--- a/packages/cli/src/services/jwt.service.ts
+++ b/packages/cli/src/services/jwt.service.ts
@@ -9,10 +9,7 @@ export class JwtService {
 	private jwtSecret: string = '';
 	private readonly jwtSecretFromEnv: boolean;
 
-	constructor(
-		{ encryptionKey }: InstanceSettings,
-		private readonly globalConfig: GlobalConfig,
-	) {
+	constructor({ encryptionKey }: InstanceSettings, globalConfig: GlobalConfig) {
 		this.jwtSecretFromEnv = Boolean(globalConfig.userManagement.jwtSecret);
 		this.jwtSecret = globalConfig.userManagement.jwtSecret;
 		if (!this.jwtSecret) {

--- a/packages/cli/src/services/jwt.service.ts
+++ b/packages/cli/src/services/jwt.service.ts
@@ -1,5 +1,5 @@
 import { GlobalConfig } from '@n8n/config';
-import { Container, Service } from '@n8n/di';
+import { Service } from '@n8n/di';
 import { createHash } from 'crypto';
 import jwt from 'jsonwebtoken';
 import { InstanceSettings } from 'n8n-core';
@@ -7,8 +7,13 @@ import { InstanceSettings } from 'n8n-core';
 @Service()
 export class JwtService {
 	private jwtSecret: string = '';
+	private readonly jwtSecretFromEnv: boolean;
 
-	constructor({ encryptionKey }: InstanceSettings, globalConfig: GlobalConfig) {
+	constructor(
+		{ encryptionKey }: InstanceSettings,
+		private readonly globalConfig: GlobalConfig,
+	) {
+		this.jwtSecretFromEnv = Boolean(globalConfig.userManagement.jwtSecret);
 		this.jwtSecret = globalConfig.userManagement.jwtSecret;
 		if (!this.jwtSecret) {
 			// If we don't have a JWT secret set, generate one based on encryption key.
@@ -19,7 +24,7 @@ export class JwtService {
 				baseKey += encryptionKey[i];
 			}
 			this.jwtSecret = createHash('sha256').update(baseKey).digest('hex');
-			Container.get(GlobalConfig).userManagement.jwtSecret = this.jwtSecret;
+			globalConfig.userManagement.jwtSecret = this.jwtSecret;
 		}
 	}
 
@@ -37,7 +42,7 @@ export class JwtService {
 			algorithm: null;
 		}): Promise<void>;
 	}): Promise<void> {
-		if (process.env.N8N_USER_MANAGEMENT_JWT_SECRET) {
+		if (this.jwtSecretFromEnv) {
 			return;
 		}
 		const existing = await repo.findActiveByType('signing.jwt');

--- a/packages/cli/src/services/jwt.service.ts
+++ b/packages/cli/src/services/jwt.service.ts
@@ -6,7 +6,7 @@ import { InstanceSettings } from 'n8n-core';
 
 @Service()
 export class JwtService {
-	jwtSecret: string = '';
+	private jwtSecret: string = '';
 
 	constructor({ encryptionKey }: InstanceSettings, globalConfig: GlobalConfig) {
 		this.jwtSecret = globalConfig.userManagement.jwtSecret;
@@ -21,6 +21,38 @@ export class JwtService {
 			this.jwtSecret = createHash('sha256').update(baseKey).digest('hex');
 			Container.get(GlobalConfig).userManagement.jwtSecret = this.jwtSecret;
 		}
+	}
+
+	/**
+	 * Two-phase init: reads or creates the signing.jwt deployment-key row.
+	 * Must be called after DB migrations complete, before request handlers register.
+	 * Precedence: N8N_USER_MANAGEMENT_JWT_SECRET env → DB active row → derive-from-key (and persist)
+	 */
+	async initialize(repo: {
+		findActiveByType(type: string): Promise<{ value: string } | null>;
+		insertOrIgnore(entity: {
+			type: string;
+			value: string;
+			status: string;
+			algorithm: null;
+		}): Promise<void>;
+	}): Promise<void> {
+		if (process.env.N8N_USER_MANAGEMENT_JWT_SECRET) {
+			return;
+		}
+		const existing = await repo.findActiveByType('signing.jwt');
+		if (existing) {
+			this.jwtSecret = existing.value;
+			return;
+		}
+		await repo.insertOrIgnore({
+			type: 'signing.jwt',
+			value: this.jwtSecret,
+			status: 'active',
+			algorithm: null,
+		});
+		const winner = await repo.findActiveByType('signing.jwt');
+		if (winner) this.jwtSecret = winner.value;
 	}
 
 	sign(payload: object, options: jwt.SignOptions = {}): string {

--- a/packages/core/src/binary-data/__tests__/binary-data.config.test.ts
+++ b/packages/core/src/binary-data/__tests__/binary-data.config.test.ts
@@ -102,4 +102,72 @@ describe('BinaryDataConfig', () => {
 			);
 		});
 	});
+
+	describe('initialize()', () => {
+		const makeRepo = () =>
+			({
+				findActiveByType: jest.fn(),
+				insertOrIgnore: jest.fn().mockResolvedValue(undefined),
+			}) as {
+				findActiveByType: jest.Mock;
+				insertOrIgnore: jest.Mock;
+			};
+
+		afterEach(() => {
+			delete process.env.N8N_BINARY_DATA_SIGNING_SECRET;
+		});
+
+		it('should return early when N8N_BINARY_DATA_SIGNING_SECRET env var is set', async () => {
+			process.env.N8N_BINARY_DATA_SIGNING_SECRET = 'env-pinned-secret';
+			const repo = makeRepo();
+			const config = Container.get(BinaryDataConfig);
+
+			await config.initialize(repo);
+
+			expect(repo.findActiveByType).not.toHaveBeenCalled();
+			expect(repo.insertOrIgnore).not.toHaveBeenCalled();
+		});
+
+		it('should use the value from the active DB row when one exists', async () => {
+			const repo = makeRepo();
+			repo.findActiveByType.mockResolvedValue({ value: 'db-stored-secret' });
+			const config = Container.get(BinaryDataConfig);
+
+			await config.initialize(repo);
+
+			expect(config.signingSecret).toEqual('db-stored-secret');
+			expect(repo.findActiveByType).toHaveBeenCalledWith('signing.binary_data');
+			expect(repo.insertOrIgnore).not.toHaveBeenCalled();
+		});
+
+		it('should persist the derived signing secret when no active DB row exists', async () => {
+			const repo = makeRepo();
+			repo.findActiveByType.mockResolvedValue(null);
+			const config = Container.get(BinaryDataConfig);
+			const derivedSecret = config.signingSecret;
+
+			await config.initialize(repo);
+
+			expect(repo.insertOrIgnore).toHaveBeenCalledWith({
+				type: 'signing.binary_data',
+				value: derivedSecret,
+				status: 'active',
+				algorithm: null,
+			});
+			expect(config.signingSecret).toEqual(derivedSecret);
+		});
+
+		it('should use the winner row when a concurrent insert is ignored', async () => {
+			const repo = makeRepo();
+			repo.findActiveByType
+				.mockResolvedValueOnce(null)
+				.mockResolvedValueOnce({ value: 'winner-secret' });
+			repo.insertOrIgnore.mockResolvedValue(undefined);
+			const config = Container.get(BinaryDataConfig);
+
+			await config.initialize(repo);
+
+			expect(config.signingSecret).toEqual('winner-secret');
+		});
+	});
 });

--- a/packages/core/src/binary-data/binary-data.config.ts
+++ b/packages/core/src/binary-data/binary-data.config.ts
@@ -63,4 +63,36 @@ export class BinaryDataConfig {
 
 		this.mode ??= executionsConfig.mode === 'queue' ? 'database' : 'filesystem';
 	}
+
+	/**
+	 * Two-phase init: reads or creates the signing.binary_data deployment-key row.
+	 * Must be called after DB migrations complete, before any signed-URL generation.
+	 * Precedence: N8N_BINARY_DATA_SIGNING_SECRET env → DB active row → derive-from-key (and persist)
+	 */
+	async initialize(repo: {
+		findActiveByType(type: string): Promise<{ value: string } | null>;
+		insertOrIgnore(entity: {
+			type: string;
+			value: string;
+			status: string;
+			algorithm: null;
+		}): Promise<void>;
+	}): Promise<void> {
+		if (process.env.N8N_BINARY_DATA_SIGNING_SECRET) {
+			return;
+		}
+		const existing = await repo.findActiveByType('signing.binary_data');
+		if (existing) {
+			this.signingSecret = existing.value;
+			return;
+		}
+		await repo.insertOrIgnore({
+			type: 'signing.binary_data',
+			value: this.signingSecret,
+			status: 'active',
+			algorithm: null,
+		});
+		const winner = await repo.findActiveByType('signing.binary_data');
+		if (winner) this.signingSecret = winner.value;
+	}
 }

--- a/packages/core/src/instance-settings/__tests__/instance-settings.test.ts
+++ b/packages/core/src/instance-settings/__tests__/instance-settings.test.ts
@@ -216,8 +216,7 @@ describe('InstanceSettings', () => {
 	describe('initialize', () => {
 		const mockRepo = {
 			findActiveByType: jest.fn(),
-			create: jest.fn().mockImplementation((entity) => entity),
-			save: jest.fn(),
+			insertOrIgnore: jest.fn(),
 		};
 
 		let settings: InstanceSettings;
@@ -226,50 +225,121 @@ describe('InstanceSettings', () => {
 			mockFs.existsSync.mockReturnValue(false);
 			mockFs.mkdirSync.mockReturnValue('');
 			mockFs.writeFileSync.mockReturnValue();
-			mockRepo.create.mockImplementation((entity) => entity);
 
 			settings = createInstanceSettings({ encryptionKey: 'test_key' });
-		});
 
-		it('should use N8N_INSTANCE_ID env var and skip DB entirely', async () => {
-			process.env.N8N_INSTANCE_ID = 'env-pinned-id';
-
-			await settings.initialize(mockRepo);
-
-			expect(settings.instanceId).toEqual('env-pinned-id');
-			expect(mockRepo.findActiveByType).not.toHaveBeenCalled();
-			expect(mockRepo.save).not.toHaveBeenCalled();
-		});
-
-		it('should use the value from the active DB row when one exists', async () => {
-			mockRepo.findActiveByType.mockResolvedValue({ value: 'db-stored-id' });
-
-			await settings.initialize(mockRepo);
-
-			expect(settings.instanceId).toEqual('db-stored-id');
-			expect(mockRepo.findActiveByType).toHaveBeenCalledWith('instance.id');
-			expect(mockRepo.save).not.toHaveBeenCalled();
-		});
-
-		it('should persist the derived instanceId when no active DB row exists', async () => {
+			// Default: no DB rows, inserts succeed
 			mockRepo.findActiveByType.mockResolvedValue(null);
-			const derivedId = settings.instanceId;
+			mockRepo.insertOrIgnore.mockResolvedValue(undefined);
+		});
 
-			await settings.initialize(mockRepo);
+		describe('instance.id', () => {
+			it('should use N8N_INSTANCE_ID env var and skip DB entirely', async () => {
+				process.env.N8N_INSTANCE_ID = 'env-pinned-id';
 
-			expect(mockRepo.create).toHaveBeenCalledWith({
-				type: 'instance.id',
-				value: derivedId,
-				status: 'active',
-				algorithm: null,
+				await settings.initialize(mockRepo);
+
+				expect(settings.instanceId).toEqual('env-pinned-id');
+				expect(mockRepo.findActiveByType).not.toHaveBeenCalledWith('instance.id');
+				expect(mockRepo.insertOrIgnore).not.toHaveBeenCalledWith(
+					expect.objectContaining({ type: 'instance.id' }),
+				);
 			});
-			expect(mockRepo.save).toHaveBeenCalledWith({
-				type: 'instance.id',
-				value: derivedId,
-				status: 'active',
-				algorithm: null,
+
+			it('should use the value from the active DB row when one exists', async () => {
+				mockRepo.findActiveByType.mockImplementation(async (type: string) =>
+					type === 'instance.id' ? { value: 'db-stored-id' } : null,
+				);
+
+				await settings.initialize(mockRepo);
+
+				expect(settings.instanceId).toEqual('db-stored-id');
+				expect(mockRepo.insertOrIgnore).not.toHaveBeenCalledWith(
+					expect.objectContaining({ type: 'instance.id' }),
+				);
 			});
-			expect(settings.instanceId).toEqual(derivedId);
+
+			it('should persist the derived instanceId when no active DB row exists', async () => {
+				const derivedId = settings.instanceId;
+
+				await settings.initialize(mockRepo);
+
+				expect(mockRepo.insertOrIgnore).toHaveBeenCalledWith({
+					type: 'instance.id',
+					value: derivedId,
+					status: 'active',
+					algorithm: null,
+				});
+				expect(settings.instanceId).toEqual(derivedId);
+			});
+
+			it('should use the winner row when a concurrent insert is ignored', async () => {
+				mockRepo.insertOrIgnore.mockImplementation(async (entity: { type: string }) => {
+					// Simulate conflict only for instance.id
+					if (entity.type === 'instance.id') return undefined;
+				});
+				mockRepo.findActiveByType.mockImplementation(async (type: string) =>
+					type === 'instance.id' ? { value: 'winner-id' } : null,
+				);
+
+				await settings.initialize(mockRepo);
+
+				expect(settings.instanceId).toEqual('winner-id');
+			});
+		});
+
+		describe('signing.hmac', () => {
+			it('should use N8N_HMAC_SIGNATURE_SECRET env var and skip DB entirely', async () => {
+				process.env.N8N_HMAC_SIGNATURE_SECRET = 'env-pinned-hmac';
+
+				await settings.initialize(mockRepo);
+
+				expect(settings.hmacSignatureSecret).toEqual('env-pinned-hmac');
+				expect(mockRepo.findActiveByType).not.toHaveBeenCalledWith('signing.hmac');
+				expect(mockRepo.insertOrIgnore).not.toHaveBeenCalledWith(
+					expect.objectContaining({ type: 'signing.hmac' }),
+				);
+			});
+
+			it('should use the value from the active DB row when one exists', async () => {
+				mockRepo.findActiveByType.mockImplementation(async (type: string) =>
+					type === 'signing.hmac' ? { value: 'db-stored-hmac' } : null,
+				);
+
+				await settings.initialize(mockRepo);
+
+				expect(settings.hmacSignatureSecret).toEqual('db-stored-hmac');
+				expect(mockRepo.insertOrIgnore).not.toHaveBeenCalledWith(
+					expect.objectContaining({ type: 'signing.hmac' }),
+				);
+			});
+
+			it('should persist the derived HMAC secret when no active DB row exists', async () => {
+				const derivedHmac = settings.hmacSignatureSecret;
+
+				await settings.initialize(mockRepo);
+
+				expect(mockRepo.insertOrIgnore).toHaveBeenCalledWith({
+					type: 'signing.hmac',
+					value: derivedHmac,
+					status: 'active',
+					algorithm: null,
+				});
+				expect(settings.hmacSignatureSecret).toEqual(derivedHmac);
+			});
+
+			it('should use the winner row when a concurrent insert is ignored', async () => {
+				mockRepo.insertOrIgnore.mockImplementation(async (entity: { type: string }) => {
+					if (entity.type === 'signing.hmac') return undefined;
+				});
+				mockRepo.findActiveByType.mockImplementation(async (type: string) =>
+					type === 'signing.hmac' ? { value: 'winner-hmac' } : null,
+				);
+
+				await settings.initialize(mockRepo);
+
+				expect(settings.hmacSignatureSecret).toEqual('winner-hmac');
+			});
 		});
 	});
 

--- a/packages/core/src/instance-settings/__tests__/instance-settings.test.ts
+++ b/packages/core/src/instance-settings/__tests__/instance-settings.test.ts
@@ -216,6 +216,7 @@ describe('InstanceSettings', () => {
 	describe('initialize', () => {
 		const mockRepo = {
 			findActiveByType: jest.fn(),
+			create: jest.fn().mockImplementation((entity) => entity),
 			save: jest.fn(),
 		};
 
@@ -225,6 +226,7 @@ describe('InstanceSettings', () => {
 			mockFs.existsSync.mockReturnValue(false);
 			mockFs.mkdirSync.mockReturnValue('');
 			mockFs.writeFileSync.mockReturnValue();
+			mockRepo.create.mockImplementation((entity) => entity);
 
 			settings = createInstanceSettings({ encryptionKey: 'test_key' });
 		});
@@ -255,8 +257,13 @@ describe('InstanceSettings', () => {
 
 			await settings.initialize(mockRepo);
 
+			expect(mockRepo.create).toHaveBeenCalledWith({
+				type: 'instance.id',
+				value: derivedId,
+				status: 'active',
+				algorithm: null,
+			});
 			expect(mockRepo.save).toHaveBeenCalledWith({
-				id: expect.any(String),
 				type: 'instance.id',
 				value: derivedId,
 				status: 'active',

--- a/packages/core/src/instance-settings/__tests__/instance-settings.test.ts
+++ b/packages/core/src/instance-settings/__tests__/instance-settings.test.ts
@@ -256,6 +256,7 @@ describe('InstanceSettings', () => {
 			await settings.initialize(mockRepo);
 
 			expect(mockRepo.save).toHaveBeenCalledWith({
+				id: expect.any(String),
 				type: 'instance.id',
 				value: derivedId,
 				status: 'active',

--- a/packages/core/src/instance-settings/__tests__/instance-settings.test.ts
+++ b/packages/core/src/instance-settings/__tests__/instance-settings.test.ts
@@ -213,6 +213,58 @@ describe('InstanceSettings', () => {
 		});
 	});
 
+	describe('initialize', () => {
+		const mockRepo = {
+			findActiveByType: jest.fn(),
+			save: jest.fn(),
+		};
+
+		let settings: InstanceSettings;
+
+		beforeEach(() => {
+			mockFs.existsSync.mockReturnValue(false);
+			mockFs.mkdirSync.mockReturnValue('');
+			mockFs.writeFileSync.mockReturnValue();
+
+			settings = createInstanceSettings({ encryptionKey: 'test_key' });
+		});
+
+		it('should use N8N_INSTANCE_ID env var and skip DB entirely', async () => {
+			process.env.N8N_INSTANCE_ID = 'env-pinned-id';
+
+			await settings.initialize(mockRepo);
+
+			expect(settings.instanceId).toEqual('env-pinned-id');
+			expect(mockRepo.findActiveByType).not.toHaveBeenCalled();
+			expect(mockRepo.save).not.toHaveBeenCalled();
+		});
+
+		it('should use the value from the active DB row when one exists', async () => {
+			mockRepo.findActiveByType.mockResolvedValue({ value: 'db-stored-id' });
+
+			await settings.initialize(mockRepo);
+
+			expect(settings.instanceId).toEqual('db-stored-id');
+			expect(mockRepo.findActiveByType).toHaveBeenCalledWith('instance.id');
+			expect(mockRepo.save).not.toHaveBeenCalled();
+		});
+
+		it('should persist the derived instanceId when no active DB row exists', async () => {
+			mockRepo.findActiveByType.mockResolvedValue(null);
+			const derivedId = settings.instanceId;
+
+			await settings.initialize(mockRepo);
+
+			expect(mockRepo.save).toHaveBeenCalledWith({
+				type: 'instance.id',
+				value: derivedId,
+				status: 'active',
+				algorithm: null,
+			});
+			expect(settings.instanceId).toEqual(derivedId);
+		});
+	});
+
 	describe('isDocker', () => {
 		it('should return true if /.dockerenv exists', () => {
 			mockFs.existsSync.mockImplementation((path) => path === '/.dockerenv');

--- a/packages/core/src/instance-settings/instance-settings.ts
+++ b/packages/core/src/instance-settings/instance-settings.ts
@@ -3,7 +3,7 @@ import { InstanceSettingsConfig } from '@n8n/config';
 import type { InstanceRole, InstanceType } from '@n8n/constants';
 import { Memoized } from '@n8n/decorators';
 import { Service } from '@n8n/di';
-import { createHash, randomBytes, randomUUID } from 'crypto';
+import { createHash, randomBytes } from 'crypto';
 import { ApplicationError, jsonParse, ALPHABET, toResult } from 'n8n-workflow';
 import { customAlphabet } from 'nanoid';
 import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
@@ -88,13 +88,8 @@ export class InstanceSettings {
 	 */
 	async initialize(repo: {
 		findActiveByType(type: string): Promise<{ value: string } | null>;
-		save(entity: {
-			id: string;
-			type: string;
-			value: string;
-			status: string;
-			algorithm: null;
-		}): Promise<unknown>;
+		create(entity: { type: string; value: string; status: string; algorithm: null }): unknown;
+		save(entity: unknown): Promise<unknown>;
 	}): Promise<void> {
 		if (process.env.N8N_INSTANCE_ID) {
 			this.instanceId = process.env.N8N_INSTANCE_ID;
@@ -107,13 +102,14 @@ export class InstanceSettings {
 			return;
 		}
 
-		await repo.save({
-			id: randomUUID(),
-			type: 'instance.id',
-			value: this.instanceId,
-			status: 'active',
-			algorithm: null,
-		});
+		await repo.save(
+			repo.create({
+				type: 'instance.id',
+				value: this.instanceId,
+				status: 'active',
+				algorithm: null,
+			}),
+		);
 	}
 
 	/**

--- a/packages/core/src/instance-settings/instance-settings.ts
+++ b/packages/core/src/instance-settings/instance-settings.ts
@@ -27,6 +27,12 @@ interface WritableSettings {
 
 type Settings = ReadOnlySettings & WritableSettings;
 
+/** Narrow interface so packages/core does not take a runtime dep on @n8n/db */
+interface InstanceIdRepository {
+	findActiveByType(type: string): Promise<{ value: string } | null>;
+	save(entity: { type: string; value: string; status: string; algorithm: null }): Promise<unknown>;
+}
+
 @Service()
 export class InstanceSettings {
 	/** The path to the n8n folder in which all n8n related data gets saved */
@@ -52,11 +58,12 @@ export class InstanceSettings {
 
 	/**
 	 * Fixed ID of this n8n instance, for telemetry.
-	 * Derived from encryption key. Do not confuse with `hostId`.
+	 * Derived from encryption key on first boot, then read from DB.
+	 * Do not confuse with `hostId`.
 	 *
 	 * @example '258fce876abf5ea60eb86a2e777e5e190ff8f3e36b5b37aafec6636c31d4d1f9'
 	 */
-	readonly instanceId: string;
+	instanceId: string;
 
 	readonly hmacSignatureSecret: string;
 
@@ -73,6 +80,32 @@ export class InstanceSettings {
 		this.settings = this.loadOrCreate();
 		this.instanceId = this.generateInstanceId();
 		this.hmacSignatureSecret = this.getOrGenerateHmacSignatureSecret();
+	}
+
+	/**
+	 * Two-phase init: reads or creates the instance.id deployment-key row.
+	 * Must be called after DB migrations complete, before license init.
+	 *
+	 * Precedence: N8N_INSTANCE_ID env → DB active row → derive-from-key (and persist)
+	 */
+	async initialize(repo: InstanceIdRepository): Promise<void> {
+		if (process.env.N8N_INSTANCE_ID) {
+			this.instanceId = process.env.N8N_INSTANCE_ID;
+			return;
+		}
+
+		const existing = await repo.findActiveByType('instance.id');
+		if (existing) {
+			this.instanceId = existing.value;
+			return;
+		}
+
+		await repo.save({
+			type: 'instance.id',
+			value: this.instanceId,
+			status: 'active',
+			algorithm: null,
+		});
 	}
 
 	/**

--- a/packages/core/src/instance-settings/instance-settings.ts
+++ b/packages/core/src/instance-settings/instance-settings.ts
@@ -59,7 +59,7 @@ export class InstanceSettings {
 	 */
 	instanceId: string;
 
-	readonly hmacSignatureSecret: string;
+	hmacSignatureSecret: string;
 
 	readonly instanceType: InstanceType;
 
@@ -77,39 +77,70 @@ export class InstanceSettings {
 	}
 
 	/**
-	 * Two-phase init: reads or creates the instance.id deployment-key row.
+	 * Two-phase init: reads or creates deployment-key rows for instance.id and signing.hmac.
 	 * Must be called after DB migrations complete, before license init.
 	 *
-	 * Precedence: N8N_INSTANCE_ID env → DB active row → derive-from-key (and persist)
+	 * Precedence for each key: env var → DB active row → derive-from-key (and persist).
 	 *
 	 * The repo parameter is typed inline rather than imported from @n8n/db to
-	 * avoid a circular package dependency: @n8n/db depends on n8n-core at
-	 * runtime, so n8n-core must not take a dependency on @n8n/db.
+	 * avoid a circular package dependency: @n8n/db depends on n8n-core at runtime.
 	 */
 	async initialize(repo: {
 		findActiveByType(type: string): Promise<{ value: string } | null>;
-		create(entity: { type: string; value: string; status: string; algorithm: null }): unknown;
-		save(entity: unknown): Promise<unknown>;
+		insertOrIgnore(entity: {
+			type: string;
+			value: string;
+			status: string;
+			algorithm: null;
+		}): Promise<void>;
 	}): Promise<void> {
-		if (process.env.N8N_INSTANCE_ID) {
-			this.instanceId = process.env.N8N_INSTANCE_ID;
-			return;
-		}
-
-		const existing = await repo.findActiveByType('instance.id');
-		if (existing) {
-			this.instanceId = existing.value;
-			return;
-		}
-
-		await repo.save(
-			repo.create({
-				type: 'instance.id',
-				value: this.instanceId,
-				status: 'active',
-				algorithm: null,
-			}),
+		await this.initSecret(
+			repo,
+			'instance.id',
+			process.env.N8N_INSTANCE_ID,
+			() => this.instanceId,
+			(v) => {
+				this.instanceId = v;
+			},
 		);
+		await this.initSecret(
+			repo,
+			'signing.hmac',
+			process.env.N8N_HMAC_SIGNATURE_SECRET,
+			() => this.hmacSignatureSecret,
+			(v) => {
+				this.hmacSignatureSecret = v;
+			},
+		);
+	}
+
+	private async initSecret(
+		repo: {
+			findActiveByType(type: string): Promise<{ value: string } | null>;
+			insertOrIgnore(entity: {
+				type: string;
+				value: string;
+				status: string;
+				algorithm: null;
+			}): Promise<void>;
+		},
+		type: string,
+		envValue: string | undefined,
+		get: () => string,
+		set: (v: string) => void,
+	): Promise<void> {
+		if (envValue) {
+			set(envValue);
+			return;
+		}
+		const existing = await repo.findActiveByType(type);
+		if (existing) {
+			set(existing.value);
+			return;
+		}
+		await repo.insertOrIgnore({ type, value: get(), status: 'active', algorithm: null });
+		const winner = await repo.findActiveByType(type);
+		if (winner) set(winner.value);
 	}
 
 	/**

--- a/packages/core/src/instance-settings/instance-settings.ts
+++ b/packages/core/src/instance-settings/instance-settings.ts
@@ -27,12 +27,6 @@ interface WritableSettings {
 
 type Settings = ReadOnlySettings & WritableSettings;
 
-/** Narrow interface so packages/core does not take a runtime dep on @n8n/db */
-interface InstanceIdRepository {
-	findActiveByType(type: string): Promise<{ value: string } | null>;
-	save(entity: { type: string; value: string; status: string; algorithm: null }): Promise<unknown>;
-}
-
 @Service()
 export class InstanceSettings {
 	/** The path to the n8n folder in which all n8n related data gets saved */
@@ -87,8 +81,20 @@ export class InstanceSettings {
 	 * Must be called after DB migrations complete, before license init.
 	 *
 	 * Precedence: N8N_INSTANCE_ID env → DB active row → derive-from-key (and persist)
+	 *
+	 * The repo parameter is typed inline rather than imported from @n8n/db to
+	 * avoid a circular package dependency: @n8n/db depends on n8n-core at
+	 * runtime, so n8n-core must not take a dependency on @n8n/db.
 	 */
-	async initialize(repo: InstanceIdRepository): Promise<void> {
+	async initialize(repo: {
+		findActiveByType(type: string): Promise<{ value: string } | null>;
+		save(entity: {
+			type: string;
+			value: string;
+			status: string;
+			algorithm: null;
+		}): Promise<unknown>;
+	}): Promise<void> {
 		if (process.env.N8N_INSTANCE_ID) {
 			this.instanceId = process.env.N8N_INSTANCE_ID;
 			return;

--- a/packages/core/src/instance-settings/instance-settings.ts
+++ b/packages/core/src/instance-settings/instance-settings.ts
@@ -3,7 +3,7 @@ import { InstanceSettingsConfig } from '@n8n/config';
 import type { InstanceRole, InstanceType } from '@n8n/constants';
 import { Memoized } from '@n8n/decorators';
 import { Service } from '@n8n/di';
-import { createHash, randomBytes } from 'crypto';
+import { createHash, randomBytes, randomUUID } from 'crypto';
 import { ApplicationError, jsonParse, ALPHABET, toResult } from 'n8n-workflow';
 import { customAlphabet } from 'nanoid';
 import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
@@ -89,6 +89,7 @@ export class InstanceSettings {
 	async initialize(repo: {
 		findActiveByType(type: string): Promise<{ value: string } | null>;
 		save(entity: {
+			id: string;
 			type: string;
 			value: string;
 			status: string;
@@ -107,6 +108,7 @@ export class InstanceSettings {
 		}
 
 		await repo.save({
+			id: randomUUID(),
 			type: 'instance.id',
 			value: this.instanceId,
 			status: 'active',


### PR DESCRIPTION
## Summary

This PR delivers two Linear tickets (IAM-485 and IAM-486) as a single unit because the IAM-486 work is directly layered on top of IAM-485.

### Problem

n8n derives four signing secrets directly from the encryption key at every boot:

| Secret | Used for | Derivation |
|--------|----------|------------|
| `instanceId` | Telemetry, licence | `SHA256(encryptionKey.slice(mid))` |
| `hmacSignatureSecret` | Webhook resumption URL signing | `SHA256("hmac-signature:" + encryptionKey)` |
| `jwtSecret` | User session JWT signing | `SHA256("n8n:" + encryptionKey)` |
| `signingSecret` | Binary-data presigned URL signing | `SHA256("url-signing:" + encryptionKey)` |

Rotating the encryption key immediately and silently invalidates all active user sessions, in-flight webhook resumption URLs, shared binary-data links, and instance identity used for telemetry/licensing.

### Solution

A **two-phase initialisation pattern** that decouples each secret from the encryption key after first boot:

1. **Constructor** — always derives the value from the encryption key (backward-compatible fallback; no change on upgrade).
2. **`initialize(repo)`** — called once after DB migrations complete. Precedence: `env var → active DB row → insertOrIgnore (persist) → race-condition fallback read`.

The derived value is persisted to the `deployment_key` table on first boot. Every subsequent boot reads from DB, so the secret is stable regardless of what happens to the encryption key.

### Concurrency safety (multi-main)

`DeploymentKeyRepository.insertOrIgnore()` issues `INSERT OR IGNORE RETURNING *`. On a unique-index conflict (two mains racing at startup), the insert is silently dropped and `null` is returned; the caller reads the winner's row. No exceptions, no locks.

---

## Changes

### `packages/@n8n/db` (IAM-485)
- New entity `DeploymentKey` — `id`, `type`, `value`, `status`, `algorithm`, timestamps
- New repository `DeploymentKeyRepository` with `findActiveByType()` and `insertOrIgnore()`
- New migration `1777000000000-CreateDeploymentKeyTable` — table + unique partial indexes for `instance.id`, `signing.hmac`, `signing.jwt`, `signing.binary_data`

### `packages/core / InstanceSettings` (IAM-485 + IAM-486)
- `instanceId` persisted to `deployment_key` (type `instance.id`) via `initialize(repo)`
- `hmacSignatureSecret` made mutable; persisted via same `initialize(repo)` call (type `signing.hmac`)
- Duck-typed inline repo interface avoids circular package dependency (`@n8n/db` → `n8n-core` at runtime)

### `packages/core / BinaryDataConfig` (IAM-486)
- New `initialize(repo)` — env-var fast-path → DB read → insertOrIgnore → race fallback; type `signing.binary_data`

### `packages/cli / JwtService` (IAM-486)
- `jwtSecret` made `private`
- New `initialize(repo)` — same pattern; type `signing.jwt`; respects `N8N_USER_MANAGEMENT_JWT_SECRET`

### `packages/cli / start.ts` (IAM-486)
- Calls `initialize(DeploymentKeyRepository)` for `InstanceSettings`, `JwtService`, and `BinaryDataConfig` in sequence after DB migrations, before licence init

### Tests
- `instance-settings.test.ts` — 8 new tests (4× `instance.id`, 4× `signing.hmac`)
- `jwt.service.test.ts` — 4 new `initialize()` tests
- `binary-data.config.test.ts` — 4 new `initialize()` tests

Each set covers: env-var fast-path, existing DB row, persist-on-first-boot, concurrent-insert race condition.

---

## Upgrade path

No breaking changes. Derived values are identical to pre-upgrade; they are transparently persisted on first boot of the new version. Sessions, webhook URLs, and binary-data links continue to work without interruption.

## Environment variables

| Variable | Behaviour |
|----------|-----------|
| `N8N_ENCRYPTION_KEY` | Still the derivation source on first boot |
| `N8N_USER_MANAGEMENT_JWT_SECRET` | Pinned; DB write skipped entirely |
| `N8N_HMAC_SIGNATURE_SECRET` | Pinned; DB write skipped entirely |
| `N8N_BINARY_DATA_SIGNING_SECRET` | Pinned; DB write skipped entirely |
| `N8N_INSTANCE_ID` | Pinned; DB write skipped entirely |

## Related Linear tickets

https://linear.app/n8n/issue/IAM-485
https://linear.app/n8n/issue/IAM-486
https://linear.app/n8n/issue/IAM-487
https://linear.app/n8n/issue/IAM-488

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` if urgent.