### PR TITLE
fix(nodes-langchain): emit ai-tool-called log streaming event for ToolWorkflow, ToolCode, and ToolHttpRequest

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
@@ -26,7 +26,7 @@ import {
 	schemaTypeField,
 } from '@utils/descriptions';
 import { convertJsonSchemaToZod, generateSchemaFromExample } from '@utils/schemaParsing';
-import { getConnectionHintNoticeField } from '@n8n/ai-utilities';
+import { getConnectionHintNoticeField, logAiEvent } from '@n8n/ai-utilities';
 
 import type { DynamicZodObject } from '../../../types/zod.types';
 
@@ -119,6 +119,7 @@ function getTool(
 			void ctx.addOutputData(NodeConnectionTypes.AiTool, index, executionError);
 		} else if (log) {
 			void ctx.addOutputData(NodeConnectionTypes.AiTool, index, [[{ json: { response } }]]);
+			logAiEvent(ctx, 'ai-tool-called', { query, response });
 		}
 
 		return response;

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
@@ -17,6 +17,8 @@ import type {
 import { NodeConnectionTypes, NodeOperationError, jsonParse } from 'n8n-workflow';
 import { z } from 'zod';
 
+import { logAiEvent } from '@n8n/ai-utilities';
+
 import type {
 	ParameterInputType,
 	ParametersValues,
@@ -784,6 +786,7 @@ export const configureToolFunction = (
 			void ctx.addOutputData(NodeConnectionTypes.AiTool, index, executionError as ExecutionError);
 		} else {
 			void ctx.addOutputData(NodeConnectionTypes.AiTool, index, [[{ json: { response } }]]);
+			logAiEvent(ctx, 'ai-tool-called', { query, response });
 		}
 
 		return response;

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
@@ -8,6 +8,8 @@ import type {
 	INode,
 } from 'n8n-workflow';
 
+import { logAiEvent } from '@n8n/ai-utilities';
+
 import { WorkflowToolService } from './utils/WorkflowToolService';
 
 // Mock the sleep functions
@@ -15,6 +17,11 @@ jest.mock('n8n-workflow', () => ({
 	...jest.requireActual('n8n-workflow'),
 	sleep: jest.fn().mockResolvedValue(undefined),
 	sleepWithAbort: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@n8n/ai-utilities', () => ({
+	...jest.requireActual('@n8n/ai-utilities'),
+	logAiEvent: jest.fn(),
 }));
 
 function createMockClonedContext(
@@ -969,6 +976,73 @@ describe('WorkflowTool::WorkflowToolService', () => {
 
 			expect(result).toBe(JSON.stringify({ result: 'success' }, null, 2));
 			expect(sleepWithAbort).toHaveBeenCalledWith(100, undefined);
+		});
+	});
+
+	describe('logAiEvent emission', () => {
+		const mockLogAiEvent = logAiEvent as jest.MockedFunction<typeof logAiEvent>;
+
+		beforeEach(() => {
+			mockLogAiEvent.mockClear();
+		});
+
+		it('should emit ai-tool-called event on successful execution with manualLogging enabled', async () => {
+			const TEST_RESPONSE = { msg: 'test response' };
+			const mockExecuteWorkflowResponse: ExecuteWorkflowData = {
+				data: [[{ json: TEST_RESPONSE }]],
+				executionId: 'test-execution',
+			};
+
+			jest.spyOn(context, 'executeWorkflow').mockResolvedValueOnce(mockExecuteWorkflowResponse);
+			jest.spyOn(context, 'addInputData').mockReturnValue({ index: 0 });
+			jest.spyOn(context, 'getNodeParameter').mockReturnValue('database');
+			jest.spyOn(context, 'getWorkflowDataProxy').mockReturnValue({
+				$execution: { id: 'exec-id' },
+				$workflow: { id: 'workflow-id' },
+			} as unknown as IWorkflowDataProxyData);
+			jest.spyOn(context, 'cloneWith').mockReturnValue(context);
+
+			const tool = await service.createTool({
+				ctx: context,
+				name: 'TestTool',
+				description: 'Test Description',
+				itemIndex: 0,
+			});
+
+			await tool.func('test query');
+
+			expect(mockLogAiEvent).toHaveBeenCalledWith(
+				expect.anything(),
+				'ai-tool-called',
+				expect.objectContaining({ query: 'test query' }),
+			);
+		});
+
+		it('should not emit ai-tool-called event when manualLogging is disabled', async () => {
+			const TEST_RESPONSE = { msg: 'test response' };
+			const mockExecuteWorkflowResponse: ExecuteWorkflowData = {
+				data: [[{ json: TEST_RESPONSE }]],
+				executionId: 'test-execution',
+			};
+
+			jest.spyOn(context, 'executeWorkflow').mockResolvedValueOnce(mockExecuteWorkflowResponse);
+			jest.spyOn(context, 'getNodeParameter').mockReturnValue('database');
+			jest.spyOn(context, 'getWorkflowDataProxy').mockReturnValue({
+				$execution: { id: 'exec-id' },
+				$workflow: { id: 'workflow-id' },
+			} as unknown as IWorkflowDataProxyData);
+
+			const tool = await service.createTool({
+				ctx: context,
+				name: 'TestTool',
+				description: 'Test Description',
+				itemIndex: 0,
+				manualLogging: false,
+			});
+
+			await tool.func('test query');
+
+			expect(mockLogAiEvent).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/utils/WorkflowToolService.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/utils/WorkflowToolService.ts
@@ -27,7 +27,7 @@ import {
 	sleepWithAbort,
 } from 'n8n-workflow';
 
-import { createZodSchemaFromArgs, extractFromAIParameters } from '@n8n/ai-utilities';
+import { createZodSchemaFromArgs, extractFromAIParameters, logAiEvent } from '@n8n/ai-utilities';
 
 function isNodeExecutionData(data: unknown): data is INodeExecutionData[] {
 	return isArray(data) && Boolean(data.length) && isObject(data[0]) && 'json' in data[0];
@@ -168,6 +168,7 @@ export class WorkflowToolService {
 							metadata,
 						);
 
+						logAiEvent(context, 'ai-tool-called', { query, response: processedResponse });
 						return processedResponse;
 					}
 					// If manualLogging is false we've been called by the engine and need


### PR DESCRIPTION
Fixes #28532

## Problem

When an AI agent uses the Call n8n Sub-Workflow Tool (`toolWorkflow`), HTTP Request Tool (`toolHttpRequest`), or Code Tool (`toolCode`) as tools, the `n8n.ai.tool.called` log streaming event is never emitted. External observability systems subscribed to this event receive no signal that these tools were invoked.

**Root cause:** These three tool types use a manual logging execution pattern where they call `addInputData`/`addOutputData` directly. This bypasses the `logWrapper` proxy from `@n8n/ai-utilities`, which normally intercepts the LangChain `_call` method and emits `ai-tool-called` via `logAiEvent`. Because these tools never go through `logWrapper`, `logAiEvent` is never called.

## Solution

Call `logAiEvent(ctx, 'ai-tool-called', { query, response })` in the success branch of each tool's handler, consistent with the pattern used by `logWrapper` for LangChain-native tools:

- **`WorkflowToolService.ts`** (ToolWorkflow v2): added after `addOutputData` in the `manualLogging` success branch
- **`ToolCode.node.ts`**: added after `addOutputData` in the `else if (log)` success branch
- **`ToolHttpRequest/utils.ts`** (`configureToolFunction`): added after `addOutputData` in the `else` success branch

## Testing

Added unit tests in `ToolWorkflowV2.test.ts` verifying:
- `logAiEvent` is called with `'ai-tool-called'` and the correct query/response data when `manualLogging=true`
- `logAiEvent` is NOT called when `manualLogging=false` (engine-called path)