### PR TITLE
fix(core):  Fixes user search functionality in ProjectSettings for pr…

### DIFF
--- a/packages/cli/src/controllers/__tests__/users.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/users.controller.test.ts
@@ -1,3 +1,4 @@
+import type { UsersListFilterDto } from '@n8n/api-types';
 import type { AuthenticatedRequest, User, UserRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 import type { Response } from 'express';
@@ -7,6 +8,7 @@ import type { JwtService } from '@/services/jwt.service';
 import type { ProvisioningService } from '@/modules/provisioning.ee/provisioning.service.ee';
 import type { ProjectService } from '@/services/project.service.ee';
 import type { UrlService } from '@/services/url.service';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
 import { UsersController } from '../users.controller';
@@ -64,6 +66,81 @@ describe('UsersController', () => {
 				targetUserNewRole: 'global:member',
 				publicApi: false,
 			});
+		});
+	});
+
+	describe('listUsers', () => {
+		const mockQueryBuilder = () => mock({ getManyAndCount: jest.fn().mockResolvedValue([[], 0]) });
+
+		it('should allow global:owner to list users without checking project scopes', async () => {
+			userRepository.buildUserQuery.mockReturnValue(mockQueryBuilder() as never);
+			const req = mock<AuthenticatedRequest>({
+				user: mock<User>({ role: { slug: 'global:owner', scopes: [] } }),
+			});
+
+			await expect(
+				controller.listUsers(
+					req,
+					mock<Response>(),
+					mock<UsersListFilterDto>({ filter: undefined, select: undefined }),
+				),
+			).resolves.toBeDefined();
+
+			expect(projectService.getProjectIdsWithScope).not.toHaveBeenCalled();
+		});
+
+		it('should allow user with project:update scope to list all users without projectId filter', async () => {
+			userRepository.buildUserQuery.mockReturnValue(mockQueryBuilder() as never);
+			projectService.getProjectIdsWithScope.mockResolvedValue(['project-1']);
+			const req = mock<AuthenticatedRequest>({
+				user: mock<User>({ role: { slug: 'global:member', scopes: [] } }),
+			});
+
+			await expect(
+				controller.listUsers(
+					req,
+					mock<Response>(),
+					mock<UsersListFilterDto>({ filter: undefined, select: undefined }),
+				),
+			).resolves.toBeDefined();
+
+			expect(projectService.getProjectIdsWithScope).toHaveBeenCalledWith(req.user, [
+				'project:update',
+			]);
+		});
+
+		it('should throw ForbiddenError when member has no project:update scope and no projectId filter', async () => {
+			projectService.getProjectIdsWithScope.mockResolvedValue([]);
+			const req = mock<AuthenticatedRequest>({
+				user: mock<User>({ role: { slug: 'global:member' } }),
+			});
+
+			await expect(
+				controller.listUsers(
+					req,
+					mock<Response>(),
+					mock<UsersListFilterDto>({ filter: undefined }),
+				),
+			).rejects.toThrow(ForbiddenError);
+
+			expect(projectService.getProjectIdsWithScope).toHaveBeenCalledWith(req.user, [
+				'project:update',
+			]);
+		});
+
+		it('should throw NotFoundError when filtering by an unknown projectId', async () => {
+			projectService.getProjectWithScope.mockResolvedValue(null);
+			const req = mock<AuthenticatedRequest>({
+				user: mock<User>({ role: { slug: 'global:member' } }),
+			});
+
+			await expect(
+				controller.listUsers(
+					req,
+					mock<Response>(),
+					mock<UsersListFilterDto>({ filter: { projectId: 'unknown-project-id' } }),
+				),
+			).rejects.toThrow(NotFoundError);
 		});
 	});
 

