### PR TITLE
feat(agents): Add Linear platform integration

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -99,6 +99,7 @@
     "@aws-sdk/client-secrets-manager": "3.808.0",
     "@azure/identity": "catalog:",
     "@azure/keyvault-secrets": "4.8.0",
+    "@chat-adapter/linear": "^4.20.2",
     "@chat-adapter/slack": "^4.20.2",
     "@chat-adapter/state-memory": "^4.20.2",
     "@chat-adapter/telegram": "^4.20.2",

--- a/packages/cli/src/modules/agents/agents.module.ts
+++ b/packages/cli/src/modules/agents/agents.module.ts
@@ -30,9 +30,11 @@ export class AgentsModule implements ModuleInterface {
 		const { ChatIntegrationRegistry } = await import('./integrations/agent-chat-integration');
 		const { SlackIntegration } = await import('./integrations/platforms/slack-integration');
 		const { TelegramIntegration } = await import('./integrations/platforms/telegram-integration');
+		const { LinearIntegration } = await import('./integrations/platforms/linear-integration');
 		const registry = Container.get(ChatIntegrationRegistry);
 		registry.register(Container.get(SlackIntegration));
 		registry.register(Container.get(TelegramIntegration));
+		registry.register(Container.get(LinearIntegration));
 
 		// Warm the node catalog so the agent runtime can attach search/execute tools
 		// synchronously on each agent reconstruction. The underlying init is idempotent.

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -76,9 +76,6 @@ export interface ExecuteAgentData {
 	finishReason: string;
 }
 
-/** Component types that cause rich_interaction to actually pause for user input. */
-const INTERACTIVE_COMPONENT_TYPES = new Set(['button', 'select', 'radio_select']);
-
 @Service()
 export class AgentsService {
 	/**
@@ -414,20 +411,17 @@ export class AgentsService {
 		const { agent, agentId, projectId, credentialProvider, nodeToolsEnabled, integrationType } =
 			params;
 
-		// Inject the rich_interaction tool for ad-hoc UI in chat integrations —
-		// but only if the target platform has at least one interactive component
-		// type. Without button/select/radio_select the handler can't suspend, so
-		// the tool call would produce no user-visible output on the platform and
-		// confuse the agent's state. Draft/editor contexts (no integrationType)
+		// Inject the rich_interaction tool for ad-hoc UI in chat integrations.
+		// Platforms opt in by declaring `supportedComponents`; integrations that
+		// omit it (e.g. Linear) are treated as having no rich_interaction surface
+		// and the tool is skipped. Draft/editor contexts (no integrationType)
 		// always get the tool.
 		const integration = integrationType
 			? Container.get(ChatIntegrationRegistry).get(integrationType)
 			: undefined;
-		const supportsInteractive =
-			!integration ||
-			(integration.supportedComponents?.some((c) => INTERACTIVE_COMPONENT_TYPES.has(c)) ?? false);
+		const hasRichInteraction = !integration || integration.supportedComponents !== undefined;
 
-		if (supportsInteractive) {
+		if (hasRichInteraction) {
 			try {
 				const { createRichInteractionTool } = await import('./integrations/rich-interaction-tool');
 				agent.tool(createRichInteractionTool(integrationType));

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -425,7 +425,7 @@ export class AgentsService {
 			: undefined;
 		const supportsInteractive =
 			!integration ||
-			integration.supportedComponents.some((c) => INTERACTIVE_COMPONENT_TYPES.has(c));
+			(integration.supportedComponents?.some((c) => INTERACTIVE_COMPONENT_TYPES.has(c)) ?? false);
 
 		if (supportsInteractive) {
 			try {

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -35,6 +35,7 @@ import { AgentExecutionService } from './agent-execution.service';
 import { AgentsToolsService } from './agents-tools.service';
 import { Agent } from './entities/agent.entity';
 import { ExecutionRecorder } from './execution-recorder';
+import { ChatIntegrationRegistry } from './integrations/agent-chat-integration';
 import { N8NCheckpointStorage } from './integrations/n8n-checkpoint-storage';
 import { N8nMemory } from './integrations/n8n-memory';
 import { AgentJsonConfigSchema, isNodeToolsEnabled } from './json-config/agent-json-config';
@@ -74,6 +75,9 @@ export interface ExecuteAgentData {
 	toolCalls: Array<{ toolName: string; input: unknown; result: unknown }>;
 	finishReason: string;
 }
+
+/** Component types that cause rich_interaction to actually pause for user input. */
+const INTERACTIVE_COMPONENT_TYPES = new Set(['button', 'select', 'radio_select']);
 
 @Service()
 export class AgentsService {
@@ -410,15 +414,29 @@ export class AgentsService {
 		const { agent, agentId, projectId, credentialProvider, nodeToolsEnabled, integrationType } =
 			params;
 
-		// Inject the rich_interaction tool for ad-hoc UI in chat integrations.
-		try {
-			const { createRichInteractionTool } = await import('./integrations/rich-interaction-tool');
-			agent.tool(createRichInteractionTool(integrationType));
-		} catch (toolError) {
-			this.logger.warn('Failed to inject rich_interaction tool', {
-				agentId,
-				error: toolError instanceof Error ? toolError.message : String(toolError),
-			});
+		// Inject the rich_interaction tool for ad-hoc UI in chat integrations —
+		// but only if the target platform has at least one interactive component
+		// type. Without button/select/radio_select the handler can't suspend, so
+		// the tool call would produce no user-visible output on the platform and
+		// confuse the agent's state. Draft/editor contexts (no integrationType)
+		// always get the tool.
+		const integration = integrationType
+			? Container.get(ChatIntegrationRegistry).get(integrationType)
+			: undefined;
+		const supportsInteractive =
+			!integration ||
+			integration.supportedComponents.some((c) => INTERACTIVE_COMPONENT_TYPES.has(c));
+
+		if (supportsInteractive) {
+			try {
+				const { createRichInteractionTool } = await import('./integrations/rich-interaction-tool');
+				agent.tool(createRichInteractionTool(integrationType));
+			} catch (toolError) {
+				this.logger.warn('Failed to inject rich_interaction tool', {
+					agentId,
+					error: toolError instanceof Error ? toolError.message : String(toolError),
+				});
+			}
 		}
 
 		if (nodeToolsEnabled) {

--- a/packages/cli/src/modules/agents/integrations/__tests__/linear-integration.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/linear-integration.test.ts
@@ -1,0 +1,107 @@
+import type { Logger } from '@n8n/backend-common';
+import { mock } from 'jest-mock-extended';
+
+import type { AgentChatIntegrationContext } from '../agent-chat-integration';
+import { LinearIntegration } from '../platforms/linear-integration';
+
+jest.mock('../esm-loader', () => ({
+	loadLinearAdapter: jest.fn(),
+}));
+
+import { loadLinearAdapter } from '../esm-loader';
+
+const mockedLoadLinearAdapter = loadLinearAdapter as jest.MockedFunction<typeof loadLinearAdapter>;
+
+describe('LinearIntegration', () => {
+	const logger = mock<Logger>();
+	let integration: LinearIntegration;
+	let fetchSpy: jest.SpyInstance;
+	const createLinearAdapter = jest.fn();
+
+	beforeEach(() => {
+		integration = new LinearIntegration(logger);
+		createLinearAdapter.mockReset();
+		createLinearAdapter.mockReturnValue({ marker: 'adapter' });
+		mockedLoadLinearAdapter.mockReset();
+		mockedLoadLinearAdapter.mockResolvedValue({
+			createLinearAdapter,
+		} as unknown as Awaited<ReturnType<typeof loadLinearAdapter>>);
+
+		fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+			ok: true,
+			json: async () => ({ data: { viewer: { displayName: 'Eugene' } } }),
+		} as Response);
+	});
+
+	afterEach(() => {
+		fetchSpy.mockRestore();
+	});
+
+	const ctx = (credential: Record<string, unknown>): AgentChatIntegrationContext => ({
+		agentId: 'agent-1',
+		projectId: 'project-1',
+		credential,
+		webhookUrlFor: () => 'https://example.test/webhook',
+	});
+
+	it('declares the expected metadata', () => {
+		expect(integration.type).toBe('linear');
+		expect(integration.credentialTypes).toEqual(['linearApi', 'linearOAuth2Api']);
+		expect(integration.supportedComponents).toEqual([
+			'section',
+			'button',
+			'divider',
+			'image',
+			'fields',
+		]);
+		expect(integration.needsShortCallbackData).toBe(false);
+	});
+
+	it('builds the adapter with an apiKey from a linearApi credential', async () => {
+		await integration.createAdapter(ctx({ apiKey: 'lin_api_xyz', signingSecret: 'sec' }));
+
+		expect(createLinearAdapter).toHaveBeenCalledWith({
+			apiKey: 'lin_api_xyz',
+			webhookSecret: 'sec',
+			userName: 'Eugene',
+		});
+	});
+
+	it('builds the adapter with an access token from a linearOAuth2Api credential', async () => {
+		await integration.createAdapter(
+			ctx({
+				oauthTokenData: { access_token: 'oauth_token' },
+				signingSecret: 'sec',
+			}),
+		);
+
+		expect(createLinearAdapter).toHaveBeenCalledWith({
+			apiKey: 'oauth_token',
+			webhookSecret: 'sec',
+			userName: 'Eugene',
+		});
+	});
+
+	it('omits userName when the viewer lookup fails', async () => {
+		fetchSpy.mockResolvedValue({ ok: false } as Response);
+
+		await integration.createAdapter(ctx({ apiKey: 'lin_api_xyz', signingSecret: 'sec' }));
+
+		expect(createLinearAdapter).toHaveBeenCalledWith({
+			apiKey: 'lin_api_xyz',
+			webhookSecret: 'sec',
+		});
+	});
+
+	it('throws when the credential has no token', async () => {
+		await expect(integration.createAdapter(ctx({ signingSecret: 'sec' }))).rejects.toThrow(
+			/Could not extract an API token/,
+		);
+	});
+
+	it('throws when the credential has no signing secret', async () => {
+		await expect(integration.createAdapter(ctx({ apiKey: 'lin_api_xyz' }))).rejects.toThrow(
+			/missing a signing secret/,
+		);
+	});
+});

--- a/packages/cli/src/modules/agents/integrations/__tests__/linear-integration.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/linear-integration.test.ts
@@ -29,7 +29,7 @@ describe('LinearIntegration', () => {
 
 		fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
 			ok: true,
-			json: async () => ({ data: { viewer: { displayName: 'Eugene' } } }),
+			json: async () => ({ data: { viewer: { displayName: 'AgentName' } } }),
 		} as Response);
 	});
 
@@ -63,7 +63,7 @@ describe('LinearIntegration', () => {
 		expect(createLinearAdapter).toHaveBeenCalledWith({
 			apiKey: 'lin_api_xyz',
 			webhookSecret: 'sec',
-			userName: 'Eugene',
+			userName: 'AgentName',
 		});
 		expect(fetchSpy.mock.calls[0][1]).toMatchObject({
 			headers: { Authorization: 'lin_api_xyz' },
@@ -81,7 +81,7 @@ describe('LinearIntegration', () => {
 		expect(createLinearAdapter).toHaveBeenCalledWith({
 			accessToken: 'oauth_token',
 			webhookSecret: 'sec',
-			userName: 'Eugene',
+			userName: 'AgentName',
 		});
 		expect(fetchSpy.mock.calls[0][1]).toMatchObject({
 			headers: { Authorization: 'Bearer oauth_token' },

--- a/packages/cli/src/modules/agents/integrations/__tests__/linear-integration.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/linear-integration.test.ts
@@ -65,9 +65,12 @@ describe('LinearIntegration', () => {
 			webhookSecret: 'sec',
 			userName: 'Eugene',
 		});
+		expect(fetchSpy.mock.calls[0][1]).toMatchObject({
+			headers: { Authorization: 'lin_api_xyz' },
+		});
 	});
 
-	it('builds the adapter with an access token from a linearOAuth2Api credential', async () => {
+	it('builds the adapter with an accessToken from a linearOAuth2Api credential', async () => {
 		await integration.createAdapter(
 			ctx({
 				oauthTokenData: { access_token: 'oauth_token' },
@@ -76,9 +79,12 @@ describe('LinearIntegration', () => {
 		);
 
 		expect(createLinearAdapter).toHaveBeenCalledWith({
-			apiKey: 'oauth_token',
+			accessToken: 'oauth_token',
 			webhookSecret: 'sec',
 			userName: 'Eugene',
+		});
+		expect(fetchSpy.mock.calls[0][1]).toMatchObject({
+			headers: { Authorization: 'Bearer oauth_token' },
 		});
 	});
 

--- a/packages/cli/src/modules/agents/integrations/__tests__/linear-integration.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/linear-integration.test.ts
@@ -44,19 +44,6 @@ describe('LinearIntegration', () => {
 		webhookUrlFor: () => 'https://example.test/webhook',
 	});
 
-	it('declares the expected metadata', () => {
-		expect(integration.type).toBe('linear');
-		expect(integration.credentialTypes).toEqual(['linearApi', 'linearOAuth2Api']);
-		expect(integration.supportedComponents).toEqual([
-			'section',
-			'button',
-			'divider',
-			'image',
-			'fields',
-		]);
-		expect(integration.needsShortCallbackData).toBe(false);
-	});
-
 	it('builds the adapter with an apiKey from a linearApi credential', async () => {
 		await integration.createAdapter(ctx({ apiKey: 'lin_api_xyz', signingSecret: 'sec' }));
 

--- a/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
@@ -32,7 +32,7 @@ export abstract class AgentChatIntegration {
 	 * Omit to signal that the platform has no rich_interaction surface — the
 	 * tool won't be injected into agents targeting this platform.
 	 */
-	readonly supportedComponents?: readonly string[];
+	readonly supportedComponents?: string[];
 
 	/** User-facing description used by `createRichInteractionTool`. */
 	readonly description?: string;

--- a/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
@@ -27,11 +27,15 @@ export abstract class AgentChatIntegration {
 	/** Credential types accepted by the frontend selector. */
 	abstract readonly credentialTypes: string[];
 
-	/** Component types this platform supports in rich_interaction cards. */
-	abstract readonly supportedComponents: string[];
+	/**
+	 * Component types this platform supports in rich_interaction cards.
+	 * Omit to signal that the platform has no rich_interaction surface — the
+	 * tool won't be injected into agents targeting this platform.
+	 */
+	readonly supportedComponents?: readonly string[];
 
 	/** User-facing description used by `createRichInteractionTool`. */
-	abstract readonly description: string;
+	readonly description?: string;
 
 	/**
 	 * True if this platform has a small callback_data limit (Telegram: 64 bytes).

--- a/packages/cli/src/modules/agents/integrations/esm-loader.ts
+++ b/packages/cli/src/modules/agents/integrations/esm-loader.ts
@@ -32,6 +32,10 @@ export async function loadTelegramAdapter() {
 	return await esmImport<typeof import('@chat-adapter/telegram')>('@chat-adapter/telegram');
 }
 
+export async function loadLinearAdapter() {
+	return await esmImport<typeof import('@chat-adapter/linear')>('@chat-adapter/linear');
+}
+
 export async function loadMemoryState() {
 	return await esmImport<typeof import('@chat-adapter/state-memory')>('@chat-adapter/state-memory');
 }

--- a/packages/cli/src/modules/agents/integrations/platforms/linear-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/linear-integration.ts
@@ -9,17 +9,12 @@ type LinearAuth = { kind: 'apiKey'; token: string } | { kind: 'accessToken'; tok
 /**
  * Linear platform integration.
  *
- * Linear issues are the threads and issue comments are the messages. The
- * Vercel Chat SDK's Linear adapter renders `rich_interaction` cards into
- * issue-comment markdown — images become markdown images, and sections,
- * dividers, and fields are preserved.
- *
- * Linear has no interactive UI surface for bot comments: action buttons
- * would render as bold markdown text that the user can't click, and selects
- * aren't rendered at all. We therefore omit `button`, `select`, and
- * `radio_select` from `supportedComponents` — the agent won't generate
- * controls the user cannot respond to, so rich_interaction always posts
- * and returns instead of suspending on a dead-end card.
+ * Linear issues are the threads and issue comments are the messages. Linear
+ * comments have no interactive UI surface (buttons render as non-clickable
+ * bold markdown, selects aren't rendered at all), so this integration omits
+ * `supportedComponents` entirely — `AgentsService` reads the absence as
+ * "skip the rich_interaction tool for this platform" and the agent responds
+ * with normal markdown replies instead of offering dead-end cards.
  *
  * Mention detection in the Chat SDK is a literal string match on
  * `@<adapter.userName>` in the comment body. The adapter defaults `userName` to
@@ -32,14 +27,6 @@ export class LinearIntegration extends AgentChatIntegration {
 	readonly type = 'linear';
 
 	readonly credentialTypes = ['linearApi', 'linearOAuth2Api'];
-
-	readonly supportedComponents = ['section', 'divider', 'image', 'fields'];
-
-	readonly description =
-		'Post formatted content as a comment on a Linear issue. Available: markdown sections, ' +
-		'dividers, images, key-value fields. Linear does not support interactive components, ' +
-		'so buttons/selects are not available — the agent should ask follow-up questions with ' +
-		'a normal reply instead. Users respond by commenting on the issue.';
 
 	constructor(private readonly logger: Logger) {
 		super();

--- a/packages/cli/src/modules/agents/integrations/platforms/linear-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/linear-integration.ts
@@ -30,13 +30,13 @@ export class LinearIntegration extends AgentChatIntegration {
 
 	readonly credentialTypes = ['linearApi', 'linearOAuth2Api'];
 
-	readonly supportedComponents = ['section', 'button', 'divider', 'image', 'fields'];
+	readonly supportedComponents = ['section', 'divider', 'image', 'fields'];
 
 	readonly description =
-		'Post rich content as a comment on a Linear issue. Available: markdown sections, ' +
-		'buttons (rendered as bold text — non-interactive on Linear), dividers, images, ' +
-		'key-value fields. Users reply by commenting on the issue, which the agent receives ' +
-		'as a new message in the thread.';
+		'Post formatted content as a comment on a Linear issue. Available: markdown sections, ' +
+		'dividers, images, key-value fields. Linear does not support interactive components, ' +
+		'so buttons/selects are not available — the agent should ask follow-up questions with ' +
+		'a normal reply instead. Users respond by commenting on the issue.';
 
 	constructor(private readonly logger: Logger) {
 		super();

--- a/packages/cli/src/modules/agents/integrations/platforms/linear-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/linear-integration.ts
@@ -9,17 +9,14 @@ type LinearAuth = { kind: 'apiKey'; token: string } | { kind: 'accessToken'; tok
 /**
  * Linear platform integration.
  *
- * Linear issues are the threads and issue comments are the messages. Linear
- * comments have no interactive UI surface, so this integration omits
- * `supportedComponents` entirely — `AgentsService` reads the absence as
- * "skip the rich_interaction tool for this platform" and the agent responds
- * with normal markdown replies instead of offering dead-end cards.
+ * Linear comments have no interactive UI surface, so this integration omits
+ * `supportedComponents` entirely.
  *
  * Mention detection in the Chat SDK is a literal string match on
  * `@<adapter.userName>` in the comment body. The adapter defaults `userName` to
- * `'linear-bot'`, which nobody types in Linear's UI, so `createAdapter`
- * eagerly fetches the bot user's Linear display name via GraphQL and passes
- * it in — that way `@AgentName`-style mentions fire `onNewMention` as expected.
+ * `'linear-bot'`, so `createAdapter` eagerly fetches the bot user's
+ * Linear display name via GraphQL and passes it in —
+ * that way `@AgentName`-style mentions fire `onNewMention` as expected.
  */
 @Service()
 export class LinearIntegration extends AgentChatIntegration {
@@ -35,9 +32,9 @@ export class LinearIntegration extends AgentChatIntegration {
 		const auth = this.extractAuth(ctx.credential);
 		const webhookSecret = this.extractSigningSecret(ctx.credential);
 		const userName = await this.fetchDisplayName(auth);
+
 		const { createLinearAdapter } = await loadLinearAdapter();
-		// Default mode is 'comments' — simpler setup, supports edit/delete.
-		// Agent-sessions mode can be opted into later via a credential flag.
+
 		return createLinearAdapter({
 			...(auth.kind === 'apiKey' ? { apiKey: auth.token } : { accessToken: auth.token }),
 			webhookSecret,
@@ -89,8 +86,7 @@ export class LinearIntegration extends AgentChatIntegration {
 	/**
 	 * Personal API keys go in as a bare `Authorization: <key>` header; OAuth
 	 * access tokens need `Authorization: Bearer <token>`. Returns undefined on
-	 * any failure — the adapter falls back to its default `linear-bot` name and
-	 * users can still set LINEAR_BOT_USERNAME as an override.
+	 * any failure — the adapter falls back to its default `linear-bot` name.
 	 */
 	private async fetchDisplayName(auth: LinearAuth): Promise<string | undefined> {
 		const authHeader = auth.kind === 'accessToken' ? `Bearer ${auth.token}` : auth.token;
@@ -101,14 +97,17 @@ export class LinearIntegration extends AgentChatIntegration {
 				body: JSON.stringify({ query: '{ viewer { displayName } }' }),
 			});
 			if (!resp.ok) return undefined;
+
 			const json = (await resp.json()) as {
 				data?: { viewer?: { displayName?: string } };
 			};
+
 			return json.data?.viewer?.displayName;
 		} catch (error) {
 			this.logger.debug(
 				`[LinearIntegration] viewer lookup failed: ${error instanceof Error ? error.message : String(error)}`,
 			);
+
 			return undefined;
 		}
 	}

--- a/packages/cli/src/modules/agents/integrations/platforms/linear-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/linear-integration.ts
@@ -11,12 +11,15 @@ type LinearAuth = { kind: 'apiKey'; token: string } | { kind: 'accessToken'; tok
  *
  * Linear issues are the threads and issue comments are the messages. The
  * Vercel Chat SDK's Linear adapter renders `rich_interaction` cards into
- * issue-comment markdown — action buttons become bold text (non-interactive),
- * images become markdown images, sections and dividers are preserved.
+ * issue-comment markdown — images become markdown images, and sections,
+ * dividers, and fields are preserved.
  *
- * Select / radio_select aren't rendered by the adapter, so this integration
- * omits them from `supportedComponents` — the agent won't generate components
- * the adapter can't render.
+ * Linear has no interactive UI surface for bot comments: action buttons
+ * would render as bold markdown text that the user can't click, and selects
+ * aren't rendered at all. We therefore omit `button`, `select`, and
+ * `radio_select` from `supportedComponents` — the agent won't generate
+ * controls the user cannot respond to, so rich_interaction always posts
+ * and returns instead of suspending on a dead-end card.
  *
  * Mention detection in the Chat SDK is a literal string match on
  * `@<adapter.userName>` in the comment body. The adapter defaults `userName` to

--- a/packages/cli/src/modules/agents/integrations/platforms/linear-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/linear-integration.ts
@@ -10,8 +10,7 @@ type LinearAuth = { kind: 'apiKey'; token: string } | { kind: 'accessToken'; tok
  * Linear platform integration.
  *
  * Linear issues are the threads and issue comments are the messages. Linear
- * comments have no interactive UI surface (buttons render as non-clickable
- * bold markdown, selects aren't rendered at all), so this integration omits
+ * comments have no interactive UI surface, so this integration omits
  * `supportedComponents` entirely — `AgentsService` reads the absence as
  * "skip the rich_interaction tool for this platform" and the agent responds
  * with normal markdown replies instead of offering dead-end cards.

--- a/packages/cli/src/modules/agents/integrations/platforms/linear-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/linear-integration.ts
@@ -22,7 +22,7 @@ type LinearAuth = { kind: 'apiKey'; token: string } | { kind: 'accessToken'; tok
  * `@<adapter.userName>` in the comment body. The adapter defaults `userName` to
  * `'linear-bot'`, which nobody types in Linear's UI, so `createAdapter`
  * eagerly fetches the bot user's Linear display name via GraphQL and passes
- * it in — that way `@Eugene`-style mentions fire `onNewMention` as expected.
+ * it in — that way `@AgentName`-style mentions fire `onNewMention` as expected.
  */
 @Service()
 export class LinearIntegration extends AgentChatIntegration {

--- a/packages/cli/src/modules/agents/integrations/platforms/linear-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/linear-integration.ts
@@ -1,0 +1,128 @@
+import { Logger } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+
+import { AgentChatIntegration, type AgentChatIntegrationContext } from '../agent-chat-integration';
+import { loadLinearAdapter } from '../esm-loader';
+
+/**
+ * Linear platform integration.
+ *
+ * Linear issues are the threads and issue comments are the messages. The
+ * Vercel Chat SDK's Linear adapter renders `rich_interaction` cards into
+ * issue-comment markdown — action buttons become bold text (non-interactive),
+ * images become markdown images, sections and dividers are preserved.
+ *
+ * Select / radio_select aren't rendered by the adapter, so this integration
+ * omits them from `supportedComponents` — the agent won't generate components
+ * the adapter can't render.
+ *
+ * Mention detection in the Chat SDK is a literal string match on
+ * `@<adapter.userName>` in the comment body. The adapter defaults `userName` to
+ * `'linear-bot'`, which nobody types in Linear's UI, so `createAdapter`
+ * eagerly fetches the bot user's Linear display name via GraphQL and passes
+ * it in — that way `@Eugene`-style mentions fire `onNewMention` as expected.
+ */
+@Service()
+export class LinearIntegration extends AgentChatIntegration {
+	readonly type = 'linear';
+
+	readonly credentialTypes = ['linearApi', 'linearOAuth2Api'];
+
+	readonly supportedComponents = ['section', 'button', 'divider', 'image', 'fields'];
+
+	readonly description =
+		'Post rich content as a comment on a Linear issue. Available: markdown sections, ' +
+		'buttons (rendered as bold text — non-interactive on Linear), dividers, images, ' +
+		'key-value fields. Users reply by commenting on the issue, which the agent receives ' +
+		'as a new message in the thread.';
+
+	constructor(private readonly logger: Logger) {
+		super();
+	}
+
+	async createAdapter(ctx: AgentChatIntegrationContext): Promise<unknown> {
+		const apiKey = this.extractApiToken(ctx.credential);
+		const webhookSecret = this.extractSigningSecret(ctx.credential);
+		const userName = await this.fetchDisplayName(apiKey);
+		const { createLinearAdapter } = await loadLinearAdapter();
+		// Default mode is 'comments' — simpler setup, supports edit/delete.
+		// Agent-sessions mode can be opted into later via a credential flag.
+		return createLinearAdapter({
+			apiKey,
+			webhookSecret,
+			...(userName ? { userName } : {}),
+		});
+	}
+
+	/**
+	 * - `linearApi` stores the token as `apiKey`.
+	 * - `linearOAuth2Api` stores the token inside `oauthTokenData.access_token`.
+	 */
+	private extractApiToken(credential: Record<string, unknown>): string {
+		let token: string | undefined;
+
+		if (typeof credential.apiKey === 'string' && credential.apiKey) {
+			token = credential.apiKey;
+		}
+
+		if (!token) {
+			const tokenData = credential.oauthTokenData as Record<string, unknown> | undefined;
+			const oauthToken = tokenData?.access_token ?? tokenData?.accessToken;
+			if (typeof oauthToken === 'string' && oauthToken) {
+				token = oauthToken;
+			}
+		}
+
+		if (!token) {
+			throw new Error(
+				'Could not extract an API token from the Linear credential. ' +
+					'Please ensure the credential has a valid API key (linearApi) ' +
+					'or completed OAuth flow (linearOAuth2Api).',
+			);
+		}
+
+		return token;
+	}
+
+	private extractSigningSecret(credential: Record<string, unknown>): string {
+		const secret = credential.signingSecret;
+		if (typeof secret === 'string' && secret) {
+			return secret;
+		}
+
+		throw new Error(
+			'The Linear credential is missing a signing secret, which is required for ' +
+				'agent integrations. Edit the credential and add the signing secret from ' +
+				'your Linear webhook configuration (Settings → API → Webhooks → Signing secret).',
+		);
+	}
+
+	/**
+	 * Try bare and Bearer Authorization headers so the same helper works for both
+	 * linearApi (personal key — bare) and linearOAuth2Api (access token — Bearer).
+	 * Returns undefined on any failure; the adapter falls back to its default
+	 * `linear-bot` name and users can still set LINEAR_BOT_USERNAME as an override.
+	 */
+	private async fetchDisplayName(apiKey: string): Promise<string | undefined> {
+		for (const authHeader of [apiKey, `Bearer ${apiKey}`]) {
+			try {
+				const resp = await fetch('https://api.linear.app/graphql', {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json', Authorization: authHeader },
+					body: JSON.stringify({ query: '{ viewer { displayName } }' }),
+				});
+				if (!resp.ok) continue;
+				const json = (await resp.json()) as {
+					data?: { viewer?: { displayName?: string } };
+				};
+				const displayName = json.data?.viewer?.displayName;
+				if (displayName) return displayName;
+			} catch (error) {
+				this.logger.debug(
+					`[LinearIntegration] viewer lookup failed: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+		}
+		return undefined;
+	}
+}

--- a/packages/cli/src/modules/agents/integrations/platforms/linear-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/linear-integration.ts
@@ -4,6 +4,8 @@ import { Service } from '@n8n/di';
 import { AgentChatIntegration, type AgentChatIntegrationContext } from '../agent-chat-integration';
 import { loadLinearAdapter } from '../esm-loader';
 
+type LinearAuth = { kind: 'apiKey'; token: string } | { kind: 'accessToken'; token: string };
+
 /**
  * Linear platform integration.
  *
@@ -41,47 +43,45 @@ export class LinearIntegration extends AgentChatIntegration {
 	}
 
 	async createAdapter(ctx: AgentChatIntegrationContext): Promise<unknown> {
-		const apiKey = this.extractApiToken(ctx.credential);
+		const auth = this.extractAuth(ctx.credential);
 		const webhookSecret = this.extractSigningSecret(ctx.credential);
-		const userName = await this.fetchDisplayName(apiKey);
+		const userName = await this.fetchDisplayName(auth);
 		const { createLinearAdapter } = await loadLinearAdapter();
 		// Default mode is 'comments' — simpler setup, supports edit/delete.
 		// Agent-sessions mode can be opted into later via a credential flag.
 		return createLinearAdapter({
-			apiKey,
+			...(auth.kind === 'apiKey' ? { apiKey: auth.token } : { accessToken: auth.token }),
 			webhookSecret,
 			...(userName ? { userName } : {}),
 		});
 	}
 
 	/**
-	 * - `linearApi` stores the token as `apiKey`.
-	 * - `linearOAuth2Api` stores the token inside `oauthTokenData.access_token`.
+	 * Determine which auth variant the adapter config expects.
+	 *
+	 * - `linearApi` stores a personal API key in `apiKey` — passed to the adapter
+	 *   as `apiKey` (adapter uses it as-is).
+	 * - `linearOAuth2Api` stores an OAuth access token in
+	 *   `oauthTokenData.access_token` — passed as `accessToken` (adapter skips
+	 *   auto-refresh and treats it as a pre-obtained token, per option B of the
+	 *   @chat-adapter/linear README).
 	 */
-	private extractApiToken(credential: Record<string, unknown>): string {
-		let token: string | undefined;
-
+	private extractAuth(credential: Record<string, unknown>): LinearAuth {
 		if (typeof credential.apiKey === 'string' && credential.apiKey) {
-			token = credential.apiKey;
+			return { kind: 'apiKey', token: credential.apiKey };
 		}
 
-		if (!token) {
-			const tokenData = credential.oauthTokenData as Record<string, unknown> | undefined;
-			const oauthToken = tokenData?.access_token ?? tokenData?.accessToken;
-			if (typeof oauthToken === 'string' && oauthToken) {
-				token = oauthToken;
-			}
+		const tokenData = credential.oauthTokenData as Record<string, unknown> | undefined;
+		const oauthToken = tokenData?.access_token ?? tokenData?.accessToken;
+		if (typeof oauthToken === 'string' && oauthToken) {
+			return { kind: 'accessToken', token: oauthToken };
 		}
 
-		if (!token) {
-			throw new Error(
-				'Could not extract an API token from the Linear credential. ' +
-					'Please ensure the credential has a valid API key (linearApi) ' +
-					'or completed OAuth flow (linearOAuth2Api).',
-			);
-		}
-
-		return token;
+		throw new Error(
+			'Could not extract an API token from the Linear credential. ' +
+				'Please ensure the credential has a valid API key (linearApi) ' +
+				'or completed OAuth flow (linearOAuth2Api).',
+		);
 	}
 
 	private extractSigningSecret(credential: Record<string, unknown>): string {
@@ -98,31 +98,29 @@ export class LinearIntegration extends AgentChatIntegration {
 	}
 
 	/**
-	 * Try bare and Bearer Authorization headers so the same helper works for both
-	 * linearApi (personal key — bare) and linearOAuth2Api (access token — Bearer).
-	 * Returns undefined on any failure; the adapter falls back to its default
-	 * `linear-bot` name and users can still set LINEAR_BOT_USERNAME as an override.
+	 * Personal API keys go in as a bare `Authorization: <key>` header; OAuth
+	 * access tokens need `Authorization: Bearer <token>`. Returns undefined on
+	 * any failure — the adapter falls back to its default `linear-bot` name and
+	 * users can still set LINEAR_BOT_USERNAME as an override.
 	 */
-	private async fetchDisplayName(apiKey: string): Promise<string | undefined> {
-		for (const authHeader of [apiKey, `Bearer ${apiKey}`]) {
-			try {
-				const resp = await fetch('https://api.linear.app/graphql', {
-					method: 'POST',
-					headers: { 'Content-Type': 'application/json', Authorization: authHeader },
-					body: JSON.stringify({ query: '{ viewer { displayName } }' }),
-				});
-				if (!resp.ok) continue;
-				const json = (await resp.json()) as {
-					data?: { viewer?: { displayName?: string } };
-				};
-				const displayName = json.data?.viewer?.displayName;
-				if (displayName) return displayName;
-			} catch (error) {
-				this.logger.debug(
-					`[LinearIntegration] viewer lookup failed: ${error instanceof Error ? error.message : String(error)}`,
-				);
-			}
+	private async fetchDisplayName(auth: LinearAuth): Promise<string | undefined> {
+		const authHeader = auth.kind === 'accessToken' ? `Bearer ${auth.token}` : auth.token;
+		try {
+			const resp = await fetch('https://api.linear.app/graphql', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json', Authorization: authHeader },
+				body: JSON.stringify({ query: '{ viewer { displayName } }' }),
+			});
+			if (!resp.ok) return undefined;
+			const json = (await resp.json()) as {
+				data?: { viewer?: { displayName?: string } };
+			};
+			return json.data?.viewer?.displayName;
+		} catch (error) {
+			this.logger.debug(
+				`[LinearIntegration] viewer lookup failed: ${error instanceof Error ? error.message : String(error)}`,
+			);
+			return undefined;
 		}
-		return undefined;
 	}
 }

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentIntegrationsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentIntegrationsPanel.vue
@@ -64,10 +64,8 @@ const integrationConfigs: IntegrationConfig[] = [
 		icon: 'list-checks',
 		description:
 			'Connect a Linear API credential to let this agent respond to comments in Linear issues. ' +
-			'Point a Linear webhook at the URL below, paste its signing secret into the credential, ' +
-			'and comments that @-mention the bot user will trigger the agent.',
-		connectedDescription:
-			'Your agent is connected to Linear. Make sure the Linear webhook points to the URL below.',
+			'Point a Linear webhook at the URL below and paste its signing secret into the credential',
+		connectedDescription: 'Your agent is connected to Linear and can reply to @-mentions',
 		credentialTypes: ['linearApi', 'linearOAuth2Api'],
 		noCredentialsMessage: 'No Linear credentials found.',
 	},

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentIntegrationsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentIntegrationsPanel.vue
@@ -58,6 +58,19 @@ const integrationConfigs: IntegrationConfig[] = [
 		credentialTypes: ['telegramApi'],
 		noCredentialsMessage: 'No Telegram API credentials found.',
 	},
+	{
+		type: 'linear',
+		label: 'Linear',
+		icon: 'list-checks',
+		description:
+			'Connect a Linear API credential to let this agent respond to comments in Linear issues. ' +
+			'Point a Linear webhook at the URL below, paste its signing secret into the credential, ' +
+			'and comments that @-mention the bot user will trigger the agent.',
+		connectedDescription:
+			'Your agent is connected to Linear. Make sure the Linear webhook points to the URL below.',
+		credentialTypes: ['linearApi', 'linearOAuth2Api'],
+		noCredentialsMessage: 'No Linear credentials found.',
+	},
 ];
 
 // Per-integration state
@@ -87,10 +100,20 @@ function hasError(type: string): boolean {
 	return (errorMessages.value[type] ?? '').length > 0;
 }
 
-const webhookUrl = computed(() => {
+function webhookUrlFor(platform: string): string {
 	const base = rootStore.urlBaseEditor;
-	return `${base}rest/projects/${props.projectId}/agents/v2/${props.agentId}/webhooks/slack`;
-});
+	return `${base}rest/projects/${props.projectId}/agents/v2/${props.agentId}/webhooks/${platform}`;
+}
+
+const linearCopied = ref(false);
+
+async function copyLinearWebhookUrl() {
+	await navigator.clipboard.writeText(webhookUrlFor('linear'));
+	linearCopied.value = true;
+	setTimeout(() => {
+		linearCopied.value = false;
+	}, 2000);
+}
 
 const oauthCallbackUrl = computed(
 	() => (rootStore.OAuthCallbackUrls as { oauth2?: string }).oauth2 ?? '',
@@ -138,12 +161,12 @@ const slackAppManifest = computed(() =>
 			},
 			settings: {
 				event_subscriptions: {
-					request_url: webhookUrl.value,
+					request_url: webhookUrlFor('slack'),
 					bot_events: ['app_mention', 'assistant_thread_context_changed', 'message.im'],
 				},
 				interactivity: {
 					is_enabled: true,
-					request_url: webhookUrl.value,
+					request_url: webhookUrlFor('slack'),
 				},
 				org_deploy_enabled: false,
 				socket_mode_enabled: false,
@@ -307,6 +330,28 @@ onMounted(async () => {
 				<N8nText :class="$style.description" size="small">
 					{{ config.description }}
 				</N8nText>
+
+				<!-- Linear webhook URL — shown regardless of connection state so users can
+				     configure Linear *before* creating a credential (the signing secret is
+				     only revealed after the webhook is saved). -->
+				<div v-if="config.type === 'linear'" :class="$style.webhookRow">
+					<input
+						:value="webhookUrlFor('linear')"
+						readonly
+						:class="$style.webhookInput"
+						:data-testid="`${config.type}-webhook-url`"
+						@focus="($event.target as HTMLInputElement).select()"
+					/>
+					<N8nButton
+						variant="outline"
+						size="small"
+						:data-testid="`${config.type}-copy-webhook-url`"
+						@click="copyLinearWebhookUrl"
+					>
+						<N8nIcon :icon="linearCopied ? 'check' : 'copy'" :size="14" />
+						{{ linearCopied ? 'Copied' : 'Copy' }}
+					</N8nButton>
+				</div>
 
 				<div v-if="!isConnected(config.type)" :class="$style.connectForm">
 					<template v-if="hasCredentials(config.type)">
@@ -561,5 +606,31 @@ onMounted(async () => {
 
 .actionButton {
 	align-self: flex-start;
+}
+
+.webhookRow {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing--2xs);
+}
+
+.webhookInput {
+	flex: 1;
+	min-width: 0;
+	padding: var(--spacing--3xs) var(--spacing--2xs);
+	background-color: var(--color--foreground--tint-2);
+	border: var(--border);
+	border-radius: var(--radius);
+	font-family: monospace;
+	font-size: var(--font-size--2xs);
+	color: var(--color--text);
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	overflow: hidden;
+}
+
+.webhookInput:focus {
+	outline: none;
+	border-color: var(--color--primary);
 }
 </style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2391,6 +2391,9 @@ importers:
       '@azure/keyvault-secrets':
         specifier: 4.8.0
         version: 4.8.0
+      '@chat-adapter/linear':
+        specifier: ^4.20.2
+        version: 4.26.0(graphql@16.11.0)
       '@chat-adapter/slack':
         specifier: ^4.20.2
         version: 4.23.0
@@ -6272,8 +6275,14 @@ packages:
   '@cfworker/json-schema@4.1.0':
     resolution: {integrity: sha512-/vYKi/qMxwNsuIJ9WGWwM2rflY40ZenK3Kh4uR5vB9/Nz12Y7IUN/Xf4wDA7vzPfw0VNh3b/jz4+MjcVgARKJg==}
 
+  '@chat-adapter/linear@4.26.0':
+    resolution: {integrity: sha512-sQfJXh9QbMnLV/odikaWHBQ3Mx1ZS+QtxIt7dTEQ4aCeIrQJflycAxxO8d6aepaGKhLQjvZx7iOkdfxMj35WlA==}
+
   '@chat-adapter/shared@4.23.0':
     resolution: {integrity: sha512-IDHgrAi3Y8Qptl1kd8zmM6jxWX+lu0cq/uZiURv8jONufWHrVwVr19pN0YK52ASnRlLZkcaNYXoa+mLFGQ2tlw==}
+
+  '@chat-adapter/shared@4.26.0':
+    resolution: {integrity: sha512-YD0MGktFXrArUqTBsyPfL5vkdD1WBS58PAWO0oVrMQAMmPxpAXfWGjBtZCkf3y8R8Svb0uVuVXiMZSForaEnMQ==}
 
   '@chat-adapter/slack@4.23.0':
     resolution: {integrity: sha512-J5Ml/Ug8Zdb3zVIcbMhkei9U9aTeY+uqpzuuzcHkwdJC6FDFhwj5TSiuocckctqW9tMCqzFl4h4gU5q9f6KSGA==}
@@ -7919,6 +7928,10 @@ packages:
     resolution: {integrity: sha512-KLB4TQKkRdki9Ugbz+X986a1F7IaZUZbPuTfPNFi7slTT+biSw0b/LPJ0tCk7EHyo5QmN8tZ1XLZwI7GgUBsfA==}
     cpu: [x64]
     os: [win32]
+
+  '@linear/sdk@76.0.0':
+    resolution: {integrity: sha512-Xt0x5Kl6qBoWhGFypb8ykyP+c5kT7scmRPs1uJidSPOaRgkMJ/4y41QpmZCWCBUMmZtf/O0VktgQio6rLXT94w==}
+    engines: {node: '>=18.x'}
 
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
@@ -12901,6 +12914,9 @@ packages:
 
   chat@4.23.0:
     resolution: {integrity: sha512-Gmw8yyDrrH9Vxs+TfxF7FoTENrCzJV4T0FiAh7APGcQPhMMYAhrpq66PKj8azhkUSEyaen8ujbneogoJWiY8vg==}
+
+  chat@4.26.0:
+    resolution: {integrity: sha512-QToDnIEGpyb8yQA6YLMHOSRK30YVk4RtsyFyuWFYyB2c4jQlyIrSWtwVK7qyvmvqzQp9uDwCdJRAhS8GtCHAGQ==}
 
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
@@ -25573,9 +25589,24 @@ snapshots:
 
   '@cfworker/json-schema@4.1.0': {}
 
+  '@chat-adapter/linear@4.26.0(graphql@16.11.0)':
+    dependencies:
+      '@chat-adapter/shared': 4.26.0
+      '@linear/sdk': 76.0.0(graphql@16.11.0)
+      chat: 4.26.0
+    transitivePeerDependencies:
+      - graphql
+      - supports-color
+
   '@chat-adapter/shared@4.23.0':
     dependencies:
       chat: 4.23.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@chat-adapter/shared@4.26.0':
+    dependencies:
+      chat: 4.26.0
     transitivePeerDependencies:
       - supports-color
 
@@ -27635,6 +27666,12 @@ snapshots:
 
   '@libsql/win32-x64-msvc@0.5.28':
     optional: true
+
+  '@linear/sdk@76.0.0(graphql@16.11.0)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.11.0)
+    transitivePeerDependencies:
+      - graphql
 
   '@lukeed/csprng@1.1.0': {}
 
@@ -33968,6 +34005,18 @@ snapshots:
       '@kurkle/color': 0.3.2
 
   chat@4.23.0:
+    dependencies:
+      '@workflow/serde': 4.1.0-beta.2
+      mdast-util-to-string: 4.0.0
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      remend: 1.3.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  chat@4.26.0:
     dependencies:
       '@workflow/serde': 4.1.0-beta.2
       mdast-util-to-string: 4.0.0


### PR DESCRIPTION
## Summary

Adds Linear integration for n8n Agents.

Notable bits:

- Fetches the bot user's Linear display name via GraphQL at connect time so `@AgentName`-style mentions in comments actually fire `onNewMention`.
- **`rich_interaction` disabled on Linear.** Linear comments have no interactive UI surface (buttons would render as non-clickable bold markdown, selects aren't rendered at all), so `LinearIntegration` omits `supportedComponents`. - `AgentsService` now reads the absence of `supportedComponents` as "skip the `rich_interaction` tool for this integration".
- **Frontend**: adds a Linear card to `AgentIntegrationsPanel.vue` with a read-only webhook URL field + Copy button.

**How to test:** Create a `Linear API` or `Linear OAuth2 API` credential, create a Linear webhook (Settings → API → Webhooks) pointing at the URL shown in the agent's Integrations card with the **Comments** resource type enabled, and paste the signing secret back into the credential. Connect the integration, then comment `@<BotDisplayName> hello` on any Linear issue — the agent should reply as a new comment. Confirm Slack/Telegram cards still suspend and post correctly (regression sanity).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-7

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI