### PR TITLE
 feat(Supabase Vector Store Node): Add custom schema support

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreSupabase/VectorStoreSupabase.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreSupabase/VectorStoreSupabase.node.test.ts
@@ -1,0 +1,283 @@
+import { mock } from 'jest-mock-extended';
+import type { ISupplyDataFunctions } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+const mockCreateClient = jest.fn();
+
+jest.mock('@langchain/community/vectorstores/supabase', () => {
+	class SupabaseVectorStore {
+		static fromDocuments = jest.fn();
+		static fromExistingIndex = jest.fn();
+	}
+	return { SupabaseVectorStore };
+});
+
+jest.mock('@supabase/supabase-js', () => ({
+	createClient: (...args: unknown[]) => mockCreateClient(...args),
+}));
+
+jest.mock('@n8n/ai-utilities', () => ({
+	metadataFilterField: {},
+	getMetadataFiltersValues: jest.fn(),
+	logAiEvent: jest.fn(),
+	N8nBinaryLoader: class {},
+	N8nJsonLoader: class {},
+	logWrapper: (fn: unknown) => fn,
+	createVectorStoreNode: (config: {
+		getVectorStoreClient: (...args: unknown[]) => unknown;
+		populateVectorStore: (...args: unknown[]) => unknown;
+	}) =>
+		class BaseNode {
+			async getVectorStoreClient(...args: unknown[]) {
+				return config.getVectorStoreClient.apply(config, args);
+			}
+			async populateVectorStore(...args: unknown[]) {
+				return config.populateVectorStore.apply(config, args);
+			}
+		},
+}));
+
+jest.mock('../shared/methods/listSearch', () => ({
+	supabaseTableNameSearch: jest.fn(),
+}));
+
+jest.mock('../shared/descriptions', () => ({
+	supabaseTableNameRLC: {},
+}));
+
+import { SupabaseVectorStore } from '@langchain/community/vectorstores/supabase';
+
+import * as SupabaseNode from './VectorStoreSupabase.node';
+
+const MockSupabaseVectorStore = SupabaseVectorStore as jest.MockedClass<typeof SupabaseVectorStore>;
+
+describe('VectorStoreSupabase.node', () => {
+	const helpers = mock<ISupplyDataFunctions['helpers']>();
+	const dataFunctions = mock<ISupplyDataFunctions>({ helpers });
+	dataFunctions.logger = {
+		info: jest.fn(),
+		debug: jest.fn(),
+		error: jest.fn(),
+		warn: jest.fn(),
+		verbose: jest.fn(),
+	} as unknown as ISupplyDataFunctions['logger'];
+
+	const baseCredentials = {
+		host: 'https://test.supabase.co',
+		serviceRole: 'test-service-role-key',
+	};
+
+	const mockSupabaseClient = { from: jest.fn() };
+
+	beforeEach(() => {
+		jest.resetAllMocks();
+		mockCreateClient.mockReturnValue(mockSupabaseClient);
+	});
+
+	function createContext(paramOverrides: Record<string, unknown> = {}) {
+		const defaults: Record<string, unknown> = {
+			tableName: 'documents',
+			useCustomSchema: false,
+			schema: 'public',
+			options: { queryName: 'match_documents' },
+		};
+		const params = { ...defaults, ...paramOverrides };
+
+		return {
+			getCredentials: jest.fn().mockResolvedValue(baseCredentials),
+			getNodeParameter: jest.fn((name: string, _itemIndex: number, fallback?: unknown) => {
+				if (name in params) return params[name];
+				return fallback;
+			}),
+			getNode: () => ({ name: 'VectorStoreSupabase' }),
+			logger: dataFunctions.logger,
+		} as never;
+	}
+
+	describe('getVectorStoreClient', () => {
+		it('should use public schema by default', async () => {
+			const mockVectorStore = { similaritySearch: jest.fn() };
+			MockSupabaseVectorStore.fromExistingIndex = jest.fn().mockResolvedValue(mockVectorStore);
+
+			const node = new SupabaseNode.VectorStoreSupabase();
+			await (node as any).getVectorStoreClient(createContext(), undefined, {}, 0);
+
+			expect(mockCreateClient).toHaveBeenCalledWith(
+				baseCredentials.host,
+				baseCredentials.serviceRole,
+				{ db: { schema: 'public' } },
+			);
+		});
+
+		it('should use custom schema when enabled', async () => {
+			const mockVectorStore = { similaritySearch: jest.fn() };
+			MockSupabaseVectorStore.fromExistingIndex = jest.fn().mockResolvedValue(mockVectorStore);
+
+			const context = createContext({
+				useCustomSchema: true,
+				schema: 'vector_store',
+			});
+
+			const node = new SupabaseNode.VectorStoreSupabase();
+			await (node as any).getVectorStoreClient(context, undefined, {}, 0);
+
+			expect(mockCreateClient).toHaveBeenCalledWith(
+				baseCredentials.host,
+				baseCredentials.serviceRole,
+				{ db: { schema: 'vector_store' } },
+			);
+		});
+
+		it('should pass table name and query name to vector store', async () => {
+			const mockEmbeddings = {};
+			const mockVectorStore = { similaritySearch: jest.fn() };
+			MockSupabaseVectorStore.fromExistingIndex = jest.fn().mockResolvedValue(mockVectorStore);
+
+			const context = createContext({
+				tableName: 'my_vectors',
+				options: { queryName: 'custom_match' },
+			});
+
+			const node = new SupabaseNode.VectorStoreSupabase();
+			const result = await (node as any).getVectorStoreClient(
+				context,
+				undefined,
+				mockEmbeddings,
+				0,
+			);
+
+			expect(MockSupabaseVectorStore.fromExistingIndex).toHaveBeenCalledWith(mockEmbeddings, {
+				client: mockSupabaseClient,
+				tableName: 'my_vectors',
+				queryName: 'custom_match',
+				filter: undefined,
+			});
+			expect(result).toBe(mockVectorStore);
+		});
+
+		it('should pass filter to vector store', async () => {
+			const mockVectorStore = { similaritySearch: jest.fn() };
+			MockSupabaseVectorStore.fromExistingIndex = jest.fn().mockResolvedValue(mockVectorStore);
+			const filter = { key: 'metadata.type', value: 'doc' };
+
+			const node = new SupabaseNode.VectorStoreSupabase();
+			await (node as any).getVectorStoreClient(createContext(), filter, {}, 0);
+
+			expect(MockSupabaseVectorStore.fromExistingIndex).toHaveBeenCalledWith(
+				{},
+				expect.objectContaining({ filter }),
+			);
+		});
+	});
+
+	describe('populateVectorStore', () => {
+		it('should use public schema by default', async () => {
+			MockSupabaseVectorStore.fromDocuments = jest.fn().mockResolvedValue(undefined);
+
+			const node = new SupabaseNode.VectorStoreSupabase();
+			await (node as any).populateVectorStore(createContext(), {}, [], 0);
+
+			expect(mockCreateClient).toHaveBeenCalledWith(
+				baseCredentials.host,
+				baseCredentials.serviceRole,
+				{ db: { schema: 'public' } },
+			);
+		});
+
+		it('should use custom schema when enabled', async () => {
+			MockSupabaseVectorStore.fromDocuments = jest.fn().mockResolvedValue(undefined);
+
+			const context = createContext({
+				useCustomSchema: true,
+				schema: 'ai_data',
+			});
+
+			const node = new SupabaseNode.VectorStoreSupabase();
+			await (node as any).populateVectorStore(context, {}, [], 0);
+
+			expect(mockCreateClient).toHaveBeenCalledWith(
+				baseCredentials.host,
+				baseCredentials.serviceRole,
+				{ db: { schema: 'ai_data' } },
+			);
+		});
+
+		it('should throw NodeOperationError when table not found', async () => {
+			MockSupabaseVectorStore.fromDocuments = jest
+				.fn()
+				.mockRejectedValue(new Error('Error inserting: undefined 404 Not Found'));
+
+			const node = new SupabaseNode.VectorStoreSupabase();
+			await expect(
+				(node as any).populateVectorStore(createContext(), {}, [{ pageContent: 'x' }], 0),
+			).rejects.toThrow(NodeOperationError);
+		});
+	});
+
+	describe('schema validation', () => {
+		it('should reject schema names with special characters', async () => {
+			MockSupabaseVectorStore.fromExistingIndex = jest.fn();
+
+			const context = createContext({
+				useCustomSchema: true,
+				schema: 'my-schema; DROP TABLE',
+			});
+
+			const node = new SupabaseNode.VectorStoreSupabase();
+			await expect(
+				(node as any).getVectorStoreClient(context, undefined, {}, 0),
+			).rejects.toThrow(NodeOperationError);
+
+			expect(mockCreateClient).not.toHaveBeenCalled();
+		});
+
+		it('should reject schema names starting with a digit', async () => {
+			MockSupabaseVectorStore.fromExistingIndex = jest.fn();
+
+			const context = createContext({
+				useCustomSchema: true,
+				schema: '123schema',
+			});
+
+			const node = new SupabaseNode.VectorStoreSupabase();
+			await expect(
+				(node as any).getVectorStoreClient(context, undefined, {}, 0),
+			).rejects.toThrow(NodeOperationError);
+		});
+
+		it('should accept valid schema names with underscores', async () => {
+			const mockVectorStore = { similaritySearch: jest.fn() };
+			MockSupabaseVectorStore.fromExistingIndex = jest.fn().mockResolvedValue(mockVectorStore);
+
+			const context = createContext({
+				useCustomSchema: true,
+				schema: '_my_custom_schema_v2',
+			});
+
+			const node = new SupabaseNode.VectorStoreSupabase();
+			await (node as any).getVectorStoreClient(context, undefined, {}, 0);
+
+			expect(mockCreateClient).toHaveBeenCalledWith(
+				baseCredentials.host,
+				baseCredentials.serviceRole,
+				{ db: { schema: '_my_custom_schema_v2' } },
+			);
+		});
+
+		it('should not validate schema when useCustomSchema is false', async () => {
+			const mockVectorStore = { similaritySearch: jest.fn() };
+			MockSupabaseVectorStore.fromExistingIndex = jest.fn().mockResolvedValue(mockVectorStore);
+
+			const context = createContext({ useCustomSchema: false });
+
+			const node = new SupabaseNode.VectorStoreSupabase();
+			await (node as any).getVectorStoreClient(context, undefined, {}, 0);
+
+			expect(mockCreateClient).toHaveBeenCalledWith(
+				baseCredentials.host,
+				baseCredentials.serviceRole,
+				{ db: { schema: 'public' } },
+			);
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreSupabase/VectorStoreSupabase.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreSupabase/VectorStoreSupabase.node.test.ts
@@ -264,6 +264,25 @@ describe('VectorStoreSupabase.node', () => {
 			);
 		});
 
+		it('should accept valid schema names with dollar signs', async () => {
+			const mockVectorStore = { similaritySearch: jest.fn() };
+			MockSupabaseVectorStore.fromExistingIndex = jest.fn().mockResolvedValue(mockVectorStore);
+
+			const context = createContext({
+				useCustomSchema: true,
+				schema: 'my$schema',
+			});
+
+			const node = new SupabaseNode.VectorStoreSupabase();
+			await (node as any).getVectorStoreClient(context, undefined, {}, 0);
+
+			expect(mockCreateClient).toHaveBeenCalledWith(
+				baseCredentials.host,
+				baseCredentials.serviceRole,
+				{ db: { schema: 'my$schema' } },
+			);
+		});
+
 		it('should not validate schema when useCustomSchema is false', async () => {
 			const mockVectorStore = { similaritySearch: jest.fn() };
 			MockSupabaseVectorStore.fromExistingIndex = jest.fn().mockResolvedValue(mockVectorStore);

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreSupabase/VectorStoreSupabase.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreSupabase/VectorStoreSupabase.node.ts
@@ -12,7 +12,7 @@ import { metadataFilterField, createVectorStoreNode } from '@n8n/ai-utilities';
 import { supabaseTableNameSearch } from '../shared/methods/listSearch';
 import { supabaseTableNameRLC } from '../shared/descriptions';
 
-const VALID_SCHEMA_NAME = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+const VALID_SCHEMA_NAME = /^[A-Za-z_][A-Za-z0-9_$]*$/;
 
 const queryNameField: INodeProperties = {
 	displayName: 'Query Name',
@@ -58,7 +58,7 @@ function createSupabaseClientForSchema(
 	if (!VALID_SCHEMA_NAME.test(schema)) {
 		throw new NodeOperationError(
 			context.getNode(),
-			`Invalid schema name: "${schema}". Schema names must start with a letter or underscore, followed by letters, digits, or underscores.`,
+			`Invalid schema name: "${schema}". Schema names must start with a letter or underscore, followed by letters, digits, underscores, or dollar signs.`,
 			{ itemIndex },
 		);
 	}

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreSupabase/VectorStoreSupabase.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreSupabase/VectorStoreSupabase.node.ts
@@ -1,9 +1,9 @@
 import { SupabaseVectorStore } from '@langchain/community/vectorstores/supabase';
-import type { SupabaseClient } from '@supabase/supabase-js';
 import { createClient } from '@supabase/supabase-js';
 import {
 	NodeOperationError,
 	type INodeProperties,
+	type IExecuteFunctions,
 	type ISupplyDataFunctions,
 } from 'n8n-workflow';
 
@@ -42,15 +42,11 @@ const schemaField: INodeProperties = {
 };
 
 function createSupabaseClientForSchema(
-	context: ISupplyDataFunctions,
+	context: IExecuteFunctions | ISupplyDataFunctions,
 	itemIndex: number,
 	credentials: { host: string; serviceRole: string },
-): SupabaseClient {
-	const useCustomSchema = context.getNodeParameter(
-		'useCustomSchema',
-		itemIndex,
-		false,
-	) as boolean;
+) {
+	const useCustomSchema = context.getNodeParameter('useCustomSchema', itemIndex, false) as boolean;
 	const schema = useCustomSchema
 		? (context.getNodeParameter('schema', itemIndex, 'public') as string)
 		: 'public';
@@ -64,7 +60,7 @@ function createSupabaseClientForSchema(
 	}
 
 	return createClient(credentials.host, credentials.serviceRole, {
-		db: { schema },
+		db: { schema: schema as 'public' },
 	});
 }
 

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreSupabase/VectorStoreSupabase.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreSupabase/VectorStoreSupabase.node.ts
@@ -1,11 +1,18 @@
 import { SupabaseVectorStore } from '@langchain/community/vectorstores/supabase';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { createClient } from '@supabase/supabase-js';
-import { NodeOperationError, type INodeProperties } from 'n8n-workflow';
+import {
+	NodeOperationError,
+	type INodeProperties,
+	type ISupplyDataFunctions,
+} from 'n8n-workflow';
 
 import { metadataFilterField, createVectorStoreNode } from '@n8n/ai-utilities';
 
 import { supabaseTableNameSearch } from '../shared/methods/listSearch';
 import { supabaseTableNameRLC } from '../shared/descriptions';
+
+const VALID_SCHEMA_NAME = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
 const queryNameField: INodeProperties = {
 	displayName: 'Query Name',
@@ -15,7 +22,53 @@ const queryNameField: INodeProperties = {
 	description: 'Name of the query to use for matching documents',
 };
 
-const sharedFields: INodeProperties[] = [supabaseTableNameRLC];
+const useCustomSchemaField: INodeProperties = {
+	displayName: 'Use Custom Schema',
+	name: 'useCustomSchema',
+	type: 'boolean',
+	default: false,
+	noDataExpression: true,
+	description:
+		'Whether to use a database schema different from the default "public" schema (requires schema exposure in the <a href="https://supabase.com/docs/guides/api/using-custom-schemas?queryGroups=language&language=curl#exposing-custom-schemas">Supabase API</a>)',
+};
+
+const schemaField: INodeProperties = {
+	displayName: 'Schema',
+	name: 'schema',
+	type: 'string',
+	default: 'public',
+	description: 'Name of database schema to use for table',
+	displayOptions: { show: { useCustomSchema: [true] } },
+};
+
+function createSupabaseClientForSchema(
+	context: ISupplyDataFunctions,
+	itemIndex: number,
+	credentials: { host: string; serviceRole: string },
+): SupabaseClient {
+	const useCustomSchema = context.getNodeParameter(
+		'useCustomSchema',
+		itemIndex,
+		false,
+	) as boolean;
+	const schema = useCustomSchema
+		? (context.getNodeParameter('schema', itemIndex, 'public') as string)
+		: 'public';
+
+	if (!VALID_SCHEMA_NAME.test(schema)) {
+		throw new NodeOperationError(
+			context.getNode(),
+			`Invalid schema name: "${schema}". Schema names must start with a letter or underscore, followed by letters, digits, or underscores.`,
+			{ itemIndex },
+		);
+	}
+
+	return createClient(credentials.host, credentials.serviceRole, {
+		db: { schema },
+	});
+}
+
+const sharedFields: INodeProperties[] = [useCustomSchemaField, schemaField, supabaseTableNameRLC];
 const insertFields: INodeProperties[] = [
 	{
 		displayName: 'Options',
@@ -72,7 +125,11 @@ export class VectorStoreSupabase extends createVectorStoreNode<SupabaseVectorSto
 			queryName: string;
 		};
 		const credentials = await context.getCredentials('supabaseApi');
-		const client = createClient(credentials.host as string, credentials.serviceRole as string);
+		const client = createSupabaseClientForSchema(
+			context,
+			itemIndex,
+			credentials as { host: string; serviceRole: string },
+		);
 
 		return await SupabaseVectorStore.fromExistingIndex(embeddings, {
 			client,
@@ -89,7 +146,11 @@ export class VectorStoreSupabase extends createVectorStoreNode<SupabaseVectorSto
 			queryName: string;
 		};
 		const credentials = await context.getCredentials('supabaseApi');
-		const client = createClient(credentials.host as string, credentials.serviceRole as string);
+		const client = createSupabaseClientForSchema(
+			context,
+			itemIndex,
+			credentials as { host: string; serviceRole: string },
+		);
 
 		try {
 			await SupabaseVectorStore.fromDocuments(documents, embeddings, {

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/methods/listSearch.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/methods/listSearch.ts
@@ -33,10 +33,24 @@ export async function supabaseTableNameSearch(this: ILoadOptionsFunctions) {
 		throw new ApplicationError('Expected Supabase credentials host to be a string');
 	}
 
+	const headers: IDataObject = {
+		Prefer: 'return=representation',
+	};
+
+	let useCustomSchema = false;
+	try {
+		useCustomSchema = this.getNodeParameter('useCustomSchema', false) as boolean;
+	} catch {
+		// Parameter may not exist on older node versions
+	}
+
+	if (useCustomSchema) {
+		const schema = this.getNodeParameter('schema', 'public') as string;
+		headers['Accept-Profile'] = schema;
+	}
+
 	const { paths } = (await this.helpers.requestWithAuthentication.call(this, 'supabaseApi', {
-		headers: {
-			Prefer: 'return=representation',
-		},
+		headers,
 		method: 'GET',
 		uri: `${credentials.host}/rest/v1/`,
 		json: true,


### PR DESCRIPTION
## Summary                                                                                                                                                        
  - Add `Use Custom Schema` toggle and `Schema` field to the Supabase Vector Store node, allowing users to target a database schema other than the default `public`
  - Validate schema names against PostgreSQL identifier rules                                                                                                       
  - Extract shared client creation logic into `createSupabaseClientForSchema()` helper to eliminate duplication                                                     
  - Update `supabaseTableNameSearch` to send `Accept-Profile` header when a custom schema is set, so the table list reflects the correct schema                     
                                                                                                                                                                    
  This mirrors the existing custom schema support added for the classic Supabase node in #13339.                                                                    
                                                                                                                                                                    
  Closes #12226                                                                                                                                                     
                                                                                                                                                                    
  ## Test plan    
  - [ ] Verify default behavior unchanged: `useCustomSchema=false` uses `public` schema                                                                             
  - [ ] Toggle `Use Custom Schema`, set a valid schema name, verify tables are listed from that schema
  - [ ] Verify invalid schema names (special characters, leading digits) are rejected with a clear error                                                            
  - [ ] Insert and retrieve documents using a custom schema                                                                                                         
  - [ ] Run unit tests: `pnpm test VectorStoreSupabase.node.test`   
