### PR TITLE
ci: Only post QA metrics on n8n-io/n8n monorepo

### DIFF
--- a/.github/workflows/util-qa-metrics-comment-reusable.yml
+++ b/.github/workflows/util-qa-metrics-comment-reusable.yml
@@ -18,7 +18,8 @@ jobs:
     name: Post Metrics Comment
     if: >-
       github.event_name == 'pull_request' &&
-      !github.event.pull_request.head.repo.fork
+      !github.event.pull_request.head.repo.fork &&
+      github.repository == 'n8n-io/n8n'
     runs-on: ubuntu-slim
     continue-on-error: true
     permissions:


### PR DESCRIPTION
## Summary

Don't post QA metrics in other repositories using this workflow other than the public `n8n-io/n8n` monorepo.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
