### PR TITLE
feat(Salesforce Node): Allow arbitrary Values for custom objects in Salesforce node

### DIFF
--- a/packages/nodes-base/nodes/Salesforce/CustomObjectDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/CustomObjectDescription.ts
@@ -164,6 +164,7 @@ export const customObjectFields: INodeProperties[] = [
 		displayName: 'Custom Object Name or ID',
 		name: 'customObject',
 		type: 'options',
+		allowArbitraryValues: true, // Allows users to specify objects using expressions for custom objects without showing an error
 		typeOptions: {
 			loadOptionsMethod: 'getCustomObjects',
 		},
@@ -217,6 +218,7 @@ export const customObjectFields: INodeProperties[] = [
 						displayName: 'Field Name or ID',
 						name: 'fieldId',
 						type: 'options',
+						allowArbitraryValues: true, // Allows users to specify fields using expressions for any given object without showing an error
 						typeOptions: {
 							loadOptionsMethod: 'getCustomObjectFields',
 							loadOptionsDependsOn: ['customObject'],
@@ -244,6 +246,7 @@ export const customObjectFields: INodeProperties[] = [
 		displayName: 'Custom Object Name or ID',
 		name: 'customObject',
 		type: 'options',
+		allowArbitraryValues: true, // Allows users to specify objects using expressions for custom objects without showing an error
 		typeOptions: {
 			loadOptionsMethod: 'getCustomObjects',
 		},
@@ -280,6 +283,7 @@ export const customObjectFields: INodeProperties[] = [
 		displayName: 'Custom Object Name or ID',
 		name: 'customObject',
 		type: 'options',
+		allowArbitraryValues: true, // Allows users to specify objects using expressions for custom objects without showing an error
 		typeOptions: {
 			loadOptionsMethod: 'getCustomObjects',
 		},
@@ -316,6 +320,7 @@ export const customObjectFields: INodeProperties[] = [
 		displayName: 'Custom Object Name or ID',
 		name: 'customObject',
 		type: 'options',
+		allowArbitraryValues: true, // Allows users to specify objects using expressions for custom objects without showing an error
 		typeOptions: {
 			loadOptionsMethod: 'getCustomObjects',
 		},

--- a/packages/nodes-base/nodes/Salesforce/CustomObjectDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/CustomObjectDescription.ts
@@ -136,6 +136,7 @@ export const customObjectFields: INodeProperties[] = [
 						displayName: 'Field Name or ID',
 						name: 'fieldId',
 						type: 'options',
+						allowArbitraryValues: true, // Allows users to specify fields using expressions for any given object without showing an error
 						typeOptions: {
 							loadOptionsMethod: 'getCustomObjectFields',
 							loadOptionsDependsOn: ['customObject'],

--- a/packages/nodes-base/nodes/Salesforce/CustomObjectDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/CustomObjectDescription.ts
@@ -61,6 +61,7 @@ export const customObjectFields: INodeProperties[] = [
 		displayName: 'Custom Object Name or ID',
 		name: 'customObject',
 		type: 'options',
+		allowArbitraryValues: true, // Allows users to specify objects using expressions for custom objects without showing an error
 		typeOptions: {
 			loadOptionsMethod: 'getCustomObjects',
 		},


### PR DESCRIPTION


## Summary

As specified by the tooltip hint introduced in 70ae90fa3c, hardcoding object names into the expression names is a valid workaround for cases where non-custom objects need to be interacted with that are not part of the predefined objects within the salesforce node. This problem is also discussed in https://github.com/n8n-io/n8n/pull/23905. This shows that this problem affects actual users!

To verify that such a workaround is indeed needed, i queried our Salesforce for all non-custom objects, which produced 1010 unique Objects. Currently the salesforce node in n8n has 12 of those hardcoded - leaving us with 998 Objects not accessible without using their keys directly. 

However, without the allowArbitraryValues flag the UI tells you that your input is wrong, even though the tooltip literally tells you to do it this way.

<img width="580" alt="n8n_sf_custom_object_value_not_allowed_1" src="https://github.com/user-attachments/assets/68bee724-83e5-4649-8103-8afab488cb80" />

This PR gets rid of this warning.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/pull/23905
https://github.com/n8n-io/n8n/pull/5235
https://community.n8n.io/t/there-is-no-email-opt-out-field-in-the-saleforce-create-lead/18616/9

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. 
  - Not required? 
