### PR TITLE
fix(core): Fix health endpoint cross-origin requests

### DIFF
--- a/packages/cli/src/abstract-server.ts
+++ b/packages/cli/src/abstract-server.ts
@@ -137,14 +137,16 @@ export abstract class AbstractServer {
 		const healthPath = this.endpointHealth;
 		const readinessPath = `${healthPath}/readiness`;
 
+		const healthMiddlewares = inDevelopment ? [corsMiddleware] : [];
+
 		// main health check should not care about DB connections
-		this.app.get(healthPath, (_req, res) => {
+		this.app.get(healthPath, ...healthMiddlewares, (_req, res) => {
 			res.send({ status: 'ok' });
 		});
 
 		const { connectionState } = this.dbConnection;
 
-		this.app.get(readinessPath, (_req, res) => {
+		this.app.get(readinessPath, ...healthMiddlewares, (_req, res) => {
 			const { connected, migrated } = connectionState;
 			if (connected && migrated && this.fullyReady) {
 				res.status(200).send({ status: 'ok' });

--- a/packages/frontend/editor-ui/src/app/composables/useBackendStatus.spec.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useBackendStatus.spec.ts
@@ -6,6 +6,7 @@ import merge from 'lodash/merge';
 import { useBackendStatus } from './useBackendStatus';
 import { useBackendConnectionStore } from '@/app/stores/backendConnection.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
+import { useRootStore } from '@n8n/stores/useRootStore';
 import { defaultSettings } from '@/__tests__/defaults';
 
 const mockStartHeartbeat = vi.fn();
@@ -94,6 +95,27 @@ describe('useBackendStatus', () => {
 		wrapper.unmount();
 
 		expect(mockStopHeartbeat).toHaveBeenCalled();
+	});
+
+	it('should prepend backend origin to health URL when baseUrl is a full URL', async () => {
+		const rootStore = useRootStore();
+		vi.spyOn(rootStore, 'baseUrl', 'get').mockReturnValue('http://localhost:5678/');
+
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ status: 'ok' }),
+		});
+
+		const wrapper = createWrapper();
+
+		await vi.waitFor(() => {
+			expect(mockFetch).toHaveBeenCalledWith('http://localhost:5678/internal/health', {
+				cache: 'no-store',
+				signal: expect.any(AbortSignal),
+			});
+		});
+
+		wrapper.unmount();
 	});
 
 	it('should skip health checks in preview mode', async () => {

--- a/packages/frontend/editor-ui/src/app/composables/useBackendStatus.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useBackendStatus.ts
@@ -2,6 +2,7 @@ import { onMounted, onUnmounted, ref } from 'vue';
 import { useBackendConnectionStore } from '@/app/stores/backendConnection.store';
 import { useHeartbeat } from '@/app/push-connection/useHeartbeat';
 import { useSettingsStore } from '@/app/stores/settings.store';
+import { useRootStore } from '@n8n/stores/useRootStore';
 
 const HEALTH_CHECK_INTERVAL = 10000;
 const HEALTH_CHECK_TIMEOUT = 5000;
@@ -9,6 +10,7 @@ const HEALTH_CHECK_TIMEOUT = 5000;
 export function useBackendStatus() {
 	const backendConnectionStore = useBackendConnectionStore();
 	const settingsStore = useSettingsStore();
+	const rootStore = useRootStore();
 	const checking = ref(false);
 
 	/**
@@ -22,8 +24,15 @@ export function useBackendStatus() {
 		const controller = new AbortController();
 		const timeoutId = setTimeout(() => controller.abort(), HEALTH_CHECK_TIMEOUT);
 
+		// When baseUrl is a full URL (e.g. http://localhost:5678/ in dev mode),
+		// extract the origin so the health request targets the backend directly.
+		// When baseUrl is a relative path (e.g. /), the request goes to the current host.
+		const base = rootStore.baseUrl;
+		const origin = base.startsWith('http') ? new URL(base).origin : '';
+		const healthUrl = origin + settingsStore.endpointHealth;
+
 		try {
-			const response = await fetch(settingsStore.endpointHealth, {
+			const response = await fetch(healthUrl, {
 				cache: 'no-store',
 				signal: controller.signal,
 			});


### PR DESCRIPTION
## Summary

- Health check requests from the frontend now correctly target the backend server in dev mode, where frontend (port 8080) and backend (port 5678) run on different origins
- Added CORS middleware to the health endpoint so the browser doesn't block cross-origin health check responses in dev mode

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-5102](https://linear.app/n8n/issue/ADO-5102/fix-health-endpoint-issues-in-dev-mode)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
