### PR TITLE
feat(core): Wire Cipher to encryption key proxy for key rotation support

### DIFF
--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -7,7 +7,13 @@ import {
 import { Container } from '@n8n/di';
 import { EntityNotFoundError } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
-import { type InstanceSettings, Cipher, CipherAes256GCM, CipherAes256CBC } from 'n8n-core';
+import {
+	type InstanceSettings,
+	Cipher,
+	CipherAes256GCM,
+	CipherAes256CBC,
+	EncryptionKeyProxy,
+} from 'n8n-core';
 import type {
 	IAuthenticateGeneric,
 	ICredentialDataDecryptedObject,
@@ -45,6 +51,7 @@ describe('CredentialsHelper', () => {
 		mock<InstanceSettings>({ encryptionKey: 'test_key_for_testing' }),
 		new CipherAes256GCM(),
 		new CipherAes256CBC(),
+		new EncryptionKeyProxy(),
 	);
 	Container.set(Cipher, cipher);
 

--- a/packages/cli/src/public-api/v1/handlers/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/__tests__/credentials.service.test.ts
@@ -2,7 +2,7 @@ import type { CredentialsEntity, Project, SharedCredentials, User } from '@n8n/d
 import { CredentialsRepository, GLOBAL_OWNER_ROLE, GLOBAL_MEMBER_ROLE } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
-import { Cipher, CipherAes256GCM, CipherAes256CBC } from 'n8n-core';
+import { Cipher, CipherAes256GCM, CipherAes256CBC, EncryptionKeyProxy } from 'n8n-core';
 import type { InstanceSettings } from 'n8n-core';
 import type { GenericValue, IDataObject, INodeProperties } from 'n8n-workflow';
 
@@ -19,6 +19,7 @@ const cipher = new Cipher(
 	mock<InstanceSettings>({ encryptionKey: 'test-encryption-key' }),
 	new CipherAes256GCM(),
 	new CipherAes256CBC(),
+	new EncryptionKeyProxy(),
 );
 Container.set(Cipher, cipher);
 

--- a/packages/core/src/__tests__/credentials.test.ts
+++ b/packages/core/src/__tests__/credentials.test.ts
@@ -7,6 +7,7 @@ import { CREDENTIAL_ERRORS } from '@/constants';
 import { CipherAes256CBC } from '@/encryption/aes-256-cbc';
 import { CipherAes256GCM } from '@/encryption/aes-256-gcm';
 import { Cipher } from '@/encryption/cipher';
+import { EncryptionKeyProxy } from '@/encryption/encryption-key-proxy';
 import type { InstanceSettings } from '@/instance-settings';
 
 import { Credentials } from '../credentials';
@@ -19,6 +20,7 @@ describe('Credentials', () => {
 		mock<InstanceSettings>({ encryptionKey: 'password' }),
 		new CipherAes256GCM(),
 		new CipherAes256CBC(),
+		new EncryptionKeyProxy(),
 	);
 	Container.set(Cipher, cipher);
 

--- a/packages/core/src/encryption/__tests__/cipher.test.ts
+++ b/packages/core/src/encryption/__tests__/cipher.test.ts
@@ -4,7 +4,7 @@ import { InstanceSettings } from '@/instance-settings';
 import { mockInstance } from '@test/utils';
 
 import { Cipher } from '../cipher';
-import type { EncryptionKeyProxy } from '../encryption-key-proxy';
+import { EncryptionKeyProxy, type IEncryptionKeyProvider } from '../encryption-key-proxy';
 
 describe('Cipher', () => {
 	mockInstance(InstanceSettings, { encryptionKey: 'test_key' });
@@ -170,21 +170,22 @@ describe('Cipher', () => {
 	describe('encryptV2 / decryptV2 (proxy-aware)', () => {
 		const instanceKeyForProxy = 'test_key';
 		const plaintextDataKey = '11'.repeat(32);
+		const encryptionKeyProxy = Container.get(EncryptionKeyProxy);
 
-		const withProxy = (proxy: Partial<EncryptionKeyProxy>) => {
-			jest.spyOn(Container, 'has').mockReturnValue(true);
-			jest.spyOn(Container, 'get').mockReturnValue(proxy as EncryptionKeyProxy);
+		const withProvider = (provider: Partial<IEncryptionKeyProvider>) => {
+			encryptionKeyProxy.setProvider(provider as IEncryptionKeyProvider);
 		};
 
 		afterEach(() => {
 			jest.restoreAllMocks();
+			encryptionKeyProxy.setProvider(undefined);
 		});
 
 		it('should use active key and embed keyId prefix when proxy is registered and feature flag is on', async () => {
 			const keyId = 'test-uuid-1234';
 			const encryptedDataKey = cipher.encryptWithInstanceKey(plaintextDataKey);
 
-			withProxy({
+			withProvider({
 				getActiveKey: async () => ({
 					id: keyId,
 					value: encryptedDataKey,
@@ -218,7 +219,7 @@ describe('Cipher', () => {
 			const ciphertext = cipher.encryptWithKey('world', plaintextDataKey, 'aes-256-gcm');
 			const prefixed = `${keyId}:${ciphertext}`;
 
-			withProxy({
+			withProvider({
 				getActiveKey: async () => ({
 					id: keyId,
 					value: encryptedDataKey,
@@ -245,7 +246,7 @@ describe('Cipher', () => {
 				'aes-256-cbc',
 			);
 
-			withProxy({
+			withProvider({
 				getActiveKey: async () => ({
 					id: 'active',
 					value: encryptedDataKey,
@@ -265,7 +266,7 @@ describe('Cipher', () => {
 
 		it('should bypass proxy when customEncryptionKey is provided', async () => {
 			const encryptedDataKey = cipher.encryptWithInstanceKey(plaintextDataKey);
-			withProxy({
+			withProvider({
 				getActiveKey: async () => ({
 					id: 'should-not-be-called',
 					value: encryptedDataKey,

--- a/packages/core/src/encryption/__tests__/cipher.test.ts
+++ b/packages/core/src/encryption/__tests__/cipher.test.ts
@@ -234,8 +234,14 @@ describe('Cipher', () => {
 				}),
 			});
 
-			const decrypted = await cipher.decryptV2(prefixed);
-			expect(decrypted).toEqual('world');
+			const originalFlag = process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION;
+			process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = 'true';
+			try {
+				const decrypted = await cipher.decryptV2(prefixed);
+				expect(decrypted).toEqual('world');
+			} finally {
+				process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = originalFlag;
+			}
 		});
 
 		it('should use legacy CBC key for unprefixed data when proxy is registered', async () => {

--- a/packages/core/src/encryption/__tests__/cipher.test.ts
+++ b/packages/core/src/encryption/__tests__/cipher.test.ts
@@ -4,6 +4,7 @@ import { InstanceSettings } from '@/instance-settings';
 import { mockInstance } from '@test/utils';
 
 import { Cipher } from '../cipher';
+import type { EncryptionKeyProxy } from '../encryption-key-proxy';
 
 describe('Cipher', () => {
 	mockInstance(InstanceSettings, { encryptionKey: 'test_key' });
@@ -163,6 +164,131 @@ describe('Cipher', () => {
 			expect(() => cipher.decryptWithKey(buf.toString('base64'), gcmKey, 'aes-256-gcm')).toThrow(
 				'Unsupported GCM ciphertext version',
 			);
+		});
+	});
+
+	describe('encryptV2 / decryptV2 (proxy-aware)', () => {
+		const instanceKeyForProxy = 'test_key';
+		const plaintextDataKey = '11'.repeat(32);
+
+		const withProxy = (proxy: Partial<EncryptionKeyProxy>) => {
+			jest.spyOn(Container, 'has').mockReturnValue(true);
+			jest.spyOn(Container, 'get').mockReturnValue(proxy as EncryptionKeyProxy);
+		};
+
+		afterEach(() => {
+			jest.restoreAllMocks();
+		});
+
+		it('should use active key and embed keyId prefix when proxy is registered and feature flag is on', async () => {
+			const keyId = 'test-uuid-1234';
+			const encryptedDataKey = cipher.encryptWithInstanceKey(plaintextDataKey);
+
+			withProxy({
+				getActiveKey: async () => ({
+					id: keyId,
+					value: encryptedDataKey,
+					algorithm: 'aes-256-gcm',
+				}),
+				getKeyById: async () => null,
+				getLegacyKey: async () => ({
+					id: 'legacy',
+					value: encryptedDataKey,
+					algorithm: 'aes-256-cbc',
+				}),
+			});
+
+			const originalFlag = process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION;
+			process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = 'true';
+			try {
+				const encrypted = await cipher.encryptV2('hello');
+				expect(encrypted.startsWith(`${keyId}:`)).toBe(true);
+
+				const ciphertext = encrypted.slice(keyId.length + 1);
+				const decrypted = cipher.decryptWithKey(ciphertext, plaintextDataKey, 'aes-256-gcm');
+				expect(decrypted).toEqual('hello');
+			} finally {
+				process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = originalFlag;
+			}
+		});
+
+		it('should decrypt using keyId from prefix when proxy is registered', async () => {
+			const keyId = 'test-uuid-5678';
+			const encryptedDataKey = cipher.encryptWithInstanceKey(plaintextDataKey);
+			const ciphertext = cipher.encryptWithKey('world', plaintextDataKey, 'aes-256-gcm');
+			const prefixed = `${keyId}:${ciphertext}`;
+
+			withProxy({
+				getActiveKey: async () => ({
+					id: keyId,
+					value: encryptedDataKey,
+					algorithm: 'aes-256-gcm',
+				}),
+				getKeyById: async (id: string) =>
+					id === keyId ? { id, value: encryptedDataKey, algorithm: 'aes-256-gcm' } : null,
+				getLegacyKey: async () => ({
+					id: 'legacy',
+					value: encryptedDataKey,
+					algorithm: 'aes-256-cbc',
+				}),
+			});
+
+			const decrypted = await cipher.decryptV2(prefixed);
+			expect(decrypted).toEqual('world');
+		});
+
+		it('should use legacy CBC key for unprefixed data when proxy is registered', async () => {
+			const encryptedDataKey = cipher.encryptWithInstanceKey(instanceKeyForProxy);
+			const legacyCiphertext = cipher.encryptWithKey(
+				'legacy-data',
+				instanceKeyForProxy,
+				'aes-256-cbc',
+			);
+
+			withProxy({
+				getActiveKey: async () => ({
+					id: 'active',
+					value: encryptedDataKey,
+					algorithm: 'aes-256-cbc',
+				}),
+				getKeyById: async () => null,
+				getLegacyKey: async () => ({
+					id: 'legacy',
+					value: encryptedDataKey,
+					algorithm: 'aes-256-cbc',
+				}),
+			});
+
+			const decrypted = await cipher.decryptV2(legacyCiphertext);
+			expect(decrypted).toEqual('legacy-data');
+		});
+
+		it('should bypass proxy when customEncryptionKey is provided', async () => {
+			const encryptedDataKey = cipher.encryptWithInstanceKey(plaintextDataKey);
+			withProxy({
+				getActiveKey: async () => ({
+					id: 'should-not-be-called',
+					value: encryptedDataKey,
+					algorithm: 'aes-256-gcm',
+				}),
+				getKeyById: async () => null,
+				getLegacyKey: async () => ({
+					id: 'should-not-be-called',
+					value: encryptedDataKey,
+					algorithm: 'aes-256-gcm',
+				}),
+			});
+
+			const originalFlag = process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION;
+			process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = 'true';
+			try {
+				const encrypted = await cipher.encryptV2('bypass-test', 'custom-key');
+				expect(encrypted.includes(':')).toBe(false);
+				const decrypted = await cipher.decryptV2(encrypted, 'custom-key');
+				expect(decrypted).toEqual('bypass-test');
+			} finally {
+				process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = originalFlag;
+			}
 		});
 	});
 });

--- a/packages/core/src/encryption/cipher.ts
+++ b/packages/core/src/encryption/cipher.ts
@@ -1,4 +1,4 @@
-import { Container, Service } from '@n8n/di';
+import { Service } from '@n8n/di';
 
 import { InstanceSettings } from '@/instance-settings';
 import { assertUnreachable } from '@/utils/assertions';
@@ -14,11 +14,8 @@ export class Cipher {
 		private readonly instanceSettings: InstanceSettings,
 		private readonly cipherAES256GCM: CipherAes256GCM,
 		private readonly cipherAES256CBC: CipherAes256CBC,
+		private readonly encryptionKeyProxy: EncryptionKeyProxy,
 	) {}
-
-	private get encryptionKeyProxy(): EncryptionKeyProxy | undefined {
-		return Container.has(EncryptionKeyProxy) ? Container.get(EncryptionKeyProxy) : undefined;
-	}
 
 	encrypt(data: string | object, customEncryptionKey?: string): string {
 		const key = customEncryptionKey ?? this.instanceSettings.encryptionKey;
@@ -34,18 +31,19 @@ export class Cipher {
 	async encryptV2(data: string | object, customEncryptionKey?: string): Promise<string> {
 		const plaintext = typeof data === 'string' ? data : JSON.stringify(data);
 
-		if (!customEncryptionKey && process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION === 'true') {
-			const proxy = this.encryptionKeyProxy;
-			if (proxy) {
-				const keyInfo = await proxy.getActiveKey();
-				const plaintextKey = this.decryptWithInstanceKey(keyInfo.value);
-				const ciphertext = this.encryptWithKey(
-					plaintext,
-					plaintextKey,
-					keyInfo.algorithm as CipherAlgorithm,
-				);
-				return `${keyInfo.id}:${ciphertext}`;
-			}
+		if (
+			!customEncryptionKey &&
+			process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION === 'true' &&
+			this.encryptionKeyProxy.isConfigured()
+		) {
+			const keyInfo = await this.encryptionKeyProxy.getActiveKey();
+			const plaintextKey = this.decryptWithInstanceKey(keyInfo.value);
+			const ciphertext = this.encryptWithKey(
+				plaintext,
+				plaintextKey,
+				keyInfo.algorithm as CipherAlgorithm,
+			);
+			return `${keyInfo.id}:${ciphertext}`;
 		}
 
 		const key = customEncryptionKey ?? this.instanceSettings.encryptionKey;
@@ -53,26 +51,19 @@ export class Cipher {
 	}
 
 	async decryptV2(data: string, customEncryptionKey?: string): Promise<string> {
-		if (!customEncryptionKey) {
-			const proxy = this.encryptionKeyProxy;
-			if (proxy) {
-				const colonIdx = data.indexOf(':');
-				if (colonIdx !== -1) {
-					const keyId = data.slice(0, colonIdx);
-					const ciphertext = data.slice(colonIdx + 1);
-					const keyInfo = await proxy.getKeyById(keyId);
-					if (!keyInfo) throw new Error(`Encryption key not found: ${keyId}`);
-					const plaintextKey = this.decryptWithInstanceKey(keyInfo.value);
-					return this.decryptWithKey(
-						ciphertext,
-						plaintextKey,
-						keyInfo.algorithm as CipherAlgorithm,
-					);
-				}
-				const keyInfo = await proxy.getLegacyKey();
+		if (!customEncryptionKey && this.encryptionKeyProxy.isConfigured()) {
+			const colonIdx = data.indexOf(':');
+			if (colonIdx !== -1) {
+				const keyId = data.slice(0, colonIdx);
+				const ciphertext = data.slice(colonIdx + 1);
+				const keyInfo = await this.encryptionKeyProxy.getKeyById(keyId);
+				if (!keyInfo) throw new Error(`Encryption key not found: ${keyId}`);
 				const plaintextKey = this.decryptWithInstanceKey(keyInfo.value);
-				return this.decryptWithKey(data, plaintextKey, 'aes-256-cbc');
+				return this.decryptWithKey(ciphertext, plaintextKey, keyInfo.algorithm as CipherAlgorithm);
 			}
+			const keyInfo = await this.encryptionKeyProxy.getLegacyKey();
+			const plaintextKey = this.decryptWithInstanceKey(keyInfo.value);
+			return this.decryptWithKey(data, plaintextKey, 'aes-256-cbc');
 		}
 
 		const key = customEncryptionKey ?? this.instanceSettings.encryptionKey;

--- a/packages/core/src/encryption/cipher.ts
+++ b/packages/core/src/encryption/cipher.ts
@@ -31,7 +31,11 @@ export class Cipher {
 	async encryptV2(data: string | object, customEncryptionKey?: string): Promise<string> {
 		const plaintext = typeof data === 'string' ? data : JSON.stringify(data);
 
-		if (!customEncryptionKey && this.encryptionKeyProxy.isConfigured()) {
+		if (
+			!customEncryptionKey &&
+			this.encryptionKeyProxy.isConfigured() &&
+			process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION === 'true'
+		) {
 			const keyInfo = await this.encryptionKeyProxy.getActiveKey();
 			const plaintextKey = this.decryptWithInstanceKey(keyInfo.value);
 			const ciphertext = this.encryptWithKey(
@@ -47,7 +51,11 @@ export class Cipher {
 	}
 
 	async decryptV2(data: string, customEncryptionKey?: string): Promise<string> {
-		if (!customEncryptionKey && this.encryptionKeyProxy.isConfigured()) {
+		if (
+			!customEncryptionKey &&
+			this.encryptionKeyProxy.isConfigured() &&
+			process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION === 'true'
+		) {
 			const colonIdx = data.indexOf(':');
 			if (colonIdx !== -1) {
 				const keyId = data.slice(0, colonIdx);
@@ -59,7 +67,7 @@ export class Cipher {
 			}
 			const keyInfo = await this.encryptionKeyProxy.getLegacyKey();
 			const plaintextKey = this.decryptWithInstanceKey(keyInfo.value);
-			return this.decryptWithKey(data, plaintextKey, 'aes-256-cbc');
+			return this.decryptWithKey(data, plaintextKey, keyInfo.algorithm as CipherAlgorithm);
 		}
 
 		const key = customEncryptionKey ?? this.instanceSettings.encryptionKey;

--- a/packages/core/src/encryption/cipher.ts
+++ b/packages/core/src/encryption/cipher.ts
@@ -1,10 +1,11 @@
-import { Service } from '@n8n/di';
+import { Container, Service } from '@n8n/di';
 
 import { InstanceSettings } from '@/instance-settings';
 import { assertUnreachable } from '@/utils/assertions';
 
 import { CipherAes256CBC } from './aes-256-cbc';
 import { CipherAes256GCM } from './aes-256-gcm';
+import { EncryptionKeyProxy } from './encryption-key-proxy';
 import { CipherAlgorithm } from './interface';
 
 @Service()
@@ -15,13 +16,65 @@ export class Cipher {
 		private readonly cipherAES256CBC: CipherAes256CBC,
 	) {}
 
-	encrypt(data: string | object, customEncryptionKey?: string) {
+	private get encryptionKeyProxy(): EncryptionKeyProxy | undefined {
+		return Container.has(EncryptionKeyProxy) ? Container.get(EncryptionKeyProxy) : undefined;
+	}
+
+	encrypt(data: string | object, customEncryptionKey?: string): string {
 		const key = customEncryptionKey ?? this.instanceSettings.encryptionKey;
 		const plaintext = typeof data === 'string' ? data : JSON.stringify(data);
 		return this.encryptWithKey(plaintext, key, 'aes-256-cbc');
 	}
 
-	decrypt(data: string, customEncryptionKey?: string) {
+	decrypt(data: string, customEncryptionKey?: string): string {
+		const key = customEncryptionKey ?? this.instanceSettings.encryptionKey;
+		return this.decryptWithKey(data, key, 'aes-256-cbc');
+	}
+
+	async encryptV2(data: string | object, customEncryptionKey?: string): Promise<string> {
+		const plaintext = typeof data === 'string' ? data : JSON.stringify(data);
+
+		if (!customEncryptionKey && process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION === 'true') {
+			const proxy = this.encryptionKeyProxy;
+			if (proxy) {
+				const keyInfo = await proxy.getActiveKey();
+				const plaintextKey = this.decryptWithInstanceKey(keyInfo.value);
+				const ciphertext = this.encryptWithKey(
+					plaintext,
+					plaintextKey,
+					keyInfo.algorithm as CipherAlgorithm,
+				);
+				return `${keyInfo.id}:${ciphertext}`;
+			}
+		}
+
+		const key = customEncryptionKey ?? this.instanceSettings.encryptionKey;
+		return this.encryptWithKey(plaintext, key, 'aes-256-cbc');
+	}
+
+	async decryptV2(data: string, customEncryptionKey?: string): Promise<string> {
+		if (!customEncryptionKey) {
+			const proxy = this.encryptionKeyProxy;
+			if (proxy) {
+				const colonIdx = data.indexOf(':');
+				if (colonIdx !== -1) {
+					const keyId = data.slice(0, colonIdx);
+					const ciphertext = data.slice(colonIdx + 1);
+					const keyInfo = await proxy.getKeyById(keyId);
+					if (!keyInfo) throw new Error(`Encryption key not found: ${keyId}`);
+					const plaintextKey = this.decryptWithInstanceKey(keyInfo.value);
+					return this.decryptWithKey(
+						ciphertext,
+						plaintextKey,
+						keyInfo.algorithm as CipherAlgorithm,
+					);
+				}
+				const keyInfo = await proxy.getLegacyKey();
+				const plaintextKey = this.decryptWithInstanceKey(keyInfo.value);
+				return this.decryptWithKey(data, plaintextKey, 'aes-256-cbc');
+			}
+		}
+
 		const key = customEncryptionKey ?? this.instanceSettings.encryptionKey;
 		return this.decryptWithKey(data, key, 'aes-256-cbc');
 	}

--- a/packages/core/src/encryption/cipher.ts
+++ b/packages/core/src/encryption/cipher.ts
@@ -31,11 +31,7 @@ export class Cipher {
 	async encryptV2(data: string | object, customEncryptionKey?: string): Promise<string> {
 		const plaintext = typeof data === 'string' ? data : JSON.stringify(data);
 
-		if (
-			!customEncryptionKey &&
-			process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION === 'true' &&
-			this.encryptionKeyProxy.isConfigured()
-		) {
+		if (!customEncryptionKey && this.encryptionKeyProxy.isConfigured()) {
 			const keyInfo = await this.encryptionKeyProxy.getActiveKey();
 			const plaintextKey = this.decryptWithInstanceKey(keyInfo.value);
 			const ciphertext = this.encryptWithKey(

--- a/packages/core/src/encryption/encryption-key-proxy.ts
+++ b/packages/core/src/encryption/encryption-key-proxy.ts
@@ -1,16 +1,43 @@
+import { Service } from '@n8n/di';
+
 export type KeyInfo = { id: string; value: string; algorithm: string };
+
+export interface IEncryptionKeyProvider {
+	getActiveKey(): Promise<KeyInfo>;
+	getKeyById(id: string): Promise<KeyInfo | null>;
+	getLegacyKey(): Promise<KeyInfo>;
+}
 
 /**
  * Bridge between `Cipher` (packages/core) and the key manager (packages/cli).
- * The concrete implementation is registered by `EncryptionKeyManagerModule`
- * via `Container.set(EncryptionKeyProxy, Container.get(KeyManagerService))`.
- * Cipher retrieves it lazily so that no circular dependency is introduced.
+ * Always registered in the DI container. `EncryptionKeyManagerModule` calls
+ * `setProvider()` at init time to wire up the concrete implementation without
+ * introducing a circular dependency.
  *
  * `value` in `KeyInfo` is the key material already encrypted with the instance key.
  * Callers must `decryptWithInstanceKey()` before using it for data encryption.
  */
-export abstract class EncryptionKeyProxy {
-	abstract getActiveKey(): Promise<KeyInfo>;
-	abstract getKeyById(id: string): Promise<KeyInfo | null>;
-	abstract getLegacyKey(): Promise<KeyInfo>;
+@Service()
+export class EncryptionKeyProxy {
+	private provider: IEncryptionKeyProvider | undefined;
+
+	setProvider(provider: IEncryptionKeyProvider | undefined): void {
+		this.provider = provider;
+	}
+
+	isConfigured(): boolean {
+		return this.provider !== undefined;
+	}
+
+	getActiveKey(): Promise<KeyInfo> {
+		return this.provider!.getActiveKey();
+	}
+
+	getKeyById(id: string): Promise<KeyInfo | null> {
+		return this.provider!.getKeyById(id);
+	}
+
+	getLegacyKey(): Promise<KeyInfo> {
+		return this.provider!.getLegacyKey();
+	}
 }

--- a/packages/core/src/encryption/encryption-key-proxy.ts
+++ b/packages/core/src/encryption/encryption-key-proxy.ts
@@ -1,4 +1,5 @@
 import { Service } from '@n8n/di';
+import { UnexpectedError } from 'n8n-workflow';
 
 export type KeyInfo = { id: string; value: string; algorithm: string };
 
@@ -30,14 +31,17 @@ export class EncryptionKeyProxy {
 	}
 
 	async getActiveKey(): Promise<KeyInfo> {
-		return await this.provider!.getActiveKey();
+		if (!this.provider) throw new UnexpectedError('Encryption key provider is not configured');
+		return await this.provider.getActiveKey();
 	}
 
 	async getKeyById(id: string): Promise<KeyInfo | null> {
-		return await this.provider!.getKeyById(id);
+		if (!this.provider) throw new UnexpectedError('Encryption key provider is not configured');
+		return await this.provider.getKeyById(id);
 	}
 
 	async getLegacyKey(): Promise<KeyInfo> {
-		return await this.provider!.getLegacyKey();
+		if (!this.provider) throw new UnexpectedError('Encryption key provider is not configured');
+		return await this.provider.getLegacyKey();
 	}
 }

--- a/packages/core/src/encryption/encryption-key-proxy.ts
+++ b/packages/core/src/encryption/encryption-key-proxy.ts
@@ -1,0 +1,16 @@
+export type KeyInfo = { id: string; value: string; algorithm: string };
+
+/**
+ * Bridge between `Cipher` (packages/core) and the key manager (packages/cli).
+ * The concrete implementation is registered by `EncryptionKeyManagerModule`
+ * via `Container.set(EncryptionKeyProxy, Container.get(KeyManagerService))`.
+ * Cipher retrieves it lazily so that no circular dependency is introduced.
+ *
+ * `value` in `KeyInfo` is the key material already encrypted with the instance key.
+ * Callers must `decryptWithInstanceKey()` before using it for data encryption.
+ */
+export abstract class EncryptionKeyProxy {
+	abstract getActiveKey(): Promise<KeyInfo>;
+	abstract getKeyById(id: string): Promise<KeyInfo | null>;
+	abstract getLegacyKey(): Promise<KeyInfo>;
+}

--- a/packages/core/src/encryption/encryption-key-proxy.ts
+++ b/packages/core/src/encryption/encryption-key-proxy.ts
@@ -29,15 +29,15 @@ export class EncryptionKeyProxy {
 		return this.provider !== undefined;
 	}
 
-	getActiveKey(): Promise<KeyInfo> {
-		return this.provider!.getActiveKey();
+	async getActiveKey(): Promise<KeyInfo> {
+		return await this.provider!.getActiveKey();
 	}
 
-	getKeyById(id: string): Promise<KeyInfo | null> {
-		return this.provider!.getKeyById(id);
+	async getKeyById(id: string): Promise<KeyInfo | null> {
+		return await this.provider!.getKeyById(id);
 	}
 
-	getLegacyKey(): Promise<KeyInfo> {
-		return this.provider!.getLegacyKey();
+	async getLegacyKey(): Promise<KeyInfo> {
+		return await this.provider!.getLegacyKey();
 	}
 }

--- a/packages/core/src/encryption/index.ts
+++ b/packages/core/src/encryption/index.ts
@@ -2,3 +2,5 @@ export { Cipher } from './cipher';
 export { CipherAes256GCM } from './aes-256-gcm';
 export { CipherAes256CBC } from './aes-256-cbc';
 export type { CipherAlgorithm } from './interface';
+export { EncryptionKeyProxy } from './encryption-key-proxy';
+export type { KeyInfo } from './encryption-key-proxy';

--- a/packages/core/src/encryption/index.ts
+++ b/packages/core/src/encryption/index.ts
@@ -3,4 +3,4 @@ export { CipherAes256GCM } from './aes-256-gcm';
 export { CipherAes256CBC } from './aes-256-cbc';
 export type { CipherAlgorithm } from './interface';
 export { EncryptionKeyProxy } from './encryption-key-proxy';
-export type { KeyInfo } from './encryption-key-proxy';
+export type { KeyInfo, IEncryptionKeyProvider } from './encryption-key-proxy';


### PR DESCRIPTION
## Summary

Adds `encryptV2` and `decryptV2` async methods to the `Cipher` service, along with the `EncryptionKeyProxy` abstraction that bridges `packages/core` to `KeyManagerService` without creating a circular dependency.

This is a prerequisite for encryption key rotation. The existing synchronous `encrypt`/`decrypt` methods are unchanged — no call sites are broken. Call sites will be migrated to the V2 methods in follow-up PRs.

### What changed

- **`Cipher.encryptV2`** – async; when `N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION=true` and a proxy is registered, fetches the active DB key and prefixes ciphertext with the key ID (`<keyId>:<ciphertext>`). Falls back to the standard AES-256-CBC path otherwise.
- **`Cipher.decryptV2`** – async; detects the key-ID prefix to select the correct decryption key; falls back to the legacy AES-256-CBC path for un-prefixed (pre-rotation) data. `customEncryptionKey` always bypasses the proxy.
- **`EncryptionKeyProxy`** – new concrete `@Service()` in `packages/core`, constructor-injected into `Cipher`. `EncryptionKeyManagerModule` calls `proxy.setProvider(keyManager)` at init to wire up the concrete implementation without introducing a circular dependency. Follows the `DynamicCredentialsProxy` setter pattern.

### How to test

1. Run the instance without the feature flag — all existing behaviour is unchanged (`encrypt`/`decrypt` are unmodified).
2. Set `N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION=true`, call `encryptV2` with a proxy registered — verify the output is prefixed with a key ID.
3. Call `decryptV2` on a prefixed value — confirm correct plaintext is returned.
4. Call `decryptV2` on an un-prefixed (legacy) value — confirm the CBC fallback works.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-493

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
