### PR TITLE
fix(core)!: Unify role mapping feature flag across backend and frontend

### DIFF
--- a/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
@@ -29,7 +29,7 @@ import type { RoleMappingConfig, ResolvedRoles, RoleResolverContext } from './ro
 import { RoleResolverService } from './role-resolver.service.ee';
 
 export function isExpressionMappingFlagEnabled(): boolean {
-	return process.env.N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY === 'true';
+	return process.env.N8N_ENV_FEAT_EXPRESSION_ROLE_MAPPING === 'true';
 }
 
 @Service()

--- a/packages/cli/test/integration/oidc/oidc.service.ee.test.ts
+++ b/packages/cli/test/integration/oidc/oidc.service.ee.test.ts
@@ -935,15 +935,15 @@ describe('OIDC service', () => {
 				});
 
 				beforeEach(() => {
-					originalEnvFlag = process.env.N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY;
-					process.env.N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY = 'true';
+					originalEnvFlag = process.env.N8N_ENV_FEAT_EXPRESSION_ROLE_MAPPING;
+					process.env.N8N_ENV_FEAT_EXPRESSION_ROLE_MAPPING = 'true';
 				});
 
 				afterEach(async () => {
 					if (originalEnvFlag === undefined) {
-						delete process.env.N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY;
+						delete process.env.N8N_ENV_FEAT_EXPRESSION_ROLE_MAPPING;
 					} else {
-						process.env.N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY = originalEnvFlag;
+						process.env.N8N_ENV_FEAT_EXPRESSION_ROLE_MAPPING = originalEnvFlag;
 					}
 					await roleMappingRuleRepository.delete({});
 				});

--- a/packages/cli/test/integration/project.api.test.ts
+++ b/packages/cli/test/integration/project.api.test.ts
@@ -233,7 +233,7 @@ describe('Project members endpoints', () => {
 		afterEach(() => {
 			// @ts-expect-error - provisioningConfig is private
 			provisioningService.provisioningConfig = { ...savedConfig };
-			delete process.env.N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY;
+			delete process.env.N8N_ENV_FEAT_EXPRESSION_ROLE_MAPPING;
 		});
 
 		test('should return 403 when SSO provider controls project roles', async () => {
@@ -253,7 +253,7 @@ describe('Project members endpoints', () => {
 		});
 
 		test('should return 403 when expression-based role mapping is active', async () => {
-			process.env.N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY = 'true';
+			process.env.N8N_ENV_FEAT_EXPRESSION_ROLE_MAPPING = 'true';
 			// @ts-expect-error - provisioningConfig is private
 			provisioningService.provisioningConfig.scopesUseExpressionMapping = true;
 

--- a/packages/cli/test/integration/saml/saml.api.test.ts
+++ b/packages/cli/test/integration/saml/saml.api.test.ts
@@ -716,8 +716,8 @@ describe('SAML SSO provisioning', () => {
 	});
 
 	beforeEach(() => {
-		originalEnvFlag = process.env.N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY;
-		process.env.N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY = 'true';
+		originalEnvFlag = process.env.N8N_ENV_FEAT_EXPRESSION_ROLE_MAPPING;
+		process.env.N8N_ENV_FEAT_EXPRESSION_ROLE_MAPPING = 'true';
 
 		const provisioningService = Container.get(ProvisioningService);
 		// @ts-expect-error - provisioningConfig is private
@@ -728,9 +728,9 @@ describe('SAML SSO provisioning', () => {
 
 	afterEach(async () => {
 		if (originalEnvFlag === undefined) {
-			delete process.env.N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY;
+			delete process.env.N8N_ENV_FEAT_EXPRESSION_ROLE_MAPPING;
 		} else {
-			process.env.N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY = originalEnvFlag;
+			process.env.N8N_ENV_FEAT_EXPRESSION_ROLE_MAPPING = originalEnvFlag;
 		}
 
 		const provisioningService = Container.get(ProvisioningService);

--- a/packages/cli/test/integration/users.api.test.ts
+++ b/packages/cli/test/integration/users.api.test.ts
@@ -1728,7 +1728,7 @@ describe('PATCH /users/:id/role', () => {
 		afterEach(() => {
 			// @ts-expect-error - provisioningConfig is private
 			provisioningService.provisioningConfig = { ...savedConfig };
-			delete process.env.N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY;
+			delete process.env.N8N_ENV_FEAT_EXPRESSION_ROLE_MAPPING;
 		});
 
 		test('should return 403 when SSO provider controls instance roles', async () => {
@@ -1742,7 +1742,7 @@ describe('PATCH /users/:id/role', () => {
 		});
 
 		test('should return 403 when expression-based role mapping is active', async () => {
-			process.env.N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY = 'true';
+			process.env.N8N_ENV_FEAT_EXPRESSION_ROLE_MAPPING = 'true';
 			// @ts-expect-error - provisioningConfig is private
 			provisioningService.provisioningConfig.scopesUseExpressionMapping = true;
 

--- a/packages/frontend/editor-ui/src/features/settings/sso/provisioning/components/UserRoleProvisioningDropdown.vue
+++ b/packages/frontend/editor-ui/src/features/settings/sso/provisioning/components/UserRoleProvisioningDropdown.vue
@@ -34,7 +34,7 @@ const { authProtocol, disabled = false } = defineProps<{
 const i18n = useI18n();
 const canManage = useRBACStore().hasScope('provisioning:manage');
 const { check: isEnvFeatEnabled } = useEnvFeatureFlag();
-const isRuleMappingEnabled = computed(() => isEnvFeatEnabled.value('ROLE_MAPPING_RULES'));
+const isRuleMappingEnabled = computed(() => isEnvFeatEnabled.value('EXPRESSION_ROLE_MAPPING'));
 const showMappingMethod = computed(() => roleAssignment.value !== 'manual');
 const showIdpInfoBox = computed(() => showMappingMethod.value && mappingMethod.value === 'idp');
 const idpInfoText = computed(() =>


### PR DESCRIPTION
## Summary

Unifies the expression-based role mapping feature flag under a single env var, so the feature toggles consistently across backend and frontend.

**Breaking change for self-hosted admins:** the old flags `N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY` (backend) and `N8N_ENV_FEAT_ROLE_MAPPING_RULES` (frontend) have been replaced by a single flag `N8N_ENV_FEAT_EXPRESSION_ROLE_MAPPING`. Any existing deployment that relied on either old flag must update its environment.

### How to manually verify in the browser

1. Pull this branch and run `pnpm build` from the repo root.
2. Start n8n with the new flag enabled: `N8N_ENV_FEAT_EXPRESSION_ROLE_MAPPING=true pnpm start` (ensure SAML/OIDC SSO is configured on the instance).
3. In the UI, open **Settings → SSO → Role provisioning**.
4. In the **Role provisioning** section set "Role assignment" to either *Instance roles* or *Instance and project roles* — the **Mapping method** control should appear with both options visible: *IDP* and *Rules in n8n*.
5. Stop n8n. Restart **without** the new flag (or set it to any value other than `'true'`).
6. Reload the Role provisioning page — the *Rules in n8n* option in the **Mapping method** control should now be hidden, leaving only *IDP*.
7. Re-run step 2 but this time setting only the old flag names (`N8N_ENV_FEAT_ROLE_MAPPING_STRATEGY=true` or `N8N_ENV_FEAT_ROLE_MAPPING_RULES=true`). Confirm the *Rules in n8n* option stays hidden and the backend rejects expression-mapping requests — the old flags must have no effect.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-559/unify-be-and-fe-feature-flags-for-role-mapping

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI