### PR TITLE
fix(editor): Keep opening executions when credential prefetch fails

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.test.ts
@@ -380,7 +380,9 @@ describe('usePostMessageHandler', () => {
 				mode: 'trigger',
 				finished: true,
 			});
-			mockFetchAllCredentialsForWorkflow.mockRejectedValueOnce(new Error('credential prefetch failed'));
+			mockFetchAllCredentialsForWorkflow.mockRejectedValueOnce(
+				new Error('credential prefetch failed'),
+			);
 
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,

--- a/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.test.ts
@@ -374,6 +374,41 @@ describe('usePostMessageHandler', () => {
 			cleanup();
 		});
 
+		it('should still open execution when workflow credential prefetch fails', async () => {
+			mockOpenExecution.mockResolvedValue({
+				workflowData: { id: 'test-wf-id', name: 'Test' },
+				mode: 'trigger',
+				finished: true,
+			});
+			mockFetchAllCredentialsForWorkflow.mockRejectedValueOnce(new Error('credential prefetch failed'));
+
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: shallowRef(null),
+			});
+			setup();
+
+			const messageEvent = new MessageEvent('message', {
+				data: JSON.stringify({
+					command: 'openExecution',
+					executionId: 'exec-1',
+					executionMode: 'trigger',
+				}),
+			});
+			window.dispatchEvent(messageEvent);
+
+			await vi.waitFor(() => {
+				expect(mockCanvasEventBusEmit).toHaveBeenCalledWith(
+					'open:execution',
+					expect.objectContaining({ workflowData: { id: 'test-wf-id', name: 'Test' } }),
+				);
+			});
+
+			expect(mockFitView).toHaveBeenCalled();
+
+			cleanup();
+		});
+
 		it('should not fetch workflow credentials when execution data is missing', async () => {
 			mockOpenExecution.mockResolvedValue(null);
 

--- a/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.ts
@@ -135,7 +135,9 @@ export function usePostMessageHandler({
 
 		try {
 			await credentialsStore.fetchAllCredentialsForWorkflow({ workflowId: data.workflowData.id });
-		} catch {}
+		} catch {
+			// Credential prefetch is best-effort; keep opening the execution preview.
+		}
 
 		const wfId = workflowsStore.workflowId;
 		if (wfId) {

--- a/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.ts
@@ -133,7 +133,9 @@ export function usePostMessageHandler({
 			return;
 		}
 
-		await credentialsStore.fetchAllCredentialsForWorkflow({ workflowId: data.workflowData.id });
+		try {
+			await credentialsStore.fetchAllCredentialsForWorkflow({ workflowId: data.workflowData.id });
+		} catch {}
 
 		const wfId = workflowsStore.workflowId;
 		if (wfId) {


### PR DESCRIPTION
## Summary

- keep `openExecution` flowing when workflow credential prefetch rejects
- still set the execution document state, update node issues, stop canvas loading, fit the view, and emit `open:execution`
- add a regression test for a rejected `fetchAllCredentialsForWorkflow()` call

## Tests

- `git diff --check`
- Attempted: `pnpm --filter n8n-editor-ui test -- usePostMessageHandler.test.ts --runInBand` (local checkout has no installed `node_modules`, so `vitest` is unavailable)
