### PR TITLE
fix(core): Generate title once there's enough user context

### DIFF
--- a/packages/@n8n/agents/src/__tests__/title-generation.test.ts
+++ b/packages/@n8n/agents/src/__tests__/title-generation.test.ts
@@ -31,15 +31,15 @@ describe('generateTitleFromMessage', () => {
 		expect(mockGenerateText).not.toHaveBeenCalled();
 	});
 
-	it('returns the message itself for trivial greetings without calling the LLM', async () => {
+	it('returns null for trivial greetings without calling the LLM', async () => {
 		const result = await generateTitleFromMessage(fakeModel, 'hey');
-		expect(result).toBe('hey');
+		expect(result).toBeNull();
 		expect(mockGenerateText).not.toHaveBeenCalled();
 	});
 
-	it('skips the LLM for short multi-word messages', async () => {
+	it('returns null for short multi-word messages without calling the LLM', async () => {
 		const result = await generateTitleFromMessage(fakeModel, 'hi there');
-		expect(result).toBe('hi there');
+		expect(result).toBeNull();
 		expect(mockGenerateText).not.toHaveBeenCalled();
 	});
 

--- a/packages/@n8n/agents/src/runtime/title-generation.ts
+++ b/packages/@n8n/agents/src/runtime/title-generation.ts
@@ -22,10 +22,10 @@ const TRIVIAL_MESSAGE_MAX_WORDS = 3;
 const MAX_TITLE_LENGTH = 80;
 
 /**
- * Whether a user message is too trivial to bother sending to an LLM for
- * title generation (e.g. "hey", "hello"). For these, the LLM tends to
- * hallucinate an assistant-voice reply as the title instead of echoing
- * the user intent — it's better to just use the message itself.
+ * Whether a user message has too little substance to title a conversation
+ * (e.g. "hey", "hello"). For these, the LLM tends to hallucinate an
+ * assistant-voice reply as the title — better to signal "defer, not enough
+ * signal yet" so the caller can retry once more context accumulates.
  */
 function isTrivialMessage(message: string): boolean {
 	const normalized = message.trim();
@@ -69,7 +69,7 @@ export async function generateTitleFromMessage(
 	if (!trimmed) return null;
 
 	if (isTrivialMessage(trimmed)) {
-		return sanitizeTitle(trimmed) || null;
+		return null;
 	}
 
 	const result = await generateText({

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -2457,14 +2457,14 @@ export class InstanceAiService {
 			// Skip if thread already has an LLM-refined title
 			if (thread.metadata?.titleRefined) return;
 
-			// Get first user message
+			// Concat all recalled user messages so retries after a trivial first message
+			// (e.g. "hey") have enough signal to produce a good title.
 			const result = await memory.recall({ threadId, resourceId: userId, perPage: 5 });
-			const firstUserMsg = result.messages.find((m) => m.role === 'user');
-			if (!firstUserMsg) return;
-			const userText =
-				typeof firstUserMsg.content === 'string'
-					? firstUserMsg.content
-					: JSON.stringify(firstUserMsg.content);
+			const userTexts = result.messages
+				.filter((m) => m.role === 'user')
+				.map((m) => (typeof m.content === 'string' ? m.content : JSON.stringify(m.content)));
+			if (userTexts.length === 0) return;
+			const userText = userTexts.join('\n');
 
 			const llmTitle = await generateTitleForRun(modelId, userText);
 			if (!llmTitle) return;


### PR DESCRIPTION
## Summary

Makes us generate the title only after we have a bit of context - so if user sends message "hey", the title isn't immediately generated, but then on the second message once a bit of user context exists the title generation happens.

This should make the titles a bit more accurate, and we can later tune what is considered a trivial message.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
