### PR TITLE
fix(QuickBooks): initialize headers object and guard option merge with .length check

### DIFF
--- a/packages/nodes-base/nodes/QuickBooks/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/QuickBooks/GenericFunctions.ts
@@ -43,6 +43,7 @@ export async function quickBooksApiRequest(
 	const credentials = await this.getCredentials<QuickBooksOAuth2Credentials>('quickBooksOAuth2Api');
 
 	const options: IRequestOptions = {
+		headers: {},
 		method,
 		uri: `${credentials.environment === 'sandbox' ? sandboxUrl : productionUrl}${endpoint}`,
 		qs,
@@ -58,7 +59,7 @@ export async function quickBooksApiRequest(
 		delete options.qs;
 	}
 
-	if (Object.keys(option)) {
+	if (Object.keys(option).length) {
 		Object.assign(options, option);
 	}
 


### PR DESCRIPTION
## Problem
`quickBooksApiRequest` constructs an `IRequestOptions` object without a `headers` key, then later writes directly to `options.headers!.Accept` / `options.headers!['Content-Type']`. Because `headers` is `undefined`, those non-null assertions silently reference `undefined` at runtime and the property writes are lost (strict mode would throw a `TypeError`). Additionally, the guard `if (Object.keys(option))` is always truthy because `Object.keys()` always returns an array — the spread was never conditionally skipped for empty option objects.

## Fix
- Added `headers: {}` to the initial `options` literal so subsequent header mutations are always safe.
- Changed `if (Object.keys(option))` to `if (Object.keys(option).length)` so the option spread is skipped when no extra options are provided.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass