### PR TITLE
test(editor): Update AgentBuilderView panel-mount test for lazy mounting (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
@@ -121,19 +121,29 @@ describe('AgentBuilderView — chat mode toggle', () => {
 		(wrapper.vm as unknown as { mode: string }).mode = 'chat';
 		await nextTick();
 
+		// Test panel mounts eagerly with chat mode; Build panel is lazy-mounted on
+		// first activation so it doesn't fire loadHistory until the user opens it.
 		const testPanel = wrapper.find('[data-testid="chat-panel-stub"][data-endpoint="chat"]');
-		const buildPanel = wrapper.find('[data-testid="chat-panel-stub"][data-endpoint="build"]');
 		expect(testPanel.exists()).toBe(true);
-		expect(buildPanel.exists()).toBe(true);
-
-		expect((testPanel.element as HTMLElement).style.display).not.toBe('none');
-		expect((buildPanel.element as HTMLElement).style.display).toBe('none');
+		expect(wrapper.find('[data-testid="chat-panel-stub"][data-endpoint="build"]').exists()).toBe(
+			false,
+		);
 
 		await wrapper.find('[data-test-id="radio-button-build"]').trigger('click');
 		await nextTick();
 
+		const buildPanel = wrapper.find('[data-testid="chat-panel-stub"][data-endpoint="build"]');
+		expect(buildPanel.exists()).toBe(true);
 		expect((testPanel.element as HTMLElement).style.display).toBe('none');
 		expect((buildPanel.element as HTMLElement).style.display).not.toBe('none');
+
+		// Switching back keeps both mounted and only toggles v-show — proves
+		// panel state is preserved rather than torn down via v-if.
+		await wrapper.find('[data-test-id="radio-button-test"]').trigger('click');
+		await nextTick();
+
+		expect((testPanel.element as HTMLElement).style.display).not.toBe('none');
+		expect((buildPanel.element as HTMLElement).style.display).toBe('none');
 	});
 
 	it('transitions from home to chat when a toggle segment is clicked', async () => {


### PR DESCRIPTION
## Summary

Fixes the failing test in `AgentBuilderView.test.ts`.

The component was recently refactored (#28701) to lazy-mount chat panels via `v-if="chatModeOpened[mode]"` so a dormant Build panel doesn't fire `loadHistory()` on chat entry. The test was still written for the old eager-mount behavior and failed on `expect(buildPanel.exists()).toBe(true)` before any Build click.

### Changes

- Assert the Build panel does **not** exist on initial chat entry (Test only).
- After clicking Build, assert both panels are mounted with Test hidden and Build visible.
- Added a toggle back to Test, asserting both panels stay mounted with visibility swapped — this is what proves `v-show` (not `v-if`) is in use.

## Related Linear tickets, Github issues, and Community forum posts

N/A — follow-up fix for the Build/Test chat toggle in #28701.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. (N/A — test-only change)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI