### PR TITLE
fix(Slack): use loop index instead of hardcoded 0 for returnAll and resolveData in channel member

### DIFF
--- a/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
+++ b/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
@@ -629,8 +629,8 @@ export class SlackV2 implements INodeType {
 					}
 					//https://api.slack.com/methods/conversations.members
 					if (operation === 'member') {
-						const returnAll = this.getNodeParameter('returnAll', 0);
-						const resolveData = this.getNodeParameter('resolveData', 0);
+						const returnAll = this.getNodeParameter('returnAll', i);
+						const resolveData = this.getNodeParameter('resolveData', i);
 						qs.channel = this.getNodeParameter(
 							'channelId',
 							i,


### PR DESCRIPTION
## Problem
In the Slack V2 node's `channel: member` operation, `returnAll` and `resolveData` are read with a hardcoded item index of `0` inside a `for` loop over all input items. When multiple items are processed, both pagination and resolve-data behaviour are incorrectly taken from the first item instead of the current one.

## Fix
Changed `this.getNodeParameter('returnAll', 0)` and `this.getNodeParameter('resolveData', 0)` to use the loop index `i` in the `channel: member` operation block.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass