### PR TITLE
fix(Mattermost): use item index instead of hardcoded 0 in channel search

### DIFF
--- a/packages/nodes-base/nodes/Mattermost/v1/actions/channel/search/execute.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/actions/channel/search/execute.ts
@@ -10,7 +10,7 @@ export async function search(
 	const qs = {} as IDataObject;
 	const requestMethod = 'POST';
 	const teamId = this.getNodeParameter('teamId', index);
-	const returnAll = this.getNodeParameter('returnAll', 0);
+	const returnAll = this.getNodeParameter('returnAll', index);
 	const endpoint = `teams/${teamId}/channels/search`;
 
 	body.term = this.getNodeParameter('term', index) as string;
@@ -18,7 +18,7 @@ export async function search(
 	let responseData = await apiRequest.call(this, requestMethod, endpoint, body, qs);
 
 	if (!returnAll) {
-		const limit = this.getNodeParameter('limit', 0);
+		const limit = this.getNodeParameter('limit', index);
 		responseData = responseData.slice(0, limit);
 	}
 


### PR DESCRIPTION
## Problem
In the Mattermost channel search action, \`returnAll\` and \`limit\` are fetched with a hardcoded item index of \`0\` instead of the current loop \`index\`. When multiple input items are processed, every item after the first will incorrectly read \`returnAll\` and \`limit\` from the first item's context, silently returning wrong result counts.

## Fix
Changed both \`getNodeParameter('returnAll', 0)\` and \`getNodeParameter('limit', 0)\` to use the \`index\` parameter that is already passed into the function, aligning with the pattern used by all other operations in this node.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass