### PR TITLE
fix(core): Widen zod peer dependency range in published packages (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/package.json
+++ b/packages/@n8n/api-types/package.json
@@ -36,6 +36,6 @@
     "@n8n/permissions": "workspace:*"
   },
   "peerDependencies": {
-    "zod": "catalog:"
+    "zod": ">=3.25.0 <4"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,7 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
-    "zod": "catalog:"
+    "zod": ">=3.25.0 <4"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "3.808.0",

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -73,6 +73,6 @@
     "jsonrepair": "catalog:"
   },
   "peerDependencies": {
-    "zod": "catalog:"
+    "zod": ">=3.25.0 <4"
   }
 }


### PR DESCRIPTION
## Summary

Replace the exact `catalog:` (`zod@3.25.67`) peer-dependency pin in the published packages `n8n-workflow`, `n8n-core`, and `@n8n/api-types` with a real semver range: `">=3.25.0 <4"`.

### Why

PR #28604 correctly moved `zod` to `peerDependencies` in these three packages to enforce a single zod instance across the workspace. The peer was declared as `"catalog:"`, which gets published as the exact catalog version (`3.25.67`).

That exact pin is what we want for our own builds, but it is not how package managers act on a peer:

- pnpm/npm/yarn treat an exact version as a single point. Consumers whose graph also pulls in an older zod (e.g. `3.24.x` via another transitive) **silently satisfy** the peer and only emit a warning.
- Our published code does `import … from 'zod/v4'` (the subpath was added in zod 3.25.0), so installs that resolve to an older zod fail at runtime with a cryptic `Package subpath './v4' is not defined by "exports"` deep inside `require-in-the-middle`. We've been seeing this in production via Sentry alerts on `creators-nodes-sync`.

Widening the peer to `">=3.25.0 <4"`:

- Communicates the actual runtime contract (anything from 3.25.0 up to but not including 4.0.0).
- Lets `pnpm install --strict-peer-dependencies` *fail* on a too-old zod instead of just warning.
- Makes the warning text package managers emit actually actionable.

### Downstream remediation

Consumers seeing the cryptic error today (e.g. `creators-nodes-sync`) should pin zod via `package.json`:

```json
"pnpm": {
  "overrides": {
    "zod": "3.25.67"
  }
}
```

…or the equivalent `overrides` (npm) / `resolutions` (yarn) idiom, then reinstall.

### What this PR is *not*

An earlier draft of this PR also added a load-time runtime guard inside `n8n-workflow` to throw a clearer error if the consumer's resolved zod was too old. Self-review uncovered that the guard:

1. broke the `n8n-workflow` CJS build (`resolveJsonModule: false` is set in `@n8n/typescript-config/modern/tsconfig.cjs.json`, so `import 'zod/package.json'` did not compile), and
2. would, even if compiled, fail at runtime in the ESM build on Node ≥ 22 because emitted JSON imports require `with { type: 'json' }` import attributes.

It was reverted. The peer-range change alone is the smaller, safer win. We can revisit a runtime guard later (likely via `createRequire` + filesystem read, with a built-artifact integration test) if needed.

## Related Linear tickets, Github issues, and Community forum posts

Sentry alert: `creators-nodes-sync` — issue [`7440848191`](https://n8nio.sentry.io/issues/7440848191/) (`Module.patchedRequire(require-in-the-middle:index)` — `Package subpath './v4' is not defined by "exports"` in `n8n-workflow@2.18.3_zod@3.24.2`).

Follows up on #28604.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. _(N/A — peer-dep range string change; no logic change. `pnpm test`, `pnpm lint`, `pnpm typecheck`, and `pnpm build` in `packages/workflow` are all clean. `pnpm install` produces no lockfile diff.)_
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

Made with [Cursor](https://cursor.com)