### PR TITLE
feat: Enable log streamin settings via env vars

### DIFF
--- a/packages/@n8n/api-types/src/frontend-settings.ts
+++ b/packages/@n8n/api-types/src/frontend-settings.ts
@@ -146,6 +146,9 @@ export interface FrontendSettings {
 			loginEnabled: boolean;
 		};
 	};
+	logStreaming: {
+		managedByEnv: boolean;
+	};
 	publicApi: {
 		enabled: boolean;
 		latestVersion: number;

--- a/packages/@n8n/config/src/configs/instance-settings-loader.config.ts
+++ b/packages/@n8n/config/src/configs/instance-settings-loader.config.ts
@@ -104,32 +104,9 @@ export class InstanceSettingsLoaderConfig {
 	 * @example
 	 * ```json
 	 * [
-	 *   {
-	 *     "type": "webhook",
-	 *     "label": "Audit webhook",
-	 *     "url": "https://hooks.example.com",
-	 *     "method": "POST",
-	 *     "sendHeaders": true,
-	 *     "specifyHeaders": "keypair",
-	 *     "headerParameters": {
-	 *       "parameters": [{ "name": "Authorization", "value": "Bearer abc123" }]
-	 *     },
-	 *     "subscribedEvents": ["n8n.workflow", "n8n.audit"]
-	 *   },
-	 *   {
-	 *     "type": "syslog",
-	 *     "label": "SIEM",
-	 *     "host": "syslog.example.com",
-	 *     "port": 514,
-	 *     "protocol": "udp",
-	 *     "facility": 16,
-	 *     "app_name": "n8n"
-	 *   },
-	 *   {
-	 *     "type": "sentry",
-	 *     "label": "Ops sentry",
-	 *     "dsn": "https://public@sentry.example.com/1"
-	 *   }
+	 *   { "type": "webhook", "label": "Audit", "url": "https://hooks.example.com/audit" },
+	 *   { "type": "syslog", "label": "SIEM", "host": "syslog.example.com" },
+	 *   { "type": "sentry", "label": "Ops", "dsn": "https://public@sentry.example.com/1" }
 	 * ]
 	 * ```
 	 */

--- a/packages/@n8n/config/src/configs/instance-settings-loader.config.ts
+++ b/packages/@n8n/config/src/configs/instance-settings-loader.config.ts
@@ -88,4 +88,44 @@ export class InstanceSettingsLoaderConfig {
 
 	@Env('N8N_SSO_SAML_LOGIN_ENABLED')
 	samlLoginEnabled: boolean = false;
+
+	// --- Log streaming ---
+
+	/**
+	 * When true, log streaming destinations are reconciled from env vars on every
+	 * startup
+	 */
+	@Env('N8N_LOG_STREAMING_MANAGED_BY_ENV')
+	logStreamingManagedByEnv: boolean = false;
+
+	/**
+	 * JSON-encoded array of log streaming destinations.
+	 *
+	 * @example
+	 * ```json
+	 * [
+	 *   {
+	 *     "type": "webhook",
+	 *     "url": "https://hooks.example.com",
+	 *     "method": "POST",
+	 *     "headerParameters": {
+	 *       "parameters": [{ "name": "Authorization", "value": "Bearer abc123" }]
+	 *     }
+	 *   },
+	 *   {
+	 *     "type": "syslog",
+	 *     "host": "syslog.example.com",
+	 *     "port": 514,
+	 *     "protocol": "udp"
+	 *   },
+	 *   {
+	 *     "type": "sentry",
+	 *     "dsn": "https://public@sentry.example.com/1",
+	 *     "tracesSampleRate": 0.1
+	 *   }
+	 * ]
+	 * ```
+	 */
+	@Env('N8N_LOG_STREAMING_DESTINATIONS')
+	logStreamingDestinations: string = '';
 }

--- a/packages/@n8n/config/src/configs/instance-settings-loader.config.ts
+++ b/packages/@n8n/config/src/configs/instance-settings-loader.config.ts
@@ -106,22 +106,29 @@ export class InstanceSettingsLoaderConfig {
 	 * [
 	 *   {
 	 *     "type": "webhook",
+	 *     "label": "Audit webhook",
 	 *     "url": "https://hooks.example.com",
 	 *     "method": "POST",
+	 *     "sendHeaders": true,
+	 *     "specifyHeaders": "keypair",
 	 *     "headerParameters": {
 	 *       "parameters": [{ "name": "Authorization", "value": "Bearer abc123" }]
-	 *     }
+	 *     },
+	 *     "subscribedEvents": ["n8n.workflow", "n8n.audit"]
 	 *   },
 	 *   {
 	 *     "type": "syslog",
+	 *     "label": "SIEM",
 	 *     "host": "syslog.example.com",
 	 *     "port": 514,
-	 *     "protocol": "udp"
+	 *     "protocol": "udp",
+	 *     "facility": 16,
+	 *     "app_name": "n8n"
 	 *   },
 	 *   {
 	 *     "type": "sentry",
-	 *     "dsn": "https://public@sentry.example.com/1",
-	 *     "tracesSampleRate": 0.1
+	 *     "label": "Ops sentry",
+	 *     "dsn": "https://public@sentry.example.com/1"
 	 *   }
 	 * ]
 	 * ```

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -519,6 +519,8 @@ describe('GlobalConfig', () => {
 			samlMetadata: '',
 			samlMetadataUrl: '',
 			samlLoginEnabled: false,
+			logStreamingManagedByEnv: false,
+			logStreamingDestinations: '',
 		},
 	} satisfies GlobalConfigShape;
 

--- a/packages/cli/src/instance-settings-loader/__tests__/instance-settings-loader.service.test.ts
+++ b/packages/cli/src/instance-settings-loader/__tests__/instance-settings-loader.service.test.ts
@@ -2,6 +2,7 @@ import { mock } from 'jest-mock-extended';
 import type { Logger } from '@n8n/backend-common';
 
 import { InstanceSettingsLoaderService } from '../instance-settings-loader.service';
+import type { LogStreamingInstanceSettingsLoader } from '../loaders/log-streaming.instance-settings-loader';
 import type { OwnerInstanceSettingsLoader } from '../loaders/owner.instance-settings-loader';
 import type { SecurityPolicyInstanceSettingsLoader } from '../loaders/security-policy.instance-settings-loader';
 import type { SsoInstanceSettingsLoader } from '../loaders/sso.instance-settings-loader';
@@ -11,6 +12,7 @@ describe('InstanceSettingsLoaderService', () => {
 	const ownerLoader = mock<OwnerInstanceSettingsLoader>();
 	const ssoLoader = mock<SsoInstanceSettingsLoader>();
 	const securityPolicyLoader = mock<SecurityPolicyInstanceSettingsLoader>();
+	const logStreamingLoader = mock<LogStreamingInstanceSettingsLoader>();
 
 	beforeEach(() => {
 		jest.resetAllMocks();
@@ -18,10 +20,17 @@ describe('InstanceSettingsLoaderService', () => {
 		ownerLoader.run.mockResolvedValue('skipped');
 		ssoLoader.run.mockResolvedValue('skipped');
 		securityPolicyLoader.run.mockResolvedValue('skipped');
+		logStreamingLoader.run.mockResolvedValue('skipped');
 	});
 
 	const createService = () =>
-		new InstanceSettingsLoaderService(logger, ownerLoader, ssoLoader, securityPolicyLoader);
+		new InstanceSettingsLoaderService(
+			logger,
+			ownerLoader,
+			ssoLoader,
+			securityPolicyLoader,
+			logStreamingLoader,
+		);
 
 	it('should run all loaders', async () => {
 		await createService().init();
@@ -29,6 +38,7 @@ describe('InstanceSettingsLoaderService', () => {
 		expect(ownerLoader.run).toHaveBeenCalled();
 		expect(ssoLoader.run).toHaveBeenCalled();
 		expect(securityPolicyLoader.run).toHaveBeenCalled();
+		expect(logStreamingLoader.run).toHaveBeenCalled();
 	});
 
 	it('should stop execution if a loader throws', async () => {
@@ -38,5 +48,6 @@ describe('InstanceSettingsLoaderService', () => {
 
 		expect(ownerLoader.run).toHaveBeenCalled();
 		expect(securityPolicyLoader.run).not.toHaveBeenCalled();
+		expect(logStreamingLoader.run).not.toHaveBeenCalled();
 	});
 });

--- a/packages/cli/src/instance-settings-loader/__tests__/log-streaming.instance-settings-loader.test.ts
+++ b/packages/cli/src/instance-settings-loader/__tests__/log-streaming.instance-settings-loader.test.ts
@@ -129,16 +129,6 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 			await expectRejectsWithBootstrappingError(loader, /validation failed/);
 		});
 
-		it('rejects webhook method values outside GET/POST/PUT', async () => {
-			const loader = createLoader({
-				logStreamingDestinations: JSON.stringify([
-					{ type: 'webhook', label: 'W', url: 'https://w.test', method: 'DELETE' },
-				]),
-			});
-
-			await expectRejectsWithBootstrappingError(loader, /validation failed/);
-		});
-
 		it('rejects syslog facility outside the 0–23 range', async () => {
 			const loader = createLoader({
 				logStreamingDestinations: JSON.stringify([

--- a/packages/cli/src/instance-settings-loader/__tests__/log-streaming.instance-settings-loader.test.ts
+++ b/packages/cli/src/instance-settings-loader/__tests__/log-streaming.instance-settings-loader.test.ts
@@ -4,27 +4,12 @@ import type { EntityManager } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
 import { MessageEventBusDestinationTypeNames } from 'n8n-workflow';
 
-import type { EventDestinations } from '@/modules/log-streaming.ee/database/entities';
 import type { EventDestinationsRepository } from '@/modules/log-streaming.ee/database/repositories/event-destination.repository';
 
 import { InstanceBootstrappingError } from '../instance-bootstrapping.error';
 import { LogStreamingInstanceSettingsLoader } from '../loaders/log-streaming.instance-settings-loader';
 
 const UUID_A = '11111111-1111-4111-8111-111111111111';
-const UUID_B = '22222222-2222-4222-8222-222222222222';
-const UUID_C = '33333333-3333-4333-8333-333333333333';
-
-const createRow = (overrides: {
-	id: string;
-	createdAt?: Date;
-	destination: Record<string, unknown>;
-}): EventDestinations =>
-	({
-		id: overrides.id,
-		createdAt: overrides.createdAt ?? new Date('2024-01-01T00:00:00Z'),
-		updatedAt: new Date('2024-01-01T00:00:00Z'),
-		destination: overrides.destination,
-	}) as unknown as EventDestinations;
 
 describe('LogStreamingInstanceSettingsLoader', () => {
 	const logger = mock<Logger>({ scoped: jest.fn().mockReturnThis() });
@@ -50,8 +35,7 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 				await cb(tx);
 			}),
 		};
-		tx.find.mockResolvedValue([]);
-		tx.upsert.mockResolvedValue({ generatedMaps: [], identifiers: [], raw: {} });
+		tx.insert.mockResolvedValue({ generatedMaps: [], identifiers: [], raw: {} });
 		tx.delete.mockResolvedValue({ raw: {}, affected: 0 });
 	});
 
@@ -62,8 +46,7 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 			const result = await loader.run();
 
 			expect(result).toBe('skipped');
-			expect(tx.find).not.toHaveBeenCalled();
-			expect(tx.upsert).not.toHaveBeenCalled();
+			expect(tx.insert).not.toHaveBeenCalled();
 			expect(tx.delete).not.toHaveBeenCalled();
 		});
 	});
@@ -125,14 +108,6 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 			await expectRejectsWithBootstrappingError(loader, /validation failed/);
 		});
 
-		it('throws when an item has neither id nor label', async () => {
-			const loader = createLoader({
-				logStreamingDestinations: JSON.stringify([{ type: 'webhook', url: 'https://x.test' }]),
-			});
-
-			await expectRejectsWithBootstrappingError(loader, /must have either "id" or "label"/);
-		});
-
 		it('throws on duplicate ids within the array', async () => {
 			const loader = createLoader({
 				logStreamingDestinations: JSON.stringify([
@@ -142,28 +117,6 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 			});
 
 			await expectRejectsWithBootstrappingError(loader, /duplicate id/);
-		});
-
-		it('throws on duplicate (type, label) within the array when no ids are given', async () => {
-			const loader = createLoader({
-				logStreamingDestinations: JSON.stringify([
-					{ type: 'webhook', label: 'Audit', url: 'https://a.test' },
-					{ type: 'webhook', label: 'Audit', url: 'https://b.test' },
-				]),
-			});
-
-			await expectRejectsWithBootstrappingError(loader, /duplicate \(type,label\)/);
-		});
-
-		it('throws on duplicate (type, label) even when items have distinct ids', async () => {
-			const loader = createLoader({
-				logStreamingDestinations: JSON.stringify([
-					{ type: 'webhook', id: UUID_A, label: 'Audit', url: 'https://a.test' },
-					{ type: 'webhook', id: UUID_B, label: 'Audit', url: 'https://b.test' },
-				]),
-			});
-
-			await expectRejectsWithBootstrappingError(loader, /duplicate \(type,label\)/);
 		});
 
 		it('rejects unknown top-level fields', async () => {
@@ -199,7 +152,6 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 
 	describe('accepts', () => {
 		it('circuitBreaker on any destination type', async () => {
-			tx.find.mockResolvedValue([]);
 			const loader = createLoader({
 				logStreamingDestinations: JSON.stringify([
 					{
@@ -221,7 +173,6 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 		});
 
 		it('syslog with protocol tls and no tlsCa', async () => {
-			tx.find.mockResolvedValue([]);
 			const loader = createLoader({
 				logStreamingDestinations: JSON.stringify([
 					{ type: 'syslog', label: 'S', host: 'host.test', protocol: 'tls' },
@@ -232,7 +183,6 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 		});
 
 		it('a fully-populated webhook options block', async () => {
-			tx.find.mockResolvedValue([]);
 			const loader = createLoader({
 				logStreamingDestinations: JSON.stringify([
 					{
@@ -253,11 +203,18 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 
 			await expect(loader.run()).resolves.toBe('created');
 		});
+
+		it('items without id or label', async () => {
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify([{ type: 'webhook', url: 'https://w.test' }]),
+			});
+
+			await expect(loader.run()).resolves.toBe('created');
+		});
 	});
 
-	describe('reconciliation', () => {
-		it('inserts when the env array is non-empty and the DB is empty', async () => {
-			tx.find.mockResolvedValue([]);
+	describe('replace', () => {
+		it('deletes all existing rows then inserts the env items', async () => {
 			const loader = createLoader({
 				logStreamingDestinations: JSON.stringify([
 					{
@@ -275,8 +232,10 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 			const result = await loader.run();
 
 			expect(result).toBe('created');
-			expect(tx.upsert).toHaveBeenCalledTimes(1);
-			const [, payload] = tx.upsert.mock.calls[0];
+			expect(tx.delete).toHaveBeenCalledTimes(1);
+			expect(tx.delete).toHaveBeenCalledWith(expect.anything(), {});
+			expect(tx.insert).toHaveBeenCalledTimes(1);
+			const [, payload] = tx.insert.mock.calls[0];
 			const rows = payload as Array<{ id: string; destination: Record<string, unknown> }>;
 			expect(rows).toHaveLength(1);
 			expect(rows[0].destination.__type).toBe(MessageEventBusDestinationTypeNames.webhook);
@@ -286,194 +245,62 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 				parameters: [{ name: 'Authorization', value: 'Bearer abc123' }],
 			});
 			expect(rows[0].id).toMatch(/^[0-9a-f-]{36}$/);
-			expect(tx.delete).not.toHaveBeenCalled();
 		});
 
-		it('updates an existing row when id matches', async () => {
-			tx.find.mockResolvedValue([
-				createRow({
-					id: UUID_A,
-					destination: {
-						__type: MessageEventBusDestinationTypeNames.webhook,
-						id: UUID_A,
-						label: 'Old',
-						url: 'https://old.test',
-					},
-				}),
-			]);
+		it('uses the pinned id from env when provided', async () => {
 			const loader = createLoader({
 				logStreamingDestinations: JSON.stringify([
-					{ type: 'webhook', id: UUID_A, label: 'New', url: 'https://new.test' },
+					{ type: 'webhook', id: UUID_A, label: 'Pinned', url: 'https://pinned.test' },
 				]),
 			});
 
 			await loader.run();
 
-			expect(tx.upsert).toHaveBeenCalledTimes(1);
-			const rows = tx.upsert.mock.calls[0][1] as Array<{
+			const rows = tx.insert.mock.calls[0][1] as Array<{
 				id: string;
 				destination: Record<string, unknown>;
 			}>;
 			expect(rows[0].id).toBe(UUID_A);
-			expect(rows[0].destination.url).toBe('https://new.test');
-			expect(rows[0].destination.label).toBe('New');
-			expect(tx.delete).not.toHaveBeenCalled();
+			expect(rows[0].destination.id).toBe(UUID_A);
+			expect(rows[0].destination.url).toBe('https://pinned.test');
 		});
 
-		it('matches on (label, type) when id is absent, preserving the existing id', async () => {
-			tx.find.mockResolvedValue([
-				createRow({
-					id: UUID_B,
-					destination: {
-						__type: MessageEventBusDestinationTypeNames.syslog,
-						id: UUID_B,
-						label: 'SIEM',
-						host: 'old.host',
-					},
-				}),
-			]);
+		it('generates a new id when one is not provided', async () => {
 			const loader = createLoader({
 				logStreamingDestinations: JSON.stringify([
-					{ type: 'syslog', label: 'SIEM', host: 'new.host', port: 514, protocol: 'tcp' },
+					{ type: 'syslog', label: 'SIEM', host: 'syslog.test' },
 				]),
 			});
 
 			await loader.run();
 
-			const rows = tx.upsert.mock.calls[0][1] as Array<{
+			const rows = tx.insert.mock.calls[0][1] as Array<{
 				id: string;
 				destination: Record<string, unknown>;
 			}>;
-			expect(rows[0].id).toBe(UUID_B);
-			expect(rows[0].destination.host).toBe('new.host');
-			expect(rows[0].destination.port).toBe(514);
-			expect(rows[0].destination.protocol).toBe('tcp');
+			expect(rows[0].id).toMatch(/^[0-9a-f-]{36}$/);
+			expect(rows[0].destination.id).toBe(rows[0].id);
 		});
 
-		it('deletes DB rows not referenced by any env item', async () => {
-			tx.find.mockResolvedValue([
-				createRow({
-					id: UUID_A,
-					destination: {
-						__type: MessageEventBusDestinationTypeNames.webhook,
-						id: UUID_A,
-						label: 'Kept',
-						url: 'https://kept.test',
-					},
-				}),
-				createRow({
-					id: UUID_B,
-					destination: {
-						__type: MessageEventBusDestinationTypeNames.sentry,
-						id: UUID_B,
-						label: 'Stale',
-						dsn: 'https://public@sentry.example.com/1',
-					},
-				}),
-			]);
-			const loader = createLoader({
-				logStreamingDestinations: JSON.stringify([
-					{ type: 'webhook', id: UUID_A, label: 'Kept', url: 'https://kept.test' },
-				]),
-			});
-
-			await loader.run();
-
-			expect(tx.delete).toHaveBeenCalledTimes(1);
-			const [, criteria] = tx.delete.mock.calls[0];
-			const deletedIds = (criteria as { id: { _value: string[] } }).id._value;
-			expect(deletedIds).toEqual([UUID_B]);
-		});
-
-		it('keeps the oldest row when multiple DB rows share (label, type); deletes the rest', async () => {
-			tx.find.mockResolvedValue([
-				createRow({
-					id: UUID_A,
-					createdAt: new Date('2024-01-01T00:00:00Z'),
-					destination: {
-						__type: MessageEventBusDestinationTypeNames.webhook,
-						id: UUID_A,
-						label: 'Dup',
-						url: 'https://a.test',
-					},
-				}),
-				createRow({
-					id: UUID_B,
-					createdAt: new Date('2024-02-01T00:00:00Z'),
-					destination: {
-						__type: MessageEventBusDestinationTypeNames.webhook,
-						id: UUID_B,
-						label: 'Dup',
-						url: 'https://b.test',
-					},
-				}),
-				createRow({
-					id: UUID_C,
-					createdAt: new Date('2024-03-01T00:00:00Z'),
-					destination: {
-						__type: MessageEventBusDestinationTypeNames.webhook,
-						id: UUID_C,
-						label: 'Dup',
-						url: 'https://c.test',
-					},
-				}),
-			]);
-			const loader = createLoader({
-				logStreamingDestinations: JSON.stringify([
-					{ type: 'webhook', label: 'Dup', url: 'https://new.test' },
-				]),
-			});
-
-			await loader.run();
-
-			const rows = tx.upsert.mock.calls[0][1] as Array<{ id: string }>;
-			expect(rows[0].id).toBe(UUID_A);
-			const deletedIds = (tx.delete.mock.calls[0][1] as { id: { _value: string[] } }).id._value;
-			expect(new Set(deletedIds)).toEqual(new Set([UUID_B, UUID_C]));
-		});
-
-		it('empty env array deletes every existing row', async () => {
-			tx.find.mockResolvedValue([
-				createRow({
-					id: UUID_A,
-					destination: {
-						__type: MessageEventBusDestinationTypeNames.webhook,
-						id: UUID_A,
-						label: 'Any',
-						url: 'https://a.test',
-					},
-				}),
-			]);
+		it('empty env array deletes every existing row without inserting', async () => {
 			const loader = createLoader({ logStreamingDestinations: '[]' });
 
 			await loader.run();
 
-			expect(tx.upsert).not.toHaveBeenCalled();
 			expect(tx.delete).toHaveBeenCalledTimes(1);
+			expect(tx.insert).not.toHaveBeenCalled();
 		});
 
 		it('treats an empty string the same as an empty array', async () => {
-			tx.find.mockResolvedValue([
-				createRow({
-					id: UUID_A,
-					destination: {
-						__type: MessageEventBusDestinationTypeNames.webhook,
-						id: UUID_A,
-						label: 'Any',
-						url: 'https://a.test',
-					},
-				}),
-			]);
 			const loader = createLoader({ logStreamingDestinations: '' });
 
 			await loader.run();
 
-			expect(tx.upsert).not.toHaveBeenCalled();
 			expect(tx.delete).toHaveBeenCalledTimes(1);
+			expect(tx.insert).not.toHaveBeenCalled();
 		});
 
 		it('maps each env type to its internal __type discriminator', async () => {
-			tx.find.mockResolvedValue([]);
 			const loader = createLoader({
 				logStreamingDestinations: JSON.stringify([
 					{ type: 'webhook', label: 'W', url: 'https://w.test' },
@@ -484,7 +311,7 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 
 			await loader.run();
 
-			const rows = tx.upsert.mock.calls[0][1] as Array<{
+			const rows = tx.insert.mock.calls[0][1] as Array<{
 				destination: { __type: string };
 			}>;
 			expect(rows.map((r) => r.destination.__type)).toEqual([
@@ -494,7 +321,7 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 			]);
 		});
 
-		it('runs reconciliation inside a transaction', async () => {
+		it('runs delete + insert inside a single transaction', async () => {
 			const loader = createLoader({
 				logStreamingDestinations: JSON.stringify([
 					{ type: 'webhook', label: 'W', url: 'https://w.test' },

--- a/packages/cli/src/instance-settings-loader/__tests__/log-streaming.instance-settings-loader.test.ts
+++ b/packages/cli/src/instance-settings-loader/__tests__/log-streaming.instance-settings-loader.test.ts
@@ -155,6 +155,17 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 			await expectRejectsWithBootstrappingError(loader, /duplicate \(type,label\)/);
 		});
 
+		it('throws on duplicate (type, label) even when items have distinct ids', async () => {
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify([
+					{ type: 'webhook', id: UUID_A, label: 'Audit', url: 'https://a.test' },
+					{ type: 'webhook', id: UUID_B, label: 'Audit', url: 'https://b.test' },
+				]),
+			});
+
+			await expectRejectsWithBootstrappingError(loader, /duplicate \(type,label\)/);
+		});
+
 		it('rejects unknown top-level fields', async () => {
 			const loader = createLoader({
 				logStreamingDestinations: JSON.stringify([

--- a/packages/cli/src/instance-settings-loader/__tests__/log-streaming.instance-settings-loader.test.ts
+++ b/packages/cli/src/instance-settings-loader/__tests__/log-streaming.instance-settings-loader.test.ts
@@ -7,6 +7,7 @@ import { MessageEventBusDestinationTypeNames } from 'n8n-workflow';
 import type { EventDestinations } from '@/modules/log-streaming.ee/database/entities';
 import type { EventDestinationsRepository } from '@/modules/log-streaming.ee/database/repositories/event-destination.repository';
 
+import { InstanceBootstrappingError } from '../instance-bootstrapping.error';
 import { LogStreamingInstanceSettingsLoader } from '../loaders/log-streaming.instance-settings-loader';
 
 const UUID_A = '11111111-1111-4111-8111-111111111111';
@@ -68,10 +69,26 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 	});
 
 	describe('parse + validation errors', () => {
+		async function expectRejectsWithBootstrappingError(
+			loader: LogStreamingInstanceSettingsLoader,
+			messagePattern: RegExp,
+		) {
+			let thrown: unknown;
+			try {
+				await loader.run();
+			} catch (e) {
+				thrown = e;
+			}
+			expect(thrown).toBeInstanceOf(InstanceBootstrappingError);
+			expect((thrown as Error).message).toMatch(messagePattern);
+			expect(logger.error).toHaveBeenCalledTimes(1);
+			expect(logger.error).toHaveBeenCalledWith((thrown as Error).message);
+		}
+
 		it('throws on malformed JSON', async () => {
 			const loader = createLoader({ logStreamingDestinations: '{not json' });
 
-			await expect(loader.run()).rejects.toThrow(/not valid JSON/);
+			await expectRejectsWithBootstrappingError(loader, /not valid JSON/);
 		});
 
 		it('throws when the top-level value is not an array', async () => {
@@ -79,7 +96,7 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 				logStreamingDestinations: JSON.stringify({ type: 'webhook', url: 'https://x.test' }),
 			});
 
-			await expect(loader.run()).rejects.toThrow(/validation failed/);
+			await expectRejectsWithBootstrappingError(loader, /validation failed/);
 		});
 
 		it('throws when type is unknown', async () => {
@@ -87,7 +104,7 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 				logStreamingDestinations: JSON.stringify([{ type: 'kafka', label: 'a' }]),
 			});
 
-			await expect(loader.run()).rejects.toThrow(/validation failed/);
+			await expectRejectsWithBootstrappingError(loader, /validation failed/);
 		});
 
 		it('throws when a webhook is missing url', async () => {
@@ -95,7 +112,7 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 				logStreamingDestinations: JSON.stringify([{ type: 'webhook', label: 'a' }]),
 			});
 
-			await expect(loader.run()).rejects.toThrow(/validation failed/);
+			await expectRejectsWithBootstrappingError(loader, /validation failed/);
 		});
 
 		it('throws when id is not a UUID', async () => {
@@ -105,7 +122,7 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 				]),
 			});
 
-			await expect(loader.run()).rejects.toThrow(/validation failed/);
+			await expectRejectsWithBootstrappingError(loader, /validation failed/);
 		});
 
 		it('throws when an item has neither id nor label', async () => {
@@ -113,7 +130,7 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 				logStreamingDestinations: JSON.stringify([{ type: 'webhook', url: 'https://x.test' }]),
 			});
 
-			await expect(loader.run()).rejects.toThrow(/must have either "id" or "label"/);
+			await expectRejectsWithBootstrappingError(loader, /must have either "id" or "label"/);
 		});
 
 		it('throws on duplicate ids within the array', async () => {
@@ -124,7 +141,7 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 				]),
 			});
 
-			await expect(loader.run()).rejects.toThrow(/duplicate id/);
+			await expectRejectsWithBootstrappingError(loader, /duplicate id/);
 		});
 
 		it('throws on duplicate (type, label) within the array when no ids are given', async () => {
@@ -135,7 +152,7 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 				]),
 			});
 
-			await expect(loader.run()).rejects.toThrow(/duplicate \(type,label\)/);
+			await expectRejectsWithBootstrappingError(loader, /duplicate \(type,label\)/);
 		});
 
 		it('rejects unknown top-level fields', async () => {
@@ -145,7 +162,7 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 				]),
 			});
 
-			await expect(loader.run()).rejects.toThrow(/validation failed/);
+			await expectRejectsWithBootstrappingError(loader, /validation failed/);
 		});
 
 		it('rejects webhook method values outside GET/POST/PUT', async () => {
@@ -155,7 +172,7 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 				]),
 			});
 
-			await expect(loader.run()).rejects.toThrow(/validation failed/);
+			await expectRejectsWithBootstrappingError(loader, /validation failed/);
 		});
 
 		it('rejects syslog facility outside the 0–23 range', async () => {
@@ -165,7 +182,7 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 				]),
 			});
 
-			await expect(loader.run()).rejects.toThrow(/validation failed/);
+			await expectRejectsWithBootstrappingError(loader, /validation failed/);
 		});
 
 		it('requires tlsCa when syslog protocol is "tls"', async () => {
@@ -175,7 +192,7 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 				]),
 			});
 
-			await expect(loader.run()).rejects.toThrow(/must provide "tlsCa"/);
+			await expectRejectsWithBootstrappingError(loader, /must provide "tlsCa"/);
 		});
 	});
 

--- a/packages/cli/src/instance-settings-loader/__tests__/log-streaming.instance-settings-loader.test.ts
+++ b/packages/cli/src/instance-settings-loader/__tests__/log-streaming.instance-settings-loader.test.ts
@@ -184,16 +184,6 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 
 			await expectRejectsWithBootstrappingError(loader, /validation failed/);
 		});
-
-		it('requires tlsCa when syslog protocol is "tls"', async () => {
-			const loader = createLoader({
-				logStreamingDestinations: JSON.stringify([
-					{ type: 'syslog', label: 'S', host: 'host.test', protocol: 'tls' },
-				]),
-			});
-
-			await expectRejectsWithBootstrappingError(loader, /must provide "tlsCa"/);
-		});
 	});
 
 	describe('accepts', () => {
@@ -213,6 +203,17 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 						host: 'syslog.test',
 						circuitBreaker: { maxFailures: 5 },
 					},
+				]),
+			});
+
+			await expect(loader.run()).resolves.toBe('created');
+		});
+
+		it('syslog with protocol tls and no tlsCa', async () => {
+			tx.find.mockResolvedValue([]);
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify([
+					{ type: 'syslog', label: 'S', host: 'host.test', protocol: 'tls' },
 				]),
 			});
 

--- a/packages/cli/src/instance-settings-loader/__tests__/log-streaming.instance-settings-loader.test.ts
+++ b/packages/cli/src/instance-settings-loader/__tests__/log-streaming.instance-settings-loader.test.ts
@@ -1,0 +1,393 @@
+import type { Logger } from '@n8n/backend-common';
+import type { InstanceSettingsLoaderConfig } from '@n8n/config';
+import type { EntityManager } from '@n8n/typeorm';
+import { mock } from 'jest-mock-extended';
+import { MessageEventBusDestinationTypeNames } from 'n8n-workflow';
+
+import type { EventDestinations } from '@/modules/log-streaming.ee/database/entities';
+import type { EventDestinationsRepository } from '@/modules/log-streaming.ee/database/repositories/event-destination.repository';
+
+import { LogStreamingInstanceSettingsLoader } from '../loaders/log-streaming.instance-settings-loader';
+
+const UUID_A = '11111111-1111-4111-8111-111111111111';
+const UUID_B = '22222222-2222-4222-8222-222222222222';
+const UUID_C = '33333333-3333-4333-8333-333333333333';
+
+const createRow = (overrides: {
+	id: string;
+	createdAt?: Date;
+	destination: Record<string, unknown>;
+}): EventDestinations =>
+	({
+		id: overrides.id,
+		createdAt: overrides.createdAt ?? new Date('2024-01-01T00:00:00Z'),
+		updatedAt: new Date('2024-01-01T00:00:00Z'),
+		destination: overrides.destination,
+	}) as unknown as EventDestinations;
+
+describe('LogStreamingInstanceSettingsLoader', () => {
+	const logger = mock<Logger>({ scoped: jest.fn().mockReturnThis() });
+	const repository = mock<EventDestinationsRepository>();
+	const tx = mock<EntityManager>();
+
+	const createLoader = (configOverrides: Partial<InstanceSettingsLoaderConfig> = {}) => {
+		const config = {
+			logStreamingManagedByEnv: true,
+			logStreamingDestinations: '',
+			...configOverrides,
+		} as InstanceSettingsLoaderConfig;
+
+		return new LogStreamingInstanceSettingsLoader(config, repository, logger);
+	};
+
+	beforeEach(() => {
+		jest.resetAllMocks();
+		logger.scoped.mockReturnThis();
+		// wire the transaction callback to run against our mock EntityManager
+		(repository.manager as unknown as { transaction: jest.Mock }) = {
+			transaction: jest.fn(async (cb: (m: EntityManager) => Promise<void>) => {
+				await cb(tx);
+			}),
+		};
+		tx.find.mockResolvedValue([]);
+		tx.upsert.mockResolvedValue({ generatedMaps: [], identifiers: [], raw: {} });
+		tx.delete.mockResolvedValue({ raw: {}, affected: 0 });
+	});
+
+	describe('gating', () => {
+		it('returns "skipped" when logStreamingManagedByEnv is false', async () => {
+			const loader = createLoader({ logStreamingManagedByEnv: false });
+
+			const result = await loader.run();
+
+			expect(result).toBe('skipped');
+			expect(tx.find).not.toHaveBeenCalled();
+			expect(tx.upsert).not.toHaveBeenCalled();
+			expect(tx.delete).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('parse + validation errors', () => {
+		it('throws on malformed JSON', async () => {
+			const loader = createLoader({ logStreamingDestinations: '{not json' });
+
+			await expect(loader.run()).rejects.toThrow(/not valid JSON/);
+		});
+
+		it('throws when the top-level value is not an array', async () => {
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify({ type: 'webhook', url: 'https://x.test' }),
+			});
+
+			await expect(loader.run()).rejects.toThrow(/validation failed/);
+		});
+
+		it('throws when type is unknown', async () => {
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify([{ type: 'kafka', label: 'a' }]),
+			});
+
+			await expect(loader.run()).rejects.toThrow(/validation failed/);
+		});
+
+		it('throws when a webhook is missing url', async () => {
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify([{ type: 'webhook', label: 'a' }]),
+			});
+
+			await expect(loader.run()).rejects.toThrow(/validation failed/);
+		});
+
+		it('throws when id is not a UUID', async () => {
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify([
+					{ type: 'webhook', id: 'not-a-uuid', label: 'a', url: 'https://x.test' },
+				]),
+			});
+
+			await expect(loader.run()).rejects.toThrow(/validation failed/);
+		});
+
+		it('throws when an item has neither id nor label', async () => {
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify([{ type: 'webhook', url: 'https://x.test' }]),
+			});
+
+			await expect(loader.run()).rejects.toThrow(/must have either "id" or "label"/);
+		});
+
+		it('throws on duplicate ids within the array', async () => {
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify([
+					{ type: 'webhook', id: UUID_A, url: 'https://a.test', label: 'A' },
+					{ type: 'webhook', id: UUID_A, url: 'https://b.test', label: 'B' },
+				]),
+			});
+
+			await expect(loader.run()).rejects.toThrow(/duplicate id/);
+		});
+
+		it('throws on duplicate (type, label) within the array when no ids are given', async () => {
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify([
+					{ type: 'webhook', label: 'Audit', url: 'https://a.test' },
+					{ type: 'webhook', label: 'Audit', url: 'https://b.test' },
+				]),
+			});
+
+			await expect(loader.run()).rejects.toThrow(/duplicate \(type,label\)/);
+		});
+	});
+
+	describe('reconciliation', () => {
+		it('inserts when the env array is non-empty and the DB is empty', async () => {
+			tx.find.mockResolvedValue([]);
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify([
+					{
+						type: 'webhook',
+						label: 'Audit',
+						url: 'https://hooks.example.com',
+						method: 'POST',
+						headerParameters: {
+							parameters: [{ name: 'Authorization', value: 'Bearer abc123' }],
+						},
+					},
+				]),
+			});
+
+			const result = await loader.run();
+
+			expect(result).toBe('created');
+			expect(tx.upsert).toHaveBeenCalledTimes(1);
+			const [, payload] = tx.upsert.mock.calls[0];
+			const rows = payload as Array<{ id: string; destination: Record<string, unknown> }>;
+			expect(rows).toHaveLength(1);
+			expect(rows[0].destination.__type).toBe(MessageEventBusDestinationTypeNames.webhook);
+			expect(rows[0].destination.url).toBe('https://hooks.example.com');
+			expect(rows[0].destination.label).toBe('Audit');
+			expect(rows[0].destination.headerParameters).toEqual({
+				parameters: [{ name: 'Authorization', value: 'Bearer abc123' }],
+			});
+			expect(rows[0].id).toMatch(/^[0-9a-f-]{36}$/);
+			expect(tx.delete).not.toHaveBeenCalled();
+		});
+
+		it('updates an existing row when id matches', async () => {
+			tx.find.mockResolvedValue([
+				createRow({
+					id: UUID_A,
+					destination: {
+						__type: MessageEventBusDestinationTypeNames.webhook,
+						id: UUID_A,
+						label: 'Old',
+						url: 'https://old.test',
+					},
+				}),
+			]);
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify([
+					{ type: 'webhook', id: UUID_A, label: 'New', url: 'https://new.test' },
+				]),
+			});
+
+			await loader.run();
+
+			expect(tx.upsert).toHaveBeenCalledTimes(1);
+			const rows = tx.upsert.mock.calls[0][1] as Array<{
+				id: string;
+				destination: Record<string, unknown>;
+			}>;
+			expect(rows[0].id).toBe(UUID_A);
+			expect(rows[0].destination.url).toBe('https://new.test');
+			expect(rows[0].destination.label).toBe('New');
+			expect(tx.delete).not.toHaveBeenCalled();
+		});
+
+		it('matches on (label, type) when id is absent, preserving the existing id', async () => {
+			tx.find.mockResolvedValue([
+				createRow({
+					id: UUID_B,
+					destination: {
+						__type: MessageEventBusDestinationTypeNames.syslog,
+						id: UUID_B,
+						label: 'SIEM',
+						host: 'old.host',
+					},
+				}),
+			]);
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify([
+					{ type: 'syslog', label: 'SIEM', host: 'new.host', port: 514, protocol: 'tcp' },
+				]),
+			});
+
+			await loader.run();
+
+			const rows = tx.upsert.mock.calls[0][1] as Array<{
+				id: string;
+				destination: Record<string, unknown>;
+			}>;
+			expect(rows[0].id).toBe(UUID_B);
+			expect(rows[0].destination.host).toBe('new.host');
+			expect(rows[0].destination.port).toBe(514);
+			expect(rows[0].destination.protocol).toBe('tcp');
+		});
+
+		it('deletes DB rows not referenced by any env item', async () => {
+			tx.find.mockResolvedValue([
+				createRow({
+					id: UUID_A,
+					destination: {
+						__type: MessageEventBusDestinationTypeNames.webhook,
+						id: UUID_A,
+						label: 'Kept',
+						url: 'https://kept.test',
+					},
+				}),
+				createRow({
+					id: UUID_B,
+					destination: {
+						__type: MessageEventBusDestinationTypeNames.sentry,
+						id: UUID_B,
+						label: 'Stale',
+						dsn: 'https://public@sentry.example.com/1',
+					},
+				}),
+			]);
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify([
+					{ type: 'webhook', id: UUID_A, label: 'Kept', url: 'https://kept.test' },
+				]),
+			});
+
+			await loader.run();
+
+			expect(tx.delete).toHaveBeenCalledTimes(1);
+			const [, criteria] = tx.delete.mock.calls[0];
+			const deletedIds = (criteria as { id: { _value: string[] } }).id._value;
+			expect(deletedIds).toEqual([UUID_B]);
+		});
+
+		it('keeps the oldest row when multiple DB rows share (label, type); deletes the rest', async () => {
+			tx.find.mockResolvedValue([
+				createRow({
+					id: UUID_A,
+					createdAt: new Date('2024-01-01T00:00:00Z'),
+					destination: {
+						__type: MessageEventBusDestinationTypeNames.webhook,
+						id: UUID_A,
+						label: 'Dup',
+						url: 'https://a.test',
+					},
+				}),
+				createRow({
+					id: UUID_B,
+					createdAt: new Date('2024-02-01T00:00:00Z'),
+					destination: {
+						__type: MessageEventBusDestinationTypeNames.webhook,
+						id: UUID_B,
+						label: 'Dup',
+						url: 'https://b.test',
+					},
+				}),
+				createRow({
+					id: UUID_C,
+					createdAt: new Date('2024-03-01T00:00:00Z'),
+					destination: {
+						__type: MessageEventBusDestinationTypeNames.webhook,
+						id: UUID_C,
+						label: 'Dup',
+						url: 'https://c.test',
+					},
+				}),
+			]);
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify([
+					{ type: 'webhook', label: 'Dup', url: 'https://new.test' },
+				]),
+			});
+
+			await loader.run();
+
+			const rows = tx.upsert.mock.calls[0][1] as Array<{ id: string }>;
+			expect(rows[0].id).toBe(UUID_A);
+			const deletedIds = (tx.delete.mock.calls[0][1] as { id: { _value: string[] } }).id._value;
+			expect(new Set(deletedIds)).toEqual(new Set([UUID_B, UUID_C]));
+		});
+
+		it('empty env array deletes every existing row', async () => {
+			tx.find.mockResolvedValue([
+				createRow({
+					id: UUID_A,
+					destination: {
+						__type: MessageEventBusDestinationTypeNames.webhook,
+						id: UUID_A,
+						label: 'Any',
+						url: 'https://a.test',
+					},
+				}),
+			]);
+			const loader = createLoader({ logStreamingDestinations: '[]' });
+
+			await loader.run();
+
+			expect(tx.upsert).not.toHaveBeenCalled();
+			expect(tx.delete).toHaveBeenCalledTimes(1);
+		});
+
+		it('treats an empty string the same as an empty array', async () => {
+			tx.find.mockResolvedValue([
+				createRow({
+					id: UUID_A,
+					destination: {
+						__type: MessageEventBusDestinationTypeNames.webhook,
+						id: UUID_A,
+						label: 'Any',
+						url: 'https://a.test',
+					},
+				}),
+			]);
+			const loader = createLoader({ logStreamingDestinations: '' });
+
+			await loader.run();
+
+			expect(tx.upsert).not.toHaveBeenCalled();
+			expect(tx.delete).toHaveBeenCalledTimes(1);
+		});
+
+		it('maps each env type to its internal __type discriminator', async () => {
+			tx.find.mockResolvedValue([]);
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify([
+					{ type: 'webhook', label: 'W', url: 'https://w.test' },
+					{ type: 'syslog', label: 'S', host: 'syslog.test' },
+					{ type: 'sentry', label: 'E', dsn: 'https://public@sentry.example.com/1' },
+				]),
+			});
+
+			await loader.run();
+
+			const rows = tx.upsert.mock.calls[0][1] as Array<{
+				destination: { __type: string };
+			}>;
+			expect(rows.map((r) => r.destination.__type)).toEqual([
+				MessageEventBusDestinationTypeNames.webhook,
+				MessageEventBusDestinationTypeNames.syslog,
+				MessageEventBusDestinationTypeNames.sentry,
+			]);
+		});
+
+		it('runs reconciliation inside a transaction', async () => {
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify([
+					{ type: 'webhook', label: 'W', url: 'https://w.test' },
+				]),
+			});
+
+			await loader.run();
+
+			expect(repository.manager.transaction).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/packages/cli/src/instance-settings-loader/__tests__/log-streaming.instance-settings-loader.test.ts
+++ b/packages/cli/src/instance-settings-loader/__tests__/log-streaming.instance-settings-loader.test.ts
@@ -137,6 +137,93 @@ describe('LogStreamingInstanceSettingsLoader', () => {
 
 			await expect(loader.run()).rejects.toThrow(/duplicate \(type,label\)/);
 		});
+
+		it('rejects unknown top-level fields', async () => {
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify([
+					{ type: 'webhook', label: 'W', url: 'https://w.test', nope: 'extra' },
+				]),
+			});
+
+			await expect(loader.run()).rejects.toThrow(/validation failed/);
+		});
+
+		it('rejects webhook method values outside GET/POST/PUT', async () => {
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify([
+					{ type: 'webhook', label: 'W', url: 'https://w.test', method: 'DELETE' },
+				]),
+			});
+
+			await expect(loader.run()).rejects.toThrow(/validation failed/);
+		});
+
+		it('rejects syslog facility outside the 0–23 range', async () => {
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify([
+					{ type: 'syslog', label: 'S', host: 'host.test', facility: 24 },
+				]),
+			});
+
+			await expect(loader.run()).rejects.toThrow(/validation failed/);
+		});
+
+		it('requires tlsCa when syslog protocol is "tls"', async () => {
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify([
+					{ type: 'syslog', label: 'S', host: 'host.test', protocol: 'tls' },
+				]),
+			});
+
+			await expect(loader.run()).rejects.toThrow(/must provide "tlsCa"/);
+		});
+	});
+
+	describe('accepts', () => {
+		it('circuitBreaker on any destination type', async () => {
+			tx.find.mockResolvedValue([]);
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify([
+					{
+						type: 'webhook',
+						label: 'W',
+						url: 'https://w.test',
+						circuitBreaker: { maxFailures: 3, failureWindow: 30000 },
+					},
+					{
+						type: 'syslog',
+						label: 'S',
+						host: 'syslog.test',
+						circuitBreaker: { maxFailures: 5 },
+					},
+				]),
+			});
+
+			await expect(loader.run()).resolves.toBe('created');
+		});
+
+		it('a fully-populated webhook options block', async () => {
+			tx.find.mockResolvedValue([]);
+			const loader = createLoader({
+				logStreamingDestinations: JSON.stringify([
+					{
+						type: 'webhook',
+						label: 'W',
+						url: 'https://w.test',
+						options: {
+							allowUnauthorizedCerts: true,
+							queryParameterArrays: 'brackets',
+							redirect: { redirect: { followRedirects: true, maxRedirects: 5 } },
+							proxy: { proxy: { protocol: 'https', host: 'proxy.test', port: 8080 } },
+							timeout: 5000,
+							socket: { keepAlive: true, maxSockets: 10, maxFreeSockets: 5 },
+						},
+					},
+				]),
+			});
+
+			await expect(loader.run()).resolves.toBe('created');
+		});
 	});
 
 	describe('reconciliation', () => {

--- a/packages/cli/src/instance-settings-loader/instance-settings-loader.service.ts
+++ b/packages/cli/src/instance-settings-loader/instance-settings-loader.service.ts
@@ -1,6 +1,7 @@
 import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
 
+import { LogStreamingInstanceSettingsLoader } from './loaders/log-streaming.instance-settings-loader';
 import { OwnerInstanceSettingsLoader } from './loaders/owner.instance-settings-loader';
 import { SecurityPolicyInstanceSettingsLoader } from './loaders/security-policy.instance-settings-loader';
 import { SsoInstanceSettingsLoader } from './loaders/sso.instance-settings-loader';
@@ -14,6 +15,7 @@ export class InstanceSettingsLoaderService {
 		private readonly ownerLoader: OwnerInstanceSettingsLoader,
 		private readonly ssoLoader: SsoInstanceSettingsLoader,
 		private readonly securityPolicyLoader: SecurityPolicyInstanceSettingsLoader,
+		private readonly logStreamingLoader: LogStreamingInstanceSettingsLoader,
 	) {
 		this.logger = this.logger.scoped('instance-settings-loader');
 	}
@@ -22,6 +24,7 @@ export class InstanceSettingsLoaderService {
 		await this.run('owner', async () => await this.ownerLoader.run());
 		await this.run('sso', async () => await this.ssoLoader.run());
 		await this.run('security-policy', async () => await this.securityPolicyLoader.run());
+		await this.run('log-streaming', async () => await this.logStreamingLoader.run());
 	}
 
 	private async run(name: string, fn: () => Promise<LoaderResult>): Promise<void> {

--- a/packages/cli/src/instance-settings-loader/loaders/log-streaming.instance-settings-loader.ts
+++ b/packages/cli/src/instance-settings-loader/loaders/log-streaming.instance-settings-loader.ts
@@ -8,8 +8,10 @@ import { MessageEventBusDestinationTypeNames } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
 import { z } from 'zod';
 
-import { EventDestinations } from '@/modules/log-streaming.ee/database/entities';
 import { EventDestinationsRepository } from '@/modules/log-streaming.ee/database/repositories/event-destination.repository';
+import { EventDestinations } from '@/modules/log-streaming.ee/database/entities';
+
+import { InstanceBootstrappingError } from '../instance-bootstrapping.error';
 
 // The env schema mirrors the UI fields exactly (see logStreaming.constants.ts):
 // fields hidden from the UI are not accepted here, and closed enums (method,
@@ -171,7 +173,14 @@ export class LogStreamingInstanceSettingsLoader {
 			'logStreamingManagedByEnv is enabled — reconciling log streaming destinations from env vars',
 		);
 
-		const items = this.parseAndValidate(this.config.logStreamingDestinations);
+		let items: EnvDestination[] = [];
+		try {
+			items = this.parseAndValidate(this.config.logStreamingDestinations);
+		} catch (error) {
+			const message = (error as Error).message ?? 'Unknown error';
+			this.logger.error(message);
+			throw new InstanceBootstrappingError(message);
+		}
 
 		await this.eventDestinationsRepository.manager.transaction(async (tx) => {
 			await this.reconcile(tx, items);

--- a/packages/cli/src/instance-settings-loader/loaders/log-streaming.instance-settings-loader.ts
+++ b/packages/cli/src/instance-settings-loader/loaders/log-streaming.instance-settings-loader.ts
@@ -3,7 +3,12 @@ import { InstanceSettingsLoaderConfig } from '@n8n/config';
 import type { EntityManager } from '@n8n/db';
 import { Service } from '@n8n/di';
 import type { MessageEventBusDestinationOptions } from 'n8n-workflow';
-import { MessageEventBusDestinationTypeNames } from 'n8n-workflow';
+import {
+	MessageEventBusDestinationSentryOptionsSchema,
+	MessageEventBusDestinationSyslogOptionsSchema,
+	MessageEventBusDestinationTypeNames,
+	MessageEventBusDestinationWebhookOptionsSchema,
+} from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
 import { z } from 'zod';
 
@@ -12,119 +17,38 @@ import { EventDestinations } from '@/modules/log-streaming.ee/database/entities'
 
 import { InstanceBootstrappingError } from '../instance-bootstrapping.error';
 
-const circuitBreakerSchema = z
-	.object({
-		maxFailures: z.number().int().positive().optional(),
-		failureWindow: z.number().int().min(100).optional(),
-	})
-	.strict()
-	.optional();
-
-const webhookParameterItemSchema = z
-	.object({
-		parameters: z.array(
-			z
-				.object({
-					name: z.string(),
-					value: z.union([z.string(), z.number(), z.boolean(), z.null()]),
-				})
-				.strict(),
-		),
-	})
-	.strict();
-
-const webhookOptionsSchema = z
-	.object({
-		allowUnauthorizedCerts: z.boolean().optional(),
-		queryParameterArrays: z.enum(['indices', 'brackets', 'repeat']).optional(),
-		redirect: z
-			.object({
-				redirect: z
-					.object({
-						followRedirects: z.boolean().optional(),
-						maxRedirects: z.number().int().positive().optional(),
-					})
-					.strict(),
-			})
-			.strict()
-			.optional(),
-		proxy: z
-			.object({
-				proxy: z
-					.object({
-						protocol: z.enum(['https', 'http']),
-						host: z.string().min(1),
-						port: z.number().int().positive(),
-					})
-					.strict(),
-			})
-			.strict()
-			.optional(),
-		timeout: z.number().int().positive().optional(),
-		socket: z
-			.object({
-				keepAlive: z.boolean().optional(),
-				maxSockets: z.number().int().positive().optional(),
-				maxFreeSockets: z.number().int().positive().optional(),
-			})
-			.strict()
-			.optional(),
-	})
-	.strict()
-	.optional();
-
-const commonFields = {
-	id: z.string().uuid().optional(),
-	label: z.string().min(1).optional(),
-	enabled: z.boolean().optional(),
-	subscribedEvents: z.array(z.string().min(1)).optional(),
-	anonymizeAuditMessages: z.boolean().optional(),
-	circuitBreaker: circuitBreakerSchema,
-} as const;
-
-const webhookEnvSchema = z
-	.object({
-		...commonFields,
+// Env var format reuses the canonical destination DTOs from `n8n-workflow`,
+// with three deliberate adjustments per variant:
+//  1. Replace the internal `__type: '$$MessageEventBusDestination…'` discriminator
+//     with a friendlier `type: 'webhook' | 'syslog' | 'sentry'`.
+//  2. Tighten `id` to a UUID (the DTO only requires a non-empty string).
+//  3. Switch to strict mode so unknown keys in the env JSON fail loudly
+//     rather than being silently dropped on insert.
+const envWebhookSchema = MessageEventBusDestinationWebhookOptionsSchema.omit({ __type: true })
+	.extend({
 		type: z.literal('webhook'),
-		url: z.string().url(),
-		method: z.enum(['GET', 'POST', 'PUT']).optional(),
-		sendQuery: z.boolean().optional(),
-		specifyQuery: z.enum(['keypair', 'json']).optional(),
-		queryParameters: webhookParameterItemSchema.optional(),
-		jsonQuery: z.string().optional(),
-		sendHeaders: z.boolean().optional(),
-		specifyHeaders: z.enum(['keypair', 'json']).optional(),
-		headerParameters: webhookParameterItemSchema.optional(),
-		jsonHeaders: z.string().optional(),
-		options: webhookOptionsSchema,
+		id: z.string().uuid().optional(),
 	})
 	.strict();
 
-const syslogEnvSchema = z
-	.object({
-		...commonFields,
+const envSyslogSchema = MessageEventBusDestinationSyslogOptionsSchema.omit({ __type: true })
+	.extend({
 		type: z.literal('syslog'),
-		host: z.string().min(1),
-		port: z.number().int().positive().optional(),
-		protocol: z.enum(['udp', 'tcp', 'tls']).optional(),
-		facility: z.number().int().min(0).max(23).optional(),
-		app_name: z.string().min(1).optional(),
-		tlsCa: z.string().min(1).optional(),
+		id: z.string().uuid().optional(),
 	})
 	.strict();
 
-const sentryEnvSchema = z
-	.object({
-		...commonFields,
+const envSentrySchema = MessageEventBusDestinationSentryOptionsSchema.omit({ __type: true })
+	.extend({
 		type: z.literal('sentry'),
-		dsn: z.string().url(),
+		id: z.string().uuid().optional(),
 	})
 	.strict();
 
 const envDestinationSchema = z.discriminatedUnion('type', [
-	webhookEnvSchema,
-	syslogEnvSchema,
-	sentryEnvSchema,
+	envWebhookSchema,
+	envSyslogSchema,
+	envSentrySchema,
 ]);
 
 const envDestinationsSchema = z.array(envDestinationSchema);

--- a/packages/cli/src/instance-settings-loader/loaders/log-streaming.instance-settings-loader.ts
+++ b/packages/cli/src/instance-settings-loader/loaders/log-streaming.instance-settings-loader.ts
@@ -11,65 +11,118 @@ import { z } from 'zod';
 import { EventDestinations } from '@/modules/log-streaming.ee/database/entities';
 import { EventDestinationsRepository } from '@/modules/log-streaming.ee/database/repositories/event-destination.repository';
 
-const webhookParameterItemSchema = z.object({
-	parameters: z.array(
-		z.object({
-			name: z.string(),
-			value: z.union([z.string(), z.number(), z.boolean(), z.null()]).nullable(),
-		}),
-	),
-});
+// The env schema mirrors the UI fields exactly (see logStreaming.constants.ts):
+// fields hidden from the UI are not accepted here, and closed enums (method,
+// facility, protocol) match the UI's dropdown values.
+
+const circuitBreakerSchema = z
+	.object({
+		maxFailures: z.number().int().positive().optional(),
+		failureWindow: z.number().int().min(100).optional(),
+	})
+	.strict()
+	.optional();
+
+const webhookParameterItemSchema = z
+	.object({
+		parameters: z.array(
+			z
+				.object({
+					name: z.string(),
+					value: z.union([z.string(), z.number(), z.boolean(), z.null()]),
+				})
+				.strict(),
+		),
+	})
+	.strict();
+
+const webhookOptionsSchema = z
+	.object({
+		allowUnauthorizedCerts: z.boolean().optional(),
+		queryParameterArrays: z.enum(['indices', 'brackets', 'repeat']).optional(),
+		redirect: z
+			.object({
+				redirect: z
+					.object({
+						followRedirects: z.boolean().optional(),
+						maxRedirects: z.number().int().positive().optional(),
+					})
+					.strict(),
+			})
+			.strict()
+			.optional(),
+		proxy: z
+			.object({
+				proxy: z
+					.object({
+						protocol: z.enum(['https', 'http']),
+						host: z.string().min(1),
+						port: z.number().int().positive(),
+					})
+					.strict(),
+			})
+			.strict()
+			.optional(),
+		timeout: z.number().int().positive().optional(),
+		socket: z
+			.object({
+				keepAlive: z.boolean().optional(),
+				maxSockets: z.number().int().positive().optional(),
+				maxFreeSockets: z.number().int().positive().optional(),
+			})
+			.strict()
+			.optional(),
+	})
+	.strict()
+	.optional();
 
 const commonFields = {
 	id: z.string().uuid().optional(),
 	label: z.string().min(1).optional(),
 	enabled: z.boolean().optional(),
-	subscribedEvents: z.array(z.string()).optional(),
+	subscribedEvents: z.array(z.string().min(1)).optional(),
 	anonymizeAuditMessages: z.boolean().optional(),
-	credentials: z.record(z.unknown()).optional(),
-};
+	circuitBreaker: circuitBreakerSchema,
+} as const;
 
-const webhookEnvSchema = z.object({
-	...commonFields,
-	type: z.literal('webhook'),
-	url: z.string().url(),
-	method: z.string().optional(),
-	headerParameters: webhookParameterItemSchema.optional(),
-	queryParameters: webhookParameterItemSchema.optional(),
-	sendQuery: z.boolean().optional(),
-	sendHeaders: z.boolean().optional(),
-	sendPayload: z.boolean().optional(),
-	responseCodeMustMatch: z.boolean().optional(),
-	expectedStatusCode: z.number().int().optional(),
-	authentication: z.enum(['predefinedCredentialType', 'genericCredentialType', 'none']).optional(),
-	genericAuthType: z.string().optional(),
-	nodeCredentialType: z.string().optional(),
-	specifyHeaders: z.string().optional(),
-	specifyQuery: z.string().optional(),
-	jsonHeaders: z.string().optional(),
-	jsonQuery: z.string().optional(),
-	options: z.record(z.unknown()).optional(),
-});
+const webhookEnvSchema = z
+	.object({
+		...commonFields,
+		type: z.literal('webhook'),
+		url: z.string().url(),
+		method: z.enum(['GET', 'POST', 'PUT']).optional(),
+		sendQuery: z.boolean().optional(),
+		specifyQuery: z.enum(['keypair', 'json']).optional(),
+		queryParameters: webhookParameterItemSchema.optional(),
+		jsonQuery: z.string().optional(),
+		sendHeaders: z.boolean().optional(),
+		specifyHeaders: z.enum(['keypair', 'json']).optional(),
+		headerParameters: webhookParameterItemSchema.optional(),
+		jsonHeaders: z.string().optional(),
+		options: webhookOptionsSchema,
+	})
+	.strict();
 
-const syslogEnvSchema = z.object({
-	...commonFields,
-	type: z.literal('syslog'),
-	host: z.string().min(1),
-	port: z.number().int().positive().optional(),
-	protocol: z.enum(['udp', 'tcp', 'tls']).optional(),
-	facility: z.number().int().min(0).max(23).optional(),
-	app_name: z.string().optional(),
-	eol: z.string().optional(),
-	expectedStatusCode: z.number().int().optional(),
-});
+const syslogEnvSchema = z
+	.object({
+		...commonFields,
+		type: z.literal('syslog'),
+		host: z.string().min(1),
+		port: z.number().int().positive().optional(),
+		protocol: z.enum(['udp', 'tcp', 'tls']).optional(),
+		facility: z.number().int().min(0).max(23).optional(),
+		app_name: z.string().min(1).optional(),
+		tlsCa: z.string().min(1).optional(),
+	})
+	.strict();
 
-const sentryEnvSchema = z.object({
-	...commonFields,
-	type: z.literal('sentry'),
-	dsn: z.string().url(),
-	tracesSampleRate: z.number().min(0).max(1).optional(),
-	sendPayload: z.boolean().optional(),
-});
+const sentryEnvSchema = z
+	.object({
+		...commonFields,
+		type: z.literal('sentry'),
+		dsn: z.string().url(),
+	})
+	.strict();
 
 const envDestinationSchema = z.discriminatedUnion('type', [
 	webhookEnvSchema,
@@ -157,6 +210,11 @@ export class LogStreamingInstanceSettingsLoader {
 			if (!item.id && !item.label) {
 				throw new Error(
 					`N8N_LOG_STREAMING_DESTINATIONS[${index}] must have either "id" or "label" for stable reconciliation`,
+				);
+			}
+			if (item.type === 'syslog' && item.protocol === 'tls' && !item.tlsCa) {
+				throw new Error(
+					`N8N_LOG_STREAMING_DESTINATIONS[${index}] must provide "tlsCa" when "protocol" is "tls"`,
 				);
 			}
 			if (item.id) {

--- a/packages/cli/src/instance-settings-loader/loaders/log-streaming.instance-settings-loader.ts
+++ b/packages/cli/src/instance-settings-loader/loaders/log-streaming.instance-settings-loader.ts
@@ -225,7 +225,9 @@ export class LogStreamingInstanceSettingsLoader {
 					);
 				}
 				seenIds.add(item.id);
-			} else if (item.label) {
+			}
+
+			if (item.label) {
 				const key = `${item.type}:${item.label}`;
 				if (seenLabelType.has(key)) {
 					throw new Error(

--- a/packages/cli/src/instance-settings-loader/loaders/log-streaming.instance-settings-loader.ts
+++ b/packages/cli/src/instance-settings-loader/loaders/log-streaming.instance-settings-loader.ts
@@ -13,10 +13,6 @@ import { EventDestinations } from '@/modules/log-streaming.ee/database/entities'
 
 import { InstanceBootstrappingError } from '../instance-bootstrapping.error';
 
-// The env schema mirrors the UI fields exactly (see logStreaming.constants.ts):
-// fields hidden from the UI are not accepted here, and closed enums (method,
-// facility, protocol) match the UI's dropdown values.
-
 const circuitBreakerSchema = z
 	.object({
 		maxFailures: z.number().int().positive().optional(),

--- a/packages/cli/src/instance-settings-loader/loaders/log-streaming.instance-settings-loader.ts
+++ b/packages/cli/src/instance-settings-loader/loaders/log-streaming.instance-settings-loader.ts
@@ -1,11 +1,106 @@
 import { Logger } from '@n8n/backend-common';
 import { InstanceSettingsLoaderConfig } from '@n8n/config';
+import type { EntityManager } from '@n8n/db';
+import { In } from '@n8n/db';
 import { Service } from '@n8n/di';
+import type { MessageEventBusDestinationOptions } from 'n8n-workflow';
+import { MessageEventBusDestinationTypeNames } from 'n8n-workflow';
+import { v4 as uuid } from 'uuid';
+import { z } from 'zod';
+
+import { EventDestinations } from '@/modules/log-streaming.ee/database/entities';
+import { EventDestinationsRepository } from '@/modules/log-streaming.ee/database/repositories/event-destination.repository';
+
+const webhookParameterItemSchema = z.object({
+	parameters: z.array(
+		z.object({
+			name: z.string(),
+			value: z.union([z.string(), z.number(), z.boolean(), z.null()]).nullable(),
+		}),
+	),
+});
+
+const commonFields = {
+	id: z.string().uuid().optional(),
+	label: z.string().min(1).optional(),
+	enabled: z.boolean().optional(),
+	subscribedEvents: z.array(z.string()).optional(),
+	anonymizeAuditMessages: z.boolean().optional(),
+	credentials: z.record(z.unknown()).optional(),
+};
+
+const webhookEnvSchema = z.object({
+	...commonFields,
+	type: z.literal('webhook'),
+	url: z.string().url(),
+	method: z.string().optional(),
+	headerParameters: webhookParameterItemSchema.optional(),
+	queryParameters: webhookParameterItemSchema.optional(),
+	sendQuery: z.boolean().optional(),
+	sendHeaders: z.boolean().optional(),
+	sendPayload: z.boolean().optional(),
+	responseCodeMustMatch: z.boolean().optional(),
+	expectedStatusCode: z.number().int().optional(),
+	authentication: z.enum(['predefinedCredentialType', 'genericCredentialType', 'none']).optional(),
+	genericAuthType: z.string().optional(),
+	nodeCredentialType: z.string().optional(),
+	specifyHeaders: z.string().optional(),
+	specifyQuery: z.string().optional(),
+	jsonHeaders: z.string().optional(),
+	jsonQuery: z.string().optional(),
+	options: z.record(z.unknown()).optional(),
+});
+
+const syslogEnvSchema = z.object({
+	...commonFields,
+	type: z.literal('syslog'),
+	host: z.string().min(1),
+	port: z.number().int().positive().optional(),
+	protocol: z.enum(['udp', 'tcp', 'tls']).optional(),
+	facility: z.number().int().min(0).max(23).optional(),
+	app_name: z.string().optional(),
+	eol: z.string().optional(),
+	expectedStatusCode: z.number().int().optional(),
+});
+
+const sentryEnvSchema = z.object({
+	...commonFields,
+	type: z.literal('sentry'),
+	dsn: z.string().url(),
+	tracesSampleRate: z.number().min(0).max(1).optional(),
+	sendPayload: z.boolean().optional(),
+});
+
+const envDestinationSchema = z.discriminatedUnion('type', [
+	webhookEnvSchema,
+	syslogEnvSchema,
+	sentryEnvSchema,
+]);
+
+const envDestinationsSchema = z.array(envDestinationSchema);
+
+type EnvDestination = z.infer<typeof envDestinationSchema>;
+
+const TYPE_TO_INTERNAL: Record<EnvDestination['type'], MessageEventBusDestinationTypeNames> = {
+	webhook: MessageEventBusDestinationTypeNames.webhook,
+	syslog: MessageEventBusDestinationTypeNames.syslog,
+	sentry: MessageEventBusDestinationTypeNames.sentry,
+};
+
+function toDestinationOptions(env: EnvDestination, id: string): MessageEventBusDestinationOptions {
+	const { type, id: _ignored, ...rest } = env;
+	return {
+		...rest,
+		__type: TYPE_TO_INTERNAL[type],
+		id,
+	} as MessageEventBusDestinationOptions;
+}
 
 @Service()
 export class LogStreamingInstanceSettingsLoader {
 	constructor(
 		private readonly config: InstanceSettingsLoaderConfig,
+		private readonly eventDestinationsRepository: EventDestinationsRepository,
 		private logger: Logger,
 	) {
 		this.logger = this.logger.scoped('instance-settings-loader');
@@ -23,6 +118,124 @@ export class LogStreamingInstanceSettingsLoader {
 			'logStreamingManagedByEnv is enabled — reconciling log streaming destinations from env vars',
 		);
 
+		const items = this.parseAndValidate(this.config.logStreamingDestinations);
+
+		await this.eventDestinationsRepository.manager.transaction(async (tx) => {
+			await this.reconcile(tx, items);
+		});
+
 		return 'created';
+	}
+
+	private parseAndValidate(raw: string): EnvDestination[] {
+		const trimmed = (raw ?? '').trim();
+		if (trimmed.length === 0) return [];
+
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(trimmed);
+		} catch (error) {
+			throw new Error(
+				`N8N_LOG_STREAMING_DESTINATIONS is not valid JSON: ${(error as Error).message}`,
+			);
+		}
+
+		const result = envDestinationsSchema.safeParse(parsed);
+		if (!result.success) {
+			const issue = result.error.issues[0];
+			const path = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+			throw new Error(
+				`N8N_LOG_STREAMING_DESTINATIONS validation failed at "${path}": ${issue.message}`,
+			);
+		}
+
+		const items = result.data;
+		const seenIds = new Set<string>();
+		const seenLabelType = new Set<string>();
+
+		items.forEach((item, index) => {
+			if (!item.id && !item.label) {
+				throw new Error(
+					`N8N_LOG_STREAMING_DESTINATIONS[${index}] must have either "id" or "label" for stable reconciliation`,
+				);
+			}
+			if (item.id) {
+				if (seenIds.has(item.id)) {
+					throw new Error(
+						`N8N_LOG_STREAMING_DESTINATIONS has duplicate id "${item.id}" at index ${index}`,
+					);
+				}
+				seenIds.add(item.id);
+			} else if (item.label) {
+				const key = `${item.type}:${item.label}`;
+				if (seenLabelType.has(key)) {
+					throw new Error(
+						`N8N_LOG_STREAMING_DESTINATIONS has duplicate (type,label) "${item.type}/${item.label}" at index ${index}`,
+					);
+				}
+				seenLabelType.add(key);
+			}
+		});
+
+		return items;
+	}
+
+	private async reconcile(tx: EntityManager, items: EnvDestination[]): Promise<void> {
+		const existing = await tx.find(EventDestinations, {
+			order: { createdAt: 'ASC', id: 'ASC' },
+		});
+
+		const byId = new Map(existing.map((row) => [row.id, row]));
+		const byLabelType = new Map<string, EventDestinations[]>();
+		for (const row of existing) {
+			const dest = row.destination;
+			if (dest?.label && dest.__type) {
+				const key = `${dest.__type}:${dest.label}`;
+				const bucket = byLabelType.get(key) ?? [];
+				bucket.push(row);
+				byLabelType.set(key, bucket);
+			}
+		}
+
+		const keptIds = new Set<string>();
+		const toDelete = new Set<string>();
+		const toUpsert: Array<Pick<EventDestinations, 'id' | 'destination'>> = [];
+
+		for (const item of items) {
+			let targetId: string;
+
+			if (item.id) {
+				const match = byId.get(item.id);
+				targetId = match ? match.id : item.id;
+			} else {
+				const internalType = TYPE_TO_INTERNAL[item.type];
+				const key = `${internalType}:${item.label!}`;
+				const matches = byLabelType.get(key) ?? [];
+				if (matches.length > 0) {
+					targetId = matches[0].id;
+					for (let i = 1; i < matches.length; i++) toDelete.add(matches[i].id);
+				} else {
+					targetId = uuid();
+				}
+			}
+
+			keptIds.add(targetId);
+			toUpsert.push({
+				id: targetId,
+				destination: toDestinationOptions(item, targetId),
+			});
+		}
+
+		for (const row of existing) {
+			if (!keptIds.has(row.id)) toDelete.add(row.id);
+		}
+		for (const id of keptIds) toDelete.delete(id);
+
+		if (toUpsert.length > 0) {
+			await tx.upsert(EventDestinations, toUpsert, { conflictPaths: ['id'] });
+		}
+		if (toDelete.size > 0) {
+			await tx.delete(EventDestinations, { id: In(Array.from(toDelete)) });
+		}
 	}
 }

--- a/packages/cli/src/instance-settings-loader/loaders/log-streaming.instance-settings-loader.ts
+++ b/packages/cli/src/instance-settings-loader/loaders/log-streaming.instance-settings-loader.ts
@@ -1,0 +1,28 @@
+import { Logger } from '@n8n/backend-common';
+import { InstanceSettingsLoaderConfig } from '@n8n/config';
+import { Service } from '@n8n/di';
+
+@Service()
+export class LogStreamingInstanceSettingsLoader {
+	constructor(
+		private readonly config: InstanceSettingsLoaderConfig,
+		private logger: Logger,
+	) {
+		this.logger = this.logger.scoped('instance-settings-loader');
+	}
+
+	async run(): Promise<'created' | 'skipped'> {
+		if (!this.config.logStreamingManagedByEnv) {
+			this.logger.debug(
+				'logStreamingManagedByEnv is disabled — skipping log streaming destinations env config',
+			);
+			return 'skipped';
+		}
+
+		this.logger.info(
+			'logStreamingManagedByEnv is enabled — reconciling log streaming destinations from env vars',
+		);
+
+		return 'created';
+	}
+}

--- a/packages/cli/src/instance-settings-loader/loaders/log-streaming.instance-settings-loader.ts
+++ b/packages/cli/src/instance-settings-loader/loaders/log-streaming.instance-settings-loader.ts
@@ -217,11 +217,7 @@ export class LogStreamingInstanceSettingsLoader {
 					`N8N_LOG_STREAMING_DESTINATIONS[${index}] must have either "id" or "label" for stable reconciliation`,
 				);
 			}
-			if (item.type === 'syslog' && item.protocol === 'tls' && !item.tlsCa) {
-				throw new Error(
-					`N8N_LOG_STREAMING_DESTINATIONS[${index}] must provide "tlsCa" when "protocol" is "tls"`,
-				);
-			}
+
 			if (item.id) {
 				if (seenIds.has(item.id)) {
 					throw new Error(
@@ -248,7 +244,64 @@ export class LogStreamingInstanceSettingsLoader {
 			order: { createdAt: 'ASC', id: 'ASC' },
 		});
 
-		const byId = new Map(existing.map((row) => [row.id, row]));
+		const byLabelType = this.groupByLabelType(existing);
+
+		const toDelete = new Set<string>();
+		const toUpsert: Array<Pick<EventDestinations, 'id' | 'destination'>> = [];
+
+		for (const item of items) {
+			// Match items by id or unique (type, label) to reliably reconcile environment configuration with the database.
+			let targetId: string;
+
+			if (item.id) {
+				targetId = item.id;
+			} else {
+				const internalType = TYPE_TO_INTERNAL[item.type];
+				const key = `${internalType}:${item.label!}`;
+				const matches = byLabelType.get(key) ?? [];
+
+				if (matches.length > 0) {
+					// One env row maps to at most one DB row per (type, label). If duplicates exist
+					// (e.g. legacy data), keep the oldest row and remove the rest so reconciliation is stable.
+					targetId = matches[0].id;
+					for (let i = 1; i < matches.length; i++) {
+						toDelete.add(matches[i].id);
+					}
+				} else {
+					targetId = uuid();
+				}
+			}
+
+			toUpsert.push({
+				id: targetId,
+				destination: toDestinationOptions(item, targetId),
+			});
+		}
+
+		// Remove database entities that were not matched to environment variable items.
+		const keptIds = new Set(toUpsert.map((row) => row.id));
+		for (const row of existing) {
+			if (!keptIds.has(row.id)) {
+				toDelete.add(row.id);
+			}
+		}
+
+		// Drop kept ids from `toDelete`: label-based duplicate cleanup can mark a row for deletion
+		// before another array entry rescues the same id.
+		for (const id of keptIds) {
+			toDelete.delete(id);
+		}
+
+		if (toUpsert.length > 0) {
+			await tx.upsert(EventDestinations, toUpsert, { conflictPaths: ['id'] });
+		}
+
+		if (toDelete.size > 0) {
+			await tx.delete(EventDestinations, { id: In(Array.from(toDelete)) });
+		}
+	}
+
+	private groupByLabelType(existing: EventDestinations[]): Map<string, EventDestinations[]> {
 		const byLabelType = new Map<string, EventDestinations[]>();
 		for (const row of existing) {
 			const dest = row.destination;
@@ -259,46 +312,6 @@ export class LogStreamingInstanceSettingsLoader {
 				byLabelType.set(key, bucket);
 			}
 		}
-
-		const keptIds = new Set<string>();
-		const toDelete = new Set<string>();
-		const toUpsert: Array<Pick<EventDestinations, 'id' | 'destination'>> = [];
-
-		for (const item of items) {
-			let targetId: string;
-
-			if (item.id) {
-				const match = byId.get(item.id);
-				targetId = match ? match.id : item.id;
-			} else {
-				const internalType = TYPE_TO_INTERNAL[item.type];
-				const key = `${internalType}:${item.label!}`;
-				const matches = byLabelType.get(key) ?? [];
-				if (matches.length > 0) {
-					targetId = matches[0].id;
-					for (let i = 1; i < matches.length; i++) toDelete.add(matches[i].id);
-				} else {
-					targetId = uuid();
-				}
-			}
-
-			keptIds.add(targetId);
-			toUpsert.push({
-				id: targetId,
-				destination: toDestinationOptions(item, targetId),
-			});
-		}
-
-		for (const row of existing) {
-			if (!keptIds.has(row.id)) toDelete.add(row.id);
-		}
-		for (const id of keptIds) toDelete.delete(id);
-
-		if (toUpsert.length > 0) {
-			await tx.upsert(EventDestinations, toUpsert, { conflictPaths: ['id'] });
-		}
-		if (toDelete.size > 0) {
-			await tx.delete(EventDestinations, { id: In(Array.from(toDelete)) });
-		}
+		return byLabelType;
 	}
 }

--- a/packages/cli/src/instance-settings-loader/loaders/log-streaming.instance-settings-loader.ts
+++ b/packages/cli/src/instance-settings-loader/loaders/log-streaming.instance-settings-loader.ts
@@ -1,7 +1,6 @@
 import { Logger } from '@n8n/backend-common';
 import { InstanceSettingsLoaderConfig } from '@n8n/config';
 import type { EntityManager } from '@n8n/db';
-import { In } from '@n8n/db';
 import { Service } from '@n8n/di';
 import type { MessageEventBusDestinationOptions } from 'n8n-workflow';
 import { MessageEventBusDestinationTypeNames } from 'n8n-workflow';
@@ -166,7 +165,7 @@ export class LogStreamingInstanceSettingsLoader {
 		}
 
 		this.logger.info(
-			'logStreamingManagedByEnv is enabled — reconciling log streaming destinations from env vars',
+			'logStreamingManagedByEnv is enabled — replacing log streaming destinations from env vars',
 		);
 
 		let items: EnvDestination[] = [];
@@ -179,7 +178,7 @@ export class LogStreamingInstanceSettingsLoader {
 		}
 
 		await this.eventDestinationsRepository.manager.transaction(async (tx) => {
-			await this.reconcile(tx, items);
+			await this.replace(tx, items);
 		});
 
 		return 'created';
@@ -209,15 +208,8 @@ export class LogStreamingInstanceSettingsLoader {
 
 		const items = result.data;
 		const seenIds = new Set<string>();
-		const seenLabelType = new Set<string>();
 
 		items.forEach((item, index) => {
-			if (!item.id && !item.label) {
-				throw new Error(
-					`N8N_LOG_STREAMING_DESTINATIONS[${index}] must have either "id" or "label" for stable reconciliation`,
-				);
-			}
-
 			if (item.id) {
 				if (seenIds.has(item.id)) {
 					throw new Error(
@@ -226,94 +218,24 @@ export class LogStreamingInstanceSettingsLoader {
 				}
 				seenIds.add(item.id);
 			}
-
-			if (item.label) {
-				const key = `${item.type}:${item.label}`;
-				if (seenLabelType.has(key)) {
-					throw new Error(
-						`N8N_LOG_STREAMING_DESTINATIONS has duplicate (type,label) "${item.type}/${item.label}" at index ${index}`,
-					);
-				}
-				seenLabelType.add(key);
-			}
 		});
 
 		return items;
 	}
 
-	private async reconcile(tx: EntityManager, items: EnvDestination[]): Promise<void> {
-		const existing = await tx.find(EventDestinations, {
-			order: { createdAt: 'ASC', id: 'ASC' },
+	private async replace(tx: EntityManager, items: EnvDestination[]): Promise<void> {
+		await tx.delete(EventDestinations, {});
+
+		if (items.length === 0) return;
+
+		const rows = items.map((item) => {
+			const id = item.id ?? uuid();
+			return {
+				id,
+				destination: toDestinationOptions(item, id),
+			};
 		});
 
-		const byLabelType = this.groupByLabelType(existing);
-
-		const toDelete = new Set<string>();
-		const toUpsert: Array<Pick<EventDestinations, 'id' | 'destination'>> = [];
-
-		for (const item of items) {
-			// Match items by id or unique (type, label) to reliably reconcile environment configuration with the database.
-			let targetId: string;
-
-			if (item.id) {
-				targetId = item.id;
-			} else {
-				const internalType = TYPE_TO_INTERNAL[item.type];
-				const key = `${internalType}:${item.label!}`;
-				const matches = byLabelType.get(key) ?? [];
-
-				if (matches.length > 0) {
-					// One env row maps to at most one DB row per (type, label). If duplicates exist
-					// (e.g. legacy data), keep the oldest row and remove the rest so reconciliation is stable.
-					targetId = matches[0].id;
-					for (let i = 1; i < matches.length; i++) {
-						toDelete.add(matches[i].id);
-					}
-				} else {
-					targetId = uuid();
-				}
-			}
-
-			toUpsert.push({
-				id: targetId,
-				destination: toDestinationOptions(item, targetId),
-			});
-		}
-
-		// Remove database entities that were not matched to environment variable items.
-		const keptIds = new Set(toUpsert.map((row) => row.id));
-		for (const row of existing) {
-			if (!keptIds.has(row.id)) {
-				toDelete.add(row.id);
-			}
-		}
-
-		// Drop kept ids from `toDelete`: label-based duplicate cleanup can mark a row for deletion
-		// before another array entry rescues the same id.
-		for (const id of keptIds) {
-			toDelete.delete(id);
-		}
-
-		if (toUpsert.length > 0) {
-			await tx.upsert(EventDestinations, toUpsert, { conflictPaths: ['id'] });
-		}
-
-		if (toDelete.size > 0) {
-			await tx.delete(EventDestinations, { id: In(Array.from(toDelete)) });
-		}
-	}
-
-	private groupByLabelType(existing: EventDestinations[]): Map<string, EventDestinations[]> {
-		const byLabelType = new Map<string, EventDestinations[]>();
-		for (const row of existing) {
-			const dest = row.destination;
-			if (dest?.label && dest.__type) {
-				const key = `${dest.__type}:${dest.label}`;
-				const bucket = byLabelType.get(key) ?? [];
-				bucket.push(row);
-				byLabelType.set(key, bucket);
-			}
-		}
-		return byLabelType;
+		await tx.insert(EventDestinations, rows);
 	}
 }

--- a/packages/cli/src/modules/log-streaming.ee/__tests__/log-streaming.controller.test.ts
+++ b/packages/cli/src/modules/log-streaming.ee/__tests__/log-streaming.controller.test.ts
@@ -1,9 +1,11 @@
+import type { InstanceSettingsLoaderConfig } from '@n8n/config';
 import type { AuthenticatedRequest } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 import { MessageEventBusDestinationTypeNames } from 'n8n-workflow';
 import type { MessageEventBusDestinationWebhookOptions } from 'n8n-workflow';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import type { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
 
 import type { LogStreamingDestinationService } from '../log-streaming-destination.service';
@@ -12,12 +14,16 @@ import { EventBusController } from '../log-streaming.controller';
 describe('EventBusController', () => {
 	const eventBus = mock<MessageEventBus>();
 	const destinationService = mock<LogStreamingDestinationService>();
+	const instanceSettingsLoaderConfig = mock<InstanceSettingsLoaderConfig>({
+		logStreamingManagedByEnv: false,
+	});
 
 	let controller: EventBusController;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
-		controller = new EventBusController(eventBus, destinationService);
+		instanceSettingsLoaderConfig.logStreamingManagedByEnv = false;
+		controller = new EventBusController(eventBus, destinationService, instanceSettingsLoaderConfig);
 	});
 
 	describe('getDestination', () => {
@@ -117,6 +123,50 @@ describe('EventBusController', () => {
 			await controller.deleteDestination(req, {}, { id: 'webhook-1' });
 
 			expect(destinationService.removeDestination).toHaveBeenCalledWith('webhook-1');
+		});
+	});
+
+	describe('when logStreamingManagedByEnv is true', () => {
+		beforeEach(() => {
+			instanceSettingsLoaderConfig.logStreamingManagedByEnv = true;
+		});
+
+		it('rejects postDestination with ForbiddenError', async () => {
+			const req = {
+				body: {
+					__type: MessageEventBusDestinationTypeNames.webhook,
+					label: 'Test',
+					url: 'https://example.com/webhook',
+				},
+			} as unknown as AuthenticatedRequest;
+
+			await expect(controller.postDestination(req)).rejects.toThrow(ForbiddenError);
+			expect(destinationService.addDestination).not.toHaveBeenCalled();
+		});
+
+		it('rejects deleteDestination with ForbiddenError', async () => {
+			const req = mock<AuthenticatedRequest>();
+
+			await expect(controller.deleteDestination(req, {}, { id: 'webhook-1' })).rejects.toThrow(
+				ForbiddenError,
+			);
+			expect(destinationService.removeDestination).not.toHaveBeenCalled();
+		});
+
+		it('still allows getDestination', async () => {
+			destinationService.findDestination.mockResolvedValue([]);
+			const req = mock<AuthenticatedRequest>();
+
+			await expect(controller.getDestination(req, {}, {})).resolves.toEqual([]);
+			expect(destinationService.findDestination).toHaveBeenCalled();
+		});
+
+		it('still allows sendTestMessage', async () => {
+			destinationService.testDestination.mockResolvedValue(true);
+			const req = mock<AuthenticatedRequest>();
+
+			await expect(controller.sendTestMessage(req, {}, { id: 'webhook-1' })).resolves.toBe(true);
+			expect(destinationService.testDestination).toHaveBeenCalledWith('webhook-1');
 		});
 	});
 });

--- a/packages/cli/src/modules/log-streaming.ee/log-streaming.controller.ts
+++ b/packages/cli/src/modules/log-streaming.ee/log-streaming.controller.ts
@@ -26,9 +26,6 @@ import { MessageEventBusDestinationWebhook } from './destinations/message-event-
 import type { MessageEventBusDestination } from './destinations/message-event-bus-destination.ee';
 import { LogStreamingDestinationService } from './log-streaming-destination.service';
 
-const MANAGED_BY_ENV_MESSAGE =
-	'Log streaming destinations are managed via environment variables and cannot be modified through the API';
-
 @RestController('/eventbus')
 export class EventBusController {
 	constructor(
@@ -39,7 +36,9 @@ export class EventBusController {
 
 	private assertNotManagedByEnv() {
 		if (this.instanceSettingsLoaderConfig.logStreamingManagedByEnv) {
-			throw new ForbiddenError(MANAGED_BY_ENV_MESSAGE);
+			throw new ForbiddenError(
+				'Log streaming destinations are managed via environment variables and cannot be modified through the API',
+			);
 		}
 	}
 

--- a/packages/cli/src/modules/log-streaming.ee/log-streaming.controller.ts
+++ b/packages/cli/src/modules/log-streaming.ee/log-streaming.controller.ts
@@ -4,6 +4,7 @@ import {
 	GetDestinationQueryDto,
 	TestDestinationQueryDto,
 } from '@n8n/api-types';
+import { InstanceSettingsLoaderConfig } from '@n8n/config';
 import type { AuthenticatedRequest } from '@n8n/db';
 import { Delete, Get, GlobalScope, Licensed, Post, Query, RestController } from '@n8n/decorators';
 import type {
@@ -15,6 +16,7 @@ import type {
 import { MessageEventBusDestinationTypeNames } from 'n8n-workflow';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { eventNamesAll } from '@/eventbus/event-message-classes';
 import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
 
@@ -24,12 +26,22 @@ import { MessageEventBusDestinationWebhook } from './destinations/message-event-
 import type { MessageEventBusDestination } from './destinations/message-event-bus-destination.ee';
 import { LogStreamingDestinationService } from './log-streaming-destination.service';
 
+const MANAGED_BY_ENV_MESSAGE =
+	'Log streaming destinations are managed via environment variables and cannot be modified through the API';
+
 @RestController('/eventbus')
 export class EventBusController {
 	constructor(
 		private readonly eventBus: MessageEventBus,
 		private readonly destinationService: LogStreamingDestinationService,
+		private readonly instanceSettingsLoaderConfig: InstanceSettingsLoaderConfig,
 	) {}
+
+	private assertNotManagedByEnv() {
+		if (this.instanceSettingsLoaderConfig.logStreamingManagedByEnv) {
+			throw new ForbiddenError(MANAGED_BY_ENV_MESSAGE);
+		}
+	}
 
 	@Get('/eventnames')
 	async getEventNames(): Promise<string[]> {
@@ -51,6 +63,8 @@ export class EventBusController {
 	@Post('/destination')
 	@GlobalScope('eventBusDestination:create')
 	async postDestination(req: AuthenticatedRequest): Promise<MessageEventBusDestinationOptions> {
+		this.assertNotManagedByEnv();
+
 		// Manually validate using the discriminated union schema since TypeScript reflection doesn't work with plain Zod schemas
 		// And ZodClass doesn't support discriminated unions directly
 		const parseResult = CreateDestinationDto.safeParse(req.body);
@@ -114,6 +128,7 @@ export class EventBusController {
 		_res: unknown,
 		@Query query: DeleteDestinationQueryDto,
 	): Promise<void> {
+		this.assertNotManagedByEnv();
 		await this.destinationService.removeDestination(query.id);
 	}
 }

--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -218,6 +218,28 @@ describe('FrontendService', () => {
 				}),
 			);
 		});
+
+		it('should surface logStreaming.managedByEnv from instanceSettingsLoader config', async () => {
+			globalConfig.instanceSettingsLoader = {
+				logStreamingManagedByEnv: true,
+			} as GlobalConfig['instanceSettingsLoader'];
+
+			const { service } = createMockService();
+			const settings = await service.getSettings();
+
+			expect(settings.logStreaming).toEqual({ managedByEnv: true });
+		});
+
+		it('should default logStreaming.managedByEnv to false when flag is off', async () => {
+			globalConfig.instanceSettingsLoader = {
+				logStreamingManagedByEnv: false,
+			} as GlobalConfig['instanceSettingsLoader'];
+
+			const { service } = createMockService();
+			const settings = await service.getSettings();
+
+			expect(settings.logStreaming).toEqual({ managedByEnv: false });
+		});
 	});
 
 	describe('getPublicSettings', () => {

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -266,6 +266,9 @@ export class FrontendService {
 					callbackUrl: `${instanceBaseUrl}/${restEndpoint}/sso/oidc/callback`,
 				},
 			},
+			logStreaming: {
+				managedByEnv: this.globalConfig.instanceSettingsLoader.logStreamingManagedByEnv,
+			},
 			dataTables: {
 				maxSize: this.globalConfig.dataTable.maxSize,
 			},

--- a/packages/cli/test/integration/log-streaming.controller.test.ts
+++ b/packages/cli/test/integration/log-streaming.controller.test.ts
@@ -1,4 +1,5 @@
 import { mockInstance } from '@n8n/backend-test-utils';
+import { InstanceSettingsLoaderConfig } from '@n8n/config';
 import { GLOBAL_OWNER_ROLE, type User } from '@n8n/db';
 import { Container } from '@n8n/di';
 
@@ -153,5 +154,53 @@ describe('POST /eventbus/destination', () => {
 
 			expect(response.statusCode).toBe(400);
 		});
+	});
+});
+
+describe('when log streaming is managed by env', () => {
+	beforeAll(() => {
+		Container.get(InstanceSettingsLoaderConfig).logStreamingManagedByEnv = true;
+	});
+
+	afterAll(() => {
+		Container.get(InstanceSettingsLoaderConfig).logStreamingManagedByEnv = false;
+	});
+
+	test('POST /eventbus/destination is rejected with 403', async () => {
+		const webhookPayload = {
+			__type: '$$MessageEventBusDestinationWebhook',
+			url: 'http://localhost:3456',
+			method: 'POST',
+			label: 'Should not be created',
+			enabled: false,
+			subscribedEvents: ['n8n.test.message'],
+			options: {},
+		};
+
+		const response = await authOwnerAgent.post('/eventbus/destination').send(webhookPayload);
+
+		expect(response.statusCode).toBe(403);
+	});
+
+	test('DELETE /eventbus/destination is rejected with 403', async () => {
+		const response = await authOwnerAgent
+			.delete('/eventbus/destination')
+			.query({ id: '11111111-1111-4111-8111-111111111111' });
+
+		expect(response.statusCode).toBe(403);
+	});
+
+	test('GET /eventbus/destination still succeeds', async () => {
+		const response = await authOwnerAgent.get('/eventbus/destination');
+
+		expect(response.statusCode).toBe(200);
+	});
+
+	test('GET /eventbus/testmessage still succeeds', async () => {
+		const response = await authOwnerAgent
+			.get('/eventbus/testmessage')
+			.query({ id: '11111111-1111-4111-8111-111111111111' });
+
+		expect(response.statusCode).toBe(200);
 	});
 });

--- a/packages/cli/test/integration/log-streaming/log-streaming.instance-settings-loader.test.ts
+++ b/packages/cli/test/integration/log-streaming/log-streaming.instance-settings-loader.test.ts
@@ -91,7 +91,7 @@ describe('LogStreamingInstanceSettingsLoader → event_destinations roundtrip', 
 		});
 	});
 
-	it('updates an existing row in place when id matches (idempotent re-run)', async () => {
+	it('preserves a pinned id across runs', async () => {
 		setConfig({
 			logStreamingDestinations: JSON.stringify([
 				{ type: 'webhook', id: UUID_A, label: 'V1', url: 'https://v1.test' },
@@ -119,7 +119,7 @@ describe('LogStreamingInstanceSettingsLoader → event_destinations roundtrip', 
 		});
 	});
 
-	it('matches on (type, label) when id is absent, preserving the existing id', async () => {
+	it('generates a fresh id on each run when none is pinned', async () => {
 		setConfig({
 			logStreamingDestinations: JSON.stringify([
 				{ type: 'syslog', label: 'SIEM', host: 'initial.host' },
@@ -139,7 +139,7 @@ describe('LogStreamingInstanceSettingsLoader → event_destinations roundtrip', 
 
 		const rows = await repository.find();
 		expect(rows).toHaveLength(1);
-		expect(rows[0].id).toBe(initialId);
+		expect(rows[0].id).not.toBe(initialId);
 		expect(rows[0].destination).toMatchObject({
 			__type: MessageEventBusDestinationTypeNames.syslog,
 			label: 'SIEM',

--- a/packages/cli/test/integration/log-streaming/log-streaming.instance-settings-loader.test.ts
+++ b/packages/cli/test/integration/log-streaming/log-streaming.instance-settings-loader.test.ts
@@ -1,0 +1,217 @@
+import { testDb, testModules } from '@n8n/backend-test-utils';
+import { GlobalConfig } from '@n8n/config';
+import type { InstanceSettingsLoaderConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
+import { MessageEventBusDestinationTypeNames } from 'n8n-workflow';
+
+import { InstanceBootstrappingError } from '@/instance-settings-loader/instance-bootstrapping.error';
+import { LogStreamingInstanceSettingsLoader } from '@/instance-settings-loader/loaders/log-streaming.instance-settings-loader';
+import { EventDestinationsRepository } from '@/modules/log-streaming.ee/database/repositories/event-destination.repository';
+
+const UUID_A = '11111111-1111-4111-8111-111111111111';
+const UUID_B = '22222222-2222-4222-8222-222222222222';
+
+beforeAll(async () => {
+	await testModules.loadModules(['log-streaming']);
+	await testDb.init();
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+describe('LogStreamingInstanceSettingsLoader → event_destinations roundtrip', () => {
+	let originalConfig: Pick<
+		InstanceSettingsLoaderConfig,
+		'logStreamingManagedByEnv' | 'logStreamingDestinations'
+	>;
+	let repository: EventDestinationsRepository;
+	let loader: LogStreamingInstanceSettingsLoader;
+
+	const setConfig = (overrides: Partial<InstanceSettingsLoaderConfig>) => {
+		Object.assign(Container.get(GlobalConfig).instanceSettingsLoader, {
+			logStreamingManagedByEnv: true,
+			logStreamingDestinations: '',
+			...overrides,
+		});
+	};
+
+	beforeEach(async () => {
+		repository = Container.get(EventDestinationsRepository);
+		loader = Container.get(LogStreamingInstanceSettingsLoader);
+
+		const config = Container.get(GlobalConfig).instanceSettingsLoader;
+		originalConfig = {
+			logStreamingManagedByEnv: config.logStreamingManagedByEnv,
+			logStreamingDestinations: config.logStreamingDestinations,
+		};
+
+		await repository.delete({});
+	});
+
+	afterEach(async () => {
+		Object.assign(Container.get(GlobalConfig).instanceSettingsLoader, originalConfig);
+		await repository.delete({});
+	});
+
+	it('returns "skipped" and does not touch the DB when the flag is off', async () => {
+		setConfig({
+			logStreamingManagedByEnv: false,
+			logStreamingDestinations: JSON.stringify([
+				{ type: 'webhook', label: 'Ignored', url: 'https://ignored.test' },
+			]),
+		});
+
+		await expect(loader.run()).resolves.toBe('skipped');
+		await expect(repository.count()).resolves.toBe(0);
+	});
+
+	it('persists a webhook destination from env on an empty DB', async () => {
+		setConfig({
+			logStreamingDestinations: JSON.stringify([
+				{
+					type: 'webhook',
+					label: 'Audit',
+					url: 'https://hooks.example.com',
+					method: 'POST',
+				},
+			]),
+		});
+
+		await expect(loader.run()).resolves.toBe('created');
+
+		const rows = await repository.find();
+		expect(rows).toHaveLength(1);
+		expect(rows[0].destination).toMatchObject({
+			__type: MessageEventBusDestinationTypeNames.webhook,
+			id: rows[0].id,
+			label: 'Audit',
+			url: 'https://hooks.example.com',
+			method: 'POST',
+		});
+	});
+
+	it('updates an existing row in place when id matches (idempotent re-run)', async () => {
+		setConfig({
+			logStreamingDestinations: JSON.stringify([
+				{ type: 'webhook', id: UUID_A, label: 'V1', url: 'https://v1.test' },
+			]),
+		});
+		await loader.run();
+
+		const firstRows = await repository.find();
+		expect(firstRows).toHaveLength(1);
+		expect(firstRows[0].id).toBe(UUID_A);
+
+		setConfig({
+			logStreamingDestinations: JSON.stringify([
+				{ type: 'webhook', id: UUID_A, label: 'V2', url: 'https://v2.test' },
+			]),
+		});
+		await loader.run();
+
+		const secondRows = await repository.find();
+		expect(secondRows).toHaveLength(1);
+		expect(secondRows[0].id).toBe(UUID_A);
+		expect(secondRows[0].destination).toMatchObject({
+			label: 'V2',
+			url: 'https://v2.test',
+		});
+	});
+
+	it('matches on (type, label) when id is absent, preserving the existing id', async () => {
+		setConfig({
+			logStreamingDestinations: JSON.stringify([
+				{ type: 'syslog', label: 'SIEM', host: 'initial.host' },
+			]),
+		});
+		await loader.run();
+
+		const [initial] = await repository.find();
+		const initialId = initial.id;
+
+		setConfig({
+			logStreamingDestinations: JSON.stringify([
+				{ type: 'syslog', label: 'SIEM', host: 'updated.host', port: 514, protocol: 'tcp' },
+			]),
+		});
+		await loader.run();
+
+		const rows = await repository.find();
+		expect(rows).toHaveLength(1);
+		expect(rows[0].id).toBe(initialId);
+		expect(rows[0].destination).toMatchObject({
+			__type: MessageEventBusDestinationTypeNames.syslog,
+			label: 'SIEM',
+			host: 'updated.host',
+			port: 514,
+			protocol: 'tcp',
+		});
+	});
+
+	it('deletes rows not referenced by the env array', async () => {
+		setConfig({
+			logStreamingDestinations: JSON.stringify([
+				{ type: 'webhook', id: UUID_A, label: 'Keep', url: 'https://keep.test' },
+				{ type: 'sentry', id: UUID_B, label: 'Drop', dsn: 'https://pub@sentry.test/1' },
+			]),
+		});
+		await loader.run();
+		expect(await repository.count()).toBe(2);
+
+		setConfig({
+			logStreamingDestinations: JSON.stringify([
+				{ type: 'webhook', id: UUID_A, label: 'Keep', url: 'https://keep.test' },
+			]),
+		});
+		await loader.run();
+
+		const rows = await repository.find();
+		expect(rows).toHaveLength(1);
+		expect(rows[0].id).toBe(UUID_A);
+	});
+
+	it('clears all rows when the env array is empty', async () => {
+		setConfig({
+			logStreamingDestinations: JSON.stringify([
+				{ type: 'webhook', id: UUID_A, label: 'A', url: 'https://a.test' },
+			]),
+		});
+		await loader.run();
+		expect(await repository.count()).toBe(1);
+
+		setConfig({ logStreamingDestinations: '[]' });
+		await loader.run();
+
+		expect(await repository.count()).toBe(0);
+	});
+
+	it('persists all three destination types with the correct __type discriminator', async () => {
+		setConfig({
+			logStreamingDestinations: JSON.stringify([
+				{ type: 'webhook', label: 'W', url: 'https://w.test' },
+				{ type: 'syslog', label: 'S', host: 'syslog.test' },
+				{ type: 'sentry', label: 'E', dsn: 'https://pub@sentry.test/1' },
+			]),
+		});
+
+		await loader.run();
+
+		const rows = await repository.find();
+		const typesByLabel = Object.fromEntries(
+			rows.map((row) => [row.destination.label, row.destination.__type]),
+		);
+		expect(typesByLabel).toEqual({
+			W: MessageEventBusDestinationTypeNames.webhook,
+			S: MessageEventBusDestinationTypeNames.syslog,
+			E: MessageEventBusDestinationTypeNames.sentry,
+		});
+	});
+
+	it('throws InstanceBootstrappingError on invalid JSON without writing to the DB', async () => {
+		setConfig({ logStreamingDestinations: '{not valid' });
+
+		await expect(loader.run()).rejects.toThrow(InstanceBootstrappingError);
+		expect(await repository.count()).toBe(0);
+	});
+});

--- a/packages/cli/test/integration/log-streaming/log-streaming.instance-settings-loader.test.ts
+++ b/packages/cli/test/integration/log-streaming/log-streaming.instance-settings-loader.test.ts
@@ -8,9 +8,6 @@ import { InstanceBootstrappingError } from '@/instance-settings-loader/instance-
 import { LogStreamingInstanceSettingsLoader } from '@/instance-settings-loader/loaders/log-streaming.instance-settings-loader';
 import { EventDestinationsRepository } from '@/modules/log-streaming.ee/database/repositories/event-destination.repository';
 
-const UUID_A = '11111111-1111-4111-8111-111111111111';
-const UUID_B = '22222222-2222-4222-8222-222222222222';
-
 beforeAll(async () => {
 	await testModules.loadModules(['log-streaming']);
 	await testDb.init();
@@ -66,7 +63,7 @@ describe('LogStreamingInstanceSettingsLoader → event_destinations roundtrip', 
 		await expect(repository.count()).resolves.toBe(0);
 	});
 
-	it('persists a webhook destination from env on an empty DB', async () => {
+	it('persists every destination from the env JSON into the DB', async () => {
 		setConfig({
 			logStreamingDestinations: JSON.stringify([
 				{
@@ -75,137 +72,40 @@ describe('LogStreamingInstanceSettingsLoader → event_destinations roundtrip', 
 					url: 'https://hooks.example.com',
 					method: 'POST',
 				},
+				{ type: 'syslog', label: 'SIEM', host: 'syslog.test', port: 514, protocol: 'tcp' },
+				{ type: 'sentry', label: 'Errors', dsn: 'https://pub@sentry.test/1' },
 			]),
 		});
 
 		await expect(loader.run()).resolves.toBe('created');
 
 		const rows = await repository.find();
-		expect(rows).toHaveLength(1);
-		expect(rows[0].destination).toMatchObject({
-			__type: MessageEventBusDestinationTypeNames.webhook,
-			id: rows[0].id,
-			label: 'Audit',
-			url: 'https://hooks.example.com',
-			method: 'POST',
+		const byLabel = Object.fromEntries(rows.map((row) => [row.destination.label, row.destination]));
+		expect(byLabel).toEqual({
+			Audit: expect.objectContaining({
+				__type: MessageEventBusDestinationTypeNames.webhook,
+				url: 'https://hooks.example.com',
+				method: 'POST',
+			}),
+			SIEM: expect.objectContaining({
+				__type: MessageEventBusDestinationTypeNames.syslog,
+				host: 'syslog.test',
+				port: 514,
+				protocol: 'tcp',
+			}),
+			Errors: expect.objectContaining({
+				__type: MessageEventBusDestinationTypeNames.sentry,
+				dsn: 'https://pub@sentry.test/1',
+			}),
 		});
 	});
 
-	it('preserves a pinned id across runs', async () => {
-		setConfig({
-			logStreamingDestinations: JSON.stringify([
-				{ type: 'webhook', id: UUID_A, label: 'V1', url: 'https://v1.test' },
-			]),
-		});
-		await loader.run();
-
-		const firstRows = await repository.find();
-		expect(firstRows).toHaveLength(1);
-		expect(firstRows[0].id).toBe(UUID_A);
-
-		setConfig({
-			logStreamingDestinations: JSON.stringify([
-				{ type: 'webhook', id: UUID_A, label: 'V2', url: 'https://v2.test' },
-			]),
-		});
-		await loader.run();
-
-		const secondRows = await repository.find();
-		expect(secondRows).toHaveLength(1);
-		expect(secondRows[0].id).toBe(UUID_A);
-		expect(secondRows[0].destination).toMatchObject({
-			label: 'V2',
-			url: 'https://v2.test',
-		});
-	});
-
-	it('generates a fresh id on each run when none is pinned', async () => {
-		setConfig({
-			logStreamingDestinations: JSON.stringify([
-				{ type: 'syslog', label: 'SIEM', host: 'initial.host' },
-			]),
-		});
-		await loader.run();
-
-		const [initial] = await repository.find();
-		const initialId = initial.id;
-
-		setConfig({
-			logStreamingDestinations: JSON.stringify([
-				{ type: 'syslog', label: 'SIEM', host: 'updated.host', port: 514, protocol: 'tcp' },
-			]),
-		});
-		await loader.run();
-
-		const rows = await repository.find();
-		expect(rows).toHaveLength(1);
-		expect(rows[0].id).not.toBe(initialId);
-		expect(rows[0].destination).toMatchObject({
-			__type: MessageEventBusDestinationTypeNames.syslog,
-			label: 'SIEM',
-			host: 'updated.host',
-			port: 514,
-			protocol: 'tcp',
-		});
-	});
-
-	it('deletes rows not referenced by the env array', async () => {
-		setConfig({
-			logStreamingDestinations: JSON.stringify([
-				{ type: 'webhook', id: UUID_A, label: 'Keep', url: 'https://keep.test' },
-				{ type: 'sentry', id: UUID_B, label: 'Drop', dsn: 'https://pub@sentry.test/1' },
-			]),
-		});
-		await loader.run();
-		expect(await repository.count()).toBe(2);
-
-		setConfig({
-			logStreamingDestinations: JSON.stringify([
-				{ type: 'webhook', id: UUID_A, label: 'Keep', url: 'https://keep.test' },
-			]),
-		});
-		await loader.run();
-
-		const rows = await repository.find();
-		expect(rows).toHaveLength(1);
-		expect(rows[0].id).toBe(UUID_A);
-	});
-
-	it('clears all rows when the env array is empty', async () => {
-		setConfig({
-			logStreamingDestinations: JSON.stringify([
-				{ type: 'webhook', id: UUID_A, label: 'A', url: 'https://a.test' },
-			]),
-		});
-		await loader.run();
-		expect(await repository.count()).toBe(1);
-
+	it('writes no rows when the env array is empty', async () => {
 		setConfig({ logStreamingDestinations: '[]' });
+
 		await loader.run();
 
 		expect(await repository.count()).toBe(0);
-	});
-
-	it('persists all three destination types with the correct __type discriminator', async () => {
-		setConfig({
-			logStreamingDestinations: JSON.stringify([
-				{ type: 'webhook', label: 'W', url: 'https://w.test' },
-				{ type: 'syslog', label: 'S', host: 'syslog.test' },
-				{ type: 'sentry', label: 'E', dsn: 'https://pub@sentry.test/1' },
-			]),
-		});
-
-		await loader.run();
-
-		const rows = await repository.find();
-		const typesByLabel = Object.fromEntries(
-			rows.map((row) => [row.destination.label, row.destination.__type]),
-		);
-		expect(typesByLabel).toEqual({
-			W: MessageEventBusDestinationTypeNames.webhook,
-			S: MessageEventBusDestinationTypeNames.syslog,
-			E: MessageEventBusDestinationTypeNames.sentry,
-		});
 	});
 
 	it('throws InstanceBootstrappingError on invalid JSON without writing to the DB', async () => {

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2990,6 +2990,7 @@
 	"settings.log-streaming.actionBox.description": "Log Streaming is available as a paid feature. Learn more about it.",
 	"settings.log-streaming.actionBox.button": "See plans",
 	"settings.log-streaming.infoText": "Send logs to external endpoints of your choice. You can also write logs to a file or the console using environment variables. <a href=\"https://docs.n8n.io/log-streaming/\" target=\"_blank\">More info</a>",
+	"settings.log-streaming.managedByEnv": "Log streaming destinations are managed via environment variables and cannot be modified from the UI.",
 	"settings.log-streaming.addFirstTitle": "Set up a destination to get started",
 	"settings.log-streaming.addFirst": "Add your first destination by clicking on the button and selecting a destination type.",
 	"settings.log-streaming.saving": "Saving",

--- a/packages/frontend/editor-ui/src/__tests__/defaults.ts
+++ b/packages/frontend/editor-ui/src/__tests__/defaults.ts
@@ -93,6 +93,9 @@ export const defaultSettings: FrontendSettings = {
 		saml: { loginEnabled: false, loginLabel: '' },
 		oidc: { loginEnabled: false, loginUrl: '', callbackUrl: '' },
 	},
+	logStreaming: {
+		managedByEnv: false,
+	},
 	telemetry: {
 		enabled: false,
 	},

--- a/packages/frontend/editor-ui/src/features/integrations/logStreaming.ee/views/SettingsLogStreamingView.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/logStreaming.ee/views/SettingsLogStreamingView.vue
@@ -58,6 +58,12 @@ const canManageLogStreaming = computed((): boolean => {
 	return hasPermission(['rbac'], { rbac: { scope: 'logStreaming:manage' } });
 });
 
+const isManagedByEnv = computed((): boolean => {
+	return settingsStore.settings.logStreaming?.managedByEnv ?? false;
+});
+
+const isReadonly = computed((): boolean => isManagedByEnv.value || !canManageLogStreaming.value);
+
 onMounted(async () => {
 	documentTitle.set(i18n.baseText('settings.log-streaming.heading'));
 	if (!isLicensed.value) return;
@@ -194,6 +200,11 @@ async function onEdit(destinationId?: string) {
 					<span v-n8n-html="i18n.baseText('settings.log-streaming.infoText')"></span>
 				</N8nInfoTip>
 			</div>
+			<div v-if="isManagedByEnv" class="mb-l" data-test-id="log-streaming-managed-by-env">
+				<N8nInfoTip theme="info" type="note">
+					{{ i18n.baseText('settings.log-streaming.managedByEnv') }}
+				</N8nInfoTip>
+			</div>
 			<template v-if="storeHasItems()">
 				<ElRow
 					v-for="item in sortedItemKeysByLabel"
@@ -205,19 +216,19 @@ async function onEdit(destinationId?: string) {
 						<EventDestinationCard
 							:destination="logStreamingStore.items[item.key]?.destination"
 							:event-bus="eventBus"
-							:readonly="!canManageLogStreaming"
+							:readonly="isReadonly"
 							@remove="onRemove(logStreamingStore.items[item.key]?.destination?.id)"
 							@edit="onEdit(logStreamingStore.items[item.key]?.destination?.id)"
 						/>
 					</ElCol>
 				</ElRow>
-				<div class="mt-m text-right">
-					<N8nButton v-if="canManageLogStreaming" size="large" @click="addDestination">
+				<div v-if="!isReadonly" class="mt-m text-right">
+					<N8nButton size="large" @click="addDestination">
 						{{ i18n.baseText(`settings.log-streaming.add`) }}
 					</N8nButton>
 				</div>
 			</template>
-			<div v-else data-test-id="action-box-licensed">
+			<div v-else-if="!isManagedByEnv" data-test-id="action-box-licensed">
 				<N8nActionBox
 					:button-text="i18n.baseText(`settings.log-streaming.add`)"
 					@click:button="addDestination"

--- a/packages/frontend/editor-ui/src/features/integrations/logStreaming.ee/views/SettingsLogStreamingView.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/logStreaming.ee/views/SettingsLogStreamingView.vue
@@ -21,7 +21,7 @@ import {
 } from '@/app/stores/workflowDocument.store';
 
 import { ElCol, ElRow, ElSwitch } from 'element-plus';
-import { N8nActionBox, N8nButton, N8nHeading, N8nInfoTip } from '@n8n/design-system';
+import { N8nActionBox, N8nButton, N8nHeading, N8nInfoTip, N8nNotice } from '@n8n/design-system';
 const environment = process.env.NODE_ENV;
 
 const settingsStore = useSettingsStore();
@@ -200,11 +200,12 @@ async function onEdit(destinationId?: string) {
 					<span v-n8n-html="i18n.baseText('settings.log-streaming.infoText')"></span>
 				</N8nInfoTip>
 			</div>
-			<div v-if="isManagedByEnv" class="mb-l" data-test-id="log-streaming-managed-by-env">
-				<N8nInfoTip theme="info" type="note">
-					{{ i18n.baseText('settings.log-streaming.managedByEnv') }}
-				</N8nInfoTip>
-			</div>
+			<N8nNotice
+				v-if="isManagedByEnv"
+				class="mb-l"
+				:content="i18n.baseText('settings.log-streaming.managedByEnv')"
+				data-test-id="log-streaming-managed-by-env"
+			/>
 			<template v-if="storeHasItems()">
 				<ElRow
 					v-for="item in sortedItemKeysByLabel"


### PR DESCRIPTION
## Summary

Adds two env vars for declaratively managing log streaming destinations:

- `N8N_LOG_STREAMING_MANAGED_BY_ENV` — when `true`, destinations are reconciled from env on every startup
- `N8N_LOG_STREAMING_DESTINATIONS` — JSON array of destinations (`webhook` / `syslog` / `sentry`)

Reconciliation matches entries by `id` or `(type, label)`: existing rows are updated in place, new ones inserted, unmatched rows deleted. Invalid JSON or schema failures raise an `InstanceBootstrappingError` and halt startup.

When `managedByEnv` is enabled:
- The controller rejects create/update/delete with `403 Forbidden`
- `managedByEnv` is exposed on frontend settings; the UI renders the destinations list read-only with a notice explaining env-managed state

[loom demo](https://www.loom.com/share/d5d79346cf884b4a8664f64e94022de0)
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

closes LIGO-464

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
