### PR TITLE
fix(zoom): format startTime with moment-timezone in meeting update operation

### DIFF
--- a/packages/nodes-base/nodes/Zoom/Zoom.node.ts
+++ b/packages/nodes-base/nodes/Zoom/Zoom.node.ts
@@ -389,7 +389,16 @@ export class Zoom implements INodeType {
 						}
 
 						if (updateFields.startTime) {
-							body.start_time = updateFields.startTime as string;
+							if (updateFields.timeZone) {
+								body.start_time = moment(updateFields.startTime as string).format(
+									'YYYY-MM-DDTHH:mm:ss',
+								);
+							} else {
+								// if no timezone is defined use n8n timezone
+								body.start_time = moment
+									.tz(updateFields.startTime as string, this.getTimezone())
+									.format();
+							}
 						}
 
 						if (updateFields.duration) {


### PR DESCRIPTION
## Summary

The Zoom meeting **create** operation correctly formats `startTime` using `moment-timezone` before sending it to the Zoom API:

- With a timezone supplied: `moment(value).format('YYYY-MM-DDTHH:mm:ss')`
- Without a timezone: `moment.tz(value, this.getTimezone()).format()`

The meeting **update** operation sets `body.start_time = updateFields.startTime as string` — passing the raw n8n ISO timestamp directly to the Zoom API. The Zoom API expects a specific datetime format and will reject or silently ignore the raw ISO string, meaning `startTime` updates have no effect.

## Fix

Apply the same `moment-timezone` formatting logic used by the create operation to the update operation, so both paths produce a Zoom-compatible datetime string.

## Files changed

- `packages/nodes-base/nodes/Zoom/Zoom.node.ts`