### PR TITLE
fix(Guardrails Node): correct threshold hint to match actual logic

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/Guardrails/description.ts
+++ b/packages/@n8n/nodes-langchain/nodes/Guardrails/description.ts
@@ -13,7 +13,7 @@ const THRESHOLD_OPTION: INodeProperties = {
 	type: 'number',
 	default: '',
 	description: 'Minimum confidence threshold to trigger the guardrail (0.0 to 1.0)',
-	hint: 'Inputs scoring less than this will be treated as violations',
+	hint: 'Inputs flagged with a confidence score at or above this value will be treated as violations',
 };
 
 const getPromptOption: (


### PR DESCRIPTION
## Summary

Fixes #29015

The threshold hint text says *"Inputs scoring less than this will be treated as violations"* but the actual code at `helpers/model.ts:137` triggers when:

```ts
const triggered = result.flagged && result.confidenceScore >= threshold;
```

This means inputs with confidence scores **at or above** the threshold are violations — the exact opposite of the hint.

## Fix

Updated the hint to: *"Inputs flagged with a confidence score at or above this value will be treated as violations"*

## Testing

- Hint text now accurately describes the behavior: higher confidence + flagged + >= threshold = violation