### PR TITLE
fix(editor): Show Manage community-node link to admins, not just owners

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
@@ -863,7 +863,7 @@ function handleSelectAction(params: INodeParameters) {
 		<CommunityNodeFooter
 			v-if="openPanel === 'settings' && isCommunityNode"
 			:package-name="packageName"
-			:show-manage="useUsersStore().isInstanceOwner"
+			:show-manage="useUsersStore().isAdminOrOwner"
 		/>
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/NodesListPanel.vue
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/NodesListPanel.vue
@@ -46,7 +46,7 @@ const { pushViewStack, popViewStack, updateCurrentViewStack } = useViewStacks();
 const { setActiveItemIndex, attachKeydownEvent, detachKeydownEvent } = useKeyboardNavigation();
 const nodeCreatorStore = useNodeCreatorStore();
 
-const { isInstanceOwner } = useUsersStore();
+const { isAdminOrOwner } = useUsersStore();
 
 const activeViewStack = computed(() => useViewStacks().activeViewStack);
 
@@ -277,7 +277,7 @@ function onBackButton() {
 			<CommunityNodeFooter
 				v-if="communityNodeDetails && !isCommunityNodeActionsMode"
 				:package-name="communityNodeDetails.packageName"
-				:show-manage="communityNodeDetails.installed && isInstanceOwner"
+				:show-manage="communityNodeDetails.installed && isAdminOrOwner"
 			/>
 		</aside>
 	</Transition>


### PR DESCRIPTION
## Summary

Admin and owner have shared the `communityPackage:*` global scopes since 2023 (`GLOBAL_ADMIN_SCOPES = GLOBAL_OWNER_SCOPES.concat()`), and the `/settings/community-nodes` route is reachable for admins (guarded by `communityPackage:list|update`). PR #26296 aligned most of the community-node UI with this by swapping `isInstanceOwner` -> `isAdminOrOwner`, but two `CommunityNodeFooter` call sites still gated the **Manage** link on `isInstanceOwner`:

- `packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue`
- `packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/NodesListPanel.vue`

This PR brings both in line with the already-fixed sibling in `ActionsMode.vue:374`, so admins see the Manage link on community nodes (inside the NDV settings panel and the nodes-creator details panel) and can navigate to the community nodes settings page from there.

Verified locally:
- `pnpm typecheck` in `packages/frontend/editor-ui` passes
- `pnpm vitest run` on `NodeSettings.test.ts` and `NodesListPanel.test.ts` passes (13/13)
- `pnpm lint` on the two files is clean

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3279

Follow-up to #26296 (which addressed the sibling ticket NODE-4258).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included. <!-- No existing tests asserted on this `show-manage` gating; the change is a trivial getter swap covered by the existing passing tests. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`.


Made with [Cursor](https://cursor.com)