### PR TITLE
feat(editor): Track favorite toggle events

### DIFF
--- a/packages/frontend/editor-ui/src/app/stores/favorites.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/favorites.store.test.ts
@@ -9,6 +9,11 @@ vi.mock('@n8n/stores/useRootStore', () => ({
 	})),
 }));
 
+const track = vi.fn();
+vi.mock('@/app/composables/useTelemetry', () => ({
+	useTelemetry: () => ({ track }),
+}));
+
 vi.mock('@/app/api/favorites');
 
 const makeFavorite = (overrides: Partial<UserFavorite> = {}): UserFavorite => ({
@@ -140,6 +145,10 @@ describe('favorites.store', () => {
 				'workflow',
 			);
 			expect(store.favorites).toHaveLength(0);
+			expect(track).toHaveBeenCalledWith('User toggled favorite', {
+				action: 'removed',
+				resource_type: 'workflow',
+			});
 		});
 
 		it('should add a favorite and re-fetch when it is not favorited', async () => {
@@ -155,6 +164,10 @@ describe('favorites.store', () => {
 
 			expect(favoritesApi.addFavorite).toHaveBeenCalledWith(expect.anything(), 'wf-2', 'workflow');
 			expect(store.favorites).toEqual([newFavorite]);
+			expect(track).toHaveBeenCalledWith('User toggled favorite', {
+				action: 'added',
+				resource_type: 'workflow',
+			});
 		});
 
 		it('should not modify local state when addFavorite API throws', async () => {
@@ -166,6 +179,7 @@ describe('favorites.store', () => {
 
 			await expect(store.toggleFavorite('wf-2', 'workflow')).rejects.toThrow('API error');
 			expect(store.favorites).toHaveLength(0);
+			expect(track).not.toHaveBeenCalled();
 		});
 
 		it('should not remove from local state when removeFavorite API throws', async () => {
@@ -179,6 +193,7 @@ describe('favorites.store', () => {
 
 			await expect(store.toggleFavorite('wf-1', 'workflow')).rejects.toThrow('API error');
 			expect(store.favorites).toHaveLength(1);
+			expect(track).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/stores/favorites.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/favorites.store.ts
@@ -4,9 +4,11 @@ import { STORES } from '@n8n/stores';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import * as favoritesApi from '@/app/api/favorites';
 import type { FavoriteResourceType, UserFavorite } from '@/app/api/favorites';
+import { useTelemetry } from '@/app/composables/useTelemetry';
 
 export const useFavoritesStore = defineStore(STORES.FAVORITES, () => {
 	const rootStore = useRootStore();
+	const telemetry = useTelemetry();
 
 	const favorites = ref<UserFavorite[]>([]);
 	const initialized = ref(false);
@@ -62,10 +64,18 @@ export const useFavoritesStore = defineStore(STORES.FAVORITES, () => {
 			favorites.value = favorites.value.filter(
 				(f) => !(f.resourceId === resourceId && f.resourceType === resourceType),
 			);
+			telemetry.track('User toggled favorite', {
+				action: 'removed',
+				resource_type: resourceType,
+			});
 		} else {
 			await favoritesApi.addFavorite(rootStore.restApiContext, resourceId, resourceType);
 			// Re-fetch to get enriched metadata from the server
 			favorites.value = await favoritesApi.getFavorites(rootStore.restApiContext);
+			telemetry.track('User toggled favorite', {
+				action: 'added',
+				resource_type: resourceType,
+			});
 		}
 	}
 


### PR DESCRIPTION
## Summary

Adds a telemetry event `User toggled favorite` to the favorites store's `toggleFavorite`, reporting `action` (`added` / `removed`) and `resource_type`. The event fires only after the API call succeeds, so failed toggles are not tracked.

**How to test:** toggle a favorite on a workflow/project/folder/data table and confirm the event appears in telemetry with the correct `action` and `resource_type`.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI