### PR TITLE
fix(Mattermost): use item index instead of hardcoded 0 in reaction getAll

### DIFF
--- a/packages/nodes-base/nodes/Mattermost/v1/actions/reaction/getAll/execute.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/actions/reaction/getAll/execute.ts
@@ -7,7 +7,7 @@ export async function getAll(
 	index: number,
 ): Promise<INodeExecutionData[]> {
 	const postId = this.getNodeParameter('postId', index) as string;
-	const limit = this.getNodeParameter('limit', 0, 0);
+	const limit = this.getNodeParameter('limit', index, 0);
 
 	const qs = {} as IDataObject;
 	const requestMethod = 'GET';


### PR DESCRIPTION
## Problem
In the Mattermost reaction getAll action, the \`limit\` parameter is fetched with a hardcoded item index of \`0\` instead of the current loop \`index\`. When multiple input items are processed, every item after the first incorrectly reads the limit from the first item's context, so the wrong number of reactions may be returned for subsequent items.

## Fix
Changed \`getNodeParameter('limit', 0, 0)\` to \`getNodeParameter('limit', index, 0)\`, using the \`index\` parameter already available in the function signature, consistent with how all other parameters are accessed in this file.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass