### PR TITLE
fix(Zendesk): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Zendesk/Zendesk.node.ts
+++ b/packages/nodes-base/nodes/Zendesk/Zendesk.node.ts
@@ -265,8 +265,8 @@ export class Zendesk implements INodeType {
 		let responseData;
 		for (let i = 0; i < length; i++) {
 			try {
-				const resource = this.getNodeParameter('resource', 0);
-				const operation = this.getNodeParameter('operation', 0);
+				const resource = this.getNodeParameter('resource', i);
+				const operation = this.getNodeParameter('operation', i);
 				//https://developer.zendesk.com/api-reference/ticketing/introduction/
 				if (resource === 'ticket') {
 					//https://developer.zendesk.com/rest_api/docs/support/tickets


### PR DESCRIPTION
## Problem
In `Zendesk.node.ts`, both `resource` and `operation` are read with a hardcoded index `0` inside the main item-processing loop (`for (let i = 0; i < length; i++)`). When n8n evaluates node parameters that use expressions referencing the current item, always reading from index 0 means all items beyond the first will use the wrong value, potentially routing each item through the wrong code path.

## Fix
Replace the hardcoded `0` with the loop variable `i` for both `resource` and `operation` `getNodeParameter` calls so each item is evaluated against its own data.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass