### PR TITLE
Fix: MCP Server Trigger reading 'getWebhookName'?!?

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
@@ -137,7 +137,8 @@ export class McpTrigger extends Node {
 		],
 	};
 
-	async webhook(context: IWebhookFunctions): Promise<IWebhookResponseData> {
+	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
+		const context = this;
 		const webhookName = context.getWebhookName();
 		const req = context.getRequestObject();
 		const resp = context.getResponseObject() as unknown as CompressionResponse;


### PR DESCRIPTION
In n8n trigger nodes, the webhook method receives its execution context (of type IWebhookFunctions) via the 'this' binding rather than as a function argument. By declaring the method with 'context: IWebhookFunctions' as a parameter, the context variable was left undefined when called by the n8n core, resulting in the reported TypeError. The fix updates the method signature to use 'this: IWebhookFunctions' and assigns it to a local 'context' variable to resolve the issue while maintaining compatibility with the rest of the method's logic.

Test: 1. Configure an MCP Server Trigger node in an n8n workflow.
2. Set a path (e.g. 'mcp-server') and Authentication to 'None'.
3. Activate the workflow.
4. Use a tool like 'curl' to make a GET request to the node's setup URL (e.g., http://localhost:5678/rest/oauth2-webhooks/mcp-server/sse).
5. Verify that the request no longer results in a 500 error and the n8n logs do not show the 'Cannot read properties of undefined (reading 'getWebhookName')' error.