### PR TITLE
fix(AwsDynamoDB): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Aws/DynamoDB/AwsDynamoDB.node.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/AwsDynamoDB.node.ts
@@ -83,13 +83,13 @@ export class AwsDynamoDB implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
-
 		let responseData;
 		const returnData: INodeExecutionData[] = [];
 
 		for (let i = 0; i < items.length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
+
 			try {
 				if (resource === 'item') {
 					if (operation === 'upsert') {


### PR DESCRIPTION
## Summary

In `AwsDynamoDB.node.ts`, `resource` and `operation` are read with a hardcoded index of `0` before the execute loop that iterates over input items. This means that when multiple items are passed to the node with different resource or operation values set via expressions, all items will be processed using the resource and operation of the first item only.

## Fix

Moved `this.getNodeParameter('resource', i)` and `this.getNodeParameter('operation', i)` inside the `for` loop so they use the current item index `i`, matching the pattern used by the rest of the parameter reads in the loop body.

## Impact

Workflows that feed multiple DynamoDB items with per-item expressions for resource or operation will now behave correctly.