### PR TITLE
feat(core): Add --projectId filter to export:workflow and export:credentials commands

### DIFF
--- a/packages/cli/src/commands/export/credentials.ts
+++ b/packages/cli/src/commands/export/credentials.ts
@@ -11,6 +11,7 @@ import z from 'zod';
 import type { ICredentialsDecryptedDb } from '@/interfaces';
 
 import { BaseCommand } from '../base-command';
+import '../../zod-alias-support';
 
 const flagsSchema = z.object({
 	all: z.boolean().describe('Export all credentials').optional(),
@@ -118,7 +119,7 @@ export class ExportCredentialsCommand extends BaseCommand<z.infer<typeof flagsSc
 
 		const credentials: ICredentialsDb[] = await Container.get(CredentialsRepository).find({
 			where: this.getWhereFilter(flags),
-			relations: { shared: true },
+			relations: ['shared.project'],
 		});
 
 		if (flags.decrypted) {

--- a/packages/cli/src/commands/export/credentials.ts
+++ b/packages/cli/src/commands/export/credentials.ts
@@ -21,6 +21,7 @@ const flagsSchema = z.object({
 		)
 		.optional(),
 	id: z.string().describe('The ID of the credential to export').optional(),
+	projectId: z.string().describe('Export all credentials in the specified project').optional(),
 	output: z
 		.string()
 		.alias('o')
@@ -46,6 +47,7 @@ const flagsSchema = z.object({
 	description: 'Export credentials',
 	examples: [
 		'--all',
+		'--projectId=Ox8O54VQrmBrb4qL',
 		'--id=5 --output=file.json',
 		'--all --output=backups/latest.json',
 		'--backup --output=backups/latest/',
@@ -64,13 +66,15 @@ export class ExportCredentialsCommand extends BaseCommand<z.infer<typeof flagsSc
 			flags.separate = true;
 		}
 
-		if (!flags.all && !flags.id) {
-			this.logger.info('Either option "--all" or "--id" have to be set!');
+		const selectorCount = [flags.all, flags.id, flags.projectId].filter(Boolean).length;
+
+		if (selectorCount === 0) {
+			this.logger.info('One of "--all", "--id", or "--projectId" has to be set!');
 			return;
 		}
 
-		if (flags.all && flags.id) {
-			this.logger.info('You should either use "--all" or "--id" but never both!');
+		if (selectorCount > 1) {
+			this.logger.info('Use exactly one of "--all", "--id", or "--projectId".');
 			return;
 		}
 
@@ -112,9 +116,10 @@ export class ExportCredentialsCommand extends BaseCommand<z.infer<typeof flagsSc
 			}
 		}
 
-		const credentials: ICredentialsDb[] = await Container.get(CredentialsRepository).findBy(
-			flags.id ? { id: flags.id } : {},
-		);
+		const credentials: ICredentialsDb[] = await Container.get(CredentialsRepository).find({
+			where: this.getWhereFilter(flags),
+			relations: { shared: true },
+		});
 
 		if (flags.decrypted) {
 			for (let i = 0; i < credentials.length; i++) {
@@ -156,5 +161,17 @@ export class ExportCredentialsCommand extends BaseCommand<z.infer<typeof flagsSc
 	async catch(error: Error) {
 		this.logger.error('Error exporting credentials. See log messages for details.');
 		this.logger.error(error.message);
+	}
+
+	private getWhereFilter(flags: z.infer<typeof flagsSchema>) {
+		if (flags.id) {
+			return { id: flags.id };
+		}
+
+		if (flags.projectId) {
+			return { shared: { projectId: flags.projectId } };
+		}
+
+		return {};
 	}
 }

--- a/packages/cli/src/commands/export/workflow.ts
+++ b/packages/cli/src/commands/export/workflow.ts
@@ -22,6 +22,7 @@ const flagsSchema = z.object({
 		)
 		.optional(),
 	id: z.string().describe('The ID of the workflow to export').optional(),
+	projectId: z.string().describe('Export all workflows in the specified project').optional(),
 	output: z
 		.string()
 		.alias('o')
@@ -43,6 +44,7 @@ const flagsSchema = z.object({
 	description: 'Export workflows',
 	examples: [
 		'--all',
+		'--projectId=Ox8O54VQrmBrb4qL',
 		'--id=5 --output=file.json',
 		'--id=5 --version=abc-123-def',
 		'--id=5 --published',
@@ -73,13 +75,15 @@ export class ExportWorkflowsCommand extends BaseCommand<z.infer<typeof flagsSche
 			return;
 		}
 
-		if (!flags.all && !flags.id) {
-			this.logger.info('Either option "--all" or "--id" have to be set!');
+		const selectorCount = [flags.all, flags.id, flags.projectId].filter(Boolean).length;
+
+		if (selectorCount === 0) {
+			this.logger.info('One of "--all", "--id", or "--projectId" has to be set!');
 			return;
 		}
 
-		if (flags.all && flags.id) {
-			this.logger.info('You should either use "--all" or "--id" but never both!');
+		if (selectorCount > 1) {
+			this.logger.info('Use exactly one of "--all", "--id", or "--projectId".');
 			return;
 		}
 
@@ -115,7 +119,7 @@ export class ExportWorkflowsCommand extends BaseCommand<z.infer<typeof flagsSche
 		}
 
 		const workflows = await Container.get(WorkflowRepository).find({
-			where: flags.id ? { id: flags.id } : {},
+			where: this.getWhereFilter(flags),
 			relations: ['tags', 'shared', 'shared.project'],
 		});
 
@@ -171,6 +175,18 @@ export class ExportWorkflowsCommand extends BaseCommand<z.infer<typeof flagsSche
 	async catch(error: Error) {
 		this.logger.error('Error exporting workflows. See log messages for details.');
 		this.logger.debug(error.message);
+	}
+
+	private getWhereFilter(flags: z.infer<typeof flagsSchema>) {
+		if (flags.id) {
+			return { id: flags.id };
+		}
+
+		if (flags.projectId) {
+			return { shared: { projectId: flags.projectId } };
+		}
+
+		return {};
 	}
 }
 

--- a/packages/cli/test/integration/commands/export/credentials.test.ts
+++ b/packages/cli/test/integration/commands/export/credentials.test.ts
@@ -1,0 +1,69 @@
+import { createTeamProject, mockInstance, testDb } from '@n8n/backend-test-utils';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { ExportCredentialsCommand } from '@/commands/export/credentials';
+import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
+import { setupTestCommand } from '@test-integration/utils/test-command';
+
+import { createCredentials } from '../../shared/db/credentials';
+
+mockInstance(LoadNodesAndCredentials);
+
+const command = setupTestCommand(ExportCredentialsCommand);
+
+let testOutputDir: string;
+
+beforeEach(async () => {
+	await testDb.truncate(['CredentialsEntity', 'SharedCredentials']);
+	testOutputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'n8n-export-credentials-test-'));
+});
+
+afterEach(() => {
+	if (fs.existsSync(testOutputDir)) {
+		fs.rmSync(testOutputDir, { recursive: true, force: true });
+	}
+});
+
+test('should reject --all with --projectId', async () => {
+	const project = await createTeamProject();
+	const outputFile = path.join(testOutputDir, 'output.json');
+
+	await command.run(['--all', `--projectId=${project.id}`, `--output=${outputFile}`]);
+
+	expect(fs.existsSync(outputFile)).toBe(false);
+});
+
+test('should reject --id with --projectId', async () => {
+	const project = await createTeamProject();
+	const credential = await createCredentials({ name: 'My credential', type: 'test', data: '' });
+	const outputFile = path.join(testOutputDir, 'output.json');
+
+	await command.run([
+		`--id=${credential.id}`,
+		`--projectId=${project.id}`,
+		`--output=${outputFile}`,
+	]);
+
+	expect(fs.existsSync(outputFile)).toBe(false);
+});
+
+test('should export credentials by project with --projectId', async () => {
+	const projectA = await createTeamProject();
+	const projectB = await createTeamProject();
+	const credentialInProjectA = await createCredentials(
+		{ name: 'Project A credential', type: 'test', data: '' },
+		projectA,
+	);
+	await createCredentials({ name: 'Project B credential', type: 'test', data: '' }, projectB);
+
+	const outputFile = path.join(testOutputDir, 'output.json');
+	await command.run([`--projectId=${projectA.id}`, `--output=${outputFile}`]);
+
+	const exportedData = JSON.parse(fs.readFileSync(outputFile, 'utf-8'));
+
+	expect(exportedData).toHaveLength(1);
+	expect(exportedData[0].id).toBe(credentialInProjectA.id);
+	expect(exportedData[0].name).toBe('Project A credential');
+});

--- a/packages/cli/test/integration/commands/export/workflow.test.ts
+++ b/packages/cli/test/integration/commands/export/workflow.test.ts
@@ -4,6 +4,7 @@ import {
 	createWorkflowWithTriggerAndHistory,
 	setActiveVersion,
 	createWorkflowHistory,
+	createTeamProject,
 } from '@n8n/backend-test-utils';
 import { WorkflowRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
@@ -53,6 +54,44 @@ test('should reject --version with --all flag', async () => {
 	await command.run(['--all', `--version=${workflow.versionId}`, `--output=${outputFile}`]);
 
 	expect(fs.existsSync(outputFile)).toBe(false);
+});
+
+test('should reject --all with --projectId', async () => {
+	const project = await createTeamProject();
+	const outputFile = path.join(testOutputDir, 'output.json');
+
+	await command.run(['--all', `--projectId=${project.id}`, `--output=${outputFile}`]);
+
+	expect(fs.existsSync(outputFile)).toBe(false);
+});
+
+test('should reject --id with --projectId', async () => {
+	const project = await createTeamProject();
+	const workflow = await createWorkflowWithTriggerAndHistory();
+	const outputFile = path.join(testOutputDir, 'output.json');
+
+	await command.run([`--id=${workflow.id}`, `--projectId=${project.id}`, `--output=${outputFile}`]);
+
+	expect(fs.existsSync(outputFile)).toBe(false);
+});
+
+test('should export workflows by project with --projectId', async () => {
+	const projectA = await createTeamProject();
+	const projectB = await createTeamProject();
+	const workflowInProjectA = await createWorkflowWithTriggerAndHistory(
+		{ name: 'Project A workflow' },
+		projectA,
+	);
+	await createWorkflowWithTriggerAndHistory({ name: 'Project B workflow' }, projectB);
+
+	const outputFile = path.join(testOutputDir, 'output.json');
+	await command.run([`--projectId=${projectA.id}`, `--output=${outputFile}`]);
+
+	const exportedData = JSON.parse(fs.readFileSync(outputFile, 'utf-8'));
+
+	expect(exportedData).toHaveLength(1);
+	expect(exportedData[0].id).toBe(workflowInProjectA.id);
+	expect(exportedData[0].name).toBe('Project A workflow');
 });
 
 test('should export current draft version when no flags set', async () => {


### PR DESCRIPTION
## Summary

https://www.loom.com/share/d4687cc87f034dfa9b8fbbf3bbb223b1

Adds a `--projectId` flag to both `export:workflow` and `export:credentials` CLI commands, allowing users to export only resources belonging to a specific project without having to export everything and filter manually.

**New behaviour:**
- `--projectId=<id>` — export all resources owned/shared in that project
- `--all --projectId` — invalid, mutually exclusive
- `--id --projectId` — invalid, mutually exclusive
- Omitting `--projectId` keeps the existing behaviour (backward-compatible)

**How to test:**
1. Create a project and add some workflows/credentials to it
2. Run `n8n export:workflow --projectId=<id> --output=out.json` and verify only that project's workflows are exported
3. Run `n8n export:credentials --projectId=<id> --output=out.json` and verify only that project's credentials are exported
4. Run with `--all --projectId=<id>` and verify it returns an error

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-481

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI