### PR TITLE
fix: Correctly rename all temporal binary files after execution

### DIFF
--- a/packages/cli/src/execution-lifecycle/__tests__/restore-binary-data-id.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/restore-binary-data-id.test.ts
@@ -186,6 +186,110 @@ for (const mode of ['filesystem', 's3'] as const) {
 
 			expect(binaryDataService.rename).toHaveBeenCalled();
 		});
+
+		it('should restore all binary fields in a single item', async () => {
+			const workflowId = '6HYhhKmJch2cYxGj';
+			const executionId = '999';
+			const uuid1 = 'a5c3f1ed-9d59-4155-bc68-9a370b3c51f6';
+			const uuid2 = 'b6d4e2fe-0e6a-5266-cd79-ab481c4d62g7';
+
+			const incorrectFileId1 = `workflows/${workflowId}/executions/temp/binary_data/${uuid1}`;
+			const incorrectFileId2 = `workflows/${workflowId}/executions/temp/binary_data/${uuid2}`;
+
+			const run = toIRun({
+				binary: {
+					field1: { id: `s3:${incorrectFileId1}` },
+					field2: { id: `s3:${incorrectFileId2}` },
+				},
+			});
+
+			await restoreBinaryDataId(run, executionId, 'webhook');
+
+			expect(binaryDataService.rename).toHaveBeenCalledWith(
+				incorrectFileId1,
+				incorrectFileId1.replace('temp', executionId),
+			);
+			expect(binaryDataService.rename).toHaveBeenCalledWith(
+				incorrectFileId2,
+				incorrectFileId2.replace('temp', executionId),
+			);
+		});
+
+		it('should restore binary fields across multiple items', async () => {
+			const workflowId = '6HYhhKmJch2cYxGj';
+			const executionId = '999';
+			const uuid1 = 'a5c3f1ed-9d59-4155-bc68-9a370b3c51f6';
+			const uuid2 = 'b6d4e2fe-0e6a-5266-cd79-ab481c4d62g7';
+
+			const incorrectFileId1 = `workflows/${workflowId}/executions/temp/binary_data/${uuid1}`;
+			const incorrectFileId2 = `workflows/${workflowId}/executions/temp/binary_data/${uuid2}`;
+
+			const run = {
+				data: {
+					resultData: {
+						runData: {
+							myNode: [
+								{
+									data: {
+										main: [
+											[
+												{ binary: { data: { id: `s3:${incorrectFileId1}` } } },
+												{ binary: { data: { id: `s3:${incorrectFileId2}` } } },
+											],
+										],
+									},
+								},
+							],
+						},
+					},
+				},
+			} as unknown as IRun;
+
+			await restoreBinaryDataId(run, executionId, 'webhook');
+
+			expect(binaryDataService.rename).toHaveBeenCalledWith(
+				incorrectFileId1,
+				incorrectFileId1.replace('temp', executionId),
+			);
+			expect(binaryDataService.rename).toHaveBeenCalledWith(
+				incorrectFileId2,
+				incorrectFileId2.replace('temp', executionId),
+			);
+		});
+
+		it('should restore binary fields across multiple node runs', async () => {
+			const workflowId = '6HYhhKmJch2cYxGj';
+			const executionId = '999';
+			const uuid1 = 'a5c3f1ed-9d59-4155-bc68-9a370b3c51f6';
+			const uuid2 = 'b6d4e2fe-0e6a-5266-cd79-ab481c4d62g7';
+
+			const incorrectFileId1 = `workflows/${workflowId}/executions/temp/binary_data/${uuid1}`;
+			const incorrectFileId2 = `workflows/${workflowId}/executions/temp/binary_data/${uuid2}`;
+
+			const run = {
+				data: {
+					resultData: {
+						runData: {
+							myNode: [
+								{ data: { main: [[{ binary: { data: { id: `s3:${incorrectFileId1}` } } }]] } },
+								{ data: { main: [[{ binary: { data: { id: `s3:${incorrectFileId2}` } } }]] } },
+							],
+						},
+					},
+				},
+			} as unknown as IRun;
+
+			await restoreBinaryDataId(run, executionId, 'webhook');
+
+			expect(binaryDataService.rename).toHaveBeenCalledWith(
+				incorrectFileId1,
+				incorrectFileId1.replace('temp', executionId),
+			);
+			expect(binaryDataService.rename).toHaveBeenCalledWith(
+				incorrectFileId2,
+				incorrectFileId2.replace('temp', executionId),
+			);
+		});
 	});
 }
 

--- a/packages/cli/src/execution-lifecycle/restore-binary-data-id.ts
+++ b/packages/cli/src/execution-lifecycle/restore-binary-data-id.ts
@@ -2,7 +2,7 @@ import { Logger } from '@n8n/backend-common';
 import { Container } from '@n8n/di';
 import type { BinaryData } from 'n8n-core';
 import { BinaryDataConfig, BinaryDataService } from 'n8n-core';
-import type { IRun, WorkflowExecuteMode } from 'n8n-workflow';
+import type { IBinaryData, IRun, WorkflowExecuteMode } from 'n8n-workflow';
 
 /**
  * Whenever the execution ID is not available to the binary data service at the
@@ -20,6 +20,47 @@ import type { IRun, WorkflowExecuteMode } from 'n8n-workflow';
  * s3:workflows/123/executions/390/binary_data/69055-83c4-4493-876a-9092c4708b9b
  * ```
  */
+type RenameEntry = {
+	binaryDataRefs: IBinaryData[];
+	mode: BinaryData.StoredMode;
+	fileId: string;
+	correctFileId: string;
+};
+
+function collectRenameEntries(run: IRun, executionId: string): RenameEntry[] {
+	const entriesByFileId = new Map<string, RenameEntry>();
+
+	for (const nodeRuns of Object.values(run.data.resultData.runData)) {
+		for (const nodeRun of nodeRuns ?? []) {
+			for (const outputs of nodeRun.data?.main ?? []) {
+				for (const item of outputs ?? []) {
+					for (const binaryData of Object.values(item?.binary ?? {})) {
+						const binaryDataId = binaryData?.id;
+						if (!binaryDataId) continue;
+
+						const [mode, fileId] = binaryDataId.split(':') as [BinaryData.StoredMode, string];
+						if (!fileId.includes('/temp/')) continue;
+
+						const existing = entriesByFileId.get(fileId);
+						if (existing) {
+							existing.binaryDataRefs.push(binaryData);
+						} else {
+							entriesByFileId.set(fileId, {
+								binaryDataRefs: [binaryData],
+								mode,
+								fileId,
+								correctFileId: fileId.replace('temp', executionId),
+							});
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return [...entriesByFileId.values()];
+}
+
 export async function restoreBinaryDataId(
 	run: IRun,
 	executionId: string,
@@ -30,34 +71,20 @@ export async function restoreBinaryDataId(
 	}
 
 	try {
-		const { runData } = run.data.resultData;
+		const entries = collectRenameEntries(run, executionId);
 
-		const promises = Object.keys(runData).map(async (nodeName) => {
-			const binaryObj = runData[nodeName]?.[0]?.data?.main?.[0]?.[0]?.binary;
-			if (!binaryObj) return;
+		await Promise.all(
+			entries.map(
+				async ({ fileId, correctFileId }) =>
+					await Container.get(BinaryDataService).rename(fileId, correctFileId),
+			),
+		);
 
-			const binaryData = Object.values(binaryObj)[0];
-			if (!binaryData) return;
-
-			const binaryDataId = binaryData.id;
-			if (!binaryDataId) return;
-
-			const [mode, fileId] = binaryDataId.split(':') as [BinaryData.StoredMode, string];
-
-			const isMissingExecutionId = fileId.includes('/temp/');
-
-			if (!isMissingExecutionId) return;
-
-			const correctFileId = fileId.replace('temp', executionId);
-
-			await Container.get(BinaryDataService).rename(fileId, correctFileId);
-
-			const correctBinaryDataId = `${mode}:${correctFileId}`;
-
-			binaryData.id = correctBinaryDataId;
-		});
-
-		await Promise.all(promises);
+		for (const { binaryDataRefs, mode, correctFileId } of entries) {
+			for (const binaryData of binaryDataRefs) {
+				binaryData.id = `${mode}:${correctFileId}`;
+			}
+		}
 	} catch (e) {
 		const error = e instanceof Error ? e : new Error(`${e}`);
 		const logger = Container.get(Logger);


### PR DESCRIPTION
## Summary

Fixes moving and updating file names from temp to correct names.
- Iterates over all nodes, outputs and items to find files to rename
- Uses a map to not include duplicates which causes an exception - this was the case when one file was passed through multiple nodes

To test use following workflow, publish it, open the published form and upload two files. Then go to execution tab and observe each nodes binary output -> click on view file -> some of them will be empty in current implementation and all are visible in the fixed version. Note that it's not only UI bug, so the files will be missing on executions on old code

```json
{
  "nodes": [
    {
      "parameters": {
        "formTitle": "test",
        "formFields": {
          "values": [
            {
              "fieldLabel": "image 1",
              "fieldType": "file"
            },
            {
              "fieldLabel": "image 2",
              "fieldType": "file"
            }
          ]
        },
        "options": {}
      },
      "type": "n8n-nodes-base.formTrigger",
      "typeVersion": 2.5,
      "position": [
        0,
        0
      ],
      "id": "b93b82ec-28ca-4932-9773-fbad2172c508",
      "name": "On form submission",
      "webhookId": "4ed531a1-6c45-42dc-bee4-80a70b7f9196"
    },
    {
      "parameters": {
        "operation": "resize",
        "dataPropertyName": "image",
        "options": {}
      },
      "type": "n8n-nodes-base.editImage",
      "typeVersion": 1,
      "position": [
        416,
        0
      ],
      "id": "79d146e2-b11b-45e7-8c8d-4c5fc09ba96b",
      "name": "Edit Image"
    },
    {
      "parameters": {
        "jsCode": "\nreturn [{binary: {image: $input.first().binary[\"image_1\"]}}, {binary: {image: $input.first().binary[\"image_2\"]}}];"
      },
      "type": "n8n-nodes-base.code",
      "typeVersion": 2,
      "position": [
        208,
        0
      ],
      "id": "b5eea589-9f05-40e2-be6e-9c5bca63195a",
      "name": "Code in JavaScript"
    },
    {
      "parameters": {
        "operation": "blur",
        "dataPropertyName": "image",
        "options": {}
      },
      "type": "n8n-nodes-base.editImage",
      "typeVersion": 1,
      "position": [
        624,
        0
      ],
      "id": "6a2bd80c-d879-4c23-b17d-52a4448d8c17",
      "name": "Edit Image1"
    }
  ],
  "connections": {
    "On form submission": {
      "main": [
        [
          {
            "node": "Code in JavaScript",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Edit Image": {
      "main": [
        [
          {
            "node": "Edit Image1",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Code in JavaScript": {
      "main": [
        [
          {
            "node": "Edit Image",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "acd7615bcc3af421bbd7517e305cc16505176a6a47045dbe39e25d904c940573"
  }
}
```

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-4594
- Most likely fixes https://linear.app/n8n/issue/ADO-4925
- fixes #24298


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
