### PR TITLE
feat(agents): Stream tool-call lifecycle for immediate agent UI feedback

### DIFF
--- a/packages/@n8n/agents/src/runtime/agent-runtime.ts
+++ b/packages/@n8n/agents/src/runtime/agent-runtime.ts
@@ -797,11 +797,16 @@ export class AgentRuntime {
 		// so the fire-and-forget is safe.
 		const onToolExecutionStart = (data: AgentEventData): void => {
 			if (data.type !== AgentEvent.ToolExecutionStart) return;
-			void writer.write({
-				type: 'tool-execution-start',
-				toolCallId: data.toolCallId,
-				toolName: data.toolName,
-			});
+			// Swallow rejections: if the writer is already closed/errored (e.g.
+			// an abort raced ahead of the subscription cleanup) there is nothing
+			// useful to do with the chunk.
+			writer
+				.write({
+					type: 'tool-execution-start',
+					toolCallId: data.toolCallId,
+					toolName: data.toolName,
+				})
+				.catch(() => {});
 		};
 		this.eventBus.on(AgentEvent.ToolExecutionStart, onToolExecutionStart);
 

--- a/packages/@n8n/agents/src/runtime/agent-runtime.ts
+++ b/packages/@n8n/agents/src/runtime/agent-runtime.ts
@@ -57,6 +57,7 @@ import {
 } from './tool-adapter';
 import { buildWorkingMemoryTool } from './working-memory';
 import { AgentEvent } from '../types/runtime/event';
+import type { AgentEventData } from '../types/runtime/event';
 import type {
 	AgentPersistenceOptions,
 	ExecutionOptions,

--- a/packages/@n8n/agents/src/runtime/agent-runtime.ts
+++ b/packages/@n8n/agents/src/runtime/agent-runtime.ts
@@ -790,8 +790,22 @@ export class AgentRuntime {
 		const { readable, writable } = new TransformStream<StreamChunk, StreamChunk>();
 		const writer = writable.getWriter();
 
-		this.runStreamLoop(list, options, writer, pendingResume, runId).catch(
-			async (error: unknown) => {
+		// Bridge tool-execution lifecycle events into the stream so consumers
+		// can show a mid-flight indicator between the LLM's tool-call message
+		// and the eventual tool-result message. Writer queues writes in order
+		// so the fire-and-forget is safe.
+		const onToolExecutionStart = (data: AgentEventData): void => {
+			if (data.type !== AgentEvent.ToolExecutionStart) return;
+			void writer.write({
+				type: 'tool-execution-start',
+				toolCallId: data.toolCallId,
+				toolName: data.toolName,
+			});
+		};
+		this.eventBus.on(AgentEvent.ToolExecutionStart, onToolExecutionStart);
+
+		this.runStreamLoop(list, options, writer, pendingResume, runId)
+			.catch(async (error: unknown) => {
 				await this.flushTelemetry(options);
 				await this.cleanupRun(runId);
 				try {
@@ -801,8 +815,10 @@ export class AgentRuntime {
 				} catch {
 					writer.abort(error).catch(() => {});
 				}
-			},
-		);
+			})
+			.finally(() => {
+				this.eventBus.off(AgentEvent.ToolExecutionStart, onToolExecutionStart);
+			});
 
 		return readable;
 	}

--- a/packages/@n8n/agents/src/runtime/event-bus.ts
+++ b/packages/@n8n/agents/src/runtime/event-bus.ts
@@ -32,6 +32,10 @@ export class AgentEventBus {
 		set.add(handler);
 	}
 
+	off(event: AgentEvent, handler: AgentEventHandler): void {
+		this.handlers.get(event)?.delete(handler);
+	}
+
 	emit(data: AgentEventData): void {
 		const set = this.handlers.get(data.type);
 		if (!set) return;

--- a/packages/@n8n/agents/src/runtime/stream.ts
+++ b/packages/@n8n/agents/src/runtime/stream.ts
@@ -67,12 +67,14 @@ export function convertChunk(c: TextStreamPart<ToolSet>): StreamChunk | undefine
 		case 'tool-input-start':
 			return {
 				type: 'tool-call-delta',
+				...(c.id !== undefined && { id: c.id }),
 				name: c.toolName,
 			};
 
 		case 'tool-input-delta':
 			return {
 				type: 'tool-call-delta',
+				...(c.id !== undefined && { id: c.id }),
 				...(c.delta !== undefined && { argumentsDelta: c.delta }),
 			};
 

--- a/packages/@n8n/agents/src/types/sdk/agent.ts
+++ b/packages/@n8n/agents/src/types/sdk/agent.ts
@@ -97,6 +97,16 @@ export type StreamChunk = ContentMetadata &
 				id?: string;
 		  }
 		| {
+				/**
+				 * Emitted just before a tool handler starts executing. Pairs with the
+				 * subsequent tool-result message chunk to let consumers show a
+				 * mid-flight indicator between "LLM picked a tool" and "result arrived".
+				 */
+				type: 'tool-execution-start';
+				toolCallId: string;
+				toolName: string;
+		  }
+		| {
 				type: 'tool-call-suspended';
 				runId?: string;
 				toolCallId?: string;

--- a/packages/cli/src/modules/agents/agents.controller.ts
+++ b/packages/cli/src/modules/agents/agents.controller.ts
@@ -37,9 +37,13 @@ function extractMessageEvents(message: AgentMessage): Array<Record<string, unkno
 		if (part.type === 'text' && 'text' in part) {
 			events.push({ text: part.text });
 		} else if (part.type === 'tool-call' && 'toolName' in part) {
-			events.push({ toolCall: { tool: part.toolName, input: part.input } });
+			const toolCallId =
+				'toolCallId' in part && typeof part.toolCallId === 'string' ? part.toolCallId : undefined;
+			events.push({ toolCall: { tool: part.toolName, toolCallId, input: part.input } });
 		} else if (part.type === 'tool-result' && 'toolName' in part) {
-			events.push({ toolResult: { tool: part.toolName, output: part.result } });
+			const toolCallId =
+				'toolCallId' in part && typeof part.toolCallId === 'string' ? part.toolCallId : undefined;
+			events.push({ toolResult: { tool: part.toolName, toolCallId, output: part.result } });
 		}
 	}
 	return events;
@@ -399,6 +403,12 @@ export class AgentsController {
 					// Track which tool is streaming
 					if (chunk.name) {
 						streamingToolName = chunk.name;
+						// Announce the tool call as soon as the LLM commits to a name —
+						// before args finish streaming. The FE dedupes by toolCallId
+						// and fills in the full input when the tool-call message arrives.
+						if (chunk.id) {
+							send({ toolCall: { tool: chunk.name, toolCallId: chunk.id } });
+						}
 					}
 					// Stream tool code deltas for build_custom_tool
 					if (streamingToolName === 'build_custom_tool' && chunk.argumentsDelta) {
@@ -605,6 +615,14 @@ export class AgentsController {
 				break;
 			case 'reasoning-delta':
 				if (chunk.delta) send({ thinking: chunk.delta });
+				break;
+			case 'tool-call-delta':
+				// Early announce: emit once when the LLM first commits to a tool
+				// name, before args finish streaming. Subsequent deltas (no name)
+				// are skipped here; the full input arrives with the message chunk.
+				if (chunk.name && chunk.id) {
+					send({ toolCall: { tool: chunk.name, toolCallId: chunk.id } });
+				}
 				break;
 			case 'message':
 				for (const event of extractMessageEvents(chunk.message)) {

--- a/packages/cli/src/modules/agents/agents.controller.ts
+++ b/packages/cli/src/modules/agents/agents.controller.ts
@@ -611,6 +611,9 @@ export class AgentsController {
 					send(event);
 				}
 				break;
+			case 'tool-execution-start':
+				send({ toolCallExecuting: { toolCallId: chunk.toolCallId, tool: chunk.toolName } });
+				break;
 			case 'error': {
 				const errMsg = chunk.error instanceof Error ? chunk.error.message : String(chunk.error);
 				send({ error: errMsg });

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -951,22 +951,14 @@ export class AgentsService {
 		const entity = await this.agentRepository.findByIdAndProjectId(agentId, projectId);
 		if (!entity) throw new NotFoundError('Agent not found');
 
-		// Store tool code + descriptor
+		// Store tool code + descriptor. Registering the tool in the agent config
+		// (adding `{ type: "custom", id }` to `schema.tools`) is the caller's
+		// responsibility — typically via a follow-up patch_config / write_config —
+		// so this method does not touch `entity.schema`.
 		entity.tools = {
 			...entity.tools,
 			[toolId]: { code, descriptor },
 		};
-
-		// Add to config tools array if not already present
-		if (entity.schema) {
-			const tools = entity.schema.tools ?? [];
-			const alreadyLinked = tools.some(
-				(t: AgentJsonToolConfig) => t.type === 'custom' && 'id' in t && t.id === toolId,
-			);
-			if (!alreadyLinked) {
-				entity.schema.tools = [...tools, { type: 'custom' as const, id: toolId }];
-			}
-		}
 
 		this.markDraftDirty(entity);
 		this.clearRuntimes(agentId);

--- a/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
@@ -96,9 +96,21 @@ export default new Tool('tool_name')
 
 Rules for custom tool code:
 - Must use \`export default new Tool(...)\` pattern
-- Only imports: '@n8n/agents' and 'zod'
+- Only imports at the top of the file: '@n8n/agents' and 'zod'
+- Inside the \`handler\` body the following are STRICTLY FORBIDDEN:
+  - \`import\` statements, \`require\`, dynamic \`import()\`
+  - Any module name (\`fs\`, \`path\`, \`http\`, \`child_process\`, npm packages, etc.)
+  - Any global other than those provided to the handler: \`crypto\`, \`process\`, \`globalThis\`, \`global\`, \`window\`, \`document\`, \`fetch\`, \`XMLHttpRequest\`, \`WebSocket\`, \`URL\`, \`URLSearchParams\`, \`Buffer\`, \`setTimeout\`, \`setInterval\`, \`setImmediate\`, \`performance\`, \`console\`, \`atob\`, \`btoa\`, and similar host globals are NOT available.
+- Inside the handler you may ONLY use:
+  - The validated \`input\` argument
+  - Pure language features: variables, control flow, arithmetic, template literals, destructuring
+  - Built-in values whose identity is a language primitive or pure standard-library object: \`Math\`, \`Date\`, \`JSON\`, \`Number\`, \`String\`, \`Boolean\`, \`Array\`, \`Object\`, \`Map\`, \`Set\`, \`RegExp\`, \`Error\`, \`Promise\`, \`Symbol\`
+  - Instance methods on values you already have (e.g. \`input.name.toUpperCase()\`, \`[1,2].map(...)\`)
+- Concretely: if a value is not \`input\`, not a language keyword, and not in the short list above, DO NOT reference it. Examples of forbidden code:
+  - \`crypto.randomUUID()\` — \`crypto\` is not available; generate IDs from \`input\` or \`Math.random\` + \`Date.now\` if you really need one
+  - \`await fetch(...)\` — no network access from a custom tool
+  - \`process.env.X\` — no environment access
 - Tool handlers are async, receive validated input
-- Do NOT use process.env, fetch external URLs only if needed
 - Do NOT call .build() -- the engine handles it`;
 
 export const N8N_EXPRESSIONS_SECTION = `\

--- a/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
@@ -94,24 +94,30 @@ export default new Tool('tool_name')
   });
 \`\`\`
 
-Rules for custom tool code:
-- Must use \`export default new Tool(...)\` pattern
-- Only imports at the top of the file: '@n8n/agents' and 'zod'
-- Inside the \`handler\` body the following are STRICTLY FORBIDDEN:
-  - \`import\` statements, \`require\`, dynamic \`import()\`
-  - Any module name (\`fs\`, \`path\`, \`http\`, \`child_process\`, npm packages, etc.)
-  - Any global other than those provided to the handler: \`crypto\`, \`process\`, \`globalThis\`, \`global\`, \`window\`, \`document\`, \`fetch\`, \`XMLHttpRequest\`, \`WebSocket\`, \`URL\`, \`URLSearchParams\`, \`Buffer\`, \`setTimeout\`, \`setInterval\`, \`setImmediate\`, \`performance\`, \`console\`, \`atob\`, \`btoa\`, and similar host globals are NOT available.
-- Inside the handler you may ONLY use:
-  - The validated \`input\` argument
-  - Pure language features: variables, control flow, arithmetic, template literals, destructuring
-  - Built-in values whose identity is a language primitive or pure standard-library object: \`Math\`, \`Date\`, \`JSON\`, \`Number\`, \`String\`, \`Boolean\`, \`Array\`, \`Object\`, \`Map\`, \`Set\`, \`RegExp\`, \`Error\`, \`Promise\`, \`Symbol\`
-  - Instance methods on values you already have (e.g. \`input.name.toUpperCase()\`, \`[1,2].map(...)\`)
-- Concretely: if a value is not \`input\`, not a language keyword, and not in the short list above, DO NOT reference it. Examples of forbidden code:
-  - \`crypto.randomUUID()\` — \`crypto\` is not available; generate IDs from \`input\` or \`Math.random\` + \`Date.now\` if you really need one
-  - \`await fetch(...)\` — no network access from a custom tool
-  - \`process.env.X\` — no environment access
-- Tool handlers are async, receive validated input
-- Do NOT call .build() -- the engine handles it`;
+Custom tools run inside a V8 isolate sandbox. Treat every handler as a pure
+function: take \`input\`, compute, return a JSON-serialisable value.
+
+- Must use \`export default new Tool(...)\` pattern.
+- Imports at the top of the file: only '@n8n/agents' and 'zod'. No other
+  modules resolve.
+- No I/O of any kind — no network, no filesystem, no waiting for wall-clock
+  time. Host globals like \`crypto\`, \`process\`, \`Buffer\`, \`fetch\`, \`atob\`,
+  \`XMLHttpRequest\` are not present and will throw \`ReferenceError\` at runtime.
+- Some web APIs appear defined but are no-op stubs (\`setTimeout\` fires
+  synchronously, \`console.log\` goes nowhere, \`TextEncoder.encode\` returns
+  its input unchanged). Don't rely on their real behaviour.
+- Free to use: \`Math\`, \`Date\`, \`JSON\`, \`RegExp\`, \`Array\`, \`Object\`, \`Map\`,
+  \`Set\`, \`Promise\`, typed arrays, and any method on values you already have.
+- The handler is async and receives \`(input, ctx)\`.
+  - \`input\` is already validated against your zod schema.
+  - \`ctx.suspend(payload)\` pauses the tool until the caller resumes it —
+    use it for human-in-the-loop flows that need to ask the user something.
+    Otherwise ignore \`ctx\`.
+- Return a JSON-serialisable value. Execution is capped at 5 seconds and
+  ~32 MB of memory.
+- If something fails at runtime, the error message is handed back to you on
+  the next turn — fix the code and try again.
+- Do NOT call \`.build()\` — the engine handles it.`;
 
 export const N8N_EXPRESSIONS_SECTION = `\
 ## n8n expressions
@@ -200,7 +206,7 @@ export const WORKFLOW_SECTION = `\
 1. FIRST call list_credentials, list_workflows to see what's available
 2. When the user describes what they want, use write_config with a complete JSON string to set up the full config
 3. PREFER attaching existing workflows(type: "workflow") or nodes(type: "node") as tools over custom tools
-4. If the user needs custom logic, use build_custom_tool (custom tools are registered separately, then referenced in config by id)
+4. If the user needs custom logic, use build_custom_tool to compile and store the tool, then add a \`{ type: "custom", id }\` entry to \`tools\` via write_config or patch_config so the agent actually uses it
 5. Use patch_config (RFC 6902) for targeted field changes; use write_config to replace the full config`;
 
 export const IMPORTANT_SECTION = `\
@@ -210,7 +216,7 @@ export const IMPORTANT_SECTION = `\
 - Use search_nodes + get_node_types to discover nodes before adding node tools
 - Prefer workflow tools and node tools over custom tools for real-world interactions
 - Memory with storage "n8n" is the default -- always enable it unless told otherwise
-- Custom tools require calling \`build_custom_tool\` - it saves the tool code and updates agent config`;
+- \`build_custom_tool\` only compiles and stores the tool code. Register it in the config separately by adding a \`{ type: "custom", id }\` entry to \`tools\` via write_config or patch_config`;
 
 export const RESPONSE_STYLE_SECTION = `\
 ## Response style

--- a/packages/cli/src/modules/agents/builder/agents-builder-tools.service.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-tools.service.ts
@@ -145,9 +145,11 @@ export class AgentsBuilderToolsService {
 	): BuiltTool[] {
 		const buildCustomToolTool = new Tool('build_custom_tool')
 			.description(
-				'Create or update a custom tool. Pass the tool ID and complete TypeScript source ' +
+				'Compile and store a custom tool. Pass the tool ID and complete TypeScript source ' +
 					'using `export default new Tool(...)` builder chain. The code is validated in a ' +
-					'sandbox. On success the tool is added to the agent config automatically. ' +
+					'sandbox and saved against the agent, but this does NOT register the tool in the ' +
+					'agent config — follow up with patch_config (or write_config) to add a ' +
+					'`{ type: "custom", id }` entry to `tools` so the agent actually uses it. ' +
 					'Returns { ok: true, descriptor } or { ok: false, errors }.',
 			)
 			.input(

--- a/packages/frontend/editor-ui/src/features/agents/composables/agentChatMessages.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/agentChatMessages.ts
@@ -5,6 +5,13 @@ export interface ToolCall {
 	toolCallId?: string;
 	input?: unknown;
 	output?: unknown;
+	/**
+	 * Lifecycle state:
+	 * - `pending`: the LLM has committed to the call but the handler has not started.
+	 * - `running`: the handler is executing (between tool-execution-start and tool-result).
+	 * - `done`: the handler has returned (also implied by `output` being set).
+	 */
+	status?: 'pending' | 'running' | 'done';
 }
 
 export interface ChatMessage {

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentChatStream.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentChatStream.ts
@@ -203,18 +203,69 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 						if (assistantMsg.content && !assistantMsg.content.endsWith('\n')) {
 							assistantMsg.content += '\n';
 						}
-						const tc = data.toolCall as { tool: string; input?: unknown };
+						const tc = data.toolCall as {
+							tool: string;
+							toolCallId?: string;
+							input?: unknown;
+						};
 						assistantMsg.toolCalls = assistantMsg.toolCalls ?? [];
-						assistantMsg.toolCalls.push({ tool: tc.tool, input: tc.input });
+						const already = tc.toolCallId
+							? assistantMsg.toolCalls.find((t: ToolCall) => t.toolCallId === tc.toolCallId)
+							: undefined;
+						if (already) {
+							if (tc.input !== undefined) already.input = tc.input;
+						} else {
+							assistantMsg.toolCalls.push({
+								tool: tc.tool,
+								toolCallId: tc.toolCallId,
+								input: tc.input,
+								status: 'pending',
+							});
+						}
+					}
+
+					if (data.toolCallInput && typeof data.toolCallInput === 'object') {
+						const tci = data.toolCallInput as { toolCallId?: string; input?: unknown };
+						if (tci.toolCallId) {
+							const existing = assistantMsg.toolCalls?.find(
+								(t: ToolCall) => t.toolCallId === tci.toolCallId,
+							);
+							if (existing) existing.input = tci.input;
+						}
+					}
+
+					if (data.toolCallExecuting && typeof data.toolCallExecuting === 'object') {
+						const tce = data.toolCallExecuting as { toolCallId?: string; tool?: string };
+						const existing =
+							(tce.toolCallId
+								? assistantMsg.toolCalls?.find((t: ToolCall) => t.toolCallId === tce.toolCallId)
+								: undefined) ??
+							(tce.tool
+								? assistantMsg.toolCalls?.find(
+										(t: ToolCall) => t.tool === tce.tool && t.status !== 'done',
+									)
+								: undefined);
+						if (existing) {
+							if (existing.status !== 'done') existing.status = 'running';
+						}
 					}
 
 					if (data.toolResult && typeof data.toolResult === 'object') {
-						const tr = data.toolResult as { tool: string; output?: unknown };
-						const existing = assistantMsg.toolCalls?.find(
-							(t: ToolCall) => t.tool === tr.tool && t.output === undefined,
-						);
+						const tr = data.toolResult as {
+							tool: string;
+							toolCallId?: string;
+							output?: unknown;
+						};
+						const existing =
+							(tr.toolCallId
+								? assistantMsg.toolCalls?.find((t: ToolCall) => t.toolCallId === tr.toolCallId)
+								: undefined) ??
+							assistantMsg.toolCalls?.find(
+								(t: ToolCall) => t.tool === tr.tool && t.output === undefined,
+							);
 						if (existing) {
 							existing.output = tr.output;
+							existing.status = 'done';
 						}
 						if (assistantMsg.content && !assistantMsg.content.endsWith('\n')) {
 							assistantMsg.content += '\n';


### PR DESCRIPTION
## Summary

- Stream three stages of each tool call (selected / executing / done) so the
  UI updates as the agent runs instead of only at the result.
- Pass `toolCallId` through so early and late stream events correlate and
  don't produce duplicate tool cards.
- Rewrite the custom-tool builder prompt around one principle ("handlers
  run in a V8 isolate — treat them as pure functions") and document
  `ctx.suspend` for HITL.
- Stop `build_custom_tool` from mutating `schema.tools`; registering the
  tool in the config is the agent's job via `patch_config` / `write_config`.


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
