### PR TITLE
feat(core): Stamp x-n8n-feature on proxied LLM calls for cost attribution

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/ai-workflow-builder-agent.service.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/ai-workflow-builder-agent.service.ts
@@ -2,6 +2,7 @@ import { ChatAnthropic } from '@langchain/anthropic';
 import { AIMessage, ToolMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import { LangChainTracer } from '@langchain/core/tracers/tracer_langchain';
+import { buildProxyHeaders } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
 import { AiAssistantClient, AiAssistantSDK } from '@n8n_io/ai-assistant-sdk';
@@ -87,6 +88,10 @@ export class AiWorkflowBuilderService {
 		const authHeaders = {
 			// eslint-disable-next-line @typescript-eslint/naming-convention
 			Authorization: `${authResponse.tokenType} ${authResponse.accessToken}`,
+			...buildProxyHeaders({
+				feature: 'workflow-builder',
+				n8nVersion: this.n8nVersion ?? 'unknown',
+			}),
 		};
 
 		return authHeaders;

--- a/packages/@n8n/ai-workflow-builder.ee/src/test/ai-workflow-builder-agent.service.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/test/ai-workflow-builder-agent.service.test.ts
@@ -469,6 +469,25 @@ describe('AiWorkflowBuilderService', () => {
 
 			expect(mockClient.markBuilderSuccess).toHaveBeenCalledWith(mockUser, {
 				Authorization: 'Bearer test-access-token',
+				// eslint-disable-next-line @typescript-eslint/naming-convention
+				'x-n8n-feature': 'workflow-builder',
+				// eslint-disable-next-line @typescript-eslint/naming-convention
+				'x-n8n-version': '1.0.0',
+			});
+		});
+
+		it('should stamp x-n8n-feature and x-n8n-version on proxy auth headers', async () => {
+			const generator = service.chat(mockPayload, mockUser);
+			await generator.next();
+
+			expect(anthropicClaudeSonnet45Mock).toHaveBeenCalledWith({
+				baseUrl: 'https://api.example.com/anthropic',
+				apiKey: '-',
+				headers: expect.objectContaining({
+					Authorization: 'Bearer test-access-token',
+					'x-n8n-feature': 'workflow-builder',
+					'x-n8n-version': '1.0.0',
+				}),
 			});
 		});
 

--- a/packages/@n8n/api-types/src/__tests__/proxy-feature.test.ts
+++ b/packages/@n8n/api-types/src/__tests__/proxy-feature.test.ts
@@ -1,0 +1,23 @@
+import {
+	N8N_PROXY_FEATURES,
+	X_N8N_FEATURE_HEADER,
+	X_N8N_VERSION_HEADER,
+	buildProxyHeaders,
+} from '../constants/proxy-feature';
+
+describe('buildProxyHeaders', () => {
+	it('should build both header fields for every registered feature', () => {
+		for (const feature of N8N_PROXY_FEATURES) {
+			const headers = buildProxyHeaders({ feature, n8nVersion: '1.2.3' });
+			expect(headers[X_N8N_FEATURE_HEADER]).toBe(feature);
+			expect(headers[X_N8N_VERSION_HEADER]).toBe('1.2.3');
+		}
+	});
+
+	it('should return exactly the two expected keys', () => {
+		const headers = buildProxyHeaders({ feature: 'instance-ai', n8nVersion: '1.2.3' });
+		expect(Object.keys(headers).sort()).toEqual(
+			[X_N8N_FEATURE_HEADER, X_N8N_VERSION_HEADER].sort(),
+		);
+	});
+});

--- a/packages/@n8n/api-types/src/constants/proxy-feature.ts
+++ b/packages/@n8n/api-types/src/constants/proxy-feature.ts
@@ -1,0 +1,29 @@
+/**
+ * Header names and registry shared between n8n and the ai-assistant-service
+ * proxy. Mirrors the `FEATURES` tuple on the proxy side — any new feature
+ * must be added in both places.
+ */
+
+export const X_N8N_FEATURE_HEADER = 'x-n8n-feature';
+export const X_N8N_VERSION_HEADER = 'x-n8n-version';
+
+export const N8N_PROXY_FEATURES = ['instance-ai', 'workflow-builder', 'agent-builder'] as const;
+export type N8nProxyFeature = (typeof N8N_PROXY_FEATURES)[number];
+
+export interface ProxyHeaderInput {
+	feature: N8nProxyFeature;
+	n8nVersion: string;
+}
+
+/**
+ * Builds the headers required on every call to `/v1/api-proxy/*`. Every
+ * caller on the n8n side must use this helper — types enforce both
+ * `feature` (constrained union) and `n8nVersion` are supplied, so
+ * omission becomes impossible at the call site.
+ */
+export function buildProxyHeaders(input: ProxyHeaderInput): Record<string, string> {
+	return {
+		[X_N8N_FEATURE_HEADER]: input.feature,
+		[X_N8N_VERSION_HEADER]: input.n8nVersion,
+	};
+}

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -386,3 +386,12 @@ export {
 export type { AgentRunState, AgentNode } from './schemas/agent-run-reducer';
 
 export { ALLOWED_DOMAINS, isAllowedDomain } from './utils/allowed-domains';
+
+export {
+	X_N8N_FEATURE_HEADER,
+	X_N8N_VERSION_HEADER,
+	N8N_PROXY_FEATURES,
+	buildProxyHeaders,
+	type N8nProxyFeature,
+	type ProxyHeaderInput,
+} from './constants/proxy-feature';

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -1,6 +1,7 @@
 import {
 	UNLIMITED_CREDITS,
 	applyBranchReadOnlyOverrides,
+	buildProxyHeaders,
 	type InstanceAiAttachment,
 	type InstanceAiEvent,
 	type InstanceAiThreadStatusResponse,
@@ -69,6 +70,7 @@ import { setSchemaBaseDirs } from '@n8n/workflow-sdk';
 import { nanoid } from 'nanoid';
 import type * as Undici from 'undici';
 
+import { N8N_VERSION } from '@/constants';
 import { SourceControlPreferencesService } from '@/modules/source-control.ee/source-control-preferences.service.ee';
 import { AiService } from '@/services/ai.service';
 import { Push } from '@/push';
@@ -424,6 +426,11 @@ export class InstanceAiService {
 				const headers = new Headers(init?.headers);
 				const auth = await tokenManager.getAuthHeaders();
 				for (const [k, v] of Object.entries(auth)) {
+					headers.set(k, v);
+				}
+				for (const [k, v] of Object.entries(
+					buildProxyHeaders({ feature: 'instance-ai', n8nVersion: N8N_VERSION }),
+				)) {
 					headers.set(k, v);
 				}
 				return await globalThis.fetch(input, { ...init, headers });
@@ -1209,13 +1216,23 @@ export class InstanceAiService {
 				return await client.getBuilderApiProxyToken({ id: user.id }, { userMessageId: nanoid() });
 			});
 			tokenManager = manager;
+			const featureHeaders = buildProxyHeaders({
+				feature: 'instance-ai',
+				n8nVersion: N8N_VERSION,
+			});
 			searchProxyConfig = {
 				apiUrl: proxyBaseUrl + '/brave-search',
-				getAuthHeaders: async () => await manager.getAuthHeaders(),
+				getAuthHeaders: async () => ({
+					...(await manager.getAuthHeaders()),
+					...featureHeaders,
+				}),
 			};
 			tracingProxyConfig = {
 				apiUrl: proxyBaseUrl + '/langsmith',
-				getAuthHeaders: async () => await manager.getAuthHeaders(),
+				getAuthHeaders: async () => ({
+					...(await manager.getAuthHeaders()),
+					...featureHeaders,
+				}),
 			};
 		}
 


### PR DESCRIPTION
## Summary

Every proxied LLM call from n8n to the ai-assistant-service now carries an `x-n8n-feature` header (plus the existing `x-n8n-version`), so the proxy can route each feature's Claude traffic to its own Anthropic credential. This unblocks per-feature cost attribution on the hosted proxy — Instance AI can be billed separately from the workflow/agent builders.

Behavior for users is unchanged. This PR only adds headers. The actual credential routing lives in the companion ai-assistant-service PR.

## What changes

- **`@n8n/api-types` — new shared helper** (`constants/proxy-feature.ts`): `buildProxyHeaders({ feature, n8nVersion })` returns the `x-n8n-feature` + `x-n8n-version` header pair. `feature` is a type-constrained union (`'instance-ai' | 'workflow-builder' | 'agent-builder'`), so a caller that names an unregistered feature doesn't compile. Mirrors the `FEATURES` tuple on the proxy side.
- **Instance AI** (`packages/cli/src/modules/instance-ai/instance-ai.service.ts`): stamps `feature: 'instance-ai'` on the Anthropic model fetch (in `resolveProxyModel`), the Brave Search proxy config, and the LangSmith tracing proxy config. Version is pulled from the existing `N8N_VERSION` constant.
- **AI Workflow Builder** (`packages/@n8n/ai-workflow-builder.ee/src/ai-workflow-builder-agent.service.ts`): stamps `feature: 'workflow-builder'` in `getApiProxyAuthHeaders`, which flows through to both the Anthropic model and the LangSmith tracing client.
- **Tests**:
  - `proxy-feature.test.ts` — covers `buildProxyHeaders` for every registered feature.
  - `ai-workflow-builder-agent.service.test.ts` — new assertion that the feature + version headers are present on both the Anthropic proxy call and the `markBuilderSuccess` call; updated the existing `markBuilderSuccess` assertion accordingly.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-119/support-separate-claude-api-key-for-instance-ai

## Companion PR

ai-assistant-service: https://github.com/n8n-io/ai-assistant-service/pull/367

## Rollout

Deploy order is flexible — the proxy is backward-compatible and silently falls back to the default key when the header is missing or unknown. No coordinated release needed.

## Test plan

- [x] `pnpm jest src/test/ai-workflow-builder-agent.service.test.ts` → 25/25 pass.
- [x] `pnpm test proxy-feature` in `@n8n/api-types` → 2/2 pass.
- [x] Typecheck clean in `@n8n/api-types` and `@n8n/ai-workflow-builder.ee`.
- [ ] Manual: trigger an Instance AI chat and a Workflow Builder session against staging; confirm proxy logs show the correct `x-n8n-feature` per caller.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)