### PR TITLE
feat(Figma Trigger Node): Add webhook request verification

### DIFF
--- a/packages/nodes-base/nodes/Figma/FigmaTrigger.node.ts
+++ b/packages/nodes-base/nodes/Figma/FigmaTrigger.node.ts
@@ -10,6 +10,7 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 
+import { verifySignature } from './FigmaTriggerHelpers';
 import { figmaApiRequest } from './GenericFunctions';
 
 export class FigmaTrigger implements INodeType {
@@ -124,12 +125,14 @@ export class FigmaTrigger implements INodeType {
 				const teamId = this.getNodeParameter('teamId') as string;
 				const endpoint = '/v2/webhooks';
 
+				const passcode = randomBytes(32).toString('hex');
+
 				const body: IDataObject = {
 					event_type: snakeCase(triggerOn).toUpperCase(),
 					team_id: teamId,
 					description: `n8n-webhook:${webhookUrl}`,
 					endpoint: webhookUrl,
-					passcode: randomBytes(10).toString('hex'),
+					passcode,
 				};
 
 				const responseData = await figmaApiRequest.call(this, 'POST', endpoint, body);
@@ -140,6 +143,7 @@ export class FigmaTrigger implements INodeType {
 				}
 
 				webhookData.webhookId = responseData.id as string;
+				webhookData.webhookSecret = passcode;
 				return true;
 			},
 			async delete(this: IHookFunctions): Promise<boolean> {
@@ -154,13 +158,23 @@ export class FigmaTrigger implements INodeType {
 					// Remove from the static workflow data so that it is clear
 					// that no webhooks are registered anymore
 					delete webhookData.webhookId;
+					delete webhookData.webhookSecret;
 				}
 				return true;
 			},
 		},
 	};
 
+	// eslint-disable-next-line @typescript-eslint/require-await
 	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
+		if (!verifySignature.call(this)) {
+			const res = this.getResponseObject();
+			res.status(401).send('Unauthorized').end();
+			return {
+				noWebhookResponse: true,
+			};
+		}
+
 		const bodyData = this.getBodyData();
 
 		if (bodyData.event_type === 'PING') {

--- a/packages/nodes-base/nodes/Figma/FigmaTriggerHelpers.ts
+++ b/packages/nodes-base/nodes/Figma/FigmaTriggerHelpers.ts
@@ -1,0 +1,31 @@
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { verifySignature as verifySignatureGeneric } from '../../utils/webhook-signature-verification';
+
+/**
+ * Verifies the Figma webhook request by comparing the `passcode` field in the
+ * payload body against the passcode stored in the workflow static data when
+ * the webhook was created.
+ *
+ * Figma includes the passcode supplied at webhook creation time in every
+ * event payload (including PING). See:
+ * https://developers.figma.com/docs/rest-api/webhooks-security/
+ *
+ * @returns true if the passcode matches, false otherwise
+ * @returns true if no passcode is stored (backward compatibility with
+ *          webhooks created before this verification was added)
+ */
+export function verifySignature(this: IWebhookFunctions): boolean {
+	const webhookData = this.getWorkflowStaticData('node');
+	const expectedPasscode = webhookData.webhookSecret;
+	const bodyData = this.getBodyData();
+	const actualPasscode = bodyData.passcode;
+
+	return verifySignatureGeneric({
+		getExpectedSignature: () =>
+			typeof expectedPasscode === 'string' && expectedPasscode.length > 0 ? expectedPasscode : null,
+		skipIfNoExpectedSignature: true,
+		getActualSignature: () =>
+			typeof actualPasscode === 'string' && actualPasscode.length > 0 ? actualPasscode : null,
+	});
+}

--- a/packages/nodes-base/nodes/Figma/test/FigmaTrigger.test.ts
+++ b/packages/nodes-base/nodes/Figma/test/FigmaTrigger.test.ts
@@ -1,0 +1,104 @@
+import type { IDataObject, IWebhookFunctions } from 'n8n-workflow';
+
+import { FigmaTrigger } from '../FigmaTrigger.node';
+import { verifySignature } from '../FigmaTriggerHelpers';
+
+jest.mock('../FigmaTriggerHelpers', () => ({
+	verifySignature: jest.fn(),
+}));
+
+describe('FigmaTrigger', () => {
+	let trigger: FigmaTrigger;
+	let mockWebhookFunctions: Partial<IWebhookFunctions>;
+	let mockResponse: { status: jest.Mock; send: jest.Mock; end: jest.Mock };
+
+	beforeEach(() => {
+		trigger = new FigmaTrigger();
+		mockResponse = {
+			status: jest.fn().mockReturnThis(),
+			send: jest.fn().mockReturnThis(),
+			end: jest.fn().mockReturnThis(),
+		};
+
+		mockWebhookFunctions = {
+			getBodyData: jest.fn(),
+			getResponseObject: jest.fn().mockReturnValue(mockResponse),
+			helpers: {
+				returnJsonArray: jest.fn((data) => data),
+			} as unknown as IWebhookFunctions['helpers'],
+		};
+
+		(verifySignature as jest.Mock).mockReturnValue(true);
+	});
+
+	describe('webhook', () => {
+		it('should return 401 when verification fails', async () => {
+			(verifySignature as jest.Mock).mockReturnValue(false);
+
+			const result = await trigger.webhook.call(mockWebhookFunctions as IWebhookFunctions);
+
+			expect(mockResponse.status).toHaveBeenCalledWith(401);
+			expect(mockResponse.send).toHaveBeenCalledWith('Unauthorized');
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		it('should respond 200 to PING events without triggering workflow', async () => {
+			const bodyData: IDataObject = {
+				event_type: 'PING',
+				passcode: 'secretpasscode',
+				timestamp: '2020-02-23T20:27:16Z',
+				webhook_id: '22',
+			};
+
+			(mockWebhookFunctions.getBodyData as jest.Mock).mockReturnValue(bodyData);
+
+			const result = await trigger.webhook.call(mockWebhookFunctions as IWebhookFunctions);
+
+			expect(mockResponse.status).toHaveBeenCalledWith(200);
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		it('should trigger workflow when verification passes', async () => {
+			const bodyData: IDataObject = {
+				event_type: 'FILE_UPDATE',
+				file_key: 'CL06nJNn5eZLQKDoARMND5',
+				file_name: 'Developer page mockup demo',
+				passcode: 'secretpasscode',
+				timestamp: '2020-02-23T20:27:16Z',
+				webhook_id: '22',
+			};
+
+			(mockWebhookFunctions.getBodyData as jest.Mock).mockReturnValue(bodyData);
+
+			const result = await trigger.webhook.call(mockWebhookFunctions as IWebhookFunctions);
+
+			expect(result.workflowData).toBeDefined();
+			expect(mockWebhookFunctions.helpers!.returnJsonArray).toHaveBeenCalledWith(bodyData);
+		});
+
+		it('should trigger workflow when no secret is configured (backward compatibility)', async () => {
+			(verifySignature as jest.Mock).mockReturnValue(true);
+
+			const bodyData: IDataObject = {
+				event_type: 'FILE_COMMENT',
+				file_key: 'zH44k2FUM629Fa4EMShiHL',
+				file_name: 'Mockup library',
+				webhook_id: '22',
+			};
+
+			(mockWebhookFunctions.getBodyData as jest.Mock).mockReturnValue(bodyData);
+
+			const result = await trigger.webhook.call(mockWebhookFunctions as IWebhookFunctions);
+
+			expect(result.workflowData).toBeDefined();
+		});
+	});
+
+	describe('description', () => {
+		it('should have correct node metadata', () => {
+			expect(trigger.description.displayName).toBe('Figma Trigger (Beta)');
+			expect(trigger.description.name).toBe('figmaTrigger');
+			expect(trigger.description.group).toContain('trigger');
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Figma/test/FigmaTrigger.test.ts
+++ b/packages/nodes-base/nodes/Figma/test/FigmaTrigger.test.ts
@@ -45,7 +45,7 @@ describe('FigmaTrigger', () => {
 		it('should respond 200 to PING events without triggering workflow', async () => {
 			const bodyData: IDataObject = {
 				event_type: 'PING',
-				passcode: 'secretpasscode',
+				passcode: 'test-passcode',
 				timestamp: '2020-02-23T20:27:16Z',
 				webhook_id: '22',
 			};
@@ -61,9 +61,9 @@ describe('FigmaTrigger', () => {
 		it('should trigger workflow when verification passes', async () => {
 			const bodyData: IDataObject = {
 				event_type: 'FILE_UPDATE',
-				file_key: 'CL06nJNn5eZLQKDoARMND5',
-				file_name: 'Developer page mockup demo',
-				passcode: 'secretpasscode',
+				file_key: 'fake-file-key-1',
+				file_name: 'Test file',
+				passcode: 'test-passcode',
 				timestamp: '2020-02-23T20:27:16Z',
 				webhook_id: '22',
 			};
@@ -81,8 +81,8 @@ describe('FigmaTrigger', () => {
 
 			const bodyData: IDataObject = {
 				event_type: 'FILE_COMMENT',
-				file_key: 'zH44k2FUM629Fa4EMShiHL',
-				file_name: 'Mockup library',
+				file_key: 'fake-file-key-2',
+				file_name: 'Test file',
 				webhook_id: '22',
 			};
 

--- a/packages/nodes-base/nodes/Figma/test/FigmaTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Figma/test/FigmaTriggerHelpers.test.ts
@@ -1,0 +1,118 @@
+import type { IDataObject, IWebhookFunctions } from 'n8n-workflow';
+
+import { verifySignature } from '../FigmaTriggerHelpers';
+
+describe('FigmaTriggerHelpers', () => {
+	describe('verifySignature', () => {
+		let mockWebhookFunctions: Partial<IWebhookFunctions>;
+
+		beforeEach(() => {
+			mockWebhookFunctions = {
+				getBodyData: jest.fn(),
+				getWorkflowStaticData: jest.fn(),
+			};
+		});
+
+		it('should return true when no passcode is stored (backward compatibility)', () => {
+			(mockWebhookFunctions.getWorkflowStaticData as jest.Mock).mockReturnValue({});
+			(mockWebhookFunctions.getBodyData as jest.Mock).mockReturnValue({
+				event_type: 'FILE_UPDATE',
+				passcode: 'whatever',
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions as IWebhookFunctions);
+			expect(result).toBe(true);
+		});
+
+		it('should return true when stored passcode is empty (backward compatibility)', () => {
+			(mockWebhookFunctions.getWorkflowStaticData as jest.Mock).mockReturnValue({
+				webhookSecret: '',
+			} as IDataObject);
+			(mockWebhookFunctions.getBodyData as jest.Mock).mockReturnValue({
+				event_type: 'FILE_UPDATE',
+				passcode: 'whatever',
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions as IWebhookFunctions);
+			expect(result).toBe(true);
+		});
+
+		it('should return true when passcode in body matches stored passcode', () => {
+			const passcode = 'a1b2c3d4e5f6';
+			(mockWebhookFunctions.getWorkflowStaticData as jest.Mock).mockReturnValue({
+				webhookSecret: passcode,
+			} as IDataObject);
+			(mockWebhookFunctions.getBodyData as jest.Mock).mockReturnValue({
+				event_type: 'FILE_UPDATE',
+				passcode,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions as IWebhookFunctions);
+			expect(result).toBe(true);
+		});
+
+		it('should return false when passcode in body does not match (same length)', () => {
+			(mockWebhookFunctions.getWorkflowStaticData as jest.Mock).mockReturnValue({
+				webhookSecret: 'correct-passcode',
+			} as IDataObject);
+			(mockWebhookFunctions.getBodyData as jest.Mock).mockReturnValue({
+				event_type: 'FILE_UPDATE',
+				passcode: 'wrongone-passcode',
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions as IWebhookFunctions);
+			expect(result).toBe(false);
+		});
+
+		it('should return false when passcode in body does not match (different length)', () => {
+			(mockWebhookFunctions.getWorkflowStaticData as jest.Mock).mockReturnValue({
+				webhookSecret: 'correct-passcode',
+			} as IDataObject);
+			(mockWebhookFunctions.getBodyData as jest.Mock).mockReturnValue({
+				event_type: 'FILE_UPDATE',
+				passcode: 'wrong',
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions as IWebhookFunctions);
+			expect(result).toBe(false);
+		});
+
+		it('should return false when passcode is missing from body', () => {
+			(mockWebhookFunctions.getWorkflowStaticData as jest.Mock).mockReturnValue({
+				webhookSecret: 'expected-passcode',
+			} as IDataObject);
+			(mockWebhookFunctions.getBodyData as jest.Mock).mockReturnValue({
+				event_type: 'FILE_UPDATE',
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions as IWebhookFunctions);
+			expect(result).toBe(false);
+		});
+
+		it('should return false when passcode in body is not a string', () => {
+			(mockWebhookFunctions.getWorkflowStaticData as jest.Mock).mockReturnValue({
+				webhookSecret: 'expected-passcode',
+			} as IDataObject);
+			(mockWebhookFunctions.getBodyData as jest.Mock).mockReturnValue({
+				event_type: 'FILE_UPDATE',
+				passcode: 12345,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions as IWebhookFunctions);
+			expect(result).toBe(false);
+		});
+
+		it('should return false when passcode in body is empty string', () => {
+			(mockWebhookFunctions.getWorkflowStaticData as jest.Mock).mockReturnValue({
+				webhookSecret: 'expected-passcode',
+			} as IDataObject);
+			(mockWebhookFunctions.getBodyData as jest.Mock).mockReturnValue({
+				event_type: 'FILE_UPDATE',
+				passcode: '',
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions as IWebhookFunctions);
+			expect(result).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Persists the passcode generated during Figma webhook creation in workflow static data and verifies it against incoming requests using constant-time comparison via the shared `verifySignature` utility. Requests with a missing or incorrect passcode receive `401 Unauthorized`.

Existing webhooks (created before this change) continue to work without modification — verification is skipped when no passcode is stored.

<img width="2502" height="1304" alt="2026-04-28 12 00 58" src="https://github.com/user-attachments/assets/9623c0dc-542f-4f89-b0d5-33a063f5f5fb" />

### Verification

Tested with [n8n-node-mocker](https://github.com/DawidMyslak/n8n-node-mocker):
- ✅ Correct secret → 200 OK
- ✅ Wrong secret → 401 Unauthorized

### How to test

1. Create a new Figma Trigger workflow and activate it.
2. Trigger an event in Figma — the workflow should run.
3. Send a `POST` to the webhook URL with a wrong `passcode` — should get `401`.
4. Confirm an existing workflow created before this change keeps working.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4306

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI