### PR TITLE
fix(Tapfiliate): use optional chaining on link header to prevent TypeError on last page

### DIFF
--- a/packages/nodes-base/nodes/Tapfiliate/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Tapfiliate/GenericFunctions.ts
@@ -66,7 +66,7 @@ export async function tapfiliateApiRequestAllItems(
 		});
 		returnData.push.apply(returnData, responseData.body as IDataObject[]);
 		query.page++;
-	} while (responseData.headers.link.includes('next'));
+	} while (responseData.headers.link?.includes('next'));
 
 	return returnData;
 }


### PR DESCRIPTION
## Problem
In `tapfiliateApiRequestAllItems`, the while condition accesses `responseData.headers.link.includes('next')` without any null guard. The Tapfiliate API omits the `Link` header on the final page of results. When this header is absent, `responseData.headers.link` is `undefined` and calling `.includes()` on it throws a `TypeError`, causing the node to error out when fetching the last page.

## Fix
Changed `responseData.headers.link.includes('next')` to use optional chaining (`responseData.headers.link?.includes('next')`) so that when the `Link` header is absent the expression evaluates to `undefined` (falsy) and the loop exits cleanly.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass