### PR TITLE
fix(core): Require auth token to mount credentials overwrite endpoint

### DIFF
--- a/packages/cli/src/scaling/__tests__/worker-server.test.ts
+++ b/packages/cli/src/scaling/__tests__/worker-server.test.ts
@@ -121,6 +121,9 @@ describe('WorkerServer', () => {
 			const CREDENTIALS_OVERWRITE_ENDPOINT = 'credentials/overwrites';
 			globalConfig.credentials.overwrite.endpoint = CREDENTIALS_OVERWRITE_ENDPOINT;
 
+			const middleware = (_req: Request, _res: Response, next: NextFunction) => next();
+			credentialsOverwriteService.getOverwriteEndpointMiddleware.mockReturnValue(middleware);
+
 			await workerServer.init({ health: true, overwrites: true, metrics: true });
 
 			expect(app.get).toHaveBeenCalledWith('/internal/health', expect.any(Function));
@@ -131,6 +134,28 @@ describe('WorkerServer', () => {
 				expect.any(Function),
 			);
 			expect(prometheusMetricsService.init).toHaveBeenCalledWith(app);
+		});
+
+		it('should refuse to mount the overwrite endpoint when no auth token is configured', async () => {
+			const server = mock<http.Server>();
+			jest.spyOn(http, 'createServer').mockReturnValue(server);
+
+			server.listen.mockImplementation((...args: unknown[]) => {
+				const callback = args.find((arg) => typeof arg === 'function');
+				if (callback) callback();
+				return server;
+			});
+
+			const workerServer = newWorkerServer();
+
+			globalConfig.credentials.overwrite.endpoint = 'credentials/overwrites';
+			credentialsOverwriteService.getOverwriteEndpointMiddleware.mockReturnValue(null);
+
+			await expect(
+				workerServer.init({ health: true, overwrites: true, metrics: false }),
+			).rejects.toThrow(/CREDENTIALS_OVERWRITE_ENDPOINT_AUTH_TOKEN/);
+
+			expect(app.post).not.toHaveBeenCalled();
 		});
 
 		it('should mount credential overwrite middleware if configured', async () => {
@@ -203,6 +228,9 @@ describe('WorkerServer', () => {
 				if (callback) callback();
 				return server;
 			});
+
+			const middleware = (_req: Request, _res: Response, next: NextFunction) => next();
+			credentialsOverwriteService.getOverwriteEndpointMiddleware.mockReturnValue(middleware);
 
 			await workerServer.init({ health: true, overwrites: true, metrics: true });
 

--- a/packages/cli/src/scaling/worker-server.ts
+++ b/packages/cli/src/scaling/worker-server.ts
@@ -5,6 +5,7 @@ import { Service } from '@n8n/di';
 import type { Application } from 'express';
 import express from 'express';
 import { InstanceSettings } from 'n8n-core';
+import { UnexpectedError } from 'n8n-workflow';
 import { strict as assert } from 'node:assert';
 import http from 'node:http';
 import type { Server } from 'node:http';
@@ -127,9 +128,13 @@ export class WorkerServer {
 			const overwriteEndpointMiddleware =
 				this.credentialsOverwrites.getOverwriteEndpointMiddleware();
 
-			if (overwriteEndpointMiddleware) {
-				this.app.use(`/${endpoint}`, overwriteEndpointMiddleware);
+			if (!overwriteEndpointMiddleware) {
+				throw new UnexpectedError(
+					'CREDENTIALS_OVERWRITE_ENDPOINT requires CREDENTIALS_OVERWRITE_ENDPOINT_AUTH_TOKEN to be set',
+				);
 			}
+
+			this.app.use(`/${endpoint}`, overwriteEndpointMiddleware);
 
 			this.app.post(`/${endpoint}`, rawBodyReader, bodyParser, async (req, res) => {
 				await this.handleOverwrites(req, res);

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -9,7 +9,7 @@ import { access as fsAccess } from 'fs/promises';
 import helmet from 'helmet';
 import isEmpty from 'lodash/isEmpty';
 import { InstanceSettings, installGlobalProxyAgent } from 'n8n-core';
-import { jsonParse } from 'n8n-workflow';
+import { jsonParse, UnexpectedError } from 'n8n-workflow';
 import { resolve } from 'path';
 
 import { AbstractServer } from '@/abstract-server';
@@ -72,8 +72,6 @@ import { PubSubRegistry } from './scaling/pubsub/pubsub.registry';
 export class Server extends AbstractServer {
 	private endpointPresetCredentials: string;
 
-	private presetCredentialsLoaded: boolean;
-
 	private frontendService?: FrontendService;
 
 	constructor(
@@ -95,8 +93,6 @@ export class Server extends AbstractServer {
 			await import('@/controllers/module-settings.controller');
 			await import('@/controllers/third-party-licenses.controller');
 		}
-
-		this.presetCredentialsLoaded = false;
 
 		this.endpointPresetCredentials = this.globalConfig.credentials.overwrite.endpoint;
 
@@ -246,43 +242,36 @@ export class Server extends AbstractServer {
 			const overwriteEndpointMiddleware =
 				Container.get(CredentialsOverwrites).getOverwriteEndpointMiddleware();
 
-			if (overwriteEndpointMiddleware) {
-				this.app.use(`/${this.endpointPresetCredentials}`, overwriteEndpointMiddleware);
+			if (!overwriteEndpointMiddleware) {
+				throw new UnexpectedError(
+					'CREDENTIALS_OVERWRITE_ENDPOINT requires CREDENTIALS_OVERWRITE_ENDPOINT_AUTH_TOKEN to be set',
+				);
 			}
 
-			const authenticationEnforced = overwriteEndpointMiddleware !== null;
+			this.app.use(`/${this.endpointPresetCredentials}`, overwriteEndpointMiddleware);
+
 			this.app.post(
 				`/${this.endpointPresetCredentials}`,
 				async (req: express.Request, res: express.Response) => {
 					try {
-						// If authentication is enforced we can allow multiple overwrites
-						if (!this.presetCredentialsLoaded || authenticationEnforced) {
-							const body = req.body as ICredentialsOverwrite;
+						const body = req.body as ICredentialsOverwrite;
 
-							if (req.contentType !== 'application/json') {
-								ResponseHelper.sendErrorResponse(
-									res,
-									new Error(
-										'Body must be a valid JSON, make sure the content-type is application/json',
-									),
-								);
-								return;
-							}
-
-							await Container.get(CredentialsOverwrites).setData(body, true, true);
-
-							this.presetCredentialsLoaded = true;
-
-							// Send push event to notify frontend to refetch types
-							Container.get(Push).broadcast({ type: 'nodeDescriptionUpdated', data: {} });
-
-							ResponseHelper.sendSuccessResponse(res, { success: true }, true, 200);
-						} else {
+						if (req.contentType !== 'application/json') {
 							ResponseHelper.sendErrorResponse(
 								res,
-								new Error('Preset credentials can be set once'),
+								new Error(
+									'Body must be a valid JSON, make sure the content-type is application/json',
+								),
 							);
+							return;
 						}
+
+						await Container.get(CredentialsOverwrites).setData(body, true, true);
+
+						// Send push event to notify frontend to refetch types
+						Container.get(Push).broadcast({ type: 'nodeDescriptionUpdated', data: {} });
+
+						ResponseHelper.sendSuccessResponse(res, { success: true }, true, 200);
 					} catch (error) {
 						this.logger.error('Error handling credentials overwrite', { error });
 						ResponseHelper.sendErrorResponse(


### PR DESCRIPTION
## Summary

Refuses to register the credentials overwrite POST route unless `CREDENTIALS_OVERWRITE_ENDPOINT_AUTH_TOKEN` is configured. If `CREDENTIALS_OVERWRITE_ENDPOINT` is set without the token, the server now throws an `UnexpectedError` at startup instead of mounting an unauthenticated handler. The same guard is applied to the worker server's overwrite route in `packages/cli/src/scaling/worker-server.ts`.

The dual-mode handler in `packages/cli/src/server.ts` is also removed: with auth always required on this route, the single-write fallback (`presetCredentialsLoaded` + `authenticationEnforced`) is no longer needed and the field is dropped.

### How to test

- Set `CREDENTIALS_OVERWRITE_ENDPOINT=/rest/presets` without `CREDENTIALS_OVERWRITE_ENDPOINT_AUTH_TOKEN` → server fails fast at startup with a clear error.
- Set both env vars → endpoint mounts as before; requests without a matching `Authorization: Bearer <token>` header get `401`.
- Run `pnpm --filter n8n test src/scaling/__tests__/worker-server.test.ts` — includes a new test asserting the fail-closed behavior.

## Related Linear tickets, Github issues, and Community forum posts

_None — reported externally._

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
