### PR TITLE
Add new WhatsApp template components and richer API error diagnostics

### DIFF
--- a/packages/nodes-base/nodes/WhatsApp/MessageFunctions.ts
+++ b/packages/nodes-base/nodes/WhatsApp/MessageFunctions.ts
@@ -20,6 +20,84 @@ interface WhatsAppApiError {
 	};
 }
 
+function normalizeTemplateParameter(parameter: IDataObject): IDataObject {
+	if (parameter.type === 'text') {
+		return {
+			type: 'text',
+			text: parameter.text,
+		};
+	}
+
+	if (parameter.type === 'currency') {
+		return {
+			type: 'currency',
+			currency: {
+				code: parameter.code,
+				fallback_value: parameter.fallback_value,
+				amount_1000: Number(parameter.amount_1000) * 1000,
+			},
+		};
+	}
+
+	if (parameter.type === 'date_time') {
+		return {
+			type: 'date_time',
+			date_time: {
+				fallback_value: parameter.date_time,
+			},
+		};
+	}
+
+	if (parameter.type === 'image' || parameter.type === 'video' || parameter.type === 'document') {
+		const linkField = `${parameter.type}Link`;
+		return {
+			type: parameter.type,
+			[parameter.type]: {
+				link: parameter[linkField],
+			},
+		};
+	}
+
+	if (parameter.type === 'payload') {
+		return {
+			type: 'payload',
+			payload: parameter.payload,
+		};
+	}
+
+	if (parameter.type === 'coupon_code') {
+		return {
+			type: 'coupon_code',
+			coupon_code: parameter.coupon_code,
+		};
+	}
+
+	if (parameter.type === 'action') {
+		return {
+			type: 'action',
+			action: {
+				flow_token: parameter.flowToken,
+			},
+		};
+	}
+
+	return parameter;
+}
+
+function formatErrorDescription(error: WhatsAppApiError['error'], statusCode: number, operation: string) {
+	const details = [
+		`Status code: ${statusCode}`,
+		`Operation: ${operation}`,
+		error.code ? `Error code: ${error.code}` : '',
+		error.type ? `Error type: ${error.type}` : '',
+		error.fbtrace_id ? `FB trace ID: ${error.fbtrace_id}` : '',
+	]
+		.filter(Boolean)
+		.join(' | ');
+
+	return `${error.message}${details ? `\n${details}` : ''}`;
+}
+
 export async function addTemplateComponents(
 	this: IExecuteSingleFunctions,
 	requestOptions: IHttpRequestOptions,
@@ -117,45 +195,17 @@ export async function componentsRequest(
 		if (component.type === 'body') {
 			comp.parameters = (
 				((component.bodyParameters as IDataObject).parameter as IDataObject[]) || []
-			).map((i: IDataObject) => {
-				if (i.type === 'text') {
-					return i;
-				} else if (i.type === 'currency') {
-					return {
-						type: 'currency',
-						currency: {
-							code: i.code,
-							fallback_value: i.fallback_value,
-							amount_1000: (i.amount_1000 as number) * 1000,
-						},
-					};
-				} else if (i.type === 'date_time') {
-					return {
-						type: 'date_time',
-						date_time: {
-							fallback_value: i.date_time,
-						},
-					};
-				}
-			});
+			).map((i: IDataObject) => normalizeTemplateParameter(i));
 		} else if (component.type === 'button') {
 			comp.index = component.index?.toString();
 			comp.sub_type = component.sub_type;
-			comp.parameters = [(component.buttonParameters as IDataObject).parameter];
+			comp.parameters = [
+				normalizeTemplateParameter((component.buttonParameters as IDataObject).parameter as IDataObject),
+			];
 		} else if (component.type === 'header') {
 			comp.parameters = (
 				(component.headerParameters as IDataObject).parameter as IDataObject[]
-			).map((i: IDataObject) => {
-				if (i.type === 'image') {
-					return {
-						type: 'image',
-						image: {
-							link: i.imageLink,
-						},
-					};
-				}
-				return i;
-			});
+			).map((i: IDataObject) => normalizeTemplateParameter(i));
 		}
 		componentsRet.push(comp);
 	}
