### PR TITLE
fix(editor): Move tooltip for required RMC fields to the right

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/MappingFields.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/MappingFields.vue
@@ -223,6 +223,15 @@ function getFieldDescription(field: ResourceMapperField): string {
 			}) || ''
 		);
 	}
+
+	if (resourceMapperMode.value === 'add' && field.required) {
+		return (
+			locale.baseText('resourceMapper.mandatoryField.title', {
+				interpolate: { fieldWord: singularFieldWord.value },
+			}) || ''
+		);
+	}
+
 	return '';
 }
 
@@ -362,27 +371,12 @@ defineExpose({
 			}"
 		>
 			<div
-				v-if="resourceMapperMode === 'add' && field.required"
-				:class="['delete-option', 'mt-2xs', $style.parameterTooltipIcon]"
-			>
-				<N8nTooltip placement="top">
-					<template #content>
-						<span>{{
-							locale.baseText('resourceMapper.mandatoryField.title', {
-								interpolate: { fieldWord: singularFieldWord },
-							})
-						}}</span>
-					</template>
-					<N8nIcon icon="circle-help" />
-				</N8nTooltip>
-			</div>
-			<div
-				v-else-if="
+				v-if="
 					!isMatchingField(
 						field.name,
 						props.paramValue.matchingColumns,
 						props.showMatchingColumnsSelector,
-					)
+					) && !(resourceMapperMode === 'add' && field.required)
 				"
 				:class="['delete-option', 'mt-5xs']"
 			>
@@ -485,13 +479,6 @@ defineExpose({
 			border-color: var(--color--danger);
 		}
 	}
-}
-
-.parameterTooltipIcon {
-	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1) !important;
-	width: 26px; // match trash button size
-	text-align: center;
 }
 
 .addOption {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Currently the `?` icon for required fields in RMC is positioned to the left of the field and isn't properly aligned vertically:
<img width="1006" height="876" alt="image" src="https://github.com/user-attachments/assets/17d93405-4b98-460a-89a4-5604e5555565" />
This PR moves the icon with tooltip to the right of the field name:
<img width="883" height="882" alt="image" src="https://github.com/user-attachments/assets/c8478ea3-a111-49cc-8b50-fffdc9d9b439" />
Which is consistent with other places where we have the tooltip, like parameter descriptions:
<img width="674" height="145" alt="image" src="https://github.com/user-attachments/assets/733a203f-b512-4b8b-aa1a-f3647f5bfb5a" />

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-4855/mcp-client-node-tooltip-icon-misaligned-in-values-to-send-id-field

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
