### PR TITLE
fix(editor): Fix flaky SQL completions for quoted identifiers in mixed language parser (no-changelog)

### DIFF
--- a/packages/@n8n/codemirror-lang-sql/src/complete.ts
+++ b/packages/@n8n/codemirror-lang-sql/src/complete.ts
@@ -1,6 +1,6 @@
 import type { Completion, CompletionContext, CompletionSource } from '@codemirror/autocomplete';
 import { completeFromList, ifNotIn } from '@codemirror/autocomplete';
-import { syntaxTree } from '@codemirror/language';
+import { ensureSyntaxTree, syntaxTree } from '@codemirror/language';
 import type { EditorState, Text } from '@codemirror/state';
 import type { SyntaxNode } from '@lezer/common';
 
@@ -45,7 +45,10 @@ function parentsFor(doc: Text, node: SyntaxNode | null) {
 }
 
 function sourceContext(state: EditorState, startPos: number) {
-	const pos = syntaxTree(state).resolveInner(startPos, -1);
+	const pos = (ensureSyntaxTree(state, startPos, 50) ?? syntaxTree(state)).resolveInner(
+		startPos,
+		-1,
+	);
 	const aliases = getAliases(state.doc, pos);
 	if (pos.name === 'Identifier' || pos.name === 'QuotedIdentifier' || pos.name === 'Keyword') {
 		return {


### PR DESCRIPTION
## Summary

> [!NOTE]
> Flakiness Discovery done via manual analysis of failing [flaky CI](https://github.com/n8n-io/n8n/actions/runs/24688604432/job/72204902462#step:5:2203) . 
> Code Discovery work done via Claude, Verification done by human.

Fixes intermittent SQL completion failures for quoted schema/table identifiers (e.g. `\"public\".\"users\"`) in the n8n SQL editor.

TLDR; CI runs are slower and GC pauses & CPU contention reveal a race condition on completion data loading vs [allocated time for completion work to be finished](https://github.com/codemirror/language/blob/main/src/language.ts#L290).

### Root cause

The `@n8n/codemirror-lang-sql` package uses a mixed language parser — an n8n expression parser that wraps an inner SQL parser via Lezer's `parseMixed`. When `EditorState` initialises the language state, it runs up to 20ms of parse work. In CI environments with GC pauses or CPU contention, this budget is sometimes exceeded before the inner SQL overlay mounts are attached to the outer expression tree.

`LanguageState.tree` — what `syntaxTree(state)` reads — is a value captured at construction time and is never updated by later parse work. The `ensureSyntaxTree` call in the test was correctly completing the parse (updating `ParseContext.tree`), but `syntaxTree(state)` in `sourceContext` was still reading the stale `LanguageState.tree`, which lacked the inner SQL mounts. `resolveInner` on this incomplete tree returned the outer `Plaintext` node instead of the expected `.` SQL token, causing the completion source to return `null`.

### Fix

Replace `syntaxTree(state)` in `sourceContext` with `ensureSyntaxTree(state, startPos, 50) ?? syntaxTree(state)`. `ensureSyntaxTree` returns `ParseContext.tree` directly — always the complete tree once any prior `ensureSyntaxTree` call has finished — rather than the possibly-stale `LanguageState.tree`.

In the common production case (background parser already caught up), `isDone(startPos)` is immediately true and there is no additional work.

### Testing

The existing test suite in `packages/@n8n/codemirror-lang-sql/test/complete.test.ts` covers the failing scenarios. All 42 tests pass.

The specific failing tests were:
- `completes column names in quoted tables for a specific quoted schema`
- `completes quoted column names in quoted tables for a specific quoted schema`

Both failed on their second assertion (`\"other\".\"users\"`) when the initial 20ms parse budget was not met.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2896/reduce-flakiness-in-codemirror-completion-tests

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI