### PR TITLE
fix(ai-builder): Scope builder sub-agent to its assigned workflow

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.prompt.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.prompt.ts
@@ -37,6 +37,22 @@ const PLACEHOLDER_RULE =
 const PLACEHOLDER_ESCALATION =
 	'When the user says "send me", "email me", "notify me", or similar and you don\'t know their specific address, use `placeholder(\'Your email address\')` for the recipient field rather than hardcoding a fake address like `user@example.com`. The setup wizard will collect this from the user after the build.';
 
+// ── Shared task-scope rule (used by both builder prompt variants) ───────────
+
+const TASK_SCOPE_SECTION = `## Scope — Build Only This Task
+
+You are building exactly ONE workflow for the task described in your briefing. Do nothing else:
+
+- Do not create, modify, or submit workflows for sibling tasks, neighboring phases, or alternate approaches mentioned in the briefing or conversation context. Each task in a multi-step plan runs as a separate builder execution — you are only responsible for yours.
+- All of your \`submit-workflow\` calls must refer to the **same single workflow** (identified by file path). Re-submitting the same workflow to fix errors or iterate is fine; submitting a second, differently-named workflow from one task is not.
+- If the briefing references other workflows (e.g. "this workflow feeds Workflow B" or "after this, task C will..."), treat that as informational context only. Those workflows are built by other executions — not by you.
+
+Read your task brief, build exactly what it describes, submit it, and stop.`;
+
+// prettier-ignore
+const TASK_SCOPE_CRITICAL_BULLET =
+	'- **Build ONLY the workflow described in your task briefing.** Do not create, submit, or modify workflows for sibling tasks or alternate approaches mentioned in the briefing or conversation context. Each task in a multi-step plan is handled by a separate builder execution. All of your `submit-workflow` calls must target the same workflow (same file path); re-submits to fix errors are fine, but a second differently-named workflow from one task is not.';
+
 // ── Shared SDK reference sections ────────────────────────────────────────────
 
 const SDK_CODE_RULES = `## SDK Code Rules
@@ -472,6 +488,8 @@ Do NOT produce visible output until step 4. All reasoning happens internally.
 - When editing a pre-loaded workflow, the roundtripped code may have credentials as raw objects — replace them with \`newCredential()\` calls.
 - Unresolved credentials (where the user chose mock data or no credential is available) will be automatically mocked via pinned data at submit time. Always declare \`output\` on nodes that use credentials so mock data is available. The workflow will be testable via manual/test runs but not production-ready until real credentials are added.
 
+${TASK_SCOPE_SECTION}
+
 ${SDK_RULES_AND_PATTERNS}
 `;
 
@@ -702,6 +720,7 @@ n8n normalizes column names to snake_case (e.g., \`dayName\` → \`day_name\`). 
 - **If you edit code after submitting, you MUST call \`submit-workflow\` again before doing anything else (verify, run, or finish).** The system tracks file hashes — if the file changed since the last submit, your work is discarded. The sequence is always: edit → submit → then verify/run/finish.
 - **Follow the runtime verification instructions in your briefing.** If the briefing says verification is required, do not stop after a successful submit.
 - **Do NOT call \`workflows(action="publish")\`.** Publishing is the user's decision after they have tested the workflow. Your job ends at a successful submit.
+${TASK_SCOPE_CRITICAL_BULLET}
 
 ## Mandatory Process
 


### PR DESCRIPTION
## Summary

When the orchestrator breaks a user request into multiple planned tasks, each task is built by its own workflow-builder sub-agent. Nothing in the builder's prompt tells it to stay within that boundary, so if the task spec mentions neighboring workflows (e.g. "this is phase 1 of 3" or "this workflow feeds Workflow B"), the builder will happily build those too — overwriting or shadowing what other builders are doing in parallel.

This PR adds a scope rule to both builder prompt variants in `packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.prompt.ts`.

## The bug

During a RAG chatbot session, the second builder sub-agent burned a lot of LLM calls before giving up. Reading the log, it kept building *both* the ingest workflow and the retrieve workflow — even though its own task spec was only for the retrieve side. The first builder had already built the ingest workflow; the second builder ignored that and re-built it from scratch with a different name, overwriting nothing but wasting the whole budget.

Root cause: the builder had no instruction to treat sibling mentions in the brief as informational. It read "Workflow A feeds Workflow B" and built both.

## Fix

Two constants added next to the other shared prompt fragments:

- `TASK_SCOPE_SECTION` — a full `## Scope — Build Only This Task` block, used by the tool-based `BUILDER_AGENT_PROMPT`.
- `TASK_SCOPE_CRITICAL_BULLET` — a one-line condensed version, appended to the existing `## CRITICAL RULES` bullet list in the sandbox-based `createSandboxBuilderAgentPrompt`.

Both carry the same three points: don't build sibling workflows, all `submit-workflow` calls must target the same file, and references to other workflows in the brief are context only.

The rule mirrors one that already exists in the data-table agent prompt — same shape, adapted for workflows.

## Why no schema change

The obvious alternative is to enrich the briefing payload with an explicit "scope" field or a list of sibling task IDs to ignore. We looked at this and it isn't needed: the planned-task scheduler already isolates each task and does not pass sibling metadata into the brief. What leaks is the prose of the task spec itself, authored by the orchestrator's planning agent. A prompt rule telling the builder how to read that prose is sufficient — and reversible, which a schema field isn't.