### PR TITLE
fix(Reddit): use loop index instead of hardcoded 0 for returnAll and limit in subreddit getAll

### DIFF
--- a/packages/nodes-base/nodes/Reddit/Reddit.node.ts
+++ b/packages/nodes-base/nodes/Reddit/Reddit.node.ts
@@ -201,10 +201,10 @@ export class Reddit implements INodeType {
 
 						responseData = await handleListing.call(this, i, endpoint, qs);
 
-						const returnAll = this.getNodeParameter('returnAll', 0);
+						const returnAll = this.getNodeParameter('returnAll', i);
 
 						if (!returnAll) {
-							const limit = this.getNodeParameter('limit', 0);
+							const limit = this.getNodeParameter('limit', i);
 							responseData = responseData.splice(0, limit);
 						}
 					}
@@ -364,12 +364,12 @@ export class Reddit implements INodeType {
 						const filters = this.getNodeParameter('filters', i);
 
 						if (filters.trending) {
-							const returnAll = this.getNodeParameter('returnAll', 0);
+							const returnAll = this.getNodeParameter('returnAll', i);
 							const endpoint = 'api/trending_subreddits.json';
 							responseData = await redditApiRequest.call(this, 'GET', endpoint, {});
 							responseData = responseData.subreddit_names.map((name: string) => ({ name }));
 							if (!returnAll) {
-								const limit = this.getNodeParameter('limit', 0);
+								const limit = this.getNodeParameter('limit', i);
 								responseData = responseData.splice(0, limit);
 							}
 						} else if (filters.keyword) {
@@ -379,10 +379,10 @@ export class Reddit implements INodeType {
 							const endpoint = 'api/search_subreddits.json';
 							responseData = await redditApiRequest.call(this, 'POST', endpoint, qs);
 
-							const returnAll = this.getNodeParameter('returnAll', 0);
+							const returnAll = this.getNodeParameter('returnAll', i);
 
 							if (!returnAll) {
-								const limit = this.getNodeParameter('limit', 0);
+								const limit = this.getNodeParameter('limit', i);
 								responseData = responseData.subreddits.splice(0, limit);
 							}
 						} else {


### PR DESCRIPTION
## Problem
In the Reddit subreddit getAll operation, \`returnAll\` and \`limit\` parameters are fetched with a hardcoded item index of \`0\` in three places (post search, trending subreddits, and keyword-based subreddit search). When processing multiple input items, every item after the first incorrectly reads these parameters from the first item's context, causing wrong result counts or unintentional full-fetch behavior for subsequent items.

## Fix
Replaced all six occurrences of \`getNodeParameter('returnAll', 0)\` and \`getNodeParameter('limit', 0)\` within the subreddit resource branch with the loop variable \`i\` that is already used by every other parameter access in the same loop body.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass