### PR TITLE
fix(editor): Allow `name` parameters to be defined by AI

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/utils/fromAIOverride.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/utils/fromAIOverride.utils.test.ts
@@ -91,6 +91,19 @@ function mockNodeFromType(type: INodeTypeDescription) {
 	} as never);
 }
 
+function mockAiToolNode(typeName: string, typeVersion: number): INodeUi {
+	return vi.mocked<INodeUi>({ type: typeName, typeVersion } as never);
+}
+
+const AI_TOOL_CODEX: INodeTypeDescription = {
+	name: '',
+	codex: {
+		categories: ['AI'],
+		subcategories: { AI: ['Tools'] },
+	},
+	...MOCK_NODE_TYPE_MIXIN,
+};
+
 describe('makeOverrideValue', () => {
 	test.each<[string, ...Parameters<typeof makeOverrideValue>]>([
 		['null nodeType', makeContext(''), null],
@@ -148,6 +161,39 @@ describe('makeOverrideValue', () => {
 
 		expect(result).toBeDefined();
 		expect(result?.extraPropValues.description).not.toBeDefined();
+	});
+
+	it('creates an override for a parameter named "name" on an allowed AI tool node', () => {
+		getNodeType.mockReturnValue(AI_NODE_TYPE);
+		const result = makeOverrideValue(
+			makeContext('', 'parameters.name'),
+			mockNodeFromType(AI_NODE_TYPE),
+		);
+
+		expect(result).not.toBeNull();
+		expect(result?.type).toEqual('fromAI');
+	});
+
+	describe('legacy tool-name node denylist', () => {
+		test.each<[string, string, number, boolean]>([
+			['toolWorkflow v2.0 denied', '@n8n/n8n-nodes-langchain.toolWorkflow', 2.0, false],
+			['toolWorkflow v2.1 denied', '@n8n/n8n-nodes-langchain.toolWorkflow', 2.1, false],
+			['toolWorkflow v2.2 allowed', '@n8n/n8n-nodes-langchain.toolWorkflow', 2.2, true],
+			['toolVectorStore v1 denied', '@n8n/n8n-nodes-langchain.toolVectorStore', 1, false],
+			['toolVectorStore v1.1 allowed', '@n8n/n8n-nodes-langchain.toolVectorStore', 1.1, true],
+		])('%s', (_name, typeName, typeVersion, shouldOverride) => {
+			getNodeType.mockReturnValue(AI_TOOL_CODEX);
+			const result = makeOverrideValue(
+				makeContext('', 'parameters.name'),
+				mockAiToolNode(typeName, typeVersion),
+			);
+
+			if (shouldOverride) {
+				expect(result).not.toBeNull();
+			} else {
+				expect(result).toBeNull();
+			}
+		});
 	});
 });
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/utils/fromAIOverride.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/utils/fromAIOverride.utils.ts
@@ -50,11 +50,14 @@ const NODE_DENYLIST = [
 	'@n8n/n8n-nodes-langchain.toolCode',
 	'@n8n/n8n-nodes-langchain.toolHttpRequest',
 	'@n8n/n8n-nodes-langchain.mcpClientTool',
-	['@n8n/n8n-nodes-langchain.toolWorkflow', 1.2],
+	// Legacy versions read `parameters.name` at runtime as the tool's identity;
+	// newer versions derive it from the node name, so $fromAI on that field would
+	// produce an invalid tool name. Keep these ranges in sync when bumping versions.
+	['@n8n/n8n-nodes-langchain.toolWorkflow', 2.1],
+	['@n8n/n8n-nodes-langchain.toolVectorStore', 1],
 ] as const;
 
 const PATH_DENYLIST = [
-	'parameters.name',
 	// this is used in vector store tools
 	'parameters.toolName',
 	'parameters.description',


### PR DESCRIPTION
## Summary
- Remove `parameters.name` from `PATH_DENYLIST`
- Added legacy versions of `toolWorkflow` and `toolVectorStore` nodes to `NODE_DENYLIST` so they don't allow their name to be AI defined

## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-5065
Fixes [28261](https://github.com/n8n-io/n8n/issues/28261)

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
