### PR TITLE
feat(core): Disable computer-use auto-connect daemon (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAiSettings.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAiSettings.store.ts
@@ -282,6 +282,11 @@ export const useInstanceAiSettingsStore = defineStore('instanceAiSettings', () =
 	// ── Auto-connect daemon ──────────────────────────────────────────────
 
 	const DAEMON_BASE = 'http://127.0.0.1:7655';
+	// Auto-probing is disabled: the EventSource + POST to 127.0.0.1 triggers
+	// Chrome's Private Network Access prompt on page load, which is unexpected.
+	// When we reintroduce this via an explicit user action, call connectDaemon()
+	// directly from the click handler instead of re-enabling the probe.
+	const AUTO_CONNECT_DAEMON = false;
 	let daemonEventSource: EventSource | null = null;
 	let daemonConnectAttempted = false;
 
@@ -321,6 +326,7 @@ export const useInstanceAiSettingsStore = defineStore('instanceAiSettings', () =
 	}
 
 	function startDaemonProbing(): void {
+		if (!AUTO_CONNECT_DAEMON) return;
 		if (daemonEventSource || daemonConnectAttempted || isGatewayConnected.value) return;
 
 		daemonEventSource = new EventSource(`${DAEMON_BASE}/events`);


### PR DESCRIPTION
## Summary

Do we want to have the auto-connect daemon enabled right now - we spoke last week that maybe not (yet)?
Maybe we could make this something opt-in, or have it enable only when user does some action like clicks on some connect button so that they expect it?

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/INS-108

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
