### PR TITLE
fix(Mailcheck): replace deprecated ApplicationError with NodeApiError in error handler

### DIFF
--- a/packages/nodes-base/nodes/Mailcheck/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Mailcheck/GenericFunctions.ts
@@ -1,4 +1,3 @@
-import { ApplicationError } from '@n8n/errors';
 import type {
 	IDataObject,
 	IExecuteFunctions,
@@ -7,7 +6,9 @@ import type {
 	ILoadOptionsFunctions,
 	IRequestOptions,
 	IWebhookFunctions,
+	JsonObject,
 } from 'n8n-workflow';
+import { NodeApiError } from 'n8n-workflow';
 
 export async function mailCheckApiRequest(
 	this: IWebhookFunctions | IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions,
@@ -45,10 +46,9 @@ export async function mailCheckApiRequest(
 	} catch (error) {
 		if (error.response?.body?.message) {
 			// Try to return the error prettier
-			throw new ApplicationError(
-				`Mailcheck error response [${error.statusCode}]: ${error.response.body.message}`,
-				{ level: 'warning' },
-			);
+			throw new NodeApiError(this.getNode(), error as JsonObject, {
+				message: `Mailcheck error response [${error.statusCode}]: ${error.response.body.message}`,
+			});
 		}
 		throw error;
 	}


### PR DESCRIPTION
## Problem
`Mailcheck/GenericFunctions.ts` throws `ApplicationError` when the API returns an error response. Per n8n's node development guidelines, `ApplicationError` is deprecated for use in nodes and should not be used in `packages/nodes-base`.

## Fix
Replaced the `ApplicationError` import (from `@n8n/errors`) with `NodeApiError` (from `n8n-workflow`) and updated the catch block to throw `NodeApiError` instead. This is consistent with the error-handling pattern used across other nodes in `packages/nodes-base`.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass