### PR TITLE
fix(editor): Remove clipping for focus panel textarea

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/FocusPanel.vue
+++ b/packages/frontend/editor-ui/src/app/components/FocusPanel.vue
@@ -556,7 +556,6 @@ function onRenameNode(value: string) {
 							v-else
 							ref="inputField"
 							v-model="inputValue"
-							:autosize="{ minRows: 3, maxRows: 20 }"
 							:class="$style.editor"
 							:readonly="isReadOnly"
 							type="textarea"
@@ -704,6 +703,11 @@ function onRenameNode(value: string) {
 				width: 100%;
 				align-items: normal;
 				font-size: var(--font-size--2xs);
+
+				textarea {
+					height: 100%;
+					resize: none;
+				}
 
 				:global(.cm-editor) {
 					background-color: var(--code--color--background);

--- a/packages/frontend/editor-ui/src/app/components/FocusPanel.vue
+++ b/packages/frontend/editor-ui/src/app/components/FocusPanel.vue
@@ -556,6 +556,7 @@ function onRenameNode(value: string) {
 							v-else
 							ref="inputField"
 							v-model="inputValue"
+							:autosize="{ minRows: 3, maxRows: 20 }"
 							:class="$style.editor"
 							:readonly="isReadOnly"
 							type="textarea"


### PR DESCRIPTION
## Summary
Fixes [ADO-5045](https://linear.app/n8n/issue/ADO-5045/focus-panel-from-a-node-parameter-not-resizing-to-fit-text)

Removes `autosize` and uses `height:100%` to expand the full panel.

| Before | After |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/20c11a58-081e-4eca-929d-f3345c864e10" width="960px" alt="image" /> | <img src="https://github.com/user-attachments/assets/d6901d26-f63c-4c57-8439-4a3eb85c9a7b" width="960px" alt="CleanShot 2026-04-29 at 13 47 17@2x" /> |



## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/ADO-5045/focus-panel-from-a-node-parameter-not-resizing-to-fit-text

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
