### PR TITLE
feat(core): Add flag to import:workflow cli to activate workflow on import

### DIFF
--- a/packages/cli/src/commands/import/workflow.ts
+++ b/packages/cli/src/commands/import/workflow.ts
@@ -51,6 +51,16 @@ const flagsSchema = z.object({
 		.string()
 		.describe('The ID of the project to assign the imported workflows to')
 		.optional(),
+	activeState: z
+		.enum(['false', 'fromJson'], {
+			errorMap: () => ({
+				message: 'Valid values for flag "--activeState" are only "false" or "fromJson".',
+			}),
+		})
+		.describe(
+			'Whether to respect the JSON active field. "false" (default) deactivates all imported workflows. "fromJson" activates/deactivates each workflow based on its JSON active field.',
+		)
+		.default('false'),
 });
 
 @Command({
@@ -62,6 +72,7 @@ const flagsSchema = z.object({
 		'--input=file.json --userId=1d64c3d2-85fe-4a83-a649-e446b07b3aae',
 		'--input=file.json --projectId=Ox8O54VQrmBrb4qL',
 		'--separate --input=backups/latest/ --userId=1d64c3d2-85fe-4a83-a649-e446b07b3aae',
+		'--input=file.json --activeState=fromJson',
 	],
 	flagsSchema,
 })
@@ -101,7 +112,9 @@ export class ImportWorkflowsCommand extends BaseCommand<z.infer<typeof flagsSche
 
 		this.logger.info(`Importing ${workflows.length} workflows...`);
 
-		await Container.get(ImportService).importWorkflows(workflows, project.id);
+		await Container.get(ImportService).importWorkflows(workflows, project.id, {
+			activeState: flags.activeState,
+		});
 
 		this.reportSuccess(workflows.length);
 	}

--- a/packages/cli/src/services/__tests__/import.service.test.ts
+++ b/packages/cli/src/services/__tests__/import.service.test.ts
@@ -1,6 +1,11 @@
 import { safeJoinPath, type Logger } from '@n8n/backend-common';
 import type { DatabaseConfig } from '@n8n/config';
-import type { CredentialsRepository, TagRepository } from '@n8n/db';
+import type {
+	CredentialsRepository,
+	TagRepository,
+	WorkflowPublishHistoryRepository,
+	WorkflowRepository,
+} from '@n8n/db';
 import { type DataSource, type EntityManager } from '@n8n/typeorm';
 import { readdir, readFile } from 'fs/promises';
 import { mock } from 'jest-mock-extended';
