### PR TITLE
fea: Pin secrets and signing

### DIFF
--- a/packages/@n8n/db/src/repositories/deployment-key.repository.ts
+++ b/packages/@n8n/db/src/repositories/deployment-key.repository.ts
@@ -16,4 +16,31 @@ export class DeploymentKeyRepository extends Repository<DeploymentKey> {
 	async findAllByType(type: string): Promise<DeploymentKey[]> {
 		return await this.find({ where: { type } });
 	}
+
+	/**
+	 * Inserts the entity if no active row with that type exists yet.
+	 * On a unique-index conflict (e.g. concurrent multi-main startup), the insert is
+	 * silently ignored and null is returned so the caller can read the winner's value.
+	 */
+	async insertOrIgnore(
+		entityData: Pick<DeploymentKey, 'type' | 'value' | 'status' | 'algorithm'>,
+	): Promise<Pick<DeploymentKey, 'value'> | null> {
+		const entity = this.create(entityData);
+		const result = await this.createQueryBuilder()
+			.insert()
+			.values(entity)
+			.orIgnore()
+			.returning('*')
+			.execute();
+		const row: unknown = result.raw[0];
+		if (
+			typeof row === 'object' &&
+			row !== null &&
+			'value' in row &&
+			typeof row.value === 'string'
+		) {
+			return { value: row.value };
+		}
+		return null;
+	}
 }

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -31,7 +31,10 @@ import { MultiMainSetup } from '@/scaling/multi-main-setup.ee';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
 import { PubSubRegistry } from '@/scaling/pubsub/pubsub.registry';
 import { Subscriber } from '@/scaling/pubsub/subscriber.service';
+import { BinaryDataConfig } from 'n8n-core';
+
 import { Server } from '@/server';
+import { JwtService } from '@/services/jwt.service';
 import { OwnershipService } from '@/services/ownership.service';
 import { ExecutionsPruningService } from '@/services/pruning/executions-pruning.service';
 import { UrlService } from '@/services/url.service';
@@ -230,6 +233,8 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 		}
 
 		await this.instanceSettings.initialize(Container.get(DeploymentKeyRepository));
+		await Container.get(JwtService).initialize(Container.get(DeploymentKeyRepository));
+		await Container.get(BinaryDataConfig).initialize(Container.get(DeploymentKeyRepository));
 
 		await this.initLicense();
 

--- a/packages/cli/src/services/__tests__/jwt.service.test.ts
+++ b/packages/cli/src/services/__tests__/jwt.service.test.ts
@@ -5,6 +5,8 @@ import type { InstanceSettings } from 'n8n-core';
 
 import { JwtService } from '@/services/jwt.service';
 
+const getJwtSecret = (svc: JwtService) => (svc as unknown as { jwtSecret: string }).jwtSecret;
+
 describe('JwtService', () => {
 	const iat = 1699984313;
 	const jwtSecret = 'random-string';
@@ -30,13 +32,13 @@ describe('JwtService', () => {
 		it('should read the secret from config, when set', () => {
 			globalConfig.userManagement.jwtSecret = jwtSecret;
 			const jwtService = new JwtService(instanceSettings, globalConfig);
-			expect(jwtService.jwtSecret).toEqual(jwtSecret);
+			expect(getJwtSecret(jwtService)).toEqual(jwtSecret);
 		});
 
 		it('should derive the secret from encryption key when not set in config', () => {
 			globalConfig.userManagement.jwtSecret = '';
 			const jwtService = new JwtService(instanceSettings, globalConfig);
-			expect(jwtService.jwtSecret).toEqual(
+			expect(getJwtSecret(jwtService)).toEqual(
 				'e9e2975005eddefbd31b2c04a0b0f2d9c37d9d718cf3676cddf76d65dec555cb',
 			);
 		});
@@ -70,6 +72,78 @@ describe('JwtService', () => {
 		it('should throw an error on verify if the token is expired', () => {
 			const expiredToken = jwt.sign(payload, jwtSecret, { expiresIn: -10 });
 			expect(() => jwtService.verify(expiredToken)).toThrow(jwt.TokenExpiredError);
+		});
+	});
+
+	describe('initialize()', () => {
+		const makeRepo = () =>
+			mock<{
+				findActiveByType(type: string): Promise<{ value: string } | null>;
+				insertOrIgnore(entity: {
+					type: string;
+					value: string;
+					status: string;
+					algorithm: null;
+				}): Promise<{ value: string } | null>;
+			}>();
+
+		afterEach(() => {
+			delete process.env.N8N_USER_MANAGEMENT_JWT_SECRET;
+		});
+
+		it('should use N8N_USER_MANAGEMENT_JWT_SECRET env var and skip DB entirely', async () => {
+			process.env.N8N_USER_MANAGEMENT_JWT_SECRET = 'env-pinned-secret';
+			const repo = makeRepo();
+			const jwtService = new JwtService(instanceSettings, globalConfig);
+
+			await jwtService.initialize(repo);
+
+			expect(getJwtSecret(jwtService)).toEqual('env-pinned-secret');
+			expect(repo.findActiveByType).not.toHaveBeenCalled();
+			expect(repo.insertOrIgnore).not.toHaveBeenCalled();
+		});
+
+		it('should use the value from the active DB row when one exists', async () => {
+			const repo = makeRepo();
+			repo.findActiveByType.mockResolvedValue({ value: 'db-stored-secret' });
+			const jwtService = new JwtService(instanceSettings, globalConfig);
+
+			await jwtService.initialize(repo);
+
+			expect(getJwtSecret(jwtService)).toEqual('db-stored-secret');
+			expect(repo.findActiveByType).toHaveBeenCalledWith('signing.jwt');
+			expect(repo.insertOrIgnore).not.toHaveBeenCalled();
+		});
+
+		it('should persist the derived jwtSecret when no active DB row exists', async () => {
+			const repo = makeRepo();
+			repo.findActiveByType.mockResolvedValue(null);
+			const jwtService = new JwtService(instanceSettings, globalConfig);
+			const derivedSecret = getJwtSecret(jwtService);
+			repo.insertOrIgnore.mockResolvedValue({ value: derivedSecret });
+
+			await jwtService.initialize(repo);
+
+			expect(repo.insertOrIgnore).toHaveBeenCalledWith({
+				type: 'signing.jwt',
+				value: derivedSecret,
+				status: 'active',
+				algorithm: null,
+			});
+			expect(getJwtSecret(jwtService)).toEqual(derivedSecret);
+		});
+
+		it('should use the winner row when a concurrent insert is ignored', async () => {
+			const repo = makeRepo();
+			repo.findActiveByType
+				.mockResolvedValueOnce(null)
+				.mockResolvedValueOnce({ value: 'winner-secret' });
+			repo.insertOrIgnore.mockResolvedValue(null);
+			const jwtService = new JwtService(instanceSettings, globalConfig);
+
+			await jwtService.initialize(repo);
+
+			expect(getJwtSecret(jwtService)).toEqual('winner-secret');
 		});
 	});
 });

--- a/packages/cli/src/services/jwt.service.ts
+++ b/packages/cli/src/services/jwt.service.ts
@@ -6,7 +6,7 @@ import { InstanceSettings } from 'n8n-core';
 
 @Service()
 export class JwtService {
-	jwtSecret: string = '';
+	private jwtSecret: string = '';
 
 	constructor({ encryptionKey }: InstanceSettings, globalConfig: GlobalConfig) {
 		this.jwtSecret = globalConfig.userManagement.jwtSecret;
@@ -20,6 +20,45 @@ export class JwtService {
 			}
 			this.jwtSecret = createHash('sha256').update(baseKey).digest('hex');
 			Container.get(GlobalConfig).userManagement.jwtSecret = this.jwtSecret;
+		}
+	}
+
+	/**
+	 * Two-phase init: reads or creates the signing.jwt deployment-key row.
+	 * Must be called after DB migrations complete, before request handlers register.
+	 */
+	async initialize(repo: {
+		findActiveByType(type: string): Promise<{ value: string } | null>;
+		insertOrIgnore(entity: {
+			type: string;
+			value: string;
+			status: string;
+			algorithm: null;
+		}): Promise<{ value: string } | null>;
+	}): Promise<void> {
+		if (process.env.N8N_USER_MANAGEMENT_JWT_SECRET) {
+			this.jwtSecret = process.env.N8N_USER_MANAGEMENT_JWT_SECRET;
+			return;
+		}
+
+		const existing = await repo.findActiveByType('signing.jwt');
+		if (existing) {
+			this.jwtSecret = existing.value;
+			return;
+		}
+
+		// Insert if no active row exists yet. Returns null on a concurrent-insert conflict,
+		// in which case we read the winner's value.
+		const inserted = await repo.insertOrIgnore({
+			type: 'signing.jwt',
+			value: this.jwtSecret,
+			status: 'active',
+			algorithm: null,
+		});
+
+		if (!inserted) {
+			const winner = await repo.findActiveByType('signing.jwt');
+			if (winner) this.jwtSecret = winner.value;
 		}
 	}
 

--- a/packages/core/src/binary-data/__tests__/binary-data.config.test.ts
+++ b/packages/core/src/binary-data/__tests__/binary-data.config.test.ts
@@ -1,4 +1,5 @@
 import { Container } from '@n8n/di';
+import { mock } from 'jest-mock-extended';
 import { existsSync } from 'node:fs';
 
 import { InstanceSettings } from '@/instance-settings';
@@ -100,6 +101,77 @@ describe('BinaryDataConfig', () => {
 			expect(console.warn).toHaveBeenCalledWith(
 				expect.stringContaining('Invalid value for N8N_BINARY_DATA_DATABASE_MAX_FILE_SIZE'),
 			);
+		});
+	});
+
+	describe('initialize()', () => {
+		const makeRepo = () =>
+			mock<{
+				findActiveByType(type: string): Promise<{ value: string } | null>;
+				insertOrIgnore(entity: {
+					type: string;
+					value: string;
+					status: string;
+					algorithm: null;
+				}): Promise<{ value: string } | null>;
+			}>();
+
+		afterEach(() => {
+			delete process.env.N8N_BINARY_DATA_SIGNING_SECRET;
+		});
+
+		it('should return early when N8N_BINARY_DATA_SIGNING_SECRET env var is set', async () => {
+			process.env.N8N_BINARY_DATA_SIGNING_SECRET = 'env-pinned-secret';
+			const repo = makeRepo();
+			const config = Container.get(BinaryDataConfig);
+
+			await config.initialize(repo);
+
+			expect(repo.findActiveByType).not.toHaveBeenCalled();
+			expect(repo.insertOrIgnore).not.toHaveBeenCalled();
+		});
+
+		it('should use the value from the active DB row when one exists', async () => {
+			const repo = makeRepo();
+			repo.findActiveByType.mockResolvedValue({ value: 'db-stored-secret' });
+			const config = Container.get(BinaryDataConfig);
+
+			await config.initialize(repo);
+
+			expect(config.signingSecret).toEqual('db-stored-secret');
+			expect(repo.findActiveByType).toHaveBeenCalledWith('signing.binary_data');
+			expect(repo.insertOrIgnore).not.toHaveBeenCalled();
+		});
+
+		it('should persist the derived signing secret when no active DB row exists', async () => {
+			const repo = makeRepo();
+			repo.findActiveByType.mockResolvedValue(null);
+			const config = Container.get(BinaryDataConfig);
+			const derivedSecret = config.signingSecret;
+			repo.insertOrIgnore.mockResolvedValue({ value: derivedSecret });
+
+			await config.initialize(repo);
+
+			expect(repo.insertOrIgnore).toHaveBeenCalledWith({
+				type: 'signing.binary_data',
+				value: derivedSecret,
+				status: 'active',
+				algorithm: null,
+			});
+			expect(config.signingSecret).toEqual(derivedSecret);
+		});
+
+		it('should use the winner row when a concurrent insert is ignored', async () => {
+			const repo = makeRepo();
+			repo.findActiveByType
+				.mockResolvedValueOnce(null)
+				.mockResolvedValueOnce({ value: 'winner-secret' });
+			repo.insertOrIgnore.mockResolvedValue(null);
+			const config = Container.get(BinaryDataConfig);
+
+			await config.initialize(repo);
+
+			expect(config.signingSecret).toEqual('winner-secret');
 		});
 	});
 });

--- a/packages/core/src/binary-data/binary-data.config.ts
+++ b/packages/core/src/binary-data/binary-data.config.ts
@@ -63,4 +63,36 @@ export class BinaryDataConfig {
 
 		this.mode ??= executionsConfig.mode === 'queue' ? 'database' : 'filesystem';
 	}
+
+	async initialize(repo: {
+		findActiveByType(type: string): Promise<{ value: string } | null>;
+		insertOrIgnore(entity: {
+			type: string;
+			value: string;
+			status: string;
+			algorithm: null;
+		}): Promise<{ value: string } | null>;
+	}): Promise<void> {
+		if (process.env.N8N_BINARY_DATA_SIGNING_SECRET) {
+			return;
+		}
+
+		const existing = await repo.findActiveByType('signing.binary_data');
+		if (existing) {
+			this.signingSecret = existing.value;
+			return;
+		}
+
+		const inserted = await repo.insertOrIgnore({
+			type: 'signing.binary_data',
+			value: this.signingSecret,
+			status: 'active',
+			algorithm: null,
+		});
+
+		if (!inserted) {
+			const winner = await repo.findActiveByType('signing.binary_data');
+			if (winner) this.signingSecret = winner.value;
+		}
+	}
 }

--- a/packages/core/src/instance-settings/__tests__/instance-settings.test.ts
+++ b/packages/core/src/instance-settings/__tests__/instance-settings.test.ts
@@ -216,8 +216,7 @@ describe('InstanceSettings', () => {
 	describe('initialize', () => {
 		const mockRepo = {
 			findActiveByType: jest.fn(),
-			create: jest.fn().mockImplementation((entity) => entity),
-			save: jest.fn(),
+			insertOrIgnore: jest.fn(),
 		};
 
 		let settings: InstanceSettings;
@@ -226,50 +225,122 @@ describe('InstanceSettings', () => {
 			mockFs.existsSync.mockReturnValue(false);
 			mockFs.mkdirSync.mockReturnValue('');
 			mockFs.writeFileSync.mockReturnValue();
-			mockRepo.create.mockImplementation((entity) => entity);
 
 			settings = createInstanceSettings({ encryptionKey: 'test_key' });
-		});
 
-		it('should use N8N_INSTANCE_ID env var and skip DB entirely', async () => {
-			process.env.N8N_INSTANCE_ID = 'env-pinned-id';
-
-			await settings.initialize(mockRepo);
-
-			expect(settings.instanceId).toEqual('env-pinned-id');
-			expect(mockRepo.findActiveByType).not.toHaveBeenCalled();
-			expect(mockRepo.save).not.toHaveBeenCalled();
-		});
-
-		it('should use the value from the active DB row when one exists', async () => {
-			mockRepo.findActiveByType.mockResolvedValue({ value: 'db-stored-id' });
-
-			await settings.initialize(mockRepo);
-
-			expect(settings.instanceId).toEqual('db-stored-id');
-			expect(mockRepo.findActiveByType).toHaveBeenCalledWith('instance.id');
-			expect(mockRepo.save).not.toHaveBeenCalled();
-		});
-
-		it('should persist the derived instanceId when no active DB row exists', async () => {
+			// Default: no DB rows, inserts succeed
 			mockRepo.findActiveByType.mockResolvedValue(null);
-			const derivedId = settings.instanceId;
+			mockRepo.insertOrIgnore.mockResolvedValue({ value: 'inserted' });
+		});
 
-			await settings.initialize(mockRepo);
+		describe('instance.id', () => {
+			it('should use N8N_INSTANCE_ID env var and skip DB entirely', async () => {
+				process.env.N8N_INSTANCE_ID = 'env-pinned-id';
 
-			expect(mockRepo.create).toHaveBeenCalledWith({
-				type: 'instance.id',
-				value: derivedId,
-				status: 'active',
-				algorithm: null,
+				await settings.initialize(mockRepo);
+
+				expect(settings.instanceId).toEqual('env-pinned-id');
+				expect(mockRepo.findActiveByType).not.toHaveBeenCalledWith('instance.id');
+				expect(mockRepo.insertOrIgnore).not.toHaveBeenCalledWith(
+					expect.objectContaining({ type: 'instance.id' }),
+				);
 			});
-			expect(mockRepo.save).toHaveBeenCalledWith({
-				type: 'instance.id',
-				value: derivedId,
-				status: 'active',
-				algorithm: null,
+
+			it('should use the value from the active DB row when one exists', async () => {
+				mockRepo.findActiveByType.mockImplementation(async (type: string) =>
+					type === 'instance.id' ? { value: 'db-stored-id' } : null,
+				);
+
+				await settings.initialize(mockRepo);
+
+				expect(settings.instanceId).toEqual('db-stored-id');
+				expect(mockRepo.insertOrIgnore).not.toHaveBeenCalledWith(
+					expect.objectContaining({ type: 'instance.id' }),
+				);
 			});
-			expect(settings.instanceId).toEqual(derivedId);
+
+			it('should persist the derived instanceId when no active DB row exists', async () => {
+				const derivedId = settings.instanceId;
+				mockRepo.insertOrIgnore.mockResolvedValue({ value: derivedId });
+
+				await settings.initialize(mockRepo);
+
+				expect(mockRepo.insertOrIgnore).toHaveBeenCalledWith({
+					type: 'instance.id',
+					value: derivedId,
+					status: 'active',
+					algorithm: null,
+				});
+				expect(settings.instanceId).toEqual(derivedId);
+			});
+
+			it('should use the winner row when a concurrent insert is ignored', async () => {
+				mockRepo.insertOrIgnore.mockImplementation(async (entity: { type: string }) =>
+					entity.type === 'instance.id' ? null : { value: 'inserted' },
+				);
+				mockRepo.findActiveByType.mockImplementation(async (type: string) =>
+					type === 'instance.id' ? { value: 'winner-id' } : null,
+				);
+
+				await settings.initialize(mockRepo);
+
+				expect(settings.instanceId).toEqual('winner-id');
+			});
+		});
+
+		describe('signing.hmac', () => {
+			it('should use N8N_HMAC_SIGNATURE_SECRET env var and skip DB entirely', async () => {
+				process.env.N8N_HMAC_SIGNATURE_SECRET = 'env-pinned-hmac';
+
+				await settings.initialize(mockRepo);
+
+				expect(settings.hmacSignatureSecret).toEqual('env-pinned-hmac');
+				expect(mockRepo.findActiveByType).not.toHaveBeenCalledWith('signing.hmac');
+				expect(mockRepo.insertOrIgnore).not.toHaveBeenCalledWith(
+					expect.objectContaining({ type: 'signing.hmac' }),
+				);
+			});
+
+			it('should use the value from the active DB row when one exists', async () => {
+				mockRepo.findActiveByType.mockImplementation(async (type: string) =>
+					type === 'signing.hmac' ? { value: 'db-stored-hmac' } : null,
+				);
+
+				await settings.initialize(mockRepo);
+
+				expect(settings.hmacSignatureSecret).toEqual('db-stored-hmac');
+				expect(mockRepo.insertOrIgnore).not.toHaveBeenCalledWith(
+					expect.objectContaining({ type: 'signing.hmac' }),
+				);
+			});
+
+			it('should persist the derived HMAC secret when no active DB row exists', async () => {
+				const derivedHmac = settings.hmacSignatureSecret;
+				mockRepo.insertOrIgnore.mockResolvedValue({ value: derivedHmac });
+
+				await settings.initialize(mockRepo);
+
+				expect(mockRepo.insertOrIgnore).toHaveBeenCalledWith({
+					type: 'signing.hmac',
+					value: derivedHmac,
+					status: 'active',
+					algorithm: null,
+				});
+				expect(settings.hmacSignatureSecret).toEqual(derivedHmac);
+			});
+
+			it('should use the winner row when a concurrent insert is ignored', async () => {
+				mockRepo.insertOrIgnore.mockImplementation(async (entity: { type: string }) =>
+					entity.type === 'signing.hmac' ? null : { value: 'inserted' },
+				);
+				mockRepo.findActiveByType.mockImplementation(async (type: string) =>
+					type === 'signing.hmac' ? { value: 'winner-hmac' } : null,
+				);
+
+				await settings.initialize(mockRepo);
+
+				expect(settings.hmacSignatureSecret).toEqual('winner-hmac');
+			});
 		});
 	});
 

--- a/packages/core/src/instance-settings/instance-settings.ts
+++ b/packages/core/src/instance-settings/instance-settings.ts
@@ -59,7 +59,7 @@ export class InstanceSettings {
 	 */
 	instanceId: string;
 
-	readonly hmacSignatureSecret: string;
+	hmacSignatureSecret: string;
 
 	readonly instanceType: InstanceType;
 
@@ -77,10 +77,10 @@ export class InstanceSettings {
 	}
 
 	/**
-	 * Two-phase init: reads or creates the instance.id deployment-key row.
+	 * Two-phase init: reads or creates deployment-key rows for instance.id and signing.hmac.
 	 * Must be called after DB migrations complete, before license init.
 	 *
-	 * Precedence: N8N_INSTANCE_ID env → DB active row → derive-from-key (and persist)
+	 * Precedence for each key: env var → DB active row → derive-from-key (and persist)
 	 *
 	 * The repo parameter is typed inline rather than imported from @n8n/db to
 	 * avoid a circular package dependency: @n8n/db depends on n8n-core at
@@ -88,8 +88,25 @@ export class InstanceSettings {
 	 */
 	async initialize(repo: {
 		findActiveByType(type: string): Promise<{ value: string } | null>;
-		create(entity: { type: string; value: string; status: string; algorithm: null }): unknown;
-		save(entity: unknown): Promise<unknown>;
+		insertOrIgnore(entity: {
+			type: string;
+			value: string;
+			status: string;
+			algorithm: null;
+		}): Promise<{ value: string } | null>;
+	}): Promise<void> {
+		await this.initInstanceId(repo);
+		await this.initHmacSecret(repo);
+	}
+
+	private async initInstanceId(repo: {
+		findActiveByType(type: string): Promise<{ value: string } | null>;
+		insertOrIgnore(entity: {
+			type: string;
+			value: string;
+			status: string;
+			algorithm: null;
+		}): Promise<{ value: string } | null>;
 	}): Promise<void> {
 		if (process.env.N8N_INSTANCE_ID) {
 			this.instanceId = process.env.N8N_INSTANCE_ID;
@@ -102,14 +119,50 @@ export class InstanceSettings {
 			return;
 		}
 
-		await repo.save(
-			repo.create({
-				type: 'instance.id',
-				value: this.instanceId,
-				status: 'active',
-				algorithm: null,
-			}),
-		);
+		const inserted = await repo.insertOrIgnore({
+			type: 'instance.id',
+			value: this.instanceId,
+			status: 'active',
+			algorithm: null,
+		});
+
+		if (!inserted) {
+			const winner = await repo.findActiveByType('instance.id');
+			if (winner) this.instanceId = winner.value;
+		}
+	}
+
+	private async initHmacSecret(repo: {
+		findActiveByType(type: string): Promise<{ value: string } | null>;
+		insertOrIgnore(entity: {
+			type: string;
+			value: string;
+			status: string;
+			algorithm: null;
+		}): Promise<{ value: string } | null>;
+	}): Promise<void> {
+		if (process.env.N8N_HMAC_SIGNATURE_SECRET) {
+			this.hmacSignatureSecret = process.env.N8N_HMAC_SIGNATURE_SECRET;
+			return;
+		}
+
+		const existing = await repo.findActiveByType('signing.hmac');
+		if (existing) {
+			this.hmacSignatureSecret = existing.value;
+			return;
+		}
+
+		const inserted = await repo.insertOrIgnore({
+			type: 'signing.hmac',
+			value: this.hmacSignatureSecret,
+			status: 'active',
+			algorithm: null,
+		});
+
+		if (!inserted) {
+			const winner = await repo.findActiveByType('signing.hmac');
+			if (winner) this.hmacSignatureSecret = winner.value;
+		}
 	}
 
 	/**

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -214,6 +214,28 @@ describe('useCanvasOperations', () => {
 		workflowDocumentStoreInstance = useWorkflowDocumentStore(
 			createWorkflowDocumentId(workflowsStore.workflowId),
 		);
+
+		// These actions are stubbed by createTestingPinia, so delegate them to workflowsStore.workflowObject
+		// (which tests set up individually). Tests that need custom behavior can override via vi.spyOn.
+		vi.spyOn(workflowDocumentStoreInstance, 'getNodeByName').mockImplementation(
+			(name: string) => useWorkflowsStore().workflowObject?.getNode(name) ?? null,
+		);
+		vi.spyOn(workflowDocumentStoreInstance, 'getParentNodesByDepth').mockImplementation(
+			(name: string, depth?: number) =>
+				useWorkflowsStore().workflowObject?.getParentNodesByDepth(name, depth) ?? [],
+		);
+		vi.spyOn(workflowDocumentStoreInstance, 'getParentNodes').mockImplementation(
+			(name: string, type, depth) =>
+				useWorkflowsStore().workflowObject?.getParentNodes(name, type, depth) ?? [],
+		);
+		vi.spyOn(workflowDocumentStoreInstance, 'getChildNodes').mockImplementation(
+			(name: string, type, depth) =>
+				useWorkflowsStore().workflowObject?.getChildNodes(name, type, depth) ?? [],
+		);
+		vi.spyOn(workflowDocumentStoreInstance, 'getConnectionsBetweenNodes').mockImplementation(
+			(sources, targets) =>
+				useWorkflowsStore().workflowObject?.getConnectionsBetweenNodes(sources, targets) ?? [],
+		);
 	});
 
 	describe('requireNodeTypeDescription', () => {

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -546,17 +546,21 @@ export function useCanvasOperations() {
 		if (!previousNode || !newNode) {
 			return;
 		}
-		const workflowObject = workflowsStore.workflowObject;
 
 		const inputNodeNames = replaceInputs
-			? uniq(workflowObject.getParentNodes(previousNode.name, 'ALL', 1))
+			? uniq(workflowDocumentStore.value?.getParentNodes(previousNode.name, 'ALL', 1))
 			: [];
 		const outputNodeNames = replaceOutputs
-			? uniq(workflowObject.getChildNodes(previousNode.name, 'ALL', 1))
+			? uniq(workflowDocumentStore.value?.getChildNodes(previousNode.name, 'ALL', 1))
 			: [];
 		const connectionPairs = [
-			...workflowObject.getConnectionsBetweenNodes(inputNodeNames, [previousNode.name]),
-			...workflowObject.getConnectionsBetweenNodes([previousNode.name], outputNodeNames),
+			...(workflowDocumentStore.value?.getConnectionsBetweenNodes(inputNodeNames, [
+				previousNode.name,
+			]) ?? []),
+			...(workflowDocumentStore.value?.getConnectionsBetweenNodes(
+				[previousNode.name],
+				outputNodeNames,
+			) ?? []),
 		];
 
 		if (trackHistory && trackBulk) {
@@ -825,7 +829,7 @@ export function useCanvasOperations() {
 	}
 
 	function updatePositionForNodeWithMultipleInputs(node: INodeUi) {
-		const inputNodes = editableWorkflowObject.value.getParentNodesByDepth(node.name, 1);
+		const inputNodes = workflowDocumentStore.value?.getParentNodesByDepth(node.name, 1) ?? [];
 
 		if (inputNodes.length > 1) {
 			inputNodes.slice(1).forEach((inputNode, index) => {
@@ -1247,7 +1251,7 @@ export function useCanvasOperations() {
 				lastInteractedWithNode.type,
 				lastInteractedWithNode.typeVersion,
 			);
-			const lastInteractedWithNodeObject = editableWorkflowObject.value.getNode(
+			const lastInteractedWithNodeObject = workflowDocumentStore.value?.getNodeByName(
 				lastInteractedWithNode.name,
 			);
 
@@ -1666,11 +1670,8 @@ export function useCanvasOperations() {
 		// Step 2: Add all downstream connected nodes from initial candidates
 		const candidateNames = new Set(initialCandidates.map((node) => node.name));
 		for (const candidate of initialCandidates) {
-			const downstream = workflowHelpers.getConnectedNodes(
-				'downstream',
-				editableWorkflowObject.value,
-				candidate.name,
-			);
+			const downstream =
+				workflowDocumentStore.value?.getConnectedNodes('downstream', candidate.name) ?? [];
 			downstream
 				// Filter the downstream nodes to find candidates that need to be shifted right.
 				.filter((name) => {
@@ -2182,7 +2183,7 @@ export function useCanvasOperations() {
 		}
 
 		const sourceNodeType = getNodeType(sourceNode);
-		const sourceWorkflowNode = editableWorkflowObject.value.getNode(sourceNode.name);
+		const sourceWorkflowNode = workflowDocumentStore.value?.getNodeByName(sourceNode.name);
 		if (!sourceWorkflowNode) {
 			return false;
 		}
@@ -2215,7 +2216,7 @@ export function useCanvasOperations() {
 		}
 
 		const targetNodeType = getNodeType(targetNode);
-		const targetWorkflowNode = editableWorkflowObject.value.getNode(targetNode.name);
+		const targetWorkflowNode = workflowDocumentStore.value?.getNodeByName(targetNode.name);
 		if (!targetWorkflowNode) {
 			return false;
 		}
@@ -2974,12 +2975,10 @@ export function useCanvasOperations() {
 			return;
 		}
 
-		const workflowObject = workflowsStore.workflowObject; // @TODO Check if we actually need workflowObject here
-
 		logsStore.toggleOpen(true);
 
 		const payload = {
-			workflow_id: workflowObject.id,
+			workflow_id: workflowDocumentStore.value?.workflowId,
 			button_type: source,
 		};
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -331,34 +331,6 @@ export async function resolveRequiredParameters(
 	return Object.fromEntries(resolvedEntries);
 }
 
-function getConnectedNodes(
-	direction: 'upstream' | 'downstream',
-	workflow: WorkflowObjectAccessors,
-	nodeName: string,
-): string[] {
-	let checkNodes: string[];
-	if (direction === 'downstream') {
-		checkNodes = workflow.getChildNodes(nodeName);
-	} else if (direction === 'upstream') {
-		checkNodes = workflow.getParentNodes(nodeName);
-	} else {
-		throw new Error(`The direction "${direction}" is not supported!`);
-	}
-
-	// Find also all nodes which are connected to the child nodes via a non-main input
-	let connectedNodes: string[] = [];
-	checkNodes.forEach((checkNode) => {
-		connectedNodes = [
-			...connectedNodes,
-			checkNode,
-			...workflow.getParentNodes(checkNode, 'ALL_NON_MAIN'),
-		];
-	});
-
-	// Remove duplicates
-	return [...new Set(connectedNodes)];
-}
-
 function getNodeTypes(): INodeTypes {
 	return useWorkflowsStore().getNodeTypes();
 }
@@ -1133,7 +1105,6 @@ export function useWorkflowHelpers() {
 	return {
 		resolveParameter,
 		resolveRequiredParameters,
-		getConnectedNodes,
 		getNodeTypes,
 		connectionInputData,
 		executeData,

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentGraph.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentGraph.ts
@@ -41,6 +41,30 @@ export function useWorkflowDocumentGraph() {
 		return workflowsStore.workflowObject.getConnectionsBetweenNodes(sources, targets);
 	}
 
+	function getConnectedNodes(direction: 'upstream' | 'downstream', nodeName: string): string[] {
+		let checkNodes: string[];
+		if (direction === 'downstream') {
+			checkNodes = workflowsStore.workflowObject.getChildNodes(nodeName);
+		} else if (direction === 'upstream') {
+			checkNodes = workflowsStore.workflowObject.getParentNodes(nodeName);
+		} else {
+			throw new Error(`The direction "${direction}" is not supported!`);
+		}
+
+		// Find also all nodes which are connected to the child nodes via a non-main input
+		let connectedNodes: string[] = [];
+		checkNodes.forEach((checkNode) => {
+			connectedNodes = [
+				...connectedNodes,
+				checkNode,
+				...workflowsStore.workflowObject.getParentNodes(checkNode, 'ALL_NON_MAIN'),
+			];
+		});
+
+		// Remove duplicates
+		return [...new Set(connectedNodes)];
+	}
+
 	// -----------------------------------------------------------------------
 	// Node lookup (returns INode from Workflow class, not INodeUi)
 	// -----------------------------------------------------------------------
@@ -59,6 +83,7 @@ export function useWorkflowDocumentGraph() {
 		getChildNodes,
 		getParentNodesByDepth,
 		getConnectionsBetweenNodes,
+		getConnectedNodes,
 
 		// Node lookup
 		getNodeByNameFromWorkflow,

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.ts
@@ -5,9 +5,8 @@ import type {
 	INodeIssueObjectProperty,
 	INodeParameters,
 	INodeTypeDescription,
-	NodeConnectionType,
 } from 'n8n-workflow';
-import { NodeConnectionTypes, NodeHelpers } from 'n8n-workflow';
+import { NodeHelpers } from 'n8n-workflow';
 import type {
 	INodeUi,
 	INodeUpdatePropertiesInformation,
@@ -135,14 +134,6 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 
 	function findNodeByPartialId(partialId: string): INodeUi | undefined {
 		return workflowsStore.findNodeByPartialId(partialId);
-	}
-
-	function getParentNodes(
-		nodeName: string,
-		type: NodeConnectionType | 'ALL' | 'ALL_NON_MAIN' = NodeConnectionTypes.Main,
-		depth = -1,
-	): string[] {
-		return workflowsStore.workflowObject.getParentNodes(nodeName, type, depth);
 	}
 
 	function getNodesByIds(ids: string[]): INodeUi[] {
@@ -339,7 +330,6 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 		getNodes,
 		findNodeByPartialId,
 		getNodesByIds,
-		getParentNodes,
 
 		// Write
 		setNodes,

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/ItemTypes/NodeItem.vue
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/ItemTypes/NodeItem.vue
@@ -194,13 +194,15 @@ function onCommunityNodeTooltipClick(event: MouseEvent) {
 		@dragend="onDragEnd"
 	>
 		<template #icon>
-			<div v-if="isSubNodeType" :class="$style.subNodeBackground"></div>
-			<NodeIcon
-				:class="$style.nodeIcon"
-				:node-type="nodeType"
-				:size="nodeListIconSize"
-				color-default="var(--color--foreground--shade-2)"
-			/>
+			<div :class="$style.iconWrapper">
+				<div v-if="isSubNodeType" :class="$style.subNodeBackground"></div>
+				<NodeIcon
+					:class="$style.nodeIcon"
+					:node-type="nodeType"
+					:size="nodeListIconSize"
+					color-default="var(--color--foreground--shade-2)"
+				/>
+			</div>
 		</template>
 
 		<template v-if="isOfficial" #extraDetails>
@@ -264,6 +266,13 @@ function onCommunityNodeTooltipClick(event: MouseEvent) {
 	user-select: none;
 }
 
+.iconWrapper {
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
 .nodeIcon {
 	z-index: 2;
 }
@@ -272,9 +281,11 @@ function onCommunityNodeTooltipClick(event: MouseEvent) {
 	background-color: var(--node-type--supplemental--color--background);
 	border-radius: 50%;
 	height: 40px;
-	position: absolute;
-	transform: translate(-7px, -7px);
 	width: 40px;
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
 	z-index: 1;
 }
 

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/viewsData.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/viewsData.ts
@@ -427,7 +427,7 @@ export function TriggerView() {
 					name: WEBHOOK_NODE_TYPE,
 					displayName: i18n.baseText('nodeCreator.triggerHelperPanel.webhookTriggerDisplayName'),
 					description: i18n.baseText('nodeCreator.triggerHelperPanel.webhookTriggerDescription'),
-					iconData: { type: 'icon', icon: 'webhook' },
+					icon: 'node:webhook',
 				},
 			},
 			{
@@ -439,7 +439,7 @@ export function TriggerView() {
 					name: FORM_TRIGGER_NODE_TYPE,
 					displayName: i18n.baseText('nodeCreator.triggerHelperPanel.formTriggerDisplayName'),
 					description: i18n.baseText('nodeCreator.triggerHelperPanel.formTriggerDescription'),
-					iconData: { type: 'icon', icon: 'form' },
+					icon: 'node:form-trigger',
 				},
 			},
 			{


### PR DESCRIPTION
## Summary

This PR delivers two Linear tickets (IAM-485 and IAM-486) as a single unit because the IAM-486 work is directly layered on top of IAM-485.

### Problem

n8n derives four signing secrets directly from the encryption key at every boot:

| Secret | Used for | Derivation |
|--------|----------|------------|
| `instanceId` | Telemetry, licence | `SHA256(encryptionKey.slice(mid))` |
| `hmacSignatureSecret` | Webhook resumption URL signing | `SHA256("hmac-signature:" + encryptionKey)` |
| `jwtSecret` | User session JWT signing | `SHA256("n8n:" + encryptionKey)` |
| `signingSecret` | Binary-data presigned URL signing | `SHA256("url-signing:" + encryptionKey)` |

Rotating the encryption key immediately and silently invalidates all active user sessions, in-flight webhook resumption URLs, shared binary-data links, and instance identity used for telemetry/licensing.

### Solution

A **two-phase initialisation pattern** that decouples each secret from the encryption key after first boot:

1. **Constructor** — always derives the value from the encryption key (backward-compatible fallback; no change on upgrade).
2. **`initialize(repo)`** — called once after DB migrations complete. Precedence: `env var → active DB row → insertOrIgnore (persist) → race-condition fallback read`.

The derived value is persisted to the `deployment_key` table on first boot. Every subsequent boot reads from DB, so the secret is stable regardless of what happens to the encryption key.

### Concurrency safety (multi-main)

`DeploymentKeyRepository.insertOrIgnore()` issues `INSERT OR IGNORE RETURNING *`. On a unique-index conflict (two mains racing at startup), the insert is silently dropped and `null` is returned; the caller reads the winner's row. No exceptions, no locks.

---

## Changes

### `packages/@n8n/db` (IAM-485)
- New entity `DeploymentKey` — `id`, `type`, `value`, `status`, `algorithm`, timestamps
- New repository `DeploymentKeyRepository` with `findActiveByType()` and `insertOrIgnore()`
- New migration `1777000000000-CreateDeploymentKeyTable` — table + unique partial indexes for `instance.id`, `signing.hmac`, `signing.jwt`, `signing.binary_data`

### `packages/core / InstanceSettings` (IAM-485 + IAM-486)
- `instanceId` persisted to `deployment_key` (type `instance.id`) via `initialize(repo)`
- `hmacSignatureSecret` made mutable; persisted via same `initialize(repo)` call (type `signing.hmac`)
- Duck-typed inline repo interface avoids circular package dependency (`@n8n/db` → `n8n-core` at runtime)

### `packages/core / BinaryDataConfig` (IAM-486)
- New `initialize(repo)` — env-var fast-path → DB read → insertOrIgnore → race fallback; type `signing.binary_data`

### `packages/cli / JwtService` (IAM-486)
- `jwtSecret` made `private`
- New `initialize(repo)` — same pattern; type `signing.jwt`; respects `N8N_USER_MANAGEMENT_JWT_SECRET`

### `packages/cli / start.ts` (IAM-486)
- Calls `initialize(DeploymentKeyRepository)` for `InstanceSettings`, `JwtService`, and `BinaryDataConfig` in sequence after DB migrations, before licence init

### Tests
- `instance-settings.test.ts` — 8 new tests (4× `instance.id`, 4× `signing.hmac`)
- `jwt.service.test.ts` — 4 new `initialize()` tests
- `binary-data.config.test.ts` — 4 new `initialize()` tests

Each set covers: env-var fast-path, existing DB row, persist-on-first-boot, concurrent-insert race condition.

---

## Upgrade path

No breaking changes. Derived values are identical to pre-upgrade; they are transparently persisted on first boot of the new version. Sessions, webhook URLs, and binary-data links continue to work without interruption.

## Environment variables

| Variable | Behaviour |
|----------|-----------|
| `N8N_ENCRYPTION_KEY` | Still the derivation source on first boot |
| `N8N_USER_MANAGEMENT_JWT_SECRET` | Pinned; DB write skipped entirely |
| `N8N_HMAC_SIGNATURE_SECRET` | Pinned; DB write skipped entirely |
| `N8N_BINARY_DATA_SIGNING_SECRET` | Pinned; DB write skipped entirely |
| `N8N_INSTANCE_ID` | Pinned; DB write skipped entirely |

## Related Linear tickets

https://linear.app/n8n/issue/IAM-485
https://linear.app/n8n/issue/IAM-486

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` if urgent.