### PR TITLE
fix: Fixes redirect bug on AI Assistant caused by settings evaluation sync issue (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-ai/instance-ai.module.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.module.ts
@@ -44,7 +44,7 @@ export class InstanceAiModule implements ModuleInterface {
 		const globalConfig = Container.get(GlobalConfig);
 		const service = Container.get(InstanceAiService);
 		const settingsService = Container.get(InstanceAiSettingsService);
-		const enabled = service.isEnabled();
+		const enabled = settingsService.isAgentEnabled();
 		const localGatewayDisabled = settingsService.isLocalGatewayDisabled();
 		const optinModalDismissed = settingsService.getAdminSettings().optinModalDismissed;
 		return {


### PR DESCRIPTION
## Summary
Fixes a bug where users opting into AI Assistant for the first time get redirected to `/home/workflows` shortly after sending their first prompt.

### Root cause
The route guard for the AI Assistant view reads `settingsStore.moduleSettings['instance-ai'].enabled`. That value is set from two different backend sources, which were not in sync:
- `PUT /instance-ai/settings` (called when the user opts in)
- `GET /module-settings` (called on `InstanceAiView` mount via `refreshModuleSettings()`) returns `service.isEnabled()`, which has a `!!instanceAiConfig.model` condition.

In deployments where the model is supplied by the proxy / AI service rather than via local config, `N8N_INSTANCE_AI_MODEL` is empty. That makes `service.isEnabled()` return `false` even right after a successful opt-in.

## Related Linear tickets, Github issues, and Community forum posts
- Solves : https://linear.app/n8n/issue/GRO-291/user-gets-navigated-away-from-instance-ai-without-doing-anything
- Impacted user recording : https://eu.posthog.com/project/122356/replay/019dced5-b414-7a3d-a5d6-e78036afb390?t=0

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