@@ -42,6 +47,8 @@ describe('ImportService', () => {
 	let mockActiveWorkflowManager: ActiveWorkflowManager;
 	let mockWorkflowIndexService: WorkflowIndexService;
 	let mockDatabaseConfig: DatabaseConfig;
+	let mockWorkflowRepository: WorkflowRepository;
+	let mockWorkflowPublishHistoryRepository: WorkflowPublishHistoryRepository;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -55,6 +62,8 @@ describe('ImportService', () => {
 		mockActiveWorkflowManager = mock<ActiveWorkflowManager>();
 		mockWorkflowIndexService = mock<WorkflowIndexService>();
 		mockDatabaseConfig = mock<DatabaseConfig>();
+		mockWorkflowRepository = mock<WorkflowRepository>();
+		mockWorkflowPublishHistoryRepository = mock<WorkflowPublishHistoryRepository>();
 
 		// Set up cipher mock
 		mockCipher.decrypt = jest.fn((data: string) => data.replace('encrypted:', ''));
@@ -103,6 +112,8 @@ describe('ImportService', () => {
 			mockActiveWorkflowManager,
 			mockWorkflowIndexService,
 			mockDatabaseConfig,
+			mockWorkflowRepository,
+			mockWorkflowPublishHistoryRepository,
 		);
 	});
 

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -9,11 +9,14 @@ import {
 	TagRepository,
 	WorkflowHistory,
 	WorkflowPublishHistory,
+	WorkflowPublishHistoryRepository,
+	WorkflowRepository,
 } from '@n8n/db';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { DataSource, EntityManager, In } from '@n8n/typeorm';
 import { Service } from '@n8n/di';
 import { type INode, type INodeCredentialsDetails, type IWorkflowBase } from 'n8n-workflow';
+import { ensureError } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
 import { readdir, readFile } from 'fs/promises';
 
@@ -58,6 +61,8 @@ export class ImportService {
 		private readonly activeWorkflowManager: ActiveWorkflowManager,
 		private readonly workflowIndexService: WorkflowIndexService,
 		private readonly databaseConfig: DatabaseConfig,
+		private readonly workflowRepository: WorkflowRepository,
+		private readonly workflowPublishHistoryRepository: WorkflowPublishHistoryRepository,
 	) {}
 
 	async initRecords() {
@@ -65,7 +70,11 @@ export class ImportService {
 		this.dbTags = await this.tagRepository.find();
 	}
 
-	async importWorkflows(workflows: IWorkflowDb[], projectId: string) {
+	async importWorkflows(
+		workflows: IWorkflowDb[],
+		projectId: string,
+		{ activeState = 'false' }: { activeState?: 'false' | 'fromJson' } = {},
+	) {
 		await this.initRecords();
 
 		const { manager: dbManager } = this.credentialsRepository;
@@ -108,6 +117,7 @@ export class ImportService {
 		}
 
 		const insertedWorkflows: IWorkflowBase[] = [];
+		const workflowsToActivate: Array<{ workflowId: string; versionId: string }> = [];
 		await dbManager.transaction(async (tx) => {
 			const workflowsNeedingPublishHistory: Array<{ workflowId: string; versionId: string }> = [];
 
@@ -116,11 +126,19 @@ export class ImportService {
 				// Always generate a new versionId on import to ensure proper history ordering
 				workflow.versionId = uuid();
 
-				// Always deactivate workflows on import - they need to be manually activated later
 				// Store the old activeVersionId to record the deactivation of the old version
 				const oldActiveVersionId = workflow.id ? activeVersionIdByWorkflow.get(workflow.id) : null;
-				if (oldActiveVersionId || workflow.activeVersionId || workflow.active) {
-					this.logger.info(`Deactivating workflow "${workflow.name}". Remember to activate later.`);
+				const shouldActivate = activeState === 'fromJson' && workflow.active;
+				const versionIdToActivate = workflow.versionId;
+
+				// Always upsert with active=false and activeVersionId=null.
+				// Activation happens post-transaction once the new workflow_history row exists
+				// (the activeVersionId FK references workflow_history.versionId).
+				if (
+					!shouldActivate &&
+					(oldActiveVersionId || workflow.activeVersionId || workflow.active)
+				) {
+					this.logger.info(`Deactivating workflow "${workflow.name}".`);
 				}
 				workflow.active = false;
 				workflow.activeVersionId = null;
@@ -132,6 +150,10 @@ export class ImportService {
 				// Only add publish history if workflow was previously active
 				if (oldActiveVersionId) {
 					workflowsNeedingPublishHistory.push({ workflowId, versionId: oldActiveVersionId });
+				}
+
+				if (shouldActivate) {
+					workflowsToActivate.push({ workflowId, versionId: versionIdToActivate });
 				}
 
 				const personalProject = await tx.findOneByOrFail(Project, { id: projectId });
@@ -180,12 +202,42 @@ export class ImportService {
 			}
 		});
 
+		for (const { workflowId, versionId } of workflowsToActivate) {
+			await this.activateWorkflow(workflowId, versionId);
+		}
+
 		// Directly update the index for the important workflows, since they don't generate
 		// workflow-update events during import.
 		// Workflow indexing isn't supported on legacy SQLite.
 		if (!this.databaseConfig.isLegacySqlite) {
 			for (const workflow of insertedWorkflows) {
 				await this.workflowIndexService.updateIndexFor(workflow);
+			}
+		}
+	}
+
+	private async activateWorkflow(workflowId: string, versionIdToActivate: string): Promise<void> {
+		let didActivate = false;
+		try {
+			await this.activeWorkflowManager.remove(workflowId);
+			await this.workflowRepository.update(
+				{ id: workflowId },
+				{ activeVersionId: versionIdToActivate },
+			);
+			await this.workflowRepository.updateActiveState(workflowId, true);
+			await this.activeWorkflowManager.add(workflowId, 'activate');
+			didActivate = true;
+		} catch (e) {
+			const error = ensureError(e);
+			this.logger.error(`Failed to activate workflow ${workflowId}`, { error });
+		} finally {
+			if (didActivate) {
+				await this.workflowPublishHistoryRepository.addRecord({
+					workflowId,
+					versionId: versionIdToActivate,
+					event: 'activated',
+					userId: null,
+				});
 			}
 		}
 	}

--- a/packages/cli/test/integration/commands/import.cmd.test.ts
+++ b/packages/cli/test/integration/commands/import.cmd.test.ts
@@ -340,3 +340,34 @@ test('`import:workflow --projectId ... --userId ...` fails explaining that only 
 		'You cannot use `--userId` and `--projectId` together. Use one or the other.',
 	);
 });
+
+test('import:workflow --activeState=fromJson should respect the JSON active field', async () => {
+	await createOwner();
+
+	await command.run([
+		'--separate',
+		'--input=./test/integration/commands/import-workflows/separate',
+		'--activeState=fromJson',
+	]);
+
+	const workflowsInDB = await getAllWorkflows();
+	expect(workflowsInDB).toMatchObject([
+		expect.objectContaining({ name: 'active-workflow', active: true }),
+		expect.objectContaining({ name: 'inactive-workflow', active: false, activeVersionId: null }),
+	]);
+	const activeWorkflow = workflowsInDB.find((w) => w.name === 'active-workflow');
+	expect(activeWorkflow?.activeVersionId).toBe(activeWorkflow?.versionId);
+});
+
+test('import:workflow --activeState with an invalid value fails', async () => {
+	await createOwner();
+
+	await expect(
+		command.run([
+			'--input=./test/integration/commands/import-workflows/combined/single.json',
+			'--activeState=bogus',
+		]),
+	).rejects.toThrowError(
+		/Valid values for flag \\?"--activeState\\?" are only \\?"false\\?" or \\?"fromJson\\?"\./,
+	);
+});

--- a/packages/cli/test/integration/import.service.test.ts
+++ b/packages/cli/test/integration/import.service.test.ts
@@ -71,6 +71,8 @@ describe('ImportService', () => {
 			mockActiveWorkflowManager,
 			mockWorkflowIndexService,
 			Container.get(DatabaseConfig),
+			workflowRepository,
+			workflowPublishHistoryRepository,
 		);
 	});
 
@@ -330,5 +332,91 @@ describe('ImportService', () => {
 		// Verify the workflow now has the new versionId
 		const updatedWorkflow = await getWorkflowById(initialWorkflow.id);
 		expect(updatedWorkflow?.versionId).toBe(historyRecords[1].versionId);
+	});
+
+	describe('activeState: fromJson', () => {
+		test('should activate imported workflow when JSON has active=true', async () => {
+			const workflowToImport = await createWorkflow();
+			workflowToImport.active = true;
+
+			await importService.importWorkflows([workflowToImport], ownerPersonalProject.id, {
+				activeState: 'fromJson',
+			});
+
+			const dbWorkflow = await getWorkflowById(workflowToImport.id);
+			if (!dbWorkflow) fail('Expected to find workflow');
+
+			expect(dbWorkflow.active).toBe(true);
+			expect(dbWorkflow.activeVersionId).toBe(dbWorkflow.versionId);
+			expect(mockActiveWorkflowManager.add).toHaveBeenCalledWith(workflowToImport.id, 'activate');
+		});
+
+		test('should deactivate imported workflow that is updating existing one when JSON has active=false', async () => {
+			jest.mocked(mockActiveWorkflowManager.add).mockClear();
+
+			const existingWorkflow = await createActiveWorkflow();
+
+			const workflowToImport = await getWorkflowById(existingWorkflow.id);
+			if (!workflowToImport) fail('Expected to find workflow');
+			workflowToImport.active = false;
+
+			await importService.importWorkflows([workflowToImport], ownerPersonalProject.id, {
+				activeState: 'fromJson',
+			});
+
+			const dbWorkflow = await getWorkflowById(workflowToImport.id);
+			if (!dbWorkflow) fail('Expected to find workflow');
+
+			expect(dbWorkflow.active).toBe(false);
+			expect(dbWorkflow.activeVersionId).toBeNull();
+			expect(mockActiveWorkflowManager.add).not.toHaveBeenCalled();
+		});
+
+		test('should leave imported workflow deactivated when JSON has active=false', async () => {
+			jest.mocked(mockActiveWorkflowManager.add).mockClear();
+
+			const workflowToImport = await createWorkflow();
+			workflowToImport.active = false;
+
+			await importService.importWorkflows([workflowToImport], ownerPersonalProject.id, {
+				activeState: 'fromJson',
+			});
+
+			const dbWorkflow = await getWorkflowById(workflowToImport.id);
+			if (!dbWorkflow) fail('Expected to find workflow');
+
+			expect(dbWorkflow.active).toBe(false);
+			expect(dbWorkflow.activeVersionId).toBeNull();
+			expect(mockActiveWorkflowManager.add).not.toHaveBeenCalled();
+		});
+
+		test('should record both deactivated (old) and activated (new) publish history when re-importing an active workflow', async () => {
+			const existingWorkflow = await createActiveWorkflow();
+			const originalActiveVersionId = existingWorkflow.activeVersionId!;
+
+			const workflowToImport = await getWorkflowById(existingWorkflow.id);
+			if (!workflowToImport) fail('Expected to find workflow');
+			workflowToImport.active = true;
+
+			await importService.importWorkflows([workflowToImport], ownerPersonalProject.id, {
+				activeState: 'fromJson',
+			});
+
+			const dbWorkflow = await getWorkflowById(existingWorkflow.id);
+			if (!dbWorkflow) fail('Expected to find workflow');
+
+			const deactivatedRecords = await workflowPublishHistoryRepository.find({
+				where: { workflowId: existingWorkflow.id, event: 'deactivated' },
+			});
+			const activatedRecords = await workflowPublishHistoryRepository.find({
+				where: { workflowId: existingWorkflow.id, event: 'activated' },
+			});
+
+			expect(deactivatedRecords).toHaveLength(1);
+			expect(deactivatedRecords[0].versionId).toBe(originalActiveVersionId);
+			expect(activatedRecords).toHaveLength(1);
+			expect(activatedRecords[0].versionId).toBe(dbWorkflow.versionId);
+			expect(activatedRecords[0].userId).toBeNull();
+		});
 	});
 });

--- a/packages/cli/test/integration/shared/utils/test-command.ts
+++ b/packages/cli/test/integration/shared/utils/test-command.ts
@@ -1,5 +1,6 @@
 import { testDb, mockInstance } from '@n8n/backend-test-utils';
-import type { CommandClass } from '@n8n/decorators';
+import { CommandMetadata, type CommandClass } from '@n8n/decorators';
+import { Container } from '@n8n/di';
 import argvParser from 'yargs-parser';
 
 import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
@@ -29,7 +30,11 @@ export const setupTestCommand = <T extends CommandClass>(Command: T) => {
 
 	const run = async (argv: string[] = []) => {
 		const command = new Command();
-		command.flags = argvParser(argv);
+		const rawFlags = argvParser(argv);
+		const entry = Container.get(CommandMetadata)
+			.getEntries()
+			.find(([, e]) => e.class === Command)?.[1];
+		command.flags = entry?.flagsSchema ? entry.flagsSchema.parse(rawFlags) : rawFlags;
 		await command.init?.();
 		await command.run();
 		return command;


### PR DESCRIPTION
## Summary

Adds an `--activeState` flag to the `import:workflow` CLI so imported workflows can optionally keep the active state from their JSON, instead of always being force-deactivated.

The implementation is inspired by the `SourceControlImportService.importWorkflowFromWorkFolder` method.

Behavior

- `--activeState=false` (default) — current behavior: all imported workflows are set to `active=false` and must be activated manually later.
- `--activeState=fromJson` — each workflow's active field from the JSON is respected. Workflows with active: true are activated post-import (registered in `ActiveWorkflowManager`, `activeVersionId` set, and a `workflow_history` event recorded); workflows with `active: false` are imported inactive as before.

How to test

1. Checkout the branch (it's a 1.x one, so make sure you reset your home dir or create a new one)
2. Create a workflow that's inactive with a schedule trigger that runs every 10 seconds
3. Run `packages/cli$ ./bin/n8n export:workflow --backup --output=backups/`
4. Edit the generated workflow json and set `active: true`
5. Run `packages/cli$ ./bin/n8n import:workflow --separate --input=backups`
6. Observe that the workflow is now active and schedule triggers are creating new executions


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-482/support-cli-import-without-deactivating-workflow

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
