### PR TITLE
fix(editor): Fix collapse/expand for Chat sidebar

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatSidebar.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatSidebar.vue
@@ -15,8 +15,15 @@ import ChatSidebarContent from '@/features/ai/chatHub/components/ChatSidebarCont
 const i18n = useI18n();
 const router = useRouter();
 
-const { isCollapsed, sidebarWidth, onResizeStart, onResize, onResizeEnd, toggleCollapse } =
-	useSidebarLayout();
+const {
+	isCollapsed,
+	isResizing,
+	sidebarWidth,
+	onResizeStart,
+	onResize,
+	onResizeEnd,
+	toggleCollapse,
+} = useSidebarLayout();
 
 function openCommandBar(event: MouseEvent) {
 	event.stopPropagation();
@@ -64,6 +71,7 @@ const onLogout = () => {
 		:class="{
 			[$style.sideMenu]: true,
 			[$style.sideMenuCollapsed]: isCollapsed,
+			[$style.sideMenuResizing]: isResizing,
 		}"
 		:width="sidebarWidth"
 		:style="isCollapsed ? {} : { width: `${sidebarWidth}px` }"
@@ -98,10 +106,16 @@ const onLogout = () => {
 	flex-direction: column;
 	border-right: var(--border);
 	background-color: var(--menu--color--background, var(--color--background--light-2));
+	transition: width var(--duration--snappy) var(--easing--ease-out);
+	will-change: width;
 
 	&.sideMenuCollapsed {
 		width: $sidebar-width;
 		min-width: auto;
+	}
+
+	&.sideMenuResizing {
+		transition: none;
 	}
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatSidebar.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatSidebar.vue
@@ -66,7 +66,7 @@ const onLogout = () => {
 			[$style.sideMenuCollapsed]: isCollapsed,
 		}"
 		:width="sidebarWidth"
-		:style="{ width: `${sidebarWidth}px` }"
+		:style="isCollapsed ? {} : { width: `${sidebarWidth}px` }"
 		:supported-directions="['right']"
 		:min-width="200"
 		:max-width="500"


### PR DESCRIPTION
## Summary

Let the Chat Hub sidebar collapsed styles control the sidebar width instead of keeping the expanded inline width applied.

This updates `ChatSidebar.vue` so the inline `width` style is only applied while the sidebar is expanded. When collapsed, the component no longer overrides the `.sideMenuCollapsed` width rule, which keeps the `/chat` layout from breaking.

https://github.com/user-attachments/assets/bfdc8d93-097d-456d-9cf8-d29a8041f793

## Related Linear tickets, Github issues, and Community forum posts

[CHA-172](https://linear.app/n8n/issue/CHA-172)

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](<../blob/master/.github/pull_request_title_conventions.md>))
- [ ] [Docs updated](<https://github.com/n8n-io/n8n-docs>) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)