### PR TITLE
fix(ActiveCampaign): count new items instead of cumulative total in activeCampaignApiRequestAllItems

### DIFF
--- a/packages/nodes-base/nodes/ActiveCampaign/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ActiveCampaign/GenericFunctions.ts
@@ -96,10 +96,9 @@ export async function activeCampaignApiRequestAllItems(
 		responseData = await activeCampaignApiRequest.call(this, method, endpoint, body, query);
 
 		if (dataKey === undefined) {
-			returnData.push.apply(returnData, responseData as IDataObject[]);
-			if (returnData !== undefined) {
-				itemsReceived += returnData.length;
-			}
+			const newItems = responseData as IDataObject[];
+			returnData.push.apply(returnData, newItems);
+			itemsReceived += newItems.length;
 		} else {
 			returnData.push.apply(returnData, responseData[dataKey] as IDataObject[]);
 			if (responseData[dataKey] !== undefined) {


### PR DESCRIPTION
## Problem
In `activeCampaignApiRequestAllItems`, when `dataKey` is `undefined`, `itemsReceived` is incremented by `returnData.length` — the cumulative total across all pages — rather than the number of items returned in the current page. This causes `query.offset` to advance by more than one page on subsequent iterations, skipping records and returning incorrect results. The condition `if (returnData !== undefined)` is also always true since `returnData` is initialised as `[]`.

## Fix
Capture the current page's response items in a local variable and increment `itemsReceived` by their count, matching the correct pattern already used in the `dataKey` branch.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass