### PR TITLE
fix(ERPNext): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/ERPNext/ERPNext.node.ts
+++ b/packages/nodes-base/nodes/ERPNext/ERPNext.node.ts
@@ -119,10 +119,9 @@ export class ERPNext implements INodeType {
 		const body: IDataObject = {};
 		const qs: IDataObject = {};
 
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
-
 		for (let i = 0; i < items.length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			// https://app.swaggerhub.com/apis-docs/alyf.de/ERPNext/11#/Resources/post_api_resource_Webhook
 			// https://frappeframework.com/docs/user/en/guides/integration/rest_api/manipulating_documents
 


### PR DESCRIPTION
## Bug

In `ERPNext.node.ts`, `resource` and `operation` are read with a hardcoded index `0` outside the `for` loop that iterates over workflow items. When a workflow uses per-item expressions for `resource` or `operation`, only the first item's values are used for all subsequent items.

## Fix

Remove the pre-loop reads of `resource` and `operation` and instead read them inside the `for` loop body using the current item index `i`. This ensures that expression-driven resource and operation values are evaluated correctly for each item.

## Impact

Workflows that set `resource` or `operation` via expressions on the ERPNext node will now behave correctly for all input items instead of always applying item 0's values to every item.