### PR TITLE
fix(DeepSeek Node): Preserve reasoning_content on tool-calling assistant messages

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatDeepSeek/LmChatDeepSeek.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatDeepSeek/LmChatDeepSeek.node.ts
@@ -15,6 +15,7 @@ import {
 
 import type { OpenAICompatibleCredential } from '../../../types/types';
 import { openAiFailedAttemptHandler } from '../../vendors/OpenAi/helpers/error-handling';
+import { createReasoningContentFetch } from './createReasoningContentFetch';
 
 export class LmChatDeepSeek implements INodeType {
 	description: INodeTypeDescription = {
@@ -234,6 +235,7 @@ export class LmChatDeepSeek implements INodeType {
 		const timeout = options.timeout;
 		const configuration: ClientOptions = {
 			baseURL: credentials.url,
+			fetch: createReasoningContentFetch(),
 			fetchOptions: {
 				dispatcher: getProxyAgent(credentials.url, {
 					headersTimeout: timeout,

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatDeepSeek/createReasoningContentFetch.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatDeepSeek/createReasoningContentFetch.ts
@@ -1,0 +1,200 @@
+/**
+ * DeepSeek's "thinking mode" (V3.2+ / V4) requires that any assistant message
+ * containing `tool_calls` is re-sent to the API with its original
+ * `reasoning_content` field intact. The OpenAI-compatible client used by
+ * `ChatOpenAI` does not preserve or forward `reasoning_content`, so multi-turn
+ * tool-calling requests fail with HTTP 400:
+ *   "The reasoning_content in the thinking mode must be passed back to the API."
+ *
+ * This helper builds a `fetch` wrapper that:
+ *  1. Captures `reasoning_content` returned alongside each `tool_call` (from
+ *     non-streaming JSON responses and from `text/event-stream` chunks).
+ *  2. Re-injects the captured `reasoning_content` into outgoing assistant
+ *     messages whose `tool_calls` reference the same ids.
+ *
+ * The store is scoped to a single fetch wrapper (i.e. one chat-model instance),
+ * so multiple parallel executions do not share state.
+ *
+ * Reference: https://api-docs.deepseek.com/guides/thinking_mode
+ */
+
+type FetchFn = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+interface ToolCallShape {
+	id?: string;
+}
+
+interface AssistantMessageShape {
+	role?: string;
+	reasoning_content?: string;
+	tool_calls?: ToolCallShape[];
+}
+
+export function createReasoningContentFetch(baseFetch: FetchFn = fetch): FetchFn {
+	const reasoningByToolCallId = new Map<string, string>();
+
+	return async function reasoningFetch(input, init) {
+		let nextInit = init;
+
+		if (init && typeof init.body === 'string' && reasoningByToolCallId.size > 0) {
+			const rewritten = injectReasoningContent(init.body, reasoningByToolCallId);
+			if (rewritten !== undefined) {
+				nextInit = { ...init, body: rewritten };
+			}
+		}
+
+		const response = await baseFetch(input, nextInit);
+
+		if (!response.ok || !response.body) {
+			return response;
+		}
+
+		const contentType = response.headers.get('content-type') ?? '';
+
+		if (contentType.includes('application/json')) {
+			try {
+				const cloned = response.clone();
+				const data = (await cloned.json()) as unknown;
+				captureFromJson(data, reasoningByToolCallId);
+			} catch {
+				// Ignore: response may not be JSON or already consumed.
+			}
+			return response;
+		}
+
+		if (contentType.includes('text/event-stream')) {
+			const [forCaller, forParser] = response.body.tee();
+			void parseSseStream(forParser, reasoningByToolCallId);
+			return new Response(forCaller, {
+				headers: response.headers,
+				status: response.status,
+				statusText: response.statusText,
+			});
+		}
+
+		return response;
+	};
+}
+
+function injectReasoningContent(body: string, store: Map<string, string>): string | undefined {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(body);
+	} catch {
+		return undefined;
+	}
+	if (!parsed || typeof parsed !== 'object') return undefined;
+	const messages = (parsed as { messages?: unknown }).messages;
+	if (!Array.isArray(messages)) return undefined;
+
+	let modified = false;
+	for (const msg of messages) {
+		if (!msg || typeof msg !== 'object') continue;
+		const m = msg as AssistantMessageShape & Record<string, unknown>;
+		if (m.role !== 'assistant') continue;
+		if (typeof m.reasoning_content === 'string' && m.reasoning_content.length > 0) continue;
+		if (!Array.isArray(m.tool_calls) || m.tool_calls.length === 0) continue;
+
+		for (const tc of m.tool_calls) {
+			const id = tc?.id;
+			if (id && store.has(id)) {
+				m.reasoning_content = store.get(id);
+				modified = true;
+				break;
+			}
+		}
+	}
+
+	return modified ? JSON.stringify(parsed) : undefined;
+}
+
+function captureFromJson(data: unknown, store: Map<string, string>): void {
+	if (!data || typeof data !== 'object') return;
+	const choices = (data as { choices?: unknown }).choices;
+	if (!Array.isArray(choices)) return;
+	for (const choice of choices) {
+		if (!choice || typeof choice !== 'object') continue;
+		const message = (choice as { message?: AssistantMessageShape }).message;
+		if (!message) continue;
+		const reasoning = message.reasoning_content;
+		if (typeof reasoning !== 'string' || reasoning.length === 0) continue;
+		if (!Array.isArray(message.tool_calls)) continue;
+		for (const tc of message.tool_calls) {
+			if (tc?.id) store.set(tc.id, reasoning);
+		}
+	}
+}
+
+async function parseSseStream(
+	stream: ReadableStream<Uint8Array>,
+	store: Map<string, string>,
+): Promise<void> {
+	const reader = stream.getReader();
+	const decoder = new TextDecoder();
+
+	const reasoningByChoice = new Map<number, string>();
+	const toolCallIdsByChoice = new Map<number, Set<string>>();
+	let buffer = '';
+
+	try {
+		while (true) {
+			const { value, done } = await reader.read();
+			if (done) break;
+			buffer += decoder.decode(value, { stream: true });
+
+			let newlineIdx: number;
+			while ((newlineIdx = buffer.indexOf('\n')) !== -1) {
+				const line = buffer.slice(0, newlineIdx).trim();
+				buffer = buffer.slice(newlineIdx + 1);
+				if (!line.startsWith('data:')) continue;
+				const payload = line.slice(5).trim();
+				if (!payload || payload === '[DONE]') continue;
+
+				let event: unknown;
+				try {
+					event = JSON.parse(payload);
+				} catch {
+					continue;
+				}
+				const choices = (event as { choices?: unknown })?.choices;
+				if (!Array.isArray(choices)) continue;
+
+				for (const choice of choices) {
+					if (!choice || typeof choice !== 'object') continue;
+					const idxRaw = (choice as { index?: unknown }).index;
+					const idx = typeof idxRaw === 'number' ? idxRaw : 0;
+					const delta = (choice as { delta?: unknown }).delta;
+					if (!delta || typeof delta !== 'object') continue;
+
+					const reasoning = (delta as { reasoning_content?: unknown }).reasoning_content;
+					if (typeof reasoning === 'string' && reasoning.length > 0) {
+						reasoningByChoice.set(idx, (reasoningByChoice.get(idx) ?? '') + reasoning);
+					}
+
+					const toolCalls = (delta as { tool_calls?: unknown }).tool_calls;
+					if (Array.isArray(toolCalls)) {
+						let ids = toolCallIdsByChoice.get(idx);
+						if (!ids) {
+							ids = new Set();
+							toolCallIdsByChoice.set(idx, ids);
+						}
+						for (const tc of toolCalls) {
+							const id = (tc as { id?: unknown })?.id;
+							if (typeof id === 'string' && id.length > 0) ids.add(id);
+						}
+					}
+				}
+			}
+		}
+	} catch {
+		// Ignore stream errors; capture is best-effort.
+	} finally {
+		reader.releaseLock();
+	}
+
+	for (const [idx, reasoning] of reasoningByChoice) {
+		const ids = toolCallIdsByChoice.get(idx);
+		if (!ids || !reasoning) continue;
+		for (const id of ids) store.set(id, reasoning);
+	}
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatDeepSeek/test/createReasoningContentFetch.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatDeepSeek/test/createReasoningContentFetch.test.ts
@@ -1,0 +1,229 @@
+import { createReasoningContentFetch } from '../createReasoningContentFetch';
+
+describe('createReasoningContentFetch', () => {
+	function buildJsonResponse(body: unknown): Response {
+		return new Response(JSON.stringify(body), {
+			status: 200,
+			headers: { 'content-type': 'application/json' },
+		});
+	}
+
+	function buildSseResponse(events: string[]): Response {
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				for (const e of events) controller.enqueue(encoder.encode(e));
+				controller.close();
+			},
+		});
+		return new Response(stream, {
+			status: 200,
+			headers: { 'content-type': 'text/event-stream' },
+		});
+	}
+
+	it('does not modify the request when no reasoning content has been seen', async () => {
+		const baseFetch = jest
+			.fn()
+			.mockResolvedValue(
+				new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } }),
+			);
+		const reasoningFetch = createReasoningContentFetch(baseFetch);
+
+		await reasoningFetch('https://api.deepseek.com/chat/completions', {
+			method: 'POST',
+			body: JSON.stringify({
+				messages: [
+					{ role: 'user', content: 'Hi' },
+					{
+						role: 'assistant',
+						tool_calls: [{ id: 'call_1', type: 'function' }],
+					},
+				],
+			}),
+		});
+
+		expect(baseFetch).toHaveBeenCalledTimes(1);
+		const init = baseFetch.mock.calls[0][1] as RequestInit;
+		const body = JSON.parse(init.body as string);
+		expect(body.messages[1].reasoning_content).toBeUndefined();
+	});
+
+	it('captures reasoning_content from a JSON response and injects it on the next request', async () => {
+		const baseFetch = jest
+			.fn<Promise<Response>, [unknown, RequestInit | undefined]>()
+			.mockResolvedValueOnce(
+				buildJsonResponse({
+					choices: [
+						{
+							index: 0,
+							message: {
+								role: 'assistant',
+								content: '',
+								reasoning_content: 'Thinking step 1',
+								tool_calls: [{ id: 'call_abc', type: 'function' }],
+							},
+						},
+					],
+				}),
+			)
+			.mockResolvedValueOnce(
+				buildJsonResponse({ choices: [{ message: { role: 'assistant', content: 'ok' } }] }),
+			);
+
+		const reasoningFetch = createReasoningContentFetch(baseFetch);
+
+		await reasoningFetch('https://api.deepseek.com/chat/completions', {
+			method: 'POST',
+			body: JSON.stringify({ messages: [{ role: 'user', content: 'Hi' }] }),
+		});
+
+		await reasoningFetch('https://api.deepseek.com/chat/completions', {
+			method: 'POST',
+			body: JSON.stringify({
+				messages: [
+					{ role: 'user', content: 'Hi' },
+					{
+						role: 'assistant',
+						content: '',
+						tool_calls: [{ id: 'call_abc', type: 'function' }],
+					},
+					{ role: 'tool', tool_call_id: 'call_abc', content: 'result' },
+				],
+			}),
+		});
+
+		const secondInit = baseFetch.mock.calls[1][1] as RequestInit;
+		const secondBody = JSON.parse(secondInit.body as string);
+		expect(secondBody.messages[1].reasoning_content).toBe('Thinking step 1');
+	});
+
+	it('does not overwrite an existing reasoning_content on outgoing messages', async () => {
+		const baseFetch = jest
+			.fn<Promise<Response>, [unknown, RequestInit | undefined]>()
+			.mockResolvedValueOnce(
+				buildJsonResponse({
+					choices: [
+						{
+							message: {
+								role: 'assistant',
+								reasoning_content: 'captured',
+								tool_calls: [{ id: 'call_1' }],
+							},
+						},
+					],
+				}),
+			)
+			.mockResolvedValueOnce(buildJsonResponse({}));
+
+		const reasoningFetch = createReasoningContentFetch(baseFetch);
+
+		await reasoningFetch('https://x', { method: 'POST', body: '{}' });
+		await reasoningFetch('https://x', {
+			method: 'POST',
+			body: JSON.stringify({
+				messages: [
+					{
+						role: 'assistant',
+						reasoning_content: 'preexisting',
+						tool_calls: [{ id: 'call_1' }],
+					},
+				],
+			}),
+		});
+
+		const init = baseFetch.mock.calls[1][1] as RequestInit;
+		expect(JSON.parse(init.body as string).messages[0].reasoning_content).toBe('preexisting');
+	});
+
+	it('captures reasoning_content from an SSE stream and re-injects it', async () => {
+		const events = [
+			`data: ${JSON.stringify({
+				choices: [{ index: 0, delta: { reasoning_content: 'thinking ' } }],
+			})}\n`,
+			`data: ${JSON.stringify({
+				choices: [{ index: 0, delta: { reasoning_content: 'about it' } }],
+			})}\n`,
+			`data: ${JSON.stringify({
+				choices: [
+					{
+						index: 0,
+						delta: { tool_calls: [{ index: 0, id: 'call_stream', type: 'function' }] },
+					},
+				],
+			})}\n`,
+			'data: [DONE]\n',
+		];
+
+		const baseFetch = jest
+			.fn<Promise<Response>, [unknown, RequestInit | undefined]>()
+			.mockResolvedValueOnce(buildSseResponse(events))
+			.mockResolvedValueOnce(buildSseResponse([]));
+
+		const reasoningFetch = createReasoningContentFetch(baseFetch);
+
+		const firstResponse = await reasoningFetch('https://x', { method: 'POST', body: '{}' });
+		// Drain the stream so the parser sees all events.
+		const reader = firstResponse.body!.getReader();
+		while (!(await reader.read()).done) {
+			// drain
+		}
+
+		await reasoningFetch('https://x', {
+			method: 'POST',
+			body: JSON.stringify({
+				messages: [
+					{
+						role: 'assistant',
+						tool_calls: [{ id: 'call_stream', type: 'function' }],
+					},
+				],
+			}),
+		});
+
+		// Allow the async SSE parser microtasks to settle.
+		await new Promise((r) => setImmediate(r));
+
+		const init = baseFetch.mock.calls[1][1] as RequestInit;
+		const body = JSON.parse(init.body as string);
+		expect(body.messages[0].reasoning_content).toBe('thinking about it');
+	});
+
+	it('passes through non-JSON, non-SSE responses unchanged', async () => {
+		const original = new Response('plain', {
+			status: 200,
+			headers: { 'content-type': 'text/plain' },
+		});
+		const baseFetch = jest.fn().mockResolvedValue(original);
+
+		const reasoningFetch = createReasoningContentFetch(baseFetch);
+		const result = await reasoningFetch('https://x');
+		expect(result).toBe(original);
+	});
+
+	it('does not interfere when the request body is not valid JSON', async () => {
+		const baseFetch = jest
+			.fn<Promise<Response>, [unknown, RequestInit | undefined]>()
+			.mockResolvedValueOnce(
+				buildJsonResponse({
+					choices: [
+						{
+							message: {
+								role: 'assistant',
+								reasoning_content: 'r',
+								tool_calls: [{ id: 'call_1' }],
+							},
+						},
+					],
+				}),
+			)
+			.mockResolvedValueOnce(buildJsonResponse({}));
+
+		const reasoningFetch = createReasoningContentFetch(baseFetch);
+
+		await reasoningFetch('https://x', { method: 'POST', body: '{}' });
+		await reasoningFetch('https://x', { method: 'POST', body: 'not-json' });
+
+		expect(baseFetch.mock.calls[1][1]?.body).toBe('not-json');
+	});
+});


### PR DESCRIPTION
## Summary

Fixes a regression for users running the AI Agent node with DeepSeek's "thinking mode" models (`deepseek-v4-flash`, `deepseek-chat`, `deepseek-reasoner`) and one or more tools attached.

DeepSeek's thinking mode (V3.2+ / V4) requires that any assistant message containing `tool_calls` is re-sent to the API with its original `reasoning_content` field intact. The OpenAI-compatible client used by `ChatOpenAI` neither preserves `reasoning_content` on the returned message nor forwards it back on subsequent requests, so multi-turn tool-calling fails with:

```
HTTP 400: The reasoning_content in the thinking mode must be passed back to the API.
```

Reference: https://api-docs.deepseek.com/guides/thinking_mode

### Approach

Wrap the chat model's `fetch` (via `ClientOptions.fetch`) with a small interceptor scoped to the chat-model instance:

1. On responses, capture `reasoning_content` keyed by each `tool_call.id` it accompanies. Both standard JSON responses and `text/event-stream` streaming responses are handled.
2. On outgoing requests, re-inject the captured `reasoning_content` into any assistant message whose `tool_calls` reference a known id and that does not already carry its own `reasoning_content`.

The capture map is per fetch wrapper (i.e. per chat-model instance), so concurrent executions do not share state. The interceptor is a no-op for non-DeepSeek code paths and for requests with no prior `reasoning_content` in flight.

### How to test

1. Configure a DeepSeek credential and an AI Agent with the DeepSeek Chat Model node (`deepseek-v4-flash` / `deepseek-chat` / `deepseek-reasoner`).
2. Attach at least one tool (sub-workflow or HTTP tool).
3. Send a prompt that requires tool use.
4. Before this PR: `400 Bad Request — The reasoning_content in the thinking mode must be passed back to the API.`
5. After this PR: the agent completes the tool round-trip and returns a final response.

Unit tests cover JSON capture + injection, SSE-stream capture, no-op when no reasoning has been seen, no-overwrite of preexisting `reasoning_content`, and pass-through of non-JSON / non-SSE responses and bodies.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/GHC-7888

Fixes #29119

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. <!-- No user-facing behavior change beyond fixing the broken case; no docs update needed. -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
