### PR TITLE
fix(editor): Prevent chat window jump when hovering prompt suggestions (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiView.vue
@@ -116,7 +116,7 @@ watch(
 	},
 );
 const showCreditBanner = computed(() => store.isLowCredits && !creditBannerDismissed.value);
-const showEmptyStateLayout = computed(() => !store.hasMessages && !store.isHydratingThread);
+const showEmptyStateLayout = computed(() => !props.threadId);
 
 // Load persisted threads from Mastra storage on mount
 onMounted(() => {
@@ -746,9 +746,9 @@ function handleStop() {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	justify-content: center;
 	gap: var(--spacing--lg);
 	padding: var(--spacing--lg);
+	padding-top: 20vh;
 }
 
 .centeredInput {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiView.test.ts
@@ -107,14 +107,14 @@ describe('InstanceAiView', () => {
 			},
 		] as typeof store.messages;
 
-		const { getByTestId } = renderView();
+		const { getByTestId } = renderView({ props: { threadId: 'thread-1' } });
 		expect(getByTestId('instance-ai-input-stub')).toHaveTextContent('unset');
 	});
 
 	it('does not pass suggestions while an existing thread is hydrating', () => {
 		store.isHydratingThread = true;
 
-		const { getByTestId } = renderView();
+		const { getByTestId } = renderView({ props: { threadId: 'thread-1' } });
 		expect(getByTestId('instance-ai-input-stub')).toHaveTextContent('unset');
 	});
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiInput.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiInput.vue
@@ -173,6 +173,13 @@ function handleSuggestionSubmit(payload: {
 	});
 	submitComposerMessage(i18n.baseText(payload.promptKey));
 }
+
+const resizable = computed(() => {
+	if (previewPromptKey.value) {
+		return { minRows: 2, maxRows: 2 };
+	}
+	return undefined;
+});
 </script>
 
 <template>
@@ -183,6 +190,7 @@ function handleSuggestionSubmit(payload: {
 			:placeholder="placeholder"
 			:is-streaming="props.isStreaming"
 			:can-submit="canSubmit"
+			:autosize="resizable"
 			show-voice
 			show-attach
 			@submit="handleSubmit"

--- a/packages/frontend/editor-ui/src/features/ai/shared/components/ChatInputBase.vue
+++ b/packages/frontend/editor-ui/src/features/ai/shared/components/ChatInputBase.vue
@@ -4,16 +4,24 @@ import { N8nIconButton, N8nInput, N8nTooltip } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import { useSpeechRecognition } from '@vueuse/core';
 
-const props = defineProps<{
-	modelValue: string;
-	placeholder?: string;
-	isStreaming: boolean;
-	canSubmit: boolean;
-	disabled?: boolean;
-	showVoice?: boolean;
-	showAttach?: boolean;
-	acceptedMimeTypes?: string;
-}>();
+const props = withDefaults(
+	defineProps<{
+		modelValue: string;
+		placeholder?: string;
+		isStreaming: boolean;
+		canSubmit: boolean;
+		disabled?: boolean;
+		showVoice?: boolean;
+		showAttach?: boolean;
+		acceptedMimeTypes?: string;
+		autosize?: boolean | { minRows: number; maxRows: number };
+	}>(),
+	{
+		placeholder: undefined,
+		acceptedMimeTypes: undefined,
+		autosize: () => ({ minRows: 2, maxRows: 6 }),
+	},
+);
 
 const emit = defineEmits<{
 	'update:modelValue': [value: string];
@@ -122,14 +130,13 @@ defineExpose({
 		/>
 
 		<slot name="attachments" />
-
 		<N8nInput
 			ref="inputRef"
 			:model-value="modelValue"
 			type="textarea"
 			:placeholder="placeholder"
 			autocomplete="off"
-			:autosize="{ minRows: 1, maxRows: 6 }"
+			:autosize="autosize"
 			:disabled="disabled"
 			@update:model-value="emit('update:modelValue', $event)"
 			@keydown="handleKeydown"


### PR DESCRIPTION
## Summary

When hovering a prompt suggestion button in the Instance AI empty state, the preview prompt text is piped into the chat textarea's `placeholder`. `N8nInput`'s autosize uses `value || placeholder` to compute height, so long previews caused the input to grow — which pushed the suggestion row down and produced a visible jump/flicker when moving the cursor between buttons.

Changes:
- `ChatInputBase` accepts an `autosize` override; `InstanceAiInput` pins the textarea to a fixed row count while a preview is active.
- `.emptyLayout` is anchored from the top (`padding-top: 20vh`) instead of being vertically centered, so the surrounding layout doesn't shift when the composer changes height.
- Empty-state visibility is driven by `!props.threadId` to avoid a flash during thread hydration.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2388

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)