### PR TITLE
fix(KoBoToolbox): remove debug console.dir from file content fetch in getAll operation

### DIFF
--- a/packages/nodes-base/nodes/KoBoToolbox/KoBoToolbox.node.ts
+++ b/packages/nodes-base/nodes/KoBoToolbox/KoBoToolbox.node.ts
@@ -415,8 +415,6 @@ export class KoBoToolbox implements INodeType {
 							encoding: 'arraybuffer',
 						});
 
-						console.dir(response);
-
 						binaryItem.binary![binaryPropertyName] = await this.helpers.prepareBinaryData(
 							response as Buffer,
 							responseData[0].metadata.filename as string,


### PR DESCRIPTION
## Summary

In `packages/nodes-base/nodes/KoBoToolbox/KoBoToolbox.node.ts`, a `console.dir(response)` debug statement was left in the `file:getAll` operation's binary data fetch path. This line dumps the raw binary buffer to the Node.js console on every execution, leaking potentially large binary payloads to server logs and polluting output.

The call serves no production purpose — it was presumably added during development to inspect the HTTP response before the binary preparation step and was never removed.

This fix removes the stray `console.dir(response)` call, eliminating the noise from production logs without changing any functional behaviour.