### PR TITLE
fix(editor): Improve disabled Google sign-in button styling and tooltip alignment

### DIFF
--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/GoogleAuthButton.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/GoogleAuthButton.vue
@@ -73,7 +73,7 @@
 
 	&:disabled {
 		svg {
-			filter: brightness(0.6);
+			opacity: 0.56;
 		}
 		cursor: not-allowed;
 	}

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/GoogleAuthButton.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/GoogleAuthButton.vue
@@ -50,14 +50,14 @@
 	background: transparent;
 	border-radius: var(--radius);
 
-	&:hover,
-	&:active {
+	&:not(:disabled):hover,
+	&:not(:disabled):active {
 		svg {
 			filter: brightness(0.9);
 		}
 	}
 
-	&:active svg {
+	&:not(:disabled):active svg {
 		filter: brightness(0.9);
 	}
 

--- a/packages/frontend/editor-ui/src/features/credentials/quickConnect/components/QuickConnectButton.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/quickConnect/components/QuickConnectButton.vue
@@ -44,7 +44,7 @@ const buttonLabel = computed(() => {
 </script>
 
 <template>
-	<N8nTooltip :disabled="!disabled || !disabledTooltip" placement="top">
+	<N8nTooltip :disabled="!disabled || !disabledTooltip" :offset="24">
 		<template #content>{{ disabledTooltip }}</template>
 		<template #default>
 			<GoogleAuthButton

--- a/packages/frontend/editor-ui/src/features/credentials/quickConnect/components/QuickConnectButton.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/quickConnect/components/QuickConnectButton.vue
@@ -44,7 +44,7 @@ const buttonLabel = computed(() => {
 </script>
 
 <template>
-	<N8nTooltip :disabled="!disabled || !disabledTooltip" placement="right">
+	<N8nTooltip :disabled="!disabled || !disabledTooltip" placement="top">
 		<template #content>{{ disabledTooltip }}</template>
 		<template #default>
 			<GoogleAuthButton


### PR DESCRIPTION
## Summary

Fixes [DS-517](https://linear.app/n8n/issue/DS-517/bug-disabled-google-sign-in-button-has-poor-styling-and-misaligned)

- Polishes credentials UI by replacing the disabled Google auth SVG `filter: brightness(0.6)` with `opacity: 0.56` in `GoogleAuthButton.vue` for a cleaner disabled state.
- Fixes quick-connect tooltip alignment by changing placement from `right` to `top` in `QuickConnectButton.vue` so the tooltip appears centered above the button.

| Before | After |
|:---:|:---:|
| <img width="1220" height="1380" alt="image" src="https://github.com/user-attachments/assets/d5e9576e-de73-41c2-86d5-3d7ba13baa42" /> | <img src="https://github.com/user-attachments/assets/30751875-efca-4aa5-8458-45cf89d91d2e" width="960px" alt="After"> |


## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/DS-517

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)