### PR TITLE
fix(core): Guard against undefined config properties in credential overwrites

### DIFF
--- a/packages/cli/src/__tests__/credentials-overwrites.test.ts
+++ b/packages/cli/src/__tests__/credentials-overwrites.test.ts
@@ -113,6 +113,36 @@ describe('CredentialsOverwrites', () => {
 			expect(result).toEqual(data);
 		});
 
+		it('should not crash when skipTypes is undefined', () => {
+			// Simulate version mismatch where skipTypes is not present on the config object
+			globalConfig.credentials.overwrite.skipTypes =
+				undefined as unknown as CommaSeparatedStringArray<string>;
+
+			const result = credentialsOverwrites.applyOverwrite('test', {
+				username: '',
+				password: '',
+			});
+
+			expect(result).toEqual({ username: 'user', password: 'pass' });
+		});
+
+		it('should not crash when overwrite config object is undefined', () => {
+			// Simulate a DI/version mismatch where the nested overwrite config is undefined
+			const savedOverwrite = globalConfig.credentials.overwrite;
+			globalConfig.credentials.overwrite = undefined as never;
+
+			try {
+				const result = credentialsOverwrites.applyOverwrite('test', {
+					username: '',
+					password: '',
+				});
+
+				expect(result).toEqual({ username: 'user', password: 'pass' });
+			} finally {
+				globalConfig.credentials.overwrite = savedOverwrite;
+			}
+		});
+
 		describe('N8N_SKIP_CREDENTIAL_OVERWRITE', () => {
 			beforeEach(() => {
 				globalConfig.credentials.overwrite.skipTypes = [

--- a/packages/cli/src/credentials-overwrites.ts
+++ b/packages/cli/src/credentials-overwrites.ts
@@ -147,7 +147,7 @@ export class CredentialsOverwrites {
 		// customized (any overwrite field has a non-empty value that differs from
 		// the overwrite value). Since overwrites are never persisted to the DB,
 		// any non-empty stored value that differs from the overwrite is user-set.
-		if (this.globalConfig.credentials.overwrite.skipTypes.includes(type)) {
+		if (this.globalConfig.credentials.overwrite?.skipTypes?.includes(type)) {
 			const isFieldCustomized = (key: string) => {
 				const storedValue = data[key];
 				return (
@@ -208,11 +208,17 @@ export class CredentialsOverwrites {
 
 	private get(name: string): ICredentialDataDecryptedObject | undefined {
 		const parentTypes = this.credentialTypes.getParentTypes(name);
-		return [name, ...parentTypes]
+		const entries = [name, ...parentTypes]
 			.reverse()
 			.map((type) => this.overwriteData[type])
-			.filter((type) => !!type)
-			.reduce((acc, current) => Object.assign(acc, current), {});
+			.filter((type): type is ICredentialDataDecryptedObject => !!type);
+
+		if (entries.length === 0) return undefined;
+
+		return entries.reduce(
+			(acc, current) => Object.assign(acc, current),
+			{} as ICredentialDataDecryptedObject,
+		);
 	}
 
 	getAll(): ICredentialsOverwrite {


### PR DESCRIPTION
## Summary

Fixes an intermittent `TypeError: Cannot read properties of undefined (reading 'skipTypes')` crash that caused nodes to fail when running workflows with credentials.

**Root causes (two bugs):**

1. `CredentialsOverwrites.get()` always returned `{}` instead of `undefined` when no overwrites existed for a credential type. This made the early-return guard at line 142 dead code, meaning every credential lookup unnecessarily reached the `skipTypes` access.

2. The `skipTypes` access at line 150 was unsafe. Based on the error stack — "reading 'skipTypes' from undefined" — the `overwrite` config object itself was `undefined`. This can occur during rolling deploys or self-hosted partial package updates where `credentials-overwrites.ts` is updated before the corresponding `@n8n/config` version (which introduced `skipTypes`) is active.

**Fixes:**
- `get()` now returns `undefined` when no entries are found, restoring the intended early-return behaviour
- Line 150 uses optional chaining (`overwrite?.skipTypes?.includes(type)`) to safely handle both `overwrite` and `skipTypes` being undefined

**Tests added:** two new cases covering `skipTypes === undefined` and `overwrite === undefined`.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-4854/intermittent-skiptypes-error

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

---
🤖 PR Summary generated by AI