### PR TITLE
fix(editor): Fix column collapse button not visible in table view

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataTable.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataTable.vue
@@ -900,7 +900,7 @@ th.isCollapsingColumn + th {
 	align-items: center;
 	padding: var(--spacing--4xs) var(--spacing--3xs);
 
-	span {
+	> :first-child {
 		white-space: nowrap;
 		text-overflow: ellipsis;
 		overflow: hidden;
@@ -1024,7 +1024,6 @@ th.isCollapsingColumn + th {
 	}
 
 	opacity: 0;
-	margin-block: calc(-2 * var(--spacing--2xs));
 
 	.isCollapsingColumn &,
 	th.isHoveredColumn &,


### PR DESCRIPTION
## Summary

- Fix the column collapse ("focus") button not appearing on hover in the NDV table view
- The N8nTooltip migration from Element Plus to reka-ui (#22838) introduced a `<span>` wrapper around tooltip triggers. The broad `.header span` CSS rule applied `overflow: hidden` to this wrapper, clipping the collapse button
- Scope the CSS selector to `> :first-child` so only the text element gets truncation styles
- Remove negative `margin-block` on the collapse button that caused clipping and vertical misalignment inside the tooltip wrapper

## Related ticket

https://linear.app/n8n/issue/ADO-4971

## Test plan

Import this workflow, execute it, then open the Edit Fields node output in Table view:

<details>
<summary>Test workflow JSON</summary>

```json
{
  "nodes": [
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [0, 0],
      "id": "94cbfb22-8799-4f3b-af5f-3c189d46123a",
      "name": "When clicking 'Execute workflow'"
    },
    {
      "parameters": {
        "mode": "raw",
        "options": {}
      },
      "type": "n8n-nodes-base.set",
      "typeVersion": 3.4,
      "position": [208, 0],
      "id": "43d672db-f2d0-443e-9a63-cf8a260fa82b",
      "name": "Edit Fields"
    }
  ],
  "connections": {
    "When clicking 'Execute workflow'": {
      "main": [
        [
          {
            "node": "Edit Fields",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {
    "When clicking 'Execute workflow'": [
      {
        "name": "First item",
        "code": 1,
        "data": {"some": "a", "large": "b", "json": "c", "object": "d", "with": "e", "many": "f", "keys": "g"}
      },
      {
        "name": "Second item",
        "code": 2,
        "data": {"some": "n", "large": "m", "json": "o", "object": "p", "with": "q", "many": "r", "keys": "s"}
      },
      {
        "name": "Third item",
        "code": 3,
        "data": {"some": "x", "large": "y", "json": "z", "object": "w", "with": "v", "many": "u", "keys": "t"}
      },
      {
        "name": "Third item",
        "code": 3,
        "data": {"some": "x", "large": "y", "json": "z", "object": "w", "with": "v", "many": "u", "keys": "t"}
      },
      {
        "name": "Third item",
        "code": 3,
        "data": {"some": "x", "large": "y", "json": "z", "object": "w", "with": "v", "many": "u", "keys": "t"}
      },
      {
        "name": "Third item",
        "code": 3,
        "data": {"some": "x", "large": "y", "json": "z", "object": "w", "with": "v", "many": "u", "keys": "t"}
      },
      {
        "name": "Third item",
        "code": 3,
        "data": {"some": "x", "large": "y", "json": "z", "object": "w", "with": "v", "many": "u", "keys": "t"}
      }
    ]
  }
}
```

</details>

- [ ] Hover over any column header — the collapse (chevrons) button should appear
- [ ] Click the button — other columns should collapse to single-line truncated text
- [ ] Click the reset button (next to search icon) to uncollapse
- [ ] Verify button appears on hover for all column types (simple values and JSON objects)
- [ ] Verify button is vertically centered in the header row
- [x] I have seen this code, I have run this code, and I take responsibility for this code.