### PR TITLE
fix(PayPal): correct typo in getEnvironment key from sanbox to sandbox

### DIFF
--- a/packages/nodes-base/nodes/PayPal/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/PayPal/GenericFunctions.ts
@@ -12,7 +12,7 @@ import { BINARY_ENCODING, NodeApiError, NodeOperationError } from 'n8n-workflow'
 
 function getEnvironment(env: string) {
 	return {
-		sanbox: 'https://api-m.sandbox.paypal.com',
+		sandbox: 'https://api-m.sandbox.paypal.com',
 		live: 'https://api-m.paypal.com',
 	}[env];
 }


### PR DESCRIPTION
## Problem
The `getEnvironment` function in the PayPal node has a typo: the key `sanbox` should be `sandbox`. When users configure PayPal with sandbox credentials and pass `'sandbox'` as the environment, the lookup returns `undefined`, making all API URLs resolve to `undefined/v1/<endpoint>` — breaking every PayPal API call in sandbox mode.

## Fix
Corrected the object key from `sanbox` to `sandbox` in `GenericFunctions.ts`, so `getEnvironment('sandbox')` now correctly returns `'https://api-m.sandbox.paypal.com'`.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass