### PR TITLE
fix(Todoist): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Todoist/v2/TodoistV2.node.ts
+++ b/packages/nodes-base/nodes/Todoist/v2/TodoistV2.node.ts
@@ -1924,9 +1924,9 @@ export class TodoistV2 implements INodeType {
 		const length = items.length;
 		const service = new TodoistService();
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			try {
 				if (resource === 'task') {
 					if (!isTaskOperationType(operation)) {


### PR DESCRIPTION
## Summary

In `TodoistV2.node.ts`, the `resource` and `operation` parameters are fetched with hardcoded index `0` before the `for` loop that iterates over input items. This means that when multiple items are processed in a single execution, every item uses the resource/operation configuration of the first item rather than its own.

## Root Cause

`getNodeParameter('resource', 0)` and `getNodeParameter('operation', 0)` are called once outside the `for (let i = 0; i < length; i++)` loop, so the values are never re-evaluated per item.

## Fix

Moved both `getNodeParameter` calls inside the loop and replaced the hardcoded `0` with the loop variable `i`, so each item correctly reads its own `resource` and `operation` parameter values.

## Impact

Workflows that pass multiple items through the Todoist node with different resource/operation configurations (e.g. via expressions) would silently process all items using only the first item's settings. This fix ensures each item is handled according to its own parameters.