### PR TITLE
fix(editor): Show saved credentials when node has mismatched credentials object

### DIFF
--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
@@ -299,6 +299,58 @@ describe('NodeCredentials', () => {
 		expect(screen.queryByText('Test OpenAi account')).toBeInTheDocument();
 	});
 
+	it('should render the dropdown with saved credentials when node has a mismatched credentials object', async () => {
+		const anthropicApiCredentialType: ICredentialType = {
+			name: 'anthropicApi',
+			displayName: 'Anthropic',
+			documentationUrl: 'anthropic',
+			properties: [
+				{ displayName: 'API Key', name: 'apiKey', type: 'string', required: true, default: '' },
+			],
+		};
+
+		const mismatchedNode: INodeUi = {
+			...httpNode,
+			parameters: {
+				...httpNode.parameters,
+				authentication: 'predefinedCredentialType',
+				nodeCredentialType: 'anthropicApi',
+			},
+			credentials: { httpHeaderAuth: { id: 'header-auth-id', name: 'Header Auth' } },
+		};
+
+		credentialsStore.state.credentialTypes = {
+			...credentialsStore.state.credentialTypes,
+			anthropicApi: anthropicApiCredentialType,
+		};
+		credentialsStore.state.credentials = {
+			'anthropic-cred-id': createCredential({
+				id: 'anthropic-cred-id',
+				name: 'My Anthropic account',
+				type: 'anthropicApi',
+			}),
+		};
+
+		ndvStore.activeNode = mismatchedNode;
+
+		renderComponent(
+			{
+				props: {
+					node: mismatchedNode,
+					overrideCredType: 'anthropicApi',
+				},
+			},
+			{ merge: true },
+		);
+
+		expect(screen.queryByTestId('node-credentials-empty-state')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('node-credentials-select')).toBeInTheDocument();
+
+		await userEvent.click(screen.getByTestId('node-credentials-select'));
+
+		expect(screen.queryByText('My Anthropic account')).toBeInTheDocument();
+	});
+
 	it('should not ignored managed credentials in the dropdown if active node is not the HTTP node', async () => {
 		ndvStore.activeNode = openAiNode;
 		credentialsStore.state.credentials = {

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -731,7 +731,7 @@ async function onQuickConnectSignIn(credentialTypeName: string) {
 				</div>
 
 				<div
-					v-else-if="showStandardEmptyState(type)"
+					v-else-if="showStandardEmptyState(type) && options.length === 0"
 					:class="$style.standardEmptyContainer"
 					data-test-id="node-credentials-empty-state"
 				>

--- a/packages/testing/playwright/tests/e2e/building-blocks/credential-mismatch.spec.ts
+++ b/packages/testing/playwright/tests/e2e/building-blocks/credential-mismatch.spec.ts
@@ -1,0 +1,194 @@
+import { nanoid } from 'nanoid';
+
+import { test, expect } from '../../../fixtures/base';
+
+test.describe(
+	'HTTP Request credential picker with mismatched credentials object',
+	{
+		annotation: [{ type: 'owner', description: 'Catalysts' }],
+	},
+	() => {
+		test('should show saved credentials when nodeCredentialType matches despite mismatched credentials object', async ({
+			n8n,
+			api,
+		}) => {
+			await n8n.start.fromHome();
+
+			const anthropicCredName = `Anthropic API ${nanoid()}`;
+			await api.credentials.createCredential({
+				name: anthropicCredName,
+				type: 'anthropicApi',
+				data: {
+					apiKey: 'test-api-key-12345',
+				},
+			});
+
+			const headerAuthCredName = `Header Auth ${nanoid()}`;
+			const headerAuthCred = await api.credentials.createCredential({
+				name: headerAuthCredName,
+				type: 'httpHeaderAuth',
+				data: {
+					name: 'x-api-key',
+					value: 'test-value',
+				},
+			});
+
+			const workflow = await api.workflows.createWorkflow({
+				name: `Test Workflow ${nanoid()}`,
+				nodes: [
+					{
+						id: nanoid(),
+						name: 'Manual Trigger',
+						type: 'n8n-nodes-base.manualTrigger',
+						typeVersion: 1,
+						position: [250, 300],
+						parameters: {},
+					},
+					{
+						id: nanoid(),
+						name: 'HTTP Request',
+						type: 'n8n-nodes-base.httpRequest',
+						typeVersion: 4.2,
+						position: [450, 300],
+						parameters: {
+							method: 'POST',
+							url: 'https://api.anthropic.com/v1/messages',
+							authentication: 'predefinedCredentialType',
+							nodeCredentialType: 'anthropicApi',
+							sendHeaders: true,
+							headerParameters: {
+								parameters: [
+									{
+										name: 'anthropic-version',
+										value: '2023-06-01',
+									},
+								],
+							},
+							sendBody: true,
+							specifyBody: 'json',
+							jsonBody: '{"model": "claude-3-5-sonnet-20241022", "max_tokens": 1024}',
+							options: {},
+						},
+						credentials: {
+							httpHeaderAuth: {
+								id: headerAuthCred.id,
+								name: headerAuthCredName,
+							},
+						},
+					},
+				],
+				connections: {
+					'Manual Trigger': {
+						main: [[{ node: 'HTTP Request', type: 'main', index: 0 }]],
+					},
+				},
+				active: false,
+				settings: {},
+			});
+
+			await n8n.navigate.toWorkflow(workflow.id);
+			await n8n.canvas.openNode('HTTP Request');
+			await expect(n8n.ndv.container).toBeVisible();
+
+			const credSelect = n8n.ndv.getCredentialSelect();
+			await credSelect.click();
+
+			const credOptions = n8n.ndv.getCredentialDropdownOptions();
+
+			const anthropicOption = credOptions.filter({ hasText: anthropicCredName });
+			await expect(anthropicOption).toBeVisible();
+
+			const headerAuthOption = credOptions.filter({ hasText: headerAuthCredName });
+			await expect(headerAuthOption).not.toBeVisible();
+		});
+
+		test('should persist credential selection across reload when mismatch is resolved', async ({
+			n8n,
+			api,
+		}) => {
+			await n8n.start.fromHome();
+
+			const anthropicCredName = `Anthropic API ${nanoid()}`;
+			await api.credentials.createCredential({
+				name: anthropicCredName,
+				type: 'anthropicApi',
+				data: {
+					apiKey: 'test-api-key-12345',
+				},
+			});
+
+			const headerAuthCredName = `Header Auth ${nanoid()}`;
+			const headerAuthCred = await api.credentials.createCredential({
+				name: headerAuthCredName,
+				type: 'httpHeaderAuth',
+				data: {
+					name: 'x-api-key',
+					value: 'test-value',
+				},
+			});
+
+			const workflow = await api.workflows.createWorkflow({
+				name: `Test Workflow ${nanoid()}`,
+				nodes: [
+					{
+						id: nanoid(),
+						name: 'Manual Trigger',
+						type: 'n8n-nodes-base.manualTrigger',
+						typeVersion: 1,
+						position: [250, 300],
+						parameters: {},
+					},
+					{
+						id: nanoid(),
+						name: 'HTTP Request',
+						type: 'n8n-nodes-base.httpRequest',
+						typeVersion: 4.2,
+						position: [450, 300],
+						parameters: {
+							method: 'POST',
+							url: 'https://api.anthropic.com/v1/messages',
+							authentication: 'predefinedCredentialType',
+							nodeCredentialType: 'anthropicApi',
+						},
+						credentials: {
+							httpHeaderAuth: {
+								id: headerAuthCred.id,
+								name: headerAuthCredName,
+							},
+						},
+					},
+				],
+				connections: {
+					'Manual Trigger': {
+						main: [[{ node: 'HTTP Request', type: 'main', index: 0 }]],
+					},
+				},
+				active: false,
+				settings: {},
+			});
+
+			await n8n.navigate.toWorkflow(workflow.id);
+			await n8n.canvas.openNode('HTTP Request');
+			await expect(n8n.ndv.container).toBeVisible();
+
+			const credSelect = n8n.ndv.getCredentialSelect();
+			await credSelect.click();
+
+			await n8n.ndv.getCredentialOptionByText(anthropicCredName).click();
+
+			await expect(credSelect).toHaveValue(anthropicCredName);
+
+			const saveResponse = n8n.canvas.waitForSaveWorkflowCompleted();
+			await n8n.ndv.close();
+			await saveResponse;
+
+			await n8n.page.reload();
+			await expect(n8n.canvas.nodeByName('HTTP Request')).toBeVisible();
+
+			await n8n.canvas.openNode('HTTP Request');
+			await expect(n8n.ndv.container).toBeVisible();
+
+			await expect(n8n.ndv.getCredentialSelect()).toHaveValue(anthropicCredName);
+		});
+	},
+);


### PR DESCRIPTION
## Summary

When an HTTP Request node declares `authentication: 'predefinedCredentialType'` with a `nodeCredentialType` (e.g. `anthropicApi`) but its top-level `credentials` object references a *different* credential type (e.g. `httpHeaderAuth`), the credential picker previously rendered a disabled "No credentials yet" empty state — hiding the user's saved credentials for the active type and forcing them to create duplicates. This state is reliably produced by the AI workflow builder when it scaffolds workflows.

### Root cause

In `NodeCredentials.vue`, the `v-else-if="showStandardEmptyState(type)"` branch rendered the disabled placeholder whenever `node.credentials[type.name]` was absent — regardless of whether saved credentials for that type actually existed in the store. The sibling quick-connect branch already had the correct guard (`&& options.length === 0`); the standard branch was just missing it. One-line template fix mirrors the quick-connect check.

### How to test

1. Create two saved credentials: *Anthropic API* (type `anthropicApi`) and *Header Auth* (type `httpHeaderAuth`).
2. Import a workflow with an HTTP Request node whose parameters declare `authentication: 'predefinedCredentialType'` + `nodeCredentialType: 'anthropicApi'`, and whose `credentials` object contains `httpHeaderAuth: { id, name }`.
   Workflow Json of the node should look similar to 
   ```
   {
     "parameters": {
        "method": "POST",
        "url": "https://api.anthropic.com/v1/messages",
        "options": {},
        "authentication": "predefinedCredentialType",
        "nodeCredentialType": "anthropicApi"
      },
      "credentials": {
        "httpHeaderAuth": { "id": "<http-header-auth-id>", "name": "Header Auth" }
      },
      "name": "HTTP Request",
      "type": "n8n-nodes-base.httpRequest"
      ...
    }
   ```
3. Open the node. Before the fix: disabled "No credentials yet" placeholder. After the fix: dropdown renders with the saved *Anthropic API* credential selectable (the picker shows "Select credential" until you pick one — the warning clears once selected).
4. Regression: clean Predefined + Anthropic flow still lists credentials; Generic Credential variants (Header Auth, Basic Auth, Query Auth) still work; SSL certificate dropdown still renders when `provideSslCertificates: true`.

### Tests

- New component test (`NodeCredentials.test.ts`) asserts the dropdown renders and the saved credential is selectable in the mismatch scenario.
- New Playwright E2E spec (`credential-mismatch.spec.ts`) covers dropdown visibility and selection persistence across reload.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4818

Fixes #28272

Replaces community PR #28361 (different root cause; see PR comment for details).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI