### PR TITLE
fix(core): Trace sub-workflow executions within their parent workflow trace

### DIFF
--- a/packages/@n8n/decorators/src/execution-lifecycle/lifecycle-metadata.ts
+++ b/packages/@n8n/decorators/src/execution-lifecycle/lifecycle-metadata.ts
@@ -6,6 +6,7 @@ import type {
 	ITaskData,
 	ITaskStartedData,
 	IWorkflowBase,
+	RelatedExecution,
 	Workflow,
 } from 'n8n-workflow';
 
@@ -38,6 +39,12 @@ export type WorkflowExecuteBeforeContext = {
 	workflowInstance: Workflow;
 	executionData?: IRunExecutionData;
 	executionId: string;
+	/**
+	 * The parent execution that triggered this one, if any. Set for
+	 * sub-workflow executions invoked via the Execute Workflow node so
+	 * modules (e.g. tracing) can link the child execution to its parent.
+	 */
+	parentExecution?: RelatedExecution;
 };
 
 export type WorkflowExecuteAfterContext = {

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -2,6 +2,9 @@ import { Logger } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
 import type { Project, User } from '@n8n/db';
 import { ExecutionRepository, UserRepository } from '@n8n/db';
+import type { WorkflowExecuteBeforeContext } from '@n8n/decorators';
+import { LifecycleMetadata } from '@n8n/decorators';
+import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import {
 	BinaryDataService,
@@ -1225,6 +1228,56 @@ describe('Execution Lifecycle Hooks', () => {
 					undefined,
 					parentExecution,
 				);
+			});
+
+			it('should expose parentExecution on the hooks instance', () => {
+				expect(lifecycleHooks.parentExecution).toEqual(parentExecution);
+			});
+
+			it('should invoke module-registered workflowExecuteBefore handlers with parentExecution in the context', async () => {
+				const handlerSpy = jest.fn();
+
+				class TestLifecycleHandler {
+					onWorkflowStart(ctx: WorkflowExecuteBeforeContext) {
+						handlerSpy(ctx);
+					}
+				}
+
+				const scopedMetadata = new LifecycleMetadata();
+				scopedMetadata.register({
+					handlerClass: TestLifecycleHandler as unknown as Parameters<
+						LifecycleMetadata['register']
+					>[0]['handlerClass'],
+					methodName: 'onWorkflowStart',
+					eventName: 'workflowExecuteBefore',
+				});
+
+				const previousMetadata = Container.get(LifecycleMetadata);
+				Container.set(LifecycleMetadata, scopedMetadata);
+				Container.set(TestLifecycleHandler, new TestLifecycleHandler());
+
+				try {
+					const hooks = getLifecycleHooksForSubExecutions(
+						'integrated',
+						executionId,
+						workflowData,
+						undefined,
+						parentExecution,
+					);
+
+					await hooks.runHook('workflowExecuteBefore', [workflow, runExecutionData]);
+
+					expect(handlerSpy).toHaveBeenCalledTimes(1);
+					expect(handlerSpy).toHaveBeenCalledWith(
+						expect.objectContaining({
+							type: 'workflowExecuteBefore',
+							executionId,
+							parentExecution,
+						}),
+					);
+				} finally {
+					Container.set(LifecycleMetadata, previousMetadata);
+				}
 			});
 
 			it('should duplicate binary data to parent execution', async () => {

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -106,6 +106,7 @@ class ModulesHooksRegistry {
 							workflowInstance,
 							executionData,
 							executionId: this.executionId,
+							parentExecution: this.parentExecution,
 						};
 						// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 						return await instance[methodName].call(instance, context);
@@ -684,7 +685,13 @@ export function getLifecycleHooksForSubExecutions(
 	projectId?: string,
 	projectName?: string,
 ): ExecutionLifecycleHooks {
-	const hooks = new ExecutionLifecycleHooks(mode, executionId, workflowData);
+	const hooks = new ExecutionLifecycleHooks(
+		mode,
+		executionId,
+		workflowData,
+		undefined,
+		parentExecution,
+	);
 	const saveSettings = toSaveSettings(workflowData.settings);
 	hookFunctionsWorkflowEvents(hooks, userId, projectId, projectName);
 	hookFunctionsNodeEvents(hooks);
@@ -693,6 +700,7 @@ export function getLifecycleHooksForSubExecutions(
 	hookFunctionsSaveProgress(hooks, { saveSettings });
 	hookFunctionsStatistics(hooks);
 	hookFunctionsExternalHooks(hooks);
+	Container.get(ModulesHooksRegistry).addHooks(hooks);
 	return hooks;
 }
 

--- a/packages/cli/src/modules/otel/__tests__/workflow-start.handler.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/workflow-start.handler.test.ts
@@ -1,0 +1,148 @@
+import type { WorkflowExecuteBeforeContext } from '@n8n/decorators';
+import { trace } from '@opentelemetry/api';
+import { mock } from 'jest-mock-extended';
+import type { IWorkflowBase, Workflow } from 'n8n-workflow';
+
+import { ATTR } from '../otel.constants';
+import { SpanRegistry } from '../span-registry';
+import { WorkflowStartHandler } from '../handlers/workflow-start.handler';
+import { OtelTestProvider } from './support/otel-test-provider';
+
+const TRACER_NAME = 'n8n-workflow';
+
+let otel: OtelTestProvider;
+let handler: WorkflowStartHandler;
+let spans: SpanRegistry;
+
+beforeAll(() => {
+	otel = OtelTestProvider.create();
+});
+
+beforeEach(() => {
+	otel.reset();
+	handler = new WorkflowStartHandler();
+	spans = new SpanRegistry();
+});
+
+afterAll(async () => {
+	await otel.shutdown();
+});
+
+const workflow: IWorkflowBase = {
+	id: 'wf-1',
+	name: 'Test Workflow',
+	active: false,
+	isArchived: false,
+	createdAt: new Date(),
+	updatedAt: new Date(),
+	activeVersionId: null,
+	versionId: 'v-1',
+	connections: {},
+	nodes: [
+		{
+			id: 'node-abc',
+			name: 'Trigger',
+			type: 'n8n-nodes-base.manualTrigger',
+			typeVersion: 1,
+			position: [0, 0],
+			parameters: {},
+		},
+	],
+};
+
+function makeCtx(
+	overrides: Partial<WorkflowExecuteBeforeContext> = {},
+): WorkflowExecuteBeforeContext {
+	return {
+		type: 'workflowExecuteBefore',
+		workflow,
+		workflowInstance: mock<Workflow>(),
+		executionId: 'exec-1',
+		...overrides,
+	};
+}
+
+describe('WorkflowStartHandler', () => {
+	it('should create a workflow.execute span with correct attributes', () => {
+		const tracer = trace.getTracer(TRACER_NAME);
+
+		handler.handle(makeCtx(), spans, tracer);
+
+		const workflowSpan = spans.getWorkflow('exec-1');
+		expect(workflowSpan).toBeDefined();
+		workflowSpan!.end();
+
+		const finished = otel.getFinishedSpans();
+		expect(finished).toHaveLength(1);
+		expect(finished[0].name).toBe('workflow.execute');
+		expect(finished[0].attributes).toMatchObject({
+			[ATTR.WORKFLOW_ID]: 'wf-1',
+			[ATTR.WORKFLOW_NAME]: 'Test Workflow',
+			[ATTR.WORKFLOW_NODE_COUNT]: 1,
+			[ATTR.WORKFLOW_VERSION_ID]: 'v-1',
+			[ATTR.EXECUTION_ID]: 'exec-1',
+		});
+	});
+
+	it('should create a root span when no parentExecution is provided', () => {
+		const tracer = trace.getTracer(TRACER_NAME);
+
+		handler.handle(makeCtx(), spans, tracer);
+
+		const span = spans.getWorkflow('exec-1');
+		span!.end();
+
+		const finished = otel.getFinishedSpans();
+		expect(finished).toHaveLength(1);
+		expect(finished[0].parentSpanContext?.spanId).toBeUndefined();
+	});
+
+	it('should link a sub-workflow span to the parent workflow span when parentExecution is provided', () => {
+		const tracer = trace.getTracer(TRACER_NAME);
+
+		// Simulate the parent workflow execution already being in progress
+		handler.handle(makeCtx({ executionId: 'parent-exec' }), spans, tracer);
+		const parentSpan = spans.getWorkflow('parent-exec')!;
+
+		// Now the child sub-workflow starts, referencing the parent execution
+		handler.handle(
+			makeCtx({
+				executionId: 'child-exec',
+				parentExecution: { executionId: 'parent-exec', workflowId: 'wf-parent' },
+			}),
+			spans,
+			tracer,
+		);
+		const childSpan = spans.getWorkflow('child-exec')!;
+
+		childSpan.end();
+		parentSpan.end();
+
+		const finished = otel.getFinishedSpans();
+		const childFinished = finished.find((s) => s.attributes[ATTR.EXECUTION_ID] === 'child-exec')!;
+		const parentFinished = finished.find((s) => s.attributes[ATTR.EXECUTION_ID] === 'parent-exec')!;
+
+		expect(childFinished.spanContext().traceId).toBe(parentFinished.spanContext().traceId);
+		expect(childFinished.parentSpanContext?.spanId).toBe(parentFinished.spanContext().spanId);
+	});
+
+	it('should fall back to a root span if parentExecution is present but the parent span is unknown', () => {
+		const tracer = trace.getTracer(TRACER_NAME);
+
+		handler.handle(
+			makeCtx({
+				executionId: 'child-exec',
+				parentExecution: { executionId: 'missing-parent', workflowId: 'wf-parent' },
+			}),
+			spans,
+			tracer,
+		);
+
+		const childSpan = spans.getWorkflow('child-exec')!;
+		childSpan.end();
+
+		const finished = otel.getFinishedSpans();
+		expect(finished).toHaveLength(1);
+		expect(finished[0].parentSpanContext?.spanId).toBeUndefined();
+	});
+});

--- a/packages/cli/src/modules/otel/handlers/workflow-start.handler.ts
+++ b/packages/cli/src/modules/otel/handlers/workflow-start.handler.ts
@@ -1,5 +1,6 @@
 import type { WorkflowExecuteBeforeContext } from '@n8n/decorators';
 import { Service } from '@n8n/di';
+import { context, trace } from '@opentelemetry/api';
 import type { Tracer } from '@opentelemetry/api';
 
 import { ATTR } from '../otel.constants';
@@ -9,15 +10,27 @@ import type { SpanRegistry } from '../span-registry';
 @Service()
 export class WorkflowStartHandler implements SpanHandler<WorkflowExecuteBeforeContext> {
 	handle(ctx: WorkflowExecuteBeforeContext, spans: SpanRegistry, tracer: Tracer) {
-		const span = tracer.startSpan('workflow.execute', {
-			attributes: {
-				[ATTR.WORKFLOW_ID]: ctx.workflow.id,
-				[ATTR.WORKFLOW_VERSION_ID]: ctx.workflow.versionId,
-				[ATTR.WORKFLOW_NAME]: ctx.workflow.name,
-				[ATTR.WORKFLOW_NODE_COUNT]: ctx.workflow.nodes.length,
-				[ATTR.EXECUTION_ID]: ctx.executionId,
+		// For sub-workflow executions invoked via the Execute Workflow node,
+		// anchor the child workflow span to the parent workflow span so both
+		// executions share a single trace with a correct parent/child chain.
+		const parentSpan = ctx.parentExecution
+			? spans.getWorkflow(ctx.parentExecution.executionId)
+			: undefined;
+		const parentCtx = parentSpan ? trace.setSpan(context.active(), parentSpan) : context.active();
+
+		const span = tracer.startSpan(
+			'workflow.execute',
+			{
+				attributes: {
+					[ATTR.WORKFLOW_ID]: ctx.workflow.id,
+					[ATTR.WORKFLOW_VERSION_ID]: ctx.workflow.versionId,
+					[ATTR.WORKFLOW_NAME]: ctx.workflow.name,
+					[ATTR.WORKFLOW_NODE_COUNT]: ctx.workflow.nodes.length,
+					[ATTR.EXECUTION_ID]: ctx.executionId,
+				},
 			},
-		});
+			parentCtx,
+		);
 
 		spans.addWorkflow(ctx.executionId, span);
 	}

--- a/packages/core/src/execution-engine/execution-lifecycle-hooks.ts
+++ b/packages/core/src/execution-engine/execution-lifecycle-hooks.ts
@@ -7,6 +7,7 @@ import type {
 	ITaskData,
 	ITaskStartedData,
 	IWorkflowBase,
+	RelatedExecution,
 	StructuredChunk,
 	Workflow,
 	WorkflowExecuteMode,
@@ -105,6 +106,7 @@ export class ExecutionLifecycleHooks {
 		readonly executionId: string,
 		readonly workflowData: IWorkflowBase,
 		readonly retryOf?: string,
+		readonly parentExecution?: RelatedExecution,
 	) {}
 
 	addHandler<Hook extends keyof ExecutionLifecycleHookHandlers>(


### PR DESCRIPTION
Context: follow-up bugfix that completes the OTel tracing coverage introduced in #27528 and #27789 — without this, sub-workflow executions were invisible in the trace tree.

## Summary

Sub-workflow executions (workflows invoked via the **Execute Workflow** node) were not being traced by the OpenTelemetry module. The parent workflow's trace showed only the parent's spans, and the sub-workflow's `workflow.execute` / `node.execute` spans never appeared. This affected any backend module that relies on `@OnLifecycleEvent` to observe the lifecycle of a sub-execution; OpenTelemetry was the most visible symptom.

**Root cause.** `getLifecycleHooksForSubExecutions` was the only lifecycle-hooks factory that did not call `Container.get(ModulesHooksRegistry).addHooks(hooks)`. The other three factories (`Main`, `ScalingMain`, `ScalingWorker`) all register module hooks, so sub-executions silently bypassed every module-registered `@OnLifecycleEvent` handler.

**Secondary gap.** `WorkflowExecuteBeforeContext` did not carry `parentExecution`, so even with module hooks registered, the OTEL handler had no way to link the sub-workflow's `workflow.execute` span to its parent's trace.

### Changes

Commit 1 — `fix(core): Register module lifecycle hooks for sub-workflow executions`
- Add `Container.get(ModulesHooksRegistry).addHooks(hooks)` to `getLifecycleHooksForSubExecutions`, matching the other three factories.
- Plumb `parentExecution` through `ExecutionLifecycleHooks` (new optional constructor parameter) and through `WorkflowExecuteBeforeContext` so modules can observe the parent of a sub-execution.
- Unit test: a module-registered `workflowExecuteBefore` handler now fires for sub-executions and sees `parentExecution` in the context.

Commit 2 — `fix(core): Link sub-workflow traces to parent workflow execution span`
- `WorkflowStartHandler` uses `ctx.parentExecution` (when present) to look up the parent's `workflow.execute` span in `SpanRegistry` and start the child `workflow.execute` span with the parent as its OTEL context. Falls back to a root span when no parent is supplied or the parent span is not in the registry.
- Unit tests for `WorkflowStartHandler` covering attributes, root-span fallback, child-of-parent linking, and missing-parent fallback.

### Resulting trace

Before: two disconnected root traces — one for the parent, one for the sub-workflow.

After: one trace with the sub-workflow's `workflow.execute` span nested under the parent's `workflow.execute` span, sharing a single `traceId`:

```
workflow.execute  (Parent)
├── node.execute  Trigger
├── node.execute  Set
├── node.execute  Execute Workflow
└── workflow.execute  (Child)
    ├── node.execute  Set
    └── node.execute  Code
```

### Known limitation

In scaling mode where parent and child executions run on different worker processes, the parent's `workflow.execute` span isn't present in the child process's `SpanRegistry`. In that case the child is still emitted as a root span — no worse than today, but a follow-up could propagate OTEL trace context through the execution queue if cross-process linking is desired. Happy to file a separate issue for that if reviewers agree.

## How to test

1. Set `N8N_OTEL_ENABLED=true` and `N8N_OTEL_EXPORTER_OTLP_ENDPOINT=http://<collector>:4318` on an n8n instance.
2. Create two workflows: a "Child" with any pair of nodes, and a "Parent" that ends with an Execute Workflow node calling Child.
3. Execute Parent and inspect the trace in your OTLP backend. The Child's `workflow.execute` span should share the Parent's `traceId` and its `parentSpanId` should match the Parent's `workflow.execute` span id.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #28592

https://linear.app/n8n/issue/GHC-7752

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
