### PR TITLE
fix(core): Link existing email users on LDAP sync instead of failing

### DIFF
--- a/packages/cli/src/modules/ldap.ee/__tests__/helpers.test.ts
+++ b/packages/cli/src/modules/ldap.ee/__tests__/helpers.test.ts
@@ -44,6 +44,7 @@ describe('Ldap/helpers', () => {
 
 		beforeEach(() => {
 			transactionManager = mock<EntityManager>({
+				findOne: jest.fn(),
 				findOneBy: jest.fn(),
 				save: jest.fn(),
 				update: jest.fn(),
@@ -52,6 +53,8 @@ describe('Ldap/helpers', () => {
 			mockManagerTransaction = jest.fn();
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			(userRepository as any).manager = { transaction: mockManagerTransaction };
+
+			userRepository.createUserWithProject.mockReset();
 		});
 
 		test('does not update user when data has not changed', async () => {
@@ -146,6 +149,132 @@ describe('Ldap/helpers', () => {
 			//
 			expect(transactionManager.save).toHaveBeenCalledWith(User, existingUser);
 			expect(existingUser.email).toBe('new@example.com');
+		});
+
+		test('links existing local user by email instead of creating a duplicate', async () => {
+			//
+			// ARRANGE
+			//
+			const ldapId = 'ldap-new';
+			const ldapUser = Object.assign(new User(), {
+				email: 'shared@example.com',
+				firstName: 'Jane',
+				lastName: 'Doe',
+			} as User);
+
+			const existingLocalUser = Object.assign(new User(), {
+				id: generateNanoId(),
+				email: 'shared@example.com',
+				firstName: 'Jane',
+				lastName: 'Doe',
+			} as User);
+
+			mockManagerTransaction.mockImplementation(
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				async (fn: (manager: EntityManager) => Promise<any>) => await fn(transactionManager),
+			);
+
+			(transactionManager.findOne as jest.Mock).mockResolvedValueOnce(existingLocalUser);
+
+			//
+			// ACT
+			//
+			await helpers.processUsers([[ldapId, ldapUser]], [], []);
+
+			//
+			// ASSERT
+			//
+			expect(userRepository.createUserWithProject).not.toHaveBeenCalled();
+			expect(transactionManager.save).toHaveBeenCalledTimes(1);
+			const savedAuthIdentity = (transactionManager.save as jest.Mock).mock.calls[0][0];
+			expect(savedAuthIdentity).toBeInstanceOf(AuthIdentity);
+			expect(savedAuthIdentity.providerId).toBe(ldapId);
+			expect(savedAuthIdentity.providerType).toBe('ldap');
+			expect(savedAuthIdentity.userId).toBe(existingLocalUser.id);
+		});
+
+		test('updates firstName/lastName when linking an existing local user with stale names', async () => {
+			//
+			// ARRANGE
+			//
+			const ldapId = 'ldap-new';
+			const ldapUser = Object.assign(new User(), {
+				email: 'shared@example.com',
+				firstName: 'Jane',
+				lastName: 'Doe',
+			} as User);
+
+			const existingLocalUser = Object.assign(new User(), {
+				id: generateNanoId(),
+				email: 'shared@example.com',
+				firstName: 'Stale',
+				lastName: 'Name',
+			} as User);
+
+			mockManagerTransaction.mockImplementation(
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				async (fn: (manager: EntityManager) => Promise<any>) => await fn(transactionManager),
+			);
+
+			(transactionManager.findOne as jest.Mock).mockResolvedValueOnce(existingLocalUser);
+
+			//
+			// ACT
+			//
+			await helpers.processUsers([[ldapId, ldapUser]], [], []);
+
+			//
+			// ASSERT
+			//
+			expect(transactionManager.save).toHaveBeenCalledWith(User, existingLocalUser);
+			expect(existingLocalUser.firstName).toBe('Jane');
+			expect(existingLocalUser.lastName).toBe('Doe');
+		});
+
+		test('creates a new user when no local user matches by email', async () => {
+			//
+			// ARRANGE
+			//
+			const ldapId = 'ldap-new';
+			const ldapUser = Object.assign(new User(), {
+				email: 'brand-new@example.com',
+				firstName: 'New',
+				lastName: 'Person',
+			} as User);
+
+			const createdUser = Object.assign(new User(), {
+				id: generateNanoId(),
+				email: 'brand-new@example.com',
+				firstName: 'New',
+				lastName: 'Person',
+			} as User);
+
+			mockManagerTransaction.mockImplementation(
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				async (fn: (manager: EntityManager) => Promise<any>) => await fn(transactionManager),
+			);
+
+			(transactionManager.findOne as jest.Mock).mockResolvedValueOnce(null);
+			(userRepository.createUserWithProject as jest.Mock).mockResolvedValueOnce({
+				user: createdUser,
+			});
+
+			//
+			// ACT
+			//
+			await helpers.processUsers([[ldapId, ldapUser]], [], []);
+
+			//
+			// ASSERT
+			//
+			expect(userRepository.createUserWithProject).toHaveBeenCalledWith(
+				ldapUser,
+				transactionManager,
+			);
+			const savedAuthIdentity = (transactionManager.save as jest.Mock).mock.calls[0][0];
+			expect(savedAuthIdentity).toBeInstanceOf(AuthIdentity);
+			expect(savedAuthIdentity.providerId).toBe(ldapId);
+			expect(savedAuthIdentity.userId).toBe(createdUser.id);
 		});
 	});
 });

--- a/packages/cli/src/modules/ldap.ee/__tests__/ldap.service.test.ts
+++ b/packages/cli/src/modules/ldap.ee/__tests__/ldap.service.test.ts
@@ -1460,10 +1460,129 @@ describe('LdapService', () => {
 			expect(eventServiceMock.emit).toHaveBeenCalledTimes(1);
 			expect(eventServiceMock.emit).toHaveBeenCalledWith('ldap-general-sync-finished', {
 				error: 'Error processing users',
-				succeeded: true,
+				succeeded: false,
 				type: 'scheduled',
 				usersSynced: 0,
 			});
+		});
+
+		it('should surface non-QueryFailedError on the sync history and emit failure', async () => {
+			const ldapService = createDefaultLdapService(ldapConfig);
+
+			Client.prototype.search = jest.fn().mockResolvedValue({ searchEntries: [] });
+
+			const mockedGetLdapIds = getLdapIds as jest.Mock;
+			mockedGetLdapIds.mockResolvedValue([]);
+
+			const mockedProcessUsers = processUsers as jest.Mock;
+			mockedProcessUsers.mockRejectedValue(new Error('Unexpected failure'));
+
+			jest.setSystemTime(new Date('2024-12-25'));
+			const expectedDate = new Date();
+
+			await ldapService.init();
+			await ldapService.runSync('live');
+
+			expect(saveLdapSynchronization).toHaveBeenCalledTimes(1);
+			expect(saveLdapSynchronization).toHaveBeenCalledWith({
+				startedAt: expectedDate,
+				endedAt: expectedDate,
+				created: 0,
+				updated: 0,
+				disabled: 0,
+				scanned: 0,
+				runMode: 'live',
+				status: 'error',
+				error: 'Unexpected failure',
+			});
+		});
+
+		it('should skip LDAP entries whose email duplicates within the batch when enforceEmailUniqueness is enabled', async () => {
+			const ldapService = createDefaultLdapService({
+				...ldapConfig,
+				enforceEmailUniqueness: true,
+			});
+
+			const duplicateUsers = [
+				{
+					dn: 'uid=jdoe1,ou=users,dc=example,dc=com',
+					cn: 'John Doe',
+					givenName: 'John',
+					sn: 'Doe',
+					mail: 'shared@example.com',
+					uid: 'jdoe1',
+				},
+				{
+					dn: 'uid=jdoe2,ou=users,dc=example,dc=com',
+					cn: 'Jane Doe',
+					givenName: 'Jane',
+					sn: 'Doe',
+					mail: 'shared@example.com',
+					uid: 'jdoe2',
+				},
+			];
+
+			const uniqueUser = {
+				dn: 'uid=unique,ou=users,dc=example,dc=com',
+				cn: 'Unique User',
+				givenName: 'Unique',
+				sn: 'User',
+				mail: 'unique@example.com',
+				uid: 'unique',
+			};
+
+			Client.prototype.search = jest
+				.fn()
+				.mockResolvedValue({ searchEntries: [...duplicateUsers, uniqueUser] });
+
+			const mockedGetLdapIds = getLdapIds as jest.Mock;
+			mockedGetLdapIds.mockResolvedValue([]);
+
+			await ldapService.init();
+			await ldapService.runSync('live');
+
+			expect(processUsers).toHaveBeenCalledTimes(1);
+			const [createArg] = (processUsers as jest.Mock).mock.calls[0];
+			expect(createArg).toHaveLength(1);
+			expect(createArg[0][0]).toBe('unique');
+		});
+
+		it('should not filter duplicates when enforceEmailUniqueness is disabled', async () => {
+			const ldapService = createDefaultLdapService({
+				...ldapConfig,
+				enforceEmailUniqueness: false,
+			});
+
+			const duplicateUsers = [
+				{
+					dn: 'uid=jdoe1,ou=users,dc=example,dc=com',
+					cn: 'John Doe',
+					givenName: 'John',
+					sn: 'Doe',
+					mail: 'shared@example.com',
+					uid: 'jdoe1',
+				},
+				{
+					dn: 'uid=jdoe2,ou=users,dc=example,dc=com',
+					cn: 'Jane Doe',
+					givenName: 'Jane',
+					sn: 'Doe',
+					mail: 'shared@example.com',
+					uid: 'jdoe2',
+				},
+			];
+
+			Client.prototype.search = jest.fn().mockResolvedValue({ searchEntries: duplicateUsers });
+
+			const mockedGetLdapIds = getLdapIds as jest.Mock;
+			mockedGetLdapIds.mockResolvedValue([]);
+
+			await ldapService.init();
+			await ldapService.runSync('live');
+
+			expect(processUsers).toHaveBeenCalledTimes(1);
+			const [createArg] = (processUsers as jest.Mock).mock.calls[0];
+			expect(createArg).toHaveLength(2);
 		});
 	});
 

--- a/packages/cli/src/modules/ldap.ee/helpers.ee.ts
+++ b/packages/cli/src/modules/ldap.ee/helpers.ee.ts
@@ -171,6 +171,28 @@ export const processUsers = async (
 	await dbManager.transaction(async (transactionManager) => {
 		return await Promise.all([
 			...toCreateUsers.map(async ([ldapId, user]) => {
+				// If a local user already exists with this email (e.g. an email/password
+				// invite that predates LDAP), link the existing user to the LDAP identity
+				// instead of creating a duplicate row and tripping the unique email
+				// constraint — same behaviour as LdapService.handleLogin.
+				const existingUser = await transactionManager.findOne(User, {
+					where: { email: user.email },
+				});
+
+				if (existingUser) {
+					const hasChanges =
+						existingUser.firstName !== user.firstName || existingUser.lastName !== user.lastName;
+
+					if (hasChanges) {
+						existingUser.firstName = user.firstName;
+						existingUser.lastName = user.lastName;
+						await transactionManager.save(User, existingUser);
+					}
+
+					const authIdentity = AuthIdentity.create(existingUser, ldapId);
+					return await transactionManager.save(authIdentity);
+				}
+
 				const { user: savedUser } = await userRepository.createUserWithProject(
 					user,
 					transactionManager,

--- a/packages/cli/src/modules/ldap.ee/ldap.service.ee.ts
+++ b/packages/cli/src/modules/ldap.ee/ldap.service.ee.ts
@@ -7,7 +7,6 @@ import type { RunningMode, SyncStatus } from '@n8n/db';
 import { Constructable, Container } from '@n8n/di';
 import type { IPasswordAuthHandler } from '@n8n/decorators';
 import { AuthHandler } from '@n8n/decorators';
-import { QueryFailedError } from '@n8n/typeorm';
 import type { Entry as LdapUser, ClientOptions, Client } from 'ldapts';
 import { Cipher } from 'n8n-core';
 import { jsonParse, UnexpectedError } from 'n8n-workflow';
@@ -388,8 +387,12 @@ export class LdapService implements IPasswordAuthHandler<User> {
 
 		const localAdUsers = await getLdapIds();
 
+		const processableAdUsers = this.config.enforceEmailUniqueness
+			? this.filterEmailDuplicates(adUsers)
+			: adUsers;
+
 		const { usersToCreate, usersToUpdate, usersToDisable } = this.getUsersToProcess(
-			adUsers,
+			processableAdUsers,
 			localAdUsers,
 		);
 
@@ -424,10 +427,8 @@ export class LdapService implements IPasswordAuthHandler<User> {
 				await processUsers(filteredUsersToCreate, filteredUsersToUpdate, usersToDisable);
 			}
 		} catch (error) {
-			if (error instanceof QueryFailedError) {
-				status = 'error';
-				errorMessage = `${error.message}`;
-			}
+			status = 'error';
+			errorMessage = error instanceof Error ? error.message : String(error);
 		}
 
 		await saveLdapSynchronization({
@@ -444,13 +445,17 @@ export class LdapService implements IPasswordAuthHandler<User> {
 
 		this.eventService.emit('ldap-general-sync-finished', {
 			type: !this.syncTimer ? 'scheduled' : `manual_${mode}`,
-			succeeded: true,
+			succeeded: status === 'success',
 			usersSynced:
 				filteredUsersToCreate.length + filteredUsersToUpdate.length + usersToDisable.length,
 			error: errorMessage,
 		});
 
-		this.logger.debug('LDAP - Synchronization finished successfully');
+		if (status === 'success') {
+			this.logger.debug('LDAP - Synchronization finished successfully');
+		} else {
+			this.logger.error('LDAP - Synchronization finished with errors', { error: errorMessage });
+		}
 	}
 
 	/** Stop the current job scheduled, if any */
@@ -473,6 +478,33 @@ export class LdapService implements IPasswordAuthHandler<User> {
 			usersToUpdate: this.getUsersToUpdate(adUsers, localAdUsers),
 			usersToDisable: this.getUsersToDisable(adUsers, localAdUsers),
 		};
+	}
+
+	/**
+	 * Drop LDAP entries whose email appears on more than one entry in the same
+	 * batch. Prevents the sync from linking or creating ambiguous identities
+	 * when `enforceEmailUniqueness` is enabled — parity with the guard applied
+	 * on the login path.
+	 */
+	private filterEmailDuplicates(adUsers: LdapUser[]): LdapUser[] {
+		const emailCounts = new Map<string, number>();
+		for (const adUser of adUsers) {
+			const email = adUser[this.config.emailAttribute] as string | undefined;
+			if (!email) continue;
+			emailCounts.set(email, (emailCounts.get(email) ?? 0) + 1);
+		}
+
+		return adUsers.filter((adUser) => {
+			const email = adUser[this.config.emailAttribute] as string | undefined;
+			if (email && (emailCounts.get(email) ?? 0) > 1) {
+				this.logger.warn('LDAP sync skipped entry: multiple LDAP accounts share the same email', {
+					email,
+					ldapId: adUser[this.config.ldapIdAttribute] as string,
+				});
+				return false;
+			}
+			return true;
+		});
 	}
 
 	/** Get users in LDAP that are not in the database yet */


### PR DESCRIPTION
## Summary

LDAP sync previously rolled back the entire transaction whenever an LDAP user matched an existing local (email/password) user by email, so no users at all were synced. This PR aligns the sync path with the login path — `processUsers` now looks up users by email inside the transaction and links a new `AuthIdentity` to the existing local user instead of trying to insert a duplicate row. `runSync` also filters out duplicate-email LDAP entries when `enforceEmailUniqueness` is enabled, surfaces any thrown error (not just `QueryFailedError`) on the sync history, and only logs "finished successfully" when the run actually succeeded. Covered by new unit tests in `helpers.test.ts` and `ldap.service.test.ts`.

To test: seed an LDAP user whose `mail` matches an existing local n8n user, run an LDAP sync, and verify the local user picks up an `auth_identity` row (`providerType='ldap'`) without a duplicate `user` row; then seed two LDAP entries sharing a `mail`, toggle `enforceEmailUniqueness` on, and confirm they get skipped with a warning.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-550

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI