### PR TITLE
fix(Zammad): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Zammad/Zammad.node.ts
+++ b/packages/nodes-base/nodes/Zammad/Zammad.node.ts
@@ -346,13 +346,12 @@ export class Zammad implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 
-		const resource = this.getNodeParameter('resource', 0) as ZammadTypes.Resource;
-		const operation = this.getNodeParameter('operation', 0);
-
 		let responseData;
 		const returnData: INodeExecutionData[] = [];
 
 		for (let i = 0; i < items.length; i++) {
+			const resource = this.getNodeParameter('resource', i) as ZammadTypes.Resource;
+			const operation = this.getNodeParameter('operation', i);
 			try {
 				if (resource === 'user') {
 					// **********************************************************************


### PR DESCRIPTION
## Summary

In `Zammad.node.ts`, `resource` and `operation` are fetched with hardcoded index `0` outside the items loop. When the node receives multiple input items, every iteration incorrectly uses the resource and operation from the first item only, ignoring per-item overrides or expressions.

## Fix

Move `getNodeParameter('resource', ...)` and `getNodeParameter('operation', ...)` inside the `for` loop and replace the hardcoded `0` with the loop variable `i`, ensuring each item's own parameters are used during execution.

## Bug Pattern

This follows the same pattern corrected in many other nodes (Salesforce, HubSpot, Trello, etc.) where parameters controlling dispatch logic are read once at index 0 rather than per-item.