### PR TITLE
fix(editor): avoid duplicate fromAI keys in assignment rows (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/utils/fromAIOverride.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/utils/fromAIOverride.utils.test.ts
@@ -259,6 +259,19 @@ describe('FromAiOverride', () => {
 			`={{ $fromAI('${DISPLAY_NAME}', \`${description}\`, 'string') }}`,
 		);
 	});
+
+	it('creates unique keys for dot-separated assignment paths', () => {
+		const override: FromAIOverride = {
+			type: 'fromAI',
+			extraProps: fromAIExtraProps,
+			extraPropValues: {},
+		};
+
+		expect(buildValueFromOverride(override, makeContext('', 'parameters.fields.assignments.0.value'), true))
+			.toContain("$fromAI('assignments0_aDisplayName'");
+		expect(buildValueFromOverride(override, makeContext('', 'parameters.fields.assignments.1.value'), true))
+			.toContain("$fromAI('assignments1_aDisplayName'");
+	});
 });
 
 describe('buildUniqueName', () => {
@@ -272,6 +285,16 @@ describe('buildUniqueName', () => {
 		[
 			'multiple list segments in the path',
 			'parameters.someList[0].nestedList[1].someParameter',
+			'someList0_nestedList1_' + DISPLAY_NAME,
+		],
+		[
+			'dot-separated list segments in the path',
+			'parameters.someList.0.someParameter',
+			'someList0_' + DISPLAY_NAME,
+		],
+		[
+			'multiple dot-separated list segments in the path',
+			'parameters.someList.0.nestedList.1.someParameter',
 			'someList0_nestedList1_' + DISPLAY_NAME,
 		],
 		[

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/utils/fromAIOverride.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/utils/fromAIOverride.utils.ts
@@ -128,11 +128,22 @@ function getBestQuoteChar(description: string) {
 export function buildUniqueName(props: Pick<OverrideContext, 'parameter' | 'path'>) {
 	const path = props.path.split('.');
 
-	// include any list segments in the path (e.g. .myListName[0].) for uniqueness
+	// include any list segments in the path (e.g. .myListName[0]. or .myListName.0.) for uniqueness
 	// but drop brackets to avoid token limits
-	const filteredPaths = path
-		.filter((x) => /\[\d+\]/i.test(x))
-		.map((x) => x.replaceAll(/[\[\]]/gi, ''));
+	const filteredPaths = path.flatMap((segment, index) => {
+		if (/\[\d+\]/i.test(segment)) {
+			return segment.replaceAll(/[\[\]]/gi, '');
+		}
+
+		if (/^\d+$/i.test(segment)) {
+			const parentSegment = path[index - 1];
+			return parentSegment && !/^\d+$/i.test(parentSegment)
+				? `${parentSegment}${segment}`
+				: segment;
+		}
+
+		return [];
+	});
 	let result = [...filteredPaths, props.parameter.displayName].join('_');
 
 	// Langchain requires the name to be <64 characters


### PR DESCRIPTION
## Summary
- recognize dot-separated list indices like `.assignments.0.` when generating auto-created `$fromAI()` keys
- add regression coverage for assignment-style paths so repeated "Field Value" rows get unique keys

## Test plan
- `corepack pnpm --filter @n8n/vitest-config build`
- `corepack pnpm --filter @n8n/permissions build`
- `corepack pnpm --filter @n8n/api-types build`
- `corepack pnpm exec tsc --build tsconfig.build.esm.json tsconfig.build.cjs.json` (in `packages/@n8n/expression-runtime`)
- `node esbuild.config.js` (in `packages/@n8n/expression-runtime`)
- `corepack pnpm exec vitest run src/features/ndv/parameters/utils/fromAIOverride.utils.test.ts` (in `packages/frontend/editor-ui`)

Fixes n8n-io/n8n#28900
