### PR TITLE
chore: Prepare tsconfigs for tsgo

### DIFF
--- a/packages/@n8n/agents/tsconfig.json
+++ b/packages/@n8n/agents/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"rootDir": ".",
 		"types": ["node", "jest"],
-		"baseUrl": "src",
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
 	},
 	"include": ["src/**/*.ts"],

--- a/packages/@n8n/ai-node-sdk/tsconfig.json
+++ b/packages/@n8n/ai-node-sdk/tsconfig.json
@@ -4,8 +4,6 @@
 		"@n8n/typescript-config/tsconfig.backend.json"
 	],
 	"compilerOptions": {
-		"rootDir": ".",
-		"baseUrl": ".",
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
 	},
 	"include": ["src/**/*.ts"]

--- a/packages/@n8n/ai-utilities/tsconfig.json
+++ b/packages/@n8n/ai-utilities/tsconfig.json
@@ -4,7 +4,6 @@
 		"@n8n/typescript-config/tsconfig.backend.json"
 	],
 	"compilerOptions": {
-		"baseUrl": ".",
 		"paths": {
 			"src/*": ["./src/*"],
 			"src": ["./src"]

--- a/packages/@n8n/ai-workflow-builder.ee/tsconfig.json
+++ b/packages/@n8n/ai-workflow-builder.ee/tsconfig.json
@@ -6,12 +6,10 @@
 	"compilerOptions": {
 		"target": "es2023",
 		"lib": ["es2023"],
-		"rootDir": ".",
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
-		"baseUrl": "src",
 		"paths": {
-			"@/*": ["./*"]
+			"@/*": ["./src/*"]
 		},
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"types": ["node", "jest"]

--- a/packages/@n8n/api-types/tsconfig.json
+++ b/packages/@n8n/api-types/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"rootDir": ".",
 		"types": ["node", "vitest/globals"],
-		"baseUrl": "src",
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
 	},
 	"include": ["src/**/*.ts"],

--- a/packages/@n8n/backend-common/tsconfig.json
+++ b/packages/@n8n/backend-common/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"rootDir": ".",
 		"types": ["node", "jest"],
-		"baseUrl": "src",
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"experimentalDecorators": true,
 		"emitDecoratorMetadata": true

--- a/packages/@n8n/backend-test-utils/tsconfig.json
+++ b/packages/@n8n/backend-test-utils/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"rootDir": ".",
 		"types": ["node", "jest"],
-		"baseUrl": "src",
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"experimentalDecorators": true,
 		"emitDecoratorMetadata": true

--- a/packages/@n8n/benchmark/tsconfig.json
+++ b/packages/@n8n/benchmark/tsconfig.json
@@ -4,10 +4,8 @@
 		"@n8n/typescript-config/tsconfig.backend.json"
 	],
 	"compilerOptions": {
-		"rootDir": ".",
-		"baseUrl": "src",
 		"paths": {
-			"@/*": ["./*"]
+			"@/*": ["./src/*"]
 		}
 	},
 	"include": ["src/**/*.ts"]

--- a/packages/@n8n/chat-hub/tsconfig.json
+++ b/packages/@n8n/chat-hub/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"rootDir": ".",
 		"types": ["node", "jest"],
-		"baseUrl": "src",
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
 	},
 	"include": ["src/**/*.ts"],

--- a/packages/@n8n/cli/tsconfig.json
+++ b/packages/@n8n/cli/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": ["@n8n/typescript-config/tsconfig.common.json"],
 	"compilerOptions": {
-		"baseUrl": ".",
 		"rootDir": "src",
 		"outDir": "dist",
 		"types": ["node", "vitest/globals"],

--- a/packages/@n8n/client-oauth2/tsconfig.json
+++ b/packages/@n8n/client-oauth2/tsconfig.json
@@ -1,11 +1,9 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"rootDir": ".",
 		"types": ["node", "vitest/globals"],
-		"baseUrl": "src",
 		"paths": {
-			"@/*": ["./*"]
+			"@/*": ["./src/*"]
 		},
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
 	},

--- a/packages/@n8n/computer-use/tsconfig.json
+++ b/packages/@n8n/computer-use/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"rootDir": ".",
 		"types": ["node", "jest"],
-		"baseUrl": "src",
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
 	},
 	"include": ["src/**/*.ts"]

--- a/packages/@n8n/config/tsconfig.json
+++ b/packages/@n8n/config/tsconfig.json
@@ -1,12 +1,10 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"rootDir": ".",
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
 		"strictPropertyInitialization": false,
 		"types": ["node", "jest"],
-		"baseUrl": "src",
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
 	},
 	"include": ["src/**/*.ts", "test/**/*.ts"],

--- a/packages/@n8n/constants/tsconfig.json
+++ b/packages/@n8n/constants/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"rootDir": ".",
 		"types": ["node", "jest"],
-		"baseUrl": "src",
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"experimentalDecorators": true,
 		"emitDecoratorMetadata": true

--- a/packages/@n8n/crdt/tsconfig.json
+++ b/packages/@n8n/crdt/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"rootDir": ".",
 		"types": ["node", "vitest/globals"],
-		"baseUrl": "src",
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
 	},
 	"include": ["src/**/*.ts"]

--- a/packages/@n8n/create-node/tsconfig.json
+++ b/packages/@n8n/create-node/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "@n8n/typescript-config/modern/tsconfig.json",
 	"compilerOptions": {
-		"baseUrl": ".",
 		"rootDir": "src",
 		"outDir": "dist",
 		"types": ["vite/client", "vitest/globals"],

--- a/packages/@n8n/db/src/constants.ts
+++ b/packages/@n8n/db/src/constants.ts
@@ -10,7 +10,7 @@ import {
 	type Role as RoleDTO,
 } from '@n8n/permissions';
 
-import type { Role } from 'entities';
+import type { Role } from './entities';
 
 export function builtInRoleToRoleObject(
 	role: RoleDTO,

--- a/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
@@ -2,9 +2,8 @@
 import { Container } from '@n8n/di';
 import { In, LessThan, And, Not } from '@n8n/typeorm';
 
-import type { IExecutionResponse } from 'entities/types-db';
-
 import { ExecutionEntity } from '../../entities';
+import type { IExecutionResponse } from '../../entities/types-db';
 import { mockEntityManager } from '../../utils/test-utils/mock-entity-manager';
 import { ExecutionRepository } from '../execution.repository';
 

--- a/packages/@n8n/db/tsconfig.json
+++ b/packages/@n8n/db/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"rootDir": ".",
 		"types": ["node", "jest"],
-		"baseUrl": "src",
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"experimentalDecorators": true,
 		"emitDecoratorMetadata": true,

--- a/packages/@n8n/decorators/tsconfig.json
+++ b/packages/@n8n/decorators/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"rootDir": ".",
 		"types": ["node", "vitest/globals"],
-		"baseUrl": "src",
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"experimentalDecorators": true,
 		"emitDecoratorMetadata": true

--- a/packages/@n8n/di/tsconfig.json
+++ b/packages/@n8n/di/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"rootDir": ".",
 		"types": ["node", "jest"],
-		"baseUrl": "src",
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"experimentalDecorators": true,
 		"emitDecoratorMetadata": true

--- a/packages/@n8n/errors/tsconfig.json
+++ b/packages/@n8n/errors/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"rootDir": ".",
 		"types": ["node", "jest"],
-		"baseUrl": "src",
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"experimentalDecorators": true,
 		"emitDecoratorMetadata": true

--- a/packages/@n8n/eslint-config/tsconfig.json
+++ b/packages/@n8n/eslint-config/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"baseUrl": ".",
 		"rootDir": "src",
 		"outDir": "dist",
 		"types": ["vitest/globals", "node"],

--- a/packages/@n8n/eslint-plugin-community-nodes/tsconfig.json
+++ b/packages/@n8n/eslint-plugin-community-nodes/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "@n8n/typescript-config/modern/tsconfig.json",
 	"compilerOptions": {
-		"baseUrl": ".",
 		"rootDir": "src",
 		"outDir": "dist",
 		"types": ["vitest/globals", "node"]

--- a/packages/@n8n/imap/tsconfig.json
+++ b/packages/@n8n/imap/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"rootDir": ".",
 		"types": ["node", "vite/client", "vitest/globals"],
-		"baseUrl": "src",
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
 	},
 	"include": ["src/**/*.ts"]

--- a/packages/@n8n/instance-ai/tsconfig.json
+++ b/packages/@n8n/instance-ai/tsconfig.json
@@ -6,12 +6,10 @@
 	"compilerOptions": {
 		"target": "es2023",
 		"lib": ["es2023"],
-		"rootDir": ".",
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
-		"baseUrl": "src",
 		"paths": {
-			"@/*": ["./*"]
+			"@/*": ["./src/*"]
 		},
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"types": ["node", "jest"]

--- a/packages/@n8n/json-schema-to-zod/tsconfig.json
+++ b/packages/@n8n/json-schema-to-zod/tsconfig.json
@@ -1,8 +1,6 @@
 {
 	"extends": ["@n8n/typescript-config/tsconfig.backend.json"],
 	"compilerOptions": {
-		"rootDir": ".",
-		"baseUrl": "src",
 		"strict": true,
 		"noEmit": true,
 		"skipLibCheck": true,

--- a/packages/@n8n/mcp-browser/tsconfig.json
+++ b/packages/@n8n/mcp-browser/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"rootDir": ".",
 		"types": ["node", "jest"],
-		"baseUrl": "src",
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
 	},
 	"include": ["src/**/*.ts"]

--- a/packages/@n8n/node-cli/tsconfig.json
+++ b/packages/@n8n/node-cli/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": ["@n8n/typescript-config/tsconfig.common.json"],
 	"compilerOptions": {
-		"baseUrl": ".",
 		"rootDir": "src",
 		"outDir": "dist",
 		"types": ["vite/client", "vitest/globals"],

--- a/packages/@n8n/nodes-langchain/tsconfig.json
+++ b/packages/@n8n/nodes-langchain/tsconfig.json
@@ -4,7 +4,6 @@
 		"@n8n/typescript-config/tsconfig.backend.json"
 	],
 	"compilerOptions": {
-		"baseUrl": ".",
 		"paths": {
 			"@utils/*": ["./utils/*"],
 			"@nodes-testing/*": ["../../core/nodes-testing/*"]

--- a/packages/@n8n/permissions/tsconfig.json
+++ b/packages/@n8n/permissions/tsconfig.json
@@ -1,11 +1,9 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"rootDir": ".",
 		"types": ["node", "vitest/globals"],
-		"baseUrl": "src",
 		"paths": {
-			"@/*": ["./*"]
+			"@/*": ["./src/*"]
 		},
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
 	},

--- a/packages/@n8n/syslog-client/tsconfig.json
+++ b/packages/@n8n/syslog-client/tsconfig.json
@@ -1,12 +1,10 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"rootDir": ".",
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
 		"strictPropertyInitialization": false,
 		"types": ["node", "jest"],
-		"baseUrl": "src",
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
 	},
 	"include": ["src/**/*.ts", "test/**/*.ts"],

--- a/packages/@n8n/task-runner/tsconfig.json
+++ b/packages/@n8n/task-runner/tsconfig.json
@@ -4,12 +4,10 @@
 		"@n8n/typescript-config/tsconfig.backend.json"
 	],
 	"compilerOptions": {
-		"rootDir": ".",
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
-		"baseUrl": "src",
 		"paths": {
-			"@/*": ["./*"]
+			"@/*": ["./src/*"]
 		},
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
 	},

--- a/packages/@n8n/utils/tsconfig.json
+++ b/packages/@n8n/utils/tsconfig.json
@@ -1,8 +1,6 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.frontend.json",
 	"compilerOptions": {
-		"baseUrl": ".",
-		"rootDir": ".",
 		"outDir": "dist",
 		"types": ["vite/client", "vitest/globals"],
 		"isolatedModules": true

--- a/packages/@n8n/vitest-config/tsconfig.json
+++ b/packages/@n8n/vitest-config/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"rootDir": ".",
 		"types": ["node"],
-		"baseUrl": ".",
 		"module": "ESNext",
 		"moduleResolution": "bundler",
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"

--- a/packages/@n8n/workflow-sdk/tsconfig.json
+++ b/packages/@n8n/workflow-sdk/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"rootDir": ".",
 		"types": ["node", "jest"],
-		"baseUrl": "src",
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
 	},
 	"include": ["src/**/*.ts"],

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -4,14 +4,12 @@
 		"@n8n/typescript-config/tsconfig.backend.json"
 	],
 	"compilerOptions": {
-		"rootDir": ".",
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
-		"baseUrl": "src",
 		"paths": {
-			"@/*": ["./*"],
-			"@test/*": ["../test/shared/*"],
-			"@test-integration/*": ["../test/integration/shared/*"]
+			"@/*": ["./src/*"],
+			"@test/*": ["./test/shared/*"],
+			"@test-integration/*": ["./test/integration/shared/*"]
 		},
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		// TODO: remove all options below this line

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,11 +5,9 @@
 	],
 	"compilerOptions": {
 		"lib": ["es2022"],
-		"rootDir": ".",
-		"baseUrl": "src",
 		"paths": {
-			"@/*": ["./*"],
-			"@test/*": ["../test/*"]
+			"@/*": ["./src/*"],
+			"@test/*": ["./test/*"]
 		},
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"emitDecoratorMetadata": true,

--- a/packages/frontend/@n8n/chat/tsconfig.json
+++ b/packages/frontend/@n8n/chat/tsconfig.json
@@ -3,7 +3,6 @@
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "dist",
-		"baseUrl": "src",
 		"target": "esnext",
 		"module": "esnext",
 		"moduleResolution": "bundler",
@@ -14,8 +13,8 @@
 		"resolveJsonModule": true,
 		"types": ["vitest/globals"],
 		"paths": {
-			"@n8n/chat/*": ["./*"],
-			"@n8n/design-system*": ["../../design-system/src*"]
+			"@n8n/chat/*": ["./src/*"],
+			"@n8n/design-system*": ["../design-system/src*"]
 		},
 		"lib": ["esnext", "dom", "dom.iterable", "scripthost"],
 		// TODO: remove all options below this line

--- a/packages/frontend/@n8n/composables/tsconfig.json
+++ b/packages/frontend/@n8n/composables/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.frontend.json",
 	"compilerOptions": {
-		"baseUrl": ".",
 		"moduleResolution": "bundler",
-		"rootDir": ".",
 		"outDir": "dist",
 		"types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"],
 		"isolatedModules": true

--- a/packages/frontend/@n8n/design-system/tsconfig.json
+++ b/packages/frontend/@n8n/design-system/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.frontend.json",
 	"compilerOptions": {
-		"baseUrl": ".",
 		"rootDirs": [".", "../composables/src"],
 		"noEmit": true,
 		"moduleResolution": "bundler",

--- a/packages/frontend/@n8n/i18n/tsconfig.json
+++ b/packages/frontend/@n8n/i18n/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.frontend.json",
 	"compilerOptions": {
-		"baseUrl": ".",
 		"moduleResolution": "bundler",
-		"rootDir": ".",
 		"outDir": "dist",
 		"types": ["vite/client", "vitest/globals"],
 		"isolatedModules": true,

--- a/packages/frontend/@n8n/rest-api-client/tsconfig.json
+++ b/packages/frontend/@n8n/rest-api-client/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.frontend.json",
 	"compilerOptions": {
-		"baseUrl": ".",
 		"moduleResolution": "bundler",
 		"outDir": "dist",
 		"noEmit": true,

--- a/packages/frontend/@n8n/stores/tsconfig.json
+++ b/packages/frontend/@n8n/stores/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.frontend.json",
 	"compilerOptions": {
-		"baseUrl": ".",
 		"moduleResolution": "bundler",
-		"rootDir": ".",
 		"outDir": "dist",
 		"types": ["vite/client", "vitest/globals"],
 		"isolatedModules": true

--- a/packages/frontend/@n8n/storybook/tsconfig.app.json
+++ b/packages/frontend/@n8n/storybook/tsconfig.app.json
@@ -2,7 +2,6 @@
 	"extends": "@n8n/typescript-config/tsconfig.frontend.json",
 	"compilerOptions": {
 		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-		"baseUrl": ".",
 		"rootDirs": [".", "../composables/src"],
 		"noEmit": true,
 		"moduleResolution": "bundler",

--- a/packages/frontend/editor-ui/tsconfig.json
+++ b/packages/frontend/editor-ui/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.frontend.json",
 	"compilerOptions": {
-		"baseUrl": ".",
 		"moduleResolution": "bundler",
 		"rootDirs": [
 			".",


### PR DESCRIPTION
## Summary

Prepare tsconfig.json files across project for TSGo / TypeScript 7.

- Remove deprecated `baseUrl`
    - Fix paths if needed
- Remove unnecessary `rootDir: '.'`, as it's the default now 

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2903/


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
