### PR TITLE
fix(core): Persist execution context before writing to db

### DIFF
--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -739,7 +739,7 @@ describe('pre-persist context establishment', () => {
 
 		expect(capturedAddData).toBeDefined();
 		const stack = capturedAddData!.executionData!.executionData!.nodeExecutionStack;
-		expect(stack[0].data.main[0][0].json).toMatchObject({
+		expect(stack[0].data.main[0]![0].json).toMatchObject({
 			headers: { authorization: '**********' },
 		});
 		expect(capturedAddData!.executionData!.executionData!.runtimeData).toBeDefined();

--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -16,6 +16,7 @@ import {
 	type IExecuteData,
 	type INode,
 	type IRun,
+	type IRunExecutionData,
 	type ITaskData,
 	type IWaitingForExecution,
 	type IWaitingForExecutionSource,
@@ -23,9 +24,11 @@ import {
 	type IWorkflowExecutionDataProcess,
 	type StartNodeData,
 	type IWorkflowExecuteAdditionalData,
+	type WorkflowExecuteMode,
 	Workflow,
 	ExecutionError,
 	TimeoutExecutionCancelledError,
+	createRunExecutionData,
 } from 'n8n-workflow';
 import PCancelable from 'p-cancelable';
 
@@ -627,6 +630,131 @@ describe('needsFullExecutionData', () => {
 		const result = runner.needsFullExecutionData('integrated', 'exec-id', undefined);
 
 		expect(result).toBe(true);
+	});
+});
+
+describe('pre-persist context establishment', () => {
+	const callOrder: string[] = [];
+	let establishSpy: jest.SpyInstance;
+	let addSpy: jest.SpyInstance;
+	let capturedAddData: IWorkflowExecutionDataProcess | undefined;
+
+	const buildRunData = (
+		executionData: IRunExecutionData | undefined,
+		executionMode: WorkflowExecuteMode = 'webhook',
+	): IWorkflowExecutionDataProcess =>
+		mock<IWorkflowExecutionDataProcess>({
+			executionMode,
+			workflowData: {
+				id: 'wf-1',
+				name: 'Test',
+				nodes: [],
+				connections: {},
+				settings: undefined,
+			},
+			executionData,
+			userId: 'u1',
+		});
+
+	const buildExecutionDataWithHeader = (): IRunExecutionData =>
+		createRunExecutionData({
+			executionData: {
+				contextData: {},
+				nodeExecutionStack: [
+					{
+						node: {
+							id: 'n1',
+							name: 'Webhook',
+							type: 'n8n-nodes-base.webhook',
+							typeVersion: 2,
+							position: [0, 0],
+							parameters: {},
+						},
+						data: {
+							main: [[{ json: { headers: { authorization: 'Bearer eyJtest' } } }]],
+						},
+						source: null,
+					},
+				],
+				metadata: {},
+				waitingExecution: {},
+				waitingExecutionSource: {},
+			},
+		});
+
+	beforeEach(() => {
+		callOrder.length = 0;
+		capturedAddData = undefined;
+
+		const permissionChecker = Container.get(CredentialsPermissionChecker);
+		jest.spyOn(permissionChecker, 'check').mockResolvedValue();
+
+		const mockAdditionalData = mock<IWorkflowExecuteAdditionalData>();
+		jest.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(mockAdditionalData);
+
+		establishSpy = jest
+			.spyOn(core, 'establishExecutionContext')
+			.mockImplementation(async (_workflow, runExecutionData) => {
+				callOrder.push('establishExecutionContext');
+				// Simulate real behaviour: mask header, set runtimeData.
+				const stack = runExecutionData.executionData?.nodeExecutionStack;
+				const item = stack?.[0]?.data?.main?.[0]?.[0];
+				const headers = item && (item.json as { headers?: Record<string, string> }).headers;
+				if (headers && typeof headers.authorization === 'string') {
+					headers.authorization = '**********';
+				}
+				if (runExecutionData.executionData) {
+					(runExecutionData.executionData as { runtimeData?: unknown }).runtimeData = {
+						version: 1,
+						establishedAt: Date.now(),
+						source: 'webhook',
+					};
+				}
+			});
+
+		const activeExecutions = Container.get(ActiveExecutions);
+		addSpy = jest
+			.spyOn(activeExecutions, 'add')
+			.mockImplementation(async (data: IWorkflowExecutionDataProcess) => {
+				capturedAddData = data;
+				callOrder.push('activeExecutions.add');
+				throw new Error('short-circuit for test');
+			});
+	});
+
+	afterEach(() => {
+		establishSpy.mockRestore();
+		addSpy.mockRestore();
+	});
+
+	it('calls establishExecutionContext before activeExecutions.add', async () => {
+		const data = buildRunData(buildExecutionDataWithHeader());
+
+		await expect(runner.run(data)).rejects.toThrow('short-circuit for test');
+
+		expect(callOrder).toEqual(['establishExecutionContext', 'activeExecutions.add']);
+	});
+
+	it('passes masked executionData to activeExecutions.add', async () => {
+		const data = buildRunData(buildExecutionDataWithHeader());
+
+		await expect(runner.run(data)).rejects.toThrow('short-circuit for test');
+
+		expect(capturedAddData).toBeDefined();
+		const stack = capturedAddData!.executionData!.executionData!.nodeExecutionStack;
+		expect(stack[0].data.main[0][0].json).toMatchObject({
+			headers: { authorization: '**********' },
+		});
+		expect(capturedAddData!.executionData!.executionData!.runtimeData).toBeDefined();
+	});
+
+	it('skips establishExecutionContext when data.executionData is undefined', async () => {
+		const data = buildRunData(undefined);
+
+		await expect(runner.run(data)).rejects.toThrow('short-circuit for test');
+
+		expect(establishSpy).not.toHaveBeenCalled();
+		expect(callOrder).toEqual(['activeExecutions.add']);
 	});
 });
 

--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -689,9 +689,6 @@ describe('pre-persist context establishment', () => {
 		const permissionChecker = Container.get(CredentialsPermissionChecker);
 		jest.spyOn(permissionChecker, 'check').mockResolvedValue();
 
-		const mockAdditionalData = mock<IWorkflowExecuteAdditionalData>();
-		jest.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(mockAdditionalData);
-
 		establishSpy = jest
 			.spyOn(core, 'establishExecutionContext')
 			.mockImplementation(async (_workflow, runExecutionData) => {

--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -767,6 +767,66 @@ describe('pre-persist context establishment', () => {
 		expect(establishSpy).not.toHaveBeenCalled();
 		expect(callOrder).toEqual(['activeExecutions.add']);
 	});
+
+	describe('when establishExecutionContext throws', () => {
+		const lifecycleRunHook = jest.fn().mockResolvedValue(undefined);
+		const responseReject = jest.fn();
+
+		beforeEach(() => {
+			establishSpy.mockReset();
+			establishSpy.mockImplementation(async () => {
+				callOrder.push('establishExecutionContext');
+				throw new Error('hook augmentation failed');
+			});
+
+			addSpy.mockReset();
+			addSpy.mockImplementation(async (data: IWorkflowExecutionDataProcess) => {
+				capturedAddData = data;
+				callOrder.push('activeExecutions.add');
+				return 'exec-1';
+			});
+
+			lifecycleRunHook.mockClear();
+			responseReject.mockClear();
+			jest
+				.spyOn(ExecutionLifecycleHooks, 'getLifecycleHooksForRegularMain')
+				.mockReturnValue(mock<core.ExecutionLifecycleHooks>({ runHook: lifecycleRunHook }));
+			jest.spyOn(Container.get(ActiveExecutions), 'finalizeExecution').mockReturnValue();
+		});
+
+		it('clears the trigger-item stack so raw headers do not get persisted', async () => {
+			const data = buildRunData(buildExecutionDataWithHeader());
+
+			await runner.run(data, undefined, undefined, undefined, {
+				reject: responseReject,
+				resolve: jest.fn(),
+				promise: Promise.resolve() as never,
+			} as never);
+
+			expect(capturedAddData).toBeDefined();
+			expect(capturedAddData!.executionData!.executionData!.nodeExecutionStack).toEqual([]);
+		});
+
+		it('creates a failed-execution record and rejects the responsePromise', async () => {
+			const data = buildRunData(buildExecutionDataWithHeader());
+
+			const executionId = await runner.run(data, undefined, undefined, undefined, {
+				reject: responseReject,
+				resolve: jest.fn(),
+				promise: Promise.resolve() as never,
+			} as never);
+
+			expect(executionId).toBe('exec-1');
+			expect(lifecycleRunHook).toHaveBeenCalledWith('workflowExecuteBefore', [
+				undefined,
+				data.executionData,
+			]);
+			expect(lifecycleRunHook).toHaveBeenCalledWith('workflowExecuteAfter', [expect.any(Object)]);
+			expect(responseReject).toHaveBeenCalledWith(
+				expect.objectContaining({ message: 'hook augmentation failed' }),
+			);
+		});
+	});
 });
 
 describe('streaming functionality', () => {

--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -753,6 +753,20 @@ describe('pre-persist context establishment', () => {
 		expect(establishSpy).not.toHaveBeenCalled();
 		expect(callOrder).toEqual(['activeExecutions.add']);
 	});
+
+	it('skips establishExecutionContext when nodeExecutionStack has not been populated yet', async () => {
+		// Queue mode with OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS=true creates
+		// the outer IRunExecutionData with `executionData: null`, which
+		// `createRunExecutionData` normalises to an object whose inner
+		// `.executionData` is undefined. The worker establishes context
+		// later, once it populates the trigger-item stack.
+		const data = buildRunData(createRunExecutionData({ executionData: null }), 'manual');
+
+		await expect(runner.run(data)).rejects.toThrow('short-circuit for test');
+
+		expect(establishSpy).not.toHaveBeenCalled();
+		expect(callOrder).toEqual(['activeExecutions.add']);
+	});
 });
 
 describe('streaming functionality', () => {

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -18,6 +18,7 @@ import type {
 	ExecutionError,
 	IDeferredPromise,
 	IExecuteResponsePromiseData,
+	INode,
 	IPinData,
 	IRun,
 	WorkflowExecuteMode,
@@ -156,6 +157,28 @@ export class WorkflowRunner {
 		await hooks?.runHook('workflowExecuteAfter', [fullRunData]);
 	}
 
+	/**
+	 * Persist a failed execution record for an already-registered execution and
+	 * finalize it, so a pre-flight failure surfaces as a normal failed run.
+	 */
+	private async failExecution(
+		data: IWorkflowExecutionDataProcess,
+		executionId: string,
+		error: ExecutionError & { node?: INode },
+		responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>,
+	): Promise<void> {
+		const runData = this.failedRunFactory.generateFailedExecutionFromError(
+			data.executionMode,
+			error,
+			error.node,
+		);
+		const lifecycleHooks = getLifecycleHooksForRegularMain(data, executionId);
+		await lifecycleHooks.runHook('workflowExecuteBefore', [undefined, data.executionData]);
+		await lifecycleHooks.runHook('workflowExecuteAfter', [runData]);
+		responsePromise?.reject(error);
+		this.activeExecutions.finalizeExecution(executionId);
+	}
+
 	/** Run the workflow
 	 * @param realtime This is used in queue mode to change the priority of an execution, making sure they are picked up quicker.
 	 */
@@ -166,6 +189,9 @@ export class WorkflowRunner {
 		restartExecutionId?: string,
 		responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>,
 	): Promise<string> {
+		// Register a new execution
+		const executionId = await this.activeExecutions.add(data, restartExecutionId);
+
 		// Establish the execution context before persisting to the DB.
 		// activeExecutions.add() -> executionPersistence.create() writes
 		// data.executionData to the DB; any header masking or runtimeData
@@ -177,6 +203,7 @@ export class WorkflowRunner {
 		// the outer IRunExecutionData is created with `executionData: null`
 		// so the trigger-item stack is undefined here; nothing to mask yet,
 		// the worker will establish context once it populates the stack.
+
 		if (data.executionData?.executionData) {
 			// Deliberately lightweight: no pinData, no staticData loading,
 			// no additionalData. establishExecutionContext only needs the
@@ -193,33 +220,29 @@ export class WorkflowRunner {
 				staticData: data.workflowData.staticData,
 				settings: data.workflowData.settings ?? {},
 			});
-			await establishExecutionContext(
-				contextWorkflow,
-				data.executionData,
-				undefined,
-				data.executionMode,
-			);
+			try {
+				await establishExecutionContext(
+					contextWorkflow,
+					data.executionData,
+					undefined,
+					data.executionMode,
+				);
+			} catch (error) {
+				// Masking may have failed partway through, so the trigger-item
+				// stack can still contain raw header data. Drop it before
+				// activeExecutions.add() persists the execution row.
+				data.executionData.executionData.nodeExecutionStack = [];
+				await this.failExecution(data, executionId, error, responsePromise);
+				return executionId;
+			}
 		}
-
-		// Register a new execution
-		const executionId = await this.activeExecutions.add(data, restartExecutionId);
 
 		const { id: workflowId, nodes } = data.workflowData;
 
 		try {
 			await this.credentialsPermissionChecker.check(workflowId, nodes);
 		} catch (error) {
-			// Create a failed execution with the data for the node, save it and abort execution
-			const runData = this.failedRunFactory.generateFailedExecutionFromError(
-				data.executionMode,
-				error,
-				error.node,
-			);
-			const lifecycleHooks = getLifecycleHooksForRegularMain(data, executionId);
-			await lifecycleHooks.runHook('workflowExecuteBefore', [undefined, data.executionData]);
-			await lifecycleHooks.runHook('workflowExecuteAfter', [runData]);
-			responsePromise?.reject(error);
-			this.activeExecutions.finalizeExecution(executionId);
+			await this.failExecution(data, executionId, error, responsePromise);
 			return executionId;
 		}
 

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -173,7 +173,11 @@ export class WorkflowRunner {
 		// does not contain raw trigger-item data (e.g. Authorization headers).
 		// The runtimeData early-exit guard in establishExecutionContext keeps
 		// the subsequent worker-side call at workflow-execute.ts idempotent.
-		if (data.executionData) {
+		// Guard on the inner executionData: in queue mode with manual offload
+		// the outer IRunExecutionData is created with `executionData: null`
+		// so the trigger-item stack is undefined here; nothing to mask yet,
+		// the worker will establish context once it populates the stack.
+		if (data.executionData?.executionData) {
 			// Deliberately lightweight: no pinData, no staticData loading,
 			// no additionalData. establishExecutionContext only needs the
 			// workflow's settings (for redactionPolicy) and node lookups.

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -7,7 +7,13 @@ import { ExecutionsConfig } from '@n8n/config';
 import { ExecutionRepository } from '@n8n/db';
 import { Container, Service } from '@n8n/di';
 import type { ExecutionLifecycleHooks } from 'n8n-core';
-import { ErrorReporter, InstanceSettings, StorageConfig, WorkflowExecute } from 'n8n-core';
+import {
+	ErrorReporter,
+	establishExecutionContext,
+	InstanceSettings,
+	StorageConfig,
+	WorkflowExecute,
+} from 'n8n-core';
 import type {
 	ExecutionError,
 	IDeferredPromise,
@@ -160,6 +166,38 @@ export class WorkflowRunner {
 		restartExecutionId?: string,
 		responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>,
 	): Promise<string> {
+		// Establish the execution context before persisting to the DB.
+		// activeExecutions.add() -> executionPersistence.create() writes
+		// data.executionData to the DB; any header masking or runtimeData
+		// population must happen before that write so the persisted record
+		// does not contain raw trigger-item data (e.g. Authorization headers).
+		// The runtimeData early-exit guard in establishExecutionContext keeps
+		// the subsequent worker-side call at workflow-execute.ts idempotent.
+		if (data.executionData) {
+			const workflowSettings = data.workflowData.settings ?? {};
+			const contextWorkflow = new Workflow({
+				id: data.workflowData.id,
+				name: data.workflowData.name,
+				nodes: data.workflowData.nodes,
+				connections: data.workflowData.connections,
+				active: data.workflowData.activeVersionId !== null,
+				nodeTypes: this.nodeTypes,
+				staticData: data.workflowData.staticData,
+				settings: workflowSettings,
+			});
+			const contextAdditionalData = await WorkflowExecuteAdditionalData.getBase({
+				userId: data.userId,
+				workflowId: data.workflowData.id,
+				workflowSettings,
+			});
+			await establishExecutionContext(
+				contextWorkflow,
+				data.executionData,
+				contextAdditionalData,
+				data.executionMode,
+			);
+		}
+
 		// Register a new execution
 		const executionId = await this.activeExecutions.add(data, restartExecutionId);
 

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -174,7 +174,11 @@ export class WorkflowRunner {
 		// The runtimeData early-exit guard in establishExecutionContext keeps
 		// the subsequent worker-side call at workflow-execute.ts idempotent.
 		if (data.executionData) {
-			const workflowSettings = data.workflowData.settings ?? {};
+			// Deliberately lightweight: no pinData, no staticData loading,
+			// no additionalData. establishExecutionContext only needs the
+			// workflow's settings (for redactionPolicy) and node lookups.
+			// runMainProcess() builds its own fully-configured Workflow for
+			// actual execution.
 			const contextWorkflow = new Workflow({
 				id: data.workflowData.id,
 				name: data.workflowData.name,
@@ -183,17 +187,12 @@ export class WorkflowRunner {
 				active: data.workflowData.activeVersionId !== null,
 				nodeTypes: this.nodeTypes,
 				staticData: data.workflowData.staticData,
-				settings: workflowSettings,
-			});
-			const contextAdditionalData = await WorkflowExecuteAdditionalData.getBase({
-				userId: data.userId,
-				workflowId: data.workflowData.id,
-				workflowSettings,
+				settings: data.workflowData.settings ?? {},
 			});
 			await establishExecutionContext(
 				contextWorkflow,
 				data.executionData,
-				contextAdditionalData,
+				undefined,
 				data.executionMode,
 			);
 		}

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -189,9 +189,6 @@ export class WorkflowRunner {
 		restartExecutionId?: string,
 		responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>,
 	): Promise<string> {
-		// Register a new execution
-		const executionId = await this.activeExecutions.add(data, restartExecutionId);
-
 		// Establish the execution context before persisting to the DB.
 		// activeExecutions.add() -> executionPersistence.create() writes
 		// data.executionData to the DB; any header masking or runtimeData
@@ -203,7 +200,7 @@ export class WorkflowRunner {
 		// the outer IRunExecutionData is created with `executionData: null`
 		// so the trigger-item stack is undefined here; nothing to mask yet,
 		// the worker will establish context once it populates the stack.
-
+		let establishContextError: (ExecutionError & { node?: INode }) | undefined;
 		if (data.executionData?.executionData) {
 			// Deliberately lightweight: no pinData, no staticData loading,
 			// no additionalData. establishExecutionContext only needs the
@@ -232,9 +229,16 @@ export class WorkflowRunner {
 				// stack can still contain raw header data. Drop it before
 				// activeExecutions.add() persists the execution row.
 				data.executionData.executionData.nodeExecutionStack = [];
-				await this.failExecution(data, executionId, error, responsePromise);
-				return executionId;
+				establishContextError = error as ExecutionError & { node?: INode };
 			}
+		}
+
+		// Register a new execution
+		const executionId = await this.activeExecutions.add(data, restartExecutionId);
+
+		if (establishContextError) {
+			await this.failExecution(data, executionId, establishContextError, responsePromise);
+			return executionId;
 		}
 
 		const { id: workflowId, nodes } = data.workflowData;

--- a/packages/core/src/execution-engine/__tests__/execution-context.test.ts
+++ b/packages/core/src/execution-engine/__tests__/execution-context.test.ts
@@ -456,6 +456,73 @@ describe('establishExecutionContext', () => {
 				'parent-exec-123',
 			);
 		});
+
+		it('should skip hook augmentation when runtimeData is already set (queue-mode worker resume)', async () => {
+			// When the main process established the context before persisting,
+			// the worker fetches the execution with runtimeData already populated.
+			// The function must return immediately without re-running hook augmentation.
+			const existingContext: IExecutionContext = {
+				version: 1,
+				establishedAt: 1234567890,
+				source: 'webhook',
+				credentials: 'encrypted-credentials-blob',
+			};
+
+			const webhookNode = mock<INode>({
+				name: 'Webhook',
+				type: 'n8n-nodes-base.webhook',
+				parameters: {},
+			});
+
+			const runExecutionData = createRunExecutionData({
+				startData: {},
+				resultData: { runData: {} },
+				executionData: {
+					contextData: {},
+					nodeExecutionStack: [
+						{
+							node: webhookNode,
+							data: {
+								main: [
+									[
+										{
+											json: {
+												headers: { authorization: 'original-header-value' },
+											},
+										},
+									],
+								],
+							},
+							source: null,
+						},
+					],
+					metadata: {},
+					waitingExecution: {},
+					waitingExecutionSource: {},
+					runtimeData: existingContext,
+				},
+			});
+
+			await establishExecutionContext(
+				mockWorkflow,
+				runExecutionData,
+				mockAdditionalData,
+				'webhook',
+			);
+
+			// runtimeData reference is preserved — same object, same values
+			expect(runExecutionData.executionData!.runtimeData).toBe(existingContext);
+			expect(runExecutionData.executionData!.runtimeData!.credentials).toBe(
+				'encrypted-credentials-blob',
+			);
+
+			// Trigger items are left untouched (hook augmentation was skipped).
+			// The main process already applied any transformations before persisting;
+			// this assertion just verifies the worker-side call is a no-op.
+			const headers = runExecutionData.executionData!.nodeExecutionStack[0].data.main[0]![0].json
+				.headers as Record<string, string>;
+			expect(headers.authorization).toBe('original-header-value');
+		});
 	});
 
 	describe('sub-workflow context inheritance', () => {

--- a/packages/core/src/execution-engine/execution-context.ts
+++ b/packages/core/src/execution-engine/execution-context.ts
@@ -109,7 +109,7 @@ import { ExecutionContextService } from './execution-context.service';
 export const establishExecutionContext = async (
 	workflow: Workflow,
 	runExecutionData: IRunExecutionData,
-	additionalData: IWorkflowExecuteAdditionalData,
+	additionalData: IWorkflowExecuteAdditionalData | undefined,
 	mode: WorkflowExecuteMode,
 ): Promise<void> => {
 	assertExecutionDataExists(runExecutionData.executionData, workflow, additionalData, mode);

--- a/packages/core/src/execution-engine/index.ts
+++ b/packages/core/src/execution-engine/index.ts
@@ -91,4 +91,5 @@ export * from './execution-context-hook-registry.service';
 export { ExecutionLifecycleHooks } from './execution-lifecycle-hooks';
 export { ExternalSecretsProxy, type IExternalSecretsManager } from './external-secrets-proxy';
 export { ExecutionContextService } from './execution-context.service';
+export { establishExecutionContext } from './execution-context';
 export { isEngineRequest } from './requests-response';

--- a/packages/core/src/utils/assertions.ts
+++ b/packages/core/src/utils/assertions.ts
@@ -9,14 +9,14 @@ import {
 export function assertExecutionDataExists(
 	executionData: IRunExecutionData['executionData'],
 	workflow: Workflow,
-	additionalData: IWorkflowExecuteAdditionalData,
+	additionalData: IWorkflowExecuteAdditionalData | undefined,
 	mode: WorkflowExecuteMode,
 ): asserts executionData is NonNullable<IRunExecutionData['executionData']> {
 	if (!executionData) {
 		throw new UnexpectedError('Failed to run workflow due to missing execution data', {
 			extra: {
 				workflowId: workflow.id,
-				executionId: additionalData.executionId,
+				executionId: additionalData?.executionId,
 				mode,
 			},
 		});


### PR DESCRIPTION
## Summary

**Change:** Before `WorkflowRunner.run()` calls `activeExecutions.add()` (which triggers the DB write via
  `executionPersistence.create()`), it now builds a `Workflow` + `additionalData` and calls `establishExecutionContext()`. Guarded by
  `if (data.executionData)` so manual executions without pre-populated data skip the call.

  **Files:**
  - `packages/cli/src/workflow-runner.ts` — the fix, plus new `n8n-core` import
  - `packages/cli/src/__tests__/workflow-runner.test.ts` — 3 tests (ordering, masked-data-persisted, undefined-guard)
  - `packages/core/src/execution-engine/index.ts` — exports `establishExecutionContext`
  - `packages/core/src/execution-engine/__tests__/execution-context.test.ts` — worker idempotency test

  # Why

  **Problem:** In queue mode, raw `Authorization: Bearer <JWT>` headers from webhook triggers were written to PostgreSQL before
  anything masked them. The worker masked in memory later, but the DB held the raw token until (and unless) the worker wrote an updated
   record. A worker crash left the raw JWT as the final row.

  **Why in `WorkflowRunner.run()`:** Every execution path funnels through here (webhooks, chat, wait-tracker resumes, manual, CLI, MCP,
   AI-builder). Placing the call at this choke point gives uniform coverage and co-locates context establishment with the
  enqueue-vs-local decision and the DB write.

  **Why it's safe to run twice:** `establishExecutionContext` early-exits if `runtimeData` is already set. The worker still calls it
  inside `WorkflowExecute.processRunExecutionData`, but finds `runtimeData` populated and returns immediately — no double-processing.

  **Why the minimal build (not the thread-through refactor):** `runMainProcess()` does more than `establishExecutionContext` needs
  (staticData loading, pinData, timeouts). Lifting that would change `loadStaticData` semantics in queue mode. Building one extra
  `Workflow` + `additionalData` per execution is cheap and keeps the diff tightly scoped to the security fix.

## Testing

  These steps verify that webhook headers are redacted in the persisted execution
  data **while the execution is still running** (not just after completion).

  ### Prerequisites

  - Docker running
  - A workflow JSON that starts with a Webhook trigger and has a long-running step
  afterwards (e.g. a `Wait` node set to several minutes). An example workflow file
  is attached to this PR.

  ### 1. Start n8n in queue mode

  From `packages/testing/containers/`:

  ```bash
  args=(--queue)
  while IFS= read -r line; do
    args+=(--env "$line")
  done < <(grep -v '^\s*#\|^\s*$' ../../../.env)
  npx tsx ./n8n-start-stack.ts "${args[@]}"
  ```

  Note the project name printed in the logs (e.g. `n8n-stack-htdxh`) — you'll need
  it to connect to Postgres.

  ### 2. Import and activate the test workflow

  1. Open the n8n URL printed by the stack starter.
  2. Import the attached workflow JSON.
  3. Activate the workflow so the webhook is live.

  ### 3. Trigger the webhook

  Call the webhook URL with some headers that should be redacted (e.g.
  `Authorization`):

  ```bash
  curl -X POST <webhook-url> \
    -H "Authorization: Bearer secret-token-123" \
    -H "Cookie: session=abc123" \
    -H "X-Custom: visible-value"
  ```

  The workflow will start and pause on the long-running node, keeping the execution
  in a running state.

  ### 4. Inspect the persisted execution data

  While the execution is still running, open a psql shell against the stack's
  Postgres container:

  ```bash
  docker exec -it <project-name>-postgres psql -U n8n_user -d n8n_db
  ```

  Find the running execution's ID:

  ```sql
  SELECT id, status FROM execution_entity WHERE status = 'running' ORDER BY id DESC
  LIMIT 5;
  ```

  Check the persisted payload for that execution:

  ```sql
  SELECT data FROM execution_data WHERE "executionId" = '<id>';
  ```

  ### 5. Verify

  - Sensitive headers (e.g. `Authorization`, `Cookie`) appear **redacted** in the
  `data` column.
  - Non-sensitive headers (e.g. `X-Custom`) appear with their original values.
  - The row exists **before the execution finishes** — confirming the context is
  persisted pre-completion.

[My workflow.json](https://github.com/user-attachments/files/27061086/My.workflow.json)


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-547/fixcli-redact-jwt-tokens-before-execution-db-write-in-queue-mode


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
