### PR TITLE
fix(HelpScout): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/HelpScout/HelpScout.node.ts
+++ b/packages/nodes-base/nodes/HelpScout/HelpScout.node.ts
@@ -142,9 +142,9 @@ export class HelpScout implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			try {
 				if (resource === 'conversation') {
 					//https://developer.helpscout.com/mailbox-api/endpoints/conversations/create


### PR DESCRIPTION
## Summary

In `HelpScout.node.ts`, `resource` and `operation` are read using hardcoded index `0` before the item loop begins. When a workflow processes multiple items with expression-based `resource` or `operation` values, all items incorrectly use the values from the first item.

## Bug

```ts
const resource = this.getNodeParameter('resource', 0);
const operation = this.getNodeParameter('operation', 0);
for (let i = 0; i < length; i++) { ... }
```

## Fix

Move the `getNodeParameter` calls inside the loop body and use the loop index `i`. This ensures each item is evaluated with its own `resource` and `operation` parameters, consistent with how all other per-item parameters (e.g., `mailboxId`, `status`, `subject`) are already read using `i`.

```ts
for (let i = 0; i < length; i++) {
  const resource = this.getNodeParameter('resource', i);
  const operation = this.getNodeParameter('operation', i);
  ...
}
```