### PR TITLE
fix(editor): Show error toasts in Instance AI executable canvas

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/WorkflowPreview.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowPreview.test.ts
@@ -1,7 +1,7 @@
 import type { Mock, MockInstance } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
 import { waitFor } from '@testing-library/vue';
-import type { ExecutionSummary } from 'n8n-workflow';
+import { jsonParse, type ExecutionSummary } from 'n8n-workflow';
 import { createComponentRenderer } from '@/__tests__/render';
 import type { INodeUi, IWorkflowDb } from '@/Interface';
 import WorkflowPreview from '@/app/components/WorkflowPreview.vue';
@@ -19,6 +19,14 @@ let consoleErrorSpy: MockInstance;
 
 const sendPostMessageCommand = (command: string) => {
 	window.postMessage(`{"command":"${command}"}`, '*');
+};
+
+const expectIframePostMessage = (expectedPayload: Record<string, unknown>) => {
+	const payloads = postMessageSpy.mock.calls
+		.filter(([payload, targetOrigin]) => typeof payload === 'string' && targetOrigin === '*')
+		.map(([payload]) => jsonParse(payload as string));
+
+	expect(payloads).toEqual(expect.arrayContaining([expect.objectContaining(expectedPayload)]));
 };
 
 describe('WorkflowPreview', () => {
@@ -105,18 +113,42 @@ describe('WorkflowPreview', () => {
 		sendPostMessageCommand('n8nReady');
 
 		await waitFor(() => {
-			expect(postMessageSpy).toHaveBeenCalledWith(
-				JSON.stringify({
-					command: 'openWorkflow',
-					workflow,
-					canOpenNDV: true,
-					hideNodeIssues: false,
-					suppressNotifications: false,
-					projectId: 'test-project-id',
-				}),
-				'*',
-			);
+			expectIframePostMessage({
+				command: 'openWorkflow',
+				workflow,
+				canOpenNDV: true,
+				hideNodeIssues: false,
+				suppressNotifications: false,
+				allowErrorNotifications: false,
+				projectId: 'test-project-id',
+			});
 			expect(focusSpy).toHaveBeenCalled();
+		});
+	});
+
+	it('should pass allowErrorNotifications using PostMessage when enabled', async () => {
+		const nodes = [{ name: 'Start' }] as INodeUi[];
+		const workflow = { nodes } as IWorkflowDb;
+		renderComponent({
+			pinia,
+			props: {
+				workflow,
+				allowErrorNotifications: true,
+			},
+		});
+
+		sendPostMessageCommand('n8nReady');
+
+		await waitFor(() => {
+			expectIframePostMessage({
+				command: 'openWorkflow',
+				workflow,
+				canOpenNDV: true,
+				hideNodeIssues: false,
+				suppressNotifications: false,
+				allowErrorNotifications: true,
+				projectId: 'test-project-id',
+			});
 		});
 	});
 
@@ -149,16 +181,13 @@ describe('WorkflowPreview', () => {
 		sendPostMessageCommand('n8nReady');
 
 		await waitFor(() => {
-			expect(postMessageSpy).toHaveBeenCalledWith(
-				JSON.stringify({
-					command: 'openExecution',
-					executionId,
-					executionMode: '',
-					canOpenNDV: true,
-					projectId: 'test-project-id',
-				}),
-				'*',
-			);
+			expectIframePostMessage({
+				command: 'openExecution',
+				executionId,
+				executionMode: '',
+				canOpenNDV: true,
+				projectId: 'test-project-id',
+			});
 		});
 	});
 
@@ -179,24 +208,18 @@ describe('WorkflowPreview', () => {
 		sendPostMessageCommand('n8nReady');
 
 		await waitFor(() => {
-			expect(postMessageSpy).toHaveBeenCalledWith(
-				JSON.stringify({
-					command: 'openExecution',
-					executionId,
-					executionMode: '',
-					canOpenNDV: true,
-					projectId: 'test-project-id',
-				}),
-				'*',
-			);
+			expectIframePostMessage({
+				command: 'openExecution',
+				executionId,
+				executionMode: '',
+				canOpenNDV: true,
+				projectId: 'test-project-id',
+			});
 
-			expect(postMessageSpy).toHaveBeenCalledWith(
-				JSON.stringify({
-					command: 'setActiveExecution',
-					executionId: 'abc',
-				}),
-				'*',
-			);
+			expectIframePostMessage({
+				command: 'setActiveExecution',
+				executionId: 'abc',
+			});
 		});
 	});
 
@@ -217,17 +240,15 @@ describe('WorkflowPreview', () => {
 		sendPostMessageCommand('n8nReady');
 
 		await waitFor(() => {
-			expect(postMessageSpy).toHaveBeenCalledWith(
-				JSON.stringify({
-					command: 'openWorkflow',
-					workflow,
-					canOpenNDV: true,
-					hideNodeIssues: false,
-					suppressNotifications: false,
-					projectId: 'test-project-id',
-				}),
-				'*',
-			);
+			expectIframePostMessage({
+				command: 'openWorkflow',
+				workflow,
+				canOpenNDV: true,
+				hideNodeIssues: false,
+				suppressNotifications: false,
+				allowErrorNotifications: false,
+				projectId: 'test-project-id',
+			});
 		});
 
 		sendPostMessageCommand('openNDV');
@@ -255,17 +276,15 @@ describe('WorkflowPreview', () => {
 		});
 		sendPostMessageCommand('n8nReady');
 		await waitFor(() => {
-			expect(postMessageSpy).toHaveBeenCalledWith(
-				JSON.stringify({
-					command: 'openWorkflow',
-					workflow,
-					canOpenNDV: false,
-					hideNodeIssues: false,
-					suppressNotifications: false,
-					projectId: 'test-project-id',
-				}),
-				'*',
-			);
+			expectIframePostMessage({
+				command: 'openWorkflow',
+				workflow,
+				canOpenNDV: false,
+				hideNodeIssues: false,
+				suppressNotifications: false,
+				allowErrorNotifications: false,
+				projectId: 'test-project-id',
+			});
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/components/WorkflowPreview.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowPreview.vue
@@ -22,6 +22,7 @@ const props = withDefaults(
 		focusOnLoad?: boolean;
 		hideControls?: boolean;
 		suppressNotifications?: boolean;
+		allowErrorNotifications?: boolean;
 		canExecute?: boolean;
 	}>(),
 	{
@@ -37,6 +38,7 @@ const props = withDefaults(
 		focusOnLoad: true,
 		hideControls: false,
 		suppressNotifications: false,
+		allowErrorNotifications: false,
 		canExecute: false,
 	},
 );
@@ -95,6 +97,7 @@ const loadWorkflow = () => {
 				canOpenNDV: props.canOpenNDV,
 				hideNodeIssues: props.hideNodeIssues,
 				suppressNotifications: props.suppressNotifications,
+				allowErrorNotifications: props.allowErrorNotifications,
 				projectId: projectsStore.currentProjectId,
 			}),
 			'*',

--- a/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.test.ts
@@ -5,6 +5,7 @@ import { createTestingPinia } from '@pinia/testing';
 import { jsonParse } from 'n8n-workflow';
 import { usePostMessageHandler } from './usePostMessageHandler';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useUIStore } from '@/app/stores/ui.store';
 import type { WorkflowState } from '@/app/composables/useWorkflowState';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
 
@@ -47,10 +48,12 @@ vi.mock('@/app/composables/useTelemetry', () => ({
 	})),
 }));
 
+const mockToastShowError = vi.hoisted(() => vi.fn());
+const mockToastShowMessage = vi.hoisted(() => vi.fn());
 vi.mock('@/app/composables/useToast', () => ({
 	useToast: vi.fn(() => ({
-		showError: vi.fn(),
-		showMessage: vi.fn(),
+		showError: mockToastShowError,
+		showMessage: mockToastShowMessage,
 	})),
 }));
 
@@ -95,6 +98,14 @@ function createMockWorkflowState(): WorkflowState {
 	return {
 		setWorkflowExecutionData: vi.fn(),
 	} as unknown as WorkflowState;
+}
+
+function dispatchPostMessage(payload: Record<string, unknown>) {
+	window.dispatchEvent(
+		new MessageEvent('message', {
+			data: JSON.stringify(payload),
+		}),
+	);
 }
 
 describe('usePostMessageHandler', () => {
@@ -194,6 +205,96 @@ describe('usePostMessageHandler', () => {
 			await vi.waitFor(() => {
 				expect(mockImportWorkflowExact).toHaveBeenCalledWith(expect.objectContaining({ workflow }));
 			});
+
+			cleanup();
+		});
+
+		it('should set notification suppression and error allowance from openWorkflow message', async () => {
+			setActivePinia(createTestingPinia({ stubActions: false }));
+			const uiStore = useUIStore();
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: shallowRef(null),
+			});
+			setup();
+
+			window.dispatchEvent(
+				new MessageEvent('message', {
+					data: JSON.stringify({
+						command: 'openWorkflow',
+						workflow: { nodes: [], connections: {} },
+						suppressNotifications: true,
+						allowErrorNotifications: true,
+					}),
+				}),
+			);
+
+			await vi.waitFor(() => {
+				expect(mockImportWorkflowExact).toHaveBeenCalled();
+			});
+
+			expect(uiStore.areNotificationsSuppressed).toBe(true);
+			expect(uiStore.allowErrorNotificationsWhenSuppressed).toBe(true);
+
+			cleanup();
+		});
+
+		it('should clear notification suppression and error allowance when suppression is false', async () => {
+			setActivePinia(createTestingPinia({ stubActions: false }));
+			const uiStore = useUIStore();
+			uiStore.setNotificationsSuppressed(true, { allowErrors: true });
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: shallowRef(null),
+			});
+			setup();
+
+			window.dispatchEvent(
+				new MessageEvent('message', {
+					data: JSON.stringify({
+						command: 'openWorkflow',
+						workflow: { nodes: [], connections: {} },
+						suppressNotifications: false,
+						allowErrorNotifications: true,
+					}),
+				}),
+			);
+
+			await vi.waitFor(() => {
+				expect(mockImportWorkflowExact).toHaveBeenCalled();
+			});
+
+			expect(uiStore.areNotificationsSuppressed).toBe(false);
+			expect(uiStore.allowErrorNotificationsWhenSuppressed).toBe(false);
+
+			cleanup();
+		});
+
+		it('should clear notification suppression and error allowance when suppression is absent', async () => {
+			setActivePinia(createTestingPinia({ stubActions: false }));
+			const uiStore = useUIStore();
+			uiStore.setNotificationsSuppressed(true, { allowErrors: true });
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: shallowRef(null),
+			});
+			setup();
+
+			window.dispatchEvent(
+				new MessageEvent('message', {
+					data: JSON.stringify({
+						command: 'openWorkflow',
+						workflow: { nodes: [], connections: {} },
+					}),
+				}),
+			);
+
+			await vi.waitFor(() => {
+				expect(mockImportWorkflowExact).toHaveBeenCalled();
+			});
+
+			expect(uiStore.areNotificationsSuppressed).toBe(false);
+			expect(uiStore.allowErrorNotificationsWhenSuppressed).toBe(false);
 
 			cleanup();
 		});
@@ -401,6 +502,47 @@ describe('usePostMessageHandler', () => {
 			cleanup();
 		});
 
+		it('should show an error toast when opening execution fails with error allowance enabled', async () => {
+			setActivePinia(createTestingPinia({ stubActions: false }));
+			const uiStore = useUIStore();
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: shallowRef(null),
+			});
+			setup();
+
+			dispatchPostMessage({
+				command: 'openWorkflow',
+				workflow: { nodes: [], connections: {} },
+				suppressNotifications: true,
+				allowErrorNotifications: true,
+			});
+
+			await vi.waitFor(() => {
+				expect(mockImportWorkflowExact).toHaveBeenCalled();
+			});
+
+			expect(uiStore.areNotificationsSuppressed).toBe(true);
+			expect(uiStore.allowErrorNotificationsWhenSuppressed).toBe(true);
+
+			mockOpenExecution.mockRejectedValueOnce(new Error('Execution could not be opened'));
+			dispatchPostMessage({
+				command: 'openExecution',
+				executionId: 'exec-1',
+				executionMode: 'trigger',
+			});
+
+			await vi.waitFor(() => {
+				expect(mockToastShowMessage).toHaveBeenCalledWith({
+					title: expect.any(String),
+					message: 'Execution could not be opened',
+					type: 'error',
+				});
+			});
+
+			cleanup();
+		});
+
 		it('should not set isProductionExecutionPreview for manual executions', async () => {
 			mockOpenExecution.mockResolvedValue({
 				workflowData: { id: 'w1', name: 'Test' },
@@ -536,6 +678,47 @@ describe('usePostMessageHandler', () => {
 			// The error is caught internally, so we check that importWorkflowExact was not called
 			await vi.waitFor(() => {
 				expect(mockImportWorkflowExact).not.toHaveBeenCalled();
+			});
+
+			cleanup();
+		});
+
+		it('should show an error toast when opening execution preview fails with error allowance enabled', async () => {
+			setActivePinia(createTestingPinia({ stubActions: false }));
+			const uiStore = useUIStore();
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: shallowRef(null),
+			});
+			setup();
+
+			dispatchPostMessage({
+				command: 'openWorkflow',
+				workflow: { nodes: [], connections: {} },
+				suppressNotifications: true,
+				allowErrorNotifications: true,
+			});
+
+			await vi.waitFor(() => {
+				expect(mockImportWorkflowExact).toHaveBeenCalled();
+			});
+
+			expect(uiStore.areNotificationsSuppressed).toBe(true);
+			expect(uiStore.allowErrorNotificationsWhenSuppressed).toBe(true);
+
+			dispatchPostMessage({
+				command: 'openExecutionPreview',
+				workflow: { connections: {} },
+				nodeExecutionSchema: {},
+				executionStatus: 'success',
+			});
+
+			await vi.waitFor(() => {
+				expect(mockToastShowMessage).toHaveBeenCalledWith({
+					title: expect.any(String),
+					message: 'Invalid workflow object',
+					type: 'error',
+				});
 			});
 
 			cleanup();

--- a/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.ts
@@ -78,10 +78,11 @@ export function usePostMessageHandler({
 		projectId?: string;
 		tidyUp?: boolean;
 		suppressNotifications?: boolean;
+		allowErrorNotifications?: boolean;
 	}) {
-		if (json.suppressNotifications) {
-			uiStore.setNotificationsSuppressed(true);
-		}
+		uiStore.setNotificationsSuppressed(json.suppressNotifications === true, {
+			allowErrors: json.allowErrorNotifications === true,
+		});
 
 		if (json.projectId) {
 			await projectsStore.fetchAndSetProject(json.projectId);

--- a/packages/frontend/editor-ui/src/app/composables/useToast.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useToast.test.ts
@@ -215,9 +215,10 @@ describe('useToast', () => {
 	});
 
 	describe('notification suppression', () => {
-		it('should not render notification when notifications are suppressed', async () => {
+		it('should not render non-error notification when notifications are suppressed', async () => {
 			const uiStore = useUIStore();
 			uiStore.areNotificationsSuppressed = true;
+			uiStore.allowErrorNotificationsWhenSuppressed = true;
 
 			toast.showMessage({ message: 'Should not appear', title: 'Suppressed' });
 
@@ -231,6 +232,69 @@ describe('useToast', () => {
 					{ timeout: 200 },
 				),
 			).rejects.toThrow();
+		});
+
+		it('should not render error notification when notifications are suppressed and errors are not allowed', async () => {
+			const uiStore = useUIStore();
+			uiStore.areNotificationsSuppressed = true;
+			uiStore.allowErrorNotificationsWhenSuppressed = false;
+
+			toast.showMessage({
+				message: 'Error should not appear',
+				title: 'Suppressed error',
+				type: 'error',
+			});
+
+			await expect(
+				waitFor(
+					() => {
+						expect(screen.getByRole('alert')).toBeVisible();
+					},
+					{ timeout: 200 },
+				),
+			).rejects.toThrow();
+			expect(telemetryTrackSpy).not.toHaveBeenCalled();
+		});
+
+		it('should render error notification when notifications are suppressed and errors are allowed', async () => {
+			const uiStore = useUIStore();
+			uiStore.areNotificationsSuppressed = true;
+			uiStore.allowErrorNotificationsWhenSuppressed = true;
+
+			toast.showMessage({
+				message: 'Error should appear',
+				title: 'Allowed error',
+				type: 'error',
+			});
+
+			await waitFor(() => {
+				expect(screen.getByRole('alert')).toBeVisible();
+				expect(
+					within(screen.getByRole('alert')).getByRole('heading', { level: 2 }),
+				).toHaveTextContent('Allowed error');
+				expect(screen.getByRole('alert')).toContainHTML('<p>Error should appear</p>');
+			});
+		});
+
+		it('should track telemetry for allowed suppressed error notification', async () => {
+			const uiStore = useUIStore();
+			uiStore.areNotificationsSuppressed = true;
+			uiStore.allowErrorNotificationsWhenSuppressed = true;
+
+			toast.showMessage({
+				message: 'Allowed error tracked',
+				title: 'Allowed error',
+				type: 'error',
+			});
+
+			await waitFor(() => {
+				expect(telemetryTrackSpy).toHaveBeenCalledWith('Instance FE emitted error', {
+					error_title: 'Allowed error',
+					error_message: 'Allowed error tracked',
+					caused_by_credential: false,
+					workflow_id: expect.any(String),
+				});
+			});
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/composables/useToast.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useToast.ts
@@ -21,7 +21,9 @@ export function useToast() {
 	const { APP_Z_INDEXES } = useStyles();
 
 	function showMessage(messageData: Partial<NotificationOptions>, track = true) {
-		if (uiStore.areNotificationsSuppressed) {
+		const suppressed = uiStore.areNotificationsSuppressed;
+		const allowErrors = uiStore.allowErrorNotificationsWhenSuppressed;
+		if (suppressed && !(allowErrors && messageData.type === 'error')) {
 			return { close: () => {} } as NotificationHandle;
 		}
 

--- a/packages/frontend/editor-ui/src/app/stores/ui.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/ui.store.ts
@@ -299,6 +299,7 @@ export const useUIStore = defineStore(STORES.UI, () => {
 	const addFirstStepOnLoad = ref<boolean>(false);
 	const pendingNotificationsForViews = ref<{ [key in VIEWS]?: NotificationOptions[] }>({});
 	const areNotificationsSuppressed = ref(false);
+	const allowErrorNotificationsWhenSuppressed = ref(false);
 	const processingExecutionResults = ref<boolean>(false);
 	const isBlankRedirect = ref<boolean>(false);
 
@@ -629,8 +630,9 @@ export const useUIStore = defineStore(STORES.UI, () => {
 		pendingNotificationsForViews.value[view] = notifications;
 	};
 
-	const setNotificationsSuppressed = (suppressed: boolean) => {
+	const setNotificationsSuppressed = (suppressed: boolean, options?: { allowErrors?: boolean }) => {
 		areNotificationsSuppressed.value = suppressed;
+		allowErrorNotificationsWhenSuppressed.value = suppressed && options?.allowErrors === true;
 	};
 
 	function resetLastInteractedWith() {
@@ -756,6 +758,7 @@ export const useUIStore = defineStore(STORES.UI, () => {
 		isAnyModalOpen,
 		pendingNotificationsForViews,
 		areNotificationsSuppressed,
+		allowErrorNotificationsWhenSuppressed,
 		activeModals,
 		isProcessingExecutionResults,
 		setTheme,

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowPreview.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowPreview.test.ts
@@ -16,8 +16,19 @@ const renderComponent = createComponentRenderer(InstanceAiWorkflowPreview, {
 	global: {
 		stubs: {
 			WorkflowPreview: {
-				template: '<div data-test-id="workflow-preview" />',
-				props: ['mode', 'workflow', 'executionId', 'canOpenNdv', 'hideControls', 'loaderType'],
+				template:
+					'<div data-test-id="workflow-preview" :data-can-execute="canExecute" :data-suppress-notifications="suppressNotifications" :data-allow-error-notifications="allowErrorNotifications" />',
+				props: [
+					'mode',
+					'workflow',
+					'executionId',
+					'canOpenNdv',
+					'canExecute',
+					'hideControls',
+					'suppressNotifications',
+					'allowErrorNotifications',
+					'loaderType',
+				],
 			},
 		},
 	},
@@ -70,6 +81,21 @@ describe('InstanceAiWorkflowPreview', () => {
 		await waitFor(() => {
 			const preview = getByTestId('workflow-preview');
 			expect(preview).toBeInTheDocument();
+		});
+	});
+
+	it('should allow error notifications for executable preview', async () => {
+		mockFetchWorkflow.mockResolvedValue(fakeWorkflow);
+
+		const { getByTestId } = renderComponent({
+			props: { workflowId: 'wf-123', executionId: null },
+		});
+
+		await waitFor(() => {
+			const preview = getByTestId('workflow-preview');
+			expect(preview).toHaveAttribute('data-can-execute', 'true');
+			expect(preview).toHaveAttribute('data-suppress-notifications', 'true');
+			expect(preview).toHaveAttribute('data-allow-error-notifications', 'true');
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowPreview.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowPreview.vue
@@ -193,6 +193,7 @@ defineExpose({ relayPushEvent });
 			:can-execute="true"
 			:hide-controls="false"
 			:suppress-notifications="true"
+			:allow-error-notifications="true"
 			loader-type="spinner"
 		/>
 


### PR DESCRIPTION
## Summary

Error toasts inside the Instance AI executable workflow preview were being swallowed alongside the routine success/warning notifications, masking workflow execution failures (most notably missing-credential errors). This PR restores error visibility while keeping the rest of the suppression in place.

**Approach**

- `useUIStore` gains a second flag: `allowErrorNotificationsWhenSuppressed`, and `setNotificationsSuppressed` now accepts `{ allowErrors }`. Turning suppression off always clears the allowance, so state can't leak across iframe re-mounts.
- `useToast.showMessage` lets `type: 'error'` messages through when both flags are on, including the existing error telemetry path.
- `WorkflowPreview` exposes a new `allowErrorNotifications` prop (default `false`) and forwards it in the `openWorkflow` postMessage payload. `usePostMessageHandler` writes both store flags from every `openWorkflow` message.
- `InstanceAiWorkflowPreview` opts in by passing `:allow-error-notifications="true"` alongside its existing `suppress-notifications` and `can-execute` flags.

**How to test**

1. Open an Instance AI thread, generate a workflow that uses a credentialed node, and run it without configuring the credential.
2. Confirm the error toast appears inside the embedded canvas and the node retains its execution-error state.
3. Run a workflow that succeeds — confirm no success/warning toasts appear inside the preview.
4. Open a regular workflow canvas and confirm normal toast behavior is unchanged.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-122

- [x] I have seen this code, I have run this code, and I take responsibility for this code.