### PR TITLE
fix(Clockify): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Clockify/Clockify.node.ts
+++ b/packages/nodes-base/nodes/Clockify/Clockify.node.ts
@@ -233,11 +233,9 @@ export class Clockify implements INodeType {
 
 		let responseData;
 
-		const resource = this.getNodeParameter('resource', 0);
-
-		const operation = this.getNodeParameter('operation', 0);
-
 		for (let i = 0; i < length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			try {
 				if (resource === 'client') {
 					if (operation === 'create') {


### PR DESCRIPTION
## Problem
In `Clockify.node.ts`, `resource` and `operation` are retrieved outside the `for` loop using the hardcoded index `0`. When a workflow processes multiple items where each item has different resource/operation expressions, all items incorrectly use the first item's values.

## Fix
Moved `getNodeParameter('resource', ...)` and `getNodeParameter('operation', ...)` inside the loop body, using the current item index `i`.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass