### PR TITLE
fix(Strava): delete options.form instead of options.body when body is empty

### DIFF
--- a/packages/nodes-base/nodes/Strava/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Strava/GenericFunctions.ts
@@ -31,7 +31,7 @@ export async function stravaApiRequest(
 			options.headers = Object.assign({}, options.headers, headers);
 		}
 		if (Object.keys(body).length === 0) {
-			delete options.body;
+			delete options.form;
 		}
 
 		if (this.getNode().type.includes('Trigger') && resource.includes('/push_subscriptions')) {


### PR DESCRIPTION
## Problem
In `stravaApiRequest` (packages/nodes-base/nodes/Strava/GenericFunctions.ts) the request options are built with `form: body`, but the guard that strips the property when the body object is empty targets `options.body` — a key that does not exist in the options object. Because the `delete` targets the wrong property, an empty `form: {}` is always included in the outgoing request, even for GET and DELETE calls that should carry no body.

## Fix
Change `delete options.body` to `delete options.form` so the empty form data is actually removed from the options when no body content is needed.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass