### PR TITLE
fix(core): Reset Redis retry counter on successful reconnect

### DIFF
--- a/packages/cli/src/services/__tests__/redis-client.service.test.ts
+++ b/packages/cli/src/services/__tests__/redis-client.service.test.ts
@@ -122,5 +122,130 @@ describe('RedisClientService', () => {
 			handlers.get('ready')!();
 			expect(service.isConnected()).toBe(true);
 		});
+
+		it("should not reset another client's retry state when one client recovers", () => {
+			const T0 = 1_700_000_000_000;
+			const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(T0);
+			const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+			const service = new RedisClientService(logger, globalConfig);
+			service.createClient({ type: 'client(bull)' });
+			service.createClient({ type: 'subscriber(bull)' });
+
+			const retryA = mockedRedis.mock.calls[0][0].retryStrategy as () => number;
+
+			const mockClientB = mockedRedis.mock.results[1].value;
+			const handlersB = new Map<string, EventHandler>();
+			jest.mocked(mockClientB.on).mock.calls.forEach(([event, handler]: [string, EventHandler]) => {
+				handlersB.set(event, handler);
+			});
+
+			// Client A retries, building up cumulative timeout.
+			dateNowSpy.mockReturnValue(T0 + 1_000);
+			retryA();
+			dateNowSpy.mockReturnValue(T0 + 2_000);
+			retryA();
+			dateNowSpy.mockReturnValue(T0 + 3_000);
+			retryA();
+
+			// Client B reconnects. Must not affect Client A's retry state.
+			dateNowSpy.mockReturnValue(T0 + 4_000);
+			handlersB.get('ready')!();
+
+			// Client A continues failing past the threshold. Should still exit.
+			dateNowSpy.mockReturnValue(T0 + 12_001);
+			retryA();
+
+			expect(exitSpy).toHaveBeenCalledWith(1);
+
+			dateNowSpy.mockRestore();
+			exitSpy.mockRestore();
+		});
+
+		it("should reset each client's retry state on its own ready, regardless of aggregate state", () => {
+			const T0 = 1_700_000_000_000;
+			const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(T0);
+			const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+			const service = new RedisClientService(logger, globalConfig);
+			service.createClient({ type: 'client(bull)' });
+			service.createClient({ type: 'subscriber(bull)' });
+
+			const retryA = mockedRedis.mock.calls[0][0].retryStrategy as () => number;
+			const retryB = mockedRedis.mock.calls[1][0].retryStrategy as () => number;
+
+			const handlersA = new Map<string, EventHandler>();
+			jest
+				.mocked(mockedRedis.mock.results[0].value.on)
+				.mock.calls.forEach(([event, handler]: [string, EventHandler]) => {
+					handlersA.set(event, handler);
+				});
+			const handlersB = new Map<string, EventHandler>();
+			jest
+				.mocked(mockedRedis.mock.results[1].value.on)
+				.mock.calls.forEach(([event, handler]: [string, EventHandler]) => {
+					handlersB.set(event, handler);
+				});
+
+			// Both clients enter retry. B accumulates state.
+			dateNowSpy.mockReturnValue(T0 + 1_000);
+			retryA();
+			retryB();
+			dateNowSpy.mockReturnValue(T0 + 2_000);
+			retryB();
+
+			// A recovers first — flips lostConnection to false.
+			dateNowSpy.mockReturnValue(T0 + 3_000);
+			handlersA.get('ready')!();
+
+			// B recovers. Per-client reset must run even though lostConnection is already false.
+			dateNowSpy.mockReturnValue(T0 + 4_000);
+			handlersB.get('ready')!();
+
+			// B disconnects again at 15s. Without per-client reset, B carries stale state from
+			// window 1, the 13s healthy interval gets billed to cumulative, and the process exits.
+			dateNowSpy.mockReturnValue(T0 + 15_000);
+			retryB();
+
+			expect(exitSpy).not.toHaveBeenCalled();
+
+			dateNowSpy.mockRestore();
+			exitSpy.mockRestore();
+		});
+
+		it('should not exit when a new disconnect occurs after recovery within the reset window', () => {
+			const T0 = 1_700_000_000_000;
+			const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(T0);
+			const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+			const service = new RedisClientService(logger, globalConfig);
+			service.createClient({ type: 'client(bull)' });
+
+			const mockClient = mockedRedis.mock.results[0].value;
+			const handlers = new Map<string, EventHandler>();
+			jest.mocked(mockClient.on).mock.calls.forEach(([event, handler]: [string, EventHandler]) => {
+				handlers.set(event, handler);
+			});
+
+			const callArgs = mockedRedis.mock.calls[0][0];
+			const retryStrategy = callArgs.retryStrategy as () => number;
+
+			// Disconnect window 1: drop at 10s, retry fails at 11s, recover at 12s
+			dateNowSpy.mockReturnValue(T0 + 10_000);
+			retryStrategy();
+			dateNowSpy.mockReturnValue(T0 + 11_000);
+			retryStrategy();
+			dateNowSpy.mockReturnValue(T0 + 12_000);
+			handlers.get('ready')!();
+
+			// Disconnect window 2: drop at 25s, within 30s of the last failed retry.
+			dateNowSpy.mockReturnValue(T0 + 25_000);
+			retryStrategy();
+
+			expect(exitSpy).not.toHaveBeenCalled();
+
+			dateNowSpy.mockRestore();
+			exitSpy.mockRestore();
+		});
 	});
 });

--- a/packages/cli/src/services/redis-client.service.ts
+++ b/packages/cli/src/services/redis-client.service.ts
@@ -14,6 +14,14 @@ type RedisEventMap = {
 	'connection-recovered': never;
 };
 
+/** Function called by ioredis on each failed reconnect. Returns ms to wait before the next attempt. */
+type RetryStrategy = () => number;
+
+type RedisClientCreateOptions = {
+	type: RedisClientType;
+	extraOptions?: RedisOptions;
+};
+
 const RECONNECT_AND_RETRY = 2;
 const DO_NOT_RECONNECT = false;
 
@@ -50,11 +58,13 @@ export class RedisClientService extends TypedEmitter<RedisEventMap> {
 		return !this.lostConnection;
 	}
 
-	createClient(arg: { type: RedisClientType; extraOptions?: RedisOptions }) {
+	createClient(options: RedisClientCreateOptions) {
+		const { retryStrategy, resetRetryState } = this.makeRetryStrategy();
+
 		const client =
 			this.clusterNodes().length > 0
-				? this.createClusterClient(arg)
-				: this.createRegularClient(arg);
+				? this.createClusterClient(options, retryStrategy)
+				: this.createRegularClient(options, retryStrategy);
 
 		client.on('error', (error: Error) => {
 			if ('code' in error && error.code === 'ECONNREFUSED') return; // handled by retryStrategy
@@ -63,6 +73,7 @@ export class RedisClientService extends TypedEmitter<RedisEventMap> {
 		});
 
 		client.on('ready', () => {
+			resetRetryState();
 			if (this.lostConnection) {
 				this.emit('connection-recovered');
 				this.lostConnection = false;
@@ -91,14 +102,11 @@ export class RedisClientService extends TypedEmitter<RedisEventMap> {
 	//            private
 	// ----------------------------------
 
-	private createRegularClient({
-		type,
-		extraOptions,
-	}: {
-		type: RedisClientType;
-		extraOptions?: RedisOptions;
-	}) {
-		const options = this.getOptions({ extraOptions });
+	private createRegularClient(
+		{ type, extraOptions }: RedisClientCreateOptions,
+		retryStrategy: RetryStrategy,
+	) {
+		const options = this.getOptions({ extraOptions, retryStrategy });
 
 		const { host, port } = this.globalConfig.queue.bull.redis;
 
@@ -112,18 +120,15 @@ export class RedisClientService extends TypedEmitter<RedisEventMap> {
 		return client;
 	}
 
-	private createClusterClient({
-		type,
-		extraOptions,
-	}: {
-		type: string;
-		extraOptions?: RedisOptions;
-	}) {
-		const options = this.getOptions({ extraOptions });
+	private createClusterClient(
+		{ type, extraOptions }: RedisClientCreateOptions,
+		retryStrategy: RetryStrategy,
+	) {
+		const options = this.getOptions({ extraOptions, retryStrategy });
 
 		const clusterNodes = this.clusterNodes();
 
-		const clusterOptions = this.getClusterOptions(options, this.retryStrategy());
+		const clusterOptions = this.getClusterOptions(options, retryStrategy);
 
 		const clusterClient = new ioRedis.Cluster(clusterNodes, clusterOptions);
 
@@ -132,7 +137,13 @@ export class RedisClientService extends TypedEmitter<RedisEventMap> {
 		return clusterClient;
 	}
 
-	private getOptions({ extraOptions }: { extraOptions?: RedisOptions }) {
+	private getOptions({
+		extraOptions,
+		retryStrategy,
+	}: {
+		extraOptions?: RedisOptions;
+		retryStrategy: RetryStrategy;
+	}) {
 		const {
 			username,
 			password,
@@ -161,7 +172,7 @@ export class RedisClientService extends TypedEmitter<RedisEventMap> {
 			db,
 			enableReadyCheck: false,
 			maxRetriesPerRequest: null,
-			retryStrategy: this.retryStrategy(),
+			retryStrategy,
 			...extraOptions,
 		};
 
@@ -190,10 +201,7 @@ export class RedisClientService extends TypedEmitter<RedisEventMap> {
 		return options;
 	}
 
-	private getClusterOptions(
-		options: RedisOptions,
-		retryStrategy: () => number | null,
-	): ClusterOptions {
+	private getClusterOptions(options: RedisOptions, retryStrategy: RetryStrategy): ClusterOptions {
 		const { slotsRefreshTimeout, slotsRefreshInterval, dnsResolveStrategy } =
 			this.globalConfig.queue.bull.redis;
 		const clusterOptions: ClusterOptions = {
@@ -213,17 +221,17 @@ export class RedisClientService extends TypedEmitter<RedisEventMap> {
 	}
 
 	/**
-	 * Strategy to retry connecting to Redis on connection failure.
+	 * Builds a per-client retry strategy and reset hook.
 	 *
-	 * Try to reconnect every 500ms. On every failed attempt, increment a timeout
-	 * counter - if the cumulative timeout exceeds a limit, exit the process.
-	 * Reset the cumulative timeout if >30s between reconnection attempts.
+	 * On every failed attempt, increment a timeout counter - if the cumulative
+	 * timeout exceeds a limit, exit the process. Reset the cumulative timeout
+	 * on successful reconnect or if >30s between reconnection attempts.
 	 */
-	private retryStrategy() {
+	private makeRetryStrategy(): { retryStrategy: RetryStrategy; resetRetryState: () => void } {
 		let lastAttemptTs = 0;
 		let cumulativeTimeout = 0;
 
-		return () => {
+		const retryStrategy: RetryStrategy = () => {
 			const nowTs = Date.now();
 
 			if (nowTs - lastAttemptTs > this.config.resetLength) {
@@ -245,6 +253,13 @@ export class RedisClientService extends TypedEmitter<RedisEventMap> {
 
 			return this.config.retryInterval;
 		};
+
+		const resetRetryState = () => {
+			lastAttemptTs = 0;
+			cumulativeTimeout = 0;
+		};
+
+		return { retryStrategy, resetRetryState };
 	}
 
 	private clusterNodes() {


### PR DESCRIPTION
## Summary

The Redis retry strategy state persisted across disconnect windows, so a disconnect was leaving behind `lastAttemptTs` and `cumulativeTimeout`, and the next disconnect within 30s was absorbing the entire intervening healthy interval as accumulated retry time, leading to tripping the threshold and exiting the process.

This PR resets each client's retry state on its own `'ready'` event. The reset is per-client, so one client recovering doesn't wipe another client's budget. It is also unconditional on the aggregate `lostConnection` flag, so a second client reconnecting after the first still resets its own state.

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C0789EN39RC/p1777363701100569

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`