### PR TITLE
fix(Ghost): use loop index instead of hardcoded 0 for returnAll and limit in post getAll

### DIFF
--- a/packages/nodes-base/nodes/Ghost/Ghost.node.ts
+++ b/packages/nodes-base/nodes/Ghost/Ghost.node.ts
@@ -152,7 +152,7 @@ export class Ghost implements INodeType {
 						}
 
 						if (operation === 'getAll') {
-							const returnAll = this.getNodeParameter('returnAll', 0);
+							const returnAll = this.getNodeParameter('returnAll', i);
 
 							const options = this.getNodeParameter('options', i);
 
@@ -168,7 +168,7 @@ export class Ghost implements INodeType {
 									qs,
 								);
 							} else {
-								qs.limit = this.getNodeParameter('limit', 0);
+								qs.limit = this.getNodeParameter('limit', i);
 								responseData = await ghostApiRequest.call(this, 'GET', '/content/posts', {}, qs);
 								responseData = responseData.posts;
 							}
@@ -265,7 +265,7 @@ export class Ghost implements INodeType {
 						}
 
 						if (operation === 'getAll') {
-							const returnAll = this.getNodeParameter('returnAll', 0);
+							const returnAll = this.getNodeParameter('returnAll', i);
 
 							const options = this.getNodeParameter('options', i);
 
@@ -281,7 +281,7 @@ export class Ghost implements INodeType {
 									qs,
 								);
 							} else {
-								qs.limit = this.getNodeParameter('limit', 0);
+								qs.limit = this.getNodeParameter('limit', i);
 								responseData = await ghostApiRequest.call(this, 'GET', '/admin/posts', {}, qs);
 								responseData = responseData.posts;
 							}


### PR DESCRIPTION
## Problem
In the Ghost node's `post: getAll` operations (both Content API and Admin API paths), `returnAll` and `limit` are read with a hardcoded item index of `0` inside a `for` loop over all input items. When processing multiple items, the pagination parameters are always taken from the first item rather than the current one.

## Fix
Changed `this.getNodeParameter('returnAll', 0)` and `this.getNodeParameter('limit', 0)` to use the loop index `i` in both the Content API `post: getAll` (lines 155/171) and Admin API `post: getAll` (lines 268/284) branches.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass