### PR TITLE
fix(core): Pin Alpine version in Docker builder stages for reproducible builds

### DIFF
--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -3,7 +3,7 @@ ARG N8N_VERSION=snapshot
 
 # Rebuild native addons for the container platform. The base image has no
 # package manager or build tools, so we compile in a throwaway builder stage.
-FROM node:${NODE_VERSION}-alpine AS builder
+FROM node:${NODE_VERSION}-alpine3.22 AS builder
 COPY ./compiled /usr/local/lib/node_modules/n8n
 RUN apk add --no-cache python3 make g++ && \
     cd /usr/local/lib/node_modules/n8n && \

--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -4,7 +4,7 @@ ARG PYTHON_VERSION=3.13
 # ==============================================================================
 # STAGE 1: JavaScript runner (@n8n/task-runner) artifact from CI
 # ==============================================================================
-FROM node:${NODE_VERSION}-alpine AS javascript-runner-builder
+FROM node:${NODE_VERSION}-alpine3.22 AS javascript-runner-builder
 COPY ./dist/task-runner-javascript /app/task-runner-javascript
 
 WORKDIR /app/task-runner-javascript
@@ -108,7 +108,7 @@ RUN set -e; \
 # ==============================================================================
 # STAGE 4: Node alpine base for JS task runner
 # ==============================================================================
-FROM node:${NODE_VERSION}-alpine AS node-alpine
+FROM node:${NODE_VERSION}-alpine3.22 AS node-alpine
 
 # ==============================================================================
 # STAGE 5: Runtime


### PR DESCRIPTION
## Summary

Pin all Docker builder stages from the floating `node:${NODE_VERSION}-alpine` tag to `node:${NODE_VERSION}-alpine3.22`, matching the already-pinned base image (`n8n-base/Dockerfile`).

The floating `-alpine` tag rolled forward to Alpine 3.23, which ships gcc 15.2 — this segfaults when compiling `isolated-vm@6.0.2` during `npm rebuild`, breaking Docker image builds.

**Changes:**
- `docker/images/n8n/Dockerfile` — builder stage pinned to `alpine3.22`
- `docker/images/runners/Dockerfile` — JS runner builder and node-alpine stages pinned to `alpine3.22`

This also enables a clean rebuild that picks up fixes for CVE-2026-31789 (OpenSSL) and CVE-2026-41242 (protobufjs) from #29093.

## Related Linear tickets, Github issues, and Community forum posts

Fixes https://github.com/n8n-io/n8n/issues/28917
Related https://github.com/n8n-io/n8n/issues/29093

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)