### PR TITLE
fix(Todoist): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Todoist/v2/TodoistV2.node.ts
+++ b/packages/nodes-base/nodes/Todoist/v2/TodoistV2.node.ts
@@ -1924,10 +1924,10 @@ export class TodoistV2 implements INodeType {
 		const length = items.length;
 		const service = new TodoistService();
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
+				const resource = this.getNodeParameter('resource', i);
+				const operation = this.getNodeParameter('operation', i);
 				if (resource === 'task') {
 					if (!isTaskOperationType(operation)) {
 						throw new NodeOperationError(


### PR DESCRIPTION
## Summary

In `TodoistV2.node.ts`, `resource` and `operation` are read with `getNodeParameter('resource', 0)` and `getNodeParameter('operation', 0)` **before** the `for` loop over `items`. When a batch contains multiple items that differ in `resource` or `operation` (e.g. via expressions), every item past index 0 is routed using the wrong values.

## Fix

Moved both `getNodeParameter` calls inside the `for` loop to use the current item index `i`, consistent with how correctly-implemented nodes handle multi-item batches.

## Impact

Ensures that each item in a multi-item execution is dispatched to the correct Todoist resource/operation branch rather than always using the values from the first item.