### PR TITLE
fix(Merge Node): Improve SQL Query mode memory efficiency and error reporting

### DIFF
--- a/packages/nodes-base/nodes/Merge/test/v3/combineBtSql.test.ts
+++ b/packages/nodes-base/nodes/Merge/test/v3/combineBtSql.test.ts
@@ -353,5 +353,27 @@ describe('combineBySql sandbox (isolated-vm)', () => {
 			// Database count must not grow – each invocation cleans up after itself
 			expect(countAfter).toBe(countBefore);
 		});
+
+		it('should handle a large dataset (25k rows) without exhausting the sandbox', async () => {
+			const context = await loadAlaSqlSandbox();
+			const rows = Array.from({ length: 25_000 }, (_, i) => ({
+				id: i,
+				a: `v${i}`,
+				b: i * 2,
+				c: i % 7,
+				d: `tag-${i % 100}`,
+				e: i % 2 === 0,
+				f: i / 3,
+				g: `group-${i % 50}`,
+				h: i,
+				j: `x${i}`,
+			}));
+			const result = await runAlaSqlInSandbox(
+				context,
+				[rows],
+				'SELECT COUNT(*) AS n FROM input1 WHERE b > 10000',
+			);
+			expect(result[0]).toEqual({ n: 19999 });
+		});
 	});
 });

--- a/packages/nodes-base/nodes/Merge/v3/actions/mode/combineBySql.ts
+++ b/packages/nodes-base/nodes/Merge/v3/actions/mode/combineBySql.ts
@@ -14,7 +14,11 @@ import { getResolvables, updateDisplayOptions } from '@utils/utilities';
 
 import { numberInputsProperty } from '../../helpers/descriptions';
 import { modifySelectQuery, rowToExecutionData } from '../../helpers/utils';
-import { loadAlaSqlSandbox, runAlaSqlInSandbox } from '../../helpers/sandbox-utils';
+import {
+	loadAlaSqlSandbox,
+	resetSandboxCache,
+	runAlaSqlInSandbox,
+} from '../../helpers/sandbox-utils';
 
 type OperationOptions = {
 	emptyQueryResult: 'success' | 'empty';
@@ -78,17 +82,24 @@ const displayOptions = {
 export const description = updateDisplayOptions(displayOptions, properties);
 
 const prepareError = (node: INode, error: Error) => {
-	let message = '';
-	if (typeof error === 'string') {
-		message = error;
-	} else {
-		message = error.message;
-	}
-	throw new NodeOperationError(node, error, {
-		message: 'Issue while executing query',
-		description: message,
-		itemIndex: 0,
-	});
+	const raw = typeof error === 'string' ? error : error.message;
+	const isDisposed = /isolate.*dispos|memory limit|exhausted/i.test(raw);
+	const isTimeout = /script execution timed out/i.test(raw);
+
+	if (isDisposed) resetSandboxCache();
+
+	const message = isDisposed
+		? 'Dataset too large for the SQL sandbox'
+		: isTimeout
+			? 'SQL query exceeded the 30 second execution limit'
+			: 'Issue while executing query';
+	const description = isDisposed
+		? 'Try filtering or aggregating upstream, or split the input into smaller batches before the Merge node.'
+		: isTimeout
+			? 'Simplify the query (remove unnecessary JOINs) or reduce the number of input rows.'
+			: raw;
+
+	throw new NodeOperationError(node, error, { message, description, itemIndex: 0 });
 };
 
 async function executeSelectWithMappedPairedItems(

--- a/packages/nodes-base/nodes/Merge/v3/helpers/sandbox-utils.ts
+++ b/packages/nodes-base/nodes/Merge/v3/helpers/sandbox-utils.ts
@@ -72,24 +72,30 @@ export async function runAlaSqlInSandbox(
 	// don't collide on alasql.databases.
 	const dbId = randomUUID();
 
-	// Double-serialization: outer JSON.stringify produces a JSON string, inner produces a JSON literal
-	// embedded in the script source. Inside the isolate, JSON.parse reconstructs the plain array.
-	// This ensures data enters the isolate as a parsed JSON literal, never as live objects.
-	const script = `(function() {
-		const __rows = JSON.parse(${JSON.stringify(JSON.stringify(tableData))});
-		const __db = new alasql.Database(${JSON.stringify(dbId)});
+	// evalClosure binds ($0, $1, $2) as parameters of an implicit wrapping function,
+	// so they stay local to this call — unlike context.global.set, they can't be
+	// overwritten by a concurrent invocation on the shared singleton context.
+	// arguments.copy uses V8 structured clone, which strips prototypes and functions
+	// so only inert plain data crosses the isolate boundary.
+	const script = `
+		const rows = $0, dbId = $1, query = $2;
+		const db = new alasql.Database(dbId);
 		try {
-			for (let i = 0; i < __rows.length; i++) {
-				__db.exec('CREATE TABLE input' + (i + 1));
-				__db.tables['input' + (i + 1)].data = __rows[i];
+			for (let i = 0; i < rows.length; i++) {
+				db.exec('CREATE TABLE input' + (i + 1));
+				db.tables['input' + (i + 1)].data = rows[i];
 			}
-			return JSON.stringify(__db.exec(${JSON.stringify(query)}));
+			return JSON.stringify(db.exec(query));
 		} finally {
-			delete alasql.databases[${JSON.stringify(dbId)}];
+			delete alasql.databases[dbId];
 		}
-	})()`;
+	`;
 
-	const resultJson = (await context.eval(script, { timeout: 5000, copy: true })) as string;
+	const resultJson = (await context.evalClosure(script, [tableData, dbId, query], {
+		arguments: { copy: true },
+		result: { copy: true },
+		timeout: 30000,
+	})) as string;
 	try {
 		return JSON.parse(resultJson) as IDataObject[];
 	} catch (e) {


### PR DESCRIPTION
## Summary

Community users running the Merge v3 node in **SQL Query** mode against larger item streams (25k+ rows) hit `Isolate is disposed` with no output. The existing isolate-based sandbox already provides the security boundary we want, but the data-transport and error-handling paths around it were exhausting the isolate on reasonable workloads.

This PR makes three coordinated changes to `combineBySql`:

1. **Data now crosses the isolate boundary via `context.evalClosure` arguments instead of a script-source JSON literal.** Previously the full dataset was embedded as a JSON string inside the script text, then re-parsed inside the isolate — peak allocation was roughly 3× the dataset. Now rows, the per-call database id, and the query string are passed as closure arguments with `arguments: { copy: true }` (V8 structured clone), dropping it to ~1×. Prototypes and functions are still stripped at the boundary, and because the arguments are local parameters of the implicit closure — not writes to the shared context's globals — concurrent `combineBySql` invocations on the singleton isolate cannot see or overwrite each other's inputs.
2. **Clearer error classification and sandbox recovery.** Disposed-isolate and timeout errors are detected and surfaced as actionable messages (`Dataset too large for the SQL sandbox` / `SQL query exceeded the 30 second execution limit`) with hints pointing at upstream filtering or batching. On dispose we also reset the cached isolate so the next execution starts fresh instead of reusing a poisoned singleton.
3. **Execution timeout raised from 5 s to 30 s**, matching real-world large-dataset query durations.

### How to test

1. Workflow: Code node → Merge v3 (SQL Query).
2. Code node:
   ```js
   return Array.from({ length: 25000 }, (_, i) => ({
     json: { id: i, val: i * 3, category: i % 100, name: `row-${i}`, flag: i % 2 === 0 },
   }));
   ```
3. Merge SQL: `SELECT category, SUM(val) AS total FROM input1 GROUP BY category ORDER BY total DESC`
4. Pre-fix: fails with `Isolate is disposed`. Post-fix: returns 100 rows in ~1–3 s.
5. Stress path: bump row count + column count past the 64 MB ceiling — new error reads `Dataset too large for the SQL sandbox`, and the very next small-dataset execution still succeeds (cache was reset).

Automated coverage: `pnpm test combineBtSql` in `packages/nodes-base` — 31/31 pass, including a new regression case that runs a `COUNT(*)` over 25k rows.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4830

closes #27861

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
