### PR TITLE
ci: Strengthen Playwright test resilience

### DIFF
--- a/packages/testing/playwright/pages/CanvasPage.ts
+++ b/packages/testing/playwright/pages/CanvasPage.ts
@@ -560,7 +560,9 @@ export class CanvasPage extends BasePage {
 
 	async executeNode(nodeName: string): Promise<void> {
 		await this.nodeByName(nodeName).hover();
-		await this.nodeExecuteButton(nodeName).click();
+		const button = this.nodeExecuteButton(nodeName);
+		await expect(button).toBeVisible();
+		await button.click();
 	}
 
 	async selectAll(): Promise<void> {

--- a/packages/testing/playwright/pages/components/InstanceAiSidebar.ts
+++ b/packages/testing/playwright/pages/components/InstanceAiSidebar.ts
@@ -24,6 +24,6 @@ export class InstanceAiSidebar {
 	}
 
 	getDeleteMenuItem(): Locator {
-		return this.root.page().getByText('Delete', { exact: true }).first();
+		return this.root.page().getByRole('menuitem').filter({ hasText: 'Delete' });
 	}
 }

--- a/packages/testing/playwright/tests/e2e/workflows/editor/expressions/mapping.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/expressions/mapping.spec.ts
@@ -265,7 +265,7 @@ test.describe(
 			);
 		});
 
-		test('maps expressions to updated fields correctly @fixme', async ({ n8n }) => {
+		test.fixme('maps expressions to updated fields correctly', async ({ n8n }) => {
 			await n8n.start.fromImportedWorkflow('schedule-trigger-with-set-nodes.json');
 			await n8n.canvas.openNode('Set');
 

--- a/packages/testing/playwright/tests/e2e/workflows/editor/ndv/pinning.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/ndv/pinning.spec.ts
@@ -179,10 +179,10 @@ test.describe(
 				await expressionInput.click();
 				await n8n.ndv.clearExpressionEditor();
 				await n8n.ndv.typeInExpressionEditor(`{{ $('${NODES.HTTP_REQUEST}').item`);
-				await n8n.page.keyboard.press('Escape');
 
-				const expectedOutput = '[Object: {"json": {"http": 123}, "pairedItem": {"item": 0}}]';
-				await expect(n8n.ndv.getParameterInputHintWithText(expectedOutput)).toBeVisible();
+				const hint = n8n.ndv.getParameterInputHint();
+				await expect(hint).toContainText('"http": 123');
+				await expect(hint).toContainText('pairedItem');
 			});
 
 			test('should use pin data in manual webhook executions', async ({


### PR DESCRIPTION
## Summary

Adds explicit visibility checks before interacting with elements to prevent race conditions. Improves locator robustness for menu items, enhancing element identification. Marks a known flaky test with `test.fixme` to temporarily skip it from regular runs. Refactors NDV hint assertions for greater flexibility and stability against minor output variations.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
