### PR TITLE
chrome: check of cycle.size (no-changelog)

### DIFF
--- a/packages/core/src/execution-engine/partial-execution-utils/handle-cycles.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/handle-cycles.ts
@@ -23,7 +23,7 @@ export function handleCycles(
 	// any inputs and thus cannot build a cycle.
 	//
 	// We're not interested in them so we filter them out.
-	const cycles = graph.getStronglyConnectedComponents().filter((cycle) => cycle.size >= 1);
+	const cycles = graph.getStronglyConnectedComponents().filter((cycle) => cycle.size > 1);
 	const newStartNodes: Set<INode> = new Set(startNodes);
 
 	// For each start node, check if the node is part of a cycle and if it is


### PR DESCRIPTION
comment say :  We're not interested in them. (They form a strongly connected component of one.)
before change :  `cycle.size=1` pass check, then replace with self
after change :  `cycle.size=1` can not pass check and replace

No actual action changed, nowhere else used. 

- [√] I have seen this code, I have run this code, and I take responsibility for this code.