### PR TITLE
fix(core): Fix publishing dynamic credential chathub flow

### DIFF
--- a/packages/cli/src/workflows/__tests__/workflow-validation.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-validation.service.test.ts
@@ -807,6 +807,53 @@ describe('WorkflowValidationService', () => {
 			expect(result.error).toContain('identity extractor');
 		});
 
+		it('should return valid when Chat Trigger with availableInChat is the trigger', async () => {
+			const nodes: INode[] = [
+				createNode('Chat Trigger', '@n8n/n8n-nodes-langchain.chatTrigger', {
+					parameters: { availableInChat: true },
+				}),
+				createNode('Google Calendar', 'n8n-nodes-base.googleCalendar', {
+					credentials: { googleCalendarOAuth2Api: { id: 'cred-1' } },
+				}),
+			];
+
+			mockCredentialsRepository.find.mockResolvedValue([
+				{ id: 'cred-1', name: 'Google Calendar account 56', resolverId: 'resolver-1' } as any,
+			]);
+
+			mockNodeTypes.getByNameAndVersion.mockImplementation(((type: string) => {
+				if (type === '@n8n/n8n-nodes-langchain.chatTrigger') return createTriggerNodeType();
+				return {} as INodeType;
+			}) as any);
+
+			const result = await service.validateDynamicCredentials(nodes, mockNodeTypes);
+
+			expect(result.isValid).toBe(true);
+		});
+
+		it('should return invalid when Chat Trigger does not have availableInChat set', async () => {
+			const nodes: INode[] = [
+				createNode('Chat Trigger', '@n8n/n8n-nodes-langchain.chatTrigger'),
+				createNode('Google Calendar', 'n8n-nodes-base.googleCalendar', {
+					credentials: { googleCalendarOAuth2Api: { id: 'cred-1' } },
+				}),
+			];
+
+			mockCredentialsRepository.find.mockResolvedValue([
+				{ id: 'cred-1', name: 'Google Calendar account 56', resolverId: 'resolver-1' } as any,
+			]);
+
+			mockNodeTypes.getByNameAndVersion.mockImplementation(((type: string) => {
+				if (type === '@n8n/n8n-nodes-langchain.chatTrigger') return createTriggerNodeType();
+				return {} as INodeType;
+			}) as any);
+
+			const result = await service.validateDynamicCredentials(nodes, mockNodeTypes);
+
+			expect(result.isValid).toBe(false);
+			expect(result.error).toContain('identity extractor');
+		});
+
 		it('should skip disabled nodes when collecting credentials', async () => {
 			const nodes: INode[] = [
 				createNode('Schedule', 'n8n-nodes-base.scheduleTrigger'),

--- a/packages/cli/src/workflows/workflow-validation.service.ts
+++ b/packages/cli/src/workflows/workflow-validation.service.ts
@@ -11,6 +11,7 @@ import {
 	isNodeConnected,
 	isTriggerLikeNode,
 	toExecutionContextEstablishmentHookParameter,
+	CHAT_TRIGGER_NODE_TYPE,
 } from 'n8n-workflow';
 import type { INode, INodes, IConnections, INodeType, IWorkflowSettings } from 'n8n-workflow';
 
@@ -240,6 +241,12 @@ export class WorkflowValidationService {
 			if (node.disabled) return false;
 			const nodeType = nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
 			if (!nodeType || !isTriggerLikeNode(nodeType)) return false;
+
+			// Chat Trigger nodes with availableInChat have identity injected at runtime by Chat Hub
+			if (node.type === CHAT_TRIGGER_NODE_TYPE && node.parameters.availableInChat === true) {
+				return true;
+			}
+
 			const hookParams = toExecutionContextEstablishmentHookParameter(node.parameters);
 			return (
 				hookParams !== null &&


### PR DESCRIPTION
## Summary

A workflow with a Chat Trigger (availableInChat: true) using a dynamic
  (resolvable) credential like "Google Calendar account" could never be
  published because the validation required contextEstablishmentHooks to be
  stored on the trigger node, but Chat Hub only injects those hooks at runtime —
   to verify the fix, create a workflow with a Chat Trigger set to "Available in
   Chat" that uses a resolvable credential, and confirm it now publishes
  successfully.

## Related Linear tickets, Github issues, and Community forum posts

--


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
