### PR TITLE
fix(KoBoToolbox): guard option merge with .length check to avoid always-truthy condition

### DIFF
--- a/packages/nodes-base/nodes/KoBoToolbox/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/KoBoToolbox/GenericFunctions.ts
@@ -47,7 +47,7 @@ export async function koBoToolboxApiRequest(
 		},
 		json: true,
 	};
-	if (Object.keys(option)) {
+	if (Object.keys(option).length) {
 		Object.assign(options, option);
 	}
 	if (options.url && !/^http(s)?:/.test(options.url)) {


### PR DESCRIPTION
## Problem
In `koBoToolboxApiRequest`, the guard `if (Object.keys(option))` is always truthy because `Object.keys()` returns an array — and non-empty arrays as well as empty arrays are both truthy in JavaScript. As a result, the `Object.assign` is executed unconditionally even when `option` is an empty object, which is inconsistent with the pattern used throughout the rest of nodes-base.

## Fix
Added `.length` to the condition so that `Object.assign` is only called when `option` actually contains keys, matching the intended guard behaviour and the convention used in every other similar check in the codebase.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass