### PR TITLE
fix(Snowflake Node): Avoid call stack overflow on large result sets

### DIFF
--- a/packages/nodes-base/nodes/Snowflake/Snowflake.node.ts
+++ b/packages/nodes-base/nodes/Snowflake/Snowflake.node.ts
@@ -182,7 +182,7 @@ export class Snowflake implements INodeType {
 
 		await connect(connection);
 
-		const returnData: INodeExecutionData[] = [];
+		let returnData: INodeExecutionData[] = [];
 		const items = this.getInputData();
 		const operation = this.getNodeParameter('operation', 0);
 
@@ -203,7 +203,7 @@ export class Snowflake implements INodeType {
 					this.helpers.returnJsonArray(responseData as IDataObject[]),
 					{ itemData: { item: i } },
 				);
-				returnData.push(...executionData);
+				returnData = returnData.concat(executionData);
 			}
 		}
 
@@ -224,7 +224,7 @@ export class Snowflake implements INodeType {
 					this.helpers.returnJsonArray(d),
 					{ itemData: { item: i } },
 				);
-				returnData.push(...executionData);
+				returnData = returnData.concat(executionData);
 			});
 		}
 
@@ -261,7 +261,7 @@ export class Snowflake implements INodeType {
 					this.helpers.returnJsonArray(d),
 					{ itemData: { item: i } },
 				);
-				returnData.push(...executionData);
+				returnData = returnData.concat(executionData);
 			});
 		}
 


### PR DESCRIPTION
## Summary

Fixes a `RangeError: Maximum call stack size exceeded` crash that occurs when the Snowflake node processes a large number of rows.

**Root cause:** `returnData.push(...executionData)` uses the spread operator to expand all array elements as function arguments. When a query returns tens of thousands of rows, this hits the JS engine's argument-count limit and crashes the execution.

**Fix:** Replace all three occurrences with `returnData = returnData.concat(executionData)`. `Array#concat()` copies elements internally without spread/function-argument expansion, handling any dataset size without stack overflow. The same fix was previously applied to Postgres, MySQL, MSSQL, Google Sheets, and Oracle nodes.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4912

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI