### PR TITLE
fix(core): Fix InstanceSettings.isMultiMain still returning false for multi-main cli command

### DIFF
--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -99,12 +99,6 @@ export abstract class BaseCommand<F = never> {
 
 		this.nodeTypes = Container.get(NodeTypes);
 
-		// Ensures that when a CLI command has a check for "instanceSettings.isMultiMainEnabled"
-		// that it reflects the configuration of the n8n instance running on the server.
-		const isMultiMainEnabled =
-			this.globalConfig.executions.mode === 'queue' && this.globalConfig.multiMainSetup.enabled;
-		this.instanceSettings.setMultiMainEnabled(isMultiMainEnabled);
-
 		await this.executionContextHookRegistry.init();
 		await Container.get(LoadNodesAndCredentials).init();
 
@@ -143,6 +137,15 @@ export abstract class BaseCommand<F = never> {
 				'Scaling mode is not officially supported with sqlite. Please use PostgreSQL instead.',
 			);
 		}
+
+		// Ensures that when a CLI command has a check for "instanceSettings.isMultiMainEnabled"
+		// that it reflects the configuration of the n8n instance running on the server.
+		const isMultiMainEnabled =
+			this.globalConfig.executions.mode === 'queue' && this.globalConfig.multiMainSetup.enabled;
+		this.instanceSettings.setMultiMainEnabled(isMultiMainEnabled);
+		// We just set the licensed value to the configured value without checking the license
+		// because we're just in the realm of a cli command, the main instance already does the license checking.
+		this.instanceSettings.setMultiMainLicensed(isMultiMainEnabled);
 
 		// @TODO: Move to community-packages module
 		const communityPackagesConfig = Container.get(CommunityPackagesConfig);


### PR DESCRIPTION
## Summary

See https://github.com/n8n-io/n8n/pull/29079 for details.
During cleanup before creating that PR, an important part of the logic was removed, which is to also call `setMultiMainLicensed`, since `InstanceSettings.isMultiMain` implements a [dynamic getter](https://github.com/n8n-io/n8n/blob/master/packages/core/src/instance-settings/instance-settings.ts#L180) combining three class members

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-478/bug-scheduled-workflow-continues-running-after-cli-import


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
