### PR TITLE
fix(MCP Server Trigger Node): Only return error name and message in tool error responses

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
@@ -505,10 +505,10 @@ export class McpServer {
 
 				return MessageFormatter.formatToolResult(result);
 			} catch (error) {
-				this.logger.error(
-					`Error while executing Tool ${toolName}: ${error instanceof Error ? error.message : String(error)}`,
-				);
 				const errorObject = error instanceof Error ? error : new Error(String(error));
+				this.logger.error(`Error while executing Tool ${toolName}: ${errorObject.message}`, {
+					error: errorObject,
+				});
 				return MessageFormatter.formatError(errorObject);
 			}
 		});

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/protocol/MessageFormatter.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/protocol/MessageFormatter.ts
@@ -23,13 +23,9 @@ export class MessageFormatter {
 	}
 
 	static formatError(error: Error): McpToolResult {
-		const errorDetails = [`${error.name}: ${error.message}`];
-		if (error.stack) {
-			errorDetails.push(error.stack);
-		}
 		return {
 			isError: true,
-			content: [{ type: 'text', text: errorDetails.join('\n') }],
+			content: [{ type: 'text', text: `${error.name}: ${error.message}` }],
 		};
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/protocol/__tests__/MessageFormatter.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/protocol/__tests__/MessageFormatter.test.ts
@@ -169,12 +169,14 @@ describe('MessageFormatter', () => {
 			expect(result.content[0].text).toContain('CustomError: Custom error message');
 		});
 
-		it('should include stack trace when available', () => {
+		it('should not include stack trace in the response', () => {
 			const error = new Error('Test error');
+			error.stack =
+				'Error: Test error\n    at Context.<anonymous> (test.ts:1:1)\n    at /internal/path/node.js:100:5';
 			const result = MessageFormatter.formatError(error);
 
-			expect(result.content[0].text).toContain('Error: Test error');
-			expect(result.content[0].text).toContain('at ');
+			expect(result.content[0].text).toBe('Error: Test error');
+			expect(result.content[0].text).not.toContain('internal/path');
 		});
 	});
 });


### PR DESCRIPTION
## Summary

The MCP Trigger's `MessageFormatter.formatError()` appended `error.stack` to the JSON-RPC response sent back to MCP clients, leaking server-side file paths, line numbers, and framework frames. Stack traces are internal implementation details and shouldn't cross the network boundary.

After this PR:
- Client response contains only `${error.name}: ${error.message}`.
- The `Error` object is passed to `logger.error` via `LogMetadata` at the single call site (`McpServer.ts`), so operators keep the full stack in server-side logs.
- The pre-existing unit test that asserted the stack was leaked is flipped to assert it is **not** present.

### How to test

1. Configure an MCP Trigger node with a sub-tool that throws (e.g. a Code tool with `throw new Error('boom')`).
2. Call that tool through any MCP client.
3. Inspect the JSON-RPC response body → `content[0].text` should be exactly `Error: boom`, with no `at …` stack frames.
4. Check the n8n server log → the error line should still carry the stack via the `error` metadata field.

```bash
cd packages/@n8n/nodes-langchain
pnpm test -- MessageFormatter
pnpm test -- McpServer
```

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-2373
- closes #28414

Credit to @joan1011 for reporting the issue and proposing the original fix at [joan1011/n8n#fix/mcp-remove-stack-traces-from-error-responses](https://github.com/joan1011/n8n/tree/fix/mcp-remove-stack-traces-from-error-responses); this PR adopts that approach and additionally preserves the stack trace in server-side log metadata so debuggability isn't lost.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. <!-- N/A: no user-facing docs change -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)