### PR TITLE
fix(breaking-changes): replace console.log with scoped logger in rule evaluation

### DIFF
--- a/packages/cli/src/modules/breaking-changes/breaking-changes.service.ts
+++ b/packages/cli/src/modules/breaking-changes/breaking-changes.service.ts
@@ -81,7 +81,7 @@ export class BreakingChangeService {
 					});
 				}
 			} catch (error) {
-				console.log('error', error);
+				this.logger.error('Failed to evaluate breaking-change rule', { error });
 				this.errorReporter.error(error, { shouldBeLogged: true });
 			}
 		}


### PR DESCRIPTION
## Problem
`BreakingChangeService.detectInstanceRuleBreakingChanges` catches rule evaluation errors and logs them with a raw `console.log('error', error)` before passing them to `errorReporter`. The service already has a structured `Logger` injected and scoped to `'breaking-changes'`, so the `console.log` bypasses the standard logging pipeline entirely.

## Fix
Replaced `console.log('error', error)` with `this.logger.error('Failed to evaluate breaking-change rule', { error })` so rule failures are emitted through the structured logger and associated with the correct scope.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass