### PR TITLE
feat(core): Add cluster check interface and decorator (no-changelog)

### DIFF
--- a/packages/@n8n/decorators/package.json
+++ b/packages/@n8n/decorators/package.json
@@ -30,6 +30,7 @@
     "zod": "catalog:"
   },
   "dependencies": {
+    "@n8n/api-types": "workspace:*",
     "@n8n/constants": "workspace:*",
     "@n8n/di": "workspace:*",
     "@n8n/permissions": "workspace:*",

--- a/packages/@n8n/decorators/src/cluster-check/__tests__/cluster-check-metadata.test.ts
+++ b/packages/@n8n/decorators/src/cluster-check/__tests__/cluster-check-metadata.test.ts
@@ -1,0 +1,179 @@
+import { Container, Service } from '@n8n/di';
+
+import type { ClusterCheckContext, ClusterCheckResult, IClusterCheck } from '../cluster-check';
+import { ClusterCheck, ClusterCheckMetadata } from '../cluster-check-metadata';
+
+describe('ClusterCheckMetadata', () => {
+	let metadata: ClusterCheckMetadata;
+
+	beforeEach(() => {
+		metadata = new ClusterCheckMetadata();
+	});
+
+	it('should register check classes', () => {
+		class TestCheck implements IClusterCheck {
+			checkDescription = { name: 'test.check' };
+			async run(_context: ClusterCheckContext): Promise<ClusterCheckResult> {
+				return {};
+			}
+		}
+
+		metadata.register({ class: TestCheck });
+
+		expect(metadata.getClasses()).toContain(TestCheck);
+	});
+
+	it('should return all registered entries', () => {
+		class FirstCheck implements IClusterCheck {
+			checkDescription = { name: 'first.check' };
+			async run(_context: ClusterCheckContext): Promise<ClusterCheckResult> {
+				return {};
+			}
+		}
+		class SecondCheck implements IClusterCheck {
+			checkDescription = { name: 'second.check' };
+			async run(_context: ClusterCheckContext): Promise<ClusterCheckResult> {
+				return {};
+			}
+		}
+
+		metadata.register({ class: FirstCheck });
+		metadata.register({ class: SecondCheck });
+
+		expect(metadata.getEntries()).toHaveLength(2);
+	});
+
+	it('should return registered classes in registration order', () => {
+		class FirstCheck implements IClusterCheck {
+			checkDescription = { name: 'first.check' };
+			async run(_context: ClusterCheckContext): Promise<ClusterCheckResult> {
+				return {};
+			}
+		}
+		class SecondCheck implements IClusterCheck {
+			checkDescription = { name: 'second.check' };
+			async run(_context: ClusterCheckContext): Promise<ClusterCheckResult> {
+				return {};
+			}
+		}
+
+		metadata.register({ class: FirstCheck });
+		metadata.register({ class: SecondCheck });
+
+		expect(metadata.getClasses()).toEqual([FirstCheck, SecondCheck]);
+	});
+});
+
+describe('@ClusterCheck decorator', () => {
+	let metadata: ClusterCheckMetadata;
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+
+		metadata = new ClusterCheckMetadata();
+		Container.set(ClusterCheckMetadata, metadata);
+	});
+
+	it('should register the decorated class in ClusterCheckMetadata', () => {
+		@ClusterCheck()
+		class TestCheck implements IClusterCheck {
+			checkDescription = { name: 'cluster.test' };
+			async run(_context: ClusterCheckContext): Promise<ClusterCheckResult> {
+				return {};
+			}
+		}
+
+		const registered = metadata.getClasses();
+
+		expect(registered).toContain(TestCheck);
+		expect(registered).toHaveLength(1);
+	});
+
+	it('should register multiple decorated classes', () => {
+		@ClusterCheck()
+		class VersionCheck implements IClusterCheck {
+			checkDescription = { name: 'cluster.versionMismatch' };
+			async run(_context: ClusterCheckContext): Promise<ClusterCheckResult> {
+				return {};
+			}
+		}
+
+		@ClusterCheck()
+		class LeaderCheck implements IClusterCheck {
+			checkDescription = { name: 'cluster.leaderMissing' };
+			async run(_context: ClusterCheckContext): Promise<ClusterCheckResult> {
+				return {};
+			}
+		}
+
+		const registered = metadata.getClasses();
+
+		expect(registered).toContain(VersionCheck);
+		expect(registered).toContain(LeaderCheck);
+		expect(registered).toHaveLength(2);
+	});
+
+	it('should apply @Service() so the class is resolvable via DI', () => {
+		@ClusterCheck()
+		class TestCheck implements IClusterCheck {
+			checkDescription = { name: 'cluster.test' };
+			async run(_context: ClusterCheckContext): Promise<ClusterCheckResult> {
+				return {};
+			}
+		}
+
+		expect(Container.has(TestCheck)).toBe(true);
+
+		const instance = Container.get(TestCheck);
+
+		expect(instance).toBeInstanceOf(TestCheck);
+		expect(instance.checkDescription).toEqual({ name: 'cluster.test' });
+	});
+
+	it('should support checks with constructor-injected dependencies', () => {
+		@Service()
+		class Logger {
+			log(message: string) {
+				return message;
+			}
+		}
+
+		@ClusterCheck()
+		class TestCheck implements IClusterCheck {
+			checkDescription = { name: 'cluster.test' };
+			constructor(private readonly logger: Logger) {}
+			async run(_context: ClusterCheckContext): Promise<ClusterCheckResult> {
+				this.logger.log('run');
+				return {};
+			}
+		}
+
+		const instance = Container.get(TestCheck);
+
+		expect(instance).toBeInstanceOf(TestCheck);
+	});
+
+	it('should expose different description names for different checks', () => {
+		@ClusterCheck()
+		class VersionCheck implements IClusterCheck {
+			checkDescription = { name: 'cluster.versionMismatch', displayName: 'Version Mismatch' };
+			async run(_context: ClusterCheckContext): Promise<ClusterCheckResult> {
+				return {};
+			}
+		}
+
+		@ClusterCheck()
+		class LeaderCheck implements IClusterCheck {
+			checkDescription = { name: 'cluster.leaderMissing', displayName: 'Leader Missing' };
+			async run(_context: ClusterCheckContext): Promise<ClusterCheckResult> {
+				return {};
+			}
+		}
+
+		const versionInstance = Container.get(VersionCheck);
+		const leaderInstance = Container.get(LeaderCheck);
+
+		expect(versionInstance.checkDescription.name).toBe('cluster.versionMismatch');
+		expect(leaderInstance.checkDescription.name).toBe('cluster.leaderMissing');
+	});
+});

--- a/packages/@n8n/decorators/src/cluster-check/__tests__/cluster-check-metadata.test.ts
+++ b/packages/@n8n/decorators/src/cluster-check/__tests__/cluster-check-metadata.test.ts
@@ -23,26 +23,6 @@ describe('ClusterCheckMetadata', () => {
 		expect(metadata.getClasses()).toContain(TestCheck);
 	});
 
-	it('should return all registered entries', () => {
-		class FirstCheck implements IClusterCheck {
-			checkDescription = { name: 'first.check' };
-			async run(_context: ClusterCheckContext): Promise<ClusterCheckResult> {
-				return {};
-			}
-		}
-		class SecondCheck implements IClusterCheck {
-			checkDescription = { name: 'second.check' };
-			async run(_context: ClusterCheckContext): Promise<ClusterCheckResult> {
-				return {};
-			}
-		}
-
-		metadata.register({ class: FirstCheck });
-		metadata.register({ class: SecondCheck });
-
-		expect(metadata.getEntries()).toHaveLength(2);
-	});
-
 	it('should return registered classes in registration order', () => {
 		class FirstCheck implements IClusterCheck {
 			checkDescription = { name: 'first.check' };

--- a/packages/@n8n/decorators/src/cluster-check/cluster-check-metadata.ts
+++ b/packages/@n8n/decorators/src/cluster-check/cluster-check-metadata.ts
@@ -1,0 +1,162 @@
+import { Container, Service } from '@n8n/di';
+
+import { ClusterCheckClass } from './cluster-check';
+
+/**
+ * Registry entry for a cluster check.
+ *
+ * Lightweight wrapper around the check class constructor, modelled on
+ * `ContextEstablishmentHookEntry`. Kept as a wrapper (rather than storing the
+ * class directly) so the entry shape can grow — e.g. module source, feature
+ * flag, license flag — without breaking the registration API.
+ *
+ * @internal
+ */
+type ClusterCheckEntry = {
+	/** The check class constructor for DI container instantiation. */
+	class: ClusterCheckClass;
+};
+
+/**
+ * Low-level metadata registry for cluster checks.
+ *
+ * `ClusterCheckMetadata` is a simple collection of every class decorated with
+ * `@ClusterCheck()`. It is populated automatically at module load time, before
+ * the Leader Service starts, so checks are discoverable without any manual
+ * registration code.
+ *
+ * **Architecture:**
+ * ```
+ * @ClusterCheck()   →   ClusterCheckMetadata   →   Cluster Check Registry   →   Leader Service
+ *   (registration)         (collection)               (instantiation)              (execution)
+ * ```
+ *
+ * **Responsibilities kept here:**
+ * - Storing registered check classes.
+ * - Exposing them for downstream consumers.
+ *
+ * **Responsibilities explicitly NOT here:**
+ * - Instantiating checks (DI container).
+ * - Validating name uniqueness (higher-level registry).
+ * - Executing checks (Leader Service).
+ *
+ * @see ClusterCheck decorator for automatic registration.
+ * @see IClusterCheck for the check contract.
+ */
+@Service()
+export class ClusterCheckMetadata {
+	/**
+	 * Internal collection of registered cluster check entries.
+	 *
+	 * Uses `Set` for efficient deduplication (though duplicate registration
+	 * should not occur with correct decorator usage).
+	 */
+	private readonly clusterChecks: Set<ClusterCheckEntry> = new Set();
+
+	/**
+	 * Registers a cluster check class in the metadata collection.
+	 *
+	 * Called automatically by the `@ClusterCheck()` decorator at module load
+	 * time. Should not be called directly by application code.
+	 *
+	 * Name uniqueness and any other semantic validation is the responsibility
+	 * of the higher-level Cluster Check Registry, not this service.
+	 *
+	 * @param entry - The check class entry to register.
+	 * @internal Called by decorator only.
+	 */
+	register(entry: ClusterCheckEntry) {
+		this.clusterChecks.add(entry);
+	}
+
+	/**
+	 * Retrieves all registered entries as `[index, entry]` tuples.
+	 *
+	 * Primarily useful for debugging or low-level iteration. Prefer
+	 * {@link getClasses} for most use cases.
+	 *
+	 * @returns Array of `[index, entry]` tuples from the internal `Set`.
+	 *
+	 * @example
+	 * ```typescript
+	 * for (const [index, entry] of metadata.getEntries()) {
+	 *   console.log(`Check #${index}:`, entry.class.name);
+	 * }
+	 * ```
+	 */
+	getEntries() {
+		return [...this.clusterChecks.entries()];
+	}
+
+	/**
+	 * Retrieves all registered check class constructors in registration order.
+	 *
+	 * This is the primary method consumed by the Cluster Check Registry to
+	 * instantiate checks via the DI container.
+	 *
+	 * @returns Array of check class constructors ready for DI instantiation.
+	 *
+	 * @example
+	 * ```typescript
+	 * @Service()
+	 * export class ClusterCheckRegistry {
+	 *   constructor(private readonly metadata: ClusterCheckMetadata) {
+	 *     this.checks = this.metadata.getClasses().map((cls) => Container.get(cls));
+	 *   }
+	 * }
+	 * ```
+	 */
+	getClasses() {
+		return [...this.clusterChecks.values()].map((entry) => entry.class);
+	}
+}
+
+/**
+ * Class decorator that registers a cluster check for auto-discovery.
+ *
+ * Performs two distinct operations at class-definition time:
+ * 1. **Registers** the class in {@link ClusterCheckMetadata} so the higher-level
+ *    registry can discover it without manual wiring.
+ * 2. **Enables DI** by applying `@Service()`, making the class constructor
+ *    resolvable via `Container.get()` (including dependencies).
+ *
+ * The decorator takes no arguments — all check metadata lives on the check
+ * instance itself via {@link IClusterCheck.checkDescription}.
+ *
+ * **Requirements:**
+ * - Decorated class MUST implement {@link IClusterCheck}.
+ * - Decorated class MUST expose a `checkDescription` with a unique `name`.
+ *
+ * **Notes:**
+ * - Registration happens eagerly at module load, not lazily.
+ * - Duplicate decoration of the same class is safe (`Set` deduplicates).
+ * - Checks are registered as singletons via `@Service()`.
+ *
+ * @example
+ * ```typescript
+ * @ClusterCheck()
+ * export class VersionMismatchCheck implements IClusterCheck {
+ *   checkDescription = {
+ *     name: 'cluster.versionMismatch',
+ *     displayName: 'Cluster Version Mismatch',
+ *   };
+ *
+ *   async run({ currentState }: ClusterCheckContext): Promise<ClusterCheckResult> {
+ *     // ... check logic
+ *     return {};
+ *   }
+ * }
+ * ```
+ *
+ * @returns A class decorator that registers the check and enables DI for it.
+ */
+export const ClusterCheck =
+	<T extends ClusterCheckClass>() =>
+	(target: T) => {
+		Container.get(ClusterCheckMetadata).register({
+			class: target,
+		});
+
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+		return Service()(target);
+	};

--- a/packages/@n8n/decorators/src/cluster-check/cluster-check-metadata.ts
+++ b/packages/@n8n/decorators/src/cluster-check/cluster-check-metadata.ts
@@ -70,25 +70,6 @@ export class ClusterCheckMetadata {
 	}
 
 	/**
-	 * Retrieves all registered entries as `[index, entry]` tuples.
-	 *
-	 * Primarily useful for debugging or low-level iteration. Prefer
-	 * {@link getClasses} for most use cases.
-	 *
-	 * @returns Array of `[index, entry]` tuples from the internal `Set`.
-	 *
-	 * @example
-	 * ```typescript
-	 * for (const [index, entry] of metadata.getEntries()) {
-	 *   console.log(`Check #${index}:`, entry.class.name);
-	 * }
-	 * ```
-	 */
-	getEntries() {
-		return [...this.clusterChecks.entries()];
-	}
-
-	/**
 	 * Retrieves all registered check class constructors in registration order.
 	 *
 	 * This is the primary method consumed by the Cluster Check Registry to

--- a/packages/@n8n/decorators/src/cluster-check/cluster-check.ts
+++ b/packages/@n8n/decorators/src/cluster-check/cluster-check.ts
@@ -1,0 +1,342 @@
+import type { InstanceRegistration } from '@n8n/api-types';
+import type { Constructable } from '@n8n/di';
+
+/**
+ * Structured difference between two cluster state snapshots.
+ *
+ * Computed once by the Cluster Check Registry from the current and previous
+ * `Map<instanceKey, InstanceRegistration>` snapshots, then passed to every
+ * registered check via {@link ClusterCheckContext}. Checks consume the diff
+ * read-only — they never mutate it and they never recompute it themselves.
+ *
+ * **Semantics:**
+ * - `added`: instances present in the current snapshot that were not in the previous snapshot.
+ * - `removed`: instances present in the previous snapshot that are no longer in the current snapshot.
+ * - `changed`: instances present in both snapshots whose registration payload differs
+ *   (e.g. role flip, version bump, `lastSeen` refresh). Each entry carries both the
+ *   `previous` and `current` registration so checks can reason about the transition.
+ *
+ * **Equality definition for `changed`** is deliberately left to the registry so checks
+ * do not depend on a specific equality strategy (deep-equal, selected-field compare, etc.).
+ *
+ * @example
+ * ```typescript
+ * async run({ diff }: ClusterCheckContext) {
+ *   const leadershipFlipped = diff.changed.filter(
+ *     ({ previous, current }) =>
+ *       previous.instanceRole !== current.instanceRole &&
+ *       current.instanceRole === 'leader',
+ *   );
+ * }
+ * ```
+ */
+export type ClusterStateDiff = {
+	/** Instances present in the current snapshot that were not in the previous one. */
+	added: readonly InstanceRegistration[];
+
+	/** Instances present in the previous snapshot that are no longer in the current one. */
+	removed: readonly InstanceRegistration[];
+
+	/**
+	 * Instances whose registration payload changed between snapshots.
+	 * Each entry carries both the `previous` and `current` registration.
+	 */
+	changed: ReadonlyArray<{ previous: InstanceRegistration; current: InstanceRegistration }>;
+};
+
+/**
+ * Input context passed to a cluster check on every invocation.
+ *
+ * The context bundles the two state snapshots the check reasons over (current and
+ * previous) together with a pre-computed {@link ClusterStateDiff}. Snapshots are
+ * keyed by `instanceKey` to match the existing instance storage contract
+ * (`InstanceStorage.getLastKnownState()` / `saveLastKnownState()`).
+ *
+ * **Read-only by contract:** the maps and the diff are shared across every
+ * registered check in a single run. Checks must not mutate them. The types
+ * enforce this with `ReadonlyMap` and `readonly` arrays.
+ *
+ * @example
+ * ```typescript
+ * async run({ currentState, previousState, diff }: ClusterCheckContext) {
+ *   const currentCount = currentState.size;
+ *   const previousCount = previousState.size;
+ *   const flapping = diff.added.length > 0 && diff.removed.length > 0;
+ *   // ...
+ * }
+ * ```
+ */
+export type ClusterCheckContext = {
+	/** Current cluster state keyed by `instanceKey`. */
+	currentState: ReadonlyMap<string, InstanceRegistration>;
+
+	/**
+	 * Previous cluster state keyed by `instanceKey`.
+	 *
+	 * Sourced from `InstanceStorage.getLastKnownState()`. May be empty on the very
+	 * first check run after a fresh leader start.
+	 */
+	previousState: ReadonlyMap<string, InstanceRegistration>;
+
+	/**
+	 * Structured diff between `previousState` and `currentState`.
+	 *
+	 * Pre-computed by the registry so every check reuses the same diff result.
+	 */
+	diff: ClusterStateDiff;
+};
+
+/**
+ * Structured warning emitted by a cluster check.
+ *
+ * Warnings are a neutral, transport-agnostic signal the check wants to raise
+ * about the cluster. A downstream handler in `packages/cli` decides how to
+ * surface them (logs, metrics, admin dashboard, etc.).
+ *
+ * @example
+ * ```typescript
+ * {
+ *   code: 'cluster.versionMismatch',
+ *   message: 'Detected 2 distinct n8n versions across 5 instances',
+ *   severity: 'warning',
+ *   context: { versions: ['1.42.0', '1.43.0'] },
+ * }
+ * ```
+ */
+export type ClusterCheckWarning = {
+	/**
+	 * Stable machine-readable identifier for the warning.
+	 *
+	 * Should be namespaced, e.g. `'cluster.versionMismatch'`, `'cluster.leaderMissing'`.
+	 * Consumers key off this field for dedup, i18n, and aggregation.
+	 */
+	code: string;
+
+	/** Human-readable single-line summary. */
+	message: string;
+
+	/**
+	 * Severity hint. Defaults to `'warning'` if omitted.
+	 *
+	 * Kept deliberately narrow — finer-grained categorisation belongs to the
+	 * downstream translator, not to the decorator layer.
+	 */
+	severity?: 'info' | 'warning' | 'error';
+
+	/**
+	 * Optional structured context for the warning (e.g. offending instance keys,
+	 * observed values). Serialised verbatim by downstream handlers.
+	 */
+	context?: Record<string, unknown>;
+};
+
+/**
+ * Structured audit event emitted by a cluster check.
+ *
+ * Audit events are intentionally loose at this layer: the `@n8n/decorators`
+ * package must not depend on the cli audit event enum. A downstream translator
+ * maps `eventName` to the concrete `EventMessageAudit` class at emit time.
+ *
+ * @example
+ * ```typescript
+ * {
+ *   eventName: 'n8n.audit.cluster.version-mismatch-detected',
+ *   payload: { detectedVersions: ['1.42.0', '1.43.0'], instanceCount: 5 },
+ * }
+ * ```
+ */
+export type ClusterCheckAuditEvent = {
+	/**
+	 * Audit event name the downstream translator will map to a concrete
+	 * audit event class (e.g. `EventMessageAudit`).
+	 */
+	eventName: string;
+
+	/** Event payload forwarded to the audit bus. Shape depends on `eventName`. */
+	payload: Record<string, unknown>;
+};
+
+/**
+ * Structured push notification emitted by a cluster check.
+ *
+ * Kept decoupled from the concrete `PushMessage` discriminated union defined in
+ * `@n8n/api-types/push` so the decorator package stays free of transport-type
+ * churn. A downstream translator narrows `{ type, data }` into the concrete
+ * push message union before broadcasting.
+ *
+ * @example
+ * ```typescript
+ * {
+ *   type: 'cluster-version-mismatch',
+ *   data: { versions: ['1.42.0', '1.43.0'] },
+ * }
+ * ```
+ */
+export type ClusterCheckPushNotification = {
+	/**
+	 * Push message type string the downstream translator maps to a concrete
+	 * `PushMessage` variant.
+	 */
+	type: string;
+
+	/** Push payload forwarded to connected clients. Shape depends on `type`. */
+	data: Record<string, unknown>;
+};
+
+/**
+ * Result returned by a cluster check after processing a {@link ClusterCheckContext}.
+ *
+ * All fields are optional. A check that finds nothing worth reporting returns
+ * an empty object (or populates only the channels it needs). The registry
+ * aggregates results from every registered check and forwards each channel
+ * (warnings, audit events, push notifications) to its downstream handler.
+ *
+ * **Why three separate channels?** Each has a distinct consumer:
+ * - `warnings` feeds admin-facing diagnostics and logs.
+ * - `auditEvents` feeds the audit log / event bus for compliance.
+ * - `pushNotifications` feeds the real-time push channel to frontends.
+ *
+ * @example
+ * ```typescript
+ * return {
+ *   warnings: [{ code: 'cluster.leaderMissing', message: 'No leader in cluster', severity: 'error' }],
+ *   auditEvents: [{ eventName: 'n8n.audit.cluster.leader-lost', payload: {} }],
+ *   pushNotifications: [{ type: 'cluster-leader-lost', data: {} }],
+ * };
+ * ```
+ */
+export type ClusterCheckResult = {
+	/** Warnings raised by the check. Omit or leave empty when nothing to report. */
+	warnings?: ClusterCheckWarning[];
+
+	/** Audit events the check wants emitted. Omit or leave empty when not applicable. */
+	auditEvents?: ClusterCheckAuditEvent[];
+
+	/** Push notifications the check wants broadcast. Omit or leave empty when not applicable. */
+	pushNotifications?: ClusterCheckPushNotification[];
+};
+
+/**
+ * Self-describing metadata for a cluster check.
+ *
+ * Each check instance carries its own description rather than passing it into
+ * the `@ClusterCheck()` decorator. This keeps the decorator parameter-free and
+ * lets checks compute display names from runtime data if needed.
+ *
+ * **Naming convention:** use namespaced lowercase ids, e.g.
+ * `'cluster.versionMismatch'`, `'cluster.leaderMissing'`. Names must be unique
+ * across all registered checks — uniqueness is validated by the higher-level
+ * registry, not by {@link ClusterCheckMetadata}.
+ *
+ * @example
+ * ```typescript
+ * checkDescription = {
+ *   name: 'cluster.versionMismatch',
+ *   displayName: 'Cluster Version Mismatch',
+ * };
+ * ```
+ */
+export type CheckDescription = {
+	/**
+	 * Unique machine-readable identifier for this check.
+	 *
+	 * **Naming convention:** namespaced lowercase, e.g. `'cluster.versionMismatch'`.
+	 * Used as the lookup key by the higher-level registry and in logs / telemetry.
+	 */
+	name: string;
+
+	/**
+	 * Human-readable display name for the check. Shown in admin UI and logs.
+	 * Falls back to `name` when omitted.
+	 */
+	displayName?: string;
+};
+
+/**
+ * Interface every cluster check must implement.
+ *
+ * Checks are stateless consumers of cluster state snapshots. The registry
+ * invokes `run()` on every reconciliation tick, passes a pre-built
+ * {@link ClusterCheckContext}, and forwards the returned
+ * {@link ClusterCheckResult} to the appropriate downstream handlers.
+ *
+ * **Lifecycle:**
+ * 1. Class is decorated with `@ClusterCheck()` — registered in
+ *    {@link ClusterCheckMetadata} and made injectable via `@Service()`.
+ * 2. Leader Service resolves the class from the DI container on startup.
+ * 3. `run()` is invoked on every tick with a fresh context.
+ *
+ * **Implementation rules:**
+ * - `run()` must be pure with respect to `context` — never mutate the maps or diff.
+ * - `run()` must be fast; it runs on the hot path of every reconciliation tick.
+ * - Throw only for unrecoverable failures. The registry logs and isolates errors
+ *   so one failing check does not stop the others from running.
+ *
+ * @example
+ * ```typescript
+ * @ClusterCheck()
+ * export class VersionMismatchCheck implements IClusterCheck {
+ *   checkDescription = {
+ *     name: 'cluster.versionMismatch',
+ *     displayName: 'Cluster Version Mismatch',
+ *   };
+ *
+ *   async run({ currentState }: ClusterCheckContext): Promise<ClusterCheckResult> {
+ *     const versions = new Set(
+ *       [...currentState.values()].map((instance) => instance.version),
+ *     );
+ *     if (versions.size <= 1) return {};
+ *     return {
+ *       warnings: [
+ *         {
+ *           code: 'cluster.versionMismatch',
+ *           message: `Detected ${versions.size} distinct n8n versions in the cluster`,
+ *           severity: 'warning',
+ *           context: { versions: [...versions] },
+ *         },
+ *       ],
+ *     };
+ *   }
+ * }
+ * ```
+ */
+export interface IClusterCheck {
+	/**
+	 * Self-describing metadata used by the registry for lookup and display.
+	 *
+	 * @see CheckDescription for naming conventions and uniqueness requirements.
+	 */
+	checkDescription: CheckDescription;
+
+	/**
+	 * Runs the check over a cluster state snapshot.
+	 *
+	 * **Contract:**
+	 * - Must treat `context` as read-only.
+	 * - Must not log or persist plaintext state beyond what the returned
+	 *   {@link ClusterCheckResult} declares.
+	 * - Errors thrown here stop this check's contribution to the current tick
+	 *   but do not stop other checks. The registry is responsible for error isolation.
+	 *
+	 * @param context - Current/previous cluster state and pre-computed diff.
+	 * @returns Warnings, audit events, and push notifications the check wants emitted.
+	 */
+	run(context: ClusterCheckContext): Promise<ClusterCheckResult>;
+}
+
+/**
+ * Type representing the constructor of a class that implements {@link IClusterCheck}.
+ *
+ * Used by {@link ClusterCheckMetadata} to store registered classes and by the
+ * DI container to instantiate them. Works with the `@ClusterCheck()` decorator.
+ *
+ * @example
+ * ```typescript
+ * import { Container } from '@n8n/di';
+ * import type { ClusterCheckClass } from '@n8n/decorators';
+ *
+ * const CheckClass: ClusterCheckClass = VersionMismatchCheck;
+ * const instance = Container.get(CheckClass);
+ * ```
+ */
+export type ClusterCheckClass = Constructable<IClusterCheck>;

--- a/packages/@n8n/decorators/src/cluster-check/index.ts
+++ b/packages/@n8n/decorators/src/cluster-check/index.ts
@@ -1,0 +1,2 @@
+export { ClusterCheckMetadata, ClusterCheck } from './cluster-check-metadata';
+export type * from './cluster-check';

--- a/packages/@n8n/decorators/src/context-establishment/context-establishment-hook-metadata.ts
+++ b/packages/@n8n/decorators/src/context-establishment/context-establishment-hook-metadata.ts
@@ -60,28 +60,6 @@ export class ContextEstablishmentHookMetadata {
 	}
 
 	/**
-	 * Retrieves all registered hook entries.
-	 *
-	 * Returns an array of [index, entry] tuples compatible with Set.entries().
-	 * Primarily used for debugging or low-level iteration.
-	 *
-	 * **Prefer getClasses()** for most use cases as it returns just the classes.
-	 *
-	 * @returns Array of [index, entry] tuples from the internal Set
-	 *
-	 * @example
-	 * ```typescript
-	 * const entries = metadata.getEntries();
-	 * for (const [index, entry] of entries) {
-	 *   console.log(`Hook ${index}:`, entry.class.name);
-	 * }
-	 * ```
-	 */
-	getEntries() {
-		return [...this.contextEstablishmentHooks.entries()];
-	}
-
-	/**
 	 * Retrieves all registered hook classes.
 	 *
 	 * This is the primary method used by the Hook Registry to obtain hook classes

--- a/packages/@n8n/decorators/src/index.ts
+++ b/packages/@n8n/decorators/src/index.ts
@@ -5,6 +5,7 @@ export { Debounce } from './debounce';
 export * from './execution-lifecycle';
 export { Memoized } from './memoized';
 export * from './auth-handler';
+export * from './cluster-check';
 export * from './context-establishment';
 export * from './credential-resolver';
 export * from './module';

--- a/packages/@n8n/decorators/tsconfig.json
+++ b/packages/@n8n/decorators/tsconfig.json
@@ -11,6 +11,7 @@
 	"include": ["src/**/*.ts"],
 	"references": [
 		{ "path": "../../workflow/tsconfig.build.esm.json" },
+		{ "path": "../api-types/tsconfig.build.json" },
 		{ "path": "../constants/tsconfig.build.json" },
 		{ "path": "../di/tsconfig.build.json" },
 		{ "path": "../permissions/tsconfig.build.json" }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -808,7 +808,7 @@ importers:
         version: link:../vitest-config
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
+        version: 4.1.1(vitest@4.1.1)
       vitest:
         specifier: 'catalog:'
         version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(@vitest/browser-playwright@4.0.16)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
@@ -979,7 +979,7 @@ importers:
         version: link:../vitest-config
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
+        version: 4.1.1(vitest@4.1.1)
       vitest:
         specifier: 'catalog:'
         version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(@vitest/browser-playwright@4.0.16)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
@@ -1273,6 +1273,9 @@ importers:
 
   packages/@n8n/decorators:
     dependencies:
+      '@n8n/api-types':
+        specifier: workspace:*
+        version: link:../api-types
       '@n8n/constants':
         specifier: workspace:*
         version: link:../constants
@@ -2242,7 +2245,7 @@ importers:
         version: link:../vitest-config
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
+        version: 4.1.1(vitest@4.1.1)
       rimraf:
         specifier: 'catalog:'
         version: 6.0.1
@@ -3084,7 +3087,7 @@ importers:
         version: 5.2.4(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))(vue@3.5.26(typescript@6.0.2))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
+        version: 4.1.1(vitest@4.1.1)
       unplugin-icons:
         specifier: ^0.19.0
         version: 0.19.0(@vue/compiler-sfc@3.5.26)
@@ -3524,7 +3527,7 @@ importers:
         version: 4.0.16(bufferutil@4.0.9)(playwright@1.58.0)(utf-8-validate@5.0.10)(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))(vitest@4.1.1)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
+        version: 4.1.1(vitest@4.1.1)
       '@vue/tsconfig':
         specifier: catalog:frontend
         version: 0.7.0(typescript@6.0.2)(vue@3.5.26(typescript@6.0.2))
@@ -3885,7 +3888,7 @@ importers:
         version: 5.2.4(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))(vue@3.5.26(typescript@6.0.2))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
+        version: 4.1.1(vitest@4.1.1)
       browserslist-to-esbuild:
         specifier: ^2.1.1
         version: 2.1.1(browserslist@4.28.1)
@@ -4365,7 +4368,7 @@ importers:
         version: 20.19.21
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
+        version: 4.1.1(vitest@4.1.1)
       ts-morph:
         specifier: 'catalog:'
         version: 27.0.2
@@ -4485,7 +4488,7 @@ importers:
         version: link:../../@n8n/vitest-config
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
+        version: 4.1.1(vitest@4.1.1)
       tsx:
         specifier: 'catalog:'
         version: 4.19.3
@@ -25564,7 +25567,7 @@ snapshots:
       '@currents/commit-info': 1.0.1-beta.0
       async-retry: 1.3.3
       axios: 1.15.0(debug@4.4.3)
-      axios-retry: 4.5.0(axios@1.15.0(debug@4.4.3))
+      axios-retry: 4.5.0(axios@1.15.0)
       c12: 1.11.2(magicast@0.3.5)
       chalk: 4.1.2
       commander: 12.1.0
@@ -32028,7 +32031,7 @@ snapshots:
       tinyrainbow: 3.0.3
       vitest: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.2))
 
-  '@vitest/coverage-v8@4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))':
+  '@vitest/coverage-v8@4.1.1(vitest@4.1.1)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.1
@@ -32967,11 +32970,6 @@ snapshots:
   aws4@1.11.0: {}
 
   axe-core@4.7.2: {}
-
-  axios-retry@4.5.0(axios@1.15.0(debug@4.4.3)):
-    dependencies:
-      axios: 1.15.0(debug@4.4.3)
-      is-retry-allowed: 2.2.0
 
   axios-retry@4.5.0(axios@1.15.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -808,7 +808,7 @@ importers:
         version: link:../vitest-config
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1)
+        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       vitest:
         specifier: 'catalog:'
         version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(@vitest/browser-playwright@4.0.16)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
@@ -979,7 +979,7 @@ importers:
         version: link:../vitest-config
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1)
+        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       vitest:
         specifier: 'catalog:'
         version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(@vitest/browser-playwright@4.0.16)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
@@ -2245,7 +2245,7 @@ importers:
         version: link:../vitest-config
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1)
+        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       rimraf:
         specifier: 'catalog:'
         version: 6.0.1
@@ -3087,7 +3087,7 @@ importers:
         version: 5.2.4(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))(vue@3.5.26(typescript@6.0.2))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1)
+        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       unplugin-icons:
         specifier: ^0.19.0
         version: 0.19.0(@vue/compiler-sfc@3.5.26)
@@ -3527,7 +3527,7 @@ importers:
         version: 4.0.16(bufferutil@4.0.9)(playwright@1.58.0)(utf-8-validate@5.0.10)(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))(vitest@4.1.1)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1)
+        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       '@vue/tsconfig':
         specifier: catalog:frontend
         version: 0.7.0(typescript@6.0.2)(vue@3.5.26(typescript@6.0.2))
@@ -3888,7 +3888,7 @@ importers:
         version: 5.2.4(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))(vue@3.5.26(typescript@6.0.2))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1)
+        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       browserslist-to-esbuild:
         specifier: ^2.1.1
         version: 2.1.1(browserslist@4.28.1)
@@ -4368,7 +4368,7 @@ importers:
         version: 20.19.21
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1)
+        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       ts-morph:
         specifier: 'catalog:'
         version: 27.0.2
@@ -4488,7 +4488,7 @@ importers:
         version: link:../../@n8n/vitest-config
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1)
+        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       tsx:
         specifier: 'catalog:'
         version: 4.19.3
@@ -32031,7 +32031,7 @@ snapshots:
       tinyrainbow: 3.0.3
       vitest: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.2))
 
-  '@vitest/coverage-v8@4.1.1(vitest@4.1.1)':
+  '@vitest/coverage-v8@4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.1


### PR DESCRIPTION
## Summary

Introduces the `@ClusterCheck()` decorator, the `IClusterCheck` contract, and the
`ClusterCheckMetadata` registry in `@n8n/decorators`. Lays the foundation for a
pluggable cluster health-check system using n8n's established auto-discovery
pattern (`@ContextEstablishmentHook`, `@AuthHandler`, `@Module`, …). No checks are
implemented here — this is the interface ticket only.

### Why

Part of the **Cluster Instance Registry** initiative, milestone *Phase 3: Health
Check Registry & Leader Service*. The Leader Service needs to run a set of
pluggable checks over every cluster state reconciliation tick and emit
warnings, audit events, and push notifications. Rather than require manual
registration of every check, checks self-register at module load time via a
class decorator, and the (future) Leader Service discovers them through the
`ClusterCheckMetadata` registry.

This is the smallest sensible slice: the contract and registry only.
**Unblocks [IAM-333 Built-in Health Checks](https://linear.app/n8n/issue/IAM-333)**
which will provide the first concrete checks (version mismatch, leader
missing, etc.) on top of this interface.

### What's in scope

- `IClusterCheck` — interface with `checkDescription` property + async `run()`.
- `ClusterCheckContext` — `{ currentState, previousState, diff }`, all read-only.
  State maps are keyed by `instanceKey`, matching the existing
  `InstanceStorage.getLastKnownState()` contract.
- `ClusterStateDiff` — pre-computed `{ added, removed, changed }` so every check
  reuses the same diff rather than recomputing it.
- `ClusterCheckResult` — three loosely-typed output channels:
  `warnings[]`, `auditEvents[]`, `pushNotifications[]`.
- `ClusterCheckMetadata` — `@Service()` registry with `register()`,
  `getEntries()`, `getClasses()`.
- `@ClusterCheck()` — class decorator that registers the class and applies
  `@Service()` for DI.
- Exports wired through `cluster-check/index.ts` and `@n8n/decorators/src/index.ts`.
- Unit tests covering registration, ordering, DI resolution, and constructor
  dependency injection (8 tests).

### Key implementation decisions

- **Output channels kept loose inside `@n8n/decorators`.** Warnings, audit
  events, and push notifications are plain structured shapes (`{ code, message,
  severity?, context? }`, `{ eventName, payload }`, `{ type, data }`) rather
  than concrete `EventMessageAudit` classes or `PushMessage` discriminated
  unions. This keeps the decorator package free of `packages/cli` audit enums
  and `@n8n/api-types/push` churn. A thin translator in `packages/cli` (future
  ticket, under the Leader Service) maps each shape to the concrete type at
  emit time. Mirrors the precedent set by `auth-handler`,
  `context-establishment`, and `pubsub`.
- **`InstanceRegistration` imported from `@n8n/api-types`.** Verified no
  circular dep (`@n8n/api-types` does not import from `@n8n/decorators`).
  Avoids a local mirror type that would drift from the canonical cluster
  state entity. Added `@n8n/api-types: workspace:*` to `@n8n/decorators`
  dependencies and the matching TypeScript project reference.
- **No `init()` lifecycle hook.** The ACs don't require it and checks are
  stateless over state snapshots. Can be added non-breakingly later if a
  concrete check needs it.
- **Pattern match with `@ContextEstablishmentHook`.** Same two-file split
  (interface + metadata/decorator), same `Set<Entry>` storage, same decorator
  body (`Container.get(Metadata).register({ class: target }); return
  Service()(target);`), same `register` / `getEntries` / `getClasses` trio.

## Related Links

closes https://linear.app/n8n/issue/IAM-332/cluster-check-interface-and-decorator

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
