### PR TITLE
fix(core): Prevent nodes tool crash on flattened required fields

### DIFF
--- a/packages/@n8n/instance-ai/src/agent/__tests__/sanitize-mcp-schemas.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/sanitize-mcp-schemas.test.ts
@@ -414,6 +414,56 @@ describe('sanitizeMcpToolSchemas', () => {
 			expect(idField.description).not.toContain('For "');
 		});
 
+		it('should annotate single-variant fields with an action hint', () => {
+			// When a field appears in only ONE variant, flattening makes it optional.
+			// Without an action hint the model cross-mixes fields between sibling
+			// actions (e.g. sends `nodeIds` when calling `describe`). Prefix with
+			// `For "<action>":` so the field is clearly bound to the right action.
+			const union = z.discriminatedUnion('action', [
+				z.object({ action: z.literal('list') }),
+				z.object({
+					action: z.literal('type-definition'),
+					nodeIds: z.array(z.string()).describe('Node IDs to get definitions for'),
+				}),
+				z.object({ action: z.literal('describe'), nodeType: z.string().describe('Node type ID') }),
+			]);
+
+			const result = sanitizeZodType(union) as z.ZodObject<z.ZodRawShape>;
+
+			expect(result.shape.nodeIds.description).toBe(
+				'For "type-definition": Node IDs to get definitions for',
+			);
+			expect(result.shape.nodeType.description).toBe('For "describe": Node type ID');
+		});
+
+		it('should annotate fields shared by a subset of variants with all their actions', () => {
+			// A field appearing in 2 of 3 variants with a consistent description
+			// still needs an action hint — the third variant doesn't use it.
+			const shared = z.string().describe('Node type ID');
+			const union = z.discriminatedUnion('action', [
+				z.object({ action: z.literal('list') }),
+				z.object({ action: z.literal('describe'), nodeType: shared }),
+				z.object({ action: z.literal('explore-resources'), nodeType: shared }),
+			]);
+
+			const result = sanitizeZodType(union) as z.ZodObject<z.ZodRawShape>;
+
+			expect(result.shape.nodeType.description).toBe(
+				'For "describe", "explore-resources": Node type ID',
+			);
+		});
+
+		it('should annotate subset-only fields without a description using "Only for" hint', () => {
+			const union = z.discriminatedUnion('action', [
+				z.object({ action: z.literal('list') }),
+				z.object({ action: z.literal('get'), id: z.string() }),
+			]);
+
+			const result = sanitizeZodType(union) as z.ZodObject<z.ZodRawShape>;
+
+			expect(result.shape.id.description).toBe('Only for "get"');
+		});
+
 		it('should combine conflicting field descriptions with action context', () => {
 			const union = z.discriminatedUnion('action', [
 				z.object({

--- a/packages/@n8n/instance-ai/src/agent/sanitize-mcp-schemas.ts
+++ b/packages/@n8n/instance-ai/src/agent/sanitize-mcp-schemas.ts
@@ -141,6 +141,14 @@ export function sanitizeZodType(schema: z.ZodTypeAny, strict = false): z.ZodType
 				// Non-strict: combine with action context for external MCP tools
 				const combined = withDesc.map((d) => `For "${d.action}": ${d.description}`).join('. ');
 				mergedShape[fieldName] = sanitizedField.describe(combined);
+			} else if (entries.length < actionMeta.length) {
+				// Field appears in a subset of variants. Annotate with an action hint so
+				// the model binds the (now-flattened-optional) field to the right actions
+				// and stops cross-mixing fields between sibling actions.
+				const actionList = entries.map((e) => `"${e.action}"`).join(', ');
+				const baseDesc = withDesc[0]?.description;
+				const merged = baseDesc ? `For ${actionList}: ${baseDesc}` : `Only for ${actionList}`;
+				mergedShape[fieldName] = sanitizedField.describe(merged);
 			} else {
 				mergedShape[fieldName] = sanitizedField;
 			}

--- a/packages/@n8n/instance-ai/src/tools/__tests__/nodes.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/nodes.tool.test.ts
@@ -178,6 +178,39 @@ describe('nodes tool', () => {
 		});
 	});
 
+	describe('type-definition action', () => {
+		it('should return a Zod-derived error when nodeIds is missing', async () => {
+			// The discriminated union is flattened for Anthropic, so `nodeIds`
+			// becomes optional at the top-level schema. The handler re-validates
+			// against the variant schema so missing fields return a structured
+			// error instead of crashing downstream on input.nodeIds.map.
+			const context = createMockContext();
+			const tool = createNodesTool(context, 'full');
+
+			const result = await tool.execute!({ action: 'type-definition' } as never, {} as never);
+
+			expect(result).toMatchObject({
+				definitions: [],
+				error: expect.stringContaining('nodeIds'),
+			});
+		});
+
+		it('should return a Zod-derived error when nodeIds is empty', async () => {
+			const context = createMockContext();
+			const tool = createNodesTool(context, 'full');
+
+			const result = await tool.execute!(
+				{ action: 'type-definition', nodeIds: [] } as never,
+				{} as never,
+			);
+
+			expect(result).toMatchObject({
+				definitions: [],
+				error: expect.stringContaining('nodeIds'),
+			});
+		});
+	});
+
 	describe('describe action', () => {
 		it('should return found: false when node type is not found', async () => {
 			const context = createMockContext();

--- a/packages/@n8n/instance-ai/src/tools/nodes.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/nodes.tool.ts
@@ -188,9 +188,25 @@ async function handleTypeDefinition(
 	context: InstanceAiContext,
 	input: Extract<FullInput, { action: 'type-definition' }>,
 ) {
+	// Mastra validates against the flattened top-level schema (required for
+	// Anthropic's `type: "object"` constraint), which makes every variant field
+	// optional. Re-assert the variant contract so missing/invalid inputs return
+	// a structured error the model can self-correct from, instead of crashing
+	// downstream on `input.nodeIds.map`.
+	const parsed = typeDefinitionAction.safeParse(input);
+	if (!parsed.success) {
+		return {
+			definitions: [],
+			error: parsed.error.issues
+				.map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`)
+				.join('; '),
+		};
+	}
+	const { nodeIds } = parsed.data;
+
 	if (!context.nodeService.getNodeTypeDefinition) {
 		return {
-			definitions: input.nodeIds.map((req: z.infer<typeof nodeRequestSchema>) => ({
+			definitions: nodeIds.map((req: z.infer<typeof nodeRequestSchema>) => ({
 				nodeId: typeof req === 'string' ? req : req.nodeId,
 				content: '',
 				error: 'Node type definitions are not available.',
@@ -199,7 +215,7 @@ async function handleTypeDefinition(
 	}
 
 	const definitions = await Promise.all(
-		input.nodeIds.map(async (req: z.infer<typeof nodeRequestSchema>) => {
+		nodeIds.map(async (req: z.infer<typeof nodeRequestSchema>) => {
 			const nodeId = typeof req === 'string' ? req : req.nodeId;
 			const options = typeof req === 'string' ? undefined : req;
 


### PR DESCRIPTION
## Summary

Instance ai was failing at calling the node tool as it had to pass `nodeIds` to it but as it was marked optional (anthropic requires this) it was just leaving it out.

Gave it a hint to include the optional parameters, and zod errors so the LLM can understand what the problem is.

## Related Linear tickets, Github issues, and Community forum posts

https://www.notion.so/n8n/aef5b6e0c94f82159cc58164aa417607?v=7965b6e0c94f823c918f88516500cb86&p=3485b6e0c94f805aba59e36bdc8d7139&pm=s

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
