### PR TITLE
fix(editor): Resolve node parameter defaults in Instance AI setup wizard (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowSetup.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowSetup.test.ts
@@ -10,6 +10,7 @@ import { useInstanceAiStore } from '../instanceAi.store';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+import { getWorkflow as fetchWorkflowApi } from '@/app/api/workflows';
 
 vi.mock('@n8n/i18n', async (importOriginal) => ({
 	...(await importOriginal()),
@@ -635,6 +636,131 @@ describe('InstanceAiWorkflowSetup', () => {
 
 			// Card with backend-tested credential and unchanged selection should show complete
 			expect(getByTestId('instance-ai-workflow-setup-step-check')).toBeTruthy();
+		});
+	});
+
+	describe('node parameter defaults hydration on mount', () => {
+		it('fills hidden node-type parameter defaults into fetched workflow nodes before setWorkflow', async () => {
+			const nodeName = 'Google Sheets Trigger';
+			vi.mocked(fetchWorkflowApi).mockResolvedValueOnce({
+				id: 'wf-1',
+				name: 'Test',
+				nodes: [
+					{
+						id: 'node-1',
+						name: nodeName,
+						type: 'n8n-nodes-base.googleSheetsTrigger',
+						typeVersion: 1,
+						parameters: {
+							documentId: { __rl: true, mode: 'list', value: '' },
+							event: 'rowAdded',
+						},
+						position: [0, 0],
+					},
+				],
+				connections: {},
+				active: false,
+				versionId: 'v1',
+				createdAt: '',
+				updatedAt: '',
+			} as unknown as Awaited<ReturnType<typeof fetchWorkflowApi>>);
+
+			const nodeTypesStore = useNodeTypesStore();
+			// @ts-expect-error Known pinia issue when spying on store getters
+			vi.spyOn(nodeTypesStore, 'getNodeType', 'get').mockReturnValue(() => ({
+				name: 'n8n-nodes-base.googleSheetsTrigger',
+				displayName: 'Google Sheets Trigger',
+				group: ['trigger'],
+				version: 1,
+				defaults: {},
+				inputs: [],
+				outputs: ['main'],
+				properties: [
+					{
+						displayName: 'Authentication',
+						name: 'authentication',
+						type: 'hidden',
+						default: 'triggerOAuth2',
+					},
+					{
+						displayName: 'Event',
+						name: 'event',
+						type: 'options',
+						options: [{ name: 'Row Added', value: 'rowAdded' }],
+						default: 'rowAdded',
+					},
+				],
+			}));
+
+			const workflowsStore = useWorkflowsStore();
+			const setWorkflowSpy = vi.spyOn(workflowsStore, 'setWorkflow');
+
+			const requests = [
+				makeSetupNodeWithCredentials('slackApi', [{ id: 'cred-1', name: 'Slack Cred' }]),
+			];
+
+			await renderAndWait({
+				props: {
+					requestId: 'req-1',
+					setupRequests: requests,
+					workflowId: 'wf-1',
+					message: 'Set up workflow',
+				},
+			});
+
+			expect(setWorkflowSpy).toHaveBeenCalled();
+			const firstCall = setWorkflowSpy.mock.calls[0][0];
+			expect(firstCall.nodes[0].parameters).toEqual(
+				expect.objectContaining({
+					authentication: 'triggerOAuth2',
+					event: 'rowAdded',
+				}),
+			);
+		});
+
+		it('skips default hydration for nodes whose node type is unknown', async () => {
+			vi.mocked(fetchWorkflowApi).mockResolvedValueOnce({
+				id: 'wf-1',
+				name: 'Test',
+				nodes: [
+					{
+						id: 'node-1',
+						name: 'Unknown',
+						type: 'custom.unknown',
+						typeVersion: 1,
+						parameters: { foo: 'bar' },
+						position: [0, 0],
+					},
+				],
+				connections: {},
+				active: false,
+				versionId: 'v1',
+				createdAt: '',
+				updatedAt: '',
+			} as unknown as Awaited<ReturnType<typeof fetchWorkflowApi>>);
+
+			const nodeTypesStore = useNodeTypesStore();
+			// @ts-expect-error Known pinia issue when spying on store getters
+			vi.spyOn(nodeTypesStore, 'getNodeType', 'get').mockReturnValue(() => null);
+
+			const workflowsStore = useWorkflowsStore();
+			const setWorkflowSpy = vi.spyOn(workflowsStore, 'setWorkflow');
+
+			const requests = [
+				makeSetupNodeWithCredentials('slackApi', [{ id: 'cred-1', name: 'Slack Cred' }]),
+			];
+
+			await renderAndWait({
+				props: {
+					requestId: 'req-1',
+					setupRequests: requests,
+					workflowId: 'wf-1',
+					message: 'Set up workflow',
+				},
+			});
+
+			const firstCall = setWorkflowSpy.mock.calls[0][0];
+			expect(firstCall.nodes[0].parameters).toEqual({ foo: 'bar' });
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowSetup.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowSetup.vue
@@ -16,6 +16,7 @@ import type { InstanceAiCredentialFlow, InstanceAiWorkflowSetupNode } from '@n8n
 import { N8nButton, N8nIcon, N8nLink, N8nText, N8nTooltip } from '@n8n/design-system';
 import { useI18n, type BaseTextKey } from '@n8n/i18n';
 import { useRootStore } from '@n8n/stores/useRootStore';
+import { NodeHelpers } from 'n8n-workflow';
 import { computed, defineComponent, onMounted, onUnmounted, provide, ref, toRef, watch } from 'vue';
 import { useInstanceAiStore } from '../instanceAi.store';
 import {
@@ -371,6 +372,27 @@ onMounted(async () => {
 	try {
 		const workflowData = await fetchWorkflowApi(rootStore.restApiContext, props.workflowId);
 		if (!isMounted) return;
+
+		// Apply node-type parameter defaults to each node, mirroring
+		// useCanvasOperations.resolveNodeParameters in initializeWorkspace. AI-generated
+		// workflow JSON can omit hidden parameters with defaults (e.g. `authentication`
+		// on the Google Sheets Trigger), and without them the backend's displayParameter
+		// check for credential displayOptions fails and load-options/resource-locator
+		// requests surface as "Credentials not found".
+		for (const node of workflowData.nodes ?? []) {
+			const nodeType = nodeTypesStore.getNodeType(node.type, node.typeVersion);
+			if (!nodeType) continue;
+			const resolved = NodeHelpers.getNodeParameters(
+				nodeType.properties,
+				node.parameters,
+				true,
+				false,
+				node,
+				nodeType,
+			);
+			node.parameters = resolved ?? {};
+		}
+
 		previousWorkflow = { ...workflowsStore.workflow };
 		workflowsStore.setWorkflow(workflowData);
 	} catch (error) {


### PR DESCRIPTION
## Summary

Without the defaults the RLC was failing to fetch values to be displayed in the setup inputs.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-2404/bug-resource-locator-items-not-loading

Prompt for testing: "create a workflow that triggers on new row in my google sheet. open the setup once the wf is built". Then add credentials for the google sheet trigger node and try to select a document

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
