### PR TITLE
fix: Link to n8n website broken in n8n forms

### DIFF
--- a/packages/core/src/__tests__/html-sandbox.test.ts
+++ b/packages/core/src/__tests__/html-sandbox.test.ts
@@ -52,7 +52,7 @@ describe('getHtmlSandboxCSP', () => {
 	it('should return correct CSP sandbox directive', () => {
 		const csp = getHtmlSandboxCSP();
 		expect(csp).toBe(
-			'sandbox allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-presentation allow-scripts allow-top-navigation-by-user-activation allow-top-navigation-to-custom-protocols',
+			'sandbox allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-scripts allow-top-navigation-by-user-activation allow-top-navigation-to-custom-protocols',
 		);
 	});
 

--- a/packages/core/src/html-sandbox.ts
+++ b/packages/core/src/html-sandbox.ts
@@ -13,5 +13,5 @@ export const isFormHtmlSandboxingDisabled = () => {
  * Returns the CSP header value that sandboxes the HTML page into a separate origin.
  */
 export const getHtmlSandboxCSP = (): string => {
-	return 'sandbox allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-presentation allow-scripts allow-top-navigation-by-user-activation allow-top-navigation-to-custom-protocols';
+	return 'sandbox allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-scripts allow-top-navigation-by-user-activation allow-top-navigation-to-custom-protocols';
 };


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

A link to the n8n website at the bottom of the form page would lead to a 500 error. The error occurred at the `n8n.io` side, but was caused by the fact that it was sandboxed, just like the form page itself. Adding `allow-popups-to-escape-sandbox` fixes that and any other potential issues caused by the fact that the new page that's opened is sandboxed. `allow-popups-to-escape-sandbox` was present when n8n used `iframe` for sandboxing, but when the CSP headers approach was adopted instead, this directive wasn't added (see [this PR](https://github.com/n8n-io/n8n/pull/18602))

####  To test
1. Create a workflow with a single n8n form trigger
2. Open the form
3. Click the "Form automated with n8n" link at the bottom
4. Check if the website loads properly or returns a 500

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-4806/community-issue-branding-not-working
Closes #28039

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
