### PR TITLE
feat(Twilio Trigger Node): Add webhook request verification

### DIFF
--- a/packages/nodes-base/nodes/Twilio/TwilioTrigger.node.ts
+++ b/packages/nodes-base/nodes/Twilio/TwilioTrigger.node.ts
@@ -8,6 +8,7 @@ import {
 } from 'n8n-workflow';
 
 import { twilioTriggerApiRequest } from './GenericFunctions';
+import { verifySignature } from './TwilioTriggerHelpers';
 
 export class TwilioTrigger implements INodeType {
 	description: INodeTypeDescription = {
@@ -188,6 +189,15 @@ export class TwilioTrigger implements INodeType {
 	};
 
 	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
+		const isSignatureValid = await verifySignature.call(this);
+		if (!isSignatureValid) {
+			const res = this.getResponseObject();
+			res.status(401).send('Unauthorized').end();
+			return {
+				noWebhookResponse: true,
+			};
+		}
+
 		const bodyData = this.getBodyData();
 
 		return {

--- a/packages/nodes-base/nodes/Twilio/TwilioTriggerHelpers.ts
+++ b/packages/nodes-base/nodes/Twilio/TwilioTriggerHelpers.ts
@@ -1,0 +1,70 @@
+import { createHash, createHmac, timingSafeEqual } from 'crypto';
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { verifySignature as verifySignatureGeneric } from '../../utils/webhook-signature-verification';
+
+/**
+ * Verifies a Twilio Event Streams webhook request.
+ *
+ * Twilio signs JSON webhooks by:
+ * 1. Computing SHA-256 of the raw body and appending it as `bodySHA256` query param
+ * 2. HMAC-SHA1 over the resulting URL using the account auth token
+ * 3. Sending the base64-encoded result in the `X-Twilio-Signature` header
+ *
+ * Falls back to skip verification when no auth token is available
+ * (e.g. credential uses API Key auth) to preserve existing workflows.
+ */
+export async function verifySignature(this: IWebhookFunctions): Promise<boolean> {
+	try {
+		const credential = await this.getCredentials<{ authType?: string; authToken?: string }>(
+			'twilioApi',
+		);
+		const req = this.getRequestObject();
+		const authToken = credential.authToken;
+
+		if (!authToken || typeof authToken !== 'string') {
+			return true;
+		}
+
+		const rawBody = req.rawBody;
+		if (!rawBody) {
+			return false;
+		}
+
+		const bodyBuffer = Buffer.isBuffer(rawBody) ? rawBody : Buffer.from(rawBody);
+		const computedBodyHash = createHash('sha256').update(bodyBuffer).digest('hex');
+		const bodyHashFromQuery = req.query?.bodySHA256;
+
+		if (
+			typeof bodyHashFromQuery !== 'string' ||
+			bodyHashFromQuery.length !== computedBodyHash.length ||
+			!timingSafeEqual(Buffer.from(bodyHashFromQuery), Buffer.from(computedBodyHash))
+		) {
+			return false;
+		}
+
+		const sinkUrl = this.getNodeWebhookUrl('default');
+		if (!sinkUrl) {
+			return false;
+		}
+
+		const originalUrl: string = req.originalUrl ?? req.url ?? '';
+		const queryIdx = originalUrl.indexOf('?');
+		const queryString = queryIdx === -1 ? '' : originalUrl.substring(queryIdx + 1);
+		const signedUrl = queryString ? `${sinkUrl}?${queryString}` : sinkUrl;
+
+		return verifySignatureGeneric({
+			getExpectedSignature: () => {
+				const hmac = createHmac('sha1', authToken);
+				hmac.update(signedUrl);
+				return hmac.digest('base64');
+			},
+			getActualSignature: () => {
+				const sig = req.header('x-twilio-signature');
+				return typeof sig === 'string' ? sig : null;
+			},
+		});
+	} catch (error) {
+		return false;
+	}
+}

--- a/packages/nodes-base/nodes/Twilio/TwilioTriggerHelpers.ts
+++ b/packages/nodes-base/nodes/Twilio/TwilioTriggerHelpers.ts
@@ -43,12 +43,21 @@ export async function verifySignature(this: IWebhookFunctions): Promise<boolean>
 			return false;
 		}
 
-		const sinkUrl = this.getNodeWebhookUrl('default');
+		let sinkUrl = this.getNodeWebhookUrl('default');
 		if (!sinkUrl) {
 			return false;
 		}
 
 		const originalUrl: string = req.originalUrl ?? req.url ?? '';
+
+		// getNodeWebhookUrl always returns the production path (/webhook/...).
+		// In test mode the request arrives at /webhook-test/..., so adjust
+		// the base URL to match what was actually signed against.
+		const originalPath = originalUrl.split('?')[0];
+		if (originalPath.includes('/webhook-test/')) {
+			sinkUrl = sinkUrl.replace('/webhook/', '/webhook-test/');
+		}
+
 		const queryIdx = originalUrl.indexOf('?');
 		const queryString = queryIdx === -1 ? '' : originalUrl.substring(queryIdx + 1);
 		const signedUrl = queryString ? `${sinkUrl}?${queryString}` : sinkUrl;

--- a/packages/nodes-base/nodes/Twilio/test/TwilioTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Twilio/test/TwilioTrigger.node.test.ts
@@ -1,0 +1,83 @@
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { TwilioTrigger } from '../TwilioTrigger.node';
+import { verifySignature } from '../TwilioTriggerHelpers';
+
+jest.mock('../TwilioTriggerHelpers');
+
+describe('TwilioTrigger', () => {
+	let trigger: TwilioTrigger;
+	let mockWebhookFunctions: Pick<
+		jest.Mocked<IWebhookFunctions>,
+		'getBodyData' | 'getResponseObject' | 'helpers'
+	>;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		trigger = new TwilioTrigger();
+
+		mockWebhookFunctions = {
+			getBodyData: jest.fn(),
+			getResponseObject: jest.fn(),
+			helpers: {
+				returnJsonArray: jest.fn((data) => data),
+			} as any,
+		};
+	});
+
+	describe('webhook', () => {
+		it('should process the webhook when signature verification passes', async () => {
+			const bodyData = [
+				{ specversion: '1.0', type: 'com.twilio.messaging.inbound-message.received' },
+			];
+
+			(verifySignature as jest.Mock).mockResolvedValue(true);
+			mockWebhookFunctions.getBodyData.mockReturnValue(bodyData as any);
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(verifySignature).toHaveBeenCalled();
+			expect(result.workflowData).toBeDefined();
+			expect(mockWebhookFunctions.helpers.returnJsonArray).toHaveBeenCalledWith(bodyData);
+		});
+
+		it('should return 401 when signature verification fails', async () => {
+			const mockResponse = {
+				status: jest.fn().mockReturnThis(),
+				send: jest.fn().mockReturnThis(),
+				end: jest.fn(),
+			};
+
+			(verifySignature as jest.Mock).mockResolvedValue(false);
+			mockWebhookFunctions.getResponseObject.mockReturnValue(mockResponse as any);
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(verifySignature).toHaveBeenCalled();
+			expect(mockResponse.status).toHaveBeenCalledWith(401);
+			expect(mockResponse.send).toHaveBeenCalledWith('Unauthorized');
+			expect(mockResponse.end).toHaveBeenCalled();
+			expect(result).toEqual({ noWebhookResponse: true });
+			expect(mockWebhookFunctions.getBodyData).not.toHaveBeenCalled();
+		});
+
+		it('should process the webhook when no auth token is configured (backward compat)', async () => {
+			const bodyData = [
+				{ specversion: '1.0', type: 'com.twilio.voice.insights.call-summary.complete' },
+			];
+
+			(verifySignature as jest.Mock).mockResolvedValue(true);
+			mockWebhookFunctions.getBodyData.mockReturnValue(bodyData as any);
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(result.workflowData).toBeDefined();
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Twilio/test/TwilioTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Twilio/test/TwilioTriggerHelpers.test.ts
@@ -168,6 +168,35 @@ describe('TwilioTriggerHelpers', () => {
 			expect(result).toBe(false);
 		});
 
+		it('should return true in test mode when signature matches test URL', async () => {
+			const testSinkUrl = 'https://n8n.example.com/webhook-test/abc/webhook';
+			const testSignedUrl = `${testSinkUrl}?${queryString}`;
+			const testModeSignature = createHmac('sha1', testAuthToken)
+				.update(testSignedUrl)
+				.digest('base64');
+
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				authToken: testAuthToken,
+			});
+			// getNodeWebhookUrl returns the production URL
+			mockWebhookFunctions.getNodeWebhookUrl.mockReturnValue(sinkUrl);
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((name: string) => {
+					if (name === 'x-twilio-signature') return testModeSignature;
+					return null;
+				}),
+				query: { bodySHA256: testBodyHash },
+				rawBody: Buffer.from(testBody),
+				// Request arrives at the test URL
+				originalUrl: `/webhook-test/abc/webhook?${queryString}`,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
 		it('should accept rawBody as a string', async () => {
 			mockWebhookFunctions.getCredentials.mockResolvedValue({
 				authType: 'authToken',

--- a/packages/nodes-base/nodes/Twilio/test/TwilioTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Twilio/test/TwilioTriggerHelpers.test.ts
@@ -1,0 +1,188 @@
+import { createHash, createHmac } from 'crypto';
+
+import { verifySignature } from '../TwilioTriggerHelpers';
+
+describe('TwilioTriggerHelpers', () => {
+	const testAuthToken = 'test-twilio-auth-token';
+	const sinkUrl = 'https://n8n.example.com/webhook/abc/webhook';
+	const testBody = '[{"specversion":"1.0","type":"com.twilio.messaging.inbound-message.received"}]';
+	const testBodyHash = createHash('sha256').update(testBody).digest('hex');
+	const queryString = `bodySHA256=${testBodyHash}`;
+	const signedUrl = `${sinkUrl}?${queryString}`;
+	const validSignature = createHmac('sha1', testAuthToken).update(signedUrl).digest('base64');
+
+	let mockWebhookFunctions: any;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		mockWebhookFunctions = {
+			getCredentials: jest.fn(),
+			getRequestObject: jest.fn(),
+			getNodeWebhookUrl: jest.fn().mockReturnValue(sinkUrl),
+		};
+
+		mockWebhookFunctions.getRequestObject.mockReturnValue({
+			header: jest.fn().mockImplementation((name: string) => {
+				if (name === 'x-twilio-signature') return validSignature;
+				return null;
+			}),
+			query: { bodySHA256: testBodyHash },
+			rawBody: Buffer.from(testBody),
+			originalUrl: `/webhook/abc/webhook?${queryString}`,
+		});
+	});
+
+	describe('verifySignature', () => {
+		it('should return true when no auth token is configured (backward compat)', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'apiKey',
+				apiKeySid: 'SK123',
+				apiKeySecret: 'secret',
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+			expect(mockWebhookFunctions.getCredentials).toHaveBeenCalledWith('twilioApi');
+		});
+
+		it('should return true when auth token is empty string', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				authToken: '',
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return true when signature is valid', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				authToken: testAuthToken,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false when signature is invalid', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				authToken: testAuthToken,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((name: string) => {
+					if (name === 'x-twilio-signature') {
+						return Buffer.from('invalidsignaturevaluepadded').toString('base64');
+					}
+					return null;
+				}),
+				query: { bodySHA256: testBodyHash },
+				rawBody: Buffer.from(testBody),
+				originalUrl: `/webhook/abc/webhook?${queryString}`,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when X-Twilio-Signature header is missing', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				authToken: testAuthToken,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(null),
+				query: { bodySHA256: testBodyHash },
+				rawBody: Buffer.from(testBody),
+				originalUrl: `/webhook/abc/webhook?${queryString}`,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when bodySHA256 query param is missing', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				authToken: testAuthToken,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(validSignature),
+				query: {},
+				rawBody: Buffer.from(testBody),
+				originalUrl: '/webhook/abc/webhook',
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when bodySHA256 does not match raw body hash', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				authToken: testAuthToken,
+			});
+			const tamperedHash = createHash('sha256').update('tampered').digest('hex');
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(validSignature),
+				query: { bodySHA256: tamperedHash },
+				rawBody: Buffer.from(testBody),
+				originalUrl: `/webhook/abc/webhook?bodySHA256=${tamperedHash}`,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when raw body is missing', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				authToken: testAuthToken,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(validSignature),
+				query: { bodySHA256: testBodyHash },
+				rawBody: undefined,
+				originalUrl: `/webhook/abc/webhook?${queryString}`,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when getCredentials throws', async () => {
+			mockWebhookFunctions.getCredentials.mockRejectedValue(new Error('credential lookup failed'));
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should accept rawBody as a string', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				authToken: testAuthToken,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(validSignature),
+				query: { bodySHA256: testBodyHash },
+				rawBody: testBody,
+				originalUrl: `/webhook/abc/webhook?${queryString}`,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Add webhook request verification to the Twilio Trigger node using Twilio's Event Streams signing scheme:

1. Verify body integrity via SHA-256 hash in the `bodySHA256` query param
2. Verify authenticity via HMAC-SHA1 of the sink URL using the account auth token, compared against the `X-Twilio-Signature` header

Skips verification when no auth token is available (API Key auth) to preserve backward compatibility.

<img width="2502" height="1304" alt="2026-04-29 10 51 16" src="https://github.com/user-attachments/assets/2dcbbf73-6090-4ab1-b76c-3bea359e6523" />

### Verification

Tested with [n8n-node-mocker](https://github.com/DawidMyslak/n8n-node-mocker):
- ✅ Correct secret → 200 OK
- ✅ Wrong secret → 401 Unauthorized

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4317

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

---
🤖 PR Summary generated by AI