### PR TITLE
fix(taiga): correct operator precedence in URI construction in taigaApiRequest

### DIFF
--- a/packages/nodes-base/nodes/Taiga/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Taiga/GenericFunctions.ts
@@ -67,9 +67,10 @@ export async function taigaApiRequest(
 		method,
 		body,
 		uri:
-			uri || credentials.url
+			uri ||
+			(credentials.url
 				? `${credentials.url}/api/v1${resource}`
-				: `https://api.taiga.io/api/v1${resource}`,
+				: `https://api.taiga.io/api/v1${resource}`),
 		json: true,
 	};
 


### PR DESCRIPTION
## Summary

The URI construction in `taigaApiRequest` has an operator-precedence bug:

```typescript
uri:
  uri || credentials.url
    ? `${credentials.url}/api/v1${resource}`
    : `https://api.taiga.io/api/v1${resource}`,
```

JavaScript evaluates `||` and `?:` left-to-right with equal precedence for `||`, so this parses as:

```typescript
uri: (uri || credentials.url) ? `${credentials.url}/…` : `https://…`
```

Two bugs result:

1. **Pagination is broken**: When a pagination `uri` is passed AND `credentials.url` is set, the condition `(uri || credentials.url)` is truthy, so the ternary picks `${credentials.url}/api/v1${resource}` — the passed `uri` is discarded. Every page re-fetches from `credentials.url`.

2. **Invalid URL when no custom host**: When `credentials.url` is falsy, the template literal produces `` `undefined/api/v1${resource}` ``, which is not a valid URL.

## Fix

Wrap the ternary in parentheses so the short-circuit `||` is evaluated first:

```typescript
uri:
  uri ||
  (credentials.url
    ? `${credentials.url}/api/v1${resource}`
    : `https://api.taiga.io/api/v1${resource}`),
```

## Files changed

- `packages/nodes-base/nodes/Taiga/GenericFunctions.ts`