### PR TITLE
fix(Dropbox): correct typo in dropboxpiRequestAllItems function name

### DIFF
--- a/packages/nodes-base/nodes/Dropbox/Dropbox.node.ts
+++ b/packages/nodes-base/nodes/Dropbox/Dropbox.node.ts
@@ -10,7 +10,7 @@ import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 
 import {
 	dropboxApiRequest,
-	dropboxpiRequestAllItems,
+	dropboxApiRequestAllItems,
 	getCredentials,
 	getRootDirectory,
 	simplify,
@@ -893,7 +893,7 @@ export class Dropbox implements INodeType {
 				let responseData;
 
 				if (returnAll) {
-					responseData = await dropboxpiRequestAllItems.call(
+					responseData = await dropboxApiRequestAllItems.call(
 						this,
 						property,
 						requestMethod,

--- a/packages/nodes-base/nodes/Dropbox/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Dropbox/GenericFunctions.ts
@@ -49,7 +49,7 @@ export async function dropboxApiRequest(
 	}
 }
 
-export async function dropboxpiRequestAllItems(
+export async function dropboxApiRequestAllItems(
 	this: IExecuteFunctions | IHookFunctions,
 	propertyName: string,
 	method: IHttpRequestMethods,


### PR DESCRIPTION
## Problem
The pagination helper in the Dropbox integration is named `dropboxpiRequestAllItems` — the letter 'A' is missing — making the function name inconsistent with every other node in the codebase and preventing future contributors from finding it by its expected name.

## Fix
Renamed `dropboxpiRequestAllItems` to `dropboxApiRequestAllItems` in `GenericFunctions.ts` and updated the import and call-site in `Dropbox.node.ts` to match.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass