### PR TITLE
fix(eventbus): ignore unfinished executions from aborted log parses

### DIFF
--- a/packages/cli/src/eventbus/message-event-bus-writer/__tests__/message-event-bus-log-writer.test.ts
+++ b/packages/cli/src/eventbus/message-event-bus-writer/__tests__/message-event-bus-log-writer.test.ts
@@ -86,6 +86,7 @@ describe('MessageEventBusLogWriter.readLoggedMessagesFromFile', () => {
 
 		expect(results.loggedMessages.length).toBeLessThan(100);
 		expect(results.loggedMessages.length).toBeLessThanOrEqual(maxMessagesPerParse + 1);
+		expect(results.unfinishedExecutions).toEqual({});
 		expect(logger.warn).toHaveBeenCalledWith(
 			expect.stringContaining('exceeded 5 in-memory messages during parse'),
 		);

--- a/packages/cli/src/eventbus/message-event-bus-writer/message-event-bus-log-writer.ts
+++ b/packages/cli/src/eventbus/message-event-bus-writer/message-event-bus-log-writer.ts
@@ -227,6 +227,12 @@ export class MessageEventBusLogWriter {
 				const maxTotalMessagesPerFile =
 					this.globalConfig.eventBus.logWriter.maxTotalMessagesPerFile;
 				const baselineCount = results.loggedMessages.length;
+				const baselineUnfinishedExecutions = Object.fromEntries(
+					Object.entries(results.unfinishedExecutions).map(([executionId, messages]) => [
+						executionId,
+						[...messages],
+					]),
+				);
 				let aborted = false;
 				// Stack-local counters: aggregate malformed lines into a single warn at
 				// the end of the parse pass. Each per-line error log allocates the raw
@@ -272,6 +278,9 @@ export class MessageEventBusLogWriter {
 				});
 				// wait for stream to finish before continue
 				await eventOnce(rl, 'close');
+				if (aborted) {
+					results.unfinishedExecutions = baselineUnfinishedExecutions;
+				}
 				if (parseSkipped > 0) {
 					this.logger.warn(
 						`Event log parse skipped ${parseSkipped} malformed line(s) in ${logFileName}. Sample (truncated): ${parseSkippedSample}`,


### PR DESCRIPTION
## Summary
- restore the unfinished execution recovery map when a log file parse is aborted by the safety guard
- keep partial unsent messages behavior unchanged while preventing aborted files from leaking incomplete recovery evidence
- add regression coverage for aborted oversized log parses

## Testing
- git diff --check
- pnpm --filter n8n test:unit -- message-event-bus-log-writer.test.ts --runInBand (blocked locally: node_modules missing / jest not installed in this checkout)

## Notes
This prevents a partially parsed oversized event log from leaving unfinishedExecutions entries that can later be consumed as crash-recovery evidence.