### PR TITLE
fix(Microsoft Outlook Trigger Node): Show nested subfolders in folder dropdowns

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/methods/listSearch.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/methods/listSearch.test.ts
@@ -405,7 +405,7 @@ describe('MicrosoftOutlookV2 - listSearch methods', () => {
 					$top: 100,
 				},
 			);
-			expect(mockTransport.getSubfolders).toHaveBeenCalledWith(mockResponse.value);
+			expect(mockTransport.getSubfolders).toHaveBeenCalledWith(mockResponse.value, true);
 			expect(result).toEqual({
 				results: [
 					{

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/methods/loadOptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/methods/loadOptions.test.ts
@@ -126,7 +126,7 @@ describe('MicrosoftOutlookV2 - loadOptions methods', () => {
 				'/mailFolders',
 				{},
 			);
-			expect(mockTransport.getSubfolders).toHaveBeenCalledWith(mockResponse);
+			expect(mockTransport.getSubfolders).toHaveBeenCalledWith(mockResponse, true);
 			expect(result).toEqual([
 				{ name: 'Inbox', value: 'folder1' },
 				{ name: 'Sent Items', value: 'folder2' },

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/transport/index.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/transport/index.test.ts
@@ -1,0 +1,94 @@
+import { mockDeep } from 'jest-mock-extended';
+import type { ILoadOptionsFunctions } from 'n8n-workflow';
+
+import { getSubfolders } from '../../../v2/transport';
+
+describe('MicrosoftOutlookV2 - getSubfolders', () => {
+	let mockLoadOptionsFunctions: jest.Mocked<ILoadOptionsFunctions>;
+
+	beforeEach(() => {
+		mockLoadOptionsFunctions = mockDeep<ILoadOptionsFunctions>();
+		mockLoadOptionsFunctions.getCredentials.mockResolvedValue({});
+		jest.clearAllMocks();
+	});
+
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it('should not request childFolders when childFolderCount is 0', async () => {
+		const folders = [
+			{ id: 'folder1', displayName: 'Inbox', childFolderCount: 0 },
+			{ id: 'folder2', displayName: 'Sent Items', childFolderCount: 0 },
+		];
+
+		const result = await getSubfolders.call(mockLoadOptionsFunctions, folders);
+
+		expect(
+			mockLoadOptionsFunctions.helpers.requestWithAuthentication as jest.Mock,
+		).not.toHaveBeenCalled();
+		expect(result).toEqual(folders);
+	});
+
+	it('should paginate child folder requests using nextLink', async () => {
+		const folders = [{ id: 'inbox', displayName: 'Inbox', childFolderCount: 2 }];
+
+		(mockLoadOptionsFunctions.helpers.requestWithAuthentication as jest.Mock)
+			.mockResolvedValueOnce({
+				value: [{ id: 'sub1', displayName: 'Work', childFolderCount: 0 }],
+				'@odata.nextLink':
+					'https://graph.microsoft.com/v1.0/me/mailFolders/inbox/childFolders?$skip=1',
+			})
+			.mockResolvedValueOnce({
+				value: [{ id: 'sub2', displayName: 'Projects', childFolderCount: 0 }],
+			});
+
+		const result = await getSubfolders.call(mockLoadOptionsFunctions, folders);
+
+		expect(
+			mockLoadOptionsFunctions.helpers.requestWithAuthentication as jest.Mock,
+		).toHaveBeenCalledTimes(2);
+		expect(result).toEqual([
+			{ id: 'inbox', displayName: 'Inbox', childFolderCount: 2 },
+			{ id: 'sub1', displayName: 'Work', childFolderCount: 0 },
+			{ id: 'sub2', displayName: 'Projects', childFolderCount: 0 },
+		]);
+	});
+
+	it('should prefix nested subfolder displayNames with full parent path', async () => {
+		const folders = [{ id: 'inbox', displayName: 'Inbox', childFolderCount: 1 }];
+
+		(mockLoadOptionsFunctions.helpers.requestWithAuthentication as jest.Mock)
+			.mockResolvedValueOnce({
+				value: [{ id: 'work', displayName: 'Work', childFolderCount: 1 }],
+			})
+			.mockResolvedValueOnce({
+				value: [{ id: 'q2', displayName: 'Q2', childFolderCount: 0 }],
+			});
+
+		const result = await getSubfolders.call(mockLoadOptionsFunctions, folders, true);
+
+		expect(result).toEqual([
+			{ id: 'inbox', displayName: 'Inbox', childFolderCount: 1 },
+			{ id: 'work', displayName: 'Inbox/Work', childFolderCount: 1 },
+			{ id: 'q2', displayName: 'Inbox/Work/Q2', childFolderCount: 0 },
+		]);
+	});
+
+	it('should return bare subfolder displayNames when addPathToDisplayName is false', async () => {
+		const folders = [{ id: 'inbox', displayName: 'Inbox', childFolderCount: 1 }];
+
+		(mockLoadOptionsFunctions.helpers.requestWithAuthentication as jest.Mock).mockResolvedValueOnce(
+			{
+				value: [{ id: 'work', displayName: 'Work', childFolderCount: 0 }],
+			},
+		);
+
+		const result = await getSubfolders.call(mockLoadOptionsFunctions, folders);
+
+		expect(result).toEqual([
+			{ id: 'inbox', displayName: 'Inbox', childFolderCount: 1 },
+			{ id: 'work', displayName: 'Work', childFolderCount: 0 },
+		]);
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/methods/listSearch.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/methods/listSearch.ts
@@ -223,7 +223,7 @@ export async function searchFolders(
 		response = await microsoftApiRequest.call(this, 'GET', '/mailFolders', undefined, qs);
 	}
 
-	let folders = await getSubfolders.call(this, response.value as IDataObject[]);
+	let folders = await getSubfolders.call(this, response.value as IDataObject[], true);
 
 	if (filter) {
 		filter = filter.toLowerCase();

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/methods/loadOptions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/methods/loadOptions.ts
@@ -24,7 +24,7 @@ export async function getCategoriesNames(
 export async function getFolders(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 	const returnData: INodePropertyOptions[] = [];
 	const response = await microsoftApiRequestAllItems.call(this, 'value', 'GET', '/mailFolders', {});
-	const folders = await getSubfolders.call(this, response);
+	const folders = await getSubfolders.call(this, response, true);
 	for (const folder of folders) {
 		returnData.push({
 			name: folder.displayName as string,

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/transport/index.ts
@@ -206,21 +206,20 @@ export async function getSubfolders(
 	const returnData: IDataObject[] = [...folders];
 	for (const folder of folders) {
 		if ((folder.childFolderCount as number) > 0) {
-			let subfolders = await microsoftApiRequest.call(
+			let subfolders = await microsoftApiRequestAllItems.call(
 				this,
+				'value',
 				'GET',
 				`/mailFolders/${folder.id}/childFolders`,
 			);
 
 			if (addPathToDisplayName) {
-				subfolders = subfolders.value.map((subfolder: IDataObject) => {
+				subfolders = subfolders.map((subfolder: IDataObject) => {
 					return {
 						...subfolder,
 						displayName: `${folder.displayName}/${subfolder.displayName}`,
 					};
 				});
-			} else {
-				subfolders = subfolders.value;
 			}
 
 			returnData.push(


### PR DESCRIPTION
## Summary

The Microsoft Outlook Trigger's "Folders to Include" / "Folders to Exclude" dropdowns only surfaced top-level mail folders, so users couldn't target Inbox subfolders. Two bugs combined: `getSubfolders` used a non-paginated request (dropping children past the first page), and `getFolders` called it without the `addPathToDisplayName` flag, so subfolders rendered as bare names and looked indistinguishable from top-level folders.

This change switches child folder fetches to `microsoftApiRequestAllItems` for full pagination and enables the path prefix in both `getFolders` (loadOptions) and `searchFolders` (resource locator), so picker entries now render as `Inbox/Work/Q2`. The action node's message-filter dropdown benefits from the same fix.

**How to test:** Add a Microsoft Outlook Trigger, open *Filters → Folders to Include*, and confirm nested subfolders appear with full paths. Verify the same on *Microsoft Outlook → Message → Get Many → Filters*. Unit tests cover pagination via `@odata.nextLink`, recursive path building, and the `childFolderCount === 0` short-circuit.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4852
Fixes https://github.com/n8n-io/n8n/issues/17078

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI