### PR TITLE
feat(GoogleApi.credentials): Add 'global' region option and improve region display formatting

### DIFF
--- a/packages/nodes-base/credentials/GoogleApi.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleApi.credentials.ts
@@ -12,6 +12,11 @@ import type {
 
 const regions = [
 	{
+		name: 'global',
+		displayName: 'Global',
+		location: '',
+	},
+	{
 		name: 'africa-south1',
 		displayName: 'Africa',
 		location: 'Johannesburg',
@@ -233,7 +238,9 @@ export class GoogleApi implements ICredentialType {
 			name: 'region',
 			type: 'options',
 			options: regions.map((r) => ({
-				name: `${r.displayName} (${r.location}) - ${r.name}`,
+				name: r.location
+					? `${r.displayName} (${r.location}) - ${r.name}`
+					: `${r.displayName} - ${r.name}`,
 				value: r.name,
 			})),
 			default: 'us-central1',


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
before
<img width="2116" height="1306" alt="image" src="https://github.com/user-attachments/assets/43dca1e0-c2aa-4ac6-8bf3-124e214a1fc7" />

after
<img width="2112" height="1314" alt="image" src="https://github.com/user-attachments/assets/82028cde-ed39-4969-8fc9-f597c378008f" />

These must be global for a few key reasons:

Global identity
A service account or user must be recognized everywhere.
→ No duplicates across regions
Consistent permissions
Access control must behave the same worldwide
→ No region-based discrepancies or security gaps
Token validation
Access tokens must be verifiable from any location
→ Requires a centralized (global) system
Avoid system fragmentation
Splitting these services by region would create sync issues, conflicts, and instability
## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
