### PR TITLE
feat(core): Accept token-exchanged scoped JWTs on the instance MCP server

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/mcp-api-key.service.integration.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp-api-key.service.integration.test.ts
@@ -57,7 +57,7 @@ describe('McpServerApiKeyService.verifyApiKey (integration)', () => {
 		await testDb.terminate();
 	});
 
-	it('accepts a valid MCP API key and returns the owning user (AC1)', async () => {
+	it('accepts a valid MCP API key and returns the owning user', async () => {
 		const owner = await createOwner();
 		const apiKey = await createMcpApiKey(owner);
 
@@ -68,7 +68,7 @@ describe('McpServerApiKeyService.verifyApiKey (integration)', () => {
 		expect(result.context).toBeUndefined();
 	});
 
-	it('accepts a scoped JWT and returns the subject when no actor is present (AC2)', async () => {
+	it('accepts a scoped JWT and returns the subject when no actor is present', async () => {
 		const subject = await createOwner();
 
 		const result = await service.verifyApiKey(makeScopedJwt(jwtService, subject.id));
@@ -78,7 +78,7 @@ describe('McpServerApiKeyService.verifyApiKey (integration)', () => {
 		expect(result.context).toBeUndefined();
 	});
 
-	it('accepts a scoped JWT with delegation and returns the actor as user (AC2)', async () => {
+	it('accepts a scoped JWT with delegation and returns the actor as user', async () => {
 		const subject = await createOwner();
 		const actor = await createMember();
 

--- a/packages/cli/src/modules/mcp/__tests__/mcp-api-key.service.integration.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp-api-key.service.integration.test.ts
@@ -1,0 +1,177 @@
+import { testDb } from '@n8n/backend-test-utils';
+import type { User } from '@n8n/db';
+import { ApiKey, ApiKeyRepository, UserRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { randomString } from 'n8n-workflow';
+
+import { ScopedJwtStrategy } from '@/modules/token-exchange/services/scoped-jwt.strategy';
+import { TOKEN_EXCHANGE_ISSUER } from '@/modules/token-exchange/token-exchange.types';
+import { ApiKeyAuthStrategy } from '@/services/api-key-auth.strategy';
+import { AuthStrategyRegistry } from '@/services/auth-strategy.registry';
+import { JwtService } from '@/services/jwt.service';
+import { createMember, createOwner, createOwnerWithApiKey } from '@test-integration/db/users';
+
+import { McpServerApiKeyService } from '../mcp-api-key.service';
+
+function makeScopedJwt(
+	jwtService: JwtService,
+	sub: string,
+	opts: { actSub?: string; expired?: boolean } = {},
+): string {
+	const now = Math.floor(Date.now() / 1000);
+	return jwtService.sign({
+		iss: TOKEN_EXCHANGE_ISSUER,
+		sub,
+		...(opts.actSub && { act: { sub: opts.actSub } }),
+		iat: opts.expired ? now - 7200 : now,
+		exp: opts.expired ? now - 1 : now + 3600,
+		jti: `jti-${randomString(8)}`,
+	});
+}
+
+async function createMcpApiKey(user: User): Promise<string> {
+	return (await Container.get(McpServerApiKeyService).createMcpServerApiKey(user)).apiKey;
+}
+
+describe('McpServerApiKeyService.verifyApiKey (integration)', () => {
+	let service: McpServerApiKeyService;
+	let jwtService: JwtService;
+
+	beforeAll(async () => {
+		await testDb.init();
+
+		// Mirror the registration order set up by public API + token-exchange module init.
+		const registry = Container.get(AuthStrategyRegistry);
+		jwtService = Container.get(JwtService);
+		registry.register(Container.get(ApiKeyAuthStrategy));
+		registry.register(Container.get(ScopedJwtStrategy));
+
+		service = Container.get(McpServerApiKeyService);
+	});
+
+	beforeEach(async () => {
+		await testDb.truncate(['User']);
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	it('accepts a valid MCP API key and returns the owning user (AC1)', async () => {
+		const owner = await createOwner();
+		const apiKey = await createMcpApiKey(owner);
+
+		const result = await service.verifyApiKey(apiKey);
+
+		expect(result.user?.id).toBe(owner.id);
+		expect(result.actor).toBeUndefined();
+		expect(result.context).toBeUndefined();
+	});
+
+	it('accepts a scoped JWT and returns the subject when no actor is present (AC2)', async () => {
+		const subject = await createOwner();
+
+		const result = await service.verifyApiKey(makeScopedJwt(jwtService, subject.id));
+
+		expect(result.user?.id).toBe(subject.id);
+		expect(result.actor).toBeUndefined();
+		expect(result.context).toBeUndefined();
+	});
+
+	it('accepts a scoped JWT with delegation and returns the actor as user (AC2)', async () => {
+		const subject = await createOwner();
+		const actor = await createMember();
+
+		const result = await service.verifyApiKey(
+			makeScopedJwt(jwtService, subject.id, { actSub: actor.id }),
+		);
+
+		expect(result.user?.id).toBe(actor.id);
+		expect(result.actor?.id).toBe(actor.id);
+	});
+
+	describe('rejects tokens that fail validation', () => {
+		it.each([
+			{
+				name: 'garbage string',
+				token: () => 'not-a-real-token',
+			},
+			{
+				name: 'public API key (audience=public-api)',
+				token: async () => {
+					const owner = await createOwnerWithApiKey();
+					return owner.apiKeys[0].apiKey;
+				},
+			},
+			{
+				name: 'MCP API key whose DB record was deleted',
+				token: async () => {
+					const owner = await createOwner();
+					const apiKey = await createMcpApiKey(owner);
+					await Container.get(ApiKeyRepository).delete({ apiKey });
+					return apiKey;
+				},
+			},
+			{
+				name: 'expired scoped JWT',
+				token: async () => {
+					const subject = await createOwner();
+					return makeScopedJwt(jwtService, subject.id, { expired: true });
+				},
+			},
+			{
+				name: 'scoped JWT whose subject is disabled',
+				token: async () => {
+					const subject = await createOwner();
+					await Container.get(UserRepository).update({ id: subject.id }, { disabled: true });
+					return makeScopedJwt(jwtService, subject.id);
+				},
+			},
+			{
+				name: 'scoped JWT whose actor is disabled',
+				token: async () => {
+					const subject = await createOwner();
+					const actor = await createMember();
+					await Container.get(UserRepository).update({ id: actor.id }, { disabled: true });
+					return makeScopedJwt(jwtService, subject.id, { actSub: actor.id });
+				},
+			},
+			{
+				name: 'scoped JWT whose subject is not in the database',
+				token: () => makeScopedJwt(jwtService, '00000000-0000-0000-0000-000000000000'),
+			},
+		])('rejects $name', async ({ token }) => {
+			const result = await service.verifyApiKey(await token());
+
+			expect(result.user).toBeNull();
+			expect(result.context?.reason).toBe('invalid_token');
+		});
+	});
+
+	it('rejects an MCP DB row whose stored JWT has a tampered audience', async () => {
+		// Defense-in-depth: even if a row is manually altered to have audience=mcp-server-api,
+		// the JWT verify step (with the expected audience) must still reject a token signed
+		// with a different aud claim.
+		const owner = await createOwner();
+		const jwt = jwtService.sign({
+			sub: owner.id,
+			iss: 'n8n',
+			aud: 'public-api',
+			jti: 'tampered',
+		});
+
+		const entity = Container.get(ApiKeyRepository).create({
+			userId: owner.id,
+			apiKey: jwt,
+			audience: 'mcp-server-api',
+			scopes: [],
+			label: `Tampered ${randomString(6)}`,
+		});
+		await Container.get(ApiKeyRepository).manager.insert(ApiKey, entity);
+
+		const result = await service.verifyApiKey(jwt);
+
+		expect(result.user).toBeNull();
+		expect(result.context?.reason).toBe('invalid_token');
+	});
+});

--- a/packages/cli/src/modules/mcp/__tests__/mcp-api-key.service.public-api-disabled.integration.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp-api-key.service.public-api-disabled.integration.test.ts
@@ -1,0 +1,27 @@
+import { Container } from '@n8n/di';
+
+import { createOwner } from '@test-integration/db/users';
+import * as utils from '@test-integration/utils';
+
+import { McpServerApiKeyService } from '../mcp-api-key.service';
+
+// Regression guard for IAM-574: ApiKeyAuthStrategy must be registered regardless
+// of whether the public API is enabled, otherwise MCP API keys stop working on
+// instances that disable the public REST API. Omitting 'publicApi' from
+// endpointGroups mirrors a production instance where isApiEnabled() returns
+// false — the MCP endpoint group is still set up so we can exercise the real
+// strategy-registration wiring.
+utils.setupTestServer({ modules: ['mcp'], endpointGroups: ['mcp'] });
+
+describe('McpServerApiKeyService.verifyApiKey with public API disabled', () => {
+	it('still authenticates valid MCP API keys', async () => {
+		const service = Container.get(McpServerApiKeyService);
+		const owner = await createOwner();
+		const { apiKey } = await service.createMcpServerApiKey(owner);
+
+		const result = await service.verifyApiKey(apiKey);
+
+		expect(result.user?.id).toBe(owner.id);
+		expect(result.context).toBeUndefined();
+	});
+});

--- a/packages/cli/src/modules/mcp/__tests__/mcp-api-key.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp-api-key.service.test.ts
@@ -1,0 +1,85 @@
+import type { ApiKeyRepository, UserRepository, User, TokenGrant } from '@n8n/db';
+import { mock } from 'jest-mock-extended';
+
+import type { AuthStrategyRegistry } from '@/services/auth-strategy.registry';
+import type { JwtService } from '@/services/jwt.service';
+
+import type { AccessTokenRepository } from '../database/repositories/oauth-access-token.repository';
+import { McpServerApiKeyService } from '../mcp-api-key.service';
+
+const makeUser = (id: string): User => ({ ...mock<User>(), id });
+
+describe('McpServerApiKeyService', () => {
+	let authStrategyRegistry: jest.Mocked<AuthStrategyRegistry>;
+	let service: McpServerApiKeyService;
+
+	beforeEach(() => {
+		authStrategyRegistry = mock<AuthStrategyRegistry>();
+		service = new McpServerApiKeyService(
+			mock<ApiKeyRepository>(),
+			mock<JwtService>(),
+			mock<UserRepository>(),
+			mock<AccessTokenRepository>(),
+			authStrategyRegistry,
+		);
+	});
+
+	describe('verifyApiKey', () => {
+		it('delegates to the registry with audience=mcp-server-api and maps the grant to UserWithContext', async () => {
+			const subject = makeUser('subject-1');
+			authStrategyRegistry.buildContextFromToken.mockResolvedValue({
+				subject,
+				scopes: [],
+			} satisfies TokenGrant);
+
+			const result = await service.verifyApiKey('any-token');
+
+			expect(authStrategyRegistry.buildContextFromToken).toHaveBeenCalledWith('any-token', {
+				audience: 'mcp-server-api',
+			});
+			expect(result.user).toBe(subject);
+			expect(result.actor).toBeUndefined();
+		});
+
+		it('returns the actor as user when delegation is present', async () => {
+			const subject = makeUser('subject-1');
+			const actor = makeUser('actor-1');
+			authStrategyRegistry.buildContextFromToken.mockResolvedValue({
+				subject,
+				actor,
+				scopes: [],
+			} satisfies TokenGrant);
+
+			const result = await service.verifyApiKey('token');
+
+			expect(result.user).toBe(actor);
+			expect(result.actor).toBe(actor);
+		});
+
+		it('returns a rejection context when the registry returns null', async () => {
+			authStrategyRegistry.buildContextFromToken.mockResolvedValue(null);
+
+			const result = await service.verifyApiKey('bad-token');
+
+			expect(result.user).toBeNull();
+			expect(result.context).toEqual({ reason: 'invalid_token', auth_type: 'api_key' });
+		});
+
+		it.each([
+			['JsonWebTokenError', 'invalid_token' as const, 'jwt malformed'],
+			['Error', 'unknown_error' as const, 'boom'],
+		])('maps %s thrown by a strategy to reason=%s', async (name, reason, message) => {
+			const error = Object.assign(new Error(message), { name });
+			authStrategyRegistry.buildContextFromToken.mockRejectedValue(error);
+
+			const result = await service.verifyApiKey('token');
+
+			expect(result.user).toBeNull();
+			expect(result.context).toEqual({
+				reason,
+				auth_type: 'api_key',
+				error_details: message,
+			});
+		});
+	});
+});

--- a/packages/cli/src/modules/mcp/__tests__/mcp-server-middleware.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp-server-middleware.service.test.ts
@@ -267,6 +267,34 @@ describe('McpServerMiddlewareService', () => {
 			expect(res.status).not.toHaveBeenCalled();
 		});
 
+		it('should authenticate with a delegated scoped JWT and set req.user to the actor', async () => {
+			const actor = mock<User>({ id: 'actor-1' });
+			const scopedJwt = jwtService.sign({
+				iss: 'n8n-token-exchange',
+				sub: 'subject-1',
+				act: { sub: 'actor-1' },
+				jti: 'test-jti',
+			});
+
+			const req = mockReqWith(`Bearer ${scopedJwt}`);
+			const res = mockDeep<Response>();
+			const next = jest.fn() as NextFunction;
+
+			// verifyApiKey returns the acting principal as `user` and keeps the actor field populated.
+			mcpServerApiKeyService.verifyApiKey.mockResolvedValue({ user: actor, actor });
+
+			const middleware = service.getAuthMiddleware();
+
+			await middleware(req, res, next);
+
+			expect((req as any).user).toEqual(actor);
+			expect(next).toHaveBeenCalled();
+			expect(res.status).not.toHaveBeenCalled();
+			// Scoped JWTs flow through verifyApiKey (no meta.isOAuth), not the OAuth path.
+			expect(mcpServerApiKeyService.verifyApiKey).toHaveBeenCalledWith(scopedJwt);
+			expect(oauthTokenService.verifyOAuthAccessToken).not.toHaveBeenCalled();
+		});
+
 		it('should return 401 with WWW-Authenticate header when token validation fails', async () => {
 			const invalidToken = jwtService.sign({
 				sub: 'user-123',

--- a/packages/cli/src/modules/mcp/mcp-api-key.service.ts
+++ b/packages/cli/src/modules/mcp/mcp-api-key.service.ts
@@ -4,10 +4,11 @@ import { EntityManager } from '@n8n/typeorm';
 import { randomUUID } from 'crypto';
 import { ApiKeyAudience, ensureError } from 'n8n-workflow';
 
+import { AuthStrategyRegistry } from '@/services/auth-strategy.registry';
+import { JwtService } from '@/services/jwt.service';
+
 import { AccessTokenRepository } from './database/repositories/oauth-access-token.repository';
 import { UserWithContext } from './mcp.types';
-
-import { JwtService } from '@/services/jwt.service';
 
 const API_KEY_AUDIENCE: ApiKeyAudience = 'mcp-server-api';
 const API_KEY_ISSUER = 'n8n';
@@ -26,6 +27,7 @@ export class McpServerApiKeyService {
 		private readonly jwtService: JwtService,
 		private readonly userRepository: UserRepository,
 		private readonly accessTokenRepository: AccessTokenRepository,
+		private readonly authStrategyRegistry: AuthStrategyRegistry,
 	) {}
 
 	async createMcpServerApiKey(user: User, trx?: EntityManager) {
@@ -66,36 +68,26 @@ export class McpServerApiKeyService {
 		return apiKey;
 	}
 
-	async getUserForApiKey(apiKey: string) {
-		return await this.userRepository.findOne({
-			where: {
-				apiKeys: {
-					apiKey,
-					audience: API_KEY_AUDIENCE,
-				},
-			},
-			relations: ['role'],
-		});
-	}
-
 	async verifyApiKey(apiKey: string): Promise<UserWithContext> {
 		try {
-			this.jwtService.verify(apiKey, {
-				issuer: API_KEY_ISSUER,
+			const tokenGrant = await this.authStrategyRegistry.buildContextFromToken(apiKey, {
 				audience: API_KEY_AUDIENCE,
 			});
 
-			const user = await this.getUserForApiKey(apiKey);
-			if (!user) {
+			if (tokenGrant) {
 				return {
-					user: null,
-					context: {
-						reason: 'user_not_found',
-						auth_type: 'api_key',
-					},
+					user: tokenGrant.actor ?? tokenGrant.subject,
+					actor: tokenGrant.actor,
 				};
 			}
-			return { user };
+
+			return {
+				user: null,
+				context: {
+					reason: 'invalid_token',
+					auth_type: 'api_key',
+				},
+			};
 		} catch (error) {
 			const errorForSure = ensureError(error);
 			return {

--- a/packages/cli/src/modules/mcp/mcp-server-middleware.service.ts
+++ b/packages/cli/src/modules/mcp/mcp-server-middleware.service.ts
@@ -3,15 +3,15 @@ import { Service } from '@n8n/di';
 import { NextFunction, Response, Request } from 'express';
 import { ensureError } from 'n8n-workflow';
 
+import { AuthError } from '@/errors/response-errors/auth.error';
+import { JwtService } from '@/services/jwt.service';
+import { Telemetry } from '@/telemetry';
+
 import { McpServerApiKeyService } from './mcp-api-key.service';
 import { McpOAuthTokenService } from './mcp-oauth-token.service';
 import { USER_CONNECTED_TO_MCP_EVENT, UNAUTHORIZED_ERROR_MESSAGE } from './mcp.constants';
 import type { TelemetryAuthContext, UserWithContext } from './mcp.types';
 import { getClientInfo } from './mcp.utils';
-
-import { AuthError } from '@/errors/response-errors/auth.error';
-import { JwtService } from '@/services/jwt.service';
-import { Telemetry } from '@/telemetry';
 
 /**
  * MCP Server Middleware Service

--- a/packages/cli/src/modules/mcp/mcp.types.ts
+++ b/packages/cli/src/modules/mcp/mcp.types.ts
@@ -126,5 +126,6 @@ export type TelemetryAuthContext = {
 
 export type UserWithContext = {
 	user: User | null;
+	actor?: User;
 	context?: TelemetryAuthContext;
 };

--- a/packages/cli/src/modules/token-exchange/services/__tests__/scoped-jwt.strategy.integration.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/scoped-jwt.strategy.integration.test.ts
@@ -5,9 +5,8 @@ import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
 
-import { createMember, createOwner } from '@test-integration/db/users';
-
 import { JwtService } from '@/services/jwt.service';
+import { createMember, createOwner } from '@test-integration/db/users';
 
 import { TOKEN_EXCHANGE_ISSUER } from '../../token-exchange.types';
 import { ScopedJwtStrategy } from '../scoped-jwt.strategy';
@@ -21,12 +20,6 @@ function makeBearerReq(token: string): AuthenticatedRequest {
 	return req;
 }
 
-function makeApiKeyReq(token: string): AuthenticatedRequest {
-	const req = mock<AuthenticatedRequest>();
-	req.headers = { 'x-n8n-api-key': token } as unknown as AuthenticatedRequest['headers'];
-	return req;
-}
-
 function makeScopedJwt(sub: string, actSub?: string): string {
 	return jwtService.sign({
 		iss: TOKEN_EXCHANGE_ISSUER,
@@ -36,6 +29,14 @@ function makeScopedJwt(sub: string, actSub?: string): string {
 		exp: Math.floor(Date.now() / 1000) + 3600,
 		jti: 'test-jti',
 	});
+}
+
+async function resolveRoleScopes(userId: string): Promise<string[]> {
+	const user = await Container.get(UserRepository).findOne({
+		where: { id: userId },
+		relations: { role: true },
+	});
+	return user!.role.scopes.map((s) => s.slug);
 }
 
 describe('ScopedJwtStrategy (integration)', () => {
@@ -54,99 +55,76 @@ describe('ScopedJwtStrategy (integration)', () => {
 		await testDb.terminate();
 	});
 
-	it('returns null for a token with a non-token-exchange issuer', async () => {
-		const token = jwtService.sign({ iss: 'n8n', sub: '123' });
-		expect(await strategy.authenticate(makeBearerReq(token))).toBeNull();
-	});
+	describe('buildTokenGrant', () => {
+		it('returns a grant with the subject role scopes when no act claim is present', async () => {
+			const owner = await createOwner();
+			const expectedScopes = await resolveRoleScopes(owner.id);
 
-	it('returns false when subject user does not exist in DB', async () => {
-		const token = makeScopedJwt('422b72e6-2df2-47c9-8082-f8393b088fde');
-		expect(await strategy.authenticate(makeBearerReq(token))).toBe(false);
-	});
+			const grant = await strategy.buildTokenGrant(makeScopedJwt(owner.id));
 
-	it('sets req.user to subject and loads subject role scopes when no act claim', async () => {
-		const owner = await createOwner();
-		const ownerWithRole = await Container.get(UserRepository).findOne({
-			where: { id: owner.id },
-			relations: { role: true },
+			if (!grant) throw new Error('expected grant');
+			expect(grant.subject.id).toBe(owner.id);
+			expect(grant.actor).toBeUndefined();
+			expect(grant.scopes).toEqual(expect.arrayContaining(expectedScopes));
+			expect(grant.scopes).toHaveLength(expectedScopes.length);
 		});
-		const expectedScopes = ownerWithRole!.role.scopes.map((s) => s.slug);
 
-		const token = makeScopedJwt(owner.id);
-		const req = makeBearerReq(token);
+		it('returns a grant with the actor role scopes when the act claim resolves', async () => {
+			const subject = await createOwner();
+			const actor = await createMember();
+			const actorScopes = await resolveRoleScopes(actor.id);
 
-		expect(await strategy.authenticate(req)).toBe(true);
+			const grant = await strategy.buildTokenGrant(makeScopedJwt(subject.id, actor.id));
 
-		expect(req.user.id).toBe(owner.id);
-		expect(req.tokenGrant?.subject.id).toBe(owner.id);
-		expect(req.tokenGrant?.actor).toBeUndefined();
-		expect(req.tokenGrant?.scopes).toEqual(expect.arrayContaining(expectedScopes));
-		expect(req.tokenGrant?.scopes).toHaveLength(expectedScopes.length);
+			if (!grant) throw new Error('expected grant');
+			expect(grant.subject.id).toBe(subject.id);
+			expect(grant.actor?.id).toBe(actor.id);
+			expect(grant.scopes).toEqual(expect.arrayContaining(actorScopes));
+			expect(grant.scopes).toHaveLength(actorScopes.length);
+		});
+
+		it('falls back to subject scopes when the actor ID is not in the DB', async () => {
+			const subject = await createOwner();
+			const subjectScopes = await resolveRoleScopes(subject.id);
+
+			const grant = await strategy.buildTokenGrant(
+				makeScopedJwt(subject.id, 'b4439ae8-4c33-4aac-9bc0-ff1891b03e13'),
+			);
+
+			if (!grant) throw new Error('expected grant');
+			expect(grant.subject.id).toBe(subject.id);
+			expect(grant.actor).toBeUndefined();
+			expect(grant.scopes).toHaveLength(subjectScopes.length);
+		});
+
+		it('rejects tokens that fail validation', async () => {
+			// Wrong issuer → abstain. Subject missing / disabled / disabled-actor → fail.
+			expect(await strategy.buildTokenGrant(jwtService.sign({ iss: 'n8n', sub: '1' }))).toBeNull();
+			expect(
+				await strategy.buildTokenGrant(makeScopedJwt('422b72e6-2df2-47c9-8082-f8393b088fde')),
+			).toBe(false);
+
+			const disabledSubject = await createOwner();
+			await Container.get(UserRepository).update({ id: disabledSubject.id }, { disabled: true });
+			expect(await strategy.buildTokenGrant(makeScopedJwt(disabledSubject.id))).toBe(false);
+
+			const subject = await createOwner();
+			const disabledActor = await createMember();
+			await Container.get(UserRepository).update({ id: disabledActor.id }, { disabled: true });
+			expect(await strategy.buildTokenGrant(makeScopedJwt(subject.id, disabledActor.id))).toBe(
+				false,
+			);
+		});
 	});
 
-	it('sets req.user to actor and uses actor scopes when act claim resolves', async () => {
+	it('authenticate wrapper sets req.user to the actor when delegation is present', async () => {
 		const subject = await createOwner();
 		const actor = await createMember();
-		const token = makeScopedJwt(subject.id, actor.id);
-		const req = makeBearerReq(token);
+		const req = makeBearerReq(makeScopedJwt(subject.id, actor.id));
 
 		expect(await strategy.authenticate(req)).toBe(true);
-
 		expect(req.user.id).toBe(actor.id);
 		expect(req.tokenGrant?.subject.id).toBe(subject.id);
 		expect(req.tokenGrant?.actor?.id).toBe(actor.id);
-
-		const actorWithRole = await Container.get(UserRepository).findOne({
-			where: { id: actor.id },
-			relations: { role: true },
-		});
-		const actorScopes = actorWithRole!.role.scopes.map((s) => s.slug);
-		expect(req.tokenGrant?.scopes).toEqual(expect.arrayContaining(actorScopes));
-		expect(req.tokenGrant?.scopes).toHaveLength(actorScopes.length);
-	});
-
-	it('continues without actor and uses subject scopes when actor ID is not in DB', async () => {
-		const subject = await createOwner();
-		const token = makeScopedJwt(subject.id, 'b4439ae8-4c33-4aac-9bc0-ff1891b03e13');
-		const req = makeBearerReq(token);
-
-		expect(await strategy.authenticate(req)).toBe(true);
-
-		expect(req.user.id).toBe(subject.id);
-		expect(req.tokenGrant?.actor).toBeUndefined();
-
-		const subjectWithRole = await Container.get(UserRepository).findOne({
-			where: { id: subject.id },
-			relations: { role: true },
-		});
-		const subjectScopes = subjectWithRole!.role.scopes.map((s) => s.slug);
-		expect(req.tokenGrant?.scopes).toEqual(expect.arrayContaining(subjectScopes));
-		expect(req.tokenGrant?.scopes).toHaveLength(subjectScopes.length);
-	});
-
-	it('accepts token from x-n8n-api-key header', async () => {
-		const owner = await createOwner();
-		const token = makeScopedJwt(owner.id);
-		const req = makeApiKeyReq(token);
-
-		expect(await strategy.authenticate(req)).toBe(true);
-		expect(req.user.id).toBe(owner.id);
-	});
-
-	it('returns false when subject is disabled', async () => {
-		const owner = await createOwner();
-		await Container.get(UserRepository).update({ id: owner.id }, { disabled: true });
-		const token = makeScopedJwt(owner.id);
-
-		expect(await strategy.authenticate(makeBearerReq(token))).toBe(false);
-	});
-
-	it('returns false when actor is disabled', async () => {
-		const subject = await createOwner();
-		const actor = await createMember();
-		await Container.get(UserRepository).update({ id: actor.id }, { disabled: true });
-		const token = makeScopedJwt(subject.id, actor.id);
-
-		expect(await strategy.authenticate(makeBearerReq(token))).toBe(false);
 	});
 });

--- a/packages/cli/src/modules/token-exchange/services/__tests__/scoped-jwt.strategy.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/scoped-jwt.strategy.test.ts
@@ -1,5 +1,4 @@
-import type { AuthenticatedRequest, User } from '@n8n/db';
-import type { UserRepository } from '@n8n/db';
+import type { AuthenticatedRequest, User, UserRepository } from '@n8n/db';
 import { ALL_API_KEY_SCOPES, type Scope as ScopeType } from '@n8n/permissions';
 import { mock } from 'jest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
@@ -46,18 +45,6 @@ function makeBearerReq(token: string): AuthenticatedRequest {
 	return req;
 }
 
-function makeApiKeyReq(token: string): AuthenticatedRequest {
-	const req = mock<AuthenticatedRequest>();
-	req.headers = { 'x-n8n-api-key': token } as unknown as AuthenticatedRequest['headers'];
-	return req;
-}
-
-function makeEmptyReq(): AuthenticatedRequest {
-	const req = mock<AuthenticatedRequest>();
-	req.headers = {} as AuthenticatedRequest['headers'];
-	return req;
-}
-
 describe('ScopedJwtStrategy', () => {
 	let strategy: ScopedJwtStrategy;
 	let userRepository: jest.Mocked<UserRepository>;
@@ -67,115 +54,142 @@ describe('ScopedJwtStrategy', () => {
 		strategy = new ScopedJwtStrategy(jwtService, userRepository);
 	});
 
-	describe('token extraction', () => {
-		it('returns null when neither Authorization nor x-n8n-api-key header is present', async () => {
-			expect(await strategy.authenticate(makeEmptyReq())).toBeNull();
+	describe('buildTokenGrant', () => {
+		it.each([
+			['empty token', ''],
+			['non-JWT garbage', 'not-a-jwt'],
+			['JWT with a non-token-exchange issuer', jwtService.sign({ iss: 'n8n', sub: '123' })],
+			['JWT with a foreign issuer', jwtService.sign({ iss: 'https://idp.example.com', sub: '1' })],
+		])('returns null (abstains) for %s', async (_name, token) => {
+			expect(await strategy.buildTokenGrant(token)).toBeNull();
 		});
 
-		it('returns null for non-Bearer Authorization header', async () => {
-			const req = mock<AuthenticatedRequest>();
-			req.headers = { authorization: 'Basic dXNlcjpwYXNz' } as AuthenticatedRequest['headers'];
-			expect(await strategy.authenticate(req)).toBeNull();
-		});
-
-		it('accepts token from x-n8n-api-key header', async () => {
-			const subject = makeUser('subject-id', ['workflow:read']);
-			userRepository.findOne.mockResolvedValue(subject);
-
-			const token = makeTokenExchangeJwt();
-			expect(await strategy.authenticate(makeApiKeyReq(token))).toBe(true);
-		});
-	});
-
-	describe('issuer check', () => {
-		it('returns null for a JWT with a non-token-exchange issuer', async () => {
-			const foreignToken = jwtService.sign({ iss: 'https://idp.example.com', sub: '123' });
-			expect(await strategy.authenticate(makeBearerReq(foreignToken))).toBeNull();
-		});
-
-		it('returns null for a JWT with the API key issuer', async () => {
-			const apiKeyToken = jwtService.sign({ iss: 'n8n', sub: '123' });
-			expect(await strategy.authenticate(makeBearerReq(apiKeyToken))).toBeNull();
-		});
-	});
-
-	describe('signature and expiry', () => {
-		it('returns false for an expired token-exchange JWT', async () => {
-			const expiredToken = jwtService.sign({
+		it('returns false when signature or expiry fail', async () => {
+			const expired = jwtService.sign({
 				iss: TOKEN_EXCHANGE_ISSUER,
 				sub: 'subject-id',
 				iat: Math.floor(Date.now() / 1000) - 7200,
 				exp: Math.floor(Date.now() / 1000) - 1,
 				jti: 'test-jti',
 			});
-			expect(await strategy.authenticate(makeBearerReq(expiredToken))).toBe(false);
-		});
-
-		it('returns false for a token signed with a different key', async () => {
-			const badToken = otherJwtService.sign({
+			const badSignature = otherJwtService.sign({
 				iss: TOKEN_EXCHANGE_ISSUER,
 				sub: 'subject-id',
 				iat: Math.floor(Date.now() / 1000),
 				exp: Math.floor(Date.now() / 1000) + 3600,
 				jti: 'test-jti',
 			});
-			expect(await strategy.authenticate(makeBearerReq(badToken))).toBe(false);
-		});
-	});
 
-	describe('user resolution', () => {
-		it('returns false when subject is not found in DB', async () => {
-			userRepository.findOne.mockResolvedValue(null);
-			expect(await strategy.authenticate(makeBearerReq(makeTokenExchangeJwt()))).toBe(false);
+			expect(await strategy.buildTokenGrant(expired)).toBe(false);
+			expect(await strategy.buildTokenGrant(badSignature)).toBe(false);
 		});
 
-		it('returns false when subject is disabled', async () => {
-			userRepository.findOne.mockResolvedValue(makeUser('subject-id', [], true));
-			expect(await strategy.authenticate(makeBearerReq(makeTokenExchangeJwt()))).toBe(false);
+		it('returns false when the subject is unknown or disabled', async () => {
+			userRepository.findOne.mockResolvedValueOnce(null);
+			expect(await strategy.buildTokenGrant(makeTokenExchangeJwt())).toBe(false);
+
+			userRepository.findOne.mockResolvedValueOnce(makeUser('subject-id', [], true));
+			expect(await strategy.buildTokenGrant(makeTokenExchangeJwt())).toBe(false);
 		});
 
-		it('continues without actor when act is present but actor not found in DB', async () => {
+		it('returns false when the actor is present but disabled', async () => {
 			const subject = makeUser('subject-id', ['workflow:read']);
-			userRepository.findOne
-				.mockResolvedValueOnce(subject) // subject lookup
-				.mockResolvedValueOnce(null); // actor not found
-
-			const token = makeTokenExchangeJwt({ act: { sub: 'unknown-actor' } });
-			const req = makeBearerReq(token);
-
-			expect(await strategy.authenticate(req)).toBe(true);
-			expect(req.user).toBe(subject);
-			expect(req.tokenGrant?.actor).toBeUndefined();
-		});
-
-		it('returns false when actor is found but disabled', async () => {
-			const subject = makeUser('subject-id', ['workflow:read']);
-			const actor = makeUser('actor-id', [], true); // disabled
+			const actor = makeUser('actor-id', [], true);
 			userRepository.findOne.mockResolvedValueOnce(subject).mockResolvedValueOnce(actor);
 
 			const token = makeTokenExchangeJwt({ act: { sub: 'actor-id' } });
-			expect(await strategy.authenticate(makeBearerReq(token))).toBe(false);
-		});
-	});
 
-	describe('successful authentication', () => {
-		it('sets req.user to subject and uses subject scopes when no act claim', async () => {
+			expect(await strategy.buildTokenGrant(token)).toBe(false);
+		});
+
+		it('builds a grant with subject scopes when no actor is present', async () => {
 			const subject = makeUser('subject-id', ['workflow:read', 'workflow:create']);
 			userRepository.findOne.mockResolvedValue(subject);
 
-			const req = makeBearerReq(makeTokenExchangeJwt({ sub: 'subject-id' }));
+			const grant = await strategy.buildTokenGrant(makeTokenExchangeJwt());
 
-			expect(await strategy.authenticate(req)).toBe(true);
-			expect(req.user).toBe(subject);
-			expect(req.tokenGrant?.subject).toBe(subject);
-			expect(req.tokenGrant?.actor).toBeUndefined();
-			expect(req.tokenGrant?.scopes).toEqual(['workflow:read', 'workflow:create']);
-			expect(req.tokenGrant?.apiKeyScopes).toEqual(Array.from(ALL_API_KEY_SCOPES));
+			if (!grant) throw new Error('expected grant');
+			expect(grant.subject).toBe(subject);
+			expect(grant.actor).toBeUndefined();
+			expect(grant.scopes).toEqual(['workflow:read', 'workflow:create']);
+			expect(grant.apiKeyScopes).toEqual(Array.from(ALL_API_KEY_SCOPES));
 		});
 
-		it('sets req.user to actor and uses actor scopes when act claim is present', async () => {
+		it('builds a grant with actor scopes when the act claim resolves', async () => {
 			const subject = makeUser('subject-id', ['workflow:read']);
 			const actor = makeUser('actor-id', ['credential:read', 'credential:create']);
+			userRepository.findOne.mockResolvedValueOnce(subject).mockResolvedValueOnce(actor);
+
+			const token = makeTokenExchangeJwt({ sub: 'subject-id', act: { sub: 'actor-id' } });
+			const grant = await strategy.buildTokenGrant(token);
+
+			if (!grant) throw new Error('expected grant');
+			expect(grant.subject).toBe(subject);
+			expect(grant.actor).toBe(actor);
+			// Scopes come from the acting principal (actor) when one is resolved.
+			expect(grant.scopes).toEqual(['credential:read', 'credential:create']);
+		});
+
+		it('falls back to subject scopes when the act claim is present but actor is not found', async () => {
+			const subject = makeUser('subject-id', ['workflow:read']);
+			userRepository.findOne.mockResolvedValueOnce(subject).mockResolvedValueOnce(null);
+
+			const grant = await strategy.buildTokenGrant(
+				makeTokenExchangeJwt({ act: { sub: 'unknown-actor' } }),
+			);
+
+			if (!grant) throw new Error('expected grant');
+			expect(grant.actor).toBeUndefined();
+			expect(grant.scopes).toEqual(['workflow:read']);
+		});
+
+		it('honours the issuer option override', async () => {
+			const subject = makeUser('subject-id', ['workflow:read']);
+			userRepository.findOne.mockResolvedValue(subject);
+
+			const token = jwtService.sign({
+				iss: 'custom-issuer',
+				sub: 'subject-id',
+				iat: Math.floor(Date.now() / 1000),
+				exp: Math.floor(Date.now() / 1000) + 3600,
+				jti: 'test-jti',
+			});
+
+			expect(await strategy.buildTokenGrant(token, { issuer: 'custom-issuer' })).not.toBeNull();
+			// Signed with the default issuer but caller expects something else → abstain.
+			expect(
+				await strategy.buildTokenGrant(makeTokenExchangeJwt(), { issuer: 'other-issuer' }),
+			).toBeNull();
+		});
+	});
+
+	describe('authenticate (wrapper)', () => {
+		it.each([
+			[
+				'no auth headers',
+				(): AuthenticatedRequest => {
+					const req = mock<AuthenticatedRequest>();
+					req.headers = {} as AuthenticatedRequest['headers'];
+					return req;
+				},
+			],
+			[
+				'non-Bearer Authorization header',
+				(): AuthenticatedRequest => {
+					const req = mock<AuthenticatedRequest>();
+					req.headers = {
+						authorization: 'Basic dXNlcjpwYXNz',
+					} as AuthenticatedRequest['headers'];
+					return req;
+				},
+			],
+		])('returns null when %s', async (_name, makeReq) => {
+			expect(await strategy.authenticate(makeReq())).toBeNull();
+		});
+
+		it('sets req.user to the acting principal and populates req.tokenGrant', async () => {
+			const subject = makeUser('subject-id', ['workflow:read']);
+			const actor = makeUser('actor-id', ['credential:read']);
 			userRepository.findOne.mockResolvedValueOnce(subject).mockResolvedValueOnce(actor);
 
 			const token = makeTokenExchangeJwt({ sub: 'subject-id', act: { sub: 'actor-id' } });
@@ -185,35 +199,6 @@ describe('ScopedJwtStrategy', () => {
 			expect(req.user).toBe(actor);
 			expect(req.tokenGrant?.subject).toBe(subject);
 			expect(req.tokenGrant?.actor).toBe(actor);
-			expect(req.tokenGrant?.scopes).toEqual(['credential:read', 'credential:create']);
-			expect(req.tokenGrant?.apiKeyScopes).toEqual(Array.from(ALL_API_KEY_SCOPES));
-		});
-
-		it('uses subject scopes when act is present but actor not found', async () => {
-			const subject = makeUser('subject-id', ['workflow:read']);
-			userRepository.findOne.mockResolvedValueOnce(subject).mockResolvedValueOnce(null); // actor not found
-
-			const token = makeTokenExchangeJwt({ sub: 'subject-id', act: { sub: 'missing' } });
-			const req = makeBearerReq(token);
-
-			await strategy.authenticate(req);
-
-			expect(req.tokenGrant?.scopes).toEqual(['workflow:read']);
-			expect(req.tokenGrant?.apiKeyScopes).toEqual(Array.from(ALL_API_KEY_SCOPES));
-			expect(req.user).toBe(subject);
-		});
-
-		it('sets apiKeyScopes to all API key scopes regardless of actor presence', async () => {
-			const subject = makeUser('subject-id', ['workflow:read']);
-			const actor = makeUser('actor-id', ['credential:read']);
-			userRepository.findOne.mockResolvedValueOnce(subject).mockResolvedValueOnce(actor);
-
-			const token = makeTokenExchangeJwt({ sub: 'subject-id', act: { sub: 'actor-id' } });
-			const req = makeBearerReq(token);
-
-			await strategy.authenticate(req);
-
-			expect(req.tokenGrant?.apiKeyScopes).toEqual(Array.from(ALL_API_KEY_SCOPES));
 		});
 	});
 });

--- a/packages/cli/src/modules/token-exchange/services/scoped-jwt.strategy.ts
+++ b/packages/cli/src/modules/token-exchange/services/scoped-jwt.strategy.ts
@@ -1,12 +1,12 @@
-import type { AuthenticatedRequest, User } from '@n8n/db';
+import type { AuthenticatedRequest, TokenGrant, User } from '@n8n/db';
 import { UserRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
+import { ALL_API_KEY_SCOPES } from '@n8n/permissions';
 import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken';
 
-import type { AuthStrategy } from '@/services/auth-strategy.types';
+import type { AuthStrategy, AuthStrategyOptions } from '@/services/auth-strategy.types';
 import { JwtService } from '@/services/jwt.service';
 
-import { ALL_API_KEY_SCOPES } from '@n8n/permissions';
 import { TOKEN_EXCHANGE_ISSUER, type IssuedJwtPayload } from '../token-exchange.types';
 
 const BEARER_PREFIX = 'Bearer ';
@@ -19,22 +19,25 @@ export class ScopedJwtStrategy implements AuthStrategy {
 		private readonly userRepository: UserRepository,
 	) {}
 
-	async authenticate(req: AuthenticatedRequest): Promise<boolean | null> {
-		// 1. Extract token from Authorization: Bearer or x-n8n-api-key header
-		const token = this.extractToken(req);
+	async buildTokenGrant(
+		token: string,
+		options?: AuthStrategyOptions,
+	): Promise<TokenGrant | false | null> {
 		if (!token) return null;
 
-		// 2. Decode (unverified) — check iss before expensive signature verification
+		const issuer = options?.issuer ?? TOKEN_EXCHANGE_ISSUER;
+
+		// 1. Decode (unverified) — check iss before expensive signature verification
 		const decoded = this.jwtService.decode<IssuedJwtPayload>(token);
-		if (!decoded || decoded.iss !== TOKEN_EXCHANGE_ISSUER) {
+		if (!decoded || decoded.iss !== issuer) {
 			return null; // Not a token-exchange JWT — pass to next strategy
 		}
 
-		// 3. Verify signature + expiry
+		// 2. Verify signature + expiry
 		let payload: IssuedJwtPayload;
 		try {
 			payload = this.jwtService.verify<IssuedJwtPayload>(token, {
-				issuer: TOKEN_EXCHANGE_ISSUER,
+				issuer,
 			});
 		} catch (error) {
 			if (error instanceof TokenExpiredError || error instanceof JsonWebTokenError) {
@@ -43,11 +46,11 @@ export class ScopedJwtStrategy implements AuthStrategy {
 			throw error;
 		}
 
-		// 4. Resolve subject (sub claim)
+		// 3. Resolve subject (sub claim)
 		const subject = await this.findUser(payload.sub);
 		if (!subject || subject.disabled) return false;
 
-		// 5. Resolve actor (act.sub claim) if present — actor is optional;
+		// 4. Resolve actor (act.sub claim) if present — actor is optional;
 		//    a missing actor is not an error, but a disabled actor is.
 		let actor: User | undefined;
 		if (payload.act) {
@@ -56,16 +59,35 @@ export class ScopedJwtStrategy implements AuthStrategy {
 			actor = found ?? undefined;
 		}
 
-		// 6. Acting principal: actor (if resolved) or subject
+		// 5. Acting principal: actor (if resolved) or subject
 		const actingUser = actor ?? subject;
 
-		// 7. Scopes come from the acting user's role (role.scopes is eager: true)
-		req.tokenGrant = {
+		// 6. Scopes come from the acting user's role (role.scopes is eager: true)
+		return {
 			scopes: actingUser.role.scopes.map((s) => s.slug),
 			apiKeyScopes: Array.from(ALL_API_KEY_SCOPES),
 			subject,
 			...(actor && { actor }),
 		};
+	}
+
+	async authenticate(req: AuthenticatedRequest): Promise<boolean | null> {
+		// 1. Extract token from Authorization: Bearer or x-n8n-api-key header
+		const token = this.extractToken(req);
+		if (!token) return null;
+
+		// 2. Build token grant
+		const tokenGrant = await this.buildTokenGrant(token);
+
+		if (tokenGrant === false || tokenGrant === null) {
+			return tokenGrant;
+		}
+
+		// 3. Acting principal: actor (if resolved) or subject
+		const actingUser = tokenGrant.actor ?? tokenGrant.subject;
+
+		// 6. Setup token grant for request
+		req.tokenGrant = tokenGrant;
 
 		req.user = actingUser;
 

--- a/packages/cli/src/public-api/index.ts
+++ b/packages/cli/src/public-api/index.ts
@@ -205,14 +205,6 @@ function createApiRouter(
 export const loadPublicApiVersions = async (
 	publicApiEndpoint: string,
 ): Promise<{ apiRouters: express.Router[]; apiLatestVersion: number }> => {
-	// Register auth strategies in priority order. The registry evaluates them
-	// sequentially — the first strategy that returns a non-null result wins.
-	// API key auth is registered first so existing behavior is preserved.
-	// Additional strategies (e.g. scoped JWT from the token-exchange module)
-	// can be appended later during their own module initialization.
-	const registry = Container.get(AuthStrategyRegistry);
-	registry.register(Container.get(ApiKeyAuthStrategy));
-
 	const folders = await fs.readdir(__dirname);
 	const versions = folders.filter((folderName) => folderName.startsWith('v'));
 

--- a/packages/cli/src/public-api/index.ts
+++ b/packages/cli/src/public-api/index.ts
@@ -12,7 +12,6 @@ import { Logger } from '@n8n/backend-common';
 
 import { EventService } from '@/events/event.service';
 import { License } from '@/license';
-import { ApiKeyAuthStrategy } from '@/services/api-key-auth.strategy';
 import { AuthStrategyRegistry } from '@/services/auth-strategy.registry';
 import { LastActiveAtService } from '@/services/last-active-at.service';
 import { UrlService } from '@/services/url.service';

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -67,6 +67,8 @@ import '@/webhooks/webhooks.controller';
 import { ChatServer } from './chat/chat-server';
 import { MfaService } from './mfa/mfa.service';
 import { PubSubRegistry } from './scaling/pubsub/pubsub.registry';
+import { ApiKeyAuthStrategy } from './services/api-key-auth.strategy';
+import { AuthStrategyRegistry } from './services/auth-strategy.registry';
 
 @Service()
 export class Server extends AbstractServer {
@@ -164,6 +166,14 @@ export class Server extends AbstractServer {
 		await this.postHogClient.init();
 
 		const publicApiEndpoint = this.globalConfig.publicApi.path;
+
+		// Register auth strategies in priority order. The registry evaluates them
+		// sequentially — the first strategy that returns a non-null result wins.
+		// API key auth is registered first so existing behavior is preserved.
+		// Additional strategies (e.g. scoped JWT from the token-exchange module)
+		// can be appended later during their own module initialization.
+		const registry = Container.get(AuthStrategyRegistry);
+		registry.register(Container.get(ApiKeyAuthStrategy));
 
 		// ----------------------------------------
 		// Public API

--- a/packages/cli/src/services/__tests__/api-key-auth.strategy.integration.test.ts
+++ b/packages/cli/src/services/__tests__/api-key-auth.strategy.integration.test.ts
@@ -1,187 +1,175 @@
 import { testDb } from '@n8n/backend-test-utils';
-import type { AuthenticatedRequest } from '@n8n/db';
-import { ApiKeyRepository, UserRepository } from '@n8n/db';
+import type { AuthenticatedRequest, User } from '@n8n/db';
+import { ApiKey, ApiKeyRepository, UserRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
+import { randomUUID } from 'crypto';
 import { mock } from 'jest-mock-extended';
 import { DateTime } from 'luxon';
 import { randomString } from 'n8n-workflow';
 
+import { TOKEN_EXCHANGE_ISSUER } from '@/modules/token-exchange/token-exchange.types';
 import { createOwnerWithApiKey } from '@test-integration/db/users';
 
 import { ApiKeyAuthStrategy } from '../api-key-auth.strategy';
 import { JwtService } from '../jwt.service';
-import { TOKEN_EXCHANGE_ISSUER } from '@/modules/token-exchange/token-exchange.types';
 import { API_KEY_ISSUER } from '../public-api-key.service';
 
-const mockReqWith = (apiKey: string, path: string, method: string): AuthenticatedRequest =>
+const mockReqWith = (apiKey: string): AuthenticatedRequest =>
 	mock<AuthenticatedRequest>({
-		path,
-		method,
-		headers: {
-			'x-n8n-api-key': apiKey,
-		},
+		path: '/test',
+		method: 'GET',
+		headers: { 'x-n8n-api-key': apiKey },
 	});
 
-const mockReqWithoutApiKey = (path: string, method: string): AuthenticatedRequest => {
-	const req = mock<AuthenticatedRequest>({
-		path,
-		method,
-	});
-	// Override the deep-mock proxy so the header lookup returns undefined
+const mockReqWithoutApiKey = (): AuthenticatedRequest => {
+	const req = mock<AuthenticatedRequest>({ path: '/test', method: 'GET' });
+	// Override the deep-mock proxy so the header lookup returns undefined.
 	req.headers = { host: 'localhost' } as AuthenticatedRequest['headers'];
 	return req;
 };
+
+async function signAndStoreMcpApiKey(owner: User): Promise<string> {
+	const apiKey = Container.get(JwtService).sign({
+		sub: owner.id,
+		iss: API_KEY_ISSUER,
+		aud: 'mcp-server-api',
+		jti: randomUUID(),
+	});
+
+	const entity = Container.get(ApiKeyRepository).create({
+		userId: owner.id,
+		apiKey,
+		audience: 'mcp-server-api',
+		scopes: [],
+		label: `Test MCP Key ${randomString(6)}`,
+	});
+	await Container.get(ApiKeyRepository).manager.insert(ApiKey, entity);
+
+	return apiKey;
+}
 
 let jwtService: JwtService;
 let strategy: ApiKeyAuthStrategy;
 
 describe('ApiKeyAuthStrategy', () => {
-	beforeEach(async () => {
-		await testDb.truncate(['User']);
-	});
-
 	beforeAll(async () => {
 		await testDb.init();
 		jwtService = Container.get(JwtService);
 		strategy = new ApiKeyAuthStrategy(Container.get(ApiKeyRepository), jwtService);
 	});
 
+	beforeEach(async () => {
+		await testDb.truncate(['User']);
+	});
+
 	afterAll(async () => {
 		await testDb.terminate();
 	});
 
-	it('should return null when no x-n8n-api-key header is present', async () => {
-		const req = mockReqWithoutApiKey('/test', 'GET');
-		expect(await strategy.authenticate(req)).toBeNull();
-	});
+	describe('buildTokenGrant', () => {
+		it('returns a grant with subject, role scopes, and apiKeyScopes for a valid public API key', async () => {
+			const owner = await createOwnerWithApiKey({ scopes: ['workflow:read', 'workflow:list'] });
+			const [{ apiKey }] = owner.apiKeys;
 
-	it('should return false if api key is invalid', async () => {
-		const req = mockReqWith('invalid', '/test', 'GET');
-		expect(await strategy.authenticate(req)).toBe(false);
-	});
+			const grant = await strategy.buildTokenGrant(apiKey);
 
-	it('should return false if valid api key is not in database', async () => {
-		const apiKey = jwtService.sign({ sub: '123', iss: API_KEY_ISSUER });
-		const req = mockReqWith(apiKey, '/test', 'GET');
-		expect(await strategy.authenticate(req)).toBe(false);
-	});
-
-	it('should return true and set req.user if valid api key exists in the database', async () => {
-		const owner = await createOwnerWithApiKey();
-		const [{ apiKey }] = owner.apiKeys;
-		const req = mockReqWith(apiKey, '/test', 'GET');
-
-		expect(await strategy.authenticate(req)).toBe(true);
-		expect(req.user).toBeDefined();
-		expect(req.user.id).toBe(owner.id);
-	});
-
-	it('should set req.user.role on successful authentication', async () => {
-		const owner = await createOwnerWithApiKey();
-		const [{ apiKey }] = owner.apiKeys;
-		const req = mockReqWith(apiKey, '/test', 'GET');
-
-		await strategy.authenticate(req);
-
-		expect(req.user.role).toBeDefined();
-		expect(req.user.role.slug).toBeDefined();
-	});
-
-	it('should set req.tokenGrant with the scopes of the authenticated user role', async () => {
-		const owner = await createOwnerWithApiKey();
-		const [{ apiKey }] = owner.apiKeys;
-		const req = mockReqWith(apiKey, '/test', 'GET');
-
-		await strategy.authenticate(req);
-
-		expect(req.tokenGrant).toBeDefined();
-		expect(Array.isArray(req.tokenGrant?.scopes)).toBe(true);
-	});
-
-	it('should set req.tokenGrant.apiKeyScopes from the scopes stored on the API key', async () => {
-		const owner = await createOwnerWithApiKey({ scopes: ['workflow:read', 'workflow:list'] });
-		const [{ apiKey }] = owner.apiKeys;
-		const req = mockReqWith(apiKey, '/test', 'GET');
-
-		await strategy.authenticate(req);
-
-		expect(req.tokenGrant?.apiKeyScopes).toEqual(['workflow:read', 'workflow:list']);
-	});
-
-	it('should set req.tokenGrant.apiKeyScopes independently from role scopes', async () => {
-		const owner = await createOwnerWithApiKey({ scopes: ['workflow:read'] });
-		const [{ apiKey }] = owner.apiKeys;
-		const req = mockReqWith(apiKey, '/test', 'GET');
-
-		await strategy.authenticate(req);
-
-		// role scopes come from the user's role — unaffected by the API key scopes restriction
-		expect(Array.isArray(req.tokenGrant?.scopes)).toBe(true);
-		expect(req.tokenGrant?.scopes.length).toBeGreaterThan(1);
-		// apiKeyScopes reflects what was stored on the key
-		expect(req.tokenGrant?.apiKeyScopes).toEqual(['workflow:read']);
-	});
-
-	it('should return false if expired JWT is used', async () => {
-		const dateInThePast = DateTime.now().minus({ days: 1 }).toUnixInteger();
-		const owner = await createOwnerWithApiKey({ expiresAt: dateInThePast });
-		const [{ apiKey }] = owner.apiKeys;
-		const req = mockReqWith(apiKey, '/test', 'GET');
-
-		expect(await strategy.authenticate(req)).toBe(false);
-	});
-
-	it('should rethrow non-TokenExpiredError from JWT verification', async () => {
-		const owner = await createOwnerWithApiKey();
-		const [{ apiKey }] = owner.apiKeys;
-		const req = mockReqWith(apiKey, '/test', 'GET');
-
-		const verifyError = new Error('Unexpected JWT error');
-		jest.spyOn(jwtService, 'verify').mockImplementationOnce(() => {
-			throw verifyError;
+			if (!grant) throw new Error('expected grant');
+			expect(grant.subject.id).toBe(owner.id);
+			expect(grant.subject.role.slug).toBeDefined();
+			// role scopes come from the user's role and are independent of the key's apiKeyScopes
+			expect(grant.scopes.length).toBeGreaterThan(1);
+			expect(grant.apiKeyScopes).toEqual(['workflow:read', 'workflow:list']);
 		});
 
-		await expect(strategy.authenticate(req)).rejects.toThrow(verifyError);
+		it('accepts legacy (non-JWT) api keys by looking up the record directly', async () => {
+			const legacyApiKey = `n8n_api_${randomString(10)}`;
+			const owner = await createOwnerWithApiKey();
+			const [{ apiKey }] = owner.apiKeys;
+			await Container.get(ApiKeyRepository).update({ apiKey }, { apiKey: legacyApiKey });
+
+			const grant = await strategy.buildTokenGrant(legacyApiKey);
+
+			expect(grant).not.toBe(false);
+			expect(grant).not.toBeNull();
+			if (grant) expect(grant.subject.id).toBe(owner.id);
+		});
+
+		it('returns null when token is empty (abstain)', async () => {
+			expect(await strategy.buildTokenGrant('')).toBeNull();
+		});
+
+		it('returns null for a JWT whose issuer does not match (abstain)', async () => {
+			const tokenExchangeJwt = jwtService.sign({ iss: TOKEN_EXCHANGE_ISSUER, sub: '123' });
+			expect(await strategy.buildTokenGrant(tokenExchangeJwt)).toBeNull();
+		});
+
+		it('returns false for tokens that cannot be validated', async () => {
+			// Covers: non-JWT garbage, valid JWT not in DB, expired JWT, disabled user.
+			// Each is a short setup with the same expected outcome — folded into one.
+			expect(await strategy.buildTokenGrant('invalid')).toBe(false);
+
+			const unknownKey = jwtService.sign({ sub: '123', iss: API_KEY_ISSUER });
+			expect(await strategy.buildTokenGrant(unknownKey)).toBe(false);
+
+			const expiredOwner = await createOwnerWithApiKey({
+				expiresAt: DateTime.now().minus({ days: 1 }).toUnixInteger(),
+			});
+			expect(await strategy.buildTokenGrant(expiredOwner.apiKeys[0].apiKey)).toBe(false);
+
+			const disabledOwner = await createOwnerWithApiKey();
+			await Container.get(UserRepository).update({ id: disabledOwner.id }, { disabled: true });
+			expect(await strategy.buildTokenGrant(disabledOwner.apiKeys[0].apiKey)).toBe(false);
+		});
+
+		it('rethrows non-TokenExpiredError from JWT verification', async () => {
+			const owner = await createOwnerWithApiKey();
+			const [{ apiKey }] = owner.apiKeys;
+
+			const verifyError = new Error('Unexpected JWT error');
+			jest.spyOn(jwtService, 'verify').mockImplementationOnce(() => {
+				throw verifyError;
+			});
+
+			await expect(strategy.buildTokenGrant(apiKey)).rejects.toThrow(verifyError);
+		});
+
+		describe('audience option', () => {
+			it('accepts an MCP API key only when audience=mcp-server-api is specified', async () => {
+				const owner = await createOwnerWithApiKey();
+				const mcpApiKey = await signAndStoreMcpApiKey(owner);
+
+				// Default audience (public-api) → DB lookup misses on audience column.
+				expect(await strategy.buildTokenGrant(mcpApiKey)).toBe(false);
+
+				const grant = await strategy.buildTokenGrant(mcpApiKey, {
+					audience: 'mcp-server-api',
+				});
+				if (!grant) throw new Error('expected grant');
+				expect(grant.subject.id).toBe(owner.id);
+			});
+
+			it('rejects a public API key when audience=mcp-server-api is required', async () => {
+				const owner = await createOwnerWithApiKey();
+				const [{ apiKey }] = owner.apiKeys;
+
+				expect(await strategy.buildTokenGrant(apiKey, { audience: 'mcp-server-api' })).toBe(false);
+			});
+		});
 	});
 
-	it('should work with non JWT (legacy) api keys', async () => {
-		const legacyApiKey = `n8n_api_${randomString(10)}`;
-		const owner = await createOwnerWithApiKey();
-		const [{ apiKey }] = owner.apiKeys;
+	describe('authenticate (wrapper)', () => {
+		it('returns null when no x-n8n-api-key header is present', async () => {
+			expect(await strategy.authenticate(mockReqWithoutApiKey())).toBeNull();
+		});
 
-		await Container.get(ApiKeyRepository).update({ apiKey }, { apiKey: legacyApiKey });
+		it('returns true and populates req.user + req.tokenGrant on success', async () => {
+			const owner = await createOwnerWithApiKey();
+			const [{ apiKey }] = owner.apiKeys;
+			const req = mockReqWith(apiKey);
 
-		const req = mockReqWith(legacyApiKey, '/test', 'GET');
-
-		expect(await strategy.authenticate(req)).toBe(true);
-		expect(req.user).toBeDefined();
-		expect(req.user.id).toBe(owner.id);
-	});
-
-	it('should return false if user is disabled', async () => {
-		const owner = await createOwnerWithApiKey();
-		await Container.get(UserRepository).update({ id: owner.id }, { disabled: true });
-		const [{ apiKey }] = owner.apiKeys;
-		const req = mockReqWith(apiKey, '/test', 'GET');
-
-		expect(await strategy.authenticate(req)).toBe(false);
-	});
-
-	it('should set req.tokenGrant.subject to the API key owner', async () => {
-		const owner = await createOwnerWithApiKey();
-		const [{ apiKey }] = owner.apiKeys;
-		const req = mockReqWith(apiKey, '/test', 'GET');
-
-		await strategy.authenticate(req);
-
-		expect(req.tokenGrant?.subject).toBeDefined();
-		expect(req.tokenGrant?.subject.id).toBe(owner.id);
-	});
-
-	it('should return null when x-n8n-api-key contains a token-exchange JWT', async () => {
-		const tokenExchangeJwt = jwtService.sign({ iss: TOKEN_EXCHANGE_ISSUER, sub: '123' });
-		const req = mockReqWith(tokenExchangeJwt, '/test', 'GET');
-
-		expect(await strategy.authenticate(req)).toBeNull();
+			expect(await strategy.authenticate(req)).toBe(true);
+			expect(req.user.id).toBe(owner.id);
+			expect(req.tokenGrant?.subject.id).toBe(owner.id);
+		});
 	});
 });

--- a/packages/cli/src/services/__tests__/auth-strategy.registry.test.ts
+++ b/packages/cli/src/services/__tests__/auth-strategy.registry.test.ts
@@ -1,8 +1,13 @@
-import type { AuthenticatedRequest } from '@n8n/db';
+import type { AuthenticatedRequest, TokenGrant, User } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 
 import { AuthStrategyRegistry } from '../auth-strategy.registry';
 import type { AuthStrategy } from '../auth-strategy.types';
+
+const makeGrant = (id: string): TokenGrant => ({
+	subject: { ...mock<User>(), id },
+	scopes: [],
+});
 
 describe('AuthStrategyRegistry', () => {
 	let registry: AuthStrategyRegistry;
@@ -46,12 +51,14 @@ describe('AuthStrategyRegistry', () => {
 					order.push(1);
 					return null;
 				}),
+				buildTokenGrant: jest.fn().mockResolvedValue(null),
 			};
 			const strategy2: AuthStrategy = {
 				authenticate: jest.fn().mockImplementation(async () => {
 					order.push(2);
 					return null;
 				}),
+				buildTokenGrant: jest.fn().mockResolvedValue(null),
 			};
 
 			registry.register(strategy1);
@@ -140,6 +147,50 @@ describe('AuthStrategyRegistry', () => {
 
 			// First registration succeeded — short-circuited
 			expect(strategy.authenticate).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('buildContextFromToken', () => {
+		it('returns the grant from the first matching strategy and skips subsequent strategies', async () => {
+			const grant = makeGrant('user-1');
+			const strategy1 = mock<AuthStrategy>();
+			const strategy2 = mock<AuthStrategy>();
+			const strategy3 = mock<AuthStrategy>();
+			strategy1.buildTokenGrant.mockResolvedValue(null); // abstain
+			strategy2.buildTokenGrant.mockResolvedValue(grant); // match
+			// strategy3 must not be invoked
+
+			registry.register(strategy1);
+			registry.register(strategy2);
+			registry.register(strategy3);
+
+			expect(
+				await registry.buildContextFromToken('the-token', { audience: 'mcp-server-api' }),
+			).toBe(grant);
+
+			expect(strategy1.buildTokenGrant).toHaveBeenCalledWith('the-token', {
+				audience: 'mcp-server-api',
+			});
+			expect(strategy3.buildTokenGrant).not.toHaveBeenCalled();
+		});
+
+		it('returns null when all strategies abstain or when a strategy returns false (fail-fast)', async () => {
+			const emptyRegistry = new AuthStrategyRegistry();
+			expect(await emptyRegistry.buildContextFromToken('token')).toBeNull();
+
+			const abstain = mock<AuthStrategy>();
+			abstain.buildTokenGrant.mockResolvedValue(null);
+			registry.register(abstain);
+			expect(await registry.buildContextFromToken('token')).toBeNull();
+
+			const unreached = mock<AuthStrategy>();
+			const failing = mock<AuthStrategy>();
+			failing.buildTokenGrant.mockResolvedValue(false);
+			const failRegistry = new AuthStrategyRegistry();
+			failRegistry.register(failing);
+			failRegistry.register(unreached);
+			expect(await failRegistry.buildContextFromToken('token')).toBeNull();
+			expect(unreached.buildTokenGrant).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/cli/src/services/api-key-auth.strategy.ts
+++ b/packages/cli/src/services/api-key-auth.strategy.ts
@@ -1,9 +1,9 @@
-import type { AuthenticatedRequest } from '@n8n/db';
+import type { AuthenticatedRequest, TokenGrant } from '@n8n/db';
 import { ApiKeyRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { TokenExpiredError } from 'jsonwebtoken';
 
-import type { AuthStrategy } from './auth-strategy.types';
+import type { AuthStrategy, AuthStrategyOptions } from './auth-strategy.types';
 import { JwtService } from './jwt.service';
 import { API_KEY_AUDIENCE, API_KEY_ISSUER, PREFIX_LEGACY_API_KEY } from './public-api-key.service';
 
@@ -16,23 +16,27 @@ export class ApiKeyAuthStrategy implements AuthStrategy {
 		private readonly jwtService: JwtService,
 	) {}
 
-	async authenticate(req: AuthenticatedRequest): Promise<boolean | null> {
-		const providedApiKey = req.headers[API_KEY_HEADER];
+	async buildTokenGrant(
+		token: string,
+		options?: AuthStrategyOptions,
+	): Promise<TokenGrant | false | null> {
+		if (typeof token !== 'string' || !token) return null;
 
-		if (typeof providedApiKey !== 'string' || !providedApiKey) return null;
+		const issuer = options?.issuer ?? API_KEY_ISSUER;
+		const audience = options?.audience ?? API_KEY_AUDIENCE;
 
 		// Abstain from non-API-key JWTs so other strategies (e.g. ScopedJwtStrategy) can handle them.
 		// Legacy keys (PREFIX_LEGACY_API_KEY prefix) are never JWTs — skip the decode for them.
 		// A null decode means the string is not a structurally valid JWT — reject authentication.
-		if (!providedApiKey.startsWith(PREFIX_LEGACY_API_KEY)) {
-			const decoded = this.jwtService.decode<{ iss?: string }>(providedApiKey);
+		if (!token.startsWith(PREFIX_LEGACY_API_KEY)) {
+			const decoded = this.jwtService.decode<{ iss?: string }>(token);
 			// Note: JwtService.decode casts its return as T, but jwt.decode() can still return null at runtime.
 			if (decoded === null) return false;
-			if (decoded.iss !== API_KEY_ISSUER) return null;
+			if (decoded.iss !== issuer) return null;
 		}
 
 		const apiKeyRecord = await this.apiKeyRepository.findOne({
-			where: { apiKey: providedApiKey, audience: API_KEY_AUDIENCE },
+			where: { apiKey: token, audience },
 			relations: { user: { role: true } },
 		});
 
@@ -40,11 +44,11 @@ export class ApiKeyAuthStrategy implements AuthStrategy {
 
 		if (apiKeyRecord.user.disabled) return false;
 
-		if (!providedApiKey.startsWith(PREFIX_LEGACY_API_KEY)) {
+		if (!token.startsWith(PREFIX_LEGACY_API_KEY)) {
 			try {
-				this.jwtService.verify(providedApiKey, {
-					issuer: API_KEY_ISSUER,
-					audience: API_KEY_AUDIENCE,
+				this.jwtService.verify(token, {
+					issuer,
+					audience,
 				});
 			} catch (e) {
 				if (e instanceof TokenExpiredError) return false;
@@ -52,12 +56,26 @@ export class ApiKeyAuthStrategy implements AuthStrategy {
 			}
 		}
 
-		req.user = apiKeyRecord.user;
-		req.tokenGrant = {
+		return {
 			scopes: apiKeyRecord.user.role.scopes.map((s) => s.slug),
 			subject: apiKeyRecord.user,
 			apiKeyScopes: apiKeyRecord.scopes ?? [],
 		};
+	}
+
+	async authenticate(req: AuthenticatedRequest): Promise<boolean | null> {
+		const providedApiKey = req.headers[API_KEY_HEADER];
+
+		if (typeof providedApiKey !== 'string' || !providedApiKey) return null;
+
+		const tokenGrant = await this.buildTokenGrant(providedApiKey);
+
+		if (tokenGrant === false || tokenGrant === null) {
+			return tokenGrant;
+		}
+
+		req.user = tokenGrant.subject;
+		req.tokenGrant = tokenGrant;
 
 		return true;
 	}

--- a/packages/cli/src/services/auth-strategy.registry.ts
+++ b/packages/cli/src/services/auth-strategy.registry.ts
@@ -1,7 +1,7 @@
-import type { AuthenticatedRequest } from '@n8n/db';
+import type { AuthenticatedRequest, TokenGrant } from '@n8n/db';
 import { Service } from '@n8n/di';
 
-import type { AuthStrategy } from './auth-strategy.types';
+import type { AuthStrategy, AuthStrategyOptions } from './auth-strategy.types';
 
 /**
  * Ordered registry of AuthStrategy implementations for the public API.
@@ -26,6 +26,24 @@ export class AuthStrategyRegistry {
 
 	register(strategy: AuthStrategy): void {
 		this.strategies.push(strategy);
+	}
+
+	async buildContextFromToken(
+		token: string,
+		options?: AuthStrategyOptions,
+	): Promise<TokenGrant | null> {
+		for (const strategy of this.strategies) {
+			const result = await strategy.buildTokenGrant(token, options);
+			if (result === false) {
+				// this strategy was responsible, but the token validation failed
+				return null;
+			}
+			if (result !== null) {
+				return result; // true = success, false = fail fast
+			}
+			// null = this strategy abstained, continue to next
+		}
+		return null; // all strategies abstained = unauthenticated
 	}
 
 	async authenticate(req: AuthenticatedRequest): Promise<boolean> {

--- a/packages/cli/src/services/auth-strategy.types.ts
+++ b/packages/cli/src/services/auth-strategy.types.ts
@@ -1,4 +1,10 @@
-import type { AuthenticatedRequest } from '@n8n/db';
+import type { ApiKeyAudience } from '@n8n/api-types';
+import type { AuthenticatedRequest, TokenGrant } from '@n8n/db';
+
+export type AuthStrategyOptions = {
+	audience?: ApiKeyAudience;
+	issuer?: string;
+};
 
 /**
  * A single authentication strategy for the public API.
@@ -13,4 +19,10 @@ import type { AuthenticatedRequest } from '@n8n/db';
  */
 export interface AuthStrategy {
 	authenticate(req: AuthenticatedRequest): Promise<boolean | null>;
+
+	/**
+	 * This builds the token grant based on the authentication token.
+	 * @param token
+	 */
+	buildTokenGrant(token: string, options?: AuthStrategyOptions): Promise<TokenGrant | false | null>;
 }

--- a/packages/cli/test/integration/shared/utils/test-server.ts
+++ b/packages/cli/test/integration/shared/utils/test-server.ts
@@ -17,6 +17,8 @@ import { License } from '@/license';
 import { rawBodyReader, bodyParser } from '@/middlewares';
 import { PostHogClient } from '@/posthog';
 import { Push } from '@/push';
+import { ApiKeyAuthStrategy } from '@/services/api-key-auth.strategy';
+import { AuthStrategyRegistry } from '@/services/auth-strategy.registry';
 import { Telemetry } from '@/telemetry';
 import { resolveBackendHealthEndpointPath } from '@/utils/health-endpoint.util';
 
@@ -147,6 +149,14 @@ export const setupTestServer = ({
 		if (!endpointGroups) return;
 
 		app.use(bodyParser);
+
+		// Register auth strategies in priority order. The registry evaluates them
+		// sequentially — the first strategy that returns a non-null result wins.
+		// API key auth is registered first so existing behavior is preserved.
+		// Additional strategies (e.g. scoped JWT from the token-exchange module)
+		// can be appended later during their own module initialization.
+		const registry = Container.get(AuthStrategyRegistry);
+		registry.register(Container.get(ApiKeyAuthStrategy));
 
 		const enablePublicAPI = endpointGroups?.includes('publicApi');
 		if (enablePublicAPI) {


### PR DESCRIPTION
The instance MCP server previously authenticated callers with an MCP API key
or an MCP OAuth access token. This PR extends MCP authentication to also
accept scoped JWTs issued by the token-exchange module (RFC 8693), so
embedding partners can drive MCP tools on behalf of a user with the same
delegated tokens they already use against the public API.

To keep a single authentication pipeline, `McpServerApiKeyService.verifyApiKey`
now delegates to `AuthStrategyRegistry` via a new `buildTokenGrant(token, options?)`
primitive on `AuthStrategy`. `ApiKeyAuthStrategy` and `ScopedJwtStrategy` both
implement it; the MCP call site asks the registry for a grant scoped to
`audience: 'mcp-server-api'`. `UserWithContext` gains an optional `actor` so
delegated calls carry both the acting principal and the subject they act on
behalf of.

Relevant context from the token-exchange initiative (see memory & Notion RFC):

- Phase 2b introduced `AuthStrategyRegistry` + the `TokenGrant` model for the
  public API.
- This ticket (IAM-574, Phase 3) reuses that pipeline on the MCP surface so the
  MCP server and public API share one auth chain.
- The same scoped JWT a partner mints via `/auth/oauth/token` now authenticates
  against `/mcp-server/http`.

### Key implementation decisions

- **Separation of extraction from verification**: `authenticate(req)` becomes a
  thin wrapper that extracts the token and calls `buildTokenGrant(token)`. The
  new primitive is reusable from any surface that has already parsed the
  bearer token (MCP middleware does this itself).
- **`audience`/`issuer` options on `AuthStrategyOptions`**: let the same
  `ApiKeyAuthStrategy` service both `audience: 'public-api'` (default) and
  `audience: 'mcp-server-api'` (MCP) without duplication. The DB filter and
  `jwtService.verify` both enforce the requested audience, so an MCP caller
  cannot present a public-API key and vice versa.
- **Registry registration is now unconditional**: `ApiKeyAuthStrategy`
  registration moved from `loadPublicApiVersions()` (only runs when
  `isApiEnabled()`) to `Server.configure()`. Without this, disabling the
  public REST API would 401 every MCP API key. The test harness
  (`test-server.ts`) mirrors the new placement.
- **Delegation plumbing**: `verifyApiKey` returns `{ user: actor ?? subject, actor }`.
  `user` is the acting principal (used for downstream req.user), `actor` is
  kept available for telemetry/audit plumbing.

### How to test manually

Prerequisites: an n8n instance with the token-exchange feature flag enabled
(`N8N_ENV_FEAT_TOKEN_EXCHANGE=true`) and a trusted external key configured
so you can mint scoped JWTs via `POST /auth/oauth/token`.

1. **MCP API key path (AC1) — still works**:
   - Obtain your MCP API key from the UI (Settings → Personal → MCP Server API Key).
   - `curl -X POST http://localhost:5678/mcp-server/http -H "Authorization: Bearer <MCP_API_KEY>" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'`
   - Expect 200 / JSON-RPC response.
   - Present a **public-API** key to the same endpoint — expect 401
     (audience mismatch).

2. **Scoped JWT path (AC2) — new**:
   - Mint a scoped JWT by exchanging a signed subject token against
     `/auth/oauth/token` (RFC 8693 `urn:ietf:params:oauth:grant-type:token-exchange`).
   - Call MCP with `Authorization: Bearer <SCOPED_JWT>` — expect 200.
   - Mint a scoped JWT with an `act.sub` claim mapping to another user. Call
     MCP, confirm the tools act as the actor.

3. **Regression path — public API disabled**:
   - Set `N8N_PUBLIC_API_DISABLED=true` (or otherwise disable the public API).
   - Restart, repeat step 1 — MCP API keys must still authenticate (this
     used to fail before the registration move). Automated regression
     coverage: `mcp-api-key.service.public-api-disabled.integration.test.ts`.

### Automated test coverage

- `mcp-api-key.service.integration.test.ts` — AC1, AC2 (with/without actor),
  rejection matrix (garbage, public-API key, deleted row, expired JWT,
  disabled subject/actor, unknown subject), and a defense-in-depth test for
  a DB row whose stored JWT has a tampered `aud` claim.
- `mcp-api-key.service.public-api-disabled.integration.test.ts` — regression
  guard; verified to fail when the registration is moved back under an
  `isApiEnabled()` guard.
- `mcp-api-key.service.test.ts` — unit coverage of the registry delegation
  and error mapping.
- `mcp-server-middleware.service.test.ts` — new delegated scoped-JWT case
  proving MCP middleware sets `req.user` to the actor.
- `scoped-jwt.strategy(.integration).test.ts` — refactored to test
  `buildTokenGrant` directly + the `authenticate` wrapper.
- `api-key-auth.strategy.integration.test.ts` — added `audience` option
  matrix (default rejects MCP key, `mcp-server-api` rejects public key,
  `mcp-server-api` accepts MCP key).
- `auth-strategy.registry.test.ts` — new `buildContextFromToken` suite.

## Related Links

- Linear ticket: https://linear.app/n8n/issue/IAM-574
- Token-exchange RFC: https://www.notion.so/n8n/32e5b6e0c94f800fa2cce56f39929a3e
- Design doc: https://www.notion.so/n8n/3305b6e0c94f808c9a18f62bb72fb618

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
