### PR TITLE
fix(core): Workflow import cli doesn't deregister crons for deactivated workflows (multi-main only)

### DIFF
--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -99,6 +99,12 @@ export abstract class BaseCommand<F = never> {
 
 		this.nodeTypes = Container.get(NodeTypes);
 
+		// Ensures that when a CLI command has a check for "instanceSettings.isMultiMainEnabled"
+		// that it reflects the configuration of the n8n instance running on the server.
+		const isMultiMainEnabled =
+			this.globalConfig.executions.mode === 'queue' && this.globalConfig.multiMainSetup.enabled;
+		this.instanceSettings.setMultiMainEnabled(isMultiMainEnabled);
+
 		await this.executionContextHookRegistry.init();
 		await Container.get(LoadNodesAndCredentials).init();
 


### PR DESCRIPTION
## Summary

This fix will only work for instances running in multi-main mode, since single instance n8n deployments have no redis to publish messages on.

### How does this fix work?

The `instanceSettings.isMultiMain` was never set for CLI commands, so its value will always be `false`, even on instances that are running in multi-main mode.

The "import:workflow" command implements a call to activeWorkflowManager.remove(workflow.id), which in turn publishes the "remove-triggers-and-pollers" command on the local redis. For single instance deplyoments, this cli command will keep having the bug where schedule triggers of imported workflows, that were deactivated as part of this import, will keep running for the disabled workflow.

#### Before

<img width="1116" height="906" alt="image" src="https://github.com/user-attachments/assets/0e6ebc76-e5d8-457d-a60c-86e231d7166a" />

#### After

<img width="1648" height="908" alt="image" src="https://github.com/user-attachments/assets/19d938a3-3652-4b06-94c1-ec0baa3e4ef7" />


### How to reproduce
For non-multi-main this is still going to be broken. So these steps describe how to reproduce it for multi-main.

- Works on any n8n version
- Build a local docker image: `pnpm run build:docker`
- Start n8n in multi-main mode: `pnpm --filter n8n-containers stack:multi-main`
- In that instance, create and activate a workflow that has a schedule trigger that runs every 10 seconds
- In a separate terminal, observe the logs of the main-1 container to see how the scheduled executions keep running every 10 seconds: `docker logs -f <your-container-id>`
- ssh into the main-1 container using `docker exec -it <your-container-id> sh`
- Run `n8n export:workflow --backup --output=backups/` (this will export the workflow you created above)
- Run `n8n import:workflow --separate --input=backups`

-> See that the workflow shows as "inactive" in the UI, but in the logs of your container, you can see that the cron trigger is still firing until you restart the instance completely.



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-478/bug-scheduled-workflow-continues-running-after-cli-import


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
