### PR TITLE
fix(Stripe): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Stripe/Stripe.node.ts
+++ b/packages/nodes-base/nodes/Stripe/Stripe.node.ts
@@ -139,14 +139,14 @@ export class Stripe implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
-
 		let responseData;
 		const returnData: INodeExecutionData[] = [];
 
 		for (let i = 0; i < items.length; i++) {
 			try {
+				const resource = this.getNodeParameter('resource', i);
+				const operation = this.getNodeParameter('operation', i);
+
 				if (resource === 'balance') {
 					// *********************************************************************
 					//                             balance


### PR DESCRIPTION
## Summary

In `Stripe.node.ts`, `resource` and `operation` are read with `getNodeParameter('resource', 0)` and `getNodeParameter('operation', 0)` **before** the `for` loop over `items`. This means all items in a batch are processed using the `resource` and `operation` from the first item only — items at index 1+ that have different expressions for these parameters will be silently misrouted.

## Fix

Moved the `getNodeParameter` calls for `resource` and `operation` inside the `for` loop so they use the current item index `i`, matching the pattern used by correctly-implemented nodes.

## Impact

Fixes silent incorrect behaviour when multiple items with different `resource`/`operation` values are processed in a single execution.