### PR TITLE
fix(core): Surface pagination state in instance AI credentials list

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/__tests__/credentials.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/credentials.tool.test.ts
@@ -72,6 +72,7 @@ describe('credentials tool', () => {
 					{ id: '3', name: 'Notion Key', type: 'notionApi' },
 				],
 				total: 3,
+				hasMore: false,
 			});
 		});
 
@@ -107,6 +108,8 @@ describe('credentials tool', () => {
 					{ id: '4', name: 'Cred 4', type: 'testType' },
 				],
 				total: 10,
+				hasMore: true,
+				hint: expect.stringContaining('Showing 2 of 10'),
 			});
 		});
 
@@ -124,6 +127,97 @@ describe('credentials tool', () => {
 
 			expect((result as { credentials: unknown[] }).credentials).toHaveLength(50);
 			expect((result as { total: number }).total).toBe(60);
+		});
+
+		it('should filter by query (case-insensitive name substring)', async () => {
+			const credentials: CredentialSummary[] = [
+				{ id: '1', name: 'Slack Work', type: 'slackApi' },
+				{ id: '2', name: 'Slack Personal', type: 'slackApi' },
+				{ id: '3', name: 'Notion Key', type: 'notionApi' },
+			];
+			const context = createMockContext();
+			(context.credentialService.list as jest.Mock).mockResolvedValue(credentials);
+
+			const tool = createCredentialsTool(context);
+			const result = await tool.execute!(
+				{ action: 'list' as const, name: 'slack' },
+				noSuspendCtx(),
+			);
+
+			expect(result).toEqual({
+				credentials: [
+					{ id: '1', name: 'Slack Work', type: 'slackApi' },
+					{ id: '2', name: 'Slack Personal', type: 'slackApi' },
+				],
+				total: 2,
+				hasMore: false,
+			});
+		});
+
+		it('should find a named credential beyond the default limit when query is used', async () => {
+			const credentials: CredentialSummary[] = Array.from({ length: 60 }, (_, i) => ({
+				id: String(i),
+				name: i === 55 ? 'Production Notion' : `Cred ${i}`,
+				type: 'notionApi',
+			}));
+			const context = createMockContext();
+			(context.credentialService.list as jest.Mock).mockResolvedValue(credentials);
+
+			const tool = createCredentialsTool(context);
+			const result = await tool.execute!(
+				{ action: 'list' as const, name: 'production' },
+				noSuspendCtx(),
+			);
+
+			expect(result).toEqual({
+				credentials: [{ id: '55', name: 'Production Notion', type: 'notionApi' }],
+				total: 1,
+				hasMore: false,
+			});
+		});
+
+		it('should include a hint when the page is truncated and no narrowing filter was used', async () => {
+			const credentials: CredentialSummary[] = Array.from({ length: 60 }, (_, i) => ({
+				id: String(i),
+				name: `Cred ${i}`,
+				type: 'testType',
+			}));
+			const context = createMockContext();
+			(context.credentialService.list as jest.Mock).mockResolvedValue(credentials);
+
+			const tool = createCredentialsTool(context);
+			const result = (await tool.execute!({ action: 'list' as const }, noSuspendCtx())) as {
+				credentials: unknown[];
+				total: number;
+				hasMore: boolean;
+				hint?: string;
+			};
+
+			expect(result.total).toBe(60);
+			expect(result.hasMore).toBe(true);
+			expect(result.hint).toContain('Showing 50 of 60');
+			expect(result.hint).toContain('`name`');
+			expect(result.hint).toContain('`type`');
+			expect(result.hint).toContain('`offset`');
+		});
+
+		it('should not include a hint when a narrowing filter (type) was provided', async () => {
+			const credentials: CredentialSummary[] = Array.from({ length: 60 }, (_, i) => ({
+				id: String(i),
+				name: `Cred ${i}`,
+				type: 'slackApi',
+			}));
+			const context = createMockContext();
+			(context.credentialService.list as jest.Mock).mockResolvedValue(credentials);
+
+			const tool = createCredentialsTool(context);
+			const result = (await tool.execute!(
+				{ action: 'list' as const, type: 'slackApi' },
+				noSuspendCtx(),
+			)) as { hasMore: boolean; hint?: string };
+
+			expect(result.hasMore).toBe(true);
+			expect(result.hint).toBeUndefined();
 		});
 
 		it('should only return id, name, and type fields', async () => {

--- a/packages/@n8n/instance-ai/src/tools/credentials.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/credentials.tool.ts
@@ -32,8 +32,18 @@ const credentialIdField = z.string().describe('Credential ID');
 // ── Action schemas ─────────────────────────────────────────────────────────
 
 const listAction = z.object({
-	action: z.literal('list').describe('List credentials accessible to the current user'),
+	action: z
+		.literal('list')
+		.describe(
+			`List credentials accessible to the current user. Results are paginated (default ${DEFAULT_LIMIT}, max 200) and include \`total\` + \`hasMore\`; when looking up a user-named credential, pass \`name\` (substring) or \`type\` for targeted lookup instead of scanning the default page.`,
+		),
 	type: z.string().optional().describe('Filter by credential type (e.g. "notionApi")'),
+	name: z
+		.string()
+		.optional()
+		.describe(
+			'Filter by credential name (case-insensitive substring). Use for targeted lookup when the user named a specific credential — prefer this over paging through results.',
+		),
 	limit: z
 		.number()
 		.int()
@@ -159,14 +169,27 @@ async function handleList(context: InstanceAiContext, input: Extract<Input, { ac
 		type: input.type,
 	});
 
-	const total = allCredentials.length;
+	const filtered = input.name
+		? allCredentials.filter((c) => c.name.toLowerCase().includes(input.name!.toLowerCase()))
+		: allCredentials;
+
+	const total = filtered.length;
 	const offset = input.offset ?? 0;
 	const limit = input.limit ?? DEFAULT_LIMIT;
-	const page = allCredentials.slice(offset, offset + limit);
+	const page = filtered.slice(offset, offset + limit);
+	const hasMore = offset + page.length < total;
+
+	const truncatedWithoutNarrowing = hasMore && !input.name && !input.type;
 
 	return {
 		credentials: page.map(({ id, name, type }) => ({ id, name, type })),
 		total,
+		hasMore,
+		...(truncatedWithoutNarrowing
+			? {
+					hint: `Showing ${page.length} of ${total} credentials. Pass \`name\` (substring) or \`type\` to narrow the search before concluding a user-named credential doesn't exist, or use \`offset\` to paginate.`,
+				}
+			: {}),
 	};
 }
 


### PR DESCRIPTION
## Summary

Follow-up from [#29087](https://github.com/n8n-io/n8n/pull/29087) (reported inline by @r00gm). When a user had more than 50 credentials and asked the builder to use a specific one that happened to sit on page 2+ of `credentials(action="list")`, the agent saw a truncated page with no indication of additional entries and told the user the credential didn't exist.

The fix is tool-side (not prompt-side), so the guidance lives next to the behavior and the agent gets a dynamic signal on every call:

- `credentials(action="list")` now returns `hasMore` on every response and a `hint` when the page is truncated without a narrowing filter. The hint tells the agent to pass `name`/`type` or paginate with `offset` before concluding a user-named credential doesn't exist.
- Added a `name` substring filter for targeted lookup (case-insensitive). The `list` action's description advertises both `name` and `type` as the preferred path over scanning the default page.
- Unit tests cover: `hasMore` on default/paginated/query responses, the hint appearing when a page is truncated without narrowing, the hint staying absent when `type` is provided, and `name` finding a credential that sits past the default limit.

### How to test

1. Seed an instance with >50 credentials.
2. Ask the builder to build a workflow that uses a specific credential by name (one that would sit on page 2+).
3. Verify the agent narrows the search (using `name` or `type`) instead of concluding the credential doesn't exist.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-137

Related to https://linear.app/n8n/issue/INS-103 / #29087

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI