### PR TITLE
fix(core): Correct LDAP search filter construction

### DIFF
--- a/packages/cli/src/modules/ldap.ee/__tests__/helpers.test.ts
+++ b/packages/cli/src/modules/ldap.ee/__tests__/helpers.test.ts
@@ -8,6 +8,63 @@ import * as helpers from '../helpers.ee';
 const userRepository = mockInstance(UserRepository);
 
 describe('Ldap/helpers', () => {
+	describe('createFilter', () => {
+		test('should wrap the inner filter with the default objectClass discriminator when no userFilter is configured', () => {
+			const result = helpers.createFilter('(uid=alice)', '');
+
+			expect(result).toBe('(&(|(objectClass=person)(objectClass=user))(uid=alice))');
+		});
+
+		test('should produce a balanced filter when userFilter is configured', () => {
+			const result = helpers.createFilter('(uid=alice)', '(objectClass=inetOrgPerson)');
+
+			expect(result).toBe('(&(objectClass=inetOrgPerson)(uid=alice))');
+			// Sanity check: every opening paren has a matching closing paren.
+			const opens = (result.match(/\(/g) ?? []).length;
+			const closes = (result.match(/\)/g) ?? []).length;
+			expect(opens).toBe(closes);
+		});
+
+		test('should fall through to the default discriminator when userFilter is empty', () => {
+			const result = helpers.createFilter('(uid=alice)', '');
+
+			expect(result).toContain('(|(objectClass=person)(objectClass=user))');
+		});
+
+		test('should interpolate the inner filter verbatim (caller is responsible for escaping)', () => {
+			// The contract: the caller passes an already-escaped filter fragment.
+			// createFilter must not re-escape or mutate it.
+			const preEscaped = '(uid=alice\\2a)';
+			const result = helpers.createFilter(preEscaped, '');
+
+			expect(result).toContain(preEscaped);
+		});
+	});
+
+	describe('escapeFilter', () => {
+		test.each([
+			['*', '\\2a'],
+			['(', '\\28'],
+			[')', '\\29'],
+			['\\', '\\5c'],
+			['\0', '\\00'],
+		])('should escape %p as %p', (input, expected) => {
+			expect(helpers.escapeFilter(input)).toBe(expected);
+		});
+
+		test('should escape combined special characters in a single string', () => {
+			expect(helpers.escapeFilter('alice*')).toBe('alice\\2a');
+			expect(helpers.escapeFilter('*)(uid=*')).toBe('\\2a\\29\\28uid=\\2a');
+			expect(helpers.escapeFilter('alice\\)')).toBe('alice\\5c\\29');
+		});
+
+		test('should pass through strings without special characters unchanged', () => {
+			expect(helpers.escapeFilter('alice')).toBe('alice');
+			expect(helpers.escapeFilter('')).toBe('');
+			expect(helpers.escapeFilter('user@example.com')).toBe('user@example.com');
+		});
+	});
+
 	describe('updateLdapUserOnLocalDb', () => {
 		// We need to use `save` so that that the subscriber in
 		// packages/@n8n/db/src/entities/Project.ts receives the full user.

--- a/packages/cli/src/modules/ldap.ee/__tests__/ldap.service.test.ts
+++ b/packages/cli/src/modules/ldap.ee/__tests__/ldap.service.test.ts
@@ -1012,6 +1012,66 @@ describe('LdapService', () => {
 
 			expect(result).toEqual(foundUsers[0]);
 		});
+
+		describe('filter construction', () => {
+			const captureFilter = () => {
+				const search = jest.fn().mockResolvedValue({ searchEntries: [] });
+				Client.prototype.search = search;
+				return () => {
+					expect(search).toHaveBeenCalledTimes(1);
+					const [, options] = search.mock.calls[0];
+					return options.filter as string;
+				};
+			};
+
+			it.each([
+				{ input: 'alice', expectedSnippet: '(uid=alice)' },
+				{ input: 'alice*', expectedSnippet: '(uid=alice\\2a)' },
+				{ input: '*)(uid=*', expectedSnippet: '(uid=\\2a\\29\\28uid=\\2a)' },
+				{ input: 'alice\\)', expectedSnippet: '(uid=alice\\5c\\29)' },
+				{ input: 'alice\0admin', expectedSnippet: '(uid=alice\\00admin)' },
+			])(
+				'should escape special characters in the loginId search filter for input %p',
+				async ({ input, expectedSnippet }) => {
+					const ldapService = createDefaultLdapService({ ...ldapConfig, userFilter: '' });
+					const getCaptured = captureFilter();
+
+					(getLdapIds as jest.Mock).mockResolvedValue([]);
+
+					await ldapService.init();
+					await ldapService.findAndAuthenticateLdapUser(
+						input,
+						'fakePassword',
+						ldapConfig.loginIdAttribute,
+						'',
+					);
+
+					expect(getCaptured()).toContain(expectedSnippet);
+				},
+			);
+
+			it('should preserve the configured userFilter when constructing the loginId filter', async () => {
+				const userFilter = '(objectClass=inetOrgPerson)';
+				const ldapService = createDefaultLdapService({ ...ldapConfig, userFilter });
+				const getCaptured = captureFilter();
+
+				(getLdapIds as jest.Mock).mockResolvedValue([]);
+
+				await ldapService.init();
+				await ldapService.findAndAuthenticateLdapUser(
+					'alice',
+					'fakePassword',
+					ldapConfig.loginIdAttribute,
+					userFilter,
+				);
+
+				const filter = getCaptured();
+				expect(filter).toBe('(&(objectClass=inetOrgPerson)(uid=alice))');
+				const opens = (filter.match(/\(/g) ?? []).length;
+				const closes = (filter.match(/\)/g) ?? []).length;
+				expect(opens).toBe(closes);
+			});
+		});
 	});
 
 	describe('testConnection()', () => {
@@ -1661,6 +1721,45 @@ describe('LdapService', () => {
 
 				const result = await ldapService.handleLogin('jdoe', 'password');
 				expect(result).toBeUndefined();
+			});
+		});
+
+		describe('filter construction', () => {
+			it('should escape special characters in the email duplicate-check filter', async () => {
+				const trickyEmail = 'eve*)(uid=admin@example.com';
+				const ldapService = createDefaultLdapService({
+					...ldapConfig,
+					enforceEmailUniqueness: true,
+				});
+
+				const search = jest
+					.fn()
+					.mockResolvedValueOnce({
+						searchEntries: [
+							{
+								dn: 'uid=eve,ou=users,dc=example,dc=com',
+								cn: 'Eve',
+								mail: trickyEmail,
+								uid: 'eve',
+							},
+						],
+					})
+					.mockResolvedValueOnce({ searchEntries: [] });
+				Client.prototype.search = search;
+
+				(getAuthIdentityByLdapId as jest.Mock).mockResolvedValue(null);
+				(getUserByEmail as jest.Mock).mockResolvedValue(null);
+				(createLdapUserOnLocalDb as jest.Mock).mockResolvedValue(mock<User>());
+
+				await ldapService.init();
+				await ldapService.handleLogin('eve', 'password');
+
+				expect(search).toHaveBeenCalledTimes(2);
+				const [, secondCallOptions] = search.mock.calls[1];
+				const emailFilter = secondCallOptions.filter as string;
+
+				expect(emailFilter).toContain('eve\\2a\\29\\28uid=admin@example.com');
+				expect(emailFilter).not.toContain(trickyEmail);
 			});
 		});
 	});

--- a/packages/cli/src/modules/ldap.ee/helpers.ee.ts
+++ b/packages/cli/src/modules/ldap.ee/helpers.ee.ts
@@ -47,7 +47,7 @@ export const resolveBinaryAttributes = (entries: LdapUser[]): void => {
 export const createFilter = (filter: string, userFilter: string) => {
 	let _filter = `(&(|(objectClass=person)(objectClass=user))${filter})`;
 	if (userFilter) {
-		_filter = `(&${userFilter}${filter}`;
+		_filter = `(&${userFilter}${filter})`;
 	}
 	return _filter;
 };


### PR DESCRIPTION
## Summary

Two related changes to the LDAP SSO module in `packages/cli/src/modules/ldap.ee`:

- **Fix**: `createFilter` now produces a balanced filter when an admin-configured `userFilter` is set. Previously the resulting expression was missing a closing `)`, so any deployment with `userFilter` configured was sending a malformed filter to the LDAP server.
- **Tests**: Added regression coverage for `createFilter` (filter shape, balanced parens, default discriminator, verbatim interpolation contract) and `escapeFilter` (RFC 4515 escape sequences for `*`, `(`, `)`, `\`, `\0`, plus combined inputs). Extended the service-level tests with parameterized payloads against `findAndAuthenticateLdapUser` and `handleLogin`'s email-duplicate path, asserting on the actual filter string passed to `client.search()` rather than re-using the same helper on both sides of the assertion.

### Behaviour to verify on QA

Deployments that have a `userFilter` configured (e.g. `(objectClass=inetOrgPerson)`) were previously receiving a syntactically invalid filter from n8n. After this change the filter is well-formed, which may change observed login or sync behaviour for those instances. Deployments without a `userFilter` are unaffected.

## Related

- Linear: https://linear.app/n8n/issue/IAM-592

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
