### PR TITLE
feat(core): Centralise user listing permissions for internal and publ…

### DIFF
--- a/packages/cli/src/controllers/__tests__/users.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/users.controller.test.ts
@@ -1,4 +1,3 @@
-import type { UsersListFilterDto } from '@n8n/api-types';
 import type { AuthenticatedRequest, User, UserRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 import type { Response } from 'express';
@@ -6,9 +5,7 @@ import type { Response } from 'express';
 import type { EventService } from '@/events/event.service';
 import type { JwtService } from '@/services/jwt.service';
 import type { ProvisioningService } from '@/modules/provisioning.ee/provisioning.service.ee';
-import type { ProjectService } from '@/services/project.service.ee';
 import type { UrlService } from '@/services/url.service';
-import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
 import { UsersController } from '../users.controller';
@@ -19,7 +16,6 @@ describe('UsersController', () => {
 	const jwtService = mock<JwtService>();
 	const urlService = mock<UrlService>();
 	const provisioningService = mock<ProvisioningService>();
-	const projectService = mock<ProjectService>();
 
 	const controller = new UsersController(
 		mock(),
@@ -36,7 +32,6 @@ describe('UsersController', () => {
 		mock(),
 		jwtService,
 		urlService,
-		projectService,
 		provisioningService,
 	);
 
@@ -66,81 +61,6 @@ describe('UsersController', () => {
 				targetUserNewRole: 'global:member',
 				publicApi: false,
 			});
-		});
-	});
-
-	describe('listUsers', () => {
-		const mockQueryBuilder = () => mock({ getManyAndCount: jest.fn().mockResolvedValue([[], 0]) });
-
-		it('should allow global:owner to list users without checking project scopes', async () => {
-			userRepository.buildUserQuery.mockReturnValue(mockQueryBuilder() as never);
-			const req = mock<AuthenticatedRequest>({
-				user: mock<User>({ role: { slug: 'global:owner', scopes: [] } }),
-			});
-
-			await expect(
-				controller.listUsers(
-					req,
-					mock<Response>(),
-					mock<UsersListFilterDto>({ filter: undefined, select: undefined }),
-				),
-			).resolves.toBeDefined();
-
-			expect(projectService.getProjectIdsWithScope).not.toHaveBeenCalled();
-		});
-
-		it('should allow user with project:update scope to list all users without projectId filter', async () => {
-			userRepository.buildUserQuery.mockReturnValue(mockQueryBuilder() as never);
-			projectService.getProjectIdsWithScope.mockResolvedValue(['project-1']);
-			const req = mock<AuthenticatedRequest>({
-				user: mock<User>({ role: { slug: 'global:member', scopes: [] } }),
-			});
-
-			await expect(
-				controller.listUsers(
-					req,
-					mock<Response>(),
-					mock<UsersListFilterDto>({ filter: undefined, select: undefined }),
-				),
-			).resolves.toBeDefined();
-
-			expect(projectService.getProjectIdsWithScope).toHaveBeenCalledWith(req.user, [
-				'project:update',
-			]);
-		});
-
-		it('should throw ForbiddenError when member has no project:update scope and no projectId filter', async () => {
-			projectService.getProjectIdsWithScope.mockResolvedValue([]);
-			const req = mock<AuthenticatedRequest>({
-				user: mock<User>({ role: { slug: 'global:member' } }),
-			});
-
-			await expect(
-				controller.listUsers(
-					req,
-					mock<Response>(),
-					mock<UsersListFilterDto>({ filter: undefined }),
-				),
-			).rejects.toThrow(ForbiddenError);
-
-			expect(projectService.getProjectIdsWithScope).toHaveBeenCalledWith(req.user, [
-				'project:update',
-			]);
-		});
-
-		it('should throw NotFoundError when filtering by an unknown projectId', async () => {
-			projectService.getProjectWithScope.mockResolvedValue(null);
-			const req = mock<AuthenticatedRequest>({
-				user: mock<User>({ role: { slug: 'global:member' } }),
-			});
-
-			await expect(
-				controller.listUsers(
-					req,
-					mock<Response>(),
-					mock<UsersListFilterDto>({ filter: { projectId: 'unknown-project-id' } }),
-				),
-			).rejects.toThrow(NotFoundError);
 		});
 	});
 

--- a/packages/cli/src/controllers/users.controller.ts
+++ b/packages/cli/src/controllers/users.controller.ts
@@ -45,7 +45,6 @@ import { ExternalHooks } from '@/external-hooks';
 import { ProvisioningService } from '@/modules/provisioning.ee/provisioning.service.ee';
 import { UserRequest } from '@/requests';
 import { FolderService } from '@/services/folder.service';
-import { ProjectService } from '@/services/project.service.ee';
 import { UserService } from '@/services/user.service';
 import { WorkflowService } from '@/workflows/workflow.service';
 import { JwtService } from '@/services/jwt.service';
@@ -68,7 +67,6 @@ export class UsersController {
 		private readonly folderService: FolderService,
 		private readonly jwtService: JwtService,
 		private readonly urlService: UrlService,
-		private readonly projectService: ProjectService,
 		private readonly provisioningService: ProvisioningService,
 	) {}
 
@@ -118,25 +116,7 @@ export class UsersController {
 		_res: Response,
 		@Query listQueryOptions: UsersListFilterDto,
 	) {
-		if (listQueryOptions.filter?.projectId) {
-			const project = await this.projectService.getProjectWithScope(
-				req.user,
-				listQueryOptions.filter.projectId,
-				['project:list'],
-			);
-			if (!project) {
-				throw new NotFoundError('Project not found');
-			}
-		} else if (!['global:owner', 'global:admin'].includes(req.user.role.slug)) {
-			// Project admins need to search all users to invite them into their projects
-			const isProjectAdmin =
-				(await this.projectService.getProjectIdsWithScope(req.user, ['project:update'])).length > 0;
-			if (!isProjectAdmin) {
-				throw new ForbiddenError(
-					'Listing all users is limited to instance administrators and project admins. Filter by project to list project members.',
-				);
-			}
-		}
+		await this.userService.assertGetUsersAccess(req.user, listQueryOptions.filter?.projectId);
 
 		const userQuery = this.userRepository.buildUserQuery(listQueryOptions);
 		const response = await userQuery.getManyAndCount();

--- a/packages/cli/src/public-api/v1/handlers/users/users.handler.ee.ts
+++ b/packages/cli/src/public-api/v1/handlers/users/users.handler.ee.ts
@@ -4,12 +4,11 @@ import { ProjectRelationRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import type express from 'express';
 import type { Response } from 'express';
-import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { InvitationController } from '@/controllers/invitation.controller';
 import { UsersController } from '@/controllers/users.controller';
 import { EventService } from '@/events/event.service';
 import type { UserRequest } from '@/requests';
-import { ProjectService } from '@/services/project.service.ee';
+import { UserService } from '@/services/user.service';
 
 import { clean, getAllUsersAndCount, getUser } from './users.service.ee';
 import {
@@ -19,7 +18,6 @@ import {
 	validLicenseWithUserQuota,
 } from '../../shared/middlewares/global.middleware';
 import { encodeNextCursor } from '../../shared/services/pagination.service';
-import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
 type Create = AuthenticatedRequest<{}, {}, InviteUsersRequestDto>;
 type Delete = UserRequest.Delete;
@@ -56,20 +54,7 @@ export = {
 		async (req: UserRequest.Get, res: express.Response) => {
 			const { offset = 0, limit = 100, includeRole = false, projectId } = req.query;
 
-			if (projectId) {
-				const project = await Container.get(ProjectService).getProjectWithScope(
-					req.user,
-					projectId,
-					['project:list'],
-				);
-				if (!project) {
-					throw new NotFoundError('Project not found');
-				}
-			} else if (!['global:owner', 'global:admin'].includes(req.user.role.slug)) {
-				throw new ForbiddenError(
-					'Listing all users is limited to instance administrators. Filter by project to list project members.',
-				);
-			}
+			await Container.get(UserService).assertGetUsersAccess(req.user, projectId);
 
 			const _in = projectId
 				? await Container.get(ProjectRelationRepository).findUserIdsByProjectId(projectId)

--- a/packages/cli/src/services/__tests__/user.service.test.ts
+++ b/packages/cli/src/services/__tests__/user.service.test.ts
@@ -17,11 +17,14 @@ import { mock } from 'jest-mock-extended';
 import { v4 as uuid } from 'uuid';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { UrlService } from '@/services/url.service';
 import { UserService } from '@/services/user.service';
 import type { UserManagementMailer } from '@/user-management/email';
 
 import type { OwnershipService } from '../ownership.service';
+import type { ProjectService } from '../project.service.ee';
 import type { PublicApiKeyService } from '../public-api-key.service';
 import type { RoleService } from '../role.service';
 import { JwtService } from '../jwt.service';
@@ -47,6 +50,7 @@ describe('UserService', () => {
 	const roleService = mock<RoleService>();
 	const mailer = mock<UserManagementMailer>();
 	const publicApiKeyService = mock<PublicApiKeyService>();
+	const projectService = mock<ProjectService>();
 	const jwtService = mockInstance(JwtService, {
 		sign: jest.fn().mockReturnValue('mock-jwt-token'),
 	});
@@ -62,6 +66,7 @@ describe('UserService', () => {
 		roleService,
 		globalConfig,
 		jwtService,
+		projectService,
 	);
 
 	const commonMockUser = Object.assign(new User(), {
@@ -647,6 +652,35 @@ describe('UserService', () => {
 			const result = await userService.findSsoIdentity(userId);
 
 			expect(result).toEqual(samlIdentity);
+		});
+	});
+
+	describe('assertGetUsersAccess', () => {
+		it('should allow project admin to list all users', async () => {
+			const member = Object.assign(new User(), { role: GLOBAL_MEMBER_ROLE });
+			projectService.getProjectIdsWithScope.mockResolvedValueOnce(['project-1']);
+
+			await expect(userService.assertGetUsersAccess(member)).resolves.toBeUndefined();
+
+			expect(projectService.getProjectIdsWithScope).toHaveBeenCalledWith(member, [
+				'project:update',
+			]);
+		});
+
+		it('should throw ForbiddenError for member without project admin scope', async () => {
+			const member = Object.assign(new User(), { role: GLOBAL_MEMBER_ROLE });
+			projectService.getProjectIdsWithScope.mockResolvedValueOnce([]);
+
+			await expect(userService.assertGetUsersAccess(member)).rejects.toThrow(ForbiddenError);
+		});
+
+		it('should throw NotFoundError when filtering by unknown projectId', async () => {
+			const member = Object.assign(new User(), { role: GLOBAL_MEMBER_ROLE });
+			projectService.getProjectWithScope.mockResolvedValueOnce(null);
+
+			await expect(userService.assertGetUsersAccess(member, 'unknown-project')).rejects.toThrow(
+				NotFoundError,
+			);
 		});
 	});
 });

--- a/packages/cli/src/services/__tests__/user.service.test.ts
+++ b/packages/cli/src/services/__tests__/user.service.test.ts
@@ -667,6 +667,17 @@ describe('UserService', () => {
 			]);
 		});
 
+		it('should allow non-admin members to list users by projectId', async () => {
+			const member = Object.assign(new User(), { role: GLOBAL_MEMBER_ROLE });
+			projectService.getProjectWithScope.mockResolvedValueOnce(mock<Project>());
+
+			await expect(userService.assertGetUsersAccess(member, 'project-1')).resolves.toBeUndefined();
+
+			expect(projectService.getProjectWithScope).toHaveBeenCalledWith(member, 'project-1', [
+				'project:list',
+			]);
+		});
+
 		it('should throw ForbiddenError for member without project admin scope', async () => {
 			const member = Object.assign(new User(), { role: GLOBAL_MEMBER_ROLE });
 			projectService.getProjectIdsWithScope.mockResolvedValueOnce([]);

--- a/packages/cli/src/services/user.service.ts
+++ b/packages/cli/src/services/user.service.ts
@@ -23,7 +23,9 @@ import type { IUserSettings } from 'n8n-workflow';
 import { UserError } from 'n8n-workflow';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { EventService } from '@/events/event.service';
 import type { Invitation } from '@/interfaces';
 import { PostHogClient } from '@/posthog';
@@ -33,6 +35,7 @@ import { UserManagementMailer } from '@/user-management/email';
 
 import { JwtService } from './jwt.service';
 import { OwnershipService } from './ownership.service';
+import { ProjectService } from './project.service.ee';
 import { PublicApiKeyService } from './public-api-key.service';
 import { RoleService } from './role.service';
 
@@ -50,6 +53,7 @@ export class UserService {
 		private readonly roleService: RoleService,
 		private readonly globalConfig: GlobalConfig,
 		private readonly jwtService: JwtService,
+		private readonly projectService: ProjectService,
 	) {}
 
 	async update(userId: string, data: Partial<User>) {
@@ -64,6 +68,25 @@ export class UserService {
 
 	getManager() {
 		return this.userRepository.manager;
+	}
+
+	async assertGetUsersAccess(user: User, projectId?: string) {
+		if (projectId) {
+			const project = await this.projectService.getProjectWithScope(user, projectId, [
+				'project:list',
+			]);
+			if (!project) {
+				throw new NotFoundError('Project not found');
+			}
+		} else if (!['global:owner', 'global:admin'].includes(user.role.slug)) {
+			const hasProjectUpdateScope =
+				(await this.projectService.getProjectIdsWithScope(user, ['project:update'])).length > 0;
+			if (!hasProjectUpdateScope) {
+				throw new ForbiddenError(
+					'Listing all users is limited to instance administrators and project admins. Filter by project to list project members.',
+				);
+			}
+		}
 	}
 
 	async updateSettings(userId: string, newSettings: Partial<IUserSettings>) {

--- a/packages/cli/src/services/user.service.ts
+++ b/packages/cli/src/services/user.service.ts
@@ -70,7 +70,7 @@ export class UserService {
 		return this.userRepository.manager;
 	}
 
-	async assertGetUsersAccess(user: User, projectId?: string) {
+	async assertGetUsersAccess(user: User, projectId?: string): Promise<void> {
 		if (projectId) {
 			const project = await this.projectService.getProjectWithScope(user, projectId, [
 				'project:list',
@@ -78,14 +78,18 @@ export class UserService {
 			if (!project) {
 				throw new NotFoundError('Project not found');
 			}
-		} else if (!['global:owner', 'global:admin'].includes(user.role.slug)) {
-			const hasProjectUpdateScope =
-				(await this.projectService.getProjectIdsWithScope(user, ['project:update'])).length > 0;
-			if (!hasProjectUpdateScope) {
-				throw new ForbiddenError(
-					'Listing all users is limited to instance administrators and project admins. Filter by project to list project members.',
-				);
-			}
+			return;
+		}
+		const isInstanceAdmin = ['global:owner', 'global:admin'].includes(user.role.slug);
+		if (isInstanceAdmin) {
+			return;
+		}
+		const hasProjectUpdateScope =
+			(await this.projectService.getProjectIdsWithScope(user, ['project:update'])).length > 0;
+		if (!hasProjectUpdateScope) {
+			throw new ForbiddenError(
+				'Listing all users is limited to instance administrators and project admins. Filter by project to list project members.',
+			);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Move permission checks into user service to make sure public API and internal follow the same rules.

Removes unit tests from users.controller as they were heavily mocked and not bringing much value. Tests were updated for the service.

## Related Linear tickets, Github issues, and Community forum posts

Closes [LIGO-479](https://linear.app/n8n/issue/LIGO-479/cant-invite-users-to-a-project)


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
