### PR TITLE
test(core): add integration test for scheduled execution deduplication

### DIFF
--- a/packages/@n8n/config/src/configs/executions.config.ts
+++ b/packages/@n8n/config/src/configs/executions.config.ts
@@ -127,4 +127,8 @@ export class ExecutionsConfig {
 	/** Whether to save execution data for manual executions. This default can be overridden at a workflow level. */
 	@Env('EXECUTIONS_DATA_SAVE_MANUAL_EXECUTIONS')
 	saveDataManualExecutions: boolean = true;
+
+	/** Whether scheduled executions receive a deduplication key enforced by a unique DB index. */
+	@Env('N8N_SCHEDULED_EXECUTION_DEDUPLICATION_ENABLED')
+	scheduledExecutionDeduplicationEnabled: boolean = false;
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import type { DatabaseConfig } from '../src/index';
-import { GlobalConfig, SSRF_DEFAULT_BLOCKED_IP_RANGES } from '../src/index';
+import { ExecutionsConfig, GlobalConfig, SSRF_DEFAULT_BLOCKED_IP_RANGES } from '../src/index';
 
 jest.mock('fs');
 const mockFs = mock<typeof fs>();
@@ -419,6 +419,7 @@ describe('GlobalConfig', () => {
 			saveDataOnSuccess: 'all',
 			saveExecutionProgress: false,
 			saveDataManualExecutions: true,
+			scheduledExecutionDeduplicationEnabled: false,
 		},
 		diagnostics: {
 			enabled: true,
@@ -718,6 +719,22 @@ describe('GlobalConfig', () => {
 
 			const config = Container.get(GlobalConfig);
 			expect(config.endpoints.health).toEqual('/api/v1/health');
+		});
+	});
+
+	describe('ExecutionsConfig', () => {
+		it('should default scheduledExecutionDeduplicationEnabled to false', () => {
+			process.env = {};
+			const config = Container.get(ExecutionsConfig);
+			expect(config.scheduledExecutionDeduplicationEnabled).toBe(false);
+		});
+
+		it('should enable scheduledExecutionDeduplicationEnabled when env var is set to true', () => {
+			process.env = {
+				N8N_SCHEDULED_EXECUTION_DEDUPLICATION_ENABLED: 'true',
+			};
+			const config = Container.get(ExecutionsConfig);
+			expect(config.scheduledExecutionDeduplicationEnabled).toBe(true);
 		});
 	});
 });

--- a/packages/@n8n/db/src/entities/execution-entity.ts
+++ b/packages/@n8n/db/src/entities/execution-entity.ts
@@ -85,6 +85,9 @@ export class ExecutionEntity {
 	@Column({ type: 'varchar', length: 2, nullable: false, default: 'db' })
 	storedAt: ExecutionDataStorageLocation;
 
+	@Column({ type: 'varchar', length: 255, nullable: true })
+	deduplicationKey: string | null;
+
 	@OneToMany('ExecutionMetadata', 'execution')
 	metadata: ExecutionMetadata[];
 

--- a/packages/@n8n/db/src/entities/types-db.ts
+++ b/packages/@n8n/db/src/entities/types-db.ts
@@ -60,6 +60,7 @@ export interface IExecutionBase {
 	status: ExecutionStatus;
 	waitTill?: Date | null;
 	storedAt: ExecutionDataStorageLocation;
+	deduplicationKey?: string | null;
 }
 
 // Required by PublicUser

--- a/packages/@n8n/db/src/migrations/common/1778000000000-AddExecutionDeduplicationKey.ts
+++ b/packages/@n8n/db/src/migrations/common/1778000000000-AddExecutionDeduplicationKey.ts
@@ -1,0 +1,13 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+export class AddExecutionDeduplicationKey1778000000000 implements ReversibleMigration {
+	async up({ schemaBuilder: { addColumns, column, createIndex } }: MigrationContext) {
+		await addColumns('execution_entity', [column('deduplicationKey').varchar(255)]);
+		await createIndex('execution_entity', ['deduplicationKey'], true);
+	}
+
+	async down({ schemaBuilder: { dropIndex, dropColumns } }: MigrationContext) {
+		await dropIndex('execution_entity', ['deduplicationKey']);
+		await dropColumns('execution_entity', ['deduplicationKey']);
+	}
+}

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -162,6 +162,7 @@ import { ChangeWorkflowPublishHistoryVersionIdToSetNull1775740765000 } from '../
 import { CreateTrustedKeyTables1776000000000 } from '../common/1776000000000-CreateTrustedKeyTables';
 import { CreateFavoritesTable1776150756000 } from '../common/1776150756000-CreateFavoritesTable';
 import { CreateDeploymentKeyTable1777000000000 } from '../common/1777000000000-CreateDeploymentKeyTable';
+import { AddExecutionDeduplicationKey1778000000000 } from '../common/1778000000000-AddExecutionDeduplicationKey';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -329,4 +330,5 @@ export const postgresMigrations: Migration[] = [
 	CreateTrustedKeyTables1776000000000,
 	CreateFavoritesTable1776150756000,
 	CreateDeploymentKeyTable1777000000000,
+	AddExecutionDeduplicationKey1778000000000,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -156,6 +156,7 @@ import { ChangeWorkflowPublishHistoryVersionIdToSetNull1775740765000 } from '../
 import { CreateTrustedKeyTables1776000000000 } from '../common/1776000000000-CreateTrustedKeyTables';
 import { CreateFavoritesTable1776150756000 } from '../common/1776150756000-CreateFavoritesTable';
 import { CreateDeploymentKeyTable1777000000000 } from '../common/1777000000000-CreateDeploymentKeyTable';
+import { AddExecutionDeduplicationKey1778000000000 } from '../common/1778000000000-AddExecutionDeduplicationKey';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -317,6 +318,7 @@ const sqliteMigrations: Migration[] = [
 	CreateTrustedKeyTables1776000000000,
 	CreateFavoritesTable1776150756000,
 	CreateDeploymentKeyTable1777000000000,
+	AddExecutionDeduplicationKey1778000000000,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/__tests__/active-executions.test.ts
+++ b/packages/cli/src/__tests__/active-executions.test.ts
@@ -119,6 +119,21 @@ describe('ActiveExecutions', () => {
 		expect(executionRepository.updateExistingExecution).toHaveBeenCalledTimes(1);
 	});
 
+	test('Should forward deduplicationKey to executionPersistence.create', async () => {
+		const executionDataWithKey: IWorkflowExecutionDataProcess = {
+			...executionData,
+			deduplicationKey: 'wf-1:node-1:1700000000000',
+		};
+
+		await activeExecutions.add(executionDataWithKey);
+
+		expect(executionPersistence.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				deduplicationKey: 'wf-1:node-1:1700000000000',
+			}),
+		);
+	});
+
 	test('Should throw ExecutionAlreadyResumingError when another process is resuming execution', async () => {
 		// Mock updateExistingExecution to return false (status check failed)
 		executionRepository.updateExistingExecution.mockResolvedValue(false);

--- a/packages/cli/src/__tests__/active-workflow-manager.test.ts
+++ b/packages/cli/src/__tests__/active-workflow-manager.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/unbound-method */
+import type { Logger } from '@n8n/backend-common';
 import { mockLogger } from '@n8n/backend-test-utils';
 import type { WorkflowEntity, WorkflowHistory, WorkflowRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
@@ -17,6 +18,7 @@ import { WorkflowActivationError } from 'n8n-workflow';
 
 import type { ActivationErrorsService } from '@/activation-errors.service';
 import { ActiveWorkflowManager } from '@/active-workflow-manager';
+import { DuplicateExecutionError } from '@/errors/duplicate-execution.error';
 import type { EventService } from '@/events/event.service';
 import type { ExecutionService } from '@/executions/execution.service';
 import type { NodeTypes } from '@/node-types';
@@ -294,6 +296,7 @@ describe('ActiveWorkflowManager', () => {
 		const activeWorkflows = mock<ActiveWorkflows>();
 		const activationErrorsService = mock<ActivationErrorsService>();
 		const executionService = mock<ExecutionService>();
+		let scopedLogger: Logger;
 
 		beforeEach(() => {
 			jest.clearAllMocks();
@@ -303,8 +306,11 @@ describe('ActiveWorkflowManager', () => {
 			activationErrorsService.register.mockResolvedValue(undefined);
 			executionService.createErrorExecution.mockResolvedValue(undefined);
 
+			scopedLogger = mock<Logger>();
+			const rootLogger = mock<Logger>({ scoped: jest.fn().mockReturnValue(scopedLogger) });
+
 			activeWorkflowManager = new ActiveWorkflowManager(
-				mockLogger(),
+				rootLogger,
 				mock(),
 				activeWorkflows,
 				mock(),
@@ -358,6 +364,7 @@ describe('ActiveWorkflowManager', () => {
 					additionalData,
 					mode,
 					undefined,
+					undefined,
 				);
 
 				await new Promise((resolve) => setTimeout(resolve, 0));
@@ -368,6 +375,73 @@ describe('ActiveWorkflowManager', () => {
 					executionId: 'exec-123',
 					source: 'trigger',
 				});
+			});
+
+			test('forwards deduplicationKey to workflowExecutionService.runWorkflow', async () => {
+				const workflowData = mock<WorkflowEntity>({ id: 'wf-1', name: 'Test Workflow' });
+				const additionalData = mock<IWorkflowExecuteAdditionalData>();
+				const mode: WorkflowExecuteMode = 'trigger';
+				const activation: WorkflowActivateMode = 'activate';
+				const workflow = mock<Workflow>({ name: 'Test Workflow' });
+				const node = mock<INode>({ name: 'Trigger Node', id: 'node-1' });
+				const triggerData: INodeExecutionData[][] = [[]];
+
+				const getTriggerFunctions = activeWorkflowManager.getExecuteTriggerFunctions(
+					workflowData,
+					additionalData,
+					mode,
+					activation,
+				);
+				const context = getTriggerFunctions(workflow, node, additionalData, mode, activation);
+
+				context.emit(triggerData, undefined, undefined, 'wf-1:node-1:1700000000000');
+
+				expect(workflowExecutionService.runWorkflow).toHaveBeenCalledWith(
+					workflowData,
+					node,
+					triggerData,
+					additionalData,
+					mode,
+					undefined,
+					'wf-1:node-1:1700000000000',
+				);
+			});
+
+			test('warns and skips event emission when runWorkflow rejects with DuplicateExecutionError', async () => {
+				const workflowData = mock<WorkflowEntity>({ id: 'wf-1', name: 'Test Workflow' });
+				const additionalData = mock<IWorkflowExecuteAdditionalData>();
+				const mode: WorkflowExecuteMode = 'trigger';
+				const activation: WorkflowActivateMode = 'activate';
+				const workflow = mock<Workflow>({ name: 'Test Workflow' });
+				const node = mock<INode>({ name: 'Trigger Node', id: 'node-1' });
+				const triggerData: INodeExecutionData[][] = [[]];
+
+				workflowExecutionService.runWorkflow.mockRejectedValueOnce(
+					new DuplicateExecutionError('wf-1:node-1:1700000000000'),
+				);
+
+				const getTriggerFunctions = activeWorkflowManager.getExecuteTriggerFunctions(
+					workflowData,
+					additionalData,
+					mode,
+					activation,
+				);
+				const context = getTriggerFunctions(workflow, node, additionalData, mode, activation);
+
+				context.emit(triggerData, undefined, undefined, 'wf-1:node-1:1700000000000');
+
+				await new Promise((resolve) => setTimeout(resolve, 0));
+
+				expect(scopedLogger.warn).toHaveBeenCalledTimes(1);
+				expect(scopedLogger.warn).toHaveBeenCalledWith(
+					expect.stringContaining('duplicate deduplication key'),
+					{
+						workflowId: 'wf-1',
+						nodeId: 'node-1',
+						deduplicationKey: 'wf-1:node-1:1700000000000',
+					},
+				);
+				expect(eventService.emit).not.toHaveBeenCalled();
 			});
 		});
 

--- a/packages/cli/src/active-executions.ts
+++ b/packages/cli/src/active-executions.ts
@@ -77,6 +77,7 @@ export class ActiveExecutions {
 					status: executionStatus,
 					workflowId: executionData.workflowData.id,
 					retryOf: executionData.retryOf ?? undefined,
+					deduplicationKey: executionData.deduplicationKey,
 				};
 
 				const workflowId = executionData.workflowData.id;

--- a/packages/cli/src/active-workflow-manager.ts
+++ b/packages/cli/src/active-workflow-manager.ts
@@ -49,6 +49,7 @@ import {
 import { strict } from 'node:assert';
 
 import { ActivationErrorsService } from '@/activation-errors.service';
+import { DuplicateExecutionError } from '@/errors/duplicate-execution.error';
 import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
 import { ActiveExecutions } from '@/active-executions';
 import { EventService } from '@/events/event.service';
@@ -364,20 +365,35 @@ export class ActiveWorkflowManager {
 				data: INodeExecutionData[][],
 				responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>,
 				donePromise?: IDeferredPromise<IRun | undefined>,
+				deduplicationKey?: string,
 			) => {
 				this.logger.debug(`Received trigger for workflow "${workflow.name}"`);
 				void this.workflowStaticDataService.saveStaticData(workflow);
 
-				const executePromise = this.workflowExecutionService.runWorkflow(
-					workflowData,
-					node,
-					data,
-					additionalData,
-					mode,
-					responsePromise,
-				);
+				const executePromise = this.workflowExecutionService
+					.runWorkflow(
+						workflowData,
+						node,
+						data,
+						additionalData,
+						mode,
+						responsePromise,
+						deduplicationKey,
+					)
+					.catch((error: unknown) => {
+						if (error instanceof DuplicateExecutionError) {
+							this.logger.warn('Scheduled execution skipped: duplicate deduplication key', {
+								workflowId: workflowData.id,
+								nodeId: node.id,
+								deduplicationKey: error.deduplicationKey,
+							});
+							return undefined;
+						}
+						throw error;
+					});
 
 				void executePromise.then((executionId) => {
+					if (executionId === undefined) return;
 					this.eventService.emit('workflow-executed', {
 						workflowId: workflowData.id,
 						workflowName: workflowData.name,
@@ -388,6 +404,10 @@ export class ActiveWorkflowManager {
 
 				if (donePromise) {
 					void executePromise.then((executionId) => {
+						if (executionId === undefined) {
+							donePromise.resolve(undefined);
+							return;
+						}
 						this.activeExecutions
 							.getPostExecutePromise(executionId)
 							.then(donePromise.resolve)

--- a/packages/cli/src/errors/duplicate-execution.error.ts
+++ b/packages/cli/src/errors/duplicate-execution.error.ts
@@ -1,7 +1,12 @@
 import { OperationalError } from 'n8n-workflow';
 
 export class DuplicateExecutionError extends OperationalError {
-	constructor(readonly deduplicationKey: string) {
-		super(`Execution with deduplication key "${deduplicationKey}" already exists`);
+	constructor(
+		readonly deduplicationKey: string,
+		cause?: Error,
+	) {
+		super(`Execution with deduplication key "${deduplicationKey}" already exists`, {
+			cause,
+		});
 	}
 }

--- a/packages/cli/src/errors/duplicate-execution.error.ts
+++ b/packages/cli/src/errors/duplicate-execution.error.ts
@@ -1,0 +1,7 @@
+import { OperationalError } from 'n8n-workflow';
+
+export class DuplicateExecutionError extends OperationalError {
+	constructor(readonly deduplicationKey: string) {
+		super(`Execution with deduplication key "${deduplicationKey}" already exists`);
+	}
+}

--- a/packages/cli/src/executions/__tests__/execution-persistence.test.ts
+++ b/packages/cli/src/executions/__tests__/execution-persistence.test.ts
@@ -9,11 +9,13 @@ import {
 	type EntityManager,
 	type ExecutionRepository,
 } from '@n8n/db';
+import { QueryFailedError } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
 import type { BinaryDataService, StorageConfig } from 'n8n-core';
 import type { IWorkflowBase } from 'n8n-workflow';
 import { createEmptyRunExecutionData } from 'n8n-workflow';
 
+import { DuplicateExecutionError } from '@/errors/duplicate-execution.error';
 import type { FsStore } from '@/executions/execution-data/fs-store';
 import { ExecutionPersistence } from '@/executions/execution-persistence';
 
@@ -158,6 +160,75 @@ describe('ExecutionPersistence', () => {
 				executionRepository.manager.transaction = createMockTx(mockTx);
 
 				await expect(executionPersistence.create(createPayload)).rejects.toThrow(fsWriteError);
+			});
+		});
+
+		describe('deduplication key handling', () => {
+			const executionPersistence = createPersistenceService('db');
+
+			const makeUniqueViolationError = () => {
+				const driverError = Object.assign(new Error('duplicate key'), { code: '23505' });
+				return new QueryFailedError('Query', [], driverError);
+			};
+
+			it('converts unique-violation into DuplicateExecutionError when payload has a deduplicationKey', async () => {
+				const uniqueViolation = makeUniqueViolationError();
+				executionRepository.manager.transaction = jest.fn().mockRejectedValue(uniqueViolation);
+
+				const payloadWithKey: CreateExecutionPayload = {
+					...createPayload,
+					deduplicationKey: 'wf-1:node-1:1700000000000',
+				};
+
+				await expect(executionPersistence.create(payloadWithKey)).rejects.toBeInstanceOf(
+					DuplicateExecutionError,
+				);
+				await expect(executionPersistence.create(payloadWithKey)).rejects.toMatchObject({
+					deduplicationKey: 'wf-1:node-1:1700000000000',
+				});
+			});
+
+			it('rethrows original unique-violation when payload has no deduplicationKey', async () => {
+				const uniqueViolation = makeUniqueViolationError();
+				executionRepository.manager.transaction = jest.fn().mockRejectedValue(uniqueViolation);
+
+				await expect(executionPersistence.create(createPayload)).rejects.toBe(uniqueViolation);
+			});
+
+			it('rethrows non-unique-violation QueryFailedError unchanged', async () => {
+				const otherError = new QueryFailedError(
+					'Query',
+					[],
+					Object.assign(new Error('not null'), { code: '23502' }),
+				);
+				executionRepository.manager.transaction = jest.fn().mockRejectedValue(otherError);
+
+				const payloadWithKey: CreateExecutionPayload = {
+					...createPayload,
+					deduplicationKey: 'wf-1:node-1:1700000000000',
+				};
+
+				await expect(executionPersistence.create(payloadWithKey)).rejects.toBe(otherError);
+			});
+
+			it('returns executionId on happy path when deduplicationKey is provided', async () => {
+				const mockTx = createMockTransaction();
+				executionRepository.manager.transaction = createMockTx(mockTx);
+
+				const payloadWithKey: CreateExecutionPayload = {
+					...createPayload,
+					deduplicationKey: 'wf-1:node-1:1700000000000',
+				};
+
+				const executionId = await executionPersistence.create(payloadWithKey);
+
+				expect(executionId).toBe('exec-1');
+				expect(mockTx.insert).toHaveBeenCalledWith(
+					ExecutionEntity,
+					expect.objectContaining({
+						deduplicationKey: 'wf-1:node-1:1700000000000',
+					}),
+				);
 			});
 		});
 	});

--- a/packages/cli/src/executions/__tests__/execution-persistence.test.ts
+++ b/packages/cli/src/executions/__tests__/execution-persistence.test.ts
@@ -185,6 +185,7 @@ describe('ExecutionPersistence', () => {
 				);
 				await expect(executionPersistence.create(payloadWithKey)).rejects.toMatchObject({
 					deduplicationKey: 'wf-1:node-1:1700000000000',
+					cause: uniqueViolation,
 				});
 			});
 

--- a/packages/cli/src/executions/__tests__/is-unique-violation-error.test.ts
+++ b/packages/cli/src/executions/__tests__/is-unique-violation-error.test.ts
@@ -1,0 +1,45 @@
+import { QueryFailedError } from '@n8n/typeorm';
+
+import { isUniqueViolationError } from '@/executions/is-unique-violation-error';
+
+describe('isUniqueViolationError', () => {
+	const makeQueryFailedError = (code?: string) => {
+		const driverError =
+			code !== undefined
+				? Object.assign(new Error('driver error'), { code })
+				: new Error('driver error');
+		return new QueryFailedError('Query', [], driverError);
+	};
+
+	it('returns true for Postgres unique-violation code "23505"', () => {
+		const error = makeQueryFailedError('23505');
+		expect(isUniqueViolationError(error)).toBe(true);
+	});
+
+	it('returns true for SQLite unique-violation code "SQLITE_CONSTRAINT_UNIQUE"', () => {
+		const error = makeQueryFailedError('SQLITE_CONSTRAINT_UNIQUE');
+		expect(isUniqueViolationError(error)).toBe(true);
+	});
+
+	it('returns false for unrelated QueryFailedError code', () => {
+		const error = makeQueryFailedError('23502'); // not-null violation
+		expect(isUniqueViolationError(error)).toBe(false);
+	});
+
+	it('returns false for QueryFailedError without a driver error code', () => {
+		const error = makeQueryFailedError();
+		expect(isUniqueViolationError(error)).toBe(false);
+	});
+
+	it('returns false for a plain Error', () => {
+		expect(isUniqueViolationError(new Error('boom'))).toBe(false);
+	});
+
+	it('returns false for undefined', () => {
+		expect(isUniqueViolationError(undefined)).toBe(false);
+	});
+
+	it('returns false for null', () => {
+		expect(isUniqueViolationError(null)).toBe(false);
+	});
+});

--- a/packages/cli/src/executions/__tests__/is-unique-violation-error.test.ts
+++ b/packages/cli/src/executions/__tests__/is-unique-violation-error.test.ts
@@ -3,11 +3,11 @@ import { QueryFailedError } from '@n8n/typeorm';
 import { isUniqueViolationError } from '@/executions/is-unique-violation-error';
 
 describe('isUniqueViolationError', () => {
-	const makeQueryFailedError = (code?: string) => {
+	const makeQueryFailedError = (code?: string, driverMessage = 'driver error') => {
 		const driverError =
 			code !== undefined
-				? Object.assign(new Error('driver error'), { code })
-				: new Error('driver error');
+				? Object.assign(new Error(driverMessage), { code })
+				: new Error(driverMessage);
 		return new QueryFailedError('Query', [], driverError);
 	};
 
@@ -19,6 +19,22 @@ describe('isUniqueViolationError', () => {
 	it('returns true for SQLite unique-violation code "SQLITE_CONSTRAINT_UNIQUE"', () => {
 		const error = makeQueryFailedError('SQLITE_CONSTRAINT_UNIQUE');
 		expect(isUniqueViolationError(error)).toBe(true);
+	});
+
+	it('returns true for SQLite base code "SQLITE_CONSTRAINT" when the message indicates a unique violation', () => {
+		const error = makeQueryFailedError(
+			'SQLITE_CONSTRAINT',
+			'SQLITE_CONSTRAINT: UNIQUE constraint failed: execution_entity.deduplicationKey',
+		);
+		expect(isUniqueViolationError(error)).toBe(true);
+	});
+
+	it('returns false for SQLite base code "SQLITE_CONSTRAINT" when the message indicates a non-unique violation', () => {
+		const error = makeQueryFailedError(
+			'SQLITE_CONSTRAINT',
+			'SQLITE_CONSTRAINT: FOREIGN KEY constraint failed',
+		);
+		expect(isUniqueViolationError(error)).toBe(false);
 	});
 
 	it('returns false for unrelated QueryFailedError code', () => {

--- a/packages/cli/src/executions/execution-persistence.ts
+++ b/packages/cli/src/executions/execution-persistence.ts
@@ -12,6 +12,8 @@ import { BinaryDataService, StorageConfig } from 'n8n-core';
 
 import { FsStore } from './execution-data/fs-store';
 import type { ExecutionRef, WorkflowSnapshot } from './execution-data/types';
+import { isUniqueViolationError } from './is-unique-violation-error';
+import { DuplicateExecutionError } from '../errors/duplicate-execution.error';
 
 type DeletionTarget = ExecutionRef & { storedAt: ExecutionDataStorageLocation };
 
@@ -43,26 +45,33 @@ export class ExecutionPersistence {
 		const data = stringify(rawData);
 		const workflowVersionId = workflowData.versionId ?? null;
 
-		return await this.executionRepository.manager.transaction(async (tx) => {
-			const { identifiers } = await tx.insert(ExecutionEntity, executionEntity);
-			const executionId = String(identifiers[0].id);
+		try {
+			return await this.executionRepository.manager.transaction(async (tx) => {
+				const { identifiers } = await tx.insert(ExecutionEntity, executionEntity);
+				const executionId = String(identifiers[0].id);
 
-			if (storedAt === 'db') {
-				await tx.insert(ExecutionData, {
-					executionId,
-					workflowData: workflowSnapshot,
-					data,
-					workflowVersionId,
-				});
+				if (storedAt === 'db') {
+					await tx.insert(ExecutionData, {
+						executionId,
+						workflowData: workflowSnapshot,
+						data,
+						workflowVersionId,
+					});
+					return executionId;
+				}
+
+				await this.fsStore.write(
+					{ workflowId: id, executionId },
+					{ data, workflowData: workflowSnapshot, workflowVersionId },
+				);
 				return executionId;
+			});
+		} catch (error) {
+			if (executionEntity.deduplicationKey && isUniqueViolationError(error)) {
+				throw new DuplicateExecutionError(executionEntity.deduplicationKey);
 			}
-
-			await this.fsStore.write(
-				{ workflowId: id, executionId },
-				{ data, workflowData: workflowSnapshot, workflowVersionId },
-			);
-			return executionId;
-		});
+			throw error;
+		}
 	}
 
 	/**

--- a/packages/cli/src/executions/execution-persistence.ts
+++ b/packages/cli/src/executions/execution-persistence.ts
@@ -68,7 +68,7 @@ export class ExecutionPersistence {
 			});
 		} catch (error) {
 			if (executionEntity.deduplicationKey && isUniqueViolationError(error)) {
-				throw new DuplicateExecutionError(executionEntity.deduplicationKey);
+				throw new DuplicateExecutionError(executionEntity.deduplicationKey, error as Error);
 			}
 			throw error;
 		}

--- a/packages/cli/src/executions/is-unique-violation-error.ts
+++ b/packages/cli/src/executions/is-unique-violation-error.ts
@@ -1,0 +1,13 @@
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
+import { QueryFailedError } from '@n8n/typeorm';
+
+const UNIQUE_VIOLATION_CODES = new Set([
+	'23505', // Postgres
+	'SQLITE_CONSTRAINT_UNIQUE', // SQLite
+]);
+
+export function isUniqueViolationError(error: unknown): boolean {
+	if (!(error instanceof QueryFailedError)) return false;
+	const driverError = (error as unknown as { driverError?: { code?: string } }).driverError;
+	return typeof driverError?.code === 'string' && UNIQUE_VIOLATION_CODES.has(driverError.code);
+}

--- a/packages/cli/src/executions/is-unique-violation-error.ts
+++ b/packages/cli/src/executions/is-unique-violation-error.ts
@@ -3,11 +3,18 @@ import { QueryFailedError } from '@n8n/typeorm';
 
 const UNIQUE_VIOLATION_CODES = new Set([
 	'23505', // Postgres
-	'SQLITE_CONSTRAINT_UNIQUE', // SQLite
+	'SQLITE_CONSTRAINT_UNIQUE', // SQLite with extended result codes enabled
 ]);
 
 export function isUniqueViolationError(error: unknown): boolean {
 	if (!(error instanceof QueryFailedError)) return false;
 	const code = (error.driverError as { code?: unknown })?.code;
-	return typeof code === 'string' && UNIQUE_VIOLATION_CODES.has(code);
+	if (typeof code !== 'string') return false;
+	if (UNIQUE_VIOLATION_CODES.has(code)) return true;
+	// SQLite without extended result codes reports the base 'SQLITE_CONSTRAINT' and
+	// carries the specific violation type in the error message.
+	if (code === 'SQLITE_CONSTRAINT') {
+		return error.message.includes('UNIQUE constraint failed');
+	}
+	return false;
 }

--- a/packages/cli/src/executions/is-unique-violation-error.ts
+++ b/packages/cli/src/executions/is-unique-violation-error.ts
@@ -8,6 +8,6 @@ const UNIQUE_VIOLATION_CODES = new Set([
 
 export function isUniqueViolationError(error: unknown): boolean {
 	if (!(error instanceof QueryFailedError)) return false;
-	const driverError = (error as unknown as { driverError?: { code?: string } }).driverError;
-	return typeof driverError?.code === 'string' && UNIQUE_VIOLATION_CODES.has(driverError.code);
+	const code = (error.driverError as { code?: unknown })?.code;
+	return typeof code === 'string' && UNIQUE_VIOLATION_CODES.has(code);
 }

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -120,6 +120,35 @@ describe('WorkflowExecutionService', () => {
 
 			expect(workflowRunner.run).toHaveBeenCalledTimes(1);
 		});
+
+		test('should forward deduplicationKey to `WorkflowRunner.run()`', async () => {
+			const node = mock<INode>();
+			const workflow = mock<IWorkflowBase>({
+				active: true,
+				activeVersionId: 'some-version-id',
+				nodes: [node],
+			});
+
+			workflowRunner.run.mockResolvedValue('fake-execution-id');
+
+			await workflowExecutionService.runWorkflow(
+				workflow,
+				node,
+				[[]],
+				mock(),
+				'trigger',
+				undefined,
+				'wf-1:node-1:1700000000000',
+			);
+
+			expect(workflowRunner.run).toHaveBeenCalledWith(
+				expect.objectContaining({ deduplicationKey: 'wf-1:node-1:1700000000000' }),
+				true,
+				undefined,
+				undefined,
+				undefined,
+			);
+		});
 	});
 
 	describe('executeManually()', () => {

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -61,6 +61,7 @@ export class WorkflowExecutionService {
 		additionalData: IWorkflowExecuteAdditionalData,
 		mode: WorkflowExecuteMode,
 		responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>,
+		deduplicationKey?: string,
 	) {
 		const nodeExecutionStack: IExecuteData[] = [
 			{
@@ -84,6 +85,7 @@ export class WorkflowExecutionService {
 			executionMode: mode,
 			executionData,
 			workflowData,
+			deduplicationKey,
 		};
 
 		return await this.workflowRunner.run(runData, true, undefined, undefined, responsePromise);

--- a/packages/cli/test/integration/scheduled-execution-deduplication.test.ts
+++ b/packages/cli/test/integration/scheduled-execution-deduplication.test.ts
@@ -1,0 +1,295 @@
+import { createWorkflow, testDb, mockInstance } from '@n8n/backend-test-utils';
+import { ExecutionsConfig } from '@n8n/config';
+import type { IWorkflowDb, User } from '@n8n/db';
+import { ExecutionRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { mock } from 'jest-mock-extended';
+import { ExternalSecretsProxy, InstanceSettings } from 'n8n-core';
+import { ScheduleTrigger } from 'n8n-nodes-base/nodes/Schedule/ScheduleTrigger.node';
+import type {
+	IDeferredPromise,
+	INode,
+	INodeTypeData,
+	IRun,
+	IWorkflowExecuteAdditionalData,
+} from 'n8n-workflow';
+import { createDeferredPromise, Workflow } from 'n8n-workflow';
+
+import { ActiveExecutions } from '@/active-executions';
+import { ActiveWorkflowManager } from '@/active-workflow-manager';
+import { DuplicateExecutionError } from '@/errors/duplicate-execution.error';
+import { ExecutionPersistence } from '@/executions/execution-persistence';
+import { ExecutionService } from '@/executions/execution.service';
+import { ExternalHooks } from '@/external-hooks';
+import { NodeTypes } from '@/node-types';
+import { Push } from '@/push';
+import { OwnershipService } from '@/services/ownership.service';
+import { WebhookService } from '@/webhooks/webhook.service';
+import { WorkflowRunner } from '@/workflow-runner';
+import { WorkflowService } from '@/workflows/workflow.service';
+
+import { createOwner } from './shared/db/users';
+import * as utils from './shared/utils/';
+
+/*
+ * End-to-end integration test for scheduled-execution deduplication (CAT-2677).
+ *
+ * Exercises the production emit closure in `ActiveWorkflowManager.getExecuteTriggerFunctions`
+ * against a real SQLite database, with the real `ActiveExecutions` and `ExecutionPersistence`
+ * on the hot path. Only `WorkflowRunner.run` is mocked (to the minimum slice that keeps
+ * `ActiveExecutions.add` exercised but skips the actual engine run).
+ */
+
+// Services we don't need exercised but may be touched during activation/trigger-context construction.
+mockInstance(Push);
+mockInstance(ExternalSecretsProxy);
+mockInstance(ExecutionService);
+mockInstance(WorkflowService);
+mockInstance(OwnershipService);
+mockInstance(WebhookService);
+mockInstance(ExternalHooks);
+// NOTE: ActiveExecutions, ExecutionPersistence, ExecutionRepository are intentionally NOT mocked:
+// they must be real so the dedup path exercises the DB-level unique constraint.
+
+let activeWorkflowManager: ActiveWorkflowManager;
+let executionRepository: ExecutionRepository;
+let executionsConfig: ExecutionsConfig;
+let owner: User;
+let workflow: IWorkflowDb;
+let workflowObject: Workflow;
+let triggerNode: INode;
+let additionalData: IWorkflowExecuteAdditionalData;
+
+const nodes: INodeTypeData = {
+	'n8n-nodes-base.scheduleTrigger': {
+		type: new ScheduleTrigger(),
+		sourcePath: '',
+	},
+};
+
+beforeAll(async () => {
+	await testDb.init();
+
+	owner = await createOwner();
+	executionRepository = Container.get(ExecutionRepository);
+	executionsConfig = Container.get(ExecutionsConfig);
+	activeWorkflowManager = Container.get(ActiveWorkflowManager);
+
+	Container.get(InstanceSettings).markAsLeader();
+});
+
+beforeEach(async () => {
+	await testDb.truncate(['ExecutionEntity', 'WorkflowEntity']);
+
+	// Re-register the mocked DirectoryLoader each test because `jest.restoreAllMocks()`
+	// in `afterEach` resets the `jest-mock-extended` stub for `loader.getNode`.
+	await utils.initNodeTypes(nodes);
+
+	// Default: feature flag off. Individual tests enable it as needed.
+	executionsConfig.scheduledExecutionDeduplicationEnabled = false;
+
+	workflow = await createWorkflow(
+		{
+			active: true,
+			nodes: [
+				{
+					id: 'schedule-node-uuid',
+					name: 'Schedule Trigger',
+					parameters: {},
+					position: [0, 0],
+					type: 'n8n-nodes-base.scheduleTrigger',
+					typeVersion: 1,
+				},
+			],
+			connections: {},
+		},
+		owner,
+	);
+
+	triggerNode = workflow.nodes[0];
+
+	workflowObject = new Workflow({
+		id: workflow.id,
+		name: workflow.name,
+		nodes: workflow.nodes,
+		connections: workflow.connections,
+		active: true,
+		nodeTypes: Container.get(NodeTypes),
+		staticData: workflow.staticData,
+		settings: workflow.settings,
+	});
+
+	// Minimal additionalData — only `userId` is actually read by the runner path we exercise;
+	// every other field is passed through to the mocked WorkflowRunner.run and discarded.
+	additionalData = mock<IWorkflowExecuteAdditionalData>({ userId: owner.id });
+});
+
+afterEach(() => {
+	jest.restoreAllMocks();
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+/**
+ * Surgical mock for `WorkflowRunner.run` that preserves the
+ * `ActiveExecutions.add → ExecutionPersistence.create` call — so the DB-level
+ * unique constraint is exercised — but skips the actual engine run.
+ * Returns an array of promises (one per invocation) that settle when the
+ * underlying `add` call does, so tests can await completion deterministically.
+ */
+function installWorkflowRunnerPassthroughMock() {
+	const runSettled: Array<Promise<unknown>> = [];
+	jest.spyOn(WorkflowRunner.prototype, 'run').mockImplementation(async function mockedRun(data) {
+		const addPromise = Container.get(ActiveExecutions).add(data);
+		runSettled.push(addPromise.catch(() => undefined));
+		return await addPromise;
+	});
+	return runSettled;
+}
+
+/**
+ * Returns a deferred promise usable as `donePromise` for an `emit` call.
+ *
+ * Note: the public `ITriggerFunctions.emit` signature types `donePromise` as
+ * `IDeferredPromise<IRun>`, but the production closure may resolve it with
+ * `undefined` on the dedup-skipped path. We keep the public type for the
+ * type-check and treat the resolved value as optional at the call site.
+ */
+function createEmitDonePromise(): IDeferredPromise<IRun> {
+	return createDeferredPromise<IRun>();
+}
+
+describe('scheduled execution deduplication', () => {
+	describe('emit-wrapper level (feature flag enabled)', () => {
+		beforeEach(() => {
+			executionsConfig.scheduledExecutionDeduplicationEnabled = true;
+		});
+
+		it('persists only one row when two emits collide on the same deduplicationKey, and warns on the skipped one', async () => {
+			const runSettled = installWorkflowRunnerPassthroughMock();
+			// Spy on the scoped logger attached to ActiveWorkflowManager during construction.
+			const managerWithLogger = activeWorkflowManager as unknown as {
+				logger: { warn: (...args: unknown[]) => void };
+			};
+			const loggerWarnSpy = jest.spyOn(managerWithLogger.logger, 'warn');
+
+			const triggerFactory = activeWorkflowManager.getExecuteTriggerFunctions(
+				workflow,
+				additionalData,
+				'trigger',
+				'init',
+			);
+			const triggerContext = triggerFactory(
+				workflowObject,
+				triggerNode,
+				additionalData,
+				'trigger',
+				'init',
+			);
+
+			const deduplicationKey = `${workflow.id}:${triggerNode.id}:2026-04-17T00:00:00.000Z`;
+
+			const done1 = createEmitDonePromise();
+			const done2 = createEmitDonePromise();
+
+			triggerContext.emit([[{ json: {} }]], undefined, done1, deduplicationKey);
+			triggerContext.emit([[{ json: {} }]], undefined, done2, deduplicationKey);
+
+			// Wait for both underlying runs to settle (one succeeds, one rejects).
+			await Promise.all(runSettled);
+			// The `.catch` on `runWorkflow` inside the emit closure is one microtask further;
+			// await the duplicate emit's `donePromise` — it resolves immediately once the
+			// emit closure observes `executionId === undefined`.
+			await done2.promise;
+
+			const rowsForKey = await executionRepository.findBy({ deduplicationKey });
+			expect(rowsForKey).toHaveLength(1);
+
+			expect(loggerWarnSpy).toHaveBeenCalledWith(
+				expect.stringContaining('duplicate deduplication key'),
+				expect.objectContaining({
+					workflowId: workflow.id,
+					nodeId: triggerNode.id,
+					deduplicationKey,
+				}),
+			);
+		});
+
+		it('allows multiple NULL deduplicationKey rows to coexist (NULLs-are-distinct semantics)', async () => {
+			const runSettled = installWorkflowRunnerPassthroughMock();
+
+			const triggerFactory = activeWorkflowManager.getExecuteTriggerFunctions(
+				workflow,
+				additionalData,
+				'trigger',
+				'init',
+			);
+			const triggerContext = triggerFactory(
+				workflowObject,
+				triggerNode,
+				additionalData,
+				'trigger',
+				'init',
+			);
+
+			const done1 = createEmitDonePromise();
+			const done2 = createEmitDonePromise();
+
+			// No deduplicationKey passed — closure forwards `undefined`.
+			triggerContext.emit([[{ json: {} }]], undefined, done1);
+			triggerContext.emit([[{ json: {} }]], undefined, done2);
+
+			const results = await Promise.allSettled(runSettled);
+			// Both underlying add() calls must succeed.
+			for (const result of results) {
+				expect(result.status).toBe('fulfilled');
+			}
+
+			const rowsForWorkflow = await executionRepository.findBy({ workflowId: workflow.id });
+			expect(rowsForWorkflow).toHaveLength(2);
+			for (const row of rowsForWorkflow) {
+				expect(row.deduplicationKey).toBeNull();
+			}
+		});
+	});
+
+	// Direct persistence-layer coverage — guards the DB behavior we rely on even if the
+	// emit-level wiring shifts in future refactors.
+	describe('ExecutionPersistence + unique index (end-to-end against SQLite)', () => {
+		it('throws DuplicateExecutionError on the second insert with the same deduplicationKey', async () => {
+			const executionPersistence = Container.get(ExecutionPersistence);
+			const deduplicationKey = `${workflow.id}:${triggerNode.id}:2026-04-17T12:00:00.000Z`;
+
+			const firstId = await executionPersistence.create({
+				workflowId: workflow.id,
+				workflowData: workflow,
+				// @ts-expect-error Partial data is sufficient for this test
+				data: { resultData: {} },
+				mode: 'trigger',
+				finished: false,
+				status: 'new',
+				deduplicationKey,
+			});
+			expect(firstId).toBeDefined();
+
+			await expect(
+				executionPersistence.create({
+					workflowId: workflow.id,
+					workflowData: workflow,
+					// @ts-expect-error Partial data is sufficient for this test
+					data: { resultData: {} },
+					mode: 'trigger',
+					finished: false,
+					status: 'new',
+					deduplicationKey,
+				}),
+			).rejects.toBeInstanceOf(DuplicateExecutionError);
+
+			const rowsForKey = await executionRepository.findBy({ deduplicationKey });
+			expect(rowsForKey).toHaveLength(1);
+			expect(rowsForKey[0].id).toBe(firstId);
+		});
+	});
+});

--- a/packages/cli/test/migration/1778000000000-add-execution-deduplication-key.test.ts
+++ b/packages/cli/test/migration/1778000000000-add-execution-deduplication-key.test.ts
@@ -1,0 +1,221 @@
+import {
+	createTestMigrationContext,
+	initDbUpToMigration,
+	runSingleMigration,
+	undoLastSingleMigration,
+	type TestMigrationContext,
+} from '@n8n/backend-test-utils';
+import { DbConnection } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { DataSource } from '@n8n/typeorm';
+import { randomUUID } from 'node:crypto';
+
+const MIGRATION_NAME = 'AddExecutionDeduplicationKey1778000000000';
+
+describe('AddExecutionDeduplicationKey Migration', () => {
+	let dataSource: DataSource;
+
+	beforeEach(async () => {
+		const dbConnection = Container.get(DbConnection);
+		await dbConnection.init();
+		dataSource = Container.get(DataSource);
+		const ctx = createTestMigrationContext(dataSource);
+		await ctx.queryRunner.clearDatabase();
+		await ctx.queryRunner.release();
+		await initDbUpToMigration(MIGRATION_NAME);
+	});
+
+	afterEach(async () => {
+		const dbConnection = Container.get(DbConnection);
+		await dbConnection.close();
+	});
+
+	async function insertWorkflow(ctx: TestMigrationContext): Promise<string> {
+		const table = ctx.escape.tableName('workflow_entity');
+		const now = new Date();
+		const id = randomUUID();
+		await ctx.runQuery(
+			`INSERT INTO ${table} (${ctx.escape.columnName('id')}, ${ctx.escape.columnName('name')}, ${ctx.escape.columnName('active')}, ${ctx.escape.columnName('nodes')}, ${ctx.escape.columnName('connections')}, ${ctx.escape.columnName('versionId')}, ${ctx.escape.columnName('createdAt')}, ${ctx.escape.columnName('updatedAt')}) VALUES (:id, :name, :active, :nodes, :connections, :versionId, :createdAt, :updatedAt)`,
+			{
+				id,
+				name: `Workflow ${id}`,
+				active: false,
+				nodes: '[]',
+				connections: '{}',
+				versionId: randomUUID(),
+				createdAt: now,
+				updatedAt: now,
+			},
+		);
+		return id;
+	}
+
+	async function insertExecution(
+		ctx: TestMigrationContext,
+		workflowId: string,
+		deduplicationKey: string | null,
+	): Promise<void> {
+		const table = ctx.escape.tableName('execution_entity');
+		const now = new Date();
+		await ctx.runQuery(
+			`INSERT INTO ${table} (${ctx.escape.columnName('finished')}, ${ctx.escape.columnName('mode')}, ${ctx.escape.columnName('status')}, ${ctx.escape.columnName('createdAt')}, ${ctx.escape.columnName('startedAt')}, ${ctx.escape.columnName('stoppedAt')}, ${ctx.escape.columnName('storedAt')}, ${ctx.escape.columnName('workflowId')}, ${ctx.escape.columnName('deduplicationKey')}) VALUES (:finished, :mode, :status, :createdAt, :startedAt, :stoppedAt, :storedAt, :workflowId, :deduplicationKey)`,
+			{
+				finished: false,
+				mode: 'trigger',
+				status: 'new',
+				createdAt: now,
+				startedAt: now,
+				stoppedAt: now,
+				storedAt: 'db',
+				workflowId,
+				deduplicationKey,
+			},
+		);
+	}
+
+	describe('up', () => {
+		it('should add deduplicationKey as a nullable varchar(255) column', async () => {
+			await runSingleMigration(MIGRATION_NAME);
+			const ctx = createTestMigrationContext(dataSource);
+
+			if (ctx.isSqlite) {
+				const rows: Array<{
+					name: string;
+					type: string;
+					notnull: number;
+				}> = await ctx.queryRunner.query(
+					`PRAGMA table_info(${ctx.escape.tableName('execution_entity')})`,
+				);
+				const column = rows.find((r) => r.name === 'deduplicationKey');
+				expect(column).toBeDefined();
+				expect(column?.notnull).toBe(0);
+				expect(column?.type.toLowerCase()).toContain('varchar');
+			} else {
+				const rows: Array<{
+					column_name: string;
+					is_nullable: string;
+					data_type: string;
+					character_maximum_length: number | null;
+				}> = await ctx.runQuery(
+					'SELECT column_name, is_nullable, data_type, character_maximum_length FROM information_schema.columns WHERE table_name = :tableName AND column_name = :columnName',
+					{
+						tableName: `${ctx.tablePrefix}execution_entity`,
+						columnName: 'deduplicationKey',
+					},
+				);
+				expect(rows).toHaveLength(1);
+				expect(rows[0].is_nullable).toBe('YES');
+				expect(rows[0].data_type).toBe('character varying');
+				expect(rows[0].character_maximum_length).toBe(255);
+			}
+
+			await ctx.queryRunner.release();
+		});
+
+		it('should create a unique index on deduplicationKey', async () => {
+			await runSingleMigration(MIGRATION_NAME);
+			const ctx = createTestMigrationContext(dataSource);
+			const tableName = ctx.escape.tableName('execution_entity');
+
+			if (ctx.isSqlite) {
+				const indexes: Array<{ name: string; unique: number }> = await ctx.queryRunner.query(
+					`PRAGMA index_list(${tableName})`,
+				);
+				const uniqueIndex = indexes.find(
+					(idx) => idx.name.includes('deduplicationKey') && idx.unique === 1,
+				);
+				expect(uniqueIndex).toBeDefined();
+			} else {
+				const actualTableName = `${ctx.tablePrefix}execution_entity`;
+				const rows: Array<{ indisunique: boolean }> = await ctx.runQuery(
+					`SELECT ix.indisunique
+					 FROM pg_class t
+					 JOIN pg_index ix ON t.oid = ix.indrelid
+					 JOIN pg_class i ON i.oid = ix.indexrelid
+					 JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey)
+					 WHERE t.relname = :tableName AND a.attname = :columnName`,
+					{ tableName: actualTableName, columnName: 'deduplicationKey' },
+				);
+				expect(rows.length).toBeGreaterThan(0);
+				expect(rows.some((r) => r.indisunique)).toBe(true);
+			}
+
+			await ctx.queryRunner.release();
+		});
+
+		it('should reject two rows with the same non-null deduplicationKey', async () => {
+			await runSingleMigration(MIGRATION_NAME);
+			const ctx = createTestMigrationContext(dataSource);
+			const workflowId = await insertWorkflow(ctx);
+
+			await insertExecution(ctx, workflowId, 'shared-key');
+			await expect(insertExecution(ctx, workflowId, 'shared-key')).rejects.toThrow();
+
+			await ctx.queryRunner.release();
+		});
+
+		it('should allow multiple rows with NULL deduplicationKey', async () => {
+			await runSingleMigration(MIGRATION_NAME);
+			const ctx = createTestMigrationContext(dataSource);
+			const workflowId = await insertWorkflow(ctx);
+
+			await insertExecution(ctx, workflowId, null);
+			await insertExecution(ctx, workflowId, null);
+			await insertExecution(ctx, workflowId, null);
+
+			const rows: Array<{ count: string | number }> = await ctx.runQuery(
+				`SELECT COUNT(*) AS count FROM ${ctx.escape.tableName('execution_entity')} WHERE ${ctx.escape.columnName('deduplicationKey')} IS NULL`,
+			);
+			expect(Number(rows[0].count)).toBe(3);
+
+			await ctx.queryRunner.release();
+		});
+	});
+
+	describe('down', () => {
+		it('should drop the unique index and the deduplicationKey column', async () => {
+			await runSingleMigration(MIGRATION_NAME);
+			await undoLastSingleMigration();
+
+			const ctx = createTestMigrationContext(dataSource);
+			const tableName = ctx.escape.tableName('execution_entity');
+
+			if (ctx.isSqlite) {
+				const cols: Array<{ name: string }> = await ctx.queryRunner.query(
+					`PRAGMA table_info(${tableName})`,
+				);
+				expect(cols.map((c) => c.name)).not.toContain('deduplicationKey');
+
+				const indexes: Array<{ name: string }> = await ctx.queryRunner.query(
+					`PRAGMA index_list(${tableName})`,
+				);
+				expect(indexes.some((i) => i.name.includes('deduplicationKey'))).toBe(false);
+			} else {
+				const colRows: Array<{ column_name: string }> = await ctx.runQuery(
+					'SELECT column_name FROM information_schema.columns WHERE table_name = :tableName AND column_name = :columnName',
+					{
+						tableName: `${ctx.tablePrefix}execution_entity`,
+						columnName: 'deduplicationKey',
+					},
+				);
+				expect(colRows).toHaveLength(0);
+
+				const idxRows: Array<{ indexname: string }> = await ctx.runQuery(
+					`SELECT i.relname AS indexname
+					 FROM pg_class t
+					 JOIN pg_index ix ON t.oid = ix.indrelid
+					 JOIN pg_class i ON i.oid = ix.indexrelid
+					 JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey)
+					 WHERE t.relname = :tableName AND a.attname = :columnName`,
+					{
+						tableName: `${ctx.tablePrefix}execution_entity`,
+						columnName: 'deduplicationKey',
+					},
+				);
+				expect(idxRows).toHaveLength(0);
+			}
+
+			await ctx.queryRunner.release();
+		});
+	});
+});

--- a/packages/core/src/execution-engine/__tests__/scheduled-task-manager.test.ts
+++ b/packages/core/src/execution-engine/__tests__/scheduled-task-manager.test.ts
@@ -75,6 +75,34 @@ describe('ScheduledTaskManager', () => {
 		expect(onTick).toHaveBeenCalledTimes(10);
 	});
 
+	it('should invoke onTick with the cron-scheduled fire time, not Date.now()', () => {
+		// Freeze wall clock at an arbitrary instant that is NOT aligned to a minute boundary.
+		const unaligned = new Date('2024-01-01T00:00:30.500Z');
+		jest.setSystemTime(unaligned);
+
+		scheduledTaskManager.registerCron(
+			{
+				workflowId: workflow.id,
+				nodeId: 'test-node-id',
+				timezone: workflow.timezone,
+				expression: everyMinute,
+			},
+			onTick,
+		);
+
+		jest.advanceTimersByTime(60 * 1000);
+
+		expect(onTick).toHaveBeenCalledTimes(1);
+		const firstArg = onTick.mock.calls[0][0];
+		expect(firstArg).toBeInstanceOf(Date);
+		// The scheduled fire time should fall on a whole-second boundary aligned to the
+		// cron expression (every minute at :00 seconds), NOT the unaligned wall-clock time.
+		expect((firstArg as Date).getUTCMilliseconds()).toBe(0);
+		expect((firstArg as Date).getUTCSeconds()).toBe(0);
+		// And it should differ from the unaligned system time.
+		expect((firstArg as Date).getTime()).not.toBe(unaligned.getTime());
+	});
+
 	it('should not invoke on follower instances', () => {
 		scheduledTaskManager = new ScheduledTaskManager(
 			mock<InstanceSettings>({ isLeader: false }),

--- a/packages/core/src/execution-engine/active-workflows.ts
+++ b/packages/core/src/execution-engine/active-workflows.ts
@@ -172,7 +172,9 @@ export class ActiveWorkflows {
 				expression,
 			};
 
-			this.scheduledTaskManager.registerCron(ctx, executeTrigger);
+			this.scheduledTaskManager.registerCron(ctx, () => {
+				void executeTrigger();
+			});
 		}
 	}
 

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/scheduling-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/scheduling-helper-functions.test.ts
@@ -34,5 +34,21 @@ describe('getSchedulingFunctions', () => {
 
 			expect(scheduledTaskManager.registerCron).toHaveBeenCalledWith(ctx, onTick);
 		});
+
+		it('should forward the scheduledT Date to the user-provided onTick', () => {
+			const userOnTick = jest.fn();
+			schedulingFunctions.registerCron({ expression: cronExpression }, userOnTick);
+
+			// Capture the onTick that getSchedulingFunctions passed down to
+			// scheduledTaskManager.registerCron, then invoke it with a Date to
+			// confirm the Date flows through unchanged.
+			const forwardedOnTick = (scheduledTaskManager.registerCron as jest.Mock).mock.calls.at(
+				-1,
+			)![1];
+			const scheduledT = new Date('2024-01-01T00:01:00.000Z');
+			forwardedOnTick(scheduledT);
+
+			expect(userOnTick).toHaveBeenCalledWith(scheduledT);
+		});
 	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/utils/scheduling-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/scheduling-helper-functions.ts
@@ -10,7 +10,7 @@ export const getSchedulingFunctions = (
 ): SchedulingFunctions => {
 	const scheduledTaskManager = Container.get(ScheduledTaskManager);
 	return {
-		registerCron: ({ expression, recurrence }: Cron, onTick) => {
+		registerCron: ({ expression, recurrence }: Cron, onTick: (scheduledT: Date) => void) => {
 			const ctx: CronContext = {
 				expression,
 				recurrence,

--- a/packages/core/src/execution-engine/scheduled-task-manager.ts
+++ b/packages/core/src/execution-engine/scheduled-task-manager.ts
@@ -73,15 +73,11 @@ export class ScheduledTaskManager {
 		}
 
 		let scheduledT: Date | null = null;
-		const job = new CronJob(
+		const job: CronJob = new CronJob(
 			expression,
 			() => {
 				const firedFor = scheduledT;
-				try {
-					scheduledT = job.nextDate().toJSDate();
-				} catch {
-					scheduledT = null;
-				}
+				scheduledT = computeNext();
 
 				if (!this.instanceSettings.isLeader) return;
 				if (firedFor === null) return;
@@ -100,11 +96,21 @@ export class ScheduledTaskManager {
 			timezone,
 		);
 
-		try {
-			scheduledT = job.nextDate().toJSDate();
-		} catch {
-			scheduledT = null;
-		}
+		const computeNext = (): Date | null => {
+			try {
+				return job.nextDate().toJSDate();
+			} catch (error) {
+				this.logger.warn('Failed to compute next scheduled fire time for cron; skipping tick', {
+					workflowId,
+					nodeId,
+					expression,
+					error,
+				});
+				return null;
+			}
+		};
+
+		scheduledT = computeNext();
 
 		const cron: Cron = { job, summary, ctx };
 

--- a/packages/core/src/execution-engine/scheduled-task-manager.ts
+++ b/packages/core/src/execution-engine/scheduled-task-manager.ts
@@ -47,7 +47,7 @@ export class ScheduledTaskManager {
 		}, activeInterval * Time.minutes.toMilliseconds);
 	}
 
-	registerCron(ctx: CronContext, onTick: () => void) {
+	registerCron(ctx: CronContext, onTick: (scheduledT: Date) => void) {
 		const { workflowId, timezone, nodeId, expression, recurrence } = ctx;
 
 		const summary = recurrence?.activated
@@ -72,10 +72,19 @@ export class ScheduledTaskManager {
 			return;
 		}
 
+		let scheduledT: Date | null = null;
 		const job = new CronJob(
 			expression,
 			() => {
+				const firedFor = scheduledT;
+				try {
+					scheduledT = job.nextDate().toJSDate();
+				} catch {
+					scheduledT = null;
+				}
+
 				if (!this.instanceSettings.isLeader) return;
+				if (firedFor === null) return;
 
 				this.logger.debug('Executing cron for workflow', {
 					workflowId,
@@ -84,12 +93,18 @@ export class ScheduledTaskManager {
 					instanceRole: this.instanceSettings.instanceRole,
 				});
 
-				onTick();
+				onTick(firedFor);
 			},
 			undefined,
 			true,
 			timezone,
 		);
+
+		try {
+			scheduledT = job.nextDate().toJSDate();
+		} catch {
+			scheduledT = null;
+		}
 
 		const cron: Cron = { job, summary, ctx };
 

--- a/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
+++ b/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
@@ -443,9 +443,12 @@ export class ScheduleTrigger implements INodeType {
 			}
 		}
 
-		const dedupEnabled = Container.get(ExecutionsConfig).scheduledExecutionDeduplicationEnabled;
 		const workflowId = this.getWorkflow().id;
 		const nodeId = this.getNode().id;
+
+		const configDedupEnabled =
+			Container.get(ExecutionsConfig).scheduledExecutionDeduplicationEnabled;
+		const dedupEnabled = configDedupEnabled && Boolean(workflowId);
 
 		const executeTrigger = (
 			recurrence: IRecurrenceRule,

--- a/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
+++ b/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
@@ -1,3 +1,5 @@
+import { ExecutionsConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
 import { sendAt } from 'cron';
 import moment from 'moment-timezone';
 import type {
@@ -441,7 +443,15 @@ export class ScheduleTrigger implements INodeType {
 			}
 		}
 
-		const executeTrigger = (recurrence: IRecurrenceRule, skipRecurrenceCheck = false) => {
+		const dedupEnabled = Container.get(ExecutionsConfig).scheduledExecutionDeduplicationEnabled;
+		const workflowId = this.getWorkflow().id;
+		const nodeId = this.getNode().id;
+
+		const executeTrigger = (
+			recurrence: IRecurrenceRule,
+			skipRecurrenceCheck = false,
+			scheduledT?: Date,
+		) => {
 			if (!skipRecurrenceCheck) {
 				const shouldTrigger = recurrenceCheck(recurrence, staticData.recurrenceRules, timezone);
 				if (!shouldTrigger) return;
@@ -462,7 +472,17 @@ export class ScheduleTrigger implements INodeType {
 				Timezone: `${timezone} (UTC${momentTz.format('Z')})`,
 			};
 
-			this.emit([this.helpers.returnJsonArray([resultData])]);
+			const deduplicationKey =
+				dedupEnabled && scheduledT
+					? `${workflowId}:${nodeId}:${scheduledT.toISOString()}`
+					: undefined;
+
+			this.emit(
+				[this.helpers.returnJsonArray([resultData])],
+				undefined,
+				undefined,
+				deduplicationKey,
+			);
 		};
 
 		const rules = intervals.map((interval, i) => ({
@@ -478,7 +498,9 @@ export class ScheduleTrigger implements INodeType {
 						expression: cronExpression,
 						recurrence,
 					};
-					this.helpers.registerCron(cron, () => executeTrigger(recurrence));
+					this.helpers.registerCron(cron, (scheduledT) =>
+						executeTrigger(recurrence, false, scheduledT),
+					);
 				} catch (error) {
 					if (interval.field === 'cronExpression') {
 						throw new NodeOperationError(this.getNode(), 'Invalid cron expression', {

--- a/packages/nodes-base/nodes/Schedule/test/ScheduleTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Schedule/test/ScheduleTrigger.node.test.ts
@@ -176,6 +176,10 @@ describe('ScheduleTrigger', () => {
 		describe('deduplication key', () => {
 			const executionsConfig = Container.get(ExecutionsConfig);
 
+			beforeEach(() => {
+				executionsConfig.scheduledExecutionDeduplicationEnabled = false;
+			});
+
 			afterEach(() => {
 				executionsConfig.scheduledExecutionDeduplicationEnabled = false;
 			});
@@ -214,6 +218,26 @@ describe('ScheduleTrigger', () => {
 				expect(scheduledT.getUTCMinutes()).toBe(0);
 				expect(scheduledT.getUTCSeconds()).toBe(0);
 				expect(scheduledT.getUTCMilliseconds()).toBe(0);
+			});
+
+			it('should not emit a deduplication key when the workflow id is undefined', async () => {
+				executionsConfig.scheduledExecutionDeduplicationEnabled = true;
+
+				const { emit } = await testTriggerNode(ScheduleTrigger, {
+					timezone,
+					node: {
+						parameters: {
+							rule: { interval: [{ field: 'cronExpression', expression: '0 */2 * * *' }] },
+						},
+					},
+					workflowStaticData: {},
+					workflow: { active: true },
+				});
+
+				jest.advanceTimersByTime(2 * HOUR);
+
+				expect(emit).toHaveBeenCalledTimes(1);
+				expect(emit.mock.calls[0][3]).toBeUndefined();
 			});
 
 			it('should not emit a deduplication key when the feature flag is disabled', async () => {

--- a/packages/nodes-base/nodes/Schedule/test/ScheduleTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Schedule/test/ScheduleTrigger.node.test.ts
@@ -1,3 +1,5 @@
+import { ExecutionsConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
 import * as n8nWorkflow from 'n8n-workflow';
 
 import { testTriggerNode } from '@test/nodes/TriggerHelpers';
@@ -169,6 +171,85 @@ describe('ScheduleTrigger', () => {
 			await expect(manualTriggerFunction?.()).rejects.toBeInstanceOf(
 				n8nWorkflow.NodeOperationError,
 			);
+		});
+
+		describe('deduplication key', () => {
+			const executionsConfig = Container.get(ExecutionsConfig);
+
+			afterEach(() => {
+				executionsConfig.scheduledExecutionDeduplicationEnabled = false;
+			});
+
+			it('should emit a deduplication key when the feature flag is enabled', async () => {
+				executionsConfig.scheduledExecutionDeduplicationEnabled = true;
+
+				const workflowId = 'wf-123';
+				const nodeId = 'node-456';
+				const { emit } = await testTriggerNode(ScheduleTrigger, {
+					timezone,
+					node: {
+						id: nodeId,
+						parameters: {
+							rule: { interval: [{ field: 'cronExpression', expression: '0 */2 * * *' }] },
+						},
+					},
+					workflowStaticData: {},
+					workflow: { id: workflowId, active: true },
+				});
+
+				jest.advanceTimersByTime(2 * HOUR);
+
+				expect(emit).toHaveBeenCalledTimes(1);
+				const fourthArg = emit.mock.calls[0][3];
+				expect(typeof fourthArg).toBe('string');
+				// Deduplication key shape: `${workflowId}:${nodeId}:${scheduledT.toISOString()}`
+				expect(fourthArg).toMatch(
+					new RegExp(
+						`^${workflowId}:${nodeId}:\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z$`,
+					),
+				);
+				// The ISO timestamp segment must match the cron-scheduled fire time exactly.
+				const iso = (fourthArg as string).slice(`${workflowId}:${nodeId}:`.length);
+				const scheduledT = new Date(iso);
+				expect(scheduledT.getUTCMinutes()).toBe(0);
+				expect(scheduledT.getUTCSeconds()).toBe(0);
+				expect(scheduledT.getUTCMilliseconds()).toBe(0);
+			});
+
+			it('should not emit a deduplication key when the feature flag is disabled', async () => {
+				executionsConfig.scheduledExecutionDeduplicationEnabled = false;
+
+				const { emit } = await testTriggerNode(ScheduleTrigger, {
+					timezone,
+					node: {
+						parameters: {
+							rule: { interval: [{ field: 'cronExpression', expression: '0 */2 * * *' }] },
+						},
+					},
+					workflowStaticData: {},
+				});
+
+				jest.advanceTimersByTime(2 * HOUR);
+
+				expect(emit).toHaveBeenCalledTimes(1);
+				expect(emit.mock.calls[0][3]).toBeUndefined();
+			});
+
+			it('should not emit a deduplication key for manual executions', async () => {
+				executionsConfig.scheduledExecutionDeduplicationEnabled = true;
+
+				const { emit, manualTriggerFunction } = await testTriggerNode(ScheduleTrigger, {
+					mode: 'manual',
+					timezone,
+					node: { parameters: { rule: { interval: [{ field: 'hours', hoursInterval: 3 }] } } },
+					workflowStaticData: { recurrenceRules: [] },
+				});
+
+				await manualTriggerFunction?.();
+
+				expect(emit).toHaveBeenCalledTimes(1);
+				expect(emit.mock.calls[0][3]).toBeUndefined();
+			});
 		});
 	});
 });

--- a/packages/nodes-base/test/nodes/TriggerHelpers.ts
+++ b/packages/nodes-base/test/nodes/TriggerHelpers.ts
@@ -46,6 +46,7 @@ type TestTriggerNodeOptions = {
 	workflowStaticData?: IDataObject;
 	credential?: ICredentialDataDecryptedObject;
 	helpers?: Partial<ITriggerFunctions['helpers']>;
+	workflow?: { id?: string; name?: string; active?: boolean };
 };
 
 type TestWebhookTriggerNodeOptions = TestTriggerNodeOptions & {
@@ -104,6 +105,11 @@ export async function testTriggerNode(
 		},
 	});
 
+	const workflowMetadata = {
+		id: options.workflow?.id,
+		name: options.workflow?.name,
+		active: options.workflow?.active ?? false,
+	};
 	const triggerFunctions = mock<ITriggerFunctions>({
 		helpers,
 		emit,
@@ -115,6 +121,7 @@ export async function testTriggerNode(
 		}),
 		getTimezone: () => timezone,
 		getNode: () => node,
+		getWorkflow: () => workflowMetadata,
 		getCredentials: async <T extends object = ICredentialDataDecryptedObject>() =>
 			(options.credential ?? {}) as T,
 		getMode: () => options.mode ?? 'trigger',

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -944,7 +944,7 @@ export type CronContext = {
 export type Cron = { expression: CronExpression; recurrence?: CronRecurrenceRule };
 
 export interface SchedulingFunctions {
-	registerCron(cron: Cron, onTick: () => void): void;
+	registerCron(cron: Cron, onTick: (scheduledT: Date) => void): void;
 }
 
 export type NodeTypeAndVersion = {
@@ -1257,6 +1257,7 @@ export interface ITriggerFunctions
 		data: INodeExecutionData[][],
 		responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>,
 		donePromise?: IDeferredPromise<IRun>,
+		deduplicationKey?: string,
 	): void;
 	/**
 	 * Persist the current run as a failed execution and run the error workflow if configured.
@@ -2979,6 +2980,7 @@ export interface IWorkflowExecutionDataProcess {
 		arguments: Record<string, unknown>;
 		sourceNodeName?: string;
 	};
+	deduplicationKey?: string;
 }
 
 export interface ExecuteWorkflowOptions {


### PR DESCRIPTION
## Summary

Fifth (follow-up) PR in the deduplication stack. **Tests only.**

**Stacked on top of:** #28649

Adds an integration test at \`packages/cli/test/integration/scheduled-execution-deduplication.test.ts\` that exercises the dedup path end-to-end against a real SQLite database:

- **Emit-wrapper level** — drives the real \`emit\` closure obtained from \`ActiveWorkflowManager.getExecuteTriggerFunctions\`. Two concurrent \`emit(...)\` calls with the same \`deduplicationKey\` → exactly one row in \`execution_entity\` + one \`warn\` log with the expected context. The only mock on the hot path is a passthrough \`WorkflowRunner.run\` that forwards to \`ActiveExecutions.add\` (so we don't have to stand up a full workflow engine for a persistence-layer test).
- **NULL-distinct check** — multiple inserts with \`NULL\` dedup keys all coexist (proves the unique index's NULL handling is correct on SQLite).
- **Persistence layer** — direct \`ExecutionPersistence.create\` twice with the same key → second throws \`DuplicateExecutionError\`.

While writing this test, it surfaced a real bug — the original \`isUniqueViolationError\` only matched the SQLite *extended* code \`SQLITE_CONSTRAINT_UNIQUE\`, but the \`sqlite3\` native binding used by TypeORM reports the *base* code \`SQLITE_CONSTRAINT\` with the violation type in the error message. The fix lives in #28649 (\`fix(core): detect SQLite unique violation when extended result codes are off\`) and is a prerequisite for this PR. That's exactly what this integration test was supposed to catch, so mission accomplished.

Design doc and full plan: https://www.notion.so/n8n/3455b6e0c94f81a4afccfa6efadaa637

Full stack:
1. Feature flag (#28642)
2. DB column + migration (#28645)
3. Schedule Trigger generates the deduplication key (#28646)
4. Runner consumes the key and warns on collision (#28649)
5. **This PR** — integration test

## Related Linear tickets

https://linear.app/n8n/issue/CAT-2677

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. _(N/A — test-only.)_
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\`.