### PR TITLE
fix(Tapfiliate): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Tapfiliate/Tapfiliate.node.ts
+++ b/packages/nodes-base/nodes/Tapfiliate/Tapfiliate.node.ts
@@ -93,9 +93,9 @@ export class Tapfiliate implements INodeType {
 		const qs: IDataObject = {};
 		let responseData;
 		const returnData: INodeExecutionData[] = [];
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			try {
 				if (resource === 'affiliate') {
 					if (operation === 'create') {


### PR DESCRIPTION
## Summary

In `Tapfiliate.node.ts`, `resource` and `operation` are read using hardcoded index `0` before the items loop, so all input items are dispatched using the resource and operation of the first item only. This breaks multi-item workflows where different items have different resources or operations set via expressions.

## Fix

Move `getNodeParameter('resource', ...)` and `getNodeParameter('operation', ...)` inside the `for` loop, replacing the hardcoded `0` with the loop index `i`, so each item's parameters are resolved individually.

## Bug Pattern

This is the same class of bug seen and fixed in many other nodes (Salesforce, HubSpot, Telegram, Trello, etc.) — reading dispatch parameters once with hardcoded index `0` rather than per-item during the execute loop.