### PR TITLE
fix(core): Shift existing rules on create to avoid order conflict

### DIFF
--- a/packages/@n8n/api-types/src/dto/roles/__tests__/create-role-mapping-rule.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/roles/__tests__/create-role-mapping-rule.dto.test.ts
@@ -1,0 +1,39 @@
+import { CreateRoleMappingRuleDto } from '../create-role-mapping-rule.dto';
+
+const VALID_BODY = {
+	expression: 'claims.admin === true',
+	role: 'global:member',
+	type: 'instance' as const,
+};
+
+describe('CreateRoleMappingRuleDto', () => {
+	describe('Valid requests', () => {
+		test.each([
+			{ name: 'order omitted', request: { ...VALID_BODY } },
+			{ name: 'order zero', request: { ...VALID_BODY, order: 0 } },
+			{ name: 'positive integer order', request: { ...VALID_BODY, order: 5 } },
+			{
+				name: 'project rule with projectIds',
+				request: {
+					...VALID_BODY,
+					type: 'project',
+					role: 'project:editor',
+					projectIds: ['p1'],
+				},
+			},
+		])('accepts $name', ({ request }) => {
+			expect(CreateRoleMappingRuleDto.safeParse(request).success).toBe(true);
+		});
+	});
+
+	describe('Invalid requests', () => {
+		test.each([
+			{ name: 'negative order', request: { ...VALID_BODY, order: -1 } },
+			{ name: 'non-integer order', request: { ...VALID_BODY, order: 1.5 } },
+			{ name: 'empty expression', request: { ...VALID_BODY, expression: '' } },
+			{ name: 'unknown type', request: { ...VALID_BODY, type: 'unknown' } },
+		])('rejects $name', ({ request }) => {
+			expect(CreateRoleMappingRuleDto.safeParse(request).success).toBe(false);
+		});
+	});
+});

--- a/packages/@n8n/api-types/src/dto/roles/create-role-mapping-rule.dto.ts
+++ b/packages/@n8n/api-types/src/dto/roles/create-role-mapping-rule.dto.ts
@@ -6,6 +6,6 @@ export class CreateRoleMappingRuleDto extends Z.class({
 	expression: z.string().min(1),
 	role: z.string().min(1).max(128),
 	type: z.enum(['instance', 'project']),
-	order: z.number().int(),
+	order: z.number().int().min(0).optional(),
 	projectIds: z.array(z.string()).optional(),
 }) {}

--- a/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.service.ee.test.ts
@@ -52,12 +52,26 @@ const projectRole: Role = {
 };
 
 describe('RoleMappingRuleService', () => {
+	const defaultUpdateSpy = jest.fn().mockResolvedValue(undefined);
+	const defaultTransactionSpy = jest
+		.fn()
+		.mockImplementation(async (cb: (tx: { update: typeof defaultUpdateSpy }) => Promise<void>) => {
+			await cb({ update: defaultUpdateSpy });
+		});
+
 	beforeEach(() => {
 		jest.clearAllMocks();
 		roleMappingRuleRepository.findOne.mockResolvedValue(null);
 		// normalizeOrderForType calls find after every mutation; default to empty
 		// so existing tests hit the early-exit path and require no transaction mock.
 		roleMappingRuleRepository.find.mockResolvedValue([]);
+		// create() always calls applyOrder (which uses a transaction) to splice the
+		// newly-saved rule into the existing order. Inner describes may override.
+		(roleMappingRuleRepository as unknown as Record<string, unknown>).manager = {
+			transaction: defaultTransactionSpy,
+		};
+		defaultUpdateSpy.mockClear();
+		defaultTransactionSpy.mockClear();
 	});
 
 	describe('create', () => {
@@ -132,22 +146,6 @@ describe('RoleMappingRuleService', () => {
 					projectIds: ['p1'],
 				}),
 			).rejects.toThrow(BadRequestError);
-		});
-
-		it('should reject when another rule already uses the same type and order', async () => {
-			roleRepository.findOne.mockResolvedValue(globalRole);
-			roleMappingRuleRepository.findOne.mockResolvedValue({
-				id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
-			} as RoleMappingRule);
-
-			await expect(
-				service.create({
-					expression: 'true',
-					role: globalRole.slug,
-					type: 'instance',
-					order: 2,
-				}),
-			).rejects.toThrow(ConflictError);
 		});
 
 		it('should reject when some project ids do not exist', async () => {
@@ -284,6 +282,146 @@ describe('RoleMappingRuleService', () => {
 
 			expect(result.projectIds).toEqual([projA.id]);
 			expect(projectRepository.findBy).toHaveBeenCalledTimes(1);
+		});
+
+		it('should append when order is omitted', async () => {
+			roleRepository.findOne.mockResolvedValue(globalRole);
+			roleMappingRuleRepository.find.mockResolvedValue([
+				{ id: 'rule-a', order: 0 } as RoleMappingRule,
+				{ id: 'rule-b', order: 1 } as RoleMappingRule,
+			]);
+
+			const savedRule = {
+				id: 'rule-c',
+				expression: 'claims.c',
+				role: globalRole,
+				type: 'instance',
+				order: 2,
+				projects: [],
+				createdAt: new Date('2025-01-01T00:00:00.000Z'),
+				updatedAt: new Date('2025-01-01T00:00:00.000Z'),
+			} as unknown as RoleMappingRule;
+
+			roleMappingRuleRepository.save.mockImplementation(async (r) => ({
+				...(r as RoleMappingRule),
+				id: 'rule-c',
+			}));
+			roleMappingRuleRepository.findOneOrFail.mockResolvedValue(savedRule);
+
+			await service.create({
+				expression: 'claims.c',
+				role: globalRole.slug,
+				type: 'instance',
+			});
+
+			// applyOrder should renumber [rule-a, rule-b, rule-c] to [0, 1, 2]
+			expect(defaultUpdateSpy).toHaveBeenCalledWith(
+				expect.anything(),
+				{ id: 'rule-a' },
+				{ order: 0 },
+			);
+			expect(defaultUpdateSpy).toHaveBeenCalledWith(
+				expect.anything(),
+				{ id: 'rule-b' },
+				{ order: 1 },
+			);
+			expect(defaultUpdateSpy).toHaveBeenCalledWith(
+				expect.anything(),
+				{ id: 'rule-c' },
+				{ order: 2 },
+			);
+		});
+
+		it('should insert at index 0 and shift existing rules down', async () => {
+			roleRepository.findOne.mockResolvedValue(globalRole);
+			roleMappingRuleRepository.find.mockResolvedValue([
+				{ id: 'rule-a', order: 0 } as RoleMappingRule,
+				{ id: 'rule-b', order: 1 } as RoleMappingRule,
+			]);
+
+			const savedRule = {
+				id: 'rule-new',
+				expression: 'claims.new',
+				role: globalRole,
+				type: 'instance',
+				order: 0,
+				projects: [],
+				createdAt: new Date('2025-01-01T00:00:00.000Z'),
+				updatedAt: new Date('2025-01-01T00:00:00.000Z'),
+			} as unknown as RoleMappingRule;
+
+			roleMappingRuleRepository.save.mockImplementation(async (r) => ({
+				...(r as RoleMappingRule),
+				id: 'rule-new',
+			}));
+			roleMappingRuleRepository.findOneOrFail.mockResolvedValue(savedRule);
+
+			await service.create({
+				expression: 'claims.new',
+				role: globalRole.slug,
+				type: 'instance',
+				order: 0,
+			});
+
+			// applyOrder should renumber [rule-new, rule-a, rule-b] to [0, 1, 2]
+			expect(defaultUpdateSpy).toHaveBeenCalledWith(
+				expect.anything(),
+				{ id: 'rule-new' },
+				{ order: 0 },
+			);
+			expect(defaultUpdateSpy).toHaveBeenCalledWith(
+				expect.anything(),
+				{ id: 'rule-a' },
+				{ order: 1 },
+			);
+			expect(defaultUpdateSpy).toHaveBeenCalledWith(
+				expect.anything(),
+				{ id: 'rule-b' },
+				{ order: 2 },
+			);
+		});
+
+		it('should clamp supplied order beyond existing list length to the end', async () => {
+			roleRepository.findOne.mockResolvedValue(globalRole);
+			roleMappingRuleRepository.find.mockResolvedValue([
+				{ id: 'rule-a', order: 0 } as RoleMappingRule,
+			]);
+
+			const savedRule = {
+				id: 'rule-new',
+				expression: 'claims.new',
+				role: globalRole,
+				type: 'instance',
+				order: 1,
+				projects: [],
+				createdAt: new Date('2025-01-01T00:00:00.000Z'),
+				updatedAt: new Date('2025-01-01T00:00:00.000Z'),
+			} as unknown as RoleMappingRule;
+
+			roleMappingRuleRepository.save.mockImplementation(async (r) => ({
+				...(r as RoleMappingRule),
+				id: 'rule-new',
+			}));
+			roleMappingRuleRepository.findOneOrFail.mockResolvedValue(savedRule);
+
+			await service.create({
+				expression: 'claims.new',
+				role: globalRole.slug,
+				type: 'instance',
+				order: 999,
+			});
+
+			// Clamped to end: [rule-a, rule-new] → orders [0, 1]
+			expect(defaultUpdateSpy).toHaveBeenCalledWith(
+				expect.anything(),
+				{ id: 'rule-a' },
+				{ order: 0 },
+			);
+			expect(defaultUpdateSpy).toHaveBeenCalledWith(
+				expect.anything(),
+				{ id: 'rule-new' },
+				{ order: 1 },
+			);
 		});
 	});
 
@@ -642,35 +780,6 @@ describe('RoleMappingRuleService', () => {
 			// Phase 2 should assign contiguous orders 0, 1, 2
 			expect(updateSpy).toHaveBeenCalledWith(expect.anything(), { id: 'a' }, { order: 0 });
 			expect(updateSpy).toHaveBeenCalledWith(expect.anything(), { id: 'b' }, { order: 1 });
-			expect(updateSpy).toHaveBeenCalledWith(expect.anything(), { id: 'c' }, { order: 2 });
-		});
-
-		it('should compact a large gap after create', async () => {
-			// Simulates [0, 1, 100] after creating a rule at order 100
-			roleMappingRuleRepository.find.mockResolvedValue([
-				makeRule('a', 0),
-				makeRule('b', 1),
-				makeRule('c', 100),
-			]);
-
-			roleRepository.findOne.mockResolvedValue(globalRole);
-			roleMappingRuleRepository.save.mockResolvedValue(makeRule('c', 100));
-			roleMappingRuleRepository.findOneOrFail.mockResolvedValue({
-				...makeRule('c', 2),
-				role: globalRole,
-				projects: [],
-				createdAt: new Date('2025-01-01T00:00:00.000Z'),
-				updatedAt: new Date('2025-01-01T00:00:00.000Z'),
-			} as unknown as RoleMappingRule);
-
-			await service.create({
-				expression: 'true',
-				role: globalRole.slug,
-				type: 'instance',
-				order: 100,
-			});
-
-			expect(transactionSpy).toHaveBeenCalledTimes(1);
 			expect(updateSpy).toHaveBeenCalledWith(expect.anything(), { id: 'c' }, { order: 2 });
 		});
 

--- a/packages/cli/src/modules/provisioning.ee/role-mapping-rule.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/role-mapping-rule.service.ee.ts
@@ -90,8 +90,6 @@ export class RoleMappingRuleService {
 
 		assertRoleCompatibleWithMappingType(role, dto.type);
 
-		await this.assertOrderAvailable(dto.type, dto.order);
-
 		const projects =
 			uniqueProjectIds.length > 0
 				? await this.projectRepository.findBy({ id: In(uniqueProjectIds) })
@@ -101,16 +99,37 @@ export class RoleMappingRuleService {
 			throw new BadRequestError('One or more projects were not found');
 		}
 
+		const existingRules = await this.roleMappingRuleRepository.find({
+			where: { type: dto.type },
+			select: ['id', 'order'],
+			order: { order: 'ASC' },
+		});
+
+		// Clamp the requested index into the valid range. Omitted order appends.
+		const requestedOrder = dto.order ?? existingRules.length;
+		const targetIndex = Math.min(Math.max(requestedOrder, 0), existingRules.length);
+
+		// Save the new rule at a temporary order beyond any currently-used slot,
+		// so the unique (type, order) constraint cannot fire on the initial insert.
+		const maxOrder = existingRules.length > 0 ? existingRules[existingRules.length - 1].order : -1;
+		const tempOrder = Math.max(maxOrder, existingRules.length - 1) + 1;
+
 		const rule = new RoleMappingRule();
 		rule.expression = dto.expression;
 		rule.role = role;
 		rule.type = dto.type;
-		rule.order = dto.order;
+		rule.order = tempOrder;
 		rule.projects = projects;
 
 		const saved = await this.roleMappingRuleRepository.save(rule);
 
-		await this.normalizeOrderForType(dto.type);
+		// Build the final ordering: existing rules in their current order, with the
+		// newly saved rule spliced in at targetIndex. applyOrder atomically renumbers
+		// everything to [0..n-1] using its two-phase transaction.
+		const reorderedIds = existingRules.map((r) => r.id);
+		reorderedIds.splice(targetIndex, 0, saved.id);
+
+		await this.applyOrder(reorderedIds);
 
 		const loaded = await this.roleMappingRuleRepository.findOneOrFail({
 			where: { id: saved.id },

--- a/packages/cli/test/integration/role-mapping-rule.api.test.ts
+++ b/packages/cli/test/integration/role-mapping-rule.api.test.ts
@@ -124,17 +124,80 @@ describe('POST /role-mapping-rule', () => {
 		expect(stored!.projects).toHaveLength(0);
 	});
 
-	it('should return 409 when type and order match an existing rule', async () => {
+	it('should shift existing rules down when a new rule is created at an occupied order', async () => {
+		const first = await ownerAgent
+			.post('/role-mapping-rule')
+			.send(validInstancePayload)
+			.expect(200);
+
+		const second = await ownerAgent
+			.post('/role-mapping-rule')
+			.send({
+				...validInstancePayload,
+				expression: 'claims.other === true',
+				order: 0,
+			})
+			.expect(200);
+
+		expect(second.body.data.order).toBe(0);
+
+		const repo = Container.get(RoleMappingRuleRepository);
+		const all = await repo.find({ where: { type: 'instance' }, order: { order: 'ASC' } });
+		expect(all.map((r) => r.id)).toEqual([second.body.data.id, first.body.data.id]);
+		expect(all.map((r) => r.order)).toEqual([0, 1]);
+	});
+
+	it('should insert at position 0 and shift all existing rules down', async () => {
+		const first = await ownerAgent
+			.post('/role-mapping-rule')
+			.send(validInstancePayload)
+			.expect(200);
+		const second = await ownerAgent
+			.post('/role-mapping-rule')
+			.send({ ...validInstancePayload, expression: 'claims.b', order: 1 })
+			.expect(200);
+
+		const inserted = await ownerAgent
+			.post('/role-mapping-rule')
+			.send({ ...validInstancePayload, expression: 'claims.new-head', order: 0 })
+			.expect(200);
+
+		expect(inserted.body.data.order).toBe(0);
+
+		const list = await ownerAgent.get('/role-mapping-rule').expect(200);
+		expect(list.body.data.items.map((r: { id: string }) => r.id)).toEqual([
+			inserted.body.data.id,
+			first.body.data.id,
+			second.body.data.id,
+		]);
+		expect(list.body.data.items.map((r: { order: number }) => r.order)).toEqual([0, 1, 2]);
+	});
+
+	it('should append when order is omitted', async () => {
+		await ownerAgent.post('/role-mapping-rule').send(validInstancePayload).expect(200);
+		await ownerAgent
+			.post('/role-mapping-rule')
+			.send({ ...validInstancePayload, expression: 'claims.b', order: 1 })
+			.expect(200);
+
+		const { role, type } = validInstancePayload;
+		const appended = await ownerAgent
+			.post('/role-mapping-rule')
+			.send({ expression: 'claims.appended', role, type })
+			.expect(200);
+
+		expect(appended.body.data.order).toBe(2);
+	});
+
+	it('should clamp order to list length when supplied value is too high', async () => {
 		await ownerAgent.post('/role-mapping-rule').send(validInstancePayload).expect(200);
 
-		const response = await ownerAgent.post('/role-mapping-rule').send({
-			...validInstancePayload,
-			expression: 'claims.other === true',
-		});
+		const tooHigh = await ownerAgent
+			.post('/role-mapping-rule')
+			.send({ ...validInstancePayload, expression: 'claims.b', order: 999 })
+			.expect(200);
 
-		expect(response.status).toBe(409);
-		expect(response.body.message).toContain('already exists');
-		expect(response.body.message).toContain('order');
+		expect(tooHigh.body.data.order).toBe(1);
 	});
 
 	it('should normalize order when created with an abnormally high order value', async () => {

--- a/packages/cli/test/integration/role-mapping-rule.api.test.ts
+++ b/packages/cli/test/integration/role-mapping-rule.api.test.ts
@@ -200,6 +200,60 @@ describe('POST /role-mapping-rule', () => {
 		expect(tooHigh.body.data.order).toBe(1);
 	});
 
+	it('should insert at a middle position and shift subsequent rules down', async () => {
+		const first = await ownerAgent
+			.post('/role-mapping-rule')
+			.send({ ...validInstancePayload, expression: 'claims.a', order: 0 })
+			.expect(200);
+		const second = await ownerAgent
+			.post('/role-mapping-rule')
+			.send({ ...validInstancePayload, expression: 'claims.b', order: 1 })
+			.expect(200);
+		const third = await ownerAgent
+			.post('/role-mapping-rule')
+			.send({ ...validInstancePayload, expression: 'claims.c', order: 2 })
+			.expect(200);
+
+		const inserted = await ownerAgent
+			.post('/role-mapping-rule')
+			.send({ ...validInstancePayload, expression: 'claims.middle', order: 1 })
+			.expect(200);
+
+		expect(inserted.body.data.order).toBe(1);
+
+		const list = await ownerAgent.get('/role-mapping-rule').expect(200);
+		expect(list.body.data.items.map((r: { id: string }) => r.id)).toEqual([
+			first.body.data.id,
+			inserted.body.data.id,
+			second.body.data.id,
+			third.body.data.id,
+		]);
+		expect(list.body.data.items.map((r: { order: number }) => r.order)).toEqual([0, 1, 2, 3]);
+	});
+
+	it('should allow instance and project rules to share the same order value', async () => {
+		const teamProject = await createTeamProject(undefined, owner);
+
+		await ownerAgent
+			.post('/role-mapping-rule')
+			.send({ ...validInstancePayload, order: 0 })
+			.expect(200);
+
+		const projectRule = await ownerAgent
+			.post('/role-mapping-rule')
+			.send({
+				expression: 'claims.project',
+				role: 'project:editor',
+				type: 'project',
+				order: 0,
+				projectIds: [teamProject.id],
+			})
+			.expect(200);
+
+		expect(projectRule.body.data.order).toBe(0);
+		expect(projectRule.body.data.type).toBe('project');
+	});
+
 	it('should normalize order when created with an abnormally high order value', async () => {
 		await ownerAgent
 			.post('/role-mapping-rule')

--- a/packages/frontend/@n8n/rest-api-client/src/api/roleMappingRule.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/roleMappingRule.ts
@@ -19,7 +19,7 @@ export type CreateRoleMappingRuleInput = {
 	expression: string;
 	role: string;
 	type: RoleMappingRuleType;
-	order: number;
+	order?: number;
 	projectIds?: string[];
 };
 

--- a/packages/frontend/editor-ui/src/features/settings/sso/provisioning/composables/useRoleMappingRules.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/sso/provisioning/composables/useRoleMappingRules.test.ts
@@ -206,28 +206,36 @@ describe('useRoleMappingRules', () => {
 	});
 
 	describe('save', () => {
-		it('should send creates without an order field', async () => {
+		it('should send the local order on creates so user-intended position is preserved', async () => {
+			vi.mocked(roleMappingRuleApi.listRoleMappingRules).mockResolvedValue([
+				makeRule({ id: 'persisted-1', type: 'instance', order: 0 }),
+			]);
 			vi.mocked(roleMappingRuleApi.createRoleMappingRule).mockResolvedValue(makeRule());
+			vi.mocked(roleMappingRuleApi.updateRoleMappingRule).mockResolvedValue(makeRule());
 
+			await composable.loadRules();
 			composable.addRule('instance');
-			composable.updateRule(composable.instanceRules.value[0].id, {
+			const localId = composable.instanceRules.value[1].id;
+			composable.updateRule(localId, {
 				expression: '$claims.admin',
 				role: 'global:member',
 			});
+			// Drag the new local rule above the persisted one.
+			await composable.reorder('instance', 1, 0);
 
 			await composable.save();
 
 			expect(roleMappingRuleApi.createRoleMappingRule).toHaveBeenCalledTimes(1);
 			const [, payload] = vi.mocked(roleMappingRuleApi.createRoleMappingRule).mock.calls[0];
-			expect(payload).not.toHaveProperty('order');
 			expect(payload).toMatchObject({
 				expression: '$claims.admin',
 				role: 'global:member',
 				type: 'instance',
+				order: 0,
 			});
 		});
 
-		it('should serialize create calls to preserve user-intended order', async () => {
+		it('should serialize create calls to avoid concurrent temp-order collisions', async () => {
 			const callOrder: string[] = [];
 			vi.mocked(roleMappingRuleApi.createRoleMappingRule).mockImplementation(
 				async (_ctx, input) => {

--- a/packages/frontend/editor-ui/src/features/settings/sso/provisioning/composables/useRoleMappingRules.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/sso/provisioning/composables/useRoleMappingRules.test.ts
@@ -204,4 +204,66 @@ describe('useRoleMappingRules', () => {
 			expect(composable.projectRules.value.every((r) => r.type === 'project')).toBe(true);
 		});
 	});
+
+	describe('save', () => {
+		it('should send creates without an order field', async () => {
+			vi.mocked(roleMappingRuleApi.createRoleMappingRule).mockResolvedValue(makeRule());
+
+			composable.addRule('instance');
+			composable.updateRule(composable.instanceRules.value[0].id, {
+				expression: '$claims.admin',
+				role: 'global:member',
+			});
+
+			await composable.save();
+
+			expect(roleMappingRuleApi.createRoleMappingRule).toHaveBeenCalledTimes(1);
+			const [, payload] = vi.mocked(roleMappingRuleApi.createRoleMappingRule).mock.calls[0];
+			expect(payload).not.toHaveProperty('order');
+			expect(payload).toMatchObject({
+				expression: '$claims.admin',
+				role: 'global:member',
+				type: 'instance',
+			});
+		});
+
+		it('should serialize create calls to preserve user-intended order', async () => {
+			const callOrder: string[] = [];
+			vi.mocked(roleMappingRuleApi.createRoleMappingRule).mockImplementation(
+				async (_ctx, input) => {
+					callOrder.push(input.expression);
+					await new Promise((r) => setTimeout(r, 0));
+					return makeRule({ expression: input.expression });
+				},
+			);
+
+			composable.addRule('instance');
+			composable.addRule('instance');
+			composable.updateRule(composable.instanceRules.value[0].id, { expression: 'first' });
+			composable.updateRule(composable.instanceRules.value[1].id, { expression: 'second' });
+
+			await composable.save();
+
+			expect(callOrder).toEqual(['first', 'second']);
+		});
+
+		it('should include order on updates to existing persisted rules', async () => {
+			vi.mocked(roleMappingRuleApi.listRoleMappingRules).mockResolvedValue([
+				makeRule({ id: 'persisted-1', type: 'instance', order: 0, expression: 'orig' }),
+			]);
+			vi.mocked(roleMappingRuleApi.updateRoleMappingRule).mockResolvedValue(
+				makeRule({ id: 'persisted-1' }),
+			);
+
+			await composable.loadRules();
+			composable.updateRule('persisted-1', { expression: 'edited' });
+			await composable.save();
+
+			expect(roleMappingRuleApi.updateRoleMappingRule).toHaveBeenCalledWith(
+				expect.anything(),
+				'persisted-1',
+				expect.objectContaining({ order: 0 }),
+			);
+		});
+	});
 });

--- a/packages/frontend/editor-ui/src/features/settings/sso/provisioning/composables/useRoleMappingRules.ts
+++ b/packages/frontend/editor-ui/src/features/settings/sso/provisioning/composables/useRoleMappingRules.ts
@@ -123,21 +123,11 @@ export function useRoleMappingRules() {
 			const allLocalRules = [...instanceRules.value, ...projectRules.value];
 			const localRuleIds = new Set(allLocalRules.map((r) => r.id));
 
-			const updatePayload = (r: RoleMappingRuleResponse) => ({
+			const rulePayload = (r: RoleMappingRuleResponse) => ({
 				expression: r.expression,
 				role: r.role,
 				type: r.type,
 				order: r.order,
-				projectIds: r.projectIds,
-			});
-
-			// New rules rely on the backend to append them in arrival order, so
-			// `order` is intentionally omitted — otherwise stale local values can
-			// conflict with the DB's unique (type, order) constraint.
-			const createPayload = (r: RoleMappingRuleResponse) => ({
-				expression: r.expression,
-				role: r.role,
-				type: r.type,
 				projectIds: r.projectIds,
 			});
 
@@ -148,14 +138,15 @@ export function useRoleMappingRules() {
 			const createRules = allLocalRules.filter((r) => r.id.startsWith('local-'));
 
 			// Deletes and updates can run concurrently. Creates must be sequential
-			// so the backend appends them in the user-intended order.
+			// because the backend reshuffles orders on each create, and race
+			// conditions between concurrent creates can collide on temp orders.
 			await Promise.all([
 				...deleteIds.map(async (id) => await api.deleteRule(id)),
-				...updateRules.map(async (r) => await api.updateRule(r.id, updatePayload(r))),
+				...updateRules.map(async (r) => await api.updateRule(r.id, rulePayload(r))),
 			]);
 
 			for (const rule of createRules) {
-				await api.createRule(createPayload(rule));
+				await api.createRule(rulePayload(rule));
 			}
 
 			await loadRules();

--- a/packages/frontend/editor-ui/src/features/settings/sso/provisioning/composables/useRoleMappingRules.ts
+++ b/packages/frontend/editor-ui/src/features/settings/sso/provisioning/composables/useRoleMappingRules.ts
@@ -122,7 +122,8 @@ export function useRoleMappingRules() {
 		try {
 			const allLocalRules = [...instanceRules.value, ...projectRules.value];
 			const localRuleIds = new Set(allLocalRules.map((r) => r.id));
-			const rulePayload = (r: RoleMappingRuleResponse) => ({
+
+			const updatePayload = (r: RoleMappingRuleResponse) => ({
 				expression: r.expression,
 				role: r.role,
 				type: r.type,
@@ -130,15 +131,32 @@ export function useRoleMappingRules() {
 				projectIds: r.projectIds,
 			});
 
+			// New rules rely on the backend to append them in arrival order, so
+			// `order` is intentionally omitted — otherwise stale local values can
+			// conflict with the DB's unique (type, order) constraint.
+			const createPayload = (r: RoleMappingRuleResponse) => ({
+				expression: r.expression,
+				role: r.role,
+				type: r.type,
+				projectIds: r.projectIds,
+			});
+
+			const deleteIds = [...serverRuleIds].filter((id) => !localRuleIds.has(id));
+			const updateRules = allLocalRules.filter(
+				(r) => !r.id.startsWith('local-') && serverRuleIds.has(r.id),
+			);
+			const createRules = allLocalRules.filter((r) => r.id.startsWith('local-'));
+
+			// Deletes and updates can run concurrently. Creates must be sequential
+			// so the backend appends them in the user-intended order.
 			await Promise.all([
-				...[...serverRuleIds]
-					.filter((id) => !localRuleIds.has(id))
-					.map(async (id) => await api.deleteRule(id)),
-				...allLocalRules.map(async (rule): Promise<void> => {
-					if (rule.id.startsWith('local-')) await api.createRule(rulePayload(rule));
-					else if (serverRuleIds.has(rule.id)) await api.updateRule(rule.id, rulePayload(rule));
-				}),
+				...deleteIds.map(async (id) => await api.deleteRule(id)),
+				...updateRules.map(async (r) => await api.updateRule(r.id, updatePayload(r))),
 			]);
+
+			for (const rule of createRules) {
+				await api.createRule(createPayload(rule));
+			}
 
 			await loadRules();
 		} finally {


### PR DESCRIPTION
## Summary

Fixes a 409 conflict when creating a role mapping rule that lands on an already-occupied `order`. The backend now splices the new rule into the requested position and atomically renumbers the sequence using the existing two-phase `applyOrder` transaction. Omitting `order` appends the rule; out-of-range values clamp to the end of the list.

### How to verify in the browser

**Prerequisites:** n8n running locally with SAML or OIDC provisioning licensed (`N8N_LICENSE_ACTIVATION_KEY` or dev license), and an SSO config that uses **Rules in n8n** for role assignment.

1. Sign in as an owner and open **Settings → SSO → Provisioning**.
2. Under **Instance role rules**, click **Add rule**, set an expression (e.g. `$claims.admin === true`) and a role, then save the SSO config.
3. Click **Add rule** again — add another instance rule **on top of** the one you just created.
4. Save the SSO config.
   - **Before this PR:** red error toast *"A role mapping rule already exists with type 'instance' and order 0. Use a different order value."*
   - **After this PR:** the rule is saved. Reload the page and confirm both rules are listed in the intended order with sequential priorities (`1.`, `2.`).
5. Drag a new local rule above an existing one, save, reload — the dragged rule should land at the top and the other rules should shift down without errors.
6. Delete the middle rule, add a new one, save — no conflict, priorities remain contiguous.
7. Repeat steps 2–4 for **Project role rules** (if enabled) — same behaviour.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-560

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI