### PR TITLE
fix(Google Drive Node): Resolve original file name when copying with empty name

### DIFF
--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/copy.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/copy.test.ts
@@ -12,8 +12,24 @@ jest.mock('../../../../v2/transport', () => {
 	};
 });
 
+const googleApiRequestMock = transport.googleApiRequest as jest.Mock;
+
+const metadataQs = { fields: 'name', supportsAllDrives: true };
+
+const copyQs = {
+	supportsAllDrives: true,
+	corpora: 'allDrives',
+	includeItemsFromAllDrives: true,
+	spaces: 'appDataFolder, drive',
+};
+
 describe('test GoogleDriveV2: file copy', () => {
-	it('should be called with', async () => {
+	beforeEach(() => {
+		googleApiRequestMock.mockReset();
+		googleApiRequestMock.mockResolvedValue({});
+	});
+
+	it('uses the user-provided name in list mode', async () => {
 		const nodeParameters = {
 			operation: 'copy',
 			fileId: {
@@ -42,8 +58,8 @@ describe('test GoogleDriveV2: file copy', () => {
 
 		await copy.execute.call(fakeExecuteFunction, 0);
 
-		expect(transport.googleApiRequest).toBeCalledTimes(1);
-		expect(transport.googleApiRequest).toBeCalledWith(
+		expect(googleApiRequestMock).toHaveBeenCalledTimes(1);
+		expect(googleApiRequestMock).toHaveBeenCalledWith(
 			'POST',
 			'/drive/v3/files/fileIDxxxxxx/copy',
 			{
@@ -52,12 +68,182 @@ describe('test GoogleDriveV2: file copy', () => {
 				name: 'copyImage.png',
 				parents: ['folderIDxxxxxx'],
 			},
-			{
-				supportsAllDrives: true,
-				corpora: 'allDrives',
-				includeItemsFromAllDrives: true,
-				spaces: 'appDataFolder, drive',
-			},
+			copyQs,
 		);
+	});
+
+	it('uses cachedResultName when name is empty in list mode (no metadata fetch)', async () => {
+		const nodeParameters = {
+			operation: 'copy',
+			fileId: {
+				__rl: true,
+				value: 'fileIDxxxxxx',
+				mode: 'list',
+				cachedResultName: 'test01.png',
+				cachedResultUrl: 'https://drive.google.com/file/d/fileIDxxxxxx/view?usp=drivesdk',
+			},
+			name: '',
+			sameFolder: true,
+			options: {},
+		};
+
+		const fakeExecuteFunction = createMockExecuteFunction(nodeParameters, driveNode);
+
+		await copy.execute.call(fakeExecuteFunction, 0);
+
+		expect(googleApiRequestMock).toHaveBeenCalledTimes(1);
+		expect(googleApiRequestMock).toHaveBeenCalledWith(
+			'POST',
+			'/drive/v3/files/fileIDxxxxxx/copy',
+			{
+				copyRequiresWriterPermission: false,
+				name: 'Copy of test01.png',
+				parents: [],
+			},
+			copyQs,
+		);
+	});
+
+	it('fetches original name via metadata when name is empty in id mode', async () => {
+		googleApiRequestMock.mockResolvedValueOnce({ name: 'original.png' }).mockResolvedValueOnce({});
+
+		const nodeParameters = {
+			operation: 'copy',
+			fileId: {
+				__rl: true,
+				value: 'fileIDxxxxxx',
+				mode: 'id',
+			},
+			name: '',
+			sameFolder: true,
+			options: {},
+		};
+
+		const fakeExecuteFunction = createMockExecuteFunction(nodeParameters, driveNode);
+
+		await copy.execute.call(fakeExecuteFunction, 0);
+
+		expect(googleApiRequestMock).toHaveBeenCalledTimes(2);
+		expect(googleApiRequestMock).toHaveBeenNthCalledWith(
+			1,
+			'GET',
+			'/drive/v3/files/fileIDxxxxxx',
+			{},
+			metadataQs,
+		);
+		expect(googleApiRequestMock).toHaveBeenNthCalledWith(
+			2,
+			'POST',
+			'/drive/v3/files/fileIDxxxxxx/copy',
+			{
+				copyRequiresWriterPermission: false,
+				name: 'Copy of original.png',
+				parents: [],
+			},
+			copyQs,
+		);
+	});
+
+	it('fetches original name via metadata when name is empty in url mode', async () => {
+		googleApiRequestMock.mockResolvedValueOnce({ name: 'from-url.pdf' }).mockResolvedValueOnce({});
+
+		const nodeParameters = {
+			operation: 'copy',
+			fileId: {
+				__rl: true,
+				value: 'fileIDxxxxxx',
+				mode: 'url',
+			},
+			name: '',
+			sameFolder: true,
+			options: {},
+		};
+
+		const fakeExecuteFunction = createMockExecuteFunction(nodeParameters, driveNode);
+
+		await copy.execute.call(fakeExecuteFunction, 0);
+
+		expect(googleApiRequestMock).toHaveBeenCalledTimes(2);
+		expect(googleApiRequestMock).toHaveBeenNthCalledWith(
+			1,
+			'GET',
+			'/drive/v3/files/fileIDxxxxxx',
+			{},
+			metadataQs,
+		);
+		expect(googleApiRequestMock).toHaveBeenNthCalledWith(
+			2,
+			'POST',
+			'/drive/v3/files/fileIDxxxxxx/copy',
+			{
+				copyRequiresWriterPermission: false,
+				name: 'Copy of from-url.pdf',
+				parents: [],
+			},
+			copyQs,
+		);
+	});
+
+	it('does not fetch metadata when name is provided in id mode', async () => {
+		const nodeParameters = {
+			operation: 'copy',
+			fileId: {
+				__rl: true,
+				value: 'fileIDxxxxxx',
+				mode: 'id',
+			},
+			name: 'explicit.png',
+			sameFolder: true,
+			options: {},
+		};
+
+		const fakeExecuteFunction = createMockExecuteFunction(nodeParameters, driveNode);
+
+		await copy.execute.call(fakeExecuteFunction, 0);
+
+		expect(googleApiRequestMock).toHaveBeenCalledTimes(1);
+		expect(googleApiRequestMock).toHaveBeenCalledWith(
+			'POST',
+			'/drive/v3/files/fileIDxxxxxx/copy',
+			{
+				copyRequiresWriterPermission: false,
+				name: 'explicit.png',
+				parents: [],
+			},
+			copyQs,
+		);
+	});
+
+	it('omits name when metadata returns no name', async () => {
+		googleApiRequestMock.mockResolvedValueOnce({}).mockResolvedValueOnce({});
+
+		const nodeParameters = {
+			operation: 'copy',
+			fileId: {
+				__rl: true,
+				value: 'fileIDxxxxxx',
+				mode: 'id',
+			},
+			name: '',
+			sameFolder: true,
+			options: {},
+		};
+
+		const fakeExecuteFunction = createMockExecuteFunction(nodeParameters, driveNode);
+
+		await copy.execute.call(fakeExecuteFunction, 0);
+
+		expect(googleApiRequestMock).toHaveBeenCalledTimes(2);
+		const copyCall = googleApiRequestMock.mock.calls[1] as [
+			string,
+			string,
+			Record<string, unknown>,
+			unknown,
+		];
+		expect(copyCall[0]).toBe('POST');
+		expect(copyCall[1]).toBe('/drive/v3/files/fileIDxxxxxx/copy');
+		const body = copyCall[2];
+		expect(body).not.toHaveProperty('name');
+		expect(JSON.stringify(body)).not.toContain('undefined');
 	});
 });

--- a/packages/nodes-base/nodes/Google/Drive/v2/actions/file/copy.operation.ts
+++ b/packages/nodes-base/nodes/Google/Drive/v2/actions/file/copy.operation.ts
@@ -82,13 +82,28 @@ export const description = updateDisplayOptions(displayOptions, properties);
 
 export async function execute(this: IExecuteFunctions, i: number): Promise<INodeExecutionData[]> {
 	const file = this.getNodeParameter('fileId', i) as INodeParameterResourceLocator;
-
-	const fileId = file.value;
+	const fileId = this.getNodeParameter('fileId', i, undefined, {
+		extractValue: true,
+	}) as string;
 
 	const options = this.getNodeParameter('options', i, {});
 
 	let name = this.getNodeParameter('name', i) as string;
-	name = name ? name : `Copy of ${file.cachedResultName}`;
+	if (!name) {
+		const cachedName = typeof file.cachedResultName === 'string' ? file.cachedResultName : '';
+		let originalName = cachedName;
+		if (!originalName) {
+			const meta = (await googleApiRequest.call(
+				this,
+				'GET',
+				`/drive/v3/files/${fileId}`,
+				{},
+				{ fields: 'name', supportsAllDrives: true },
+			)) as { name?: string };
+			originalName = meta?.name ?? '';
+		}
+		name = originalName ? `Copy of ${originalName}` : '';
+	}
 
 	const copyRequiresWriterPermission = options.copyRequiresWriterPermission || false;
 
@@ -114,7 +129,11 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 		parents.push(setParentFolder(folderId, driveId));
 	}
 
-	const body: IDataObject = { copyRequiresWriterPermission, parents, name };
+	const body: IDataObject = { copyRequiresWriterPermission, parents };
+
+	if (name) {
+		body.name = name;
+	}
 
 	if (options.description) {
 		body.description = options.description;


### PR DESCRIPTION
## Summary

When copying a file with the Google Drive node and leaving **File Name** empty, the copy previously landed as `"Copy of undefined"` whenever the source was picked **By ID** or **By URL** (but worked for **From list**). The cause: the default name was composed from `fileId.cachedResultName`, which is only populated by the list picker. This fix resolves the original file name across all resource locator modes: we keep the cached name when it is available and otherwise fall back to a lightweight `GET /drive/v3/files/{id}?fields=name` before the copy request. If the metadata response has no name, the `name` property is omitted so Google's own server-side default kicks in — never `"Copy of undefined"`.

To test: add a Google Drive → File → Copy node, choose a file **By ID** or **By URL**, leave File Name blank, execute, and confirm the resulting file is named `"Copy of {original}"` in Drive.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4877
fixes #28735

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI