### PR TITLE
fix(PagerDuty): delete options.body instead of options.form when body is empty

### DIFF
--- a/packages/nodes-base/nodes/PagerDuty/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/PagerDuty/GenericFunctions.ts
@@ -38,7 +38,7 @@ export async function pagerDutyApiRequest(
 	};
 
 	if (!Object.keys(body as IDataObject).length) {
-		delete options.form;
+		delete options.body;
 	}
 	if (!Object.keys(query).length) {
 		delete options.qs;


### PR DESCRIPTION
## Problem
In `pagerDutyApiRequest`, the `options` object is built with a `body` property, but the empty-body guard does `delete options.form` instead of `delete options.body`. Since `options.form` never exists, this is a no-op — the empty body object `{}` is always sent on every request, including GETs.

## Fix
Change `delete options.form` to `delete options.body` so the empty body is correctly stripped before the request is dispatched.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass