### PR TITLE
fix(editor): Prevent executions table flicker on empty auto-refresh

### DIFF
--- a/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsList.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsList.vue
@@ -24,6 +24,7 @@ import ExecutionStopAllText from '../ExecutionStopAllText.vue';
 import GlobalExecutionsListItem from './GlobalExecutionsListItem.vue';
 
 import { N8nButton, N8nCheckbox, N8nTableBase } from '@n8n/design-system';
+import { ElSkeletonItem } from 'element-plus';
 
 const props = withDefaults(
 	defineProps<{
@@ -56,6 +57,7 @@ const pageRedirectionHelper = usePageRedirectionHelper();
 const allVisibleSelected = ref(false);
 const allExistingSelected = ref(false);
 const selectedItems = ref<Record<string, boolean>>({});
+const isInitialLoad = ref(true);
 
 const message = useMessage();
 const toast = useToast();
@@ -95,6 +97,15 @@ watch(
 			handleClearSelection();
 		}
 		adjustSelectionAfterMoreItemsLoaded();
+	},
+);
+
+watch(
+	() => executionsStore.loading,
+	(isLoading, wasLoading) => {
+		if (wasLoading && !isLoading) {
+			isInitialLoad.value = false;
+		}
 	},
 );
 
@@ -422,6 +433,13 @@ const goToUpgrade = () => {
 							@retry-original="retryOriginalExecution"
 							@go-to-upgrade="goToUpgrade"
 						/>
+						<template v-if="isInitialLoad && executionsStore.loading && !executions.length">
+							<tr v-for="item in executionsStore.itemsPerPage" :key="item">
+								<td v-for="col in 9" :key="col">
+									<ElSkeletonItem />
+								</td>
+							</tr>
+						</template>
 						<tr>
 							<td colspan="9" style="text-align: center">
 								<template v-if="!executions.length">

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsList.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsList.vue
@@ -24,7 +24,7 @@ import ExecutionStopAllText from '../ExecutionStopAllText.vue';
 import GlobalExecutionsListItem from './GlobalExecutionsListItem.vue';
 
 import { N8nButton, N8nCheckbox, N8nTableBase } from '@n8n/design-system';
-import { ElSkeletonItem } from 'element-plus';
+
 const props = withDefaults(
 	defineProps<{
 		executions: ExecutionSummaryWithScopes[];
@@ -422,13 +422,6 @@ const goToUpgrade = () => {
 							@retry-original="retryOriginalExecution"
 							@go-to-upgrade="goToUpgrade"
 						/>
-						<template v-if="executionsStore.loading && !executions.length">
-							<tr v-for="item in executionsStore.itemsPerPage" :key="item">
-								<td v-for="col in 9" :key="col">
-									<ElSkeletonItem />
-								</td>
-							</tr>
-						</template>
 						<tr>
 							<td colspan="9" style="text-align: center">
 								<template v-if="!executions.length">


### PR DESCRIPTION
## Summary

The global executions table flickered every 4 seconds when the list was empty, because fetchExecutions toggles the store's loading flag on each auto-refresh, which repeatedly rendered/removed the skeleton rows.

Fix: Gate the skeleton rows in [GlobalExecutionsList.vue](vscode-webview://132pupg29pgrbpdm047ftj9otjthjfblad7gmphph140arak5i92/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsList.vue) on a new isInitialLoad flag so the skeleton only renders on the very first fetch. A watcher on executionsStore.loading flips the flag to false after the first true → false transition, so subsequent auto-refreshes leave the empty state untouched.

Changes:

Added isInitialLoad ref and a watcher on executionsStore.loading
Added isInitialLoad to the skeleton block's v-if condition
Store untouched

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-9923/bug-flickering-on-empty-execution-table

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
