### PR TITLE
refactor(editor): Migrate workflow name consumers to workflowDocumentStore

### DIFF
--- a/packages/frontend/editor-ui/eslint.config.mjs
+++ b/packages/frontend/editor-ui/eslint.config.mjs
@@ -63,9 +63,9 @@ export default defineConfig(
 				},
 				{
 					selector:
-						"MemberExpression[property.name='nodes'][object.property.name='workflow'][object.object.name='workflowsStore']",
+						"MemberExpression[property.name=/^(name|nodes|connections|active|isArchived|settings|tags|pinData|meta|versionId|activeVersionId|createdAt|updatedAt|parentFolder|scopes|usedCredentials|homeProject|description|versionData)$/][object.property.name='workflow'][object.object.name='workflowsStore']",
 					message:
-						'Use workflowDocumentStore node accessors instead of workflowsStore.workflow.nodes',
+						'Use the equivalent workflowDocumentStore accessor instead of workflowsStore.workflow.<property>',
 				},
 				{
 					selector:

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionStarted.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionStarted.test.ts
@@ -2,6 +2,10 @@ import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
 import { executionStarted } from './executionStarted';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	createWorkflowDocumentId,
+	useWorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
 import { mockedStore } from '@/__tests__/utils';
 import type { ExecutionStarted } from '@n8n/api-types/push/execution';
 import type { WorkflowState } from '@/app/composables/useWorkflowState';
@@ -20,7 +24,7 @@ describe('executionStarted', () => {
 	}
 
 	beforeEach(() => {
-		const pinia = createTestingPinia({ stubActions: true });
+		const pinia = createTestingPinia({ stubActions: false });
 		setActivePinia(pinia);
 
 		workflowsStore = mockedStore(useWorkflowsStore);
@@ -43,7 +47,8 @@ describe('executionStarted', () => {
 		workflowsStore.activeExecutionId = null;
 		workflowsStore.workflowExecutionData = null;
 		workflowsStore.workflow.id = 'wf-123';
-		workflowsStore.workflow.name = 'My Workflow';
+		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId('wf-123'));
+		workflowDocumentStore.setName('My Workflow');
 
 		await executionStarted(makeEvent('exec-1'), mockOptions);
 

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionStarted.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionStarted.ts
@@ -1,5 +1,9 @@
 import type { ExecutionStarted } from '@n8n/api-types/push/execution';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	createWorkflowDocumentId,
+	useWorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
 import { parse } from 'flatted';
 import { createRunExecutionData } from 'n8n-workflow';
 import type { WorkflowState } from '@/app/composables/useWorkflowState';
@@ -35,6 +39,9 @@ export async function executionStarted(
 	// node status (e.g. DemoLayout iframe receiving push events for a new execution).
 	if (!workflowsStore.workflowExecutionData?.data || needsInit) {
 		const wf = workflowsStore.workflow;
+		const workflowDocumentStore = workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined;
 		options.workflowState.setWorkflowExecutionData({
 			id: data.executionId,
 			finished: false,
@@ -44,7 +51,7 @@ export async function executionStarted(
 			startedAt: new Date(),
 			workflowData: {
 				id: wf.id,
-				name: wf.name,
+				name: workflowDocumentStore?.name ?? '',
 				active: wf.active,
 				isArchived: wf.isArchived,
 				nodes: wf.nodes,

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
@@ -125,7 +125,6 @@ describe('useWorkflowsStore', () => {
 	});
 
 	it('should initialize with default state', () => {
-		expect(workflowsStore.workflow.name).toBe('');
 		expect(workflowsStore.workflow.id).toBe('');
 	});
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
@@ -20,7 +20,6 @@ import { defaultSettings } from '@/__tests__/defaults';
 import { createTestNode } from '@/__tests__/mocks';
 import merge from 'lodash/merge';
 import { DEFAULT_POSTHOG_SETTINGS } from '@/app/stores/posthog.store.test';
-import { DEFAULT_NEW_WORKFLOW_NAME } from '@/app/constants';
 import { nextTick, reactive } from 'vue';
 import * as chatAPI from '@/features/ai/assistant/assistant.api';
 import * as telemetryModule from '@/app/composables/useTelemetry';
@@ -174,7 +173,6 @@ describe('AI Builder store', () => {
 		credentialsStore = mockedStore(useCredentialsStore);
 
 		workflowsStore.workflowId = 'test-workflow-id';
-		workflowsStore.workflow.name = DEFAULT_NEW_WORKFLOW_NAME;
 		workflowsStore.workflow.nodes = [];
 		workflowsStore.workflow.connections = {};
 		workflowsStore.nodesByName = {};


### PR DESCRIPTION
## Summary

Make `workflowDocumentStore` the single source of truth for the current workflow `name`. Migrate the `executionStarted` push handler to read `name` from `workflowDocumentStore` instead of `workflowsStore.workflow`, update the corresponding test, and drop dead mock setup in `builder.store.test.ts` and a stale default-state assertion in `workflows.store.test.ts`. Extend the editor ESLint `no-restricted-syntax` guardrail from only `.nodes`/`.name` to all 19 `workflowsStore.workflow.<property>` accesses that have `workflowDocumentStore` equivalents, so new consumers can't regress.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2752/migrate-name-consumers-to-workflowdocumentstore

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)