### PR TITLE
fix(core): Fix credential mocking in eval mode for multi-auth nodes (no-changelog)

### DIFF
--- a/packages/core/src/execution-engine/__tests__/eval-mock-helpers.test.ts
+++ b/packages/core/src/execution-engine/__tests__/eval-mock-helpers.test.ts
@@ -191,6 +191,14 @@ describe('eval-mock-helpers', () => {
 			expect(result.oauthTokenData).toBeDefined();
 			expect(result.privateKey).toBeDefined();
 		});
+
+		it('should produce structurally valid JSON for properties of type "json"', () => {
+			const result = buildEvalMockCredentials([
+				credProp({ name: 'json', type: 'json', default: '' }),
+			]);
+
+			expect(() => JSON.parse(result.json as string)).not.toThrow();
+		});
 	});
 
 	// -----------------------------------------------------------------------

--- a/packages/core/src/execution-engine/eval-mock-helpers.ts
+++ b/packages/core/src/execution-engine/eval-mock-helpers.ts
@@ -90,7 +90,11 @@ function toPlaceholder(name: string): string {
 export function buildEvalMockCredentials(properties: INodeProperties[]): Record<string, unknown> {
 	const mockCredentials: Record<string, unknown> = {};
 	for (const prop of properties) {
-		if (isSecretCredentialProperty(prop)) {
+		if (prop.type === 'json') {
+			// Nodes `jsonParse` these before the request — must be valid JSON.
+			mockCredentials[prop.name] =
+				typeof prop.default === 'string' && prop.default.trim() ? prop.default : '{}';
+		} else if (isSecretCredentialProperty(prop)) {
 			mockCredentials[prop.name] = toPlaceholder(prop.name);
 		} else {
 			mockCredentials[prop.name] = prop.default ?? toPlaceholder(prop.name);

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/node-execution-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/node-execution-context.test.ts
@@ -256,6 +256,31 @@ describe('NodeExecutionContext', () => {
 				undefined,
 			);
 		});
+
+		it('should not build mock credentials in eval mode when the node has other credentials configured but not the requested type', async () => {
+			const testNode = mock<INode>({ type: 'n8n-nodes-base.graphql' });
+			testNode.credentials = { httpHeaderAuth: { id: 'cred1', name: 'Header' } };
+
+			const getCredentialsProperties = jest
+				.fn()
+				.mockReturnValue([{ displayName: 'JSON', name: 'json', type: 'json', default: '' }]);
+			const evalAdditionalData = mock<IWorkflowExecuteAdditionalData>({
+				credentialsHelper: mock({ getCredentialsProperties }),
+				evalLlmMockHandler: jest.fn(),
+				webhookWaitingBaseUrl: 'http://localhost:5678/webhook-waiting',
+				formWaitingBaseUrl: 'http://localhost:5678/form-waiting',
+			});
+
+			const evalContext = new TestContext(workflow, testNode, evalAdditionalData, 'evaluation');
+
+			let resolved: unknown;
+			try {
+				resolved = await evalContext['_getCredentials']('httpCustomAuth');
+			} catch {
+				return;
+			}
+			expect(resolved).toBeUndefined();
+		});
 	});
 
 	describe('prepareOutputData', () => {

--- a/packages/core/src/execution-engine/node-execution-context/node-execution-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/node-execution-context.ts
@@ -305,15 +305,16 @@ export abstract class NodeExecutionContext implements Omit<FunctionsBase, 'getCr
 	): Promise<T> {
 		const { workflow, node, additionalData, mode, runExecutionData, runIndex } = this;
 
-		// Eval-mode bypass: when executing with LLM mock handler and node has no credentials
-		// configured, return mock credentials built from the credential type's property definitions.
-		// This allows the node to execute (build requests, parse responses) without real credentials.
-		// Triple-gated: evaluation mode + mock handler present + credentials actually missing.
+		// Eval-mode bypass: only mock when the node is fully unconfigured, so
+		// nodes that probe multiple auth types still get production's throw.
 		if (mode === 'evaluation' && additionalData.evalLlmMockHandler && !node.credentials?.[type]) {
-			const { buildEvalMockCredentials } = await import('../eval-mock-helpers');
-			return buildEvalMockCredentials(
-				additionalData.credentialsHelper.getCredentialsProperties(type),
-			) as T;
+			const hasOtherCreds = !!node.credentials && Object.keys(node.credentials).length > 0;
+			if (!hasOtherCreds) {
+				const { buildEvalMockCredentials } = await import('../eval-mock-helpers');
+				return buildEvalMockCredentials(
+					additionalData.credentialsHelper.getCredentialsProperties(type),
+				) as T;
+			}
 		}
 
 		// Get the NodeType as it has the information if the credentials are required


### PR DESCRIPTION
## Summary

Fixes two over-mocking bugs in the eval-mode credential helper that caused intermittent eval failures, observed on CI as the `Invalid Custom Auth JSON` error on the Linear Cross-Team scenarios:

- **Scope the bypass to fully unconfigured nodes.** Previously the mock fired for any missing credential type — even when the node had *other* credentials configured. Nodes that speculatively probe multiple auth types (GraphQL, HttpRequest V1/V2) ended up running against mocks instead of throwing like production does, causing unintended auth branches to execute.
- **Emit valid JSON for `type: 'json'` credential properties.** Nodes like `httpCustomAuth` `jsonParse` these fields before the request; a `<json>` placeholder crashed before the HTTP mock layer ran. Now returns `{}` (or the credential's non-empty default).

Linear: https://linear.app/n8n/issue/TRUST-51

## Test plan

- [x] Unit tests covering both failure modes in `eval-mock-helpers.test.ts` and `node-execution-context.test.ts` (failing pre-fix, passing post-fix)
- [x] Deterministic integration repro: GraphQL + `httpHeaderAuth` workflow hit via `/rest/instance-ai/eval/execute-with-llm-mock/:workflowId` — 5/5 `Invalid Custom Auth JSON` failures before → 5/5 pass after
- [x] Full eval suite N=3 shows no new error classes; pass-rate delta explained by agent non-determinism (Switch-empty-main, Phase 1 empty trigger content)
- [x] `pnpm test`, `pnpm typecheck`, `pnpm lint` in `packages/core` all clean
- [x] I have seen this code, I have run this code, and I take responsibility for this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)