### PR TITLE
feat(API): Add encryption key management endpoints

### DIFF
--- a/packages/@n8n/api-types/src/dto/encryption/__tests__/create-encryption-key.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/encryption/__tests__/create-encryption-key.dto.test.ts
@@ -1,0 +1,39 @@
+import { CreateEncryptionKeyDto } from '../create-encryption-key.dto';
+
+describe('CreateEncryptionKeyDto', () => {
+	describe('Valid requests', () => {
+		test('should succeed for type=data_encryption', () => {
+			const result = CreateEncryptionKeyDto.safeParse({ type: 'data_encryption' });
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe('Invalid type', () => {
+		test.each([
+			{ name: 'unknown string', type: 'other_type' },
+			{ name: 'empty string', type: '' },
+			{ name: 'number', type: 123 },
+			{ name: 'boolean', type: true },
+			{ name: 'null', type: null },
+			{ name: 'missing', type: undefined },
+		])('should fail for $name', ({ type }) => {
+			const result = CreateEncryptionKeyDto.safeParse({ type });
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0].path).toEqual(['type']);
+			}
+		});
+	});
+
+	test('should strip unknown fields', () => {
+		const result = CreateEncryptionKeyDto.safeParse({
+			type: 'data_encryption',
+			value: 'should-be-ignored',
+			algorithm: 'aes-256-gcm',
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data).toEqual({ type: 'data_encryption' });
+		}
+	});
+});

--- a/packages/@n8n/api-types/src/dto/encryption/__tests__/list-encryption-keys-query.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/encryption/__tests__/list-encryption-keys-query.dto.test.ts
@@ -1,0 +1,41 @@
+import { ListEncryptionKeysQueryDto } from '../list-encryption-keys-query.dto';
+
+describe('ListEncryptionKeysQueryDto', () => {
+	describe('Valid requests', () => {
+		test('should succeed with no query params', () => {
+			const result = ListEncryptionKeysQueryDto.safeParse({});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.type).toBeUndefined();
+			}
+		});
+
+		test('should succeed with type filter', () => {
+			const result = ListEncryptionKeysQueryDto.safeParse({ type: 'data_encryption' });
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.type).toBe('data_encryption');
+			}
+		});
+
+		test('should accept arbitrary type string', () => {
+			const result = ListEncryptionKeysQueryDto.safeParse({ type: 'some_future_type' });
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe('Invalid requests', () => {
+		test.each([
+			{ name: 'number', type: 123 },
+			{ name: 'boolean', type: true },
+			{ name: 'array', type: ['data_encryption'] },
+			{ name: 'object', type: { kind: 'data_encryption' } },
+		])('should fail when type is a $name', ({ type }) => {
+			const result = ListEncryptionKeysQueryDto.safeParse({ type });
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0].path).toEqual(['type']);
+			}
+		});
+	});
+});

--- a/packages/@n8n/api-types/src/dto/encryption/create-encryption-key.dto.ts
+++ b/packages/@n8n/api-types/src/dto/encryption/create-encryption-key.dto.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+
+export class CreateEncryptionKeyDto extends Z.class({
+	type: z.literal('data_encryption'),
+}) {}

--- a/packages/@n8n/api-types/src/dto/encryption/encryption-key-response.dto.ts
+++ b/packages/@n8n/api-types/src/dto/encryption/encryption-key-response.dto.ts
@@ -1,0 +1,7 @@
+export type EncryptionKeyResponseDto = {
+	id: string;
+	type: string;
+	algorithm: string | null;
+	status: string;
+	createdAt: string;
+};

--- a/packages/@n8n/api-types/src/dto/encryption/list-encryption-keys-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/encryption/list-encryption-keys-query.dto.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+
+export class ListEncryptionKeysQueryDto extends Z.class({
+	type: z.string().optional(),
+}) {}

--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -218,3 +218,7 @@ export {
 
 export { VersionSinceDateQueryDto } from './instance-version-history/version-since-date-query.dto';
 export { VersionQueryDto } from './instance-version-history/version-query.dto';
+
+export { CreateEncryptionKeyDto } from './encryption/create-encryption-key.dto';
+export { ListEncryptionKeysQueryDto } from './encryption/list-encryption-keys-query.dto';
+export type { EncryptionKeyResponseDto } from './encryption/encryption-key-response.dto';

--- a/packages/@n8n/permissions/src/__tests__/__snapshots__/scope-information.test.ts.snap
+++ b/packages/@n8n/permissions/src/__tests__/__snapshots__/scope-information.test.ts.snap
@@ -174,6 +174,8 @@ exports[`Scope Information > ensure scopes are defined correctly 1`] = `
   "breakingChanges:*",
   "apiKey:manage",
   "apiKey:*",
+  "encryptionKey:manage",
+  "encryptionKey:*",
   "credentialResolver:create",
   "credentialResolver:read",
   "credentialResolver:update",

--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -58,6 +58,7 @@ export const RESOURCES = {
 	chatHubAgent: [...DEFAULT_OPERATIONS] as const,
 	breakingChanges: ['list'] as const,
 	apiKey: ['manage'] as const,
+	encryptionKey: ['manage'] as const,
 	credentialResolver: [...DEFAULT_OPERATIONS] as const,
 	instanceAi: ['message', 'manage', 'gateway'] as const,
 	roleMappingRule: [...DEFAULT_OPERATIONS] as const,

--- a/packages/@n8n/permissions/src/roles/scopes/global-scopes.ee.ts
+++ b/packages/@n8n/permissions/src/roles/scopes/global-scopes.ee.ts
@@ -123,6 +123,7 @@ export const GLOBAL_OWNER_SCOPES: Scope[] = [
 	'breakingChanges:list',
 	'execution:reveal',
 	'apiKey:manage',
+	'encryptionKey:manage',
 	'credentialResolver:create',
 	'credentialResolver:read',
 	'credentialResolver:update',

--- a/packages/@n8n/permissions/src/scope-information.ts
+++ b/packages/@n8n/permissions/src/scope-information.ts
@@ -28,6 +28,10 @@ export const scopeInformation: Partial<Record<Scope, ScopeInformation>> = {
 		displayName: 'Manage AI Usage',
 		description: 'Allows managing AI Usage settings.',
 	},
+	'encryptionKey:manage': {
+		displayName: 'Manage Encryption Keys',
+		description: 'Allows listing and rotating instance encryption keys.',
+	},
 	'annotationTag:create': {
 		displayName: 'Create Annotation Tag',
 		description: 'Allows creating new annotation tags.',

--- a/packages/@n8n/permissions/src/utilities/__tests__/get-resource-permissions.test.ts
+++ b/packages/@n8n/permissions/src/utilities/__tests__/get-resource-permissions.test.ts
@@ -45,6 +45,7 @@ describe('permissions', () => {
 			chatHubAgent: {},
 			breakingChanges: {},
 			apiKey: {},
+			encryptionKey: {},
 			credentialResolver: {},
 			instanceAi: {},
 			roleMappingRule: {},
@@ -170,6 +171,7 @@ describe('permissions', () => {
 			apiKey: {
 				manage: true,
 			},
+			encryptionKey: {},
 			credentialResolver: {},
 			instanceAi: {},
 			roleMappingRule: {},

--- a/packages/cli/src/modules/encryption-key-manager/__tests__/encryption-key.controller.test.ts
+++ b/packages/cli/src/modules/encryption-key-manager/__tests__/encryption-key.controller.test.ts
@@ -1,0 +1,121 @@
+import { mockInstance } from '@n8n/backend-test-utils';
+import type { DeploymentKey } from '@n8n/db';
+import { Container } from '@n8n/di';
+
+import { EncryptionKeyController } from '@/modules/encryption-key-manager/encryption-key.controller';
+import { KeyManagerService } from '@/modules/encryption-key-manager/key-manager.service';
+
+const makeKey = (overrides: Partial<DeploymentKey> = {}): DeploymentKey =>
+	({
+		id: 'key-1',
+		type: 'data_encryption',
+		value: 'secret-material',
+		algorithm: 'aes-256-gcm',
+		status: 'active',
+		createdAt: new Date('2026-01-15T00:00:00.000Z'),
+		updatedAt: new Date('2026-01-15T00:00:00.000Z'),
+		...overrides,
+	}) as DeploymentKey;
+
+describe('EncryptionKeyController', () => {
+	const keyManagerService = mockInstance(KeyManagerService);
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('GET /encryption/keys', () => {
+		it('returns all keys when no type filter is provided', async () => {
+			keyManagerService.listKeys.mockResolvedValue([
+				makeKey({ id: 'k1', algorithm: 'aes-256-cbc', status: 'inactive' }),
+				makeKey({ id: 'k2', algorithm: 'aes-256-gcm', status: 'active' }),
+			]);
+
+			const result = await Container.get(EncryptionKeyController).list({}, {}, { type: undefined });
+
+			expect(keyManagerService.listKeys).toHaveBeenCalledWith(undefined);
+			expect(result).toEqual([
+				{
+					id: 'k1',
+					type: 'data_encryption',
+					algorithm: 'aes-256-cbc',
+					status: 'inactive',
+					createdAt: '2026-01-15T00:00:00.000Z',
+				},
+				{
+					id: 'k2',
+					type: 'data_encryption',
+					algorithm: 'aes-256-gcm',
+					status: 'active',
+					createdAt: '2026-01-15T00:00:00.000Z',
+				},
+			]);
+		});
+
+		it('forwards the type filter to the service', async () => {
+			keyManagerService.listKeys.mockResolvedValue([makeKey({ id: 'k1' })]);
+
+			const result = await Container.get(EncryptionKeyController).list(
+				{},
+				{},
+				{ type: 'data_encryption' },
+			);
+
+			expect(keyManagerService.listKeys).toHaveBeenCalledWith('data_encryption');
+			expect(result).toHaveLength(1);
+		});
+
+		it('never includes the raw key value in the response', async () => {
+			keyManagerService.listKeys.mockResolvedValue([makeKey({ value: 'very-secret' })]);
+
+			const result = await Container.get(EncryptionKeyController).list({}, {}, { type: undefined });
+
+			expect(JSON.stringify(result)).not.toContain('very-secret');
+			expect(result[0]).not.toHaveProperty('value');
+		});
+
+		it('returns an empty array when no keys exist', async () => {
+			keyManagerService.listKeys.mockResolvedValue([]);
+
+			const result = await Container.get(EncryptionKeyController).list({}, {}, { type: undefined });
+
+			expect(result).toEqual([]);
+		});
+
+		it('preserves service ordering and maps nullable algorithm', async () => {
+			keyManagerService.listKeys.mockResolvedValue([
+				makeKey({ id: 'first', algorithm: null }),
+				makeKey({ id: 'second', algorithm: 'aes-256-gcm' }),
+			]);
+
+			const result = await Container.get(EncryptionKeyController).list({}, {}, { type: undefined });
+
+			expect(result.map((row) => row.id)).toEqual(['first', 'second']);
+			expect(result[0].algorithm).toBeNull();
+			expect(result[1].algorithm).toBe('aes-256-gcm');
+		});
+	});
+
+	describe('POST /encryption/keys', () => {
+		it('rotates a new active key and returns the response DTO without value', async () => {
+			const newRow = makeKey({ id: 'new-id', algorithm: 'aes-256-gcm', status: 'active' });
+			keyManagerService.rotateKey.mockResolvedValue(newRow);
+
+			const result = await Container.get(EncryptionKeyController).create(
+				{},
+				{},
+				{ type: 'data_encryption' },
+			);
+
+			expect(keyManagerService.rotateKey).toHaveBeenCalledWith();
+			expect(result).toEqual({
+				id: 'new-id',
+				type: 'data_encryption',
+				algorithm: 'aes-256-gcm',
+				status: 'active',
+				createdAt: '2026-01-15T00:00:00.000Z',
+			});
+			expect(result).not.toHaveProperty('value');
+		});
+	});
+});

--- a/packages/cli/src/modules/encryption-key-manager/__tests__/key-manager.service.test.ts
+++ b/packages/cli/src/modules/encryption-key-manager/__tests__/key-manager.service.test.ts
@@ -121,11 +121,11 @@ describe('KeyManagerService', () => {
 			const saved = makeKey({ id: 'new-key', status: 'inactive' });
 			repository.create.mockReturnValue(saved);
 			repository.save.mockResolvedValue(saved);
-			cipher.encrypt.mockReturnValue('encrypted-base64');
+			cipher.encryptWithInstanceKey.mockReturnValue('encrypted-base64');
 
 			const result = await Container.get(KeyManagerService).addKey('secret', 'aes-256-gcm');
 
-			expect(cipher.encrypt).toHaveBeenCalledWith('secret');
+			expect(cipher.encryptWithInstanceKey).toHaveBeenCalledWith('secret');
 			expect(repository.insertAsActive).not.toHaveBeenCalled();
 			expect(repository.create).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -141,11 +141,11 @@ describe('KeyManagerService', () => {
 			const saved = makeKey({ id: 'new-key', status: 'active' });
 			repository.create.mockReturnValue(saved);
 			repository.insertAsActive.mockResolvedValue(saved);
-			cipher.encrypt.mockReturnValue('encrypted-base64');
+			cipher.encryptWithInstanceKey.mockReturnValue('encrypted-base64');
 
 			const result = await Container.get(KeyManagerService).addKey('secret', 'aes-256-gcm', true);
 
-			expect(cipher.encrypt).toHaveBeenCalledWith('secret');
+			expect(cipher.encryptWithInstanceKey).toHaveBeenCalledWith('secret');
 			expect(repository.save).not.toHaveBeenCalled();
 			expect(repository.create).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -164,12 +164,12 @@ describe('KeyManagerService', () => {
 			const saved = makeKey({ id: 'rotated', status: 'active', algorithm: 'aes-256-gcm' });
 			repository.create.mockReturnValue(saved);
 			repository.insertAsActive.mockResolvedValue(saved);
-			cipher.encrypt.mockReturnValue('encrypted-base64');
+			cipher.encryptWithInstanceKey.mockReturnValue('encrypted-base64');
 
 			const result = await Container.get(KeyManagerService).rotateKey();
 
-			expect(cipher.encrypt).toHaveBeenCalledTimes(1);
-			const [rawKey] = cipher.encrypt.mock.calls[0];
+			expect(cipher.encryptWithInstanceKey).toHaveBeenCalledTimes(1);
+			const [rawKey] = cipher.encryptWithInstanceKey.mock.calls[0];
 			expect(typeof rawKey).toBe('string');
 			expect((rawKey as string).length).toBe(64);
 
@@ -188,13 +188,15 @@ describe('KeyManagerService', () => {
 			const saved = makeKey();
 			repository.create.mockReturnValue(saved);
 			repository.insertAsActive.mockResolvedValue(saved);
-			cipher.encrypt.mockImplementation((data: string | object) => `enc:${String(data)}`);
+			cipher.encryptWithInstanceKey.mockImplementation(
+				(data: string | object) => `enc:${String(data)}`,
+			);
 
 			await Container.get(KeyManagerService).rotateKey();
 			await Container.get(KeyManagerService).rotateKey();
 
-			const [first] = cipher.encrypt.mock.calls[0];
-			const [second] = cipher.encrypt.mock.calls[1];
+			const [first] = cipher.encryptWithInstanceKey.mock.calls[0];
+			const [second] = cipher.encryptWithInstanceKey.mock.calls[1];
 			expect(first).not.toBe(second);
 		});
 	});

--- a/packages/cli/src/modules/encryption-key-manager/__tests__/key-manager.service.test.ts
+++ b/packages/cli/src/modules/encryption-key-manager/__tests__/key-manager.service.test.ts
@@ -2,6 +2,7 @@ import { mockInstance } from '@n8n/backend-test-utils';
 import type { DeploymentKey } from '@n8n/db';
 import { DeploymentKeyRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
+import { Cipher } from 'n8n-core';
 
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { KeyManagerService } from '@/modules/encryption-key-manager/key-manager.service';
@@ -20,6 +21,7 @@ const makeKey = (overrides: Partial<DeploymentKey> = {}): DeploymentKey =>
 
 describe('KeyManagerService', () => {
 	const repository = mockInstance(DeploymentKeyRepository);
+	const cipher = mockInstance(Cipher);
 
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -115,30 +117,109 @@ describe('KeyManagerService', () => {
 	});
 
 	describe('addKey()', () => {
-		it('inserts as inactive when setAsActive is not set', async () => {
+		it('encrypts the value and inserts as inactive when setAsActive is not set', async () => {
 			const saved = makeKey({ id: 'new-key', status: 'inactive' });
 			repository.create.mockReturnValue(saved);
 			repository.save.mockResolvedValue(saved);
+			cipher.encrypt.mockReturnValue('encrypted-base64');
 
 			const result = await Container.get(KeyManagerService).addKey('secret', 'aes-256-gcm');
 
+			expect(cipher.encrypt).toHaveBeenCalledWith('secret');
 			expect(repository.insertAsActive).not.toHaveBeenCalled();
 			expect(repository.create).toHaveBeenCalledWith(
-				expect.objectContaining({ status: 'inactive', type: 'data_encryption' }),
+				expect.objectContaining({
+					status: 'inactive',
+					type: 'data_encryption',
+					value: 'encrypted-base64',
+				}),
 			);
-			expect(result).toEqual({ id: 'new-key' });
+			expect(result).toBe(saved);
 		});
 
-		it('delegates to insertAsActive when setAsActive=true', async () => {
+		it('encrypts the value and delegates to insertAsActive when setAsActive=true', async () => {
 			const saved = makeKey({ id: 'new-key', status: 'active' });
 			repository.create.mockReturnValue(saved);
 			repository.insertAsActive.mockResolvedValue(saved);
+			cipher.encrypt.mockReturnValue('encrypted-base64');
 
 			const result = await Container.get(KeyManagerService).addKey('secret', 'aes-256-gcm', true);
 
+			expect(cipher.encrypt).toHaveBeenCalledWith('secret');
 			expect(repository.save).not.toHaveBeenCalled();
+			expect(repository.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'data_encryption',
+					value: 'encrypted-base64',
+					algorithm: 'aes-256-gcm',
+				}),
+			);
 			expect(repository.insertAsActive).toHaveBeenCalledWith(saved);
-			expect(result).toEqual({ id: 'new-key' });
+			expect(result).toBe(saved);
+		});
+	});
+
+	describe('rotateKey()', () => {
+		it('generates a 64-char hex key and inserts it as active with aes-256-gcm', async () => {
+			const saved = makeKey({ id: 'rotated', status: 'active', algorithm: 'aes-256-gcm' });
+			repository.create.mockReturnValue(saved);
+			repository.insertAsActive.mockResolvedValue(saved);
+			cipher.encrypt.mockReturnValue('encrypted-base64');
+
+			const result = await Container.get(KeyManagerService).rotateKey();
+
+			expect(cipher.encrypt).toHaveBeenCalledTimes(1);
+			const [rawKey] = cipher.encrypt.mock.calls[0];
+			expect(typeof rawKey).toBe('string');
+			expect((rawKey as string).length).toBe(64);
+
+			expect(repository.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'data_encryption',
+					value: 'encrypted-base64',
+					algorithm: 'aes-256-gcm',
+				}),
+			);
+			expect(repository.insertAsActive).toHaveBeenCalledWith(saved);
+			expect(result).toBe(saved);
+		});
+
+		it('generates a fresh key value on each call', async () => {
+			const saved = makeKey();
+			repository.create.mockReturnValue(saved);
+			repository.insertAsActive.mockResolvedValue(saved);
+			cipher.encrypt.mockImplementation((data: string | object) => `enc:${String(data)}`);
+
+			await Container.get(KeyManagerService).rotateKey();
+			await Container.get(KeyManagerService).rotateKey();
+
+			const [first] = cipher.encrypt.mock.calls[0];
+			const [second] = cipher.encrypt.mock.calls[1];
+			expect(first).not.toBe(second);
+		});
+	});
+
+	describe('listKeys()', () => {
+		it('returns all keys when no type filter is provided', async () => {
+			const rows = [makeKey({ id: 'k1' }), makeKey({ id: 'k2' })];
+			repository.find.mockResolvedValue(rows);
+
+			const result = await Container.get(KeyManagerService).listKeys();
+
+			expect(repository.find).toHaveBeenCalledWith();
+			expect(repository.findAllByType).not.toHaveBeenCalled();
+			expect(result).toBe(rows);
+		});
+
+		it('filters by type when provided', async () => {
+			const rows = [makeKey({ id: 'k1' })];
+			repository.findAllByType.mockResolvedValue(rows);
+
+			const result = await Container.get(KeyManagerService).listKeys('data_encryption');
+
+			expect(repository.findAllByType).toHaveBeenCalledWith('data_encryption');
+			expect(repository.find).not.toHaveBeenCalled();
+			expect(result).toBe(rows);
 		});
 	});
 

--- a/packages/cli/src/modules/encryption-key-manager/encryption-key-manager.module.ts
+++ b/packages/cli/src/modules/encryption-key-manager/encryption-key-manager.module.ts
@@ -6,6 +6,7 @@ import { Container } from '@n8n/di';
 export class EncryptionKeyManagerModule implements ModuleInterface {
 	async init() {
 		await import('./key-manager.service');
+		await import('./encryption-key.controller');
 
 		const { EncryptionBootstrapService } = await import('./encryption-bootstrap.service');
 		await Container.get(EncryptionBootstrapService).run();

--- a/packages/cli/src/modules/encryption-key-manager/encryption-key-manager.module.ts
+++ b/packages/cli/src/modules/encryption-key-manager/encryption-key-manager.module.ts
@@ -9,13 +9,11 @@ function isKeyRotationApiEnabled(): boolean {
 @BackendModule({ name: 'encryption-key-manager', instanceTypes: ['main'] })
 export class EncryptionKeyManagerModule implements ModuleInterface {
 	async init() {
-		await import('./key-manager.service');
-
 		if (isKeyRotationApiEnabled()) {
+			await import('./key-manager.service');
 			await import('./encryption-key.controller');
+			const { EncryptionBootstrapService } = await import('./encryption-bootstrap.service');
+			await Container.get(EncryptionBootstrapService).run();
 		}
-
-		const { EncryptionBootstrapService } = await import('./encryption-bootstrap.service');
-		await Container.get(EncryptionBootstrapService).run();
 	}
 }

--- a/packages/cli/src/modules/encryption-key-manager/encryption-key-manager.module.ts
+++ b/packages/cli/src/modules/encryption-key-manager/encryption-key-manager.module.ts
@@ -2,11 +2,18 @@ import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 
+function isKeyRotationApiEnabled(): boolean {
+	return process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION === 'true';
+}
+
 @BackendModule({ name: 'encryption-key-manager', instanceTypes: ['main'] })
 export class EncryptionKeyManagerModule implements ModuleInterface {
 	async init() {
 		await import('./key-manager.service');
-		await import('./encryption-key.controller');
+
+		if (isKeyRotationApiEnabled()) {
+			await import('./encryption-key.controller');
+		}
 
 		const { EncryptionBootstrapService } = await import('./encryption-bootstrap.service');
 		await Container.get(EncryptionBootstrapService).run();

--- a/packages/cli/src/modules/encryption-key-manager/encryption-key.controller.ts
+++ b/packages/cli/src/modules/encryption-key-manager/encryption-key.controller.ts
@@ -1,0 +1,46 @@
+import {
+	CreateEncryptionKeyDto,
+	ListEncryptionKeysQueryDto,
+	type EncryptionKeyResponseDto,
+} from '@n8n/api-types';
+import { type DeploymentKey } from '@n8n/db';
+import { Body, Get, GlobalScope, Post, Query, RestController } from '@n8n/decorators';
+
+import { KeyManagerService } from './key-manager.service';
+
+function toResponseDto(row: DeploymentKey): EncryptionKeyResponseDto {
+	return {
+		id: row.id,
+		type: row.type,
+		algorithm: row.algorithm,
+		status: row.status,
+		createdAt: row.createdAt.toISOString(),
+	};
+}
+
+@RestController('/encryption/keys')
+export class EncryptionKeyController {
+	constructor(private readonly keyManagerService: KeyManagerService) {}
+
+	@Get('/')
+	@GlobalScope('encryptionKey:manage')
+	async list(
+		_req: unknown,
+		_res: unknown,
+		@Query query: ListEncryptionKeysQueryDto,
+	): Promise<EncryptionKeyResponseDto[]> {
+		const rows = await this.keyManagerService.listKeys(query.type);
+		return rows.map(toResponseDto);
+	}
+
+	@Post('/')
+	@GlobalScope('encryptionKey:manage')
+	async create(
+		_req: unknown,
+		_res: unknown,
+		@Body _body: CreateEncryptionKeyDto,
+	): Promise<EncryptionKeyResponseDto> {
+		const row = await this.keyManagerService.rotateKey();
+		return toResponseDto(row);
+	}
+}

--- a/packages/cli/src/modules/encryption-key-manager/key-manager.service.ts
+++ b/packages/cli/src/modules/encryption-key-manager/key-manager.service.ts
@@ -1,5 +1,7 @@
 import { Service } from '@n8n/di';
-import { DeploymentKeyRepository } from '@n8n/db';
+import { DeploymentKeyRepository, type DeploymentKey } from '@n8n/db';
+import { Cipher } from 'n8n-core';
+import { randomBytes } from 'node:crypto';
 
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
@@ -7,7 +9,10 @@ type KeyInfo = { id: string; value: string; algorithm: string };
 
 @Service()
 export class KeyManagerService {
-	constructor(private readonly deploymentKeyRepository: DeploymentKeyRepository) {}
+	constructor(
+		private readonly deploymentKeyRepository: DeploymentKeyRepository,
+		private readonly cipher: Cipher,
+	) {}
 
 	/** Returns the current active encryption key. Throws if none exists or if multiple are found. */
 	async getActiveKey(): Promise<KeyInfo> {
@@ -59,25 +64,52 @@ export class KeyManagerService {
 		});
 	}
 
-	/** Inserts a new encryption key. If setAsActive, atomically deactivates the current key first. */
-	async addKey(value: string, algorithm: string, setAsActive = false): Promise<{ id: string }> {
+	/** Lists encryption keys, optionally filtered by type. */
+	async listKeys(type?: string): Promise<DeploymentKey[]> {
+		if (type) return await this.deploymentKeyRepository.findAllByType(type);
+		return await this.deploymentKeyRepository.find();
+	}
+
+	/**
+	 * Generates a new 256-bit data-encryption key and inserts it as the active key,
+	 * atomically deactivating the previous active key.
+	 */
+	async rotateKey(): Promise<DeploymentKey> {
+		const rawKey = randomBytes(32).toString('hex');
+		return await this.addKey(rawKey, 'aes-256-gcm', true);
+	}
+
+	/**
+	 * Encrypts the given plaintext value with the instance encryption key and inserts
+	 * it as a new deployment key row. If setAsActive, atomically deactivates the
+	 * previous active key; otherwise the new key is inserted as inactive.
+	 */
+	async addKey(
+		plaintextValue: string,
+		algorithm: string,
+		setAsActive = false,
+	): Promise<DeploymentKey> {
+		const encryptedValue = this.cipher.encrypt(plaintextValue);
+
 		if (!setAsActive) {
 			const entity = this.deploymentKeyRepository.create({
 				type: 'data_encryption',
-				value,
+				value: encryptedValue,
 				algorithm,
 				status: 'inactive',
 			});
-			const saved = await this.deploymentKeyRepository.save(entity);
-			return { id: saved.id };
+			return await this.deploymentKeyRepository.save(entity);
 		}
 
 		const entity = Object.assign(
-			this.deploymentKeyRepository.create({ type: 'data_encryption', value, algorithm }),
+			this.deploymentKeyRepository.create({
+				type: 'data_encryption',
+				value: encryptedValue,
+				algorithm,
+			}),
 			{ status: 'active' as const },
 		);
-		const saved = await this.deploymentKeyRepository.insertAsActive(entity);
-		return { id: saved.id };
+		return await this.deploymentKeyRepository.insertAsActive(entity);
 	}
 
 	/** Atomically deactivates the current active key and promotes the given key. */

--- a/packages/cli/src/modules/encryption-key-manager/key-manager.service.ts
+++ b/packages/cli/src/modules/encryption-key-manager/key-manager.service.ts
@@ -83,13 +83,17 @@ export class KeyManagerService {
 	 * Encrypts the given plaintext value with the instance encryption key and inserts
 	 * it as a new deployment key row. If setAsActive, atomically deactivates the
 	 * previous active key; otherwise the new key is inserted as inactive.
+	 *
+	 * Data-encryption keys must always be wrapped with the instance key — never with
+	 * the currently active data key — which is why this goes through
+	 * `encryptWithInstanceKey` rather than the generic `encrypt`.
 	 */
 	async addKey(
 		plaintextValue: string,
 		algorithm: CipherAlgorithm,
 		setAsActive = false,
 	): Promise<DeploymentKey> {
-		const encryptedValue = this.cipher.encrypt(plaintextValue);
+		const encryptedValue = this.cipher.encryptWithInstanceKey(plaintextValue);
 
 		if (!setAsActive) {
 			const entity = this.deploymentKeyRepository.create({

--- a/packages/cli/src/modules/encryption-key-manager/key-manager.service.ts
+++ b/packages/cli/src/modules/encryption-key-manager/key-manager.service.ts
@@ -1,6 +1,6 @@
-import { Service } from '@n8n/di';
 import { DeploymentKeyRepository, type DeploymentKey } from '@n8n/db';
-import { Cipher } from 'n8n-core';
+import { Service } from '@n8n/di';
+import { Cipher, type CipherAlgorithm } from 'n8n-core';
 import { randomBytes } from 'node:crypto';
 
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
@@ -86,7 +86,7 @@ export class KeyManagerService {
 	 */
 	async addKey(
 		plaintextValue: string,
-		algorithm: string,
+		algorithm: CipherAlgorithm,
 		setAsActive = false,
 	): Promise<DeploymentKey> {
 		const encryptedValue = this.cipher.encrypt(plaintextValue);

--- a/packages/cli/test/integration/encryption-keys.api.test.ts
+++ b/packages/cli/test/integration/encryption-keys.api.test.ts
@@ -1,0 +1,153 @@
+import { testDb } from '@n8n/backend-test-utils';
+import type { User } from '@n8n/db';
+import { DeploymentKeyRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+
+import { createMember, createOwner } from './shared/db/users';
+import type { SuperAgentTest } from './shared/types';
+import * as utils from './shared/utils/';
+
+const testServer = utils.setupTestServer({ endpointGroups: ['encryption-keys'] });
+
+let deploymentKeyRepository: DeploymentKeyRepository;
+let owner: User;
+let ownerAgent: SuperAgentTest;
+let member: User;
+let memberAgent: SuperAgentTest;
+
+beforeAll(() => {
+	deploymentKeyRepository = Container.get(DeploymentKeyRepository);
+});
+
+beforeEach(async () => {
+	await testDb.truncate(['User', 'DeploymentKey']);
+	owner = await createOwner();
+	ownerAgent = testServer.authAgentFor(owner);
+	member = await createMember();
+	memberAgent = testServer.authAgentFor(member);
+});
+
+const seedKey = async (
+	overrides: Partial<{
+		type: string;
+		algorithm: string | null;
+		status: string;
+		value: string;
+	}> = {},
+) =>
+	await deploymentKeyRepository.save(
+		deploymentKeyRepository.create({
+			type: 'data_encryption',
+			value: 'seed-value',
+			algorithm: 'aes-256-cbc',
+			status: 'inactive',
+			...overrides,
+		}),
+	);
+
+describe('GET /encryption/keys', () => {
+	test('returns all keys for owner with id/type/algorithm/status/createdAt (never value)', async () => {
+		const legacy = await seedKey({ algorithm: 'aes-256-cbc', status: 'inactive', value: 'legacy' });
+		const active = await seedKey({
+			algorithm: 'aes-256-gcm',
+			status: 'active',
+			value: 'active-secret',
+		});
+
+		const response = await ownerAgent.get('/encryption/keys').expect(200);
+
+		const rows = response.body.data as Array<Record<string, unknown>>;
+		expect(rows).toHaveLength(2);
+
+		const ids = rows.map((r) => r.id);
+		expect(ids).toEqual(expect.arrayContaining([legacy.id, active.id]));
+
+		for (const row of rows) {
+			expect(row).toEqual({
+				id: expect.any(String),
+				type: 'data_encryption',
+				algorithm: expect.any(String),
+				status: expect.any(String),
+				createdAt: expect.any(String),
+			});
+			expect(row).not.toHaveProperty('value');
+		}
+
+		expect(JSON.stringify(response.body)).not.toContain('active-secret');
+		expect(JSON.stringify(response.body)).not.toContain('legacy');
+	});
+
+	test('filters by type query param', async () => {
+		await seedKey({ type: 'data_encryption', algorithm: 'aes-256-gcm', status: 'active' });
+		await seedKey({ type: 'other_type', algorithm: null, status: 'active' });
+
+		const response = await ownerAgent.get('/encryption/keys?type=data_encryption').expect(200);
+
+		const rows = response.body.data as Array<Record<string, unknown>>;
+		expect(rows).toHaveLength(1);
+		expect(rows[0].type).toBe('data_encryption');
+	});
+
+	test('returns 403 for a non-owner user', async () => {
+		await memberAgent.get('/encryption/keys').expect(403);
+	});
+
+	test('returns empty list when no keys exist', async () => {
+		const response = await ownerAgent.get('/encryption/keys').expect(200);
+		expect(response.body.data).toEqual([]);
+	});
+});
+
+describe('POST /encryption/keys', () => {
+	test('creates a new active key and deactivates the previous active key', async () => {
+		const previousActive = await seedKey({
+			algorithm: 'aes-256-cbc',
+			status: 'active',
+			value: 'previous',
+		});
+
+		const response = await ownerAgent
+			.post('/encryption/keys')
+			.send({ type: 'data_encryption' })
+			.expect(200);
+
+		expect(response.body.data).toEqual({
+			id: expect.any(String),
+			type: 'data_encryption',
+			algorithm: 'aes-256-gcm',
+			status: 'active',
+			createdAt: expect.any(String),
+		});
+		expect(response.body.data).not.toHaveProperty('value');
+
+		const rows = await deploymentKeyRepository.find({ where: { type: 'data_encryption' } });
+		expect(rows).toHaveLength(2);
+
+		const active = rows.filter((r) => r.status === 'active');
+		expect(active).toHaveLength(1);
+		expect(active[0].algorithm).toBe('aes-256-gcm');
+		expect(typeof active[0].value).toBe('string');
+		expect(active[0].value.length).toBeGreaterThan(0);
+		expect(JSON.stringify(response.body)).not.toContain(active[0].value);
+
+		const reloadedPrevious = await deploymentKeyRepository.findOneByOrFail({
+			id: previousActive.id,
+		});
+		expect(reloadedPrevious.status).toBe('inactive');
+	});
+
+	test('returns 400 when type is not data_encryption', async () => {
+		await ownerAgent.post('/encryption/keys').send({ type: 'other_type' }).expect(400);
+	});
+
+	test('returns 400 when body is missing type', async () => {
+		await ownerAgent.post('/encryption/keys').send({}).expect(400);
+	});
+
+	test('returns 403 for a non-owner user', async () => {
+		await memberAgent.post('/encryption/keys').send({ type: 'data_encryption' }).expect(403);
+
+		const rows = await deploymentKeyRepository.find();
+		expect(rows).toHaveLength(0);
+	});
+});

--- a/packages/cli/test/integration/shared/types.ts
+++ b/packages/cli/test/integration/shared/types.ts
@@ -49,7 +49,8 @@ type EndpointGroup =
 	| 'data-table'
 	| 'third-party-licenses'
 	| 'mcp'
-	| 'workflowDependencies';
+	| 'workflowDependencies'
+	| 'encryption-keys';
 
 type ModuleName =
 	| 'insights'

--- a/packages/cli/test/integration/shared/utils/test-server.ts
+++ b/packages/cli/test/integration/shared/utils/test-server.ts
@@ -340,6 +340,10 @@ export const setupTestServer = ({
 					case 'third-party-licenses':
 						await import('@/controllers/third-party-licenses.controller');
 						break;
+
+					case 'encryption-keys':
+						await import('@/modules/encryption-key-manager/encryption-key.controller');
+						break;
 				}
 			}
 

--- a/packages/core/src/encryption/__tests__/cipher.test.ts
+++ b/packages/core/src/encryption/__tests__/cipher.test.ts
@@ -35,6 +35,28 @@ describe('Cipher', () => {
 		});
 	});
 
+	describe('encryptWithInstanceKey / decryptWithInstanceKey', () => {
+		it('should roundtrip strings using the instance key regardless of custom args', () => {
+			const encrypted = cipher.encryptWithInstanceKey('random-string');
+			expect(cipher.decryptWithInstanceKey(encrypted)).toEqual('random-string');
+		});
+
+		it('should JSON-stringify objects before encrypting', () => {
+			const encrypted = cipher.encryptWithInstanceKey({ key: 'value' });
+			expect(cipher.decryptWithInstanceKey(encrypted)).toEqual('{"key":"value"}');
+		});
+
+		it('should produce ciphertext that is interoperable with decryptWithKey(instance-key)', () => {
+			const encrypted = cipher.encryptWithInstanceKey('random-string');
+			expect(cipher.decryptWithKey(encrypted, 'test_key', 'aes-256-cbc')).toEqual('random-string');
+		});
+
+		it('should fail to decrypt with a non-instance key', () => {
+			const encrypted = cipher.encryptWithInstanceKey('random-string');
+			expect(() => cipher.decryptWithKey(encrypted, 'some-other-key', 'aes-256-cbc')).toThrow();
+		});
+	});
+
 	describe('encryptWithKey', () => {
 		it('should roundtrip with decryptWithKey using the same key', () => {
 			const encrypted = cipher.encryptWithKey('random-string', 'explicit-key', 'aes-256-cbc');

--- a/packages/core/src/encryption/cipher.ts
+++ b/packages/core/src/encryption/cipher.ts
@@ -26,6 +26,21 @@ export class Cipher {
 		return this.decryptWithKey(data, key, 'aes-256-cbc');
 	}
 
+	/**
+	 * Encrypts with the instance encryption key specifically. Use this for payloads
+	 * that must be protected by the instance key (e.g. data-encryption keys
+	 * themselves), independently of any future change to the default `encrypt` key.
+	 */
+	encryptWithInstanceKey(data: string | object): string {
+		const plaintext = typeof data === 'string' ? data : JSON.stringify(data);
+		return this.encryptWithKey(plaintext, this.instanceSettings.encryptionKey, 'aes-256-cbc');
+	}
+
+	/** Counterpart of {@link encryptWithInstanceKey}. */
+	decryptWithInstanceKey(data: string): string {
+		return this.decryptWithKey(data, this.instanceSettings.encryptionKey, 'aes-256-cbc');
+	}
+
 	encryptWithKey(data: string, key: string, algorithm: CipherAlgorithm): string {
 		switch (algorithm) {
 			case 'aes-256-cbc':

--- a/packages/core/src/encryption/index.ts
+++ b/packages/core/src/encryption/index.ts
@@ -1,3 +1,4 @@
 export { Cipher } from './cipher';
 export { CipherAes256GCM } from './aes-256-gcm';
 export { CipherAes256CBC } from './aes-256-cbc';
+export type { CipherAlgorithm } from './interface';

--- a/packages/frontend/editor-ui/src/app/stores/rbac.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/rbac.store.ts
@@ -50,6 +50,7 @@ export const useRBACStore = defineStore(STORES.RBAC, () => {
 		chatHubAgent: {},
 		breakingChanges: {},
 		apiKey: {},
+		encryptionKey: {},
 		credentialResolver: {},
 		instanceAi: {},
 		securitySettings: {},


### PR DESCRIPTION
## Summary

Introduces two owner-only REST endpoints under `/api/v1/encryption/keys`, gated by a new `encryptionKey:manage` global scope:

- `GET /encryption/keys` — lists deployment keys (optionally filtered by `type`), returning id/type/algorithm/status/createdAt. Raw key material is never exposed.
- `POST /encryption/keys` — accepts `{ type: 'data_encryption' }`, server-generates a 256-bit key, encrypts it with the instance encryption key via `Cipher`, and atomically promotes it to active (deactivating the previous active key).

Includes DTO validation (via `Z.class` zod wrappers), controller + service unit tests, and an integration test covering the happy path, 400s for bad input, and 403s for non-owners. To test: authenticate as owner, `GET /encryption/keys` and `POST /encryption/keys` with `{ "type": "data_encryption" }`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-495

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI