### PR TITLE
fix: Validate loadOptions routing to prevent SSRF via absolute URLs

### DIFF
--- a/packages/@n8n/api-types/src/dto/dynamic-node-parameters/options-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/dynamic-node-parameters/options-request.dto.ts
@@ -3,6 +3,9 @@ import { z } from 'zod';
 
 import { BaseDynamicParametersRequestDto } from './base-dynamic-parameters-request.dto';
 
+const isRelativeOrExpressionUrl = (url: string) =>
+	url.startsWith('=') || (!/^[a-zA-Z][a-zA-Z0-9+\-.]*:\/\//.test(url) && !url.startsWith('//'));
+
 export class OptionsRequestDto extends BaseDynamicParametersRequestDto.extend({
 	loadOptions: z
 		.object({
@@ -10,7 +13,13 @@ export class OptionsRequestDto extends BaseDynamicParametersRequestDto.extend({
 				.object({
 					operations: z.any().optional(),
 					output: z.any().optional(),
-					request: z.any().optional(),
+					request: z
+						.object({ url: z.string().optional() })
+						.passthrough()
+						.refine((req) => req?.url === undefined || isRelativeOrExpressionUrl(req.url), {
+							message: 'routing.request.url must be a relative path, not an absolute URL',
+						})
+						.optional(),
 				})
 				.optional(),
 		})

--- a/packages/cli/src/services/__tests__/dynamic-node-parameters.service.test.ts
+++ b/packages/cli/src/services/__tests__/dynamic-node-parameters.service.test.ts
@@ -277,7 +277,7 @@ describe('DynamicNodeParametersService', () => {
 		});
 
 		it('should allow a relative path in url', () => {
-			const routing = { request: { url: '/v1/models', method: 'GET' } };
+			const routing = { request: { url: '/v1/models', method: 'GET' as const } };
 			expect(sanitize(routing)).toEqual(routing);
 		});
 

--- a/packages/cli/src/services/__tests__/dynamic-node-parameters.service.test.ts
+++ b/packages/cli/src/services/__tests__/dynamic-node-parameters.service.test.ts
@@ -6,12 +6,14 @@ import {
 	type INodeType,
 	type IWorkflowExecuteAdditionalData,
 	type ResourceMapperFields,
+	type ILoadOptions,
 } from 'n8n-workflow';
 
 import { DynamicNodeParametersService } from '../dynamic-node-parameters.service';
 import { WorkflowLoaderService } from '../workflow-loader.service';
 
 import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NodeTypes } from '@/node-types';
 import * as checkAccess from '@/permissions.ee/check-access';
@@ -256,6 +258,59 @@ describe('DynamicNodeParametersService', () => {
 					// workflowId intentionally omitted
 				}),
 			).rejects.toThrow(ForbiddenError);
+		});
+	});
+
+	describe('sanitizeLoadOptionsRouting', () => {
+		// Access the private method for focused unit testing of security validation
+		const sanitize = (routing: ILoadOptions['routing']) =>
+			(
+				service as unknown as {
+					sanitizeLoadOptionsRouting: (r: ILoadOptions['routing']) => ILoadOptions['routing'];
+				}
+			).sanitizeLoadOptionsRouting(routing);
+
+		it('should return routing unchanged when request is absent', () => {
+			expect(sanitize(undefined)).toBeUndefined();
+			expect(sanitize({})).toEqual({});
+			expect(sanitize({ operations: {} })).toEqual({ operations: {} });
+		});
+
+		it('should allow a relative path in url', () => {
+			const routing = { request: { url: '/v1/models', method: 'GET' } };
+			expect(sanitize(routing)).toEqual(routing);
+		});
+
+		it('should allow an expression url (starts with =)', () => {
+			const routing = { request: { url: '=/v1/{{ $parameter.version }}/models' } };
+			expect(sanitize(routing)).toEqual(routing);
+		});
+
+		it('should strip baseURL from routing.request', () => {
+			const routing = { request: { url: '/v1/models', baseURL: 'http://attacker.com' } };
+			const result = sanitize(routing);
+			expect(result?.request).not.toHaveProperty('baseURL');
+			expect((result?.request as Record<string, unknown>)?.url).toBe('/v1/models');
+		});
+
+		it('should throw for an http:// absolute url', () => {
+			expect(() => sanitize({ request: { url: 'http://127.0.0.1:5678/rest/settings' } })).toThrow(
+				BadRequestError,
+			);
+		});
+
+		it('should throw for an https:// absolute url', () => {
+			expect(() => sanitize({ request: { url: 'https://attacker.com/steal' } })).toThrow(
+				BadRequestError,
+			);
+		});
+
+		it('should throw for a protocol-relative url', () => {
+			expect(() => sanitize({ request: { url: '//attacker.com/steal' } })).toThrow(BadRequestError);
+		});
+
+		it('should throw for other scheme absolute urls', () => {
+			expect(() => sanitize({ request: { url: 'file:///etc/passwd' } })).toThrow(BadRequestError);
 		});
 	});
 });

--- a/packages/cli/src/services/__tests__/dynamic-node-parameters.service.test.ts
+++ b/packages/cli/src/services/__tests__/dynamic-node-parameters.service.test.ts
@@ -281,9 +281,10 @@ describe('DynamicNodeParametersService', () => {
 			expect(sanitize(routing)).toEqual(routing);
 		});
 
-		it('should allow an expression url (starts with =)', () => {
-			const routing = { request: { url: '=/v1/{{ $parameter.version }}/models' } };
-			expect(sanitize(routing)).toEqual(routing);
+		it('should throw for an expression url (starts with =)', () => {
+			expect(() => sanitize({ request: { url: '=/v1/{{ $parameter.version }}/models' } })).toThrow(
+				BadRequestError,
+			);
 		});
 
 		it('should strip baseURL from routing.request', () => {

--- a/packages/cli/src/services/dynamic-node-parameters.service.ts
+++ b/packages/cli/src/services/dynamic-node-parameters.service.ts
@@ -23,6 +23,7 @@ import type {
 import { Workflow, UnexpectedError, createEmptyRunExecutionData } from 'n8n-workflow';
 
 import { NodeTypes } from '@/node-types';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 
@@ -181,7 +182,7 @@ export class DynamicNodeParametersService {
 							type: 'string',
 							name: '',
 							default: '',
-							routing: loadOptions.routing,
+							routing: this.sanitizeLoadOptionsRouting(loadOptions.routing),
 						} as INodeProperties,
 					],
 				},
@@ -221,6 +222,32 @@ export class DynamicNodeParametersService {
 		}
 
 		return optionsData[0].map((item) => item.json) as unknown as INodePropertyOptions[];
+	}
+
+	/**
+	 * Sanitizes user-supplied loadOptions routing to prevent SSRF attacks.
+	 *
+	 * Strips `baseURL` (must never be user-controllable; `requestDefaults.baseURL` takes precedence)
+	 * and rejects absolute URLs in `request.url` (plain strings only; `=`-prefixed expressions are
+	 * evaluated server-side from trusted node code and are therefore allowed).
+	 */
+	private sanitizeLoadOptionsRouting(routing: ILoadOptions['routing']): ILoadOptions['routing'] {
+		if (!routing?.request) return routing;
+
+		// Strip baseURL so it cannot override requestDefaults.baseURL
+		const { baseURL: _stripped, ...safeRequest } = routing.request as Record<string, unknown>;
+
+		// Reject absolute URLs supplied as plain strings
+		const url = safeRequest.url;
+		if (typeof url === 'string' && !url.startsWith('=')) {
+			if (/^[a-zA-Z][a-zA-Z0-9+\-.]*:\/\//.test(url) || url.startsWith('//')) {
+				throw new BadRequestError(
+					'loadOptions.routing.request.url must be a relative path, not an absolute URL',
+				);
+			}
+		}
+
+		return { ...routing, request: safeRequest as typeof routing.request };
 	}
 
 	async getResourceLocatorResults(

--- a/packages/cli/src/services/dynamic-node-parameters.service.ts
+++ b/packages/cli/src/services/dynamic-node-parameters.service.ts
@@ -228,8 +228,10 @@ export class DynamicNodeParametersService {
 	 * Sanitizes user-supplied loadOptions routing to prevent SSRF attacks.
 	 *
 	 * Strips `baseURL` (must never be user-controllable; `requestDefaults.baseURL` takes precedence)
-	 * and rejects absolute URLs in `request.url` (plain strings only; `=`-prefixed expressions are
-	 * evaluated server-side from trusted node code and are therefore allowed).
+	 * and rejects absolute URLs and expressions in `request.url`. Expressions are rejected because
+	 * this routing comes from an untrusted request body — unlike node-type definitions where
+	 * expressions are part of trusted node code, here they are fully user-controlled and could
+	 * evaluate to arbitrary absolute URLs inside RoutingNode.
 	 */
 	private sanitizeLoadOptionsRouting(routing: ILoadOptions['routing']): ILoadOptions['routing'] {
 		if (!routing?.request) return routing;
@@ -237,10 +239,14 @@ export class DynamicNodeParametersService {
 		// Strip baseURL so it cannot override requestDefaults.baseURL
 		const { baseURL: _stripped, ...safeRequest } = routing.request as Record<string, unknown>;
 
-		// Reject absolute URLs supplied as plain strings
+		// Reject absolute URLs and expressions — both are unsafe in user-supplied routing
 		const url = safeRequest.url;
-		if (typeof url === 'string' && !url.startsWith('=')) {
-			if (/^[a-zA-Z][a-zA-Z0-9+\-.]*:\/\//.test(url) || url.startsWith('//')) {
+		if (typeof url === 'string') {
+			if (
+				url.startsWith('=') ||
+				/^[a-zA-Z][a-zA-Z0-9+\-.]*:\/\//.test(url) ||
+				url.startsWith('//')
+			) {
 				throw new BadRequestError(
 					'loadOptions.routing.request.url must be a relative path, not an absolute URL',
 				);


### PR DESCRIPTION
## Summary

Adds validation to `loadOptions` routing so that user-supplied `routing.request.url` values are restricted to relative paths or expression strings (those beginning with `=`). Absolute URLs — including `http://`, `https://`, `file://`, and protocol-relative `//` forms — are now rejected with a `400 Bad Request`.

Additionally, `baseURL` is stripped from any user-supplied `routing.request` object before it reaches the executor, ensuring it cannot override the node's `requestDefaults.baseURL`.

Validation is applied at two layers:

- **DTO level** (`OptionsRequestDto`): the `loadOptions.routing.request.url` field is validated via a Zod refinement before the request reaches the service.
- **Service level** (`DynamicNodeParametersService.sanitizeLoadOptionsRouting`): a dedicated private method enforces the same URL constraints and strips `baseURL` before the routing object is passed to the workflow executor.

## How to test

### Happy path — relative URL is accepted

1. Start n8n locally.
2. Open any workflow and add a node that loads options via routing (e.g. a custom community node or the built-in HTTP Request node with dynamic parameter routing).
3. Click the parameter dropdown that triggers an options load.
4. Verify that options load successfully (no regression).

### Blocked path — absolute URL is rejected

1. Log in to n8n and open any workflow.
2. Open **DevTools → Network**.
3. Trigger any dropdown that fires a `POST /rest/dynamic-node-parameters/options` request.
4. Right-click the request → **Copy as cURL**.
5. Paste the curl command into a terminal and modify the `loadOptions` body to include an absolute URL:

```json
"loadOptions": {
  "routing": {
    "request": {
      "url": "http://127.0.0.1:5678/rest/settings"
    }
  }
}
```

6. Run the modified curl command.
7. Verify the response is **`400 Bad Request`** with message `routing.request.url must be a relative path, not an absolute URL`.

### Blocked path — `baseURL` override is stripped

Repeat step 5–6 above but instead of (or in addition to) an absolute `url`, include `"baseURL": "http://attacker.example.com"` in `routing.request`. Confirm the request either completes without hitting the attacker URL, or returns a 400 if the `url` field is also invalid.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-548

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)