### PR TITLE
fix(Pushbullet): pass pagination cursor to next request in getAllItems

### DIFF
--- a/packages/nodes-base/nodes/Pushbullet/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Pushbullet/GenericFunctions.ts
@@ -54,6 +54,7 @@ export async function pushbulletApiRequestAllItems(
 	do {
 		responseData = await pushbulletApiRequest.call(this, method, endpoint, body, query);
 		returnData.push.apply(returnData, responseData[propertyName] as IDataObject[]);
+		query.cursor = responseData.cursor;
 	} while (responseData.cursor !== undefined);
 
 	return returnData;


### PR DESCRIPTION
## Problem
In `pushbulletApiRequestAllItems`, the do-while loop checks `responseData.cursor !== undefined` to determine whether to continue fetching pages, but never actually sets `query.cursor` to the returned cursor value. As a result, every iteration re-fetches the first page, causing an infinite pagination loop when the API returns a cursor.

## Fix
Added `query.cursor = responseData.cursor` after collecting results from each page so the next request uses the correct cursor to advance to the following page, matching the pagination pattern used by the Pushbullet API.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass