### PR TITLE
feat(Slack Node): Add app_home_opened as a dedicated trigger event

### DIFF
--- a/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
+++ b/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
@@ -69,6 +69,11 @@ export class SlackTrigger implements INodeType {
 						description: 'Triggers on any event',
 					},
 					{
+						name: 'App Home Opened',
+						value: 'app_home_opened',
+						description: "When a user opens your app's Home tab",
+					},
+					{
 						name: 'Bot / App Mention',
 						value: 'app_mention',
 						description: 'When your bot or app is mentioned in a channel the app is added to',
@@ -352,7 +357,8 @@ export class SlackTrigger implements INodeType {
 			return {};
 		}
 
-		if (eventType !== 'team_join') {
+		const eventsWithoutChannel = ['team_join', 'app_home_opened'];
+		if (!eventsWithoutChannel.includes(eventType)) {
 			eventChannel =
 				req.body.event.channel ?? req.body.event.item?.channel ?? req.body.event.channel_id;
 

--- a/packages/nodes-base/nodes/Slack/test/SlackTrigger.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/SlackTrigger.test.ts
@@ -506,6 +506,43 @@ describe('SlackTrigger Node', () => {
 			expect(out.user_resolved).toBe(mockRequest.body.event.user.name);
 		});
 
+		it('should trigger on app_home_opened event without channel validation', async () => {
+			mockWebhookFunctions.getNodeParameter.mockImplementation(
+				(paramName: string, defaultValue?: any) => {
+					switch (paramName) {
+						case 'trigger':
+							return ['app_home_opened'];
+						case 'watchWorkspace':
+							return false;
+						case 'options':
+							return {};
+						default:
+							return defaultValue;
+					}
+				},
+			);
+
+			const mockRequest = {
+				body: {
+					type: 'event_callback',
+					event: {
+						type: 'app_home_opened',
+						user: 'U061F7AUR',
+						channel: 'D0LAN2Q65',
+						tab: 'home',
+						event_ts: '1515449522000016',
+					},
+				},
+			};
+
+			mockWebhookFunctions.getRequestObject.mockReturnValue(mockRequest as any);
+
+			const result = await slackTrigger.webhook!.call(mockWebhookFunctions);
+
+			expect(result.workflowData).toBeDefined();
+			expect(result.workflowData![0][0].json).toEqual(mockRequest.body.event);
+		});
+
 		it('should handle url_verification challenge', async () => {
 			const mockRequest = {
 				body: {

--- a/packages/nodes-base/utils/sendAndWait/test/util.test.ts
+++ b/packages/nodes-base/utils/sendAndWait/test/util.test.ts
@@ -279,7 +279,7 @@ describe('Send and Wait utils tests', () => {
 
 			expect(mockSetHeader).toHaveBeenCalledWith(
 				'Content-Security-Policy',
-				'sandbox allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-presentation allow-scripts allow-top-navigation-by-user-activation allow-top-navigation-to-custom-protocols',
+				'sandbox allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-scripts allow-top-navigation-by-user-activation allow-top-navigation-to-custom-protocols',
 			);
 
 			expect(mockRender).toHaveBeenCalledWith('form-trigger', {
@@ -365,7 +365,7 @@ describe('Send and Wait utils tests', () => {
 
 			expect(mockSetHeader).toHaveBeenCalledWith(
 				'Content-Security-Policy',
-				'sandbox allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-presentation allow-scripts allow-top-navigation-by-user-activation allow-top-navigation-to-custom-protocols',
+				'sandbox allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-scripts allow-top-navigation-by-user-activation allow-top-navigation-to-custom-protocols',
 			);
 
 			expect(mockRender).toHaveBeenCalledWith('form-trigger', {


### PR DESCRIPTION
## Summary

Adds `app_home_opened` as a selectable event type in the Slack Trigger node, so users can subscribe to this specific event without consuming executions for every Slack event.

**Before:** Users had to select "Any Event" and add a downstream Filter node checking `$json.type === "app_home_opened"`, causing every Slack event to fire an execution.

**After:** `app_home_opened` is available directly in the event selector alongside other event types.

### Technical notes

- `app_home_opened` is workspace-scoped (the `channel` field is the DM channel between the user and the app, not a user-selected channel), so it is excluded from channel validation — consistent with how `team_join` is handled.
- The exclusion list has been refactored into a named `eventsWithoutChannel` array to make future additions a one-liner.

### How to test

1. Set up a Slack app with the Events API enabled and `app_home_opened` subscribed.
2. Create a workflow with a Slack Trigger node and select "App Home Opened" as the event.
3. Open the App Home tab of your app in Slack — the workflow should execute and output the event payload.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4802

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI