### PR TITLE
fix(Salesforce): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
+++ b/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
@@ -1043,14 +1043,14 @@ export class Salesforce implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		let responseData;
 		const qs: IDataObject = {};
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
-
-		this.logger.debug(
-			`Running "Salesforce" node named "${this.getNode.name}" resource "${resource}" operation "${operation}"`,
-		);
 
 		for (let i = 0; i < items.length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
+
+			this.logger.debug(
+				`Running "Salesforce" node named "${this.getNode.name}" resource "${resource}" operation "${operation}"`,
+			);
 			try {
 				if (resource === 'lead') {
 					//https://developer.salesforce.com/docs/api-explorer/sobject/Lead/post-lead


### PR DESCRIPTION
## Summary

In `Salesforce.node.ts`, `resource` and `operation` are read with a hardcoded item index of `0` before the `for` loop that iterates over all input items. This means that when a workflow passes multiple items with different resource/operation values (e.g., via an expression), every item will be processed using the resource and operation from the very first item, silently ignoring the intended values for items at index 1+.

## Fix

Moved the `this.getNodeParameter('resource', i)` and `this.getNodeParameter('operation', i)` calls inside the loop body so they use the current item index `i`, and also moved the debug log inside the loop so it reflects the correct per-item values.

## Impact

Any workflow that uses expressions to set `resource` or `operation` on a per-item basis will now work correctly instead of always using the first item's values.