### PR TITLE
fix(editor): Show credential dropdown when assigned credential is deleted

### DIFF
--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -731,7 +731,7 @@ async function onQuickConnectSignIn(credentialTypeName: string) {
 				</div>
 
 				<div
-					v-else-if="showStandardEmptyState(type)"
+					v-else-if="options.length === 0 && showStandardEmptyState(type)"
 					:class="$style.standardEmptyContainer"
 					data-test-id="node-credentials-empty-state"
 				>


### PR DESCRIPTION
## Summary

When a credential assigned to a node (e.g. HTTP Request with Basic Auth) is deleted from the Credentials page, reopening the node shows a disabled "No credentials yet" dropdown instead of the normal credential selector. The user cannot select another credential or create a new one from that dropdown.

The fix adds an `options.length === 0` guard to the empty state condition so it only renders when there are truly no credentials available. When other credentials exist or the dropdown has a "Create new" option, the normal selector is shown instead.

## Related Linear tickets, Github issues, and Community forum posts

<!-- N/A -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.