### PR TITLE
fix(ConvertKit): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/ConvertKit/ConvertKit.node.ts
+++ b/packages/nodes-base/nodes/ConvertKit/ConvertKit.node.ts
@@ -156,10 +156,9 @@ export class ConvertKit implements INodeType {
 		const qs: IDataObject = {};
 		let responseData;
 
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
-
 		for (let i = 0; i < items.length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			try {
 				if (resource === 'customField') {
 					if (operation === 'create') {


### PR DESCRIPTION
## Summary

In `ConvertKit.node.ts`, `resource` and `operation` are read once using `getNodeParameter('resource', 0)` and `getNodeParameter('operation', 0)` before the item loop. This means all items in a multi-item execution always use the resource/operation resolved from item 0, ignoring per-item expressions.

Moving these reads inside the `for` loop and using the current index `i` ensures each item resolves its own `resource` and `operation` values, which is consistent with how other nodes handle this pattern.

## Related Issues

No related issue — found during code review of node parameter patterns.

## Review / Merge Checklist

- [ ] PR title follows the [conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md)
- [ ] Tests for the changes have been added
- [ ] All existing tests pass