### PR TITLE
fix(editor): Constrain InstanceAiView stacking context below sidebar

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiView.vue
@@ -636,6 +636,8 @@ function handleStop() {
 	width: 100%;
 	min-width: 900px;
 	overflow: hidden;
+	position: relative;
+	z-index: 0;
 }
 
 .sidebar {


### PR DESCRIPTION
## Summary

Fixes overall + dropdown disappearing on hover. See linear for reproduction.

Adds `position: relative; z-index: 0` to the `.container` of `InstanceAiView` to establish a new stacking context. This confines all descendant z-indices (including the `z-index: 9999` on `InstanceAiPreviewTabBar` and the floating input/scroll button at z-index 2/3) within the view, so they no longer compete with the main app sidebar's popovers, dropdowns, and overlays.

**How to test:**
- Open the Instance AI view (`/instance-ai`).
- Open any sidebar dropdown/popover (e.g. the user menu, project switcher).
- Verify the sidebar's overlays render above the chat view, including above the preview tab bar and the floating input.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5137

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI