### PR TITLE
fix(Hunter): spread email items into returnData and fix pagination offset check

### DIFF
--- a/packages/nodes-base/nodes/Hunter/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Hunter/GenericFunctions.ts
@@ -60,11 +60,11 @@ export async function hunterApiRequestAllItems(
 
 	do {
 		responseData = await hunterApiRequest.call(this, method, resource, body, query);
-		returnData.push(responseData[propertyName] as IDataObject);
-		query.offset += query.limit;
+		returnData.push.apply(returnData, responseData[propertyName] as IDataObject[]);
+		query.offset = (query.offset as number) + (query.limit as number);
 	} while (
 		responseData.meta?.results !== undefined &&
-		responseData.meta.offset <= responseData.meta.results
+		(query.offset as number) <= responseData.meta.results
 	);
 	return returnData;
 }


### PR DESCRIPTION
## Problem
`hunterApiRequestAllItems` has two bugs:

1. `returnData.push(responseData[propertyName])` pushes the entire `data` wrapper object as a single element instead of spreading the individual email entries, so callers receive an array of one object rather than a flat list of emails.

2. The do-while condition reads `responseData.meta.offset` (the current page's offset echoed back by the API) instead of the locally-tracked `query.offset` that was just incremented, so the loop may stop one page early or overshoot by one iteration.

## Fix
Replaced `push` with `push.apply` to spread individual items into `returnData`, and changed the loop condition to compare the locally-incremented `query.offset` against `responseData.meta.results`.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass