### PR TITLE
fix(core): Update output schemas for create/update mcp tools

### DIFF
--- a/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
@@ -58,6 +58,7 @@ const outputSchema = {
 			z.object({
 				nodeName: z.string().describe('The name of the node that had credentials auto-assigned'),
 				credentialName: z.string().describe('The name of the credential that was auto-assigned'),
+				credentialType: z.string().describe('The type of the credential that was auto-assigned'),
 			}),
 		)
 		.describe('List of credentials that were automatically assigned to nodes'),

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -49,6 +49,7 @@ const outputSchema = {
 			z.object({
 				nodeName: z.string().describe('The name of the node that had credentials auto-assigned'),
 				credentialName: z.string().describe('The name of the credential that was auto-assigned'),
+				credentialType: z.string().describe('The type of the credential that was auto-assigned'),
 			}),
 		)
 		.describe('List of credentials that were automatically assigned to nodes'),


### PR DESCRIPTION
## Summary
Add missing `credentialType` property to the output schemas so responses match the schema.

## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-5048
Fixes [28274](https://github.com/n8n-io/n8n/issues/28274)

## How to test
This can be tested by connecting instance-level mcp server to one of these clients and asking the client to build a workflow:

1. [OpenCode](https://opencode.ai)
2. n8n MCP client: Create a workflow with an agent and a MCP client tool and connect it to the same instance (oAuth or API Token works)

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
