### PR TITLE
chore: Deprecate SerpAPI tool node in favour of official verified node

### DIFF
--- a/packages/@n8n/nodes-langchain/credentials/SerpApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/SerpApi.credentials.ts
@@ -14,6 +14,13 @@ export class SerpApi implements ICredentialType {
 
 	properties: INodeProperties[] = [
 		{
+			displayName:
+				'This node is deprecated and will not be updated in the future. Please use the official verified community node instead.',
+			name: 'oldVersionNotice',
+			type: 'notice',
+			default: '',
+		},
+		{
 			displayName: 'API Key',
 			name: 'apiKey',
 			type: 'string',

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolSerpApi/ToolSerpApi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolSerpApi/ToolSerpApi.node.ts
@@ -27,6 +27,7 @@ export class ToolSerpApi implements INodeType {
 		icon: 'file:serpApi.svg',
 		group: ['transform'],
 		version: 1,
+		hidden: true,
 		description: 'Search in Google using SerpAPI',
 		defaults: {
 			name: 'SerpAPI',
@@ -58,6 +59,13 @@ export class ToolSerpApi implements INodeType {
 		],
 		properties: [
 			getConnectionHintNoticeField([NodeConnectionTypes.AiAgent]),
+			{
+				displayName:
+					'This node is deprecated and will not be updated in the future. Please use the official verified community node instead.',
+				name: 'oldVersionNotice',
+				type: 'notice',
+				default: '',
+			},
 			{
 				displayName: 'Options',
 				name: 'options',


### PR DESCRIPTION
## Summary
Marks the SerpAPI tool node as deprecated in favour of the official verified community node, We should remove this node fully in v3.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-4876/deprecate-serpapi-tool-node


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
