### PR TITLE
fix(ZohoCrm): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Zoho/ZohoCrm.node.ts
+++ b/packages/nodes-base/nodes/Zoho/ZohoCrm.node.ts
@@ -331,12 +331,11 @@ export class ZohoCrm implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 
-		const resource = this.getNodeParameter('resource', 0) as CamelCaseResource;
-		const operation = this.getNodeParameter('operation', 0);
-
 		let responseData;
 
 		for (let i = 0; i < items.length; i++) {
+			const resource = this.getNodeParameter('resource', i) as CamelCaseResource;
+			const operation = this.getNodeParameter('operation', i);
 			// https://www.zoho.com/crm/developer/docs/api/insert-records.html
 			// https://www.zoho.com/crm/developer/docs/api/get-records.html
 			// https://www.zoho.com/crm/developer/docs/api/update-specific-record.html


### PR DESCRIPTION
## Bug

In `ZohoCrm.node.ts`, `resource` and `operation` are read from `getNodeParameter` with a hardcoded index `0` before the item-processing loop. When expressions are used to set these values per-item (e.g., routing different items to different Zoho CRM modules), all items incorrectly use the resource and operation from item 0.

## Fix

Move the `getNodeParameter('resource', i)` and `getNodeParameter('operation', i)` calls inside the `for` loop, replacing the hardcoded `0` with the loop variable `i`. This aligns with how every other parameter in the same function is fetched.

## Impact

Without this fix, workflows with multiple items using different Zoho CRM resources or operations will silently process all items using item 0's routing, leading to incorrect API calls and potential data corruption.