### PR TITLE
fix(Zulip): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Zulip/Zulip.node.ts
+++ b/packages/nodes-base/nodes/Zulip/Zulip.node.ts
@@ -131,9 +131,9 @@ export class Zulip implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			try {
 				if (resource === 'message') {
 					//https://zulipchat.com/api/send-message


### PR DESCRIPTION
## Summary

In `Zulip.node.ts`, `resource` and `operation` are read with hardcoded index `0` before the items loop begins. This means every iteration of the loop uses the resource and operation from the first input item only, so workflows with multiple input items of different resources or operations are processed incorrectly.

## Fix

Move the `getNodeParameter('resource', ...)` and `getNodeParameter('operation', ...)` calls inside the `for` loop and replace the hardcoded `0` with the loop variable `i`, so each item's own resource and operation are used.

## Bug Pattern

This is the same class of bug fixed in nodes like Salesforce, HubSpot, Telegram, and others: reading node parameters with hardcoded index `0` outside the execute loop causes all items to be processed as if they were the first item.