### PR TITLE
fix(Xero): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Xero/Xero.node.ts
+++ b/packages/nodes-base/nodes/Xero/Xero.node.ts
@@ -211,8 +211,8 @@ export class Xero implements INodeType {
 		let responseData;
 		for (let i = 0; i < length; i++) {
 			try {
-				const resource = this.getNodeParameter('resource', 0);
-				const operation = this.getNodeParameter('operation', 0);
+				const resource = this.getNodeParameter('resource', i);
+				const operation = this.getNodeParameter('operation', i);
 				//https://developer.xero.com/documentation/api/invoices
 				if (resource === 'invoice') {
 					if (operation === 'create') {


### PR DESCRIPTION
## Summary

In `Xero.node.ts`, the `resource` and `operation` parameters are fetched with hardcoded index `0` inside the `for` loop that iterates over input items, but still using the wrong index. The call `getNodeParameter('resource', 0)` always reads from the first item regardless of the current loop variable `i`.

## Root Cause

`getNodeParameter('resource', 0)` and `getNodeParameter('operation', 0)` use the hardcoded literal `0` rather than the loop index `i`. When expressions set different resource/operation values per item, every iteration silently reads only the first item's values.

## Fix

Changed the hardcoded `0` to the loop variable `i` in both `getNodeParameter` calls so each item is evaluated against its own configuration.

## Impact

Multi-item workflows that use expressions to vary the Xero resource or operation per input item would incorrectly apply the first item's resource/operation to all subsequent items, leading to wrong API calls or silent data loss.