### PR TITLE
fix(editor): Refresh wallet balance when usage refresh is clicked

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/gateway/views/SettingsAiGatewayView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/gateway/views/SettingsAiGatewayView.test.ts
@@ -149,6 +149,20 @@ describe('SettingsAiGatewayView', () => {
 			await waitFor(() => expect(mockGetGatewayUsage).toHaveBeenCalledOnce());
 			expect(mockGetGatewayUsage).toHaveBeenCalledWith(expect.anything(), 0, 50);
 		});
+
+		it('should re-fetch wallet balance when refresh is clicked', async () => {
+			mockGetGatewayUsage.mockResolvedValue({ entries: MOCK_ENTRIES, total: 100 });
+			renderComponent();
+			await waitFor(() => expect(screen.getByText('gemini-pro')).toBeInTheDocument());
+			await waitFor(() => expect(screen.getByText('$42.00 remaining')).toBeInTheDocument());
+
+			mockGetGatewayWallet.mockClear();
+			mockGetGatewayWallet.mockResolvedValue({ balance: 35, budget: 100 });
+			await userEvent.click(screen.getByRole('button', { name: /refresh/i }));
+
+			await waitFor(() => expect(mockGetGatewayWallet).toHaveBeenCalledOnce());
+			await waitFor(() => expect(screen.getByText('$35.00 remaining')).toBeInTheDocument());
+		});
 	});
 
 	describe('loadMore()', () => {

--- a/packages/frontend/editor-ui/src/features/ai/gateway/views/SettingsAiGatewayView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/gateway/views/SettingsAiGatewayView.vue
@@ -119,7 +119,7 @@ async function load(): Promise<void> {
 }
 
 async function refresh(): Promise<void> {
-	await load();
+	await Promise.all([aiGatewayStore.fetchWallet(), load()]);
 }
 
 async function loadMore(): Promise<void> {
@@ -137,7 +137,7 @@ async function loadMore(): Promise<void> {
 
 onMounted(async () => {
 	documentTitle.set(i18n.baseText('settings.n8nConnect.title'));
-	await Promise.all([aiGatewayStore.fetchWallet(), load()]);
+	await refresh();
 });
 </script>
 


### PR DESCRIPTION
## Summary

The refresh button on the n8n Connect settings page only re-fetched the usage table but did not update the wallet balance badge in the header. Now clicking refresh also calls `fetchWallet()`, so the displayed balance stays current.

Also refactored `onMounted` to delegate to `refresh()` to avoid duplicating the fetch logic.

**How to test:**
1. Go to Settings → n8n Connect
2. Observe the balance badge in the header
3. Click the refresh button on the usage table
4. The balance badge should update to reflect the latest value from the API

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4891

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)