### PR TITLE
fix(Pipedrive): add optional chaining when reading next_start in pipedriveApiRequestAllItems

### DIFF
--- a/packages/nodes-base/nodes/Pipedrive/v1/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v1/GenericFunctions.ts
@@ -126,7 +126,7 @@ export async function pipedriveApiRequestAllItems(
 			returnData.push.apply(returnData, responseData.data as IDataObject[]);
 		}
 
-		query.start = responseData.additionalData.pagination.next_start;
+		query.start = responseData.additionalData?.pagination?.next_start;
 	} while (responseData.additionalData?.pagination?.more_items_in_collection === true);
 
 	return {


### PR DESCRIPTION
## Problem
In `pipedriveApiRequestAllItems`, line 129 unconditionally accesses `responseData.additionalData.pagination.next_start` before the while condition on line 130 can guard against a missing `additionalData` or `pagination` object. When the Pipedrive API returns a response without a `pagination` object (for example, on the search endpoint or when the result set is empty), this throws a `TypeError: Cannot read properties of undefined`.

## Fix
Added optional chaining (`?.`) to `responseData.additionalData?.pagination?.next_start`, making the read safe and consistent with the existing optional chaining already used in the while condition on line 130.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass