### PR TITLE
fix(ai-builder): Stop tombstoning example UUIDs in LangSmith dataset sync (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/dataset-sync.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/dataset-sync.test.ts
@@ -1,0 +1,182 @@
+jest.mock('../data/workflows', () => ({
+	loadWorkflowTestCasesWithFiles: jest.fn(),
+}));
+
+import type { Client } from 'langsmith';
+import type { Example } from 'langsmith/schemas';
+
+import { loadWorkflowTestCasesWithFiles } from '../data/workflows';
+import type { EvalLogger } from '../harness/logger';
+import { syncDataset } from '../langsmith/dataset-sync';
+
+const mockedLoad = jest.mocked(loadWorkflowTestCasesWithFiles);
+
+function scenarioFixture(testCaseFile: string, scenarioName: string) {
+	return {
+		testCase: {
+			prompt: `prompt for ${testCaseFile}`,
+			complexity: 'medium' as const,
+			tags: ['test'],
+			triggerType: 'manual' as const,
+			scenarios: [
+				{
+					name: scenarioName,
+					description: `desc for ${scenarioName}`,
+					dataSetup: `setup for ${scenarioName}`,
+					successCriteria: `criteria for ${scenarioName}`,
+				},
+			],
+		},
+		fileSlug: testCaseFile,
+	};
+}
+
+function existingExample(id: string, testCaseFile: string, scenarioName: string): Example {
+	return {
+		id,
+		dataset_id: 'dataset-1',
+		created_at: '2024-01-01',
+		modified_at: '2024-01-01',
+		inputs: {
+			prompt: `prompt for ${testCaseFile}`,
+			testCaseFile,
+			scenarioName,
+			scenarioDescription: `desc for ${scenarioName}`,
+			dataSetup: `setup for ${scenarioName}`,
+			successCriteria: `criteria for ${scenarioName}`,
+		},
+		metadata: {
+			testCaseFile,
+			complexity: 'medium',
+			tags: ['test'],
+			triggerType: 'manual',
+		},
+		outputs: {},
+		runs: [],
+	} as unknown as Example;
+}
+
+type UpsertArg = Array<{ id: string; inputs: Record<string, unknown> }>;
+
+function buildClient(existing: Example[] = []): {
+	client: Client;
+	createExamples: jest.Mock<Promise<void>, [UpsertArg]>;
+	updateExamples: jest.Mock<Promise<void>, [UpsertArg]>;
+	deleteExamples: jest.Mock<Promise<void>, [string[]]>;
+} {
+	const createExamples = jest.fn<Promise<void>, [UpsertArg]>().mockResolvedValue(undefined);
+	const updateExamples = jest.fn<Promise<void>, [UpsertArg]>().mockResolvedValue(undefined);
+	const deleteExamples = jest.fn<Promise<void>, [string[]]>().mockResolvedValue(undefined);
+
+	async function* listExamples() {
+		await Promise.resolve();
+		for (const ex of existing) yield ex;
+	}
+
+	const client = {
+		hasDataset: jest.fn().mockResolvedValue(true),
+		readDataset: jest.fn().mockResolvedValue({ id: 'dataset-1' }),
+		createDataset: jest.fn(),
+		listExamples: jest.fn().mockImplementation(listExamples),
+		createExamples,
+		updateExamples,
+		deleteExamples,
+	} as unknown as Client;
+
+	return { client, createExamples, updateExamples, deleteExamples };
+}
+
+const logger: EvalLogger = {
+	info: jest.fn(),
+	warn: jest.fn(),
+	error: jest.fn(),
+	verbose: jest.fn(),
+} as unknown as EvalLogger;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+describe('syncDataset', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('creates new examples with random UUIDs when they are not already in the dataset', async () => {
+		mockedLoad.mockReturnValue([scenarioFixture('foo', 'happy-path')]);
+		const { client, createExamples, updateExamples, deleteExamples } = buildClient([]);
+
+		await syncDataset(client, 'ds', logger);
+
+		expect(createExamples).toHaveBeenCalledTimes(1);
+		expect(updateExamples).not.toHaveBeenCalled();
+		expect(deleteExamples).not.toHaveBeenCalled();
+
+		const created = createExamples.mock.calls[0][0];
+		expect(created).toHaveLength(1);
+		expect(created[0].id).toMatch(UUID_RE);
+		expect(created[0].inputs).toMatchObject({ testCaseFile: 'foo', scenarioName: 'happy-path' });
+	});
+
+	it('updates existing examples in place when inputs change, preserving the existing UUID', async () => {
+		const existingId = '11111111-2222-3333-4444-555555555555';
+		const existing = existingExample(existingId, 'foo', 'happy-path');
+		// Drift the existing inputs so diffing reports a change
+		(existing.inputs as { successCriteria: string }).successCriteria = 'old criteria';
+
+		mockedLoad.mockReturnValue([scenarioFixture('foo', 'happy-path')]);
+		const { client, createExamples, updateExamples, deleteExamples } = buildClient([existing]);
+
+		await syncDataset(client, 'ds', logger);
+
+		expect(createExamples).not.toHaveBeenCalled();
+		expect(deleteExamples).not.toHaveBeenCalled();
+		expect(updateExamples).toHaveBeenCalledTimes(1);
+
+		const updated = updateExamples.mock.calls[0][0];
+		expect(updated[0].id).toBe(existingId);
+	});
+
+	it('never calls deleteExamples, even when a previously-synced scenario is no longer in the filesystem', async () => {
+		const orphan = existingExample('orphan-uuid', 'gone-file', 'gone-scenario');
+		mockedLoad.mockReturnValue([scenarioFixture('foo', 'happy-path')]);
+		const { client, deleteExamples, createExamples } = buildClient([orphan]);
+
+		await syncDataset(client, 'ds', logger);
+
+		expect(deleteExamples).not.toHaveBeenCalled();
+		// The present scenario should still be created
+		expect(createExamples).toHaveBeenCalledTimes(1);
+	});
+
+	it('is a no-op when every current scenario matches an existing example', async () => {
+		const existing = existingExample('stable-uuid', 'foo', 'happy-path');
+		mockedLoad.mockReturnValue([scenarioFixture('foo', 'happy-path')]);
+		const { client, createExamples, updateExamples, deleteExamples } = buildClient([existing]);
+
+		await syncDataset(client, 'ds', logger);
+
+		expect(createExamples).not.toHaveBeenCalled();
+		expect(updateExamples).not.toHaveBeenCalled();
+		expect(deleteExamples).not.toHaveBeenCalled();
+	});
+
+	it('creates a fresh example when a previously-deleted scenario is re-added (resurrection path)', async () => {
+		// Scenario was removed from the filesystem between earlier runs, so LangSmith
+		// has no example for it now. Running the sync after re-adding the file must
+		// create a fresh example with a new random UUID — no 409 possible.
+		mockedLoad.mockReturnValue([scenarioFixture('foo', 'happy-path')]);
+		const { client, createExamples } = buildClient([]);
+
+		await syncDataset(client, 'ds', logger);
+
+		expect(createExamples).toHaveBeenCalledTimes(1);
+		const firstId = createExamples.mock.calls[0][0][0].id;
+		expect(firstId).toMatch(UUID_RE);
+
+		// A second pass (simulating the next run after the example persists) should
+		// find-by-inputs and not re-create.
+		const survivor = existingExample(firstId, 'foo', 'happy-path');
+		const second = buildClient([survivor]);
+		await syncDataset(second.client, 'ds', logger);
+		expect(second.createExamples).not.toHaveBeenCalled();
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/langsmith/dataset-sync.ts
+++ b/packages/@n8n/instance-ai/evaluations/langsmith/dataset-sync.ts
@@ -1,39 +1,20 @@
 // ---------------------------------------------------------------------------
 // LangSmith dataset sync
 //
-// Syncs JSON test case files from the repo to a LangSmith dataset.
-// Uses derived IDs (fileSlug/scenarioName) so examples are stable across
-// runs, enabling experiment comparison over time.
+// Syncs JSON test case files from the repo to a LangSmith dataset. Existing
+// examples are found by inputs (testCaseFile + scenarioName) and updated in
+// place; new scenarios get a random UUID. Stale examples are left in place
+// — LangSmith's soft-delete tombstones UUIDs, which historically caused 409
+// conflicts on resurrection; manual orphan cleanup happens via UI or MCP.
 // ---------------------------------------------------------------------------
 
-import { createHash } from 'crypto';
+import { randomUUID } from 'crypto';
 import type { Client } from 'langsmith';
 import type { Example, KVMap } from 'langsmith/schemas';
 import { z } from 'zod';
 
 import { loadWorkflowTestCasesWithFiles } from '../data/workflows';
 import type { EvalLogger } from '../harness/logger';
-
-// Bump this if existing IDs get tombstoned by LangSmith soft-delete and need
-// to be regenerated fresh. UUIDs for the same derivedId stay stable within a
-// version, so experiment comparison still works.
-const UUID_VERSION = 'v2';
-
-/**
- * Generate a deterministic UUID from a string.
- * Same input always produces the same UUID, so example IDs are stable across runs.
- */
-function deterministicUuid(input: string): string {
-	const hash = createHash('sha256').update(`${UUID_VERSION}:${input}`).digest('hex');
-	// Format as UUID v4 shape (8-4-4-4-12)
-	return [
-		hash.slice(0, 8),
-		hash.slice(8, 12),
-		'4' + hash.slice(13, 16),
-		'8' + hash.slice(17, 20),
-		hash.slice(20, 32),
-	].join('-');
-}
 
 /**
  * Shape of the inputs passed to the target function for each scenario.
@@ -64,10 +45,12 @@ export type DatasetExampleMetadata = z.infer<typeof datasetExampleMetadataSchema
  * Sync JSON test cases to a LangSmith dataset.
  *
  * - Creates the dataset if it doesn't exist
- * - Diffs local scenarios against existing examples
- * - Creates, updates, or deletes examples to match
+ * - Finds existing examples by (testCaseFile, scenarioName) and updates in place
+ * - Creates new scenarios with a random UUID
  * - Orders examples round-robin across test cases for optimal parallelism
  * - Assigns each example to a split (test case file slug) for UI filtering
+ *
+ * Never deletes. Orphan cleanup is manual (LangSmith UI or MCP).
  *
  * Returns the dataset name for use with evaluate().
  */
@@ -110,13 +93,11 @@ export async function syncDataset(
 	}
 
 	// Diff and sync
-	const currentIds = new Set<string>();
 	const toCreate: Array<{ id: string; inputs: KVMap; metadata: KVMap; split: string }> = [];
 	const toUpdate: Array<{ id: string; inputs: KVMap; metadata: KVMap; split: string }> = [];
 
 	for (const scenario of scenarios) {
 		const derivedId = `${scenario.testCaseFile}/${scenario.scenarioName}`;
-		currentIds.add(derivedId);
 
 		const inputs: DatasetExampleInputs = {
 			prompt: scenario.prompt,
@@ -149,24 +130,11 @@ export async function syncDataset(
 			}
 		} else {
 			toCreate.push({
-				id: deterministicUuid(derivedId),
+				id: randomUUID(),
 				inputs,
 				metadata,
 				split: scenario.testCaseFile,
 			});
-		}
-	}
-
-	// Only delete stale examples on a full sync (no filter). With a filter,
-	// we're only syncing a subset and mustn't delete the others.
-	// LangSmith also soft-deletes, which tombstones the UUID and prevents
-	// recreation with the same ID on a later full run.
-	const toDelete: string[] = [];
-	if (!filter) {
-		for (const [derivedId, example] of existingByDerivedId) {
-			if (!currentIds.has(derivedId)) {
-				toDelete.push(example.id);
-			}
 		}
 	}
 
@@ -196,12 +164,7 @@ export async function syncDataset(
 		logger.info(`  Updated ${String(toUpdate.length)} example(s)`);
 	}
 
-	if (toDelete.length > 0) {
-		await lsClient.deleteExamples(toDelete);
-		logger.info(`  Deleted ${String(toDelete.length)} stale example(s)`);
-	}
-
-	if (toCreate.length === 0 && toUpdate.length === 0 && toDelete.length === 0) {
+	if (toCreate.length === 0 && toUpdate.length === 0) {
 		logger.info('  Dataset up to date');
 	}
 


### PR DESCRIPTION
## Summary

Fixes the recurring `LangSmithConflictError: 409` that aborts eval runs during `syncDataset`. Two compounding design choices caused it:

1. **Deterministic UUIDs** derived from `${testCaseFile}/${scenarioName}`.
2. **Soft-delete on every full sync** for examples missing from the filesystem.

LangSmith soft-delete tombstones UUIDs permanently. Because our UUIDs were a pure function of the derivedId, any later sync reintroducing a previously-deleted scenario collided and the sync aborted before any evaluation could run. Branch rotation between teammates working on different scenario sets was the most common real-world trigger.

**Changes:**
- Drop `deterministicUuid` + `UUID_VERSION`. New examples get a random UUID via `crypto.randomUUID()`. Existing examples continue to be matched by their `(testCaseFile, scenarioName)` inputs — the lookup path was never keyed by UUID anyway, so updates preserve the stored UUID and historical experiment comparisons survive.
- Remove the `toDelete` branch. The sync is now append/update-only. Orphaned examples (files removed from disk) stay in the dataset harmlessly; `evaluate()` only runs against current scenarios. Manual cleanup happens via LangSmith UI or MCP when needed.

Linear: https://linear.app/n8n/issue/TRUST-63

## Why not keep deterministic UUIDs + just catch the 409?

The determinism didn't earn its cost. `syncDataset` already looks up examples by inputs — not by UUID — so determinism adds no value on the read path. The only value claimed was "same scenario has the same UUID across time," but that claim is already broken under renames (change the filename or scenarioName and the UUID changes anyway). Net: we paid complexity for a property we didn't actually have.

## Scenarios validated

| Scenario | Outcome |
|---|---|
| `--filter` run | Unchanged behavior. |
| Local file deleted | Example stays in LangSmith (harmless). No tombstone. |
| New local file / scenario | Fresh random UUID. Works. |
| File or scenario renamed | Old stays, new created. No collision. |
| Inputs changed in place | Existing example updated, same UUID. Unchanged. |
| Branch rotation | Both devs' scenarios accumulate; no soft-deletes; no future 409s. |
| Deleted-then-readded scenario (the bug we're fixing) | Creates fresh; no collision. |

## What's given up

- Auto-removal of stale examples. Replaced by manual cleanup (UI or MCP) when needed — runs at most a few times a year.
- "Recompute an existing example's UUID from its derivedId" as a property. No tool in the repo uses this.

## Test plan

- [x] Unit tests in `evaluations/__tests__/dataset-sync.test.ts` cover: create-with-random-UUID, update-in-place, no-deleteExamples-call, no-op when matched, and the resurrection path (previously-deleted scenario re-added creates fresh without collision).
- [x] `pnpm test dataset-sync` — 5/5 pass.
- [x] `pnpm typecheck` clean, lint clean on changed files.
- [x] I have seen this code, I have run this code, and I take responsibility for this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)