### PR TITLE
fix(Clearbit): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Clearbit/Clearbit.node.ts
+++ b/packages/nodes-base/nodes/Clearbit/Clearbit.node.ts
@@ -66,10 +66,10 @@ export class Clearbit implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
+				const resource = this.getNodeParameter('resource', i);
+				const operation = this.getNodeParameter('operation', i);
 				if (resource === 'person') {
 					if (operation === 'enrich') {
 						const email = this.getNodeParameter('email', i) as string;


### PR DESCRIPTION
## Problem
In the Clearbit node's `execute` method, `resource` and `operation` parameters are fetched once outside the loop using hardcoded index `0`. When multiple items are processed with different resource/operation configurations per item, the node always uses the first item's values for all iterations.

## Fix
Moved the `resource` and `operation` `getNodeParameter` calls inside the `for` loop, using the current index `i`, so each item can have its own resource and operation resolved independently.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass