### PR TITLE
fix(Gitlab): use loop index instead of hardcoded 0 for returnAll and limit

### DIFF
--- a/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
@@ -1527,10 +1527,10 @@ export class Gitlab implements INodeType {
 
 						qs = this.getNodeParameter('additionalFields', i, {});
 
-						returnAll = this.getNodeParameter('returnAll', 0);
+						returnAll = this.getNodeParameter('returnAll', i);
 
 						if (!returnAll) {
-							qs.per_page = this.getNodeParameter('limit', 0);
+							qs.per_page = this.getNodeParameter('limit', i);
 						}
 
 						endpoint = `/projects/${id}/releases`;
@@ -1571,10 +1571,10 @@ export class Gitlab implements INodeType {
 
 						qs = this.getNodeParameter('getRepositoryIssuesFilters', i) as IDataObject;
 
-						returnAll = this.getNodeParameter('returnAll', 0);
+						returnAll = this.getNodeParameter('returnAll', i);
 
 						if (!returnAll) {
-							qs.per_page = this.getNodeParameter('limit', 0);
+							qs.per_page = this.getNodeParameter('limit', i);
 						}
 
 						endpoint = `${baseEndpoint}/issues`;


### PR DESCRIPTION
## Problem
In the Gitlab node's `release: getAll` and `repository: getIssues` operations, `returnAll` and `limit` are read with a hardcoded item index of `0` inside a `for` loop over all input items. This means that when multiple items are processed, the pagination parameters are always taken from the first item instead of the current one.

## Fix
Changed `this.getNodeParameter('returnAll', 0)` and `this.getNodeParameter('limit', 0)` to use the loop index `i` in both the `release: getAll` (lines 1530/1533) and `repository: getIssues` (lines 1574/1577) operation branches.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass