### PR TITLE
fix: Allow task runner to invoke skills via slash command prefix (no-changelog)

### DIFF
--- a/.claude/plugins/n8n/skills/linear-issue/SKILL.md
+++ b/.claude/plugins/n8n/skills/linear-issue/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Fetch and analyze Linear issue with all related context. Use when starting work on a Linear ticket, analyzing issues, or gathering context about a Linear issue.
-disable-model-invocation: true
 argument-hint: "[issue-id]"
 compatibility:
   requires:

--- a/.claude/plugins/n8n/skills/linear-issue/SKILL.md
+++ b/.claude/plugins/n8n/skills/linear-issue/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Fetch and analyze Linear issue with all related context. Use when starting work on a Linear ticket, analyzing issues, or gathering context about a Linear issue.
-disable-model-invocation: false
 argument-hint: "[issue-id]"
 compatibility:
   requires:

--- a/.claude/plugins/n8n/skills/linear-issue/SKILL.md
+++ b/.claude/plugins/n8n/skills/linear-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Fetch and analyze Linear issue with all related context. Use when starting work on a Linear ticket, analyzing issues, or gathering context about a Linear issue.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[issue-id]"
 compatibility:
   requires:

--- a/.claude/plugins/n8n/skills/linear-issue/SKILL.md
+++ b/.claude/plugins/n8n/skills/linear-issue/SKILL.md
@@ -1,5 +1,6 @@
 ---
 description: Fetch and analyze Linear issue with all related context. Use when starting work on a Linear ticket, analyzing issues, or gathering context about a Linear issue.
+disable-model-invocation: true
 argument-hint: "[issue-id]"
 compatibility:
   requires:

--- a/.github/scripts/claude-task/prepare-claude-prompt.mjs
+++ b/.github/scripts/claude-task/prepare-claude-prompt.mjs
@@ -32,6 +32,13 @@ let prompt;
 
 if (useRaw) {
 	prompt = task;
+} else if (task.startsWith('/')) {
+	// Task is a skill invocation (e.g. "/n8n:linear-issue CAT-2820").
+	// Wrap it so the model invokes the Skill tool instead of implementing code.
+	prompt = `# Skill Invocation
+Invoke the following skill using the Skill tool. Do NOT implement code changes, do NOT make commits, do NOT create branches. Your only job is to run this skill and report its output.
+
+${task}`;
 } else {
 	// List available templates so Claude knows what exists (reads them if needed)
 	const templateDir = '.github/claude-templates';

--- a/.github/scripts/claude-task/prepare-claude-prompt.mjs
+++ b/.github/scripts/claude-task/prepare-claude-prompt.mjs
@@ -36,7 +36,7 @@ if (useRaw) {
 	// Task is a skill invocation (e.g. "/n8n:linear-issue CAT-2820").
 	// Wrap it so the model invokes the Skill tool instead of implementing code.
 	prompt = `# Skill Invocation
-Invoke the following skill using the Skill tool. Do NOT implement code changes, do NOT make commits, do NOT create branches. Your only job is to run this skill and report its output.
+Invoke the following skill using the Skill tool and follow its instructions.
 
 ${task}`;
 } else {

--- a/.github/workflows/util-claude-task.yml
+++ b/.github/workflows/util-claude-task.yml
@@ -30,7 +30,7 @@ on:
         description: 'Suppress console output and job summary'
         required: false
         type: boolean
-        default: false
+        default: true
       ref:
         description: 'Git ref (branch/tag/SHA) to check out and work on'
         required: false

--- a/.github/workflows/util-claude-task.yml
+++ b/.github/workflows/util-claude-task.yml
@@ -131,6 +131,8 @@ jobs:
           prompt: ${{ env.CLAUDE_PROMPT }}
           show_full_output: ${{ inputs.suppress_output != true }}
           display_report: false
+          plugin_marketplaces: "./.claude/plugins/n8n"
+          plugins: "n8n@n8n"
           settings: |
             {
               "permissions": {

--- a/.github/workflows/util-claude-task.yml
+++ b/.github/workflows/util-claude-task.yml
@@ -30,7 +30,7 @@ on:
         description: 'Suppress console output and job summary'
         required: false
         type: boolean
-        default: true
+        default: false
       ref:
         description: 'Git ref (branch/tag/SHA) to check out and work on'
         required: false


### PR DESCRIPTION
## Summary
- Add `plugin_marketplaces` and `plugins` inputs to the Claude Task Runner workflow so the n8n plugin is properly installed via CLI (not just declared in settings)
- Detect `/` prefix in `prepare-claude-prompt.mjs` and use a skill-invocation wrapper instead of the implementation wrapper
- Remove `disable-model-invocation` from `linear-issue` skill so the model can invoke it programmatically

## Context
When the Claude Task Runner workflow receives a skill task like `/n8n:linear-issue CAT-2820`, two things went wrong:
1. The prompt wrapper added implementation instructions ("make commits", "complete the task") causing Claude to implement code instead of running the triage skill
2. The plugin was configured in settings but never formally installed — `claude plugin install` was never called, so skills weren't activated in the SDK session

Ref: https://linear.app/n8n/issue/CE-851

## Test plan
- [x] Trigger task runner with `{"task": "/n8n:linear-issue CAT-2820"}` — invokes skill and produces triage output, not code changes
- [x] Verify plugin installs successfully in action logs (`✔ Successfully installed plugin: n8n@n8n`)
- [x] Verify skill is listed in available skills
- [X] Trigger task runner with a normal task (no `/` prefix) — should behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
- [x] I have seen this code, I have run this code, and I take responsibility for this code.