### PR TITLE
fix(Salesforce): strip versioned API prefix from nextRecordsUrl in pagination

### DIFF
--- a/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
@@ -156,7 +156,11 @@ export async function salesforceApiRequestAllItems(
 
 	do {
 		responseData = await salesforceApiRequest.call(this, method, endpoint, body, query, uri);
-		uri = `${endpoint}/${responseData.nextRecordsUrl?.split('/')?.pop()}`;
+		if (responseData.nextRecordsUrl) {
+			// nextRecordsUrl is an absolute path like "/services/data/v59.0/query/<id>/results".
+			// Strip the versioned API prefix so getOptions prepends only instanceUrl.
+			uri = (responseData.nextRecordsUrl as string).replace(/^\/services\/data\/v[\d.]+/, '');
+		}
 		returnData.push.apply(returnData, responseData[propertyName] as IDataObject[]);
 	} while (responseData.nextRecordsUrl !== undefined && responseData.nextRecordsUrl !== null);
 


### PR DESCRIPTION
## Problem
`salesforceApiRequestAllItems` builds the next-page URI incorrectly: it takes only the last path segment of `nextRecordsUrl` (e.g. `results`) and appends it to the initial endpoint (e.g. `/query`), producing `/query/results` instead of the full relative path like `/query/<batchId>/results`. This means pagination always fails after the first page.

## Fix
Strip the versioned API prefix (`/services/data/vXX.X`) from `nextRecordsUrl` using a regex so that `getOptions` can build the correct full URI by prepending the instance URL. This matches how Salesforce returns `nextRecordsUrl` as an absolute versioned path.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass