### PR TITLE
fix(Segment): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Segment/Segment.node.ts
+++ b/packages/nodes-base/nodes/Segment/Segment.node.ts
@@ -75,10 +75,10 @@ export class Segment implements INodeType {
 		const returnData: IDataObject[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			try {
 				if (resource === 'group') {
 					//https://segment.com/docs/connections/sources/catalog/libraries/server/http-api/#group


### PR DESCRIPTION
## Problem
In the Segment node's `execute` method, `resource` and `operation` parameters are fetched once before the loop using hardcoded index `0`. When multiple items are processed, the node always uses the first item's resource/operation values for every iteration, ignoring per-item overrides.

## Fix
Moved the `resource` and `operation` `getNodeParameter` calls inside the `for` loop, using the current index `i`, consistent with all other per-item parameter reads in the same loop.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass