### PR TITLE
fix(ai-builder): Validate merge node connections matches 'numberInputs' parameter

### DIFF
--- a/packages/@n8n/workflow-sdk/src/validation/index.ts
+++ b/packages/@n8n/workflow-sdk/src/validation/index.ts
@@ -493,11 +493,62 @@ export function validateWorkflow(
 		validateParentSupportsInputs(json, options.nodeTypesProvider, warnings);
 	}
 
+	// Merge node input-count consistency
+	checkMergeNodeInputCount(json, warnings);
+
 	return {
 		valid: errors.length === 0,
 		errors,
 		warnings,
 	};
+}
+
+/**
+ * Validate that the Merge node's `numberInputs` parameter is consistent with
+ * the input indices actually used by incoming connections.
+ *
+ * The Merge node has expression-based inputs (count derived from
+ * `numberInputs`, default 2), so checkNodeInputIndices can't resolve the count
+ * statically. Without this check, a workflow with three branches wired into a
+ * Merge node that still has `numberInputs=2` passes validation and silently
+ * drops the third branch at runtime.
+ */
+function checkMergeNodeInputCount(json: WorkflowJSON, warnings: ValidationWarning[]): void {
+	const connectionsByDest = mapConnectionsByDestination(
+		json.connections as unknown as N8nIConnections,
+	);
+
+	for (const node of json.nodes) {
+		if (!node.name) continue;
+		if (node.type !== 'n8n-nodes-base.merge') continue;
+
+		const numberInputsParam = node.parameters?.numberInputs;
+		const declaredInputs = typeof numberInputsParam === 'number' ? numberInputsParam : 2;
+
+		const incomingMain = connectionsByDest[node.name]?.main;
+		if (!incomingMain) continue;
+
+		let maxConnectedIndex = -1;
+		for (let i = 0; i < incomingMain.length; i++) {
+			const slot = incomingMain[i];
+			if (Array.isArray(slot) && slot.length > 0) {
+				maxConnectedIndex = i;
+			}
+		}
+
+		if (maxConnectedIndex >= declaredInputs) {
+			warnings.push(
+				new ValidationWarning(
+					'INVALID_INPUT_INDEX',
+					`Merge node '${node.name}' has a connection to input index ${maxConnectedIndex} but 'numberInputs' is ${declaredInputs}. Set 'numberInputs' to ${maxConnectedIndex + 1} so every branch is accepted.`,
+					node.name,
+					'numberInputs',
+					undefined,
+					'major',
+				),
+			);
+		}
+	}
 }
 
 /**

--- a/packages/@n8n/workflow-sdk/src/validation/input-validation.test.ts
+++ b/packages/@n8n/workflow-sdk/src/validation/input-validation.test.ts
@@ -65,16 +65,19 @@ describe('input index validation', () => {
 		expect(result.warnings.filter((w) => w.code === 'INVALID_INPUT_INDEX')).toHaveLength(0);
 	});
 
-	it('skips validation for dynamic input nodes like Merge', () => {
+	it('warns when a Merge input index exceeds numberInputs even though inputs are dynamic', () => {
 		const myTrigger = trigger({ type: 'n8n-nodes-base.manualTrigger', version: 1, config: {} });
 		const mergeNode = merge({ version: 3 });
 
-		// Dynamic inputs - can't validate statically
+		// checkNodeInputIndices can't resolve dynamic inputs, but the Merge-specific
+		// check uses the numberInputs parameter (default 2) and catches the overflow.
 		const wf = workflow('test-id', 'Test').add(myTrigger.to(mergeNode.input(5)));
 
 		const result = validateWorkflow(wf, { nodeTypesProvider: mockNodeTypesProvider });
 
-		expect(result.warnings.filter((w) => w.code === 'INVALID_INPUT_INDEX')).toHaveLength(0);
+		const mergeWarnings = result.warnings.filter((w) => w.code === 'INVALID_INPUT_INDEX');
+		expect(mergeWarnings).toHaveLength(1);
+		expect(mergeWarnings[0].message).toContain("'numberInputs' is 2");
 	});
 
 	it('reports warning with node name and input index in message', () => {
@@ -121,5 +124,140 @@ describe('input index validation', () => {
 
 		const invalidInputWarnings = result.warnings.filter((w) => w.code === 'INVALID_INPUT_INDEX');
 		expect(invalidInputWarnings.length).toBe(2);
+	});
+});
+
+describe('merge node input-count validation', () => {
+	it('warns when connections exceed the default numberInputs of 2', () => {
+		const result = validateWorkflow({
+			id: 'test-id',
+			name: 'Test',
+			nodes: [
+				{
+					id: '1',
+					name: 'Trigger',
+					type: 'n8n-nodes-base.manualTrigger',
+					typeVersion: 1,
+					position: [0, 0],
+				},
+				{ id: 'a', name: 'A', type: 'n8n-nodes-base.set', typeVersion: 3, position: [100, 0] },
+				{ id: 'b', name: 'B', type: 'n8n-nodes-base.set', typeVersion: 3, position: [200, 0] },
+				{ id: 'c', name: 'C', type: 'n8n-nodes-base.set', typeVersion: 3, position: [300, 0] },
+				// Merge has no parameters → numberInputs defaults to 2, but three branches connect.
+				{
+					id: 'm',
+					name: 'Merge',
+					type: 'n8n-nodes-base.merge',
+					typeVersion: 3.2,
+					position: [500, 0],
+					parameters: {},
+				},
+			],
+			connections: {
+				Trigger: { main: [[{ node: 'A', type: 'main', index: 0 }]] },
+				A: { main: [[{ node: 'Merge', type: 'main', index: 0 }]] },
+				B: { main: [[{ node: 'Merge', type: 'main', index: 1 }]] },
+				C: { main: [[{ node: 'Merge', type: 'main', index: 2 }]] },
+			},
+		});
+
+		const warning = result.warnings.find(
+			(w) => w.code === 'INVALID_INPUT_INDEX' && w.nodeName === 'Merge',
+		);
+		expect(warning).toBeDefined();
+		expect(warning?.message).toContain("'numberInputs' is 2");
+		expect(warning?.message).toContain('input index 2');
+		expect(warning?.parameterPath).toBe('numberInputs');
+	});
+
+	it('does not warn when numberInputs matches connection count', () => {
+		const result = validateWorkflow({
+			id: 'test-id',
+			name: 'Test',
+			nodes: [
+				{ id: 'a', name: 'A', type: 'n8n-nodes-base.set', typeVersion: 3, position: [100, 0] },
+				{ id: 'b', name: 'B', type: 'n8n-nodes-base.set', typeVersion: 3, position: [200, 0] },
+				{ id: 'c', name: 'C', type: 'n8n-nodes-base.set', typeVersion: 3, position: [300, 0] },
+				{
+					id: 'm',
+					name: 'Merge',
+					type: 'n8n-nodes-base.merge',
+					typeVersion: 3.2,
+					position: [500, 0],
+					parameters: { numberInputs: 3 },
+				},
+			],
+			connections: {
+				A: { main: [[{ node: 'Merge', type: 'main', index: 0 }]] },
+				B: { main: [[{ node: 'Merge', type: 'main', index: 1 }]] },
+				C: { main: [[{ node: 'Merge', type: 'main', index: 2 }]] },
+			},
+		});
+
+		const warning = result.warnings.find(
+			(w) => w.code === 'INVALID_INPUT_INDEX' && w.nodeName === 'Merge',
+		);
+		expect(warning).toBeUndefined();
+	});
+
+	it('does not warn on the default 2-branch merge case', () => {
+		const result = validateWorkflow({
+			id: 'test-id',
+			name: 'Test',
+			nodes: [
+				{ id: 'a', name: 'A', type: 'n8n-nodes-base.set', typeVersion: 3, position: [100, 0] },
+				{ id: 'b', name: 'B', type: 'n8n-nodes-base.set', typeVersion: 3, position: [200, 0] },
+				{
+					id: 'm',
+					name: 'Merge',
+					type: 'n8n-nodes-base.merge',
+					typeVersion: 3.2,
+					position: [500, 0],
+					parameters: {},
+				},
+			],
+			connections: {
+				A: { main: [[{ node: 'Merge', type: 'main', index: 0 }]] },
+				B: { main: [[{ node: 'Merge', type: 'main', index: 1 }]] },
+			},
+		});
+
+		const warning = result.warnings.find(
+			(w) => w.code === 'INVALID_INPUT_INDEX' && w.nodeName === 'Merge',
+		);
+		expect(warning).toBeUndefined();
+	});
+
+	it('suggests the correct numberInputs value in the message', () => {
+		const result = validateWorkflow({
+			id: 'test-id',
+			name: 'Test',
+			nodes: [
+				{ id: 'a', name: 'A', type: 'n8n-nodes-base.set', typeVersion: 3, position: [100, 0] },
+				{ id: 'b', name: 'B', type: 'n8n-nodes-base.set', typeVersion: 3, position: [200, 0] },
+				{ id: 'c', name: 'C', type: 'n8n-nodes-base.set', typeVersion: 3, position: [300, 0] },
+				{ id: 'd', name: 'D', type: 'n8n-nodes-base.set', typeVersion: 3, position: [400, 0] },
+				{
+					id: 'm',
+					name: 'Merge',
+					type: 'n8n-nodes-base.merge',
+					typeVersion: 3.2,
+					position: [500, 0],
+					parameters: { numberInputs: 2 },
+				},
+			],
+			connections: {
+				A: { main: [[{ node: 'Merge', type: 'main', index: 0 }]] },
+				B: { main: [[{ node: 'Merge', type: 'main', index: 1 }]] },
+				C: { main: [[{ node: 'Merge', type: 'main', index: 2 }]] },
+				D: { main: [[{ node: 'Merge', type: 'main', index: 3 }]] },
+			},
+		});
+
+		const warning = result.warnings.find(
+			(w) => w.code === 'INVALID_INPUT_INDEX' && w.nodeName === 'Merge',
+		);
+		expect(warning).toBeDefined();
+		expect(warning?.message).toContain("'numberInputs' to 4");
 	});
 });


### PR DESCRIPTION
## Summary

Make sure merge node's `numberInputs` parameter value matches the amount of connected nodes so that extra connections aren't dropped at runtime.

## Related Linear tickets, Github issues, and Community forum posts

[Merge not working with 2+ inputs](https://www.notion.so/n8n/aef5b6e0c94f82159cc58164aa417607?v=7965b6e0c94f823c918f88516500cb86&p=3345b6e0c94f806faeffd38f922a00e3&pm=s)

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
