### PR TITLE
fix(GoToWebinar): guard option merge with .length check to avoid always-truthy condition

### DIFF
--- a/packages/nodes-base/nodes/GoToWebinar/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/GoToWebinar/GenericFunctions.ts
@@ -58,7 +58,7 @@ export async function goToWebinarApiRequest(
 		delete options.qs;
 	}
 
-	if (Object.keys(option)) {
+	if (Object.keys(option).length) {
 		Object.assign(options, option);
 	}
 


### PR DESCRIPTION
## Problem
`goToWebinarApiRequest` checks `if (Object.keys(option))` before merging the `option` object into request options. `Object.keys()` always returns an array, and a non-null array is always truthy, so the `Object.assign` runs unconditionally even when `option` is empty — the check is a no-op.

## Fix
Changed `if (Object.keys(option))` to `if (Object.keys(option).length)` so the merge only happens when the `option` object actually has properties to merge.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass