### PR TITLE
fix(Discourse): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Discourse/Discourse.node.ts
+++ b/packages/nodes-base/nodes/Discourse/Discourse.node.ts
@@ -110,10 +110,10 @@ export class Discourse implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
+				const resource = this.getNodeParameter('resource', i);
+				const operation = this.getNodeParameter('operation', i);
 				if (resource === 'category') {
 					//https://docs.discourse.org/#tag/Categories/paths/~1categories.json/post
 					if (operation === 'create') {


### PR DESCRIPTION
## Bug

In `Discourse.node.ts`, `resource` and `operation` are fetched with a hardcoded index `0` before the item loop begins. When the node processes multiple input items that use expression mode for the resource or operation fields, every iteration incorrectly reads the values from item 0 instead of the current item `i`.

## Fix

Move `getNodeParameter('resource', i)` and `getNodeParameter('operation', i)` inside the loop body (inside the existing `try` block), using the current loop index `i`. This matches the pattern used by all other parameters in the same file and is consistent with other fixed nodes in the codebase.

## Impact

Without this fix, multi-item executions where different items target different Discourse resources or operations will silently apply item 0's routing to all items, producing wrong results or runtime errors.