### PR TITLE
fix(Box): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Box/Box.node.ts
+++ b/packages/nodes-base/nodes/Box/Box.node.ts
@@ -66,9 +66,9 @@ export class Box implements INodeType {
 		const qs: IDataObject = {};
 		let responseData;
 		const timezone = this.getTimezone();
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			try {
 				if (resource === 'file') {
 					// https://developer.box.com/reference/post-files-id-copy


### PR DESCRIPTION
## Problem
In `Box.node.ts`, `resource` and `operation` are retrieved outside the `for` loop using the hardcoded index `0`. When a workflow processes multiple items where each item may have different resource/operation expressions, all items incorrectly use the first item's values.

## Fix
Moved `getNodeParameter('resource', ...)` and `getNodeParameter('operation', ...)` inside the loop, using the current item index `i`, so each item's parameters are evaluated correctly.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass