### PR TITLE
fix(editor): Hide credential check icon while Instance AI setup card has pending params (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowSetup.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowSetup.test.ts
@@ -637,6 +637,38 @@ describe('InstanceAiWorkflowSetup', () => {
 			// Card with backend-tested credential and unchanged selection should show complete
 			expect(getByTestId('instance-ai-workflow-setup-step-check')).toBeTruthy();
 		});
+
+		it('suppresses credential-test check icon when parameter issues remain', async () => {
+			const requests = [
+				makeSetupNodeWithCredentials('telegramApi', [{ id: 'cred-1', name: 'Telegram Cred' }], {
+					isAutoApplied: true,
+					credentialTestResult: { success: true },
+					parameterIssues: { chatId: ['Parameter "Chat ID" is required.'] },
+					node: {
+						id: 'node-1',
+						name: 'Telegram',
+						type: 'n8n-nodes-base.telegram',
+						typeVersion: 1,
+						parameters: { resource: 'message', operation: 'sendMessage' },
+						position: [0, 0],
+						credentials: { telegramApi: { id: 'cred-1', name: 'Telegram Cred' } },
+					},
+				}),
+			];
+
+			const { queryByTestId } = await renderAndWait({
+				props: {
+					requestId: 'req-1',
+					setupRequests: requests,
+					workflowId: 'wf-1',
+					message: 'Set up workflow',
+				},
+			});
+
+			// The small credential-test check icon must not render while the card still
+			// has pending parameter work — users read it as "step complete".
+			expect(queryByTestId('instance-ai-workflow-setup-cred-check')).toBeNull();
+		});
 	});
 
 	describe('node parameter defaults hydration on mount', () => {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowSetup.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowSetup.vue
@@ -574,7 +574,8 @@ const nodeNamesTooltip = computed(() => nodeNames.value.join(', '));
 						:class="$style.loading"
 					/>
 					<N8nIcon
-						v-else-if="getCredTestIcon(currentCard) === 'check'"
+						v-else-if="getCredTestIcon(currentCard) === 'check' && !cardHasParamWork(currentCard)"
+						data-test-id="instance-ai-workflow-setup-cred-check"
 						icon="check"
 						size="small"
 						:class="$style.success"


### PR DESCRIPTION
## Summary

In the Instance AI workflow setup wizard, the small green ✓ next to the card title rendered as soon as the credential test succeeded, regardless of whether required parameters were still empty. Users read that checkmark as "step complete" even though fields like Telegram's `chatId` were still blank.

The small icon is driven by `getCredTestIcon(currentCard)`, which only reflects credential test state. The fix gates the `check` variant on `!cardHasParamWork(currentCard)` so it only renders once there is no pending parameter work. Spinner and warning variants are unchanged; the full "Complete" label (already gated on `isCardComplete`) is also unchanged. A `data-test-id` is added on the icon for test coverage.

- `InstanceAiWorkflowSetup.vue:577`: gate success ✓ on `!cardHasParamWork(currentCard)`.
- `InstanceAiWorkflowSetup.test.ts`: regression test: tested credential + pending param issues → no ✓ in header.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2411/bug-card-shows-completed-icon-when-its-not-really-completed

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.