### PR TITLE
refactor(editor): Migrate `nodeMetadata` to `workflowDocumentStore` (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -1750,7 +1750,6 @@ describe('useCanvasOperations', () => {
 		});
 
 		it('should set node as dirty when node is set active', () => {
-			const workflowsStore = mockedStore(useWorkflowsStore);
 			const node = createTestNode();
 
 			vi.spyOn(workflowDocumentStoreInstance, 'getNodeById').mockImplementation(() => node);
@@ -1758,7 +1757,7 @@ describe('useCanvasOperations', () => {
 			const { setNodeActive } = useCanvasOperations();
 			setNodeActive(node.id, 'other');
 
-			expect(workflowsStore.setNodePristine).toHaveBeenCalledWith(node.name, false);
+			expect(workflowDocumentStoreInstance.setNodePristine).toHaveBeenCalledWith(node.name, false);
 		});
 	});
 
@@ -4857,13 +4856,13 @@ describe('useCanvasOperations', () => {
 				credentials: {},
 				disabled: false,
 			});
-			expect(workflowsStore.setNodePristine).toHaveBeenCalledWith(nodeA.name, true);
+			expect(workflowDocumentStoreInstance.setNodePristine).toHaveBeenCalledWith(nodeA.name, true);
 			expect(workflowDocumentStoreInstance.addNode).toHaveBeenNthCalledWith(2, {
 				...nodeB,
 				credentials: {},
 				disabled: false,
 			});
-			expect(workflowsStore.setNodePristine).toHaveBeenCalledWith(nodeB.name, true);
+			expect(workflowDocumentStoreInstance.setNodePristine).toHaveBeenCalledWith(nodeB.name, true);
 			expect(getNewWorkflowData).toHaveBeenCalledWith(templateName, projectsStore.currentProjectId);
 		});
 	});

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -624,7 +624,7 @@ export function useCanvasOperations() {
 			return;
 		}
 
-		workflowsStore.setNodePristine(node.name, false);
+		workflowDocumentStore.value.setNodePristine(node.name, false);
 		setNodeActiveByName(node.name, source);
 	}
 
@@ -892,7 +892,7 @@ export function useCanvasOperations() {
 				uiStore.markStateDirty();
 			}
 
-			workflowsStore.setNodePristine(nodeData.name, true);
+			workflowDocumentStore.value.setNodePristine(nodeData.name, true);
 			nodeHelpers.matchCredentials(nodeData);
 			nodeHelpers.updateNodeParameterIssues(nodeData);
 			nodeHelpers.updateNodeCredentialIssues(nodeData);

--- a/packages/frontend/editor-ui/src/app/composables/useNodeDirtiness.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeDirtiness.test.ts
@@ -302,10 +302,10 @@ describe(useNodeDirtiness, () => {
 			setupTestWorkflow('a🚨✅ -> b✅📌 -> c✅, b -> d, b -> e✅ -> f✅');
 
 			// Simulate updating pinned data for node 'b' (set metadata timestamp as usePinnedData.setData would)
-			workflowsStore.nodeMetadata.b = {
-				...workflowsStore.nodeMetadata.b,
-				pinnedDataLastUpdatedAt: Date.now(),
-			};
+			const workflowDocumentStore = useWorkflowDocumentStore(
+				createWorkflowDocumentId(workflowsStore.workflow.id),
+			);
+			workflowDocumentStore.touchPinnedDataLastUpdatedAt('b');
 
 			expect(useNodeDirtiness().dirtinessByName.value).toEqual({
 				// 'd' is not marked as pinned-data-updated because it has no run data.
@@ -460,12 +460,12 @@ describe(useNodeDirtiness, () => {
 
 		const workflow = createTestWorkflow({ nodes: Object.values(nodes), connections });
 
-		workflowsStore.setNodes(workflow.nodes);
-		workflowsStore.setConnections(workflow.connections);
-
 		const workflowDocumentStore = useWorkflowDocumentStore(
 			createWorkflowDocumentId(workflowsStore.workflow.id),
 		);
+		workflowDocumentStore.setNodes(workflow.nodes);
+		workflowDocumentStore.setConnections(workflow.connections);
+
 		for (const name of nodeNamesWithPinnedData) {
 			workflowDocumentStore.pinNodeData(name, [{ json: {} }]);
 		}

--- a/packages/frontend/editor-ui/src/app/composables/useNodeDirtiness.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeDirtiness.ts
@@ -147,7 +147,7 @@ export function useNodeDirtiness() {
 		nodeName: string,
 		after: number,
 	): CanvasNodeDirtinessType | undefined {
-		if ((workflowsStore.getParametersLastUpdate(nodeName) ?? 0) > after) {
+		if ((workflowDocumentStore.value.getParametersLastUpdate(nodeName) ?? 0) > after) {
 			return CanvasNodeDirtiness.PARAMETERS_UPDATED;
 		}
 
@@ -292,7 +292,7 @@ export function useNodeDirtiness() {
 				.filter((connection) => connection !== null)
 				.some((connection) => {
 					const pinnedDataLastUpdatedAt =
-						workflowsStore.getPinnedDataLastUpdate(connection.node) ?? 0;
+						workflowDocumentStore.value.getPinnedDataLastUpdate(connection.node) ?? 0;
 
 					return pinnedDataLastUpdatedAt > runAt;
 				});
@@ -302,7 +302,8 @@ export function useNodeDirtiness() {
 				continue;
 			}
 
-			const pinnedDataLastRemovedAt = workflowsStore.getPinnedDataLastRemovedAt(nodeName) ?? 0;
+			const pinnedDataLastRemovedAt =
+				workflowDocumentStore.value.getPinnedDataLastRemovedAt(nodeName) ?? 0;
 
 			if (pinnedDataLastRemovedAt > runAt) {
 				setDirtiness(nodeName, CanvasNodeDirtiness.PINNED_DATA_UPDATED);

--- a/packages/frontend/editor-ui/src/app/composables/usePinnedData.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePinnedData.ts
@@ -283,11 +283,8 @@ export function usePinnedData(
 		if (workflowDocumentStore.value) {
 			const nodeName = targetNode.name;
 			// Update metadata timestamp for existing pinned data
-			if (
-				(workflowDocumentStore.value.pinData[nodeName] ?? []).length > 0 &&
-				workflowsStore.nodeMetadata[nodeName]
-			) {
-				workflowsStore.nodeMetadata[nodeName].pinnedDataLastUpdatedAt = Date.now();
+			if ((workflowDocumentStore.value.pinData[nodeName] ?? []).length > 0) {
+				workflowDocumentStore.value.touchPinnedDataLastUpdatedAt(nodeName);
 			}
 			workflowDocumentStore.value.pinNodeData(nodeName, data as INodeExecutionData[]);
 			uiStore.markStateDirty();
@@ -317,9 +314,7 @@ export function usePinnedData(
 		onUnsetData({ source });
 		if (workflowDocumentStore.value) {
 			workflowDocumentStore.value.unpinNodeData(targetNode.name);
-			if (workflowsStore.nodeMetadata[targetNode.name]) {
-				workflowsStore.nodeMetadata[targetNode.name].pinnedDataLastRemovedAt = Date.now();
-			}
+			workflowDocumentStore.value.touchPinnedDataLastRemovedAt(targetNode.name);
 			uiStore.markStateDirty();
 		}
 	}

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
@@ -57,6 +57,9 @@ const { mockDocumentStore } = vi.hoisted(() => {
 		pinData: {} as Record<string, unknown>,
 		incomingConnectionsByNodeName: vi.fn().mockReturnValue({}),
 		outgoingConnectionsByNodeName: vi.fn().mockReturnValue({}),
+		getParametersLastUpdate: vi.fn(),
+		getPinnedDataLastUpdate: vi.fn(),
+		getPinnedDataLastRemovedAt: vi.fn(),
 		getSnapshot: vi.fn(),
 	};
 	store.getSnapshot.mockReturnValue({
@@ -112,9 +115,6 @@ vi.mock('@/app/stores/workflows.store', () => {
 		getExecution: vi.fn(),
 		checkIfNodeHasChatParent: vi.fn(),
 		checkIfToolNodeHasChatParent: vi.fn(),
-		getParametersLastUpdate: vi.fn(),
-		getPinnedDataLastUpdate: vi.fn(),
-		getPinnedDataLastRemovedAt: vi.fn(),
 		incomingConnectionsByNodeName: vi.fn(),
 		outgoingConnectionsByNodeName: vi.fn(),
 		private: {
@@ -529,7 +529,7 @@ describe('useRunWorkflow({ router })', () => {
 			} as IExecuteData);
 
 			vi.mocked(workflowsStore).checkIfNodeHasChatParent.mockReturnValue(false);
-			vi.mocked(workflowsStore).getParametersLastUpdate.mockImplementation((name: string) => {
+			vi.mocked(mockDocumentStore.getParametersLastUpdate).mockImplementation((name: string) => {
 				if (name === executeName) return 2;
 				return undefined;
 			});

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowState.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowState.test.ts
@@ -253,47 +253,4 @@ describe('useWorkflowState', () => {
 			expect(result).toBe(false);
 		});
 	});
-
-	describe('resetParametersLastUpdatedAt', () => {
-		it('should set parametersLastUpdatedAt on existing metadata', () => {
-			const nodeName = 'Test Node';
-			workflowDocumentStore.addNode({
-				parameters: {},
-				id: 'test-node-id',
-				name: nodeName,
-				type: 'n8n-nodes-base.set',
-				position: [0, 0],
-				typeVersion: 1,
-			});
-
-			expect(workflowDocumentStore.getParametersLastUpdate(nodeName)).toBeUndefined();
-
-			workflowState.resetParametersLastUpdatedAt(nodeName);
-
-			expect(workflowDocumentStore.getParametersLastUpdate(nodeName)).toEqual(expect.any(Number));
-		});
-
-		it('should create metadata if it does not exist', () => {
-			const nodeName = 'New Node Without Metadata';
-			// Node metadata doesn't exist yet
-			expect(workflowDocumentStore.nodeMetadata[nodeName]).toBeUndefined();
-
-			workflowState.resetParametersLastUpdatedAt(nodeName);
-
-			expect(workflowDocumentStore.nodeMetadata[nodeName]).toBeDefined();
-			expect(workflowDocumentStore.getParametersLastUpdate(nodeName)).toEqual(expect.any(Number));
-		});
-
-		it('should preserve existing metadata properties when updating', () => {
-			const nodeName = 'Node With Existing Metadata';
-			workflowDocumentStore.setAllNodeMetadata({
-				[nodeName]: { pristine: true },
-			});
-
-			workflowState.resetParametersLastUpdatedAt(nodeName);
-
-			expect(workflowDocumentStore.isNodePristine(nodeName)).toBe(true);
-			expect(workflowDocumentStore.getParametersLastUpdate(nodeName)).toEqual(expect.any(Number));
-		});
-	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowState.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowState.test.ts
@@ -8,14 +8,22 @@ import {
 } from '@/__tests__/mocks';
 import type { IWorkflowDb } from '@/Interface';
 import { createRunExecutionData } from 'n8n-workflow';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 describe('useWorkflowState', () => {
 	let workflowsStore: ReturnType<typeof useWorkflowsStore>;
+	let workflowDocumentStore: ReturnType<typeof useWorkflowDocumentStore>;
 	let workflowState: WorkflowState;
 	beforeEach(() => {
 		setActivePinia(createPinia());
 
 		workflowsStore = useWorkflowsStore();
+		workflowDocumentStore = useWorkflowDocumentStore(
+			createWorkflowDocumentId(workflowsStore.workflow.id),
+		);
 		workflowState = useWorkflowState();
 	});
 
@@ -82,7 +90,9 @@ describe('useWorkflowState', () => {
 	});
 	describe('setNodeParameters', () => {
 		beforeEach(() => {
-			workflowsStore.setNodes([createTestNode({ name: 'a', parameters: { p: 1, q: true } })]);
+			workflowDocumentStore.setNodes([
+				createTestNode({ name: 'a', parameters: { p: 1, q: true } }),
+			]);
 		});
 
 		it('should set node parameters', () => {
@@ -102,17 +112,17 @@ describe('useWorkflowState', () => {
 		});
 
 		it('should not update last parameter update time if parameters are set to the same value', () => {
-			expect(workflowsStore.getParametersLastUpdate('a')).toEqual(undefined);
+			expect(workflowDocumentStore.getParametersLastUpdate('a')).toEqual(undefined);
 
 			workflowState.setNodeParameters({ name: 'a', value: { p: 1, q: true } });
 
-			expect(workflowsStore.getParametersLastUpdate('a')).toEqual(undefined);
+			expect(workflowDocumentStore.getParametersLastUpdate('a')).toEqual(undefined);
 		});
 	});
 	describe('setNodeValue()', () => {
 		it('should update a node', () => {
 			const nodeName = 'Edit Fields';
-			workflowsStore.addNode({
+			workflowDocumentStore.addNode({
 				parameters: {},
 				id: '554c7ff4-7ee2-407c-8931-e34234c5056a',
 				name: nodeName,
@@ -121,14 +131,12 @@ describe('useWorkflowState', () => {
 				typeVersion: 3.4,
 			});
 
-			expect(workflowsStore.nodeMetadata[nodeName].parametersLastUpdatedAt).toBe(undefined);
+			expect(workflowDocumentStore.getParametersLastUpdate(nodeName)).toBe(undefined);
 
 			workflowState.setNodeValue({ name: 'Edit Fields', key: 'executeOnce', value: true });
 
 			expect(workflowsStore.workflow.nodes[0].executeOnce).toBe(true);
-			expect(workflowsStore.nodeMetadata[nodeName].parametersLastUpdatedAt).toEqual(
-				expect.any(Number),
-			);
+			expect(workflowDocumentStore.getParametersLastUpdate(nodeName)).toEqual(expect.any(Number));
 		});
 	});
 
@@ -136,7 +144,7 @@ describe('useWorkflowState', () => {
 		it('should NOT update parametersLastUpdatedAt', () => {
 			const nodeName = 'Edit Fields';
 			const nodeId = '554c7ff4-7ee2-407c-8931-e34234c5056a';
-			workflowsStore.addNode({
+			workflowDocumentStore.addNode({
 				parameters: {},
 				id: nodeId,
 				name: nodeName,
@@ -145,12 +153,12 @@ describe('useWorkflowState', () => {
 				typeVersion: 3.4,
 			});
 
-			expect(workflowsStore.nodeMetadata[nodeName].parametersLastUpdatedAt).toBe(undefined);
+			expect(workflowDocumentStore.getParametersLastUpdate(nodeName)).toBe(undefined);
 
 			workflowState.setNodePositionById(nodeId, [0, 0]);
 
 			expect(workflowsStore.workflow.nodes[0].position).toStrictEqual([0, 0]);
-			expect(workflowsStore.nodeMetadata[nodeName].parametersLastUpdatedAt).toBe(undefined);
+			expect(workflowDocumentStore.getParametersLastUpdate(nodeName)).toBe(undefined);
 		});
 	});
 	describe('updateNodeAtIndex', () => {
@@ -249,7 +257,7 @@ describe('useWorkflowState', () => {
 	describe('resetParametersLastUpdatedAt', () => {
 		it('should set parametersLastUpdatedAt on existing metadata', () => {
 			const nodeName = 'Test Node';
-			workflowsStore.addNode({
+			workflowDocumentStore.addNode({
 				parameters: {},
 				id: 'test-node-id',
 				name: nodeName,
@@ -258,40 +266,34 @@ describe('useWorkflowState', () => {
 				typeVersion: 1,
 			});
 
-			expect(workflowsStore.nodeMetadata[nodeName].parametersLastUpdatedAt).toBeUndefined();
+			expect(workflowDocumentStore.getParametersLastUpdate(nodeName)).toBeUndefined();
 
 			workflowState.resetParametersLastUpdatedAt(nodeName);
 
-			expect(workflowsStore.nodeMetadata[nodeName].parametersLastUpdatedAt).toEqual(
-				expect.any(Number),
-			);
+			expect(workflowDocumentStore.getParametersLastUpdate(nodeName)).toEqual(expect.any(Number));
 		});
 
 		it('should create metadata if it does not exist', () => {
 			const nodeName = 'New Node Without Metadata';
 			// Node metadata doesn't exist yet
-			expect(workflowsStore.nodeMetadata[nodeName]).toBeUndefined();
+			expect(workflowDocumentStore.nodeMetadata[nodeName]).toBeUndefined();
 
 			workflowState.resetParametersLastUpdatedAt(nodeName);
 
-			expect(workflowsStore.nodeMetadata[nodeName]).toBeDefined();
-			expect(workflowsStore.nodeMetadata[nodeName].parametersLastUpdatedAt).toEqual(
-				expect.any(Number),
-			);
+			expect(workflowDocumentStore.nodeMetadata[nodeName]).toBeDefined();
+			expect(workflowDocumentStore.getParametersLastUpdate(nodeName)).toEqual(expect.any(Number));
 		});
 
 		it('should preserve existing metadata properties when updating', () => {
 			const nodeName = 'Node With Existing Metadata';
-			workflowsStore.nodeMetadata[nodeName] = {
-				pristine: true,
-			};
+			workflowDocumentStore.setAllNodeMetadata({
+				[nodeName]: { pristine: true },
+			});
 
 			workflowState.resetParametersLastUpdatedAt(nodeName);
 
-			expect(workflowsStore.nodeMetadata[nodeName].pristine).toBe(true);
-			expect(workflowsStore.nodeMetadata[nodeName].parametersLastUpdatedAt).toEqual(
-				expect.any(Number),
-			);
+			expect(workflowDocumentStore.isNodePristine(nodeName)).toBe(true);
+			expect(workflowDocumentStore.getParametersLastUpdate(nodeName)).toEqual(expect.any(Number));
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
@@ -74,18 +74,17 @@ export function useWorkflowState() {
 			uiStore.markStateDirty();
 		}
 
+		const workflowDocumentStore = useWorkflowDocumentStore(
+			createWorkflowDocumentId(ws.workflow.id),
+		);
+
 		if (data.removePinData) {
-			if (ws.workflow.id) {
-				const workflowDocumentStore = useWorkflowDocumentStore(
-					createWorkflowDocumentId(ws.workflow.id),
-				);
-				workflowDocumentStore.setPinData({});
-			}
+			workflowDocumentStore.setPinData({});
 		}
 
 		ws.workflow.nodes.splice(0, ws.workflow.nodes.length);
 		ws.workflowObject.setNodes(ws.workflow.nodes);
-		ws.nodeMetadata = {};
+		workflowDocumentStore.setAllNodeMetadata({});
 	}
 
 	function setWorkflowExecutionData(workflowResultData: IExecutionResponse | null) {
@@ -263,7 +262,10 @@ export function useWorkflowState() {
 
 		if (changed) {
 			uiStore.markStateDirty();
-			ws.nodeMetadata[name].parametersLastUpdatedAt = Date.now();
+			const workflowDocumentStore = useWorkflowDocumentStore(
+				createWorkflowDocumentId(ws.workflow.id),
+			);
+			workflowDocumentStore.touchParametersLastUpdatedAt(name);
 		}
 	}
 
@@ -314,7 +316,10 @@ export function useWorkflowState() {
 		const excludeKeys = ['position', 'notes', 'notesInFlow'];
 
 		if (changed && !excludeKeys.includes(updateInformation.key)) {
-			ws.nodeMetadata[ws.workflow.nodes[nodeIndex].name].parametersLastUpdatedAt = Date.now();
+			const workflowDocumentStore = useWorkflowDocumentStore(
+				createWorkflowDocumentId(ws.workflow.id),
+			);
+			workflowDocumentStore.touchParametersLastUpdatedAt(ws.workflow.nodes[nodeIndex].name);
 		}
 	}
 
@@ -340,13 +345,13 @@ export function useWorkflowState() {
 	/**
 	 * Reset parametersLastUpdatedAt to current timestamp for a node.
 	 * Used to mark a node as "dirty" when its parameters change.
-	 * @deprecated Use `workflowDocumentStore.resetParametersLastUpdatedAt()` instead.
+	 * @deprecated Use `workflowDocumentStore.touchParametersLastUpdatedAt()` instead.
 	 */
 	function resetParametersLastUpdatedAt(nodeName: string): void {
-		if (!ws.nodeMetadata[nodeName]) {
-			ws.nodeMetadata[nodeName] = { pristine: true };
-		}
-		ws.nodeMetadata[nodeName].parametersLastUpdatedAt = Date.now();
+		const workflowDocumentStore = useWorkflowDocumentStore(
+			createWorkflowDocumentId(ws.workflow.id),
+		);
+		workflowDocumentStore.touchParametersLastUpdatedAt(nodeName);
 	}
 
 	/** @deprecated Use `workflowDocumentStore.updateNodeProperties()` instead. */

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
@@ -342,18 +342,6 @@ export function useWorkflowState() {
 		return updateNodeAtIndex(nodeIndex, nodeData);
 	}
 
-	/**
-	 * Reset parametersLastUpdatedAt to current timestamp for a node.
-	 * Used to mark a node as "dirty" when its parameters change.
-	 * @deprecated Use `workflowDocumentStore.touchParametersLastUpdatedAt()` instead.
-	 */
-	function resetParametersLastUpdatedAt(nodeName: string): void {
-		const workflowDocumentStore = useWorkflowDocumentStore(
-			createWorkflowDocumentId(ws.workflow.id),
-		);
-		workflowDocumentStore.touchParametersLastUpdatedAt(nodeName);
-	}
-
 	/** @deprecated Use `workflowDocumentStore.updateNodeProperties()` instead. */
 	function updateNodeProperties(
 		this: WorkflowState,
@@ -437,7 +425,6 @@ export function useWorkflowState() {
 		updateNodeAtIndex,
 		updateNodeById,
 		updateNodeProperties,
-		resetParametersLastUpdatedAt,
 
 		// reexport
 		executingNode: workflowStateStore.executingNode,

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.test.ts
@@ -36,7 +36,7 @@ const mockDocumentStore = vi.hoisted(() => ({
 	setName: vi.fn(),
 	setNodes: vi.fn(),
 	setConnections: vi.fn(),
-	resetParametersLastUpdatedAt: vi.fn(),
+	touchParametersLastUpdatedAt: vi.fn(),
 	setPinData: vi.fn(),
 	getPinDataSnapshot: vi.fn().mockReturnValue({}),
 	getNodeByName: vi.fn().mockReturnValue(null),
@@ -51,7 +51,7 @@ vi.mock('@/app/stores/workflowDocument.store', () => ({
 
 // Mock useWorkflowState - using hoisted for proper initialization
 const mockWorkflowState = vi.hoisted(() => ({
-	resetParametersLastUpdatedAt: vi.fn(),
+	touchParametersLastUpdatedAt: vi.fn(),
 }));
 vi.mock('@/app/composables/useWorkflowState', () => ({
 	injectWorkflowState: vi.fn(() => mockWorkflowState),
@@ -100,7 +100,7 @@ describe('useWorkflowUpdate', () => {
 		vi.mocked(mockDocumentStore.setName).mockClear();
 		vi.mocked(mockDocumentStore.setNodes).mockClear();
 		vi.mocked(mockDocumentStore.setConnections).mockClear();
-		vi.mocked(mockDocumentStore.resetParametersLastUpdatedAt).mockClear();
+		vi.mocked(mockDocumentStore.touchParametersLastUpdatedAt).mockClear();
 		vi.mocked(mockDocumentStore.setPinData).mockClear();
 		vi.mocked(mockDocumentStore.getPinDataSnapshot).mockReturnValue({});
 		vi.mocked(mockDocumentStore.getNodeByName).mockReturnValue(null);
@@ -605,7 +605,7 @@ describe('useWorkflowUpdate', () => {
 					connections: {},
 				});
 
-				expect(mockDocumentStore.resetParametersLastUpdatedAt).toHaveBeenCalledWith('HTTP Request');
+				expect(mockDocumentStore.touchParametersLastUpdatedAt).toHaveBeenCalledWith('HTTP Request');
 			});
 
 			it('should not mark node as dirty when parameters are unchanged', async () => {
@@ -640,7 +640,7 @@ describe('useWorkflowUpdate', () => {
 					connections: {},
 				});
 
-				expect(mockDocumentStore.resetParametersLastUpdatedAt).not.toHaveBeenCalled();
+				expect(mockDocumentStore.touchParametersLastUpdatedAt).not.toHaveBeenCalled();
 			});
 		});
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
@@ -168,7 +168,7 @@ export function useWorkflowUpdate() {
 
 			// Mark node as dirty if parameters changed
 			if (!isEqual(existing.parameters, updated.parameters)) {
-				workflowDocumentStore.value.resetParametersLastUpdatedAt(nodeName);
+				workflowDocumentStore.value.touchParametersLastUpdatedAt(nodeName);
 				hasChanges = true;
 			}
 		}

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -23,6 +23,7 @@ import { useWorkflowDocumentConnections } from './workflowDocument/useWorkflowDo
 import { useWorkflowDocumentGraph } from './workflowDocument/useWorkflowDocumentGraph';
 import { useWorkflowDocumentExpression } from './workflowDocument/useWorkflowDocumentExpression';
 import { useWorkflowDocumentName } from './workflowDocument/useWorkflowDocumentName';
+import { useWorkflowDocumentNodeMetadata } from './workflowDocument/useWorkflowDocumentNodeMetadata';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import type { WorkflowObjectAccessors } from '../types';
@@ -67,6 +68,7 @@ type ExpressionReturn = ReturnType<typeof useWorkflowDocumentExpression>;
 type MetaReturn = ReturnType<typeof useWorkflowDocumentMeta>;
 type PinDataReturn = ReturnType<typeof useWorkflowDocumentPinData>;
 type SettingsReturn = ReturnType<typeof useWorkflowDocumentSettings>;
+type NodeMetadataReturn = ReturnType<typeof useWorkflowDocumentNodeMetadata>;
 
 // Pairwise collision checks — add new composables here when they are created.
 // If any pair shares a key, the corresponding tuple slot becomes an error type
@@ -83,6 +85,12 @@ void (0 as unknown as [
 	AssertNoOverlap<MetaReturn, ConnectionsReturn>,
 	AssertNoOverlap<PinDataReturn, NodesReturn>,
 	AssertNoOverlap<SettingsReturn, NodesReturn>,
+	AssertNoOverlap<NodeMetadataReturn, NodesReturn>,
+	AssertNoOverlap<NodeMetadataReturn, ConnectionsReturn>,
+	AssertNoOverlap<NodeMetadataReturn, GraphReturn>,
+	AssertNoOverlap<NodeMetadataReturn, PinDataReturn>,
+	AssertNoOverlap<NodeMetadataReturn, MetaReturn>,
+	AssertNoOverlap<NodeMetadataReturn, SettingsReturn>,
 ]);
 
 export type WorkflowDocumentId = `${string}@${string}`;
@@ -133,8 +141,10 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 		const workflowDocumentVersionData = useWorkflowDocumentVersionData();
 		const workflowDocumentViewport = useWorkflowDocumentViewport();
 		const nodeTypesStore = useNodeTypesStore();
+		const workflowDocumentNodeMetadata = useWorkflowDocumentNodeMetadata();
 		const { onStateDirty: onNodesStateDirty, ...workflowDocumentNodes } = useWorkflowDocumentNodes({
 			getNodeType: (typeName, version) => nodeTypesStore.getNodeType(typeName, version),
+			nodeMetadata: workflowDocumentNodeMetadata,
 		});
 		const { onStateDirty: onConnectionsStateDirty, ...workflowDocumentConnections } =
 			useWorkflowDocumentConnections({
@@ -198,6 +208,7 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 			...workflowDocumentConnections,
 			...workflowDocumentGraph,
 			...workflowDocumentExpression,
+			...workflowDocumentNodeMetadata,
 			removeAllNodes,
 			getSnapshot,
 		};

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentGraph.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentGraph.test.ts
@@ -30,13 +30,17 @@ import {
 } from './useWorkflowDocumentNodes';
 import { useWorkflowDocumentConnections } from './useWorkflowDocumentConnections';
 import { useWorkflowDocumentGraph } from './useWorkflowDocumentGraph';
+import { useWorkflowDocumentNodeMetadata } from './useWorkflowDocumentNodeMetadata';
 
 function createNode(overrides: Partial<INodeUi> = {}): INodeUi {
 	return createTestNode({ name: 'Test Node', ...overrides }) as INodeUi;
 }
 
 function createNodesDeps(): WorkflowDocumentNodesDeps {
-	return { getNodeType: vi.fn().mockReturnValue(null) };
+	return {
+		getNodeType: vi.fn().mockReturnValue(null),
+		nodeMetadata: useWorkflowDocumentNodeMetadata(),
+	};
 }
 
 describe('useWorkflowDocumentGraph', () => {

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodeMetadata.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodeMetadata.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useWorkflowDocumentNodeMetadata } from './useWorkflowDocumentNodeMetadata';
+
+function createStore() {
+	return useWorkflowDocumentNodeMetadata();
+}
+
+describe('useWorkflowDocumentNodeMetadata', () => {
+	describe('init lifecycle', () => {
+		it('initPristineNodeMetadata creates { pristine: true }', () => {
+			const store = createStore();
+			store.initPristineNodeMetadata('A');
+			expect(store.nodeMetadata.value.A).toEqual({ pristine: true });
+		});
+
+		it('initNodeMetadata creates {}', () => {
+			const store = createStore();
+			store.initNodeMetadata('A');
+			expect(store.nodeMetadata.value.A).toEqual({});
+		});
+
+		it('initNodeMetadata does not overwrite existing entry', () => {
+			const store = createStore();
+			store.initPristineNodeMetadata('A');
+			store.initNodeMetadata('A');
+			expect(store.nodeMetadata.value.A).toEqual({ pristine: true });
+		});
+
+		it('initPristineNodeMetadata does not overwrite existing entry', () => {
+			const store = createStore();
+			store.initNodeMetadata('A');
+			store.initPristineNodeMetadata('A');
+			expect(store.nodeMetadata.value.A).toEqual({});
+		});
+
+		it('removeNodeMetadata removes entry', () => {
+			const store = createStore();
+			store.initPristineNodeMetadata('A');
+			store.removeNodeMetadata('A');
+			expect(store.nodeMetadata.value.A).toBeUndefined();
+		});
+
+		it('renameNodeMetadata moves key, preserves fields', () => {
+			const store = createStore();
+			store.initPristineNodeMetadata('A');
+			store.touchParametersLastUpdatedAt('A');
+			const ts = store.nodeMetadata.value.A.parametersLastUpdatedAt;
+
+			store.renameNodeMetadata('A', 'B');
+
+			expect(store.nodeMetadata.value.A).toBeUndefined();
+			expect(store.nodeMetadata.value.B).toEqual({ pristine: true, parametersLastUpdatedAt: ts });
+		});
+
+		it('renameNodeMetadata is a no-op when source does not exist', () => {
+			const store = createStore();
+			store.renameNodeMetadata('A', 'B');
+			expect(store.nodeMetadata.value.B).toBeUndefined();
+		});
+
+		it('setAllNodeMetadata replaces map', () => {
+			const store = createStore();
+			store.initPristineNodeMetadata('A');
+			store.setAllNodeMetadata({ Z: { pristine: false } });
+			expect(store.nodeMetadata.value).toEqual({ Z: { pristine: false } });
+		});
+	});
+
+	describe('touches', () => {
+		it('touchParametersLastUpdatedAt sets Date.now', () => {
+			const store = createStore();
+			store.initPristineNodeMetadata('A');
+			store.touchParametersLastUpdatedAt('A');
+			expect(store.nodeMetadata.value.A.parametersLastUpdatedAt).toEqual(expect.any(Number));
+		});
+
+		it('touchParametersLastUpdatedAt creates { pristine: true } if missing', () => {
+			const store = createStore();
+			store.touchParametersLastUpdatedAt('A');
+			expect(store.nodeMetadata.value.A.pristine).toBe(true);
+			expect(store.nodeMetadata.value.A.parametersLastUpdatedAt).toEqual(expect.any(Number));
+		});
+
+		it('touchPinnedDataLastUpdatedAt sets pinnedDataLastUpdatedAt only', () => {
+			const store = createStore();
+			store.initPristineNodeMetadata('A');
+			store.touchPinnedDataLastUpdatedAt('A');
+			expect(store.nodeMetadata.value.A.pinnedDataLastUpdatedAt).toEqual(expect.any(Number));
+			expect(store.nodeMetadata.value.A.pinnedDataLastRemovedAt).toBeUndefined();
+			expect(store.nodeMetadata.value.A.parametersLastUpdatedAt).toBeUndefined();
+		});
+
+		it('touchPinnedDataLastRemovedAt sets pinnedDataLastRemovedAt only', () => {
+			const store = createStore();
+			store.initPristineNodeMetadata('A');
+			store.touchPinnedDataLastRemovedAt('A');
+			expect(store.nodeMetadata.value.A.pinnedDataLastRemovedAt).toEqual(expect.any(Number));
+			expect(store.nodeMetadata.value.A.pinnedDataLastUpdatedAt).toBeUndefined();
+		});
+
+		it('clearPinnedDataTimestamps removes both pinned timestamps', () => {
+			const store = createStore();
+			store.initPristineNodeMetadata('A');
+			store.touchPinnedDataLastUpdatedAt('A');
+			store.touchPinnedDataLastRemovedAt('A');
+
+			store.clearPinnedDataTimestamps('A');
+
+			expect(store.nodeMetadata.value.A.pinnedDataLastUpdatedAt).toBeUndefined();
+			expect(store.nodeMetadata.value.A.pinnedDataLastRemovedAt).toBeUndefined();
+			// Preserves pristine and other fields
+			expect(store.nodeMetadata.value.A.pristine).toBe(true);
+		});
+
+		it('clearPinnedDataTimestamps is a no-op when entry is missing', () => {
+			const store = createStore();
+			store.clearPinnedDataTimestamps('A');
+			expect(store.nodeMetadata.value.A).toBeUndefined();
+		});
+	});
+
+	describe('getters', () => {
+		it('isNodePristine returns true when entry missing', () => {
+			const store = createStore();
+			expect(store.isNodePristine('A')).toBe(true);
+		});
+
+		it('isNodePristine returns pristine flag when entry present', () => {
+			const store = createStore();
+			store.initPristineNodeMetadata('A');
+			expect(store.isNodePristine('A')).toBe(true);
+
+			store.setNodePristine('A', false);
+			expect(store.isNodePristine('A')).toBe(false);
+		});
+
+		it('getParametersLastUpdate returns undefined when missing', () => {
+			const store = createStore();
+			expect(store.getParametersLastUpdate('A')).toBeUndefined();
+		});
+
+		it('getParametersLastUpdate returns timestamp when set', () => {
+			const store = createStore();
+			store.touchParametersLastUpdatedAt('A');
+			expect(store.getParametersLastUpdate('A')).toEqual(expect.any(Number));
+		});
+
+		it('getPinnedDataLastUpdate returns undefined when missing', () => {
+			const store = createStore();
+			expect(store.getPinnedDataLastUpdate('A')).toBeUndefined();
+		});
+
+		it('getPinnedDataLastRemovedAt returns undefined when missing', () => {
+			const store = createStore();
+			expect(store.getPinnedDataLastRemovedAt('A')).toBeUndefined();
+		});
+	});
+
+	describe('events', () => {
+		it('fires ADD on init', () => {
+			const store = createStore();
+			const hookSpy = vi.fn();
+			store.onNodeMetadataChange(hookSpy);
+
+			store.initPristineNodeMetadata('A');
+
+			expect(hookSpy).toHaveBeenCalledWith({
+				action: 'add',
+				payload: { nodeName: 'A', metadata: { pristine: true } },
+			});
+		});
+
+		it('fires DELETE on removeNodeMetadata', () => {
+			const store = createStore();
+			store.initPristineNodeMetadata('A');
+
+			const hookSpy = vi.fn();
+			store.onNodeMetadataChange(hookSpy);
+			store.removeNodeMetadata('A');
+
+			expect(hookSpy).toHaveBeenCalledWith({
+				action: 'delete',
+				payload: { nodeName: 'A', metadata: undefined },
+			});
+		});
+
+		it('fires UPDATE on rename', () => {
+			const store = createStore();
+			store.initPristineNodeMetadata('A');
+
+			const hookSpy = vi.fn();
+			store.onNodeMetadataChange(hookSpy);
+			store.renameNodeMetadata('A', 'B');
+
+			expect(hookSpy).toHaveBeenCalledWith({
+				action: 'update',
+				payload: { nodeName: 'B', metadata: { pristine: true } },
+			});
+		});
+
+		it('fires UPDATE on setNodePristine', () => {
+			const store = createStore();
+			store.initPristineNodeMetadata('A');
+
+			const hookSpy = vi.fn();
+			store.onNodeMetadataChange(hookSpy);
+			store.setNodePristine('A', false);
+
+			expect(hookSpy).toHaveBeenCalledWith({
+				action: 'update',
+				payload: { nodeName: 'A', metadata: { pristine: false } },
+			});
+		});
+
+		it('fires bulk UPDATE on setAllNodeMetadata', () => {
+			const store = createStore();
+			const hookSpy = vi.fn();
+			store.onNodeMetadataChange(hookSpy);
+
+			store.setAllNodeMetadata({ A: { pristine: true } });
+
+			expect(hookSpy).toHaveBeenCalledWith({
+				action: 'update',
+				payload: { nodeMetadata: { A: { pristine: true } } },
+			});
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodeMetadata.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodeMetadata.ts
@@ -1,0 +1,177 @@
+import { ref, readonly } from 'vue';
+import { createEventHook } from '@vueuse/core';
+import type { INodeMetadata, NodeMetadataMap } from '@/Interface';
+import { CHANGE_ACTION } from './types';
+import type { ChangeAction, ChangeEvent } from './types';
+
+export type NodeMetadataNodePayload = {
+	nodeName: string;
+	metadata: INodeMetadata | undefined;
+};
+
+export type NodeMetadataBulkPayload = {
+	nodeMetadata: NodeMetadataMap;
+};
+
+export type NodeMetadataChangeEvent =
+	| ChangeEvent<NodeMetadataNodePayload>
+	| ChangeEvent<NodeMetadataBulkPayload>;
+
+export function useWorkflowDocumentNodeMetadata() {
+	const nodeMetadata = ref<NodeMetadataMap>({});
+
+	const onNodeMetadataChange = createEventHook<NodeMetadataChangeEvent>();
+
+	// -------------------------------------------------------------------
+	// Apply methods (private) — only functions that mutate state
+	// -------------------------------------------------------------------
+
+	function applySetAll(map: NodeMetadataMap, action: ChangeAction = CHANGE_ACTION.UPDATE) {
+		nodeMetadata.value = map;
+		void onNodeMetadataChange.trigger({ action, payload: { nodeMetadata: map } });
+	}
+
+	function applyInitNode(name: string, seed: INodeMetadata) {
+		nodeMetadata.value = { ...nodeMetadata.value, [name]: seed };
+		void onNodeMetadataChange.trigger({
+			action: CHANGE_ACTION.ADD,
+			payload: { nodeName: name, metadata: seed },
+		});
+	}
+
+	function applyPatchNode(name: string, patch: Partial<INodeMetadata>) {
+		const existing = nodeMetadata.value[name] ?? ({} as INodeMetadata);
+		const merged: INodeMetadata = { ...existing, ...patch };
+		nodeMetadata.value = { ...nodeMetadata.value, [name]: merged };
+		void onNodeMetadataChange.trigger({
+			action: CHANGE_ACTION.UPDATE,
+			payload: { nodeName: name, metadata: merged },
+		});
+	}
+
+	function applyDeleteFields(name: string, fields: Array<keyof INodeMetadata>) {
+		if (!nodeMetadata.value[name]) return;
+		const next = { ...nodeMetadata.value[name] };
+		for (const field of fields) {
+			delete next[field];
+		}
+		nodeMetadata.value = { ...nodeMetadata.value, [name]: next };
+		void onNodeMetadataChange.trigger({
+			action: CHANGE_ACTION.UPDATE,
+			payload: { nodeName: name, metadata: next },
+		});
+	}
+
+	function applyDeleteNode(name: string) {
+		if (!nodeMetadata.value.hasOwnProperty(name)) return;
+		const { [name]: _removed, ...rest } = nodeMetadata.value;
+		nodeMetadata.value = rest;
+		void onNodeMetadataChange.trigger({
+			action: CHANGE_ACTION.DELETE,
+			payload: { nodeName: name, metadata: undefined },
+		});
+	}
+
+	function applyRenameNode(oldName: string, newName: string) {
+		if (!nodeMetadata.value.hasOwnProperty(oldName)) return;
+		const { [oldName]: renamed, ...rest } = nodeMetadata.value;
+		nodeMetadata.value = { ...rest, [newName]: renamed };
+		void onNodeMetadataChange.trigger({
+			action: CHANGE_ACTION.UPDATE,
+			payload: { nodeName: newName, metadata: renamed },
+		});
+	}
+
+	// -------------------------------------------------------------------
+	// Public API
+	// -------------------------------------------------------------------
+
+	function setAllNodeMetadata(map: NodeMetadataMap): void {
+		applySetAll(map);
+	}
+
+	/** Idempotent init — matches legacy `addNode` which creates an empty entry. */
+	function initNodeMetadata(nodeName: string): void {
+		if (nodeMetadata.value[nodeName]) return;
+		applyInitNode(nodeName, {} as INodeMetadata);
+	}
+
+	/** Idempotent init with pristine=true — matches legacy `setNodes` behavior. */
+	function initPristineNodeMetadata(nodeName: string): void {
+		if (nodeMetadata.value[nodeName]) return;
+		applyInitNode(nodeName, { pristine: true });
+	}
+
+	function removeNodeMetadata(nodeName: string): void {
+		applyDeleteNode(nodeName);
+	}
+
+	function renameNodeMetadata(oldName: string, newName: string): void {
+		applyRenameNode(oldName, newName);
+	}
+
+	function setNodePristine(nodeName: string, pristine: boolean): void {
+		applyPatchNode(nodeName, { pristine });
+	}
+
+	function touchParametersLastUpdatedAt(nodeName: string): void {
+		if (!nodeMetadata.value[nodeName]) {
+			applyInitNode(nodeName, { pristine: true });
+		}
+		applyPatchNode(nodeName, { parametersLastUpdatedAt: Date.now() });
+	}
+
+	function touchPinnedDataLastUpdatedAt(nodeName: string): void {
+		if (!nodeMetadata.value[nodeName]) {
+			applyInitNode(nodeName, { pristine: true });
+		}
+		applyPatchNode(nodeName, { pinnedDataLastUpdatedAt: Date.now() });
+	}
+
+	function touchPinnedDataLastRemovedAt(nodeName: string): void {
+		if (!nodeMetadata.value[nodeName]) {
+			applyInitNode(nodeName, { pristine: true });
+		}
+		applyPatchNode(nodeName, { pinnedDataLastRemovedAt: Date.now() });
+	}
+
+	function clearPinnedDataTimestamps(nodeName: string): void {
+		applyDeleteFields(nodeName, ['pinnedDataLastUpdatedAt', 'pinnedDataLastRemovedAt']);
+	}
+
+	function getParametersLastUpdate(nodeName: string): number | undefined {
+		return nodeMetadata.value[nodeName]?.parametersLastUpdatedAt;
+	}
+
+	function getPinnedDataLastUpdate(nodeName: string): number | undefined {
+		return nodeMetadata.value[nodeName]?.pinnedDataLastUpdatedAt;
+	}
+
+	function getPinnedDataLastRemovedAt(nodeName: string): number | undefined {
+		return nodeMetadata.value[nodeName]?.pinnedDataLastRemovedAt;
+	}
+
+	function isNodePristine(nodeName: string): boolean {
+		const entry = nodeMetadata.value[nodeName];
+		return entry === undefined || entry.pristine;
+	}
+
+	return {
+		nodeMetadata: readonly(nodeMetadata),
+		setAllNodeMetadata,
+		initNodeMetadata,
+		initPristineNodeMetadata,
+		removeNodeMetadata,
+		renameNodeMetadata,
+		setNodePristine,
+		touchParametersLastUpdatedAt,
+		touchPinnedDataLastUpdatedAt,
+		touchPinnedDataLastRemovedAt,
+		clearPinnedDataTimestamps,
+		getParametersLastUpdate,
+		getPinnedDataLastUpdate,
+		getPinnedDataLastRemovedAt,
+		isNodePristine,
+		onNodeMetadataChange: onNodeMetadataChange.on,
+	};
+}

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.test.ts
@@ -190,6 +190,20 @@ describe('useWorkflowDocumentNodes', () => {
 
 			expect(deps.nodeMetadata.nodeMetadata.value).toEqual({});
 		});
+
+		it('setNodes replaces all metadata to match the new node list', () => {
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([createNode({ name: 'A' }), createNode({ name: 'B' })]);
+			deps.nodeMetadata.touchParametersLastUpdatedAt('A');
+
+			workflowDocumentNodes.setNodes([createNode({ name: 'A' }), createNode({ name: 'C' })]);
+
+			// Metadata is reset: 'B' removed, 'A' reset to pristine, 'C' added
+			expect(deps.nodeMetadata.nodeMetadata.value).toEqual({
+				A: { pristine: true },
+				C: { pristine: true },
+			});
+		});
 	});
 
 	describe('round-trip: mutations → read', () => {

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.test.ts
@@ -17,13 +17,13 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { createTestNode } from '@/__tests__/mocks';
 import type { INodeUi } from '@/Interface';
 import {
 	useWorkflowDocumentNodes,
 	type WorkflowDocumentNodesDeps,
 } from './useWorkflowDocumentNodes';
+import { useWorkflowDocumentNodeMetadata } from './useWorkflowDocumentNodeMetadata';
 
 function createNode(overrides: Partial<INodeUi> = {}): INodeUi {
 	return createTestNode({ name: 'Test Node', ...overrides }) as INodeUi;
@@ -32,17 +32,16 @@ function createNode(overrides: Partial<INodeUi> = {}): INodeUi {
 function createDeps(overrides: Partial<WorkflowDocumentNodesDeps> = {}): WorkflowDocumentNodesDeps {
 	return {
 		getNodeType: vi.fn().mockReturnValue(null),
+		nodeMetadata: useWorkflowDocumentNodeMetadata(),
 		...overrides,
 	};
 }
 
 describe('useWorkflowDocumentNodes', () => {
-	let workflowsStore: ReturnType<typeof useWorkflowsStore>;
 	let deps: WorkflowDocumentNodesDeps;
 
 	beforeEach(() => {
 		setActivePinia(createPinia());
-		workflowsStore = useWorkflowsStore();
 		deps = createDeps();
 	});
 
@@ -185,11 +184,11 @@ describe('useWorkflowDocumentNodes', () => {
 			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
 			workflowDocumentNodes.setNodes([createNode({ name: 'A' })]);
 
-			expect(workflowsStore.nodeMetadata).toHaveProperty('A');
+			expect(deps.nodeMetadata.nodeMetadata.value).toHaveProperty('A');
 
 			workflowDocumentNodes.removeAllNodes();
 
-			expect(workflowsStore.nodeMetadata).toEqual({});
+			expect(deps.nodeMetadata.nodeMetadata.value).toEqual({});
 		});
 	});
 
@@ -381,10 +380,10 @@ describe('useWorkflowDocumentNodes', () => {
 			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
 			workflowDocumentNodes.setNodes([node]);
 
-			const tsBefore = workflowsStore.nodeMetadata.Target.parametersLastUpdatedAt;
+			const tsBefore = deps.nodeMetadata.getParametersLastUpdate('Target');
 			workflowDocumentNodes.setNodeValue({ name: 'Target', key: 'position', value: [300, 400] });
 
-			expect(workflowsStore.nodeMetadata.Target.parametersLastUpdatedAt).toBe(tsBefore);
+			expect(deps.nodeMetadata.getParametersLastUpdate('Target')).toBe(tsBefore);
 		});
 
 		it('setNodeValue updates parametersLastUpdatedAt for non-position changes', () => {
@@ -395,27 +394,7 @@ describe('useWorkflowDocumentNodes', () => {
 
 			workflowDocumentNodes.setNodeValue({ name: 'Target', key: 'disabled', value: true });
 
-			expect(workflowsStore.nodeMetadata.Target.parametersLastUpdatedAt).toBeGreaterThan(0);
-		});
-
-		it('resetParametersLastUpdatedAt updates timestamp', () => {
-			const node = createNode({ name: 'Target' });
-
-			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
-			workflowDocumentNodes.setNodes([node]);
-
-			workflowDocumentNodes.resetParametersLastUpdatedAt('Target');
-
-			expect(workflowsStore.nodeMetadata.Target.parametersLastUpdatedAt).toBeGreaterThan(0);
-		});
-
-		it('resetParametersLastUpdatedAt creates metadata entry if missing', () => {
-			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
-
-			workflowDocumentNodes.resetParametersLastUpdatedAt('NewNode');
-
-			expect(workflowsStore.nodeMetadata.NewNode).toBeDefined();
-			expect(workflowsStore.nodeMetadata.NewNode.parametersLastUpdatedAt).toBeGreaterThan(0);
+			expect(deps.nodeMetadata.getParametersLastUpdate('Target') ?? 0).toBeGreaterThan(0);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.ts
@@ -80,6 +80,8 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 
 	function applySetNodes(nodes: INodeUi[]) {
 		workflowsStore.setNodes(nodes);
+		// setNodes replaces the full node list, so reset metadata to match
+		deps.nodeMetadata.setAllNodeMetadata({});
 		for (const node of nodes) {
 			deps.nodeMetadata.initPristineNodeMetadata(node.name);
 		}

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.ts
@@ -20,6 +20,7 @@ import isEqual from 'lodash/isEqual';
 import findLast from 'lodash/findLast';
 import { CHANGE_ACTION } from './types';
 import type { ChangeEvent } from './types';
+import type { useWorkflowDocumentNodeMetadata } from './useWorkflowDocumentNodeMetadata';
 
 // --- Event types ---
 
@@ -32,6 +33,7 @@ export type NodesChangeEvent = ChangeEvent<NodeAddedPayload> | ChangeEvent<NodeR
 
 export interface WorkflowDocumentNodesDeps {
 	getNodeType: (typeName: string, version?: number) => INodeTypeDescription | null;
+	nodeMetadata: ReturnType<typeof useWorkflowDocumentNodeMetadata>;
 }
 
 // --- Composable ---
@@ -78,10 +80,14 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 
 	function applySetNodes(nodes: INodeUi[]) {
 		workflowsStore.setNodes(nodes);
+		for (const node of nodes) {
+			deps.nodeMetadata.initPristineNodeMetadata(node.name);
+		}
 	}
 
 	function applyAddNode(node: INodeUi) {
 		workflowsStore.addNode(node);
+		deps.nodeMetadata.initNodeMetadata(node.name);
 		void onNodesChange.trigger({
 			action: CHANGE_ACTION.ADD,
 			payload: { node },
@@ -91,6 +97,7 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 
 	function applyRemoveNode(node: INodeUi) {
 		workflowsStore.removeNode(node);
+		deps.nodeMetadata.removeNodeMetadata(node.name);
 		void onNodesChange.trigger({
 			action: CHANGE_ACTION.DELETE,
 			payload: { name: node.name, id: node.id },
@@ -101,6 +108,9 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 	function applyRemoveNodeById(id: string) {
 		const node = workflowsStore.getNodeById(id);
 		workflowsStore.removeNodeById(id);
+		if (node) {
+			deps.nodeMetadata.removeNodeMetadata(node.name);
+		}
 		void onNodesChange.trigger({
 			action: CHANGE_ACTION.DELETE,
 			payload: { name: node?.name ?? '', id },
@@ -184,7 +194,7 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 
 		if (changed) {
 			void onStateDirty.trigger();
-			workflowsStore.nodeMetadata[name].parametersLastUpdatedAt = Date.now();
+			deps.nodeMetadata.touchParametersLastUpdatedAt(name);
 		}
 	}
 
@@ -232,9 +242,7 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 		const excludeKeys = ['position', 'notes', 'notesInFlow'];
 
 		if (changed && !excludeKeys.includes(updateInformation.key)) {
-			workflowsStore.nodeMetadata[
-				workflowsStore.workflow.nodes[nodeIndex].name
-			].parametersLastUpdatedAt = Date.now();
+			deps.nodeMetadata.touchParametersLastUpdatedAt(workflowsStore.workflow.nodes[nodeIndex].name);
 		}
 	}
 
@@ -303,7 +311,7 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 	function removeAllNodes(): void {
 		workflowsStore.workflow.nodes.splice(0, workflowsStore.workflow.nodes.length);
 		workflowsStore.workflowObject.setNodes(workflowsStore.workflow.nodes);
-		workflowsStore.nodeMetadata = {};
+		deps.nodeMetadata.setAllNodeMetadata({});
 	}
 
 	function resetAllNodesIssues(): boolean {
@@ -311,13 +319,6 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 			node.issues = undefined;
 		});
 		return true;
-	}
-
-	function resetParametersLastUpdatedAt(nodeName: string): void {
-		if (!workflowsStore.nodeMetadata[nodeName]) {
-			workflowsStore.nodeMetadata[nodeName] = { pristine: true };
-		}
-		workflowsStore.nodeMetadata[nodeName].parametersLastUpdatedAt = Date.now();
 	}
 
 	return {
@@ -345,7 +346,6 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 		removeAllNodes,
 		resetAllNodesIssues,
 		setLastNodeParameters,
-		resetParametersLastUpdatedAt,
 
 		// Events
 		onNodesChange: onNodesChange.on,

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
@@ -1369,10 +1369,6 @@ describe('useWorkflowsStore', () => {
 			expect(workflowsStore.workflow.nodes[0].id).toEqual(setNodeId);
 			expect(workflowsStore.workflow.nodes[1].id).toEqual(credentialOnlyNodeId);
 			expect(workflowsStore.workflow.nodes[1].type).toEqual('n8n-creds-base.alienVaultApi');
-			expect(workflowsStore.nodeMetadata).toEqual({
-				'AlienVault Request': { pristine: true },
-				'Edit Fields': { pristine: true },
-			});
 		});
 	});
 
@@ -1769,7 +1765,10 @@ describe('useWorkflowsStore', () => {
 
 			workflowsStore.workflow.id = 'test-workflow-id';
 
-			workflowsStore.addNode({
+			const workflowDocumentStore = useWorkflowDocumentStore(
+				createWorkflowDocumentId(workflowsStore.workflow.id),
+			);
+			workflowDocumentStore.addNode({
 				parameters: {},
 				id: '554c7ff4-7ee2-407c-8931-e34234c5056a',
 				name: nodeName,
@@ -1778,9 +1777,6 @@ describe('useWorkflowsStore', () => {
 				typeVersion: 3.4,
 			});
 
-			const workflowDocumentStore = useWorkflowDocumentStore(
-				createWorkflowDocumentId(workflowsStore.workflow.id),
-			);
 			workflowDocumentStore.setPinData({
 				[nodeName]: [
 					{
@@ -1814,8 +1810,8 @@ describe('useWorkflowsStore', () => {
 
 			workflowsStore.renameNodeSelectedAndExecution({ old: nodeName, new: newName });
 
-			expect(workflowsStore.nodeMetadata[nodeName]).not.toBeDefined();
-			expect(workflowsStore.nodeMetadata[newName]).toEqual({});
+			expect(workflowDocumentStore.nodeMetadata[nodeName]).not.toBeDefined();
+			expect(workflowDocumentStore.nodeMetadata[newName]).toEqual({});
 			expect(
 				workflowsStore.workflowExecutionData?.data?.resultData.runData[nodeName],
 			).not.toBeDefined();

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -8,14 +8,7 @@ import {
 	WAIT_NODE_TYPE,
 } from '@/app/constants';
 import { STORES } from '@n8n/stores';
-import type {
-	INodeMetadata,
-	INodeUi,
-	IStartRunData,
-	IWorkflowDb,
-	NodeMetadataMap,
-	WorkflowValidationIssue,
-} from '@/Interface';
+import type { INodeUi, IStartRunData, IWorkflowDb, WorkflowValidationIssue } from '@/Interface';
 import type {
 	IExecutionPushResponse,
 	IExecutionResponse,
@@ -137,7 +130,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	const workflowExecutionResultDataLastUpdate = ref<number>();
 	const workflowExecutionPairedItemMappings = ref<Record<string, Set<string>>>({});
 	const executionWaitingForWebhook = ref(false);
-	const nodeMetadata = ref<NodeMetadataMap>({});
 	const isInDebugMode = ref(false);
 	const chatMessages = ref<string[]>([]);
 	const chatPartialExecutionDestinationNode = ref<string | null>(null);
@@ -473,22 +465,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	/** @deprecated Use `workflowDocumentStore.getNodesByIds()` instead. */
 	function getNodesByIds(nodeIds: string[]): INodeUi[] {
 		return nodeIds.map(getNodeById).filter(isPresent);
-	}
-
-	function getParametersLastUpdate(nodeName: string): number | undefined {
-		return nodeMetadata.value[nodeName]?.parametersLastUpdatedAt;
-	}
-
-	function getPinnedDataLastUpdate(nodeName: string): number | undefined {
-		return nodeMetadata.value[nodeName]?.pinnedDataLastUpdatedAt;
-	}
-
-	function getPinnedDataLastRemovedAt(nodeName: string): number | undefined {
-		return nodeMetadata.value[nodeName]?.pinnedDataLastRemovedAt;
-	}
-
-	function isNodePristine(nodeName: string): boolean {
-		return nodeMetadata.value[nodeName] === undefined || nodeMetadata.value[nodeName].pristine;
 	}
 
 	function getExecutionDataById(id: string): ExecutionSummary | undefined {
@@ -1000,13 +976,11 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			uiStore.lastSelectedNode = nameData.new;
 		}
 
-		const { [nameData.old]: removed, ...rest } = nodeMetadata.value;
-		nodeMetadata.value = { ...rest, [nameData.new]: nodeMetadata.value[nameData.old] };
-
 		if (workflowId.value) {
 			const workflowDocumentStore = useWorkflowDocumentStore(
 				createWorkflowDocumentId(workflowId.value),
 			);
+			workflowDocumentStore.renameNodeMetadata(nameData.old, nameData.new);
 			workflowDocumentStore.renamePinDataNode(nameData.old, nameData.new);
 		}
 
@@ -1056,10 +1030,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			if (node.position) {
 				node.position = snapPositionToGrid(node.position);
 			}
-
-			if (!nodeMetadata.value[node.name]) {
-				nodeMetadata.value[node.name] = { pristine: true };
-			}
 		});
 
 		workflow.value.nodes = nodes;
@@ -1085,18 +1055,10 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 		workflow.value.nodes.push(nodeData);
 		workflowObject.value.setNodes(workflow.value.nodes);
-
-		// Init node metadata
-		if (!nodeMetadata.value[nodeData.name]) {
-			nodeMetadata.value[nodeData.name] = {} as INodeMetadata;
-		}
 	}
 
 	/** @deprecated Use `workflowDocumentStore.removeNode()` instead. */
 	function removeNode(node: INodeUi): void {
-		const { [node.name]: removedNodeMetadata, ...remainingNodeMetadata } = nodeMetadata.value;
-		nodeMetadata.value = remainingNodeMetadata;
-
 		if (workflowId.value) {
 			const workflowDocumentStore = useWorkflowDocumentStore(
 				createWorkflowDocumentId(workflowId.value),
@@ -1531,10 +1493,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		return url.toString();
 	}
 
-	function setNodePristine(nodeName: string, isPristine: boolean): void {
-		nodeMetadata.value[nodeName].pristine = isPristine;
-	}
-
 	function resetChatMessages(): void {
 		chatMessages.value = [];
 	}
@@ -1666,7 +1624,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		activeExecutionId: readonlyActiveExecutionId,
 		previousExecutionId: readonlyPreviousExecutionId,
 		executionWaitingForWebhook,
-		nodeMetadata,
 		isInDebugMode,
 		chatMessages,
 		chatPartialExecutionDestinationNode,
@@ -1704,10 +1661,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		findRootWithMainConnection,
 		getNodeById,
 		getNodesByIds,
-		getParametersLastUpdate,
-		getPinnedDataLastUpdate,
-		getPinnedDataLastRemovedAt,
-		isNodePristine,
 		getExecutionDataById,
 		getNodeTypes,
 		getNodes,
@@ -1755,7 +1708,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		deleteExecution,
 		addToCurrentExecutions,
 		getBinaryUrl,
-		setNodePristine,
 		resetChatMessages,
 		appendChatMessage,
 		checkIfNodeHasChatParent,

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
@@ -1397,9 +1397,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 		if (!pinData) return;
 		for (const nodeName of Object.keys(pinData)) {
 			workflowDocumentStore.value.unpinNodeData(nodeName);
-			if (workflowsStore.nodeMetadata[nodeName]) {
-				workflowsStore.nodeMetadata[nodeName].pinnedDataLastRemovedAt = Date.now();
-			}
+			workflowDocumentStore.value.touchPinnedDataLastRemovedAt(nodeName);
 		}
 		uiStore.markStateDirty();
 	}

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useBuilderSetupCards.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useBuilderSetupCards.test.ts
@@ -34,11 +34,11 @@ vi.mock('@/features/ai/assistant/builder.store', () => ({
 }));
 
 const mockUnpinNodeData = vi.fn();
+const mockTouchPinnedDataLastRemovedAt = vi.fn();
 const mockAllNodes = ref<INodeUi[]>([]);
 vi.mock('@/app/stores/workflows.store', () => ({
 	useWorkflowsStore: () => ({
 		workflowId: 'test-workflow-id',
-		nodeMetadata: {} as Record<string, { pinnedDataLastRemovedAt?: number }>,
 		get allNodes() {
 			return mockAllNodes.value;
 		},
@@ -49,6 +49,7 @@ vi.mock('@/app/stores/workflowDocument.store', () => ({
 	useWorkflowDocumentStore: () => ({
 		pinData: {},
 		unpinNodeData: mockUnpinNodeData,
+		touchPinnedDataLastRemovedAt: mockTouchPinnedDataLastRemovedAt,
 		allNodes: [],
 		name: '',
 		settings: {},

--- a/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionDebugging.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionDebugging.test.ts
@@ -33,6 +33,7 @@ const { mockWorkflowDocumentStore } = vi.hoisted(() => ({
 		getNodes: vi.fn().mockReturnValue([]),
 		getParentNodes: vi.fn().mockReturnValue([]),
 		pinNodeData: vi.fn(),
+		clearPinnedDataTimestamps: vi.fn(),
 		resetAllNodesIssues: vi.fn(),
 		getPinDataSnapshot: vi.fn().mockReturnValue({}),
 		pinData: {},

--- a/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionDebugging.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionDebugging.ts
@@ -125,10 +125,7 @@ export const useExecutionDebugging = (providedWorkflowState?: WorkflowState) => 
 
 					// Clear dirtiness timestamps so nodes don't appear dirty after restoration.
 					// The old pinData({ isRestoration: true }) handled this internally.
-					if (workflowsStore.nodeMetadata[node.name]) {
-						delete workflowsStore.nodeMetadata[node.name].pinnedDataLastUpdatedAt;
-						delete workflowsStore.nodeMetadata[node.name].pinnedDataLastRemovedAt;
-					}
+					workflowDocumentStore.value.clearPinnedDataTimestamps(node.name);
 				}
 			}
 		});

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataJsonActions.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataJsonActions.test.ts
@@ -10,6 +10,10 @@ import type { IWorkflowDb } from '@/Interface';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 import { createComponentRenderer } from '@/__tests__/render';
 import { setupServer } from '@/__tests__/server';
@@ -56,7 +60,8 @@ async function createPiniaWithActiveNode() {
 
 	nodeTypesStore.setNodeTypes(defaultNodeDescriptions);
 	workflowsStore.workflow = workflow;
-	workflowsStore.nodeMetadata[node.name] = { pristine: true };
+	const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflow.id));
+	workflowDocumentStore.initPristineNodeMetadata(node.name);
 	workflowsStore.workflowExecutionData = {
 		id: '1',
 		finished: true,

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
@@ -484,12 +484,12 @@ const onOpenConnectionNodeCreator = (
 };
 
 const populateHiddenIssuesSet = () => {
-	if (!node.value || !workflowsStore.isNodePristine(node.value.name)) return;
+	if (!node.value || !workflowDocumentStore?.value?.isNodePristine(node.value.name)) return;
 	hiddenIssuesInputs.value.push('credentials');
 	parametersByTab.value.params.forEach((parameter) => {
 		hiddenIssuesInputs.value.push(parameter.name);
 	});
-	workflowsStore.setNodePristine(node.value.name, false);
+	workflowDocumentStore?.value?.setNodePristine(node.value.name, false);
 };
 
 const nodeSettings = computed(() =>

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.test.ts
@@ -8,6 +8,10 @@ import { useUsersStore } from '@/features/settings/users/users.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 import { createComponentRenderer } from '@/__tests__/render';
 import { setupServer } from '@/__tests__/server';
@@ -45,7 +49,8 @@ async function createPiniaStore(isActiveNode: boolean) {
 
 	nodeTypesStore.setNodeTypes(defaultNodeDescriptions);
 	workflowsStore.workflow = workflow;
-	workflowsStore.nodeMetadata[node.name] = { pristine: true };
+	const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflow.id));
+	workflowDocumentStore.initPristineNodeMetadata(node.name);
 
 	if (isActiveNode) {
 		ndvStore.setActiveNodeName(node.name, 'other');

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.test.ts
@@ -8,6 +8,10 @@ import { MANUAL_TRIGGER_NODE_TYPE, SET_NODE_TYPE, STICKY_NODE_TYPE, VIEWS } from
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 import { createComponentRenderer } from '@/__tests__/render';
 import {
@@ -43,9 +47,9 @@ const setupStore = (nodes: Array<ReturnType<typeof createTestNode>>) => {
 
 	nodeTypesStore.setNodeTypes(defaultNodeDescriptions);
 	workflowsStore.workflow = workflow;
-	workflowsStore.nodeMetadata = nodes.reduce(
-		(acc, node) => ({ ...acc, [node.name]: { pristine: true } }),
-		{},
+	const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflow.id));
+	workflowDocumentStore.setAllNodeMetadata(
+		nodes.reduce((acc, node) => ({ ...acc, [node.name]: { pristine: true } }), {}),
 	);
 
 	return {


### PR DESCRIPTION
## Summary

Extracts per-node editing state — `pristine`, `parametersLastUpdatedAt`, `pinnedDataLastUpdatedAt`, `pinnedDataLastRemovedAt` — out of `workflows.store` into a new `useWorkflowDocumentNodeMetadata` composable under `stores/workflowDocument/`, following the apply/public pattern documented in the folder's `CLAUDE.md`. All mutations now go through public methods (`initNodeMetadata`, `setNodePristine`, `touchParametersLastUpdatedAt`, `touchPinnedDataLastUpdatedAt`, `touchPinnedDataLastRemovedAt`, `clearPinnedDataTimestamps`, `renameNodeMetadata`, `removeNodeMetadata`, …) and fire typed change events, making the store the sole owner of node metadata and unblocking future CRDT sync. Call sites updated: `useWorkflowState`, `usePinnedData`, `useExecutionDebugging`, `useNodeDirtiness`, `useCanvasOperations`, `useWorkflowUpdate`, `builder.store`, and `NodeSettings.vue`.

## Related Linear tickets, Github issues, and Community forum posts

<!-- https://linear.app/n8n/issue/[TICKET-ID] -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)