### PR TITLE
fix: Fix computer use deny button size (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/GatewayResourceDecision.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/GatewayResourceDecision.vue
@@ -107,7 +107,7 @@ async function confirm(decision: string) {
 			<N8nButton
 				v-if="denyPrimary"
 				variant="outline"
-				size="small"
+				size="medium"
 				:label="denyPrimary.label"
 				data-test-id="gateway-decision-deny"
 				@click="confirm(denyPrimary.decision)"


### PR DESCRIPTION
## Summary

Fixes the "Deny" button size for computer use confirmation dialog.

<img width="818" height="390" alt="Bildschirmfoto 2026-04-22 um 13 53 48" src="https://github.com/user-attachments/assets/c2cdc48f-fc45-44b1-848b-a6e0a6125a78" />

After fix:

<img width="814" height="267" alt="Bildschirmfoto 2026-04-22 um 15 25 27" src="https://github.com/user-attachments/assets/67edaa85-ee58-4d2e-a559-0864686aa73a" />

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
