### PR TITLE
fix(editor): Allow users to logout of dynamic creds in chathub

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -549,6 +549,7 @@
 	"chatHub.chat.header.button.editAgent": "Edit Agent",
 	"chatHub.chat.header.button.newChat": "New Chat",
 	"chatHub.chat.header.button.openWorkflow": "Open Workflow",
+	"chatHub.chat.header.button.manageConnections": "Manage connections",
 	"chatHub.chat.prompt.microphone.accessDenied": "Microphone access denied",
 	"chatHub.chat.prompt.microphone.allowAccess": "Please allow microphone access to use voice input",
 	"chatHub.chat.prompt.microphone.noSpeech": "No speech detected. Please try again",

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
@@ -715,12 +715,16 @@ function onFilesDropped(files: File[]) {
 					:show-artifact-icon="
 						artifacts.allArtifacts.value.length > 0 && artifacts.isViewerCollapsed.value
 					"
+					:has-dynamic-credentials="dynamicCreds.hasDynamicCredentials.value"
 					@select-model="handleSelectModel"
 					@edit-custom-agent="handleEditAgent"
 					@create-custom-agent="openNewAgentCreator"
 					@select-credential="selectCredential"
 					@open-workflow="handleOpenWorkflow"
 					@reopen-artifact="artifacts.handleOpenViewer"
+					@toggle-dynamic-credentials="
+						isDynamicCredentialsDrawerOpen = !isDynamicCredentialsDrawerOpen
+					"
 				/>
 
 				<N8nScrollArea

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatConversationHeader.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatConversationHeader.vue
@@ -13,11 +13,18 @@ import { useI18n } from '@n8n/i18n';
 import { computed, useTemplateRef, watch, ref } from 'vue';
 import { useChatStore } from '../chat.store';
 
-const { selectedModel, credentials, readyToShowModelSelector, showArtifactIcon } = defineProps<{
+const {
+	selectedModel,
+	credentials,
+	readyToShowModelSelector,
+	showArtifactIcon,
+	hasDynamicCredentials,
+} = defineProps<{
 	selectedModel: ChatModelDto | null;
 	credentials: CredentialsMap | null;
 	readyToShowModelSelector: boolean;
 	showArtifactIcon: boolean;
+	hasDynamicCredentials: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -28,6 +35,7 @@ const emit = defineEmits<{
 	selectCredential: [provider: ChatHubProvider, credentialId: string | null];
 	openWorkflow: [workflowId: string];
 	reopenArtifact: [];
+	toggleDynamicCredentials: [];
 }>();
 
 const modelSelectorRef = useTemplateRef('modelSelectorRef');
@@ -109,6 +117,16 @@ defineExpose({
 				size="small"
 				icon="panel-right"
 				@click="emit('reopenArtifact')"
+			/>
+			<N8nIconButton
+				v-if="hasDynamicCredentials"
+				variant="subtle"
+				size="small"
+				icon="key-round"
+				:title="i18n.baseText('chatHub.chat.header.button.manageConnections')"
+				:aria-label="i18n.baseText('chatHub.chat.header.button.manageConnections')"
+				data-testid="manage-dynamic-credentials-button"
+				@click="emit('toggleDynamicCredentials')"
 			/>
 			<N8nButton
 				v-if="showOpenWorkflow"


### PR DESCRIPTION
## Summary

Adds a **Manage connections** icon button to the chat hub conversation header so users can open the dynamic credentials drawer directly from the chat view and log out of any dynamic credentials they've connected.

- New `N8nIconButton` (key-round icon) appears in `ChatConversationHeader` only when there are dynamic credentials available (`hasDynamicCredentials`).
- `ChatView` passes `hasDynamicCredentials` down and listens for `toggleDynamicCredentials` to toggle `isDynamicCredentialsDrawerOpen`.
- i18n key `chatHub.chat.header.button.manageConnections` added.

### How to test

1. Open the chat hub and start a conversation that uses a provider requiring a dynamic credential (e.g. connect via OAuth).
2. Confirm the key-round **Manage connections** button appears in the conversation header.
3. Click it and verify the dynamic credentials drawer opens, and that logging out from the drawer clears the credential.
4. Verify the button is hidden when no dynamic credentials are connected.

## Related Linear tickets, Github issues, and Community forum posts

_No Linear ticket — branch is `noref-*`._

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI