### PR TITLE
test: Surface container logs on postgres/redis startup failure

### DIFF
--- a/packages/testing/containers/services/postgres.ts
+++ b/packages/testing/containers/services/postgres.ts
@@ -1,6 +1,7 @@
 import { PostgreSqlContainer } from '@testcontainers/postgresql';
 import type { StartedNetwork } from 'testcontainers';
 
+import { createSilentLogConsumer } from '../helpers/utils';
 import { TEST_CONTAINER_IMAGES } from '../test-containers';
 import type { Service, ServiceResult } from './types';
 
@@ -19,7 +20,8 @@ export const postgres: Service<PostgresResult> = {
 	shouldStart: (ctx) => ctx.usePostgres,
 
 	async start(network: StartedNetwork, projectName: string): Promise<PostgresResult> {
-		const container = await new PostgreSqlContainer(TEST_CONTAINER_IMAGES.postgres)
+		const { consumer, throwWithLogs } = createSilentLogConsumer();
+		const builder = new PostgreSqlContainer(TEST_CONTAINER_IMAGES.postgres)
 			.withNetwork(network)
 			.withNetworkAliases(HOSTNAME)
 			.withDatabase('n8n_db')
@@ -45,16 +47,21 @@ export const postgres: Service<PostgresResult> = {
 				'max_connections=200',
 			])
 			.withReuse()
-			.start();
+			.withLogConsumer(consumer);
 
-		return {
-			container,
-			meta: {
-				database: container.getDatabase(),
-				username: container.getUsername(),
-				password: container.getPassword(),
-			},
-		};
+		try {
+			const container = await builder.start();
+			return {
+				container,
+				meta: {
+					database: container.getDatabase(),
+					username: container.getUsername(),
+					password: container.getPassword(),
+				},
+			};
+		} catch (error: unknown) {
+			return throwWithLogs(error);
+		}
 	},
 
 	env(result: PostgresResult, external?: boolean): Record<string, string> {

--- a/packages/testing/containers/services/redis.ts
+++ b/packages/testing/containers/services/redis.ts
@@ -1,6 +1,7 @@
 import { RedisContainer } from '@testcontainers/redis';
 import type { StartedNetwork } from 'testcontainers';
 
+import { createSilentLogConsumer } from '../helpers/utils';
 import { TEST_CONTAINER_IMAGES } from '../test-containers';
 import type { Service, ServiceResult } from './types';
 
@@ -18,7 +19,8 @@ export const redis: Service<RedisResult> = {
 	shouldStart: (ctx) => ctx.isQueueMode,
 
 	async start(network: StartedNetwork, projectName: string): Promise<RedisResult> {
-		const container = await new RedisContainer(TEST_CONTAINER_IMAGES.redis)
+		const { consumer, throwWithLogs } = createSilentLogConsumer();
+		const builder = new RedisContainer(TEST_CONTAINER_IMAGES.redis)
 			.withNetwork(network)
 			.withNetworkAliases(HOSTNAME)
 			.withLabels({
@@ -27,15 +29,20 @@ export const redis: Service<RedisResult> = {
 			})
 			.withName(`${projectName}-${HOSTNAME}`)
 			.withReuse()
-			.start();
+			.withLogConsumer(consumer);
 
-		return {
-			container,
-			meta: {
-				host: HOSTNAME,
-				port: 6379,
-			},
-		};
+		try {
+			const container = await builder.start();
+			return {
+				container,
+				meta: {
+					host: HOSTNAME,
+					port: 6379,
+				},
+			};
+		} catch (error: unknown) {
+			return throwWithLogs(error);
+		}
 	},
 
 	env(result: RedisResult, external?: boolean): Record<string, string> {


### PR DESCRIPTION
## Summary

- Add `createSilentLogConsumer` + `throwWithLogs` pattern to postgres and redis container services, mirroring the existing implementation in `services/n8n.ts`
- On startup/healthcheck failure, container stdout/stderr is now printed with `--- Container Logs ---` separators before the error rethrows
- No behaviour change on the success path — logs are only surfaced when `start()` throws

## Related Linear tickets, Github issues, and Community forum posts

<!-- No Linear ticket for this change -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.