### PR TITLE
fix(Paddle): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Paddle/Paddle.node.ts
+++ b/packages/nodes-base/nodes/Paddle/Paddle.node.ts
@@ -163,9 +163,9 @@ export class Paddle implements INodeType {
 		const length = items.length;
 		let responseData;
 		const body: IDataObject = {};
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			try {
 				if (resource === 'coupon') {
 					if (operation === 'create') {


### PR DESCRIPTION
## Summary

In the Paddle node's `execute` method, `resource` and `operation` are fetched using hardcoded index `0` before the item loop begins. When multiple items are processed and different items carry different resource/operation values via expressions, all items incorrectly use the resource and operation from the first item only.

This fix moves the `getNodeParameter` calls for `resource` and `operation` inside the `for` loop so the correct item index `i` is used for each iteration, consistent with how other n8n nodes handle this pattern.

## Changes

- Moved `getNodeParameter('resource', 0)` and `getNodeParameter('operation', 0)` inside the `for` loop, replacing the hardcoded `0` with `i`.