### PR TITLE
fix: Preserve OAuth2 proxy routing when Ignore SSL Issues is enabled

### DIFF
--- a/packages/@n8n/client-oauth2/src/client-oauth2.ts
+++ b/packages/@n8n/client-oauth2/src/client-oauth2.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import axios from 'axios';
 import type { AxiosRequestConfig, AxiosResponse } from 'axios';
-import { Agent } from 'https';
+import crypto from 'crypto';
+import type http from 'http';
+import https, { Agent } from 'https';
 import * as qs from 'querystring';
 
 import type { ClientOAuth2TokenData } from './client-oauth2-token';
@@ -48,7 +50,22 @@ export class ResponseError extends Error {
 	}
 }
 
-const sslIgnoringAgent = new Agent({ rejectUnauthorized: false });
+type AgentWithAddRequest = Agent & {
+	addRequest(req: http.ClientRequest, options: https.RequestOptions): void;
+};
+
+class ProxyPreservingInsecureAgent extends Agent {
+	addRequest(req: http.ClientRequest, options: https.RequestOptions) {
+		const globalHttpsAgent = https.globalAgent as AgentWithAddRequest;
+		return globalHttpsAgent.addRequest(req, {
+			...options,
+			rejectUnauthorized: false,
+			secureOptions: crypto.constants.SSL_OP_LEGACY_SERVER_CONNECT,
+		});
+	}
+}
+
+const sslIgnoringAgent = new ProxyPreservingInsecureAgent();
 
 /**
  * Construct an object that can handle the multiple OAuth 2.0 flows.

--- a/packages/@n8n/client-oauth2/test/client-oauth2.test.ts
+++ b/packages/@n8n/client-oauth2/test/client-oauth2.test.ts
@@ -81,6 +81,48 @@ describe('ClientOAuth2', () => {
 			);
 		});
 
+		it('should preserve proxy routing when ignoreSSLIssues is enabled', async () => {
+			mockTokenResponse({
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					access_token: config.accessToken,
+					refresh_token: config.refreshToken,
+				}),
+			});
+
+			const axiosSpy = jest.spyOn(axios, 'request');
+
+			await client.accessTokenRequest({
+				url: config.accessTokenUri,
+				method: 'POST',
+				headers: {
+					Authorization: authHeader,
+					Accept: 'application/json',
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: {
+					refresh_token: 'test',
+					grant_type: 'refresh_token',
+				},
+				ignoreSSLIssues: true,
+			});
+
+			expect(axiosSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					proxy: false,
+					httpsAgent: expect.anything(),
+				}),
+			);
+
+			expect(
+				axiosSpy.mock.calls.some(
+					([requestConfig]) =>
+						requestConfig?.httpsAgent?.constructor?.name === 'ProxyPreservingInsecureAgent',
+				),
+			).toBe(true);
+		});
+
 		test.each([
 			{
 				contentType: 'application/json',


### PR DESCRIPTION
## Summary

This PR fixes a follow-on OAuth2 transport issue after `#28513`.

`@n8n/client-oauth2` correctly disables axios's built-in proxy handling with `proxy: false`, but when `ignoreSSLIssues=true` it currently swaps in a per-request `https.Agent({ rejectUnauthorized: false })`.

In proxy-based deployments, that per-request agent bypasses n8n's global `HttpsProxyManager` path, so OAuth2 token requests can fail before they ever reach the proxy.

This change keeps the `Ignore SSL Issues` behavior but preserves proxy routing by delegating through the current global HTTPS agent and forcing TLS validation off on the forwarded request.

It also adds regression coverage for the `ignoreSSLIssues` transport choice in `@n8n/client-oauth2`.

## Related Linear tickets, Github issues, and Community forum posts

fixes #28576

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
