### PR TITLE
fix(WooCommerce): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/WooCommerce/WooCommerce.node.ts
+++ b/packages/nodes-base/nodes/WooCommerce/WooCommerce.node.ts
@@ -128,10 +128,9 @@ export class WooCommerce implements INodeType {
 		const length = items.length;
 		let responseData;
 		const qs: IDataObject = {};
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
-
 		for (let i = 0; i < length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			if (resource === 'customer') {
 				// **********************************************************************
 				//                                customer


### PR DESCRIPTION
## Summary

In the WooCommerce node's `execute` method, `resource` and `operation` are read using hardcoded index `0` outside the item loop. When multiple items are processed and different items have different resource/operation values (via expressions), all items incorrectly use the values from the first item only.

This fix moves the `resource` and `operation` reads inside the `for` loop so each item index `i` is used, matching the established pattern in other multi-item nodes.

## Changes

- Moved `getNodeParameter('resource', 0)` and `getNodeParameter('operation', 0)` inside the `for` loop, replacing `0` with `i`.