### PR TITLE
fix(Linear): use optional chaining on error.context in catch block to prevent TypeError

### DIFF
--- a/packages/nodes-base/nodes/Linear/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Linear/GenericFunctions.ts
@@ -53,11 +53,11 @@ export async function linearApiRequest(
 			{
 				message:
 					error.errorResponse?.[0]?.message ||
-					error.context.data.errors[0]?.message ||
+					error.context?.data?.errors?.[0]?.message ||
 					'Unknown API error',
 				description:
 					error.errorResponse?.[0]?.extensions?.userPresentableMessage ||
-					error.context.data.errors[0]?.extensions?.userPresentableMessage,
+					error.context?.data?.errors?.[0]?.extensions?.userPresentableMessage,
 			},
 		);
 	}


### PR DESCRIPTION
## Problem
The catch block in `linearApiRequest` accesses `error.context.data.errors[0]?.message` without optional chaining on `context` or `data`. Any error that does not carry a `context` property (e.g. a network timeout or an authentication failure) causes a secondary `TypeError: Cannot read properties of undefined (reading 'data')`, masking the real error.

## Fix
Apply optional chaining throughout the `error.context` access path (`error.context?.data?.errors?.[0]?.message`) so the catch block falls back gracefully to `'Unknown API error'` without throwing.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass