### PR TITLE
fix(Copper): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Copper/Copper.node.ts
+++ b/packages/nodes-base/nodes/Copper/Copper.node.ts
@@ -120,12 +120,11 @@ export class Copper implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
-
 		let responseData;
 
 		for (let i = 0; i < items.length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			try {
 				if (resource === 'company') {
 					// **********************************************************************


### PR DESCRIPTION
## Summary

In `Copper.node.ts`, `resource` and `operation` are read using hardcoded index `0` before the item loop begins. This means that when a workflow passes multiple items with different expression-based `resource` or `operation` values, all items are processed using the values from the first item only.

## Bug

```ts
const resource = this.getNodeParameter('resource', 0); // always uses item 0
const operation = this.getNodeParameter('operation', 0);
for (let i = 0; i < items.length; i++) { ... }
```

## Fix

Move the `getNodeParameter` calls inside the loop and use the loop index `i` instead of the hardcoded `0`. This ensures each item is processed with its own `resource` and `operation` values, consistent with how other parameters in this node are already read.

```ts
for (let i = 0; i < items.length; i++) {
  const resource = this.getNodeParameter('resource', i);
  const operation = this.getNodeParameter('operation', i);
  ...
}
```