### PR TITLE
fix(Discord Node): Correctly handle API rate limits

### DIFF
--- a/packages/nodes-base/nodes/Discord/test/v2/transport/discord.api.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/transport/discord.api.test.ts
@@ -1,0 +1,323 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+import { sleep } from 'n8n-workflow';
+
+import { discordApiMultiPartRequest, discordApiRequest } from '../../../v2/transport/discord.api';
+import { handleRateLimitHeaders, requestApi } from '../../../v2/transport/helpers';
+
+jest.mock('n8n-workflow', () => ({
+	...jest.requireActual('n8n-workflow'),
+	sleep: jest.fn().mockResolvedValue(undefined),
+}));
+
+const sleepMock = sleep as unknown as jest.Mock;
+
+function createMockContext(authentication = 'botToken') {
+	const requestWithAuthentication = jest.fn();
+	const request = jest.fn();
+	const context = {
+		helpers: { requestWithAuthentication, request },
+		getCredentials: jest.fn(),
+		getNodeParameter: jest.fn().mockReturnValue(authentication),
+		getNode: jest.fn().mockReturnValue({ type: 'n8n-nodes-base.discord', typeVersion: 2 }),
+	} as unknown as jest.Mocked<IExecuteFunctions>;
+	return { context, requestWithAuthentication, request };
+}
+
+describe('Discord v2 > transport', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('handleRateLimitHeaders', () => {
+		it('sleeps for reset-after converted from seconds to ms when remaining is 0', async () => {
+			await handleRateLimitHeaders({
+				'x-ratelimit-remaining': '0',
+				'x-ratelimit-reset-after': '2',
+			});
+			expect(sleepMock).toHaveBeenCalledWith(2000);
+		});
+
+		it('handles fractional seconds', async () => {
+			await handleRateLimitHeaders({
+				'x-ratelimit-remaining': '0',
+				'x-ratelimit-reset-after': '1.5',
+			});
+			expect(sleepMock).toHaveBeenCalledWith(1500);
+		});
+
+		it('caps the sleep at 60 seconds', async () => {
+			await handleRateLimitHeaders({
+				'x-ratelimit-remaining': '0',
+				'x-ratelimit-reset-after': '9999',
+			});
+			expect(sleepMock).toHaveBeenCalledWith(60_000);
+		});
+
+		it('sleeps 20ms as a global-rate-limit guard when remaining is greater than 0', async () => {
+			await handleRateLimitHeaders({
+				'x-ratelimit-remaining': '4',
+				'x-ratelimit-reset-after': '2',
+			});
+			expect(sleepMock).toHaveBeenCalledWith(20);
+		});
+
+		it('sleeps 20ms when headers are missing', async () => {
+			await handleRateLimitHeaders({});
+			expect(sleepMock).toHaveBeenCalledWith(20);
+			sleepMock.mockClear();
+			await handleRateLimitHeaders(undefined);
+			expect(sleepMock).toHaveBeenCalledWith(20);
+		});
+
+		it('sleeps 0 when remaining is 0 but reset-after is missing or non-positive', async () => {
+			await handleRateLimitHeaders({
+				'x-ratelimit-remaining': '0',
+			});
+			expect(sleepMock).toHaveBeenCalledWith(0);
+			sleepMock.mockClear();
+			await handleRateLimitHeaders({
+				'x-ratelimit-remaining': '0',
+				'x-ratelimit-reset-after': '0',
+			});
+			expect(sleepMock).toHaveBeenCalledWith(0);
+		});
+	});
+
+	describe('requestApi', () => {
+		it('returns the response on success', async () => {
+			const { context, requestWithAuthentication } = createMockContext();
+			const response = { body: { ok: true }, headers: {} };
+			requestWithAuthentication.mockResolvedValueOnce(response);
+
+			const result = await requestApi.call(
+				context,
+				{ url: 'https://discord.com/api/v10/x', headers: {} },
+				'discordBotApi',
+				'/x',
+			);
+
+			expect(result).toBe(response);
+			expect(requestWithAuthentication).toHaveBeenCalledTimes(1);
+			expect(sleepMock).not.toHaveBeenCalled();
+		});
+
+		it('retries once after a 429 then returns the success response', async () => {
+			const { context, requestWithAuthentication } = createMockContext();
+			const response = { body: { ok: true }, headers: {} };
+			requestWithAuthentication
+				.mockRejectedValueOnce({
+					statusCode: 429,
+					response: { headers: { 'retry-after': '1' } },
+				})
+				.mockResolvedValueOnce(response);
+
+			const result = await requestApi.call(
+				context,
+				{ url: 'https://discord.com/api/v10/x', headers: {} },
+				'discordBotApi',
+				'/x',
+			);
+
+			expect(result).toBe(response);
+			expect(requestWithAuthentication).toHaveBeenCalledTimes(2);
+			expect(sleepMock).toHaveBeenCalledTimes(1);
+			expect(sleepMock).toHaveBeenCalledWith(1000);
+		});
+
+		it('uses a 1s fallback when retry-after is missing on a 429', async () => {
+			const { context, requestWithAuthentication } = createMockContext();
+			const response = { body: { ok: true }, headers: {} };
+			requestWithAuthentication
+				.mockRejectedValueOnce({ statusCode: 429, response: { headers: {} } })
+				.mockResolvedValueOnce(response);
+
+			await requestApi.call(
+				context,
+				{ url: 'https://discord.com/api/v10/x', headers: {} },
+				'discordBotApi',
+				'/x',
+			);
+
+			expect(sleepMock).toHaveBeenCalledWith(1000);
+		});
+
+		it('throws after exhausting max retries on repeated 429s', async () => {
+			const { context, requestWithAuthentication } = createMockContext();
+			const error = {
+				statusCode: 429,
+				response: { headers: { 'retry-after': '1' } },
+			};
+			requestWithAuthentication.mockRejectedValue(error);
+
+			await expect(
+				requestApi.call(
+					context,
+					{ url: 'https://discord.com/api/v10/x', headers: {} },
+					'discordBotApi',
+					'/x',
+				),
+			).rejects.toBe(error);
+
+			expect(requestWithAuthentication).toHaveBeenCalledTimes(4); // initial + 3 retries
+			expect(sleepMock).toHaveBeenCalledTimes(3);
+		});
+
+		it('does not retry on non-429 errors', async () => {
+			const { context, requestWithAuthentication } = createMockContext();
+			const error = { statusCode: 500, response: { headers: {} } };
+			requestWithAuthentication.mockRejectedValueOnce(error);
+
+			await expect(
+				requestApi.call(
+					context,
+					{ url: 'https://discord.com/api/v10/x', headers: {} },
+					'discordBotApi',
+					'/x',
+				),
+			).rejects.toBe(error);
+
+			expect(requestWithAuthentication).toHaveBeenCalledTimes(1);
+			expect(sleepMock).not.toHaveBeenCalled();
+		});
+
+		it('fetches OAuth2 credentials once even across retries', async () => {
+			const { context, request } = createMockContext('oAuth2');
+			const getCredentials = context.getCredentials as jest.Mock;
+			getCredentials.mockResolvedValue({ botToken: 'abc' });
+			request
+				.mockRejectedValueOnce({
+					statusCode: 429,
+					response: { headers: { 'retry-after': '1' } },
+				})
+				.mockResolvedValueOnce({ body: {}, headers: {} });
+
+			await requestApi.call(
+				context,
+				{ url: 'https://discord.com/api/v10/x', headers: {} },
+				'discordOAuth2Api',
+				'/x',
+			);
+
+			expect(getCredentials).toHaveBeenCalledTimes(1);
+			expect(request).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe('discordApiRequest', () => {
+		it('sleeps for reset-after (in ms) when remaining is 0 on a successful response', async () => {
+			const { context, requestWithAuthentication } = createMockContext();
+			requestWithAuthentication.mockResolvedValueOnce({
+				body: { id: '1' },
+				headers: {
+					'x-ratelimit-remaining': '0',
+					'x-ratelimit-reset-after': '2',
+				},
+			});
+
+			const result = await discordApiRequest.call(context, 'POST', '/channels/1/messages', {
+				content: 'hi',
+			});
+
+			expect(result).toEqual({ id: '1' });
+			expect(sleepMock).toHaveBeenCalledWith(2000);
+		});
+
+		it('sleeps 20ms as a global-rate-limit guard on happy-path responses with remaining > 0', async () => {
+			const { context, requestWithAuthentication } = createMockContext();
+			requestWithAuthentication.mockResolvedValueOnce({
+				body: { id: '1' },
+				headers: {
+					'x-ratelimit-remaining': '5',
+					'x-ratelimit-reset-after': '2',
+				},
+			});
+
+			await discordApiRequest.call(context, 'POST', '/channels/1/messages', { content: 'hi' });
+
+			expect(sleepMock).toHaveBeenCalledWith(20);
+		});
+
+		it('retries on 429 and then respects the success-response reset-after', async () => {
+			const { context, requestWithAuthentication } = createMockContext();
+			requestWithAuthentication
+				.mockRejectedValueOnce({
+					statusCode: 429,
+					response: { headers: { 'retry-after': '1' } },
+				})
+				.mockResolvedValueOnce({
+					body: { id: '1' },
+					headers: {
+						'x-ratelimit-remaining': '0',
+						'x-ratelimit-reset-after': '3',
+					},
+				});
+
+			const result = await discordApiRequest.call(context, 'POST', '/channels/1/messages', {
+				content: 'hi',
+			});
+
+			expect(result).toEqual({ id: '1' });
+			expect(sleepMock).toHaveBeenNthCalledWith(1, 1000); // retry-after
+			expect(sleepMock).toHaveBeenNthCalledWith(2, 3000); // post-success reset-after
+		});
+
+		it('wraps non-429 errors as NodeApiError', async () => {
+			const { context, requestWithAuthentication } = createMockContext();
+			requestWithAuthentication.mockRejectedValueOnce({ statusCode: 400, message: 'bad request' });
+
+			await expect(
+				discordApiRequest.call(context, 'POST', '/channels/1/messages', { content: 'hi' }),
+			).rejects.toThrow();
+		});
+	});
+
+	describe('discordApiMultiPartRequest', () => {
+		it('sleeps for reset-after (in ms) when remaining is 0 on a successful response', async () => {
+			const { context, requestWithAuthentication } = createMockContext();
+			requestWithAuthentication.mockResolvedValueOnce({
+				body: JSON.stringify({ id: '1' }),
+				headers: {
+					'x-ratelimit-remaining': '0',
+					'x-ratelimit-reset-after': '2',
+				},
+			});
+
+			const result = await discordApiMultiPartRequest.call(
+				context,
+				'POST',
+				'/channels/1/messages',
+				{} as never,
+			);
+
+			expect(result).toEqual({ id: '1' });
+			expect(sleepMock).toHaveBeenCalledWith(2000);
+		});
+
+		it('retries on 429 then parses the success body', async () => {
+			const { context, requestWithAuthentication } = createMockContext();
+			requestWithAuthentication
+				.mockRejectedValueOnce({
+					statusCode: 429,
+					response: { headers: { 'retry-after': '1' } },
+				})
+				.mockResolvedValueOnce({
+					body: JSON.stringify({ id: '1' }),
+					headers: {
+						'x-ratelimit-remaining': '5',
+					},
+				});
+
+			const result = await discordApiMultiPartRequest.call(
+				context,
+				'POST',
+				'/channels/1/messages',
+				{} as never,
+			);
+
+			expect(result).toEqual({ id: '1' });
+			expect(sleepMock).toHaveBeenCalledWith(1000);
+			expect(sleepMock).toHaveBeenCalledWith(20);
+			expect(sleepMock).toHaveBeenCalledTimes(2);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Discord/v2/transport/discord.api.ts
+++ b/packages/nodes-base/nodes/Discord/v2/transport/discord.api.ts
@@ -8,9 +8,9 @@ import type {
 	ILoadOptionsFunctions,
 	IRequestOptions,
 } from 'n8n-workflow';
-import { sleep, NodeApiError, jsonParse } from 'n8n-workflow';
+import { NodeApiError, jsonParse } from 'n8n-workflow';
 
-import { getCredentialsType, requestApi } from './helpers';
+import { getCredentialsType, handleRateLimitHeaders, requestApi } from './helpers';
 
 export async function discordApiRequest(
 	this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions,
@@ -41,14 +41,7 @@ export async function discordApiRequest(
 	try {
 		const response = await requestApi.call(this, options, credentialType, endpoint);
 
-		const resetAfter = Number(response.headers['x-ratelimit-reset-after']);
-		const remaining = Number(response.headers['x-ratelimit-remaining']);
-
-		if (remaining === 0) {
-			await sleep(resetAfter);
-		} else {
-			await sleep(20); //prevent exceeding global rate limit of 50 requests per second
-		}
+		await handleRateLimitHeaders(response.headers as IDataObject);
 
 		return response.body || { success: true };
 	} catch (error) {
@@ -84,14 +77,7 @@ export async function discordApiMultiPartRequest(
 	try {
 		const response = await requestApi.call(this, options, credentialType, endpoint);
 
-		const resetAfter = Number(response.headers['x-ratelimit-reset-after']);
-		const remaining = Number(response.headers['x-ratelimit-remaining']);
-
-		if (remaining === 0) {
-			await sleep(resetAfter);
-		} else {
-			await sleep(20); //prevent exceeding global rate limit of 50 requests per second
-		}
+		await handleRateLimitHeaders(response.headers as IDataObject);
 
 		return jsonParse<IDataObject[]>(response.body);
 	} catch (error) {

--- a/packages/nodes-base/nodes/Discord/v2/transport/helpers.ts
+++ b/packages/nodes-base/nodes/Discord/v2/transport/helpers.ts
@@ -6,6 +6,12 @@ import type {
 	ILoadOptionsFunctions,
 	IRequestOptions,
 } from 'n8n-workflow';
+import { sleep } from 'n8n-workflow';
+
+const MAX_RATE_LIMIT_RETRIES = 3;
+const MAX_RATE_LIMIT_SLEEP_MS = 60_000;
+const FALLBACK_RETRY_AFTER_MS = 1_000;
+const GLOBAL_RATE_LIMIT_SLEEP_MS = 20;
 
 export const getCredentialsType = (authentication: string) => {
 	let credentialType = '';
@@ -25,22 +31,60 @@ export const getCredentialsType = (authentication: string) => {
 	return credentialType;
 };
 
+const secondsToMs = (value: unknown): number => {
+	const seconds = Number(value);
+	if (!Number.isFinite(seconds) || seconds <= 0) return 0;
+	return Math.min(seconds * 1000, MAX_RATE_LIMIT_SLEEP_MS);
+};
+
+export async function handleRateLimitHeaders(headers: IDataObject | undefined) {
+	if (Number(headers?.['x-ratelimit-remaining']) === 0) {
+		await sleep(secondsToMs(headers?.['x-ratelimit-reset-after']));
+	} else {
+		await sleep(GLOBAL_RATE_LIMIT_SLEEP_MS); // prevent exceeding global rate limit of 50 requests per second
+	}
+}
+
+function isRateLimitError(
+	error: unknown,
+): error is { statusCode: 429; response?: { headers?: IDataObject } } {
+	return (error as { statusCode?: unknown })?.statusCode === 429;
+}
+
 export async function requestApi(
 	this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions,
 	options: IRequestOptions,
 	credentialType: string,
 	endpoint: string,
 ) {
-	let response;
-	if (credentialType === 'discordOAuth2Api' && endpoint !== '/users/@me/guilds') {
+	const useCustomAuth = credentialType === 'discordOAuth2Api' && endpoint !== '/users/@me/guilds';
+
+	if (useCustomAuth) {
 		const credentials = await this.getCredentials('discordOAuth2Api');
 		(options.headers as IDataObject).Authorization = `Bot ${credentials.botToken}`;
-		response = await this.helpers.request({ ...options, resolveWithFullResponse: true });
-	} else {
-		response = await this.helpers.requestWithAuthentication.call(this, credentialType, {
-			...options,
-			resolveWithFullResponse: true,
-		});
 	}
-	return response;
+
+	const requestOptions = { ...options, resolveWithFullResponse: true };
+
+	let attempt = 0;
+	for (;;) {
+		try {
+			if (useCustomAuth) {
+				return await this.helpers.request(requestOptions);
+			}
+			return await this.helpers.requestWithAuthentication.call(
+				this,
+				credentialType,
+				requestOptions,
+			);
+		} catch (error) {
+			if (!isRateLimitError(error) || attempt === MAX_RATE_LIMIT_RETRIES) {
+				throw error;
+			}
+			const waitMs =
+				secondsToMs(error.response?.headers?.['retry-after']) || FALLBACK_RETRY_AFTER_MS;
+			await sleep(waitMs);
+			attempt++;
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Discord's `x-ratelimit-reset-after` header is in seconds, but the value was passed directly to `sleep()` which expects milliseconds — so the client barely waited at all when a per-route bucket was exhausted and was likely to hit further limits. This PR converts the header from seconds to milliseconds, caps the wait at 60s, and adds a 429-aware retry loop in `requestApi` that honors `Retry-After` (with a 1s fallback and up to 3 retries). Rate-limit handling is extracted into a dedicated `handleRateLimitHeaders` helper and covered by new unit tests for both success-path header handling and the retry path.

**How to test:** Run the new unit tests:

```bash
cd packages/nodes-base && pnpm test discord.api.test
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4839

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI