### PR TITLE
test: Retry SSE webhook setup on 404

### DIFF
--- a/packages/testing/playwright/services/mcp-api-helper.ts
+++ b/packages/testing/playwright/services/mcp-api-helper.ts
@@ -177,6 +177,29 @@ export class McpApiHelper {
 	 */
 	async sseSetup(
 		path: string,
+		options?: {
+			headers?: Record<string, string>;
+			maxNotFoundRetries?: number;
+			notFoundRetryDelayMs?: number;
+		},
+	): Promise<McpSession> {
+		const maxNotFoundRetries = options?.maxNotFoundRetries ?? 5;
+		const notFoundRetryDelayMs = options?.notFoundRetryDelayMs ?? 500;
+
+		for (let attempt = 0; attempt <= maxNotFoundRetries; attempt++) {
+			try {
+				return await this.attemptSseSetup(path, options);
+			} catch (error) {
+				const isNotFound = error instanceof Error && 'isSseNotFound' in error;
+				if (!isNotFound || attempt === maxNotFoundRetries) throw error;
+				await new Promise((resolve) => setTimeout(resolve, notFoundRetryDelayMs));
+			}
+		}
+		throw new Error('SSE setup: retry loop exhausted');
+	}
+
+	private async attemptSseSetup(
+		path: string,
 		options?: { headers?: Record<string, string> },
 	): Promise<McpSession> {
 		// Get base URL and auth cookie from Playwright context
@@ -216,6 +239,17 @@ export class McpApiHelper {
 					headers,
 				},
 				(res) => {
+					if (res.statusCode === 404) {
+						res.resume();
+						clearTimeout(timeout);
+						const notFound = new Error(`SSE setup got 404 for ${path}`) as Error & {
+							isSseNotFound: true;
+						};
+						notFound.isSseNotFound = true;
+						reject(notFound);
+						return;
+					}
+
 					let buffer = '';
 					let resolved = false;
 

--- a/packages/testing/playwright/services/mcp-api-helper.ts
+++ b/packages/testing/playwright/services/mcp-api-helper.ts
@@ -197,6 +197,7 @@ export class McpApiHelper {
 				await wait(notFoundRetryDelayMs);
 			}
 		}
+		// unreachable: the catch above rethrows on the final attempt. Here to satisfy TS.
 		throw new Error('SSE setup: retry loop exhausted');
 	}
 

--- a/packages/testing/playwright/services/mcp-api-helper.ts
+++ b/packages/testing/playwright/services/mcp-api-helper.ts
@@ -2,6 +2,7 @@ import type { APIResponse } from '@playwright/test';
 import * as http from 'http';
 import * as https from 'https';
 import { nanoid } from 'nanoid';
+import { setTimeout as wait } from 'node:timers/promises';
 
 import type { ApiHelpers } from './api-helper';
 import { N8N_AUTH_COOKIE } from '../config/constants';
@@ -192,7 +193,7 @@ export class McpApiHelper {
 			} catch (error) {
 				const isNotFound = error instanceof Error && 'isSseNotFound' in error;
 				if (!isNotFound || attempt === maxNotFoundRetries) throw error;
-				await new Promise((resolve) => setTimeout(resolve, notFoundRetryDelayMs));
+				await wait(notFoundRetryDelayMs);
 			}
 		}
 		throw new Error('SSE setup: retry loop exhausted');

--- a/packages/testing/playwright/services/mcp-api-helper.ts
+++ b/packages/testing/playwright/services/mcp-api-helper.ts
@@ -9,6 +9,8 @@ import { N8N_AUTH_COOKIE } from '../config/constants';
 
 type HttpMethod = 'GET' | 'POST' | 'DELETE';
 
+class SseNotFoundError extends Error {}
+
 interface SseConnection {
 	sessionId: string;
 	postUrl: string;
@@ -191,8 +193,7 @@ export class McpApiHelper {
 			try {
 				return await this.attemptSseSetup(path, options);
 			} catch (error) {
-				const isNotFound = error instanceof Error && 'isSseNotFound' in error;
-				if (!isNotFound || attempt === maxNotFoundRetries) throw error;
+				if (!(error instanceof SseNotFoundError) || attempt === maxNotFoundRetries) throw error;
 				await wait(notFoundRetryDelayMs);
 			}
 		}
@@ -243,11 +244,7 @@ export class McpApiHelper {
 					if (res.statusCode === 404) {
 						res.resume();
 						clearTimeout(timeout);
-						const notFound = new Error(`SSE setup got 404 for ${path}`) as Error & {
-							isSseNotFound: true;
-						};
-						notFound.isSseNotFound = true;
-						reject(notFound);
+						reject(new SseNotFoundError(`SSE setup got 404 for ${path}`));
 						return;
 					}
 

--- a/packages/testing/playwright/services/mcp-api-helper.ts
+++ b/packages/testing/playwright/services/mcp-api-helper.ts
@@ -243,6 +243,7 @@ export class McpApiHelper {
 				},
 				(res) => {
 					if (res.statusCode === 404) {
+						// Drain the response so the socket is released back to the pool across retries.
 						res.resume();
 						clearTimeout(timeout);
 						reject(new SseNotFoundError(`SSE setup got 404 for ${path}`));


### PR DESCRIPTION
`Test: E2E VM Expressions Nightly` failed 13 of 15 recent runs with isolated expressions, consistently on `mcp-trigger.spec.ts` specifically the SSE transport tests.

This is because there's a race between workflow activation and the first request that hits the webhook. In multi-main mode, a request to `/rest/workflows/:id/activate` causes themain that receives it to publish a message to the leader over Redis. The leader then evaluates the webhook's path expressions and insert the webhook in the DB.

In the legacy expression engine, expression evaluation is sub-ms, so the leader almost always wins the race. But in the `vm` engine, that same evaluation means acquiring a V8 isolate bridge and having each `$parameter["path"]` etc. lookup cross the isolate boundary via a callback back to Node. This is much slower, consistently enough for the test client to beat the leader, so the client gets a 404. 

The fix mirrors the same retry loop into `sseSetup`. But importantly, the activation race remains regardless of expression engine. The `vm` engine just widens the window enough to expose it. A deeper fix is architectural and should be tackled separately.

- [x] I have seen this code, I have run this code, and I take responsibility for this code.