### PR TITLE
ci: Change token used for dist-tag updates

### DIFF
--- a/.github/workflows/release-publish-new-package.yml
+++ b/.github/workflows/release-publish-new-package.yml
@@ -47,7 +47,7 @@ jobs:
           echo "Package '$PACKAGE_NAME' does not exist on NPM yet. Proceeding with publish."
 
       - name: Configure NPM token
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_INITIAL_PUBLISH_TOKEN }}" > ~/.npmrc
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_DIST_TAG_AND_INITIAL_PUBLISH_TOKEN }}" > ~/.npmrc
 
       - name: Publish package
         working-directory: ${{ github.event.inputs.package-path }}

--- a/.github/workflows/release-set-stable-npm-packages-to-latest.yml
+++ b/.github/workflows/release-set-stable-npm-packages-to-latest.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Set npm packages to latest
         run: node ./.github/scripts/set-latest-for-monorepo-packages.mjs
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_DIST_TAG_AND_INITIAL_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Summary

Currently our automation to update the `latest` tag in npm packages during release fails due to it utilizing out `NPM_TOKEN` which doesn't have write access to the `@n8n` namespace. 

We already have another token for initial publications as `NPM_INITIAL_PUBLISH_TOKEN`

Consolidate this token for use in here too, and rename it to describe the use case as `NPM_DIST_TAG_AND_INITIAL_PUBLISH_TOKEN`

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/actions/runs/24876633231/job/72842041970


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
