### PR TITLE
fix(google-drive): fetch original filename when copying file by ID with no name

### DIFF
--- a/packages/nodes-base/nodes/Google/Drive/v2/actions/file/copy.operation.ts
+++ b/packages/nodes-base/nodes/Google/Drive/v2/actions/file/copy.operation.ts
@@ -88,7 +88,17 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	const options = this.getNodeParameter('options', i, {});
 
 	let name = this.getNodeParameter('name', i) as string;
-	name = name ? name : `Copy of ${file.cachedResultName}`;
+	if (!name) {
+		const originalName =
+			file.cachedResultName ??
+			((
+				await googleApiRequest.call(this, 'GET', `/drive/v3/files/${fileId}`, {}, {
+					fields: 'name',
+					supportsAllDrives: true,
+				})
+			) as IDataObject).name as string;
+		name = `Copy of ${originalName}`;
+	}
 
 	const copyRequiresWriterPermission = options.copyRequiresWriterPermission || false;
 

--- a/packages/nodes-base/nodes/Google/Drive/v2/test/GoogleDriveV2.workflow.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/v2/test/GoogleDriveV2.workflow.test.ts
@@ -55,6 +55,28 @@ describe('Google Drive V2', () => {
 				})
 				.persist();
 
+			// Mock file metadata fetch for copy when no filename is provided (falls back to API)
+			mock
+				.get('/drive/v3/files/456')
+				.query({ fields: 'name', supportsAllDrives: true })
+				.reply(200, {
+					id: '456',
+					name: 'My Document',
+					mimeType: 'text/plain',
+				})
+				.persist();
+
+			// Mock file copy for the no-name test case
+			mock
+				.post('/drive/v3/files/456/copy')
+				.query(true)
+				.reply(200, {
+					id: 'copy456',
+					name: 'Copy of My Document',
+					mimeType: 'text/plain',
+				})
+				.persist();
+
 			// Mock file createFromText - multipart upload
 			mock
 				.post('/upload/drive/v3/files')
@@ -147,6 +169,7 @@ describe('Google Drive V2', () => {
 			credentials,
 			workflowFiles: [
 				'file-copy.workflow.json',
+				'file-copy-no-name.workflow.json',
 				'file-createFromText.workflow.json',
 				'file-delete.workflow.json',
 				'file-download.workflow.json',

--- a/packages/nodes-base/nodes/Google/Drive/v2/test/file-copy-no-name.workflow.json
+++ b/packages/nodes-base/nodes/Google/Drive/v2/test/file-copy-no-name.workflow.json
@@ -1,0 +1,64 @@
+{
+	"name": "Google Drive V2 File Copy No Name Test",
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0],
+			"id": "trigger-id",
+			"name": "When clicking 'Execute Workflow'"
+		},
+		{
+			"parameters": {
+				"resource": "file",
+				"operation": "copy",
+				"fileId": {
+					"__rl": true,
+					"value": "456",
+					"mode": "id"
+				},
+				"name": ""
+			},
+			"type": "n8n-nodes-base.googleDrive",
+			"typeVersion": 3,
+			"position": [200, 0],
+			"id": "file-copy-no-name",
+			"name": "Copy File No Name",
+			"credentials": {
+				"googleDriveOAuth2Api": {
+					"id": "test-credential-id",
+					"name": "Test Google Drive OAuth2"
+				}
+			}
+		}
+	],
+	"pinData": {
+		"Copy File No Name": [
+			{
+				"json": {
+					"id": "copy456",
+					"name": "Copy of My Document",
+					"mimeType": "text/plain"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking 'Execute Workflow'": {
+			"main": [
+				[
+					{
+						"node": "Copy File No Name",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #28735

When using the Google Drive node to **Copy a file by ID** and leaving the **File Name** field empty, the resulting file was named `"Copy of undefined"` instead of `"Copy of {original file name}"`.

**Root cause:** The fallback name was built from `file.cachedResultName`, which is only populated when the file is picked from the resource-locator dropdown. When a raw file ID is typed in directly, `cachedResultName` is `undefined`, producing the string `"Copy of undefined"`.

**Fix:** When both the user-provided name and `cachedResultName` are absent, make a lightweight `GET /drive/v3/files/{id}?fields=name` API call to retrieve the original filename before constructing the fallback name.

```typescript
// Before
name = name ? name : `Copy of ${file.cachedResultName}`;

// After
if (!name) {
  const originalName =
    file.cachedResultName ??
    ((await googleApiRequest.call(this, 'GET', `/drive/v3/files/${fileId}`, {}, {
      fields: 'name',
      supportsAllDrives: true,
    })) as IDataObject).name as string;
  name = `Copy of ${originalName}`;
}
```

The extra API call is only made when the user provides neither a custom name nor selects the file from the dropdown — it is completely skipped in the normal (dropdown-picked) flow.

## Changes

- `packages/nodes-base/nodes/Google/Drive/v2/actions/file/copy.operation.ts` — core fix
- `packages/nodes-base/nodes/Google/Drive/v2/test/GoogleDriveV2.workflow.test.ts` — nock mocks for the new code path
- `packages/nodes-base/nodes/Google/Drive/v2/test/file-copy-no-name.workflow.json` — new workflow test covering copy-by-ID with no filename

## Test plan

- [ ] Existing `file-copy.workflow.json` test still passes (provided name path unchanged)
- [ ] New `file-copy-no-name.workflow.json` test passes (no name → API fetch → `"Copy of My Document"`)
- [ ] Manual: copy a file by pasting a raw file ID, leave File Name blank → copied file is named `"Copy of {original name}"`
