### PR TITLE
fix(editor): ensure duplicated tabs use unique push refs

### DIFF
--- a/packages/frontend/@n8n/stores/src/useRootStore.ts
+++ b/packages/frontend/@n8n/stores/src/useRootStore.ts
@@ -6,6 +6,19 @@ import { STORES } from './constants';
 import { getConfigFromMetaTag } from './metaTagConfig';
 
 const { VUE_APP_URL_BASE_API } = import.meta.env;
+const CLIENT_ID_STORAGE_KEY = 'n8n-client-id';
+const PUSH_REF_CHANNEL_NAME = 'n8n-push-ref-sync';
+const PUSH_REF_CHECK_TIMEOUT = 100;
+
+type PushRefChannelMessage =
+	| {
+			type: 'push-ref-check';
+			pushRef: string;
+	  }
+	| {
+			type: 'push-ref-taken';
+			pushRef: string;
+	  };
 
 export type RootStoreState = {
 	baseUrl: string;
@@ -35,15 +48,45 @@ export type RootStoreState = {
 };
 
 export const useRootStore = defineStore(STORES.ROOT, () => {
+	const generateClientId = (): string => randomString(10).toLowerCase();
+
+	const getPushRefChannel = (() => {
+		let channel: BroadcastChannel | null = null;
+
+		return () => {
+			if (typeof BroadcastChannel === 'undefined') {
+				return null;
+			}
+
+			channel ??= new BroadcastChannel(PUSH_REF_CHANNEL_NAME);
+			return channel;
+		};
+	})();
+
+	const isPushRefChannelMessage = (value: unknown): value is PushRefChannelMessage => {
+		if (typeof value !== 'object' || value === null) {
+			return false;
+		}
+
+		if (!('type' in value) || !('pushRef' in value)) {
+			return false;
+		}
+
+		return (
+			(value.type === 'push-ref-check' || value.type === 'push-ref-taken') &&
+			typeof value.pushRef === 'string'
+		);
+	};
+
 	// Generate or retrieve client ID from sessionStorage
 	const getClientId = (): string => {
-		const storageKey = 'n8n-client-id';
-		const existingId = sessionStorage.getItem(storageKey);
+		const existingId = sessionStorage.getItem(CLIENT_ID_STORAGE_KEY);
 		if (existingId) {
 			return existingId;
 		}
-		const newId = randomString(10).toLowerCase();
-		sessionStorage.setItem(storageKey, newId);
+
+		const newId = generateClientId();
+		sessionStorage.setItem(CLIENT_ID_STORAGE_KEY, newId);
 		return newId;
 	};
 
@@ -71,6 +114,31 @@ export const useRootStore = defineStore(STORES.ROOT, () => {
 		instanceId: '',
 		binaryDataMode: 'default',
 	});
+
+	const setPushRef = (value: string) => {
+		sessionStorage.setItem(CLIENT_ID_STORAGE_KEY, value);
+		state.value.pushRef = value;
+	};
+
+	const channel = getPushRefChannel();
+
+	channel?.addEventListener('message', (event: MessageEvent<unknown>) => {
+		if (!isPushRefChannelMessage(event.data)) {
+			return;
+		}
+
+		if (event.data.type !== 'push-ref-check' || event.data.pushRef !== state.value.pushRef) {
+			return;
+		}
+
+		channel.postMessage({
+			type: 'push-ref-taken',
+			pushRef: state.value.pushRef,
+		} satisfies PushRefChannelMessage);
+	});
+
+	let hasUniquePushRef = false;
+	let uniquePushRefPromise: Promise<string> | null = null;
 
 	// ---------------------------------------------------------------------------
 	// #region Computed
@@ -212,8 +280,55 @@ export const useRootStore = defineStore(STORES.ROOT, () => {
 		state.value.binaryDataMode = value;
 	};
 
-	const setPushRef = (value: string) => {
-		state.value.pushRef = value;
+	const ensureUniquePushRef = async () => {
+		if (hasUniquePushRef) {
+			return state.value.pushRef;
+		}
+
+		if (uniquePushRefPromise) {
+			return await uniquePushRefPromise;
+		}
+
+		const currentChannel = getPushRefChannel();
+		if (!currentChannel) {
+			hasUniquePushRef = true;
+			return state.value.pushRef;
+		}
+
+		uniquePushRefPromise = new Promise<string>((resolve) => {
+			const currentPushRef = state.value.pushRef;
+			let isPushRefTaken = false;
+
+			const onMessage = (event: MessageEvent<unknown>) => {
+				if (!isPushRefChannelMessage(event.data)) {
+					return;
+				}
+
+				if (event.data.type === 'push-ref-taken' && event.data.pushRef === currentPushRef) {
+					isPushRefTaken = true;
+				}
+			};
+
+			currentChannel.addEventListener('message', onMessage);
+			currentChannel.postMessage({
+				type: 'push-ref-check',
+				pushRef: currentPushRef,
+			} satisfies PushRefChannelMessage);
+
+			window.setTimeout(() => {
+				currentChannel.removeEventListener('message', onMessage);
+
+				if (isPushRefTaken) {
+					setPushRef(generateClientId());
+				}
+
+				hasUniquePushRef = true;
+				uniquePushRefPromise = null;
+				resolve(state.value.pushRef);
+			}, PUSH_REF_CHECK_TIMEOUT);
+		});
+
+		return await uniquePushRefPromise;
 	};
 
 	// #endregion
@@ -260,5 +375,6 @@ export const useRootStore = defineStore(STORES.ROOT, () => {
 		setDefaultLocale,
 		setBinaryDataMode,
 		setPushRef,
+		ensureUniquePushRef,
 	};
 });

--- a/packages/frontend/editor-ui/src/app/stores/pushConnection.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/pushConnection.store.test.ts
@@ -23,6 +23,7 @@ vi.mock('@n8n/stores/useRootStore', () => ({
 	useRootStore: vi.fn().mockReturnValue({
 		restUrl: 'http://localhost:5678/api/v1',
 		pushRef: 'test-push-ref',
+		ensureUniquePushRef: vi.fn().mockResolvedValue('test-push-ref'),
 	}),
 }));
 
@@ -33,6 +34,11 @@ vi.mock('./settings.store', () => ({
 }));
 
 describe('usePushConnectionStore', () => {
+	const flushConnect = async () => {
+		await Promise.resolve();
+		await Promise.resolve();
+	};
+
 	beforeEach(() => {
 		vi.useFakeTimers();
 	});
@@ -90,11 +96,12 @@ describe('usePushConnectionStore', () => {
 	});
 
 	describe('connection handling', () => {
-		test('should connect and disconnect with debounce', () => {
+		test('should connect and disconnect with debounce', async () => {
 			const { store, mockWebSocketClient } = createTestInitialState();
 
 			store.pushConnect();
 			expect(store.isConnectionRequested).toBe(true);
+			await flushConnect();
 			expect(mockWebSocketClient.connect).toHaveBeenCalled();
 
 			// Wait for the connect intent to expire (500ms debounce window)
@@ -111,12 +118,13 @@ describe('usePushConnectionStore', () => {
 			expect(mockWebSocketClient.disconnect).toHaveBeenCalled();
 		});
 
-		test('should not disconnect if connect is called within debounce window (new view mounts before old unmounts)', () => {
+		test('should not disconnect if connect is called within debounce window (new view mounts before old unmounts)', async () => {
 			const { store, mockWebSocketClient } = createTestInitialState();
 
 			// Initial connect
 			store.pushConnect();
 			expect(store.isConnectionRequested).toBe(true);
+			await flushConnect();
 			expect(mockWebSocketClient.connect).toHaveBeenCalledTimes(1);
 
 			// Simulate route transition: disconnect called but connect follows quickly
@@ -127,11 +135,12 @@ describe('usePushConnectionStore', () => {
 			expect(store.isConnectionRequested).toBe(true);
 		});
 
-		test('should not disconnect if connect is called during disconnect debounce window', () => {
+		test('should not disconnect if connect is called during disconnect debounce window', async () => {
 			const { store, mockWebSocketClient } = createTestInitialState();
 
 			// Initial connect
 			store.pushConnect();
+			await flushConnect();
 			expect(mockWebSocketClient.connect).toHaveBeenCalledTimes(1);
 
 			// Wait for connect intent to expire
@@ -144,6 +153,7 @@ describe('usePushConnectionStore', () => {
 			// Before disconnect completes, connect is called again
 			vi.advanceTimersByTime(250);
 			store.pushConnect();
+			await flushConnect();
 			expect(mockWebSocketClient.connect).toHaveBeenCalledTimes(2);
 
 			// Wait for what would have been the disconnect timeout

--- a/packages/frontend/editor-ui/src/app/stores/pushConnection.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/pushConnection.store.ts
@@ -142,7 +142,17 @@ export const usePushConnectionStore = defineStore(STORES.PUSH, () => {
 
 		isConnectionRequested.value = true;
 		isConnecting.value = true;
-		client.value.connect();
+		void rootStore
+			.ensureUniquePushRef()
+			.catch(() => undefined)
+			.then(() => {
+				if (!isConnectionRequested.value) {
+					isConnecting.value = false;
+					return;
+				}
+
+				client.value.connect();
+			});
 	};
 
 	const pushDisconnect = () => {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

before: 


https://github.com/user-attachments/assets/72a247e5-31b6-4c46-9dec-51e6adcc951a




after: 

https://github.com/user-attachments/assets/47c224d7-9b46-4a8e-b90d-8eb3eed8c6f8



## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
--> fixes #28741 

## The problem : 
duplicating a tab also duplicated the session storage and hence the same pushRef. 

## The fix:
1. If found a duplicate pushRef,a new client id is generated and replaced in session storage so the collision doesn't happen.
2. Used BroadcastChannel to check for duplicate pushRef's across different tabs from same origin.




<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
