### PR TITLE
fix(CiscoWebex): move resource and operation reads inside execute loop to use item index

### DIFF
--- a/packages/nodes-base/nodes/Cisco/Webex/CiscoWebex.node.ts
+++ b/packages/nodes-base/nodes/Cisco/Webex/CiscoWebex.node.ts
@@ -110,13 +110,12 @@ export class CiscoWebex implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 		const timezone = this.getTimezone();
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
-
 		let responseData;
 
 		for (let i = 0; i < items.length; i++) {
 			try {
+				const resource = this.getNodeParameter('resource', i);
+				const operation = this.getNodeParameter('operation', i);
 				if (resource === 'message') {
 					// **********************************************************************
 					//                                message


### PR DESCRIPTION
## Bug

In `CiscoWebex.node.ts`, the `execute` method reads `resource` and `operation` using hardcoded index `0` outside the items loop. This means every iteration of the loop uses the parameter values from the first item only. When the node processes multiple items with different resource or operation expression values, the wrong resource/operation pair is used for all items past index 0.

## Fix

Moved `this.getNodeParameter('resource', 0)` and `this.getNodeParameter('operation', 0)` inside the `for` loop and changed the index to `i`, so each item's own parameter expression is evaluated correctly on every iteration.

## Impact

Multi-item workflows passing different `resource` or `operation` expressions to the CiscoWebex node will now process each item correctly instead of silently applying the first item's resource/operation to all subsequent items.