### PR TITLE
chore(Anthropic Chat Model Node): Update default model to Claude Sonnet 4.6

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -86,8 +86,8 @@ export class LmChatAnthropic implements INodeType {
 		name: 'lmChatAnthropic',
 		icon: 'file:anthropic.svg',
 		group: ['transform'],
-		version: [1, 1.1, 1.2, 1.3],
-		defaultVersion: 1.3,
+		version: [1, 1.1, 1.2, 1.3, 1.4],
+		defaultVersion: 1.4,
 		description: 'Language Model Anthropic',
 		defaults: {
 			name: 'Anthropic Chat Model',
@@ -155,6 +155,42 @@ export class LmChatAnthropic implements INodeType {
 				type: 'resourceLocator',
 				default: {
 					mode: 'list',
+					value: 'claude-sonnet-4-5-20250929',
+					cachedResultName: 'Claude Sonnet 4.5',
+				},
+				required: true,
+				modes: [
+					{
+						displayName: 'From List',
+						name: 'list',
+						type: 'list',
+						placeholder: 'Select a model...',
+						typeOptions: {
+							searchListMethod: 'searchModels',
+							searchable: true,
+						},
+					},
+					{
+						displayName: 'ID',
+						name: 'id',
+						type: 'string',
+						placeholder: 'Claude Sonnet',
+					},
+				],
+				description:
+					'The model. Choose from the list, or specify an ID. <a href="https://docs.anthropic.com/claude/docs/models-overview">Learn more</a>.',
+				displayOptions: {
+					show: {
+						'@version': [1.3],
+					},
+				},
+			},
+			{
+				displayName: 'Model',
+				name: 'model',
+				type: 'resourceLocator',
+				default: {
+					mode: 'list',
 					value: 'claude-sonnet-4-6',
 					cachedResultName: 'Claude Sonnet 4.6',
 				},
@@ -181,7 +217,7 @@ export class LmChatAnthropic implements INodeType {
 					'The model. Choose from the list, or specify an ID. <a href="https://docs.anthropic.com/claude/docs/models-overview">Learn more</a>.',
 				displayOptions: {
 					show: {
-						'@version': [{ _cnd: { gte: 1.3 } }],
+						'@version': [{ _cnd: { gte: 1.4 } }],
 					},
 				},
 			},

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -155,8 +155,8 @@ export class LmChatAnthropic implements INodeType {
 				type: 'resourceLocator',
 				default: {
 					mode: 'list',
-					value: 'claude-sonnet-4-5-20250929',
-					cachedResultName: 'Claude Sonnet 4.5',
+					value: 'claude-sonnet-4-6',
+					cachedResultName: 'Claude Sonnet 4.6',
 				},
 				required: true,
 				modes: [

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
@@ -79,7 +79,7 @@ describe('LmChatAnthropic', () => {
 				displayName: 'Anthropic Chat Model',
 				name: 'lmChatAnthropic',
 				group: ['transform'],
-				version: [1, 1.1, 1.2, 1.3],
+				version: [1, 1.1, 1.2, 1.3, 1.4],
 				description: 'Language Model Anthropic',
 			});
 		});
@@ -554,16 +554,33 @@ describe('LmChatAnthropic', () => {
 			);
 		});
 
-		it('should have a default model in v1.3 resource locator', () => {
+		it('should keep Claude Sonnet 4.5 as default for v1.3 resource locator', () => {
 			const v13ModelField = lmChatAnthropic.description.properties.find(
 				(p) =>
 					p.name === 'model' &&
 					p.type === 'resourceLocator' &&
-					p.displayOptions?.show?.['@version']?.[0] !== undefined,
+					p.displayOptions?.show?.['@version']?.[0] === 1.3,
 			);
 
 			expect(v13ModelField).toBeDefined();
 			expect(v13ModelField!.default).toEqual({
+				mode: 'list',
+				value: 'claude-sonnet-4-5-20250929',
+				cachedResultName: 'Claude Sonnet 4.5',
+			});
+		});
+
+		it('should have Claude Sonnet 4.6 as default for v1.4+ resource locator', () => {
+			const v14ModelField = lmChatAnthropic.description.properties.find(
+				(p) =>
+					p.name === 'model' &&
+					p.type === 'resourceLocator' &&
+					(p.displayOptions?.show?.['@version']?.[0] as { _cnd?: { gte?: number } })?._cnd?.gte ===
+						1.4,
+			);
+
+			expect(v14ModelField).toBeDefined();
+			expect(v14ModelField!.default).toEqual({
 				mode: 'list',
 				value: 'claude-sonnet-4-6',
 				cachedResultName: 'Claude Sonnet 4.6',

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
@@ -565,8 +565,8 @@ describe('LmChatAnthropic', () => {
 			expect(v13ModelField).toBeDefined();
 			expect(v13ModelField!.default).toEqual({
 				mode: 'list',
-				value: 'claude-sonnet-4-5-20250929',
-				cachedResultName: 'Claude Sonnet 4.5',
+				value: 'claude-sonnet-4-6',
+				cachedResultName: 'Claude Sonnet 4.6',
 			});
 		});
 	});

--- a/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatAnthropic.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatAnthropic.test.ts
@@ -64,7 +64,7 @@ describe('LmChatAnthropic', () => {
 				displayName: 'Anthropic Chat Model',
 				name: 'lmChatAnthropic',
 				group: ['transform'],
-				version: [1, 1.1, 1.2, 1.3],
+				version: [1, 1.1, 1.2, 1.3, 1.4],
 				description: 'Language Model Anthropic',
 			});
 		});

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/descriptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/descriptions.ts
@@ -20,7 +20,7 @@ export const modelRLC: INodeProperties = {
 			displayName: 'ID',
 			name: 'id',
 			type: 'string',
-			placeholder: 'e.g. claude-sonnet-4-5-20250929',
+			placeholder: 'e.g. claude-sonnet-4-6',
 		},
 	],
 };


### PR DESCRIPTION
## Summary

Bumps the default Anthropic model in the `Anthropic Chat Model` node (v1.3 resource locator) from Claude Sonnet 4.5 (`claude-sonnet-4-5-20250929`) to Claude Sonnet 4.6 (`claude-sonnet-4-6`). Also updates the Anthropic vendor node placeholder example and the associated unit-test expectation.

Note: Sonnet 4.6 uses an undated model identifier per Anthropic's docs, departing from the previous date-stamped convention.

### How to test

1. Open a workflow and add an **Anthropic Chat Model** node.
2. Confirm the default selection in the Model field is **Claude Sonnet 4.6** (`claude-sonnet-4-6`).
3. Run `pnpm --filter @n8n/n8n-nodes-langchain test -- LmChatAnthropic`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2412/update-default-anthropic-model-to-sonnet-46

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)