### PR TITLE
fix(Trello): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Trello/Trello.node.ts
+++ b/packages/nodes-base/nodes/Trello/Trello.node.ts
@@ -188,9 +188,6 @@ export class Trello implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 
-		const operation = this.getNodeParameter('operation', 0);
-		const resource = this.getNodeParameter('resource', 0);
-
 		// For Post
 		let body: IDataObject;
 		// For Query string
@@ -207,6 +204,9 @@ export class Trello implements INodeType {
 				endpoint = '';
 				body = {};
 				qs = {};
+
+				const operation = this.getNodeParameter('operation', i) as string;
+				const resource = this.getNodeParameter('resource', i) as string;
 
 				if (resource === 'board') {
 					if (operation === 'create') {


### PR DESCRIPTION
## Problem
In `Trello.node.ts`, `resource` and `operation` are read with hardcoded index `0` before the item loop begins, so when the node processes a multi-item input all items after the first are dispatched using the resource and operation values from item 0 rather than their own.

## Fix
Moved the `getNodeParameter` calls for `resource` and `operation` inside the `for` loop so each item uses its own index `i`, matching the pattern used by the rest of the parameter reads in the same loop.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass