### PR TITLE
fix(GetResponse): use lowercase header names in getResponseApiRequestAllItems pagination

### DIFF
--- a/packages/nodes-base/nodes/GetResponse/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/GetResponse/GenericFunctions.ts
@@ -73,7 +73,7 @@ export async function getResponseApiRequestAllItems(
 		);
 		query.page++;
 		returnData.push.apply(returnData, responseData.body as IDataObject[]);
-	} while (responseData.headers.TotalPages !== responseData.headers.CurrentPage);
+	} while (responseData.headers['totalpages'] !== responseData.headers['currentpage']);
 
 	return returnData;
 }


### PR DESCRIPTION
## Problem
The `getResponseApiRequestAllItems` function compares `responseData.headers.TotalPages` and `responseData.headers.CurrentPage` to decide whether to continue paginating. Node.js always lowercases HTTP response header names, so both fields resolve to `undefined` and the loop exits after the first page, returning incomplete results.

## Fix
Changed the header lookups to use the lowercase keys (`totalpages` and `currentpage`) that Node.js actually exposes on the response headers object.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass