### PR TITLE
fix(HubSpot): guard paging.next access to prevent TypeError on last page

### DIFF
--- a/packages/nodes-base/nodes/Hubspot/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Hubspot/V2/GenericFunctions.ts
@@ -89,7 +89,7 @@ export async function hubspotApiRequestAllItems(
 		query.offset = responseData.offset;
 		query.vidOffset = responseData['vid-offset'];
 		//Used by Search endpoints
-		if (responseData.paging) {
+		if (responseData.paging?.next) {
 			body.after = responseData.paging.next.after;
 		}
 		returnData.push.apply(returnData, responseData[propertyName] as IDataObject[]);
@@ -98,7 +98,7 @@ export async function hubspotApiRequestAllItems(
 		if (limit && limit <= returnData.length && endpoint.includes('/tickets/paged')) {
 			return returnData;
 		}
-	} while (responseData.hasMore || responseData['has-more'] || responseData.paging);
+	} while (responseData.hasMore || responseData['has-more'] || responseData.paging?.next);
 	return returnData;
 }
 


### PR DESCRIPTION
## Problem
In `hubspotApiRequestAllItems`, when HubSpot returns a `paging` object without a `next` property (indicating the last page), the code unconditionally accesses `responseData.paging.next.after`, which throws a `TypeError: Cannot read properties of undefined`. The `while` condition also continues looping when `responseData.paging` is truthy but `paging.next` is absent.

## Fix
Use optional chaining (`responseData.paging?.next`) to guard the access and update the `while` condition to check `responseData.paging?.next` so the loop terminates correctly when there are no more pages.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass