### PR TITLE
fix(Bannerbear): delete options.body instead of options.form when body is empty

### DIFF
--- a/packages/nodes-base/nodes/Bannerbear/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Bannerbear/GenericFunctions.ts
@@ -35,7 +35,7 @@ export async function bannerbearApiRequest(
 		json: true,
 	};
 	if (!Object.keys(body as IDataObject).length) {
-		delete options.form;
+		delete options.body;
 	}
 	if (!Object.keys(query).length) {
 		delete options.qs;


### PR DESCRIPTION
## Problem
In `bannerbearApiRequest`, the `options` object is built with a `body` property, but the empty-body guard does `delete options.form` instead of `delete options.body`. Since `options.form` never exists on this options object, the guard is a no-op — the empty body `{}` is always sent, including on GET requests.

## Fix
Change `delete options.form` to `delete options.body` so the empty body is correctly removed before the request is dispatched.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass