### PR TITLE
fix(Brandfetch): use item index instead of hardcoded 0 for operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Brandfetch/Brandfetch.node.ts
+++ b/packages/nodes-base/nodes/Brandfetch/Brandfetch.node.ts
@@ -152,9 +152,9 @@ export class Brandfetch implements INodeType {
 		const items = this.getInputData();
 		const length = items.length;
 
-		const operation = this.getNodeParameter('operation', 0);
 		const responseData: INodeExecutionData[] = [];
 		for (let i = 0; i < length; i++) {
+			const operation = this.getNodeParameter('operation', i);
 			try {
 				const domain = this.getNodeParameter('domain', i) as string;
 				if (operation === 'logo') {


### PR DESCRIPTION
## Bug

In `Brandfetch.node.ts`, `operation` is read with `getNodeParameter('operation', 0)` outside the `for` loop before processing items. When a workflow passes multiple items where different items specify different operations via expressions, all items are incorrectly processed using the operation of the first item only.

## Fix

Move the `getNodeParameter('operation', ...)` call inside the `for (let i = 0; i < length; i++)` loop, replacing the hardcoded `0` with the loop index `i`. This ensures each item is processed according to its own operation value.

This matches the pattern used by most other multi-operation nodes in the codebase.