### PR TITLE
fix(core): Preserve submitted workflow outcome when builder errors after submit (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-workflow-agent.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-workflow-agent.tool.test.ts
@@ -16,13 +16,14 @@ const MAIN_PATH = '/home/daytona/workspace/src/workflow.ts';
 
 describe('resultFromPostStreamError', () => {
 	it('preserves the submitted workflow when the stream errors after a successful submit', () => {
-		const submitAttempts = new Map<string, SubmitWorkflowAttempt>();
-		submitAttempts.set(MAIN_PATH, {
-			filePath: MAIN_PATH,
-			sourceHash: 'abc',
-			success: true,
-			workflowId: 'WF_123',
-		});
+		const submitAttempts: SubmitWorkflowAttempt[] = [
+			{
+				filePath: MAIN_PATH,
+				sourceHash: 'abc',
+				success: true,
+				workflowId: 'WF_123',
+			},
+		];
 
 		const result = resultFromPostStreamError({
 			error: new Error('Unauthorized'),
@@ -43,11 +44,9 @@ describe('resultFromPostStreamError', () => {
 	});
 
 	it('returns undefined when no submit happened before the error', () => {
-		const submitAttempts = new Map<string, SubmitWorkflowAttempt>();
-
 		const result = resultFromPostStreamError({
 			error: new Error('Unauthorized'),
-			submitAttempts,
+			submitAttempts: [],
 			mainWorkflowPath: MAIN_PATH,
 			workItemId: 'wi_test',
 			taskId: 'task_test',
@@ -56,14 +55,15 @@ describe('resultFromPostStreamError', () => {
 		expect(result).toBeUndefined();
 	});
 
-	it('returns undefined when the submit attempt failed', () => {
-		const submitAttempts = new Map<string, SubmitWorkflowAttempt>();
-		submitAttempts.set(MAIN_PATH, {
-			filePath: MAIN_PATH,
-			sourceHash: 'abc',
-			success: false,
-			errors: ['validation failed'],
-		});
+	it('returns undefined when the only submit attempt failed', () => {
+		const submitAttempts: SubmitWorkflowAttempt[] = [
+			{
+				filePath: MAIN_PATH,
+				sourceHash: 'abc',
+				success: false,
+				errors: ['validation failed'],
+			},
+		];
 
 		const result = resultFromPostStreamError({
 			error: new Error('Unauthorized'),
@@ -77,13 +77,14 @@ describe('resultFromPostStreamError', () => {
 	});
 
 	it('returns undefined when only sub-workflows were submitted (not the main path)', () => {
-		const submitAttempts = new Map<string, SubmitWorkflowAttempt>();
-		submitAttempts.set('/home/daytona/workspace/src/subworkflow.ts', {
-			filePath: '/home/daytona/workspace/src/subworkflow.ts',
-			sourceHash: 'abc',
-			success: true,
-			workflowId: 'SUB_123',
-		});
+		const submitAttempts: SubmitWorkflowAttempt[] = [
+			{
+				filePath: '/home/daytona/workspace/src/subworkflow.ts',
+				sourceHash: 'abc',
+				success: true,
+				workflowId: 'SUB_123',
+			},
+		];
 
 		const result = resultFromPostStreamError({
 			error: new Error('Unauthorized'),
@@ -94,5 +95,36 @@ describe('resultFromPostStreamError', () => {
 		});
 
 		expect(result).toBeUndefined();
+	});
+
+	it('preserves an earlier successful main-path submit when a later submit failed', () => {
+		const submitAttempts: SubmitWorkflowAttempt[] = [
+			{
+				filePath: MAIN_PATH,
+				sourceHash: 'a',
+				success: true,
+				workflowId: 'WF_123',
+			},
+			{
+				filePath: MAIN_PATH,
+				sourceHash: 'b',
+				success: false,
+				errors: ['validation failed'],
+			},
+		];
+
+		const result = resultFromPostStreamError({
+			error: new Error('Unauthorized'),
+			submitAttempts,
+			mainWorkflowPath: MAIN_PATH,
+			workItemId: 'wi_test',
+			taskId: 'task_test',
+		});
+
+		expect(result).toBeDefined();
+		expect(result!.outcome).toMatchObject({
+			workflowId: 'WF_123',
+			submitted: true,
+		});
 	});
 });

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-workflow-agent.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-workflow-agent.tool.test.ts
@@ -1,0 +1,98 @@
+// Mock heavy Mastra dependencies to avoid ESM issues in Jest
+jest.mock('@mastra/core/agent', () => ({
+	Agent: jest.fn(),
+}));
+jest.mock('@mastra/core/mastra', () => ({
+	Mastra: jest.fn(),
+}));
+
+import type { SubmitWorkflowAttempt } from '../../workflows/submit-workflow.tool';
+
+const { resultFromPostStreamError } =
+	// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
+	require('../build-workflow-agent.tool') as typeof import('../build-workflow-agent.tool');
+
+const MAIN_PATH = '/home/daytona/workspace/src/workflow.ts';
+
+describe('resultFromPostStreamError', () => {
+	it('preserves the submitted workflow when the stream errors after a successful submit', () => {
+		const submitAttempts = new Map<string, SubmitWorkflowAttempt>();
+		submitAttempts.set(MAIN_PATH, {
+			filePath: MAIN_PATH,
+			sourceHash: 'abc',
+			success: true,
+			workflowId: 'WF_123',
+		});
+
+		const result = resultFromPostStreamError({
+			error: new Error('Unauthorized'),
+			submitAttempts,
+			mainWorkflowPath: MAIN_PATH,
+			workItemId: 'wi_test',
+			taskId: 'task_test',
+		});
+
+		expect(result).toBeDefined();
+		expect(result!.outcome).toMatchObject({
+			workItemId: 'wi_test',
+			taskId: 'task_test',
+			workflowId: 'WF_123',
+			submitted: true,
+		});
+		expect(result!.text).toContain('Unauthorized');
+	});
+
+	it('returns undefined when no submit happened before the error', () => {
+		const submitAttempts = new Map<string, SubmitWorkflowAttempt>();
+
+		const result = resultFromPostStreamError({
+			error: new Error('Unauthorized'),
+			submitAttempts,
+			mainWorkflowPath: MAIN_PATH,
+			workItemId: 'wi_test',
+			taskId: 'task_test',
+		});
+
+		expect(result).toBeUndefined();
+	});
+
+	it('returns undefined when the submit attempt failed', () => {
+		const submitAttempts = new Map<string, SubmitWorkflowAttempt>();
+		submitAttempts.set(MAIN_PATH, {
+			filePath: MAIN_PATH,
+			sourceHash: 'abc',
+			success: false,
+			errors: ['validation failed'],
+		});
+
+		const result = resultFromPostStreamError({
+			error: new Error('Unauthorized'),
+			submitAttempts,
+			mainWorkflowPath: MAIN_PATH,
+			workItemId: 'wi_test',
+			taskId: 'task_test',
+		});
+
+		expect(result).toBeUndefined();
+	});
+
+	it('returns undefined when only sub-workflows were submitted (not the main path)', () => {
+		const submitAttempts = new Map<string, SubmitWorkflowAttempt>();
+		submitAttempts.set('/home/daytona/workspace/src/subworkflow.ts', {
+			filePath: '/home/daytona/workspace/src/subworkflow.ts',
+			sourceHash: 'abc',
+			success: true,
+			workflowId: 'SUB_123',
+		});
+
+		const result = resultFromPostStreamError({
+			error: new Error('Unauthorized'),
+			submitAttempts,
+			mainWorkflowPath: MAIN_PATH,
+			workItemId: 'wi_test',
+			taskId: 'task_test',
+		});
+
+		expect(result).toBeUndefined();
+	});
+});

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
@@ -150,19 +150,27 @@ function hashContent(content: string | null): string {
 
 /**
  * When the builder's stream errors mid-run, recover a successful-submit outcome
- * from `submitAttempts` so the orchestrator doesn't redo a build that already
- * produced a workflow. Returns undefined when nothing was successfully submitted
- * yet — the caller should rethrow in that case.
+ * from the submit-attempt history so the orchestrator doesn't redo a build that
+ * already produced a workflow. Scans in reverse so a later failed submit for
+ * the main path cannot mask an earlier success. Returns undefined when nothing
+ * was successfully submitted yet — the caller should rethrow in that case.
  */
 export function resultFromPostStreamError(input: {
 	error: unknown;
-	submitAttempts: Map<string, SubmitWorkflowAttempt>;
+	submitAttempts: SubmitWorkflowAttempt[];
 	mainWorkflowPath: string;
 	workItemId: string;
 	taskId: string;
 }): BackgroundTaskResult | undefined {
-	const attempt = input.submitAttempts.get(input.mainWorkflowPath);
-	if (!attempt?.success) return undefined;
+	let attempt: SubmitWorkflowAttempt | undefined;
+	for (let i = input.submitAttempts.length - 1; i >= 0; i--) {
+		const a = input.submitAttempts[i];
+		if (a.filePath === input.mainWorkflowPath && a.success) {
+			attempt = a;
+			break;
+		}
+	}
+	if (!attempt) return undefined;
 
 	const errorText = input.error instanceof Error ? input.error.message : String(input.error);
 	const text = `Workflow ${attempt.workflowId} submitted successfully. A later step failed: ${errorText}`;
@@ -325,6 +333,9 @@ export async function startBuildWorkflowAgentTask(
 			await withTraceContextActor(traceContext, async () => {
 				let builderWs: BuilderWorkspace | undefined;
 				const submitAttempts = new Map<string, SubmitWorkflowAttempt>();
+				// Append-only history so a later failed submit for the main path
+				// cannot mask an earlier successful submit during post-error recovery.
+				const submitAttemptHistory: SubmitWorkflowAttempt[] = [];
 				try {
 					if (useSandbox) {
 						builderWs = await factory.create(subAgentId, domainContext);
@@ -358,6 +369,7 @@ export async function startBuildWorkflowAgentTask(
 							credMap,
 							async (attempt) => {
 								submitAttempts.set(attempt.filePath, attempt);
+								submitAttemptHistory.push(attempt);
 								if (attempt.filePath !== mainWorkflowPath || !context.workflowTaskService) {
 									return;
 								}
@@ -444,7 +456,7 @@ export async function startBuildWorkflowAgentTask(
 						} catch (error) {
 							const recovered = resultFromPostStreamError({
 								error,
-								submitAttempts,
+								submitAttempts: submitAttemptHistory,
 								mainWorkflowPath,
 								workItemId,
 								taskId,

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
@@ -148,6 +148,30 @@ function hashContent(content: string | null): string {
 		.digest('hex');
 }
 
+/**
+ * When the builder's stream errors mid-run, recover a successful-submit outcome
+ * from `submitAttempts` so the orchestrator doesn't redo a build that already
+ * produced a workflow. Returns undefined when nothing was successfully submitted
+ * yet — the caller should rethrow in that case.
+ */
+export function resultFromPostStreamError(input: {
+	error: unknown;
+	submitAttempts: Map<string, SubmitWorkflowAttempt>;
+	mainWorkflowPath: string;
+	workItemId: string;
+	taskId: string;
+}): BackgroundTaskResult | undefined {
+	const attempt = input.submitAttempts.get(input.mainWorkflowPath);
+	if (!attempt?.success) return undefined;
+
+	const errorText = input.error instanceof Error ? input.error.message : String(input.error);
+	const text = `Workflow ${attempt.workflowId} submitted successfully. A later step failed: ${errorText}`;
+	return {
+		text,
+		outcome: buildOutcome(input.workItemId, input.taskId, attempt, text),
+	};
+}
+
 export interface StartBuildWorkflowAgentInput {
 	task: string;
 	workflowId?: string;
@@ -383,38 +407,51 @@ export async function startBuildWorkflowAgentTask(
 						registerWithMastra(subAgentId, subAgent, context.storage);
 
 						const traceParent = getTraceParentRun();
-						const hitlResult = await withTraceParentContext(traceParent, async () => {
-							const llmStepTraceHooks = createLlmStepTraceHooks(traceParent);
-							const stream = await subAgent.stream(briefing, {
-								maxSteps: MAX_STEPS.BUILDER,
-								abortSignal: signal,
-								providerOptions: {
-									anthropic: { cacheControl: { type: 'ephemeral' } },
-								},
-								...(llmStepTraceHooks?.executionOptions ?? {}),
+						let finalText: string;
+						try {
+							const hitlResult = await withTraceParentContext(traceParent, async () => {
+								const llmStepTraceHooks = createLlmStepTraceHooks(traceParent);
+								const stream = await subAgent.stream(briefing, {
+									maxSteps: MAX_STEPS.BUILDER,
+									abortSignal: signal,
+									providerOptions: {
+										anthropic: { cacheControl: { type: 'ephemeral' } },
+									},
+									...(llmStepTraceHooks?.executionOptions ?? {}),
+								});
+
+								return await consumeStreamWithHitl({
+									agent: subAgent,
+									stream: stream as {
+										runId?: string;
+										fullStream: AsyncIterable<unknown>;
+										text: Promise<string>;
+									},
+									runId: context.runId,
+									agentId: subAgentId,
+									eventBus: context.eventBus,
+									logger: context.logger,
+									threadId: context.threadId,
+									abortSignal: signal,
+									waitForConfirmation: context.waitForConfirmation,
+									drainCorrections,
+									waitForCorrection,
+									llmStepTraceHooks,
+								});
 							});
 
-							return await consumeStreamWithHitl({
-								agent: subAgent,
-								stream: stream as {
-									runId?: string;
-									fullStream: AsyncIterable<unknown>;
-									text: Promise<string>;
-								},
-								runId: context.runId,
-								agentId: subAgentId,
-								eventBus: context.eventBus,
-								logger: context.logger,
-								threadId: context.threadId,
-								abortSignal: signal,
-								waitForConfirmation: context.waitForConfirmation,
-								drainCorrections,
-								waitForCorrection,
-								llmStepTraceHooks,
+							finalText = await hitlResult.text;
+						} catch (error) {
+							const recovered = resultFromPostStreamError({
+								error,
+								submitAttempts,
+								mainWorkflowPath,
+								workItemId,
+								taskId,
 							});
-						});
-
-						const finalText = await hitlResult.text;
+							if (recovered) return recovered;
+							throw error;
+						}
 
 						const mainWorkflowAttempt = submitAttempts.get(mainWorkflowPath);
 						const currentMainWorkflow = await readFileViaSandbox(workspace, mainWorkflowPath);


### PR DESCRIPTION
## Summary

When the workflow builder sub-agent hit an error after a successful `submit-workflow` (e.g. a transient 401 on the next LLM call, which can happen when the proxy JWT expires during a long HITL-suspended credential setup), the error propagated out of the background task's `run` function and the task result discarded the successful submit. The orchestrator saw only the error, treated the whole build as failed, and retried `build-workflow-with-agent` — producing a duplicate workflow on the instance under the same name.

This PR wraps the builder's stream consumption in a try/catch. On error, if a successful submit for the main workflow was already recorded in `submitAttempts`, the task returns a `BackgroundTaskResult` with the preserved outcome (`workflowId`, `submitted: true`) and a text note explaining that a later step failed. If no successful submit occurred, the error is rethrown so the orchestrator's retry stays correct.

### How to test

- Unit coverage: `cd packages/@n8n/instance-ai && pnpm test src/tools/orchestration/__tests__/build-workflow-agent.tool.test.ts`
  - Asserts that `resultFromPostStreamError` preserves the outcome when a successful submit precedes the error, and returns `undefined` when no successful submit occurred / when only sub-workflows were submitted / when the submit itself failed.
- Manual repro against a real instance: request a workflow that requires credentials (e.g. Gmail), then force the builder's next LLM call to fail with 401 after `setup-credentials` resumes. Before: two workflows with the same name. After: one workflow, the orchestrator does not rebuild.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Add Linear ticket URL here if applicable -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI