### PR TITLE
fix(editor): Disable WF version menu only when all actions are unavailable

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
@@ -494,6 +494,21 @@ describe('WorkflowHeaderDraftPublishActions', () => {
 			expect(queryByTestId('workflow-open-publish-modal-button')).toBeDisabled();
 		});
 
+		it('should keep the version menu enabled when workflow is published with no changes', () => {
+			workflowsStore.workflowTriggerNodes = [triggerNode];
+			workflowsStore.workflow.versionId = 'version-1';
+			workflowDocumentStore.setActiveState({
+				activeVersionId: 'version-1',
+				activeVersion: createMockActiveVersion('version-1'),
+			});
+			uiStore.markStateClean();
+
+			const { getByTestId } = renderComponent();
+
+			expect(getByTestId('workflow-open-publish-modal-button')).toBeDisabled();
+			expect(getByTestId('version-menu-button')).not.toBeDisabled();
+		});
+
 		it('should show publish button enabled when workflow has never been published (no active version)', () => {
 			workflowsStore.workflowTriggerNodes = [triggerNode];
 			workflowsStore.workflow.versionId = 'version-1';

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
@@ -352,6 +352,10 @@ const versionMenuActions = computed<Array<ActionDropdownItem<VERSION_ACTIONS>>>(
 	return actions;
 });
 
+const shouldDisableActionDropdown = computed(() => {
+	return versionMenuActions.value.every((action) => action.disabled);
+});
+
 const onNameVersion = async () => {
 	// If there are unsaved changes, save the workflow first
 	if (uiStore.stateIsDirty || props.isNewWorkflow) {
@@ -560,7 +564,7 @@ defineExpose({
 							:class="$style.groupButtonRight"
 							variant="ghost"
 							icon="chevron-down"
-							:disabled="!publishButtonConfig.enabled || shouldDisablePublishButton"
+							:disabled="shouldDisableActionDropdown"
 							:aria-label="i18n.baseText('node.moreActions')"
 							data-test-id="version-menu-button"
 						/>


### PR DESCRIPTION
## Summary

This PR fixes the workflow header version actions dropdown being disabled based on publish availability instead of the actual availability of actions inside the menu.

<img height="150" alt="image" src="https://github.com/user-attachments/assets/6a786339-37ee-4b98-9c49-b7281d2ed611" />

Previously, the dropdown trigger reused the publish button disabled state. That caused the menu to become inaccessible in states where publishing was not allowed but other actions were still valid. One visible case was a published workflow with no unpublished changes, where the workflow could not be unpublished from the header.

To test, open a workflow with the latest version published.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-5127](https://linear.app/n8n/issue/ADO-5127/cant-un-publish-workflow)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
