### PR TITLE
fix(Venafi): replace deprecated ApplicationError with NodeApiError in Datacenter error handler

### DIFF
--- a/packages/nodes-base/nodes/Venafi/Datacenter/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Venafi/Datacenter/GenericFunctions.ts
@@ -1,5 +1,4 @@
 import get from 'lodash/get';
-import { ApplicationError } from '@n8n/errors';
 import type {
 	IDataObject,
 	IExecuteFunctions,
@@ -7,7 +6,9 @@ import type {
 	ILoadOptionsFunctions,
 	IPollFunctions,
 	IRequestOptions,
+	JsonObject,
 } from 'n8n-workflow';
+import { NodeApiError } from 'n8n-workflow';
 
 export async function venafiApiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions,
@@ -50,10 +51,9 @@ export async function venafiApiRequest(
 
 			errors = errors.map((e: IDataObject) => e.message);
 			// Try to return the error prettier
-			throw new ApplicationError(
-				`Venafi error response [${error.statusCode}]: ${errors.join('|')}`,
-				{ level: 'warning' },
-			);
+			throw new NodeApiError(this.getNode(), error as JsonObject, {
+				message: `Venafi error response [${error.statusCode}]: ${errors.join('|')}`,
+			});
 		}
 		throw error;
 	}


### PR DESCRIPTION
## Problem
`Venafi/Datacenter/GenericFunctions.ts` throws `ApplicationError` when the Venafi API returns an error response. Per n8n's node development guidelines, `ApplicationError` is deprecated for use in nodes and should not be used in `packages/nodes-base`. The correct class for API errors in nodes is `NodeApiError`.

## Fix
Replaced the `ApplicationError` import (from `@n8n/errors`) with `NodeApiError` (from `n8n-workflow`) and updated the catch block accordingly. This matches the error-handling pattern used across other Venafi nodes in the same package (e.g., `Venafi/ProtectCloud/GenericFunctions.ts`).

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass