### PR TITLE
fix(Gmail Trigger Node): Exclude scheduled emails from trigger query

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -33,7 +33,7 @@ export class GmailTrigger implements INodeType {
 		name: 'gmailTrigger',
 		icon: 'file:gmail.svg',
 		group: ['trigger'],
-		version: [1, 1.1, 1.2, 1.3],
+		version: [1, 1.1, 1.2, 1.3, 1.4],
 		description:
 			'Fetches emails from Gmail and starts the workflow on specified polling intervals.',
 		subtitle: '={{"Gmail Trigger"}}',
@@ -299,6 +299,14 @@ export class GmailTrigger implements INodeType {
 			}
 
 			Object.assign(qs, prepareQuery.call(this, allFilters, 0), options);
+
+			if (node.typeVersion > 1.3) {
+				if (qs.q) {
+					qs.q += ' -in:scheduled';
+				} else {
+					qs.q = '-in:scheduled';
+				}
+			}
 
 			const messagesResponse: MessageListResponse = await googleApiRequest.call(
 				this,

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -432,6 +432,59 @@ describe('GmailTrigger', () => {
 		]);
 	});
 
+	it('should exclude scheduled emails from query on v1.4', async () => {
+		const messageListResponse: MessageListResponse = {
+			messages: [createListMessage({ id: '1' })],
+			resultSizeEstimate: 1,
+		};
+		nock(baseUrl)
+			.get('/gmail/v1/users/me/labels')
+			.reply(200, {
+				labels: [
+					{ id: 'INBOX', name: 'INBOX' },
+					{ id: 'SCHEDULED', name: 'SCHEDULED' },
+				],
+			});
+		nock(baseUrl)
+			.get('/gmail/v1/users/me/messages')
+			.query((q) => (q.q as string).includes('-in:scheduled'))
+			.reply(200, messageListResponse);
+		nock(baseUrl)
+			.get(new RegExp('/gmail/v1/users/me/messages/1?.*'))
+			.reply(200, createMessage({ id: '1', labelIds: ['INBOX'] }));
+
+		const { response } = await testPollingTriggerNode(GmailTrigger, {
+			node: { typeVersion: 1.4, parameters: { simple: true } },
+		});
+
+		expect(response).toEqual([[{ json: expect.objectContaining({ id: '1' }) }]]);
+	});
+
+	it('should not add -in:scheduled filter on v1.3', async () => {
+		const messageListResponse: MessageListResponse = {
+			messages: [createListMessage({ id: '1' })],
+			resultSizeEstimate: 1,
+		};
+		nock(baseUrl)
+			.get('/gmail/v1/users/me/labels')
+			.reply(200, {
+				labels: [{ id: 'INBOX', name: 'INBOX' }],
+			});
+		nock(baseUrl)
+			.get('/gmail/v1/users/me/messages')
+			.query((q) => !(q.q as string).includes('-in:scheduled'))
+			.reply(200, messageListResponse);
+		nock(baseUrl)
+			.get(new RegExp('/gmail/v1/users/me/messages/1?.*'))
+			.reply(200, createMessage({ id: '1', labelIds: ['INBOX'] }));
+
+		const { response } = await testPollingTriggerNode(GmailTrigger, {
+			node: { typeVersion: 1.3, parameters: { simple: true } },
+		});
+
+		expect(response).toEqual([[{ json: expect.objectContaining({ id: '1' }) }]]);
+	});
+
 	it('should handle multiple emails with the same timestamp', async () => {
 		const timestamp = '1727777957000';
 		const messageListResponse: MessageListResponse = {


### PR DESCRIPTION
## Summary

The Gmail Trigger was picking up scheduled (send-later) emails, which caused it to advance its `lastTimeChecked` timestamp past those messages and miss real incoming emails.

**Fix:** Append `-in:scheduled` to the Gmail API search query (`q` parameter) for node version 1.4+. This excludes scheduled emails at the query level so they're never fetched.

- Added `1.4` to the Gmail Trigger version array
- Added `-in:scheduled` query filter for `typeVersion > 1.3` in the `poll()` method
- Existing workflows on v1.0–v1.3 are unaffected (backward compatible)

**How to test:**
1. Create a Gmail Trigger node (new nodes default to v1.4)
2. Schedule an email in Gmail for later delivery
3. Send a test email from another account
4. Verify the trigger fires for the incoming email and ignores the scheduled one

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2929
closes #15090

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<details>
<summary>Implementation plan</summary>

$(cat .claude/plans/NODE-2929.md)

</details>