### PR TITLE
fix(Netlify): guard option merge with .length check and add optional chaining on link header

### DIFF
--- a/packages/nodes-base/nodes/Netlify/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Netlify/GenericFunctions.ts
@@ -34,7 +34,7 @@ export async function netlifyApiRequest(
 		delete options.body;
 	}
 
-	if (Object.keys(option)) {
+	if (Object.keys(option).length) {
 		Object.assign(options, option);
 	}
 
@@ -69,7 +69,7 @@ export async function netlifyRequestAllItems(
 		});
 		query.page++;
 		returnData.push.apply(returnData, responseData.body as IDataObject[]);
-	} while (responseData.headers.link.includes('next'));
+	} while (responseData.headers.link?.includes('next'));
 
 	return returnData;
 }


### PR DESCRIPTION
## Problem
`netlifyApiRequest` checks `if (Object.keys(option))` which always evaluates to `true` (an array is always truthy) so the `Object.assign` runs unconditionally even when `option` is empty. Additionally, `netlifyRequestAllItems` accesses `responseData.headers.link.includes('next')` without a null guard, throwing a `TypeError` on the last page when the `link` header is absent.

## Fix
Changed `if (Object.keys(option))` to `if (Object.keys(option).length)` so the merge only happens when the `option` object is non-empty. Added optional chaining (`?.`) to the `link` header access in the `do…while` condition to prevent a `TypeError` when the header is missing.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass