### PR TITLE
fix(core): Use upsert for MCP OAuth consent to allow re-authorization

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/mcp-oauth-consent.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp-oauth-consent.service.test.ts
@@ -151,7 +151,7 @@ describe('McpOAuthConsentService', () => {
 				clientId: 'client-123',
 				userId: 'user-123',
 			});
-			expect(userConsentRepository.insert).not.toHaveBeenCalled();
+			expect(userConsentRepository.upsert).not.toHaveBeenCalled();
 		});
 
 		it('should handle user approval and generate authorization code', async () => {
@@ -166,18 +166,21 @@ describe('McpOAuthConsentService', () => {
 			const authCode = 'generated-auth-code';
 
 			oauthSessionService.verifySession.mockReturnValue(sessionPayload);
-			userConsentRepository.insert.mockResolvedValue(mock());
+			userConsentRepository.upsert.mockResolvedValue(mock());
 			authorizationCodeService.createAuthorizationCode.mockResolvedValue(authCode);
 
 			const result = await service.handleConsentDecision(sessionToken, userId, true);
 
 			expect(result.redirectUrl).toContain('code=generated-auth-code');
 			expect(result.redirectUrl).toContain('state=state-xyz');
-			expect(userConsentRepository.insert).toHaveBeenCalledWith({
-				userId: 'user-123',
-				clientId: 'client-123',
-				grantedAt: expect.any(Number),
-			});
+			expect(userConsentRepository.upsert).toHaveBeenCalledWith(
+				{
+					userId: 'user-123',
+					clientId: 'client-123',
+					grantedAt: expect.any(Number),
+				},
+				['userId', 'clientId'],
+			);
 			expect(authorizationCodeService.createAuthorizationCode).toHaveBeenCalledWith(
 				'client-123',
 				'user-123',
@@ -203,13 +206,44 @@ describe('McpOAuthConsentService', () => {
 			const authCode = 'generated-auth-code';
 
 			oauthSessionService.verifySession.mockReturnValue(sessionPayload);
-			userConsentRepository.insert.mockResolvedValue(mock());
+			userConsentRepository.upsert.mockResolvedValue(mock());
 			authorizationCodeService.createAuthorizationCode.mockResolvedValue(authCode);
 
 			const result = await service.handleConsentDecision(sessionToken, userId, true);
 
 			expect(result.redirectUrl).toContain('code=generated-auth-code');
 			expect(result.redirectUrl).not.toContain('state=');
+		});
+
+		it('should handle re-authorization for existing consent by upserting', async () => {
+			const sessionToken = 'valid-session-token';
+			const userId = 'user-123';
+			const sessionPayload = {
+				clientId: 'client-123',
+				redirectUri: 'https://example.com/callback',
+				codeChallenge: 'challenge-abc',
+				state: 'state-xyz',
+			};
+			const authCode = 'generated-auth-code';
+
+			oauthSessionService.verifySession.mockReturnValue(sessionPayload);
+			userConsentRepository.upsert.mockResolvedValue(mock());
+			authorizationCodeService.createAuthorizationCode.mockResolvedValue(authCode);
+
+			// First authorization
+			await service.handleConsentDecision(sessionToken, userId, true);
+			// Re-authorization with same userId + clientId should not throw
+			await service.handleConsentDecision(sessionToken, userId, true);
+
+			expect(userConsentRepository.upsert).toHaveBeenCalledTimes(2);
+			expect(userConsentRepository.upsert).toHaveBeenCalledWith(
+				{
+					userId: 'user-123',
+					clientId: 'client-123',
+					grantedAt: expect.any(Number),
+				},
+				['userId', 'clientId'],
+			);
 		});
 
 		it('should throw error when session verification fails', async () => {

--- a/packages/cli/src/modules/mcp/mcp-oauth-consent.service.ts
+++ b/packages/cli/src/modules/mcp/mcp-oauth-consent.service.ts
@@ -83,11 +83,14 @@ export class McpOAuthConsentService {
 			return { redirectUrl };
 		}
 
-		await this.userConsentRepository.insert({
-			userId,
-			clientId: sessionPayload.clientId,
-			grantedAt: Date.now(),
-		});
+		await this.userConsentRepository.upsert(
+			{
+				userId,
+				clientId: sessionPayload.clientId,
+				grantedAt: Date.now(),
+			},
+			['userId', 'clientId'],
+		);
 
 		const code = await this.authorizationCodeService.createAuthorizationCode(
 			sessionPayload.clientId,


### PR DESCRIPTION
## Summary

Replace `insert()` with `upsert()` in `McpOAuthConsentService.handleConsentDecision()` so that re-authorizing an MCP OAuth client updates the existing consent record instead of failing with a duplicate key violation.

The `oauth_user_consents` table has a unique constraint on `(userId, clientId)`. When a user who previously authorized an MCP client goes through the OAuth flow again (e.g., after refresh token expiry or token revocation), the unconditional `insert()` throws `duplicate key value violates unique constraint "UQ_083721d99ce8db4033e2958ebb4"`. Using `upsert()` with the conflict columns updates `grantedAt` on the existing record instead.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5090
Fixes #28496

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] Tests included.