### PR TITLE
fix(ClickUp): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/ClickUp/ClickUp.node.ts
+++ b/packages/nodes-base/nodes/ClickUp/ClickUp.node.ts
@@ -406,10 +406,9 @@ export class ClickUp implements INodeType {
 		const qs: IDataObject = {};
 		let responseData;
 
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
-
 		for (let i = 0; i < length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			try {
 				if (resource === 'checklist') {
 					if (operation === 'create') {


### PR DESCRIPTION
## Problem
In `ClickUp.node.ts`, `resource` and `operation` are retrieved outside the `for` loop using the hardcoded index `0`. When processing multiple items with different resource/operation expressions, all items incorrectly use the first item's values.

## Fix
Moved `getNodeParameter('resource', ...)` and `getNodeParameter('operation', ...)` inside the loop body, using the current item index `i`.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass