### PR TITLE
fix(BambooHr): use item index instead of hardcoded 0 for returnAll and limit in file getAll

### DIFF
--- a/packages/nodes-base/nodes/BambooHr/v1/actions/file/getAll/execute.ts
+++ b/packages/nodes-base/nodes/BambooHr/v1/actions/file/getAll/execute.ts
@@ -12,8 +12,8 @@ export async function getAll(
 
 	//limit parameters
 	const simplifyOutput: boolean = this.getNodeParameter('simplifyOutput', index) as boolean;
-	const returnAll: boolean = this.getNodeParameter('returnAll', 0, false);
-	const limit: number = this.getNodeParameter('limit', 0, 0);
+	const returnAll: boolean = this.getNodeParameter('returnAll', index, false);
+	const limit: number = this.getNodeParameter('limit', index, 0);
 
 	//response
 	const responseData = await apiRequest.call(this, requestMethod, endpoint, body);


### PR DESCRIPTION
## Summary

In `packages/nodes-base/nodes/BambooHr/v1/actions/file/getAll/execute.ts`, the `getAll` function correctly receives an `index` parameter and uses it for `simplifyOutput`, but then uses a hardcoded `0` for both `returnAll` and `limit` parameter lookups.

When a workflow processes multiple items, each item should read its own `returnAll` and `limit` values using its respective index. With the hardcoded `0`, all items silently share the first item's values, causing incorrect behavior when per-item parameters differ.

This fix replaces the hardcoded `0` with `index` for the `returnAll` and `limit` calls, making the function consistent with how it already reads `simplifyOutput` and `employeeId`.

## Bug pattern

Same pattern as other nodes where `getNodeParameter` is called with a hardcoded `0` inside a function that receives an `index` argument — the function correctly uses `index` for some parameters but not all.