### PR TITLE
fix(Lemlist): guard option merge with .length check to avoid always-truthy condition

### DIFF
--- a/packages/nodes-base/nodes/Lemlist/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Lemlist/GenericFunctions.ts
@@ -36,7 +36,7 @@ export async function lemlistApiRequest(
 		delete options.qs;
 	}
 
-	if (Object.keys(option)) {
+	if (Object.keys(option).length) {
 		Object.assign(options, option);
 	}
 


### PR DESCRIPTION
## Problem
In `lemlistApiRequest`, the condition `if (Object.keys(option))` always evaluates to `true` because `Object.keys()` always returns an array (a truthy value), even when `option` is empty. This means extra options are always merged into the request options object, even when none were provided, which could inadvertently override default request settings.

## Fix
Changed the condition to `if (Object.keys(option).length)` so that the `Object.assign` only runs when there are actual option keys to merge, consistent with the pattern used by other nodes in the codebase (e.g., Pushbullet, Tapfiliate).

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass