### PR TITLE
fix(ai-builder): Validate nested collection/fixedCollection fields

### DIFF
--- a/packages/@n8n/workflow-sdk/package.json
+++ b/packages/@n8n/workflow-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n8n/workflow-sdk",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "TypeScript SDK for programmatically creating n8n workflows",
   "exports": {
     ".": {

--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.test.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.test.ts
@@ -1290,3 +1290,137 @@ describe('mapPropertyToZodSchema for fixedCollection with field-count constraint
 		expect(schema).not.toContain('.min(');
 	});
 });
+
+describe('mapPropertyToZodSchema recursion for nested collection/fixedCollection', () => {
+	const stringLeaf: NodeProperty = {
+		name: 'leaf',
+		displayName: 'Leaf',
+		type: 'string',
+		default: '',
+	};
+
+	const typeOptionsField: NodeProperty = {
+		name: 'type',
+		displayName: 'Type',
+		type: 'options',
+		default: 'qs',
+		options: [
+			{ name: 'Body', value: 'body' },
+			{ name: 'Header', value: 'headers' },
+			{ name: 'Query', value: 'qs' },
+		],
+	};
+
+	it('walks into a fixedCollection nested inside another fixedCollection', () => {
+		const prop: NodeProperty = {
+			name: 'outer',
+			displayName: 'Outer',
+			type: 'fixedCollection',
+			default: {},
+			options: [
+				{
+					name: 'group',
+					displayName: 'Group',
+					values: [
+						{
+							name: 'inner',
+							displayName: 'Inner',
+							type: 'fixedCollection',
+							default: {},
+							options: [
+								{
+									name: 'innerGroup',
+									displayName: 'Inner Group',
+									values: [stringLeaf],
+								},
+							],
+						},
+					],
+				},
+			],
+		};
+
+		const schema = mapPropertyToZodSchema(prop);
+
+		expect(schema).not.toContain('z.unknown()');
+		expect(schema).toContain('inner: z.object({');
+		expect(schema).toContain('innerGroup: z.object({');
+		expect(schema).toContain('leaf: stringOrExpression.optional()');
+	});
+
+	it('walks into a fixedCollection nested inside a collection (HTTP pagination shape)', () => {
+		const nestedPagination: NodeProperty = {
+			name: 'pagination',
+			displayName: 'Pagination',
+			type: 'fixedCollection',
+			default: {},
+			options: [
+				{
+					name: 'pagination',
+					displayName: 'Pagination',
+					values: [
+						{
+							name: 'parameters',
+							displayName: 'Parameters',
+							type: 'fixedCollection',
+							default: {},
+							typeOptions: { multipleValues: true },
+							options: [
+								{
+									name: 'parameters',
+									displayName: 'Parameter',
+									values: [typeOptionsField],
+								},
+							],
+						},
+					],
+				},
+			],
+		};
+		const prop = {
+			name: 'options',
+			displayName: 'Options',
+			type: 'collection',
+			default: {},
+			options: [nestedPagination],
+		} as unknown as NodeProperty;
+
+		const schema = mapPropertyToZodSchema(prop);
+
+		expect(schema).not.toContain('z.unknown()');
+		expect(schema).toContain("z.literal('body')");
+		expect(schema).toContain("z.literal('headers')");
+		expect(schema).toContain("z.literal('qs')");
+		expect(schema).toContain('expressionSchema');
+	});
+
+	it('walks into a collection nested inside a fixedCollection', () => {
+		const prop: NodeProperty = {
+			name: 'outer',
+			displayName: 'Outer',
+			type: 'fixedCollection',
+			default: {},
+			options: [
+				{
+					name: 'group',
+					displayName: 'Group',
+					values: [
+						{
+							name: 'inner',
+							displayName: 'Inner',
+							type: 'collection',
+							default: {},
+							options: [stringLeaf],
+						},
+					],
+				},
+			],
+		};
+
+		const schema = mapPropertyToZodSchema(prop);
+
+		expect(schema).not.toContain('z.unknown()');
+		expect(schema).toContain('inner: z.object({');
+		expect(schema).toContain('leaf: stringOrExpression.optional()');
+	});
+});

--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.ts
@@ -436,6 +436,12 @@ function mapNestedPropertyToZodSchemaInner(prop: NodeProperty): string {
 		case 'assignmentCollection':
 			return 'assignmentCollectionValueSchema';
 
+		case 'fixedCollection':
+			return generateFixedCollectionZodSchema(prop);
+
+		case 'collection':
+			return generateCollectionZodSchema(prop);
+
 		case 'hidden':
 			return 'z.unknown()';
 


### PR DESCRIPTION
## Summary

Followup to https://github.com/n8n-io/n8n/pull/28794.
Validate nested collection fields so that they don't get validated as `z.unknown()`, passing anything. This caused builder to think `"query"` was a valid value for the query type, while the valid value was `"qs"`.

This seems to substantially reduce the `z.unknown()` usage in nodes, as counted by claude reducing the use of z.unknown() in node schemas by...

  - nodes-base: 1458 → 79 z.unknown() (−95%)
  - nodes-langchain: 468 → 251 (−46%)
  - HTTP Request v44: 5 → 0
  - Remaining z.unknown() are legitimate hidden-type fields.

I'm slightly worried of this introducing some regression - but then again, why would it 🤔 But that's hard to prove, tests pass and it seemed to work just fine, I did manually also test cases that would've failed before this change by generating workflows where it had to set these fields correctly.

## Related Linear tickets, Github issues, and Community forum posts

[Failed to set up HTTP pagination because used ‘query’ rather than ‘Query’, and validation didn’t pick it up](https://www.notion.so/n8n/aef5b6e0c94f82159cc58164aa417607?v=7965b6e0c94f823c918f88516500cb86&p=3445b6e0c94f805bbc86ee231920a1d5&pm=s)

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
