### PR TITLE
fix(Google Gemini Node): Show Number of Images option only for models that supports it

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/image/generate.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/image/generate.operation.ts
@@ -43,9 +43,13 @@ const properties: INodeProperties[] = [
 				displayName: 'Number of Images',
 				name: 'sampleCount',
 				default: 1,
-				description:
-					'Number of images to generate. Not supported by Gemini models, supported by Imagen models.',
+				description: 'Number of images to generate',
 				type: 'number',
+				displayOptions: {
+					show: {
+						'/modelId': [{ _cnd: { includes: 'imagen' } }],
+					},
+				},
 				typeOptions: {
 					minValue: 1,
 				},


### PR DESCRIPTION
## Summary

Show Number of Images option only for models that supports it

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/RLY-30/number-of-images-option-in-gemini-generate-image-action-not-working
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
