### PR TITLE
fix(GitHub Node): Return pagination token as string in resource locators

### DIFF
--- a/packages/nodes-base/nodes/Github/SearchFunctions.ts
+++ b/packages/nodes-base/nodes/Github/SearchFunctions.ts
@@ -61,7 +61,8 @@ export async function getUsers(
 		url: item.html_url,
 	}));
 
-	const nextPaginationToken = page * per_page < responseData.total_count ? page + 1 : undefined;
+	const nextPaginationToken =
+		page * per_page < responseData.total_count ? String(page + 1) : undefined;
 	return { results, paginationToken: nextPaginationToken };
 }
 
@@ -97,7 +98,8 @@ export async function getRepositories(
 		url: item.html_url,
 	}));
 
-	const nextPaginationToken = page * per_page < responseData.total_count ? page + 1 : undefined;
+	const nextPaginationToken =
+		page * per_page < responseData.total_count ? String(page + 1) : undefined;
 	return { results, paginationToken: nextPaginationToken };
 }
 
@@ -126,7 +128,8 @@ export async function getWorkflows(
 		value: workflow.id,
 	}));
 
-	const nextPaginationToken = page * per_page < responseData.total_count ? page + 1 : undefined;
+	const nextPaginationToken =
+		page * per_page < responseData.total_count ? String(page + 1) : undefined;
 	return { results, paginationToken: nextPaginationToken };
 }
 
@@ -177,6 +180,6 @@ export async function getRefs(
 		);
 		return { results: filteredRefs };
 	}
-	const nextPaginationToken = responseData.length === per_page ? page + 1 : undefined;
+	const nextPaginationToken = responseData.length === per_page ? String(page + 1) : undefined;
 	return { results: refs, paginationToken: nextPaginationToken };
 }

--- a/packages/nodes-base/nodes/Github/__tests__/SearchFunctions.test.ts
+++ b/packages/nodes-base/nodes/Github/__tests__/SearchFunctions.test.ts
@@ -73,7 +73,7 @@ describe('Search Functions', () => {
 					{ name: 'test-user-1', value: 'test-user-1', url: 'https://github.com/test-user-1' },
 					{ name: 'test-user-2', value: 'test-user-2', url: 'https://github.com/test-user-2' },
 				],
-				paginationToken: 2,
+				paginationToken: '2',
 			});
 		});
 
@@ -303,7 +303,7 @@ describe('Search Functions', () => {
 					{ name: 'workflow-1', value: '1' },
 					{ name: 'workflow-2', value: '2' },
 				],
-				paginationToken: 2,
+				paginationToken: '2',
 			});
 		});
 
@@ -333,7 +333,7 @@ describe('Search Functions', () => {
 					{ name: 'workflow-3', value: '3' },
 					{ name: 'workflow-4', value: '4' },
 				],
-				paginationToken: 2,
+				paginationToken: '2',
 			});
 
 			expect(mockLoadOptionsFunctions.helpers.requestWithAuthentication).toHaveBeenCalledWith(
@@ -492,7 +492,7 @@ describe('Search Functions', () => {
 
 			const result = await getRefs.call(mockLoadOptionsFunctions);
 
-			expect(result.paginationToken).toBe(2);
+			expect(result.paginationToken).toBe('2');
 			expect(result.results.length).toBe(100);
 		});
 	});


### PR DESCRIPTION
## Summary

The GitHub node's resource locator dropdowns (Ref, Repository, Owner, Workflow) failed to load with *"Could not load list — Expected string, received number"*. The four list search methods in `SearchFunctions.ts` returned `paginationToken` as a number (`page + 1`), but the backend validates the echoed token as `z.string().optional()`, so the next-page request was rejected by Zod and the dropdown rendered an error state. Stringifying the token restores loading across all four selectors. The existing unit tests that asserted numeric tokens are now strings and act as the regression guard.

**How to test:** Open a GitHub node with a valid credential, pick any operation that exposes the Ref/Repository/Workflow/Owner dropdowns, and confirm the list loads and pagination works.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4444

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI