### PR TITLE
feat(core): Expose instance registry via proxy service (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-registry/instance-registry.module.ts
+++ b/packages/cli/src/modules/instance-registry/instance-registry.module.ts
@@ -24,7 +24,13 @@ export class InstanceRegistryModule implements ModuleInterface {
 		await import('./instance-registry.controller');
 
 		const { InstanceRegistryService } = await import('./instance-registry.service');
-		await Container.get(InstanceRegistryService).init();
+		const instanceRegistryService = Container.get(InstanceRegistryService);
+		await instanceRegistryService.init();
+
+		const { InstanceRegistryProxyService } = await import(
+			'@/services/instance-registry-proxy.service'
+		);
+		Container.get(InstanceRegistryProxyService).registerProvider(instanceRegistryService);
 
 		const { StaleMemberCleanupService } = await import('./stale-member-cleanup.service');
 		Container.get(StaleMemberCleanupService).init();

--- a/packages/cli/src/services/__tests__/instance-registry-proxy.service.test.ts
+++ b/packages/cli/src/services/__tests__/instance-registry-proxy.service.test.ts
@@ -1,0 +1,88 @@
+import type { InstanceRegistration } from '@n8n/api-types';
+import { mock } from 'jest-mock-extended';
+
+import type { InstanceRegistryProvider } from '../instance-registry-proxy.service';
+import { InstanceRegistryProxyService } from '../instance-registry-proxy.service';
+
+const makeRegistration = (overrides: Partial<InstanceRegistration> = {}): InstanceRegistration => ({
+	schemaVersion: 1,
+	instanceKey: 'instance-key-1',
+	hostId: 'main-abc123',
+	instanceType: 'main',
+	instanceRole: 'leader',
+	version: '1.0.0',
+	registeredAt: 1_000,
+	lastSeen: 2_000,
+	...overrides,
+});
+
+describe('InstanceRegistryProxyService', () => {
+	let service: InstanceRegistryProxyService;
+
+	beforeEach(() => {
+		service = new InstanceRegistryProxyService();
+	});
+
+	describe('without a registered provider', () => {
+		it('getAllInstances returns an empty array', async () => {
+			await expect(service.getAllInstances()).resolves.toEqual([]);
+		});
+
+		it('getLocalInstance returns null', () => {
+			expect(service.getLocalInstance()).toBeNull();
+		});
+	});
+
+	describe('with a registered provider', () => {
+		it('getAllInstances delegates to the provider', async () => {
+			const instances = [makeRegistration(), makeRegistration({ instanceKey: 'instance-key-2' })];
+			const provider = mock<InstanceRegistryProvider>();
+			provider.getAllInstances.mockResolvedValue(instances);
+
+			service.registerProvider(provider);
+
+			await expect(service.getAllInstances()).resolves.toBe(instances);
+			expect(provider.getAllInstances).toHaveBeenCalledTimes(1);
+			expect(provider.getLocalInstance).not.toHaveBeenCalled();
+		});
+
+		it('getLocalInstance delegates to the provider', () => {
+			const local = makeRegistration();
+			const provider = mock<InstanceRegistryProvider>();
+			provider.getLocalInstance.mockReturnValue(local);
+
+			service.registerProvider(provider);
+
+			expect(service.getLocalInstance()).toBe(local);
+			expect(provider.getLocalInstance).toHaveBeenCalledTimes(1);
+			expect(provider.getAllInstances).not.toHaveBeenCalled();
+		});
+
+		it('getLocalInstance forwards a null from the provider', () => {
+			const provider = mock<InstanceRegistryProvider>();
+			provider.getLocalInstance.mockReturnValue(null);
+
+			service.registerProvider(provider);
+
+			expect(service.getLocalInstance()).toBeNull();
+		});
+	});
+
+	describe('re-registration', () => {
+		it('uses the most recently registered provider', async () => {
+			const firstProvider = mock<InstanceRegistryProvider>();
+			firstProvider.getAllInstances.mockResolvedValue([makeRegistration({ instanceKey: 'first' })]);
+
+			const secondProvider = mock<InstanceRegistryProvider>();
+			const secondInstances = [makeRegistration({ instanceKey: 'second' })];
+			secondProvider.getAllInstances.mockResolvedValue(secondInstances);
+
+			service.registerProvider(firstProvider);
+			service.registerProvider(secondProvider);
+
+			await expect(service.getAllInstances()).resolves.toBe(secondInstances);
+			expect(firstProvider.getAllInstances).not.toHaveBeenCalled();
+			expect(secondProvider.getAllInstances).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/packages/cli/src/services/instance-registry-proxy.service.ts
+++ b/packages/cli/src/services/instance-registry-proxy.service.ts
@@ -1,0 +1,26 @@
+import type { InstanceRegistration } from '@n8n/api-types';
+import { Service } from '@n8n/di';
+
+export interface InstanceRegistryProvider {
+	getAllInstances(): Promise<InstanceRegistration[]>;
+	getLocalInstance(): InstanceRegistration | null;
+}
+
+@Service()
+export class InstanceRegistryProxyService implements InstanceRegistryProvider {
+	private provider: InstanceRegistryProvider | null = null;
+
+	registerProvider(provider: InstanceRegistryProvider): void {
+		this.provider = provider;
+	}
+
+	async getAllInstances(): Promise<InstanceRegistration[]> {
+		if (!this.provider) return [];
+		return await this.provider.getAllInstances();
+	}
+
+	getLocalInstance(): InstanceRegistration | null {
+		if (!this.provider) return null;
+		return this.provider.getLocalInstance();
+	}
+}


### PR DESCRIPTION
## Summary

Introduces `InstanceRegistryProxyService` — a CLI-level bridge that exposes the
instance-registry module to the rest of the CLI through a stable interface
(`InstanceRegistryProvider`), without coupling consumers to the module's
feature-flag state.

### Why

The `instance-registry` module (gated by `N8N_ENV_FEAT_INSTANCE_REGISTRY`)
tracks main/worker/webhook processes in distributed deployments. Until now,
any CLI code that wanted cluster information had to import
`InstanceRegistryService` directly — a hard dependency on an optional module.

This PR lays the consumer-facing surface for that module:

- `InstanceRegistryProvider` — the well-known interface (`getAllInstances`,
  `getLocalInstance`).
- `InstanceRegistryProxyService` — a singleton, always-available
  `@Service()` in `src/services/` that implements the interface.
- When the module initializes, it registers `InstanceRegistryService` as the
  proxy's provider. When the feature flag is off, no provider is registered
  and the proxy returns safe defaults (`[]` / `null`), so consumers can call
  it unconditionally.

Scope is deliberately narrow. Version-mismatch computation
(`getVersionMismatch()`) and rewiring
`InstanceRegistryController.getClusterInfo()` to the proxy are handled in
follow-up tickets.

### How to test manually

There is no user-visible change in this PR. The existing REST endpoint
`GET /rest/instance-registry` still returns `{ instances, versionMismatch: null }`
exactly as before (hardcoded `null` in the controller, unchanged).

Smoke verification is covered by unit tests
(`packages/cli/src/services/__tests__/instance-registry-proxy.service.test.ts`):

- Without a registered provider → `getAllInstances()` returns `[]`,
  `getLocalInstance()` returns `null`.
- With a registered provider → both methods delegate.
- `getLocalInstance()` forwards a `null` from the provider unchanged.
- Re-registering swaps in the latest provider (latest-wins).

If desired, you can also run n8n locally with
`N8N_ENV_FEAT_INSTANCE_REGISTRY=true` and confirm the existing endpoint
still responds normally — behavior is unchanged in this PR.

### Key implementation decisions

- **Proxy lives in `packages/cli/src/services/`, not inside the module folder.**
  The module file cannot eagerly import the proxy (blocked by
  `n8n-local-rules/no-top-level-relative-imports-in-backend-module`), and the
  proxy must remain resolvable from DI even when the feature flag is off.
  Placing it under `src/services/` lets CLI consumers import it
  unconditionally while the module performs a lazy dynamic `import(...)`
  inside its `init()` to call `registerProvider()`.
- **`InstanceRegistryProvider.getLocalInstance()` returns `InstanceRegistration | null`.**
  The proxy widens the underlying service's non-nullable return type so the
  "no provider registered" state is expressible through the same contract.
  `InstanceRegistryService`'s non-null return remains structurally compatible.
- **Latest-wins on re-registration.** Simple and sufficient for the current
  single-module topology; documented via a test.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-330

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
