### PR TITLE
fix(TheHiveProject Node): Return pagination tokens as strings

### DIFF
--- a/packages/nodes-base/nodes/TheHiveProject/methods/listSearch.ts
+++ b/packages/nodes-base/nodes/TheHiveProject/methods/listSearch.ts
@@ -54,7 +54,7 @@ async function listResource(
 			url:
 				urlPlaceholder !== undefined ? `${url}/${urlPlaceholder}/${entry._id}/details` : undefined,
 		})),
-		paginationToken: to,
+		paginationToken: `${to}`,
 	};
 }
 
@@ -187,7 +187,7 @@ export async function pageSearch(
 			name: entry.title,
 			value: entry._id,
 		})),
-		paginationToken: to,
+		paginationToken: `${to}`,
 	};
 }
 
@@ -266,6 +266,6 @@ export async function observableSearch(
 			name: entry.data || (entry.attachment as IDataObject)?.name || entry.message || entry._id,
 			value: entry._id,
 		})),
-		paginationToken: to,
+		paginationToken: `${to}`,
 	};
 }

--- a/packages/nodes-base/nodes/TheHiveProject/test/listSearch.test.ts
+++ b/packages/nodes-base/nodes/TheHiveProject/test/listSearch.test.ts
@@ -1,0 +1,43 @@
+import type { ILoadOptionsFunctions } from 'n8n-workflow';
+
+import { caseSearch, observableSearch, pageSearch } from '../methods/listSearch';
+
+const createLoadOptionsFunctions = (response: unknown[]): ILoadOptionsFunctions =>
+	({
+		getCredentials: jest.fn().mockResolvedValue({
+			url: 'https://thehive.example.com',
+			apiKey: 'test-api-key',
+		}),
+		getNodeParameter: jest.fn(),
+		helpers: {
+			requestWithAuthentication: jest.fn().mockResolvedValue(response),
+		},
+	}) as unknown as ILoadOptionsFunctions;
+
+describe('TheHiveProject listSearch', () => {
+	it('returns string pagination tokens from shared resource searches', async () => {
+		const loadOptionsFunctions = createLoadOptionsFunctions([{ _id: '~case1', title: 'Case 1' }]);
+
+		const result = await caseSearch.call(loadOptionsFunctions);
+
+		expect(result.paginationToken).toBe('100');
+	});
+
+	it('returns string pagination tokens from page search', async () => {
+		const loadOptionsFunctions = createLoadOptionsFunctions([{ _id: '~page1', title: 'Page 1' }]);
+
+		const result = await pageSearch.call(loadOptionsFunctions);
+
+		expect(result.paginationToken).toBe('100');
+	});
+
+	it('returns string pagination tokens from observable search', async () => {
+		const loadOptionsFunctions = createLoadOptionsFunctions([
+			{ _id: '~observable1', data: 'example.com' },
+		]);
+
+		const result = await observableSearch.call(loadOptionsFunctions);
+
+		expect(result.paginationToken).toBe('100');
+	});
+});


### PR DESCRIPTION
## Summary

TheHiveProject node's resource locator list-search methods returned numeric `paginationToken` values from case/comment/alert/task/log shared searches, page search, and observable search. The resource-locator request DTO validates the echoed token as `z.string().optional()`, so pagination can fail with "Expected string, received number" when the next page is requested.

Stringify the existing offset token to keep current pagination behavior while matching the backend request contract. The regression test covers the shared resource search helper plus the separate page and observable search paths.

**How to test:**
- `pnpm --filter n8n-nodes-base test -- nodes/TheHiveProject/test/listSearch.test.ts --runInBand`
- `pnpm --filter n8n-nodes-base test -- nodes/TheHiveProject/test --runInBand`
- `pnpm --filter n8n-nodes-base typecheck`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter n8n-nodes-base lint`

## Related Linear tickets, Github issues, and Community forum posts

Related to https://github.com/n8n-io/n8n/pull/29099

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. No docs needed; this is an internal resource-locator pagination contract fix.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)