### PR TITLE
fix(Freshdesk): add missing Basic prefix in Authorization header

### DIFF
--- a/packages/nodes-base/nodes/Freshdesk/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Freshdesk/GenericFunctions.ts
@@ -27,7 +27,7 @@ export async function freshdeskApiRequest(
 	let options: IRequestOptions = {
 		headers: {
 			'Content-Type': 'application/json',
-			Authorization: `${Buffer.from(apiKey).toString(BINARY_ENCODING)}`,
+			Authorization: `Basic ${Buffer.from(apiKey).toString(BINARY_ENCODING)}`,
 		},
 		method,
 		body,


### PR DESCRIPTION
## Problem
`freshdeskApiRequest` builds a base64-encoded API key string and sets it directly as the `Authorization` header value, but omits the required `Basic ` scheme prefix. Per RFC 7617, HTTP Basic authentication requires the format `Authorization: Basic <base64-credentials>`. Without the `Basic ` prefix the header value is unrecognised and Freshdesk returns 401 Unauthorized on every request.

## Fix
Prepended `Basic ` to the base64-encoded credential string in the `Authorization` header so it reads `Basic ${Buffer.from(apiKey).toString(BINARY_ENCODING)}`.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass