### PR TITLE
fix(Shopify): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Shopify/Shopify.node.ts
+++ b/packages/nodes-base/nodes/Shopify/Shopify.node.ts
@@ -168,10 +168,10 @@ export class Shopify implements INodeType {
 		const length = items.length;
 		let responseData;
 		const qs: IDataObject = {};
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
+				const resource = this.getNodeParameter('resource', i);
+				const operation = this.getNodeParameter('operation', i);
 				if (resource === 'order') {
 					//https://shopify.dev/docs/admin-api/rest/reference/orders/order#create-2020-04
 					if (operation === 'create') {


### PR DESCRIPTION
## Summary

In `Shopify.node.ts`, `resource` and `operation` are resolved with a hardcoded index `0` outside the item loop. If a workflow passes multiple Shopify items with different `resource` or `operation` values (via expressions), all items after the first will be processed under the first item's resource/operation — silently producing wrong results or errors.

## Fix

Moved `getNodeParameter('resource', ...)` and `getNodeParameter('operation', ...)` inside the `for` loop to use the loop index `i`, so each item is evaluated with its own parameter values.

## Impact

Fixes incorrect batch-processing behaviour when items carry different resource or operation expressions, aligning Shopify with the correct pattern used by other nodes in the codebase.