### PR TITLE
fix(editor): Fix styles on disabled Publish button (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
@@ -382,6 +382,13 @@ const handleClick = (event: MouseEvent) => {
 	&.disabled {
 		opacity: 0.5;
 		cursor: not-allowed;
+
+		&:hover {
+			background-color: var(--button--color--background);
+			box-shadow:
+				inset var(--button--border--shadow),
+				var(--button--shadow);
+		}
 	}
 
 	&.loading {

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.vue
@@ -512,7 +512,7 @@ $--header-spacing: 20px;
 .actions {
 	display: flex;
 	align-items: center;
-	gap: var(--spacing--md);
+	gap: var(--spacing--4xs);
 	flex-wrap: nowrap;
 }
 

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
@@ -599,10 +599,7 @@ defineExpose({
 .publishButtonWrapper {
 	position: relative;
 	display: inline-flex;
-	margin-right: var(--spacing--2xs);
-	box-shadow:
-		0 1px 3px light-dark(var(--color--black-alpha-100), var(--color--black-alpha-300)),
-		0 0 0 1.5px light-dark(transparent, var(--color--black-alpha-100));
+	margin-inline: var(--spacing--2xs);
 }
 
 .buttonGroup {

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
@@ -524,7 +524,7 @@ defineExpose({
 						:class="$style.groupButtonLeft"
 						:loading="autoSaveForPublish"
 						:disabled="!publishButtonConfig.enabled || shouldDisablePublishButton"
-						variant="subtle"
+						variant="ghost"
 						data-test-id="workflow-open-publish-modal-button"
 						@click="onPublishButtonClick"
 					>
@@ -558,8 +558,9 @@ defineExpose({
 					<template #activator>
 						<N8nIconButton
 							:class="$style.groupButtonRight"
-							variant="subtle"
+							variant="ghost"
 							icon="chevron-down"
+							:disabled="!publishButtonConfig.enabled || shouldDisablePublishButton"
 							:aria-label="i18n.baseText('node.moreActions')"
 							data-test-id="version-menu-button"
 						/>
@@ -599,10 +600,15 @@ defineExpose({
 	position: relative;
 	display: inline-flex;
 	margin-right: var(--spacing--2xs);
+	box-shadow:
+		0 1px 3px light-dark(var(--color--black-alpha-100), var(--color--black-alpha-300)),
+		0 0 0 1.5px light-dark(transparent, var(--color--black-alpha-100));
 }
 
 .buttonGroup {
 	display: inline-flex;
+	border: var(--border);
+	border-radius: var(--radius--3xs);
 }
 
 .groupButtonLeft,
@@ -620,6 +626,7 @@ defineExpose({
 .groupButtonRight {
 	border-top-left-radius: 0;
 	border-bottom-left-radius: 0;
+	border-left: var(--border);
 }
 
 .buttonGroup:has(.groupButtonLeft:not(:disabled):hover) .groupButtonRight {


### PR DESCRIPTION
## Summary
Fixes [DS-522](https://linear.app/n8n/issue/DS-522/re-style-publish-button-so-it-respects-disabled-state)

- Re-style the Publish button so the disabled state is visually distinct and consistent with the design system.
- Ensure disabled Publish button styles no longer look interactive.
- Fix spacing with peer elements

| Before | After |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/b13ab7ab-47cf-443f-85b4-365e8add8dda" width="960px" alt="Before image" /> | <img src="https://github.com/user-attachments/assets/7e45fcfb-b086-4935-93c5-84a581bd4cc2" width="960px" alt="After image" /> |

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/DS-522/re-style-publish-button-so-it-respects-disabled-state

<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
