### PR TITLE
fix(Jira): use item index instead of hardcoded 0 for jsonParameters in notify and issueComment

### DIFF
--- a/packages/nodes-base/nodes/Jira/Jira.node.ts
+++ b/packages/nodes-base/nodes/Jira/Jira.node.ts
@@ -973,7 +973,7 @@ export class Jira implements INodeType {
 					try {
 						const issueKey = this.getNodeParameter('issueKey', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
-						const jsonActive = this.getNodeParameter('jsonParameters', 0);
+						const jsonActive = this.getNodeParameter('jsonParameters', i);
 						const body: INotify = {};
 						if (additionalFields.textBody) {
 							body.textBody = additionalFields.textBody as string;
@@ -1398,7 +1398,7 @@ export class Jira implements INodeType {
 			if (operation === 'add') {
 				for (let i = 0; i < length; i++) {
 					try {
-						const jsonParameters = this.getNodeParameter('jsonParameters', 0);
+						const jsonParameters = this.getNodeParameter('jsonParameters', i);
 						const issueKey = this.getNodeParameter('issueKey', i) as string;
 						const options = this.getNodeParameter('options', i);
 
@@ -1603,7 +1603,7 @@ export class Jira implements INodeType {
 						const issueKey = this.getNodeParameter('issueKey', i) as string;
 						const commentId = this.getNodeParameter('commentId', i) as string;
 						const options = this.getNodeParameter('options', i);
-						const jsonParameters = this.getNodeParameter('jsonParameters', 0);
+						const jsonParameters = this.getNodeParameter('jsonParameters', i);
 						const body: IDataObject = {};
 						if (options.expand) {
 							qs.expand = options.expand as string;


### PR DESCRIPTION
## Problem
In the Jira node, three `getNodeParameter` calls inside item-processing loops use a hardcoded index `0` instead of the current loop variable `i`. Specifically, `jsonParameters` is read at index `0` in the `issue.notify` operation (line 976), the `issueComment.add` operation (line 1401), and the `issueComment.update` operation (line 1606). When a workflow processes multiple input items with different `jsonParameters` values, every item incorrectly reads the parameter from item 0.

## Fix
Replace the hardcoded `0` with the loop variable `i` in all three `getNodeParameter('jsonParameters', ...)` calls so each item reads its own parameter value.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass