### PR TITLE
fix: the jwt node in jwt in Jwt.node.ts

### DIFF
--- a/packages/nodes-base/nodes/Jwt/Jwt.node.ts
+++ b/packages/nodes-base/nodes/Jwt/Jwt.node.ts
@@ -416,8 +416,13 @@ export class Jwt implements INodeType {
 
 					const { ignoreExpiration, ignoreNotBefore, clockTolerance, complete } = options;
 
+					const algorithm = options.algorithm || credentials.algorithm;
+					if (!algorithm) {
+						throw new NodeOperationError(this.getNode(), 'Algorithm must be specified for JWT verification', { itemIndex });
+					}
+
 					const data = jwt.verify(token, secretOrPublicKey, {
-						algorithms: [options.algorithm ?? credentials.algorithm],
+						algorithms: [algorithm],
 						ignoreExpiration,
 						ignoreNotBefore,
 						clockTolerance,


### PR DESCRIPTION
## Summary
Fix medium severity security issue in `packages/nodes-base/nodes/Jwt/Jwt.node.ts`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | MEDIUM |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `packages/nodes-base/nodes/Jwt/Jwt.node.ts:430` |

**Description**: The JWT node in Jwt.node.ts performs token verification operations without confirmed enforcement of an algorithm allowlist. If the underlying jwt.verify() call does not explicitly restrict accepted algorithms, an attacker can exploit two well-known JWT vulnerabilities: (1) the 'alg:none' attack, where a token with no signature is accepted as valid; and (2) the RS256-to-HS256 confusion attack, where an attacker signs a token with HS256 using the server's RSA public key as the HMAC secret. Both attacks allow complete forgery of JWT tokens with arbitrary payloads.

## Changes
- `packages/nodes-base/nodes/Jwt/Jwt.node.ts`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
