### PR TITLE
test: Enhance test discovery to support dynamic titles

### DIFF
--- a/packages/testing/janitor/src/core/test-discovery-analyzer.test.ts
+++ b/packages/testing/janitor/src/core/test-discovery-analyzer.test.ts
@@ -69,6 +69,21 @@ describe('TestDiscoveryAnalyzer', () => {
 
 			expect(report.specs.map((s) => s.path)).toEqual(['tests/a.spec.ts', 'tests/b.spec.ts']);
 		});
+
+		it('discovers tests whose titles are template literals with substitutions', () => {
+			const file = createFile(
+				'tests/dynamic.spec.ts',
+				`
+for (const path of ['a', 'b']) {
+	test(\`handles \${path}\`, async () => {});
+}
+`,
+			);
+			const report = discoverWith([file]);
+
+			expect(report.specs).toHaveLength(1);
+			expect(report.specs[0].path).toBe('tests/dynamic.spec.ts');
+		});
 	});
 
 	describe('skip and fixme detection', () => {

--- a/packages/testing/janitor/src/core/test-discovery-analyzer.ts
+++ b/packages/testing/janitor/src/core/test-discovery-analyzer.ts
@@ -199,7 +199,10 @@ export class TestDiscoveryAnalyzer {
 
 	/**
 	 * Extract the title string from the first argument of a test/describe call.
-	 * Returns null for calls without a string title (e.g., test.fixme() with no args).
+	 * Returns null for calls without a title argument (e.g., test.fixme() with no args).
+	 * Dynamic titles (template literals with substitutions, concatenation, identifiers)
+	 * return the raw source text so the call still counts as a real test and tags inside
+	 * the static portions can be extracted.
 	 */
 	private extractTitle(call: CallExpression): string | null {
 		const args = call.getArguments();
@@ -207,14 +210,13 @@ export class TestDiscoveryAnalyzer {
 
 		const firstArg = args[0];
 
-		// Handle string literals: 'title', "title", `title`
 		const asString = firstArg.asKind(SyntaxKind.StringLiteral);
 		if (asString) return asString.getLiteralText();
 
 		const asTemplate = firstArg.asKind(SyntaxKind.NoSubstitutionTemplateLiteral);
 		if (asTemplate) return asTemplate.getLiteralText();
 
-		return null;
+		return firstArg.getText();
 	}
 
 	private parseTags(title: string): string[] {

--- a/packages/testing/playwright/tests/e2e/api/webhook-isolation.spec.ts
+++ b/packages/testing/playwright/tests/e2e/api/webhook-isolation.spec.ts
@@ -32,7 +32,7 @@ test.describe(
 		];
 
 		const expectedCSP =
-			'sandbox allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-presentation allow-scripts allow-top-navigation-by-user-activation allow-top-navigation-to-custom-protocols';
+			'sandbox allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-scripts allow-top-navigation-by-user-activation allow-top-navigation-to-custom-protocols';
 
 		for (const webhookPath of webhookPaths) {
 			test(`Webhook responses should include the correct response headers for ${webhookPath}`, async ({


### PR DESCRIPTION
## Summary

Updates the `TestDiscoveryAnalyzer` to correctly process test and describe titles that use template literals with substitutions or other dynamic expressions. This change ensures such tests are recognized for discovery and allows for tag extraction from their static portions.

Also, updates the expected Content Security Policy in Playwright E2E webhook tests to include `allow-popups-to-escape-sandbox`

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
