### PR TITLE
feat(core): Add AES-256-GCM cipher support

### DIFF
--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -7,7 +7,7 @@ import {
 import { Container } from '@n8n/di';
 import { EntityNotFoundError } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
-import { type InstanceSettings, Cipher } from 'n8n-core';
+import { type InstanceSettings, Cipher, CipherAes256GCM, CipherAes256CBC } from 'n8n-core';
 import type {
 	IAuthenticateGeneric,
 	ICredentialDataDecryptedObject,
@@ -41,7 +41,11 @@ describe('CredentialsHelper', () => {
 	const dynamicCredentialProxy = new DynamicCredentialsProxy(mockLogger);
 
 	// Setup cipher for testing
-	const cipher = new Cipher(mock<InstanceSettings>({ encryptionKey: 'test_key_for_testing' }));
+	const cipher = new Cipher(
+		mock<InstanceSettings>({ encryptionKey: 'test_key_for_testing' }),
+		new CipherAes256GCM(),
+		new CipherAes256CBC(),
+	);
 	Container.set(Cipher, cipher);
 
 	const credentialsHelper = new CredentialsHelper(

--- a/packages/cli/src/public-api/v1/handlers/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/__tests__/credentials.service.test.ts
@@ -2,7 +2,7 @@ import type { CredentialsEntity, Project, SharedCredentials, User } from '@n8n/d
 import { CredentialsRepository, GLOBAL_OWNER_ROLE, GLOBAL_MEMBER_ROLE } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
-import { Cipher } from 'n8n-core';
+import { Cipher, CipherAes256GCM, CipherAes256CBC } from 'n8n-core';
 import type { InstanceSettings } from 'n8n-core';
 import type { GenericValue, IDataObject, INodeProperties } from 'n8n-workflow';
 
@@ -15,7 +15,11 @@ import * as checkAccess from '@/permissions.ee/check-access';
 import type { IDependency } from '@/public-api/types';
 
 // Set up real Cipher with mocked InstanceSettings for encryption
-const cipher = new Cipher(mock<InstanceSettings>({ encryptionKey: 'test-encryption-key' }));
+const cipher = new Cipher(
+	mock<InstanceSettings>({ encryptionKey: 'test-encryption-key' }),
+	new CipherAes256GCM(),
+	new CipherAes256CBC(),
+);
 Container.set(Cipher, cipher);
 
 describe('CredentialsService', () => {

--- a/packages/core/src/__tests__/credentials.test.ts
+++ b/packages/core/src/__tests__/credentials.test.ts
@@ -4,6 +4,8 @@ import type { CredentialInformation } from 'n8n-workflow';
 import { AssertionError } from 'node:assert';
 
 import { CREDENTIAL_ERRORS } from '@/constants';
+import { CipherAes256CBC } from '@/encryption/aes-256-cbc';
+import { CipherAes256GCM } from '@/encryption/aes-256-gcm';
 import { Cipher } from '@/encryption/cipher';
 import type { InstanceSettings } from '@/instance-settings';
 
@@ -13,7 +15,11 @@ describe('Credentials', () => {
 	const nodeCredentials = { id: '123', name: 'Test Credential' };
 	const credentialType = 'testApi';
 
-	const cipher = new Cipher(mock<InstanceSettings>({ encryptionKey: 'password' }));
+	const cipher = new Cipher(
+		mock<InstanceSettings>({ encryptionKey: 'password' }),
+		new CipherAes256GCM(),
+		new CipherAes256CBC(),
+	);
 	Container.set(Cipher, cipher);
 
 	const setDataKey = (credentials: Credentials, key: string, data: CredentialInformation) => {

--- a/packages/core/src/encryption/__tests__/cipher.test.ts
+++ b/packages/core/src/encryption/__tests__/cipher.test.ts
@@ -53,18 +53,6 @@ describe('Cipher', () => {
 			expect(() => cipher.decryptWithKey(encrypted, 'key-b', 'aes-256-cbc')).toThrow();
 		});
 
-		it('should throw on aes-256-gcm for encryptWithKey', () => {
-			expect(() => cipher.encryptWithKey('data', 'key', 'aes-256-gcm')).toThrow(
-				'GCM not yet implemented',
-			);
-		});
-
-		it('should throw on aes-256-gcm for decryptWithKey', () => {
-			expect(() => cipher.decryptWithKey('data', 'key', 'aes-256-gcm')).toThrow(
-				'GCM not yet implemented',
-			);
-		});
-
 		it('should be interoperable with legacy encrypt when given the same key', () => {
 			const encrypted = cipher.encrypt('random-string', 'shared-key');
 			const decrypted = cipher.decryptWithKey(encrypted, 'shared-key', 'aes-256-cbc');
@@ -72,35 +60,87 @@ describe('Cipher', () => {
 		});
 	});
 
-	describe('getKeyAndIv', () => {
-		it('should generate a key and iv using instance settings encryption key', () => {
-			const salt = Buffer.from('test-salt');
-			mockInstance(InstanceSettings, { encryptionKey: 'settings-encryption-key' });
-			// Clear the cached Cipher instance to get a new one with the new mock
-			Container.set(Cipher, new Cipher(Container.get(InstanceSettings)));
-			const testCipher = Container.get(Cipher);
-			const bufferFromSpy = jest.spyOn(Buffer, 'from');
-			// @ts-expect-error - getKeyAndIv is private
-			const [key, iv] = testCipher.getKeyAndIv(salt);
-			expect(key).toBeInstanceOf(Buffer);
-			expect(iv).toBeInstanceOf(Buffer);
-			expect(bufferFromSpy).toHaveBeenCalledWith('settings-encryption-key', 'binary');
-			bufferFromSpy.mockRestore();
+	describe('encryptWithKey / decryptWithKey — aes-256-gcm', () => {
+		const gcmKey = '11'.repeat(32);
+		const otherGcmKey = '22'.repeat(32);
+
+		// Ciphertext layout: version(1) || salt(32) || authTag(16) || ciphertext(...)
+		const VERSION_OFFSET = 0;
+		const SALT_OFFSET = 1;
+		const AUTH_TAG_OFFSET = 33;
+		const CIPHERTEXT_OFFSET = 49;
+
+		it('should roundtrip with decryptWithKey using the same key', () => {
+			const encrypted = cipher.encryptWithKey('random-string', gcmKey, 'aes-256-gcm');
+			const decrypted = cipher.decryptWithKey(encrypted, gcmKey, 'aes-256-gcm');
+			expect(decrypted).toEqual('random-string');
 		});
 
-		it('should generate a key and iv using custom encryption key', () => {
-			const salt = Buffer.from('test-salt');
-			mockInstance(InstanceSettings, { encryptionKey: 'settings-encryption-key' });
-			// Clear the cached Cipher instance to get a new one with the new mock
-			Container.set(Cipher, new Cipher(Container.get(InstanceSettings)));
-			const testCipher = Container.get(Cipher);
-			const bufferFromSpy = jest.spyOn(Buffer, 'from');
-			// @ts-expect-error - getKeyAndIv is private
-			const [key, iv] = testCipher.getKeyAndIv(salt, 'custom-encryption-key');
-			expect(key).toBeInstanceOf(Buffer);
-			expect(iv).toBeInstanceOf(Buffer);
-			expect(bufferFromSpy).toHaveBeenCalledWith('custom-encryption-key', 'binary');
-			bufferFromSpy.mockRestore();
+		it('should roundtrip an empty string', () => {
+			const encrypted = cipher.encryptWithKey('', gcmKey, 'aes-256-gcm');
+			expect(cipher.decryptWithKey(encrypted, gcmKey, 'aes-256-gcm')).toEqual('');
+		});
+
+		it('should produce different ciphertexts for the same plaintext on successive calls', () => {
+			const first = cipher.encryptWithKey('random-string', gcmKey, 'aes-256-gcm');
+			const second = cipher.encryptWithKey('random-string', gcmKey, 'aes-256-gcm');
+			expect(first).not.toEqual(second);
+		});
+
+		it('should fail to decrypt with a different key', () => {
+			const encrypted = cipher.encryptWithKey('random-string', gcmKey, 'aes-256-gcm');
+			expect(() => cipher.decryptWithKey(encrypted, otherGcmKey, 'aes-256-gcm')).toThrow();
+		});
+
+		it.each([
+			{ region: 'salt', offset: SALT_OFFSET + 4 },
+			{ region: 'auth tag', offset: AUTH_TAG_OFFSET + 7 },
+			{ region: 'ciphertext body', offset: CIPHERTEXT_OFFSET + 1 },
+		])('should throw when the $region has been tampered with', ({ offset }) => {
+			const encrypted = cipher.encryptWithKey('some-longer-plaintext', gcmKey, 'aes-256-gcm');
+			const buf = Buffer.from(encrypted, 'base64');
+			buf[offset] = buf[offset] ^ 0x01;
+			const tampered = buf.toString('base64');
+			expect(() => cipher.decryptWithKey(tampered, gcmKey, 'aes-256-gcm')).toThrow();
+		});
+
+		it('should throw when a CBC ciphertext is fed into the GCM decryption path', () => {
+			const cbcCiphertext = cipher.encryptWithKey('random-string', gcmKey, 'aes-256-cbc');
+			expect(() => cipher.decryptWithKey(cbcCiphertext, gcmKey, 'aes-256-gcm')).toThrow();
+		});
+
+		it('should throw before any cipher operation when the key is not 32 bytes', () => {
+			const shortKey = '00'.repeat(31);
+			const expectedError = 'GCM key must be exactly 32 bytes (64 hex characters)';
+			expect(() => cipher.encryptWithKey('random-string', shortKey, 'aes-256-gcm')).toThrow(
+				expectedError,
+			);
+			expect(() => cipher.decryptWithKey('irrelevant', shortKey, 'aes-256-gcm')).toThrow(
+				expectedError,
+			);
+		});
+
+		it('should throw when ciphertext is shorter than the minimum header size', () => {
+			// version(1) || salt(32) || truncated tag(4) = 37 bytes, below the 49-byte minimum
+			const truncated = Buffer.concat([Buffer.from([0x01]), Buffer.alloc(32), Buffer.alloc(4)]);
+			expect(() =>
+				cipher.decryptWithKey(truncated.toString('base64'), gcmKey, 'aes-256-gcm'),
+			).toThrow('GCM ciphertext too short');
+		});
+
+		it('should throw when given an empty ciphertext', () => {
+			expect(() => cipher.decryptWithKey('', gcmKey, 'aes-256-gcm')).toThrow(
+				'GCM ciphertext too short',
+			);
+		});
+
+		it('should throw when ciphertext has an unsupported version byte', () => {
+			const encrypted = cipher.encryptWithKey('random-string', gcmKey, 'aes-256-gcm');
+			const buf = Buffer.from(encrypted, 'base64');
+			buf[VERSION_OFFSET] = 0xff;
+			expect(() => cipher.decryptWithKey(buf.toString('base64'), gcmKey, 'aes-256-gcm')).toThrow(
+				'Unsupported GCM ciphertext version',
+			);
 		});
 	});
 });

--- a/packages/core/src/encryption/aes-256-cbc.ts
+++ b/packages/core/src/encryption/aes-256-cbc.ts
@@ -1,0 +1,40 @@
+import { Service } from '@n8n/di';
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'crypto';
+
+import { CipherWrapper } from './interface';
+
+const RANDOM_BYTES = Buffer.from('53616c7465645f5f', 'hex');
+
+@Service()
+export class CipherAes256CBC implements CipherWrapper {
+	encrypt(data: string, key: string): string {
+		const salt = randomBytes(8);
+		const [derivedKey, iv] = this.getKeyAndIv(salt, key);
+		const cipher = createCipheriv('aes-256-cbc', derivedKey, iv);
+		const encrypted = cipher.update(data);
+		return Buffer.concat([RANDOM_BYTES, salt, encrypted, cipher.final()]).toString('base64');
+	}
+
+	decrypt(data: string, key: string): string {
+		const input = Buffer.from(data, 'base64');
+		if (input.length < 16) return '';
+		const salt = input.subarray(8, 16);
+		const [derivedKey, iv] = this.getKeyAndIv(salt, key);
+		const contents = input.subarray(16);
+		const decipher = createDecipheriv('aes-256-cbc', derivedKey, iv);
+		return Buffer.concat([decipher.update(contents), decipher.final()]).toString('utf-8');
+	}
+
+	private getKeyAndIv(salt: Buffer, key: string): [Buffer, Buffer] {
+		const password = Buffer.concat([Buffer.from(key, 'binary'), salt]);
+		const hash1 = createHash('md5').update(password).digest();
+		const hash2 = createHash('md5')
+			.update(Buffer.concat([hash1, password]))
+			.digest();
+		const iv = createHash('md5')
+			.update(Buffer.concat([hash2, password]))
+			.digest();
+		const derivedKey = Buffer.concat([hash1, hash2]);
+		return [derivedKey, iv];
+	}
+}

--- a/packages/core/src/encryption/aes-256-gcm.ts
+++ b/packages/core/src/encryption/aes-256-gcm.ts
@@ -1,0 +1,73 @@
+import { Service } from '@n8n/di';
+import { createCipheriv, createDecipheriv, hkdfSync, randomBytes } from 'crypto';
+import { UnexpectedError } from 'n8n-workflow';
+
+import { CipherWrapper } from './interface';
+
+const FORMAT_VERSION = 0x01;
+
+// Changing this value invalidates every ciphertext previously produced with it.
+// Introduce a new FORMAT_VERSION alongside any change.
+const HKDF_INFO = 'n8n-encryption-v1';
+
+const KEY_LENGTH_BYTES = 32;
+const SALT_LENGTH_BYTES = 32;
+const IV_LENGTH_BYTES = 12;
+const AUTH_TAG_LENGTH_BYTES = 16;
+const HKDF_OUTPUT_LENGTH_BYTES = KEY_LENGTH_BYTES + IV_LENGTH_BYTES;
+
+const VERSION_OFFSET = 0;
+const SALT_OFFSET = VERSION_OFFSET + 1;
+const AUTH_TAG_OFFSET = SALT_OFFSET + SALT_LENGTH_BYTES;
+const CIPHERTEXT_OFFSET = AUTH_TAG_OFFSET + AUTH_TAG_LENGTH_BYTES;
+const MIN_CIPHERTEXT_LENGTH_BYTES = CIPHERTEXT_OFFSET;
+
+@Service()
+export class CipherAes256GCM implements CipherWrapper {
+	encrypt(data: string, key: string): string {
+		const keyBuf = this.toKeyBuf(key);
+		const salt = randomBytes(SALT_LENGTH_BYTES);
+		const [derivedKey, iv] = this.deriveKeyAndIv(keyBuf, salt);
+		const cipher = createCipheriv('aes-256-gcm', derivedKey, iv);
+		const encrypted = Buffer.concat([cipher.update(data, 'utf8'), cipher.final()]);
+		const authTag = cipher.getAuthTag();
+		const version = Buffer.from([FORMAT_VERSION]);
+		return Buffer.concat([version, salt, authTag, encrypted]).toString('base64');
+	}
+
+	decrypt(data: string, key: string): string {
+		const keyBuf = this.toKeyBuf(key);
+		const buf = Buffer.from(data, 'base64');
+		if (buf.length < MIN_CIPHERTEXT_LENGTH_BYTES) {
+			throw new UnexpectedError('GCM ciphertext too short');
+		}
+		const version = buf[VERSION_OFFSET];
+		if (version !== FORMAT_VERSION) {
+			throw new UnexpectedError(`Unsupported GCM ciphertext version: ${version}`);
+		}
+		const salt = buf.subarray(SALT_OFFSET, AUTH_TAG_OFFSET);
+		const authTag = buf.subarray(AUTH_TAG_OFFSET, CIPHERTEXT_OFFSET);
+		const ciphertext = buf.subarray(CIPHERTEXT_OFFSET);
+		const [derivedKey, iv] = this.deriveKeyAndIv(keyBuf, salt);
+		const decipher = createDecipheriv('aes-256-gcm', derivedKey, iv, {
+			authTagLength: AUTH_TAG_LENGTH_BYTES,
+		});
+		decipher.setAuthTag(authTag);
+		return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+	}
+
+	private toKeyBuf(key: string): Buffer {
+		const buf = Buffer.from(key, 'hex');
+		if (buf.length !== KEY_LENGTH_BYTES) {
+			throw new UnexpectedError('GCM key must be exactly 32 bytes (64 hex characters)');
+		}
+		return buf;
+	}
+
+	private deriveKeyAndIv(keyBuf: Buffer, salt: Buffer): [Buffer, Buffer] {
+		const derived = Buffer.from(
+			hkdfSync('sha256', keyBuf, salt, HKDF_INFO, HKDF_OUTPUT_LENGTH_BYTES),
+		);
+		return [derived.subarray(0, KEY_LENGTH_BYTES), derived.subarray(KEY_LENGTH_BYTES)];
+	}
+}

--- a/packages/core/src/encryption/cipher.ts
+++ b/packages/core/src/encryption/cipher.ts
@@ -1,16 +1,19 @@
 import { Service } from '@n8n/di';
-import { createHash, createCipheriv, createDecipheriv, randomBytes } from 'crypto';
 
 import { InstanceSettings } from '@/instance-settings';
+import { assertUnreachable } from '@/utils/assertions';
 
-// Data encrypted by CryptoJS always starts with these bytes
-const RANDOM_BYTES = Buffer.from('53616c7465645f5f', 'hex');
-
-export type CipherAlgorithm = 'aes-256-cbc' | 'aes-256-gcm';
+import { CipherAes256CBC } from './aes-256-cbc';
+import { CipherAes256GCM } from './aes-256-gcm';
+import { CipherAlgorithm } from './interface';
 
 @Service()
 export class Cipher {
-	constructor(private readonly instanceSettings: InstanceSettings) {}
+	constructor(
+		private readonly instanceSettings: InstanceSettings,
+		private readonly cipherAES256GCM: CipherAes256GCM,
+		private readonly cipherAES256CBC: CipherAes256CBC,
+	) {}
 
 	encrypt(data: string | object, customEncryptionKey?: string) {
 		const key = customEncryptionKey ?? this.instanceSettings.encryptionKey;
@@ -24,40 +27,22 @@ export class Cipher {
 	}
 
 	encryptWithKey(data: string, key: string, algorithm: CipherAlgorithm): string {
-		if (algorithm === 'aes-256-gcm') {
-			throw new Error('GCM not yet implemented');
+		switch (algorithm) {
+			case 'aes-256-cbc':
+				return this.cipherAES256CBC.encrypt(data, key);
+			case 'aes-256-gcm':
+				return this.cipherAES256GCM.encrypt(data, key);
 		}
-		const salt = randomBytes(8);
-		const [derivedKey, iv] = this.getKeyAndIv(salt, key);
-		const cipher = createCipheriv('aes-256-cbc', derivedKey, iv);
-		const encrypted = cipher.update(data);
-		return Buffer.concat([RANDOM_BYTES, salt, encrypted, cipher.final()]).toString('base64');
+		assertUnreachable(algorithm);
 	}
 
 	decryptWithKey(data: string, key: string, algorithm: CipherAlgorithm): string {
-		if (algorithm === 'aes-256-gcm') {
-			throw new Error('GCM not yet implemented');
+		switch (algorithm) {
+			case 'aes-256-cbc':
+				return this.cipherAES256CBC.decrypt(data, key);
+			case 'aes-256-gcm':
+				return this.cipherAES256GCM.decrypt(data, key);
 		}
-		const input = Buffer.from(data, 'base64');
-		if (input.length < 16) return '';
-		const salt = input.subarray(8, 16);
-		const [derivedKey, iv] = this.getKeyAndIv(salt, key);
-		const contents = input.subarray(16);
-		const decipher = createDecipheriv('aes-256-cbc', derivedKey, iv);
-		return Buffer.concat([decipher.update(contents), decipher.final()]).toString('utf-8');
-	}
-
-	private getKeyAndIv(salt: Buffer, customEncryptionKey?: string): [Buffer, Buffer] {
-		const encryptionKey = customEncryptionKey ?? this.instanceSettings.encryptionKey;
-		const password = Buffer.concat([Buffer.from(encryptionKey, 'binary'), salt]);
-		const hash1 = createHash('md5').update(password).digest();
-		const hash2 = createHash('md5')
-			.update(Buffer.concat([hash1, password]))
-			.digest();
-		const iv = createHash('md5')
-			.update(Buffer.concat([hash2, password]))
-			.digest();
-		const key = Buffer.concat([hash1, hash2]);
-		return [key, iv];
+		assertUnreachable(algorithm);
 	}
 }

--- a/packages/core/src/encryption/index.ts
+++ b/packages/core/src/encryption/index.ts
@@ -1,1 +1,3 @@
 export { Cipher } from './cipher';
+export { CipherAes256GCM } from './aes-256-gcm';
+export { CipherAes256CBC } from './aes-256-cbc';

--- a/packages/core/src/encryption/interface.ts
+++ b/packages/core/src/encryption/interface.ts
@@ -1,0 +1,14 @@
+export type CipherAlgorithm = 'aes-256-cbc' | 'aes-256-gcm';
+
+/**
+ * Adapter for a single cipher algorithm. `Cipher` dispatches encrypt/decrypt
+ * calls to an implementation by algorithm.
+ *
+ * Key format is implementation-specific:
+ * - `CipherAes256CBC` accepts any string (passed to the MD5-based legacy KDF).
+ * - `CipherAes256GCM` requires a 64-character hex string (32 raw bytes).
+ */
+export interface CipherWrapper {
+	encrypt(data: string, key: string): string;
+	decrypt(data: string, key: string): string;
+}

--- a/packages/core/src/utils/assertions.ts
+++ b/packages/core/src/utils/assertions.ts
@@ -22,3 +22,7 @@ export function assertExecutionDataExists(
 		});
 	}
 }
+
+export function assertUnreachable(value: never): never {
+	throw new UnexpectedError(`Unhandled value in exhaustive switch: ${String(value)}`);
+}


### PR DESCRIPTION
## Summary

Adds authenticated AES-256-GCM encryption/decryption to the `Cipher` service, replacing the stub left in IAM-494 (T09). This is T12 of the Encryption Key Rotation epic and unblocks the key-rotation flow so keys added via the rotation API can be used for actual encryption operations.

GCM is fragile to nonce reuse: a single repeated 96-bit IV under the same key leaks the GCM authentication key. To make that failure mode unreachable, each encryption generates a 32-byte random salt and uses HKDF-SHA256 to derive a per-message key and a 12-byte IV from it. Even if two messages ever collide on the derived IV, they run under different derived keys, so GCM's catastrophic forge-anywhere failure cannot be triggered. This is standard nonce-misuse-resistant construction.

### Key implementation decisions

- **Adapter split.** `Cipher` is now a thin dispatcher over two adapters implementing a shared `CipherWrapper` interface: `CipherAes256CBC` (the existing legacy path, moved verbatim) and `CipherAes256GCM` (new). This isolates algorithm-specific code, makes each algorithm individually testable, and keeps `Cipher` free of algorithm internals.
- **Versioned ciphertext format.** Layout is `base64( version(1) || salt(32) || authTag(16) || ciphertext )`. A single leading version byte (`0x01`) lets us evolve the construction (e.g. change the HKDF `info`, widen the salt, switch KDF) without breaking decryption of existing ciphertexts. The ticket did not require a version prefix; added defensively since this is a persistent on-disk format.
- **HKDF `info` is fixed at `'n8n-encryption-v1'`.** Changing it invalidates every ciphertext previously produced with it — noted in-code; any future change must bump `FORMAT_VERSION` and keep the v1 decode path.
- **Strict key validation.** GCM requires a 64-char hex string (32 raw bytes) and rejects anything else *before* any crypto call. CBC keeps its legacy KDF-accepts-anything behavior to preserve backwards compatibility with existing ciphertexts.
- **Exhaustiveness.** Added `assertUnreachable` in `core/src/utils/assertions.ts` so the `CipherAlgorithm` dispatch is compiler-checked; a new algorithm forces a match-arm update.
- **`CipherAlgorithm` type moved** to `encryption/interface.ts` alongside `CipherWrapper` to avoid a circular import between `cipher.ts` and the adapters.


## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-496/aes-256-gcm-cipher-support

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
