### PR TITLE
fix(Bubble): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Bubble/Bubble.node.ts
+++ b/packages/nodes-base/nodes/Bubble/Bubble.node.ts
@@ -53,14 +53,13 @@ export class Bubble implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
-
 		let responseData;
 		const qs: IDataObject = {};
 		const returnData: INodeExecutionData[] = [];
 
 		for (let i = 0; i < items.length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			if (resource === 'object') {
 				// *********************************************************************
 				//                             object


### PR DESCRIPTION
## Bug

In `Bubble.node.ts`, `resource` and `operation` are read with a hardcoded index `0` before the `for` loop that iterates over workflow items. When expressions are used to set `resource` or `operation` per-item, only the value from item `0` is used for all items, silently routing every item through the wrong operation.

## Fix

Move the `getNodeParameter('resource', ...)` and `getNodeParameter('operation', ...)` calls inside the `for` loop body, using the current item index `i`. This ensures each item's own values are respected.

## Impact

Any workflow that uses expressions on the `resource` or `operation` fields in the Bubble node with multiple input items will now correctly branch per item instead of always using item 0's values.