### PR TITLE
feat(core): Add PATCH endpoint for data table column management

### DIFF
--- a/packages/@n8n/api-types/src/dto/data-table/update-data-table-column.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-table/update-data-table-column.dto.ts
@@ -2,13 +2,17 @@ import { z } from 'zod';
 
 import { dataTableColumnNameSchema } from '../../schemas/data-table.schema';
 
-export const updateDataTableColumnSchema = z
-	.object({
+const updateDataTableColumnIndexSchema = z.number().int().nonnegative();
+
+export const updateDataTableColumnSchema = z.union([
+	z.object({
+		name: dataTableColumnNameSchema,
+		index: updateDataTableColumnIndexSchema.optional(),
+	}),
+	z.object({
 		name: dataTableColumnNameSchema.optional(),
-		index: z.number().int().nonnegative().optional(),
-	})
-	.refine(({ name, index }) => name !== undefined || index !== undefined, {
-		message: 'At least one of name or index is required',
-	});
+		index: updateDataTableColumnIndexSchema,
+	}),
+]);
 
 export type UpdateDataTableColumnDto = z.infer<typeof updateDataTableColumnSchema>;

--- a/packages/@n8n/api-types/src/dto/data-table/update-data-table-column.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-table/update-data-table-column.dto.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+import { dataTableColumnNameSchema } from '../../schemas/data-table.schema';
+
+export const updateDataTableColumnSchema = z
+	.object({
+		name: dataTableColumnNameSchema.optional(),
+		index: z.number().int().nonnegative().optional(),
+	})
+	.refine(({ name, index }) => name !== undefined || index !== undefined, {
+		message: 'At least one of name or index is required',
+	});
+
+export type UpdateDataTableColumnDto = z.infer<typeof updateDataTableColumnSchema>;

--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -186,6 +186,10 @@ export { AddDataTableRowsDto } from './data-table/add-data-table-rows.dto';
 export { AddDataTableColumnDto } from './data-table/add-data-table-column.dto';
 export { MoveDataTableColumnDto } from './data-table/move-data-table-column.dto';
 export { RenameDataTableColumnDto } from './data-table/rename-data-table-column.dto';
+export {
+	updateDataTableColumnSchema,
+	type UpdateDataTableColumnDto,
+} from './data-table/update-data-table-column.dto';
 export { DownloadDataTableCsvQueryDto } from './data-table/download-data-table-csv-query.dto';
 export { ImportCsvToDataTableDto } from './data-table/import-csv-to-data-table.dto';
 

--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -86,7 +86,7 @@ export const API_KEY_RESOURCES = {
 	communityPackage: ['install', 'uninstall', 'update', 'list'] as const,
 	dataTable: ['create', 'read', 'update', 'delete', 'list'] as const,
 	dataTableRow: ['create', 'read', 'update', 'delete', 'upsert'] as const,
-	dataTableColumn: ['create', 'read', 'delete'] as const,
+	dataTableColumn: ['create', 'read', 'delete', 'update'] as const,
 	folder: ['create', 'delete', 'read', 'update', 'list'] as const,
 	insights: ['read'] as const,
 } as const;

--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -86,8 +86,8 @@ export const API_KEY_RESOURCES = {
 	communityPackage: ['install', 'uninstall', 'update', 'list'] as const,
 	dataTable: ['create', 'read', 'update', 'delete', 'list'] as const,
 	dataTableRow: ['create', 'read', 'update', 'delete', 'upsert'] as const,
-	folder: ['create', 'delete', 'read', 'update', 'list'] as const,
 	dataTableColumn: ['create', 'read', 'delete'] as const,
+	folder: ['create', 'delete', 'read', 'update', 'list'] as const,
 	insights: ['read'] as const,
 } as const;
 

--- a/packages/@n8n/permissions/src/public-api-permissions.ee.ts
+++ b/packages/@n8n/permissions/src/public-api-permissions.ee.ts
@@ -67,6 +67,7 @@ export const OWNER_API_KEY_SCOPES: ApiKeyScope[] = [
 	'folder:list',
 	'dataTableColumn:create',
 	'dataTableColumn:read',
+	'dataTableColumn:update',
 	'dataTableColumn:delete',
 	'insights:read',
 ];
@@ -116,6 +117,7 @@ export const MEMBER_API_KEY_SCOPES: ApiKeyScope[] = [
 	'folder:list',
 	'dataTableColumn:create',
 	'dataTableColumn:read',
+	'dataTableColumn:update',
 	'dataTableColumn:delete',
 	'insights:read',
 ];
@@ -162,6 +164,7 @@ export const API_KEY_SCOPES_FOR_IMPLICIT_PERSONAL_PROJECT: ApiKeyScope[] = [
 	'dataTableRow:upsert',
 	'dataTableColumn:create',
 	'dataTableColumn:read',
+	'dataTableColumn:update',
 	'dataTableColumn:delete',
 	'insights:read',
 ];

--- a/packages/cli/src/modules/data-table/data-table-column.repository.ts
+++ b/packages/cli/src/modules/data-table/data-table-column.repository.ts
@@ -12,6 +12,7 @@ import { DataTableColumn } from './data-table-column.entity';
 import { DataTableDDLService } from './data-table-ddl.service';
 import { DataTable } from './data-table.entity';
 import { DataTableColumnNameConflictError } from './errors/data-table-column-name-conflict.error';
+import { DataTableColumnNotFoundError } from './errors/data-table-column-not-found.error';
 import { DataTableSystemColumnNameConflictError } from './errors/data-table-system-column-name-conflict.error';
 import { DataTableValidationError } from './errors/data-table-validation.error';
 
@@ -70,6 +71,14 @@ export class DataTableColumnRepository extends Repository<DataTableColumn> {
 		// join order in @OneToMany relations.
 		columns.sort((a, b) => a.index - b.index);
 		return columns;
+	}
+
+	async getColumnByIdOrFail(dataTableId: string, columnId: string) {
+		const column = await this.findOneBy({ id: columnId, dataTableId });
+		if (!column) {
+			throw new DataTableColumnNotFoundError(dataTableId, columnId);
+		}
+		return column;
 	}
 
 	/**

--- a/packages/cli/src/modules/data-table/data-table.service.ts
+++ b/packages/cli/src/modules/data-table/data-table.service.ts
@@ -30,6 +30,9 @@ import type {
 } from 'n8n-workflow';
 import { DATA_TABLE_SYSTEM_COLUMN_TYPE_MAP, validateFieldType } from 'n8n-workflow';
 
+import { EventService } from '@/events/event.service';
+import { RoleService } from '@/services/role.service';
+
 import { DataTableColumn } from './data-table-column.entity';
 import { DataTableColumnRepository } from './data-table-column.repository';
 import { DataTableCsvImportService } from './data-table-csv-import.service';
@@ -42,9 +45,6 @@ import { DataTableNameConflictError } from './errors/data-table-name-conflict.er
 import { DataTableNotFoundError } from './errors/data-table-not-found.error';
 import { DataTableValidationError } from './errors/data-table-validation.error';
 import { normalizeRows } from './utils/sql-utils';
-
-import { EventService } from '@/events/event.service';
-import { RoleService } from '@/services/role.service';
 
 @Service()
 export class DataTableService {
@@ -258,6 +258,20 @@ export class DataTableService {
 		await this.validateDataTableExists(dataTableId, projectId);
 
 		return await this.dataTableColumnRepository.getColumns(dataTableId);
+	}
+
+	async getColumnById({
+		projectId,
+		dataTableId,
+		columnId,
+	}: {
+		projectId: string;
+		dataTableId: string;
+		columnId: string;
+	}) {
+		await this.validateDataTableExists(dataTableId, projectId);
+
+		return await this.dataTableColumnRepository.getColumnByIdOrFail(dataTableId, columnId);
 	}
 
 	async insertRows<T extends DataTableInsertRowsReturnType = 'count'>(

--- a/packages/cli/src/modules/data-table/data-table.service.ts
+++ b/packages/cli/src/modules/data-table/data-table.service.ts
@@ -65,6 +65,19 @@ export class DataTableService {
 	async start() {}
 	async shutdown() {}
 
+	async getProjectIdForDataTable(dataTableId: string): Promise<string> {
+		const dataTable = await this.dataTableRepository.findOne({
+			select: ['projectId'],
+			where: { id: dataTableId },
+		});
+
+		if (!dataTable) {
+			throw new DataTableNotFoundError(dataTableId);
+		}
+
+		return dataTable.projectId;
+	}
+
 	async createDataTable(projectId: string, dto: CreateDataTableDto) {
 		if (dto.fileId && dto.columns.length === 0) {
 			throw new DataTableValidationError(

--- a/packages/cli/src/public-api/types.ts
+++ b/packages/cli/src/public-api/types.ts
@@ -1,13 +1,14 @@
-import type { AuthenticatedRequest, TagEntity, WorkflowEntity } from '@n8n/db';
-import type { ExecutionStatus, ICredentialDataDecryptedObject } from 'n8n-workflow';
 import type {
 	AddDataTableColumnDto,
 	AddDataTableRowsDto,
 	PublicApiCreateDataTableDto,
 	UpdateDataTableDto,
+	UpdateDataTableColumnDto,
 	UpdateDataTableRowDto,
 	UpsertDataTableRowDto,
 } from '@n8n/api-types';
+import type { AuthenticatedRequest, TagEntity, WorkflowEntity } from '@n8n/db';
+import type { ExecutionStatus, ICredentialDataDecryptedObject } from 'n8n-workflow';
 
 import type { AuthlessRequest } from '@/requests';
 import type { Risk } from '@/security-audit/types';
@@ -306,6 +307,13 @@ export declare namespace DataTableRequest {
 	type CreateColumn = AuthenticatedRequest<{ dataTableId: string }, {}, AddDataTableColumnDto, {}>;
 
 	type DeleteColumn = AuthenticatedRequest<{ dataTableId: string; columnId: string }, {}, {}, {}>;
+
+	type UpdateColumn = AuthenticatedRequest<
+		{ dataTableId: string; columnId: string },
+		{},
+		UpdateDataTableColumnDto,
+		{}
+	>;
 }
 
 // ----------------------------------

--- a/packages/cli/src/public-api/v1/handlers/data-tables/__tests__/data-table-column-name.openapi.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/__tests__/data-table-column-name.openapi.test.ts
@@ -1,0 +1,28 @@
+import { DATA_TABLE_COLUMN_MAX_LENGTH, DATA_TABLE_COLUMN_REGEX } from '@n8n/api-types';
+import fs from 'fs';
+import path from 'path';
+import { parse } from 'yaml';
+import { z } from 'zod';
+
+describe('dataTableColumnName OpenAPI fragment', () => {
+	const columnNameYmlSchema = z.object({
+		minLength: z.number(),
+		maxLength: z.number(),
+		pattern: z.string(),
+	});
+
+	const expectedOpenApiColumnNameConstraints = {
+		minLength: 1,
+		maxLength: DATA_TABLE_COLUMN_MAX_LENGTH,
+		pattern: DATA_TABLE_COLUMN_REGEX.source,
+	} as const;
+
+	it('matches column name validation constants from @n8n/api-types', () => {
+		const ymlPath = path.join(__dirname, '../spec/schemas/dataTableColumnName.yml');
+		const doc = columnNameYmlSchema.parse(parse(fs.readFileSync(ymlPath, 'utf8')));
+
+		expect(doc.minLength).toBe(expectedOpenApiColumnNameConstraints.minLength);
+		expect(doc.maxLength).toBe(expectedOpenApiColumnNameConstraints.maxLength);
+		expect(doc.pattern).toBe(expectedOpenApiColumnNameConstraints.pattern);
+	});
+});

--- a/packages/cli/src/public-api/v1/handlers/data-tables/__tests__/data-tables.handler.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/__tests__/data-tables.handler.test.ts
@@ -6,9 +6,9 @@ import type { Response } from 'express';
 import { DataTableRepository } from '@/modules/data-table/data-table.repository';
 import { DataTableService } from '@/modules/data-table/data-table.service';
 import { DataTableNotFoundError } from '@/modules/data-table/errors/data-table-not-found.error';
-import { ProjectService } from '@/services/project.service.ee';
 import type { DataTableRequest } from '@/public-api/types';
 import * as middlewares from '@/public-api/v1/shared/middlewares/global.middleware';
+import { ProjectService } from '@/services/project.service.ee';
 
 // Mock middleware before requiring handler
 const mockMiddleware = jest.fn(async (_req, _res, next) => next()) as any;
@@ -42,32 +42,24 @@ describe('DataTable Handler', () => {
 
 		jest.spyOn(Container, 'get').mockImplementation((serviceClass) => {
 			if (serviceClass === DataTableService) {
-				return mockDataTableService as any;
+				return mockDataTableService;
 			}
 			if (serviceClass === DataTableRepository) {
-				return mockDataTableRepository as any;
+				return mockDataTableRepository;
 			}
 			if (serviceClass === ProjectRepository) {
-				return mockProjectRepository as any;
+				return mockProjectRepository;
 			}
 			if (serviceClass === ProjectRelationRepository) {
-				return mockProjectRelationRepository as any;
+				return mockProjectRelationRepository;
 			}
 			if (serviceClass === ProjectService) {
-				return mockProjectService as any;
+				return mockProjectService;
 			}
-			return {} as any;
+			return {};
 		});
 
-		mockDataTableRepository.findOne.mockResolvedValue({
-			id: dataTableId,
-			project: { id: projectId },
-		} as any);
-
-		mockProjectRepository.getPersonalProjectForUserOrFail.mockResolvedValue({
-			id: projectId,
-		} as any);
-
+		mockDataTableService.getProjectIdForDataTable.mockResolvedValue(projectId);
 		mockProjectRelationRepository.find.mockResolvedValue([]);
 
 		mockResponse = {
@@ -75,7 +67,9 @@ describe('DataTable Handler', () => {
 			status: jest.fn().mockReturnThis(),
 			send: jest.fn().mockReturnThis(),
 		};
+	});
 
+	afterEach(() => {
 		jest.clearAllMocks();
 	});
 
@@ -144,10 +138,7 @@ describe('DataTable Handler', () => {
 			await handler.getDataTableRows[3](req, mockResponse as Response);
 
 			// Assert
-			expect(mockDataTableRepository.findOne).toHaveBeenCalledWith({
-				where: { id: dataTableId },
-				relations: ['project'],
-			});
+			expect(mockDataTableService.getProjectIdForDataTable).toHaveBeenCalledWith(dataTableId);
 			expect(mockDataTableService.getManyRowsAndCount).toHaveBeenCalledWith(
 				dataTableId,
 				projectId,
@@ -204,7 +195,9 @@ describe('DataTable Handler', () => {
 				user: { id: userId },
 			} as unknown as DataTableRequest.GetRows;
 
-			mockDataTableRepository.findOne.mockRejectedValue(new DataTableNotFoundError(dataTableId));
+			mockDataTableService.getProjectIdForDataTable.mockRejectedValue(
+				new DataTableNotFoundError(dataTableId),
+			);
 
 			// Act
 			await handler.getDataTableRows[3](req, mockResponse as Response);
@@ -317,7 +310,9 @@ describe('DataTable Handler', () => {
 				user: { id: userId },
 			} as unknown as DataTableRequest.InsertRows;
 
-			mockDataTableRepository.findOne.mockRejectedValue(new DataTableNotFoundError(dataTableId));
+			mockDataTableService.getProjectIdForDataTable.mockRejectedValue(
+				new DataTableNotFoundError(dataTableId),
+			);
 
 			// Act
 			await handler.insertDataTableRows[2](req, mockResponse as Response);
@@ -616,8 +611,8 @@ describe('DataTable Handler', () => {
 				id: projectId,
 			} as any);
 
-			// But the data table belongs to another project, so getProjectIdForDataTable throws
-			mockDataTableRepository.findOne.mockRejectedValue(
+			// But the data table belongs to another project, so resolving project id throws
+			mockDataTableService.getProjectIdForDataTable.mockRejectedValue(
 				new DataTableNotFoundError(otherUserDataTableId),
 			);
 
@@ -625,10 +620,9 @@ describe('DataTable Handler', () => {
 			await handler.getDataTableRows[3](req, mockResponse as Response);
 
 			// Assert
-			expect(mockDataTableRepository.findOne).toHaveBeenCalledWith({
-				where: { id: otherUserDataTableId },
-				relations: ['project'],
-			});
+			expect(mockDataTableService.getProjectIdForDataTable).toHaveBeenCalledWith(
+				otherUserDataTableId,
+			);
 			expect(mockResponse.status).toHaveBeenCalledWith(404);
 			expect(mockResponse.json).toHaveBeenCalledWith({
 				message: expect.stringContaining(otherUserDataTableId),
@@ -776,7 +770,7 @@ describe('DataTable Handler', () => {
 				id: projectId,
 			} as any);
 
-			mockDataTableRepository.findOne.mockRejectedValue(
+			mockDataTableService.getProjectIdForDataTable.mockRejectedValue(
 				new DataTableNotFoundError(nonExistentDataTableId),
 			);
 

--- a/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.columns.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.columns.handler.ts
@@ -65,7 +65,7 @@ export = {
 	],
 
 	updateDataTableColumn: [
-		publicApiScope('dataTableColumn:create'),
+		publicApiScope('dataTableColumn:update'),
 		projectScope('dataTable:writeColumn', 'dataTable'),
 		async (req: DataTableRequest.UpdateColumn, res: express.Response) => {
 			try {

--- a/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.columns.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.columns.handler.ts
@@ -8,7 +8,6 @@ import { DataTableService } from '@/modules/data-table/data-table.service';
 import { DataTableColumnNameConflictError } from '@/modules/data-table/errors/data-table-column-name-conflict.error';
 import { DataTableSystemColumnNameConflictError } from '@/modules/data-table/errors/data-table-system-column-name-conflict.error';
 
-import { getProjectIdForDataTable } from './data-tables.service';
 import type { DataTableRequest } from '../../../types';
 import { projectScope, publicApiScope } from '../../shared/middlewares/global.middleware';
 
@@ -18,7 +17,7 @@ export = {
 		projectScope('dataTable:readColumn', 'dataTable'),
 		async (req: DataTableRequest.ListColumns, res: express.Response) => {
 			const { dataTableId } = req.params;
-			const projectId = await getProjectIdForDataTable(dataTableId);
+			const projectId = await Container.get(DataTableService).getProjectIdForDataTable(dataTableId);
 			return res.json(await Container.get(DataTableService).getColumns(dataTableId, projectId));
 		},
 	],
@@ -32,7 +31,7 @@ export = {
 			if (!payload.success) {
 				throw new BadRequestError(payload.error.errors[0]?.message);
 			}
-			const projectId = await getProjectIdForDataTable(dataTableId);
+			const projectId = await Container.get(DataTableService).getProjectIdForDataTable(dataTableId);
 
 			try {
 				const column = await Container.get(DataTableService).addColumn(
@@ -58,7 +57,7 @@ export = {
 		projectScope('dataTable:writeColumn', 'dataTable'),
 		async (req: DataTableRequest.DeleteColumn, res: express.Response) => {
 			const { dataTableId, columnId } = req.params;
-			const projectId = await getProjectIdForDataTable(dataTableId);
+			const projectId = await Container.get(DataTableService).getProjectIdForDataTable(dataTableId);
 			await Container.get(DataTableService).deleteColumn(dataTableId, projectId, columnId);
 			return res.status(204).send();
 		},
@@ -77,8 +76,8 @@ export = {
 
 				const { name, index } = payload.data;
 
-				const projectId = await getProjectIdForDataTable(dataTableId);
 				const service = Container.get(DataTableService);
+				const projectId = await service.getProjectIdForDataTable(dataTableId);
 
 				if (name !== undefined) {
 					await service.renameColumn(dataTableId, projectId, columnId, { name });

--- a/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.columns.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.columns.handler.ts
@@ -1,4 +1,4 @@
-import { AddDataTableColumnDto } from '@n8n/api-types';
+import { AddDataTableColumnDto, updateDataTableColumnSchema } from '@n8n/api-types';
 import { Container } from '@n8n/di';
 import type express from 'express';
 
@@ -61,6 +61,43 @@ export = {
 			const projectId = await getProjectIdForDataTable(dataTableId);
 			await Container.get(DataTableService).deleteColumn(dataTableId, projectId, columnId);
 			return res.status(204).send();
+		},
+	],
+
+	updateDataTableColumn: [
+		publicApiScope('dataTableColumn:create'),
+		projectScope('dataTable:writeColumn', 'dataTable'),
+		async (req: DataTableRequest.UpdateColumn, res: express.Response) => {
+			try {
+				const { dataTableId, columnId } = req.params;
+				const payload = updateDataTableColumnSchema.safeParse(req.body);
+				if (!payload.success) {
+					throw new BadRequestError(payload.error.errors[0]?.message);
+				}
+
+				const { name, index } = payload.data;
+
+				const projectId = await getProjectIdForDataTable(dataTableId);
+				const service = Container.get(DataTableService);
+
+				if (name !== undefined) {
+					await service.renameColumn(dataTableId, projectId, columnId, { name });
+				}
+				if (index !== undefined) {
+					await service.moveColumn(dataTableId, projectId, columnId, { targetIndex: index });
+				}
+
+				const updatedColumn = await service.getColumnById({ projectId, dataTableId, columnId });
+				return res.json(updatedColumn);
+			} catch (error) {
+				if (
+					error instanceof DataTableColumnNameConflictError ||
+					error instanceof DataTableSystemColumnNameConflictError
+				) {
+					throw new ConflictError(error.message);
+				}
+				throw error;
+			}
 		},
 	],
 };

--- a/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.handler.ts
@@ -3,10 +3,19 @@ import {
 	PublicApiCreateDataTableDto,
 	UpdateDataTableDto,
 } from '@n8n/api-types';
-import { DataTableRepository } from '@/modules/data-table/data-table.repository';
 import { Container } from '@n8n/di';
 import type express from 'express';
 
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { DataTableRepository } from '@/modules/data-table/data-table.repository';
+import { DataTableService } from '@/modules/data-table/data-table.service';
+import { DataTableNameConflictError } from '@/modules/data-table/errors/data-table-name-conflict.error';
+import { DataTableNotFoundError } from '@/modules/data-table/errors/data-table-not-found.error';
+import { DataTableValidationError } from '@/modules/data-table/errors/data-table-validation.error';
+import { ProjectService } from '@/services/project.service.ee';
+
+import { getDataTableListFilter, resolveProjectIdForCreate } from './data-tables.service';
 import type { DataTableRequest } from '../../../types';
 import {
 	publicApiScope,
@@ -14,18 +23,6 @@ import {
 	validCursor,
 } from '../../shared/middlewares/global.middleware';
 import { encodeNextCursor } from '../../shared/services/pagination.service';
-import { DataTableService } from '@/modules/data-table/data-table.service';
-import { DataTableNotFoundError } from '@/modules/data-table/errors/data-table-not-found.error';
-import { DataTableNameConflictError } from '@/modules/data-table/errors/data-table-name-conflict.error';
-import { DataTableValidationError } from '@/modules/data-table/errors/data-table-validation.error';
-import { BadRequestError } from '@/errors/response-errors/bad-request.error';
-import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
-import {
-	getProjectIdForDataTable,
-	getDataTableListFilter,
-	resolveProjectIdForCreate,
-} from './data-tables.service';
-import { ProjectService } from '@/services/project.service.ee';
 
 const handleError = (error: unknown, res: express.Response): express.Response => {
 	if (error instanceof DataTableNotFoundError) {
@@ -150,7 +147,8 @@ export = {
 			try {
 				const { dataTableId } = req.params;
 
-				const projectId = await getProjectIdForDataTable(dataTableId);
+				const projectId =
+					await Container.get(DataTableService).getProjectIdForDataTable(dataTableId);
 
 				const result = await Container.get(DataTableRepository).findOne({
 					where: { id: dataTableId, project: { id: projectId } },
@@ -184,7 +182,8 @@ export = {
 					});
 				}
 
-				const projectId = await getProjectIdForDataTable(dataTableId);
+				const projectId =
+					await Container.get(DataTableService).getProjectIdForDataTable(dataTableId);
 
 				await Container.get(DataTableService).updateDataTable(dataTableId, projectId, payload.data);
 
@@ -213,7 +212,8 @@ export = {
 			try {
 				const { dataTableId } = req.params;
 
-				const projectId = await getProjectIdForDataTable(dataTableId);
+				const projectId =
+					await Container.get(DataTableService).getProjectIdForDataTable(dataTableId);
 
 				await Container.get(DataTableService).deleteDataTable(dataTableId, projectId);
 

--- a/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.rows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.rows.handler.ts
@@ -5,9 +5,12 @@ import {
 	UpsertDataTableRowDto,
 	DeleteDataTableRowsDto,
 } from '@n8n/api-types';
-import { DataTableRepository } from '@/modules/data-table/data-table.repository';
 import { Container } from '@n8n/di';
 import type express from 'express';
+
+import { DataTableService } from '@/modules/data-table/data-table.service';
+import { DataTableNotFoundError } from '@/modules/data-table/errors/data-table-not-found.error';
+import { DataTableValidationError } from '@/modules/data-table/errors/data-table-validation.error';
 
 import type { DataTableRequest } from '../../../types';
 import {
@@ -16,9 +19,6 @@ import {
 	validCursor,
 } from '../../shared/middlewares/global.middleware';
 import { encodeNextCursor } from '../../shared/services/pagination.service';
-import { DataTableService } from '@/modules/data-table/data-table.service';
-import { DataTableNotFoundError } from '@/modules/data-table/errors/data-table-not-found.error';
-import { DataTableValidationError } from '@/modules/data-table/errors/data-table-validation.error';
 
 const handleError = (error: unknown, res: express.Response): express.Response => {
 	if (error instanceof DataTableNotFoundError) {
@@ -47,23 +47,6 @@ const stringifyQuery = (query: Record<string, unknown>): Record<string, string |
 	return result;
 };
 
-/**
- * Gets the project ID for a data table.
- * Called AFTER projectScope middleware has validated access.
- */
-const getProjectIdForDataTable = async (dataTableId: string): Promise<string> => {
-	const dataTable = await Container.get(DataTableRepository).findOne({
-		where: { id: dataTableId },
-		relations: ['project'],
-	});
-
-	if (!dataTable) {
-		throw new DataTableNotFoundError(dataTableId);
-	}
-
-	return dataTable.project.id;
-};
-
 export = {
 	getDataTableRows: [
 		publicApiScope('dataTableRow:read'),
@@ -82,7 +65,8 @@ export = {
 
 				const { offset, limit, filter, sortBy, search } = payload.data;
 
-				const projectId = await getProjectIdForDataTable(dataTableId);
+				const projectId =
+					await Container.get(DataTableService).getProjectIdForDataTable(dataTableId);
 
 				const result = await Container.get(DataTableService).getManyRowsAndCount(
 					dataTableId,
@@ -124,7 +108,8 @@ export = {
 					});
 				}
 
-				const projectId = await getProjectIdForDataTable(dataTableId);
+				const projectId =
+					await Container.get(DataTableService).getProjectIdForDataTable(dataTableId);
 
 				const result = await Container.get(DataTableService).insertRows(
 					dataTableId,
@@ -154,7 +139,8 @@ export = {
 					});
 				}
 
-				const projectId = await getProjectIdForDataTable(dataTableId);
+				const projectId =
+					await Container.get(DataTableService).getProjectIdForDataTable(dataTableId);
 				const service = Container.get(DataTableService);
 				const { filter, data, returnData = false, dryRun = false } = payload.data;
 				const params = { filter, data };
@@ -186,7 +172,8 @@ export = {
 					});
 				}
 
-				const projectId = await getProjectIdForDataTable(dataTableId);
+				const projectId =
+					await Container.get(DataTableService).getProjectIdForDataTable(dataTableId);
 				const service = Container.get(DataTableService);
 				const { filter, data, returnData = false, dryRun = false } = payload.data;
 				const params = { filter, data };
@@ -218,7 +205,8 @@ export = {
 					});
 				}
 
-				const projectId = await getProjectIdForDataTable(dataTableId);
+				const projectId =
+					await Container.get(DataTableService).getProjectIdForDataTable(dataTableId);
 				const service = Container.get(DataTableService);
 				const { filter, returnData = false, dryRun = false } = payload.data;
 				const params = { filter };

--- a/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.service.ts
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.service.ts
@@ -2,28 +2,9 @@ import { type DataTableListFilter } from '@n8n/api-types';
 import { ProjectRepository, ProjectRelationRepository, type User } from '@n8n/db';
 import { Container } from '@n8n/di';
 
-import { DataTableRepository } from '@/modules/data-table/data-table.repository';
-import { DataTableNotFoundError } from '@/modules/data-table/errors/data-table-not-found.error';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { ProjectService } from '@/services/project.service.ee';
-
-/**
- * Gets the project ID for a data table.
- * Called AFTER projectScope middleware has validated access.
- */
-export async function getProjectIdForDataTable(dataTableId: string): Promise<string> {
-	const dataTable = await Container.get(DataTableRepository).findOne({
-		where: { id: dataTableId },
-		select: ['projectId'],
-	});
-
-	if (!dataTable) {
-		throw new DataTableNotFoundError(dataTableId);
-	}
-
-	return dataTable.projectId;
-}
 
 export async function getDataTableListFilter(
 	userId: string,

--- a/packages/cli/src/public-api/v1/handlers/data-tables/spec/paths/data-tables.dataTableId.columns.columnId.yml
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/spec/paths/data-tables.dataTableId.columns.columnId.yml
@@ -18,3 +18,41 @@ delete:
       $ref: '../../../../shared/spec/responses/notFound.yml'
   security:
     - ApiKeyAuth: []
+
+patch:
+  x-eov-operation-id: updateDataTableColumn
+  x-eov-operation-handler: v1/handlers/data-tables/data-tables.columns.handler
+  tags:
+    - DataTable
+  summary: Update a column
+  description: Rename and/or reorder a column in a data table.
+  operationId: update-data-table-column
+  parameters:
+    - $ref: '../schemas/parameters/dataTableId.yml'
+    - $ref: '../schemas/parameters/columnId.yml'
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/updateColumnRequest.yml'
+        example:
+          name: 'email'
+          index: 1
+  responses:
+    '200':
+      description: Column updated successfully
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/dataTableColumn.yml'
+    '400':
+      $ref: '../../../../shared/spec/responses/badRequest.yml'
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
+    '404':
+      $ref: '../../../../shared/spec/responses/notFound.yml'
+    '409':
+      $ref: '../../../../shared/spec/responses/conflict.yml'
+  security:
+    - ApiKeyAuth: []

--- a/packages/cli/src/public-api/v1/handlers/data-tables/spec/schemas/createColumnRequest.yml
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/spec/schemas/createColumnRequest.yml
@@ -1,11 +1,7 @@
 type: object
 properties:
   name:
-    type: string
-    description: Column name
-    minLength: 1
-    maxLength: 63
-    pattern: '^[a-zA-Z][a-zA-Z0-9_]*$'
+    $ref: './dataTableColumnName.yml'
   type:
     type: string
     enum: [string, number, boolean, date]

--- a/packages/cli/src/public-api/v1/handlers/data-tables/spec/schemas/dataTableColumnName.yml
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/spec/schemas/dataTableColumnName.yml
@@ -1,0 +1,8 @@
+# minLength / maxLength / pattern guarded by data-table-column-name.openapi.test.ts (vs @n8n/api-types constants).
+type: string
+description: >-
+  Column name. Must start with a letter; only letters, digits, and underscores
+  after that; maximum 63 characters.
+minLength: 1
+maxLength: 63
+pattern: '^[a-zA-Z][a-zA-Z0-9_]*$'

--- a/packages/cli/src/public-api/v1/handlers/data-tables/spec/schemas/updateColumnRequest.yml
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/spec/schemas/updateColumnRequest.yml
@@ -1,0 +1,13 @@
+type: object
+properties:
+  name:
+    type: string
+    description: New column name
+  index:
+    type: integer
+    minimum: 0
+    description: New zero-based position for the column
+additionalProperties: false
+anyOf:
+  - required: [name]
+  - required: [index]

--- a/packages/cli/src/public-api/v1/handlers/data-tables/spec/schemas/updateColumnRequest.yml
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/spec/schemas/updateColumnRequest.yml
@@ -1,8 +1,7 @@
 type: object
 properties:
   name:
-    type: string
-    description: New column name
+    $ref: './dataTableColumnName.yml'
   index:
     type: integer
     minimum: 0

--- a/packages/cli/test/integration/public-api/data-tables.test.ts
+++ b/packages/cli/test/integration/public-api/data-tables.test.ts
@@ -2,6 +2,7 @@ import { testDb, createTeamProject, linkUserToProject } from '@n8n/backend-test-
 import type { Project, User } from '@n8n/db';
 import { ProjectRelationRepository, ProjectRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
+import { DATA_TABLE_SYSTEM_COLUMNS } from 'n8n-workflow';
 
 import type { DataTable } from '@/modules/data-table/data-table.entity';
 
@@ -1837,5 +1838,166 @@ describe('DELETE /data-tables/:dataTableId/columns/:columnId', () => {
 
 		const afterResponse = await authOwnerAgent.get(`/data-tables/${dataTable.id}/columns`);
 		expect(afterResponse.body).toHaveLength(1);
+	});
+});
+
+describe('PATCH /data-tables/:dataTableId/columns/:columnId', () => {
+	test(
+		'should fail due to missing API Key',
+		testWithAPIKey('patch', '/data-tables/123/columns/456', null),
+	);
+
+	test(
+		'should fail due to invalid API Key',
+		testWithAPIKey('patch', '/data-tables/123/columns/456', 'abcXYZ'),
+	);
+
+	test('should rename a column', async () => {
+		const dataTable = await createDataTable(ownerPersonalProject, {
+			name: 'rename-column-test',
+			columns: [{ name: 'old_name', type: 'string' }],
+		});
+
+		const columnsResponse = await authOwnerAgent.get(`/data-tables/${dataTable.id}/columns`);
+		const columnId = columnsResponse.body[0].id;
+
+		const response = await authOwnerAgent
+			.patch(`/data-tables/${dataTable.id}/columns/${columnId}`)
+			.send({
+				name: 'new_name',
+			});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body).toHaveProperty('id', columnId);
+		expect(response.body).toHaveProperty('name', 'new_name');
+		expect(response.body).toHaveProperty('index', 0);
+	});
+
+	test('should move a column', async () => {
+		const dataTable = await createDataTable(ownerPersonalProject, {
+			name: 'move-column-test',
+			columns: [
+				{ name: 'first', type: 'string' },
+				{ name: 'second', type: 'string' },
+				{ name: 'third', type: 'string' },
+			],
+		});
+
+		const columnsResponse = await authOwnerAgent.get(`/data-tables/${dataTable.id}/columns`);
+		const secondColumn = columnsResponse.body.find((column: any) => column.name === 'second');
+
+		const response = await authOwnerAgent
+			.patch(`/data-tables/${dataTable.id}/columns/${secondColumn.id}`)
+			.send({ index: 0 });
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body).toHaveProperty('id', secondColumn.id);
+		expect(response.body).toHaveProperty('name', 'second');
+		expect(response.body).toHaveProperty('index', 0);
+
+		const afterResponse = await authOwnerAgent.get(`/data-tables/${dataTable.id}/columns`);
+		expect(afterResponse.body[0]).toHaveProperty('id', secondColumn.id);
+	});
+
+	test('should rename and move a column in one request', async () => {
+		const dataTable = await createDataTable(ownerPersonalProject, {
+			name: 'rename-move-column-test',
+			columns: [
+				{ name: 'alpha', type: 'string' },
+				{ name: 'beta', type: 'string' },
+				{ name: 'gamma', type: 'string' },
+			],
+		});
+
+		const columnsResponse = await authOwnerAgent.get(`/data-tables/${dataTable.id}/columns`);
+		const betaColumn = columnsResponse.body.find((column: any) => column.name === 'beta');
+
+		const response = await authOwnerAgent
+			.patch(`/data-tables/${dataTable.id}/columns/${betaColumn.id}`)
+			.send({ name: 'beta_renamed', index: 2 });
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body).toHaveProperty('id', betaColumn.id);
+		expect(response.body).toHaveProperty('name', 'beta_renamed');
+		expect(response.body).toHaveProperty('index', 2);
+
+		const afterResponse = await authOwnerAgent.get(`/data-tables/${dataTable.id}/columns`);
+		expect(afterResponse.body[2]).toHaveProperty('id', betaColumn.id);
+		expect(afterResponse.body[2]).toHaveProperty('name', 'beta_renamed');
+	});
+
+	test('should fail when no update fields are provided', async () => {
+		const dataTable = await createDataTable(ownerPersonalProject, {
+			name: 'empty-patch-column-test',
+			columns: [{ name: 'name', type: 'string' }],
+		});
+
+		const columnsResponse = await authOwnerAgent.get(`/data-tables/${dataTable.id}/columns`);
+		const columnId = columnsResponse.body[0].id;
+
+		const response = await authOwnerAgent
+			.patch(`/data-tables/${dataTable.id}/columns/${columnId}`)
+			.send({});
+
+		expect(response.statusCode).toBe(400);
+		expect(response.body).toHaveProperty('message');
+	});
+
+	test('should fail with duplicate column name', async () => {
+		const dataTable = await createDataTable(ownerPersonalProject, {
+			name: 'duplicate-name-column-test',
+			columns: [
+				{ name: 'email', type: 'string' },
+				{ name: 'phone', type: 'string' },
+			],
+		});
+
+		const columnsResponse = await authOwnerAgent.get(`/data-tables/${dataTable.id}/columns`);
+		const phoneColumn = columnsResponse.body.find((column: any) => column.name === 'phone');
+
+		const response = await authOwnerAgent
+			.patch(`/data-tables/${dataTable.id}/columns/${phoneColumn.id}`)
+			.send({ name: 'email' });
+
+		expect(response.statusCode).toBe(409);
+		expect(response.body).toHaveProperty('message');
+	});
+
+	test.each(DATA_TABLE_SYSTEM_COLUMNS)(
+		'should fail with reserved system column name %s',
+		async (systemColumnName) => {
+			const dataTable = await createDataTable(ownerPersonalProject, {
+				name: `reserved-name-column-test-${systemColumnName}`,
+				columns: [{ name: 'custom_name', type: 'string' }],
+			});
+
+			const columnsResponse = await authOwnerAgent.get(`/data-tables/${dataTable.id}/columns`);
+			const columnId = columnsResponse.body[0].id;
+
+			const response = await authOwnerAgent
+				.patch(`/data-tables/${dataTable.id}/columns/${columnId}`)
+				.send({ name: systemColumnName });
+
+			expect(response.statusCode).toBe(409);
+			expect(response.body).toHaveProperty('message');
+		},
+	);
+
+	test('should return 403 when user does not have access', async () => {
+		const dataTable = await createDataTable(ownerPersonalProject, {
+			name: 'no-access-update-col',
+			columns: [{ name: 'col1', type: 'string' }],
+		});
+
+		const columnsResponse = await authOwnerAgent.get(`/data-tables/${dataTable.id}/columns`);
+		const columnId = columnsResponse.body[0].id;
+
+		const response = await authMemberAgent
+			.patch(`/data-tables/${dataTable.id}/columns/${columnId}`)
+			.send({
+				name: 'updated_by_member',
+			});
+
+		expect(response.statusCode).toBe(403);
 	});
 });

--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -205,6 +205,9 @@
 		"POST /data-tables/{dataTableId}/columns": {
 			"status": "gap"
 		},
+		"PATCH /data-tables/{dataTableId}/columns/{columnId}": {
+			"status": "gap"
+		},
 		"DELETE /data-tables/{dataTableId}/columns/{columnId}": {
 			"status": "gap"
 		},


### PR DESCRIPTION
## Summary

https://www.loom.com/share/8143c026f74b49658b632ac5ed5e1b26

Adds a `PATCH /data-tables/{dataTableId}/columns/{columnId}` public API endpoint that allows updating a data table column's name and/or position (index).

The endpoint supports partial updates — callers can rename a column, reorder it, or do both in a single request. It delegates to the existing internal `DataTableService` methods (`renameColumn`, `moveColumn`, `getColumnById`) and returns the updated column object.

**Also refactored:** `getProjectIdForDataTable` was duplicated between the public-API handler service and `DataTableService`. The standalone helper in `data-tables.service.ts` has been removed; all handlers (table, row, column) now call `DataTableService.getProjectIdForDataTable` directly, reducing duplication and keeping ownership of data-table DB access inside the core service.

**New files:**
- `packages/@n8n/api-types/src/dto/data-table/update-data-table-column.dto.ts` — Zod schema + inferred type for the request body
- `spec/schemas/updateColumnRequest.yml` — OpenAPI schema for `PATCH` request body
- `spec/paths/data-tables.dataTableId.columns.columnId.yml` (extended) — `PATCH` operation added alongside existing `DELETE`

**How to test:**

1. Rename only:
```bash
curl -sS -X PATCH "${N8N_URL:-http://localhost:5678}/api/v1/data-tables/DATA_TABLE_ID/columns/COLUMN_ID" \
  -H "X-N8N-API-KEY: $N8N_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"name":"new_column_name"}'
```

2. Reorder only (index):
```bash
curl -sS -X PATCH "${N8N_URL:-http://localhost:5678}/api/v1/data-tables/DATA_TABLE_ID/columns/COLUMN_ID" \
  -H "X-N8N-API-KEY: $N8N_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"index":1}'
```

3. Rename and reorder together:
```bash
curl -sS -X PATCH "${N8N_URL:-http://localhost:5678}/api/v1/data-tables/DATA_TABLE_ID/columns/COLUMN_ID" \
  -H "X-N8N-API-KEY: $N8N_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"name":"renamed_column","index":2}'
```

4. Verify column name conflicts return `409 Conflict`
5. Verify invalid payloads return `400 Bad Request`

Integration tests covering all PATCH scenarios are included in `packages/cli/test/integration/public-api/data-tables.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-477

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI