### PR TITLE
fix(Spotify): remove leading space from Accept header value in spotifyApiRequest

### DIFF
--- a/packages/nodes-base/nodes/Spotify/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Spotify/GenericFunctions.ts
@@ -25,7 +25,7 @@ export async function spotifyApiRequest(
 		method,
 		headers: {
 			'Content-Type': 'text/plain',
-			Accept: ' application/json',
+			Accept: 'application/json',
 		},
 		qs: query,
 		url: uri ?? `https://api.spotify.com/v1${endpoint}`,


### PR DESCRIPTION
## Problem
The `Accept` header in `spotifyApiRequest` was set to `' application/json'` (with a leading whitespace character). This is a malformed header value per RFC 7230 and can cause `406 Not Acceptable` responses on strict servers or HTTP proxies, and may lead to unexpected content negotiation failures.

## Fix
Removed the leading space so the header value is the valid string `'application/json'`.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass