### PR TITLE
fix(HomeAssistant): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/HomeAssistant/HomeAssistant.node.ts
+++ b/packages/nodes-base/nodes/HomeAssistant/HomeAssistant.node.ts
@@ -175,11 +175,11 @@ export class HomeAssistant implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 		const length = items.length;
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
 		const qs: IDataObject = {};
 		let responseData;
 		for (let i = 0; i < length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			try {
 				if (resource === 'config') {
 					if (operation === 'get') {


### PR DESCRIPTION
## Summary

In `HomeAssistant.node.ts`, `resource` and `operation` are read using hardcoded index `0` outside the item loop. When a workflow processes multiple items where `resource` or `operation` are set via expressions, all items incorrectly use the parameter values from the first item only.

## Bug

```ts
const resource = this.getNodeParameter('resource', 0);
const operation = this.getNodeParameter('operation', 0);
for (let i = 0; i < length; i++) { ... }
```

## Fix

Move the `getNodeParameter` calls inside the loop and replace the hardcoded `0` with the loop index `i`. This aligns with n8n's convention that per-item parameters should be fetched using the current item index.

```ts
for (let i = 0; i < length; i++) {
  const resource = this.getNodeParameter('resource', i);
  const operation = this.getNodeParameter('operation', i);
  ...
}
```