### PR TITLE
fix(Magento): replace deprecated ApplicationError with UserError in getFilterQuery

### DIFF
--- a/packages/nodes-base/nodes/Magento/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Magento/GenericFunctions.ts
@@ -10,7 +10,7 @@ import type {
 	IHttpRequestMethods,
 	IRequestOptions,
 } from 'n8n-workflow';
-import { ApplicationError, NodeApiError } from 'n8n-workflow';
+import { NodeApiError, UserError } from 'n8n-workflow';
 
 import type { Filter, Address, Search, FilterGroup, ProductAttribute } from './types';
 
@@ -482,7 +482,7 @@ export function getFilterQuery(data: {
 	sort: [{ direction: string; field: string }];
 }): Search {
 	if (!data.hasOwnProperty('conditions') || data.conditions?.length === 0) {
-		throw new ApplicationError('At least one filter has to be set', { level: 'warning' });
+		throw new UserError('At least one filter has to be set');
 	}
 
 	if (data.matchType === 'anyFilter') {


### PR DESCRIPTION
## Problem
`getFilterQuery` in `Magento/GenericFunctions.ts` throws `ApplicationError` when no filter conditions are provided. Per the node development guidelines, `ApplicationError` is deprecated in CLI and node code — `UserError`, `OperationalError`, or `UnexpectedError` should be used instead.

## Fix
Replaced `ApplicationError` with `UserError` (imported from `n8n-workflow`) and removed the now-unused `ApplicationError` import. `UserError` is the appropriate choice for this validation case since it represents a mistake made by the workflow author rather than an infrastructure failure.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass