### PR TITLE
fix(AgileCrm): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/AgileCrm/AgileCrm.node.ts
+++ b/packages/nodes-base/nodes/AgileCrm/AgileCrm.node.ts
@@ -86,10 +86,9 @@ export class AgileCrm implements INodeType {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
-
 		for (let i = 0; i < items.length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			if (resource === 'contact' || resource === 'company') {
 				const idGetter = resource === 'contact' ? 'contactId' : 'companyId';
 


### PR DESCRIPTION
## Summary

In `AgileCrm.node.ts`, `resource` and `operation` are read with hardcoded index `0` before the `for` loop over `items`. When a workflow processes multiple items that may have different `resource` or `operation` values set via expressions, every item incorrectly uses the values from the first item.

## Fix

Moved `resource` and `operation` reads inside the `for` loop, using the loop index `i` so each item correctly resolves its own parameter values. This matches the pattern used by other nodes in the codebase that support per-item resource/operation switching.

## Impact

Workflows using AgileCrm with expression-based `resource` or `operation` parameters across multiple items will now evaluate them correctly per item instead of always using item 0's value.