### PR TITLE
feat(editor): Warn when data table cell value exceeds safe integer range

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4163,6 +4163,8 @@
 	"dataTable.addRow.label": "Add Row",
 	"dataTable.addRow.error": "Error adding row",
 	"dataTable.updateRow.error": "Error updating row",
+	"dataTable.updateRow.numberPrecisionWarning.title": "Number precision may be lost",
+	"dataTable.updateRow.numberPrecisionWarning.message": "Values above 9,007,199,254,740,991 can lose precision. Store large numbers as text if you need exact values.",
 	"dataTable.deleteRows.title": "Delete Rows",
 	"dataTable.deleteRows.confirmation": "Are you sure you want to delete {count} row? | Are you sure you want to delete {count} rows?",
 	"dataTable.deleteRows.error": "Error deleting rows",

--- a/packages/frontend/editor-ui/src/features/core/dataTable/composables/useDataTableOperations.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/composables/useDataTableOperations.test.ts
@@ -64,6 +64,7 @@ describe('useDataTableOperations', () => {
 	let dataTableStore: ReturnType<typeof useDataTableStore>;
 	let confirmMock: ReturnType<typeof vi.fn>;
 	let showErrorMock: ReturnType<typeof vi.fn>;
+	let showMessageMock: ReturnType<typeof vi.fn>;
 	let telemetryTrackMock: ReturnType<typeof vi.fn>;
 
 	beforeEach(() => {
@@ -86,8 +87,10 @@ describe('useDataTableOperations', () => {
 		} as unknown as ReturnType<typeof useMessage>);
 
 		showErrorMock = vi.fn();
+		showMessageMock = vi.fn();
 		vi.mocked(useToast).mockReturnValue({
 			showError: showErrorMock,
+			showMessage: showMessageMock,
 		} as unknown as ReturnType<typeof useToast>);
 
 		telemetryTrackMock = vi.fn();
@@ -598,6 +601,51 @@ describe('useDataTableOperations', () => {
 			});
 			expect(showErrorMock).toHaveBeenCalledWith(updateError, 'dataTable.updateRow.error');
 			expect(params.toggleSave).toHaveBeenCalledWith(false);
+		});
+
+		it('should show a precision warning when the new number exceeds MAX_SAFE_INTEGER', async () => {
+			vi.mocked(useDataTableStore).mockReturnValue({
+				...dataTableStore,
+				updateRow: vi.fn().mockResolvedValue(undefined),
+			});
+
+			const { onCellValueChanged } = useDataTableOperations(params);
+			const unsafeValue = Number.MAX_SAFE_INTEGER + 10;
+			const event = {
+				data: { id: 1, amount: unsafeValue },
+				api: { applyTransaction: vi.fn() },
+				oldValue: 0,
+				colDef: { field: 'amount', cellDataType: 'number', colId: 'col1' },
+			} as unknown as CellValueChangedEvent<DataTableRow>;
+
+			await onCellValueChanged(event);
+
+			expect(showMessageMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					title: 'dataTable.updateRow.numberPrecisionWarning.title',
+					message: 'dataTable.updateRow.numberPrecisionWarning.message',
+					type: 'warning',
+				}),
+			);
+		});
+
+		it('should not show a precision warning for safe numbers', async () => {
+			vi.mocked(useDataTableStore).mockReturnValue({
+				...dataTableStore,
+				updateRow: vi.fn().mockResolvedValue(undefined),
+			});
+
+			const { onCellValueChanged } = useDataTableOperations(params);
+			const event = {
+				data: { id: 1, amount: 42 },
+				api: { applyTransaction: vi.fn() },
+				oldValue: 0,
+				colDef: { field: 'amount', cellDataType: 'number', colId: 'col1' },
+			} as unknown as CellValueChangedEvent<DataTableRow>;
+
+			await onCellValueChanged(event);
+
+			expect(showMessageMock).not.toHaveBeenCalled();
 		});
 
 		it('should revert cell value to null when old value is invalid', async () => {

--- a/packages/frontend/editor-ui/src/features/core/dataTable/composables/useDataTableOperations.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/composables/useDataTableOperations.ts
@@ -21,6 +21,7 @@ import { MODAL_CONFIRM } from '@/app/constants';
 import { isDataTableValue, isAGGridCellType } from '@/features/core/dataTable/typeGuards';
 import { useDataTableTypes } from '@/features/core/dataTable/composables/useDataTableTypes';
 import { areValuesEqual } from '@/features/core/dataTable/utils/typeUtils';
+import { isUnsafeNumberValue } from '@/features/core/dataTable/utils/columnUtils';
 import { ResponseError } from '@n8n/rest-api-client';
 
 export type UseDataTableOperationsParams = {
@@ -303,6 +304,13 @@ export const useDataTableOperations = ({
 				column_id: colDef.colId,
 				column_type: colDef.cellDataType,
 			});
+			if (isUnsafeNumberValue(value)) {
+				toast.showMessage({
+					title: i18n.baseText('dataTable.updateRow.numberPrecisionWarning.title'),
+					message: i18n.baseText('dataTable.updateRow.numberPrecisionWarning.message'),
+					type: 'warning',
+				});
+			}
 		} catch (error) {
 			// Revert cell to original value if the update fails
 			const validOldValue = isDataTableValue(oldValue) ? oldValue : null;

--- a/packages/frontend/editor-ui/src/features/core/dataTable/utils/columnUtils.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/utils/columnUtils.test.ts
@@ -23,6 +23,7 @@ import {
 	getNumberColumnFilterOptions,
 	getDateColumnFilterOptions,
 	isOversizedValue,
+	isUnsafeNumberValue,
 } from './columnUtils';
 import {
 	ADD_ROW_ROW_ID,
@@ -58,6 +59,35 @@ describe('columnUtils', () => {
 			expect(isOversizedValue(null)).toBe(false);
 			expect(isOversizedValue(undefined)).toBe(false);
 			expect(isOversizedValue({ key: 'value' })).toBe(false);
+		});
+	});
+
+	describe('isUnsafeNumberValue', () => {
+		it('should return false for non-number values', () => {
+			expect(isUnsafeNumberValue('9007199254740993')).toBe(false);
+			expect(isUnsafeNumberValue(null)).toBe(false);
+			expect(isUnsafeNumberValue(undefined)).toBe(false);
+			expect(isUnsafeNumberValue(true)).toBe(false);
+		});
+
+		it('should return false for numbers within the safe range', () => {
+			expect(isUnsafeNumberValue(0)).toBe(false);
+			expect(isUnsafeNumberValue(42)).toBe(false);
+			expect(isUnsafeNumberValue(-42.5)).toBe(false);
+			expect(isUnsafeNumberValue(Number.MAX_SAFE_INTEGER)).toBe(false);
+			expect(isUnsafeNumberValue(-Number.MAX_SAFE_INTEGER)).toBe(false);
+		});
+
+		it('should return true for numbers beyond the safe range', () => {
+			expect(isUnsafeNumberValue(Number.MAX_SAFE_INTEGER + 1)).toBe(true);
+			expect(isUnsafeNumberValue(-(Number.MAX_SAFE_INTEGER + 1))).toBe(true);
+			expect(isUnsafeNumberValue(1e20)).toBe(true);
+		});
+
+		it('should return true for non-finite numbers', () => {
+			expect(isUnsafeNumberValue(Infinity)).toBe(true);
+			expect(isUnsafeNumberValue(-Infinity)).toBe(true);
+			expect(isUnsafeNumberValue(NaN)).toBe(true);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/core/dataTable/utils/columnUtils.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/utils/columnUtils.ts
@@ -26,6 +26,12 @@ import { isDataTableValue } from '@/features/core/dataTable/typeGuards';
 export const isOversizedValue = (value: unknown): boolean =>
 	typeof value === 'string' && value.length > MAX_CELL_DISPLAY_LENGTH;
 
+export const isUnsafeNumberValue = (value: unknown): boolean => {
+	if (typeof value !== 'number') return false;
+	if (!Number.isFinite(value)) return true;
+	return Math.abs(value) > Number.MAX_SAFE_INTEGER;
+};
+
 export const createCellClass =
 	(col: DataTableColumn) =>
 	(params: CellClassParams<DataTableRow>): string => {


### PR DESCRIPTION
## Summary

Add a warning if users input numbers larger than MAX_SAFE_INTEGER:

<img width="485" height="780" alt="image" src="https://github.com/user-attachments/assets/71a53da4-9cd7-4325-aa53-99aa9a89570d" />


**How to test:** open any data table, add a `number` column, and enter `9007199254740993`. Saving should succeed and a warning toast should appear noting precision may be lost. Entering a safe value (e.g. `42`, or `9007199254740991`) should not trigger the warning.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5106

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI