### PR TITLE
feat(agents): disable streaming for Telegram integration

### DIFF
--- a/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
@@ -1,0 +1,236 @@
+import type { CredentialProvider, StreamChunk } from '@n8n/agents';
+import { Container } from '@n8n/di';
+import { mock } from 'jest-mock-extended';
+import type { Logger } from 'n8n-workflow';
+
+import { AgentChatBridge } from '../agent-chat-bridge';
+import {
+	AgentChatIntegration,
+	ChatIntegrationRegistry,
+	type AgentChatIntegrationContext,
+} from '../agent-chat-integration';
+import type { ComponentMapper } from '../component-mapper';
+
+type ChatBotLike = ConstructorParameters<typeof AgentChatBridge>[0];
+
+interface FakeThread {
+	id: string;
+	subscribe: jest.Mock;
+	post: jest.Mock;
+}
+
+function makeBot() {
+	const handlers: {
+		mention?: (thread: unknown, message: unknown) => Promise<void>;
+		subscribed?: (thread: unknown, message: unknown) => Promise<void>;
+		action?: (event: unknown) => Promise<void>;
+	} = {};
+	const bot = {
+		onNewMention: (h: typeof handlers.mention) => {
+			handlers.mention = h;
+		},
+		onSubscribedMessage: (h: typeof handlers.subscribed) => {
+			handlers.subscribed = h;
+		},
+		onAction: (h: typeof handlers.action) => {
+			handlers.action = h;
+		},
+	};
+	return { bot, handlers };
+}
+
+function makeThread(): FakeThread {
+	return {
+		id: 'thread-1',
+		subscribe: jest.fn().mockResolvedValue(undefined),
+		post: jest.fn().mockResolvedValue(undefined),
+	};
+}
+
+async function* toStream(chunks: StreamChunk[]): AsyncGenerator<StreamChunk> {
+	for (const c of chunks) yield c;
+}
+
+async function drainIterable(value: unknown): Promise<string> {
+	if (typeof value === 'string') return value;
+	if (
+		value &&
+		typeof value === 'object' &&
+		Symbol.asyncIterator in (value as Record<PropertyKey, unknown>)
+	) {
+		let out = '';
+		for await (const part of value as AsyncIterable<string>) out += part;
+		return out;
+	}
+	throw new Error(`post() received unexpected argument: ${JSON.stringify(value)}`);
+}
+
+class BufferingTestIntegration extends AgentChatIntegration {
+	readonly type = 'test-buffered';
+	readonly credentialTypes: string[] = [];
+	readonly supportedComponents: string[] = [];
+	readonly description = '';
+	readonly disableStreaming = true;
+	async createAdapter(_ctx: AgentChatIntegrationContext): Promise<unknown> {
+		return {};
+	}
+}
+
+class StreamingTestIntegration extends AgentChatIntegration {
+	readonly type = 'test-streaming';
+	readonly credentialTypes: string[] = [];
+	readonly supportedComponents: string[] = [];
+	readonly description = '';
+	async createAdapter(_ctx: AgentChatIntegrationContext): Promise<unknown> {
+		return {};
+	}
+}
+
+describe('AgentChatBridge — consumeStream', () => {
+	let registry: ChatIntegrationRegistry;
+	const credentialProvider = mock<CredentialProvider>();
+	const componentMapper = mock<ComponentMapper>();
+	const logger = mock<Logger>();
+
+	beforeEach(() => {
+		registry = new ChatIntegrationRegistry();
+		registry.register(new BufferingTestIntegration());
+		registry.register(new StreamingTestIntegration());
+		Container.set(ChatIntegrationRegistry, registry);
+	});
+
+	afterEach(() => {
+		Container.reset();
+		jest.clearAllMocks();
+	});
+
+	function makeAgentExecutor(chunks: StreamChunk[]) {
+		return {
+			executeForChat: () => toStream(chunks),
+			executeForChatPublished: () => toStream(chunks),
+			resumeForChat: () => toStream(chunks),
+		};
+	}
+
+	describe('when integration disables streaming', () => {
+		it('posts a single collected string for a run that only has text deltas', async () => {
+			const { bot, handlers } = makeBot();
+			const thread = makeThread();
+			const agentExecutor = makeAgentExecutor([
+				{ type: 'text-delta', delta: 'Hello ' },
+				{ type: 'text-delta', delta: 'world' },
+				{ type: 'finish', finishReason: 'stop' },
+			]);
+
+			new AgentChatBridge(
+				bot as unknown as ChatBotLike,
+				'agent-1',
+				agentExecutor as never,
+				credentialProvider,
+				componentMapper,
+				logger,
+				'user-1',
+				'project-1',
+				'test-buffered',
+			);
+
+			await handlers.mention!(thread, { text: 'hi', author: { userId: 'u1' } });
+
+			expect(thread.post).toHaveBeenCalledTimes(1);
+			expect(thread.post).toHaveBeenCalledWith('Hello world');
+		});
+
+		it('flushes the buffer before posting a suspension card, then continues buffering', async () => {
+			const { bot, handlers } = makeBot();
+			const thread = makeThread();
+			componentMapper.toCard.mockResolvedValue({ kind: 'card' } as never);
+
+			const agentExecutor = makeAgentExecutor([
+				{ type: 'text-delta', delta: 'Before suspend. ' },
+				{
+					type: 'tool-call-suspended',
+					runId: 'run-1',
+					toolCallId: 'tool-1',
+					toolName: 'approval',
+					suspendPayload: { message: 'Approve?' },
+				},
+				{ type: 'text-delta', delta: 'After resume.' },
+				{ type: 'finish', finishReason: 'stop' },
+			]);
+
+			new AgentChatBridge(
+				bot as unknown as ChatBotLike,
+				'agent-1',
+				agentExecutor as never,
+				credentialProvider,
+				componentMapper,
+				logger,
+				'user-1',
+				'project-1',
+				'test-buffered',
+			);
+
+			await handlers.mention!(thread, { text: 'hi', author: { userId: 'u1' } });
+
+			expect(thread.post).toHaveBeenCalledTimes(3);
+			expect(thread.post.mock.calls[0][0]).toBe('Before suspend. ');
+			expect(thread.post.mock.calls[1][0]).toEqual({ card: { kind: 'card' } });
+			expect(thread.post.mock.calls[2][0]).toBe('After resume.');
+		});
+
+		it('does not post when the buffer is only whitespace', async () => {
+			const { bot, handlers } = makeBot();
+			const thread = makeThread();
+			const agentExecutor = makeAgentExecutor([
+				{ type: 'text-delta', delta: '   ' },
+				{ type: 'finish', finishReason: 'stop' },
+			]);
+
+			new AgentChatBridge(
+				bot as unknown as ChatBotLike,
+				'agent-1',
+				agentExecutor as never,
+				credentialProvider,
+				componentMapper,
+				logger,
+				'user-1',
+				'project-1',
+				'test-buffered',
+			);
+
+			await handlers.mention!(thread, { text: 'hi', author: { userId: 'u1' } });
+
+			expect(thread.post).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('when integration keeps streaming enabled', () => {
+		it('posts an AsyncIterable whose drained content equals the concatenated deltas', async () => {
+			const { bot, handlers } = makeBot();
+			const thread = makeThread();
+			const agentExecutor = makeAgentExecutor([
+				{ type: 'text-delta', delta: 'Hello ' },
+				{ type: 'text-delta', delta: 'world' },
+				{ type: 'finish', finishReason: 'stop' },
+			]);
+
+			new AgentChatBridge(
+				bot as unknown as ChatBotLike,
+				'agent-1',
+				agentExecutor as never,
+				credentialProvider,
+				componentMapper,
+				logger,
+				'user-1',
+				'project-1',
+				'test-streaming',
+			);
+
+			await handlers.mention!(thread, { text: 'hi', author: { userId: 'u1' } });
+
+			expect(thread.post).toHaveBeenCalledTimes(1);
+			const received = await drainIterable(thread.post.mock.calls[0][0]);
+			expect(received).toBe('Hello world');
+		});
+	});
+});

--- a/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
@@ -136,7 +136,7 @@ describe('AgentChatBridge — consumeStream', () => {
 			await handlers.mention!(thread, { text: 'hi', author: { userId: 'u1' } });
 
 			expect(thread.post).toHaveBeenCalledTimes(1);
-			expect(thread.post).toHaveBeenCalledWith('Hello world');
+			expect(thread.post).toHaveBeenCalledWith({ markdown: 'Hello world' });
 		});
 
 		it('flushes the buffer before posting a suspension card, then continues buffering', async () => {
@@ -172,9 +172,9 @@ describe('AgentChatBridge — consumeStream', () => {
 			await handlers.mention!(thread, { text: 'hi', author: { userId: 'u1' } });
 
 			expect(thread.post).toHaveBeenCalledTimes(3);
-			expect(thread.post).toHaveBeenNthCalledWith(1, 'Before suspend. ');
+			expect(thread.post).toHaveBeenNthCalledWith(1, { markdown: 'Before suspend. ' });
 			expect(thread.post).toHaveBeenNthCalledWith(2, { card: { kind: 'card' } });
-			expect(thread.post).toHaveBeenNthCalledWith(3, 'After resume.');
+			expect(thread.post).toHaveBeenNthCalledWith(3, { markdown: 'After resume.' });
 		});
 
 		it('does not post when the buffer is only whitespace', async () => {

--- a/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
@@ -106,7 +106,6 @@ describe('AgentChatBridge — consumeStream', () => {
 
 	function makeAgentExecutor(chunks: StreamChunk[]) {
 		return {
-			executeForChat: () => toStream(chunks),
 			executeForChatPublished: () => toStream(chunks),
 			resumeForChat: () => toStream(chunks),
 		};
@@ -173,9 +172,9 @@ describe('AgentChatBridge — consumeStream', () => {
 			await handlers.mention!(thread, { text: 'hi', author: { userId: 'u1' } });
 
 			expect(thread.post).toHaveBeenCalledTimes(3);
-			expect(thread.post.mock.calls[0][0]).toBe('Before suspend. ');
-			expect(thread.post.mock.calls[1][0]).toEqual({ card: { kind: 'card' } });
-			expect(thread.post.mock.calls[2][0]).toBe('After resume.');
+			expect(thread.post).toHaveBeenNthCalledWith(1, 'Before suspend. ');
+			expect(thread.post).toHaveBeenNthCalledWith(2, { card: { kind: 'card' } });
+			expect(thread.post).toHaveBeenNthCalledWith(3, 'After resume.');
 		});
 
 		it('does not post when the buffer is only whitespace', async () => {

--- a/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
@@ -93,10 +93,16 @@ type TextEndFn = () => void;
  * 2. `onSubscribedMessage` — follow-up messages in subscribed threads
  * 3. `onAction` — button clicks for HITL resume flow
  *
- * Streaming strategy (Phase 1 — collect-and-post):
- * Text chunks are accumulated in a buffer. When a non-text event arrives
- * (suspension, message, error, finish), the buffer is flushed as a markdown
- * post. This sacrifices real-time streaming but ensures correct ordering.
+ * Stream consumption has two strategies, selected per integration via the
+ * `disableStreaming` flag on `AgentChatIntegration`:
+ *   • streaming (default, e.g. Slack): text deltas are piped as an
+ *     AsyncIterable<string> into `thread.post()` so Chat SDK can render
+ *     incrementally (post-and-edit).
+ *   • buffered (Telegram): deltas accumulate into a string and are posted as
+ *     a single message per flush event, avoiding `editMessageText` rate limits.
+ *
+ * In both strategies, non-text chunks (`tool-call-suspended`, `message`,
+ * `error`) flush any pending text before being handled, preserving ordering.
  */
 export class AgentChatBridge {
 	/** Short-lived set of run IDs that have been resumed to prevent double resumption */

--- a/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
@@ -247,7 +247,7 @@ export class AgentChatBridge {
 	 * so Chat SDK can render incrementally (post-and-edit). Integrations that
 	 * set `disableStreaming` short-circuit to `consumeStreamBuffered`, which
 	 * accumulates deltas into a string and posts them as a single message per
-	 * flush event (used by Telegram to avoid `editMessageText` rate limits).
+	 * flush event (used by Telegram to avoid Markdown streaming issues).
 	 *
 	 * In both strategies, non-text chunks (`tool-call-suspended`, `message`,
 	 * `error`) flush any pending text first, then get handled in order.

--- a/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
@@ -237,17 +237,17 @@ export class AgentChatBridge {
 	}
 
 	// ---------------------------------------------------------------------------
-	// Stream consumer — dispatches between streaming and buffered strategies
+	// Stream consumer
 	// ---------------------------------------------------------------------------
 
 	/**
 	 * Consume the agent stream and post to the thread.
 	 *
-	 * Two strategies — selected per integration via the `disableStreaming` flag:
-	 *   • streaming (default): pipe text deltas as an AsyncIterable<string> to
-	 *     `thread.post()`. Chat SDK renders incrementally (post-and-edit).
-	 *   • buffered: accumulate text/reasoning deltas into a string and post once
-	 *     per flush event. Used by Telegram to avoid edit_message rate limits.
+	 * Default: pipe text deltas as an AsyncIterable<string> to `thread.post()`
+	 * so Chat SDK can render incrementally (post-and-edit). Integrations that
+	 * set `disableStreaming` short-circuit to `consumeStreamBuffered`, which
+	 * accumulates deltas into a string and posts them as a single message per
+	 * flush event (used by Telegram to avoid `editMessageText` rate limits).
 	 *
 	 * In both strategies, non-text chunks (`tool-call-suspended`, `message`,
 	 * `error`) flush any pending text first, then get handled in order.
@@ -258,19 +258,9 @@ export class AgentChatBridge {
 	): Promise<void> {
 		if (this.disableStreaming) {
 			await this.consumeStreamBuffered(stream, thread);
-		} else {
-			await this.consumeStreamStreaming(stream, thread);
+			return;
 		}
-	}
 
-	/**
-	 * Streaming consumer — pipes text deltas through an AsyncIterable so the Chat
-	 * SDK can edit the posted message incrementally.
-	 */
-	private async consumeStreamStreaming(
-		stream: AsyncGenerator<StreamChunk>,
-		thread: ChatThread,
-	): Promise<void> {
 		// Controller for the text stream iterable that Chat SDK consumes.
 		// These are reassigned inside `createTextIterable()` (called transitively
 		// by `ensureStreamingPost()`). TypeScript cannot track mutations through

--- a/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
@@ -105,6 +105,9 @@ export class AgentChatBridge {
 	/** Store for shortening callback data on platforms with size limits (Telegram) */
 	private readonly callbackStore?: CallbackStore;
 
+	/** When true, buffer deltas and post as a single message (see integration flag). */
+	private readonly disableStreaming: boolean;
+
 	constructor(
 		private readonly bot: ChatBot,
 		private readonly agentId: string,
@@ -120,6 +123,7 @@ export class AgentChatBridge {
 		if (integration?.needsShortCallbackData) {
 			this.callbackStore = new CallbackStore();
 		}
+		this.disableStreaming = integration?.disableStreaming ?? false;
 		this.registerHandlers();
 	}
 
@@ -227,20 +231,37 @@ export class AgentChatBridge {
 	}
 
 	// ---------------------------------------------------------------------------
-	// Stream consumer — collect-and-post strategy
+	// Stream consumer — dispatches between streaming and buffered strategies
 	// ---------------------------------------------------------------------------
 
 	/**
-	 * Consume the agent stream and post to the thread with real-time streaming.
+	 * Consume the agent stream and post to the thread.
 	 *
-	 * Text deltas are piped as an AsyncIterable<string> to thread.post(),
-	 * which Chat SDK renders incrementally (post-and-edit pattern).
+	 * Two strategies — selected per integration via the `disableStreaming` flag:
+	 *   • streaming (default): pipe text deltas as an AsyncIterable<string> to
+	 *     `thread.post()`. Chat SDK renders incrementally (post-and-edit).
+	 *   • buffered: accumulate text/reasoning deltas into a string and post once
+	 *     per flush event. Used by Telegram to avoid edit_message rate limits.
 	 *
-	 * When a non-text event arrives (suspension, custom message, error),
-	 * the current text stream is terminated, the event is handled, and a
-	 * new text stream starts for subsequent text deltas.
+	 * In both strategies, non-text chunks (`tool-call-suspended`, `message`,
+	 * `error`) flush any pending text first, then get handled in order.
 	 */
 	private async consumeStream(
+		stream: AsyncGenerator<StreamChunk>,
+		thread: ChatThread,
+	): Promise<void> {
+		if (this.disableStreaming) {
+			await this.consumeStreamBuffered(stream, thread);
+		} else {
+			await this.consumeStreamStreaming(stream, thread);
+		}
+	}
+
+	/**
+	 * Streaming consumer — pipes text deltas through an AsyncIterable so the Chat
+	 * SDK can edit the posted message incrementally.
+	 */
+	private async consumeStreamStreaming(
 		stream: AsyncGenerator<StreamChunk>,
 		thread: ChatThread,
 	): Promise<void> {
@@ -358,6 +379,58 @@ export class AgentChatBridge {
 		}
 
 		await endStreamingPost();
+	}
+
+	/**
+	 * Buffered consumer — accumulates text/reasoning deltas and posts them as a
+	 * single message per flush. Used when the integration disables streaming
+	 * (e.g. Telegram).
+	 */
+	private async consumeStreamBuffered(
+		stream: AsyncGenerator<StreamChunk>,
+		thread: ChatThread,
+	): Promise<void> {
+		let buffer = '';
+
+		const flushBuffer = async () => {
+			const text = buffer;
+			buffer = '';
+			if (!text.trim()) return;
+			try {
+				await thread.post(text);
+			} catch (postError: unknown) {
+				this.logger.error('[AgentChatBridge] Buffered post failed', {
+					error: postError instanceof Error ? postError.message : String(postError),
+				});
+			}
+		};
+
+		for await (const chunk of stream) {
+			switch (chunk.type) {
+				case 'text-delta':
+					buffer += chunk.delta;
+					break;
+				case 'reasoning-delta':
+					buffer += `_${chunk.delta}_`;
+					break;
+				case 'tool-call-suspended':
+					await flushBuffer();
+					await this.handleSuspension(chunk, thread);
+					break;
+				case 'message':
+					await flushBuffer();
+					await this.handleMessage(chunk, thread);
+					break;
+				case 'error':
+					await flushBuffer();
+					await this.postErrorToThread(thread, chunk.error);
+					break;
+				default:
+					break;
+			}
+		}
+
+		await flushBuffer();
 	}
 
 	// ---------------------------------------------------------------------------

--- a/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
@@ -404,8 +404,8 @@ export class AgentChatBridge {
 			if (!text.trim()) return;
 			try {
 				// Chat SDK's streaming path wraps accumulated deltas as `{ markdown }`
-				// so the platform adapter applies markdown parse-mode (e.g. Telegram's
-				// sendMessage with parse_mode=MarkdownV2). A raw string bypasses that
+				// so the platform adapter applies its markdown parse-mode (Telegram:
+				// sendMessage with parse_mode=Markdown). A raw string bypasses that
 				// and renders as plain text, so we post the buffered message the same
 				// shape the streaming path uses under the hood.
 				await thread.post({ markdown: text });

--- a/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
@@ -99,7 +99,8 @@ type TextEndFn = () => void;
  *     AsyncIterable<string> into `thread.post()` so Chat SDK can render
  *     incrementally (post-and-edit).
  *   • buffered (Telegram): deltas accumulate into a string and are posted as
- *     a single message per flush event, avoiding `editMessageText` rate limits.
+ *     a single message per flush event, so the platform adapter only ever
+ *     sees well-formed Markdown (streaming edits ship half-formed markup).
  *
  * In both strategies, non-text chunks (`tool-call-suspended`, `message`,
  * `error`) flush any pending text before being handled, preserving ordering.

--- a/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
@@ -403,7 +403,12 @@ export class AgentChatBridge {
 			buffer = '';
 			if (!text.trim()) return;
 			try {
-				await thread.post(text);
+				// Chat SDK's streaming path wraps accumulated deltas as `{ markdown }`
+				// so the platform adapter applies markdown parse-mode (e.g. Telegram's
+				// sendMessage with parse_mode=MarkdownV2). A raw string bypasses that
+				// and renders as plain text, so we post the buffered message the same
+				// shape the streaming path uses under the hood.
+				await thread.post({ markdown: text });
 			} catch (postError: unknown) {
 				this.logger.error('[AgentChatBridge] Buffered post failed', {
 					error: postError instanceof Error ? postError.message : String(postError),

--- a/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
@@ -43,13 +43,6 @@ export abstract class AgentChatIntegration {
 	/**
 	 * True if the bridge should buffer streaming output and post it as a single
 	 * message instead of streaming text deltas via post-and-edit.
-	 *
-	 * Telegram sets this to true because streaming token-by-token Markdown ships
-	 * intermediate edits with half-formed markup (unmatched `*`, unclosed code
-	 * fences, dangling link prefixes) which Telegram rejects or renders
-	 * inconsistently. Flushing only on completed boundaries guarantees the
-	 * platform adapter always gets well-formed Markdown. Slack and other
-	 * platforms that handle streaming edits cleanly leave this false.
 	 */
 	readonly disableStreaming: boolean = false;
 

--- a/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
@@ -40,6 +40,17 @@ export abstract class AgentChatIntegration {
 	 */
 	readonly needsShortCallbackData: boolean = false;
 
+	/**
+	 * True if the bridge should buffer streaming output and post it as a single
+	 * message instead of streaming text deltas via post-and-edit.
+	 *
+	 * Telegram sets this to true because the Bot API rate-limits `editMessageText`
+	 * per chat (≈1 req/s per chat, 30 req/s per bot) — streaming token-by-token
+	 * blows through the quota and produces visible edit flicker. Slack and other
+	 * platforms that handle streaming edits cleanly leave this false.
+	 */
+	readonly disableStreaming: boolean = false;
+
 	/** Build the Chat SDK adapter for this platform. */
 	abstract createAdapter(ctx: AgentChatIntegrationContext): Promise<unknown>;
 

--- a/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
@@ -44,9 +44,11 @@ export abstract class AgentChatIntegration {
 	 * True if the bridge should buffer streaming output and post it as a single
 	 * message instead of streaming text deltas via post-and-edit.
 	 *
-	 * Telegram sets this to true because the Bot API rate-limits `editMessageText`
-	 * per chat (≈1 req/s per chat, 30 req/s per bot) — streaming token-by-token
-	 * blows through the quota and produces visible edit flicker. Slack and other
+	 * Telegram sets this to true because streaming token-by-token Markdown ships
+	 * intermediate edits with half-formed markup (unmatched `*`, unclosed code
+	 * fences, dangling link prefixes) which Telegram rejects or renders
+	 * inconsistently. Flushing only on completed boundaries guarantees the
+	 * platform adapter always gets well-formed Markdown. Slack and other
 	 * platforms that handle streaming edits cleanly leave this false.
 	 */
 	readonly disableStreaming: boolean = false;

--- a/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
@@ -30,6 +30,8 @@ export class TelegramIntegration extends AgentChatIntegration {
 
 	readonly needsShortCallbackData = true;
 
+	readonly disableStreaming = true;
+
 	constructor(
 		private readonly logger: Logger,
 		private readonly urlService: UrlService,

--- a/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
@@ -10,10 +10,16 @@ import { loadTelegramAdapter } from '../esm-loader';
 /**
  * Telegram platform integration.
  *
- * Telegram's Bot API caps callback_data at 64 bytes, so {@link needsShortCallbackData}
- * is true — the bridge stores full payloads in a CallbackStore and emits short
- * 8-char keys as button IDs. The adapter runs in webhook mode when a public
- * `WEBHOOK_URL` is configured, otherwise it falls back to polling for local dev.
+ * Two capability flags are enabled here because of Telegram Bot API constraints:
+ * - {@link needsShortCallbackData} — `callback_data` is capped at 64 bytes, so the
+ *   bridge stores full payloads in a CallbackStore and emits short 8-char keys as
+ *   button IDs.
+ * - {@link disableStreaming} — `editMessageText` is rate-limited (~1 req/s per chat,
+ *   30 req/s per bot), so the bridge buffers agent output and posts it as a single
+ *   message per flush instead of streaming token-by-token.
+ *
+ * The adapter runs in webhook mode when a public `WEBHOOK_URL` is configured,
+ * otherwise it falls back to polling for local dev.
  */
 @Service()
 export class TelegramIntegration extends AgentChatIntegration {

--- a/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
@@ -10,13 +10,14 @@ import { loadTelegramAdapter } from '../esm-loader';
 /**
  * Telegram platform integration.
  *
- * Two capability flags are enabled here because of Telegram Bot API constraints:
+ * Two capability flags are enabled here because of Telegram constraints:
  * - {@link needsShortCallbackData} — `callback_data` is capped at 64 bytes, so the
  *   bridge stores full payloads in a CallbackStore and emits short 8-char keys as
  *   button IDs.
- * - {@link disableStreaming} — `editMessageText` is rate-limited (~1 req/s per chat,
- *   30 req/s per bot), so the bridge buffers agent output and posts it as a single
- *   message per flush instead of streaming token-by-token.
+ * - {@link disableStreaming} — streaming Markdown edits are unstable: intermediate
+ *   frames carry half-formed markup that Telegram rejects or renders inconsistently.
+ *   The bridge buffers agent output and posts it as a single message per flush,
+ *   guaranteeing well-formed Markdown on every post.
  *
  * The adapter runs in webhook mode when a public `WEBHOOK_URL` is configured,
  * otherwise it falls back to polling for local dev.


### PR DESCRIPTION
## Summary

Streaming token-by-token Markdown to Telegram is unstable: the post-and-edit loop ships partial messages containing half-formed markup (unmatched `*`, unclosed code fences, dangling `[` link prefixes, etc.), and Telegram's `sendMessage`/`editMessageText` either rejects the edit or renders escapes inconsistently between intermediate frames. The result is visible flicker, dropped updates, and broken formatting.

This PR adds a per-integration opt-out that switches `AgentChatBridge` to collect-and-post for Telegram.

### Changes

- Adds `disableStreaming: boolean = false` capability flag on `AgentChatIntegration`.
- `TelegramIntegration` overrides it to `true`.
- `AgentChatBridge.consumeStream` now short-circuits to a new `consumeStreamBuffered` helper when the flag is set. The buffered path accumulates `text-delta` and `reasoning-delta` chunks into a string and posts them as a single `thread.post({ markdown })` call.

### Why `{ markdown: text }` and not a plain string

Chat SDK's streaming path internally wraps accumulated deltas as `{ markdown }` before handing them to the platform adapter. The Telegram adapter only sets `parse_mode=Markdown` when the payload is an object with a `markdown` key — a raw string would render as plain text. Posting `{ markdown: text }` from the buffered path keeps parity with the streaming path's rendering.

### Test plan

- [ ] `pnpm --filter=n8n test src/modules/agents/integrations` — all tests green (4 new, 44 total in the integration folder).
- [ ] Manual: mention an agent bound to a Telegram integration with a prompt that produces a multi-sentence reply with formatting — confirm a single message arrives with bold / italic / code rendered correctly and no flicker.
- [ ] Manual: same prompt on Slack — confirm streaming still works incrementally.