### PR TITLE
fix(core): Pass userId through webhook test execution path for redaction

### DIFF
--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -523,6 +523,38 @@ describe('Execution Lifecycle Hooks', () => {
 				expect(redactionProxy.processExecution).toHaveBeenCalledTimes(1);
 			});
 
+			it('should skip nodeExecuteAfterData push when userId is not provided (e.g. webhook execution missing userId)', async () => {
+				lifecycleHooks = getLifecycleHooksForRegularMain(
+					{ executionMode: 'manual', workflowData, pushRef, retryOf, userId: undefined },
+					executionId,
+				);
+
+				const mockTaskData: ITaskData = {
+					startTime: 1,
+					executionTime: 1,
+					executionIndex: 0,
+					source: [],
+					data: { main: [[{ json: { key: 'value' } }]] },
+				};
+
+				await lifecycleHooks.runHook('nodeExecuteAfter', [
+					nodeName,
+					mockTaskData,
+					runExecutionData,
+				]);
+
+				expect(push.send).toHaveBeenCalledWith(
+					expect.objectContaining({ type: 'nodeExecuteAfter' }),
+					pushRef,
+				);
+
+				expect(push.send).not.toHaveBeenCalledWith(
+					expect.objectContaining({ type: 'nodeExecuteAfterData' }),
+					pushRef,
+					true,
+				);
+			});
+
 			it('should skip nodeExecuteAfterData push when user cannot be resolved (fail-closed)', async () => {
 				userRepository.findOne.mockResolvedValue(null);
 				lifecycleHooks = createHooks();

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -656,6 +656,7 @@ export async function executeWebhook(
 			pinData,
 			projectId: project?.id,
 			projectName: project?.name,
+			userId: webhookData.userId,
 		};
 
 		// When resuming from a wait node, copy over the pushRef from the execution-data


### PR DESCRIPTION
## Summary

Fixes the editor showing an endless loading spinner when manually executing webhook-triggered workflows that have "Save Manual Executions" disabled. The fail-closed redaction logic added in #27102 requires resolving the executing user before pushing `nodeExecuteAfterData` to the editor. The test webhook execution path in `webhook-helpers.ts` was not including `webhookData.userId` in the `runData` object passed to `WorkflowRunner`, so `getUser()` returned `null` and all execution data pushes were skipped.

When "Save Manual Executions" is enabled, this is masked because the editor can fall back to reading the completed execution from the DB. When disabled, the execution is soft-deleted after completion and the editor has no way to get the data — hence the endless spinner.

- Adds `userId: webhookData.userId` to the `runData` construction in `executeWebhook()`
- Adds regression test for the missing userId scenario

Regression introduced in https://github.com/n8n-io/n8n/pull/27102.

Fixes https://github.com/n8n-io/n8n/issues/28296

https://linear.app/n8n/issue/ADO-5055

## How to reproduce

1. Create a workflow with a **Webhook** trigger node
2. Add any node after it (e.g. Edit Fields / Set)
3. Open **Workflow Settings** and set **"Save Manual Executions"** to **disabled**
4. Click **"Test workflow"** in the editor to activate the test webhook listener
5. Trigger the webhook: `curl -X POST http://localhost:5678/webhook-test/<path> -H "Content-Type: application/json" -d '{"test":true}'`
6. Observe: node input/output data never renders — the editor shows an endless loading spinner
7. Server logs show: `Skipping execution data push: unable to resolve user for redaction`

## Test plan

- [ ] Reproduce using the steps above and confirm the loading spinner no longer appears
- [ ] Confirm node output data renders correctly in the editor after triggering the webhook
- [ ] Confirm no `Skipping execution data push: unable to resolve user for redaction` in server logs
- [ ] Verify non-webhook manual executions (e.g. Schedule trigger) still work as before
- [ ] Verify production webhook executions (non-test) are unaffected
- [x] I have seen this code, I have run this code, and I take responsibility for this code.