### PR TITLE
Remove resizable sidebar and make chat jump to bottom on load

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChatMessageList.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChatMessageList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, useTemplateRef, watch } from 'vue';
+import { computed, nextTick, onMounted, useTemplateRef, watch } from 'vue';
 import { N8nIcon } from '@n8n/design-system';
 import ChatMarkdownChunk from '@/features/ai/chatHub/components/ChatMarkdownChunk.vue';
 import ChatTypingIndicator from '@/features/ai/chatHub/components/ChatTypingIndicator.vue';
@@ -17,11 +17,21 @@ const displayGroups = computed(() => buildDisplayGroups(props.messages));
 
 function scrollToBottom(): void {
 	void nextTick(() => {
-		if (scrollRef.value) {
-			scrollRef.value.scrollTop = scrollRef.value.scrollHeight;
-		}
+		// Double rAF — async children (markdown, highlighters) can grow content
+		// after the first frame, so we measure on the second one.
+		requestAnimationFrame(() => {
+			requestAnimationFrame(() => {
+				if (scrollRef.value) {
+					scrollRef.value.scrollTop = scrollRef.value.scrollHeight;
+				}
+			});
+		});
 	});
 }
+
+onMounted(() => {
+	if (props.messages.length > 0) scrollToBottom();
+});
 
 watch(
 	() => [props.messages.length, props.messagingState],

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentSettingsSidebar.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentSettingsSidebar.vue
@@ -168,39 +168,10 @@ watch(
 	},
 	{ immediate: true },
 );
-
-// --- Resizable width ---
-const sidebarWidth = ref(480);
-const MIN_WIDTH = 360;
-const MAX_WIDTH = 700;
-
-function onResizeStart(event: MouseEvent) {
-	const startX = event.clientX;
-	const startWidth = sidebarWidth.value;
-
-	function onMouseMove(e: MouseEvent) {
-		const delta = startX - e.clientX;
-		sidebarWidth.value = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, startWidth + delta));
-	}
-
-	function onMouseUp() {
-		document.removeEventListener('mousemove', onMouseMove);
-		document.removeEventListener('mouseup', onMouseUp);
-	}
-
-	document.addEventListener('mousemove', onMouseMove);
-	document.addEventListener('mouseup', onMouseUp);
-}
 </script>
 
 <template>
-	<aside
-		:class="$style.sidebar"
-		:style="{ width: `${sidebarWidth}px`, minWidth: `${MIN_WIDTH}px` }"
-	>
-		<!-- Resize handle -->
-		<div :class="$style.resizeHandle" @mousedown="onResizeStart" />
-
+	<aside :class="$style.sidebar">
 		<!-- Sidebar header -->
 		<div :class="$style.header">
 			<N8nText tag="span" bold>{{ locale.baseText('agents.settings.title') }}</N8nText>
@@ -381,25 +352,12 @@ function onResizeStart(event: MouseEvent) {
 <style module>
 .sidebar {
 	position: relative;
+	width: 480px;
 	border-left: var(--border-width) var(--border-style) var(--color--foreground);
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
 	flex-shrink: 0;
-}
-
-.resizeHandle {
-	position: absolute;
-	top: 0;
-	left: -3px;
-	width: 6px;
-	height: 100%;
-	cursor: col-resize;
-	z-index: 5;
-}
-
-.resizeHandle:hover {
-	background-color: var(--color--primary--tint-2);
 }
 
 .header {


### PR DESCRIPTION
## Summary

Remove resizable sidebar and make chat jump to bottom on load

Settings sidebar is now fixed at 480px; the drag-to-resize handle and mouse listeners are gone.
Chat view scrolls to the latest message on load (added onMounted scroll plus a double-rAF so late markdown rendering doesn't leave it short), instead of opening at the top.
Minor UI tweaks

Added a floating copy button in the JSON config editor that copies the live buffer, with a checkmark flash after copy.
Added a per-tool copy icon in each custom tool's header row, keyboard-accessible and guarded against toggling the collapsible section.
While the builder is running, every editable region of the settings sidebar (model, instructions, triggers, tools, advanced/memory) is frozen via inert + a dim class. Section headers still toggle so users can read content, but can't change anything mid-build.


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
