### PR TITLE
fix(ai-builder): Honor --timeout-ms across the eval harness (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -240,6 +240,7 @@ async function runWithLangSmith(config: RunConfig): Promise<MultiRunEvaluation> 
 				execArgs.scenario,
 				execArgs.workflowJsons,
 				logger,
+				args.timeoutMs,
 			),
 		{ name: 'scenario_execution', run_type: 'chain', client: lsClient },
 	);

--- a/packages/@n8n/instance-ai/evaluations/harness/runner.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/runner.ts
@@ -41,8 +41,6 @@ const MAX_CONCURRENT_SCENARIOS = 99;
 // Workflow test case runner — build once, run scenarios against it
 // ---------------------------------------------------------------------------
 
-const SCENARIO_BG_TASK_TIMEOUT_MS = 240_000;
-
 interface WorkflowTestCaseConfig {
 	client: N8nClient;
 	testCase: WorkflowTestCase;
@@ -100,6 +98,7 @@ export async function runWorkflowTestCase(
 					scenario,
 					build.workflowJsons,
 					logger,
+					timeoutMs,
 				);
 			} catch (error: unknown) {
 				const errorMessage = error instanceof Error ? error.message : String(error);
@@ -181,7 +180,7 @@ export async function buildWorkflow(config: BuildWorkflowConfig): Promise<BuildR
 			events,
 			approvedRequests,
 			startTime,
-			timeoutMs: Math.min(timeoutMs, SCENARIO_BG_TASK_TIMEOUT_MS),
+			timeoutMs,
 			logger,
 		});
 
@@ -288,8 +287,9 @@ export async function executeScenario(
 	scenario: TestScenario,
 	workflowJsons: WorkflowResponse[],
 	logger: EvalLogger,
+	timeoutMs?: number,
 ): Promise<ScenarioResult> {
-	return await runScenario(client, scenario, workflowId, workflowJsons, logger);
+	return await runScenario(client, scenario, workflowId, workflowJsons, logger, timeoutMs);
 }
 
 /**
@@ -335,9 +335,10 @@ async function runScenario(
 	workflowId: string,
 	workflowJsons: WorkflowResponse[],
 	logger: EvalLogger,
+	timeoutMs?: number,
 ): Promise<ScenarioResult> {
 	const execStart = Date.now();
-	const evalResult = await client.executeWithLlmMock(workflowId, scenario.dataSetup);
+	const evalResult = await client.executeWithLlmMock(workflowId, scenario.dataSetup, timeoutMs);
 	const execMs = Date.now() - execStart;
 
 	logger.info(


### PR DESCRIPTION
## Summary

The eval CLI's `--timeout-ms` flag was silently capped or ignored in two places, leaving complex test cases stuck under hidden ceilings:

- **Build phase** clamped to 240s via `Math.min(timeoutMs, 240_000)` even though the flag's documented default is 600s. The cap was always the binding constraint, so the flag effectively did nothing.
- **Scenario execution** used a hardcoded 120s timeout in the n8n client; the CLI flag never reached this path.

After this change `--timeout-ms` is the single per-task budget for both phases, behaving as documented.

- Drop the 240s build cap and the `SCENARIO_BG_TASK_TIMEOUT_MS` constant.
- Plumb `timeoutMs` through `executeScenario` → `runScenario` → `client.executeWithLlmMock`.
- Update both callers (`runWorkflowTestCase` internal, `runWithLangSmith` CLI) to pass `args.timeoutMs`.

Linear: https://linear.app/n8n/issue/TRUST-64

## Validation

Stability run on `linear-bq-leaderboard` with the fix in place (5 iterations of useful data before the local server died for unrelated reasons):

| Iter | Build | Scenario |
|------|-------|----------|
| 1 | ✅ 215s | FAIL `builder_issue` (agent forgot BQ Project param) |
| 2 | ✅ 262s | FAIL `builder_issue` |
| 3 | ✅ 276s | FAIL `builder_issue` |
| 4 | ✅ 241s | **PASS** |
| 5 | ✅ 250s | **PASS** |

**4 of 5 builds (80%) exceeded 240s** — most would have been silently killed by the old cap. Build success rate is 100% with the fix; the framework now surfaces real `builder_issue` failures (missing required params, branch synchronization issues) instead of silent harness aborts. Sibling to TRUST-55, which becomes diagnosable once the cap stops masking real issues.

## Test plan

- [x] `pnpm typecheck` and lint clean on changed files (`evaluations/harness/runner.ts`, `evaluations/cli/index.ts`).
- [x] N=10 stability run confirms `--timeout-ms 600000` is honored end-to-end (5 successful build+scenario completions before unrelated server crash).
- [x] No behavioral change for runs where the build naturally finishes under 240s — they take the same path through the harness.
- [x] I have seen this code, I have run this code, and I take responsibility for this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)