### PR TITLE
fix(core): Use leaf-level scope check for OAuth2 cleanup (no-changelog)

### DIFF
--- a/packages/cli/src/oauth/__tests__/oauth.service.test.ts
+++ b/packages/cli/src/oauth/__tests__/oauth.service.test.ts
@@ -54,7 +54,7 @@ describe('OauthService', () => {
 	beforeEach(() => {
 		jest.setSystemTime(new Date(timestamp));
 		jest.clearAllMocks();
-		credentialsHelper.getParentTypes.mockReturnValue([]);
+		credentialsHelper.getCredentialsProperties.mockReturnValue([]);
 
 		globalConfig.endpoints = { rest: 'rest' } as any;
 		urlService.getInstanceBaseUrl.mockReturnValue('http://localhost:5678');
@@ -1131,32 +1131,6 @@ describe('OauthService', () => {
 			);
 		});
 
-		it('should not delete scope for credentials inheriting editable generic OAuth2 scope', async () => {
-			const credential = mock<CredentialsEntity>({
-				id: '1',
-				type: 'customOAuth2Api',
-			});
-			const mockDecryptedData = { clientId: 'client-id', scope: 'custom-scope' };
-			const mockOAuthCredentials = { clientId: 'client-id', scope: 'custom-scope' };
-			const mockAdditionalData = mock<IWorkflowExecuteAdditionalData>();
-
-			jest.mocked(WorkflowExecuteAdditionalData.getBase).mockResolvedValue(mockAdditionalData);
-			credentialsHelper.getDecrypted.mockResolvedValue(mockDecryptedData);
-			credentialsHelper.getParentTypes.mockReturnValue(['oAuth2Api']);
-			credentialsHelper.applyDefaultsAndOverwrites.mockResolvedValue(mockOAuthCredentials);
-
-			await service.getOAuthCredentials(credential);
-
-			expect(credentialsHelper.applyDefaultsAndOverwrites).toHaveBeenCalledWith(
-				mockAdditionalData,
-				{ clientId: 'client-id', scope: 'custom-scope' },
-				credential.type,
-				'internal',
-				undefined,
-				undefined,
-			);
-		});
-
 		it('should not delete scope for wordpressOAuth2Api credentials', async () => {
 			const credential = mock<CredentialsEntity>({
 				id: '1',
@@ -1200,6 +1174,90 @@ describe('OauthService', () => {
 			expect(credentialsHelper.applyDefaultsAndOverwrites).toHaveBeenCalledWith(
 				mockAdditionalData,
 				{ clientId: 'client-id', scope: 'old-scope' },
+				credential.type,
+				'internal',
+				undefined,
+				undefined,
+			);
+		});
+
+		it('should not delete scope when the credential inherits an editable scope property', async () => {
+			const credential = mock<CredentialsEntity>({
+				id: '1',
+				type: 'customOAuth2Api',
+			});
+			const mockDecryptedData = { clientId: 'client-id', scope: 'custom-scope' };
+			const mockOAuthCredentials = { clientId: 'client-id', scope: 'custom-scope' };
+			const mockAdditionalData = mock<IWorkflowExecuteAdditionalData>();
+
+			jest.mocked(WorkflowExecuteAdditionalData.getBase).mockResolvedValue(mockAdditionalData);
+			credentialsHelper.getDecrypted.mockResolvedValue(mockDecryptedData);
+			credentialsHelper.applyDefaultsAndOverwrites.mockResolvedValue(mockOAuthCredentials);
+			credentialsHelper.getCredentialsProperties.mockReturnValue([
+				{ displayName: 'Scope', name: 'scope', type: 'string', default: '' },
+			]);
+
+			await service.getOAuthCredentials(credential);
+
+			expect(credentialsHelper.applyDefaultsAndOverwrites).toHaveBeenCalledWith(
+				mockAdditionalData,
+				{ clientId: 'client-id', scope: 'custom-scope' },
+				credential.type,
+				'internal',
+				undefined,
+				undefined,
+			);
+		});
+
+		it('should delete scope when the credential overrides the inherited scope as hidden', async () => {
+			const credential = mock<CredentialsEntity>({
+				id: '1',
+				type: 'gmailOAuth2',
+			});
+			const mockDecryptedData = { clientId: 'client-id', scope: 'stale-scope' };
+			const mockOAuthCredentials = { clientId: 'client-id' };
+			const mockAdditionalData = mock<IWorkflowExecuteAdditionalData>();
+
+			jest.mocked(WorkflowExecuteAdditionalData.getBase).mockResolvedValue(mockAdditionalData);
+			credentialsHelper.getDecrypted.mockResolvedValue(mockDecryptedData);
+			credentialsHelper.applyDefaultsAndOverwrites.mockResolvedValue(mockOAuthCredentials);
+			credentialsHelper.getCredentialsProperties.mockReturnValue([
+				{ displayName: 'Scope', name: 'scope', type: 'hidden', default: 'default-scope' },
+			]);
+
+			await service.getOAuthCredentials(credential);
+
+			expect(credentialsHelper.applyDefaultsAndOverwrites).toHaveBeenCalledWith(
+				mockAdditionalData,
+				{ clientId: 'client-id' },
+				credential.type,
+				'internal',
+				undefined,
+				undefined,
+			);
+		});
+
+		it('should delete scope when getCredentialsProperties throws', async () => {
+			const credential = mock<CredentialsEntity>({
+				id: '1',
+				type: 'unknownOAuth2Api',
+			});
+			const mockDecryptedData = { clientId: 'client-id', scope: 'stale-scope' };
+			const mockOAuthCredentials = { clientId: 'client-id' };
+			const mockAdditionalData = mock<IWorkflowExecuteAdditionalData>();
+
+			jest.mocked(WorkflowExecuteAdditionalData.getBase).mockResolvedValue(mockAdditionalData);
+			credentialsHelper.getDecrypted.mockResolvedValue(mockDecryptedData);
+			credentialsHelper.applyDefaultsAndOverwrites.mockResolvedValue(mockOAuthCredentials);
+			credentialsHelper.getCredentialsProperties.mockImplementation(() => {
+				throw new Error('Unknown credential type');
+			});
+
+			await service.getOAuthCredentials(credential);
+
+			expect(credentialsHelper.applyDefaultsAndOverwrites).toHaveBeenCalledWith(
+				mockAdditionalData,
+				{ clientId: 'client-id' },
 				credential.type,
 				'internal',
 				undefined,

--- a/packages/cli/src/oauth/oauth.service.ts
+++ b/packages/cli/src/oauth/oauth.service.ts
@@ -342,19 +342,16 @@ export class OauthService {
 	async getOAuthCredentials<T>(credential: CredentialsEntity): Promise<T> {
 		const additionalData = await this.getAdditionalData();
 		const decryptedDataOriginal = await this.getDecryptedDataForAuthUri(credential, additionalData);
-		const parentTypes = this.credentialsHelper.getParentTypes(credential.type);
-		const hasEditableInheritedScope = parentTypes.some((parentType) =>
-			GENERIC_OAUTH2_CREDENTIALS_WITH_EDITABLE_SCOPE.includes(parentType),
-		);
 
 		// At some point in the past we saved hidden scopes to credentials (but shouldn't)
 		// Delete scope before applying defaults to make sure new scopes are present on reconnect
-		// Generic Oauth2 API is an exception because it needs to save the scope
+		// Skip the cleanup when the credential exposes scope as user-editable (directly or via
+		// inheritance) so that manually entered scopes survive reconnects.
 		if (
 			decryptedDataOriginal?.scope &&
 			credential.type.includes('OAuth2') &&
 			!GENERIC_OAUTH2_CREDENTIALS_WITH_EDITABLE_SCOPE.includes(credential.type) &&
-			!hasEditableInheritedScope
+			!this.hasEditableScopeProperty(credential.type)
 		) {
 			delete decryptedDataOriginal.scope;
 		}
@@ -366,6 +363,21 @@ export class OauthService {
 		);
 
 		return oauthCredentials;
+	}
+
+	/**
+	 * Checks whether the credential type (after merging inherited properties) exposes
+	 * a user-editable `scope` property. A property is considered editable when it is
+	 * defined and its `type` is not `'hidden'`.
+	 */
+	private hasEditableScopeProperty(credentialType: string): boolean {
+		try {
+			const properties = this.credentialsHelper.getCredentialsProperties(credentialType);
+			const scopeProperty = properties.find((property) => property.name === 'scope');
+			return scopeProperty !== undefined && scopeProperty.type !== 'hidden';
+		} catch {
+			return false;
+		}
 	}
 
 	async generateAOauth2AuthUri(


### PR DESCRIPTION
## Summary

Follow-up to #27858 that narrows the OAuth2 scope-preservation logic.

#27858 introduced a parent-based check: skip the pre-reconnect `scope` cleanup whenever any ancestor type is in `GENERIC_OAUTH2_CREDENTIALS_WITH_EDITABLE_SCOPE`. That signal is too broad — every Gmail / Slack / Discord / Google Drive / Microsoft Teams / etc. credential extends `oAuth2Api`, `googleOAuth2Api`, or `microsoftOAuth2Api`, but each of those leaves overrides `scope` as `type: 'hidden'`. After #27858, stale hidden scopes from older versions stop being cleaned up for ~95 built-in credentials, meaning they would not pick up updated default scopes on reconnect.

This PR replaces the parent walk with a leaf-level check on the merged credential properties: preserve the saved scope iff the credential's own (or inherited) `scope` property is *not* `type: 'hidden'`. 

| Case | Before #27858 | With #27858 | This PR |
|---|---|---|---|
| Custom credential `extends = ['oAuth2Api']`, no scope override (issue #27780) | wiped ❌ | preserved ✅ | preserved ✅ |
| `gmailOAuth2` (leaf scope `type: 'hidden'`) | cleaned ✅ | preserved ❌ | cleaned ✅ |
| `discordOAuth2Api` (leaf scope `type: 'hidden'` + expression) | cleaned ✅ | preserved ❌ | cleaned ✅ |
| `oAuth2Api`, `googleOAuth2Api`, … (allowlist) | preserved ✅ | preserved ✅ | preserved ✅ |

### How it works

`credentialsHelper.getCredentialsProperties(type)` returns properties merged across the `extends` chain (child overrides parent). The new `hasEditableScopeProperty()` helper finds the `scope` entry in that merged set and returns `true` iff it exists and its `type` is not `'hidden'`. The cleanup guard now uses that signal instead of the parent walk.

### Testing

Unit tests updated:
- `should not delete scope when the credential inherits an editable scope property` (custom type extending `oAuth2Api`, scope `type: 'string'`)
- `should delete scope when the credential overrides the inherited scope as hidden` (Gmail-shape regression guard)
- `should delete scope when getCredentialsProperties throws` (defensive fallback for unknown types)
- Existing allowlist and non-OAuth2 tests pass unchanged.

Manual verification with a community-style credential (`extends = ['oAuth2Api']`, no properties) against Entra ID:
- On `master`: auth URL has empty `scope` → `AADSTS900144`.
- On this branch: auth URL carries the user-entered scope.

## Related Linear tickets, Github issues, and Community forum posts

- GitHub issue: https://github.com/n8n-io/n8n/issues/27780
- Prior PR: https://github.com/n8n-io/n8n/pull/27858

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with Backport labels if needed.