### PR TITLE
fix(HubspotV2): use item index instead of hardcoded 0 for resource, operation, returnAll and limit

### DIFF
--- a/packages/nodes-base/nodes/Hubspot/V2/HubspotV2.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/V2/HubspotV2.node.ts
@@ -1202,6 +1202,8 @@ export class HubspotV2 implements INodeType {
 			}
 		} else {
 			for (let i = 0; i < length; i++) {
+				const resource = this.getNodeParameter('resource', i);
+				const operation = this.getNodeParameter('operation', i);
 				try {
 					//https://developers.hubspot.com/docs/methods/contacts/create_or_update
 					if (resource === 'contact') {
@@ -1678,7 +1680,7 @@ export class HubspotV2 implements INodeType {
 						//https://developers.hubspot.com/docs/methods/contacts/get_contacts
 						if (operation === 'getAll') {
 							const additionalFields = this.getNodeParameter('additionalFields', i);
-							const returnAll = this.getNodeParameter('returnAll', 0);
+							const returnAll = this.getNodeParameter('returnAll', i);
 							if (additionalFields.formSubmissionMode) {
 								qs.formSubmissionMode = additionalFields.formSubmissionMode as string;
 							}
@@ -1705,14 +1707,14 @@ export class HubspotV2 implements INodeType {
 									qs,
 								);
 							} else {
-								qs.count = this.getNodeParameter('limit', 0);
+								qs.count = this.getNodeParameter('limit', i);
 								responseData = await hubspotApiRequest.call(this, 'GET', endpoint, {}, qs);
 								responseData = responseData.contacts;
 							}
 						}
 						//https://developers.hubspot.com/docs/methods/contacts/get_recently_created_contacts
 						if (operation === 'getRecentlyCreatedUpdated') {
-							const returnAll = this.getNodeParameter('returnAll', 0);
+							const returnAll = this.getNodeParameter('returnAll', i);
 							const additionalFields = this.getNodeParameter('additionalFields', i);
 							if (additionalFields.formSubmissionMode) {
 								qs.formSubmissionMode = additionalFields.formSubmissionMode as string;
@@ -1742,7 +1744,7 @@ export class HubspotV2 implements INodeType {
 									qs,
 								);
 							} else {
-								qs.count = this.getNodeParameter('limit', 0);
+								qs.count = this.getNodeParameter('limit', i);
 								responseData = await hubspotApiRequest.call(this, 'GET', endpoint, {}, qs);
 								responseData = responseData.contacts;
 							}
@@ -1760,7 +1762,7 @@ export class HubspotV2 implements INodeType {
 						//https://developers.hubspot.com/docs/api/crm/search
 						if (operation === 'search') {
 							const additionalFields = this.getNodeParameter('additionalFields', i);
-							const returnAll = this.getNodeParameter('returnAll', 0);
+							const returnAll = this.getNodeParameter('returnAll', i);
 							const filtersGroupsUi = this.getNodeParameter('filterGroupsUi', i) as IDataObject;
 							const sortBy = additionalFields.sortBy || 'createdate';
 							const direction = additionalFields.direction || 'DESCENDING';
@@ -1813,7 +1815,7 @@ export class HubspotV2 implements INodeType {
 									qs,
 								);
 							} else {
-								body.limit = this.getNodeParameter('limit', 0);
+								body.limit = this.getNodeParameter('limit', i);
 								responseData = await hubspotApiRequest.call(this, 'POST', endpoint, body, qs);
 								responseData = responseData.results;
 							}
@@ -2290,7 +2292,7 @@ export class HubspotV2 implements INodeType {
 						//https://developers.hubspot.com/docs/methods/companies/get-all-companies
 						if (operation === 'getAll') {
 							const additionalFields = this.getNodeParameter('options', i);
-							const returnAll = this.getNodeParameter('returnAll', 0);
+							const returnAll = this.getNodeParameter('returnAll', i);
 							if (additionalFields.formSubmissionMode) {
 								qs.formSubmissionMode = additionalFields.formSubmissionMode as string;
 							}
@@ -2317,14 +2319,14 @@ export class HubspotV2 implements INodeType {
 									qs,
 								);
 							} else {
-								qs.limit = this.getNodeParameter('limit', 0);
+								qs.limit = this.getNodeParameter('limit', i);
 								responseData = await hubspotApiRequest.call(this, 'GET', endpoint, {}, qs);
 								responseData = responseData.companies;
 							}
 						}
 						//https://developers.hubspot.com/docs/methods/companies/get_companies_modified
 						if (operation === 'getRecentlyCreatedUpdated') {
-							const returnAll = this.getNodeParameter('returnAll', 0);
+							const returnAll = this.getNodeParameter('returnAll', i);
 							const additionalFields = this.getNodeParameter('additionalFields', i);
 							if (additionalFields.since) {
 								qs.since = new Date(additionalFields.since as string).getTime();
@@ -2349,7 +2351,7 @@ export class HubspotV2 implements INodeType {
 									qs,
 								);
 							} else {
-								qs.count = this.getNodeParameter('limit', 0);
+								qs.count = this.getNodeParameter('limit', i);
 								responseData = await hubspotApiRequest.call(this, 'GET', endpoint, {}, qs);
 								responseData = responseData.results;
 							}
@@ -2358,7 +2360,7 @@ export class HubspotV2 implements INodeType {
 						if (operation === 'searchByDomain') {
 							let domain = this.getNodeParameter('domain', i) as string;
 							const options = this.getNodeParameter('options', i);
-							const returnAll = this.getNodeParameter('returnAll', 0);
+							const returnAll = this.getNodeParameter('returnAll', i);
 							if (domain.includes('https://')) {
 								domain = domain.replace('https://', '');
 							} else if (domain.includes('http://')) {
@@ -2380,7 +2382,7 @@ export class HubspotV2 implements INodeType {
 									body,
 								);
 							} else {
-								body.limit = this.getNodeParameter('limit', 0);
+								body.limit = this.getNodeParameter('limit', i);
 								responseData = await hubspotApiRequest.call(this, 'POST', endpoint, body);
 								responseData = responseData.results;
 							}
@@ -2575,7 +2577,7 @@ export class HubspotV2 implements INodeType {
 						}
 						if (operation === 'getAll') {
 							const filters = this.getNodeParameter('filters', i);
-							const returnAll = this.getNodeParameter('returnAll', 0);
+							const returnAll = this.getNodeParameter('returnAll', i);
 							if (filters.includeAssociations) {
 								qs.includeAssociations = filters.includeAssociations as boolean;
 							}
@@ -2614,7 +2616,7 @@ export class HubspotV2 implements INodeType {
 									qs,
 								);
 							} else {
-								qs.limit = this.getNodeParameter('limit', 0);
+								qs.limit = this.getNodeParameter('limit', i);
 								responseData = await hubspotApiRequest.call(this, 'GET', endpoint, {}, qs);
 								responseData = responseData.deals;
 							}
@@ -2622,7 +2624,7 @@ export class HubspotV2 implements INodeType {
 						if (operation === 'getRecentlyCreatedUpdated') {
 							const endpoint = '/deals/v1/deal/recent/created';
 							const filters = this.getNodeParameter('filters', i);
-							const returnAll = this.getNodeParameter('returnAll', 0);
+							const returnAll = this.getNodeParameter('returnAll', i);
 							if (filters.since) {
 								qs.since = new Date(filters.since as string).getTime();
 							}
@@ -2639,7 +2641,7 @@ export class HubspotV2 implements INodeType {
 									qs,
 								);
 							} else {
-								qs.count = this.getNodeParameter('limit', 0);
+								qs.count = this.getNodeParameter('limit', i);
 								responseData = await hubspotApiRequest.call(this, 'GET', endpoint, {}, qs);
 								responseData = responseData.results;
 							}
@@ -2659,7 +2661,7 @@ export class HubspotV2 implements INodeType {
 						//https://developers.hubspot.com/docs/api/crm/search
 						if (operation === 'search') {
 							const additionalFields = this.getNodeParameter('additionalFields', i);
-							const returnAll = this.getNodeParameter('returnAll', 0);
+							const returnAll = this.getNodeParameter('returnAll', i);
 							const filtersGroupsUi = this.getNodeParameter('filterGroupsUi', i) as IDataObject;
 							const sortBy = additionalFields.sortBy || 'createdate';
 							const direction = additionalFields.direction || 'DESCENDING';
@@ -2712,7 +2714,7 @@ export class HubspotV2 implements INodeType {
 									qs,
 								);
 							} else {
-								body.limit = this.getNodeParameter('limit', 0);
+								body.limit = this.getNodeParameter('limit', i);
 								responseData = await hubspotApiRequest.call(this, 'POST', endpoint, body, qs);
 								responseData = responseData.results;
 							}
@@ -2804,7 +2806,7 @@ export class HubspotV2 implements INodeType {
 						}
 						//https://legacydocs.hubspot.com/docs/methods/engagements/get-all-engagements
 						if (operation === 'getAll') {
-							const returnAll = this.getNodeParameter('returnAll', 0);
+							const returnAll = this.getNodeParameter('returnAll', i);
 							const endpoint = '/engagements/v1/engagements/paged';
 							if (returnAll) {
 								responseData = await hubspotApiRequestAllItems.call(
@@ -2816,7 +2818,7 @@ export class HubspotV2 implements INodeType {
 									qs,
 								);
 							} else {
-								qs.limit = this.getNodeParameter('limit', 0);
+								qs.limit = this.getNodeParameter('limit', i);
 								responseData = await hubspotApiRequest.call(this, 'GET', endpoint, {}, qs);
 								responseData = responseData.results;
 							}
@@ -3026,7 +3028,7 @@ export class HubspotV2 implements INodeType {
 						//https://developers.hubspot.com/docs/methods/tickets/get-all-tickets
 						if (operation === 'getAll') {
 							const additionalFields = this.getNodeParameter('additionalFields', i);
-							const returnAll = this.getNodeParameter('returnAll', 0);
+							const returnAll = this.getNodeParameter('returnAll', i);
 							if (additionalFields.properties) {
 								qs.properties = additionalFields.properties as string[];
 							}
@@ -3046,7 +3048,7 @@ export class HubspotV2 implements INodeType {
 									qs,
 								);
 							} else {
-								qs.limit = this.getNodeParameter('limit', 0);
+								qs.limit = this.getNodeParameter('limit', i);
 								responseData = await hubspotApiRequestAllItems.call(
 									this,
 									'objects',


### PR DESCRIPTION
## Bug

In `HubspotV2.node.ts`, `resource` and `operation` are read at the top of `execute()` with a hardcoded item index of `0`. For multi-item inputs with different resource/operation values per item the node always processes using item 0's values. Similarly, all `getNodeParameter('returnAll', 0)` and `getNodeParameter('limit', 0)` calls inside the main per-item for loop ignore per-item pagination overrides.

## Fix

Added per-item `resource` and `operation` reads inside the `for (let i = 0; i < length; i++)` else-branch loop, shadowing the outer `0`-indexed declarations which are still correctly used by the `contactList` batch branch. Replaced all `getNodeParameter('returnAll', 0)` and `getNodeParameter('limit', 0)` within the loop with `i`.

## Impact

Multi-item workflows using different HubSpot resources, operations, or pagination settings per item will now be handled correctly rather than always relying on item 0's parameters.