### PR TITLE
fix(Zammad Node): Add To and CC fields for email articles

### DIFF
--- a/packages/nodes-base/nodes/Zammad/descriptions/TicketDescription.ts
+++ b/packages/nodes-base/nodes/Zammad/descriptions/TicketDescription.ts
@@ -253,6 +253,33 @@ export const ticketDescription: INodeProperties[] = [
 						default: 'note',
 					},
 					{
+						displayName: 'To',
+						name: 'to',
+						type: 'string',
+						placeholder: 'name@email.com',
+						default: '',
+						required: true,
+						description: 'Recipient email address',
+						displayOptions: {
+							show: {
+								type: ['email'],
+							},
+						},
+					},
+					{
+						displayName: 'CC',
+						name: 'cc',
+						type: 'string',
+						placeholder: 'name@email.com',
+						default: '',
+						description: 'CC recipient email address(es), comma-separated',
+						displayOptions: {
+							show: {
+								type: ['email'],
+							},
+						},
+					},
+					{
 						displayName: 'Reply To',
 						name: 'reply_to',
 						type: 'string',

--- a/packages/nodes-base/nodes/Zammad/test/Zammad.node.test.ts
+++ b/packages/nodes-base/nodes/Zammad/test/Zammad.node.test.ts
@@ -616,6 +616,63 @@ describe('Zammad Node', () => {
 			});
 		});
 
+		it('should include to and cc for email articles', async () => {
+			const mockTicket = { id: 2, title: 'Email Ticket' };
+			const mockArticles = [{ id: 2, body: 'Email body' }];
+
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockImplementation(
+				(paramName, _itemIndex) => {
+					switch (paramName) {
+						case 'resource':
+							return 'ticket';
+						case 'operation':
+							return 'create';
+						case 'title':
+							return 'Email Ticket';
+						case 'group':
+							return 'Support';
+						case 'customer':
+							return 'customer@example.com';
+						case 'article':
+							return {
+								articleDetails: {
+									subject: 'Hello',
+									body: 'Email body',
+									type: 'email',
+									visibility: 'external',
+									to: 'recipient@example.com',
+									cc: 'other@example.com',
+								},
+							};
+						case 'additionalFields':
+							return {};
+						default:
+							return null;
+					}
+				},
+			);
+
+			(GenericFunctions.zammadApiRequest as jest.Mock)
+				.mockResolvedValueOnce(mockTicket)
+				.mockResolvedValueOnce(mockArticles);
+
+			await node.execute.call(mockExecuteFunctions as IExecuteFunctions);
+
+			expect(GenericFunctions.zammadApiRequest).toHaveBeenCalledWith('POST', '/tickets', {
+				article: {
+					subject: 'Hello',
+					body: 'Email body',
+					type: 'email',
+					internal: false,
+					to: 'recipient@example.com',
+					cc: 'other@example.com',
+				},
+				title: 'Email Ticket',
+				group: 'Support',
+				customer: 'customer@example.com',
+			});
+		});
+
 		it('should throw error when creating ticket without article', async () => {
 			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockImplementation(
 				(paramName, _itemIndex) => {

--- a/packages/nodes-base/nodes/Zammad/types.ts
+++ b/packages/nodes-base/nodes/Zammad/types.ts
@@ -91,6 +91,8 @@ export declare namespace Zammad {
 			sender: 'Agent' | 'Customer' | 'System';
 			type: 'chat' | 'email' | 'fax' | 'note' | 'phone' | 'sms';
 			reply_to: string;
+			to?: string;
+			cc?: string;
 		};
 	};
 }


### PR DESCRIPTION
## Summary

The Zammad \"Create a Ticket\" node could not create email-type tickets because the Article collection never exposed a recipient field, so Zammad's API rejected the request. This PR adds `To` (required) and `CC` string inputs to the Article collection, shown only when Article Type is *Email*. The existing execute logic spreads the article fields into the payload, so no changes to `Zammad.node.ts` were needed.

To test: open a Zammad \"Create a Ticket\" node, pick Article Type = *Email*, fill in `To`, and execute — Zammad should accept the request and create the email ticket. Confirm `To` / `CC` are hidden for non-email article types (note, phone, etc.).

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-4824
- closes #27952
- https://community.n8n.io/t/zammad-ticket-creation-misses-to-field-and-fails/89277

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI