### PR TITLE
fix(Intercom): update users through contacts API (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Intercom/Intercom.node.ts
+++ b/packages/nodes-base/nodes/Intercom/Intercom.node.ts
@@ -18,6 +18,62 @@ import type { IAvatar, ILead, ILeadCompany } from './LeadInterface';
 import { userFields, userOperations } from './UserDescription';
 import type { IUser, IUserCompany } from './UserInterface';
 
+async function getIntercomUserContactId(
+	this: IExecuteFunctions,
+	updateBy: string,
+	value: string,
+): Promise<string> {
+	if (updateBy === 'id') {
+		return value;
+	}
+
+	if (updateBy === 'userId') {
+		const response = await intercomApiRequest.call(
+			this,
+			`/contacts/find_by_external_id/${encodeURIComponent(value)}`,
+			'GET',
+		);
+
+		return response.id as string;
+	}
+
+	const response = await intercomApiRequest.call(this, '/contacts/search', 'POST', {
+		query: {
+			field: 'email',
+			operator: '=',
+			value,
+		},
+	});
+
+	const [contact] = (response.data ?? []) as Array<{ id?: string }>;
+
+	if (!contact?.id) {
+		throw new NodeOperationError(this.getNode(), `No Intercom user found for email "${value}"`);
+	}
+
+	return contact.id;
+}
+
+function prepareIntercomUserUpdateBody(body: IUser): IUser {
+	const updateBody: IUser = {
+		...body,
+		role: 'user',
+	};
+
+	if (updateBody.user_id) {
+		updateBody.external_id = updateBody.user_id;
+		delete updateBody.user_id;
+	}
+
+	if (typeof updateBody.avatar === 'object' && updateBody.avatar?.image_url) {
+		updateBody.avatar = updateBody.avatar.image_url;
+	}
+
+	delete updateBody.id;
+
+	return updateBody;
+}
+
 export class Intercom implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'Intercom',
@@ -366,21 +422,26 @@ export class Intercom implements INodeType {
 						if (operation === 'update') {
 							const updateBy = this.getNodeParameter('updateBy', 0) as string;
 							const value = this.getNodeParameter('value', i) as string;
-							if (updateBy === 'userId') {
-								body.user_id = value;
-							}
-							if (updateBy === 'id') {
-								body.id = value;
-							}
-							if (updateBy === 'email') {
-								body.email = value;
-							}
-						}
+							const contactId = await getIntercomUserContactId.call(this, updateBy, value);
+							const updateBody = prepareIntercomUserUpdateBody(body);
 
-						try {
-							responseData = await intercomApiRequest.call(this, '/users', 'POST', body, qs);
-						} catch (error) {
-							throw new NodeApiError(this.getNode(), error as JsonObject);
+							try {
+								responseData = await intercomApiRequest.call(
+									this,
+									`/contacts/${contactId}`,
+									'PUT',
+									updateBody,
+									qs,
+								);
+							} catch (error) {
+								throw new NodeApiError(this.getNode(), error as JsonObject);
+							}
+						} else {
+							try {
+								responseData = await intercomApiRequest.call(this, '/users', 'POST', body, qs);
+							} catch (error) {
+								throw new NodeApiError(this.getNode(), error as JsonObject);
+							}
 						}
 					}
 					if (operation === 'get') {

--- a/packages/nodes-base/nodes/Intercom/UserInterface.ts
+++ b/packages/nodes-base/nodes/Intercom/UserInterface.ts
@@ -11,7 +11,9 @@ export interface IAvatar {
 
 export interface IUser {
 	user_id?: string;
+	external_id?: string;
 	id?: string;
+	role?: string;
 	email?: string;
 	phone?: string;
 	name?: string;
@@ -23,7 +25,7 @@ export interface IUser {
 	update_last_request_at?: boolean;
 	last_seen_user_agent?: boolean;
 	session_count?: number;
-	avatar?: IAvatar;
+	avatar?: IAvatar | string;
 	utm_source?: string;
 	utm_medium?: string;
 	utm_campaign?: string;

--- a/packages/nodes-base/nodes/Intercom/test/Intercom.node.test.ts
+++ b/packages/nodes-base/nodes/Intercom/test/Intercom.node.test.ts
@@ -1,0 +1,174 @@
+import { mockDeep } from 'jest-mock-extended';
+import type { IExecuteFunctions, INode } from 'n8n-workflow';
+
+jest.mock(
+	'n8n-workflow',
+	() => ({
+		NodeConnectionTypes: { Main: 'main' },
+		NodeApiError: class NodeApiError extends Error {},
+		NodeOperationError: class NodeOperationError extends Error {},
+	}),
+	{ virtual: true },
+);
+
+import * as GenericFunctions from '../GenericFunctions';
+import { Intercom } from '../Intercom.node';
+
+jest.mock('../GenericFunctions', () => ({
+	intercomApiRequest: jest.fn(),
+	intercomApiRequestAllItems: jest.fn(),
+	validateJSON: jest.fn((value: string) => JSON.parse(value)),
+}));
+
+describe('Intercom', () => {
+	let node: Intercom;
+	let mockExecuteFunctions: jest.Mocked<IExecuteFunctions>;
+	let mockNode: INode;
+
+	const intercomApiRequestSpy = jest.spyOn(GenericFunctions, 'intercomApiRequest');
+
+	beforeEach(() => {
+		node = new Intercom();
+		mockExecuteFunctions = mockDeep<IExecuteFunctions>();
+		mockNode = {
+			id: 'test-node-id',
+			name: 'Intercom Test',
+			type: 'n8n-nodes-base.intercom',
+			typeVersion: 1,
+			position: [0, 0],
+			parameters: {},
+		};
+
+		jest.clearAllMocks();
+
+		mockExecuteFunctions.getNode.mockReturnValue(mockNode);
+		mockExecuteFunctions.getInputData.mockReturnValue([{ json: {} }]);
+		mockExecuteFunctions.continueOnFail.mockReturnValue(false);
+		(mockExecuteFunctions.helpers.constructExecutionMetaData as jest.Mock).mockImplementation(
+			(data: unknown[], options: { itemData?: { item: number } }) =>
+				data.map((item, index) => ({
+					...(item as object),
+					pairedItem: { item: options?.itemData?.item ?? index },
+				})),
+		);
+		(mockExecuteFunctions.helpers.returnJsonArray as jest.Mock).mockImplementation(
+			(data: unknown) => [{ json: data }],
+		);
+	});
+
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it('updates a user by Intercom ID via the contacts endpoint', async () => {
+		mockExecuteFunctions.getNodeParameter.mockImplementation((parameterName: string) => {
+			const parameters: Record<string, unknown> = {
+				resource: 'user',
+				operation: 'update',
+				updateBy: 'id',
+				value: 'contact-123',
+				additionalFields: {
+					userId: 'external-123',
+					name: 'Jane Doe',
+					avatar: 'https://example.com/avatar.png',
+				},
+				jsonParameters: false,
+				customAttributesUi: { customAttributesValues: [] },
+			};
+
+			return parameters[parameterName];
+		});
+
+		intercomApiRequestSpy.mockResolvedValueOnce({ id: 'contact-123', name: 'Jane Doe' });
+
+		const result = await node.execute.call(mockExecuteFunctions);
+
+		expect(intercomApiRequestSpy).toHaveBeenCalledWith('/contacts/contact-123', 'PUT', {
+			role: 'user',
+			external_id: 'external-123',
+			name: 'Jane Doe',
+			avatar: 'https://example.com/avatar.png',
+			custom_attributes: {},
+		}, {});
+		expect(result).toEqual([
+			[
+				{
+					json: { id: 'contact-123', name: 'Jane Doe' },
+					pairedItem: { item: 0 },
+				},
+			],
+		]);
+	});
+
+	it('looks up a user by external ID before updating', async () => {
+		mockExecuteFunctions.getNodeParameter.mockImplementation((parameterName: string) => {
+			const parameters: Record<string, unknown> = {
+				resource: 'user',
+				operation: 'update',
+				updateBy: 'userId',
+				value: 'external-123',
+				additionalFields: {
+					name: 'Jane Doe',
+				},
+				jsonParameters: false,
+				customAttributesUi: { customAttributesValues: [] },
+			};
+
+			return parameters[parameterName];
+		});
+
+		intercomApiRequestSpy
+			.mockResolvedValueOnce({ id: 'contact-123' })
+			.mockResolvedValueOnce({ id: 'contact-123', name: 'Jane Doe' });
+
+		await node.execute.call(mockExecuteFunctions);
+
+		expect(intercomApiRequestSpy).toHaveBeenNthCalledWith(
+			1,
+			'/contacts/find_by_external_id/external-123',
+			'GET',
+		);
+		expect(intercomApiRequestSpy).toHaveBeenNthCalledWith(2, '/contacts/contact-123', 'PUT', {
+			role: 'user',
+			name: 'Jane Doe',
+			custom_attributes: {},
+		}, {});
+	});
+
+	it('looks up a user by email before updating', async () => {
+		mockExecuteFunctions.getNodeParameter.mockImplementation((parameterName: string) => {
+			const parameters: Record<string, unknown> = {
+				resource: 'user',
+				operation: 'update',
+				updateBy: 'email',
+				value: 'jane@example.com',
+				additionalFields: {
+					name: 'Jane Doe',
+				},
+				jsonParameters: false,
+				customAttributesUi: { customAttributesValues: [] },
+			};
+
+			return parameters[parameterName];
+		});
+
+		intercomApiRequestSpy
+			.mockResolvedValueOnce({ data: [{ id: 'contact-123' }] })
+			.mockResolvedValueOnce({ id: 'contact-123', name: 'Jane Doe' });
+
+		await node.execute.call(mockExecuteFunctions);
+
+		expect(intercomApiRequestSpy).toHaveBeenNthCalledWith(1, '/contacts/search', 'POST', {
+			query: {
+				field: 'email',
+				operator: '=',
+				value: 'jane@example.com',
+			},
+		});
+		expect(intercomApiRequestSpy).toHaveBeenNthCalledWith(2, '/contacts/contact-123', 'PUT', {
+			role: 'user',
+			name: 'Jane Doe',
+			custom_attributes: {},
+		}, {});
+	});
+});


### PR DESCRIPTION
## Summary
- route Intercom user updates through the Contacts API and resolve contact IDs when updates are keyed by email or user ID
- map the legacy update payload to the contact update shape and add regression tests for ID, email, and user ID updates

## Test plan
- corepack pnpm --filter n8n-nodes-base test -- Intercom.node.test.ts
- attempted corepack pnpm --filter n8n-nodes-base exec eslint nodes/Intercom/Intercom.node.ts nodes/Intercom/UserInterface.ts nodes/Intercom/test/Intercom.node.test.ts but it is blocked in this checkout because @n8n/eslint-config is not built locally

Fixes n8n-io/n8n#28580