### PR TITLE
test: Refactor test workflow initialization

### DIFF
--- a/packages/testing/playwright/composables/WorkflowComposer.ts
+++ b/packages/testing/playwright/composables/WorkflowComposer.ts
@@ -1,5 +1,4 @@
 import { expect } from '@playwright/test';
-import { nanoid } from 'nanoid';
 
 import type { n8nPage } from '../pages/n8nPage';
 
@@ -54,23 +53,6 @@ export class WorkflowComposer {
 		await this.n8n.page.keyboard.press('Enter');
 
 		await this.n8n.canvas.waitForSaveWorkflowCompleted();
-	}
-
-	/**
-	 * Creates a new workflow by importing a JSON file
-	 * @param fileName - The workflow JSON file name (e.g., 'test_pdf_workflow.json', will search in workflows folder)
-	 * @param name - Optional custom name. If not provided, generates a unique name
-	 * @returns The actual workflow name that was used
-	 */
-	async createWorkflowFromJsonFile(
-		fileName: string,
-		name?: string,
-	): Promise<{ workflowName: string }> {
-		const workflowName = name ?? `Imported Workflow ${nanoid(8)}`;
-		await this.n8n.goHome();
-		await this.n8n.workflows.addResource.workflow();
-		await this.n8n.canvas.importWorkflow(fileName, workflowName);
-		return { workflowName };
 	}
 
 	/**

--- a/packages/testing/playwright/tests/e2e/workflows/editor/editor-after-route-changes.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/editor-after-route-changes.spec.ts
@@ -10,15 +10,13 @@ test.describe(
 			await n8n.api.enableFeature('debugInEditor');
 			await n8n.api.enableFeature('workflowHistory');
 
-			await n8n.workflowComposer.createWorkflowFromJsonFile(
-				'Lots_of_nodes.json',
-				'Lots of nodes test',
-			);
+			await n8n.start.fromImportedWorkflow('Lots_of_nodes.json');
 		});
 
 		test('should maintain zoom functionality after switching between Editor and Workflow history and Workflow list', async ({
 			n8n,
 		}) => {
+			await expect(n8n.canvas.getCanvasNodes().first()).toBeVisible();
 			const initialNodeCount = await n8n.canvas.getCanvasNodes().count();
 			expect(initialNodeCount).toBeGreaterThan(0);
 


### PR DESCRIPTION
## Summary

Removes the specific 'createWorkflowFromJsonFile' method from 'WorkflowComposer'. Replaces its usage in E2E tests with the more streamlined 'n8n.start.fromImportedWorkflow' helper. This change centralizes the logic for preparing imported workflows, leading to cleaner and more consistent test setups. Adds a canvas visibility check to ensure nodes are rendered after the workflow is imported.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
