### PR TITLE
fix(PhilipsHue): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/PhilipsHue/PhilipsHue.node.ts
+++ b/packages/nodes-base/nodes/PhilipsHue/PhilipsHue.node.ts
@@ -91,9 +91,9 @@ export class PhilipsHue implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			if (resource === 'light') {
 				if (operation === 'update') {
 					const lightId = this.getNodeParameter('lightId', i) as string;


### PR DESCRIPTION
## Problem
In `PhilipsHue.node.ts`, `resource` and `operation` are read with hardcoded index `0` before the item loop begins. When the node processes a multi-item input where expressions set different `resource` or `operation` values per item, all items after the first are dispatched using the values from item 0 instead of their own.

## Fix
Moved the `getNodeParameter` calls for `resource` and `operation` inside the `for` loop so each item uses its own index `i`, matching the pattern used by the rest of the parameter reads in the same loop.

## Testing
- Manually verified the fix resolves the described behavior
- Existing tests continue to pass