### PR TITLE
fix(Databricks Node): Handle 403 as token-expired status code for OAuth2

### DIFF
--- a/packages/nodes-base/credentials/DatabricksOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/DatabricksOAuth2Api.credentials.ts
@@ -52,6 +52,14 @@ export class DatabricksOAuth2Api implements ICredentialType {
 			type: 'hidden',
 			default: 'header',
 		},
+		{
+			displayName: 'Token Expired Status Code',
+			name: 'tokenExpiredStatusCode',
+			type: 'hidden',
+			default: 403,
+			description:
+				'Databricks may return 403 (not just 401) for expired tokens. This ensures automatic token refresh on 403.',
+		},
 	];
 
 	test: ICredentialTestRequest = {


### PR DESCRIPTION
## Summary

Fixes #28832

The base `oAuth2Api` credential marks `tokenExpiredStatusCode` with `doNotInherit: true`, so extending credentials (like Databricks) can't inherit it and default to 401. Databricks (especially Azure-fronted endpoints) may return **403** for expired bearer tokens, causing requests to fail instead of triggering automatic token refresh.

## Fix

Explicitly set `tokenExpiredStatusCode` to `403` as a hidden field in the Databricks OAuth2 credential. The existing `resolveTokenExpiredStatusCode()` in `request-helper-functions.ts` already reads from credential-level `tokenExpiredStatusCode` and will pick up this value.

## Testing

1. Configure Databricks OAuth2 credential
2. Wait for token to expire (or manually invalidate)
3. Databricks returns 403 → n8n should now auto-refresh the token and retry