### PR TITLE
fix(Telegram): use item index instead of hardcoded 0 for resource, operation, and binaryData in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -1823,14 +1823,13 @@ export class Telegram implements INodeType {
 		let requestMethod: IHttpRequestMethods;
 		let endpoint: string;
 
-		const operation = this.getNodeParameter('operation', 0);
-		const resource = this.getNodeParameter('resource', 0);
-		const binaryData = this.getNodeParameter('binaryData', 0, false);
-
 		const nodeVersion = this.getNode().typeVersion;
 		const instanceId = this.getInstanceId();
 
-		if (resource === 'message' && operation === SEND_AND_WAIT_OPERATION) {
+		if (
+			this.getNodeParameter('resource', 0) === 'message' &&
+			this.getNodeParameter('operation', 0) === SEND_AND_WAIT_OPERATION
+		) {
 			body = createSendAndWaitMessageBody(this);
 
 			await apiRequest.call(this, 'POST', 'sendMessage', body);
@@ -1848,6 +1847,10 @@ export class Telegram implements INodeType {
 				endpoint = '';
 				body = {};
 				qs = {};
+
+				const operation = this.getNodeParameter('operation', i);
+				const resource = this.getNodeParameter('resource', i);
+				const binaryData = this.getNodeParameter('binaryData', i, false);
 
 				if (resource === 'callback') {
 					if (operation === 'answerQuery') {


### PR DESCRIPTION
## Summary

In `Telegram.node.ts`, `operation`, `resource`, and `binaryData` are all read with a hardcoded item index of `0` before the `for` loop that processes input items. When a workflow delivers multiple items with different resource or operation values via expressions, every item is processed using the resource/operation from the first item only.

## Fix

Removed the three pre-loop parameter reads and moved them inside the loop body using the current index `i`. The special `SEND_AND_WAIT_OPERATION` early-exit check (which returns before the loop) is preserved and now reads the parameters inline with index `0` since it handles only a single send-and-wait event.

## Impact

Workflows that use expressions to vary `resource`, `operation`, or `binaryData` across multiple input items will now be processed correctly per item.