--- a/packages/cli/src/controllers/users.controller.ts
+++ b/packages/cli/src/controllers/users.controller.ts
@@ -128,9 +128,14 @@ export class UsersController {
 				throw new NotFoundError('Project not found');
 			}
 		} else if (!['global:owner', 'global:admin'].includes(req.user.role.slug)) {
-			throw new ForbiddenError(
-				'Listing all users is limited to instance administrators. Filter by project to list project members.',
-			);
+			// Project admins need to search all users to invite them into their projects
+			const isProjectAdmin =
+				(await this.projectService.getProjectIdsWithScope(req.user, ['project:update'])).length > 0;
+			if (!isProjectAdmin) {
+				throw new ForbiddenError(
+					'Listing all users is limited to instance administrators and project admins. Filter by project to list project members.',
+				);
+			}
 		}
 
 		const userQuery = this.userRepository.buildUserQuery(listQueryOptions);

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.test.ts
@@ -686,6 +686,27 @@ describe('ProjectSettings', () => {
 		});
 	});
 
+	describe('User search for member invitation', () => {
+		it('preloads all users without projectId filter on mount when user has project:update scope', async () => {
+			renderComponent();
+			await nextTick();
+
+			expect(usersStore.fetchUsers).toHaveBeenCalledWith({ take: 50, filter: {} });
+		});
+
+		it('skips user preloading on mount when user cannot update the project', async () => {
+			projectsStore.currentProject = {
+				...projectsStore.currentProject!,
+				scopes: ['project:read'],
+			};
+
+			renderComponent();
+			await nextTick();
+
+			expect(usersStore.fetchUsers).not.toHaveBeenCalled();
+		});
+	});
+
 	describe('Icon updates', () => {
 		it('updates project icon and shows success toast', async () => {
 			const updateSpy = vi.spyOn(projectsStore, 'updateProject').mockResolvedValue(undefined);

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.vue
@@ -104,6 +104,8 @@ const userSearchQuery = ref('');
 const userSearchResults = ref<typeof usersStore.allUsers>([]);
 const isLoadingUsers = ref(false);
 
+const shouldFetchAllUsers = computed(() => usersStore.isAdminOrOwner || canUpdateProject.value);
+
 const usersList = computed(() =>
 	userSearchResults.value.filter((user) => {
 		const isAlreadySharedWithUser = (formData.value.relations || []).find((r) => r.id === user.id);
@@ -504,13 +506,17 @@ const searchUsers = async (query: string) => {
 			userSearchResults.value = [];
 			return;
 		}
-		// List users in this project only (global /users requires user:create without projectId).
-		const filter = query.trim() ? { fullText: query, projectId } : { projectId };
-		await usersStore.fetchUsers({
-			take: 50,
-			filter,
-		});
-		// Get the search results from the store
+
+		const filter: Record<string, string> = {};
+		if (query.trim()) {
+			filter.fullText = query;
+		}
+		if (!shouldFetchAllUsers.value) {
+			filter.projectId = projectId;
+		}
+
+		await usersStore.fetchUsers({ take: 50, filter });
+
 		if (query.trim()) {
 			userSearchResults.value = usersStore.allUsers.filter((user) => {
 				const searchLower = query.toLowerCase();
@@ -519,7 +525,6 @@ const searchUsers = async (query: string) => {
 				return fullName.includes(searchLower) || email.includes(searchLower);
 			});
 		} else {
-			// Show all loaded users when no search query
 			userSearchResults.value = usersStore.allUsers;
 		}
 	} catch (error) {

--- a/packages/testing/playwright/pages/ProjectSettingsPage.ts
+++ b/packages/testing/playwright/pages/ProjectSettingsPage.ts
@@ -46,6 +46,11 @@ export class ProjectSettingsPage extends BasePage {
 		return this.page.getByPlaceholder('Add users...');
 	}
 
+	async searchForMember(query: string) {
+		await this.getMembersSearchInput().click();
+		await this.page.keyboard.type(query, { delay: 50 });
+	}
+
 	getRoleDropdownFor(email: string) {
 		return this.getMembersTable()
 			.locator('tr')
@@ -57,15 +62,9 @@ export class ProjectSettingsPage extends BasePage {
 		return this.page.getByTestId('project-members-table');
 	}
 
-	async getMemberRowCount() {
-		const table = this.getMembersTable();
-		const rows = table.locator('tbody tr');
-		return await rows.count();
-	}
-
 	async expectTableHasMemberCount(expectedCount: number) {
-		const actualCount = await this.getMemberRowCount();
-		expect(actualCount).toBe(expectedCount);
+		const rows = this.getMembersTable().locator('tbody tr');
+		await expect(rows).toHaveCount(expectedCount);
 	}
 
 	getTitle() {

--- a/packages/testing/playwright/tests/e2e/projects/project-settings.spec.ts
+++ b/packages/testing/playwright/tests/e2e/projects/project-settings.spec.ts
@@ -189,6 +189,58 @@ test.describe(
 			await expect(n8n.projectSettings.getDeleteButton()).toBeVisible();
 		});
 
+		test('should allow owner to search and add a member to the project @auth:owner', async ({
+			n8n,
+			api,
+		}) => {
+			const member = await api.publicApi.createUser({
+				email: `member-${nanoid()}@test.com`.toLowerCase(),
+				firstName: 'Invited',
+				lastName: 'Member',
+			});
+
+			const projectName = `Invite Test ${nanoid(8)}`;
+			const { projectId } = await n8n.projectComposer.createProject(projectName);
+
+			await n8n.navigate.toProjectSettings(projectId);
+			await n8n.projectSettings.expectTableHasMemberCount(1);
+
+			await n8n.projectSettings.searchForMember('Invited');
+			await n8n.projectSettings.getVisiblePopoverOption(member.email).click();
+
+			await expect(n8n.projectSettings.getMembersTable()).toContainText(member.email);
+			await n8n.projectSettings.expectTableHasMemberCount(2);
+			await expect(n8n.notifications.getSuccessNotifications().first()).toBeVisible();
+		});
+
+		test('should allow project admin to search and add a member to the project @auth:owner', async ({
+			n8n,
+			api,
+		}) => {
+			const projectAdmin = await api.publicApi.createUser({
+				email: `proj-admin-${nanoid()}@test.com`.toLowerCase(),
+				firstName: 'Project',
+				lastName: 'Admin',
+			});
+			const invitee = await api.publicApi.createUser({
+				email: `invitee-${nanoid()}@test.com`.toLowerCase(),
+				firstName: 'New',
+				lastName: 'Invitee',
+			});
+
+			const project = await api.projects.createProject(`PA Invite ${nanoid(8)}`);
+			await api.projects.addUserToProject(project.id, projectAdmin.id, 'project:admin');
+
+			const adminN8n = await n8n.start.withUser(projectAdmin);
+			await adminN8n.navigate.toProjectSettings(project.id);
+
+			await adminN8n.projectSettings.searchForMember('Invitee');
+			await adminN8n.projectSettings.getVisiblePopoverOption(invitee.email).click();
+
+			await expect(adminN8n.projectSettings.getMembersTable()).toContainText(invitee.email);
+			await expect(adminN8n.notifications.getSuccessNotifications().first()).toBeVisible();
+		});
+
 		test('should persist settings after page reload @auth:owner', async ({ n8n }) => {
 			// Create a new project
 			const projectName = `Persistence ${nanoid(8)}`;


### PR DESCRIPTION
Allow project admins to list all users

## Summary

**Problem**: Project admins could not invite users to their projects. When a project admin opened Project Settings and tried to search for users to add as members, the backend returned a 403

**Fix**:
- Backend: Instead of throwing a ForbiddenError for non-admins, the controller now checks whether the requesting user has project:update scope on any project. If they do, the request is allowed.
- Frontend: `shouldFetchAllUsers` computed property checks if the user is a global admin/owner or has canUpdateProject scope. If true, the projectId filter is omitted so the search returns all instance users (enabling invitations).


## Related Linear tickets, Github issues, and Community forum posts

Fixes [LIGO-479](https://linear.app/n8n/issue/LIGO-479/cant-invite-users-to-a-project)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
