### PR TITLE
ci: Ensure stable npm packages are tagged as latest after release

### DIFF
--- a/.github/scripts/pnpm-utils.mjs
+++ b/.github/scripts/pnpm-utils.mjs
@@ -1,0 +1,25 @@
+import child_process from 'child_process';
+import { promisify } from 'node:util';
+
+const exec = promisify(child_process.exec);
+
+/**
+ * @typedef PnpmPackage
+ * @property { string } name
+ * @property { string } version
+ * @property { string } path
+ * @property { boolean } private
+ * */
+
+/**
+ * @returns { Promise<PnpmPackage[]> }
+ * */
+export async function getMonorepoProjects() {
+	return JSON.parse(
+		(
+			await exec(
+				`pnpm ls -r --only-projects --json | jq -r '[.[] | { name: .name, version: .version, path: .path,  private: .private}]'`,
+			)
+		).stdout,
+	);
+}

--- a/.github/scripts/set-latest-for-monorepo-packages.mjs
+++ b/.github/scripts/set-latest-for-monorepo-packages.mjs
@@ -14,7 +14,7 @@ async function setLatestForMonorepoPackages() {
 		if (res.ok) {
 			console.log(`Set ${versionName} as latest`);
 		} else {
-			console.warn(`Update failed for ${versionName}: ${res.out}`);
+			console.warn(`Update failed for ${versionName}`);
 		}
 	}
 }

--- a/.github/scripts/set-latest-for-monorepo-packages.mjs
+++ b/.github/scripts/set-latest-for-monorepo-packages.mjs
@@ -1,0 +1,28 @@
+import { trySh } from './github-helpers.mjs';
+import { getMonorepoProjects } from './pnpm-utils.mjs';
+
+async function setLatestForMonorepoPackages() {
+	const packages = await getMonorepoProjects();
+
+	const publishedPackages = packages //
+		.filter((pkg) => !pkg.private)
+		.filter((pkg) => pkg.version);
+
+	for (const pkg of publishedPackages) {
+		const versionName = `${pkg.name}@${pkg.version}`;
+		const res = trySh('npm', ['dist-tag', 'add', versionName, 'latest']);
+		if (res.ok) {
+			console.log(`Set ${versionName} as latest`);
+		} else {
+			console.warn(`Update failed for ${versionName}: ${res.out}`);
+		}
+	}
+}
+
+// only run when executed directly, not when imported by tests
+if (import.meta.url === `file://${process.argv[1]}`) {
+	setLatestForMonorepoPackages().catch((err) => {
+		console.error(err);
+		process.exit(1);
+	});
+}

--- a/.github/workflows/release-publish-post-release.yml
+++ b/.github/workflows/release-publish-post-release.yml
@@ -66,6 +66,14 @@ jobs:
     uses: ./.github/workflows/util-ensure-release-candidate-branches.yml
     secrets: inherit
 
+  ensure-correct-latest-version-on-npm:
+    name: Ensure correct latest version on npm
+    if: |
+      inputs.bump == 'minor' ||
+      inputs.track == 'stable'
+    uses: ./.github/workflows/release-set-stable-npm-packages-to-latest.yml
+    secrets: inherit
+
   populate-cloud-with-releases:
     name: 'Populate cloud database with releases'
     uses: ./.github/workflows/release-populate-cloud-with-releases.yml

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Publish other packages to NPM
         env:
           PUBLISH_BRANCH: ${{ github.event.pull_request.base.ref }}
-          PUBLISH_TAG: ${{ needs.determine-version-info.outputs.track == 'stable' && 'latest' || needs.determine-version-info.outputs.track }}
+          PUBLISH_TAG: ${{ needs.determine-version-info.outputs.track }}
         run: |
           # Prefix version-like track names (e.g. "1", "v1") to avoid npm rejecting them as semver ranges
           if [[ "$PUBLISH_TAG" =~ ^v?[0-9] ]]; then

--- a/.github/workflows/release-set-stable-npm-packages-to-latest.yml
+++ b/.github/workflows/release-set-stable-npm-packages-to-latest.yml
@@ -26,5 +26,10 @@ jobs:
           build-command: ''
           install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
 
+      # Remove after https://github.com/npm/cli/issues/8547 gets resolved
+      - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Set npm packages to latest
         run: node ./.github/scripts/set-latest-for-monorepo-packages.mjs

--- a/.github/workflows/release-set-stable-npm-packages-to-latest.yml
+++ b/.github/workflows/release-set-stable-npm-packages-to-latest.yml
@@ -1,0 +1,30 @@
+name: 'Release: Set stable npm packages to latest'
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  promote-github-releases:
+    name: Promote current stable releases as latest
+    runs-on: ubuntu-slim
+    environment: release
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: refs/tags/stable
+          fetch-depth: 1
+
+      - name: Setup NodeJS
+        uses: ./.github/actions/setup-nodejs
+        with:
+          build-command: ''
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
+
+      - name: Set npm packages to latest
+        run: node ./.github/scripts/set-latest-for-monorepo-packages.mjs


### PR DESCRIPTION
## Summary

Adds a workflow and supporting scripts to ensure that stable npm packages in the monorepo are correctly tagged as `latest` on npm after a release.

**What this does:**
- Adds a new reusable workflow `release-set-stable-npm-packages-to-latest.yml` that checks out the `stable` tag, lists all public monorepo packages, and runs `npm dist-tag add <pkg>@<version> latest` for each.
- Adds a shared `pnpm-utils.mjs` helper to list monorepo packages via `pnpm ls`.
- Adds `set-latest-for-monorepo-packages.mjs` script that performs the actual dist-tag updates.
- Calls the new workflow from `release-publish-post-release.yml` on `minor` bumps or `stable` track releases.

**Changes to existing release code:**
- Publishing new version of package on stable track doesn't anymore set directly to "latest" but instead uses the track tag like other tracks.

**How to test:**
Run the `release-set-stable-npm-packages-to-latest` workflow manually via `workflow_dispatch` after a stable release, and verify npm packages have the `latest` dist-tag pointing to the stable version.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2847

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

---
🤖 PR Summary generated by AI