### PR TITLE
fix(Bitly): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Bitly/Bitly.node.ts
+++ b/packages/nodes-base/nodes/Bitly/Bitly.node.ts
@@ -128,9 +128,9 @@ export class Bitly implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			try {
 				if (resource === 'link') {
 					if (operation === 'create') {


### PR DESCRIPTION
## Summary

In `Bitly.node.ts`, `resource` and `operation` are read once using `getNodeParameter('resource', 0)` and `getNodeParameter('operation', 0)` before the item loop. When a workflow sends multiple items with different resource/operation expressions, all items incorrectly use values from item 0.

Moving these reads inside the `for` loop to use the current index `i` ensures each item correctly resolves its own resource and operation, matching the established pattern in other n8n nodes.

## Related Issues

No related issue — found during code review of node parameter patterns.

## Review / Merge Checklist

- [ ] PR title follows the [conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md)
- [ ] Tests for the changes have been added
- [ ] All existing tests pass