### PR TITLE
fix(editor): Align Model and Sandbox visibility with edit permissions

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/SettingsInstanceAiView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/SettingsInstanceAiView.test.ts
@@ -176,6 +176,36 @@ describe('SettingsInstanceAiView', () => {
 		});
 	});
 
+	describe('section visibility — cloud managed (proxy disabled)', () => {
+		beforeEach(() => {
+			setModuleSettings(settingsStore, {
+				...defaultModuleSettings,
+				proxyEnabled: false,
+				cloudManaged: true,
+			});
+		});
+
+		it('hides Model section', () => {
+			const { container } = renderComponent();
+			expect(queryStub(container, 'ModelSection')).toBeNull();
+		});
+
+		it('hides Sandbox section', () => {
+			const { container } = renderComponent();
+			expect(queryStub(container, 'SandboxSection')).toBeNull();
+		});
+
+		it('hides Memory section', () => {
+			const { container } = renderComponent();
+			expect(queryStub(container, 'MemorySection')).toBeNull();
+		});
+
+		it('hides Advanced section', () => {
+			const { container } = renderComponent();
+			expect(queryStub(container, 'AdvancedSection')).toBeNull();
+		});
+	});
+
 	describe('section visibility — cloud managed', () => {
 		beforeEach(() => {
 			setModuleSettings(settingsStore, {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/views/SettingsInstanceAiView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/views/SettingsInstanceAiView.vue
@@ -189,14 +189,14 @@ function handlePermissionChange(key: keyof InstanceAiPermissions, value: Instanc
 					</div>
 				</template>
 
-				<div v-if="!store.isProxyEnabled" :class="$style.card">
+				<div v-if="!store.isProxyEnabled && !store.isCloudManaged" :class="$style.card">
 					<div :class="$style.sectionBlock">
 						<ModelSection />
 					</div>
 				</div>
 
 				<template v-if="isAdmin">
-					<div v-if="!store.isProxyEnabled" :class="$style.card">
+					<div v-if="!store.isProxyEnabled && !store.isCloudManaged" :class="$style.card">
 						<div :class="$style.sectionBlock">
 							<SandboxSection />
 						</div>


### PR DESCRIPTION
## Summary

In Settings → AI Assistant, the Model and Sandbox cards were visible and appeared editable on cloud-managed instances, but every save was rejected by the backend with `Cannot update cloud-managed fields: …`. The UI visibility gate only checked `isProxyEnabled`, while the server's edit rejection also covers `isCloudManaged` (see `CLOUD_MANAGED_ADMIN_FIELDS` / `CLOUD_MANAGED_PREFERENCE_FIELDS` in `instance-ai-settings.service.ts`).

This aligns the visibility gate for both sections with `MemorySection` / `AdvancedSection`, which already check both flags. After the fix, the sections render in the exact modes where the server will actually accept edits:

| Mode | `isProxyEnabled` | `isCloudManaged` | Model / Sandbox cards |
|---|---|---|---|
| Self-hosted | false | false | Shown, editable |
| Self-hosted + proxy | true | false | Hidden |
| n8n Cloud | false | true | Hidden *(was incorrectly shown)* |
| Cloud + proxy | true | true | Hidden |

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-118

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)