### PR TITLE
fix(Ssh): use item index instead of hardcoded 0 for resource and operation in execute loop

### DIFF
--- a/packages/nodes-base/nodes/Ssh/Ssh.node.ts
+++ b/packages/nodes-base/nodes/Ssh/Ssh.node.ts
@@ -332,8 +332,6 @@ export class Ssh implements INodeType {
 
 		const returnItems: INodeExecutionData[] = [];
 
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
 		const authentication = this.getNodeParameter('authentication', 0) as string;
 
 		const ssh = new NodeSSH();
@@ -365,6 +363,8 @@ export class Ssh implements INodeType {
 			}
 
 			for (let i = 0; i < items.length; i++) {
+				const resource = this.getNodeParameter('resource', i);
+				const operation = this.getNodeParameter('operation', i);
 				try {
 					if (resource === 'command') {
 						if (operation === 'execute') {


### PR DESCRIPTION
## Bug

In `Ssh.node.ts`, `resource` and `operation` are read with `getNodeParameter('resource', 0)` and `getNodeParameter('operation', 0)` outside the items `for` loop. The SSH connection setup (which reads `authentication` at index 0) is intentionally done once per execution, but the per-item `resource` and `operation` reads should use the current item's index. When multiple items with different resource/operation values are processed, all items incorrectly use the values from the first item.

## Fix

Remove the hardcoded-0 `resource` and `operation` reads from before the loop and add them inside the `for (let i = 0; i < items.length; i++)` loop with index `i`. The SSH connection and `authentication` read remain outside the loop since a single connection is shared across all items.