### PR TITLE
fix(ClickUp Node): Unclear error message when using OAuth credentials

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
@@ -1428,6 +1428,50 @@ describe('Request Helper Functions', () => {
 			expect(result).toEqual({ success: true });
 			expect(mockThis.helpers.httpRequest).toHaveBeenCalledTimes(2);
 		});
+
+		test('should NOT retry on token-expired status when oAuth2Options.skipTokenRefresh is true (isN8nRequest path)', async () => {
+			mockThis.getCredentials.mockResolvedValue(makeCredentialData());
+			const error401 = Object.assign(new Error('401'), { response: { status: 401 } });
+			mockThis.helpers.httpRequest.mockRejectedValueOnce(error401);
+
+			await expect(
+				requestOAuth2.call(
+					mockThis,
+					'testOAuth2',
+					{ method: 'GET', url: `${baseUrl}/data` },
+					mockNode,
+					mockAdditionalData,
+					{ skipTokenRefresh: true },
+					true,
+				),
+			).rejects.toThrow('401');
+			expect(mockThis.helpers.httpRequest).toHaveBeenCalledTimes(1);
+			expect(
+				mockAdditionalData.credentialsHelper.updateCredentialsOauthTokenData,
+			).not.toHaveBeenCalled();
+		});
+
+		test('should NOT retry on token-expired status when oAuth2Options.skipTokenRefresh is true (legacy request path)', async () => {
+			mockThis.getCredentials.mockResolvedValue(makeCredentialData());
+			const error401 = Object.assign(new Error('401'), { statusCode: 401 });
+			mockThis.helpers.request.mockRejectedValueOnce(error401);
+
+			await expect(
+				requestOAuth2.call(
+					mockThis,
+					'testOAuth2',
+					{ method: 'GET', url: `${baseUrl}/data` },
+					mockNode,
+					mockAdditionalData,
+					{ skipTokenRefresh: true },
+					false,
+				),
+			).rejects.toThrow('401');
+			expect(mockThis.helpers.request).toHaveBeenCalledTimes(1);
+			expect(
+				mockAdditionalData.credentialsHelper.updateCredentialsOauthTokenData,
+			).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('requestOAuth2 - client credentials initial token fetch', () => {

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
@@ -889,6 +889,7 @@ export async function requestOAuth2(
 		});
 	}
 	const tokenExpiredStatusCode = resolveTokenExpiredStatusCode(oAuth2Options, credentials);
+	const shouldSkipTokenRefresh = oAuth2Options?.skipTokenRefresh === true;
 
 	const refreshCtx: RefreshOAuth2TokenContext = {
 		credentials,
@@ -916,7 +917,7 @@ export async function requestOAuth2(
 
 	if (isN8nRequest) {
 		return await this.helpers.httpRequest(newRequestOptions).catch(async (error: AxiosError) => {
-			if (error.response?.status === tokenExpiredStatusCode) {
+			if (!shouldSkipTokenRefresh && error.response?.status === tokenExpiredStatusCode) {
 				return await retryWithNewToken(async (opts) => await this.helpers.httpRequest(opts));
 			}
 			throw error;
@@ -928,6 +929,7 @@ export async function requestOAuth2(
 		.then((response) => {
 			const requestOptions = newRequestOptions as any;
 			if (
+				!shouldSkipTokenRefresh &&
 				requestOptions.resolveWithFullResponse === true &&
 				requestOptions.simple === false &&
 				response.statusCode === tokenExpiredStatusCode
@@ -937,7 +939,7 @@ export async function requestOAuth2(
 			return response;
 		})
 		.catch(async (error: IResponseError) => {
-			if (error.statusCode === tokenExpiredStatusCode) {
+			if (!shouldSkipTokenRefresh && error.statusCode === tokenExpiredStatusCode) {
 				return await retryWithNewToken(
 					async (opts) => await this.helpers.request(opts as IRequestOptions),
 				);

--- a/packages/nodes-base/nodes/ClickUp/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ClickUp/GenericFunctions.ts
@@ -41,6 +41,9 @@ export async function clickupApiRequest(
 			const oAuth2Options: IOAuth2Options = {
 				keepBearer: false,
 				tokenType: 'Bearer',
+				// ClickUp's access token don't expire and
+				// ClickUp does not return refresh tokens
+				skipTokenRefresh: true,
 			};
 			return await this.helpers.requestOAuth2.call(
 				this,

--- a/packages/nodes-base/nodes/ClickUp/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ClickUp/GenericFunctions.ts
@@ -41,7 +41,7 @@ export async function clickupApiRequest(
 			const oAuth2Options: IOAuth2Options = {
 				keepBearer: false,
 				tokenType: 'Bearer',
-				// ClickUp's access token don't expire and
+				// ClickUp's access token doesn't expire and
 				// ClickUp does not return refresh tokens
 				skipTokenRefresh: true,
 			};

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -79,6 +79,7 @@ export interface IBinaryData {
 // credentials file.
 export interface IOAuth2Options {
 	includeCredentialsOnRefreshOnBody?: boolean;
+	skipTokenRefresh?: boolean;
 	property?: string;
 	tokenType?: string;
 	keepBearer?: boolean;


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

ClickUp doesn't support token refresh for OAuth access token, so it does not return the refresh token when authorizing and the access token has no expiry ([docs](https://developer.clickup.com/docs/authentication#step-3-request-a-token)). Besides that, if a user tries to access a resource (task, list, etc) by ID and it's not a valid ID, ClickUp's API returns a 401 with `{ "err": "Team(s) not authorized", "ECODE": "OAUTH_023" }`. n8n by default would try to initiate a token refresh, but will throw an error because the refresh token is missing [here](https://github.com/n8n-io/n8n/blob/c6534fa0b389a394e7591d3fc5ec565409279004/packages/%40n8n/client-oauth2/src/client-oauth2-token.ts#L77). This PR fixes it by adding a flag to disable token refresh on 401. This way, the behavior and errors are consistent between using OAuth and Access Token

#### Video of behavior before the fix:
https://github.com/user-attachments/assets/448df6cd-acb3-4e46-9830-58ba2e32a678

#### Video of behavior after the fix:
https://github.com/user-attachments/assets/4f96a9f4-caa6-4f51-9efa-30ee60bd71a8

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-4545/community-issue-clickup-trigger-consistently-returns-errors-and-is
Closes #14277

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
