### PR TITLE
fix(Discord Node): Fix file name and mimetype for file upload

### DIFF
--- a/packages/nodes-base/nodes/Discord/v2/helpers/__tests__/utils.test.ts
+++ b/packages/nodes-base/nodes/Discord/v2/helpers/__tests__/utils.test.ts
@@ -252,6 +252,42 @@ describe('Discord V2 Utils', () => {
 			});
 		});
 
+		it('should use filename as filename and mimeType as content-type in file parts', async () => {
+			const files: IDataObject[] = [{ inputFieldName: 'document' }];
+			const jsonPayload: IDataObject = { content: 'Test' };
+			const itemIndex = 0;
+
+			const binaryData = {
+				data: 'base64data',
+				mimeType: 'application/pdf',
+				fileName: 'report.pdf',
+				fileExtension: 'pdf',
+			};
+
+			mockExecuteFunctions.helpers.assertBinaryData = jest.fn().mockReturnValue(binaryData);
+			mockExecuteFunctions.helpers.getBinaryDataBuffer = jest
+				.fn()
+				.mockResolvedValue(Buffer.from('pdf content'));
+			mockExecuteFunctions.getNode = jest.fn().mockReturnValue({ name: 'Discord' });
+
+			const result = await prepareMultiPartForm.call(
+				mockExecuteFunctions,
+				files,
+				jsonPayload,
+				itemIndex,
+			);
+
+			const body = result.getBuffer().toString();
+
+			// File part should have the actual filename, not the mime type
+			expect(body).toContain('filename="report.pdf"');
+			// File part should have the actual mime type, not the filename
+			expect(body).toContain('Content-Type: application/pdf');
+			// Sanity check: the values must not be swapped
+			expect(body).not.toContain('filename="application/pdf"');
+			expect(body).not.toContain('Content-Type: report.pdf');
+		});
+
 		it('should handle empty files array', async () => {
 			const files: IDataObject[] = [];
 			const jsonPayload: IDataObject = { content: 'Test message no files' };

--- a/packages/nodes-base/nodes/Discord/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Discord/v2/helpers/utils.ts
@@ -216,8 +216,8 @@ export async function prepareMultiPartForm(
 
 	for (const [index, binaryData] of filesData.entries()) {
 		multiPartBody.append(`files[${index}]`, binaryData.data, {
-			contentType: binaryData.name as string,
-			filename: binaryData.mime as string,
+			contentType: binaryData.mime as string,
+			filename: binaryData.name as string,
 		});
 	}
 


### PR DESCRIPTION
## Summary

Fixes name and mimetype mapping when sending files to Discort via Webhook method

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4629/community-issue-discord-node-uses-incorrect-file-name-and-mime-type
Fixes #25787


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
