### PR TITLE
fix(core): Honor request encoding when shaping eval mock HTTP responses (no-changelog)

### DIFF
--- a/packages/core/src/execution-engine/__tests__/eval-mock-helpers.test.ts
+++ b/packages/core/src/execution-engine/__tests__/eval-mock-helpers.test.ts
@@ -1,5 +1,6 @@
 import { mock } from 'jest-mock-extended';
 import type { IHttpRequestOptions, INode, INodeProperties, IRequestOptions } from 'n8n-workflow';
+import { Readable } from 'node:stream';
 
 import {
 	buildEvalMockCredentials,
@@ -196,7 +197,7 @@ describe('eval-mock-helpers', () => {
 	// serializeMockToHttpResponse
 	// -----------------------------------------------------------------------
 	describe('serializeMockToHttpResponse', () => {
-		it('should convert a JSON body to a Buffer', () => {
+		it('should pass through a JSON body as the parsed object', () => {
 			const mockResponse: EvalMockHttpResponse = {
 				body: { message: 'hello' },
 				headers: { 'content-type': 'application/json' },
@@ -205,8 +206,102 @@ describe('eval-mock-helpers', () => {
 
 			const result = serializeMockToHttpResponse(mockResponse);
 
-			expect(Buffer.isBuffer(result.body)).toBe(true);
-			expect(result.body.toString()).toBe(JSON.stringify({ message: 'hello' }));
+			expect(result.body).toEqual({ message: 'hello' });
+			expect(Buffer.isBuffer(result.body)).toBe(false);
+		});
+
+		it('should mark JSON responses as __bodyResolved', () => {
+			// HttpRequestV3's autodetect path only re-decodes body if
+			// __bodyResolved is falsy. When we hand over a parsed object we must
+			// set this flag so the node skips its Buffer→string→parse pipeline.
+			const mockResponse: EvalMockHttpResponse = {
+				body: [{ id: 1 }],
+				headers: { 'content-type': 'application/json' },
+				statusCode: 200,
+			};
+
+			const result = serializeMockToHttpResponse(mockResponse) as { __bodyResolved?: boolean };
+
+			expect(result.__bodyResolved).toBe(true);
+		});
+
+		it('should pass string bodies through as-is with __bodyResolved on the default path', () => {
+			// Matches axios default (responseType: 'json') which returns the
+			// original string when JSON.parse fails — consumer-ready.
+			const mockResponse: EvalMockHttpResponse = {
+				body: 'plain text',
+				headers: { 'content-type': 'text/plain' },
+				statusCode: 200,
+			};
+
+			const result = serializeMockToHttpResponse(mockResponse) as {
+				body: unknown;
+				__bodyResolved?: boolean;
+			};
+
+			expect(result.body).toBe('plain text');
+			expect(result.__bodyResolved).toBe(true);
+		});
+
+		it('should match JSON content types with charset parameters', () => {
+			const mockResponse: EvalMockHttpResponse = {
+				body: [{ id: 1 }, { id: 2 }],
+				headers: { 'content-type': 'application/json; charset=utf-8' },
+				statusCode: 200,
+			};
+
+			const result = serializeMockToHttpResponse(mockResponse);
+
+			expect(result.body).toEqual([{ id: 1 }, { id: 2 }]);
+			expect(Buffer.isBuffer(result.body)).toBe(false);
+		});
+
+		it('should accept mixed-case Content-Type headers', () => {
+			const mockResponse: EvalMockHttpResponse = {
+				body: { ok: true },
+				headers: { 'Content-Type': 'application/json' },
+				statusCode: 200,
+			};
+
+			const result = serializeMockToHttpResponse(mockResponse);
+
+			expect(result.body).toEqual({ ok: true });
+			expect(Buffer.isBuffer(result.body)).toBe(false);
+		});
+
+		it('should pass object bodies through regardless of content-type on the default path', () => {
+			// Content-Type is not the gatekeeper — axios's default responseType
+			// ('json') parses any parseable body. The mock respects the
+			// producer's chosen body shape and marks it consumer-ready.
+			const mockResponse: EvalMockHttpResponse = {
+				body: { message: 'hello' },
+				headers: { 'content-type': 'text/plain' },
+				statusCode: 200,
+			};
+
+			const result = serializeMockToHttpResponse(mockResponse) as {
+				body: unknown;
+				__bodyResolved?: boolean;
+			};
+
+			expect(result.body).toEqual({ message: 'hello' });
+			expect(result.__bodyResolved).toBe(true);
+		});
+
+		it('should pass object bodies through as-is when no content-type is set', () => {
+			// Matches axios's default behavior (responseType: 'json') — when no
+			// Content-Type is declared, axios tries to JSON.parse the body, so
+			// the mock hands over the already-parsed object with __bodyResolved.
+			const mockResponse: EvalMockHttpResponse = {
+				body: { message: 'hello' },
+				headers: {},
+				statusCode: 200,
+			};
+
+			const result = serializeMockToHttpResponse(mockResponse);
+
+			expect(result.body).toEqual({ message: 'hello' });
+			expect((result as { __bodyResolved?: boolean }).__bodyResolved).toBe(true);
 		});
 
 		it('should preserve headers and statusCode', () => {
@@ -234,7 +329,139 @@ describe('eval-mock-helpers', () => {
 			const result = serializeMockToHttpResponse(mockResponse);
 
 			expect(result.body).toBe(originalBuffer);
-			expect(result.body.toString()).toBe('raw-binary-data');
+			expect((result.body as Buffer).toString()).toBe('raw-binary-data');
+		});
+
+		it('should pass a Buffer body through even when Content-Type is JSON', () => {
+			// If the mock handler hands us a Buffer explicitly, trust it — don't
+			// silently unwrap it to an object just because headers claim JSON.
+			const originalBuffer = Buffer.from('{"already":"serialized"}');
+			const mockResponse: EvalMockHttpResponse = {
+				body: originalBuffer,
+				headers: { 'content-type': 'application/json' },
+				statusCode: 200,
+			};
+
+			const result = serializeMockToHttpResponse(mockResponse);
+
+			expect(result.body).toBe(originalBuffer);
+		});
+
+		// -----------------------------------------------------------------------
+		// Request-aware body shaping — matches axios responseType behavior
+		// -----------------------------------------------------------------------
+		describe('with request options (axios-parity mode)', () => {
+			const jsonResponse: EvalMockHttpResponse = {
+				body: { data: [1, 2, 3] },
+				headers: { 'content-type': 'application/json' },
+				statusCode: 200,
+			};
+
+			it('should return a Readable stream when requestOptions.encoding is "stream"', async () => {
+				const result = serializeMockToHttpResponse(jsonResponse, {
+					url: 'https://api.example.com/file',
+					encoding: 'stream',
+				});
+
+				expect(result.body).toBeInstanceOf(Readable);
+				// Consume the stream to verify it holds the serialized body bytes.
+				const chunks: Buffer[] = [];
+				for await (const chunk of result.body as Readable) {
+					chunks.push(chunk as Buffer);
+				}
+				expect(Buffer.concat(chunks).toString()).toBe(JSON.stringify({ data: [1, 2, 3] }));
+			});
+
+			it('should return a Buffer when requestOptions.encoding is "arraybuffer"', () => {
+				const result = serializeMockToHttpResponse(jsonResponse, {
+					url: 'https://api.example.com/image',
+					encoding: 'arraybuffer',
+				});
+
+				expect(Buffer.isBuffer(result.body)).toBe(true);
+				expect((result.body as Buffer).toString()).toBe(JSON.stringify({ data: [1, 2, 3] }));
+				// No __bodyResolved flag on the Buffer path — the node still needs to decode.
+				expect((result as { __bodyResolved?: boolean }).__bodyResolved).toBeUndefined();
+			});
+
+			it('should return parsed body + __bodyResolved in the default (JSON) path', () => {
+				const result = serializeMockToHttpResponse(jsonResponse, {
+					url: 'https://api.example.com/posts',
+				});
+
+				expect(result.body).toEqual({ data: [1, 2, 3] });
+				expect(Buffer.isBuffer(result.body)).toBe(false);
+				expect((result as { __bodyResolved?: boolean }).__bodyResolved).toBe(true);
+			});
+
+			it('should pass text responses through as strings on the default path', () => {
+				// The default path (undefined encoding) matches axios responseType:'json',
+				// which keeps unparseable strings as strings — not Buffers.
+				const textResponse: EvalMockHttpResponse = {
+					body: 'hello world',
+					headers: { 'content-type': 'text/plain' },
+					statusCode: 200,
+				};
+
+				const result = serializeMockToHttpResponse(textResponse, {
+					url: 'https://api.example.com/robots.txt',
+				});
+
+				expect(result.body).toBe('hello world');
+				expect((result as { __bodyResolved?: boolean }).__bodyResolved).toBe(true);
+			});
+
+			it('should preserve a Buffer body on the stream path (wrap, not copy)', async () => {
+				const bufferResponse: EvalMockHttpResponse = {
+					body: Buffer.from('raw bytes'),
+					headers: { 'content-type': 'application/octet-stream' },
+					statusCode: 200,
+				};
+
+				const result = serializeMockToHttpResponse(bufferResponse, {
+					url: 'https://api.example.com/file',
+					encoding: 'stream',
+				});
+
+				expect(result.body).toBeInstanceOf(Readable);
+				const chunks: Buffer[] = [];
+				for await (const chunk of result.body as Readable) {
+					chunks.push(chunk as Buffer);
+				}
+				expect(Buffer.concat(chunks).toString()).toBe('raw bytes');
+			});
+
+			it('should pass Buffer through unchanged on the arraybuffer path', () => {
+				const original = Buffer.from('raw bytes');
+				const bufferResponse: EvalMockHttpResponse = {
+					body: original,
+					headers: { 'content-type': 'application/octet-stream' },
+					statusCode: 200,
+				};
+
+				const result = serializeMockToHttpResponse(bufferResponse, {
+					url: 'https://api.example.com/file',
+					encoding: 'arraybuffer',
+				});
+
+				expect(result.body).toBe(original);
+			});
+
+			it('should return a string body + __bodyResolved when encoding is "text"', () => {
+				const textResponse: EvalMockHttpResponse = {
+					body: 'hello world',
+					headers: { 'content-type': 'text/plain' },
+					statusCode: 200,
+				};
+
+				const result = serializeMockToHttpResponse(textResponse, {
+					url: 'https://api.example.com/robots.txt',
+					encoding: 'text',
+				});
+
+				expect(result.body).toBe('hello world');
+				expect((result as { __bodyResolved?: boolean }).__bodyResolved).toBe(true);
+			});
 		});
 	});
 
@@ -345,7 +572,27 @@ describe('eval-mock-helpers', () => {
 			expect(result).toHaveProperty('headers');
 			expect(result).toHaveProperty('statusCode', 200);
 			const typedResult = result as ReturnType<typeof serializeMockToHttpResponse>;
+			// JSON Content-Type → body passes through parsed so HTTP Request nodes on
+			// responseFormat: autodetect see parsed items rather than a raw Buffer.
+			expect(typedResult.body).toEqual({ data: 'mocked' });
+		});
+
+		it('should return a Buffer body when the mock already handed over one', async () => {
+			// If the mock producer decided the body is binary (mock-handler.ts
+			// 'binary' type), we respect that and keep it as a Buffer even on
+			// the default path — the node's autodetect handles raw bytes fine.
+			const bufferResponse: EvalMockHttpResponse = {
+				body: Buffer.from('raw bytes'),
+				headers: { 'content-type': 'application/octet-stream' },
+				statusCode: 200,
+			};
+			const handler: EvalLlmMockHandler = jest.fn().mockResolvedValue(bufferResponse);
+
+			const result = await callEvalMockHandler(handler, requestOptions, node, true);
+
+			const typedResult = result as ReturnType<typeof serializeMockToHttpResponse>;
 			expect(Buffer.isBuffer(typedResult.body)).toBe(true);
+			expect((typedResult.body as Buffer).toString()).toBe('raw bytes');
 		});
 
 		it('should return undefined when handler returns undefined', async () => {

--- a/packages/core/src/execution-engine/eval-mock-helpers.ts
+++ b/packages/core/src/execution-engine/eval-mock-helpers.ts
@@ -8,6 +8,7 @@
  */
 
 import type { IHttpRequestOptions, INode, INodeProperties, IRequestOptions } from 'n8n-workflow';
+import { Readable } from 'node:stream';
 
 import type { EvalLlmMockHandler, EvalMockHttpResponse } from './index';
 
@@ -109,17 +110,55 @@ export function buildEvalMockCredentials(properties: INodeProperties[]): Record<
 // ---------------------------------------------------------------------------
 
 /**
- * Convert an EvalMockHttpResponse into the full-response shape that callers expect
- * when `returnFullResponse` / `resolveWithFullResponse` is true.
- * Body is serialized to a Buffer so downstream processing (binary detection,
- * encoding detection, stream handling) works exactly as with a real HTTP response.
+ * Shape a mock response to match what axios's `result.data` would be for the
+ * same request. Node code reads body based on the request's `encoding` field,
+ * which maps 1:1 onto axios `responseType`.
+ *
+ * `__bodyResolved` tells HttpRequestV3 the body is already consumer-ready so
+ * it skips its Buffer→string→JSON.parse pipeline (which would crash on a
+ * plain object with "stream.on is not a function").
  */
-export function serializeMockToHttpResponse(mock: EvalMockHttpResponse) {
-	const body =
+export function serializeMockToHttpResponse(
+	mock: EvalMockHttpResponse,
+	requestOptions?: IHttpRequestOptions,
+) {
+	const common = {
+		headers: mock.headers,
+		statusCode: mock.statusCode,
+		statusMessage: 'OK',
+	};
+
+	const bytes = () =>
 		mock.body instanceof Buffer
 			? mock.body
-			: Buffer.from(typeof mock.body === 'string' ? mock.body : JSON.stringify(mock.body));
-	return { body, headers: mock.headers, statusCode: mock.statusCode, statusMessage: 'OK' };
+			: Buffer.from(typeof mock.body === 'string' ? mock.body : JSON.stringify(mock.body ?? ''));
+
+	switch (requestOptions?.encoding) {
+		case 'stream':
+			return { ...common, body: Readable.from(bytes()) };
+		case 'arraybuffer':
+		case 'blob':
+			return { ...common, body: bytes() };
+		case 'text':
+			return {
+				...common,
+				body:
+					mock.body instanceof Buffer
+						? mock.body.toString()
+						: typeof mock.body === 'string'
+							? mock.body
+							: JSON.stringify(mock.body ?? ''),
+				__bodyResolved: true,
+			};
+	}
+
+	// Default path (encoding is 'json' or undefined) — axios would return
+	// parsed data. If the mock already produced a parsed object, hand it
+	// through. If it handed us raw bytes, return them and let the node decode.
+	if (mock.body instanceof Buffer) {
+		return { ...common, body: mock.body };
+	}
+	return { ...common, body: mock.body, __bodyResolved: true };
 }
 
 /** Normalize legacy IRequestOptions or (uri, options) args into IHttpRequestOptions for the eval mock handler. */
@@ -167,7 +206,7 @@ export async function callEvalMockHandler(
 		throwHttpError(response, httpLibrary);
 	}
 
-	return returnFullResponse ? serializeMockToHttpResponse(response) : response.body;
+	return returnFullResponse ? serializeMockToHttpResponse(response, requestOptions) : response.body;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `serializeMockToHttpResponse` returned a fixed `{ body: Buffer }` regardless of what the caller asked for. Nodes that pass `encoding: 'stream'` to the n8n request helpers blew up with `stream.on is not a function`, and JSON-expecting callers re-entered HttpRequestV3's body-consumption pipeline only to hit the same shape mismatch.
- Shape the response to match what axios `result.data` would look like for the request's `responseType`: `Readable` for `stream`, `Buffer` for `arraybuffer`/`blob`, `string` for `text`, and the parsed value with `__bodyResolved: true` on the default (JSON) path so downstream consumers skip redundant parsing.
- Covered by 44 unit tests in `eval-mock-helpers.test.ts`.

Surfaced while running Instance AI eval harness against MCP-built workflows — the stream/arraybuffer branches exercised paths that production builds had not hit before.

## Test plan

- [x] `pnpm --filter n8n-core test eval-mock-helpers` (44/44 pass)
- [ ] Reviewer runs a full workflow eval (`pnpm eval:instance-ai`) against a mix of scenarios (HTTP Request + binary + JSON) — no `stream.on is not a function` errors should surface

- [x] I have seen this code, I have run this code, and I take responsibility for this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)