### PR TITLE
fix(ai-builder): Expose outputCount when eval node output is truncated (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -992,6 +992,8 @@ export interface InstanceAiEvalInterceptedRequest {
 
 export interface InstanceAiEvalNodeResult {
 	output: unknown;
+	/** Full count of output items (`output` is truncated for artifact size) */
+	outputCount?: number;
 	interceptedRequests: InstanceAiEvalInterceptedRequest[];
 	executionMode: InstanceAiEvalNodeExecutionMode;
 	/** Missing required parameters detected before execution (empty = fully configured) */

--- a/packages/@n8n/instance-ai/evaluations/system-prompts/mock-execution-verify.ts
+++ b/packages/@n8n/instance-ai/evaluations/system-prompts/mock-execution-verify.ts
@@ -18,6 +18,7 @@ The verification artifact contains:
 - **Errors**: Any runtime errors from the execution
 - **Workflow structure**: ALL nodes that were built, whether they executed or not, plus the full connections JSON showing how nodes are wired. Use this to verify node existence and wiring before making claims about missing nodes or wrong connections.
 - **Execution trace**: Per-node detail including HTTP requests sent, mock responses returned, and node output. Only includes nodes that actually ran. **IMPORTANT: The trace is NOT in chronological order.** Do not infer execution sequence from the order nodes appear in the trace. Use the connections JSON in the workflow structure to determine execution flow.
+- **Output truncation**: Each node's \`output\` array is capped at 10 items for artifact size. The full untruncated count is preserved in the node's \`outputCount\` field. **Do not treat a smaller \`output\` array as a bug.** If \`outputCount\` > 10, the node emitted more items than are shown — downstream nodes processed the full set. Only flag a count mismatch as a real issue when \`outputCount\` itself is inconsistent with what the mock returned or what the scenario requires.
 
 ## How to evaluate
 

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/execution.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/execution.service.test.ts
@@ -416,8 +416,8 @@ describe('EvalExecutionService', () => {
 			expect(result.nodeResults['HTTP Request'].startTime).toBe(1710000000);
 		});
 
-		it('captures output from run data, limited to MAX_OUTPUT_ITEMS_PER_NODE', async () => {
-			const items = Array.from({ length: 10 }, (_, i) => ({ json: { idx: i } }));
+		it('captures output limited to MAX_OUTPUT_ITEMS_PER_NODE and reports full outputCount', async () => {
+			const items = Array.from({ length: 15 }, (_, i) => ({ json: { idx: i } }));
 			mockProcessRunExecutionData.mockResolvedValue(
 				makeIRun({
 					data: {
@@ -440,8 +440,8 @@ describe('EvalExecutionService', () => {
 
 			const result = await service.executeWithLlmMock('wf-1', makeUser());
 
-			// MAX_OUTPUT_ITEMS_PER_NODE is 5
-			expect(result.nodeResults['HTTP Request'].output).toHaveLength(5);
+			expect(result.nodeResults['HTTP Request'].output).toHaveLength(10);
+			expect(result.nodeResults['HTTP Request'].outputCount).toBe(15);
 		});
 	});
 

--- a/packages/cli/src/modules/instance-ai/eval/execution.service.ts
+++ b/packages/cli/src/modules/instance-ai/eval/execution.service.ts
@@ -48,8 +48,8 @@ import { createLlmMockHandler } from './mock-handler';
 // Constants
 // ---------------------------------------------------------------------------
 
-/** Maximum number of output items to include per node in the result */
-const MAX_OUTPUT_ITEMS_PER_NODE = 5;
+/** Max output items per node kept in the artifact. The full count lives in `outputCount`. */
+const MAX_OUTPUT_ITEMS_PER_NODE = 10;
 
 // ---------------------------------------------------------------------------
 // Service
@@ -438,10 +438,9 @@ export class EvalExecutionService {
 			}
 			if (lastRun?.data?.main) {
 				// Capture output from all branches (Switch/IF nodes have multiple outputs)
-				const allOutputs = lastRun.data.main
-					.flat()
-					.filter(Boolean)
-					.slice(0, MAX_OUTPUT_ITEMS_PER_NODE);
+				const flattened = lastRun.data.main.flat().filter(Boolean);
+				entry.outputCount = flattened.length;
+				const allOutputs = flattened.slice(0, MAX_OUTPUT_ITEMS_PER_NODE);
 				if (allOutputs.length > 0) {
 					entry.output = allOutputs;
 				}


### PR DESCRIPTION
## Summary

- Eval execution artifacts kept only the first 5 output items per node to cap artifact size, but had no signal of how much was trimmed. The verifier LLM treated truncation as a builder bug ("node emitted 5 items, expected 13").
- Add `outputCount` to `InstanceAiEvalNodeResult` (full, untruncated count), raise the per-node cap 5 → 10 (still small for verifier context), and update the verifier prompt to distinguish a truncated-but-valid output from a genuinely short one.
- Surfaced during Instance AI vs MCP-built workflow comparison work — denser MCP workflows exposed the false-positive rate on truncation flags.

## Test plan

- [x] `pnpm --filter n8n test execution.service` (17/17 pass, including new `outputCount` assertion)
- [ ] Reviewer runs a workflow eval with a high-cardinality scenario (e.g. `daily-slack-summary high-volume`) and confirms the verifier no longer flags truncation as a bug

- [x] I have seen this code, I have run this code, and I take responsibility for this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)