### PR TITLE
fix(Google Drive Node): Support URL mode when copying files

### DIFF
--- a/packages/nodes-base/nodes/Google/Drive/v2/actions/file/copy.operation.ts
+++ b/packages/nodes-base/nodes/Google/Drive/v2/actions/file/copy.operation.ts
@@ -81,14 +81,16 @@ const displayOptions = {
 export const description = updateDisplayOptions(displayOptions, properties);
 
 export async function execute(this: IExecuteFunctions, i: number): Promise<INodeExecutionData[]> {
-	const file = this.getNodeParameter('fileId', i) as INodeParameterResourceLocator;
+	const fileLocator = this.getNodeParameter('fileId', i) as INodeParameterResourceLocator;
 
-	const fileId = file.value;
+	const fileId = this.getNodeParameter('fileId', i, undefined, {
+		extractValue: true,
+	}) as string;
 
 	const options = this.getNodeParameter('options', i, {});
 
 	let name = this.getNodeParameter('name', i) as string;
-	name = name ? name : `Copy of ${file.cachedResultName}`;
+	name = name ? name : `Copy of ${fileLocator.cachedResultName}`;
 
 	const copyRequiresWriterPermission = options.copyRequiresWriterPermission || false;
 

--- a/packages/nodes-base/nodes/Google/Drive/v2/test/GoogleDriveV2.workflow.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/v2/test/GoogleDriveV2.workflow.test.ts
@@ -147,6 +147,7 @@ describe('Google Drive V2', () => {
 			credentials,
 			workflowFiles: [
 				'file-copy.workflow.json',
+				'file-copy-url-mode.workflow.json',
 				'file-createFromText.workflow.json',
 				'file-delete.workflow.json',
 				'file-download.workflow.json',

--- a/packages/nodes-base/nodes/Google/Drive/v2/test/file-copy-url-mode.workflow.json
+++ b/packages/nodes-base/nodes/Google/Drive/v2/test/file-copy-url-mode.workflow.json
@@ -1,0 +1,64 @@
+{
+	"name": "Google Drive V2 File Copy URL Mode Test",
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0],
+			"id": "trigger-id",
+			"name": "When clicking 'Execute Workflow'"
+		},
+		{
+			"parameters": {
+				"resource": "file",
+				"operation": "copy",
+				"fileId": {
+					"__rl": true,
+					"value": "https://drive.google.com/file/d/123/view",
+					"mode": "url"
+				},
+				"name": "Copy of Test File"
+			},
+			"type": "n8n-nodes-base.googleDrive",
+			"typeVersion": 3,
+			"position": [200, 0],
+			"id": "file-copy-url",
+			"name": "Copy File",
+			"credentials": {
+				"googleDriveOAuth2Api": {
+					"id": "test-credential-id",
+					"name": "Test Google Drive OAuth2"
+				}
+			}
+		}
+	],
+	"pinData": {
+		"Copy File": [
+			{
+				"json": {
+					"id": "copy123",
+					"name": "Copy of Test File",
+					"mimeType": "text/plain"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking 'Execute Workflow'": {
+			"main": [
+				[
+					{
+						"node": "Copy File",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	}
+}


### PR DESCRIPTION
## Summary

Google Drive → File → Copy returns a 404 when the file is selected via URL mode. The copy operation reads the `fileId` resource locator with `getNodeParameter('fileId', i)` and takes `.value` directly. In URL mode that value is the raw `https://drive.google.com/file/d/<ID>/view` string rather than the extracted ID, so it ends up concatenated into `/drive/v3/files/${url}/copy` and Google responds with 404.

Every sibling file operation in the same directory (`deleteFile`, `move`, `update`, `share`, `download`) already uses the correct form:

```ts
const fileId = this.getNodeParameter('fileId', i, undefined, {
  extractValue: true,
}) as string;
```

That path triggers the `GOOGLE_DRIVE_FILE_URL_REGEX` extractor declared on `fileRLC` in `packages/nodes-base/nodes/Google/Drive/v2/actions/common.descriptions.ts`. This PR brings `copy` in line with the sibling pattern and keeps the existing resource locator around (as `fileLocator`) so the `Copy of ${fileLocator.cachedResultName}` fallback for the default name continues to work.

### How to test

1. Add a Google Drive node (v2), pick Resource = File, Operation = Copy.
2. In the File selector, switch to URL mode and paste any share URL like `https://drive.google.com/file/d/<ID>/view`.
3. Before the fix: request hits `/drive/v3/files/https:%2F%2Fdrive.google.com%2Ffile%2Fd%2F<ID>%2Fview/copy` and Google returns 404.
4. After the fix: request hits `/drive/v3/files/<ID>/copy` and the copy succeeds.

### Regression test

`packages/nodes-base/nodes/Google/Drive/v2/test/file-copy-url-mode.workflow.json` exercises URL mode against the existing shared nock mock (`POST /drive/v3/files/123/copy`). The test only passes if the regex extractor runs — verified locally by reverting the fix, watching the test fail, and re-applying it.

### Out of scope

- Open PR #28819 addresses the `Copy of undefined` default-name fallback when `cachedResultName` is missing (ID mode). The same cosmetic fallback is still imperfect in URL mode (`cachedResultName` is only populated by the list-mode picker), but that is orthogonal to the 404 fixed here and belongs in that separate PR's scope.
- The analogous pattern in other Google nodes (Sheets, Docs) is not audited in this PR.

## Related Linear tickets, Github issues, and Community forum posts

Closes #28962

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- No user-facing docs change; behavior matches what the node already advertises for URL mode. -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
