### PR TITLE
fix(RabbitMQ Trigger Node): Redeliver messages on failed executions

### DIFF
--- a/packages/nodes-base/nodes/RabbitMQ/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/GenericFunctions.ts
@@ -218,17 +218,52 @@ export async function handleMessage(
 
 		let responsePromise: IDeferredPromise<IRun> | undefined = undefined;
 		let responsePromiseHook: IDeferredPromise<IExecuteResponsePromiseData> | undefined = undefined;
-		if (acknowledgeMode !== 'immediately' && acknowledgeMode !== 'laterMessageNode') {
-			responsePromise = this.helpers.createDeferredPromise();
-		} else if (acknowledgeMode === 'laterMessageNode') {
+		if (acknowledgeMode === 'laterMessageNode') {
 			responsePromiseHook = this.helpers.createDeferredPromise<IExecuteResponsePromiseData>();
+			// Also await execution end so we can nack when the run errors
+			// before the Delete-from-Queue node fires sendResponse. The engine
+			// unconditionally resolves the hook at teardown via
+			// resolveExecutionResponsePromise with an empty {} — the payload
+			// shape is what tells a real sendResponse apart from that cleanup.
+			responsePromise = this.helpers.createDeferredPromise<IRun>();
+		} else if (acknowledgeMode !== 'immediately') {
+			responsePromise = this.helpers.createDeferredPromise();
 		}
-		if (responsePromiseHook) {
-			this.emit([[item]], responsePromiseHook, undefined);
-		} else {
-			this.emit([[item]], undefined, responsePromise);
-		}
-		if (responsePromise && acknowledgeMode !== 'laterMessageNode') {
+		this.emit([[item]], responsePromiseHook, responsePromise);
+		if (acknowledgeMode === 'laterMessageNode' && responsePromise && responsePromiseHook) {
+			// The hook resolves both from a node calling sendResponse
+			// (mid-execution, carries the item JSON) AND from teardown cleanup
+			// (resolves with {}). Treat only a non-empty payload as a real
+			// sendResponse from Delete-from-Queue — that's the fast-ack path.
+			// For the empty cleanup, fall through to the final IRun and decide
+			// ack vs nack based on error state.
+			type RaceResult = { kind: 'hook'; isRealSendResponse: boolean } | { kind: 'run'; data: IRun };
+			const hookRace: Promise<RaceResult> = responsePromiseHook.promise.then((data) => ({
+				kind: 'hook',
+				isRealSendResponse:
+					data !== null &&
+					data !== undefined &&
+					typeof data === 'object' &&
+					Object.keys(data as object).length > 0,
+			}));
+			const runRace: Promise<RaceResult> = responsePromise.promise.then((data) => ({
+				kind: 'run',
+				data,
+			}));
+			const first = await Promise.race([hookRace, runRace]);
+
+			if (first.kind === 'hook' && first.isRealSendResponse) {
+				channel.ack(message);
+			} else {
+				const runData = first.kind === 'run' ? first.data : await responsePromise.promise;
+				if (runData?.data?.resultData?.error) {
+					channel.nack(message);
+				} else {
+					channel.ack(message);
+				}
+			}
+			messageTracker.answered(message);
+		} else if (responsePromise && acknowledgeMode !== 'laterMessageNode') {
 			// Acknowledge message after the execution finished
 			await responsePromise.promise.then(async (data: IRun) => {
 				if (data.data.resultData.error) {
@@ -239,11 +274,6 @@ export async function handleMessage(
 						return;
 					}
 				}
-				channel.ack(message);
-				messageTracker.answered(message);
-			});
-		} else if (responsePromiseHook && acknowledgeMode === 'laterMessageNode') {
-			await responsePromiseHook.promise.then(() => {
 				channel.ack(message);
 				messageTracker.answered(message);
 			});

--- a/packages/nodes-base/nodes/RabbitMQ/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/test/GenericFunctions.test.ts
@@ -1,6 +1,12 @@
 import type { Channel, Connection, ConsumeMessage, Message } from 'amqplib';
 import { mock, mockDeep } from 'jest-mock-extended';
-import type { INode, IRun, ITriggerFunctions, IWorkflowMetadata } from 'n8n-workflow';
+import type {
+	IExecuteResponsePromiseData,
+	INode,
+	IRun,
+	ITriggerFunctions,
+	IWorkflowMetadata,
+} from 'n8n-workflow';
 
 const mockChannel = mock<Channel>();
 const mockConnection = mock<Connection>({ createChannel: async () => mockChannel });
@@ -336,44 +342,168 @@ describe('RabbitMQ GenericFunctions', () => {
 			expect(messageTracker.answered).toHaveBeenCalledWith(message);
 		});
 
-		it('should ack a message with "acknowledgeMode" set to "laterMessageNode"', async () => {
-			let resolvePromise: (data: IRun) => void = () => {};
-			const deferredPromise = {
-				promise: new Promise<IRun>((resolve) => {
-					resolvePromise = resolve;
-				}),
-				resolve: jest.fn(),
-				reject: jest.fn(),
+		describe('acknowledgeMode = "laterMessageNode"', () => {
+			const buildRunDeferred = () => {
+				let resolvePromise: (data: IRun) => void = () => {};
+				const deferred = {
+					promise: new Promise<IRun>((resolve) => {
+						resolvePromise = resolve;
+					}),
+					resolve: jest.fn(),
+					reject: jest.fn(),
+				};
+				return { deferred, resolve: (data: IRun) => resolvePromise(data) };
 			};
-			context.helpers.createDeferredPromise.mockReturnValue(deferredPromise);
 
-			const handleMessagePromise = handleMessage.call(
-				context,
-				message,
-				mockChannel,
-				messageTracker,
-				'laterMessageNode',
-				options,
-			);
+			const buildHookDeferred = () => {
+				let resolvePromise: (data: IExecuteResponsePromiseData) => void = () => {};
+				const deferred = {
+					promise: new Promise<IExecuteResponsePromiseData>((resolve) => {
+						resolvePromise = resolve;
+					}),
+					resolve: jest.fn(),
+					reject: jest.fn(),
+				};
+				return {
+					deferred,
+					resolve: (data: IExecuteResponsePromiseData) => resolvePromise(data),
+				};
+			};
 
-			await Promise.resolve(); // yield control to let handleMessage run
+			it('should ack the message on a clean execution when Delete-from-Queue was not fired', async () => {
+				// Simulates the engine's teardown: resolveExecutionResponsePromise
+				// resolves the hook with an empty {}, then finalizeExecution
+				// resolves the IRun with no error.
+				const { deferred: hookDeferred, resolve: resolveHook } = buildHookDeferred();
+				const { deferred: runDeferred, resolve: resolveRun } = buildRunDeferred();
+				context.helpers.createDeferredPromise
+					.mockReturnValueOnce(hookDeferred)
+					.mockReturnValueOnce(runDeferred);
 
-			expect(messageTracker.received).toHaveBeenCalledWith(message);
-			expect(context.emit).toHaveBeenCalledWith([[item]], deferredPromise, undefined);
-			expect(mockChannel.ack).not.toHaveBeenCalled();
-			expect(messageTracker.answered).not.toHaveBeenCalled();
+				const handleMessagePromise = handleMessage.call(
+					context,
+					message,
+					mockChannel,
+					messageTracker,
+					'laterMessageNode',
+					options,
+				);
 
-			resolvePromise({
-				data: {
-					resultData: {
-						error: undefined,
-					},
-				},
-			} as IRun);
-			await handleMessagePromise;
+				await Promise.resolve();
 
-			expect(mockChannel.ack).toHaveBeenCalledWith(message);
-			expect(messageTracker.answered).toHaveBeenCalledWith(message);
+				expect(messageTracker.received).toHaveBeenCalledWith(message);
+				expect(context.emit).toHaveBeenCalledWith([[item]], hookDeferred, runDeferred);
+				expect(mockChannel.ack).not.toHaveBeenCalled();
+				expect(messageTracker.answered).not.toHaveBeenCalled();
+
+				resolveHook({} as IExecuteResponsePromiseData);
+				resolveRun({
+					data: { resultData: { error: undefined } },
+				} as IRun);
+				await handleMessagePromise;
+
+				expect(mockChannel.ack).toHaveBeenCalledWith(message);
+				expect(mockChannel.nack).not.toHaveBeenCalled();
+				expect(messageTracker.answered).toHaveBeenCalledWith(message);
+			});
+
+			it('should nack the message when the execution errors before the Delete-from-Queue node runs', async () => {
+				// Real engine behavior on crash: resolveExecutionResponsePromise
+				// resolves the hook with {} first, then finalizeExecution
+				// resolves the IRun with the error. The hook payload shape is
+				// the only reliable signal — empty {} means cleanup, so we must
+				// fall through to the IRun and nack on error.
+				const { deferred: hookDeferred, resolve: resolveHook } = buildHookDeferred();
+				const { deferred: runDeferred, resolve: resolveRun } = buildRunDeferred();
+				context.helpers.createDeferredPromise
+					.mockReturnValueOnce(hookDeferred)
+					.mockReturnValueOnce(runDeferred);
+
+				const handleMessagePromise = handleMessage.call(
+					context,
+					message,
+					mockChannel,
+					messageTracker,
+					'laterMessageNode',
+					options,
+				);
+
+				await Promise.resolve();
+
+				resolveHook({} as IExecuteResponsePromiseData);
+				resolveRun({
+					data: { resultData: { error: new Error('workflow crashed') } },
+				} as IRun);
+				await handleMessagePromise;
+
+				expect(mockChannel.ack).not.toHaveBeenCalled();
+				expect(mockChannel.nack).toHaveBeenCalledWith(message);
+				expect(messageTracker.answered).toHaveBeenCalledWith(message);
+			});
+
+			it('should ack as soon as the Delete-from-Queue hook fires, without waiting for the full execution', async () => {
+				// Happy path: sendResponse from the Delete-from-Queue node
+				// resolves the hook with the item JSON mid-execution. Ack
+				// immediately, don't wait for the IRun (downstream nodes may
+				// still be running).
+				const { deferred: hookDeferred, resolve: resolveHook } = buildHookDeferred();
+				const { deferred: runDeferred } = buildRunDeferred();
+				context.helpers.createDeferredPromise
+					.mockReturnValueOnce(hookDeferred)
+					.mockReturnValueOnce(runDeferred);
+
+				const handleMessagePromise = handleMessage.call(
+					context,
+					message,
+					mockChannel,
+					messageTracker,
+					'laterMessageNode',
+					options,
+				);
+
+				await Promise.resolve();
+				expect(mockChannel.ack).not.toHaveBeenCalled();
+
+				resolveHook({ content: 'hello' } as unknown as IExecuteResponsePromiseData);
+				await handleMessagePromise;
+
+				expect(mockChannel.ack).toHaveBeenCalledWith(message);
+				expect(mockChannel.nack).not.toHaveBeenCalled();
+				expect(messageTracker.answered).toHaveBeenCalledWith(message);
+			});
+
+			it('should ack when Delete-from-Queue fired before the workflow errored', async () => {
+				// At-least-once semantics: if the Delete-from-Queue node ran
+				// (real sendResponse with a non-empty payload), the user's
+				// intent was satisfied. A later crash in a downstream node
+				// should still ack.
+				const { deferred: hookDeferred, resolve: resolveHook } = buildHookDeferred();
+				const { deferred: runDeferred, resolve: resolveRun } = buildRunDeferred();
+				context.helpers.createDeferredPromise
+					.mockReturnValueOnce(hookDeferred)
+					.mockReturnValueOnce(runDeferred);
+
+				const handleMessagePromise = handleMessage.call(
+					context,
+					message,
+					mockChannel,
+					messageTracker,
+					'laterMessageNode',
+					options,
+				);
+
+				await Promise.resolve();
+
+				resolveHook({ content: 'hello' } as unknown as IExecuteResponsePromiseData);
+				resolveRun({
+					data: { resultData: { error: new Error('downstream crash') } },
+				} as IRun);
+				await handleMessagePromise;
+
+				expect(mockChannel.ack).toHaveBeenCalledWith(message);
+				expect(mockChannel.nack).not.toHaveBeenCalled();
+				expect(messageTracker.answered).toHaveBeenCalledWith(message);
+			});
 		});
 
 		it('should handle error when "acknowledgeMode" is set to "immediately"', async () => {


### PR DESCRIPTION
## Summary

When the RabbitMQ Trigger is configured with **Delete From Queue When = Specific later in workflow** and a workflow crashes before reaching the explicit *Delete from Queue* action node, the message was being ack'd anyway, silently dropping it from the broker.

`handleMessage` used to await only the `sendResponse` hook for this acknowledge mode. The engine resolves that hook unconditionally at execution teardown (`resolveExecutionResponsePromise` in `packages/cli/src/active-executions.ts`), so the hook fires on every run — including crashes, before `sendResponse` was ever called. That made the hook useless as an ack signal.

This PR races the `sendResponse` hook against the final `IRun` (`workflowExecuteAfter`) and acts on whichever resolves first:

- **Hook wins** — the *Delete from Queue* node fired `sendResponse` mid-execution → `ack` immediately, without waiting for downstream nodes.
- **IRun wins with error** — the workflow crashed before the Delete node ran → `nack` so the broker redelivers. This is safe because `workflowExecuteAfter` fires strictly before the teardown-level hook resolve, so the IRun reliably wins the race on crash.
- **IRun wins clean** — workflow completed without firing the Delete node (misconfiguration) → `ack`, preserving pre-fix behaviour for this non-bug case.

**Behavior change (at-least-once semantics restored):** users who were unknowingly losing messages during failed runs will now see those messages redelivered — the documented intent of this feature. Happy-path timing is unchanged: the ack still happens as soon as the Delete-from-Queue node fires.

### How to test

1. Run a local broker: `docker run --rm -p 5672:5672 rabbitmq:3`.
2. Create a workflow: RabbitMQ Trigger (`acknowledge = laterMessageNode`) → Code node that throws → RabbitMQ (Delete from Queue).
3. Activate, publish a message, observe the queue:
   - **Scenario A** (no crash, Delete from Queue runs): queue returns to 0 as soon as Delete fires, even if later nodes keep running.
   - **Scenario B** (Code node crashes): before this PR the queue still returns to 0 (message lost); after this PR the message is redelivered on the next consumer.

 Queue before fix:

<img width="1074" height="409" alt="Bildschirmfoto 2026-04-20 um 16 43 25" src="https://github.com/user-attachments/assets/9fa0632a-2369-41ed-8c81-302a56d9452a" />

 Queue after fix:

<img width="870" height="340" alt="Bildschirmfoto 2026-04-20 um 16 44 19" src="https://github.com/user-attachments/assets/63412be2-b835-49c7-b8ae-3e75d67cf649" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4863
Fixes #28605

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)