### PR TITLE
feat(GitLab Trigger Node): Add webhook request verification

### DIFF
--- a/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
@@ -200,6 +200,7 @@ export class GitlabTrigger implements INodeType {
 						// Webhook does not exist
 						delete webhookData.webhookId;
 						delete webhookData.webhookEvents;
+						delete webhookData.webhookSecret;
 
 						return false;
 					}

--- a/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
@@ -10,6 +10,7 @@ import type {
 import { NodeConnectionTypes, NodeApiError } from 'n8n-workflow';
 
 import { gitlabApiRequest } from './GenericFunctions';
+import { generateWebhookSecret, verifySignature } from './GitlabTriggerHelpers';
 
 const GITLAB_EVENTS = [
 	{
@@ -240,10 +241,13 @@ export class GitlabTrigger implements INodeType {
 
 				const endpoint = `/projects/${path}/hooks`;
 
+				const webhookSecret = generateWebhookSecret();
+
 				const body = {
 					url: webhookUrl,
 					...events,
 					enable_ssl_verification: false,
+					token: webhookSecret,
 				};
 
 				let responseData;
@@ -263,6 +267,7 @@ export class GitlabTrigger implements INodeType {
 				const webhookData = this.getWorkflowStaticData('node');
 				webhookData.webhookId = responseData.id as string;
 				webhookData.webhookEvents = eventsArray;
+				webhookData.webhookSecret = webhookSecret;
 
 				return true;
 			},
@@ -288,6 +293,7 @@ export class GitlabTrigger implements INodeType {
 					// that no webhooks are registered anymore
 					delete webhookData.webhookId;
 					delete webhookData.webhookEvents;
+					delete webhookData.webhookSecret;
 				}
 
 				return true;
@@ -295,7 +301,16 @@ export class GitlabTrigger implements INodeType {
 		},
 	};
 
+	// eslint-disable-next-line @typescript-eslint/require-await
 	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
+		if (!verifySignature.call(this)) {
+			const res = this.getResponseObject();
+			res.status(401).send('Unauthorized').end();
+			return {
+				noWebhookResponse: true,
+			};
+		}
+
 		const bodyData = this.getBodyData();
 
 		const returnData: IDataObject[] = [];

--- a/packages/nodes-base/nodes/Gitlab/GitlabTriggerHelpers.ts
+++ b/packages/nodes-base/nodes/Gitlab/GitlabTriggerHelpers.ts
@@ -1,0 +1,25 @@
+import { randomBytes } from 'crypto';
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { verifySignature as verifySignatureGeneric } from '../../utils/webhook-signature-verification';
+
+const WEBHOOK_TOKEN_HEADER = 'x-gitlab-token';
+
+export function generateWebhookSecret(): string {
+	return randomBytes(32).toString('hex');
+}
+
+export function verifySignature(this: IWebhookFunctions): boolean {
+	const headerData = this.getHeaderData();
+	const webhookData = this.getWorkflowStaticData('node');
+	const expectedSecret = webhookData.webhookSecret;
+
+	return verifySignatureGeneric({
+		getExpectedSignature: () => (typeof expectedSecret === 'string' ? expectedSecret : null),
+		skipIfNoExpectedSignature: true,
+		getActualSignature: () => {
+			const actualSecret = headerData[WEBHOOK_TOKEN_HEADER];
+			return typeof actualSecret === 'string' ? actualSecret : null;
+		},
+	});
+}

--- a/packages/nodes-base/nodes/Gitlab/__tests__/GitlabTrigger.test.ts
+++ b/packages/nodes-base/nodes/Gitlab/__tests__/GitlabTrigger.test.ts
@@ -1,0 +1,94 @@
+import type { IDataObject, IWebhookFunctions } from 'n8n-workflow';
+
+import { GitlabTrigger } from '../GitlabTrigger.node';
+
+jest.mock('../GitlabTriggerHelpers', () => ({
+	generateWebhookSecret: jest.fn(() => 'generated-secret'),
+	verifySignature: jest.fn(),
+}));
+
+import { verifySignature } from '../GitlabTriggerHelpers';
+
+describe('GitlabTrigger', () => {
+	let trigger: GitlabTrigger;
+	let mockWebhookFunctions: Partial<IWebhookFunctions>;
+	let mockResponse: { status: jest.Mock; send: jest.Mock; end: jest.Mock };
+
+	beforeEach(() => {
+		trigger = new GitlabTrigger();
+		mockResponse = {
+			status: jest.fn().mockReturnThis(),
+			send: jest.fn().mockReturnThis(),
+			end: jest.fn().mockReturnThis(),
+		};
+
+		mockWebhookFunctions = {
+			getBodyData: jest.fn().mockReturnValue({}),
+			getHeaderData: jest.fn().mockReturnValue({}),
+			getQueryData: jest.fn().mockReturnValue({}),
+			getResponseObject: jest.fn().mockReturnValue(mockResponse),
+			helpers: {
+				returnJsonArray: jest.fn((data) => data),
+			} as unknown as IWebhookFunctions['helpers'],
+		};
+
+		(verifySignature as jest.Mock).mockReturnValue(true);
+	});
+
+	describe('webhook', () => {
+		it('should return 401 when verification fails', async () => {
+			(verifySignature as jest.Mock).mockReturnValue(false);
+
+			const result = await trigger.webhook.call(mockWebhookFunctions as IWebhookFunctions);
+
+			expect(mockResponse.status).toHaveBeenCalledWith(401);
+			expect(mockResponse.send).toHaveBeenCalledWith('Unauthorized');
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		it('should trigger workflow when verification succeeds', async () => {
+			const bodyData: IDataObject = {
+				object_kind: 'push',
+				project: { id: 1 },
+			};
+			const headerData = { 'x-gitlab-event': 'Push Hook' };
+			const queryData = {};
+
+			(mockWebhookFunctions.getBodyData as jest.Mock).mockReturnValue(bodyData);
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue(headerData);
+			(mockWebhookFunctions.getQueryData as jest.Mock).mockReturnValue(queryData);
+
+			const result = await trigger.webhook.call(mockWebhookFunctions as IWebhookFunctions);
+
+			expect(result.workflowData).toBeDefined();
+			expect(mockWebhookFunctions.helpers!.returnJsonArray).toHaveBeenCalledWith([
+				{
+					body: bodyData,
+					headers: headerData,
+					query: queryData,
+				},
+			]);
+		});
+
+		it('should trigger workflow when no secret is stored (backward compatibility)', async () => {
+			// verifySignature returns true via skipIfNoExpectedSignature when secret is missing
+			(verifySignature as jest.Mock).mockReturnValue(true);
+
+			const bodyData: IDataObject = { object_kind: 'push' };
+			(mockWebhookFunctions.getBodyData as jest.Mock).mockReturnValue(bodyData);
+
+			const result = await trigger.webhook.call(mockWebhookFunctions as IWebhookFunctions);
+
+			expect(result.workflowData).toBeDefined();
+			expect(mockResponse.status).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('description', () => {
+		it('should have correct node metadata', () => {
+			expect(trigger.description.displayName).toBe('GitLab Trigger');
+			expect(trigger.description.name).toBe('gitlabTrigger');
+			expect(trigger.description.group).toContain('trigger');
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Gitlab/__tests__/GitlabTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Gitlab/__tests__/GitlabTriggerHelpers.test.ts
@@ -1,0 +1,98 @@
+import type { IDataObject, IWebhookFunctions } from 'n8n-workflow';
+
+import { generateWebhookSecret, verifySignature } from '../GitlabTriggerHelpers';
+
+describe('GitlabTriggerHelpers', () => {
+	describe('generateWebhookSecret', () => {
+		it('should generate a 64-character hex string', () => {
+			const secret = generateWebhookSecret();
+			expect(secret).toHaveLength(64);
+			expect(/^[0-9a-f]+$/.test(secret)).toBe(true);
+		});
+
+		it('should generate unique secrets', () => {
+			const secret1 = generateWebhookSecret();
+			const secret2 = generateWebhookSecret();
+			expect(secret1).not.toBe(secret2);
+		});
+	});
+
+	describe('verifySignature', () => {
+		let mockWebhookFunctions: Partial<IWebhookFunctions>;
+
+		beforeEach(() => {
+			mockWebhookFunctions = {
+				getHeaderData: jest.fn(),
+				getWorkflowStaticData: jest.fn(),
+			};
+		});
+
+		it('should return true when no secret is stored (backward compatibility)', () => {
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue({});
+			(mockWebhookFunctions.getWorkflowStaticData as jest.Mock).mockReturnValue({});
+
+			const result = verifySignature.call(mockWebhookFunctions as IWebhookFunctions);
+			expect(result).toBe(true);
+		});
+
+		it('should return true when token matches stored secret', () => {
+			const secret = 'auto-generated-secret';
+
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue({
+				'x-gitlab-token': secret,
+			});
+			(mockWebhookFunctions.getWorkflowStaticData as jest.Mock).mockReturnValue({
+				webhookSecret: secret,
+			} as IDataObject);
+
+			const result = verifySignature.call(mockWebhookFunctions as IWebhookFunctions);
+			expect(result).toBe(true);
+		});
+
+		it('should return false when token does not match (different length)', () => {
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue({
+				'x-gitlab-token': 'wrong',
+			});
+			(mockWebhookFunctions.getWorkflowStaticData as jest.Mock).mockReturnValue({
+				webhookSecret: 'correct-secret',
+			} as IDataObject);
+
+			const result = verifySignature.call(mockWebhookFunctions as IWebhookFunctions);
+			expect(result).toBe(false);
+		});
+
+		it('should return false when token does not match (same length)', () => {
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue({
+				'x-gitlab-token': 'wrong-secret-aa',
+			});
+			(mockWebhookFunctions.getWorkflowStaticData as jest.Mock).mockReturnValue({
+				webhookSecret: 'correct-secret-',
+			} as IDataObject);
+
+			const result = verifySignature.call(mockWebhookFunctions as IWebhookFunctions);
+			expect(result).toBe(false);
+		});
+
+		it('should return false when token header is missing but secret is stored', () => {
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue({});
+			(mockWebhookFunctions.getWorkflowStaticData as jest.Mock).mockReturnValue({
+				webhookSecret: 'expected-secret',
+			} as IDataObject);
+
+			const result = verifySignature.call(mockWebhookFunctions as IWebhookFunctions);
+			expect(result).toBe(false);
+		});
+
+		it('should return false when token header has wrong type', () => {
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue({
+				'x-gitlab-token': ['unexpected-array'],
+			});
+			(mockWebhookFunctions.getWorkflowStaticData as jest.Mock).mockReturnValue({
+				webhookSecret: 'expected-secret',
+			} as IDataObject);
+
+			const result = verifySignature.call(mockWebhookFunctions as IWebhookFunctions);
+			expect(result).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds webhook request verification to the GitLab Trigger node using GitLab's secret token mechanism.

- Generates a random secret token on webhook creation and sends it to GitLab via the `token` field.
- Validates the `X-Gitlab-Token` header on incoming requests; mismatches return `401 Unauthorized`.
- Backward compatible — existing webhooks without a stored secret continue to work unchanged.
- Uses the shared `webhook-signature-verification` utility with constant-time comparison.

<img width="2502" height="1304" alt="2026-04-28 13 12 51" src="https://github.com/user-attachments/assets/a91d0ccb-2dbd-4830-8619-1985fdd9a86a" />

### Verification

Tested with [n8n-node-mocker](https://github.com/DawidMyslak/n8n-node-mocker):
- ✅ Correct secret → 200 OK
- ✅ Wrong secret → 401 Unauthorized

### How to test

1. Create a workflow with a GitLab Trigger node and activate it.
2. Confirm the GitLab project hook has a "Secret token" populated.
3. Trigger an event — workflow runs as expected.
4. Send a `POST` without (or with a wrong) `X-Gitlab-Token` header — rejected with `401`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4308

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI