### PR TITLE
fix(UptimeRobot): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/UptimeRobot/UptimeRobot.node.ts
+++ b/packages/nodes-base/nodes/UptimeRobot/UptimeRobot.node.ts
@@ -122,8 +122,8 @@ export class UptimeRobot implements INodeType {
 		const timezone = this.getTimezone();
 		for (let i = 0; i < length; i++) {
 			try {
-				const resource = this.getNodeParameter('resource', 0);
-				const operation = this.getNodeParameter('operation', 0);
+				const resource = this.getNodeParameter('resource', i);
+				const operation = this.getNodeParameter('operation', i);
 				let body: IDataObject = {};
 				//https://uptimerobot.com/#methods
 				if (resource === 'account') {


### PR DESCRIPTION
## Bug

In `UptimeRobot.node.ts`, the `execute` method reads `resource` and `operation` using hardcoded index `0` inside the items loop, meaning every iteration uses the parameter values from the first item only. When the node processes multiple items where each could have a different resource or operation expression, the wrong values are used for items at index 1 and beyond.

## Fix

Changed `this.getNodeParameter('resource', 0)` and `this.getNodeParameter('operation', 0)` to use the loop variable `i` so each item's own parameter expression is evaluated correctly.

## Impact

Any workflow that passes multiple items with different `resource` or `operation` expression values into the UptimeRobot node will now process each item with the correct resource/operation pair instead of always using the first item's values.