### PR TITLE
fix(Databricks Node): Expose token expired status code on OAuth2 credential

### DIFF
--- a/packages/nodes-base/credentials/DatabricksOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/DatabricksOAuth2Api.credentials.ts
@@ -52,6 +52,14 @@ export class DatabricksOAuth2Api implements ICredentialType {
 			type: 'hidden',
 			default: 'header',
 		},
+		{
+			displayName: 'Token Expired Status Code',
+			name: 'tokenExpiredStatusCode',
+			type: 'number',
+			default: 401,
+			description:
+				'HTTP status code that indicates the token has expired. Set to 403 if your Databricks deployment returns 403 on expired tokens.',
+		},
 	];
 
 	test: ICredentialTestRequest = {


### PR DESCRIPTION
## Summary

The base `oAuth2Api` credential defines `tokenExpiredStatusCode` with
`doNotInherit: true`, so extending credentials never surface the field in
the UI. For Databricks OAuth2, this means `credentials.tokenExpiredStatusCode`
is always `undefined` at runtime, and `resolveTokenExpiredStatusCode` in
`packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts`
falls back to **401**. Any 403 (or other non-401) response from Databricks
therefore skips the refresh path in `requestOAuth2` and fails instead of
transparently minting a new token.

This PR redeclares `tokenExpiredStatusCode` on `DatabricksOAuth2Api` so users
whose deployments signal token expiry with a non-401 status can override the
default. Default stays at **401**, preserving current behavior for everyone else.

### Before / After

- **Before:** field absent from `DatabricksOAuth2Api`; status code hardcoded to 401 via fallback; no refresh on 403.
- **After:** field present on the credential with default 401; users can set it to 403 (or anything else) if needed; existing credentials keep the 401 default.

### How to test

1. Create a Databricks OAuth2 credential — the new `Token Expired Status Code` field should appear with default `401`.
2. Execute any Databricks node operation — behavior should be unchanged for deployments that return 401 on expired tokens.
3. For deployments that return 403: set the field to `403`, let the cached token expire, re-execute — n8n should mint a new `client_credentials` token and retry the request once.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #28832

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if needed).