### PR TITLE
fix(Plivo): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Plivo/Plivo.node.ts
+++ b/packages/nodes-base/nodes/Plivo/Plivo.node.ts
@@ -70,10 +70,9 @@ export class Plivo implements INodeType {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
 
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
-
 		for (let i = 0; i < items.length; i++) {
+			const resource = this.getNodeParameter('resource', i);
+			const operation = this.getNodeParameter('operation', i);
 			let responseData;
 
 			if (resource === 'sms') {


### PR DESCRIPTION
## Bug

In `Plivo.node.ts`, `resource` and `operation` are read with `getNodeParameter('resource', 0)` and `getNodeParameter('operation', 0)` outside the `for` loop before processing items. When a workflow passes multiple items where different items specify different resource/operation values via expressions, all items are incorrectly processed using the resource and operation of the first item only.

## Fix

Move both `getNodeParameter` calls inside the `for (let i = 0; i < items.length; i++)` loop, replacing the hardcoded `0` with the loop index `i`. This ensures each item is processed according to its own resource and operation values.

This matches the pattern used by most other multi-resource nodes in the codebase.