### PR TITLE
ci: Adjusts Docker builds for Colima compatibility

### DIFF
--- a/scripts/dockerize-n8n.mjs
+++ b/scripts/dockerize-n8n.mjs
@@ -86,6 +86,22 @@ async function isDockerPodmanShim() {
 		return false;
 	}
 }
+
+/**
+ * Get the driver of the currently selected buildx builder ('docker', 'docker-container', etc).
+ * Colima defaults to the 'docker' driver, which doesn't support buildkit-container flags
+ * like `--load` or `--provenance=false`.
+ * @returns {Promise<string|null>}
+ */
+async function getBuildxDriver() {
+	try {
+		const { stdout } = await $`docker buildx inspect`;
+		const match = stdout.match(/Driver:\s+(\S+)/);
+		return match ? match[1] : null;
+	} catch {
+		return null;
+	}
+}
 /**
  * @returns {Promise<(typeof SupportedContainerEngines[number])>}
  */
@@ -268,9 +284,23 @@ async function buildDockerImage({ name, dockerfilePath, fullImageName, buildArgs
 		echo(chalk.yellow(`INFO: Registry detected - pushing directly to ${fullImageName}`));
 	}
 
+	const buildxDriver = containerEngine === 'docker' ? await getBuildxDriver() : null;
+	const useLegacyDockerBuild = containerEngine === 'docker' && buildxDriver === 'docker';
+
 	try {
 		if (containerEngine === 'podman') {
 			const { stdout } = await $`podman build \
+				--platform ${platform} \
+				--build-arg TARGETPLATFORM=${platform} \
+				${extraFlags} \
+				-t ${fullImageName} \
+				-f ${dockerfilePath} \
+				${config.buildContext}`;
+			echo(stdout);
+		} else if (useLegacyDockerBuild) {
+			// Buildx 'docker' driver (colima default) doesn't support `--load` or
+			// `--provenance=false`. Use plain `docker build` instead.
+			const { stdout } = await $`docker build \
 				--platform ${platform} \
 				--build-arg TARGETPLATFORM=${platform} \
 				${extraFlags} \


### PR DESCRIPTION
## Summary

Detects if the active buildx driver is 'docker' (Colima's default) and falls back to a standard `docker build`. The 'docker' buildx driver does not support certain buildkit-container flags like `--load` or `--provenance=false`, which were causing failures for local builds using Colima.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
