### PR TITLE
fix(Affinity): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Affinity/Affinity.node.ts
+++ b/packages/nodes-base/nodes/Affinity/Affinity.node.ts
@@ -144,9 +144,9 @@ export class Affinity implements INodeType {
 		const length = items.length;
 		let responseData;
 		const qs: IDataObject = {};
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
+			const resource = this.getNodeParameter('resource', i) as string;
+			const operation = this.getNodeParameter('operation', i) as string;
 			try {
 				if (resource === 'list') {
 					//https://api-docs.affinity.co/#get-a-specific-list


### PR DESCRIPTION
## Problem
In `Affinity.node.ts`, `resource` and `operation` are read with hardcoded index `0` before the item loop begins, so when the node processes a multi-item input all items after the first are dispatched using the resource and operation values from item 0 rather than their own.

## Fix
Moved the `getNodeParameter` calls for `resource` and `operation` inside the `for` loop so each item uses its own index `i`, matching the pattern used by the rest of the parameter reads in the same loop.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass