### PR TITLE
fix(task-runner-python): allow strptime imports

### DIFF
--- a/packages/@n8n/task-runner-python/src/task_executor.py
+++ b/packages/@n8n/task-runner-python/src/task_executor.py
@@ -436,7 +436,7 @@ class TaskExecutor:
 
         filtered["__import__"] = TaskExecutor._create_safe_import(security_config)
 
-        return types.MappingProxyType(filtered)
+        return filtered
 
     @staticmethod
     def _sanitize_sys_modules(security_config: SecurityConfig):

--- a/packages/@n8n/task-runner-python/tests/integration/test_execution.py
+++ b/packages/@n8n/task-runner-python/tests/integration/test_execution.py
@@ -185,6 +185,27 @@ async def test_per_item_with_continue_on_fail(broker, manager):
     assert "division by zero" in done_msg["data"]["result"][0]["json"]["error"]
 
 
+@pytest.mark.asyncio
+async def test_per_item_datetime_strptime_works(broker, manager):
+    task_id = nanoid()
+    items = [{"json": {"value": "2026-04-23T16:04:28+0000"}}]
+    code = textwrap.dedent("""
+        from datetime import datetime
+
+        parsed = datetime.strptime(_item['json']['value'], "%Y-%m-%dT%H:%M:%S%z")
+        return {'parsed': parsed.isoformat()}
+    """)
+    task_settings = create_task_settings(code=code, node_mode="per_item", items=items)
+    await broker.send_task(task_id=task_id, task_settings=task_settings)
+
+    done_msg = await wait_for_task_done(broker, task_id)
+
+    assert done_msg["taskId"] == task_id
+    assert done_msg["data"]["result"] == [
+        {"json": {"parsed": "2026-04-23T16:04:28+00:00"}, "pairedItem": {"item": 0}}
+    ]
+
+
 # ========== Security ===========
 
 

--- a/packages/@n8n/task-runner-python/tests/unit/test_task_executor.py
+++ b/packages/@n8n/task-runner-python/tests/unit/test_task_executor.py
@@ -1,6 +1,5 @@
 import pytest
 import json
-import types
 from unittest.mock import MagicMock, patch
 
 from src.task_executor import TaskExecutor
@@ -209,7 +208,7 @@ class TestFilterBuiltins:
             runner_env_deny=False,
         )
 
-    def test_returns_mapping_proxy(self):
+    def test_returns_dict(self):
         result = TaskExecutor._filter_builtins(self._make_security_config())
 
-        assert isinstance(result, types.MappingProxyType)
+        assert isinstance(result, dict)


### PR DESCRIPTION
## Summary
- stop wrapping filtered Python builtins in `MappingProxyType`
- keep the safe `__import__` override in place while restoring stdlib compatibility for `datetime.strptime()`
- add regression coverage for the `strptime()` per-item execution path and update the builtins unit expectation

## Root cause
The Python task runner injects `__builtins__` as a `MappingProxyType`. That breaks stdlib code paths used by `datetime.strptime()`, which expect builtins to expose import machinery the same way normal exec globals do. In practice this crashes with `"mappingproxy object has no attribute __import__"` before user code can complete.

## Changes
- return a plain filtered builtins dict from `_filter_builtins()`
- preserve the sandboxed safe import function on `__import__`
- add an integration regression test for `datetime.strptime()` in per-item mode
- update the builtins unit test to match the new return type

## Validation
- `git diff --check`
- local Python reproduction outside the runner: `MappingProxyType(dict(__builtins__))` reproduces the reported `__import__` failure, while `dict(__builtins__)` allows the same `datetime.strptime()` call to succeed
- attempted: `uv run pytest tests/unit/test_task_executor.py -k filter_builtins`
- attempted: `uv run pytest tests/integration/test_execution.py -k datetime_strptime_works`

## Notes
The `uv run pytest` commands are blocked in this environment because the task runner package assumes Unix process primitives (`ForkServerProcess`) and the available environment here is Windows, so the full runner test suite could not be completed locally.

Fixes #29010