### PR TITLE
fix(Copper): use item index instead of hardcoded 0 in handleListing for returnAll and limit

### DIFF
--- a/packages/nodes-base/nodes/Copper/Copper.node.ts
+++ b/packages/nodes-base/nodes/Copper/Copper.node.ts
@@ -184,7 +184,7 @@ export class Copper implements INodeType {
 							Object.assign(body, filterFields);
 						}
 
-						responseData = await handleListing.call(this, 'POST', '/companies/search', body);
+						responseData = await handleListing.call(this, 'POST', '/companies/search', body, {}, '', i);
 					} else if (operation === 'update') {
 						// ----------------------------------------
 						//             company: update
@@ -218,7 +218,7 @@ export class Copper implements INodeType {
 						//        customerSource: getAll
 						// ----------------------------------------
 
-						responseData = await handleListing.call(this, 'GET', '/customer_sources');
+						responseData = await handleListing.call(this, 'GET', '/customer_sources', {}, {}, '', i);
 					}
 				} else if (resource === 'lead') {
 					// **********************************************************************
@@ -275,7 +275,7 @@ export class Copper implements INodeType {
 							Object.assign(body, filterFields);
 						}
 
-						responseData = await handleListing.call(this, 'POST', '/leads/search', body);
+						responseData = await handleListing.call(this, 'POST', '/leads/search', body, {}, '', i);
 					} else if (operation === 'update') {
 						// ----------------------------------------
 						//               lead: update
@@ -355,7 +355,7 @@ export class Copper implements INodeType {
 							Object.assign(body, filterFields);
 						}
 
-						responseData = await handleListing.call(this, 'POST', '/opportunities/search', body);
+						responseData = await handleListing.call(this, 'POST', '/opportunities/search', body, {}, '', i);
 					} else if (operation === 'update') {
 						// ----------------------------------------
 						//           opportunity: update
@@ -434,7 +434,7 @@ export class Copper implements INodeType {
 							Object.assign(body, filterFields);
 						}
 
-						responseData = await handleListing.call(this, 'POST', '/people/search', body);
+						responseData = await handleListing.call(this, 'POST', '/people/search', body, {}, '', i);
 					} else if (operation === 'update') {
 						// ----------------------------------------
 						//              person: update
@@ -510,7 +510,7 @@ export class Copper implements INodeType {
 							Object.assign(body, filterFields);
 						}
 
-						responseData = await handleListing.call(this, 'POST', '/projects/search', body);
+						responseData = await handleListing.call(this, 'POST', '/projects/search', body, {}, '', i);
 					} else if (operation === 'update') {
 						// ----------------------------------------
 						//             project: update
@@ -586,7 +586,7 @@ export class Copper implements INodeType {
 							Object.assign(body, adjustTaskFields(filterFields));
 						}
 
-						responseData = await handleListing.call(this, 'POST', '/tasks/search', body);
+						responseData = await handleListing.call(this, 'POST', '/tasks/search', body, {}, '', i);
 					} else if (operation === 'update') {
 						// ----------------------------------------
 						//               task: update
@@ -615,7 +615,7 @@ export class Copper implements INodeType {
 						//              user: getAll
 						// ----------------------------------------
 
-						responseData = await handleListing.call(this, 'POST', '/users/search');
+						responseData = await handleListing.call(this, 'POST', '/users/search', {}, {}, '', i);
 					}
 				}
 			} catch (error) {

--- a/packages/nodes-base/nodes/Copper/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Copper/GenericFunctions.ts
@@ -171,8 +171,9 @@ export async function handleListing(
 	qs: IDataObject = {},
 	body: IDataObject = {},
 	uri = '',
+	itemIndex = 0,
 ) {
-	const returnAll = this.getNodeParameter('returnAll', 0);
+	const returnAll = this.getNodeParameter('returnAll', itemIndex);
 
 	const option = { resolveWithFullResponse: true };
 
@@ -180,7 +181,7 @@ export async function handleListing(
 		return await copperApiRequestAllItems.call(this, method, endpoint, body, qs, uri, option);
 	}
 
-	const limit = this.getNodeParameter('limit', 0);
+	const limit = this.getNodeParameter('limit', itemIndex);
 	const responseData = await copperApiRequestAllItems.call(
 		this,
 		method,


### PR DESCRIPTION
## Bug

`handleListing` in `packages/nodes-base/nodes/Copper/GenericFunctions.ts` calls `this.getNodeParameter('returnAll', 0)` and `this.getNodeParameter('limit', 0)` with a hardcoded item index of `0`. When the Copper node processes a multi-item input and the per-item `returnAll` or `limit` value differs across items, only the value from the first input item is ever used.

## Fix

Added an optional `itemIndex` parameter (defaulting to `0` for backward compatibility) to `handleListing` and forwarded it to both `getNodeParameter` calls. Updated all eight `handleListing.call(...)` sites in `Copper.node.ts` to pass the current loop variable `i` so each item is evaluated with its own parameters.

## Impact

Workflows that pass multiple Copper items with different `returnAll` or `limit` values per item will now correctly honour each item's settings instead of always using item 0's values.