### PR TITLE
feat(core): Add opt-in RFC-style outbound User-Agent via env flag

### DIFF
--- a/packages/@n8n/config/src/configs/http-request.config.ts
+++ b/packages/@n8n/config/src/configs/http-request.config.ts
@@ -1,0 +1,30 @@
+import { Config, Env } from '../decorators';
+
+@Config
+export class HttpRequestConfig {
+	/**
+	 * Whether n8n-initiated outbound HTTP requests send an RFC-style
+	 * User-Agent (e.g. `Mozilla/5.0 (compatible; n8n/<version>; +https://n8n.io/)`)
+	 * that passes strict WAF validation.
+	 *
+	 * When `false` (current default), the legacy bare `n8n` User-Agent is sent,
+	 * preserving backwards compatibility for downstream systems that match on it.
+	 *
+	 * Planned to default to `true` in the next major version.
+	 *
+	 * @see https://github.com/n8n-io/n8n/issues/28280
+	 */
+	@Env('N8N_ENFORCE_GLOBAL_USER_AGENT')
+	enforceGlobalUserAgent: boolean = false;
+
+	/**
+	 * Overrides the default User-Agent used for n8n-initiated outbound HTTP
+	 * requests when `N8N_ENFORCE_GLOBAL_USER_AGENT` is `true`. Empty string
+	 * means "use the RFC-style default including version".
+	 *
+	 * Useful for compliance scenarios where the n8n version should not be
+	 * disclosed to upstream servers.
+	 */
+	@Env('N8N_GLOBAL_USER_AGENT_VALUE')
+	globalUserAgentValue: string = '';
+}

--- a/packages/@n8n/config/src/index.ts
+++ b/packages/@n8n/config/src/index.ts
@@ -19,6 +19,7 @@ import { ExpressionEngineConfig } from './configs/expression-engine.config';
 import { ExternalHooksConfig } from './configs/external-hooks.config';
 import { GenericConfig } from './configs/generic.config';
 import { HiringBannerConfig } from './configs/hiring-banner.config';
+import { HttpRequestConfig } from './configs/http-request.config';
 import { InstanceAiConfig } from './configs/instance-ai.config';
 import { InstanceSettingsLoaderConfig } from './configs/instance-settings-loader.config';
 import { LicenseConfig } from './configs/license.config';
@@ -65,6 +66,7 @@ export * from './custom-types';
 export { DeploymentConfig } from './configs/deployment.config';
 export { MfaConfig } from './configs/mfa.config';
 export { HiringBannerConfig } from './configs/hiring-banner.config';
+export { HttpRequestConfig } from './configs/http-request.config';
 export { PersonalizationConfig } from './configs/personalization.config';
 export { NodesConfig } from './configs/nodes.config';
 export { CronLoggingConfig } from './configs/logging.config';
@@ -201,6 +203,9 @@ export class GlobalConfig {
 
 	@Nested
 	ssrfProtection: SsrfProtectionConfig;
+
+	@Nested
+	httpRequest: HttpRequestConfig;
 
 	/** Default locale for the UI. */
 	@Env('N8N_DEFAULT_LOCALE')

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -471,6 +471,10 @@ describe('GlobalConfig', () => {
 			allowedHostnames: [],
 			dnsCacheMaxSize: 1024 * 1024,
 		},
+		httpRequest: {
+			enforceGlobalUserAgent: false,
+			globalUserAgentValue: '',
+		},
 		redis: {
 			prefix: 'n8n',
 		},
@@ -542,6 +546,8 @@ describe('GlobalConfig', () => {
 			N8N_DYNAMIC_BANNERS_ENDPOINT: 'https://localhost:5678/api/banners',
 			N8N_DYNAMIC_BANNERS_ENABLED: 'false',
 			N8N_PASSWORD_MIN_LENGTH: '12',
+			N8N_ENFORCE_GLOBAL_USER_AGENT: 'true',
+			N8N_GLOBAL_USER_AGENT_VALUE: 'AcmeCorp/1.0',
 		};
 		const config = Container.get(GlobalConfig);
 
@@ -584,6 +590,10 @@ describe('GlobalConfig', () => {
 				password: {
 					minLength: 12,
 				},
+			},
+			httpRequest: {
+				enforceGlobalUserAgent: true,
+				globalUserAgentValue: 'AcmeCorp/1.0',
 			},
 		});
 		expect(mockFs.readFileSync).not.toHaveBeenCalled();

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/outbound-user-agent.integration.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/outbound-user-agent.integration.test.ts
@@ -1,0 +1,217 @@
+import { HttpRequestConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
+import { mock } from 'jest-mock-extended';
+import type { INode, IWorkflowExecuteAdditionalData, Workflow } from 'n8n-workflow';
+import nock from 'nock';
+
+import type { ExecutionLifecycleHooks } from '@/execution-engine/execution-lifecycle-hooks';
+
+import { buildRfcStyleUserAgent, getDefaultN8nOutboundUserAgent } from '../outbound-user-agent';
+import { httpRequest, proxyRequestToAxios } from '../request-helper-functions';
+
+/** Exercises the full httpRequest → axios path for outbound User-Agent resolution. */
+describe('Outbound User-Agent (httpRequest integration)', () => {
+	const baseUrl = 'https://example.com';
+	const originalConfig = new HttpRequestConfig();
+
+	beforeEach(() => {
+		nock.cleanAll();
+	});
+
+	afterEach(() => {
+		nock.cleanAll();
+		Container.set(HttpRequestConfig, { ...originalConfig });
+	});
+
+	it('sends legacy "n8n" User-Agent when enforcement flag is off (default)', async () => {
+		Container.set(HttpRequestConfig, {
+			enforceGlobalUserAgent: false,
+			globalUserAgentValue: '',
+		});
+
+		const scope = nock(baseUrl, {
+			reqheaders: { 'user-agent': 'n8n' },
+		})
+			.get('/legacy')
+			.reply(200, { success: true });
+
+		await expect(httpRequest({ method: 'GET', url: `${baseUrl}/legacy` })).resolves.toEqual({
+			success: true,
+		});
+
+		scope.done();
+	});
+
+	it('sends RFC-style User-Agent when enforcement flag is on', async () => {
+		Container.set(HttpRequestConfig, {
+			enforceGlobalUserAgent: true,
+			globalUserAgentValue: '',
+		});
+
+		const scope = nock(baseUrl, {
+			reqheaders: {
+				'user-agent': /^Mozilla\/5\.0 \(compatible; n8n\/.+; \+https:\/\/n8n\.io\/\)$/,
+			},
+		})
+			.get('/rfc-default')
+			.reply(200, { success: true });
+
+		await expect(httpRequest({ method: 'GET', url: `${baseUrl}/rfc-default` })).resolves.toEqual({
+			success: true,
+		});
+
+		scope.done();
+	});
+
+	it('sends the custom User-Agent value when both flag and value are set', async () => {
+		Container.set(HttpRequestConfig, {
+			enforceGlobalUserAgent: true,
+			globalUserAgentValue: 'AcmeCorp/2.0',
+		});
+
+		const scope = nock(baseUrl, {
+			reqheaders: { 'user-agent': 'AcmeCorp/2.0' },
+		})
+			.get('/custom')
+			.reply(200, { success: true });
+
+		await expect(httpRequest({ method: 'GET', url: `${baseUrl}/custom` })).resolves.toEqual({
+			success: true,
+		});
+
+		scope.done();
+	});
+
+	it('uses the RFC-style UA via getDefaultN8nOutboundUserAgent helper', () => {
+		expect(buildRfcStyleUserAgent('9.9.9')).toBe(
+			'Mozilla/5.0 (compatible; n8n/9.9.9; +https://n8n.io/)',
+		);
+
+		Container.set(HttpRequestConfig, {
+			enforceGlobalUserAgent: true,
+			globalUserAgentValue: '',
+		});
+		expect(getDefaultN8nOutboundUserAgent()).toMatch(
+			/^Mozilla\/5\.0 \(compatible; n8n\/.+; \+https:\/\/n8n\.io\/\)$/,
+		);
+	});
+});
+
+/**
+ * Exercises the legacy proxyRequestToAxios → axios path (used by HTTP Request node
+ * and many built-in nodes via helpers.request / helpers.requestWithAuthentication).
+ */
+describe('Outbound User-Agent (proxyRequestToAxios integration)', () => {
+	const baseUrl = 'https://legacy.example.com';
+	const originalConfig = new HttpRequestConfig();
+	const workflow = mock<Workflow>();
+	const node = mock<INode>();
+	const additionalData = mock<IWorkflowExecuteAdditionalData>({
+		hooks: mock<ExecutionLifecycleHooks>(),
+		ssrfBridge: undefined,
+	});
+
+	beforeEach(() => {
+		nock.cleanAll();
+	});
+
+	afterEach(() => {
+		nock.cleanAll();
+		Container.set(HttpRequestConfig, { ...originalConfig });
+	});
+
+	it('sends legacy "n8n" User-Agent when enforcement flag is off (default)', async () => {
+		Container.set(HttpRequestConfig, {
+			enforceGlobalUserAgent: false,
+			globalUserAgentValue: '',
+		});
+
+		const scope = nock(baseUrl, {
+			reqheaders: { 'user-agent': 'n8n' },
+		})
+			.get('/legacy')
+			.reply(200, { success: true });
+
+		await expect(
+			proxyRequestToAxios(workflow, additionalData, node, {
+				method: 'GET',
+				uri: `${baseUrl}/legacy`,
+				json: true,
+			}),
+		).resolves.toEqual({ success: true });
+
+		scope.done();
+	});
+
+	it('sends RFC-style User-Agent when enforcement flag is on', async () => {
+		Container.set(HttpRequestConfig, {
+			enforceGlobalUserAgent: true,
+			globalUserAgentValue: '',
+		});
+
+		const scope = nock(baseUrl, {
+			reqheaders: {
+				'user-agent': /^Mozilla\/5\.0 \(compatible; n8n\/.+; \+https:\/\/n8n\.io\/\)$/,
+			},
+		})
+			.get('/rfc-default')
+			.reply(200, { success: true });
+
+		await expect(
+			proxyRequestToAxios(workflow, additionalData, node, {
+				method: 'GET',
+				uri: `${baseUrl}/rfc-default`,
+				json: true,
+			}),
+		).resolves.toEqual({ success: true });
+
+		scope.done();
+	});
+
+	it('sends the custom User-Agent value when both flag and value are set', async () => {
+		Container.set(HttpRequestConfig, {
+			enforceGlobalUserAgent: true,
+			globalUserAgentValue: 'AcmeCorp/2.0',
+		});
+
+		const scope = nock(baseUrl, {
+			reqheaders: { 'user-agent': 'AcmeCorp/2.0' },
+		})
+			.get('/custom')
+			.reply(200, { success: true });
+
+		await expect(
+			proxyRequestToAxios(workflow, additionalData, node, {
+				method: 'GET',
+				uri: `${baseUrl}/custom`,
+				json: true,
+			}),
+		).resolves.toEqual({ success: true });
+
+		scope.done();
+	});
+
+	it('preserves a caller-supplied User-Agent header', async () => {
+		Container.set(HttpRequestConfig, {
+			enforceGlobalUserAgent: true,
+			globalUserAgentValue: 'AcmeCorp/2.0',
+		});
+
+		const scope = nock(baseUrl, {
+			reqheaders: { 'user-agent': 'MyCustomNode/1.0' },
+		})
+			.get('/preserved')
+			.reply(200, { success: true });
+
+		await expect(
+			proxyRequestToAxios(workflow, additionalData, node, {
+				method: 'GET',
+				uri: `${baseUrl}/preserved`,
+				headers: { 'User-Agent': 'MyCustomNode/1.0' },
+				json: true,
+			}),
+		).resolves.toEqual({ success: true });
+
+		scope.done();
+	});
+});

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/outbound-user-agent.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/outbound-user-agent.test.ts
@@ -1,0 +1,89 @@
+import type * as configModule from '@n8n/config';
+import { HttpRequestConfig } from '@n8n/config';
+import type * as diModule from '@n8n/di';
+import { Container } from '@n8n/di';
+
+import type * as outboundUserAgentModule from '../outbound-user-agent';
+import { buildRfcStyleUserAgent, getDefaultN8nOutboundUserAgent } from '../outbound-user-agent';
+
+describe('outbound-user-agent', () => {
+	const originalConfig = new HttpRequestConfig();
+
+	afterEach(() => {
+		Container.set(HttpRequestConfig, { ...originalConfig });
+		jest.resetModules();
+	});
+
+	describe('buildRfcStyleUserAgent', () => {
+		it('formats a conventional product token', () => {
+			expect(buildRfcStyleUserAgent('1.2.3')).toBe(
+				'Mozilla/5.0 (compatible; n8n/1.2.3; +https://n8n.io/)',
+			);
+		});
+	});
+
+	describe('getDefaultN8nOutboundUserAgent', () => {
+		it('returns the legacy "n8n" value when the enforce flag is off', () => {
+			Container.set(HttpRequestConfig, {
+				enforceGlobalUserAgent: false,
+				globalUserAgentValue: '',
+			});
+
+			expect(getDefaultN8nOutboundUserAgent()).toBe('n8n');
+		});
+
+		it('returns the legacy "n8n" value even when a custom UA is set but the flag is off', () => {
+			Container.set(HttpRequestConfig, {
+				enforceGlobalUserAgent: false,
+				globalUserAgentValue: 'some-custom-value',
+			});
+
+			expect(getDefaultN8nOutboundUserAgent()).toBe('n8n');
+		});
+
+		it('returns the RFC-style UA with n8n version when the enforce flag is on', () => {
+			Container.set(HttpRequestConfig, {
+				enforceGlobalUserAgent: true,
+				globalUserAgentValue: '',
+			});
+
+			expect(getDefaultN8nOutboundUserAgent()).toMatch(
+				/^Mozilla\/5\.0 \(compatible; n8n\/.+; \+https:\/\/n8n\.io\/\)$/,
+			);
+		});
+
+		it('returns the custom UA verbatim when both the flag and custom value are set', () => {
+			Container.set(HttpRequestConfig, {
+				enforceGlobalUserAgent: true,
+				globalUserAgentValue: 'AcmeCorp/1.0',
+			});
+
+			expect(getDefaultN8nOutboundUserAgent()).toBe('AcmeCorp/1.0');
+		});
+
+		it('falls back to version "0.0.0" when the package.json cannot be resolved', () => {
+			jest.isolateModules(() => {
+				jest.doMock('node:path', () => ({
+					...jest.requireActual<object>('node:path'),
+					join: () => '/definitely/not/a/real/path/package.json',
+				}));
+
+				// eslint-disable-next-line @typescript-eslint/no-require-imports
+				const di = require('@n8n/di') as typeof diModule;
+				// eslint-disable-next-line @typescript-eslint/no-require-imports
+				const config = require('@n8n/config') as typeof configModule;
+				// eslint-disable-next-line @typescript-eslint/no-require-imports
+				const mod = require('../outbound-user-agent') as typeof outboundUserAgentModule;
+
+				di.Container.set(config.HttpRequestConfig, {
+					enforceGlobalUserAgent: true,
+					globalUserAgentValue: '',
+				});
+
+				expect(mod.getDefaultN8nOutboundUserAgent()).toBe(
+					'Mozilla/5.0 (compatible; n8n/0.0.0; +https://n8n.io/)',
+				);
+			});
+		});
+	});
+});

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
@@ -375,11 +375,35 @@ describe('Request Helper Functions', () => {
 				expect.objectContaining({
 					url: 'https://example.com',
 					method: 'POST',
-					headers: { accept: '*/*', 'content-type': 'application/json' },
+					headers: {
+						accept: '*/*',
+						'content-type': 'application/json',
+						'User-Agent': 'n8n',
+					},
 					data: { key: 'value' },
 					maxRedirects: 0,
 				}),
 			);
+		});
+
+		test('should set default User-Agent when none provided', async () => {
+			const axiosOptions = await parseRequestObject({
+				url: 'https://example.com',
+				method: 'GET',
+			});
+
+			expect(axiosOptions.headers).toMatchObject({ 'User-Agent': 'n8n' });
+		});
+
+		test('should preserve a caller-supplied User-Agent header', async () => {
+			const axiosOptions = await parseRequestObject({
+				url: 'https://example.com',
+				method: 'GET',
+				headers: { 'User-Agent': 'MyCustomNode/1.0' },
+			});
+
+			expect(axiosOptions.headers).toMatchObject({ 'User-Agent': 'MyCustomNode/1.0' });
+			expect(axiosOptions.headers).not.toMatchObject({ 'User-Agent': 'n8n' });
 		});
 
 		test('should set correct headers for FormData', async () => {

--- a/packages/core/src/execution-engine/node-execution-context/utils/outbound-user-agent.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/outbound-user-agent.ts
@@ -1,0 +1,61 @@
+import { HttpRequestConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
+import type { AxiosRequestConfig } from 'axios';
+import { join } from 'node:path';
+
+import { searchForHeader } from './request-helpers';
+
+const N8N_PRODUCT_URL = 'https://n8n.io/';
+const LEGACY_USER_AGENT = 'n8n';
+
+function readN8nVersion(): string {
+	try {
+		// require self-caches, so repeated calls are cheap
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		const pkg = require(join(__dirname, '../../../../package.json')) as { version: string };
+		return pkg.version;
+	} catch {
+		return '0.0.0';
+	}
+}
+
+/**
+ * Builds the RFC-style User-Agent for n8n-initiated HTTP requests.
+ * Uses a conventional browser-style token so strict WAFs accept the value.
+ *
+ * @see https://github.com/n8n-io/n8n/issues/28280
+ */
+export function buildRfcStyleUserAgent(version: string): string {
+	return `Mozilla/5.0 (compatible; n8n/${version}; +${N8N_PRODUCT_URL})`;
+}
+
+/**
+ * Resolves the outbound User-Agent to apply when a request does not set one.
+ *
+ * Precedence:
+ * 1. Legacy default `n8n` when `N8N_ENFORCE_GLOBAL_USER_AGENT` is `false` (current default).
+ * 2. `N8N_GLOBAL_USER_AGENT_VALUE` when set.
+ * 3. RFC-style `Mozilla/5.0 (compatible; n8n/<version>; +https://n8n.io/)` otherwise.
+ */
+export function getDefaultN8nOutboundUserAgent(): string {
+	const { enforceGlobalUserAgent, globalUserAgentValue } = Container.get(HttpRequestConfig);
+
+	if (!enforceGlobalUserAgent) return LEGACY_USER_AGENT;
+
+	if (globalUserAgentValue.length > 0) return globalUserAgentValue;
+
+	return buildRfcStyleUserAgent(readN8nVersion());
+}
+
+/**
+ * Applies the n8n default outbound User-Agent to an axios request config,
+ * unless the caller already supplied a User-Agent header.
+ */
+export function applyDefaultOutboundUserAgent(axiosConfig: AxiosRequestConfig): void {
+	if (searchForHeader(axiosConfig, 'user-agent')) return;
+
+	axiosConfig.headers = {
+		...axiosConfig.headers,
+		'User-Agent': getDefaultN8nOutboundUserAgent(),
+	};
+}

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
@@ -71,6 +71,7 @@ import { callEvalMockHandler, normalizeLegacyRequest } from '@/execution-engine/
 import type { IResponseError } from '@/interfaces';
 
 import { binaryToString } from './binary-helper-functions';
+import { applyDefaultOutboundUserAgent } from './outbound-user-agent';
 import { parseIncomingMessage } from './parse-incoming-message';
 // Imported for side effects: sets axios defaults and registers the request interceptor
 import './request-helpers/axios-config';
@@ -400,6 +401,8 @@ export async function parseRequestObject(requestObject: IRequestOptions, ssrfBri
 		axiosConfig.validateStatus = () => true;
 	}
 
+	applyDefaultOutboundUserAgent(axiosConfig);
+
 	/**
 	 * Missing properties:
 	 * encoding (need testing)
@@ -607,15 +610,7 @@ export function convertN8nRequestToAxios(
 		}
 	}
 
-	const userAgentHeader = searchForHeader(axiosRequest, 'user-agent');
-	// If key exists, then the user has set both accept
-	// header and the json flag. Header should take precedence.
-	if (!userAgentHeader) {
-		axiosRequest.headers = {
-			...axiosRequest.headers,
-			'User-Agent': 'n8n',
-		};
-	}
+	applyDefaultOutboundUserAgent(axiosRequest);
 
 	if (n8nRequest.ignoreHttpStatusErrors) {
 		const ignoreHttpStatusErrors = n8nRequest.ignoreHttpStatusErrors;

--- a/packages/nodes-base/credentials/DropcontactApi.credentials.ts
+++ b/packages/nodes-base/credentials/DropcontactApi.credentials.ts
@@ -26,7 +26,6 @@ export class DropcontactApi implements ICredentialType {
 		type: 'generic',
 		properties: {
 			headers: {
-				'user-agent': 'n8n',
 				'X-Access-Token': '={{$credentials.apiKey}}',
 			},
 		},

--- a/packages/nodes-base/credentials/PerplexityApi.credentials.ts
+++ b/packages/nodes-base/credentials/PerplexityApi.credentials.ts
@@ -29,7 +29,6 @@ export class PerplexityApi implements ICredentialType {
 		properties: {
 			headers: {
 				Authorization: '=Bearer {{$credentials.apiKey}}',
-				'User-Agent': 'n8n',
 				'X-Source': 'n8n',
 			},
 		},

--- a/packages/nodes-base/credentials/RundeckApi.credentials.ts
+++ b/packages/nodes-base/credentials/RundeckApi.credentials.ts
@@ -33,7 +33,6 @@ export class RundeckApi implements ICredentialType {
 		type: 'generic',
 		properties: {
 			headers: {
-				'user-agent': 'n8n',
 				'X-Rundeck-Auth-Token': '={{$credentials?.token}}',
 			},
 		},

--- a/packages/nodes-base/nodes/ApiTemplateIo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ApiTemplateIo/GenericFunctions.ts
@@ -16,7 +16,6 @@ export async function apiTemplateIoApiRequest(
 ) {
 	const options: IRequestOptions = {
 		headers: {
-			'user-agent': 'n8n',
 			Accept: 'application/json',
 		},
 		uri: `https://api.apitemplate.io/v1${endpoint}`,

--- a/packages/nodes-base/nodes/Bitwarden/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Bitwarden/GenericFunctions.ts
@@ -43,7 +43,6 @@ export async function bitwardenApiRequest(
 	const baseUrl = await getBaseUrl.call(this);
 	const options: IRequestOptions = {
 		headers: {
-			'user-agent': 'n8n',
 			Authorization: `Bearer ${token}`,
 			'Content-Type': 'application/json',
 		},

--- a/packages/nodes-base/nodes/Bubble/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Bubble/GenericFunctions.ts
@@ -32,7 +32,6 @@ export async function bubbleApiRequest(
 
 	const options: IRequestOptions = {
 		headers: {
-			'user-agent': 'n8n',
 			Authorization: `Bearer ${apiToken}`,
 		},
 		method,

--- a/packages/nodes-base/nodes/Coda/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Coda/GenericFunctions.ts
@@ -23,7 +23,6 @@ export async function codaApiRequest(
 	let options: IRequestOptions = {
 		headers: {
 			Authorization: `Bearer ${credentials.accessToken}`,
-			'User-Agent': 'n8n',
 		},
 		method,
 		qs,

--- a/packages/nodes-base/nodes/Github/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Github/GenericFunctions.ts
@@ -23,9 +23,6 @@ export async function githubApiRequest(
 ): Promise<any> {
 	const options: IRequestOptions = {
 		method,
-		headers: {
-			'User-Agent': 'n8n',
-		},
 		body,
 		qs: query,
 		uri: '',

--- a/packages/nodes-base/nodes/Github/__tests__/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Github/__tests__/GenericFunctions.test.ts
@@ -53,7 +53,6 @@ describe('GenericFunctions', () => {
 				'githubApi',
 				{
 					method: 'GET',
-					headers: { 'User-Agent': 'n8n' },
 					body: {},
 					qs: undefined,
 					uri: 'https://api.github.com/repos/test-owner/test-repo',
@@ -103,7 +102,6 @@ describe('GenericFunctions', () => {
 				'githubApi',
 				{
 					method: 'GET',
-					headers: { 'User-Agent': 'n8n' },
 					body: {},
 					qs: { ref: 'main' },
 					uri: 'https://api.github.com/repos/test-owner/test-repo/contents/README.md',

--- a/packages/nodes-base/nodes/Github/__tests__/node/Github.node.test.ts
+++ b/packages/nodes-base/nodes/Github/__tests__/node/Github.node.test.ts
@@ -120,7 +120,6 @@ describe('Test Github Node', () => {
 					'githubOAuth2Api',
 					{
 						body: {},
-						headers: { 'User-Agent': 'n8n' },
 						json: true,
 						method: 'GET',
 						qs: {},

--- a/packages/nodes-base/nodes/GoToWebinar/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/GoToWebinar/GenericFunctions.ts
@@ -36,7 +36,6 @@ export async function goToWebinarApiRequest(
 
 	const options: IRequestOptions = {
 		headers: {
-			'user-agent': 'n8n',
 			Accept: 'application/json',
 			'Content-Type': 'application/json',
 		},

--- a/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequest.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequest.test.ts
@@ -4,8 +4,21 @@ import { parse as parseUrl } from 'url';
 
 describe('Test HTTP Request Node', () => {
 	const baseUrl = 'https://dummyjson.com';
+	const uaBaseUrl = 'https://ua.example.com';
 
 	beforeAll(async () => {
+		// User-Agent: default resolution applies when no override is set
+		nock(uaBaseUrl)
+			.matchHeader('user-agent', 'n8n')
+			.get('/default')
+			.reply(200, { ok: true, seen: 'default' });
+
+		// User-Agent: caller-supplied header must win over the default
+		nock(uaBaseUrl)
+			.matchHeader('user-agent', 'MyCustomAgent/1.0')
+			.get('/override')
+			.reply(200, { ok: true, seen: 'override' });
+
 		function getPaginationReturnData(this: nock.ReplyFnContext, limit = 10, skip = 0) {
 			const nextUrl = `${baseUrl}/users?skip=${skip + limit}&limit=${limit}`;
 

--- a/packages/nodes-base/nodes/HttpRequest/test/node/workflow.userAgent.json
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/workflow.userAgent.json
@@ -1,0 +1,90 @@
+{
+	"name": "HTTP Request User-Agent test",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "8a43a8dc-6e32-4a5e-9b3c-3a4d5e6f7a8b",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [160, 720]
+		},
+		{
+			"parameters": {
+				"url": "https://ua.example.com/default",
+				"options": {}
+			},
+			"id": "1aa13a8d-6e32-4a5e-9b3c-3a4d5e6f7a01",
+			"name": "HTTP Request default UA",
+			"type": "n8n-nodes-base.httpRequest",
+			"typeVersion": 3,
+			"position": [460, 600]
+		},
+		{
+			"parameters": {
+				"url": "https://ua.example.com/override",
+				"sendHeaders": true,
+				"headerParameters": {
+					"parameters": [
+						{
+							"name": "User-Agent",
+							"value": "MyCustomAgent/1.0"
+						}
+					]
+				},
+				"options": {}
+			},
+			"id": "2bb13a8d-6e32-4a5e-9b3c-3a4d5e6f7a02",
+			"name": "HTTP Request custom UA",
+			"type": "n8n-nodes-base.httpRequest",
+			"typeVersion": 3,
+			"position": [460, 800]
+		}
+	],
+	"pinData": {
+		"HTTP Request default UA": [
+			{
+				"json": {
+					"ok": true,
+					"seen": "default"
+				}
+			}
+		],
+		"HTTP Request custom UA": [
+			{
+				"json": {
+					"ok": true,
+					"seen": "override"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "HTTP Request default UA",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "HTTP Request custom UA",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "",
+	"meta": {
+		"templateCredsSetupCompleted": true,
+		"instanceId": "27cc9b56542ad45b38725555722c50a1c3fee1670bbb67980558314ee08517c4"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Odoo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Odoo/GenericFunctions.ts
@@ -110,7 +110,6 @@ export async function odooJSONRPCRequest(
 	try {
 		const options: IRequestOptions = {
 			headers: {
-				'User-Agent': 'n8n',
 				Connection: 'keep-alive',
 				Accept: '*/*',
 				'Content-Type': 'application/json',

--- a/packages/nodes-base/nodes/Odoo/Odoo.node.ts
+++ b/packages/nodes-base/nodes/Odoo/Odoo.node.ts
@@ -248,7 +248,6 @@ export class Odoo implements INodeType {
 
 					const options: IRequestOptions = {
 						headers: {
-							'User-Agent': 'n8n',
 							Connection: 'keep-alive',
 							Accept: '*/*',
 							'Content-Type': 'application/json',

--- a/packages/nodes-base/nodes/QuickBase/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/QuickBase/GenericFunctions.ts
@@ -33,7 +33,6 @@ export async function quickbaseApiRequest(
 		const options: IRequestOptions = {
 			headers: {
 				'QB-Realm-Hostname': credentials.hostname,
-				'User-Agent': 'n8n',
 				Authorization: `QB-USER-TOKEN ${credentials.userToken}`,
 				'Content-Type': 'application/json',
 			},

--- a/packages/nodes-base/nodes/QuickBooks/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/QuickBooks/GenericFunctions.ts
@@ -43,9 +43,6 @@ export async function quickBooksApiRequest(
 	const credentials = await this.getCredentials<QuickBooksOAuth2Credentials>('quickBooksOAuth2Api');
 
 	const options: IRequestOptions = {
-		headers: {
-			'user-agent': 'n8n',
-		},
 		method,
 		uri: `${credentials.environment === 'sandbox' ? sandboxUrl : productionUrl}${endpoint}`,
 		qs,

--- a/packages/nodes-base/nodes/Raindrop/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Raindrop/GenericFunctions.ts
@@ -22,7 +22,6 @@ export async function raindropApiRequest(
 ) {
 	const options: IRequestOptions = {
 		headers: {
-			'user-agent': 'n8n',
 			'Content-Type': 'application/json',
 		},
 		method,

--- a/packages/nodes-base/nodes/Reddit/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Reddit/GenericFunctions.ts
@@ -24,9 +24,6 @@ export async function redditApiRequest(
 	qs.api_type = 'json';
 
 	const options: IRequestOptions = {
-		headers: {
-			'user-agent': 'n8n',
-		},
 		method,
 		uri: authRequired
 			? `https://oauth.reddit.com/${endpoint}`

--- a/packages/nodes-base/nodes/Spotify/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Spotify/GenericFunctions.ts
@@ -24,7 +24,6 @@ export async function spotifyApiRequest(
 	const options: IHttpRequestOptions = {
 		method,
 		headers: {
-			'User-Agent': 'n8n',
 			'Content-Type': 'text/plain',
 			Accept: ' application/json',
 		},

--- a/packages/nodes-base/nodes/Spotify/__tests__/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Spotify/__tests__/GenericFunctions.test.ts
@@ -31,7 +31,6 @@ describe('Spotify -> GenericFunctions', () => {
 			{
 				method,
 				headers: {
-					'User-Agent': 'n8n',
 					'Content-Type': 'text/plain',
 					Accept: ' application/json',
 				},

--- a/packages/nodes-base/nodes/UrlScanIo/descriptions/ScanDescription.ts
+++ b/packages/nodes-base/nodes/UrlScanIo/descriptions/ScanDescription.ts
@@ -142,7 +142,7 @@ export const scanFields: INodeProperties[] = [
 				displayName: 'Custom Agent',
 				name: 'customAgent',
 				description:
-					'<code>User-Agent</code> header to set for this scan. Defaults to <code>n8n</code>',
+					'<code>User-Agent</code> header to set for this scan. Defaults to n8n standard outbound User-Agent.',
 				type: 'string',
 				default: '',
 			},

--- a/packages/nodes-base/nodes/Wise/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Wise/GenericFunctions.ts
@@ -33,7 +33,6 @@ export async function wiseApiRequest(
 
 	const options: IHttpRequestOptions = {
 		headers: {
-			'user-agent': 'n8n',
 			Authorization: `Bearer ${apiToken}`,
 		},
 		method,

--- a/packages/nodes-base/nodes/Wordpress/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Wordpress/GenericFunctions.ts
@@ -46,7 +46,6 @@ export async function wordpressApiRequest(
 		headers: {
 			Accept: 'application/json',
 			'Content-Type': 'application/json',
-			'User-Agent': 'n8n',
 		},
 		method,
 		qs,


### PR DESCRIPTION
## Summary

Adds two environment variables to let operators control the outbound `User-Agent` used by n8n-initiated HTTP requests:

- `N8N_ENFORCE_GLOBAL_USER_AGENT` (bool, default `false`) — when `true`, replaces the legacy bare `n8n` User-Agent with an RFC-style token `Mozilla/5.0 (compatible; n8n/<version>; +https://n8n.io/)` that passes strict WAF validation.
- `N8N_GLOBAL_USER_AGENT_VALUE` (string) — overrides the RFC default with a custom value. Useful for compliance scenarios where the n8n version should not be disclosed to upstream servers.

The default remains `n8n` to preserve backwards compatibility for downstream systems that substring-match the current User-Agent. We plan to flip this to `true` in the next major version.

Resolution is applied on **both** outbound request paths:

- The modern path (`httpRequest` / `httpRequestWithAuthentication` → `convertN8nRequestToAxios`).
- The legacy path (`request` / `requestWithAuthentication` / `requestOAuth1/2` / `requestWithAuthenticationPaginated` → `proxyRequestToAxios` → `parseRequestObject`), which is what the **HTTP Request node (V1/V2/V3)** and many built-in nodes actually use.

Shared logic lives in `applyDefaultOutboundUserAgent(axiosConfig)` inside `outbound-user-agent.ts` so both call sites stay in sync.

Also drops redundant hard-coded `'n8n'` User-Agent overrides in nodes and credentials so they participate in the new default resolution (GitHub, Spotify, Reddit, Bitwarden, Bubble, Coda, GoToWebinar, Odoo, QuickBase, QuickBooks, Raindrop, UrlScanIo, Wise, Wordpress, ApiTemplateIo, Dropcontact, Perplexity, Rundeck). Genuinely custom User-Agents (Onfleet, HaloPSA, Harvest, AWS) are left intact.

## Credit

Builds on @muhammadosama984's work in #28360 — this PR keeps the RFC-style token, the version-resolution utility, and the node/credential cleanup, but puts the new default behind an env flag so it can ship without a silent behavioral change for self-hosted users who may rely on substring-matching the existing `n8n` User-Agent.

## Related Linear tickets, Github issues, and Community forum posts

- Resolves [NODE-4832](https://linear.app/n8n/issue/NODE-4832)
- Fixes #28280
- Supersedes #28360

## Test plan

- [x] Unit tests for `outbound-user-agent` util (flag off, flag on, custom value)
- [x] Integration tests through `httpRequest` / `convertN8nRequestToAxios` (legacy `n8n`, RFC-style, custom override)
- [x] Integration tests through `proxyRequestToAxios` / `parseRequestObject` (legacy `n8n`, RFC-style, custom override, caller-supplied UA preserved) — covers the HTTP Request node and helpers.request consumers
- [x] Unit tests for `parseRequestObject` asserting default injection and preservation of caller-supplied UA
- [x] `packages/@n8n/config` test updated with new `httpRequest` block
- [x] Manual smoke: run against a WAF-protected endpoint with flag on and confirm 403 → 200

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. _(Docs PR to follow: env var additions + v3 flip announcement.)_
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if needed)