### PR TITLE
fix(cli): use valid grant type fallback when authorization server omits grant_types_supported

### DIFF
--- a/packages/cli/src/oauth/__tests__/oauth.service.test.ts
+++ b/packages/cli/src/oauth/__tests__/oauth.service.test.ts
@@ -1512,6 +1512,62 @@ describe('OauthService', () => {
 			expect(callArgs[2] || []).toEqual([]);
 		});
 
+		it('should use pkce when server omits grant_types_supported but supports S256 and PKCE', async () => {
+			const axios = require('axios');
+			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
+			const mockGetUri = jest.fn().mockReturnValue({
+				toString: () =>
+					'https://example.domain/oauth2/auth?client_id=registered_client_id&redirect_uri=http://localhost:5678/rest/oauth2-credential/callback&response_type=code&state=state',
+			});
+			jest.mocked(ClientOAuth2).mockImplementation(
+				() =>
+					({
+						code: {
+							getUri: mockGetUri,
+						},
+					}) as any,
+			);
+
+			const credential = mock<CredentialsEntity>({ id: '1', type: 'googleOAuth2Api' });
+			const oauthCredentials = {
+				serverUrl: 'https://example.domain',
+				useDynamicClientRegistration: true,
+			} as OAuth2CredentialData;
+
+			jest.spyOn(service, 'getOAuthCredentials').mockResolvedValue(oauthCredentials);
+			// Simulate an authorization server that omits grant_types_supported (valid per RFC 8414)
+			// but advertises S256 PKCE support and standard token auth methods.
+			jest.mocked(axios.get).mockResolvedValue({
+				data: {
+					authorization_endpoint: 'https://example.domain/oauth2/auth',
+					token_endpoint: 'https://example.domain/oauth2/token',
+					registration_endpoint: 'https://example.domain/oauth2/register',
+					// grant_types_supported intentionally omitted
+					token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post'],
+					code_challenge_methods_supported: ['S256', 'plain'],
+				},
+			} as any);
+
+			jest.mocked(axios.post).mockResolvedValue({
+				data: {
+					client_id: 'registered_client_id',
+					client_secret: 'registered_client_secret',
+				},
+			} as any);
+
+			jest.spyOn(service, 'encryptAndSaveData').mockResolvedValue(undefined);
+
+			const authUri = await service.generateAOauth2AuthUri(credential, {
+				cid: credential.id,
+				origin: 'static-credential',
+				userId: 'user-id',
+			});
+
+			expect(authUri).toContain('https://example.domain/oauth2/auth');
+			const callArgs = (service.encryptAndSaveData as jest.Mock).mock.calls[0];
+			expect(callArgs[1]).toHaveProperty('grantType', 'pkce');
+		});
+
 		it('should throw BadRequestError when OAuth2 server metadata is invalid', async () => {
 			const axios = require('axios');
 			const credential = mock<CredentialsEntity>({ id: '1', type: 'googleOAuth2Api' });

--- a/packages/cli/src/oauth/oauth.service.ts
+++ b/packages/cli/src/oauth/oauth.service.ts
@@ -498,7 +498,10 @@ export class OauthService {
 			}
 
 			const { grantType, authentication } = this.selectGrantTypeAndAuthenticationMethod(
-				metadataValidation.data.grant_types_supported ?? ['authorization_code', 'implicit'],
+				metadataValidation.data.grant_types_supported ?? [
+					'authorization_code',
+					'refresh_token',
+				],
 				metadataValidation.data.token_endpoint_auth_methods_supported ?? ['client_secret_basic'],
 				metadataValidation.data.code_challenge_methods_supported ?? [],
 			);


### PR DESCRIPTION
Fixes #29147

## Problem

When an authorization server omits the optional `grant_types_supported` field from its OAuth discovery metadata (which is valid per [RFC 8414](https://www.rfc-editor.org/rfc/rfc8414)), n8n fell back to `['authorization_code', 'implicit']`. However, `selectGrantTypeAndAuthenticationMethod()` requires **both** `authorization_code` **and** `refresh_token` to be present before selecting the auth-code or PKCE flow. Since `implicit` ≠ `refresh_token`, neither the PKCE branch nor the auth-code branch matched, causing:

```
BadRequestError: No supported grant type and authentication method found
```

This broke MCP/OAuth integrations (e.g. Auth0) that:
- Support PKCE (`code_challenge_methods_supported: ['S256', 'plain']`)
- Advertise token auth methods
- But omit `grant_types_supported` from their metadata

## Solution

Change the fallback value for `grant_types_supported` from `['authorization_code', 'implicit']` to `['authorization_code', 'refresh_token']`. This aligns the fallback with what `selectGrantTypeAndAuthenticationMethod()` expects, so PKCE or auth-code flow is correctly selected when the server omits this optional field.

## Testing

Added a unit test in `oauth.service.test.ts` that simulates an authorization server omitting `grant_types_supported` but advertising `S256` PKCE support. The test verifies that `grantType` is correctly set to `'pkce'` without throwing.