### PR TITLE
feat(core): Add encryptWithKey and decryptWithKey to Cipher service

### DIFF
--- a/packages/core/src/encryption/__tests__/cipher.test.ts
+++ b/packages/core/src/encryption/__tests__/cipher.test.ts
@@ -35,6 +35,43 @@ describe('Cipher', () => {
 		});
 	});
 
+	describe('encryptWithKey', () => {
+		it('should roundtrip with decryptWithKey using the same key', () => {
+			const encrypted = cipher.encryptWithKey('random-string', 'explicit-key', 'aes-256-cbc');
+			const decrypted = cipher.decryptWithKey(encrypted, 'explicit-key', 'aes-256-cbc');
+			expect(decrypted).toEqual('random-string');
+		});
+
+		it('should produce different ciphertexts for the same plaintext on successive calls', () => {
+			const first = cipher.encryptWithKey('random-string', 'explicit-key', 'aes-256-cbc');
+			const second = cipher.encryptWithKey('random-string', 'explicit-key', 'aes-256-cbc');
+			expect(first).not.toEqual(second);
+		});
+
+		it('should fail to decrypt with a different key', () => {
+			const encrypted = cipher.encryptWithKey('random-string', 'key-a', 'aes-256-cbc');
+			expect(() => cipher.decryptWithKey(encrypted, 'key-b', 'aes-256-cbc')).toThrow();
+		});
+
+		it('should throw on aes-256-gcm for encryptWithKey', () => {
+			expect(() => cipher.encryptWithKey('data', 'key', 'aes-256-gcm')).toThrow(
+				'GCM not yet implemented',
+			);
+		});
+
+		it('should throw on aes-256-gcm for decryptWithKey', () => {
+			expect(() => cipher.decryptWithKey('data', 'key', 'aes-256-gcm')).toThrow(
+				'GCM not yet implemented',
+			);
+		});
+
+		it('should be interoperable with legacy encrypt when given the same key', () => {
+			const encrypted = cipher.encrypt('random-string', 'shared-key');
+			const decrypted = cipher.decryptWithKey(encrypted, 'shared-key', 'aes-256-cbc');
+			expect(decrypted).toEqual('random-string');
+		});
+	});
+
 	describe('getKeyAndIv', () => {
 		it('should generate a key and iv using instance settings encryption key', () => {
 			const salt = Buffer.from('test-salt');

--- a/packages/core/src/encryption/cipher.ts
+++ b/packages/core/src/encryption/cipher.ts
@@ -6,25 +6,44 @@ import { InstanceSettings } from '@/instance-settings';
 // Data encrypted by CryptoJS always starts with these bytes
 const RANDOM_BYTES = Buffer.from('53616c7465645f5f', 'hex');
 
+export type CipherAlgorithm = 'aes-256-cbc' | 'aes-256-gcm';
+
 @Service()
 export class Cipher {
 	constructor(private readonly instanceSettings: InstanceSettings) {}
 
 	encrypt(data: string | object, customEncryptionKey?: string) {
-		const salt = randomBytes(8);
-		const [key, iv] = this.getKeyAndIv(salt, customEncryptionKey);
-		const cipher = createCipheriv('aes-256-cbc', key, iv);
-		const encrypted = cipher.update(typeof data === 'string' ? data : JSON.stringify(data));
-		return Buffer.concat([RANDOM_BYTES, salt, encrypted, cipher.final()]).toString('base64');
+		const key = customEncryptionKey ?? this.instanceSettings.encryptionKey;
+		const plaintext = typeof data === 'string' ? data : JSON.stringify(data);
+		return this.encryptWithKey(plaintext, key, 'aes-256-cbc');
 	}
 
 	decrypt(data: string, customEncryptionKey?: string) {
+		const key = customEncryptionKey ?? this.instanceSettings.encryptionKey;
+		return this.decryptWithKey(data, key, 'aes-256-cbc');
+	}
+
+	encryptWithKey(data: string, key: string, algorithm: CipherAlgorithm): string {
+		if (algorithm === 'aes-256-gcm') {
+			throw new Error('GCM not yet implemented');
+		}
+		const salt = randomBytes(8);
+		const [derivedKey, iv] = this.getKeyAndIv(salt, key);
+		const cipher = createCipheriv('aes-256-cbc', derivedKey, iv);
+		const encrypted = cipher.update(data);
+		return Buffer.concat([RANDOM_BYTES, salt, encrypted, cipher.final()]).toString('base64');
+	}
+
+	decryptWithKey(data: string, key: string, algorithm: CipherAlgorithm): string {
+		if (algorithm === 'aes-256-gcm') {
+			throw new Error('GCM not yet implemented');
+		}
 		const input = Buffer.from(data, 'base64');
 		if (input.length < 16) return '';
 		const salt = input.subarray(8, 16);
-		const [key, iv] = this.getKeyAndIv(salt, customEncryptionKey);
+		const [derivedKey, iv] = this.getKeyAndIv(salt, key);
 		const contents = input.subarray(16);
-		const decipher = createDecipheriv('aes-256-cbc', key, iv);
+		const decipher = createDecipheriv('aes-256-cbc', derivedKey, iv);
 		return Buffer.concat([decipher.update(contents), decipher.final()]).toString('utf-8');
 	}
 


### PR DESCRIPTION
## Summary

Adds `encryptWithKey(data, key, algorithm)` and `decryptWithKey(data, key, algorithm)` to the `Cipher` service in `packages/core`. These let callers pass pre-resolved key material and an algorithm explicitly, instead of relying on the hardcoded `InstanceSettings` encryption key — unblocking call sites that resolve keys per row via `KeyManagerService`.

The legacy `encrypt`/`decrypt` methods are preserved and now delegate to the new ones, so there's a single CBC implementation and no regression for existing callers. The `aes-256-gcm` branch is stubbed and throws until the GCM implementation lands in a later ticket.

**How to test:** `pnpm --filter n8n-core test cipher` — 12 tests pass, including roundtrip, random-IV, wrong-key failure, GCM throws on both directions, and cross-compat between legacy `encrypt` and new `decryptWithKey`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-492

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI