### PR TITLE
fix(core): Pin sandbox workflow-sdk to host version

### DIFF
--- a/packages/@n8n/instance-ai/src/workspace/builder-sandbox-factory.ts
+++ b/packages/@n8n/instance-ai/src/workspace/builder-sandbox-factory.ts
@@ -11,6 +11,7 @@ import { Daytona } from '@daytonaio/sdk';
 import { Workspace, LocalFilesystem, LocalSandbox } from '@mastra/core/workspace';
 import { DaytonaSandbox } from '@mastra/daytona';
 import assert from 'node:assert/strict';
+import { join as posixJoin } from 'node:path/posix';
 
 import type { Logger } from '../logger';
 import type { SandboxConfig } from './create-workspace';
@@ -86,7 +87,7 @@ export class BuilderSandboxFactory {
 		const packed = await this.sdkTarballPromise;
 		if (!packed) return;
 
-		const remotePath = `${root}/${packed.filename}`;
+		const remotePath = posixJoin(root, packed.filename);
 		if (workspace.filesystem) {
 			await workspace.filesystem.writeFile(remotePath, packed.tarball);
 		} else {

--- a/packages/@n8n/instance-ai/src/workspace/builder-sandbox-factory.ts
+++ b/packages/@n8n/instance-ai/src/workspace/builder-sandbox-factory.ts
@@ -12,15 +12,24 @@ import { Workspace, LocalFilesystem, LocalSandbox } from '@mastra/core/workspace
 import { DaytonaSandbox } from '@mastra/daytona';
 import assert from 'node:assert/strict';
 
+import type { Logger } from '../logger';
 import type { SandboxConfig } from './create-workspace';
 import { DaytonaFilesystem } from './daytona-filesystem';
 import { N8nSandboxFilesystem } from './n8n-sandbox-filesystem';
 import { N8nSandboxImageManager } from './n8n-sandbox-image-manager';
 import { N8nSandboxServiceSandbox } from './n8n-sandbox-sandbox';
-import { writeFileViaSandbox } from './sandbox-fs';
+import { packWorkspaceSdk, type WorkspaceSdkTarball } from './pack-workspace-sdk';
+import { runInSandbox, writeFileViaSandbox } from './sandbox-fs';
 import type { SnapshotManager } from './snapshot-manager';
 import type { InstanceAiContext } from '../types';
 import { formatNodeCatalogLine, getWorkspaceRoot, setupSandboxWorkspace } from './sandbox-setup';
+
+const NOOP_LOGGER: Logger = {
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+	debug: () => {},
+};
 
 export interface BuilderWorkspace {
 	workspace: Workspace;
@@ -61,7 +70,47 @@ export class BuilderSandboxFactory {
 	constructor(
 		private readonly config: SandboxConfig,
 		private readonly imageManager?: SnapshotManager,
+		private readonly logger: Logger = NOOP_LOGGER,
 	) {}
+
+	/** Cached workspace-SDK tarball promise (one pack per process). */
+	private sdkTarballPromise: Promise<WorkspaceSdkTarball | null> | null = null;
+
+	/**
+	 * Pack and install the host's workspace `@n8n/workflow-sdk` into the remote
+	 * sandbox, overriding the registry version baked in at image build time.
+	 * No-op unless `N8N_INSTANCE_AI_SANDBOX_LINK_SDK=1` is set.
+	 */
+	private async linkWorkspaceSdkIfEnabled(workspace: Workspace, root: string): Promise<void> {
+		this.sdkTarballPromise ??= packWorkspaceSdk(this.logger);
+		const packed = await this.sdkTarballPromise;
+		if (!packed) return;
+
+		const remotePath = `${root}/${packed.filename}`;
+		if (workspace.filesystem) {
+			await workspace.filesystem.writeFile(remotePath, packed.tarball);
+		} else {
+			await writeFileViaSandbox(workspace, remotePath, packed.tarball);
+		}
+
+		const install = await runInSandbox(
+			workspace,
+			`npm install ${remotePath} --no-save --ignore-scripts --force`,
+			root,
+		);
+		if (install.exitCode !== 0) {
+			this.logger.error('Failed to link workspace SDK into sandbox', {
+				exitCode: install.exitCode,
+				stderr: install.stderr,
+			});
+			throw new Error(`Failed to install workspace SDK tarball: ${install.stderr}`);
+		}
+
+		this.logger.info('Linked workspace SDK into sandbox', {
+			version: packed.version,
+			sdkPath: packed.sdkPath,
+		});
+	}
 
 	async create(builderId: string, context: InstanceAiContext): Promise<BuilderWorkspace> {
 		if (this.config.provider === 'local') {
@@ -166,6 +215,8 @@ export class BuilderSandboxFactory {
 				await writeFileViaSandbox(workspace, `${root}/node-types/index.txt`, catalog);
 			}
 
+			await this.linkWorkspaceSdkIfEnabled(workspace, root);
+
 			return {
 				workspace,
 				cleanup: async () => {
@@ -208,6 +259,8 @@ export class BuilderSandboxFactory {
 		} else {
 			await writeFileViaSandbox(workspace, `${root}/node-types/index.txt`, catalog);
 		}
+
+		await this.linkWorkspaceSdkIfEnabled(workspace, root);
 
 		return {
 			workspace,

--- a/packages/@n8n/instance-ai/src/workspace/pack-workspace-sdk.ts
+++ b/packages/@n8n/instance-ai/src/workspace/pack-workspace-sdk.ts
@@ -1,0 +1,132 @@
+/**
+ * Host-side helper for injecting the workspace `@n8n/workflow-sdk` into a
+ * remote Daytona / n8n-sandbox sandbox during local development.
+ *
+ * Opt-in via `N8N_INSTANCE_AI_SANDBOX_LINK_SDK=1`. Production sandboxes
+ * continue to install the registry-pinned version from `PACKAGE_JSON`.
+ *
+ * Why this exists: remote sandboxes have no line-of-sight to the dev's
+ * monorepo. When a dev rebuilds the SDK locally, the sandbox still runs
+ * whatever version is on npm. This packs the workspace SDK into a tarball
+ * on the host so the sandbox can `npm install` it post-creation and
+ * override the registry copy.
+ *
+ * We use `pnpm pack` (not `npm pack`) because the workspace `package.json`
+ * uses pnpm protocols (`workspace:*`, `catalog:`) that npm can't resolve;
+ * pnpm rewrites those to concrete semver during packing.
+ */
+
+import { execFile } from 'node:child_process';
+import { readFile, mkdtemp, rm, stat } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import type { Logger } from '../logger';
+
+const hostRequire = createRequire(__filename);
+const execFileAsync = promisify(execFile);
+
+const ENV_FLAG = 'N8N_INSTANCE_AI_SANDBOX_LINK_SDK';
+
+export interface WorkspaceSdkTarball {
+	/** Raw tarball bytes, ready to upload to the sandbox. */
+	tarball: Buffer;
+	/** Version packed (post-rewrite). Useful for logs. */
+	version: string;
+	/** Basename of the packed archive (e.g. `n8n-workflow-sdk-0.11.2.tgz`). */
+	filename: string;
+	/** Absolute path of the packed package on the host. */
+	sdkPath: string;
+}
+
+export function isLinkWorkspaceSdkEnabled(): boolean {
+	const v = process.env[ENV_FLAG];
+	return v === '1' || v === 'true';
+}
+
+/**
+ * Pack the host-resolved `@n8n/workflow-sdk` into a tarball using `pnpm pack`.
+ *
+ * Returns `null` when the feature flag is off (caller can skip work
+ * without needing to read the env var themselves).
+ */
+export async function packWorkspaceSdk(
+	logger: Logger,
+	packageName = '@n8n/workflow-sdk',
+): Promise<WorkspaceSdkTarball | null> {
+	if (!isLinkWorkspaceSdkEnabled()) return null;
+
+	const sdkPath = resolvePackagePath(packageName);
+	if (!sdkPath) {
+		logger.warn(
+			`${ENV_FLAG} is set but ${packageName} could not be resolved on the host — skipping SDK link`,
+		);
+		return null;
+	}
+
+	// Sanity check: dist/ must exist, otherwise the tarball would ship stale
+	// or empty bytes. Fail loudly so the dev knows they need to `pnpm build`.
+	const distPath = path.join(sdkPath, 'dist');
+	try {
+		await stat(distPath);
+	} catch {
+		logger.warn(
+			`${ENV_FLAG} is set but ${packageName}/dist is missing — run \`pnpm build\` in ${sdkPath} first. Skipping SDK link.`,
+		);
+		return null;
+	}
+
+	const tmpDir = await mkdtemp(path.join(tmpdir(), 'n8n-sdk-pack-'));
+	try {
+		const { stdout } = await execFileAsync('pnpm', ['pack', '--pack-destination', tmpDir], {
+			cwd: sdkPath,
+			env: process.env,
+			maxBuffer: 16 * 1024 * 1024,
+		});
+
+		const filename = parsePackFilename(stdout);
+		if (!filename) {
+			throw new Error(`pnpm pack produced no tarball — stdout:\n${stdout}`);
+		}
+		const tarballPath = path.join(tmpDir, filename);
+		const tarball = await readFile(tarballPath);
+		const version = parseVersionFromFilename(filename);
+
+		logger.info('Packed workspace SDK for sandbox link', {
+			package: packageName,
+			version,
+			bytes: tarball.byteLength,
+			sdkPath,
+		});
+
+		return { tarball, version, filename, sdkPath };
+	} finally {
+		await rm(tmpDir, { recursive: true, force: true });
+	}
+}
+
+function resolvePackagePath(name: string): string | null {
+	try {
+		const pkgJsonPath = hostRequire.resolve(`${name}/package.json`);
+		return path.dirname(pkgJsonPath);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * `pnpm pack` writes human-readable output; the tarball path is the last
+ * `.tgz` filename it prints. Scrape it out in a forgiving way so minor
+ * pnpm format changes don't break us.
+ */
+function parsePackFilename(stdout: string): string | null {
+	const match = stdout.match(/([^\s/\\]+\.tgz)/g);
+	return match ? match[match.length - 1] : null;
+}
+
+function parseVersionFromFilename(filename: string): string {
+	const match = filename.match(/-(\d[^/]*)\.tgz$/);
+	return match ? match[1] : 'unknown';
+}

--- a/packages/@n8n/instance-ai/src/workspace/sandbox-fs.ts
+++ b/packages/@n8n/instance-ai/src/workspace/sandbox-fs.ts
@@ -47,7 +47,7 @@ export async function runInSandbox(
 export async function writeFileViaSandbox(
 	workspace: Workspace,
 	filePath: string,
-	content: string,
+	content: string | Buffer,
 ): Promise<void> {
 	// Ensure parent directory exists
 	const dir = filePath.substring(0, filePath.lastIndexOf('/'));
@@ -56,7 +56,10 @@ export async function writeFileViaSandbox(
 	}
 
 	// Encode content as base64 and decode in the sandbox
-	const b64 = Buffer.from(content, 'utf-8').toString('base64');
+	const b64 =
+		typeof content === 'string'
+			? Buffer.from(content, 'utf-8').toString('base64')
+			: content.toString('base64');
 	const cmd = `echo '${b64}' | base64 -d > '${escapeSingleQuotes(filePath)}'`;
 	const result = await runInSandbox(workspace, cmd);
 	if (result.exitCode !== 0) {

--- a/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
+++ b/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
@@ -23,9 +23,12 @@
  */
 
 import type { Workspace } from '@mastra/core/workspace';
+import { createRequire } from 'node:module';
 
 import type { InstanceAiContext, SearchableNodeDescription } from '../types';
 import { runInSandbox, readFileViaSandbox, escapeSingleQuotes } from './sandbox-fs';
+
+const hostRequire = createRequire(__filename);
 
 export const WORKSPACE_DIR = 'workspace';
 
@@ -35,21 +38,87 @@ export const N8N_SANDBOX_HOME = '/home/user';
 /** Absolute workspace root for n8n sandbox service Dockerfile steps (build-time). */
 export const N8N_SANDBOX_WORKSPACE_ROOT = `${N8N_SANDBOX_HOME}/${WORKSPACE_DIR}`;
 
-export const PACKAGE_JSON = JSON.stringify(
-	{
-		name: 'sandbox-workspace',
-		private: true,
-		dependencies: {
-			'@n8n/workflow-sdk': '*',
-			tsx: '*',
+/**
+ * Resolve a dependency's installed version from the host's node_modules.
+ * Falls back to `'*'` if the package is unresolvable (should only happen in
+ * out-of-tree test setups — production always has these as real deps).
+ */
+function resolveHostDepVersion(name: string): string {
+	try {
+		const pkg = hostRequire(`${name}/package.json`) as { version?: string };
+		return pkg.version ?? '*';
+	} catch {
+		return '*';
+	}
+}
+
+/**
+ * Versions pinned from the host's installed packages. Pinning is load-bearing
+ * for two reasons:
+ *   1. `npm install '@n8n/workflow-sdk': '*'` inside the sandbox resolves to
+ *      the dist-tag `latest`, which lags well behind the version the CLI was
+ *      built against. Host-pinned versions keep the sandbox SDK in lock-step
+ *      with the server that orchestrates it.
+ *   2. Sandbox images are content-addressed by their Dockerfile bytes. When
+ *      the SDK version bumps on a new release, PACKAGE_JSON changes, the
+ *      `npm install` RUN layer's hash changes, and the sandbox service
+ *      rebuilds the image. Floating `'*'` never changes the bytes, so stale
+ *      images are reused indefinitely.
+ */
+const SANDBOX_SDK_VERSION = resolveHostDepVersion('@n8n/workflow-sdk');
+const SANDBOX_TSX_VERSION = resolveHostDepVersion('tsx');
+
+function buildPackageJson(sdkSpecifier: string): string {
+	return JSON.stringify(
+		{
+			name: 'sandbox-workspace',
+			private: true,
+			dependencies: {
+				'@n8n/workflow-sdk': sdkSpecifier,
+				tsx: SANDBOX_TSX_VERSION,
+			},
+			devDependencies: {
+				'@types/node': '*',
+			},
 		},
-		devDependencies: {
-			'@types/node': '*',
-		},
-	},
-	null,
-	2,
-);
+		null,
+		2,
+	);
+}
+
+/**
+ * Registry-pinned PACKAGE_JSON used for Dockerfile-baked images
+ * (Daytona / n8n-sandbox). See `resolveHostDepVersion` for why pinning matters.
+ */
+export const PACKAGE_JSON = buildPackageJson(SANDBOX_SDK_VERSION);
+
+/**
+ * Return the absolute on-disk path of a host-installed package, or `null`
+ * if it can't be resolved. Used by the local provider to point the sandbox
+ * at the workspace SDK via a `file:` reference instead of the npm registry.
+ */
+function resolveHostDepPath(name: string): string | null {
+	try {
+		const pkgPath = hostRequire.resolve(`${name}/package.json`);
+		return pkgPath.slice(0, pkgPath.length - '/package.json'.length);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Build a PACKAGE_JSON that points `@n8n/workflow-sdk` at its host-resolved
+ * location via `file:` — so the local provider picks up workspace SDK
+ * changes after `pnpm build` without needing a publish.
+ *
+ * Falls back to the registry-pinned PACKAGE_JSON if the SDK can't be
+ * resolved on disk (e.g. a stripped-down test harness).
+ */
+function buildLocalProviderPackageJson(): string {
+	const sdkPath = resolveHostDepPath('@n8n/workflow-sdk');
+	if (!sdkPath) return PACKAGE_JSON;
+	return buildPackageJson(`file:${sdkPath}`);
+}
 
 /**
  * Runner script that executes a workflow TS file via tsx, calls validate() + toJSON(),
@@ -194,8 +263,11 @@ export async function setupSandboxWorkspace(
 
 	const files = new Map<string, string>();
 
-	// Config files
-	files.set('package.json', PACKAGE_JSON);
+	// Config files. Local provider runs on the dev host, so point the SDK at
+	// its workspace location via `file:` — this makes SDK changes visible in
+	// the sandbox after `pnpm build`, without a publish. Daytona/n8n-sandbox
+	// stay on the registry-pinned PACKAGE_JSON (they can't see the host FS).
+	files.set('package.json', buildLocalProviderPackageJson());
 	files.set('tsconfig.json', TSCONFIG_JSON);
 	files.set('build.mjs', BUILD_MJS);
 

--- a/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
+++ b/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
@@ -68,6 +68,15 @@ function resolveHostDepVersion(name: string): string {
 const SANDBOX_SDK_VERSION = resolveHostDepVersion('@n8n/workflow-sdk');
 const SANDBOX_TSX_VERSION = resolveHostDepVersion('tsx');
 
+/**
+ * Hard-coded to match the monorepo-wide `@types/node` catalog entry in
+ * `pnpm-workspace.yaml`. `@types/node` isn't a direct dep of this package, so
+ * `resolveHostDepVersion` wouldn't find it reliably; a fixed version also
+ * keeps Dockerfile bytes stable and avoids the floating-`*` dist-tag problem
+ * described above. Keep this in sync with the catalog entry on upgrades.
+ */
+const SANDBOX_TYPES_NODE_VERSION = '24.10.1';
+
 function buildPackageJson(sdkSpecifier: string): string {
 	return JSON.stringify(
 		{
@@ -78,7 +87,7 @@ function buildPackageJson(sdkSpecifier: string): string {
 				tsx: SANDBOX_TSX_VERSION,
 			},
 			devDependencies: {
-				'@types/node': '*',
+				'@types/node': SANDBOX_TYPES_NODE_VERSION,
 			},
 		},
 		null,

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -346,10 +346,14 @@ export class InstanceAiService {
 		if (!config.enabled) return undefined;
 
 		if (config.provider === 'daytona') {
-			return new BuilderSandboxFactory(config, new SnapshotManager(config.image, this.logger));
+			return new BuilderSandboxFactory(
+				config,
+				new SnapshotManager(config.image, this.logger),
+				this.logger,
+			);
 		}
 
-		return new BuilderSandboxFactory(config);
+		return new BuilderSandboxFactory(config, undefined, this.logger);
 	}
 
 	/** Get or create a sandbox + workspace for a thread. Returns undefined when sandbox is disabled. */


### PR DESCRIPTION
## Summary

The Instance AI sandbox declared `@n8n/workflow-sdk: '*'` in its `PACKAGE_JSON`, which resolves to the npm `latest` dist-tag. That tag sits several versions behind what the CLI host is built against, so every remote sandbox has been running an older SDK than the code orchestrating it. Sandbox images are content-addressed by Dockerfile bytes, so floating `*` never invalidates the image cache on release.

This PR pins the version and adds a dev-only escape hatch for iterating on SDK changes end-to-end.

## Changes

**Pin sandbox deps to host-installed versions** (`sandbox-setup.ts`)

`resolveHostDepVersion(name)` reads `<host>/node_modules/<name>/package.json` at module load and returns the installed version. `PACKAGE_JSON` uses these pins for `@n8n/workflow-sdk` and `tsx` instead of `*`. On a CLI release where the SDK bumps, `PACKAGE_JSON` bytes change → Dockerfile bytes change → sandbox images invalidate.

**Opt-in workspace-SDK link for local dev** (new `pack-workspace-sdk.ts`, wired in `builder-sandbox-factory.ts`)

Gated by `N8N_INSTANCE_AI_SANDBOX_LINK_SDK=1`. When set:

- `pnpm pack` the host's workspace SDK (not `npm pack` — pnpm rewrites `workspace:*` / `catalog:` specifiers).
- Upload the tarball to the sandbox via `workspace.filesystem.writeFile`.
- `npm install <tarball> --no-save --ignore-scripts --force` to replace the registry copy.

Fails fast with a clear log if `<sdk>/dist` is missing so the dev knows to run `pnpm build`. No-op when unset — production sandboxes are unaffected.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
