### PR TITLE
fix(Freshservice): set per_page param and align pagination threshold in freshserviceApiRequestAllItems

### DIFF
--- a/packages/nodes-base/nodes/Freshservice/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Freshservice/GenericFunctions.ts
@@ -81,6 +81,7 @@ export async function freshserviceApiRequestAllItems(
 ) {
 	const returnData: IDataObject[] = [];
 	qs.page = 1;
+	qs.per_page = 100;
 	let items;
 
 	do {
@@ -90,7 +91,7 @@ export async function freshserviceApiRequestAllItems(
 		if (!items.length) return returnData;
 		returnData.push(...(items as IDataObject[]));
 		qs.page++;
-	} while (items.length >= 30);
+	} while (items.length >= (qs.per_page as number));
 
 	return returnData;
 }


### PR DESCRIPTION
## Problem
`freshserviceApiRequestAllItems` never sends a `per_page` parameter to the Freshservice API, leaving the page size at the server default (30). The loop condition `items.length >= 30` is hardcoded to that magic number, so any change in the server's default page size would silently cause either an infinite loop (if default > 30 and the last page has ≥ 30 items) or premature termination (if default < 30).

## Fix
Added `qs.per_page = 100` to explicitly request the maximum page size, and changed the loop condition to compare `items.length` against `qs.per_page` so the threshold always matches the requested page size.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass