### PR TITLE
fix(editor): Fix NDV not loading parameters after refresh on instance AI (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/types/nodeSettings.ts
+++ b/packages/frontend/editor-ui/src/app/types/nodeSettings.ts
@@ -4,5 +4,4 @@ export type NodeSettingsTab =
 	| 'communityNode'
 	| 'docs'
 	| 'action'
-	| 'credential'
-	| 'output';
+	| 'credential';

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
 import { shallowRef } from 'vue';
-import { waitFor } from '@testing-library/vue';
+import { fireEvent, waitFor } from '@testing-library/vue';
 import { createRunExecutionData, type INodeTypeDescription, type IRunData } from 'n8n-workflow';
 
 import { createTestNode, createTestWorkflow } from '@/__tests__/mocks';
@@ -120,10 +120,6 @@ const renderNodeSettings = (runData?: IRunData) => {
 };
 
 describe('NodeSettings', () => {
-	// Regression: the NDV used to open with `openPanel = 'output'` in read-only
-	// mode when the active node had execution data, but nothing in the template
-	// handles that value — the center panel rendered with no active tab and no
-	// content. See https://linear.app/n8n/issue/INS-23.
 	it('defaults to the Parameters tab when read-only and the active node has execution data', async () => {
 		const runData: IRunData = {
 			[httpNode.name]: [
@@ -145,12 +141,23 @@ describe('NodeSettings', () => {
 		});
 	});
 
-	it('defaults to the Parameters tab when the active node has no execution data', async () => {
+	it('switches to the Settings tab when the user clicks it', async () => {
 		const { findByTestId } = renderNodeSettings();
 
 		const paramsTab = await findByTestId('tab-params');
+		const settingsTab = await findByTestId('tab-settings');
+
 		await waitFor(() => {
 			expect(paramsTab.querySelector('.tab')?.className).toContain('activeTab');
+		});
+
+		const settingsTabClickable = settingsTab.querySelector<HTMLElement>('.tab');
+		expect(settingsTabClickable).not.toBeNull();
+		await fireEvent.click(settingsTabClickable!);
+
+		await waitFor(() => {
+			expect(settingsTab.querySelector('.tab')?.className).toContain('activeTab');
+			expect(paramsTab.querySelector('.tab')?.className).not.toContain('activeTab');
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+import { shallowRef } from 'vue';
+import { waitFor } from '@testing-library/vue';
+import { createRunExecutionData, type INodeTypeDescription, type IRunData } from 'n8n-workflow';
+
+import { createTestNode, createTestWorkflow } from '@/__tests__/mocks';
+import { createComponentRenderer } from '@/__tests__/render';
+
+import NodeSettings from './NodeSettings.vue';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+import { useWorkflowState } from '@/app/composables/useWorkflowState';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	createWorkflowDocumentId,
+	injectWorkflowDocumentStore,
+	useWorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
+
+vi.mock('@/app/stores/workflowDocument.store', async () => {
+	const actual = await vi.importActual('@/app/stores/workflowDocument.store');
+	return { ...actual, injectWorkflowDocumentStore: vi.fn() };
+});
+
+vi.mock('vue-router', () => ({
+	useRouter: () => ({}),
+	useRoute: () => ({ meta: {}, name: 'fake-route' }),
+	RouterLink: { template: '<a><slot /></a>' },
+}));
+
+const httpNode = createTestNode({
+	name: 'HTTP Request',
+	type: 'n8n-nodes-base.httpRequest',
+	typeVersion: 4,
+});
+
+const httpNodeType = {
+	displayName: 'HTTP Request',
+	name: 'n8n-nodes-base.httpRequest',
+	group: ['transform'],
+	description: 'Make HTTP requests',
+	version: 4,
+	defaults: { name: 'HTTP Request' },
+	inputs: ['main'],
+	outputs: ['main'],
+	properties: [{ displayName: 'URL', name: 'url', type: 'string', default: '' }],
+} as unknown as INodeTypeDescription;
+
+const renderNodeSettings = (runData?: IRunData) => {
+	const pinia = createTestingPinia({ stubActions: false });
+	setActivePinia(pinia);
+
+	const workflow = createTestWorkflow({ nodes: [httpNode], connections: {} });
+	const workflowsStore = useWorkflowsStore();
+	const workflowState = useWorkflowState();
+	const nodeTypesStore = useNodeTypesStore();
+	const ndvStore = useNDVStore();
+
+	workflowsStore.setWorkflow(workflow);
+	nodeTypesStore.setNodeTypes([httpNodeType]);
+	ndvStore.activeNodeName = httpNode.name;
+
+	if (runData) {
+		workflowState.setWorkflowExecutionData({
+			id: 'exec-1',
+			workflowData: {
+				...workflow,
+				active: false,
+				activeVersionId: null,
+				isArchived: false,
+				createdAt: '',
+				updatedAt: '',
+				versionId: '',
+			},
+			finished: true,
+			mode: 'manual',
+			status: 'success',
+			startedAt: new Date(),
+			createdAt: new Date(),
+			data: createRunExecutionData({ resultData: { runData } }),
+		} as never);
+	}
+
+	vi.mocked(injectWorkflowDocumentStore).mockReturnValue(
+		shallowRef(useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))),
+	);
+
+	return createComponentRenderer(NodeSettings, {
+		global: {
+			stubs: {
+				NodeTitle: true,
+				NodeExecuteButton: true,
+				NodeCredentials: true,
+				NodeWebhooks: true,
+				NodeActionsList: true,
+				NodeSettingsHeader: true,
+				NodeSettingsInvalidNodeWarning: true,
+				ExperimentalEmbeddedNdvHeader: true,
+				NDVSubConnections: true,
+				ParameterInputList: true,
+				FreeAiCreditsCallout: true,
+				NodeStorageLimitCallout: true,
+				QuickConnectBanner: true,
+				CommunityNodeFooter: true,
+				CommunityNodeUpdateInfo: true,
+			},
+		},
+	})({
+		props: {
+			dragging: false,
+			pushRef: 'pushRef',
+			readOnly: true,
+			foreignCredentials: [],
+			blockUI: false,
+			executable: false,
+		},
+	});
+};
+
+describe('NodeSettings', () => {
+	// Regression: the NDV used to open with `openPanel = 'output'` in read-only
+	// mode when the active node had execution data, but nothing in the template
+	// handles that value — the center panel rendered with no active tab and no
+	// content. See https://linear.app/n8n/issue/INS-23.
+	it('defaults to the Parameters tab when read-only and the active node has execution data', async () => {
+		const runData: IRunData = {
+			[httpNode.name]: [
+				{
+					startTime: 0,
+					executionTime: 0,
+					executionIndex: 0,
+					source: [],
+					data: {},
+				},
+			],
+		};
+
+		const { findByTestId } = renderNodeSettings(runData);
+
+		const paramsTab = await findByTestId('tab-params');
+		await waitFor(() => {
+			expect(paramsTab.querySelector('.tab')?.className).toContain('activeTab');
+		});
+	});
+
+	it('defaults to the Parameters tab when the active node has no execution data', async () => {
+		const { findByTestId } = renderNodeSettings();
+
+		const paramsTab = await findByTestId('tab-params');
+		await waitFor(() => {
+			expect(paramsTab.querySelector('.tab')?.className).toContain('activeTab');
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
@@ -149,12 +149,7 @@ if (props.isEmbeddedInCanvas) {
 
 const nodeValid = ref(true);
 
-const initialNode = props.activeNode ?? ndvStore.activeNode;
-const initialHasExecutionData =
-	!!initialNode && !!workflowsStore.getWorkflowRunData?.[initialNode.name]?.length;
-const openPanel = ref<NodeSettingsTab>(
-	props.readOnly && initialHasExecutionData ? 'output' : 'params',
-);
+const openPanel = ref<NodeSettingsTab>('params');
 
 // Used to prevent nodeValues from being overwritten by defaults on reopening ndv
 const nodeValuesInitialized = ref(false);
@@ -579,16 +574,8 @@ const onFeatureRequestClick = () => {
 	}
 };
 
-watch(node, (newNode, oldNode) => {
+watch(node, () => {
 	setNodeValues();
-
-	// When the active node changes in a read-only view, re-evaluate which
-	// tab to open so nodes with execution data land on 'output' by default.
-	if (newNode?.name !== oldNode?.name && props.readOnly) {
-		const hasExecutionData =
-			!!newNode && !!workflowsStore.getWorkflowRunData?.[newNode.name]?.length;
-		openPanel.value = hasExecutionData ? 'output' : 'params';
-	}
 });
 
 onMounted(async () => {


### PR DESCRIPTION
## Summary

Remove logic attempting to open 'output' as the fallback for `NodeSettings.openPanel` state, as no such panel actually exists. This seems to be a recent mistake introduced in #28412 and this PR undoes those changes.

Now NDV falls back to "params" tab correctly, so when the artifact view refreshes (after update) it no longer ends up in limbo state where the tab it tries to open is nonexisting "output" tab.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-23/bug-node-preview-empty

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
