### PR TITLE
fix(sendgrid): pass next-page URL as dedicated uri parameter in sendGridApiRequestAllItems

### DIFF
--- a/packages/nodes-base/nodes/SendGrid/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/SendGrid/GenericFunctions.ts
@@ -14,6 +14,7 @@ export async function sendGridApiRequest(
 
 	body: any = {},
 	qs: IDataObject = {},
+	uri?: string,
 	option: IDataObject = {},
 ): Promise<any> {
 	const host = 'api.sendgrid.com/v3';
@@ -22,7 +23,7 @@ export async function sendGridApiRequest(
 		method,
 		qs,
 		body,
-		uri: `https://${host}${endpoint}`,
+		uri: uri ?? `https://${host}${endpoint}`,
 		json: true,
 	};
 
@@ -50,10 +51,10 @@ export async function sendGridApiRequestAllItems(
 
 	let responseData;
 
-	let uri;
+	let uri: string | undefined;
 
 	do {
-		responseData = await sendGridApiRequest.call(this, endpoint, method, body, query, uri); // possible bug, as function does not have uri parameter
+		responseData = await sendGridApiRequest.call(this, endpoint, method, body, query, uri);
 		uri = responseData._metadata.next;
 		returnData.push.apply(returnData, responseData[propertyName] as IDataObject[]);
 		const limit = query.limit as number | undefined;

--- a/packages/nodes-base/nodes/SendGrid/SendGrid.node.ts
+++ b/packages/nodes-base/nodes/SendGrid/SendGrid.node.ts
@@ -638,7 +638,7 @@ export class SendGrid implements INodeType {
 								.map((entry) => ({ email: entry.trim() }));
 						}
 
-						const data = await sendGridApiRequest.call(this, '/mail/send', 'POST', body, qs, {
+						const data = await sendGridApiRequest.call(this, '/mail/send', 'POST', body, qs, undefined, {
 							resolveWithFullResponse: true,
 						});
 


### PR DESCRIPTION
## Summary

`sendGridApiRequestAllItems` uses a `do/while` loop that reads `responseData._metadata.next` to advance pages, but passes the next-page URL as the **fifth** argument to `sendGridApiRequest`. The fifth parameter of that function is `option` (an options-object to merge into the request config), **not** a URL override. As a result:

- The `endpoint` parameter never changes between iterations, so every loop iteration re-requests the first page.
- The URL string is merged in as an options object, potentially corrupting the request options.

This produces either an infinite loop or silently returns only the first page of results, repeated.

## Fix

Add an explicit `uri` parameter at position 5 to `sendGridApiRequest`. When provided, it is used as the absolute request URL instead of constructing one from `endpoint`. The `option` parameter moves to position 6.

Update the one existing call-site (`/mail/send`) that passed an options object as the 5th argument to pass `undefined` for `uri` and the options object as the new 6th argument.

## Files changed

- `packages/nodes-base/nodes/SendGrid/GenericFunctions.ts`
- `packages/nodes-base/nodes/SendGrid/SendGrid.node.ts`