### PR TITLE
fix(SentryIo): correct limit check and return returnData in sentryApiRequestAllItems

### DIFF
--- a/packages/nodes-base/nodes/SentryIo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/SentryIo/GenericFunctions.ts
@@ -115,8 +115,8 @@ export async function sentryApiRequestAllItems(
 		uri = getNext(link as string);
 		returnData.push.apply(returnData, responseData.body as IDataObject[]);
 		const limit = query.limit as number | undefined;
-		if (limit && limit >= returnData.length) {
-			return;
+		if (limit && returnData.length >= limit) {
+			return returnData;
 		}
 	} while (hasMore(link as string));
 


### PR DESCRIPTION
## Problem
In `sentryApiRequestAllItems`, the early-exit limit check is both inverted and incomplete. The condition `limit >= returnData.length` is almost always true from the very first iteration, causing the function to bail out immediately when a limit is provided. Additionally, the bare `return` returns `undefined` instead of the accumulated `returnData`, so callers receive no data at all.

## Fix
Flipped the comparison to `returnData.length >= limit` so the guard only triggers once enough items have been collected, and changed `return` to `return returnData` so the accumulated results are always returned to the caller.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass