### PR TITLE
feat(core): Add public API endpoints for folder management (folderId)

### DIFF
--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -79,7 +79,7 @@ export const API_KEY_RESOURCES = {
 	communityPackage: ['install', 'uninstall', 'update', 'list'] as const,
 	dataTable: ['create', 'read', 'update', 'delete', 'list'] as const,
 	dataTableRow: ['create', 'read', 'update', 'delete', 'upsert'] as const,
-	folder: ['create', 'delete', 'list'] as const,
+	folder: ['create', 'delete', 'read', 'update', 'list'] as const,
 	insights: ['read'] as const,
 } as const;
 

--- a/packages/@n8n/permissions/src/public-api-permissions.ee.ts
+++ b/packages/@n8n/permissions/src/public-api-permissions.ee.ts
@@ -62,6 +62,8 @@ export const OWNER_API_KEY_SCOPES: ApiKeyScope[] = [
 	'dataTableRow:upsert',
 	'folder:create',
 	'folder:delete',
+	'folder:read',
+	'folder:update',
 	'folder:list',
 	'insights:read',
 ];
@@ -106,6 +108,8 @@ export const MEMBER_API_KEY_SCOPES: ApiKeyScope[] = [
 	'dataTableRow:upsert',
 	'folder:create',
 	'folder:delete',
+	'folder:read',
+	'folder:update',
 	'folder:list',
 	'insights:read',
 ];

--- a/packages/cli/src/controllers/folder.controller.ts
+++ b/packages/cli/src/controllers/folder.controller.ts
@@ -187,7 +187,7 @@ export class ProjectController {
 
 		try {
 			const { totalSubFolders, totalWorkflows } =
-				await this.folderService.getFolderAndWorkflowCount(folderId, projectId);
+				await this.folderService.findFolderWithContentCounts(folderId, projectId);
 
 			return {
 				totalSubFolders,

--- a/packages/cli/src/public-api/v1/handlers/folders/folders.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/folders/folders.handler.ts
@@ -1,4 +1,9 @@
-import { CreateFolderDto, DeleteFolderDto, ListFolderQueryDto } from '@n8n/api-types';
+import {
+	CreateFolderDto,
+	DeleteFolderDto,
+	ListFolderQueryDto,
+	UpdateFolderDto,
+} from '@n8n/api-types';
 import { Container } from '@n8n/di';
 import { UserError } from 'n8n-workflow';
 
@@ -24,6 +29,8 @@ type FolderHandlers = {
 	createFolder: FoldersEndpoint<{ projectId: string }>;
 	getFolders: FoldersEndpoint<{ projectId: string }>;
 	deleteFolder: FoldersEndpoint<{ projectId: string; folderId: string }>;
+	getFolder: FoldersEndpoint<{ projectId: string; folderId: string }>;
+	updateFolder: FoldersEndpoint<{ projectId: string; folderId: string }>;
 };
 
 const folderHandlers: FolderHandlers = {
@@ -82,6 +89,59 @@ const folderHandlers: FolderHandlers = {
 			try {
 				await Container.get(FolderService).deleteFolder(req.user, folderId, projectId, query.data);
 				return res.status(204).send();
+			} catch (e) {
+				if (e instanceof FolderNotFoundError) throw new NotFoundError(e.message);
+				if (e instanceof UserError) throw new BadRequestError(e.message);
+				throw e;
+			}
+		},
+	],
+	getFolder: [
+		isLicensed('feat:folders'),
+		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'folder:read' }),
+		async (req, res) => {
+			const { projectId } = req.params;
+			await assertProjectScope(req.user, projectId, ['folder:read']);
+
+			try {
+				const folder = await Container.get(FolderService).findFolderInProjectOrFail(
+					req.params.folderId,
+					projectId,
+				);
+				const { totalSubFolders, totalWorkflows } = await Container.get(
+					FolderService,
+				).getFolderAndWorkflowCount(req.params.folderId, projectId);
+
+				return res.json({ ...folder, totalSubFolders, totalWorkflows });
+			} catch (e) {
+				if (e instanceof FolderNotFoundError) throw new NotFoundError(e.message);
+				throw e;
+			}
+		},
+	],
+	updateFolder: [
+		isLicensed('feat:folders'),
+		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'folder:update' }),
+		async (req, res) => {
+			const { projectId } = req.params;
+			await assertProjectScope(req.user, projectId, ['folder:update']);
+
+			const payload = UpdateFolderDto.safeParse(req.body);
+			if (payload.error) {
+				throw new BadRequestError(payload.error.errors[0].message);
+			}
+
+			try {
+				await Container.get(FolderService).updateFolder(
+					req.params.folderId,
+					projectId,
+					payload.data,
+				);
+				const updated = await Container.get(FolderService).findFolderInProjectOrFail(
+					req.params.folderId,
+					projectId,
+				);
+				return res.json(updated);
 			} catch (e) {
 				if (e instanceof FolderNotFoundError) throw new NotFoundError(e.message);
 				if (e instanceof UserError) throw new BadRequestError(e.message);

--- a/packages/cli/src/public-api/v1/handlers/folders/folders.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/folders/folders.handler.ts
@@ -104,13 +104,9 @@ const folderHandlers: FolderHandlers = {
 			await assertProjectScope(req.user, projectId, ['folder:read']);
 
 			try {
-				const folder = await Container.get(FolderService).findFolderInProjectOrFail(
-					req.params.folderId,
-					projectId,
-				);
-				const { totalSubFolders, totalWorkflows } = await Container.get(
+				const { folder, totalSubFolders, totalWorkflows } = await Container.get(
 					FolderService,
-				).getFolderAndWorkflowCount(req.params.folderId, projectId);
+				).findFolderWithContentCounts(req.params.folderId, projectId);
 
 				return res.json({ ...folder, totalSubFolders, totalWorkflows });
 			} catch (e) {
@@ -132,16 +128,12 @@ const folderHandlers: FolderHandlers = {
 			}
 
 			try {
-				await Container.get(FolderService).updateFolder(
+				const folder = await Container.get(FolderService).updateFolder(
 					req.params.folderId,
 					projectId,
 					payload.data,
 				);
-				const updated = await Container.get(FolderService).findFolderInProjectOrFail(
-					req.params.folderId,
-					projectId,
-				);
-				return res.json(updated);
+				return res.json(folder);
 			} catch (e) {
 				if (e instanceof FolderNotFoundError) throw new NotFoundError(e.message);
 				if (e instanceof UserError) throw new BadRequestError(e.message);

--- a/packages/cli/src/public-api/v1/handlers/folders/spec/paths/folders.folderId.yml
+++ b/packages/cli/src/public-api/v1/handlers/folders/spec/paths/folders.folderId.yml
@@ -35,3 +35,102 @@ delete:
       $ref: '../../../../shared/spec/responses/forbidden.yml'
     '404':
       $ref: '../../../../shared/spec/responses/notFound.yml'
+get:
+  x-eov-operation-id: getFolder
+  x-eov-operation-handler: v1/handlers/folders/folders.handler
+  tags:
+    - Folders
+  summary: Get folder details
+  description: Get folder details including sub-folder and workflow counts.
+  parameters:
+    - name: projectId
+      in: path
+      description: The ID of the project.
+      required: true
+      schema:
+        type: string
+    - name: folderId
+      in: path
+      description: The ID of the folder.
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: Operation successful.
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            properties:
+              id:
+                type: string
+                readOnly: true
+              name:
+                type: string
+              parentFolderId:
+                type: string
+                nullable: true
+              createdAt:
+                type: string
+                format: date-time
+                readOnly: true
+              updatedAt:
+                type: string
+                format: date-time
+                readOnly: true
+              totalSubFolders:
+                type: integer
+                description: Total number of sub-folders (recursive).
+              totalWorkflows:
+                type: integer
+                description: Total number of workflows (recursive).
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
+    '403':
+      $ref: '../../../../shared/spec/responses/forbidden.yml'
+    '404':
+      $ref: '../../../../shared/spec/responses/notFound.yml'
+patch:
+  x-eov-operation-id: updateFolder
+  x-eov-operation-handler: v1/handlers/folders/folders.handler
+  tags:
+    - Folders
+  summary: Update a folder
+  description: Update folder name or parent folder.
+  parameters:
+    - name: projectId
+      in: path
+      description: The ID of the project.
+      required: true
+      schema:
+        type: string
+    - name: folderId
+      in: path
+      description: The ID of the folder.
+      required: true
+      schema:
+        type: string
+  requestBody:
+    description: Payload for folder update.
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/folder.update.yml'
+    required: true
+  responses:
+    '200':
+      description: Operation successful.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/folder.yml'
+    '400':
+      $ref: '../../../../shared/spec/responses/badRequest.yml'
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
+    '403':
+      $ref: '../../../../shared/spec/responses/forbidden.yml'
+    '404':
+      $ref: '../../../../shared/spec/responses/notFound.yml'

--- a/packages/cli/src/public-api/v1/handlers/folders/spec/schemas/folder.update.yml
+++ b/packages/cli/src/public-api/v1/handlers/folders/spec/schemas/folder.update.yml
@@ -1,0 +1,10 @@
+type: object
+additionalProperties: false
+minProperties: 1
+properties:
+  name:
+    type: string
+    example: Renamed Folder
+  parentFolderId:
+    type: string
+    example: abc123

--- a/packages/cli/src/services/folder.service.ts
+++ b/packages/cli/src/services/folder.service.ts
@@ -90,6 +90,8 @@ export class FolderService {
 				{ parentFolder: parentFolderId !== PROJECT_ROOT ? { id: parentFolderId } : null },
 			);
 		}
+
+		return await this.findFolderInProjectOrFail(folderId, projectId);
 	}
 
 	async findFolderInProjectOrFail(folderId: string, projectId: string, em?: EntityManager) {
@@ -242,11 +244,11 @@ export class FolderService {
 		});
 	}
 
-	async getFolderAndWorkflowCount(
+	async findFolderWithContentCounts(
 		folderId: string,
 		projectId: string,
-	): Promise<{ totalSubFolders: number; totalWorkflows: number }> {
-		await this.findFolderInProjectOrFail(folderId, projectId);
+	): Promise<{ folder: Folder; totalSubFolders: number; totalWorkflows: number }> {
+		const folder = await this.findFolderInProjectOrFail(folderId, projectId);
 
 		const baseQuery = this.folderRepository
 			.createQueryBuilder('folder')
@@ -300,6 +302,7 @@ export class FolderService {
 		]);
 
 		return {
+			folder,
 			totalSubFolders: parseInt(subFolderResult?.count ?? '0', 10),
 			totalWorkflows: parseInt(workflowResult?.count ?? '0', 10),
 		};

--- a/packages/cli/test/integration/public-api/folders.test.ts
+++ b/packages/cli/test/integration/public-api/folders.test.ts
@@ -63,7 +63,7 @@ beforeEach(async () => {
 });
 
 const testWithAPIKey =
-	(method: 'get' | 'post' | 'delete', url: string, apiKey: string | null) => async () => {
+	(method: 'get' | 'post' | 'patch' | 'delete', url: string, apiKey: string | null) => async () => {
 		void authOwnerAgent.set({ 'X-N8N-API-KEY': apiKey });
 		const response = await authOwnerAgent[method](url);
 		expect(response.statusCode).toBe(401);
@@ -523,5 +523,213 @@ describe('DELETE /projects/:projectId/folders/:folderId', () => {
 		const response = await agent.delete(`/projects/${personalProject.id}/folders/${folder.id}`);
 
 		expect(response.statusCode).toBe(500);
+	});
+});
+
+describe('GET /projects/:projectId/folders/:folderId', () => {
+	test(
+		'should fail due to missing API Key',
+		testWithAPIKey('get', `/projects/${String('any-id')}/folders/${String('folder-id')}`, null),
+	);
+
+	test(
+		'should fail due to invalid API Key',
+		testWithAPIKey('get', `/projects/${String('any-id')}/folders/${String('folder-id')}`, 'abcXYZ'),
+	);
+
+	test('should return 403 when feature is not licensed', async () => {
+		const folder = await createFolder(ownerPersonalProject, { name: 'Folder' });
+
+		const response = await authOwnerAgent.get(
+			`/projects/${ownerPersonalProject.id}/folders/${folder.id}`,
+		);
+
+		expect(response.statusCode).toBe(403);
+	});
+
+	test('should return 403 when API key is missing folder:read scope', async () => {
+		testServer.license.enable('feat:folders');
+		const ownerWithWrongScope = await createOwnerWithApiKey({ scopes: ['folder:list'] });
+		const projectRepository = Container.get(ProjectRepository);
+		const personalProject = await projectRepository.getPersonalProjectForUserOrFail(
+			ownerWithWrongScope.id,
+		);
+		const folder = await createFolder(personalProject, { name: 'Folder' });
+
+		const response = await testServer
+			.publicApiAgentFor(ownerWithWrongScope)
+			.get(`/projects/${personalProject.id}/folders/${folder.id}`);
+
+		expect(response.statusCode).toBe(403);
+	});
+
+	test('should return 403 when user is not a member of the project', async () => {
+		testServer.license.enable('feat:folders');
+		testServer.license.setQuota('quota:maxTeamProjects', -1);
+		testServer.license.enable('feat:projectRole:admin');
+
+		const teamProject = await createTeamProject('No Access');
+		const folder = await createFolder(teamProject, { name: 'Team Folder' });
+
+		const response = await authMemberAgent.get(`/projects/${teamProject.id}/folders/${folder.id}`);
+
+		expect(response.statusCode).toBe(403);
+	});
+
+	test('should return folder details with counts', async () => {
+		testServer.license.enable('feat:folders');
+
+		const folder = await createFolder(ownerPersonalProject, { name: 'Parent' });
+		await createFolder(ownerPersonalProject, { name: 'Child', parentFolder: folder });
+
+		const response = await authOwnerAgent.get(
+			`/projects/${ownerPersonalProject.id}/folders/${folder.id}`,
+		);
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body).toEqual(
+			expect.objectContaining({
+				id: folder.id,
+				name: 'Parent',
+				totalSubFolders: 1,
+				totalWorkflows: 0,
+			}),
+		);
+	});
+
+	test('should return 404 when folder does not exist', async () => {
+		testServer.license.enable('feat:folders');
+
+		const response = await authOwnerAgent.get(
+			`/projects/${ownerPersonalProject.id}/folders/non-existent-folder-id`,
+		);
+
+		expect(response.statusCode).toBe(404);
+	});
+
+	test('should return 404 when project does not exist', async () => {
+		testServer.license.enable('feat:folders');
+
+		const response = await authOwnerAgent.get(
+			'/projects/non-existent-project-id/folders/any-folder-id',
+		);
+
+		expect(response.statusCode).toBe(404);
+	});
+});
+
+describe('PATCH /projects/:projectId/folders/:folderId', () => {
+	test(
+		'should fail due to missing API Key',
+		testWithAPIKey('patch', `/projects/${String('any-id')}/folders/${String('folder-id')}`, null),
+	);
+
+	test(
+		'should fail due to invalid API Key',
+		testWithAPIKey(
+			'patch',
+			`/projects/${String('any-id')}/folders/${String('folder-id')}`,
+			'abcXYZ',
+		),
+	);
+
+	test('should return 403 when feature is not licensed', async () => {
+		const folder = await createFolder(ownerPersonalProject, { name: 'Folder' });
+
+		const response = await authOwnerAgent
+			.patch(`/projects/${ownerPersonalProject.id}/folders/${folder.id}`)
+			.send({ name: 'Renamed' });
+
+		expect(response.statusCode).toBe(403);
+	});
+
+	test('should return 403 when API key is missing folder:update scope', async () => {
+		testServer.license.enable('feat:folders');
+		const ownerWithWrongScope = await createOwnerWithApiKey({ scopes: ['folder:list'] });
+		const projectRepository = Container.get(ProjectRepository);
+		const personalProject = await projectRepository.getPersonalProjectForUserOrFail(
+			ownerWithWrongScope.id,
+		);
+		const folder = await createFolder(personalProject, { name: 'Folder' });
+
+		const response = await testServer
+			.publicApiAgentFor(ownerWithWrongScope)
+			.patch(`/projects/${personalProject.id}/folders/${folder.id}`)
+			.send({ name: 'Renamed' });
+
+		expect(response.statusCode).toBe(403);
+	});
+
+	test('should return 400 when setting folder as its own parent', async () => {
+		testServer.license.enable('feat:folders');
+
+		const folder = await createFolder(ownerPersonalProject, { name: 'Folder' });
+
+		const response = await authOwnerAgent
+			.patch(`/projects/${ownerPersonalProject.id}/folders/${folder.id}`)
+			.send({ parentFolderId: folder.id });
+
+		expect(response.statusCode).toBe(400);
+	});
+
+	test('should update folder name', async () => {
+		testServer.license.enable('feat:folders');
+
+		const folder = await createFolder(ownerPersonalProject, { name: 'Original' });
+
+		const response = await authOwnerAgent
+			.patch(`/projects/${ownerPersonalProject.id}/folders/${folder.id}`)
+			.send({ name: 'Renamed' });
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body).toHaveProperty('name', 'Renamed');
+	});
+
+	test('should update parent folder', async () => {
+		testServer.license.enable('feat:folders');
+
+		const parentFolder = await createFolder(ownerPersonalProject, { name: 'Parent' });
+		const childFolder = await createFolder(ownerPersonalProject, { name: 'Child' });
+
+		const response = await authOwnerAgent
+			.patch(`/projects/${ownerPersonalProject.id}/folders/${childFolder.id}`)
+			.send({ parentFolderId: parentFolder.id });
+
+		expect(response.statusCode).toBe(200);
+	});
+
+	test('should return 404 when folder does not exist', async () => {
+		testServer.license.enable('feat:folders');
+
+		const response = await authOwnerAgent
+			.patch(`/projects/${ownerPersonalProject.id}/folders/non-existent-folder-id`)
+			.send({ name: 'Renamed' });
+
+		expect(response.statusCode).toBe(404);
+	});
+
+	test('should return 404 when project does not exist', async () => {
+		testServer.license.enable('feat:folders');
+
+		const response = await authOwnerAgent
+			.patch('/projects/non-existent-project-id/folders/any-folder-id')
+			.send({ name: 'Renamed' });
+
+		expect(response.statusCode).toBe(404);
+	});
+
+	test('should return 403 when user is not a member of the project', async () => {
+		testServer.license.enable('feat:folders');
+		testServer.license.setQuota('quota:maxTeamProjects', -1);
+		testServer.license.enable('feat:projectRole:admin');
+
+		const teamProject = await createTeamProject('No Access');
+		const folder = await createFolder(teamProject, { name: 'Team Folder' });
+
+		const response = await authMemberAgent
+			.patch(`/projects/${teamProject.id}/folders/${folder.id}`)
+			.send({ name: 'Renamed' });
+
+		expect(response.statusCode).toBe(403);
 	});
 });

--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -231,6 +231,21 @@
 		},
 		"PATCH /projects/{projectId}/users/{userId}": {
 			"status": "gap"
+		},
+		"DELETE /projects/{projectId}/folders/{folderId}": {
+			"status": "gap"
+		},
+		"POST /projects/{projectId}/folders": {
+			"status": "gap"
+		},
+		"GET /projects/{projectId}/folders": {
+			"status": "gap"
+		},
+		"GET /projects/{projectId}/folders/{folderId}": {
+			"status": "gap"
+		},
+		"PATCH /projects/{projectId}/folders/{folderId}": {
+			"status": "gap"
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Add folder CRUD endpoints to the public API, scoped under `/projects/{projectId}/folders`:
- `GET /projects/{projectId}/folders/{folderId}` -- get folder details with sub-folder and workflow counts
- `PATCH /projects/{projectId}/folders/{folderId}` -- update folder name or parent
- 
All endpoints reuse `FolderService` business logic from the internal API. A shared
`resolveProjectId` middleware handles project validation and authorization.

### Permissions changes
- Add scopes `folder:read` and `folder:update` to `OWNER_API_KEY_SCOPES` and `MEMBER_API_KEY_SCOPES`

## Related Linear tickets, Github issues, and Community forum posts

Closes [LIGO-466](https://linear.app/n8n/issue/LIGO-466/add-missing-get-and-patch-folders-endpoints)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
