### PR TITLE
fix(instance-ai): Make SANDBOX_LINK_SDK flag bypass Dockerfile SDK install (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/src/workspace/__tests__/sandbox-setup.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/sandbox-setup.test.ts
@@ -1,5 +1,57 @@
+import { jsonParse } from 'n8n-workflow';
+
 import type { SearchableNodeDescription } from '../../types';
 import { formatNodeCatalogLine } from '../sandbox-setup';
+
+function loadSandboxPackageJson(linkSdk: boolean): {
+	dependencies: Record<string, string>;
+	devDependencies: Record<string, string>;
+} {
+	jest.resetModules();
+	if (linkSdk) {
+		process.env.N8N_INSTANCE_AI_SANDBOX_LINK_SDK = '1';
+	} else {
+		delete process.env.N8N_INSTANCE_AI_SANDBOX_LINK_SDK;
+	}
+
+	let packageJson = '';
+	jest.isolateModules(() => {
+		const sandboxSetup = jest.requireActual<{ PACKAGE_JSON: string }>('../sandbox-setup');
+		packageJson = sandboxSetup.PACKAGE_JSON;
+	});
+
+	return jsonParse<{
+		dependencies: Record<string, string>;
+		devDependencies: Record<string, string>;
+	}>(packageJson);
+}
+
+describe('PACKAGE_JSON', () => {
+	const originalLinkSdk = process.env.N8N_INSTANCE_AI_SANDBOX_LINK_SDK;
+
+	afterEach(() => {
+		jest.resetModules();
+		if (originalLinkSdk === undefined) {
+			delete process.env.N8N_INSTANCE_AI_SANDBOX_LINK_SDK;
+		} else {
+			process.env.N8N_INSTANCE_AI_SANDBOX_LINK_SDK = originalLinkSdk;
+		}
+	});
+
+	it('should include a registry SDK dependency when workspace SDK linking is disabled', () => {
+		const packageJson = loadSandboxPackageJson(false);
+
+		expect(packageJson.dependencies['@n8n/workflow-sdk']).toBeDefined();
+		expect(packageJson.dependencies.tsx).toBeDefined();
+	});
+
+	it('should omit the registry SDK dependency when workspace SDK linking is enabled', () => {
+		const packageJson = loadSandboxPackageJson(true);
+
+		expect(packageJson.dependencies).not.toHaveProperty('@n8n/workflow-sdk');
+		expect(packageJson.dependencies.tsx).toBeDefined();
+	});
+});
 
 describe('formatNodeCatalogLine', () => {
 	it('should format a basic node with a string version', () => {

--- a/packages/@n8n/instance-ai/src/workspace/builder-sandbox-factory.ts
+++ b/packages/@n8n/instance-ai/src/workspace/builder-sandbox-factory.ts
@@ -19,7 +19,11 @@ import { DaytonaFilesystem } from './daytona-filesystem';
 import { N8nSandboxFilesystem } from './n8n-sandbox-filesystem';
 import { N8nSandboxImageManager } from './n8n-sandbox-image-manager';
 import { N8nSandboxServiceSandbox } from './n8n-sandbox-sandbox';
-import { packWorkspaceSdk, type WorkspaceSdkTarball } from './pack-workspace-sdk';
+import {
+	isLinkWorkspaceSdkEnabled,
+	packWorkspaceSdk,
+	type WorkspaceSdkTarball,
+} from './pack-workspace-sdk';
 import { runInSandbox, writeFileViaSandbox } from './sandbox-fs';
 import type { SnapshotManager } from './snapshot-manager';
 import type { InstanceAiContext } from '../types';
@@ -79,13 +83,21 @@ export class BuilderSandboxFactory {
 
 	/**
 	 * Pack and install the host's workspace `@n8n/workflow-sdk` into the remote
-	 * sandbox, overriding the registry version baked in at image build time.
+	 * sandbox. In linked-SDK mode the baked image omits the registry SDK so
+	 * unpublished workspace versions can still create a sandbox.
 	 * No-op unless `N8N_INSTANCE_AI_SANDBOX_LINK_SDK=1` is set.
 	 */
 	private async linkWorkspaceSdkIfEnabled(workspace: Workspace, root: string): Promise<void> {
 		this.sdkTarballPromise ??= packWorkspaceSdk(this.logger);
 		const packed = await this.sdkTarballPromise;
-		if (!packed) return;
+		if (!packed) {
+			if (isLinkWorkspaceSdkEnabled()) {
+				throw new Error(
+					'N8N_INSTANCE_AI_SANDBOX_LINK_SDK is enabled, but the workspace SDK could not be packed. Run `pnpm build` in packages/@n8n/workflow-sdk or unset N8N_INSTANCE_AI_SANDBOX_LINK_SDK.',
+				);
+			}
+			return;
+		}
 
 		const remotePath = posixJoin(root, packed.filename);
 		if (workspace.filesystem) {

--- a/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
+++ b/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
@@ -26,6 +26,7 @@ import type { Workspace } from '@mastra/core/workspace';
 import { createRequire } from 'node:module';
 
 import type { InstanceAiContext, SearchableNodeDescription } from '../types';
+import { isLinkWorkspaceSdkEnabled } from './pack-workspace-sdk';
 import { runInSandbox, readFileViaSandbox, escapeSingleQuotes } from './sandbox-fs';
 
 const hostRequire = createRequire(__filename);
@@ -77,15 +78,19 @@ const SANDBOX_TSX_VERSION = resolveHostDepVersion('tsx');
  */
 const SANDBOX_TYPES_NODE_VERSION = '24.10.1';
 
-function buildPackageJson(sdkSpecifier: string): string {
+function buildPackageJson(sdkSpecifier: string | null): string {
+	const dependencies: Record<string, string> = {
+		tsx: SANDBOX_TSX_VERSION,
+	};
+	if (sdkSpecifier) {
+		dependencies['@n8n/workflow-sdk'] = sdkSpecifier;
+	}
+
 	return JSON.stringify(
 		{
 			name: 'sandbox-workspace',
 			private: true,
-			dependencies: {
-				'@n8n/workflow-sdk': sdkSpecifier,
-				tsx: SANDBOX_TSX_VERSION,
-			},
+			dependencies,
 			devDependencies: {
 				'@types/node': SANDBOX_TYPES_NODE_VERSION,
 			},
@@ -96,10 +101,18 @@ function buildPackageJson(sdkSpecifier: string): string {
 }
 
 /**
- * Registry-pinned PACKAGE_JSON used for Dockerfile-baked images
- * (Daytona / n8n-sandbox). See `resolveHostDepVersion` for why pinning matters.
+ * PACKAGE_JSON used for Dockerfile-baked images (Daytona / n8n-sandbox).
+ *
+ * Normal mode pins to the host SDK version. See `resolveHostDepVersion` for
+ * why pinning matters.
+ *
+ * Linked-SDK mode intentionally omits @n8n/workflow-sdk from the baked image:
+ * the host SDK may be ahead of npm on master, and the packed workspace tarball
+ * is installed after sandbox creation.
  */
-export const PACKAGE_JSON = buildPackageJson(SANDBOX_SDK_VERSION);
+export const PACKAGE_JSON = buildPackageJson(
+	isLinkWorkspaceSdkEnabled() ? null : SANDBOX_SDK_VERSION,
+);
 
 /**
  * Return the absolute on-disk path of a host-installed package, or `null`


### PR DESCRIPTION
## Summary
Fixes sandbox creation in `@n8n/instance-ai` when the host `@n8n/workflow-sdk` version is ahead of what's published on npm (the typical state on `master` between releases).

**Symptom:** sandbox creation fails with `Sandbox failed to become ready within the timeout period` and a `502 Bad Gateway` from the sandbox service.

**Root cause:** the Dockerfile baked by `N8nSandboxImageManager` runs `npm install` against `PACKAGE_JSON`, which pins `@n8n/workflow-sdk` to the host version (e.g. `0.11.4`). When that version isn't on the registry, image build hits a 404 inside the sandbox service — the sandbox never becomes ready.

`N8N_INSTANCE_AI_SANDBOX_LINK_SDK=1` was supposed to be the escape hatch, but it ran *after* sandbox creation, so the failed image build killed it before it could help.

**Fix:** under the flag, bake an SDK-less `PACKAGE_JSON` (only `tsx` + `@types/node`). The post-creation step then `npm install`s the packed workspace tarball as before. If packing fails under the flag, we now throw with a clear `pnpm build` hint instead of silently degrading to a broken sandbox.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
