### PR TITLE
fix(core): support hybrid dot/bracket notation for external secrets

### DIFF
--- a/packages/cli/src/credentials/__tests__/external-secrets.utils.test.ts
+++ b/packages/cli/src/credentials/__tests__/external-secrets.utils.test.ts
@@ -10,6 +10,19 @@ describe('External secrets utils', () => {
 			expect(extractProviderKeysFromExpression('={{ $secrets.vault.myKey }}')).toEqual(['vault']);
 		});
 
+		it('should extract provider keys from hybrid dot and bracket notation', () => {
+			const expression = '={{ $secrets.azureKeyVault["postgres-n8n-data"] }}';
+			const result = extractProviderKeysFromExpression(expression);
+			expect(result).toEqual(['azureKeyVault']);
+		});
+
+		it('should extract provider keys from multiple hybrid notations in one expression', () => {
+			const expression =
+				'={{ $secrets.azureKeyVault["postgres-n8n-data"] + $secrets.awsSecretsManager["my-key"] }}';
+			const result = extractProviderKeysFromExpression(expression);
+			expect(result).toEqual(['azureKeyVault', 'awsSecretsManager']);
+		});
+
 		it('extracts single provider from bracket notation', () => {
 			expect(extractProviderKeysFromExpression("={{ $secrets['aws']['secret'] }}")).toEqual([
 				'aws',

--- a/packages/cli/src/credentials/external-secrets.utils.ts
+++ b/packages/cli/src/credentials/external-secrets.utils.ts
@@ -38,11 +38,11 @@ export function extractProviderKeysFromExpression(expression: string): string[] 
 	for (const expression of expressionBlocks) {
 		const expressionContent = expression[1]; // Content inside {{ }}
 
-		// Match all dot notation occurrences: $secrets.providerKey
-		const dotMatches = expressionContent.matchAll(
-			new RegExp(`\\$secrets\\.(${PROVIDER_KEY_PATTERN})(?=\\.)`, 'g'),
+		// Match dot notation ($secrets.vault.key) and hybrid notation ($secrets.vault['key'])
+		const dotAndHybridMatches = expressionContent.matchAll(
+			new RegExp(`\\$secrets\\.(${PROVIDER_KEY_PATTERN})(?=\\.|\\[)`, 'g'),
 		);
-		for (const match of dotMatches) {
+		for (const match of dotAndHybridMatches) {
 			providerKeys.add(match[1]);
 		}
 


### PR DESCRIPTION
## Summary

This PR resolves a regression introduced in 2.9.0 where external secrets using a hybrid dot/bracket notation (e.g., `{{ $secrets.azureKeyVault["postgres-n8n-data"] }}`) would fail backend validation.

**The Issue:**
The Regex lookahead in `extractProviderKeysFromExpression` required dot-notation vault names to be followed strictly by another dot `(?=\.)`. It failed to account for valid bracket-notation keys that follow a dot-notation vault.

**The Fix:**
Updated the lookahead to `(?=\.|\[)` to support matching provider names followed by either a dot or an opening bracket. Added unit tests to cover hybrid string parsing, and renamed the internal variable to `dotAndHybridMatches` for clarity.

**How to test:**
1. Enable the project secrets feature flag: `N8N_ENV_FEAT_EXTERNAL_SECRETS_FOR_PROJECTS=true`
2. Create a credential supporting external secrets (e.g., PostgreSQL).
3. Input a hybrid string into the password field: `={{ $secrets.azureKeyVault["my-key"] }}`
4. Save the credential. It should save successfully without throwing a validation error.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #28516

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included. 
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`


<details>
<summary><b>Show Test Results (All Passing)</b></summary>

```text
 PASS  src/credentials/__tests__/external-secrets.utils.test.ts
  External secrets utils
    extractProviderKeysFromExpression
      √ extracts single provider from dot notation (8 ms)
      √ should extract provider keys from hybrid dot and bracket notation (1 ms)
      √ should extract provider keys from multiple hybrid notations in one expression
      √ extracts single provider from bracket notation
      √ extracts multiple providers from same expression (1 ms)
      √ deduplicates repeated provider keys
      √ does not extract partial provider keys from malformed dot notation
      √ returns empty array when no $secrets references found (1 ms)
      √ returns empty array for plain text
      √ returns empty array when $secrets is not inside expression braces
      √ only extracts providers from inside expression braces (1 ms)
      √ extracts providers from multiple expression blocks
    getExternalSecretExpressionPaths
      √ returns all paths that contain external secret expressions
    extractProviderKeysFromCredentialData
      √ extracts unique provider keys across nested credential data (1 ms)

Test Suites: 1 passed, 1 total
Tests:       14 passed, 14 total
Snapshots:   0 total
Time:        2.271 s