### PR TITLE
fix: Filter out disabled AI Agent tool parents when mapping connected tools

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/tests/helpers.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/tests/helpers.test.ts
@@ -322,6 +322,39 @@ describe('getConnectedTools', () => {
 		});
 	});
 
+	it('should ignore disabled parent tool nodes when mapping source node metadata', async () => {
+		const mockParentNodes = [
+			{ name: 'RegularTool', type: 'test', typeVersion: 1, disabled: false },
+			{ name: 'Disabled Tool', type: 'test', typeVersion: 1, disabled: true },
+			{ name: 'MCP Client Tool', type: 'test', typeVersion: 1, disabled: false },
+		];
+		const mockTools = [
+			{ name: 'tool1', description: 'desc1' },
+			new StructuredToolkit([
+				{ name: 'toolkitTool1', description: 'toolkitToolDesc1' },
+				{ name: 'toolkitTool2', description: 'toolkitToolDesc2' },
+			] as any),
+		];
+
+		mockExecuteFunctions.getInputConnectionData = jest.fn().mockResolvedValue(mockTools);
+		mockExecuteFunctions.getParentNodes = jest.fn().mockReturnValue(mockParentNodes);
+
+		const tools = await getConnectedTools(mockExecuteFunctions, false);
+
+		expect(tools[0].metadata).toEqual({
+			isFromToolkit: false,
+			sourceNodeName: 'RegularTool',
+		});
+		expect(tools[1].metadata).toEqual({
+			isFromToolkit: true,
+			sourceNodeName: 'MCP Client Tool',
+		});
+		expect(tools[2].metadata).toEqual({
+			isFromToolkit: true,
+			sourceNodeName: 'MCP Client Tool',
+		});
+	});
+
 	it('should preserve existing metadata when adding toolkit metadata', async () => {
 		const mockParentNodes = [{ name: 'MCP Client Tool' }];
 		const mockTools = [


### PR DESCRIPTION
## Summary

This fixes a tool/source-node desync in getConnectedTools() for AI Agent tool connections when disabled AI tool nodes remain connected.

Previously, `toolkitConnections` excluded disabled AI tool nodes, while `parentNodes` still included them. Because the helper correlates both arrays by index, disabling any AI tool node caused later tools to receive the wrong `sourceNodeName`.

This change filters disabled nodes out of `parentNodes` so both arrays use the same active-node set and stay index-aligned.

A regression test was added to cover the case where a disabled tool node appears between active tool connections.

How to test:
1. Create an AI Agent with multiple connected AI tool nodes.
2. Disable one tool node that is not the last in the connection order.
3. On the affected code path, later tools are mapped to the wrong `sourceNodeName`.
4. Verify with this change that later tools remain mapped to the correct source node.
5. Run `pnpm test -- utils/tests/helpers.test.ts --runInBand` in `packages/@n8n/nodes-langchain`.

## Related Linear tickets, Github issues, and Community forum posts

#26356 

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
