### PR TITLE
fix(nodes): fix 'occured' -> 'occurred' in trigger node comments

### DIFF
--- a/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
@@ -203,7 +203,7 @@ export class GitlabTrigger implements INodeType {
 						return false;
 					}
 
-					// Some error occured
+					// Some error occurred
 					throw error;
 				}
 

--- a/packages/nodes-base/nodes/Stripe/StripeTrigger.node.ts
+++ b/packages/nodes-base/nodes/Stripe/StripeTrigger.node.ts
@@ -877,7 +877,7 @@ export class StripeTrigger implements INodeType {
 						return false;
 					}
 
-					// Some error occured
+					// Some error occurred
 					throw error;
 				}
 


### PR DESCRIPTION
Comments in two trigger nodes read `Some error occured`:
- `packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts` line 206
- `packages/nodes-base/nodes/Stripe/StripeTrigger.node.ts` line 880

Fixed to `occurred`. Comment-only change.