### PR TITLE
fix(PagerDuty): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/PagerDuty/PagerDuty.node.ts
+++ b/packages/nodes-base/nodes/PagerDuty/PagerDuty.node.ts
@@ -201,9 +201,9 @@ export class PagerDuty implements INodeType {
 		const length = items.length;
 		let responseData;
 		const qs: IDataObject = {};
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			try {
 				if (resource === 'incident') {
 					//https://api-reference.pagerduty.com/#!/Incidents/post_incidents


### PR DESCRIPTION
## Summary

In the PagerDuty node's `execute` method, `resource` and `operation` are fetched outside the item iteration loop using the hardcoded index `0`. When multiple input items have different resource/operation values via expressions, every item will incorrectly use the values from item 0 rather than its own.

This fix moves the `getNodeParameter` calls for `resource` and `operation` inside the `for` loop and replaces the hardcoded `0` with the loop index `i`, ensuring each item's parameters are resolved correctly.

## Changes

- Moved `getNodeParameter('resource', 0)` and `getNodeParameter('operation', 0)` inside the `for` loop, replacing `0` with `i`.