@@ -191,38 +241,46 @@ export async function sendErrorPostReceive(
 	data: INodeExecutionData[],
 	response: IN8nHttpFullResponse,
 ): Promise<INodeExecutionData[]> {
+	const operation = this.getNodeParameter('operation', 'send') as string;
+
 	if (response.statusCode === 500) {
 		throw new NodeApiError(
 			this.getNode(),
-			{},
+			response as unknown as JsonObject,
 			{
 				message: 'Sending failed',
 				description:
-					'If you’re sending to a new test number, try sending a message to it from within the Meta developer portal first.',
+					'If you are sending to a new test number, try sending a message to it from within the Meta developer portal first.\nStatus code: 500',
 				httpCode: '500',
 			},
 		);
 	} else if (response.statusCode === 400) {
-		const error = { ...(response.body as WhatsAppApiError).error };
+		const apiError = (response.body as WhatsAppApiError | undefined)?.error;
+		if (!apiError?.message) {
+			throw new NodeApiError(this.getNode(), response as unknown as JsonObject);
+		}
+
+		const error = { ...apiError };
 		error.message = error.message.replace(/^\(#\d+\) /, '');
 		const messageType = this.getNodeParameter('messageType', 'media');
+		const description = formatErrorDescription(error, response.statusCode, operation);
 		if (error.message.endsWith('is not a valid whatsapp business account media attachment ID')) {
 			throw new NodeApiError(
 				this.getNode(),
-				{ error },
+				{ ...(response as unknown as JsonObject), body: { error } },
 				{
 					message: `Invalid ${messageType} ID`,
-					description: error.message,
+					description,
 					httpCode: '400',
 				},
 			);
 		} else if (error.message.endsWith('is not a valid URI.')) {
 			throw new NodeApiError(
 				this.getNode(),
-				{ error },
+				{ ...(response as unknown as JsonObject), body: { error } },
 				{
 					message: `Invalid ${messageType} URL`,
-					description: error.message,
+					description,
 					httpCode: '400',
 				},
 			);
@@ -230,10 +288,18 @@ export async function sendErrorPostReceive(
 		throw new NodeApiError(
 			this.getNode(),
 			{ ...(response as unknown as JsonObject), body: { error } },
-			{},
+			{
+				message: 'WhatsApp API request failed',
+				description,
+				httpCode: '400',
+			},
 		);
 	} else if (response.statusCode > 399) {
-		throw new NodeApiError(this.getNode(), response as unknown as JsonObject);
+		throw new NodeApiError(this.getNode(), response as unknown as JsonObject, {
+			message: 'WhatsApp API request failed',
+			description: `Status code: ${response.statusCode} | Operation: ${operation}`,
+			httpCode: `${response.statusCode}`,
+		});
 	}
 	return data;
 }

--- a/packages/nodes-base/nodes/WhatsApp/MessagesDescription.ts
+++ b/packages/nodes-base/nodes/WhatsApp/MessagesDescription.ts
@@ -1357,6 +1357,14 @@ export const messageTypeFields: INodeProperties[] = [
 								name: 'URL',
 								value: 'url',
 							},
+							{
+								name: 'Copy Code',
+								value: 'copy_code',
+							},
+							{
+								name: 'Flow',
+								value: 'flow',
+							},
 						],
 						default: 'quick_reply',
 					},
@@ -1407,6 +1415,14 @@ export const messageTypeFields: INodeProperties[] = [
 												name: 'Text',
 												value: 'text',
 											},
+											{
+												name: 'Coupon Code',
+												value: 'coupon_code',
+											},
+											{
+												name: 'Action',
+												value: 'action',
+											},
 										],
 										default: 'payload',
 									},
@@ -1428,6 +1444,28 @@ export const messageTypeFields: INodeProperties[] = [
 										displayOptions: {
 											show: {
 												type: ['text'],
+											},
+										},
+										default: '',
+									},
+									{
+										displayName: 'Coupon Code',
+										name: 'coupon_code',
+										type: 'string',
+										displayOptions: {
+											show: {
+												type: ['coupon_code'],
+											},
+										},
+										default: '',
+									},
+									{
+										displayName: 'Flow Token',
+										name: 'flowToken',
+										type: 'string',
+										displayOptions: {
+											show: {
+												type: ['action'],
 											},
 										},
 										default: '',
@@ -1476,6 +1514,14 @@ export const messageTypeFields: INodeProperties[] = [
 											{
 												name: 'Image',
 												value: 'image',
+											},
+											{
+												name: 'Video',
+												value: 'video',
+											},
+											{
+												name: 'Document',
+												value: 'document',
 											},
 										],
 										default: 'text',
@@ -1535,6 +1581,28 @@ export const messageTypeFields: INodeProperties[] = [
 										displayOptions: {
 											show: {
 												type: ['image'],
+											},
+										},
+										default: '',
+									},
+									{
+										displayName: 'Video Link',
+										name: 'videoLink',
+										type: 'string',
+										displayOptions: {
+											show: {
+												type: ['video'],
+											},
+										},
+										default: '',
+									},
+									{
+										displayName: 'Document Link',
+										name: 'documentLink',
+										type: 'string',
+										displayOptions: {
+											show: {
+												type: ['document'],
 											},
 										},
 										default: '',

--- a/packages/nodes-base/nodes/WhatsApp/__schema__/v1.0.0/message/send.json
+++ b/packages/nodes-base/nodes/WhatsApp/__schema__/v1.0.0/message/send.json
@@ -22,6 +22,9 @@
                 "properties": {
                     "id": {
                         "type": "string"
+                    },
+                    "message_status": {
+                        "type": "string"
                     }
                 }
             }

--- a/packages/nodes-base/nodes/WhatsApp/tests/utils.test.ts
+++ b/packages/nodes-base/nodes/WhatsApp/tests/utils.test.ts
@@ -1,8 +1,9 @@
 import type { IHttpRequestOptions } from 'n8n-workflow';
+import { NodeApiError } from 'n8n-workflow';
 
 import type { SendAndWaitConfig } from '../../../utils/sendAndWait/utils';
 import { createMessage, WHATSAPP_BASE_URL } from '../GenericFunctions';
-import { sanitizePhoneNumber } from '../MessageFunctions';
+import { componentsRequest, sanitizePhoneNumber, sendErrorPostReceive } from '../MessageFunctions';
 
 describe('sanitizePhoneNumber', () => {
 	const testNumber = '+99-(000)-111-2222';
@@ -104,5 +105,110 @@ describe('createMessage', () => {
 				to: recipientPhone,
 			},
 		});
+	});
+});
+
+describe('componentsRequest', () => {
+	it('maps new header and button parameter types for template components', async () => {
+		const mockContext = {
+			getNodeParameter: jest.fn().mockReturnValue({
+				component: [
+					{
+						type: 'header',
+						headerParameters: {
+							parameter: [
+								{ type: 'video', videoLink: 'https://cdn.example.com/video.mp4' },
+								{ type: 'document', documentLink: 'https://cdn.example.com/doc.pdf' },
+							],
+						},
+					},
+					{
+						type: 'button',
+						sub_type: 'copy_code',
+						index: 1,
+						buttonParameters: {
+							parameter: { type: 'coupon_code', coupon_code: 'SPRING26' },
+						},
+					},
+					{
+						type: 'button',
+						sub_type: 'flow',
+						index: 2,
+						buttonParameters: {
+							parameter: { type: 'action', flowToken: 'flow-token-123' },
+						},
+					},
+				],
+			}),
+		} as any;
+
+		const requestOptions: IHttpRequestOptions = { body: {} };
+
+		const result = await componentsRequest.call(mockContext, requestOptions);
+
+		expect(result.body).toEqual({
+			template: {
+				components: [
+					{
+						type: 'header',
+						parameters: [
+							{ type: 'video', video: { link: 'https://cdn.example.com/video.mp4' } },
+							{ type: 'document', document: { link: 'https://cdn.example.com/doc.pdf' } },
+						],
+					},
+					{
+						type: 'button',
+						sub_type: 'copy_code',
+						index: '1',
+						parameters: [{ type: 'coupon_code', coupon_code: 'SPRING26' }],
+					},
+					{
+						type: 'button',
+						sub_type: 'flow',
+						index: '2',
+						parameters: [{ type: 'action', action: { flow_token: 'flow-token-123' } }],
+					},
+				],
+			},
+		});
+	});
+});
+
+describe('sendErrorPostReceive', () => {
+	it('adds detailed metadata to invalid URL errors', async () => {
+		const mockContext = {
+			getNode: jest.fn().mockReturnValue({ name: 'WhatsApp' }),
+			getNodeParameter: jest.fn((name: string, fallbackValue?: unknown) => {
+				if (name === 'operation') return 'sendTemplate';
+				if (name === 'messageType') return 'image';
+				return fallbackValue;
+			}),
+		} as any;
+
+		const response = {
+			statusCode: 400,
+			body: {
+				error: {
+					message: '(#100) image link is not a valid URI.',
+					type: 'OAuthException',
+					code: 100,
+					fbtrace_id: 'ABC123',
+				},
+			},
+		} as any;
+
+		await expect(sendErrorPostReceive.call(mockContext, [], response)).rejects.toBeInstanceOf(
+			NodeApiError,
+		);
+
+		try {
+			await sendErrorPostReceive.call(mockContext, [], response);
+		} catch (error) {
+			const apiError = error as NodeApiError;
+			expect(apiError.message).toContain('Invalid image URL');
+			expect(apiError.description).toContain('Operation: sendTemplate');
+			expect(apiError.description).toContain('Error code: 100');
+			expect(apiError.description).toContain('FB trace ID: ABC123');
+		}
 	});
 });


### PR DESCRIPTION
## Summary
This PR updates the WhatsApp Business Cloud node to support newer template component variants and improves runtime error diagnostics when Meta API calls fail.

## Changes
- Add missing template component options in the node UI:
  - Button sub-types: `copy_code`, `flow`
  - Button parameter types: `coupon_code`, `action` (with flow token)
  - Header parameter types: `video`, `document`
- Extend component request mapping so new parameter types are serialized to WhatsApp API payloads correctly.
- Improve error details returned from `sendErrorPostReceive` by including:
  - HTTP status
  - operation
  - Meta error code/type
  - `fbtrace_id`
- Align send response schema with current WhatsApp responses by adding `message_status`.
- Add unit tests for:
  - new template component mappings
  - enhanced error context handling

## Notes
- Test execution in this environment is currently blocked by missing local dependencies (`jest` not found in `packages/nodes-base`).