### PR TITLE
fix(HumanticAI): move resource and operation reads inside execute loop to use item index

### DIFF
--- a/packages/nodes-base/nodes/HumanticAI/HumanticAi.node.ts
+++ b/packages/nodes-base/nodes/HumanticAI/HumanticAi.node.ts
@@ -58,9 +58,9 @@ export class HumanticAi implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			if (resource === 'profile') {
 				if (operation === 'create') {
 					const userId = this.getNodeParameter('userId', i) as string;


### PR DESCRIPTION
## Bug

In `HumanticAi.node.ts`, the `execute` method reads `resource` and `operation` using hardcoded index `0` before the items loop starts. As a result, every iteration of the loop uses the parameter values from the first item only. When the node processes multiple items with different `resource` or `operation` expression values, the wrong values silently drive all iterations.

## Fix

Moved the `getNodeParameter('resource', 0)` and `getNodeParameter('operation', 0)` calls inside the `for` loop body and updated the index to `i`, so each item evaluates its own parameter expressions on every iteration.

## Impact

Workflows that pass multiple items with varying `resource` or `operation` expressions to the HumanticAI node will now correctly process each item using its own parameter values rather than always using those from the first item.