### PR TITLE
fix(Beeminder): replace deprecated ApplicationError with NodeOperationError

### DIFF
--- a/packages/nodes-base/nodes/Beeminder/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Beeminder/GenericFunctions.ts
@@ -7,7 +7,7 @@ import type {
 	IHttpRequestMethods,
 	IRequestOptions,
 } from 'n8n-workflow';
-import { ApplicationError } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
 
 const BEEMINDER_URI = 'https://www.beeminder.com/api/v1';
 
@@ -26,7 +26,10 @@ export async function beeminderApiRequest(
 	const authenticationMethod = this.getNodeParameter('authentication', 0, 'apiToken');
 
 	if (!isValidAuthenticationMethod(authenticationMethod)) {
-		throw new ApplicationError(`Invalid authentication method: ${authenticationMethod}`);
+		throw new NodeOperationError(
+			this.getNode(),
+			`Invalid authentication method: ${authenticationMethod}`,
+		);
 	}
 
 	let credentialType = 'beeminderApi';


### PR DESCRIPTION
## Problem
`beeminderApiRequest` throws an `ApplicationError` when the authentication method is invalid. `ApplicationError` is deprecated in nodes-base and should not be used for user-facing validation errors inside node execution — the correct class is `NodeOperationError`.

## Fix
Replaced the `ApplicationError` import with `NodeOperationError` and updated the throw site to pass `this.getNode()` as the first argument, matching the error-handling convention used throughout the rest of nodes-base.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass