### PR TITLE
fix(Telegram Trigger Node): Drop pending updates when creating a new webhook

### DIFF
--- a/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
+++ b/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
@@ -19,8 +19,8 @@ export class TelegramTrigger implements INodeType {
 		name: 'telegramTrigger',
 		icon: 'file:telegram.svg',
 		group: ['trigger'],
-		version: [1, 1.1, 1.2],
-		defaultVersion: 1.2,
+		version: [1, 1.1, 1.2, 1.3],
+		defaultVersion: 1.3,
 		subtitle: '=Updates: {{$parameter["updates"].join(", ")}}',
 		description: 'Starts the workflow on a Telegram update',
 		defaults: {
@@ -226,10 +226,13 @@ export class TelegramTrigger implements INodeType {
 
 				const secret_token = getSecretToken.call(this);
 
+				const drop_pending_updates = this.getNode().typeVersion >= 1.3;
+
 				const body = {
 					url: webhookUrl,
 					allowed_updates: allowedUpdates,
 					secret_token,
+					drop_pending_updates,
 				};
 
 				await apiRequest.call(this, 'POST', endpoint, body);

--- a/packages/nodes-base/nodes/Telegram/tests/TelegramTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/TelegramTrigger.node.test.ts
@@ -1,8 +1,9 @@
 import { mock } from 'jest-mock-extended';
-import { type INode, type Workflow } from 'n8n-workflow';
+import type { IHookFunctions, INode, Workflow } from 'n8n-workflow';
 
 import { testWebhookTriggerNode } from '@test/nodes/TriggerHelpers';
 
+import { apiRequest } from '../GenericFunctions';
 import { TelegramTrigger } from '../TelegramTrigger.node';
 
 jest.mock('../GenericFunctions', () => {
@@ -171,6 +172,48 @@ describe('TelegramTrigger', () => {
 			});
 
 			expect(responseData).toEqual({ workflowData: [[{ json: mockResult }]] });
+		});
+	});
+
+	describe('create', () => {
+		test('should set drop_pending_updates for version 1.3', async () => {
+			const telegramTrigger = new TelegramTrigger();
+			const mockHookFunctions = mock<IHookFunctions>({
+				getNodeWebhookUrl: jest.fn().mockReturnValue('https://example.com/webhook'),
+				getNodeParameter: jest.fn().mockReturnValue(['message']),
+				getNode: jest.fn().mockReturnValue({ id: '2', typeVersion: 1.3 }),
+				getWorkflow: jest.fn().mockReturnValue({ id: '1' }),
+			});
+
+			await telegramTrigger.webhookMethods.default.create.call(mockHookFunctions);
+
+			expect(jest.mocked(apiRequest)).toHaveBeenCalledWith(
+				'POST',
+				'setWebhook',
+				expect.objectContaining({
+					drop_pending_updates: true,
+				}),
+			);
+		});
+
+		test('should not set drop_pending_updates for version 1.2', async () => {
+			const telegramTrigger = new TelegramTrigger();
+			const mockHookFunctions = mock<IHookFunctions>({
+				getNodeWebhookUrl: jest.fn().mockReturnValue('https://example.com/webhook'),
+				getNodeParameter: jest.fn().mockReturnValue(['*']),
+				getNode: jest.fn().mockReturnValue({ id: '2', typeVersion: 1.2 }),
+				getWorkflow: jest.fn().mockReturnValue({ id: '1' }),
+			});
+
+			await telegramTrigger.webhookMethods.default.create.call(mockHookFunctions);
+
+			expect(jest.mocked(apiRequest)).toHaveBeenCalledWith(
+				'POST',
+				'setWebhook',
+				expect.objectContaining({
+					drop_pending_updates: false,
+				}),
+			);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

When running webhook-based triggers in test mode, webhook is deleted really quickly after receiving the first update. In a case with Telegram, this likely causes a race condition on Telegram's side: webhook is deleted before the update is marked as delivered. As a result, the same update may come on subsequent test executions

This PR fixes that by introducing a new node version (`1.3`) in which `drop_pending_updates: true` is passed when creating a webhook. This drops any updates that happened prior to webhook creation. It also means that workflow won't trigger for any updates that happened when there weren't any webhooks listening for updates, preventing a big number of updates hitting the workflow suddenly

Old version (`1.2`) doesn't drop pending updates for backwards compatibility

#### Demo

https://github.com/user-attachments/assets/ab565f76-d0fc-4638-91eb-06c2ed95676c


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-4838/community-issue-telegram-trigger-returns-stale-data-on-second-manual
Closes #28378 

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
