### PR TITLE
fix(core): Harden event log parse against malformed input

### DIFF
--- a/packages/@n8n/config/src/configs/event-bus.config.ts
+++ b/packages/@n8n/config/src/configs/event-bus.config.ts
@@ -23,6 +23,14 @@ class LogWriterConfig {
 	 */
 	@Env('N8N_EVENTBUS_LOGWRITER_MAXMESSAGESPERPARSE')
 	maxMessagesPerParse: number = 10_000;
+
+	/**
+	 * Absolute ceiling on total lines processed from a single event log file during
+	 * parsing, across all return modes (including 'all'). Skipped/invalid lines count
+	 * toward this total, bounding worst-case memory on malformed files.
+	 */
+	@Env('N8N_EVENTBUS_LOGWRITER_MAXTOTALMESSAGESPERFILE')
+	maxTotalMessagesPerFile: number = 500_000;
 }
 
 const recoveryModeSchema = z.enum(['simple', 'extensive']);

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -163,6 +163,7 @@ describe('GlobalConfig', () => {
 				logBaseName: 'n8nEventLog',
 				maxFileSizeInKB: 10240,
 				maxMessagesPerParse: 10_000,
+				maxTotalMessagesPerFile: 500_000,
 			},
 		},
 		externalHooks: {

--- a/packages/cli/src/eventbus/message-event-bus-writer/__tests__/message-event-bus-log-writer.test.ts
+++ b/packages/cli/src/eventbus/message-event-bus-writer/__tests__/message-event-bus-log-writer.test.ts
@@ -42,9 +42,14 @@ describe('MessageEventBusLogWriter.readLoggedMessagesFromFile', () => {
 		return path;
 	};
 
-	const setMaxMessagesPerParse = (maxMessagesPerParse: number) => {
+	const setMaxMessagesPerParse = (
+		maxMessagesPerParse: number,
+		maxTotalMessagesPerFile: number = 500_000,
+	) => {
 		const globalConfig = mock<GlobalConfig>({
-			eventBus: { logWriter: { maxMessagesPerParse, keepLogCount: 3 } },
+			eventBus: {
+				logWriter: { maxMessagesPerParse, maxTotalMessagesPerFile, keepLogCount: 3 },
+			},
 		});
 		Container.set(GlobalConfig, globalConfig);
 	};
@@ -165,5 +170,130 @@ describe('MessageEventBusLogWriter.readLoggedMessagesFromFile', () => {
 
 		expect(results.loggedMessages).toHaveLength(0);
 		expect(logger.warn).not.toHaveBeenCalled();
+	});
+
+	it('aggregates malformed lines into a single warn and logs no per-line errors', async () => {
+		setMaxMessagesPerParse(1000, 500_000);
+		writer = new MessageEventBusLogWriter();
+
+		const lines: string[] = [];
+		for (let i = 0; i < 1000; i++) {
+			lines.push(`malformed-${i}-not-json`);
+		}
+		const logFile = writeLogFile('malformed.log', lines);
+
+		const results = {
+			loggedMessages: [] as EventMessageTypes[],
+			sentMessages: [] as EventMessageTypes[],
+			unfinishedExecutions: {} as Record<string, EventMessageTypes[]>,
+		};
+
+		await writer.readLoggedMessagesFromFile(results, 'unsent', logFile);
+
+		expect(results.loggedMessages).toHaveLength(0);
+		expect(logger.error).not.toHaveBeenCalled();
+		expect(logger.warn).toHaveBeenCalledTimes(1);
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining('skipped 1000 malformed line(s)'),
+		);
+	});
+
+	it('returns valid messages and one aggregated warn on mixed valid/invalid input', async () => {
+		setMaxMessagesPerParse(1000, 500_000);
+		writer = new MessageEventBusLogWriter();
+
+		const lines: string[] = [];
+		for (let i = 0; i < 5; i++) {
+			lines.push(makeWorkflowStartedLine(`id-${i}`, `exec-${i}`));
+			lines.push(`malformed-${i}`);
+		}
+		const logFile = writeLogFile('mixed.log', lines);
+
+		const results = {
+			loggedMessages: [] as EventMessageTypes[],
+			sentMessages: [] as EventMessageTypes[],
+			unfinishedExecutions: {} as Record<string, EventMessageTypes[]>,
+		};
+
+		await writer.readLoggedMessagesFromFile(results, 'unsent', logFile);
+
+		expect(results.loggedMessages).toHaveLength(5);
+		expect(logger.error).not.toHaveBeenCalled();
+		expect(logger.warn).toHaveBeenCalledTimes(1);
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining('skipped 5 malformed line(s)'),
+		);
+	});
+
+	it('aborts "all"-mode parsing when the total line ceiling is exceeded', async () => {
+		setMaxMessagesPerParse(1000, 10);
+		writer = new MessageEventBusLogWriter();
+
+		const lines: string[] = [];
+		for (let i = 0; i < 50; i++) {
+			lines.push(makeWorkflowStartedLine(`id-${i}`, `exec-${i}`));
+		}
+		const logFile = writeLogFile('large-all.log', lines);
+
+		const results = {
+			loggedMessages: [] as EventMessageTypes[],
+			sentMessages: [] as EventMessageTypes[],
+			unfinishedExecutions: {} as Record<string, EventMessageTypes[]>,
+		};
+
+		await writer.readLoggedMessagesFromFile(results, 'all', logFile);
+
+		expect(results.loggedMessages.length).toBeLessThanOrEqual(11);
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining('exceeded 10 total lines during parse'),
+		);
+	});
+
+	it('counts malformed lines toward the total-messages ceiling', async () => {
+		setMaxMessagesPerParse(1000, 20);
+		writer = new MessageEventBusLogWriter();
+
+		const lines: string[] = [];
+		for (let i = 0; i < 100; i++) {
+			lines.push(`malformed-${i}`);
+		}
+		const logFile = writeLogFile('all-malformed.log', lines);
+
+		const results = {
+			loggedMessages: [] as EventMessageTypes[],
+			sentMessages: [] as EventMessageTypes[],
+			unfinishedExecutions: {} as Record<string, EventMessageTypes[]>,
+		};
+
+		await writer.readLoggedMessagesFromFile(results, 'all', logFile);
+
+		expect(results.loggedMessages).toHaveLength(0);
+		expect(logger.error).not.toHaveBeenCalled();
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining('exceeded 20 total lines during parse'),
+		);
+		expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('skipped'));
+	});
+
+	it('truncates the aggregated warn sample to 200 characters', async () => {
+		setMaxMessagesPerParse(1000, 500_000);
+		writer = new MessageEventBusLogWriter();
+
+		const longMalformed = 'x'.repeat(500);
+		const logFile = writeLogFile('long-malformed.log', [longMalformed]);
+
+		const results = {
+			loggedMessages: [] as EventMessageTypes[],
+			sentMessages: [] as EventMessageTypes[],
+			unfinishedExecutions: {} as Record<string, EventMessageTypes[]>,
+		};
+
+		await writer.readLoggedMessagesFromFile(results, 'unsent', logFile);
+
+		expect(logger.warn).toHaveBeenCalledTimes(1);
+		const warnCall = logger.warn.mock.calls[0]?.[0];
+		const sampleMatch = warnCall?.match(/Sample \(truncated\): (.*)$/);
+		expect(sampleMatch).not.toBeNull();
+		expect(sampleMatch![1].length).toBeLessThanOrEqual(200);
 	});
 });

--- a/packages/cli/src/eventbus/message-event-bus-writer/message-event-bus-log-writer.ts
+++ b/packages/cli/src/eventbus/message-event-bus-writer/message-event-bus-log-writer.ts
@@ -224,11 +224,26 @@ export class MessageEventBusLogWriter {
 				// The guard is skipped in 'all' mode because confirms don't prune there,
 				// so the count would grow monotonically even for healthy files.
 				const maxMessagesPerParse = this.globalConfig.eventBus.logWriter.maxMessagesPerParse;
+				const maxTotalMessagesPerFile =
+					this.globalConfig.eventBus.logWriter.maxTotalMessagesPerFile;
 				const baselineCount = results.loggedMessages.length;
 				let aborted = false;
+				// Stack-local counters: aggregate malformed lines into a single warn at
+				// the end of the parse pass. Each per-line error log allocates the raw
+				// line into the message template and runs the winston format pipeline,
+				// which on 100k-line malformed files blows the heap.
+				let parseSkipped = 0;
+				let parseSkippedSample: string | undefined;
 				rl.on('line', (line) => {
 					if (aborted) return;
-					this.processLoggedLine(line, results, mode, logFileName);
+					try {
+						this.processLoggedLine(line, results, mode);
+					} catch {
+						parseSkipped += 1;
+						if (parseSkippedSample === undefined) {
+							parseSkippedSample = line.slice(0, 200);
+						}
+					}
 					if (
 						mode !== 'all' &&
 						results.loggedMessages.length - baselineCount > maxMessagesPerParse
@@ -239,10 +254,29 @@ export class MessageEventBusLogWriter {
 						);
 						rl.close();
 						stream.destroy();
+						return;
+					}
+					// Absolute ceiling applied in every mode, counting skipped lines too
+					// so 100%-malformed files also trip it.
+					if (
+						results.loggedMessages.length - baselineCount + parseSkipped >=
+						maxTotalMessagesPerFile
+					) {
+						aborted = true;
+						this.logger.warn(
+							`Event log ${logFileName} exceeded ${maxTotalMessagesPerFile} total lines during parse; aborting to prevent out-of-memory. Tune via N8N_EVENTBUS_LOGWRITER_MAXTOTALMESSAGESPERFILE.`,
+						);
+						rl.close();
+						stream.destroy();
 					}
 				});
 				// wait for stream to finish before continue
 				await eventOnce(rl, 'close');
+				if (parseSkipped > 0) {
+					this.logger.warn(
+						`Event log parse skipped ${parseSkipped} malformed line(s) in ${logFileName}. Sample (truncated): ${parseSkippedSample}`,
+					);
+				}
 			} catch {
 				this.logger.error(`Error reading logged messages from file: ${logFileName}`);
 			}
@@ -255,48 +289,41 @@ export class MessageEventBusLogWriter {
 		line: string,
 		results: ReadMessagesFromLogFileResult,
 		mode: EventMessageReturnMode,
-		logFileName: string,
 	): void {
-		try {
-			const json = jsonParse(line);
-			if (isEventMessageOptions(json) && json.__type !== undefined) {
-				const msg = this.getEventMessageObjectByType(json);
-				if (msg !== null) results.loggedMessages.push(msg);
-				if (msg?.eventName && msg.payload?.executionId) {
-					const executionId = msg.payload.executionId as string;
-					switch (msg.eventName) {
-						case 'n8n.workflow.started':
-							if (!Object.keys(results.unfinishedExecutions).includes(executionId)) {
-								results.unfinishedExecutions[executionId] = [];
-							}
-							results.unfinishedExecutions[executionId] = [msg];
-							break;
-						case 'n8n.workflow.success':
-						case 'n8n.workflow.failed':
-						case 'n8n.execution.throttled':
-						case 'n8n.execution.started-during-bootup':
-							delete results.unfinishedExecutions[executionId];
-							break;
-						case 'n8n.node.started':
-						case 'n8n.node.finished':
-							if (!Object.keys(results.unfinishedExecutions).includes(executionId)) {
-								results.unfinishedExecutions[executionId] = [];
-							}
-							results.unfinishedExecutions[executionId].push(msg);
-							break;
-					}
+		const json = jsonParse(line);
+		if (isEventMessageOptions(json) && json.__type !== undefined) {
+			const msg = this.getEventMessageObjectByType(json);
+			if (msg !== null) results.loggedMessages.push(msg);
+			if (msg?.eventName && msg.payload?.executionId) {
+				const executionId = msg.payload.executionId as string;
+				switch (msg.eventName) {
+					case 'n8n.workflow.started':
+						if (!Object.keys(results.unfinishedExecutions).includes(executionId)) {
+							results.unfinishedExecutions[executionId] = [];
+						}
+						results.unfinishedExecutions[executionId] = [msg];
+						break;
+					case 'n8n.workflow.success':
+					case 'n8n.workflow.failed':
+					case 'n8n.execution.throttled':
+					case 'n8n.execution.started-during-bootup':
+						delete results.unfinishedExecutions[executionId];
+						break;
+					case 'n8n.node.started':
+					case 'n8n.node.finished':
+						if (!Object.keys(results.unfinishedExecutions).includes(executionId)) {
+							results.unfinishedExecutions[executionId] = [];
+						}
+						results.unfinishedExecutions[executionId].push(msg);
+						break;
 				}
 			}
-			if (isEventMessageConfirm(json) && mode !== 'all') {
-				const removedMessage = remove(results.loggedMessages, (e) => e.id === json.confirm);
-				if (mode === 'sent') {
-					results.sentMessages.push(...removedMessage);
-				}
+		}
+		if (isEventMessageConfirm(json) && mode !== 'all') {
+			const removedMessage = remove(results.loggedMessages, (e) => e.id === json.confirm);
+			if (mode === 'sent') {
+				results.sentMessages.push(...removedMessage);
 			}
-		} catch (error) {
-			this.logger.error(
-				`Error reading line messages from file: ${logFileName}, line: ${line}, ${error.message}}`,
-			);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Hardens `MessageEventBusLogWriter` read-side so heap usage stays bounded when parsing event log files that contain malformed lines. Two defensive changes:

- **Aggregate malformed-line warnings.** Previously every invalid line produced its own `logger.error` with the raw line interpolated into the message template. In tight-loop parses this allocates per-line memory faster than the runtime can reclaim. `readLoggedMessagesFromFile` now counts skipped lines in stack-local state and emits a single aggregated `logger.warn` at the end of each parse pass, with a 200-char truncated sample for ops triage.
- **Absolute ceiling on total lines processed per file.** The existing `maxMessagesPerParse` guard (PR #28594) only applies in non-`'all'` modes and only counts successful parses, so it doesn't bound pathological files at all. A new `N8N_EVENTBUS_LOGWRITER_MAXTOTALMESSAGESPERFILE` (default `500_000`) caps total lines processed in every mode, with skipped lines counted toward the total so 100%-malformed files also trip it.

Empirically validated with a micro-benchmark: 100k tight-loop `logger.error` calls with a 10 kB line interpolated allocate ~1 GB of heap; collapsing to a single aggregated warn drops the delta to 0 MB and the wall time from 2 s to 1 ms.

### How to test manually

**Aggregate-warn path:**

1. Create a malformed event log file on a dev instance:
   ```bash
   for i in $(seq 1 10000); do echo "not-json-$i"; done > ~/.n8n/n8nEventLog.log
   ```
2. Start n8n and observe startup logs.
3. Before this change: ~10k `error` lines and visible memory growth during boot. After: a single `warn` of the form `Event log parse skipped 10000 malformed line(s) in <file>. Sample (truncated): not-json-...`, no per-line errors, flat memory.

**Total-ceiling path:**

1. Export `N8N_EVENTBUS_LOGWRITER_MAXTOTALMESSAGESPERFILE=100`.
2. Seed a file with more than 100 lines (`seq 1 500 > ~/.n8n/n8nEventLog.log`).
3. Start n8n. Expect a single `warn`: `Event log <file> exceeded 100 total lines during parse; aborting to prevent out-of-memory.`

**Healthy-file regression:**

With no config changes and a healthy event log, behavior is byte-identical — no new warns, no dropped messages. Covered by the four pre-existing unit tests, which pass unmodified.

### Key implementation decisions

- **`processLoggedLine` lets exceptions propagate** instead of logging-and-swallowing. Aggregation lives in the caller (`readLoggedMessagesFromFile`) where stack-local counters are natural. The raw line is no longer baked into any log message — the truncated sample in the aggregate warn is sufficient for triage.
- **Counters are stack-local per parse pass**, not instance state. Two concurrent parse passes each get their own counters; no process-global retention.
- **Skipped lines count toward `maxTotalMessagesPerFile`.** Closes the 100%-malformed-file case the existing `maxMessagesPerParse` guard misses. Existing guard left intact to preserve PR #28594's semantics for the orphaned-messages scenario.
- **Out of scope, flagged as follow-ups:** the post-parse `send()` fanout amplification via `MessageEventBus.initialize` (re-emits every parsed message to all log-streaming destinations including Sentry NodeClient) and the unbounded `ErrorReporter.seenErrors` Set. This PR is partial-defence-in-depth against both (bounded parse → bounded fanout) but doesn't fix them at their source. Separate tickets to follow.

## Related Links

- Linear ticket: https://linear.app/n8n/issue/IAM-578
- Layers on top of #28594 (parse guard) — that guard stays intact; this adds a second absolute guard covering the modes it doesn't.

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)