### PR TITLE
fix(Intercom): guard pages.next access with optional chaining to prevent TypeError

### DIFF
--- a/packages/nodes-base/nodes/Intercom/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Intercom/GenericFunctions.ts
@@ -56,9 +56,9 @@ export async function intercomApiRequestAllItems(
 
 	do {
 		responseData = await intercomApiRequest.call(this, endpoint, method, body, query, uri);
-		uri = responseData.pages.next;
+		uri = responseData.pages?.next;
 		returnData.push.apply(returnData, responseData[propertyName] as IDataObject[]);
-	} while (responseData.pages?.next !== null);
+	} while (responseData.pages?.next != null);
 
 	return returnData;
 }


### PR DESCRIPTION
## Problem
`intercomApiRequestAllItems` reads `responseData.pages.next` on line 59 without optional chaining. When the API response does not include a `pages` object (e.g. endpoints that do not support cursor pagination), this throws `TypeError: Cannot read properties of undefined (reading 'next')`. The `while` condition on the following line already used optional chaining (`responseData.pages?.next !== null`) but the assignment did not.

## Fix
Apply optional chaining to the `uri` assignment (`responseData.pages?.next`) and change the strict inequality in the loop condition to loose (`!= null`) so that both `undefined` and `null` terminate the loop correctly.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass