### PR TITLE
feat(Asana Trigger Node): Add webhook request verification

### DIFF
--- a/packages/nodes-base/nodes/Asana/AsanaTrigger.node.ts
+++ b/packages/nodes-base/nodes/Asana/AsanaTrigger.node.ts
@@ -10,11 +10,8 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 
+import { verifySignature } from './AsanaTriggerHelpers';
 import { asanaApiRequest, getWorkspaces } from './GenericFunctions';
-
-// import {
-// 	createHmac,
-// } from 'crypto';
 
 export class AsanaTrigger implements INodeType {
 	description: INodeTypeDescription = {
@@ -209,6 +206,12 @@ export class AsanaTrigger implements INodeType {
 			};
 		}
 
+		if (!verifySignature.call(this)) {
+			const res = this.getResponseObject();
+			res.status(401).send('Unauthorized').end();
+			return { noWebhookResponse: true };
+		}
+
 		// Is regular webhook call
 		// Check if it contains any events
 		if (
@@ -220,18 +223,6 @@ export class AsanaTrigger implements INodeType {
 			// start the workflow
 			return {};
 		}
-
-		// TODO: Had to be deactivated as it is currently not possible to get the secret
-		//       in production mode as the static data overwrites each other because the
-		//       two exist at the same time (create webhook [with webhookId] and receive
-		//       webhook [with secret])
-		// // Check if the request is valid
-		// // (if the signature matches to data and hookSecret)
-		// const computedSignature = createHmac('sha256', webhookData.hookSecret as string).update(JSON.stringify(req.body)).digest('hex');
-		// if (headerData['x-hook-signature'] !== computedSignature) {
-		// 	// Signature is not valid so ignore call
-		// 	return {};
-		// }
 
 		return {
 			workflowData: [this.helpers.returnJsonArray(req.body.events as IDataObject[])],

--- a/packages/nodes-base/nodes/Asana/AsanaTriggerHelpers.ts
+++ b/packages/nodes-base/nodes/Asana/AsanaTriggerHelpers.ts
@@ -1,0 +1,40 @@
+import { createHmac } from 'crypto';
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { verifySignature as verifySignatureGeneric } from '../../utils/webhook-signature-verification';
+
+/**
+ * Verifies the Asana webhook signature.
+ *
+ * Asana signs webhooks using HMAC SHA-256:
+ * 1. Compute an HMAC SHA-256 of the raw request body using the shared secret
+ *    received during the initial handshake (X-Hook-Secret header)
+ * 2. Encode the digest as a hexadecimal string
+ * 3. Compare against the value of the `X-Hook-Signature` header
+ *
+ * @returns true if the signature is valid, or no secret has been stored yet
+ *          (backward compatibility with webhooks created before verification
+ *          was introduced); false otherwise.
+ */
+export function verifySignature(this: IWebhookFunctions): boolean {
+	const req = this.getRequestObject();
+	const webhookData = this.getWorkflowStaticData('node');
+	const secret = webhookData.hookSecret;
+
+	return verifySignatureGeneric({
+		getExpectedSignature: () => {
+			if (!secret || typeof secret !== 'string' || !req.rawBody) {
+				return null;
+			}
+			const hmac = createHmac('sha256', secret);
+			const payload = Buffer.isBuffer(req.rawBody) ? req.rawBody : Buffer.from(req.rawBody);
+			hmac.update(payload);
+			return hmac.digest('hex');
+		},
+		skipIfNoExpectedSignature: !secret || typeof secret !== 'string',
+		getActualSignature: () => {
+			const receivedSignature = req.header('x-hook-signature');
+			return typeof receivedSignature === 'string' ? receivedSignature : null;
+		},
+	});
+}

--- a/packages/nodes-base/nodes/Asana/test/AsanaTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Asana/test/AsanaTrigger.node.test.ts
@@ -1,0 +1,149 @@
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { AsanaTrigger } from '../AsanaTrigger.node';
+import { verifySignature } from '../AsanaTriggerHelpers';
+
+jest.mock('../AsanaTriggerHelpers');
+jest.mock('../GenericFunctions');
+
+describe('AsanaTrigger', () => {
+	let trigger: AsanaTrigger;
+	let mockWebhookFunctions: Pick<
+		jest.Mocked<IWebhookFunctions>,
+		| 'getBodyData'
+		| 'getHeaderData'
+		| 'getRequestObject'
+		| 'getResponseObject'
+		| 'getWorkflowStaticData'
+		| 'helpers'
+	>;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		trigger = new AsanaTrigger();
+
+		mockWebhookFunctions = {
+			getBodyData: jest.fn(),
+			getHeaderData: jest.fn(),
+			getRequestObject: jest.fn(),
+			getResponseObject: jest.fn(),
+			getWorkflowStaticData: jest.fn(),
+			helpers: {
+				returnJsonArray: jest.fn((data) => data),
+			} as any,
+		};
+	});
+
+	describe('webhook', () => {
+		it('should complete the handshake when X-Hook-Secret header is present', async () => {
+			const handshakeSecret = 'asana-handshake-secret';
+			const mockResponse = {
+				set: jest.fn().mockReturnThis(),
+				status: jest.fn().mockReturnThis(),
+				end: jest.fn(),
+			};
+			const webhookData: any = {};
+
+			mockWebhookFunctions.getBodyData.mockReturnValue({});
+			mockWebhookFunctions.getHeaderData.mockReturnValue({
+				'x-hook-secret': handshakeSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({} as any);
+			mockWebhookFunctions.getResponseObject.mockReturnValue(mockResponse as any);
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue(webhookData);
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(webhookData.hookSecret).toBe(handshakeSecret);
+			expect(mockResponse.set).toHaveBeenCalledWith('X-Hook-Secret', handshakeSecret);
+			expect(mockResponse.status).toHaveBeenCalledWith(200);
+			expect(verifySignature).not.toHaveBeenCalled();
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		it('should return 401 when signature verification fails', async () => {
+			const mockResponse = {
+				status: jest.fn().mockReturnThis(),
+				send: jest.fn().mockReturnThis(),
+				end: jest.fn(),
+			};
+
+			(verifySignature as jest.Mock).mockReturnValue(false);
+			mockWebhookFunctions.getBodyData.mockReturnValue({});
+			mockWebhookFunctions.getHeaderData.mockReturnValue({});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({} as any);
+			mockWebhookFunctions.getResponseObject.mockReturnValue(mockResponse as any);
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({});
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(verifySignature).toHaveBeenCalled();
+			expect(mockResponse.status).toHaveBeenCalledWith(401);
+			expect(mockResponse.send).toHaveBeenCalledWith('Unauthorized');
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		it('should process events when signature verification passes', async () => {
+			const events = [{ action: 'changed', resource: { gid: '1' } }];
+
+			(verifySignature as jest.Mock).mockReturnValue(true);
+			mockWebhookFunctions.getBodyData.mockReturnValue({ events });
+			mockWebhookFunctions.getHeaderData.mockReturnValue({});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				body: { events },
+			} as any);
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				hookSecret: 'secret',
+			});
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(verifySignature).toHaveBeenCalled();
+			expect(result.workflowData).toBeDefined();
+			expect(result.workflowData?.[0]).toEqual(events);
+		});
+
+		it('should process events when no secret is configured (backward compatibility)', async () => {
+			const events = [{ action: 'added' }];
+
+			(verifySignature as jest.Mock).mockReturnValue(true);
+			mockWebhookFunctions.getBodyData.mockReturnValue({ events });
+			mockWebhookFunctions.getHeaderData.mockReturnValue({});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				body: { events },
+			} as any);
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({});
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(verifySignature).toHaveBeenCalled();
+			expect(result.workflowData).toBeDefined();
+			expect(result.workflowData?.[0]).toEqual(events);
+		});
+
+		it('should return empty result when events array is empty after verification', async () => {
+			(verifySignature as jest.Mock).mockReturnValue(true);
+			mockWebhookFunctions.getBodyData.mockReturnValue({ events: [] });
+			mockWebhookFunctions.getHeaderData.mockReturnValue({});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				body: { events: [] },
+			} as any);
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({});
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(verifySignature).toHaveBeenCalled();
+			expect(result).toEqual({});
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Asana/test/AsanaTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Asana/test/AsanaTriggerHelpers.test.ts
@@ -83,6 +83,28 @@ describe('AsanaTriggerHelpers', () => {
 			expect(result).toBe(false);
 		});
 
+		it('should return true if rawBody is a string and signature matches', () => {
+			const stringPayload = '{"events":[{"action":"changed"}]}';
+			const hmac = createHmac('sha256', testSecret);
+			hmac.update(Buffer.from(stringPayload));
+			const expectedSignature = hmac.digest('hex');
+
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				hookSecret: testSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header: string) => {
+					if (header === 'x-hook-signature') return expectedSignature;
+					return null;
+				}),
+				rawBody: stringPayload,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
 		it('should return false if raw body is missing when secret is set', () => {
 			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
 				hookSecret: testSecret,

--- a/packages/nodes-base/nodes/Asana/test/AsanaTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Asana/test/AsanaTriggerHelpers.test.ts
@@ -1,0 +1,100 @@
+import { createHmac } from 'crypto';
+
+import { verifySignature } from '../AsanaTriggerHelpers';
+
+describe('AsanaTriggerHelpers', () => {
+	let mockWebhookFunctions: any;
+	const testSecret = 'test-secret-key-12345';
+	const testPayload = Buffer.from('{"events":[{"action":"changed"}]}');
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		mockWebhookFunctions = {
+			getRequestObject: jest.fn(),
+			getWorkflowStaticData: jest.fn(),
+		};
+	});
+
+	describe('verifySignature', () => {
+		it('should return true if no secret is configured (backward compatibility)', () => {
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(null),
+				rawBody: testPayload,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return true if signatures match', () => {
+			const hmac = createHmac('sha256', testSecret);
+			hmac.update(testPayload);
+			const expectedSignature = hmac.digest('hex');
+
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				hookSecret: testSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'x-hook-signature') return expectedSignature;
+					return null;
+				}),
+				rawBody: testPayload,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false if signatures do not match', () => {
+			const wrongSignature = '0'.repeat(64);
+
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				hookSecret: testSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'x-hook-signature') return wrongSignature;
+					return null;
+				}),
+				rawBody: testPayload,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false if signature header is missing', () => {
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				hookSecret: testSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(null),
+				rawBody: testPayload,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false if raw body is missing when secret is set', () => {
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				hookSecret: testSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue('any'),
+				rawBody: undefined,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Verify the `X-Hook-Signature` header on incoming Asana webhook requests using
HMAC SHA-256 with the shared secret captured during the `X-Hook-Secret` handshake.
Rejects unsigned/tampered requests with `401 Unauthorized`.

Verification is skipped when no secret is present in static data, preserving
backward compatibility with webhooks created before this change.

<img width="2502" height="1304" alt="2026-04-28 11 21 48" src="https://github.com/user-attachments/assets/bfbfd1f0-95e8-4c0d-b255-b8b40c7277ed" />

### Verification

Tested with [n8n-node-mocker](https://github.com/DawidMyslak/n8n-node-mocker):
- ✅ Correct secret → 200 OK
- ✅ Wrong secret → 401 Unauthorized

### How to test

1. Add an Asana Trigger node and activate the workflow.
2. Confirm the `X-Hook-Secret` handshake completes (webhook visible in Asana).
3. Trigger an event — workflow should run normally.
4. Replay the request with a tampered body or wrong signature — should get `401`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4300

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI