### PR TITLE
fix(BambooHr): use item index instead of hardcoded 0 for returnAll and limit in employeeDocument getAll

### DIFF
--- a/packages/nodes-base/nodes/BambooHr/v1/actions/employeeDocument/getAll/execute.ts
+++ b/packages/nodes-base/nodes/BambooHr/v1/actions/employeeDocument/getAll/execute.ts
@@ -14,8 +14,8 @@ export async function getAll(
 
 	//limit parameters
 	const simplifyOutput: boolean = this.getNodeParameter('simplifyOutput', index) as boolean;
-	const returnAll: boolean = this.getNodeParameter('returnAll', 0, false);
-	const limit: number = this.getNodeParameter('limit', 0, 0);
+	const returnAll: boolean = this.getNodeParameter('returnAll', index, false);
+	const limit: number = this.getNodeParameter('limit', index, 0);
 
 	//endpoint
 	const endpoint = `employees/${id}/files/view/`;


### PR DESCRIPTION
## Summary

In `packages/nodes-base/nodes/BambooHr/v1/actions/employeeDocument/getAll/execute.ts`, the `getAll` function receives an `index` parameter and uses it correctly for `employeeId` and `simplifyOutput`, but uses a hardcoded `0` for both `returnAll` and `limit` parameter lookups.

When a workflow runs with multiple items, each item may have its own `returnAll`/`limit` settings. With the hardcoded `0`, all items always read the first item's pagination parameters, producing wrong results when items configure pagination differently.

This fix replaces the hardcoded `0` with `index` for `returnAll` and `limit`, making the function consistent with how it already reads `employeeId` and `simplifyOutput`.

## Bug pattern

Same pattern as other nodes where `getNodeParameter` is called with a hardcoded `0` inside a function that already receives and uses an `index` argument for other parameters.