### PR TITLE
fix(editor): Restore missing node icons for HTTP-auth credentials

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAiWorkflowSetup.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAiWorkflowSetup.utils.test.ts
@@ -273,15 +273,16 @@ describe('isTriggerOnly', () => {
 });
 
 describe('shouldUseCredentialIcon', () => {
-	const noParamWork = () => false;
-
-	test('returns true when card has credential and is not trigger-only', () => {
-		const card = makeCard({ credentialType: 'slackApi', isTrigger: false });
-		expect(shouldUseCredentialIcon(card, noParamWork)).toBe(true);
+	test('returns true for multi-node credential-grouping cards', () => {
+		const card = makeCard({
+			credentialType: 'googleOAuth2Api',
+			nodes: [makeSetupNode(), makeSetupNode(), makeSetupNode()],
+		});
+		expect(shouldUseCredentialIcon(card)).toBe(true);
 	});
 
-	test('returns false when card has no credential', () => {
-		const card = makeCard({ credentialType: undefined });
-		expect(shouldUseCredentialIcon(card, noParamWork)).toBe(false);
+	test('returns false for single-node cards', () => {
+		const card = makeCard({ credentialType: 'slackApi', nodes: [makeSetupNode()] });
+		expect(shouldUseCredentialIcon(card)).toBe(false);
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowSetup.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowSetup.vue
@@ -5,6 +5,7 @@ import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { getAppNameFromCredType } from '@/app/utils/nodeTypesUtils';
 import { useWizardNavigation } from '@/features/ai/shared/composables/useWizardNavigation';
+import NodeIcon from '@/app/components/NodeIcon.vue';
 import CredentialIcon from '@/features/credentials/components/CredentialIcon.vue';
 import NodeCredentials from '@/features/credentials/components/NodeCredentials.vue';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
@@ -439,8 +440,9 @@ function isTriggerOnly(card: SetupCard): boolean {
 	return isTriggerOnlyUtil(card, cardHasParamWork);
 }
 
-function useCredentialIcon(card: SetupCard): boolean {
-	return shouldUseCredentialIcon(card, cardHasParamWork);
+function getCardNodeType(card: SetupCard) {
+	const node = card.nodes[0].node;
+	return nodeTypesStore.getNodeType(node.type, node.typeVersion);
 }
 
 function openNdv(card: SetupCard): void {
@@ -486,11 +488,11 @@ const nodeNamesTooltip = computed(() => nodeNames.value.join(', '));
 					<ul :class="$style.confirmList">
 						<li v-for="card in cards" :key="card.id" :class="$style.confirmItem">
 							<CredentialIcon
-								v-if="useCredentialIcon(card)"
+								v-if="shouldUseCredentialIcon(card)"
 								:credential-type-name="card.credentialType!"
 								:size="14"
 							/>
-							<N8nIcon v-else icon="check" size="xsmall" :class="$style.success" />
+							<NodeIcon v-else :node-type="getCardNodeType(card)" :size="14" />
 							<N8nText size="small">{{ getCardTitle(card) }}</N8nText>
 						</li>
 					</ul>
@@ -535,11 +537,11 @@ const nodeNamesTooltip = computed(() => nodeNames.value.join(', '));
 				<!-- Header -->
 				<header :class="$style.header">
 					<CredentialIcon
-						v-if="useCredentialIcon(currentCard)"
+						v-if="shouldUseCredentialIcon(currentCard)"
 						:credential-type-name="currentCard.credentialType!"
 						:size="16"
 					/>
-					<N8nIcon v-else icon="play" size="small" />
+					<NodeIcon v-else :node-type="getCardNodeType(currentCard)" :size="16" />
 					<N8nText :class="$style.title" size="medium" color="text-dark" bold>
 						{{ getCardTitle(currentCard) }}
 					</N8nText>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAiWorkflowSetup.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAiWorkflowSetup.utils.ts
@@ -107,10 +107,11 @@ export function isTriggerOnly(
 	return card.isTrigger && !card.credentialType && !cardHasParamWork(card);
 }
 
-/** Use credential icon when it's a credential card */
-export function shouldUseCredentialIcon(
-	card: SetupCard,
-	cardHasParamWork: (c: SetupCard) => boolean,
-): boolean {
-	return !!card.credentialType && !isTriggerOnly(card, cardHasParamWork);
+/**
+ * Use credential icon only for multi-node credential-grouping cards, where the card
+ * title is the credential display name. By construction (see `useSetupCards`), cards
+ * with more than one node always have a credentialType.
+ */
+export function shouldUseCredentialIcon(card: SetupCard): boolean {
+	return card.nodes.length > 1;
 }

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialIcon.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialIcon.test.ts
@@ -87,6 +87,33 @@ describe('CredentialIcon', () => {
 		expect(getByRole('img')).toHaveAttribute('src', useRootStore().baseUrl + testIconUrl);
 	});
 
+	it('shows named icon when referenced node uses a named icon (e.g. HTTP Request)', () => {
+		useCredentialsStore().setCredentialTypes([
+			mock<ICredentialType>({
+				name: 'httpQueryAuth',
+				icon: 'node:n8n-nodes-base.httpRequest',
+			}),
+		]);
+
+		useNodeTypesStore().setNodeTypes([
+			mock<INodeTypeDescription>({
+				version: 1,
+				name: 'n8n-nodes-base.httpRequest',
+				icon: 'node:http-request',
+				iconUrl: undefined,
+			}),
+		]);
+
+		const { container } = renderComponent({
+			pinia,
+			props: {
+				credentialTypeName: 'httpQueryAuth',
+			},
+		});
+
+		expect(container.querySelector('.nodeIconPlaceholder')).not.toBeInTheDocument();
+	});
+
 	it('shows fallback icon when icon is not found', () => {
 		useCredentialsStore().setCredentialTypes([
 			mock<ICredentialType>({

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialIcon.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialIcon.vue
@@ -4,6 +4,7 @@ import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useUIStore } from '@/app/stores/ui.store';
 import { getThemedValue } from '@/app/utils/nodeTypesUtils';
+import { getNodeIconSource } from '@/app/utils/nodeIcon';
 import type { ICredentialType } from 'n8n-workflow';
 import { computed } from 'vue';
 import { N8nNodeIcon } from '@n8n/design-system';
@@ -24,21 +25,23 @@ const credentialWithIcon = computed(() => getCredentialWithIcon(props.credential
 
 const theme = computed(() => props.theme ?? uiStore.appliedTheme);
 
-const nodeBasedIconUrl = computed(() => {
+// Route through getNodeIconSource so named icons (e.g. HTTP Request's `node:http-request`)
+// resolve correctly — reading `iconUrl` alone misses them and falls back to the `?` placeholder.
+const referencedNodeIconSource = computed(() => {
 	const icon = getThemedValue(credentialWithIcon.value?.icon, theme.value);
-	if (!icon?.startsWith('node:')) return null;
-	return nodeTypesStore.getNodeType(icon.replace('node:', ''))?.iconUrl;
+	if (!icon?.startsWith('node:')) return undefined;
+	const nodeType = nodeTypesStore.getNodeType(icon.replace('node:', ''));
+	if (!nodeType) return undefined;
+	return getNodeIconSource(nodeType, null, null);
 });
 
 const iconSource = computed(() => {
-	const themeIconUrl = getThemedValue(
-		nodeBasedIconUrl.value ?? credentialWithIcon.value?.iconUrl,
-		theme.value,
-	);
-
-	if (!themeIconUrl) {
-		return undefined;
+	if (referencedNodeIconSource.value?.type === 'file') {
+		return referencedNodeIconSource.value.src;
 	}
+
+	const themeIconUrl = getThemedValue(credentialWithIcon.value?.iconUrl, theme.value);
+	if (!themeIconUrl) return undefined;
 
 	return rootStore.baseUrl + themeIconUrl;
 });
@@ -50,12 +53,20 @@ const iconType = computed(() => {
 });
 
 const iconName = computed(() => {
-	const icon = getThemedValue(credentialWithIcon.value?.icon, uiStore.appliedTheme);
+	if (referencedNodeIconSource.value?.type === 'icon') {
+		return referencedNodeIconSource.value.name;
+	}
+
+	const icon = getThemedValue(credentialWithIcon.value?.icon, theme.value);
 	if (!icon?.startsWith('fa:')) return undefined;
 	return icon.replace('fa:', '');
 });
 
 const iconColor = computed(() => {
+	if (referencedNodeIconSource.value?.type === 'icon' && referencedNodeIconSource.value.color) {
+		return referencedNodeIconSource.value.color;
+	}
+
 	const { iconColor: color } = credentialWithIcon.value ?? {};
 	if (!color) return undefined;
 	return `var(--node--icon--color--${color})`;


### PR DESCRIPTION
## Summary

Fixes the `?` placeholder rendered by `CredentialIcon` whenever a credential's icon references a node that uses a **named** design-system icon rather than a file-based `iconUrl` — most visibly, all four HTTP-auth credentials (`httpBasicAuth`, `httpDigestAuth`, `httpHeaderAuth`, `httpQueryAuth`) after HTTP Request migrated to `icon: 'node:http-request'` in #28104.
<img width="1350" height="688" alt="image" src="https://github.com/user-attachments/assets/6494e646-cdd2-4c4f-8d93-1239a8263447" />
<img width="1381" height="449" alt="image" src="https://github.com/user-attachments/assets/bad4d0e8-79f1-432f-aaff-53ce48c5655c" />


### Root cause

`CredentialIcon.vue` resolved `node:<type>` references by reading the referenced node's `iconUrl` only (see `nodeBasedIconUrl` computed). Nodes with named icons don't expose `iconUrl` (the loader at `directory-loader.ts:448-463` only sets `iconUrl` for `file:`-prefixed icons), so the lookup returned `undefined` → `iconType: 'unknown'` → `?` placeholder.

The bug was latent since #10988 (2024-09-27) rewrote `CredentialIcon` to inline the lookup for perf reasons. #28104 (2026-04-10) made it visible by migrating HTTP Request to a named icon.

### Fix

Route the `node:<type>` lookup through `getNodeIconSource` — the canonical resolver already used by `NodeIcon`, `CanvasNodeDefault`, etc. — which handles every icon shape (file iconUrls, named icons, community `iconData`, themed variants). Impacts everywhere `CredentialIcon` is rendered: credentials list, credential edit modal, quick-connect button, and the instance AI workflow setup wizard.


### Drive-by cleanup in the instance AI wizard

- Single-node cards now render the actual node icon via `NodeIcon` instead of a generic `play`/`check` fallback.
- `shouldUseCredentialIcon` simplified from a param-work predicate to `card.nodes.length > 1` — that's the real distinction: multi-node cards are credential-grouping cards whose title is the credential display name, so the credential icon is the meaningful choice there. Single-node cards should show their own node icon.
- Also fixes a pre-existing theme inconsistency in `CredentialIcon`: `iconName` was reading `uiStore.appliedTheme` directly, ignoring the `props.theme` override that every other computed respects.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2410
https://www.notion.so/n8n/n8n-cred-type-shown-with-a-question-mark-in-the-creds-modal-3445b6e0c94f80aabb1ae2d17f1a7695?source=copy_link

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.