### PR TITLE
fix(Nasa): guard option merge with .length check to avoid always-truthy condition

### DIFF
--- a/packages/nodes-base/nodes/Nasa/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Nasa/GenericFunctions.ts
@@ -27,7 +27,7 @@ export async function nasaApiRequest(
 		json: true,
 	};
 
-	if (Object.keys(option)) {
+	if (Object.keys(option).length) {
 		Object.assign(options, option);
 	}
 


### PR DESCRIPTION
## Problem
In `nasaApiRequest`, the guard `if (Object.keys(option))` is always truthy because `Object.keys()` returns an array object, which is truthy even when the array is empty. As a result, `Object.assign(options, option)` is called unconditionally — including when `option` is the default empty object `{}` — producing no harm but masking the intent and differing from the established pattern across the rest of the codebase.

## Fix
Changed `if (Object.keys(option))` to `if (Object.keys(option).length)` so the spread is correctly skipped when no extra options are provided, matching the guard pattern used in other nodes such as Airtable, GitHub, GitLab, and others.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass