### PR TITLE
fix(editor): harden node rename space handling

### DIFF
--- a/packages/frontend/editor-ui/src/app/views/NodeView.utils.test.ts
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.utils.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldStopRenamePromptSpacePropagation } from './NodeView.utils';
+
+describe('shouldStopRenamePromptSpacePropagation', () => {
+	it.each([
+		[{ key: ' ', code: 'Space' }],
+		[{ key: ' ', code: '' }],
+		[{ key: 'Spacebar', code: '' }],
+		[{ key: '', code: 'Space' }],
+	])('returns true for space key variants: %o', (event) => {
+		expect(shouldStopRenamePromptSpacePropagation(event)).toBe(true);
+	});
+
+	it.each([
+		[{ key: 'Enter', code: 'Enter' }],
+		[{ key: 'Tab', code: 'Tab' }],
+		[{ key: ':', code: 'Semicolon' }],
+	])('returns false for non-space keys: %o', (event) => {
+		expect(shouldStopRenamePromptSpacePropagation(event)).toBe(false);
+	});
+});

--- a/packages/frontend/editor-ui/src/app/views/NodeView.utils.ts
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.utils.ts
@@ -1,0 +1,3 @@
+export function shouldStopRenamePromptSpacePropagation(event: Pick<KeyboardEvent, 'key' | 'code'>) {
+	return event.code === 'Space' || event.key === ' ' || event.key === 'Spacebar';
+}

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -14,6 +14,7 @@ import {
 import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router';
 import WorkflowCanvas from '@/features/workflows/canvas/components/WorkflowCanvas.vue';
 import FocusSidebar from '@/app/components/FocusSidebar.vue';
+import { shouldStopRenamePromptSpacePropagation } from './NodeView.utils';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import CanvasRunWorkflowButton from '@/features/workflows/canvas/components/elements/buttons/CanvasRunWorkflowButton.vue';
@@ -657,7 +658,7 @@ async function onOpenRenameNodeModal(id: string) {
 		// Stop propagation for space key to prevent VueFlow from intercepting it
 		// when modifier keys (like Shift) are pressed. See: https://github.com/bcakmakoglu/vue-flow/issues/1999
 		const handleKeyDown = (e: KeyboardEvent) => {
-			if (e.key === ' ') {
+			if (shouldStopRenamePromptSpacePropagation(e)) {
 				e.stopPropagation();
 			}
 		};


### PR DESCRIPTION
## Summary
- prevent the rename prompt input from bubbling space-key events based on either `code` or legacy `key` values
- keep the workaround focused to the rename prompt path that Firefox users hit when typing with modifiers held down
- add regression coverage for supported space key variants

## Root cause
The rename prompt only stopped propagation when `KeyboardEvent.key === ' '`. That is narrower than the browser variations we can receive for the same physical key, especially when modifier keys are held, so Vue Flow can still intercept the space press and drop it from the input.

## Changes
- extract the rename-prompt key check into a small helper
- treat `code === 'Space'`, `key === ' '`, and legacy `key === 'Spacebar'` as the same space press
- add a focused unit test for the helper

## Validation
- `pnpm --dir packages/frontend/editor-ui exec vitest run src/app/views/NodeView.utils.test.ts`
- `git diff --check master...HEAD`

Fixes #25543