### PR TITLE
fix(RabbitMQ Node): Fix RabbitMQ routing key resolution

### DIFF
--- a/packages/nodes-base/nodes/RabbitMQ/RabbitMQ.node.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/RabbitMQ.node.ts
@@ -466,7 +466,6 @@ export class RabbitMQ implements INodeType {
 				await channel.connection.close();
 			} else if (mode === 'exchange') {
 				const exchange = this.getNodeParameter('exchange', 0) as string;
-				const routingKey = this.getNodeParameter('routingKey', 0) as string;
 
 				const options = this.getNodeParameter('options', 0, {}) as Options;
 
@@ -478,6 +477,8 @@ export class RabbitMQ implements INodeType {
 
 				const exchangePromises = [];
 				for (let i = 0; i < items.length; i++) {
+					const routingKey = this.getNodeParameter('routingKey', i) as string;
+
 					if (sendInputData) {
 						message = JSON.stringify(items[i].json);
 					} else {

--- a/packages/nodes-base/nodes/RabbitMQ/test/RabbitMQ.node.test.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/test/RabbitMQ.node.test.ts
@@ -1,0 +1,161 @@
+import type { Channel, Connection } from 'amqplib';
+import { mock } from 'jest-mock-extended';
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+const mockChannel = mock<Channel>();
+const mockConnection = mock<Connection>({ createChannel: async () => mockChannel });
+mockChannel.connection = mockConnection;
+const amqpConnect = jest.fn().mockReturnValue(mockConnection);
+jest.mock('amqplib', () => ({ connect: amqpConnect }));
+
+import { RabbitMQ } from '../RabbitMQ.node';
+
+describe('RabbitMQ Node', () => {
+	const executeFunctions = mock<IExecuteFunctions>();
+	const credentials = {
+		hostname: 'localhost',
+		port: 5672,
+		username: 'guest',
+		password: 'guest',
+		vhost: '/',
+		ssl: false,
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		executeFunctions.getCredentials.calledWith('rabbitmq').mockResolvedValue(credentials);
+	});
+
+	describe('exchange mode', () => {
+		beforeEach(() => {
+			executeFunctions.getNodeParameter.calledWith('operation', 0).mockReturnValue('sendMessage');
+			executeFunctions.getNodeParameter.calledWith('mode', 0).mockReturnValue('exchange');
+			executeFunctions.getNodeParameter.calledWith('exchange', 0).mockReturnValue('test.exchange');
+			executeFunctions.getNodeParameter.calledWith('exchangeType', 0).mockReturnValue('topic');
+			executeFunctions.getNodeParameter.calledWith('sendInputData', 0).mockReturnValue(true);
+			executeFunctions.getNodeParameter.calledWith('options', 0).mockReturnValue({});
+			executeFunctions.getNodeParameter.calledWith('options', 0, {}).mockReturnValue({});
+			mockChannel.publish.mockReturnValue(true);
+			executeFunctions.continueOnFail.mockReturnValue(false);
+		});
+
+		it('should publish a single item to exchange with correct routing key', async () => {
+			executeFunctions.getInputData.mockReturnValue([{ json: { msg: 'hello' } }]);
+			executeFunctions.getNodeParameter.calledWith('routingKey', 0).mockReturnValue('key.alpha');
+
+			const result = await new RabbitMQ().execute.call(executeFunctions);
+
+			expect(result).toEqual([[{ json: { success: true } }]]);
+			expect(mockChannel.publish).toHaveBeenCalledTimes(1);
+			expect(mockChannel.publish).toHaveBeenCalledWith(
+				'test.exchange',
+				'key.alpha',
+				Buffer.from(JSON.stringify({ msg: 'hello' })),
+				{ headers: {} },
+			);
+			expect(mockChannel.close).toHaveBeenCalledTimes(1);
+			expect(mockConnection.close).toHaveBeenCalledTimes(1);
+		});
+
+		it('should evaluate routingKey per item for multiple items', async () => {
+			executeFunctions.getInputData.mockReturnValue([
+				{ json: { seq: 1, _routingKey: 'key.alpha' } },
+				{ json: { seq: 2, _routingKey: 'key.beta' } },
+				{ json: { seq: 3, _routingKey: 'key.gamma' } },
+			]);
+			executeFunctions.getNodeParameter.calledWith('routingKey', 0).mockReturnValue('key.alpha');
+			executeFunctions.getNodeParameter.calledWith('routingKey', 1).mockReturnValue('key.beta');
+			executeFunctions.getNodeParameter.calledWith('routingKey', 2).mockReturnValue('key.gamma');
+
+			const result = await new RabbitMQ().execute.call(executeFunctions);
+
+			expect(result).toEqual([
+				[{ json: { success: true } }, { json: { success: true } }, { json: { success: true } }],
+			]);
+			expect(mockChannel.publish).toHaveBeenCalledTimes(3);
+			expect(mockChannel.publish).toHaveBeenNthCalledWith(
+				1,
+				'test.exchange',
+				'key.alpha',
+				Buffer.from(JSON.stringify({ seq: 1, _routingKey: 'key.alpha' })),
+				{ headers: {} },
+			);
+			expect(mockChannel.publish).toHaveBeenNthCalledWith(
+				2,
+				'test.exchange',
+				'key.beta',
+				Buffer.from(JSON.stringify({ seq: 2, _routingKey: 'key.beta' })),
+				{ headers: {} },
+			);
+			expect(mockChannel.publish).toHaveBeenNthCalledWith(
+				3,
+				'test.exchange',
+				'key.gamma',
+				Buffer.from(JSON.stringify({ seq: 3, _routingKey: 'key.gamma' })),
+				{ headers: {} },
+			);
+		});
+
+		it('should publish custom message per item in exchange mode', async () => {
+			executeFunctions.getNodeParameter.calledWith('sendInputData', 0).mockReturnValue(false);
+			executeFunctions.getInputData.mockReturnValue([{ json: { seq: 1 } }, { json: { seq: 2 } }]);
+			executeFunctions.getNodeParameter.calledWith('routingKey', 0).mockReturnValue('rk.one');
+			executeFunctions.getNodeParameter.calledWith('routingKey', 1).mockReturnValue('rk.two');
+			executeFunctions.getNodeParameter.calledWith('message', 0).mockReturnValue('msg-one');
+			executeFunctions.getNodeParameter.calledWith('message', 1).mockReturnValue('msg-two');
+
+			const result = await new RabbitMQ().execute.call(executeFunctions);
+
+			expect(result).toEqual([[{ json: { success: true } }, { json: { success: true } }]]);
+			expect(mockChannel.publish).toHaveBeenNthCalledWith(
+				1,
+				'test.exchange',
+				'rk.one',
+				Buffer.from('msg-one'),
+				{ headers: {} },
+			);
+			expect(mockChannel.publish).toHaveBeenNthCalledWith(
+				2,
+				'test.exchange',
+				'rk.two',
+				Buffer.from('msg-two'),
+				{ headers: {} },
+			);
+		});
+	});
+
+	describe('queue mode', () => {
+		beforeEach(() => {
+			executeFunctions.getNodeParameter.calledWith('operation', 0).mockReturnValue('sendMessage');
+			executeFunctions.getNodeParameter.calledWith('mode', 0).mockReturnValue('queue');
+			executeFunctions.getNodeParameter.calledWith('queue', 0).mockReturnValue('test.queue');
+			executeFunctions.getNodeParameter.calledWith('sendInputData', 0).mockReturnValue(true);
+			executeFunctions.getNodeParameter.calledWith('options', 0).mockReturnValue({});
+			executeFunctions.getNodeParameter.calledWith('options', 0, {}).mockReturnValue({});
+			mockChannel.sendToQueue.mockReturnValue(true);
+			executeFunctions.continueOnFail.mockReturnValue(false);
+		});
+
+		it('should publish input data to queue', async () => {
+			executeFunctions.getInputData.mockReturnValue([{ json: { testing: true } }]);
+
+			const result = await new RabbitMQ().execute.call(executeFunctions);
+
+			expect(result).toEqual([[{ json: { success: true } }]]);
+			expect(mockChannel.sendToQueue).toHaveBeenCalledWith(
+				'test.queue',
+				Buffer.from(JSON.stringify({ testing: true })),
+				{ headers: {} },
+			);
+		});
+
+		it('should publish multiple items to queue', async () => {
+			executeFunctions.getInputData.mockReturnValue([{ json: { seq: 1 } }, { json: { seq: 2 } }]);
+
+			const result = await new RabbitMQ().execute.call(executeFunctions);
+
+			expect(result).toEqual([[{ json: { success: true } }, { json: { success: true } }]]);
+			expect(mockChannel.sendToQueue).toHaveBeenCalledTimes(2);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

The RabbitMQ node's `routingKey` parameter was evaluated once (at item index 0)
and reused for every item in a batch when publishing to an exchange. This meant
dynamic expressions like `={{ $json._routingKey }}` only resolved to the first
item's value — all subsequent items were silently published with the wrong
routing key.

The fix moves `getNodeParameter('routingKey', i)` inside the per-item loop so
each item's routing key expression is evaluated independently, matching the
existing behavior of `message` and `options.headers`.

**Before:** 3 items with distinct routing keys all published under the first
item's key.

| item | expression value       | AMQP routing key       |
|------|------------------------|------------------------|
| 0    | `test.dynamic.alpha`   | `test.dynamic.alpha`   |
| 1    | `test.dynamic.beta`    | `test.dynamic.alpha` ❌ |
| 2    | `test.dynamic.gamma`   | `test.dynamic.alpha` ❌ |

**After:** each item publishes with its own evaluated routing key.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/issues/28525

fixes #28525 

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

