### PR TITLE
fix(core): preserve bracket secret provider keys

### DIFF
--- a/packages/cli/src/credentials/__tests__/external-secrets.utils.test.ts
+++ b/packages/cli/src/credentials/__tests__/external-secrets.utils.test.ts
@@ -28,6 +28,14 @@ describe('External secrets utils', () => {
 			).toEqual(['awsSecretsManager']);
 		});
 
+		it('extracts hyphenated provider keys from bracket notation', () => {
+			expect(
+				extractProviderKeysFromExpression(
+					"={{ $secrets['aws-secrets-manager']['token'] }}",
+				),
+			).toEqual(['aws-secrets-manager']);
+		});
+
 		it('extracts multiple providers from same expression', () => {
 			const result = extractProviderKeysFromExpression(
 				'={{ $secrets.vault.myKey + ":" + $secrets.aws.otherKey }}',

--- a/packages/cli/src/credentials/external-secrets.utils.ts
+++ b/packages/cli/src/credentials/external-secrets.utils.ts
@@ -4,6 +4,8 @@ import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
 
 import { getAllKeyPaths } from '@/utils';
 
+const BRACKET_SECRETS_PROVIDER_KEY_PATTERN = `[^'"\\]]+`;
+
 /**
  * Checks if a string value contains an external secret expression.
  * Detects both dot notation ($secrets.vault.key) and bracket notation ($secrets['vault']['key']).
@@ -48,7 +50,7 @@ export function extractProviderKeysFromExpression(expression: string): string[] 
 		// - $secrets['providerKey']
 		// - $secrets["providerKey"]
 		const bracketMatches = expressionContent.matchAll(
-			new RegExp(`\\$secrets\\[['"](${SECRETS_PROVIDER_KEY_PATTERN})['"]\\]`, 'g'),
+			new RegExp(`\\$secrets\\[['"](${BRACKET_SECRETS_PROVIDER_KEY_PATTERN})['"]\\]`, 'g'),
 		);
 		for (const match of bracketMatches) {
 			providerKeys.add(match[1]);

--- a/packages/cli/src/credentials/external-secrets.utils.ts
+++ b/packages/cli/src/credentials/external-secrets.utils.ts
@@ -4,6 +4,8 @@ import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
 
 import { getAllKeyPaths } from '@/utils';
 
+const BRACKET_SECRETS_PROVIDER_KEY_PATTERN = `[^'"\\]]+`;
+
 const SECRETS_REFERENCE_REGEX = /\$secrets\b/;
 
 /**
@@ -57,7 +59,7 @@ export function extractProviderKeysFromExpression(expression: string): string[] 
 		// - $secrets ['providerKey']
 		// - $secrets["providerKey"]
 		const bracketMatches = expressionContent.matchAll(
-			new RegExp(`\\$secrets\\s*\\[\\s*['"](${SECRETS_PROVIDER_KEY_PATTERN})['"]\\s*\\]`, 'g'),
+			new RegExp(`\\$secrets\\s*\\[\\s*['"](${BRACKET_SECRETS_PROVIDER_KEY_PATTERN})['"]\\s*\\]`, 'g'),
 		);
 		for (const match of bracketMatches) {
 			providerKeys.add(match[1]);


### PR DESCRIPTION
## Summary
- keep dot-notation external secret provider extraction restricted to JS-safe provider keys
- allow bracket-notation provider references to preserve existing hyphenated provider keys
- add regression coverage for `$secrets['aws-secrets-manager']['token']`

## Tests
- `node` smoke check of the updated extraction regex for hyphenated bracket provider keys, malformed dot notation, and existing bracket provider access
- `git diff --check`

> I did not run the repository Jest target locally because this checkout does not have `node_modules` installed.
