### PR TITLE
fix(core): Retry Phase 1 hint generation when triggerContent is empty (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-ai/eval/__tests__/workflow-analysis.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/workflow-analysis.test.ts
@@ -7,9 +7,17 @@ jest.mock('../node-config', () => ({
 	extractNodeConfig: jest.fn(),
 }));
 
+import { createEvalAgent, extractText } from '@n8n/instance-ai';
 import type { IConnections, INode, IWorkflowBase } from 'n8n-workflow';
 
-import { identifyNodesForHints, identifyNodesForPinData } from '../workflow-analysis';
+import {
+	generateMockHints,
+	identifyNodesForHints,
+	identifyNodesForPinData,
+} from '../workflow-analysis';
+
+const mockedCreateEvalAgent = jest.mocked(createEvalAgent);
+const mockedExtractText = jest.mocked(extractText);
 
 function makeNode(overrides: Partial<INode> & { name: string; type: string }): INode {
 	return {
@@ -218,5 +226,123 @@ describe('identifyNodesForHints', () => {
 		expect(names).not.toContain('OpenAI');
 		expect(names).not.toContain('Agent');
 		expect(names).not.toContain('Postgres');
+	});
+});
+
+describe('generateMockHints', () => {
+	const workflow = makeWorkflow([
+		makeNode({ name: 'Schedule', type: 'n8n-nodes-base.scheduleTrigger' }),
+		makeNode({ name: 'Slack', type: 'n8n-nodes-base.slack' }),
+	]);
+
+	function mockAgentResponses(...responses: Array<string | Error>) {
+		const generate = jest.fn();
+		for (const r of responses) {
+			if (r instanceof Error) generate.mockRejectedValueOnce(r);
+			else generate.mockResolvedValueOnce({ __raw: r });
+		}
+		mockedCreateEvalAgent.mockReturnValue({ generate } as unknown as ReturnType<
+			typeof createEvalAgent
+		>);
+		mockedExtractText.mockImplementation((result: unknown) => (result as { __raw: string }).__raw);
+		return generate;
+	}
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should succeed on the first attempt when the LLM returns a well-formed response', async () => {
+		const generate = mockAgentResponses(
+			JSON.stringify({
+				globalContext: 'shared context',
+				triggerContent: { timestamp: '2024-01-01T00:00:00Z' },
+				nodeHints: { Slack: 'post a message' },
+			}),
+		);
+
+		const result = await generateMockHints({ workflow, nodeNames: ['Schedule', 'Slack'] });
+
+		expect(generate).toHaveBeenCalledTimes(1);
+		expect(result.triggerContent).toEqual({ timestamp: '2024-01-01T00:00:00Z' });
+		expect(result.warnings).toEqual([]);
+	});
+
+	it('should retry when the first attempt returns empty triggerContent, then succeed', async () => {
+		const generate = mockAgentResponses(
+			JSON.stringify({ globalContext: '', triggerContent: {}, nodeHints: { Slack: 'foo' } }),
+			JSON.stringify({
+				globalContext: '',
+				triggerContent: { timestamp: '2024-01-01T00:00:00Z' },
+				nodeHints: { Slack: 'foo' },
+			}),
+		);
+
+		const result = await generateMockHints({ workflow, nodeNames: ['Schedule', 'Slack'] });
+
+		expect(generate).toHaveBeenCalledTimes(2);
+		expect(result.triggerContent).toEqual({ timestamp: '2024-01-01T00:00:00Z' });
+		expect(result.warnings).toEqual([
+			expect.stringContaining('Phase 1 attempt 1/2: empty triggerContent'),
+		]);
+	});
+
+	it('should return emptyResult with both warnings when every attempt fails', async () => {
+		const generate = mockAgentResponses(
+			JSON.stringify({ globalContext: '', triggerContent: {}, nodeHints: { Slack: 'foo' } }),
+			JSON.stringify({ globalContext: '', triggerContent: {}, nodeHints: { Slack: 'foo' } }),
+		);
+
+		const result = await generateMockHints({ workflow, nodeNames: ['Schedule', 'Slack'] });
+
+		expect(generate).toHaveBeenCalledTimes(2);
+		expect(result.triggerContent).toEqual({});
+		expect(result.warnings).toEqual([
+			expect.stringContaining('attempt 1/2'),
+			expect.stringContaining('attempt 2/2'),
+		]);
+	});
+
+	it('should retry when the first attempt throws, then succeed', async () => {
+		const generate = mockAgentResponses(
+			new Error('anthropic rate limit'),
+			JSON.stringify({
+				globalContext: '',
+				triggerContent: { timestamp: '2024-01-01T00:00:00Z' },
+				nodeHints: { Slack: 'foo' },
+			}),
+		);
+
+		const result = await generateMockHints({ workflow, nodeNames: ['Schedule', 'Slack'] });
+
+		expect(generate).toHaveBeenCalledTimes(2);
+		expect(result.triggerContent).toEqual({ timestamp: '2024-01-01T00:00:00Z' });
+		expect(result.warnings).toEqual([expect.stringContaining('anthropic rate limit')]);
+	});
+
+	it('should retry when the first attempt returns invalid nodeHints structure', async () => {
+		const generate = mockAgentResponses(
+			JSON.stringify({ globalContext: '', triggerContent: { a: 1 }, nodeHints: [] }),
+			JSON.stringify({
+				globalContext: '',
+				triggerContent: { a: 1 },
+				nodeHints: { Slack: 'foo' },
+			}),
+		);
+
+		const result = await generateMockHints({ workflow, nodeNames: ['Schedule', 'Slack'] });
+
+		expect(generate).toHaveBeenCalledTimes(2);
+		expect(result.warnings).toEqual([expect.stringContaining('invalid nodeHints')]);
+	});
+
+	it('should not call the agent when there are no hint-eligible nodes', async () => {
+		const generate = mockAgentResponses('should never be called');
+
+		const result = await generateMockHints({ workflow, nodeNames: [] });
+
+		expect(generate).not.toHaveBeenCalled();
+		expect(result.triggerContent).toEqual({});
+		expect(result.warnings).toEqual([]);
 	});
 });

--- a/packages/cli/src/modules/instance-ai/eval/workflow-analysis.ts
+++ b/packages/cli/src/modules/instance-ai/eval/workflow-analysis.ts
@@ -160,6 +160,7 @@ RULES:
    - For service-specific triggers (Gmail Trigger, Slack Trigger, etc.): match the service's real event/message output format
    - For schedule triggers: include timestamp fields
    - For manual triggers: include the fields that downstream nodes reference
+   - CRITICAL: triggerContent must NEVER be an empty object ({}). Even for scenarios that test empty payloads ("empty submission", "no data", "missing fields"), emit the trigger envelope with empty *nested* fields — an empty webhook is { headers: {}, query: {}, body: {} }, a schedule with no context is { timestamp: "..." }. The workflow cannot execute without trigger output.
    - CRITICAL: check what downstream nodes reference (e.g., $json.body.email, $json.subject, $json.text) and ensure those paths exist in triggerContent
 3. Create a "nodeHints" object with one entry per node. Each hint describes what data that specific node's API response should contain, referencing entities from the global context.
 4. Hints should describe the DATA CONTENT, not the API response format. The mock server already knows the API schema.
@@ -220,9 +221,12 @@ function buildUserPrompt(
 	return sections.join('\n');
 }
 
+const MAX_HINT_ATTEMPTS = 2;
+
 /**
- * Generate consistent mock hints for service nodes in a workflow.
- * One LLM call produces a global context, trigger data, and per-node hints.
+ * Generate consistent mock hints for service nodes in a workflow. One Sonnet
+ * call produces globalContext, triggerContent, and per-node hints — retried
+ * once if the LLM returns an empty triggerContent or any structural issue.
  */
 export async function generateMockHints(options: GenerateMockHintsOptions): Promise<MockHints> {
 	const { workflow, nodeNames, scenarioHints } = options;
@@ -237,72 +241,78 @@ export async function generateMockHints(options: GenerateMockHintsOptions): Prom
 	if (nodeNames.length === 0) return emptyResult;
 
 	const userPrompt = buildUserPrompt(workflow, nodeNames, scenarioHints);
+	const warnings: string[] = [];
 
-	try {
-		const agent = createEvalAgent('eval-hint-generator', {
-			instructions: SYSTEM_PROMPT,
-		});
+	for (let attempt = 1; attempt <= MAX_HINT_ATTEMPTS; attempt++) {
+		let reason = '';
+		try {
+			const agent = createEvalAgent('eval-hint-generator', {
+				instructions: SYSTEM_PROMPT,
+			});
 
-		const result = await agent.generate(userPrompt, {
-			providerOptions: { anthropic: { maxTokens: 4096 } },
-		});
+			const result = await agent.generate(userPrompt, {
+				providerOptions: { anthropic: { maxTokens: 4096 } },
+			});
 
-		let text: string = extractText(result);
+			const text = extractText(result)
+				.replace(/^```(?:json)?\s*\n?/i, '')
+				.replace(/\n?\s*```\s*$/i, '')
+				.trim();
 
-		text = text
-			.replace(/^```(?:json)?\s*\n?/i, '')
-			.replace(/\n?\s*```\s*$/i, '')
-			.trim();
+			const parsed: Record<string, unknown> = jsonParse(text);
 
-		const parsed: Record<string, unknown> = jsonParse(text);
+			// globalContext may come back as a string or object — normalize to string
+			let globalContext = '';
+			if (typeof parsed.globalContext === 'string') {
+				globalContext = parsed.globalContext;
+			} else if (typeof parsed.globalContext === 'object' && parsed.globalContext !== null) {
+				globalContext = JSON.stringify(parsed.globalContext);
+			}
 
-		// globalContext may come back as a string or object — normalize to string
-		let globalContext = '';
-		if (typeof parsed.globalContext === 'string') {
-			globalContext = parsed.globalContext;
-		} else if (typeof parsed.globalContext === 'object' && parsed.globalContext !== null) {
-			globalContext = JSON.stringify(parsed.globalContext);
+			if (
+				typeof parsed.nodeHints !== 'object' ||
+				parsed.nodeHints === null ||
+				Array.isArray(parsed.nodeHints)
+			) {
+				reason = `invalid nodeHints structure (raw: ${text.slice(0, 200)})`;
+			} else {
+				const triggerContent =
+					typeof parsed.triggerContent === 'object' &&
+					parsed.triggerContent !== null &&
+					!Array.isArray(parsed.triggerContent)
+						? parsed.triggerContent
+						: {};
+				if (Object.keys(triggerContent).length === 0) {
+					reason = 'empty triggerContent';
+				} else {
+					// Coerce nodeHints values to strings — LLM may return objects instead of strings
+					const nodeHints: Record<string, string> = {};
+					for (const [key, value] of Object.entries(parsed.nodeHints as Record<string, unknown>)) {
+						nodeHints[key] = typeof value === 'string' ? value : JSON.stringify(value);
+					}
+					return {
+						globalContext,
+						nodeHints,
+						triggerContent: triggerContent as Record<string, unknown>,
+						warnings,
+						bypassPinData: {},
+					};
+				}
+			}
+		} catch (error) {
+			reason = error instanceof Error ? error.message : String(error);
 		}
 
-		if (
-			typeof parsed.nodeHints !== 'object' ||
-			parsed.nodeHints === null ||
-			Array.isArray(parsed.nodeHints)
-		) {
-			const preview = text.slice(0, 300);
-			return {
-				...emptyResult,
-				warnings: [`Phase 1: LLM returned invalid structure. Raw: ${preview}`],
-			};
+		warnings.push(`Phase 1 attempt ${attempt}/${MAX_HINT_ATTEMPTS}: ${reason}`);
+		if (attempt < MAX_HINT_ATTEMPTS) {
+			Container.get(Logger).warn(
+				`[EvalMock] Phase 1 attempt ${attempt}/${MAX_HINT_ATTEMPTS} unusable (${reason}) — retrying`,
+			);
 		}
-
-		const warnings: string[] = [];
-		const triggerContent =
-			typeof parsed.triggerContent === 'object' &&
-			parsed.triggerContent !== null &&
-			!Array.isArray(parsed.triggerContent)
-				? parsed.triggerContent
-				: {};
-		if (Object.keys(triggerContent).length === 0) {
-			warnings.push('Phase 1: LLM returned empty triggerContent — trigger node will have no data');
-		}
-
-		// Coerce nodeHints values to strings — LLM may return objects instead of strings
-		const nodeHints: Record<string, string> = {};
-		for (const [key, value] of Object.entries(parsed.nodeHints as Record<string, unknown>)) {
-			nodeHints[key] = typeof value === 'string' ? value : JSON.stringify(value);
-		}
-
-		return {
-			globalContext,
-			nodeHints,
-			triggerContent: triggerContent as Record<string, unknown>,
-			warnings,
-			bypassPinData: {},
-		};
-	} catch (error) {
-		const errorMsg = error instanceof Error ? error.message : String(error);
-		Container.get(Logger).error(`[EvalMock] Phase 1 hint generation failed: ${errorMsg}`);
-		return { ...emptyResult, warnings: [`Phase 1 error: ${errorMsg}`] };
 	}
+
+	Container.get(Logger).error(
+		`[EvalMock] Phase 1 exhausted ${MAX_HINT_ATTEMPTS} attempts — ${warnings.join('; ')}`,
+	);
+	return { ...emptyResult, warnings };
 }


### PR DESCRIPTION
## Summary

Phase 1 of the eval mock pipeline generates `globalContext`, `triggerContent`, and per-node hints in a single Sonnet call. On schedule/cron-triggered workflows, the LLM occasionally reasons "a schedule trigger doesn't really produce data, it just fires" and returns `triggerContent: {}`. With no pin data on the start node, n8n refuses to execute the workflow (`"The workflow has issues and cannot be executed"`) — surfacing as `framework_issue` in the eval verifier.

- **Retry `generateMockHints` once** when the LLM returns empty `triggerContent`, invalid `nodeHints`, or throws. Matches the retry convention already in `mock-handler.ts` (`DEFAULT_MAX_RETRIES = 1`) and `checklist/verifier.ts` (`MAX_VERIFY_ATTEMPTS = 2`).
- **Sharpen the Phase 1 system prompt**: `triggerContent` must never be `{}` — even for empty-payload scenarios ("empty submission", "no data", "missing fields"), emit the trigger envelope with empty nested fields (`{ headers: {}, query: {}, body: {} }` for webhooks, `{ timestamp: "..." }` for schedules).

Linear: https://linear.app/n8n/issue/TRUST-62

## Test plan

- [x] Unit tests cover all four retry paths: empty `triggerContent` → retry, invalid `nodeHints` → retry, throw → retry, 2× failure → return emptyResult with both warnings.
- [x] Integration: targeted N=5 GitHub cohort (2 scenarios × 5 iterations) after the change — no new error classes, no `framework_issue` from empty triggerContent observed in ~10 runs. Retry code path did not fire in this sample (LLM produced valid `triggerContent` every time), but the unit tests cover its behavior.
- [x] `pnpm test` on `packages/cli` scoped to `workflow-analysis` — 16/16 tests pass.
- [x] I have seen this code, I have run this code, and I take responsibility for this code.

## Follow-ups

Sibling ticket [TRUST-63](https://linear.app/n8n/issue/TRUST-63/handle-langsmith-409-conflicts-on-tombstoned-example-uuids) tracks the LangSmith tombstone 409 — surfaced during this validation run, but orthogonal to Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)