### PR TITLE
fix(nodes): replace silent catch blocks with explicit logging

### DIFF
--- a/packages/nodes-base/nodes/Google/CloudStorage/BucketDescription.ts
+++ b/packages/nodes-base/nodes/Google/CloudStorage/BucketDescription.ts
@@ -25,72 +25,128 @@ async function parseJSONBody(
 	if (body.acl) {
 		try {
 			body.acl = JSON.parse(body.acl as string);
-		} catch (error) {}
+		} catch (error) {
+			console.warn('Failed to parse Google Cloud Storage bucket ACL as JSON', {
+				error: error instanceof Error ? error.message : error,
+			});
+		}
 	}
 	if (body.billing) {
 		try {
 			body.billing = JSON.parse(body.billing as string);
-		} catch (error) {}
+		} catch (error) {
+			console.warn('Failed to parse Google Cloud Storage bucket billing as JSON', {
+				error: error instanceof Error ? error.message : error,
+			});
+		}
 	}
 	if (body.cors) {
 		try {
 			body.cors = JSON.parse(body.cors as string);
-		} catch (error) {}
+		} catch (error) {
+			console.warn('Failed to parse Google Cloud Storage bucket CORS as JSON', {
+				error: error instanceof Error ? error.message : error,
+			});
+		}
 	}
 	if (body.customPlacementConfig) {
 		try {
 			body.customPlacementConfig = JSON.parse(body.customPlacementConfig as string);
-		} catch (error) {}
+		} catch (error) {
+			console.warn('Failed to parse Google Cloud Storage bucket customPlacementConfig as JSON', {
+				error: error instanceof Error ? error.message : error,
+			});
+		}
 	}
 	if (body.dataLocations) {
 		try {
 			body.dataLocations = JSON.parse(body.dataLocations as string);
-		} catch (error) {}
+		} catch (error) {
+			console.warn('Failed to parse Google Cloud Storage bucket dataLocations as JSON', {
+				error: error instanceof Error ? error.message : error,
+			});
+		}
 	}
 	if (body.defaultObjectAcl) {
 		try {
 			body.defaultObjectAcl = JSON.parse(body.defaultObjectAcl as string);
-		} catch (error) {}
+		} catch (error) {
+			console.warn('Failed to parse Google Cloud Storage bucket defaultObjectAcl as JSON', {
+				error: error instanceof Error ? error.message : error,
+			});
+		}
 	}
 	if (body.encryption) {
 		try {
 			body.encryption = JSON.parse(body.encryption as string);
-		} catch (error) {}
+		} catch (error) {
+			console.warn('Failed to parse Google Cloud Storage bucket encryption as JSON', {
+				error: error instanceof Error ? error.message : error,
+			});
+		}
 	}
 	if (body.iamConfiguration) {
 		try {
 			body.iamConfiguration = JSON.parse(body.iamConfiguration as string);
-		} catch (error) {}
+		} catch (error) {
+			console.warn('Failed to parse Google Cloud Storage bucket iamConfiguration as JSON', {
+				error: error instanceof Error ? error.message : error,
+			});
+		}
 	}
 	if (body.labels) {
 		try {
 			body.labels = JSON.parse(body.labels as string);
-		} catch (error) {}
+		} catch (error) {
+			console.warn('Failed to parse Google Cloud Storage bucket labels as JSON', {
+				error: error instanceof Error ? error.message : error,
+			});
+		}
 	}
 	if (body.lifecycle) {
 		try {
 			body.lifecycle = JSON.parse(body.lifecycle as string);
-		} catch (error) {}
+		} catch (error) {
+			console.warn('Failed to parse Google Cloud Storage bucket lifecycle as JSON', {
+				error: error instanceof Error ? error.message : error,
+			});
+		}
 	}
 	if (body.logging) {
 		try {
 			body.logging = JSON.parse(body.logging as string);
-		} catch (error) {}
+		} catch (error) {
+			console.warn('Failed to parse Google Cloud Storage bucket logging as JSON', {
+				error: error instanceof Error ? error.message : error,
+			});
+		}
 	}
 	if (body.retentionPolicy) {
 		try {
 			body.retentionPolicy = JSON.parse(body.retentionPolicy as string);
-		} catch (error) {}
+		} catch (error) {
+			console.warn('Failed to parse Google Cloud Storage bucket retentionPolicy as JSON', {
+				error: error instanceof Error ? error.message : error,
+			});
+		}
 	}
 	if (body.versioning) {
 		try {
 			body.versioning = JSON.parse(body.versioning as string);
-		} catch (error) {}
+		} catch (error) {
+			console.warn('Failed to parse Google Cloud Storage bucket versioning as JSON', {
+				error: error instanceof Error ? error.message : error,
+			});
+		}
 	}
 	if (body.website) {
 		try {
 			body.website = JSON.parse(body.website as string);
-		} catch (error) {}
+		} catch (error) {
+			console.warn('Failed to parse Google Cloud Storage bucket website as JSON', {
+				error: error instanceof Error ? error.message : error,
+			});
+		}
 	}
 
 	requestOptions.body = Object.assign(requestOptions.body, body);

--- a/packages/nodes-base/nodes/Google/CloudStorage/ObjectDescription.ts
+++ b/packages/nodes-base/nodes/Google/CloudStorage/ObjectDescription.ts
@@ -134,12 +134,20 @@ export const objectOperations: INodeProperties[] = [
 								if (bodyData.acl) {
 									try {
 										bodyData.acl = JSON.parse(bodyData.acl as string);
-									} catch (error) {}
+									} catch (error) {
+										console.warn('Failed to parse Google Cloud Storage object ACL as JSON', {
+											error: error instanceof Error ? error.message : error,
+										});
+									}
 								}
 								if (bodyData.metadata) {
 									try {
 										bodyData.metadata = JSON.parse(bodyData.metadata as string);
-									} catch (error) {}
+									} catch (error) {
+										console.warn('Failed to parse Google Cloud Storage object metadata as JSON', {
+											error: error instanceof Error ? error.message : error,
+										});
+									}
 								}
 								metadata = Object.assign(metadata, bodyData);
 
@@ -357,12 +365,20 @@ export const objectOperations: INodeProperties[] = [
 								if (body.acl) {
 									try {
 										body.acl = JSON.parse(body.acl as string);
-									} catch (error) {}
+									} catch (error) {
+										console.warn('Failed to parse Google Cloud Storage object ACL as JSON', {
+											error: error instanceof Error ? error.message : error,
+										});
+									}
 								}
 								if (body.metadata) {
 									try {
 										body.metadata = JSON.parse(body.metadata as string);
-									} catch (error) {}
+									} catch (error) {
+										console.warn('Failed to parse Google Cloud Storage object metadata as JSON', {
+											error: error instanceof Error ? error.message : error,
+										});
+									}
 								}
 
 								// Merge in the options into the queryset and headers objects

--- a/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
@@ -588,7 +588,13 @@ export class GoogleSheet {
 				if (typeof updateValue === 'object') {
 					try {
 						updateValue = JSON.stringify(updateValue);
-					} catch (error) {}
+					} catch (error) {
+						// If stringify fails, keep the original object value
+						console.warn('Failed to stringify Google Sheets cell value:', {
+							columnName: name,
+							error: error instanceof Error ? error.message : error,
+						});
+					}
 				}
 				updateData.push({
 					range: `${decodedRange.name}!${columnToUpdate}${updateRowIndex}`,
@@ -635,7 +641,13 @@ export class GoogleSheet {
 				if (typeof updateValue === 'object') {
 					try {
 						updateValue = JSON.stringify(updateValue);
-					} catch (error) {}
+					} catch (error) {
+						// If stringify fails, keep the original object value
+						console.warn('Failed to stringify Google Sheets cell value by row:', {
+							columnName: name,
+							error: error instanceof Error ? error.message : error,
+						});
+					}
 				}
 				updateData.push({
 					range: `${decodedRange.name}!${columnToUpdate}${updateRowIndex}`,

--- a/packages/nodes-base/nodes/HttpRequest/shared/optimizeResponse.ts
+++ b/packages/nodes-base/nodes/HttpRequest/shared/optimizeResponse.ts
@@ -98,7 +98,12 @@ const textOptimizer = (
 		if (typeof response === 'object') {
 			try {
 				response = JSON.stringify(response, null, 2);
-			} catch (error) {}
+			} catch (error) {
+				// If JSON.stringify fails, the response will be validated as non-string below
+				console.debug('Failed to stringify response object:', {
+					error: error instanceof Error ? error.message : error,
+				});
+			}
 		}
 
 		if (typeof response !== 'string') {

--- a/packages/nodes-base/nodes/Jira/JiraTrigger.node.ts
+++ b/packages/nodes-base/nodes/Jira/JiraTrigger.node.ts
@@ -569,7 +569,11 @@ export class JiraTrigger implements INodeType {
 
 			try {
 				httpQueryAuth = await this.getCredentials<ICredentialDataDecryptedObject>('httpQueryAuth');
-			} catch (error) {}
+			} catch (error) {
+				this.logger.warn('Failed to retrieve httpQueryAuth credentials for Jira webhook', {
+					error: error instanceof Error ? error.message : error,
+				});
+			}
 
 			if (httpQueryAuth === undefined || !httpQueryAuth.name || !httpQueryAuth.value) {
 				response

--- a/packages/nodes-base/nodes/Kafka/utils.ts
+++ b/packages/nodes-base/nodes/Kafka/utils.ts
@@ -432,7 +432,10 @@ export async function runWithHeartbeat<T>(
 		timer = setInterval(async () => {
 			try {
 				await heartbeat();
-			} catch (error) {}
+			} catch (error) {
+				// Log heartbeat errors but don't interrupt the main task
+				console.warn('Kafka heartbeat failed:', error instanceof Error ? error.message : error);
+			}
 		}, intervalMs);
 
 		return await task;

--- a/packages/nodes-base/nodes/Postgres/PostgresTrigger.node.ts
+++ b/packages/nodes-base/nodes/Postgres/PostgresTrigger.node.ts
@@ -261,7 +261,12 @@ export class PostgresTrigger implements INodeType {
 			if (data.payload) {
 				try {
 					data.payload = JSON.parse(data.payload as string) as IDataObject;
-				} catch (error) {}
+				} catch (error) {
+					// If parsing fails, keep the raw string payload
+					this.logger.debug('Failed to parse Postgres notification payload as JSON, using raw string', {
+						error: error instanceof Error ? error.message : error,
+					});
+				}
 			}
 			this.emit([this.helpers.returnJsonArray([data])]);
 		};
@@ -348,7 +353,12 @@ export class PostgresTrigger implements INodeType {
 					if (data.payload) {
 						try {
 							data.payload = JSON.parse(data.payload as string) as IDataObject;
-						} catch (error) {}
+						} catch (error) {
+							// If parsing fails, keep the raw string payload
+							this.logger.debug('Failed to parse Postgres notification payload as JSON, using raw string', {
+								error: error instanceof Error ? error.message : error,
+							});
+						}
 					}
 
 					this.emit([this.helpers.returnJsonArray([data])]);

--- a/packages/nodes-base/nodes/Redis/RedisTrigger.node.ts
+++ b/packages/nodes-base/nodes/Redis/RedisTrigger.node.ts
@@ -92,7 +92,12 @@ export class RedisTrigger implements INodeType {
 			if (options.jsonParseBody) {
 				try {
 					message = JSON.parse(message);
-				} catch (error) {}
+				} catch (error) {
+					this.logger.debug('Could not parse Redis message as JSON, using raw string', {
+						channel,
+						error: error instanceof Error ? error.message : error,
+					});
+				}
 			}
 
 			const data = options.onlyMessage ? { message } : { channel, message };

--- a/packages/nodes-base/nodes/Redis/__tests__/RedisTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Redis/__tests__/RedisTrigger.node.test.ts
@@ -18,6 +18,7 @@ describe('Redis Trigger Node', () => {
 	const credentials = mock<ICredentialDataDecryptedObject>();
 	const triggerFunctions = mock<ITriggerFunctions>({
 		helpers: { returnJsonArray },
+		logger: { debug: jest.fn() },
 	});
 
 	beforeEach(() => {
@@ -115,6 +116,30 @@ describe('Redis Trigger Node', () => {
 		onMessage('{"testing": true}', channel);
 		expect(triggerFunctions.emit).toHaveBeenCalledWith([
 			[{ json: { message: { testing: true }, channel } }],
+		]);
+	});
+
+	it('should emit raw message and log debug when JSON parsing fails', async () => {
+		triggerFunctions.getMode.mockReturnValue('trigger');
+		triggerFunctions.getNodeParameter.calledWith('options').mockReturnValue({
+			jsonParseBody: true,
+		});
+
+		await new RedisTrigger().trigger.call(triggerFunctions);
+
+		const mockRedisClient = setupRedisClient(mock());
+		const onMessageCaptor = captor<(message: string, channel: string) => unknown>();
+		expect(mockRedisClient.pSubscribe).toHaveBeenCalledWith([channel], onMessageCaptor);
+
+		const onMessage = onMessageCaptor.value;
+		onMessage('not-valid-json', channel);
+
+		expect(triggerFunctions.logger.debug).toHaveBeenCalledWith(
+			'Could not parse Redis message as JSON, using raw string',
+			expect.objectContaining({ channel, error: expect.any(String) }),
+		);
+		expect(triggerFunctions.emit).toHaveBeenCalledWith([
+			[{ json: { message: 'not-valid-json', channel } }],
 		]);
 	});
 });

--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -263,7 +263,12 @@ export class Webhook extends Node {
 		if (nodeVersion > 1 && !req.body && !options.rawBody) {
 			try {
 				return await this.handleBinaryData(context, prepareOutput);
-			} catch (error) {}
+			} catch (error) {
+				// If binary data handling fails, continue with normal processing
+				console.debug('Failed to handle binary data in webhook, continuing with normal processing', {
+					error: error instanceof Error ? error.message : error,
+				});
+			}
 		}
 
 		if (options.rawBody && !req.rawBody) {


### PR DESCRIPTION
## Summary

Replaces silent `catch {}` blocks with explicit log calls across 10 node files.
All existing fallback behavior is preserved — no return paths or throws were changed.
This is a logging-only change that improves production observability and debuggability.

**Files changed:**
- `Google/CloudStorage/BucketDescription.ts` — warn on JSON parse failures for bucket fields (acl, billing, cors, labels, lifecycle, etc.)
- `Google/CloudStorage/ObjectDescription.ts` — warn on parse failures for acl/metadata fields
- `Google/Sheet/v2/helpers/GoogleSheet.ts` — warn when JSON.stringify fails on object values in update flows
- `HttpRequest/shared/optimizeResponse.ts` — debug log when stringify fails in textOptimizer
- `Jira/JiraTrigger.node.ts` — warn when httpQueryAuth credential lookup fails
- `Kafka/utils.ts` — warn on heartbeat failures in runWithHeartbeat (main task not interrupted)
- `Postgres/PostgresTrigger.node.ts` — debug log on JSON.parse payload failures, raw string fallback preserved
- `Redis/RedisTrigger.node.ts` — debug log on invalid JSON messages, raw message still emitted
- `Webhook/Webhook.node.ts` — debug log when handleBinaryData fails, normal processing continues

**To test:** trigger a parse failure in any of the affected nodes (e.g. pass invalid JSON to a Redis message body with jsonParseBody enabled) and confirm the log appears without any change in output behavior.

## Related Linear tickets, Github issues, and Community forum posts

N/A — proactive observability improvement, not tied to a specific bug report.

## Review / Merge checklist
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created. *(N/A — no user-facing behavior change)*
- [x] Tests included. *(Added logger mock + test case for Redis invalid JSON fallback in `RedisTrigger.node.test.ts`)*
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` *(not an urgent fix)*