### PR TITLE
fix(core): Accept mixed dot and bracket notation in external secret expressions

### DIFF
--- a/packages/cli/src/credentials/__tests__/external-secrets.utils.test.ts
+++ b/packages/cli/src/credentials/__tests__/external-secrets.utils.test.ts
@@ -63,6 +63,37 @@ describe('External secrets utils', () => {
 			const result = extractProviderKeysFromExpression(expression);
 			expect(result.sort()).toEqual(['aws', 'vault']);
 		});
+
+		it('extracts provider from mixed dot and double-quoted bracket notation', () => {
+			expect(
+				extractProviderKeysFromExpression('={{ $secrets.azureKeyVault["postgres-n8n-data"] }}'),
+			).toEqual(['azureKeyVault']);
+		});
+
+		it('extracts provider from mixed dot and single-quoted bracket notation', () => {
+			expect(
+				extractProviderKeysFromExpression("={{ $secrets.azureKeyVault['postgres-n8n-data'] }}"),
+			).toEqual(['azureKeyVault']);
+		});
+
+		it('extracts hyphenated provider from mixed dot and bracket notation', () => {
+			expect(
+				extractProviderKeysFromExpression('={{ $secrets.my-vault["postgres-n8n-data"] }}'),
+			).toEqual(['my-vault']);
+		});
+
+		it('extracts provider when bracket access is followed by further dot access', () => {
+			expect(extractProviderKeysFromExpression('={{ $secrets.vault["key"].subfield }}')).toEqual([
+				'vault',
+			]);
+		});
+
+		it('extracts multiple providers from expression mixing dot and bracket notation', () => {
+			const result = extractProviderKeysFromExpression(
+				'={{ $secrets.vault["a"] + ":" + $secrets.aws.b }}',
+			);
+			expect(result.sort()).toEqual(['aws', 'vault']);
+		});
 	});
 
 	describe('getExternalSecretExpressionPaths', () => {

--- a/packages/cli/src/credentials/external-secrets.utils.ts
+++ b/packages/cli/src/credentials/external-secrets.utils.ts
@@ -38,9 +38,12 @@ export function extractProviderKeysFromExpression(expression: string): string[] 
 	for (const expression of expressionBlocks) {
 		const expressionContent = expression[1]; // Content inside {{ }}
 
-		// Match all dot notation occurrences: $secrets.providerKey
+		// Match dot-accessed provider keys: $secrets.providerKey. The lookahead
+		// accepts either a further dot ($secrets.vault.key) or an opening
+		// bracket ($secrets.vault["key"]) so mixed expressions still resolve
+		// the provider key when the secret name can't use dot notation.
 		const dotMatches = expressionContent.matchAll(
-			new RegExp(`\\$secrets\\.(${PROVIDER_KEY_PATTERN})(?=\\.)`, 'g'),
+			new RegExp(`\\$secrets\\.(${PROVIDER_KEY_PATTERN})(?=[.\\[])`, 'g'),
 		);
 		for (const match of dotMatches) {
 			providerKeys.add(match[1]);


### PR DESCRIPTION
## Summary

Credentials using the external secrets vault can't be saved when an expression combines dot and bracket notation, e.g. `$secrets.azureKeyVault["postgres-n8n-data"]`. The save request fails with `Could not find a valid external secret vault name`, and the only workaround is to rewrite every affected expression as pure bracket notation.

The root cause is in `extractProviderKeysFromExpression` in `packages/cli/src/credentials/external-secrets.utils.ts`. The dot-notation regex uses a `(?=\.)` lookahead, so it requires the character after the provider key to be another dot. A mixed expression like `$secrets.azureKeyVault["postgres-n8n-data"]` has `[` there, so neither the dot regex nor the bracket regex (which expects `$secrets['vault']`) matches, and `extractProviderKeysFromExpression` returns `[]`. `validateAccessToReferencedSecretProviders` in `credentials/validation.ts` then treats the expression as having no valid provider and throws.

This regression was introduced by #25406 (release 2.9.0) when the validator was added.

### The fix

Widen the dot-notation lookahead from `(?=\.)` to `(?=[.\[])`, so it accepts either further dot access (`$secrets.vault.key`) or a transition into bracket notation (`$secrets.vault["key"]`). The new regex is a strict superset of the old one, so existing working expressions are unaffected.

### Key decisions

- **Only the dot regex was widened.** Pure bracket notation (`$secrets["vault"]["key"]`) already works via the separate bracket regex, so no change there. The analogous mirror-image case `$secrets["vault"].key` is a separate shape that would need its own fix — I'm intentionally not scope-creeping into it here.
- **Single-file change.** Only `external-secrets.utils.ts` needs to change; `containsExternalSecretExpression` and `validation.ts` don't require updates because they already detect the `$secrets.` prefix and dispatch to the extractor.

### Tests

Added five unit tests in `external-secrets.utils.test.ts` covering the new surface:
- Double-quoted bracket key with hyphenated secret name (exact reproducer from the report)
- Single-quoted bracket key variant
- Hyphenated provider name with bracket access (`$secrets.my-vault["key"]`)
- Bracket access followed by further dot access (`$secrets.vault["key"].subfield`)
- Multiple providers in one expression mixing both forms

All five fail on master and pass with the fix. The existing 12 tests in `external-secrets.utils.test.ts` and 39 tests in `credentials/validation.test.ts` remain green.

## Related Linear tickets, Github issues, and Community forum posts

closes #28516

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included
- [ ] Docs updated or follow-up ticket created (n/a — no public API change)
- [ ] Backport label if urgent fix
