### PR TITLE
fix: Allow task runner to invoke skills via slash command prefix

### DIFF
--- a/.claude/plugins/n8n/skills/linear-issue/SKILL.md
+++ b/.claude/plugins/n8n/skills/linear-issue/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Fetch and analyze Linear issue with all related context. Use when starting work on a Linear ticket, analyzing issues, or gathering context about a Linear issue.
-disable-model-invocation: false
 argument-hint: "[issue-id]"
 compatibility:
   requires:

--- a/.claude/plugins/n8n/skills/linear-issue/SKILL.md
+++ b/.claude/plugins/n8n/skills/linear-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Fetch and analyze Linear issue with all related context. Use when starting work on a Linear ticket, analyzing issues, or gathering context about a Linear issue.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[issue-id]"
 compatibility:
   requires:

--- a/.github/scripts/claude-task/prepare-claude-prompt.mjs
+++ b/.github/scripts/claude-task/prepare-claude-prompt.mjs
@@ -32,6 +32,13 @@ let prompt;
 
 if (useRaw) {
 	prompt = task;
+} else if (task.startsWith('/')) {
+	// Task is a skill invocation (e.g. "/n8n:linear-issue CAT-2820").
+	// Wrap it so the model invokes the Skill tool instead of implementing code.
+	prompt = `# Skill Invocation
+Invoke the following skill using the Skill tool. Do NOT implement code changes, do NOT make commits, do NOT create branches. Your only job is to run this skill and report its output.
+
+${task}`;
 } else {
 	// List available templates so Claude knows what exists (reads them if needed)
 	const templateDir = '.github/claude-templates';

--- a/.github/scripts/claude-task/prepare-claude-prompt.mjs
+++ b/.github/scripts/claude-task/prepare-claude-prompt.mjs
@@ -36,7 +36,7 @@ if (useRaw) {
 	// Task is a skill invocation (e.g. "/n8n:linear-issue CAT-2820").
 	// Wrap it so the model invokes the Skill tool instead of implementing code.
 	prompt = `# Skill Invocation
-Invoke the following skill using the Skill tool. Do NOT implement code changes, do NOT make commits, do NOT create branches. Your only job is to run this skill and report its output.
+Invoke the following skill using the Skill tool and follow its instructions.
 
 ${task}`;
 } else {


### PR DESCRIPTION
## Summary
- Detect `/` prefix in `prepare-claude-prompt.mjs` and use a skill-only wrapper instead of the implementation wrapper, so skill invocations (e.g. `/n8n:linear-issue CAT-2820`) are routed through the Skill tool rather than treated as implementation tasks
- Set `disable-model-invocation: false` on `linear-issue` skill so the model can invoke it programmatically

## Context
When the Claude Task Runner workflow receives a task like `/n8n:linear-issue CAT-2820`, the prompt wrapper adds implementation instructions ("make commits", "complete the task") that cause Claude to implement code instead of running the triage skill. This fix detects skill invocations by the `/` prefix and wraps them with skill-only instructions.

## Test plan
- [ ] Trigger task runner with `{"task": "/n8n:linear-issue CAT-2820", "model": "claude-opus-4-6"}` — should invoke skill and produce triage output, not code changes
- [ ] Trigger task runner with a normal task (no `/` prefix) — should behave as before with implementation instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)