### PR TITLE
refactor(core): Move instance AI user settings under actual user settings (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-settings.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-settings.service.test.ts
@@ -1,9 +1,10 @@
 import type { InstanceAiConfig } from '@n8n/config';
-import type { SettingsRepository, User } from '@n8n/db';
+import type { SettingsRepository, User, UserRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 
 import { UnprocessableRequestError } from '@/errors/response-errors/unprocessable.error';
 import type { AiService } from '@/services/ai.service';
+import type { UserService } from '@/services/user.service';
 import type { CredentialsFinderService } from '@/credentials/credentials-finder.service';
 import type { CredentialsService } from '@/credentials/credentials.service';
 
@@ -33,6 +34,8 @@ describe('InstanceAiSettingsService', () => {
 		deployment: { type: 'default' },
 	});
 	const settingsRepository = mock<SettingsRepository>();
+	const userRepository = mock<UserRepository>();
+	const userService = mock<UserService>();
 	const aiService = mock<AiService>();
 	const credentialsService = mock<CredentialsService>();
 	const credentialsFinderService = mock<CredentialsFinderService>();
@@ -44,6 +47,8 @@ describe('InstanceAiSettingsService', () => {
 		service = new InstanceAiSettingsService(
 			globalConfig as never,
 			settingsRepository,
+			userRepository,
+			userService,
 			aiService,
 			credentialsService,
 			credentialsFinderService,
@@ -112,11 +117,28 @@ describe('InstanceAiSettingsService', () => {
 
 		it('should allow non-proxy-managed fields when proxy is enabled', async () => {
 			aiService.isProxyEnabled.mockReturnValue(true);
-			settingsRepository.upsert.mockResolvedValue(undefined as never);
 
 			await expect(
 				service.updateUserPreferences(user, { localGatewayDisabled: true }),
 			).resolves.toBeDefined();
+
+			expect(userService.updateSettings).toHaveBeenCalledWith('user-1', {
+				instanceAi: { localGatewayDisabled: true },
+			});
+		});
+
+		it('should merge new fields with existing instanceAi settings on update', async () => {
+			aiService.isProxyEnabled.mockReturnValue(false);
+			const existingUser = mock<User>({
+				id: 'user-2',
+				settings: { instanceAi: { credentialId: 'cred-old', modelName: 'gpt-3.5' } },
+			});
+
+			await service.updateUserPreferences(existingUser, { modelName: 'gpt-4' });
+
+			expect(userService.updateSettings).toHaveBeenCalledWith('user-2', {
+				instanceAi: { credentialId: 'cred-old', modelName: 'gpt-4' },
+			});
 		});
 	});
 
@@ -195,11 +217,13 @@ describe('InstanceAiSettingsService', () => {
 			});
 
 			it('should allow localGatewayDisabled on cloud', async () => {
-				settingsRepository.upsert.mockResolvedValue(undefined as never);
-
 				await expect(
 					service.updateUserPreferences(user, { localGatewayDisabled: true }),
 				).resolves.toBeDefined();
+
+				expect(userService.updateSettings).toHaveBeenCalledWith('user-1', {
+					instanceAi: { localGatewayDisabled: true },
+				});
 			});
 		});
 	});

--- a/packages/cli/src/modules/instance-ai/instance-ai-settings.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-settings.service.ts
@@ -1,8 +1,4 @@
-import { GlobalConfig } from '@n8n/config';
-import type { InstanceAiConfig, DeploymentConfig } from '@n8n/config';
-import { SettingsRepository } from '@n8n/db';
-import type { User } from '@n8n/db';
-import { Service } from '@n8n/di';
+import { DEFAULT_INSTANCE_AI_PERMISSIONS } from '@n8n/api-types';
 import type {
 	InstanceAiAdminSettingsResponse,
 	InstanceAiAdminSettingsUpdateRequest,
@@ -11,17 +7,24 @@ import type {
 	InstanceAiModelCredential,
 	InstanceAiPermissions,
 } from '@n8n/api-types';
-import { DEFAULT_INSTANCE_AI_PERMISSIONS } from '@n8n/api-types';
+import { GlobalConfig } from '@n8n/config';
+import type { InstanceAiConfig, DeploymentConfig } from '@n8n/config';
+import { SettingsRepository, UserRepository } from '@n8n/db';
+import type { User } from '@n8n/db';
+import { Service } from '@n8n/di';
 import type { ModelConfig } from '@n8n/instance-ai';
+import type { IUserSettings } from 'n8n-workflow';
 import { jsonParse } from 'n8n-workflow';
 
-import { AiService } from '@/services/ai.service';
 import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
 import { CredentialsService } from '@/credentials/credentials.service';
 import { UnprocessableRequestError } from '@/errors/response-errors/unprocessable.error';
+import { AiService } from '@/services/ai.service';
+import { UserService } from '@/services/user.service';
 
 const ADMIN_SETTINGS_KEY = 'instanceAi.settings';
-const USER_PREFERENCES_KEY_PREFIX = 'instanceAi.preferences.';
+
+type UserInstanceAiPreferences = NonNullable<IUserSettings['instanceAi']>;
 
 /** Credential types we support and their Mastra provider mapping. */
 const CREDENTIAL_TO_MASTRA_PROVIDER: Record<string, string> = {
@@ -77,13 +80,6 @@ interface PersistedAdminSettings {
 	optinModalDismissed?: boolean;
 }
 
-/** Per-user preferences stored under USER_PREFERENCES_KEY_PREFIX + userId. */
-interface PersistedUserPreferences {
-	credentialId?: string | null;
-	modelName?: string;
-	localGatewayDisabled?: boolean;
-}
-
 @Service()
 export class InstanceAiSettingsService {
 	private readonly config: InstanceAiConfig;
@@ -105,12 +101,11 @@ export class InstanceAiSettingsService {
 
 	private optinModalDismissed: boolean = false;
 
-	/** In-memory cache of per-user preferences keyed by userId. */
-	private readonly userPreferences = new Map<string, PersistedUserPreferences>();
-
 	constructor(
 		globalConfig: GlobalConfig,
 		private readonly settingsRepository: SettingsRepository,
+		private readonly userRepository: UserRepository,
+		private readonly userService: UserService,
 		private readonly aiService: AiService,
 		private readonly credentialsService: CredentialsService,
 		private readonly credentialsFinderService: CredentialsFinderService,
@@ -213,7 +208,7 @@ export class InstanceAiSettingsService {
 	// ── User preferences ──────────────────────────────────────────────────
 
 	async getUserPreferences(user: User): Promise<InstanceAiUserPreferencesResponse> {
-		const prefs = await this.loadUserPreferences(user.id);
+		const prefs = this.readUserPreferences(user);
 		const credentialId = prefs.credentialId ?? null;
 
 		let credentialType: string | null = null;
@@ -255,13 +250,13 @@ export class InstanceAiSettingsService {
 				'proxy',
 			);
 		}
-		const prefs = await this.loadUserPreferences(user.id);
+		const prefs: UserInstanceAiPreferences = { ...this.readUserPreferences(user) };
 		if (update.credentialId !== undefined) prefs.credentialId = update.credentialId;
 		if (update.modelName !== undefined) prefs.modelName = update.modelName;
 		if (update.localGatewayDisabled !== undefined)
 			prefs.localGatewayDisabled = update.localGatewayDisabled;
-		this.userPreferences.set(user.id, prefs);
-		await this.persistUserPreferences(user.id, prefs);
+		await this.userService.updateSettings(user.id, { instanceAi: prefs });
+		user.settings = { ...(user.settings ?? {}), instanceAi: prefs };
 		return await this.getUserPreferences(user);
 	}
 
@@ -394,8 +389,9 @@ export class InstanceAiSettingsService {
 	async isLocalGatewayDisabledForUser(userId: string): Promise<boolean> {
 		if (!this.enabled) return true;
 		if (this.config.localGatewayDisabled) return true;
-		const prefs = await this.loadUserPreferences(userId);
-		return prefs?.localGatewayDisabled ?? false;
+		const user = await this.userRepository.findOneBy({ id: userId });
+		if (!user) return true;
+		return this.readUserPreferences(user).localGatewayDisabled ?? false;
 	}
 
 	/** Whether the n8n Agent is enabled by the admin. */
@@ -415,13 +411,13 @@ export class InstanceAiSettingsService {
 
 	/** Resolve just the model name (e.g. 'claude-sonnet-4-20250514') for proxy routing. */
 	async resolveModelName(user: User): Promise<string> {
-		const prefs = await this.loadUserPreferences(user.id);
+		const prefs = this.readUserPreferences(user);
 		return prefs.modelName || this.extractModelName(this.config.model);
 	}
 
 	/** Resolve the current model configuration for an agent run. */
 	async resolveModelConfig(user: User): Promise<ModelConfig> {
-		const prefs = await this.loadUserPreferences(user.id);
+		const prefs = this.readUserPreferences(user);
 		const credentialId = prefs.credentialId ?? null;
 
 		if (!credentialId) {
@@ -565,18 +561,8 @@ export class InstanceAiSettingsService {
 			this.optinModalDismissed = persisted.optinModalDismissed;
 	}
 
-	private async loadUserPreferences(userId: string): Promise<PersistedUserPreferences> {
-		const cached = this.userPreferences.get(userId);
-		if (cached) return { ...cached };
-
-		const row = await this.settingsRepository.findByKey(`${USER_PREFERENCES_KEY_PREFIX}${userId}`);
-		if (row) {
-			const prefs = jsonParse<PersistedUserPreferences>(row.value, { fallbackValue: {} });
-			this.userPreferences.set(userId, prefs);
-			return { ...prefs };
-		}
-
-		return {};
+	private readUserPreferences(user: User): UserInstanceAiPreferences {
+		return user.settings?.instanceAi ?? {};
 	}
 
 	private async persistAdminSettings(): Promise<void> {
@@ -603,20 +589,6 @@ export class InstanceAiSettingsService {
 
 		await this.settingsRepository.upsert(
 			{ key: ADMIN_SETTINGS_KEY, value: JSON.stringify(value), loadOnStartup: true },
-			['key'],
-		);
-	}
-
-	private async persistUserPreferences(
-		userId: string,
-		prefs: PersistedUserPreferences,
-	): Promise<void> {
-		await this.settingsRepository.upsert(
-			{
-				key: `${USER_PREFERENCES_KEY_PREFIX}${userId}`,
-				value: JSON.stringify(prefs),
-				loadOnStartup: false,
-			},
 			['key'],
 		);
 	}

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -3541,6 +3541,11 @@ export interface IUserSettings {
 	easyAIWorkflowOnboarded?: boolean;
 	userClaimedAiCredits?: boolean;
 	dismissedCallouts?: Record<string, boolean>;
+	instanceAi?: {
+		credentialId?: string | null;
+		modelName?: string;
+		localGatewayDisabled?: boolean;
+	};
 }
 
 export interface IProcessedDataConfig {


### PR DESCRIPTION
## Summary

Unlike other features we were storing instanceAI user specific settings under `settings` table as `instanceAi.preferences.<userId>`. We have a place to store user settings, and that place is on the `settings` column of the `user` table. Storing data there also ensures the data won't be left behind if user is deleted or something.

This PR refactors this, and uses the user table's settings column instead for storing these.

This doens't copy existing data over, considering we haven't launched this I'm happy to do this as a breaking change and just abandon this data on settings table, its easy to fix on settings anyways for us.

## Related Linear tickets, Github issues, and Community forum posts

https://www.notion.so/n8n/aef5b6e0c94f82159cc58164aa417607?v=7965b6e0c94f823c918f88516500cb86&p=3485b6e0c94f80879a46fd7ce92039e0&pm=s

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
