### PR TITLE
fix: guard breaking-changes latestEvent sort against non-Date values

### DIFF
--- a/packages/cli/src/modules/breaking-changes/__tests__/breaking-changes.service.test.ts
+++ b/packages/cli/src/modules/breaking-changes/__tests__/breaking-changes.service.test.ts
@@ -112,6 +112,49 @@ describe('BreakingChangeService', () => {
 			expect(fileAccessResult?.affectedWorkflows).toHaveLength(1);
 		});
 
+		it('should ignore malformed latestEvent values when computing lastExecutedAt', async () => {
+			const { workflow } = createWorkflow('wf-1', 'Workflow With Stats', [
+				createNode('Spontit Node', 'n8n-nodes-base.spontit'),
+			]);
+
+			workflowRepository.find.mockResolvedValue([workflow as never]);
+			workflowRepository.count.mockResolvedValue(1);
+			workflowStatisticsRepository.find.mockResolvedValue([
+				{
+					workflowId: 'wf-1',
+					count: 1,
+					latestEvent: 'not-a-date',
+				} as never,
+				{
+					workflowId: 'wf-1',
+					count: 2,
+					latestEvent: null,
+				} as never,
+				{
+					workflowId: 'wf-1',
+					count: 3,
+					latestEvent: new Date('2025-01-02T00:00:00.000Z'),
+				} as never,
+				{
+					workflowId: 'wf-1',
+					count: 4,
+					latestEvent: '2025-01-03T00:00:00.000Z',
+				} as never,
+			]);
+
+			const report = await service.detect('v2');
+			const removedNodesResult = report.report.workflowResults.find(
+				(result) => result.ruleId === 'removed-nodes-v2',
+			);
+
+			expect(removedNodesResult?.affectedWorkflows).toHaveLength(1);
+			expect(removedNodesResult?.affectedWorkflows[0]).toMatchObject({
+				id: 'wf-1',
+				numberOfExecutions: 10,
+				lastExecutedAt: new Date('2025-01-03T00:00:00.000Z'),
+			});
+		});
+
 		it('should include all required fields in the report', async () => {
 			workflowRepository.find.mockResolvedValue([]);
 			workflowRepository.count.mockResolvedValue(0);

--- a/packages/cli/src/modules/breaking-changes/breaking-changes.service.ts
+++ b/packages/cli/src/modules/breaking-changes/breaking-changes.service.ts
@@ -99,6 +99,19 @@ export class BreakingChangeService {
 		return nodesGroupedByType;
 	}
 
+	private normalizeLatestEvent(latestEvent: unknown): Date | undefined {
+		if (latestEvent instanceof Date) {
+			return Number.isNaN(latestEvent.getTime()) ? undefined : latestEvent;
+		}
+
+		if (typeof latestEvent === 'string' || typeof latestEvent === 'number') {
+			const normalizedDate = new Date(latestEvent);
+			return Number.isNaN(normalizedDate.getTime()) ? undefined : normalizedDate;
+		}
+
+		return undefined;
+	}
+
 	private async aggregateRegularRuleResults(
 		workflowLevelRules: IBreakingChangeWorkflowRule[],
 		allAffectedWorkflowsByRule: Map<string, BreakingChangeAffectedWorkflow[]>,
@@ -220,14 +233,16 @@ export class BreakingChangeService {
 			for (const workflow of workflows) {
 				const nodesGroupedByType = this.groupNodesByType(workflow.nodes);
 				const statistics = statisticsByWorkflowId.get(workflow.id) ?? [];
+				const lastExecutedAt = statistics
+					.map((stat) => this.normalizeLatestEvent(stat.latestEvent))
+					.filter((latestEvent): latestEvent is Date => latestEvent !== undefined)
+					.sort((a, b) => b.getTime() - a.getTime())[0];
 
 				const workflowMetadata: WorkflowMetadata = {
 					name: workflow.name,
 					active: !!workflow.activeVersionId,
 					numberOfExecutions: statistics.reduce((acc, cur) => acc + (cur.count || 0), 0),
-					lastExecutedAt: statistics.sort(
-						(a, b) => b.latestEvent.getTime() - a.latestEvent.getTime(),
-					)[0]?.latestEvent,
+					lastExecutedAt,
 					lastUpdatedAt: workflow.updatedAt,
 				};
 				workflowMetadataMap.set(workflow.id, workflowMetadata);


### PR DESCRIPTION
## Summary
Defensively handle non-Date `latestEvent` values in the breaking-changes statistics sort path to avoid runtime errors like:

`dbTime.getTime is not a function`

## Changes
- Normalize `latestEvent` before calling `getTime()`
- Fallback safely when the value is null, undefined, or invalid

## Why this is safe
- Preserves behavior for valid `Date` objects
- Prevents runtime errors for malformed timestamp values
- Small, isolated change

## Validation
- Added focused unit test for breaking-changes service
- Ran targeted test suite successfully

## Related issues
Related to #28640 and #28541
