### PR TITLE
fix(Bitwarden): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Bitwarden/Bitwarden.node.ts
+++ b/packages/nodes-base/nodes/Bitwarden/Bitwarden.node.ts
@@ -103,9 +103,6 @@ export class Bitwarden implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
-
 		let responseData;
 		const returnData: INodeExecutionData[] = [];
 
@@ -114,6 +111,8 @@ export class Bitwarden implements INodeType {
 		const handleGetAll = partialRight(tokenlessHandleGetAll, token);
 
 		for (let i = 0; i < items.length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			if (resource === 'collection') {
 				// *********************************************************************
 				//       collection


### PR DESCRIPTION
## Bug

In `Bitwarden.node.ts`, `resource` and `operation` are read with a hardcoded index `0` before the `for` loop that iterates over workflow items. This means that when expressions are used to set `resource` or `operation` per-item, only the value from item `0` is used for all items.

## Fix

Move the `getNodeParameter('resource', ...)` and `getNodeParameter('operation', ...)` calls inside the `for` loop, using the current item index `i`. This ensures each item's own resource and operation values are respected.

## Impact

Any workflow that uses expressions on the `resource` or `operation` fields in the Bitwarden node with multiple input items will now behave correctly instead of always routing based on item 0's values.