### PR TITLE
fix(Strava): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Strava/Strava.node.ts
+++ b/packages/nodes-base/nodes/Strava/Strava.node.ts
@@ -58,9 +58,9 @@ export class Strava implements INodeType {
 		const qs: IDataObject = {};
 		let responseData;
 		const nodeVersion = this.getNode().typeVersion;
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			try {
 				if (resource === 'activity') {
 					//https://developers.strava.com/docs/reference/#api-Activities-createActivity


### PR DESCRIPTION
## Summary

In `Strava.node.ts`, the `resource` and `operation` parameters are fetched before the `for` loop using hardcoded index `0`. This means that when multiple items are processed in a single execution, every item uses the resource/operation from the first item rather than its own values.

## Root Cause

`getNodeParameter('resource', 0)` and `getNodeParameter('operation', 0)` are called once outside the `for (let i = 0; i < length; i++)` loop, so the values are never re-evaluated per item. When an expression sets different resource or operation values on different input items, the node silently ignores all but the first item's settings.

## Fix

Moved both `getNodeParameter` calls inside the loop and replaced the hardcoded `0` with the loop variable `i`, so each item correctly reads its own `resource` and `operation` parameter values.

## Impact

Workflows that pass multiple items through the Strava node with expression-driven resource/operation values would silently apply the first item's configuration to every subsequent item, causing incorrect API calls or data being written to the wrong Strava resource.