### PR TITLE
ci: Fix urlencoding in set-latest ci script

### DIFF
--- a/.github/scripts/set-latest-for-monorepo-packages.mjs
+++ b/.github/scripts/set-latest-for-monorepo-packages.mjs
@@ -9,8 +9,8 @@ const NPM_REGISTRY = 'https://registry.npmjs.org';
  * @param {string} token
  */
 async function setDistTag(name, version, tag, token) {
-	// Scoped package names need the slash encoded (e.g. @n8n/foo → @n8n%2ffoo)
-	const encodedName = name.replace('/', '%2f');
+	// Scoped package names need both @ and / encoded (e.g. @n8n/foo → %40n8n%2ffoo)
+	const encodedName = encodeURIComponent(name);
 	const url = `${NPM_REGISTRY}/-/package/${encodedName}/dist-tags/${tag}`;
 
 	return fetch(url, {
@@ -33,6 +33,7 @@ async function setLatestForMonorepoPackages() {
 
 	const publishedPackages = packages //
 		.filter((pkg) => !pkg.private)
+		.filter((pkg) => pkg.name.startsWith('@n8n'))
 		.filter((pkg) => pkg.version);
 
 	const failures = [];

--- a/.github/scripts/set-latest-for-monorepo-packages.mjs
+++ b/.github/scripts/set-latest-for-monorepo-packages.mjs
@@ -33,7 +33,7 @@ async function setLatestForMonorepoPackages() {
 
 	const publishedPackages = packages //
 		.filter((pkg) => !pkg.private)
-		.filter((pkg) => pkg.name.startsWith('@n8n'))
+		.filter((pkg) => pkg.name.startsWith('@n8n/'))
 		.filter((pkg) => pkg.version);
 
 	const failures = [];


### PR DESCRIPTION
## Summary

Followup on [this](https://github.com/n8n-io/n8n/pull/28898). Fixes urlencoding in requests and only targets `@n8n` packages 

## Related Linear tickets, Github issues, and Community forum posts

[Fixes issues in release to stable processes](https://github.com/n8n-io/n8n/actions/runs/24826109637/job/72666532092#step:4:12)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
