### PR TITLE
fix(core): Cascade-cancel dependent planned tasks when a parent task fails

### DIFF
--- a/packages/@n8n/instance-ai/src/planned-tasks/__tests__/planned-task-service.test.ts
+++ b/packages/@n8n/instance-ai/src/planned-tasks/__tests__/planned-task-service.test.ts
@@ -172,6 +172,165 @@ describe('PlannedTaskCoordinator', () => {
 			expect(result?.tasks[0].status).toBe('failed');
 			expect(result?.tasks[0].error).toBe('Build failed');
 		});
+
+		it('cancels direct dependents with a dependency-name reason', async () => {
+			storage.update.mockImplementation(async (_threadId, updater) => {
+				const graph = makeGraph({
+					tasks: [
+						makeTaskRecord({ id: 'a', status: 'running' }),
+						makeTaskRecord({ id: 'b', deps: ['a'], status: 'planned' }),
+					],
+				});
+				return await Promise.resolve(updater(graph));
+			});
+
+			const result = await coordinator.markFailed('thread-1', 'a', {
+				error: 'Build failed',
+			});
+
+			const a = result?.tasks.find((t) => t.id === 'a');
+			const b = result?.tasks.find((t) => t.id === 'b');
+			expect(a?.status).toBe('failed');
+			expect(a?.error).toBe('Build failed');
+			expect(b?.status).toBe('cancelled');
+			expect(b?.error).toBe('Cancelled: dependency "a" failed');
+		});
+
+		it('cancels transitive dependents', async () => {
+			storage.update.mockImplementation(async (_threadId, updater) => {
+				const graph = makeGraph({
+					tasks: [
+						makeTaskRecord({ id: 'a', status: 'running' }),
+						makeTaskRecord({ id: 'b', deps: ['a'], status: 'planned' }),
+						makeTaskRecord({ id: 'c', deps: ['b'], status: 'planned' }),
+					],
+				});
+				return await Promise.resolve(updater(graph));
+			});
+
+			const result = await coordinator.markFailed('thread-1', 'a', {});
+
+			expect(result?.tasks.find((t) => t.id === 'a')?.status).toBe('failed');
+			expect(result?.tasks.find((t) => t.id === 'b')?.status).toBe('cancelled');
+			expect(result?.tasks.find((t) => t.id === 'c')?.status).toBe('cancelled');
+		});
+
+		it('cancels dependents in a diamond graph', async () => {
+			storage.update.mockImplementation(async (_threadId, updater) => {
+				const graph = makeGraph({
+					tasks: [
+						makeTaskRecord({ id: 'a', status: 'running' }),
+						makeTaskRecord({ id: 'b', deps: ['a'], status: 'planned' }),
+						makeTaskRecord({ id: 'c', deps: ['a'], status: 'planned' }),
+						makeTaskRecord({ id: 'd', deps: ['b', 'c'], status: 'planned' }),
+					],
+				});
+				return await Promise.resolve(updater(graph));
+			});
+
+			const result = await coordinator.markFailed('thread-1', 'a', {});
+
+			expect(result?.tasks.find((t) => t.id === 'a')?.status).toBe('failed');
+			expect(result?.tasks.find((t) => t.id === 'b')?.status).toBe('cancelled');
+			expect(result?.tasks.find((t) => t.id === 'c')?.status).toBe('cancelled');
+			expect(result?.tasks.find((t) => t.id === 'd')?.status).toBe('cancelled');
+		});
+
+		it('leaves independent tasks untouched', async () => {
+			storage.update.mockImplementation(async (_threadId, updater) => {
+				const graph = makeGraph({
+					tasks: [
+						makeTaskRecord({ id: 'a', status: 'running' }),
+						makeTaskRecord({ id: 'b', deps: ['a'], status: 'planned' }),
+						makeTaskRecord({ id: 'c', deps: [], status: 'planned' }),
+					],
+				});
+				return await Promise.resolve(updater(graph));
+			});
+
+			const result = await coordinator.markFailed('thread-1', 'a', {});
+
+			expect(result?.tasks.find((t) => t.id === 'c')?.status).toBe('planned');
+			expect(result?.tasks.find((t) => t.id === 'c')?.error).toBeUndefined();
+		});
+
+		it('preserves already-terminal dependents', async () => {
+			storage.update.mockImplementation(async (_threadId, updater) => {
+				const graph = makeGraph({
+					tasks: [
+						makeTaskRecord({ id: 'a', status: 'running' }),
+						makeTaskRecord({ id: 'b', deps: ['a'], status: 'succeeded' }),
+						makeTaskRecord({ id: 'c', deps: ['a'], status: 'failed', error: 'earlier fail' }),
+						makeTaskRecord({
+							id: 'd',
+							deps: ['a'],
+							status: 'cancelled',
+							error: 'user aborted',
+						}),
+					],
+				});
+				return await Promise.resolve(updater(graph));
+			});
+
+			const result = await coordinator.markFailed('thread-1', 'a', {});
+
+			expect(result?.tasks.find((t) => t.id === 'b')?.status).toBe('succeeded');
+			expect(result?.tasks.find((t) => t.id === 'c')?.status).toBe('failed');
+			expect(result?.tasks.find((t) => t.id === 'c')?.error).toBe('earlier fail');
+			expect(result?.tasks.find((t) => t.id === 'd')?.status).toBe('cancelled');
+			expect(result?.tasks.find((t) => t.id === 'd')?.error).toBe('user aborted');
+		});
+
+		it('is a no-op when the failed task id is not in the graph', async () => {
+			const graph = makeGraph({
+				tasks: [makeTaskRecord({ id: 'a', status: 'running' })],
+			});
+			storage.update.mockImplementation(async (_threadId, updater) => {
+				return await Promise.resolve(updater(graph));
+			});
+
+			const result = await coordinator.markFailed('thread-1', 'nonexistent', {});
+
+			expect(result?.tasks.find((t) => t.id === 'a')?.status).toBe('running');
+		});
+
+		it('propagates the same finishedAt to the failed task and cancelled dependents', async () => {
+			storage.update.mockImplementation(async (_threadId, updater) => {
+				const graph = makeGraph({
+					tasks: [
+						makeTaskRecord({ id: 'a', status: 'running' }),
+						makeTaskRecord({ id: 'b', deps: ['a'], status: 'planned' }),
+					],
+				});
+				return await Promise.resolve(updater(graph));
+			});
+
+			const result = await coordinator.markFailed('thread-1', 'a', {
+				finishedAt: 1_700_000_000_000,
+			});
+
+			expect(result?.tasks.find((t) => t.id === 'a')?.finishedAt).toBe(1_700_000_000_000);
+			expect(result?.tasks.find((t) => t.id === 'b')?.finishedAt).toBe(1_700_000_000_000);
+		});
+
+		it('cancels a running dependent defensively even though the scheduler guard should prevent this', async () => {
+			storage.update.mockImplementation(async (_threadId, updater) => {
+				const graph = makeGraph({
+					tasks: [
+						makeTaskRecord({ id: 'a', status: 'running' }),
+						makeTaskRecord({ id: 'b', deps: ['a'], status: 'running' }),
+					],
+				});
+				return await Promise.resolve(updater(graph));
+			});
+
+			const result = await coordinator.markFailed('thread-1', 'a', {});
+
+			expect(result?.tasks.find((t) => t.id === 'b')?.status).toBe('cancelled');
+			expect(result?.tasks.find((t) => t.id === 'b')?.error).toBe(
+				'Cancelled: dependency "a" failed',
+			);
+		});
 	});
 
 	describe('markCancelled', () => {

--- a/packages/@n8n/instance-ai/src/planned-tasks/planned-task-service.ts
+++ b/packages/@n8n/instance-ai/src/planned-tasks/planned-task-service.ts
@@ -56,6 +56,23 @@ function isSuccess(task: PlannedTaskRecord): boolean {
 	return task.status === 'succeeded';
 }
 
+function collectDependents(graph: PlannedTaskGraph, rootId: string): Set<string> {
+	const dependents = new Set<string>();
+	const queue = [rootId];
+
+	while (queue.length > 0) {
+		const current = queue.shift()!;
+		for (const task of graph.tasks) {
+			if (task.deps.includes(current) && !dependents.has(task.id)) {
+				dependents.add(task.id);
+				queue.push(task.id);
+			}
+		}
+	}
+
+	return dependents;
+}
+
 function updateTaskRecord(
 	graph: PlannedTaskGraph,
 	taskId: string,
@@ -136,14 +153,36 @@ export class PlannedTaskCoordinator implements PlannedTaskService {
 		taskId: string,
 		update: { error?: string; finishedAt?: number },
 	): Promise<PlannedTaskGraph | null> {
-		return await this.storage.update(threadId, (graph) =>
-			updateTaskRecord(graph, taskId, (task) => ({
-				...task,
-				status: 'failed',
-				error: update.error ?? task.error ?? 'Unknown error',
-				finishedAt: update.finishedAt ?? Date.now(),
-			})),
-		);
+		return await this.storage.update(threadId, (graph) => {
+			const failedTask = graph.tasks.find((task) => task.id === taskId);
+			if (!failedTask) return graph;
+
+			const dependents = collectDependents(graph, taskId);
+			const finishedAt = update.finishedAt ?? Date.now();
+			const failureError = update.error ?? failedTask.error ?? 'Unknown error';
+
+			const tasks = graph.tasks.map<PlannedTaskRecord>((task) => {
+				if (task.id === taskId) {
+					return {
+						...task,
+						status: 'failed',
+						error: failureError,
+						finishedAt,
+					};
+				}
+				if (dependents.has(task.id) && (task.status === 'planned' || task.status === 'running')) {
+					return {
+						...task,
+						status: 'cancelled',
+						error: `Cancelled: dependency "${taskId}" failed`,
+						finishedAt,
+					};
+				}
+				return task;
+			});
+
+			return { ...graph, tasks };
+		});
 	}
 
 	async markCancelled(


### PR DESCRIPTION
## Summary

When a planned task fails, its transitive dependents are now marked `cancelled` with an explicit dependency-name reason, inside the same atomic `storage.update()` call that marks the root task failed.

**Before:** dependents stayed in `'planned'` status. The scheduler's graph-status guard (`planned-task-service.ts:173`) prevented them from dispatching, but the UI still displayed them as `'todo'` next to the failed parent. They only cleared if the orchestrator's replan LLM call tidied them up.

**After:** dependents transition to `'cancelled'` with `error = 'Cancelled: dependency "<id>" failed'`. UI is unambiguous, the orchestrator's replan context sees explicit state instead of limbo, and dependents are no longer protected only by a single defensive check in the scheduler.

Terminal-state dependents (`succeeded`, `failed`, `cancelled`) are preserved — only `planned` and `running` transition to `cancelled`.

### Shape of the change

```
Plan: [a, b:deps=a, c:deps=b]
markFailed(a) →
  a: failed (error: "Build failed")
  b: cancelled (error: 'Cancelled: dependency "a" failed')
  c: cancelled (error: 'Cancelled: dependency "a" failed')
```

### How to test

1. Create a plan with a failing dependency (e.g. a build-workflow task that errors) and dependents downstream.
2. Observe: dependent tasks immediately show as cancelled (not stuck as "todo") with a clear reason.
3. The existing replan flow continues unchanged — orchestrator still receives the `replan` action via `tick()`.

Unit coverage (9 new cases in `planned-task-service.test.ts`):
- Direct, transitive, and diamond dependent cascades
- Independent task unaffected
- Terminal-state dependents preserved (`succeeded`/`failed`/`cancelled`)
- No-op when root task id is missing
- Same `finishedAt` propagates to root + cancelled dependents
- Defensive cancel of a `running` dependent (scheduler guard should prevent this, but covered)

## Related Linear tickets, Github issues, and Community forum posts

None. Surfaced during an Instance AI coordination audit — small, self-contained behavioral fix to eliminate an ambiguous state in the planned-task scheduler.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. — N/A (no user-facing docs affected; internal scheduler behavior)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)