### PR TITLE
fix: Fixes AI Assistant opt-in modal terms link

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -5518,7 +5518,7 @@
 	"instanceAi.welcomeModal.toggle.enabled": "Enabled",
 	"instanceAi.welcomeModal.toggle.disabled": "Disabled",
 	"instanceAi.welcomeModal.disclaimer": "Conversations are processed by external AI providers.",
-	"instanceAi.welcomeModal.readMore": "Read more.",
+	"instanceAi.welcomeModal.readMore": "Read more",
 	"instanceAi.welcomeModal.continue": "Continue",
 	"instanceAi.welcomeModal.enable": "Enable",
 	"instanceAi.welcomeModal.skip": "Skip for now",

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiOptinModal.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiOptinModal.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed, ref, onMounted, watch } from 'vue';
 import { useRouter } from 'vue-router';
-import { N8nButton, N8nHeading, N8nIcon, N8nText } from '@n8n/design-system';
+import { N8nButton, N8nHeading, N8nIcon, N8nLink, N8nText } from '@n8n/design-system';
 import { ElCheckbox } from 'element-plus';
 import { useI18n } from '@n8n/i18n';
 import Modal from '@/app/components/Modal.vue';
@@ -186,9 +186,15 @@ onMounted(() => {
 				<div :class="$style.footer">
 					<N8nText size="small" color="text-light" :class="$style.disclaimer">
 						{{ i18n.baseText('instanceAi.welcomeModal.disclaimer') }}
-						<span :class="$style.readMore">{{
-							i18n.baseText('instanceAi.welcomeModal.readMore')
-						}}</span>
+						<N8nLink
+							href="https://n8n.io/legal/ai-terms/"
+							target="_blank"
+							theme="text"
+							size="small"
+							:underline="true"
+							:class="$style.readMore"
+							>{{ i18n.baseText('instanceAi.welcomeModal.readMore') }}</N8nLink
+						>.
 					</N8nText>
 					<N8nButton
 						variant="solid"
@@ -396,7 +402,11 @@ onMounted(() => {
 }
 
 .readMore {
-	text-decoration: underline;
+	span {
+		&:hover {
+			color: var(--color--text);
+		}
+	}
 }
 
 .continueButton {


### PR DESCRIPTION
## Summary
Adds legal [AI terms URL](https://n8n.io/legal/ai-terms/) to AI Assistant's "Read more" link on opt-in modal

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
