### PR TITLE
fix(GoogleCalendar): remove debug console.log calls from GenericFunctions

### DIFF
--- a/packages/nodes-base/nodes/Google/Calendar/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Calendar/GenericFunctions.ts
@@ -199,8 +199,8 @@ export function addNextOccurrence(items: RecurrentEvent[]) {
 						},
 					};
 				}
-			} catch (error) {
-				console.log(`Error adding next occurrence ${eventRecurrence}`);
+			} catch {
+				// Skip recurring event occurrences that cannot be parsed
 			}
 		}
 	}
@@ -232,8 +232,6 @@ async function requestWithRetries(
 
 		if (error.httpCode === '403' || error.httpCode === '429') {
 			const delay = 1000 * Math.pow(2, retryCount);
-
-			console.log(`Rate limit hit. Retrying in ${delay}ms... (Attempt ${retryCount + 1})`);
 
 			await sleep(delay);
 			return await requestWithRetries(node, requestFn, retryCount + 1, maxRetries, itemIndex);


### PR DESCRIPTION
## Problem
Two `console.log` statements were left in production code inside `packages/nodes-base/nodes/Google/Calendar/GenericFunctions.ts`:

1. **Recurring-event catch block** (line 203): On every failed attempt to compute the next occurrence of a recurring event, the raw `eventRecurrence` string is printed to stdout. The value can contain calendar data and should not be emitted uncontrolled in production.

2. **`requestWithRetries` rate-limit branch** (line 236): On every 403 or 429 retry, a "Rate limit hit" message with delay and attempt count is printed to stdout. The retry logic itself is correct; the log leaks internal retry details to server stdout.

## Fix
- Replace the `catch (error) { console.log(...) }` block with a `catch { /* comment */ }` that preserves the silent-skip behavior without emitting anything.
- Remove the `console.log` from the retry branch; the exponential `sleep(delay)` and recursive call are unaffected.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass