### PR TITLE
fix(AI Agent Node): Honor returnIntermediateSteps when persisting tool steps to memory

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/runAgent.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/runAgent.ts
@@ -101,10 +101,12 @@ export async function runAgent(
 				metadata: buildResponseMetadata(response, itemIndex),
 			};
 		}
-		// Save conversation to memory including any tool call context
+		// Persist intermediate tool steps to memory only when the user has opted in;
+		// otherwise the tool sequence leaks into the chat transcript on reload.
 		if (memory && input && result?.output) {
 			const previousCount = response?.metadata?.previousRequests?.length;
-			await saveToMemory(input, result.output, memory, steps, previousCount);
+			const stepsForMemory = options.returnIntermediateSteps ? steps : undefined;
+			await saveToMemory(input, result.output, memory, stepsForMemory, previousCount);
 		}
 
 		if (options.returnIntermediateSteps && steps.length > 0) {
@@ -125,10 +127,18 @@ export async function runAgent(
 		);
 
 		if ('returnValues' in modelResponse) {
-			// Save conversation to memory including any tool call context
+			// Persist intermediate tool steps to memory only when the user has opted in;
+			// otherwise the tool sequence leaks into the chat transcript on reload.
 			if (memory && input && modelResponse.returnValues.output) {
 				const previousCount = response?.metadata?.previousRequests?.length;
-				await saveToMemory(input, modelResponse.returnValues.output, memory, steps, previousCount);
+				const stepsForMemory = options.returnIntermediateSteps ? steps : undefined;
+				await saveToMemory(
+					input,
+					modelResponse.returnValues.output,
+					memory,
+					stepsForMemory,
+					previousCount,
+				);
 			}
 			// Include intermediate steps if requested
 			const result = { ...modelResponse.returnValues };

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/runAgent.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/runAgent.ts
@@ -101,10 +101,12 @@ export async function runAgent(
 				metadata: buildResponseMetadata(response, itemIndex),
 			};
 		}
-		// Save conversation to memory including any tool call context
+		// Persist intermediate tool steps to memory only when the user has opted in;
+		// otherwise the tool sequence leaks into the chat transcript on reload.
 		if (memory && input && result?.output) {
 			const previousCount = response?.metadata?.previousRequests?.length;
-			await saveToMemory(input, result.output, memory, steps, previousCount);
+			const stepsForMemory = options.returnIntermediateSteps ? steps : undefined;
+			await saveToMemory(input, result.output, memory, stepsForMemory, previousCount);
 			if (memoryHits) {
 				memoryHits.saves++;
 			}
@@ -131,10 +133,18 @@ export async function runAgent(
 		);
 
 		if ('returnValues' in modelResponse) {
-			// Save conversation to memory including any tool call context
+			// Persist intermediate tool steps to memory only when the user has opted in;
+			// otherwise the tool sequence leaks into the chat transcript on reload.
 			if (memory && input && modelResponse.returnValues.output) {
 				const previousCount = response?.metadata?.previousRequests?.length;
-				await saveToMemory(input, modelResponse.returnValues.output, memory, steps, previousCount);
+				const stepsForMemory = options.returnIntermediateSteps ? steps : undefined;
+				await saveToMemory(
+					input,
+					modelResponse.returnValues.output,
+					memory,
+					stepsForMemory,
+					previousCount,
+				);
 				if (memoryHits) {
 					memoryHits.saves++;
 				}

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/runAgent.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/runAgent.test.ts
@@ -1,4 +1,5 @@
-import type { RequestResponseMetadata } from '@utils/agent-execution';
+import type { RequestResponseMetadata, ToolCallData } from '@utils/agent-execution';
+import type { BaseChatMemory } from '@langchain/classic/memory';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { mock } from 'jest-mock-extended';
 import type { AgentRunnableSequence } from '@langchain/classic/agents';
@@ -429,5 +430,157 @@ describe('runAgent - tracing configuration', () => {
 		});
 		expect(mockWithConfig).toHaveBeenCalledWith(mockTracingConfig);
 		expect(mockStreamEvents).toHaveBeenCalled();
+	});
+});
+
+describe('runAgent - intermediate step memory persistence', () => {
+	const fixtureSteps: ToolCallData[] = [
+		{
+			action: {
+				tool: 'calculator',
+				toolInput: { expression: '2+2' },
+				log: 'Using calculator',
+				toolCallId: 'call-123',
+				type: 'tool_call',
+			},
+			observation: '4',
+		},
+	];
+
+	function buildItemContext(returnIntermediateSteps: boolean): ItemContext {
+		return {
+			itemIndex: 0,
+			input: 'Calculate 2+2',
+			steps: fixtureSteps,
+			tools: [],
+			prompt: mock(),
+			options: {
+				maxIterations: 10,
+				returnIntermediateSteps,
+			},
+			outputParser: undefined,
+		};
+	}
+
+	it('omits intermediate steps from saveToMemory when returnIntermediateSteps is false (non-streaming)', async () => {
+		const mockInvoke = jest.fn().mockResolvedValue({
+			returnValues: { output: 'The answer is 4' },
+		});
+		const mockExecutor = mock<AgentRunnableSequence>({
+			withConfig: jest.fn().mockReturnValue({ invoke: mockInvoke }),
+		});
+		const mockModel = mock<BaseChatModel>();
+		const mockMemory = mock<BaseChatMemory>();
+
+		jest.spyOn(agentExecution, 'loadMemory').mockResolvedValue([]);
+		jest.spyOn(agentExecution, 'saveToMemory').mockResolvedValue();
+		mockContext.getExecutionCancelSignal.mockReturnValue(new AbortController().signal);
+
+		await runAgent(mockContext, mockExecutor, buildItemContext(false), mockModel, mockMemory);
+
+		expect(agentExecution.saveToMemory).toHaveBeenCalledWith(
+			'Calculate 2+2',
+			'The answer is 4',
+			mockMemory,
+			undefined,
+			undefined,
+		);
+	});
+
+	it('passes intermediate steps to saveToMemory when returnIntermediateSteps is true (non-streaming)', async () => {
+		const mockInvoke = jest.fn().mockResolvedValue({
+			returnValues: { output: 'The answer is 4' },
+		});
+		const mockExecutor = mock<AgentRunnableSequence>({
+			withConfig: jest.fn().mockReturnValue({ invoke: mockInvoke }),
+		});
+		const mockModel = mock<BaseChatModel>();
+		const mockMemory = mock<BaseChatMemory>();
+
+		jest.spyOn(agentExecution, 'loadMemory').mockResolvedValue([]);
+		jest.spyOn(agentExecution, 'saveToMemory').mockResolvedValue();
+		mockContext.getExecutionCancelSignal.mockReturnValue(new AbortController().signal);
+
+		await runAgent(mockContext, mockExecutor, buildItemContext(true), mockModel, mockMemory);
+
+		expect(agentExecution.saveToMemory).toHaveBeenCalledWith(
+			'Calculate 2+2',
+			'The answer is 4',
+			mockMemory,
+			fixtureSteps,
+			undefined,
+		);
+	});
+
+	it('omits intermediate steps from saveToMemory when returnIntermediateSteps is false (streaming)', async () => {
+		const mockEventStream = (async function* () {})();
+		const mockStreamEvents = jest.fn().mockReturnValue(mockEventStream);
+		const mockExecutor = mock<AgentRunnableSequence>({
+			withConfig: jest.fn().mockReturnValue({ streamEvents: mockStreamEvents }),
+		});
+		const mockModel = mock<BaseChatModel>();
+		const mockMemory = mock<BaseChatMemory>();
+
+		const streamingContext = mock<IExecuteFunctions>({
+			getNode: jest.fn().mockReturnValue({ ...mockNode, typeVersion: 2.1 }),
+			isStreaming: jest.fn().mockReturnValue(true),
+			getExecutionCancelSignal: jest.fn().mockReturnValue(new AbortController().signal),
+		});
+		streamingContext.getExecuteData = jest.fn() as any;
+
+		const itemContext = buildItemContext(false);
+		itemContext.options.enableStreaming = true;
+
+		jest.spyOn(agentExecution, 'loadMemory').mockResolvedValue([]);
+		jest.spyOn(agentExecution, 'processEventStream').mockResolvedValue({
+			output: 'The answer is 4',
+		});
+		jest.spyOn(agentExecution, 'saveToMemory').mockResolvedValue();
+
+		await runAgent(streamingContext, mockExecutor, itemContext, mockModel, mockMemory);
+
+		expect(agentExecution.saveToMemory).toHaveBeenCalledWith(
+			'Calculate 2+2',
+			'The answer is 4',
+			mockMemory,
+			undefined,
+			undefined,
+		);
+	});
+
+	it('passes intermediate steps to saveToMemory when returnIntermediateSteps is true (streaming)', async () => {
+		const mockEventStream = (async function* () {})();
+		const mockStreamEvents = jest.fn().mockReturnValue(mockEventStream);
+		const mockExecutor = mock<AgentRunnableSequence>({
+			withConfig: jest.fn().mockReturnValue({ streamEvents: mockStreamEvents }),
+		});
+		const mockModel = mock<BaseChatModel>();
+		const mockMemory = mock<BaseChatMemory>();
+
+		const streamingContext = mock<IExecuteFunctions>({
+			getNode: jest.fn().mockReturnValue({ ...mockNode, typeVersion: 2.1 }),
+			isStreaming: jest.fn().mockReturnValue(true),
+			getExecutionCancelSignal: jest.fn().mockReturnValue(new AbortController().signal),
+		});
+		streamingContext.getExecuteData = jest.fn() as any;
+
+		const itemContext = buildItemContext(true);
+		itemContext.options.enableStreaming = true;
+
+		jest.spyOn(agentExecution, 'loadMemory').mockResolvedValue([]);
+		jest.spyOn(agentExecution, 'processEventStream').mockResolvedValue({
+			output: 'The answer is 4',
+		});
+		jest.spyOn(agentExecution, 'saveToMemory').mockResolvedValue();
+
+		await runAgent(streamingContext, mockExecutor, itemContext, mockModel, mockMemory);
+
+		expect(agentExecution.saveToMemory).toHaveBeenCalledWith(
+			'Calculate 2+2',
+			'The answer is 4',
+			mockMemory,
+			fixtureSteps,
+			undefined,
+		);
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/runAgent.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/runAgent.test.ts
@@ -1,4 +1,5 @@
 import type { AgentRunnableSequence } from '@langchain/classic/agents';
+import type { BaseChatMemory } from '@langchain/classic/memory';
 import type { Tool } from '@langchain/classic/tools';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import type { IExecuteFunctions, INode, EngineResponse } from 'n8n-workflow';
@@ -586,5 +587,156 @@ describe('runAgent - intermediate steps', () => {
 
 		expect(result).toHaveProperty('intermediateSteps');
 		expect((result as any).intermediateSteps).toEqual([]);
+	});
+});
+
+describe('runAgent - intermediate step memory persistence', () => {
+	const fixtureSteps: ToolCallData[] = [
+		{
+			action: {
+				tool: 'calculator',
+				toolInput: { expression: '2+2' },
+				log: 'Using calculator',
+				messageLog: [],
+				toolCallId: 'call-123',
+				type: 'tool_call',
+			},
+			observation: '4',
+		},
+	];
+
+	const buildItemContext = (returnIntermediateSteps: boolean): ItemContext => ({
+		itemIndex: 0,
+		input: 'Calculate 2+2',
+		steps: fixtureSteps,
+		tools: [],
+		prompt: mock(),
+		options: {
+			maxIterations: 10,
+			returnIntermediateSteps,
+		},
+		outputParser: undefined,
+	});
+
+	it('should omit intermediate steps from saveToMemory when the option is disabled (non-streaming)', async () => {
+		const mockInvoke = vi.fn().mockResolvedValue({
+			returnValues: { output: 'The answer is 4' },
+		});
+		const mockExecutor = mock<AgentRunnableSequence>({
+			withConfig: vi.fn().mockReturnValue({ invoke: mockInvoke }),
+		});
+		const mockModel = mock<BaseChatModel>();
+		const mockMemory = mock<BaseChatMemory>();
+
+		vi.spyOn(agentExecution, 'loadMemory').mockResolvedValue([]);
+		vi.spyOn(agentExecution, 'saveToMemory').mockResolvedValue();
+		mockContext.getExecutionCancelSignal.mockReturnValue(new AbortController().signal);
+
+		await runAgent(mockContext, mockExecutor, buildItemContext(false), mockModel, mockMemory);
+
+		expect(agentExecution.saveToMemory).toHaveBeenCalledWith(
+			'Calculate 2+2',
+			'The answer is 4',
+			mockMemory,
+			undefined,
+			undefined,
+		);
+	});
+
+	it('should pass intermediate steps to saveToMemory when the option is enabled (non-streaming)', async () => {
+		const mockInvoke = vi.fn().mockResolvedValue({
+			returnValues: { output: 'The answer is 4' },
+		});
+		const mockExecutor = mock<AgentRunnableSequence>({
+			withConfig: vi.fn().mockReturnValue({ invoke: mockInvoke }),
+		});
+		const mockModel = mock<BaseChatModel>();
+		const mockMemory = mock<BaseChatMemory>();
+
+		vi.spyOn(agentExecution, 'loadMemory').mockResolvedValue([]);
+		vi.spyOn(agentExecution, 'saveToMemory').mockResolvedValue();
+		mockContext.getExecutionCancelSignal.mockReturnValue(new AbortController().signal);
+
+		await runAgent(mockContext, mockExecutor, buildItemContext(true), mockModel, mockMemory);
+
+		expect(agentExecution.saveToMemory).toHaveBeenCalledWith(
+			'Calculate 2+2',
+			'The answer is 4',
+			mockMemory,
+			fixtureSteps,
+			undefined,
+		);
+	});
+
+	it('should omit intermediate steps from saveToMemory when the option is disabled (streaming)', async () => {
+		const mockEventStream = (async function* () {})();
+		const mockStreamEvents = vi.fn().mockReturnValue(mockEventStream);
+		const mockExecutor = mock<AgentRunnableSequence>({
+			withConfig: vi.fn().mockReturnValue({ streamEvents: mockStreamEvents }),
+		});
+		const mockModel = mock<BaseChatModel>();
+		const mockMemory = mock<BaseChatMemory>();
+
+		const streamingContext = mock<IExecuteFunctions>({
+			getNode: vi.fn().mockReturnValue({ ...mockNode, typeVersion: 2.1 }),
+			isStreaming: vi.fn().mockReturnValue(true),
+			getExecutionCancelSignal: vi.fn().mockReturnValue(new AbortController().signal),
+		});
+		streamingContext.getExecuteData = vi.fn() as any;
+
+		const itemContext = buildItemContext(false);
+		itemContext.options.enableStreaming = true;
+
+		vi.spyOn(agentExecution, 'loadMemory').mockResolvedValue([]);
+		vi.spyOn(agentExecution, 'saveToMemory').mockResolvedValue();
+		vi.spyOn(agentExecution, 'processEventStream').mockResolvedValue({
+			output: 'The answer is 4',
+		});
+
+		await runAgent(streamingContext, mockExecutor, itemContext, mockModel, mockMemory);
+
+		expect(agentExecution.saveToMemory).toHaveBeenCalledWith(
+			'Calculate 2+2',
+			'The answer is 4',
+			mockMemory,
+			undefined,
+			undefined,
+		);
+	});
+
+	it('should pass intermediate steps to saveToMemory when the option is enabled (streaming)', async () => {
+		const mockEventStream = (async function* () {})();
+		const mockStreamEvents = vi.fn().mockReturnValue(mockEventStream);
+		const mockExecutor = mock<AgentRunnableSequence>({
+			withConfig: vi.fn().mockReturnValue({ streamEvents: mockStreamEvents }),
+		});
+		const mockModel = mock<BaseChatModel>();
+		const mockMemory = mock<BaseChatMemory>();
+
+		const streamingContext = mock<IExecuteFunctions>({
+			getNode: vi.fn().mockReturnValue({ ...mockNode, typeVersion: 2.1 }),
+			isStreaming: vi.fn().mockReturnValue(true),
+			getExecutionCancelSignal: vi.fn().mockReturnValue(new AbortController().signal),
+		});
+		streamingContext.getExecuteData = vi.fn() as any;
+
+		const itemContext = buildItemContext(true);
+		itemContext.options.enableStreaming = true;
+
+		vi.spyOn(agentExecution, 'loadMemory').mockResolvedValue([]);
+		vi.spyOn(agentExecution, 'saveToMemory').mockResolvedValue();
+		vi.spyOn(agentExecution, 'processEventStream').mockResolvedValue({
+			output: 'The answer is 4',
+		});
+
+		await runAgent(streamingContext, mockExecutor, itemContext, mockModel, mockMemory);
+
+		expect(agentExecution.saveToMemory).toHaveBeenCalledWith(
+			'Calculate 2+2',
+			'The answer is 4',
+			mockMemory,
+			fixtureSteps,
+			undefined,
+		);
 	});
 });


### PR DESCRIPTION
## Summary

The V3 AI Agent's `saveToMemory` was always called with the full intermediate-step
sequence (`AIMessage` with `tool_calls` + paired `ToolMessage`s) regardless of the
`returnIntermediateSteps` option. On memory reload, those intermediate messages
surfaced in the chat transcript — either as visible `AIMessage` content
(`Calling <tool> with input: ...`) or, on memory backends without `addMessages`
support, as the literal `[Used tools: Tool: X, Input: ..., Result: ...]` string
prepended to the assistant's reply. The flag previously only controlled the
node's output shape, not memory persistence.

The fix gates the `steps` argument to `saveToMemory` on `options.returnIntermediateSteps`
in both the streaming and non-streaming code paths. With the flag disabled (the
default), only `HumanMessage(input)` and `AIMessage(output)` are persisted —
matching the v2.2 agent's `AgentExecutor.saveContext` semantics. With the flag
enabled, the full tool-call sequence is still saved so the LLM retains
multi-turn tool context.

## Related Linear tickets, Github issues, and Community forum posts

Closes #22112

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. <!-- No user-facing docs change; the existing returnIntermediateSteps option's behavior is now self-consistent. -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`.

### Verification

Ran from `packages/@n8n/nodes-langchain`:

- `pnpm test --testPathPattern=runAgent.test` — 11/11 passing (4 new cases covering both flag states across streaming and non-streaming paths)
- `pnpm lint` — clean
- `pnpm typecheck` — clean