### PR TITLE
fix(Google Drive Node): resolve "Copy of undefined" when copying file by ID

### DIFF
--- a/packages/nodes-base/nodes/Google/Drive/v2/actions/file/copy.operation.ts
+++ b/packages/nodes-base/nodes/Google/Drive/v2/actions/file/copy.operation.ts
@@ -88,7 +88,23 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	const options = this.getNodeParameter('options', i, {});
 
 	let name = this.getNodeParameter('name', i) as string;
-	name = name ? name : `Copy of ${file.cachedResultName}`;
+
+	if (!name) {
+		if (file.cachedResultName) {
+			name = `Copy of ${file.cachedResultName}`;
+		} else {
+			// When file is selected by ID, cachedResultName may be undefined.
+			// Fetch the original file name from the API to avoid "Copy of undefined".
+			const originalFile = await googleApiRequest.call(
+				this,
+				'GET',
+				`/drive/v3/files/${fileId}`,
+				{},
+				{ fields: 'name', supportsAllDrives: true },
+			);
+			name = `Copy of ${(originalFile as IDataObject).name ?? fileId}`;
+		}
+	}
 
 	const copyRequiresWriterPermission = options.copyRequiresWriterPermission || false;
 


### PR DESCRIPTION
## Summary

Fixes #28735

When copying a file using the Google Drive node by entering the file ID directly (instead of selecting from the resource locator list), `cachedResultName` is `undefined`. The fallback name template `Copy of ${file.cachedResultName}` produces `"Copy of undefined"`.

## Fix

When `cachedResultName` is not available, fetch the original file name from the Google Drive API (`GET /drive/v3/files/{id}?fields=name`) before constructing the copy name. Falls back to the file ID if the API call doesn't return a name.

## Testing

1. Use Google Drive node → File → Copy
2. Enter a file ID manually (not from list)
3. Leave File Name empty
4. Result: copied file is named `Copy of {actual file name}` instead of `Copy of undefined`