### PR TITLE
fix(core): Set terminal execution status when pruning unsaved runs

### DIFF
--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -93,23 +93,27 @@ describe('Execution Lifecycle Hooks', () => {
 	const taskData = mock<ITaskData>();
 	const runExecutionData = mock<IRunExecutionData>();
 
+	const stoppedAt = new Date('2025-01-13T18:25:50.267Z');
 	const successfulRunWithRewiredDestination = mock<IRun>({
 		status: 'success',
 		finished: true,
 		waitTill: undefined,
 		storedAt: 'db',
+		stoppedAt,
 	});
 	const successfulRun = mock<IRun>({
 		status: 'success',
 		finished: true,
 		waitTill: undefined,
 		storedAt: 'db',
+		stoppedAt,
 	});
 	const failedRun = mock<IRun>({
 		status: 'error',
 		finished: true,
 		waitTill: undefined,
 		storedAt: 'db',
+		stoppedAt,
 	});
 	const waitingRun = mock<IRun>({
 		finished: true,
@@ -128,6 +132,7 @@ describe('Execution Lifecycle Hooks', () => {
 		finished: true,
 		waitTill: undefined,
 		storedAt: 'db',
+		stoppedAt,
 		data: {
 			resultData: {
 				metadata: {
@@ -1070,11 +1075,18 @@ describe('Execution Lifecycle Hooks', () => {
 
 				await testHooks.runHook('workflowExecuteAfter', [successfulRun, {}]);
 
-				expect(executionPersistence.deleteInFlightExecution).toHaveBeenCalledWith({
-					workflowId,
-					executionId,
-					storedAt: 'db',
-				});
+				expect(executionPersistence.deleteInFlightExecution).toHaveBeenCalledWith(
+					{
+						workflowId,
+						executionId,
+						storedAt: 'db',
+					},
+					{
+						status: 'success',
+						finished: true,
+						stoppedAt: successfulRun.stoppedAt,
+					},
+				);
 			});
 
 			it('should delete unsaved failed executions when error saving is disabled', async () => {
@@ -1094,11 +1106,18 @@ describe('Execution Lifecycle Hooks', () => {
 
 				await testHooks.runHook('workflowExecuteAfter', [failedRun, {}]);
 
-				expect(executionPersistence.deleteInFlightExecution).toHaveBeenCalledWith({
-					workflowId,
-					executionId,
-					storedAt: 'db',
-				});
+				expect(executionPersistence.deleteInFlightExecution).toHaveBeenCalledWith(
+					{
+						workflowId,
+						executionId,
+						storedAt: 'db',
+					},
+					{
+						status: 'error',
+						finished: true,
+						stoppedAt: failedRun.stoppedAt,
+					},
+				);
 			});
 
 			describe('metadata handling', () => {
@@ -1132,11 +1151,18 @@ describe('Execution Lifecycle Hooks', () => {
 					// Metadata should not be saved before deletion
 					expect(executionMetadataService.save).not.toHaveBeenCalled();
 					// Execution should be deleted
-					expect(executionPersistence.deleteInFlightExecution).toHaveBeenCalledWith({
-						workflowId,
-						executionId,
-						storedAt: 'db',
-					});
+					expect(executionPersistence.deleteInFlightExecution).toHaveBeenCalledWith(
+						{
+							workflowId,
+							executionId,
+							storedAt: 'db',
+						},
+						{
+							status: 'success',
+							finished: true,
+							stoppedAt: successfulRunWithMetadata.stoppedAt,
+						},
+					);
 				});
 
 				it('should NOT save metadata when execution has none', async () => {

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -571,11 +571,18 @@ function hookFunctionsSave(
 			if (shouldNotSave && !fullRunData.waitTill && !isManualMode) {
 				executeErrorWorkflow(this.workflowData, fullRunData, this.mode, this.executionId, retryOf);
 
-				await executionPersistence.deleteInFlightExecution({
-					workflowId: this.workflowData.id,
-					executionId: this.executionId,
-					storedAt: fullRunData.storedAt,
-				});
+				await executionPersistence.deleteInFlightExecution(
+					{
+						workflowId: this.workflowData.id,
+						executionId: this.executionId,
+						storedAt: fullRunData.storedAt,
+					},
+					{
+						status: fullRunData.status,
+						finished: fullRunData.finished,
+						stoppedAt: fullRunData.stoppedAt,
+					},
+				);
 
 				return;
 			}
@@ -794,11 +801,18 @@ export function getLifecycleHooksForScalingMain(
 			(fullRunData.status !== 'success' && !saveSettings.error);
 
 		if (!isManualMode && shouldNotSave && !fullRunData.waitTill) {
-			await executionPersistence.deleteInFlightExecution({
-				workflowId: this.workflowData.id,
-				executionId: this.executionId,
-				storedAt: fullRunData.storedAt,
-			});
+			await executionPersistence.deleteInFlightExecution(
+				{
+					workflowId: this.workflowData.id,
+					executionId: this.executionId,
+					storedAt: fullRunData.storedAt,
+				},
+				{
+					status: fullRunData.status,
+					finished: fullRunData.finished,
+					stoppedAt: fullRunData.stoppedAt,
+				},
+			);
 		} else {
 			// Only save metadata if execution is being kept
 			await updateExistingExecutionMetadata(

--- a/packages/cli/src/executions/__tests__/execution-persistence.test.ts
+++ b/packages/cli/src/executions/__tests__/execution-persistence.test.ts
@@ -213,8 +213,11 @@ describe('ExecutionPersistence', () => {
 
 	describe('deleteUnsaved', () => {
 		const target = { workflowId: 'wf-1', executionId: 'exec-1', storedAt: 'db' as const };
+		const stoppedAt = new Date('2026-01-01T00:00:00Z');
+		const successRunStatus = { status: 'success' as const, finished: true, stoppedAt };
+		const errorRunStatus = { status: 'error' as const, finished: true, stoppedAt };
 
-		it('should soft-delete with backdated `deletedAt` when pruning is enabled', async () => {
+		it('should soft-delete with backdated `deletedAt` and record terminal status when pruning is enabled', async () => {
 			jest.useFakeTimers();
 			const now = Date.now();
 
@@ -222,12 +225,35 @@ describe('ExecutionPersistence', () => {
 			executionsConfig.pruneDataHardDeleteBuffer = 1;
 			const executionPersistence = createPersistenceService('db');
 
-			await executionPersistence.deleteInFlightExecution(target);
+			await executionPersistence.deleteInFlightExecution(target, successRunStatus);
 
 			expect(executionRepository.update).toHaveBeenCalledWith('exec-1', {
 				deletedAt: new Date(now - 3600_000),
+				status: 'success',
+				finished: true,
+				stoppedAt,
 			});
 			expect(executionRepository.deleteByIds).not.toHaveBeenCalled();
+
+			jest.useRealTimers();
+		});
+
+		it('should record error terminal status on soft-delete when the run failed', async () => {
+			jest.useFakeTimers();
+			const now = Date.now();
+
+			executionsConfig.pruneData = true;
+			executionsConfig.pruneDataHardDeleteBuffer = 1;
+			const executionPersistence = createPersistenceService('db');
+
+			await executionPersistence.deleteInFlightExecution(target, errorRunStatus);
+
+			expect(executionRepository.update).toHaveBeenCalledWith('exec-1', {
+				deletedAt: new Date(now - 3600_000),
+				status: 'error',
+				finished: true,
+				stoppedAt,
+			});
 
 			jest.useRealTimers();
 		});
@@ -236,7 +262,7 @@ describe('ExecutionPersistence', () => {
 			executionsConfig.pruneData = false;
 			const executionPersistence = createPersistenceService('db');
 
-			await executionPersistence.deleteInFlightExecution(target);
+			await executionPersistence.deleteInFlightExecution(target, successRunStatus);
 
 			expect(executionRepository.deleteByIds).toHaveBeenCalledWith(['exec-1']);
 			expect(executionRepository.update).not.toHaveBeenCalled();

--- a/packages/cli/src/executions/execution-persistence.ts
+++ b/packages/cli/src/executions/execution-persistence.ts
@@ -9,6 +9,7 @@ import { ExecutionData, ExecutionEntity, ExecutionRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { stringify } from 'flatted';
 import { BinaryDataService, StorageConfig } from 'n8n-core';
+import type { IRun } from 'n8n-workflow';
 
 import { FsStore } from './execution-data/fs-store';
 import type { ExecutionRef, WorkflowSnapshot } from './execution-data/types';
@@ -70,14 +71,25 @@ export class ExecutionPersistence {
 	 *
 	 * - When pruning is enabled, soft-deletes with a backdated `deletedAt` so the
 	 * execution is immediately eligible for the next pruning hard-delete batch.
+	 * The terminal `status`, `finished`, and `stoppedAt` from the completed run
+	 * are also recorded so the row does not linger as `running` until the next
+	 * pruning sweep hard-deletes it.
 	 * - When pruning is disabled, hard-deletes immediately so the execution
 	 * is not persisted indefinitely.
 	 */
-	async deleteInFlightExecution(target: DeletionTarget) {
+	async deleteInFlightExecution(
+		target: DeletionTarget,
+		{ status, finished, stoppedAt }: Pick<IRun, 'status' | 'finished' | 'stoppedAt'>,
+	) {
 		if (this.executionsConfig.pruneData) {
 			const bufferMs = this.executionsConfig.pruneDataHardDeleteBuffer * Time.hours.toMilliseconds;
 			const deletedAt = new Date(Date.now() - bufferMs);
-			await this.executionRepository.update(target.executionId, { deletedAt });
+			await this.executionRepository.update(target.executionId, {
+				deletedAt,
+				status,
+				finished,
+				stoppedAt,
+			});
 		} else {
 			await this.hardDelete(target);
 		}


### PR DESCRIPTION
## Summary

Sub-workflows that finish successfully with "Save successful production executions = Do not save" (or error with error-saving disabled) used to leave their DB row at `status='running'` until the next pruning hard-delete swept it. The UI, `executions` endpoints, and any Postgres/SQL inspection therefore showed finished sub-workflows as still running.

Root cause lives in `ExecutionPersistence.deleteInFlightExecution` (`packages/cli/src/executions/execution-persistence.ts`). The soft-delete branch only wrote a backdated `deletedAt`:

```ts
await this.executionRepository.update(target.executionId, { deletedAt });
```

`fullRunData.status` had already been finalized by `hookFunctionsFinalizeExecutionStatus` before this call, but it was being discarded. The row retained the `'running'` status it had when the execution started.

This PR threads the terminal status, `finished` flag, and `stoppedAt` from the completed run through `deleteInFlightExecution` and into the UPDATE, so the row immediately reflects the real outcome:

```ts
await this.executionRepository.update(target.executionId, {
  deletedAt,
  status,
  finished,
  stoppedAt,
});
```

Both call sites in `execution-lifecycle-hooks.ts` (`hookFunctionsSave` and the delete branch in `getLifecycleHooksForScalingMain`) forward those fields from `fullRunData`.

### Scope of the change

- Touched only `packages/cli/src/executions/` and `packages/cli/src/execution-lifecycle/` — no changes to `packages/core`, no frontend, no node changes.
- 2 production files, 2 test files, +108 / -30 LOC.
- No new public API or new package dependencies.
- Pruning schedule, hard-delete path, and metadata-on-keep guard are unchanged.

### Testing

- `packages/cli/src/executions/__tests__/execution-persistence.test.ts` — the existing "soft-delete with backdated deletedAt" test now asserts the full UPDATE payload including terminal status, a new `'error'`-status variant covers the error path, and the hard-delete test supplies the now-required run-status argument.
- `packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts` — the three `deleteInFlightExecution` call-site assertions in `getLifecycleHooksForScalingMain` verify the new second argument is forwarded from `fullRunData`.

Local run:

```
pnpm jest src/executions src/execution-lifecycle
Test Suites: 17 passed, 17 total
Tests:       246 passed, 246 total
```

## Related Linear tickets, Github issues, and Community forum posts

Fixes #28867

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [ ] Docs updated (N/A — internal persistence helper, no public docs or node surface)
- [x] Tests included
- [ ] Backport label if urgent fix
