### PR TITLE
fix(CustomerIo): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/CustomerIo/CustomerIo.node.ts
+++ b/packages/nodes-base/nodes/CustomerIo/CustomerIo.node.ts
@@ -78,13 +78,13 @@ export class CustomerIo implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const returnData: IDataObject[] = [];
 		const items = this.getInputData();
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
 		const body: IDataObject = {};
 
 		let responseData;
 		for (let i = 0; i < items.length; i++) {
 			try {
+				const resource = this.getNodeParameter('resource', i);
+				const operation = this.getNodeParameter('operation', i);
 				if (resource === 'campaign') {
 					if (operation === 'get') {
 						const campaignId = this.getNodeParameter('campaignId', i) as number;


### PR DESCRIPTION
## Bug

In `CustomerIo.node.ts`, `resource` and `operation` are fetched outside the item loop using a hardcoded index `0`. When multiple input items are processed with expression-mode resource or operation selectors, every iteration reads the routing parameters from item 0 instead of the current item.

## Fix

Move `getNodeParameter('resource', i)` and `getNodeParameter('operation', i)` inside the `for` loop, using the current index `i`. The parameters are now resolved per-item, matching the pattern used everywhere else in the same execute function.

## Impact

Multi-item executions where items target different Customer.io resources or operations (e.g., one item for a campaign, another for a segment) will incorrectly apply item 0's routing to every item. This fix ensures each item is routed to the correct resource and operation.