### PR TITLE
fix(instance-ai): scope submit workflow identity by project

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/submit-workflow-identity.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/submit-workflow-identity.test.ts
@@ -152,6 +152,27 @@ describe('wrapSubmitExecuteWithIdentity', () => {
 		expect(calls[2].workflowId).toBe('wf_1');
 	});
 
+	it('treats omitted projectId and its resolved default projectId as the same identity', async () => {
+		const { execute, calls } = makeUnderlying();
+		const wrapped = wrapSubmitExecuteWithIdentity(
+			execute,
+			resolvePath,
+			(projectId) => projectId ?? 'personal-project',
+		);
+
+		const implicitPersonal = await wrapped({ filePath: MAIN_PATH });
+		const explicitPersonal = await wrapped({
+			filePath: MAIN_PATH,
+			projectId: 'personal-project',
+		});
+
+		expect(implicitPersonal.workflowId).toBe('wf_1');
+		expect(explicitPersonal.workflowId).toBe('wf_1');
+		expect(calls).toHaveLength(2);
+		expect(calls[0].workflowId).toBeUndefined();
+		expect(calls[1].workflowId).toBe('wf_1');
+	});
+
 	it('resolves differently-spelled paths to the same identity', async () => {
 		const { execute } = makeUnderlying();
 		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath);

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/submit-workflow-identity.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/submit-workflow-identity.test.ts
@@ -134,6 +134,24 @@ describe('wrapSubmitExecuteWithIdentity', () => {
 		expect(chunkAgain.workflowId).toBe(chunkResult.workflowId);
 	});
 
+	it('does not reuse workflow identity across different projectIds for the same filePath', async () => {
+		const { execute, calls } = makeUnderlying();
+		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath);
+
+		const teamA = await wrapped({ filePath: MAIN_PATH, projectId: 'project-a' });
+		const teamB = await wrapped({ filePath: MAIN_PATH, projectId: 'project-b' });
+		const teamAAgain = await wrapped({ filePath: MAIN_PATH, projectId: 'project-a' });
+
+		expect(teamA.workflowId).toBe('wf_1');
+		expect(teamB.workflowId).toBe('wf_2');
+		expect(teamAAgain.workflowId).toBe('wf_1');
+
+		expect(calls).toHaveLength(3);
+		expect(calls[0].workflowId).toBeUndefined();
+		expect(calls[1].workflowId).toBeUndefined();
+		expect(calls[2].workflowId).toBe('wf_1');
+	});
+
 	it('resolves differently-spelled paths to the same identity', async () => {
 		const { execute } = makeUnderlying();
 		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath);

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/submit-workflow-identity.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/submit-workflow-identity.test.ts
@@ -211,6 +211,16 @@ describe('wrapSubmitExecuteWithIdentity', () => {
 		expect(calls).toEqual([{ filePath: MAIN_PATH, workflowId: 'wf_existing' }]);
 	});
 
+	it('uses the personal fallback when an explicit update has no owner resolver', async () => {
+		const { execute, calls } = makeUnderlying();
+		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath);
+
+		const result = await wrapped({ filePath: MAIN_PATH, workflowId: 'wf_existing' });
+
+		expect(result).toMatchObject({ success: true, workflowId: 'wf_existing' });
+		expect(calls).toEqual([{ filePath: MAIN_PATH, workflowId: 'wf_existing' }]);
+	});
+
 	it('uses the owning project when an update omits projectId', async () => {
 		const { execute, calls } = makeUnderlying();
 		const resolveWorkflowProjectId = jest.fn(async () => 'personal-project');

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/submit-workflow-identity.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/submit-workflow-identity.test.ts
@@ -1,0 +1,477 @@
+import { createRemediation } from '../../../workflow-loop/remediation';
+import type { WorkflowLoopState } from '../../../workflow-loop/workflow-loop-state';
+import {
+	createPreSaveBudgetTracker,
+	withDefaultWorkflowFilePath,
+	wrapSubmitExecuteWithIdentity,
+} from '../submit-workflow-identity';
+import type { SubmitWorkflowInput, SubmitWorkflowOutput } from '../submit-workflow.tool';
+
+const ROOT = '/home/daytona/workspace';
+const MAIN_PATH = `${ROOT}/src/workflow.ts`;
+const CHUNK_PATH = `${ROOT}/src/chunk.ts`;
+const TASK_MAIN_PATH = `${ROOT}/builder-work-items/wi-one/src/workflow.ts`;
+
+function resolvePath(rawFilePath: string | undefined): string {
+	if (!rawFilePath) return MAIN_PATH;
+	if (rawFilePath.startsWith('/')) return rawFilePath;
+	return `${ROOT}/${rawFilePath}`;
+}
+
+/**
+ * Build a fake underlying `execute` that:
+ *   - On a call without `workflowId`, returns a freshly-minted id (simulating create).
+ *   - On a call with `workflowId`, returns that same id (simulating update).
+ *   - Records every call it received.
+ * An optional `gate` promise lets tests hold dispatch mid-flight to exercise races.
+ */
+function makeUnderlying(opts: { idPrefix?: string; gate?: Promise<void> } = {}) {
+	const prefix = opts.idPrefix ?? 'wf';
+	let counter = 0;
+	const calls: SubmitWorkflowInput[] = [];
+
+	const execute = async (input: SubmitWorkflowInput): Promise<SubmitWorkflowOutput> => {
+		calls.push({ ...input });
+		if (opts.gate) await opts.gate;
+		if (input.workflowId) {
+			return { success: true, workflowId: input.workflowId };
+		}
+		counter += 1;
+		return { success: true, workflowId: `${prefix}_${counter}` };
+	};
+
+	return { execute, calls };
+}
+
+describe('withDefaultWorkflowFilePath', () => {
+	it('uses the task main workflow file when submit-workflow omits filePath', () => {
+		expect(withDefaultWorkflowFilePath({ name: 'Workflow' }, TASK_MAIN_PATH)).toEqual({
+			name: 'Workflow',
+			filePath: TASK_MAIN_PATH,
+		});
+	});
+
+	it('preserves explicit filePath values for chunks and follow-up submits', () => {
+		expect(
+			withDefaultWorkflowFilePath({ filePath: CHUNK_PATH, name: 'Chunk' }, TASK_MAIN_PATH),
+		).toEqual({
+			filePath: CHUNK_PATH,
+			name: 'Chunk',
+		});
+	});
+});
+
+describe('wrapSubmitExecuteWithIdentity', () => {
+	it('parallel submits for the same filePath produce one create and N-1 updates sharing the workflowId', async () => {
+		let release: () => void = () => {};
+		const gate = new Promise<void>((res) => {
+			release = res;
+		});
+		const { execute, calls } = makeUnderlying({ gate });
+		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath);
+
+		const inFlight = Array.from({ length: 5 }, async () => await wrapped({}));
+		// Let the dispatcher land first, then release.
+		await Promise.resolve();
+		release();
+
+		const results = await Promise.all(inFlight);
+
+		const ids = results.map((r) => r.workflowId);
+		expect(new Set(ids).size).toBe(1);
+		expect(results.every((r) => r.success)).toBe(true);
+
+		const createCalls = calls.filter((c) => !c.workflowId);
+		const updateCalls = calls.filter((c) => c.workflowId);
+		expect(createCalls).toHaveLength(1);
+		expect(updateCalls).toHaveLength(4);
+		expect(updateCalls.every((c) => c.workflowId === ids[0])).toBe(true);
+	});
+
+	it('sequential submits for the same filePath reuse the bound workflowId', async () => {
+		const { execute, calls } = makeUnderlying();
+		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath);
+
+		const first = await wrapped({});
+		const second = await wrapped({});
+
+		expect(first.workflowId).toBe('wf_1');
+		expect(second.workflowId).toBe('wf_1');
+		expect(calls).toHaveLength(2);
+		expect(calls[0].workflowId).toBeUndefined();
+		expect(calls[1].workflowId).toBe('wf_1');
+	});
+
+	it('overrides an LLM-supplied workflowId once the wrapper has bound one', async () => {
+		const { execute, calls } = makeUnderlying();
+		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath);
+
+		const first = await wrapped({});
+		const second = await wrapped({ workflowId: 'llm_hallucinated_id' });
+
+		expect(first.workflowId).toBe('wf_1');
+		expect(second.workflowId).toBe('wf_1');
+		expect(calls[1].workflowId).toBe('wf_1');
+	});
+
+	it('different filePaths dispatch independently (chunk + main composition)', async () => {
+		const { execute, calls } = makeUnderlying();
+		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath);
+
+		const [mainResult, chunkResult] = await Promise.all([
+			wrapped({ filePath: MAIN_PATH }),
+			wrapped({ filePath: CHUNK_PATH }),
+		]);
+
+		expect(mainResult.workflowId).not.toBe(chunkResult.workflowId);
+		const createCalls = calls.filter((c) => !c.workflowId);
+		expect(createCalls).toHaveLength(2);
+
+		const mainAgain = await wrapped({ filePath: MAIN_PATH });
+		expect(mainAgain.workflowId).toBe(mainResult.workflowId);
+
+		const chunkAgain = await wrapped({ filePath: CHUNK_PATH });
+		expect(chunkAgain.workflowId).toBe(chunkResult.workflowId);
+	});
+
+	it('does not reuse workflow identity across different projectIds for the same filePath', async () => {
+		const { execute, calls } = makeUnderlying();
+		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath);
+
+		const teamA = await wrapped({ filePath: MAIN_PATH, projectId: 'project-a' });
+		const teamB = await wrapped({ filePath: MAIN_PATH, projectId: 'project-b' });
+		const teamAAgain = await wrapped({ filePath: MAIN_PATH, projectId: 'project-a' });
+
+		expect(teamA.workflowId).toBe('wf_1');
+		expect(teamB.workflowId).toBe('wf_2');
+		expect(teamAAgain.workflowId).toBe('wf_1');
+
+		expect(calls).toHaveLength(3);
+		expect(calls[0].workflowId).toBeUndefined();
+		expect(calls[1].workflowId).toBeUndefined();
+		expect(calls[2].workflowId).toBe('wf_1');
+	});
+
+	it('resolves differently-spelled paths to the same identity', async () => {
+		const { execute } = makeUnderlying();
+		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath);
+
+		const absolute = await wrapped({ filePath: MAIN_PATH });
+		const relative = await wrapped({ filePath: 'src/workflow.ts' });
+		const defaulted = await wrapped({});
+
+		expect(absolute.workflowId).toBe('wf_1');
+		expect(relative.workflowId).toBe('wf_1');
+		expect(defaulted.workflowId).toBe('wf_1');
+	});
+
+	it('clears the map when the first dispatch fails so subsequent calls can retry', async () => {
+		let call = 0;
+		const execute = async (input: SubmitWorkflowInput): Promise<SubmitWorkflowOutput> => {
+			await Promise.resolve();
+			call += 1;
+			if (call === 1) {
+				return { success: false, errors: ['transient failure'] };
+			}
+			if (input.workflowId) return { success: true, workflowId: input.workflowId };
+			return { success: true, workflowId: 'wf_recovered' };
+		};
+		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath);
+
+		const failed = await wrapped({});
+		expect(failed.success).toBe(false);
+
+		const retried = await wrapped({});
+		expect(retried.success).toBe(true);
+		expect(retried.workflowId).toBe('wf_recovered');
+	});
+
+	it('reports a failure to concurrent waiters when the dispatcher fails', async () => {
+		let release: () => void = () => {};
+		const gate = new Promise<void>((res) => {
+			release = res;
+		});
+		let call = 0;
+		const execute = async (): Promise<SubmitWorkflowOutput> => {
+			call += 1;
+			await gate;
+			if (call === 1) return { success: false, errors: ['create failed'] };
+			return { success: true, workflowId: 'wf_unused' };
+		};
+		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath);
+
+		const a = wrapped({});
+		const b = wrapped({});
+		await Promise.resolve();
+		release();
+
+		const [aResult, bResult] = await Promise.all([a, b]);
+		expect(aResult.success).toBe(false);
+		expect(bResult.success).toBe(false);
+		expect(bResult.errors?.[0]).toContain('Previous submit-workflow for this file failed');
+	});
+
+	it('propagates thrown errors from the dispatcher and clears the map', async () => {
+		let call = 0;
+		const execute = async (input: SubmitWorkflowInput): Promise<SubmitWorkflowOutput> => {
+			await Promise.resolve();
+			call += 1;
+			if (call === 1) throw new Error('boom');
+			if (input.workflowId) return { success: true, workflowId: input.workflowId };
+			return { success: true, workflowId: 'wf_after_throw' };
+		};
+		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath);
+
+		await expect(wrapped({})).rejects.toThrow('boom');
+
+		const retried = await wrapped({});
+		expect(retried.workflowId).toBe('wf_after_throw');
+	});
+
+	it('blocks submit when persisted remediation says editing must stop', async () => {
+		const execute = jest.fn(async (): Promise<SubmitWorkflowOutput> => {
+			await Promise.resolve();
+			return { success: true, workflowId: 'wf_unused' };
+		});
+		const onGuardFired = jest.fn();
+		const state: WorkflowLoopState = {
+			workItemId: 'wi_test',
+			threadId: 'thread_1',
+			runId: 'run_1',
+			phase: 'blocked',
+			status: 'blocked',
+			source: 'create',
+			rebuildAttempts: 0,
+			lastRemediation: createRemediation({
+				category: 'needs_setup',
+				shouldEdit: false,
+				reason: 'mocked_credentials_or_placeholders',
+				guidance: 'Route to setup.',
+			}),
+		};
+		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath, {
+			getWorkflowLoopState: async () => {
+				await Promise.resolve();
+				return state;
+			},
+			onGuardFired,
+		});
+
+		const result = await wrapped({});
+
+		expect(result.success).toBe(false);
+		expect(result.remediation).toMatchObject({ shouldEdit: false, category: 'needs_setup' });
+		expect(execute).not.toHaveBeenCalled();
+		expect(onGuardFired).toHaveBeenCalledWith(
+			expect.objectContaining({
+				category: 'needs_setup',
+				reason: 'mocked_credentials_or_placeholders',
+			}),
+		);
+	});
+
+	it('records terminal submit output and blocks later submits in-process', async () => {
+		let terminalRemediation: SubmitWorkflowOutput['remediation'];
+		const remediation = createRemediation({
+			category: 'blocked',
+			shouldEdit: false,
+			reason: 'workflow_save_failed',
+			guidance: 'Stop editing.',
+		});
+		const execute = jest
+			.fn<Promise<SubmitWorkflowOutput>, [SubmitWorkflowInput]>()
+			.mockResolvedValueOnce({
+				success: false,
+				errors: ['Workflow save failed.'],
+				remediation,
+			})
+			.mockResolvedValueOnce({ success: true, workflowId: 'wf_should_not_save' });
+		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath, {
+			getTerminalRemediation: () => terminalRemediation,
+			onTerminalRemediation: (recorded) => {
+				terminalRemediation = recorded;
+			},
+		});
+
+		const first = await wrapped({});
+		const second = await wrapped({});
+
+		expect(first.remediation).toBe(remediation);
+		expect(second).toMatchObject({
+			success: false,
+			errors: ['Stop editing.'],
+			remediation,
+		});
+		expect(execute).toHaveBeenCalledTimes(1);
+	});
+
+	it('returns terminal remediation to concurrent submit waiters when the first submit stops editing', async () => {
+		let release: () => void = () => {};
+		const gate = new Promise<void>((res) => {
+			release = res;
+		});
+		let terminalRemediation: SubmitWorkflowOutput['remediation'];
+		const remediation = createRemediation({
+			category: 'blocked',
+			shouldEdit: false,
+			reason: 'workflow_save_failed',
+			guidance: 'Stop editing.',
+		});
+		const execute = jest.fn(async (): Promise<SubmitWorkflowOutput> => {
+			await gate;
+			return {
+				success: false,
+				errors: ['Workflow save failed.'],
+				remediation,
+			};
+		});
+		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath, {
+			getTerminalRemediation: () => terminalRemediation,
+			onTerminalRemediation: (recorded) => {
+				terminalRemediation = recorded;
+			},
+		});
+
+		const first = wrapped({});
+		const second = wrapped({});
+		await Promise.resolve();
+		release();
+
+		await expect(first).resolves.toMatchObject({ success: false, remediation });
+		await expect(second).resolves.toMatchObject({
+			success: false,
+			errors: ['Stop editing.'],
+			remediation,
+		});
+		expect(execute).toHaveBeenCalledTimes(1);
+	});
+
+	it('ignores terminal remediation from a previous run', async () => {
+		const execute = jest.fn(async (): Promise<SubmitWorkflowOutput> => {
+			await Promise.resolve();
+			return { success: true, workflowId: 'wf_current' };
+		});
+		const state: WorkflowLoopState = {
+			workItemId: 'wi_test',
+			threadId: 'thread_1',
+			runId: 'run_previous',
+			phase: 'blocked',
+			status: 'blocked',
+			source: 'create',
+			rebuildAttempts: 0,
+			lastRemediation: createRemediation({
+				category: 'needs_setup',
+				shouldEdit: false,
+				reason: 'mocked_credentials_or_placeholders',
+				guidance: 'Route to setup.',
+			}),
+		};
+		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath, {
+			currentRunId: 'run_current',
+			getWorkflowLoopState: async () => {
+				await Promise.resolve();
+				return state;
+			},
+		});
+
+		const result = await wrapped({});
+
+		expect(result).toMatchObject({ success: true, workflowId: 'wf_current' });
+		expect(execute).toHaveBeenCalledTimes(1);
+	});
+
+	it('re-checks terminal remediation after awaiting an in-flight submit', async () => {
+		let release: () => void = () => {};
+		const gate = new Promise<void>((res) => {
+			release = res;
+		});
+		const terminalState: WorkflowLoopState = {
+			workItemId: 'wi_test',
+			threadId: 'thread_1',
+			runId: 'run_1',
+			workflowId: 'wf_1',
+			phase: 'verifying',
+			status: 'active',
+			source: 'create',
+			rebuildAttempts: 0,
+			successfulSubmitSeen: true,
+			postSubmitRemediationSubmitsUsed: 2,
+		};
+		const getWorkflowLoopState = jest
+			.fn<Promise<WorkflowLoopState | undefined>, []>()
+			.mockResolvedValueOnce(undefined)
+			.mockResolvedValueOnce(undefined)
+			.mockResolvedValueOnce(terminalState);
+		const execute = jest.fn(async (input: SubmitWorkflowInput): Promise<SubmitWorkflowOutput> => {
+			await gate;
+			return { success: true, workflowId: input.workflowId ?? 'wf_1' };
+		});
+		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath, {
+			currentRunId: 'run_1',
+			getWorkflowLoopState,
+		});
+
+		const first = wrapped({});
+		await Promise.resolve();
+		await Promise.resolve();
+		const second = wrapped({});
+		await Promise.resolve();
+		release();
+
+		await expect(first).resolves.toMatchObject({ success: true, workflowId: 'wf_1' });
+		await expect(second).resolves.toMatchObject({
+			success: false,
+			remediation: {
+				category: 'blocked',
+				shouldEdit: false,
+				reason: 'post_submit_budget_exhausted',
+			},
+		});
+		expect(execute).toHaveBeenCalledTimes(1);
+	});
+
+	it('marks the third pre-save failed submit as terminal', async () => {
+		const tracker = createPreSaveBudgetTracker();
+		const execute = async (): Promise<SubmitWorkflowOutput> => {
+			await Promise.resolve();
+			tracker.recordAttempt({
+				filePath: MAIN_PATH,
+				sourceHash: 'current',
+				success: false,
+				errors: ['validation'],
+			});
+			return {
+				success: false,
+				errors: ['validation'],
+				remediation: createRemediation({
+					category: 'code_fixable',
+					shouldEdit: true,
+					guidance: 'Fix code.',
+				}),
+			};
+		};
+		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath, {
+			budgetTracker: tracker,
+		});
+
+		tracker.recordAttempt({
+			filePath: MAIN_PATH,
+			sourceHash: '1',
+			success: false,
+			errors: ['validation'],
+		});
+		tracker.recordAttempt({
+			filePath: MAIN_PATH,
+			sourceHash: '2',
+			success: false,
+			errors: ['validation'],
+		});
+		const third = await wrapped({});
+
+		expect(third.remediation).toMatchObject({
+			category: 'blocked',
+			shouldEdit: false,
+			reason: 'pre_save_submit_budget_exhausted',
+		});
+	});
+});

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/submit-workflow-identity.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/submit-workflow-identity.test.ts
@@ -198,13 +198,36 @@ describe('wrapSubmitExecuteWithIdentity', () => {
 		const resolveProjectId = jest.fn(async () => {
 			throw new Error('workflow:create is not allowed');
 		});
-		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath, resolveProjectId);
+		const resolveWorkflowProjectId = jest.fn(async () => 'personal-project');
+		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath, resolveProjectId, {
+			resolveWorkflowProjectId,
+		});
 
 		const result = await wrapped({ filePath: MAIN_PATH, workflowId: 'wf_existing' });
 
 		expect(result).toMatchObject({ success: true, workflowId: 'wf_existing' });
 		expect(resolveProjectId).not.toHaveBeenCalled();
+		expect(resolveWorkflowProjectId).toHaveBeenCalledWith('wf_existing');
 		expect(calls).toEqual([{ filePath: MAIN_PATH, workflowId: 'wf_existing' }]);
+	});
+
+	it('uses the owning project when an update omits projectId', async () => {
+		const { execute, calls } = makeUnderlying();
+		const resolveWorkflowProjectId = jest.fn(async () => 'personal-project');
+		const wrapped = wrapSubmitExecuteWithIdentity(
+			execute,
+			resolvePath,
+			(projectId) => projectId ?? 'personal-project',
+			{ resolveWorkflowProjectId },
+		);
+
+		const created = await wrapped({ filePath: MAIN_PATH });
+		const updated = await wrapped({ filePath: MAIN_PATH, workflowId: 'wf_existing' });
+
+		expect(created.workflowId).toBe('wf_1');
+		expect(updated.workflowId).toBe('wf_1');
+		expect(resolveWorkflowProjectId).toHaveBeenCalledWith('wf_existing');
+		expect(calls[1]).toMatchObject({ filePath: MAIN_PATH, workflowId: 'wf_1' });
 	});
 
 	it('resolves differently-spelled paths to the same identity', async () => {

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/submit-workflow-identity.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/submit-workflow-identity.test.ts
@@ -173,6 +173,40 @@ describe('wrapSubmitExecuteWithIdentity', () => {
 		expect(calls[1].workflowId).toBe('wf_1');
 	});
 
+	it('returns a structured blocker when create project resolution fails', async () => {
+		const { execute, calls } = makeUnderlying();
+		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath, async () => {
+			throw new Error('workflow:create is not allowed');
+		});
+
+		const result = await wrapped({ filePath: MAIN_PATH });
+
+		expect(result).toMatchObject({
+			success: false,
+			remediation: {
+				category: 'blocked',
+				shouldEdit: false,
+				reason: 'project_resolution_failed',
+			},
+		});
+		expect(result.errors?.[0]).toContain('workflow:create is not allowed');
+		expect(calls).toHaveLength(0);
+	});
+
+	it('does not require create project access when updating an explicit workflow', async () => {
+		const { execute, calls } = makeUnderlying();
+		const resolveProjectId = jest.fn(async () => {
+			throw new Error('workflow:create is not allowed');
+		});
+		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath, resolveProjectId);
+
+		const result = await wrapped({ filePath: MAIN_PATH, workflowId: 'wf_existing' });
+
+		expect(result).toMatchObject({ success: true, workflowId: 'wf_existing' });
+		expect(resolveProjectId).not.toHaveBeenCalled();
+		expect(calls).toEqual([{ filePath: MAIN_PATH, workflowId: 'wf_existing' }]);
+	});
+
 	it('resolves differently-spelled paths to the same identity', async () => {
 		const { execute } = makeUnderlying();
 		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath);

--- a/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow-identity.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow-identity.ts
@@ -121,15 +121,26 @@ export function createPreSaveBudgetTracker(): SubmitBudgetTracker {
  * Exposed separately from the tool factory so it can be unit-tested without
  * constructing a tool or a sandbox workspace.
  */
-function buildIdentityKey(resolvedPath: string, projectId: string | undefined): string {
-	return JSON.stringify([projectId ?? null, resolvedPath]);
+function buildIdentityKey(resolvedPath: string, projectId: string): string {
+	return JSON.stringify([projectId, resolvedPath]);
 }
+
+type ResolveSubmitProjectId = (projectId: string | undefined) => string | Promise<string>;
+
+type SubmitIdentityOptions = SubmitGuardOptions & { budgetTracker?: SubmitBudgetTracker };
 
 export function wrapSubmitExecuteWithIdentity(
 	underlying: SubmitExecute,
 	resolvePath: (rawFilePath: string | undefined) => string,
-	options: SubmitGuardOptions & { budgetTracker?: SubmitBudgetTracker } = {},
+	optionsOrResolveProjectId: SubmitIdentityOptions | ResolveSubmitProjectId = {},
+	maybeOptions: SubmitIdentityOptions = {},
 ): SubmitExecute {
+	const resolveProjectId: ResolveSubmitProjectId =
+		typeof optionsOrResolveProjectId === 'function'
+			? optionsOrResolveProjectId
+			: (projectId) => projectId ?? 'personal';
+	const options: SubmitIdentityOptions =
+		typeof optionsOrResolveProjectId === 'function' ? maybeOptions : optionsOrResolveProjectId;
 	const pending = new Map<string, Promise<string>>();
 
 	function recordTerminalRemediation(
@@ -181,7 +192,8 @@ export function wrapSubmitExecuteWithIdentity(
 
 	return async (input) => {
 		const resolvedPath = resolvePath(input.filePath);
-		const identityKey = buildIdentityKey(resolvedPath, input.projectId);
+		const projectId = await resolveProjectId(input.projectId);
+		const identityKey = buildIdentityKey(resolvedPath, projectId);
 		const terminalResult = await blockedByTerminalRemediation(input.workflowId);
 		if (terminalResult) return terminalResult;
 
@@ -287,6 +299,8 @@ export function createIdentityEnforcedSubmitWorkflowTool(args: {
 			rawFilePath
 				? resolveSandboxWorkflowFilePath(rawFilePath, args.root)
 				: (args.defaultFilePath ?? resolveSandboxWorkflowFilePath(rawFilePath, args.root)),
+		(projectId) =>
+			args.context.workflowService.resolveCreateProjectId?.(projectId) ?? projectId ?? 'personal',
 		{
 			budgetTracker,
 			currentRunId: args.currentRunId,

--- a/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow-identity.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow-identity.ts
@@ -5,10 +5,11 @@
  * a single assistant turn. When the LLM drops `workflowId` on calls 2..N, each
  * call takes the create branch and persists a duplicate row with the same name.
  *
- * This wrapper keys identity per resolved `filePath`. The first call for a given
- * path synchronously installs a deferred in the pending map before dispatching,
- * so concurrent calls for the same path await the first result and inject the
- * bound `workflowId` — forcing the update branch.
+ * This wrapper keys identity per resolved `filePath` and target `projectId`. The
+ * first call for a given path/project pair synchronously installs a deferred in
+ * the pending map before dispatching, so concurrent calls for the same target
+ * await the first result and inject the bound `workflowId` — forcing the update
+ * branch.
  *
  * The map is scoped to the builder-task closure: it dies with the task. No
  * cross-module coordinator, eviction hook, or TTL sweep is required.
@@ -111,15 +112,19 @@ export function createPreSaveBudgetTracker(): SubmitBudgetTracker {
 }
 
 /**
- * Wrap a submit-workflow `execute` with per-filePath identity enforcement.
+ * Wrap a submit-workflow `execute` with per-filePath/per-project identity enforcement.
  *
- * - First call for a given resolved path dispatches and populates the map on success.
- * - Concurrent calls for the same path await the first result and inject the bound id.
+ * - First call for a given resolved path/project pair dispatches and populates the map on success.
+ * - Concurrent calls for the same target await the first result and inject the bound id.
  * - On dispatch failure, the map entry is cleared and waiters see a failure result.
  *
  * Exposed separately from the tool factory so it can be unit-tested without
  * constructing a tool or a sandbox workspace.
  */
+function buildIdentityKey(resolvedPath: string, projectId: string | undefined): string {
+	return JSON.stringify([projectId ?? null, resolvedPath]);
+}
+
 export function wrapSubmitExecuteWithIdentity(
 	underlying: SubmitExecute,
 	resolvePath: (rawFilePath: string | undefined) => string,
@@ -176,10 +181,11 @@ export function wrapSubmitExecuteWithIdentity(
 
 	return async (input) => {
 		const resolvedPath = resolvePath(input.filePath);
+		const identityKey = buildIdentityKey(resolvedPath, input.projectId);
 		const terminalResult = await blockedByTerminalRemediation(input.workflowId);
 		if (terminalResult) return terminalResult;
 
-		const existing = pending.get(resolvedPath);
+		const existing = pending.get(identityKey);
 
 		if (existing) {
 			let boundId: string;
@@ -218,7 +224,7 @@ export function wrapSubmitExecuteWithIdentity(
 		// Swallow rejections on the stored promise so Node doesn't warn about
 		// unhandled rejections when no concurrent waiter happens to attach.
 		promise.catch(() => {});
-		pending.set(resolvedPath, promise);
+		pending.set(identityKey, promise);
 
 		try {
 			const result = await underlying(input);
@@ -227,12 +233,12 @@ export function wrapSubmitExecuteWithIdentity(
 				resolveFn?.(guarded.workflowId);
 			} else {
 				rejectFn?.(new Error(guarded.errors?.join(' ') ?? 'submit-workflow failed'));
-				pending.delete(resolvedPath);
+				pending.delete(identityKey);
 			}
 			return guarded;
 		} catch (error) {
 			rejectFn?.(error);
-			pending.delete(resolvedPath);
+			pending.delete(identityKey);
 			throw error;
 		}
 	};

--- a/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow-identity.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow-identity.ts
@@ -319,6 +319,25 @@ export function createIdentityEnforcedSubmitWorkflowTool(args: {
 	if (!underlyingExecute) {
 		throw new Error('createSubmitWorkflowTool returned a tool without a handler');
 	}
+	const workflowProjectResolver = args.context.workflowService.resolveWorkflowProjectId;
+	const identityOptions: SubmitIdentityOptions = {
+		budgetTracker,
+		currentRunId: args.currentRunId,
+		getWorkflowLoopState: args.getWorkflowLoopState,
+		onGuardFired: args.onGuardFired,
+	};
+	if (workflowProjectResolver) {
+		identityOptions.resolveWorkflowProjectId = async (workflowId) => {
+			const projectId = await workflowProjectResolver.call(
+				args.context.workflowService,
+				workflowId,
+			);
+			if (!projectId) {
+				throw new Error(`Workflow ${workflowId} has no owning project`);
+			}
+			return projectId;
+		};
+	}
 
 	const wrappedExecute = wrapSubmitExecuteWithIdentity(
 		underlyingExecute,
@@ -330,19 +349,7 @@ export function createIdentityEnforcedSubmitWorkflowTool(args: {
 			(await args.context.workflowService.resolveCreateProjectId?.(projectId)) ??
 			projectId ??
 			'personal',
-		{
-			budgetTracker,
-			currentRunId: args.currentRunId,
-			getWorkflowLoopState: args.getWorkflowLoopState,
-			resolveWorkflowProjectId: async (workflowId) => {
-				const projectId = await args.context.workflowService.resolveWorkflowProjectId?.(workflowId);
-				if (!projectId) {
-					throw new Error(`Workflow ${workflowId} has no owning project`);
-				}
-				return projectId;
-			},
-			onGuardFired: args.onGuardFired,
-		},
+		identityOptions,
 	);
 
 	return new Tool('submit-workflow')

--- a/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow-identity.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow-identity.ts
@@ -42,6 +42,7 @@ import type { SandboxWorkspace } from '../../workspace/sandbox-fs';
 export type SubmitExecute = (input: SubmitWorkflowInput) => Promise<SubmitWorkflowOutput>;
 
 interface SubmitGuardOptions {
+	resolveWorkflowProjectId?: (workflowId: string) => Promise<string>;
 	getWorkflowLoopState?: () => Promise<WorkflowLoopState | undefined>;
 	getTerminalRemediation?: () => RemediationMetadata | undefined;
 	currentRunId?: string;
@@ -197,7 +198,9 @@ export function wrapSubmitExecuteWithIdentity(
 			// An explicit workflowId identifies an existing workflow. Resolving its
 			// project with workflow:create would reject valid update-only access.
 			projectId = input.workflowId
-				? (input.projectId ?? 'personal')
+				? (input.projectId ??
+						(await options.resolveWorkflowProjectId?.(input.workflowId)) ??
+						'personal')
 				: await resolveProjectId(input.projectId);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
@@ -331,6 +334,13 @@ export function createIdentityEnforcedSubmitWorkflowTool(args: {
 			budgetTracker,
 			currentRunId: args.currentRunId,
 			getWorkflowLoopState: args.getWorkflowLoopState,
+			resolveWorkflowProjectId: async (workflowId) => {
+				const projectId = await args.context.workflowService.resolveWorkflowProjectId?.(workflowId);
+				if (!projectId) {
+					throw new Error(`Workflow ${workflowId} has no owning project`);
+				}
+				return projectId;
+			},
 			onGuardFired: args.onGuardFired,
 		},
 	);

--- a/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow-identity.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow-identity.ts
@@ -1,0 +1,307 @@
+/**
+ * Identity-enforcing wrapper for the sandbox submit-workflow tool.
+ *
+ * The builder sub-agent can emit multiple parallel submit-workflow calls within
+ * a single assistant turn. When the LLM drops `workflowId` on calls 2..N, each
+ * call takes the create branch and persists a duplicate row with the same name.
+ *
+ * This wrapper keys identity per resolved `filePath` and target `projectId`. The
+ * first call for a given path/project pair synchronously installs a deferred in
+ * the pending map before dispatching, so concurrent calls for the same target
+ * await the first result and inject the bound `workflowId` — forcing the update
+ * branch.
+ *
+ * The map is scoped to the builder-task closure: it dies with the task. No
+ * cross-module coordinator, eviction hook, or TTL sweep is required.
+ */
+
+import { Tool } from '@n8n/agents';
+
+import type { CredentialMap } from './resolve-credentials';
+import {
+	createSubmitWorkflowTool,
+	resolveSandboxWorkflowFilePath,
+	submitWorkflowInputSchema,
+	submitWorkflowOutputSchema,
+	type SubmitWorkflowAttempt,
+	type SubmitWorkflowInput,
+	type SubmitWorkflowOutput,
+} from './submit-workflow.tool';
+import type { InstanceAiContext } from '../../types';
+import {
+	MAX_PRE_SAVE_SUBMIT_FAILURES,
+	createRemediation,
+	terminalRemediationFromState,
+} from '../../workflow-loop/remediation';
+import type {
+	RemediationMetadata,
+	WorkflowLoopState,
+} from '../../workflow-loop/workflow-loop-state';
+import type { SandboxWorkspace } from '../../workspace/sandbox-fs';
+
+export type SubmitExecute = (input: SubmitWorkflowInput) => Promise<SubmitWorkflowOutput>;
+
+interface SubmitGuardOptions {
+	getWorkflowLoopState?: () => Promise<WorkflowLoopState | undefined>;
+	getTerminalRemediation?: () => RemediationMetadata | undefined;
+	currentRunId?: string;
+	onGuardFired?: (event: {
+		workflowId?: string;
+		category: RemediationMetadata['category'];
+		attemptCount?: number;
+		reason?: string;
+	}) => void;
+	onTerminalRemediation?: (remediation: RemediationMetadata) => void;
+}
+
+interface SubmitBudgetTracker {
+	recordAttempt(attempt: SubmitWorkflowAttempt): SubmitWorkflowAttempt;
+	applyToOutput(path: string, output: SubmitWorkflowOutput): SubmitWorkflowOutput;
+}
+
+export function createPreSaveBudgetTracker(): SubmitBudgetTracker {
+	const failuresByPath = new Map<string, number>();
+
+	function blockRemediation(attemptCount: number): RemediationMetadata {
+		return createRemediation({
+			category: 'blocked',
+			shouldEdit: false,
+			reason: 'pre_save_submit_budget_exhausted',
+			attemptCount,
+			remainingSubmitFixes: 0,
+			guidance:
+				'The workflow could not be saved after three submit attempts. Stop editing and explain the blocker to the user.',
+		});
+	}
+
+	return {
+		recordAttempt(attempt) {
+			if (attempt.success) {
+				failuresByPath.delete(attempt.filePath);
+				return attempt;
+			}
+
+			const attemptCount = (failuresByPath.get(attempt.filePath) ?? 0) + 1;
+			failuresByPath.set(attempt.filePath, attemptCount);
+			if (attemptCount < MAX_PRE_SAVE_SUBMIT_FAILURES) return attempt;
+
+			return {
+				...attempt,
+				remediation: blockRemediation(attemptCount),
+				errors: [
+					...(attempt.errors ?? []),
+					'Submit remediation budget exhausted for this workflow file.',
+				],
+			};
+		},
+
+		applyToOutput(path, output) {
+			if (output.success) return output;
+			const attemptCount = failuresByPath.get(path) ?? 0;
+			if (attemptCount < MAX_PRE_SAVE_SUBMIT_FAILURES) return output;
+			return {
+				...output,
+				remediation: blockRemediation(attemptCount),
+				errors: [
+					...(output.errors ?? []),
+					'Submit remediation budget exhausted for this workflow file.',
+				],
+			};
+		},
+	};
+}
+
+/**
+ * Wrap a submit-workflow `execute` with per-filePath/per-project identity enforcement.
+ *
+ * - First call for a given resolved path/project pair dispatches and populates the map on success.
+ * - Concurrent calls for the same target await the first result and inject the bound id.
+ * - On dispatch failure, the map entry is cleared and waiters see a failure result.
+ *
+ * Exposed separately from the tool factory so it can be unit-tested without
+ * constructing a tool or a sandbox workspace.
+ */
+function buildIdentityKey(resolvedPath: string, projectId: string | undefined): string {
+	return JSON.stringify([projectId ?? null, resolvedPath]);
+}
+
+export function wrapSubmitExecuteWithIdentity(
+	underlying: SubmitExecute,
+	resolvePath: (rawFilePath: string | undefined) => string,
+	options: SubmitGuardOptions & { budgetTracker?: SubmitBudgetTracker } = {},
+): SubmitExecute {
+	const pending = new Map<string, Promise<string>>();
+
+	function recordTerminalRemediation(
+		workflowId: string | undefined,
+		remediation: RemediationMetadata | undefined,
+	): void {
+		if (!remediation || remediation.shouldEdit) return;
+
+		options.onTerminalRemediation?.(remediation);
+		options.onGuardFired?.({
+			workflowId,
+			category: remediation.category,
+			attemptCount: remediation.attemptCount,
+			reason: remediation.reason,
+		});
+	}
+
+	function applyOutputGuards(
+		path: string,
+		output: SubmitWorkflowOutput,
+		fallbackWorkflowId?: string,
+	): SubmitWorkflowOutput {
+		const guarded = options.budgetTracker?.applyToOutput(path, output) ?? output;
+		recordTerminalRemediation(guarded.workflowId ?? fallbackWorkflowId, guarded.remediation);
+		return guarded;
+	}
+
+	async function blockedByTerminalRemediation(
+		workflowId: string | undefined,
+	): Promise<SubmitWorkflowOutput | undefined> {
+		const terminalRemediation =
+			options.getTerminalRemediation?.() ??
+			terminalRemediationFromState(await options.getWorkflowLoopState?.(), options.currentRunId);
+		if (!terminalRemediation) return undefined;
+
+		options.onTerminalRemediation?.(terminalRemediation);
+		options.onGuardFired?.({
+			workflowId,
+			category: terminalRemediation.category,
+			attemptCount: terminalRemediation.attemptCount,
+			reason: terminalRemediation.reason,
+		});
+		return {
+			success: false,
+			errors: [terminalRemediation.guidance],
+			remediation: terminalRemediation,
+		};
+	}
+
+	return async (input) => {
+		const resolvedPath = resolvePath(input.filePath);
+		const identityKey = buildIdentityKey(resolvedPath, input.projectId);
+		const terminalResult = await blockedByTerminalRemediation(input.workflowId);
+		if (terminalResult) return terminalResult;
+
+		const existing = pending.get(identityKey);
+
+		if (existing) {
+			let boundId: string;
+			try {
+				boundId = await existing;
+			} catch (error) {
+				const terminalAfterFailure = await blockedByTerminalRemediation(input.workflowId);
+				if (terminalAfterFailure) return terminalAfterFailure;
+
+				const message = error instanceof Error ? error.message : String(error);
+				return {
+					success: false,
+					errors: [`Previous submit-workflow for this file failed: ${message}`],
+					remediation: createRemediation({
+						category: 'code_fixable',
+						shouldEdit: true,
+						reason: 'previous_submit_failed',
+						guidance:
+							'The previous submit-workflow call for this file failed. Fix the workflow code and submit again.',
+					}),
+				};
+			}
+			const terminalAfterWait = await blockedByTerminalRemediation(boundId);
+			if (terminalAfterWait) return terminalAfterWait;
+
+			const result = await underlying({ ...input, workflowId: boundId });
+			return applyOutputGuards(resolvedPath, result, boundId);
+		}
+
+		let resolveFn: ((id: string) => void) | undefined;
+		let rejectFn: ((reason: unknown) => void) | undefined;
+		const promise = new Promise<string>((res, rej) => {
+			resolveFn = res;
+			rejectFn = rej;
+		});
+		// Swallow rejections on the stored promise so Node doesn't warn about
+		// unhandled rejections when no concurrent waiter happens to attach.
+		promise.catch(() => {});
+		pending.set(identityKey, promise);
+
+		try {
+			const result = await underlying(input);
+			const guarded = applyOutputGuards(resolvedPath, result, input.workflowId);
+			if (guarded.success && typeof guarded.workflowId === 'string') {
+				resolveFn?.(guarded.workflowId);
+			} else {
+				rejectFn?.(new Error(guarded.errors?.join(' ') ?? 'submit-workflow failed'));
+				pending.delete(identityKey);
+			}
+			return guarded;
+		} catch (error) {
+			rejectFn?.(error);
+			pending.delete(identityKey);
+			throw error;
+		}
+	};
+}
+
+export function withDefaultWorkflowFilePath(
+	input: SubmitWorkflowInput,
+	defaultFilePath: string | undefined,
+): SubmitWorkflowInput {
+	return defaultFilePath && !input.filePath ? { ...input, filePath: defaultFilePath } : input;
+}
+
+/**
+ * Build a submit-workflow tool wired with identity enforcement.
+ * Convenience factory used at the builder-agent callsite.
+ */
+export function createIdentityEnforcedSubmitWorkflowTool(args: {
+	context: InstanceAiContext;
+	workspace: SandboxWorkspace;
+	credentialMap?: CredentialMap;
+	onAttempt: (attempt: SubmitWorkflowAttempt) => Promise<void> | void;
+	root: string;
+	defaultFilePath?: string;
+	currentRunId?: string;
+	getWorkflowLoopState?: () => Promise<WorkflowLoopState | undefined>;
+	onGuardFired?: SubmitGuardOptions['onGuardFired'];
+}) {
+	const budgetTracker = createPreSaveBudgetTracker();
+	const underlying = createSubmitWorkflowTool(
+		args.context,
+		args.workspace,
+		args.credentialMap,
+		async (attempt) => {
+			await args.onAttempt(budgetTracker.recordAttempt(attempt));
+		},
+	);
+
+	const underlyingExecute = underlying.handler as SubmitExecute | undefined;
+	if (!underlyingExecute) {
+		throw new Error('createSubmitWorkflowTool returned a tool without a handler');
+	}
+
+	const wrappedExecute = wrapSubmitExecuteWithIdentity(
+		underlyingExecute,
+		(rawFilePath) =>
+			rawFilePath
+				? resolveSandboxWorkflowFilePath(rawFilePath, args.root)
+				: (args.defaultFilePath ?? resolveSandboxWorkflowFilePath(rawFilePath, args.root)),
+		{
+			budgetTracker,
+			currentRunId: args.currentRunId,
+			getWorkflowLoopState: args.getWorkflowLoopState,
+			onGuardFired: args.onGuardFired,
+		},
+	);
+
+	return new Tool('submit-workflow')
+		.description(underlying.description)
+		.input(submitWorkflowInputSchema)
+		.output(submitWorkflowOutputSchema)
+		.handler(
+			async (input) =>
+				await wrappedExecute(withDefaultWorkflowFilePath(input, args.defaultFilePath)),
+		)
+		.build();
+}

--- a/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow-identity.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow-identity.ts
@@ -192,7 +192,31 @@ export function wrapSubmitExecuteWithIdentity(
 
 	return async (input) => {
 		const resolvedPath = resolvePath(input.filePath);
-		const projectId = await resolveProjectId(input.projectId);
+		let projectId: string;
+		try {
+			// An explicit workflowId identifies an existing workflow. Resolving its
+			// project with workflow:create would reject valid update-only access.
+			projectId = input.workflowId
+				? (input.projectId ?? 'personal')
+				: await resolveProjectId(input.projectId);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return applyOutputGuards(
+				resolvedPath,
+				{
+					success: false,
+					errors: [`Could not resolve the target project: ${message}`],
+					remediation: createRemediation({
+						category: 'blocked',
+						shouldEdit: false,
+						reason: 'project_resolution_failed',
+						guidance:
+							'The target project could not be resolved. Stop editing and explain the project access blocker.',
+					}),
+				},
+				input.workflowId,
+			);
+		}
 		const identityKey = buildIdentityKey(resolvedPath, projectId);
 		const terminalResult = await blockedByTerminalRemediation(input.workflowId);
 		if (terminalResult) return terminalResult;
@@ -299,8 +323,10 @@ export function createIdentityEnforcedSubmitWorkflowTool(args: {
 			rawFilePath
 				? resolveSandboxWorkflowFilePath(rawFilePath, args.root)
 				: (args.defaultFilePath ?? resolveSandboxWorkflowFilePath(rawFilePath, args.root)),
-		(projectId) =>
-			args.context.workflowService.resolveCreateProjectId?.(projectId) ?? projectId ?? 'personal',
+		async (projectId) =>
+			(await args.context.workflowService.resolveCreateProjectId?.(projectId)) ??
+			projectId ??
+			'personal',
 		{
 			budgetTracker,
 			currentRunId: args.currentRunId,

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -172,6 +172,8 @@ export interface InstanceAiWorkflowService {
 	get(workflowId: string): Promise<WorkflowDetail>;
 	/** Get the workflow as the SDK's WorkflowJSON (full node data for generateWorkflowCode). */
 	getAsWorkflowJSON(workflowId: string): Promise<WorkflowJSON>;
+	/** Resolve the project used for workflow creation, defaulting to the user's personal project. */
+	resolveCreateProjectId?(projectId?: string): Promise<string>;
 	/** Create a workflow from SDK-produced WorkflowJSON (full NodeJSON with typeVersion, credentials, etc.). */
 	createFromWorkflowJSON(
 		json: WorkflowJSON,

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -348,6 +348,8 @@ export interface InstanceAiWorkflowService {
 	getWorkflowSnapshot(
 		workflowId: string,
 	): Promise<{ json: WorkflowJSON; versionId: string; updatedAt: number }>;
+	/** Resolve the project used for workflow creation, defaulting to the user's personal project. */
+	resolveCreateProjectId?(projectId?: string): Promise<string>;
 	/** Create a workflow from SDK-produced WorkflowJSON (full NodeJSON with typeVersion, credentials, etc.). */
 	createFromWorkflowJSON(
 		json: WorkflowJSON,

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -350,6 +350,8 @@ export interface InstanceAiWorkflowService {
 	): Promise<{ json: WorkflowJSON; versionId: string; updatedAt: number }>;
 	/** Resolve the project used for workflow creation, defaulting to the user's personal project. */
 	resolveCreateProjectId?(projectId?: string): Promise<string>;
+	/** Resolve the owning project for an existing workflow without requiring workflow:create. */
+	resolveWorkflowProjectId?(workflowId: string): Promise<string>;
 	/** Create a workflow from SDK-produced WorkflowJSON (full NodeJSON with typeVersion, credentials, etc.). */
 	createFromWorkflowJSON(
 		json: WorkflowJSON,

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -475,6 +475,10 @@ export class InstanceAiAdapterService {
 				return execution?.data?.resultData?.runData ?? null;
 			},
 
+			async resolveCreateProjectId(projectId?: string) {
+				return await resolveProjectId(['workflow:create'], projectId);
+			},
+
 			async createFromWorkflowJSON(
 				json: WorkflowJSON,
 				options?: { projectId?: string; markAsAiTemporary?: boolean },

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -871,6 +871,14 @@ export class InstanceAiAdapterService {
 				return await resolveProjectId(['workflow:create'], projectId);
 			},
 
+			async resolveWorkflowProjectId(workflowId: string) {
+				const project = await sharedWorkflowRepository.getWorkflowOwningProject(workflowId);
+				if (!project) {
+					throw new Error(`Workflow ${workflowId} has no owning project`);
+				}
+				return project.id;
+			},
+
 			async createFromWorkflowJSON(
 				json: WorkflowJSON,
 				options?: { projectId?: string; markAsAiTemporary?: boolean },

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -867,6 +867,10 @@ export class InstanceAiAdapterService {
 				return execution?.data?.resultData?.runData ?? null;
 			},
 
+			async resolveCreateProjectId(projectId?: string) {
+				return await resolveProjectId(['workflow:create'], projectId);
+			},
+
 			async createFromWorkflowJSON(
 				json: WorkflowJSON,
 				options?: { projectId?: string; markAsAiTemporary?: boolean },


### PR DESCRIPTION
## Summary

- include `projectId` in the submit-workflow identity key, alongside the resolved workflow `filePath`
- keep same-file/same-project submissions deduped into updates
- add a regression test showing same file path submissions to different projects get independent workflow IDs

## Tests

- `git diff --check`
- Attempted: `pnpm --filter @n8n/instance-ai test -- submit-workflow-identity.test.ts --runInBand` (local checkout has no installed `node_modules`, so `jest` is unavailable)
