### PR TITLE
ci: Run ci-pr-quality only on n8n team PRs

### DIFF
--- a/.github/workflows/ci-pr-quality.yml
+++ b/.github/workflows/ci-pr-quality.yml
@@ -1,7 +1,7 @@
 name: 'CI: PR Quality Checks'
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
@@ -47,7 +47,8 @@ jobs:
     # Checks that the author has acknowledged the ownership of their code
     # by checking the checkbox in the PR summary.
     if: |
-      github.event_name == 'pull_request_target' &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       !contains(github.event.pull_request.labels.*.name, 'automation:backport') &&
       !contains(github.event.pull_request.title, '(backport to')
     runs-on: ubuntu-latest
@@ -75,7 +76,8 @@ jobs:
     # Checks that the PR size doesn't exceed the limit (currently 1000 lines)
     # Allows for override via '/size-limit-override' comment
     if: |
-      github.event_name == 'pull_request_target' &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       !contains(github.event.pull_request.labels.*.name, 'automation:backport') &&
       !contains(github.event.pull_request.title, '(backport to')
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-pr-quality.yml
+++ b/.github/workflows/ci-pr-quality.yml
@@ -1,7 +1,7 @@
 name: 'CI: PR Quality Checks'
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited
@@ -47,7 +47,7 @@ jobs:
     # Checks that the author has acknowledged the ownership of their code
     # by checking the checkbox in the PR summary.
     if: |
-      github.event_name == 'pull_request' &&
+      github.event_name == 'pull_request_target' &&
       !contains(github.event.pull_request.labels.*.name, 'automation:backport') &&
       !contains(github.event.pull_request.title, '(backport to')
     runs-on: ubuntu-latest
@@ -75,7 +75,7 @@ jobs:
     # Checks that the PR size doesn't exceed the limit (currently 1000 lines)
     # Allows for override via '/size-limit-override' comment
     if: |
-      github.event_name == 'pull_request' &&
+      github.event_name == 'pull_request_target' &&
       !contains(github.event.pull_request.labels.*.name, 'automation:backport') &&
       !contains(github.event.pull_request.title, '(backport to')
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

[Community PRs](https://github.com/n8n-io/n8n/actions/runs/24712546901/job/72280709766?pr=27563) were failing on quality gates due to how GitHub runs fork PRs. Let's for now, remove the checks on community PRs. (forks).

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/actions/runs/24712546901/job/72280709766?pr=27563

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
