### PR TITLE
docs: fix "seperate" typo in Anthropic/GoogleGemini node descriptions

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/document/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/document/analyze.operation.ts
@@ -54,7 +54,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the document(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the document(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/image/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/image/analyze.operation.ts
@@ -53,7 +53,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the image(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the image(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/audio/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/audio/analyze.operation.ts
@@ -53,7 +53,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the audio(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the audio(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/audio/transcribe.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/audio/transcribe.operation.ts
@@ -50,7 +50,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the audio(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the audio(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/document/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/document/analyze.operation.ts
@@ -54,7 +54,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the document(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the document(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/video/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/video/analyze.operation.ts
@@ -53,7 +53,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the video(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the video(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],


### PR DESCRIPTION

**Repo:** n8n-io/n8n (⭐ 46000)
**Type:** docs
**Files changed:** 6
**Lines:** +6/-6

## What
Fixes the common misspelling "seperate" → "separate" in user-visible node
parameter `description` strings across six langchain vendor operations:
Anthropic (image analyze, document analyze) and GoogleGemini (audio analyze,
audio transcribe, document analyze, video analyze). These strings render in
the n8n editor UI when users configure the binary-input field for the
"Analyze" / "Transcribe" operations.

## Why
"Seperate" is a user-facing spelling mistake that appears on six different
parameter tooltips in the node editor. The text is otherwise identical
boilerplate copy-pasted between vendors, so a single sweep catches all
instances and keeps the node descriptions consistent and professional.

## Testing
- Grep confirms no remaining occurrences of "seperate" in the changed
  packages.
- Change is a pure string edit within TypeScript literals — no logic,
  import, or type surface affected; existing tests continue to apply.
- Verifying in the UI would mean opening each node's binary-input mode and
  hovering the field to read the corrected description.

## Risk
Low — single-word string fix in user-facing descriptions, no behavior change.
