### PR TITLE
fix: Stop persisting client id in session storage to fix duplicate tab problem (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/stores/src/useRootStore.ts
+++ b/packages/frontend/@n8n/stores/src/useRootStore.ts
@@ -35,18 +35,6 @@ export type RootStoreState = {
 };
 
 export const useRootStore = defineStore(STORES.ROOT, () => {
-	// Generate or retrieve client ID from sessionStorage
-	const getClientId = (): string => {
-		const storageKey = 'n8n-client-id';
-		const existingId = sessionStorage.getItem(storageKey);
-		if (existingId) {
-			return existingId;
-		}
-		const newId = randomString(10).toLowerCase();
-		sessionStorage.setItem(storageKey, newId);
-		return newId;
-	};
-
 	const state = ref<RootStoreState>({
 		baseUrl: VUE_APP_URL_BASE_API ?? window.BASE_PATH,
 		restEndpoint: getConfigFromMetaTag('rest-endpoint') ?? 'rest',
@@ -65,7 +53,7 @@ export const useRootStore = defineStore(STORES.ROOT, () => {
 		versionCli: '0.0.0',
 		oauthCallbackUrls: {},
 		n8nMetadata: {},
-		pushRef: getClientId(),
+		pushRef: randomString(10).toLowerCase(),
 		urlBaseWebhook: 'http://localhost:5678/',
 		urlBaseEditor: 'http://localhost:5678',
 		instanceId: '',


### PR DESCRIPTION
## Summary

This PR reverts the change introduced in https://github.com/n8n-io/n8n/pull/25646 which assumed it would be nice to persist client id on page refresh and missed the duplicate tab problem where this causes issues with sending and receiving push events. Full info in the Linear ticket.

How to test: duplicate a tab and notice that push connection is broken.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-5095](https://linear.app/n8n/issue/ADO-5095/bug-duplicate-tabs-share-the-same-pushref-causing-missed-push-updates)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
