### PR TITLE
refactor(core): Use versioned Daytona snapshots for Instance AI sandboxes

### DIFF
--- a/packages/@n8n/instance-ai/src/workspace/__tests__/builder-sandbox-factory.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/builder-sandbox-factory.test.ts
@@ -1,0 +1,166 @@
+// Hoisted mock instance the fake Daytona constructor returns — gives tests a
+// single handle to inspect `create`, `delete`, and the snapshot namespace.
+const mockDaytonaInstance: {
+	snapshot: { get: jest.Mock; create: jest.Mock };
+	create: jest.Mock;
+	delete: jest.Mock;
+} = {
+	snapshot: { get: jest.fn(), create: jest.fn() },
+	create: jest.fn(),
+	delete: jest.fn(),
+};
+
+jest.mock('@daytonaio/sdk', () => {
+	const Daytona = jest.fn(() => mockDaytonaInstance);
+	return { Daytona, Image: { base: jest.fn() } };
+});
+
+jest.mock('@mastra/core/workspace', () => {
+	class LocalSandbox {
+		readonly type = 'local';
+		constructor(public opts: { workingDirectory: string }) {}
+	}
+	class LocalFilesystem {
+		readonly type = 'local-fs';
+		constructor(public opts: { basePath: string }) {}
+	}
+	class Workspace {
+		filesystem = { writeFile: jest.fn().mockResolvedValue(undefined) };
+		sandbox = { processes: undefined };
+		constructor(public opts: { sandbox: unknown; filesystem: unknown }) {}
+		async init(): Promise<void> {}
+	}
+	return { LocalSandbox, LocalFilesystem, Workspace };
+});
+
+jest.mock('@mastra/daytona', () => {
+	class DaytonaSandbox {
+		readonly type = 'daytona';
+		constructor(public opts: Record<string, unknown>) {}
+	}
+	return { DaytonaSandbox };
+});
+
+jest.mock('../daytona-filesystem', () => ({ DaytonaFilesystem: class {} }));
+jest.mock('../n8n-sandbox-filesystem', () => ({ N8nSandboxFilesystem: class {} }));
+jest.mock('../n8n-sandbox-sandbox', () => ({ N8nSandboxServiceSandbox: class {} }));
+jest.mock('../n8n-sandbox-image-manager', () => ({ N8nSandboxImageManager: class {} }));
+
+jest.mock('../sandbox-setup', () => ({
+	formatNodeCatalogLine: (n: { nodeType: string }) => `line:${n.nodeType}`,
+	getWorkspaceRoot: jest.fn().mockResolvedValue('/workspace'),
+	setupSandboxWorkspace: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../sandbox-fs', () => ({
+	writeFileViaSandbox: jest.fn().mockResolvedValue(undefined),
+}));
+
+import type { Logger } from '../../logger';
+import type { InstanceAiContext } from '../../types';
+import { BuilderSandboxFactory } from '../builder-sandbox-factory';
+import type { SandboxConfig } from '../create-workspace';
+import { SnapshotManager } from '../snapshot-manager';
+
+function createLogger(): Logger {
+	return {
+		info: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+		debug: jest.fn(),
+	};
+}
+
+function createContext(): InstanceAiContext {
+	return {
+		nodeService: {
+			listSearchable: jest
+				.fn()
+				.mockResolvedValue([{ nodeType: 'n8n-nodes-base.set' }, { nodeType: 'n8n-nodes-base.if' }]),
+		},
+	} as unknown as InstanceAiContext;
+}
+
+describe('BuilderSandboxFactory.createDaytona', () => {
+	const daytonaConfig: SandboxConfig = {
+		enabled: true,
+		provider: 'daytona',
+		daytonaApiUrl: 'https://api.daytona.io',
+		daytonaApiKey: 'test-key',
+		n8nVersion: '1.97.0',
+	};
+
+	let snapshotManager: SnapshotManager;
+	let ensureSnapshotSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		mockDaytonaInstance.snapshot.get.mockReset();
+		mockDaytonaInstance.snapshot.create.mockReset();
+		mockDaytonaInstance.create.mockReset().mockResolvedValue({ id: 'sb-test' });
+		mockDaytonaInstance.delete.mockReset().mockResolvedValue(undefined);
+
+		snapshotManager = new SnapshotManager(undefined, 'n8n-instance-ai-1.97.0', createLogger());
+		ensureSnapshotSpy = jest
+			.spyOn(snapshotManager, 'ensureSnapshot')
+			.mockResolvedValue('n8n-instance-ai-1.97.0');
+	});
+
+	afterEach(() => {
+		ensureSnapshotSpy.mockRestore();
+	});
+
+	it('calls daytona.create with the snapshot name and no image', async () => {
+		const factory = new BuilderSandboxFactory(daytonaConfig, snapshotManager);
+
+		await factory.create('builder-1', createContext());
+
+		expect(mockDaytonaInstance.create).toHaveBeenCalledTimes(1);
+		const [params] = mockDaytonaInstance.create.mock.calls[0] as [
+			{
+				snapshot: string;
+				image?: unknown;
+				language: string;
+				ephemeral: boolean;
+				labels: Record<string, string>;
+			},
+		];
+		expect(params.snapshot).toBe('n8n-instance-ai-1.97.0');
+		expect(params).not.toHaveProperty('image');
+		expect(params.language).toBe('typescript');
+		expect(params.ephemeral).toBe(true);
+		expect(params.labels).toEqual({ 'n8n-builder': 'builder-1' });
+	});
+
+	it('awaits ensureSnapshot before calling daytona.create', async () => {
+		const factory = new BuilderSandboxFactory(daytonaConfig, snapshotManager);
+		const order: string[] = [];
+		ensureSnapshotSpy.mockImplementation(async () => {
+			await Promise.resolve();
+			order.push('ensureSnapshot');
+			return 'n8n-instance-ai-1.97.0';
+		});
+		mockDaytonaInstance.create.mockImplementation(async () => {
+			await Promise.resolve();
+			order.push('create');
+			return { id: 'sb-test' };
+		});
+
+		await factory.create('builder-2', createContext());
+
+		expect(order).toEqual(['ensureSnapshot', 'create']);
+	});
+
+	it('deletes the sandbox when post-create workspace init fails', async () => {
+		const workspaceModule: { Workspace: { prototype: { init: jest.Mock } } } =
+			jest.requireMock('@mastra/core/workspace');
+		const initSpy = jest
+			.spyOn(workspaceModule.Workspace.prototype, 'init')
+			.mockRejectedValueOnce(new Error('init failed'));
+
+		const factory = new BuilderSandboxFactory(daytonaConfig, snapshotManager);
+
+		await expect(factory.create('builder-fail', createContext())).rejects.toThrow('init failed');
+		expect(mockDaytonaInstance.delete).toHaveBeenCalledTimes(1);
+		initSpy.mockRestore();
+	});
+});

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/snapshot-manager.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/snapshot-manager.test.ts
@@ -1,0 +1,202 @@
+import type { Daytona, Image } from '@daytonaio/sdk';
+
+import type { Logger } from '../../logger';
+import { SnapshotManager } from '../snapshot-manager';
+
+interface MockDaytona {
+	snapshot: {
+		get: jest.Mock;
+		create: jest.Mock;
+	};
+}
+
+function createMockDaytona(): MockDaytona {
+	return {
+		snapshot: {
+			get: jest.fn(),
+			create: jest.fn(),
+		},
+	};
+}
+
+function asDaytona(daytona: MockDaytona): Daytona {
+	return daytona as unknown as Daytona;
+}
+
+function createMockLogger(): Logger {
+	return {
+		info: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+		debug: jest.fn(),
+	};
+}
+
+function notFoundError(name: string): Error {
+	return new Error(`Snapshot ${name} not found`);
+}
+
+describe('SnapshotManager', () => {
+	const snapshotName = 'n8n-instance-ai-1.97.0';
+	let logger: Logger;
+
+	beforeEach(() => {
+		logger = createMockLogger();
+	});
+
+	describe('ensureSnapshot', () => {
+		it('returns the configured snapshot name when it already exists', async () => {
+			const manager = new SnapshotManager(undefined, snapshotName, logger);
+			const daytona = createMockDaytona();
+			daytona.snapshot.get.mockResolvedValue({ name: snapshotName });
+
+			const result = await manager.ensureSnapshot(asDaytona(daytona));
+
+			expect(result).toBe(snapshotName);
+			expect(daytona.snapshot.get).toHaveBeenCalledWith(snapshotName);
+			expect(daytona.snapshot.create).not.toHaveBeenCalled();
+		});
+
+		it('creates the snapshot when it does not exist', async () => {
+			const manager = new SnapshotManager(undefined, snapshotName, logger);
+			const daytona = createMockDaytona();
+			daytona.snapshot.get.mockRejectedValue(notFoundError(snapshotName));
+			daytona.snapshot.create.mockResolvedValue({ name: snapshotName });
+
+			const result = await manager.ensureSnapshot(asDaytona(daytona));
+
+			expect(result).toBe(snapshotName);
+			expect(daytona.snapshot.create).toHaveBeenCalledTimes(1);
+			const [params, options] = daytona.snapshot.create.mock.calls[0] as [
+				{ name: string; image: Image },
+				{ timeout: number; onLogs: (chunk: string) => void },
+			];
+			expect(params.name).toBe(snapshotName);
+			expect(params.image.dockerfile).toContain('daytonaio/sandbox:0.5.0');
+			expect(params.image.dockerfile).toContain('npm install');
+			expect(options.timeout).toBe(600);
+		});
+
+		it('uses the provided base image when building the snapshot image', async () => {
+			const manager = new SnapshotManager('custom/base:1.0', snapshotName, logger);
+			const daytona = createMockDaytona();
+			daytona.snapshot.get.mockRejectedValue(notFoundError(snapshotName));
+			daytona.snapshot.create.mockResolvedValue({ name: snapshotName });
+
+			await manager.ensureSnapshot(asDaytona(daytona));
+
+			const [params] = daytona.snapshot.create.mock.calls[0] as [{ image: Image }];
+			expect(params.image.dockerfile).toContain('custom/base:1.0');
+		});
+
+		it('memoizes — concurrent callers share a single snapshot.create', async () => {
+			const manager = new SnapshotManager(undefined, snapshotName, logger);
+			const daytona = createMockDaytona();
+			daytona.snapshot.get.mockRejectedValue(notFoundError(snapshotName));
+
+			let resolveCreate: (value: { name: string }) => void = () => {};
+			const createCalled = new Promise<void>((resolveCalled) => {
+				daytona.snapshot.create.mockImplementation(
+					async () =>
+						await new Promise((resolve) => {
+							resolveCreate = resolve;
+							resolveCalled();
+						}),
+				);
+			});
+
+			const p1 = manager.ensureSnapshot(asDaytona(daytona));
+			const p2 = manager.ensureSnapshot(asDaytona(daytona));
+			const p3 = manager.ensureSnapshot(asDaytona(daytona));
+
+			await createCalled;
+			resolveCreate({ name: snapshotName });
+			const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+
+			expect(r1).toBe(snapshotName);
+			expect(r2).toBe(snapshotName);
+			expect(r3).toBe(snapshotName);
+			expect(daytona.snapshot.create).toHaveBeenCalledTimes(1);
+			expect(daytona.snapshot.get).toHaveBeenCalledTimes(1);
+		});
+
+		it('short-circuits subsequent calls via memoization after success', async () => {
+			const manager = new SnapshotManager(undefined, snapshotName, logger);
+			const daytona = createMockDaytona();
+			daytona.snapshot.get.mockResolvedValue({ name: snapshotName });
+
+			await manager.ensureSnapshot(asDaytona(daytona));
+			await manager.ensureSnapshot(asDaytona(daytona));
+			await manager.ensureSnapshot(asDaytona(daytona));
+
+			expect(daytona.snapshot.get).toHaveBeenCalledTimes(1);
+		});
+
+		it('tolerates "already exists" conflict from create (race with another caller)', async () => {
+			const manager = new SnapshotManager(undefined, snapshotName, logger);
+			const daytona = createMockDaytona();
+			daytona.snapshot.get.mockRejectedValue(notFoundError(snapshotName));
+			daytona.snapshot.create.mockRejectedValue(
+				new Error('Snapshot with name n8n-instance-ai-1.97.0 already exists'),
+			);
+
+			const result = await manager.ensureSnapshot(asDaytona(daytona));
+
+			expect(result).toBe(snapshotName);
+		});
+
+		it('treats "conflict" messages from create as success', async () => {
+			const manager = new SnapshotManager(undefined, snapshotName, logger);
+			const daytona = createMockDaytona();
+			daytona.snapshot.get.mockRejectedValue(notFoundError(snapshotName));
+			daytona.snapshot.create.mockRejectedValue(new Error('409 Conflict'));
+
+			const result = await manager.ensureSnapshot(asDaytona(daytona));
+
+			expect(result).toBe(snapshotName);
+		});
+
+		it('clears memoization on genuine failure so next caller retries', async () => {
+			const manager = new SnapshotManager(undefined, snapshotName, logger);
+			const daytona = createMockDaytona();
+			daytona.snapshot.get.mockRejectedValue(notFoundError(snapshotName));
+			daytona.snapshot.create
+				.mockRejectedValueOnce(new Error('internal server error'))
+				.mockResolvedValueOnce({ name: snapshotName });
+
+			await expect(manager.ensureSnapshot(asDaytona(daytona))).rejects.toThrow(
+				'internal server error',
+			);
+
+			const result = await manager.ensureSnapshot(asDaytona(daytona));
+
+			expect(result).toBe(snapshotName);
+			expect(daytona.snapshot.create).toHaveBeenCalledTimes(2);
+		});
+
+		it('rethrows the original error on genuine create failure', async () => {
+			const manager = new SnapshotManager(undefined, snapshotName, logger);
+			const daytona = createMockDaytona();
+			daytona.snapshot.get.mockRejectedValue(notFoundError(snapshotName));
+			daytona.snapshot.create.mockRejectedValue(new Error('daytona unreachable'));
+
+			await expect(manager.ensureSnapshot(asDaytona(daytona))).rejects.toThrow(
+				'daytona unreachable',
+			);
+		});
+	});
+
+	describe('invalidate', () => {
+		it('forces the next ensureSnapshot call to re-check Daytona', async () => {
+			const manager = new SnapshotManager(undefined, snapshotName, logger);
+			const daytona = createMockDaytona();
+			daytona.snapshot.get.mockResolvedValue({ name: snapshotName });
+
+			await manager.ensureSnapshot(asDaytona(daytona));
+			manager.invalidate();
+			await manager.ensureSnapshot(asDaytona(daytona));
+
+			expect(daytona.snapshot.get).toHaveBeenCalledTimes(2);
+		});
+	});
+});

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/snapshot-manager.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/snapshot-manager.test.ts
@@ -69,12 +69,14 @@ describe('SnapshotManager', () => {
 			expect(daytona.snapshot.create).toHaveBeenCalledTimes(1);
 			const [params, options] = daytona.snapshot.create.mock.calls[0] as [
 				{ name: string; image: Image },
-				{ timeout: number; onLogs: (chunk: string) => void },
+				{ timeout?: number; onLogs: (chunk: string) => void },
 			];
 			expect(params.name).toBe(snapshotName);
 			expect(params.image.dockerfile).toContain('daytonaio/sandbox:0.5.0');
 			expect(params.image.dockerfile).toContain('npm install');
-			expect(options.timeout).toBe(600);
+			// No timeout: SDK's `timeout` only bounds the initial POST, not the
+			// build-state poll; Daytona owns build duration.
+			expect(options.timeout).toBeUndefined();
 		});
 
 		it('uses the provided base image when building the snapshot image', async () => {

--- a/packages/@n8n/instance-ai/src/workspace/builder-sandbox-factory.ts
+++ b/packages/@n8n/instance-ai/src/workspace/builder-sandbox-factory.ts
@@ -109,16 +109,17 @@ export class BuilderSandboxFactory {
 	): Promise<BuilderWorkspace> {
 		const config = this.assertIsDaytona();
 		assert(this.imageManager, 'Daytona snapshot manager required');
+		const snapshotManager = this.imageManager;
 
-		// Get pre-warmed image (config + deps, no catalog — catalog is too large for API body)
-		const image = this.imageManager.ensureImage();
-
-		// Start sandbox creation AND catalog generation in parallel
+		// Start sandbox creation AND catalog generation in parallel.
+		// ensureSnapshot is lazy + memoized: first call builds the snapshot,
+		// subsequent calls short-circuit to the cached name.
 		const createSandboxFn = async () => {
 			const daytona = await this.getDaytona();
+			const snapshot = await snapshotManager.ensureSnapshot(daytona);
 			return await daytona.create(
 				{
-					image,
+					snapshot,
 					language: 'typescript',
 					ephemeral: true,
 					labels: { 'n8n-builder': builderId },

--- a/packages/@n8n/instance-ai/src/workspace/create-workspace.ts
+++ b/packages/@n8n/instance-ai/src/workspace/create-workspace.ts
@@ -22,6 +22,12 @@ interface DaytonaSandboxConfig extends SandboxConfigBase {
 	daytonaApiUrl?: string;
 	daytonaApiKey?: string;
 	image?: string;
+	/**
+	 * n8n runtime version — used to name the prebuilt Daytona snapshot so that
+	 * each n8n release gets its own versioned snapshot. Daytona dedupes
+	 * snapshots sharing the same underlying ref, so over-versioning is free.
+	 */
+	n8nVersion?: string;
 	/** When provided, called before each Daytona interaction to get a fresh auth token (e.g. a short-lived JWT for proxy mode). */
 	getAuthToken?: () => Promise<string>;
 }

--- a/packages/@n8n/instance-ai/src/workspace/snapshot-manager.ts
+++ b/packages/@n8n/instance-ai/src/workspace/snapshot-manager.ts
@@ -16,8 +16,6 @@ import { type Daytona, Image } from '@daytonaio/sdk';
 import type { Logger } from '../logger';
 import { PACKAGE_JSON, TSCONFIG_JSON, BUILD_MJS } from './sandbox-setup';
 
-const SNAPSHOT_CREATE_TIMEOUT_SECONDS = 600;
-
 /** Base64-encode content for safe embedding in RUN commands (avoids newline/quote issues). */
 function b64(s: string): string {
 	return Buffer.from(s, 'utf-8').toString('base64');
@@ -76,12 +74,13 @@ export class SnapshotManager {
 		});
 
 		try {
+			// No `timeout` — the SDK's `timeout` here only bounds the initial
+			// HTTP POST, not the subsequent build-state poll loop (which runs
+			// until ACTIVE / ERROR / BUILD_FAILED with no wall-clock limit).
+			// We let the poll run; Daytona's build system owns build duration.
 			await daytona.snapshot.create(
 				{ name: this.snapshotName, image },
-				{
-					onLogs: (chunk) => this.logger.debug('snapshot build log', { chunk }),
-					timeout: SNAPSHOT_CREATE_TIMEOUT_SECONDS,
-				},
+				{ onLogs: (chunk) => this.logger.debug('snapshot build log', { chunk }) },
 			);
 		} catch (error) {
 			if (isAlreadyExistsError(error)) {

--- a/packages/@n8n/instance-ai/src/workspace/snapshot-manager.ts
+++ b/packages/@n8n/instance-ai/src/workspace/snapshot-manager.ts
@@ -1,39 +1,104 @@
 /**
- * Prepares and caches a Daytona Image descriptor with config files and
- * node_modules pre-installed. The Image is declarative — actual building
- * happens when a sandbox is created from it.
+ * Manages the lifecycle of a Daytona snapshot that holds the pre-configured
+ * builder image (config files + node_modules baked in).
  *
- * The node-types catalog is NOT baked into the image (too large for API body limit).
- * It's written to each sandbox after creation via the filesystem API.
+ * Snapshots are created lazily on the first builder call per process and
+ * memoized in-memory. Concurrent first-callers share one in-flight
+ * `snapshot.create` promise via `pendingEnsure`.
  *
- * Exported as SnapshotManager for backward compatibility (name in index.ts/service).
+ * The node-types catalog is NOT baked into the snapshot (too large for the
+ * Daytona API body limit). It's written to each sandbox after creation via
+ * the filesystem API.
  */
 
-import { Image } from '@daytonaio/sdk';
+import { type Daytona, Image } from '@daytonaio/sdk';
 
 import type { Logger } from '../logger';
 import { PACKAGE_JSON, TSCONFIG_JSON, BUILD_MJS } from './sandbox-setup';
+
+const SNAPSHOT_CREATE_TIMEOUT_SECONDS = 600;
 
 /** Base64-encode content for safe embedding in RUN commands (avoids newline/quote issues). */
 function b64(s: string): string {
 	return Buffer.from(s, 'utf-8').toString('base64');
 }
 
+function isAlreadyExistsError(erroror: unknown): boolean {
+	if (!(erroror instanceof Error)) return false;
+	const msg = erroror.message.toLowerCase();
+	return msg.includes('already exists') || msg.includes('conflict');
+}
+
 export class SnapshotManager {
-	private cachedImage: Image | null = null;
+	private pendingEnsure: Promise<string> | null = null;
 
 	constructor(
 		private readonly baseImage: string | undefined,
+		private readonly snapshotName: string,
 		private readonly logger: Logger,
 	) {}
 
-	/** Get or prepare the image descriptor. Synchronous after first call. */
-	ensureImage(): Image {
-		if (this.cachedImage) return this.cachedImage;
+	/**
+	 * Ensure the named snapshot exists in Daytona and return its name.
+	 * Idempotent and race-safe — concurrent callers share one in-flight promise,
+	 * and a "already exists" response from create is treated as success.
+	 */
+	async ensureSnapshot(daytona: Daytona): Promise<string> {
+		if (this.pendingEnsure) return await this.pendingEnsure;
 
+		const attempt = this.runEnsure(daytona).catch((error) => {
+			this.pendingEnsure = null;
+			throw error;
+		});
+		this.pendingEnsure = attempt;
+		return await attempt;
+	}
+
+	/** Invalidate cached ensure-promise (e.g. for tests or manual re-provisioning). */
+	invalidate(): void {
+		this.pendingEnsure = null;
+	}
+
+	private async runEnsure(daytona: Daytona): Promise<string> {
+		try {
+			await daytona.snapshot.get(this.snapshotName);
+			this.logger.debug('Builder snapshot already present', { name: this.snapshotName });
+			return this.snapshotName;
+		} catch {
+			// Not found (or transient get failure) — try to create.
+		}
+
+		const image = this.buildImage();
+		this.logger.info('Creating builder snapshot', {
+			name: this.snapshotName,
+			base: this.baseImage ?? 'default',
+			dockerfileLength: image.dockerfile.length,
+		});
+
+		try {
+			await daytona.snapshot.create(
+				{ name: this.snapshotName, image },
+				{
+					onLogs: (chunk) => this.logger.debug('snapshot build log', { chunk }),
+					timeout: SNAPSHOT_CREATE_TIMEOUT_SECONDS,
+				},
+			);
+		} catch (error) {
+			if (isAlreadyExistsError(error)) {
+				this.logger.debug('Builder snapshot created concurrently by another caller', {
+					name: this.snapshotName,
+				});
+				return this.snapshotName;
+			}
+			throw error;
+		}
+
+		return this.snapshotName;
+	}
+
+	private buildImage(): Image {
 		const base = this.baseImage ?? 'daytonaio/sandbox:0.5.0';
-
-		this.cachedImage = Image.base(base)
+		return Image.base(base)
 			.runCommands(
 				'mkdir -p /home/daytona/workspace/src /home/daytona/workspace/chunks /home/daytona/workspace/node-types',
 			)
@@ -43,17 +108,5 @@ export class SnapshotManager {
 				`echo '${b64(BUILD_MJS)}' | base64 -d > /home/daytona/workspace/build.mjs`,
 			)
 			.runCommands('cd /home/daytona/workspace && npm install --ignore-scripts');
-
-		this.logger.info('Builder image descriptor prepared', {
-			base,
-			dockerfileLength: this.cachedImage.dockerfile.length,
-		});
-
-		return this.cachedImage;
-	}
-
-	/** Invalidate cached image (e.g., when base image changes). */
-	invalidate(): void {
-		this.cachedImage = null;
 	}
 }

--- a/packages/@n8n/instance-ai/src/workspace/snapshot-manager.ts
+++ b/packages/@n8n/instance-ai/src/workspace/snapshot-manager.ts
@@ -23,9 +23,9 @@ function b64(s: string): string {
 	return Buffer.from(s, 'utf-8').toString('base64');
 }
 
-function isAlreadyExistsError(erroror: unknown): boolean {
-	if (!(erroror instanceof Error)) return false;
-	const msg = erroror.message.toLowerCase();
+function isAlreadyExistsError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	const msg = error.message.toLowerCase();
 	return msg.includes('already exists') || msg.includes('conflict');
 }
 

--- a/packages/@n8n/instance-ai/src/workspace/snapshot-manager.ts
+++ b/packages/@n8n/instance-ai/src/workspace/snapshot-manager.ts
@@ -97,6 +97,13 @@ export class SnapshotManager {
 	}
 
 	private buildImage(): Image {
+		// Daytona's cache key is the underlying ref (hashed from Dockerfile +
+		// build context). The snapshot *name* (e.g. `n8n-instance-ai-1.97.0`)
+		// is just an alias we use for lookup — it does not affect caching, and
+		// neither do image tags. Two snapshot names whose images produce the
+		// same ref are deduped server-side and share storage, so versioning
+		// by name is free: identical Dockerfiles across n8n versions activate
+		// instantly, and different Dockerfiles get distinct refs as expected.
 		const base = this.baseImage ?? 'daytonaio/sandbox:0.5.0';
 		return Image.base(base)
 			.runCommands(

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -15,6 +15,7 @@ import { Time } from '@n8n/constants';
 import type { InstanceAiConfig } from '@n8n/config';
 import type { User } from '@n8n/db';
 import { Service } from '@n8n/di';
+import { N8N_VERSION } from '@/constants';
 import { UrlService } from '@/services/url.service';
 import {
 	MAX_STEPS,
@@ -278,6 +279,7 @@ export class InstanceAiService {
 				daytonaApiUrl: daytonaApiUrl || undefined,
 				daytonaApiKey: daytonaApiKey || undefined,
 				image: sandboxImage || undefined,
+				n8nVersion: N8N_VERSION,
 				timeout: sandboxTimeout,
 			};
 		}
@@ -346,7 +348,11 @@ export class InstanceAiService {
 		if (!config.enabled) return undefined;
 
 		if (config.provider === 'daytona') {
-			return new BuilderSandboxFactory(config, new SnapshotManager(config.image, this.logger));
+			const snapshotName = `n8n-instance-ai-${config.n8nVersion ?? 'dev'}`;
+			return new BuilderSandboxFactory(
+				config,
+				new SnapshotManager(config.image, snapshotName, this.logger),
+			);
 		}
 
 		return new BuilderSandboxFactory(config);


### PR DESCRIPTION
## Summary

Switches `@n8n/instance-ai` from Daytona's ad-hoc declarative image (rebuilt per call with a 24h cache) to **versioned prebuilt snapshots**. Daytona flagged the previous approach as a reliability risk under traffic surges.

- Snapshot name: `n8n-instance-ai-<N8N_VERSION>` (e.g. `n8n-instance-ai-1.97.0`).
- `SnapshotManager` now exposes `ensureSnapshot(daytona): Promise<string>` — lazy, client-side, idempotent `get → create if missing` flow, memoized per process with a shared in-flight promise so concurrent first-callers wait on one create.
- `BuilderSandboxFactory.createDaytona` now passes `{ snapshot }` to `daytona.create` instead of `{ image }`. Catalog generation still runs in parallel with snapshot ensure + sandbox create.
- `N8N_VERSION` is threaded from `packages/cli` into `SandboxConfig.n8nVersion` so `@n8n/instance-ai` stays framework-agnostic.
- Race handling: "already exists" conflicts from `snapshot.create` are treated as success (another process won the race). Genuine failures clear the memoized promise so the next caller retries.

### Why name (not tag) carries the version

Per Ivan @ Daytona: tags aren't part of the snapshot cache key — the **name** is the differentiator. The underlying ref is computed from Dockerfile + build context, so Daytona dedupes snapshots sharing the same ref automatically. Over-versioning by name is therefore free; different content naturally gets distinct refs.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-116

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with Backport label (if needed)

## Test plan

- [x] Typecheck passes in `@n8n/instance-ai` and `packages/cli`.
- [x] New unit tests pass (`snapshot-manager.test.ts`, `builder-sandbox-factory.test.ts`) — 13 cases covering get-or-create, memoization under concurrency, "already exists" race tolerance, cache invalidation on error, and cleanup on post-create init failure.
- [x] Existing workspace + cli instance-ai test suites still pass (51 + 542 tests).
- [ ] Manual direct-mode run: trigger a builder session, verify a `n8n-instance-ai-<version>` snapshot appears in Daytona dashboard and a second session reuses it.
- [ ] Manual proxy-mode run: confirm ai-assistant-service JWT allows `snapshot.get` / `snapshot.create` (open question — if not, follow-up ticket for pre-provisioning per release).
- [ ] Concurrent safety: fire 3 near-simultaneous builder sessions on a fresh process; logs should show exactly one `snapshot.create`.
- [ ] E2E (replay mode): `pnpm test:local:instance-ai` — no regressions.

## Open follow-ups

- Proxy-mode JWT permissions for `snapshot.create` / `snapshot.get` — verify during rollout; fallback is server-side pre-provisioning per release.
- Old snapshot cleanup/retention as n8n versions age out (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)