### PR TITLE
fix(SyncroMSP): remove duplicate slash in validateCredentials test URL

### DIFF
--- a/packages/nodes-base/nodes/SyncroMSP/v1/transport/index.ts
+++ b/packages/nodes-base/nodes/SyncroMSP/v1/transport/index.ts
@@ -76,7 +76,7 @@ export async function validateCredentials(
 		qs: {
 			api_key: apiKey,
 		},
-		url: `https://${subdomain}.syncromsp.com/api/v1//me`,
+		url: `https://${subdomain}.syncromsp.com/api/v1/me`,
 	};
 
 	return await this.helpers.request(options);


### PR DESCRIPTION
## Problem
The credential-test URL in `validateCredentials` was `https://${subdomain}.syncromsp.com/api/v1//me` — note the double slash before `me`. This causes a 404 response from the SyncroMSP API, making credential verification always fail even with valid credentials.

## Fix
Removed the extra leading slash so the URL is correctly `https://${subdomain}.syncromsp.com/api/v1/me`.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass