### PR TITLE
fix(Copper): add page_number increment in copperApiRequestAllItems to prevent infinite loop

### DIFF
--- a/packages/nodes-base/nodes/Copper/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Copper/GenericFunctions.ts
@@ -149,6 +149,7 @@ export async function copperApiRequestAllItems(
 ) {
 	let responseData;
 	qs.page_size = 200;
+	qs.page_number = 1;
 	let totalItems = 0;
 	const returnData: IDataObject[] = [];
 
@@ -156,6 +157,7 @@ export async function copperApiRequestAllItems(
 		responseData = await copperApiRequest.call(this, method, resource, body, qs, uri, option);
 		totalItems = responseData.headers['x-pw-total'];
 		returnData.push(...(responseData.body as IDataObject[]));
+		qs.page_number++;
 	} while (totalItems > returnData.length);
 
 	return returnData;


### PR DESCRIPTION
## Problem
`copperApiRequestAllItems` sets `qs.page_size = 200` but never increments `qs.page_number`. When the total number of items exceeds 200, the loop fetches the same first page on every iteration, creating an infinite loop.

## Fix
Initialize `qs.page_number = 1` before the loop and increment it after each successful response, so successive requests fetch the correct pages.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass