### PR TITLE
fix(editor): stop redirecting failed workflow opens (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.test.ts
@@ -1,0 +1,234 @@
+import { VIEWS } from '@/app/constants';
+import type { WorkflowState } from '@/app/composables/useWorkflowState';
+import { useWorkflowInitialization } from './useWorkflowInitialization';
+
+const {
+	mockRoute,
+	mockRouter,
+	mockToast,
+	mockWorkflowsStore,
+	mockWorkflowsListStore,
+	mockUiStore,
+	mockProjectsStore,
+	mockHistoryStore,
+	mockCanvasOperations,
+} = vi.hoisted(() => ({
+	mockRoute: {
+		params: { name: 'wf-1' },
+		query: {},
+		name: '',
+		meta: { nodeView: true },
+	},
+	mockRouter: {
+		replace: vi.fn(),
+		push: vi.fn(),
+	},
+	mockToast: {
+		showError: vi.fn(),
+	},
+	mockWorkflowsStore: {
+		workflowId: '',
+		isInDebugMode: false,
+		fetchLastSuccessfulExecution: vi.fn(),
+	},
+	mockWorkflowsListStore: {
+		fetchWorkflow: vi.fn(),
+		fetchActiveWorkflows: vi.fn(),
+		checkWorkflowExists: vi.fn(),
+		updateWorkflowInCache: vi.fn(),
+	},
+	mockUiStore: {
+		nodeViewInitialized: false,
+		isBlankRedirect: false,
+	},
+	mockProjectsStore: {
+		currentProjectId: 'project-1',
+		currentProject: null,
+		personalProject: null,
+		refreshCurrentProject: vi.fn(),
+		setProjectNavActiveIdByWorkflowHomeProject: vi.fn(),
+	},
+	mockHistoryStore: {
+		reset: vi.fn(),
+	},
+	mockCanvasOperations: {
+		resetWorkspace: vi.fn(),
+		initializeWorkspace: vi.fn(),
+		fitView: vi.fn(),
+		openWorkflowTemplate: vi.fn(),
+		openWorkflowTemplateFromJSON: vi.fn(),
+	},
+}));
+
+vi.mock('vue-router', () => ({
+	useRoute: vi.fn(() => mockRoute),
+	useRouter: vi.fn(() => mockRouter),
+}));
+
+vi.mock('@n8n/i18n', () => ({
+	useI18n: vi.fn(() => ({
+		baseText: vi.fn((key: string) => key),
+	})),
+}));
+
+vi.mock('@/app/composables/useToast', () => ({
+	useToast: vi.fn(() => mockToast),
+}));
+
+vi.mock('@/app/composables/useDocumentTitle', () => ({
+	useDocumentTitle: vi.fn(() => ({
+		setDocumentTitle: vi.fn(),
+	})),
+}));
+
+vi.mock('@/app/composables/useExternalHooks', () => ({
+	useExternalHooks: vi.fn(() => ({
+		run: vi.fn(),
+	})),
+}));
+
+vi.mock('@/app/composables/useCanvasOperations', () => ({
+	useCanvasOperations: vi.fn(() => mockCanvasOperations),
+}));
+
+vi.mock('@/features/core/folders/composables/useParentFolder', () => ({
+	useParentFolder: vi.fn(() => ({
+		fetchParentFolder: vi.fn(),
+	})),
+}));
+
+vi.mock('@/app/stores/workflows.store', () => ({
+	useWorkflowsStore: vi.fn(() => mockWorkflowsStore),
+}));
+
+vi.mock('@/app/stores/workflowsList.store', () => ({
+	useWorkflowsListStore: vi.fn(() => mockWorkflowsListStore),
+}));
+
+vi.mock('@/app/stores/ui.store', () => ({
+	useUIStore: vi.fn(() => mockUiStore),
+}));
+
+vi.mock('@/app/stores/nodeTypes.store', () => ({
+	useNodeTypesStore: vi.fn(() => ({
+		allNodeTypes: [],
+		getNodeTypes: vi.fn(),
+		fetchCommunityNodePreviews: vi.fn(),
+	})),
+}));
+
+vi.mock('@/features/credentials/credentials.store', () => ({
+	useCredentialsStore: vi.fn(() => ({
+		fetchAllCredentialsForWorkflow: vi.fn(),
+		fetchCredentialTypes: vi.fn(),
+	})),
+}));
+
+vi.mock('@/features/settings/environments.ee/environments.store', () => ({
+	useEnvironmentsStore: vi.fn(() => ({
+		fetchAllVariables: vi.fn(),
+	})),
+}));
+
+vi.mock('@/app/stores/settings.store', () => ({
+	useSettingsStore: vi.fn(() => ({
+		isPreviewMode: false,
+		isEnterpriseFeatureEnabled: {},
+	})),
+}));
+
+vi.mock('@/features/collaboration/projects/projects.store', () => ({
+	useProjectsStore: vi.fn(() => mockProjectsStore),
+}));
+
+vi.mock('@/app/stores/history.store', () => ({
+	useHistoryStore: vi.fn(() => mockHistoryStore),
+}));
+
+vi.mock('@/features/ai/assistant/builder.store', () => ({
+	useBuilderStore: vi.fn(() => ({
+		streaming: false,
+	})),
+}));
+
+vi.mock('@/experiments/aiTemplatesStarterCollection/stores/aiTemplatesStarterCollection.store', () => ({
+	useAITemplatesStarterCollectionStore: vi.fn(() => ({
+		trackUserOpenedWorkflow: vi.fn(),
+	})),
+}));
+
+vi.mock('@/experiments/readyToRunWorkflows/stores/readyToRunWorkflows.store', () => ({
+	useReadyToRunWorkflowsStore: vi.fn(() => ({
+		trackOpenWorkflow: vi.fn(),
+	})),
+}));
+
+vi.mock('@/app/composables/useTelemetry', () => ({
+	useTelemetry: vi.fn(() => ({
+		track: vi.fn(),
+	})),
+}));
+
+vi.mock('@/features/execution/executions/composables/useExecutionDebugging', () => ({
+	useExecutionDebugging: vi.fn(() => ({
+		applyExecutionData: vi.fn(),
+	})),
+}));
+
+vi.mock('@/app/stores/workflowDocument.store', () => ({
+	useWorkflowDocumentStore: vi.fn(),
+	createWorkflowDocumentId: vi.fn((id: string, version?: string) => `${id}@${version ?? 'latest'}`),
+	disposeWorkflowDocumentStore: vi.fn(),
+}));
+
+describe('useWorkflowInitialization', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		mockRoute.params = { name: 'wf-1' };
+		mockRoute.query = {};
+		mockRoute.name = VIEWS.WORKFLOW;
+		mockRoute.meta = { nodeView: true };
+
+		mockUiStore.nodeViewInitialized = false;
+		mockUiStore.isBlankRedirect = false;
+		mockWorkflowsStore.workflowId = '';
+		mockWorkflowsStore.isInDebugMode = false;
+	});
+
+	it('does not redirect to a new workflow when opening an existing workflow fails', async () => {
+		mockWorkflowsListStore.fetchWorkflow.mockRejectedValue(new Error('boom'));
+
+		const { initializeWorkflow, initializedWorkflowId } = useWorkflowInitialization(
+			{} as WorkflowState,
+		);
+
+		await initializeWorkflow();
+
+		expect(mockToast.showError).toHaveBeenCalledWith(
+			expect.any(Error),
+			'openWorkflow.workflowNotFoundError',
+		);
+		expect(mockRouter.push).not.toHaveBeenCalled();
+		expect(mockRouter.replace).not.toHaveBeenCalled();
+		expect(mockUiStore.nodeViewInitialized).toBe(true);
+		expect(initializedWorkflowId.value).toBeUndefined();
+	});
+
+	it('keeps redirecting to the not-found view on a 404 error', async () => {
+		mockWorkflowsListStore.fetchWorkflow.mockRejectedValue({ httpStatusCode: 404 });
+
+		const { initializeWorkflow, initializedWorkflowId } = useWorkflowInitialization(
+			{} as WorkflowState,
+		);
+
+		await initializeWorkflow();
+
+		expect(mockRouter.replace).toHaveBeenCalledWith({
+			name: VIEWS.ENTITY_NOT_FOUND,
+			params: { entityType: 'workflow' },
+		});
+		expect(mockToast.showError).not.toHaveBeenCalled();
+		expect(initializedWorkflowId.value).toBeUndefined();
+	});
+});

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.test.ts
@@ -252,4 +252,19 @@ describe('useWorkflowInitialization', () => {
 		expect(mockToast.showError).not.toHaveBeenCalled();
 		expect(initializedWorkflowId.value).toBeUndefined();
 	});
+
+	it('ignores stale workflow-open failures after navigating away', async () => {
+		mockRoute.params = { name: 'wf-2' };
+		mockWorkflowsListStore.fetchWorkflow.mockRejectedValue(new Error('boom'));
+
+		const { initializeWorkspaceForExistingWorkflow, initializedWorkflowId } =
+			useWorkflowInitialization({} as WorkflowState);
+		initializedWorkflowId.value = 'wf-1';
+
+		await initializeWorkspaceForExistingWorkflow('wf-1');
+
+		expect(mockToast.showError).not.toHaveBeenCalled();
+		expect(mockRouter.replace).not.toHaveBeenCalled();
+		expect(initializedWorkflowId.value).toBe('wf-1');
+	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.test.ts
@@ -215,6 +215,27 @@ describe('useWorkflowInitialization', () => {
 		expect(initializedWorkflowId.value).toBeUndefined();
 	});
 
+	it('returns to the last opened workflow when another workflow fails to open', async () => {
+		mockRoute.params = { name: 'wf-2' };
+		mockWorkflowsListStore.fetchWorkflow.mockRejectedValue(new Error('boom'));
+
+		const { initializeWorkflow, initializedWorkflowId } = useWorkflowInitialization(
+			{} as WorkflowState,
+		);
+		initializedWorkflowId.value = 'wf-1';
+		await initializeWorkflow();
+
+		expect(mockToast.showError).toHaveBeenCalledWith(
+			expect.any(Error),
+			'openWorkflow.workflowNotFoundError',
+		);
+		expect(mockRouter.replace).toHaveBeenCalledWith({
+			name: VIEWS.WORKFLOW,
+			params: { name: 'wf-1' },
+		});
+		expect(initializedWorkflowId.value).toBe('wf-1');
+	});
+
 	it('keeps redirecting to the not-found view on a 404 error', async () => {
 		mockWorkflowsListStore.fetchWorkflow.mockRejectedValue({ httpStatusCode: 404 });
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -337,6 +337,13 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 			}
 
 			toast.showError(error, i18n.baseText('openWorkflow.workflowNotFoundError'));
+
+			if (initializedWorkflowId.value && initializedWorkflowId.value !== workflowId.value) {
+				return await router.replace({
+					name: VIEWS.WORKFLOW,
+					params: { name: initializedWorkflowId.value },
+				});
+			}
 		} finally {
 			uiStore.nodeViewInitialized = true;
 			if (didOpenWorkflow) {

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -289,10 +289,13 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 	}
 
 	async function initializeWorkspaceForExistingWorkflow(id: string) {
+		let didOpenWorkflow = false;
+
 		try {
 			const workflowData = await workflowsListStore.fetchWorkflow(id);
 
 			await openWorkflow(workflowData);
+			didOpenWorkflow = true;
 
 			// Track telemetry for onboarding and experiment workflows
 			if (workflowData.meta?.onboardingId) {
@@ -334,12 +337,11 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 			}
 
 			toast.showError(error, i18n.baseText('openWorkflow.workflowNotFoundError'));
-			void router.push({
-				name: VIEWS.NEW_WORKFLOW,
-			});
 		} finally {
 			uiStore.nodeViewInitialized = true;
-			initializedWorkflowId.value = workflowId.value;
+			if (didOpenWorkflow) {
+				initializedWorkflowId.value = workflowId.value;
+			}
 		}
 	}
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -323,6 +323,10 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 			);
 			void workflowsStore.fetchLastSuccessfulExecution();
 		} catch (error) {
+			if (workflowId.value !== id) {
+				return;
+			}
+
 			if ((error as { httpStatusCode?: number }).httpStatusCode === 404) {
 				return await router.replace({
 					name: VIEWS.ENTITY_NOT_FOUND,


### PR DESCRIPTION
## Summary
- stop routing users to `NEW_WORKFLOW` when opening an existing workflow fails with a non-404/non-403 error
- add regression coverage to keep 404 redirects intact while leaving generic open failures on the current workflow route

## Test plan
- `corepack pnpm exec vitest run src/app/composables/useWorkflowInitialization.test.ts` (in `packages/frontend/editor-ui`)

Fixes n8n-io/n8n#28842
