### PR TITLE
fix(core): Persist execution metadata for failed executions in scaling mode

### DIFF
--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -107,7 +107,7 @@ describe('Execution Lifecycle Hooks', () => {
 	});
 	const failedRun = mock<IRun>({
 		status: 'error',
-		finished: true,
+		finished: false,
 		waitTill: undefined,
 		storedAt: 'db',
 	});
@@ -120,6 +120,48 @@ describe('Execution Lifecycle Hooks', () => {
 	const successfulRunWithMetadata = mock<IRun>({
 		status: 'success',
 		finished: true,
+		waitTill: undefined,
+		storedAt: 'db',
+		data: {
+			resultData: {
+				metadata: {
+					testKey1: 'testValue1',
+					testKey2: 'testValue2',
+				},
+			},
+		},
+	});
+	const failedRunWithMetadata = mock<IRun>({
+		status: 'error',
+		finished: false,
+		waitTill: undefined,
+		storedAt: 'db',
+		data: {
+			resultData: {
+				metadata: {
+					testKey1: 'testValue1',
+					testKey2: 'testValue2',
+				},
+			},
+		},
+	});
+	const crashedRunWithMetadata = mock<IRun>({
+		status: 'crashed',
+		finished: false,
+		waitTill: undefined,
+		storedAt: 'db',
+		data: {
+			resultData: {
+				metadata: {
+					testKey1: 'testValue1',
+					testKey2: 'testValue2',
+				},
+			},
+		},
+	});
+	const canceledRunWithMetadata = mock<IRun>({
+		status: 'canceled',
+		finished: false,
 		waitTill: undefined,
 		storedAt: 'db',
 		data: {
@@ -167,6 +209,34 @@ describe('Execution Lifecycle Hooks', () => {
 			},
 		});
 		successfulRunWithMetadata.data = createRunExecutionData({
+			resultData: {
+				runData: {},
+				metadata: {
+					testKey1: 'testValue1',
+					testKey2: 'testValue2',
+				},
+			},
+		});
+		failedRunWithMetadata.data = createRunExecutionData({
+			resultData: {
+				runData: {},
+				error: expressionError,
+				metadata: {
+					testKey1: 'testValue1',
+					testKey2: 'testValue2',
+				},
+			},
+		});
+		crashedRunWithMetadata.data = createRunExecutionData({
+			resultData: {
+				runData: {},
+				metadata: {
+					testKey1: 'testValue1',
+					testKey2: 'testValue2',
+				},
+			},
+		});
+		canceledRunWithMetadata.data = createRunExecutionData({
 			resultData: {
 				runData: {},
 				metadata: {
@@ -1047,6 +1117,58 @@ describe('Execution Lifecycle Hooks', () => {
 					await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRun, {}]);
 
 					expect(executionMetadataService.save).not.toHaveBeenCalled();
+				});
+
+				it('should save metadata for failed executions when error saving is enabled', async () => {
+					await lifecycleHooks.runHook('workflowExecuteAfter', [failedRunWithMetadata, {}]);
+
+					expect(executionMetadataService.save).toHaveBeenCalledWith(executionId, {
+						testKey1: 'testValue1',
+						testKey2: 'testValue2',
+					});
+				});
+
+				it('should NOT save metadata for failed executions when error saving is disabled', async () => {
+					workflowData.settings = {
+						saveDataSuccessExecution: 'all' as const,
+						saveDataErrorExecution: 'none' as const,
+					};
+					const testLifecycleHooks = getLifecycleHooksForScalingMain(
+						{
+							executionMode: 'webhook',
+							workflowData,
+							pushRef,
+							retryOf,
+						},
+						executionId,
+					);
+
+					await testLifecycleHooks.runHook('workflowExecuteAfter', [failedRunWithMetadata, {}]);
+
+					expect(executionMetadataService.save).not.toHaveBeenCalled();
+					expect(executionPersistence.deleteInFlightExecution).toHaveBeenCalledWith({
+						workflowId,
+						executionId,
+						storedAt: 'db',
+					});
+				});
+
+				it('should save metadata for crashed executions when error saving is enabled', async () => {
+					await lifecycleHooks.runHook('workflowExecuteAfter', [crashedRunWithMetadata, {}]);
+
+					expect(executionMetadataService.save).toHaveBeenCalledWith(executionId, {
+						testKey1: 'testValue1',
+						testKey2: 'testValue2',
+					});
+				});
+
+				it('should save metadata for canceled executions when error saving is enabled', async () => {
+					await lifecycleHooks.runHook('workflowExecuteAfter', [canceledRunWithMetadata, {}]);
+
+					expect(executionMetadataService.save).toHaveBeenCalledWith(executionId, {
+						testKey1: 'testValue1',
+						testKey2: 'testValue2',
+					});
 				});
 			});
 		});

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -12,6 +12,7 @@ import {
 	ExecutionLifecycleHooks,
 } from 'n8n-core';
 import type {
+	ExecutionStatus,
 	IRun,
 	IRunData,
 	IRunExecutionData,
@@ -753,8 +754,11 @@ export function getLifecycleHooksForScalingMain(
 	hookFunctionsFinalizeExecutionStatus(hooks);
 
 	hooks.addHandler('workflowExecuteAfter', async function (fullRunData) {
-		// Don't delete executions before they are finished
-		if (!fullRunData.finished) return;
+		// Only process executions that have reached a terminal status.
+		// We check `status` (not the deprecated `finished` field) because
+		// errored executions have `finished = false` but a terminal `status`.
+		const terminalStatuses: ExecutionStatus[] = ['success', 'error', 'crashed', 'canceled'];
+		if (!terminalStatuses.includes(fullRunData.status) && !fullRunData.waitTill) return;
 
 		const isManualMode = this.mode === 'manual';
 


### PR DESCRIPTION
## Summary

In scaling mode, the `workflowExecuteAfter` hook on the main process returned early whenever the deprecated `finished` flag was falsy. Since `finished` is only `true` for successful executions, this caused all errored/crashed/canceled executions to skip the metadata save step — so any data written via the Execution Data node's "Save Highlight Data" operation was lost.

The guard now checks `status` against the terminal statuses (`success`, `error`, `crashed`, `canceled`), matching how regular mode already behaves. Metadata is correctly flowing from worker to main via `JobFinishedProps.metadata`; the fix simply stops discarding it before it reaches the `execution_metadata` table.

**How to test:** Run a workflow in queue mode (`EXECUTIONS_MODE=queue`) containing an Execution Data node configured to save highlight data, followed by a node that throws. Confirm the highlight data appears on the failed execution.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-446

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- ~[ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included.
- ~[ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)~

🤖 PR Summary generated by AI