### PR TITLE
fix(Harvest): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Harvest/Harvest.node.ts
+++ b/packages/nodes-base/nodes/Harvest/Harvest.node.ts
@@ -196,9 +196,6 @@ export class Harvest implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
-
 		let endpoint = '';
 		let requestMethod: IHttpRequestMethods;
 		let body: IDataObject | Buffer;
@@ -208,6 +205,9 @@ export class Harvest implements INodeType {
 			try {
 				body = {};
 				qs = {};
+
+				const resource = this.getNodeParameter('resource', i) as string;
+				const operation = this.getNodeParameter('operation', i) as string;
 
 				if (resource === 'timeEntry') {
 					if (operation === 'get') {


### PR DESCRIPTION
## Problem
In `Harvest.node.ts`, `resource` and `operation` are read with hardcoded index `0` before the item loop begins, so when the node processes a multi-item input all items after the first are dispatched using the resource and operation values from item 0 rather than their own.

## Fix
Moved the `getNodeParameter` calls for `resource` and `operation` inside the `for` loop so each item uses its own index `i`, matching the pattern used by the rest of the parameter reads in the same loop.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass