### PR TITLE
fix(google-drive): default filename when copying file without name

### DIFF
--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/copy.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/copy.test.ts
@@ -13,7 +13,13 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: file copy', () => {
+	beforeEach(() => {
+		jest.mocked(transport.googleApiRequest).mockReset();
+	});
+
 	it('should be called with', async () => {
+		jest.mocked(transport.googleApiRequest).mockResolvedValue({});
+
 		const nodeParameters = {
 			operation: 'copy',
 			fileId: {
@@ -51,6 +57,60 @@ describe('test GoogleDriveV2: file copy', () => {
 				description: 'image copy',
 				name: 'copyImage.png',
 				parents: ['folderIDxxxxxx'],
+			},
+			{
+				supportsAllDrives: true,
+				corpora: 'allDrives',
+				includeItemsFromAllDrives: true,
+				spaces: 'appDataFolder, drive',
+			},
+		);
+	});
+
+	it('should fetch file name from Drive when defaulting copy name in id mode', async () => {
+		jest
+			.mocked(transport.googleApiRequest)
+			.mockResolvedValueOnce({ name: 'MyDoc.gsheet' })
+			.mockResolvedValueOnce({});
+
+		const nodeParameters = {
+			operation: 'copy',
+			fileId: {
+				__rl: true,
+				value: 'fileIDxxxxxx',
+				mode: 'id',
+			},
+			name: '',
+			sameFolder: true,
+			options: {},
+		};
+
+		const fakeExecuteFunction = createMockExecuteFunction(nodeParameters, driveNode);
+
+		await copy.execute.call(fakeExecuteFunction, 0);
+
+		expect(transport.googleApiRequest).toHaveBeenCalledTimes(2);
+		expect(transport.googleApiRequest).toHaveBeenNthCalledWith(
+			1,
+			'GET',
+			'/drive/v3/files/fileIDxxxxxx',
+			undefined,
+			{
+				supportsAllDrives: true,
+				corpora: 'allDrives',
+				includeItemsFromAllDrives: true,
+				spaces: 'appDataFolder, drive',
+				fields: 'name',
+			},
+		);
+		expect(transport.googleApiRequest).toHaveBeenNthCalledWith(
+			2,
+			'POST',
+			'/drive/v3/files/fileIDxxxxxx/copy',
+			{
+				copyRequiresWriterPermission: false,
+				parents: [],
+				name: 'Copy of MyDoc.gsheet',
 			},
 			{
 				supportsAllDrives: true,

--- a/packages/nodes-base/nodes/Google/Drive/v2/actions/file/copy.operation.ts
+++ b/packages/nodes-base/nodes/Google/Drive/v2/actions/file/copy.operation.ts
@@ -87,17 +87,33 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 
 	const options = this.getNodeParameter('options', i, {});
 
-	let name = this.getNodeParameter('name', i) as string;
-	name = name ? name : `Copy of ${file.cachedResultName}`;
-
-	const copyRequiresWriterPermission = options.copyRequiresWriterPermission || false;
-
 	const qs = {
 		includeItemsFromAllDrives: true,
 		supportsAllDrives: true,
 		spaces: 'appDataFolder, drive',
 		corpora: 'allDrives',
 	};
+
+	let name = this.getNodeParameter('name', i) as string | undefined;
+	if (!name) {
+		name = file.cachedResultName;
+		if (!name) {
+			const fileMetadata = (await googleApiRequest.call(
+				this,
+				'GET',
+				`/drive/v3/files/${fileId}`,
+				undefined,
+				{
+					...qs,
+					fields: 'name',
+				},
+			)) as IDataObject;
+			name = typeof fileMetadata.name === 'string' ? fileMetadata.name : undefined;
+		}
+		name = name ? `Copy of ${name}` : 'Copy';
+	}
+
+	const copyRequiresWriterPermission = options.copyRequiresWriterPermission || false;
 
 	const parents: string[] = [];
 	const sameFolder = this.getNodeParameter('sameFolder', i) as boolean;


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
Fixes an issue in the Google Drive node where copying a file by ID without providing a filename results in the new file being named "Copy of undefined".

This PR ensures that when the File Name field is left empty, the node falls back to using the original file’s name and correctly prefixes it as:

`Copy of {original file name}`

This aligns the behavior with the expected default naming convention and prevents invalid filenames.

### How to test:
1. Add a Google Drive node
2. Set:
3. Resource → File
4. Operation → Copy
5. Select File by ID and provide a valid file ID
6. Leave the File Name field empty
7. Execute the node

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
closes #28735

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
