### PR TITLE
fix(Disqus): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Disqus/Disqus.node.ts
+++ b/packages/nodes-base/nodes/Disqus/Disqus.node.ts
@@ -573,14 +573,13 @@ export class Disqus implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
-
 		let endpoint = '';
 		let requestMethod: IHttpRequestMethods;
 		let qs: IDataObject;
 
 		for (let i = 0; i < items.length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			try {
 				qs = {};
 


### PR DESCRIPTION
## Summary

In `Disqus.node.ts`, `resource` and `operation` are read once using hardcoded index `0` before the item loop, then used throughout all iterations. When a workflow provides multiple items where the resource or operation differs per item (via expressions), all items incorrectly use the values from item 0.

Moving these reads inside the `for` loop and using the current index `i` ensures per-item expression resolution works correctly, consistent with the pattern used across other n8n nodes.

## Related Issues

No related issue — found during code review of node parameter patterns.

## Review / Merge Checklist

- [ ] PR title follows the [conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md)
- [ ] Tests for the changes have been added
- [ ] All existing tests pass