### PR TITLE
fix(HighLevel): replace deprecated ApplicationError with NodeOperationError in GenericFunctions

### DIFF
--- a/packages/nodes-base/nodes/HighLevel/v2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/HighLevel/v2/GenericFunctions.ts
@@ -16,7 +16,7 @@ import type {
 	IPollFunctions,
 	IWebhookFunctions,
 } from 'n8n-workflow';
-import { ApplicationError, NodeApiError } from 'n8n-workflow';
+import { NodeApiError, NodeOperationError } from 'n8n-workflow';
 
 const VALID_EMAIL_REGEX =
 	/^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
@@ -207,7 +207,10 @@ export const addNotePostReceiveAction = async function (
 
 	// Ensure there is a valid response and extract contactId and userId
 	if (!response || !response.body || !contact) {
-		throw new ApplicationError('No response data available to extract contact ID and user ID.');
+		throw new NodeOperationError(
+			this.getNode(),
+			'No response data available to extract contact ID and user ID.',
+		);
 	}
 
 	const contactId = contact.id;
@@ -405,7 +408,7 @@ export async function addCustomFieldsPreSendAction(
 						field_value: typedField.fieldValue,
 					};
 				} else {
-					throw new ApplicationError('Error processing custom fields.');
+					throw new NodeOperationError(this.getNode(), 'Error processing custom fields.');
 				}
 			});
 			requestBody.customFields = formattedCustomFields;


### PR DESCRIPTION
## Problem
`HighLevel/v2/GenericFunctions.ts` throws `ApplicationError` in two places: inside `addNotePostReceiveAction` when no response body is available, and inside `addCustomFieldsPreSendAction` when a custom field cannot be processed. Per n8n's node development guidelines, `ApplicationError` is deprecated for use in nodes (`packages/nodes-base`) and should be replaced with the appropriate workflow-level error class.

## Fix
Replaced `ApplicationError` with `NodeOperationError` in both locations, using `this.getNode()` as the node context. Also removed the now-unused `ApplicationError` import and replaced it with `NodeOperationError` in the import statement.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass