### PR TITLE
fix(WooCommerce): delete options.body instead of options.form when body is empty

### DIFF
--- a/packages/nodes-base/nodes/WooCommerce/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/WooCommerce/GenericFunctions.ts
@@ -35,7 +35,7 @@ export async function woocommerceApiRequest(
 	};
 
 	if (!Object.keys(body as IDataObject).length) {
-		delete options.form;
+		delete options.body;
 	}
 	options = Object.assign({}, options, option);
 	return await this.helpers.requestWithAuthentication.call(this, 'wooCommerceApi', options);


### PR DESCRIPTION
## Problem
In `woocommerceApiRequest`, the `options` object is built with a `body` property, but the empty-body guard does `delete options.form` instead of `delete options.body`. Since `options.form` is never set on the options object, this guard is a no-op — the empty body `{}` is always included in every request, including GET requests.

## Fix
Change `delete options.form` to `delete options.body` so the empty body is correctly removed before the request is dispatched.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass