### PR TITLE
refactor(editor): Scope NDV store per workflow document (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -19,7 +19,7 @@ import { RemoveNodeCommand, ReplaceNodeParametersCommand } from '@/app/models/hi
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useHistoryStore } from '@/app/stores/history.store';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { getNDVStoreId, useNDVStore } from '@/features/ndv/shared/ndv.store';
 import {
 	createTestNode,
 	createTestNodeProperties,
@@ -178,7 +178,7 @@ describe('useCanvasOperations', () => {
 	function createInitialState() {
 		return {
 			[STORES.NODE_TYPES]: {},
-			[STORES.NDV]: {},
+			[getNDVStoreId(createWorkflowDocumentId('default'))]: {},
 			[STORES.WORKFLOWS]: {
 				workflowId,
 				workflow: mock<IWorkflowDb>({

--- a/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.test.ts
@@ -130,6 +130,7 @@ describe('usePostMessageHandler', () => {
 			const { setup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
 			});
 
 			setup();
@@ -142,6 +143,7 @@ describe('usePostMessageHandler', () => {
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
 			});
 
 			setup();
@@ -155,6 +157,7 @@ describe('usePostMessageHandler', () => {
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
 			});
 
 			setup();
@@ -172,6 +175,7 @@ describe('usePostMessageHandler', () => {
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
 			});
 
 			setup();
@@ -192,6 +196,7 @@ describe('usePostMessageHandler', () => {
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
 			});
 			setup();
 
@@ -215,6 +220,7 @@ describe('usePostMessageHandler', () => {
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
 			});
 			setup();
 
@@ -246,6 +252,7 @@ describe('usePostMessageHandler', () => {
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
 			});
 			setup();
 
@@ -277,6 +284,7 @@ describe('usePostMessageHandler', () => {
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
 			});
 			setup();
 
@@ -305,6 +313,7 @@ describe('usePostMessageHandler', () => {
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
 			});
 			setup();
 
@@ -330,6 +339,7 @@ describe('usePostMessageHandler', () => {
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
 			});
 			setup();
 
@@ -352,6 +362,7 @@ describe('usePostMessageHandler', () => {
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
 			});
 			setup();
 
@@ -385,6 +396,7 @@ describe('usePostMessageHandler', () => {
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
 			});
 			setup();
 
@@ -421,6 +433,7 @@ describe('usePostMessageHandler', () => {
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: storeRef,
+				currentNDVStore: shallowRef(null),
 			});
 			setup();
 
@@ -452,6 +465,7 @@ describe('usePostMessageHandler', () => {
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
 			});
 			setup();
 
@@ -481,6 +495,7 @@ describe('usePostMessageHandler', () => {
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
 			});
 			setup();
 
@@ -508,6 +523,7 @@ describe('usePostMessageHandler', () => {
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
 			});
 			setup();
 
@@ -553,6 +569,7 @@ describe('usePostMessageHandler', () => {
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
 			});
 			setup();
 
@@ -587,6 +604,7 @@ describe('usePostMessageHandler', () => {
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: storeRef,
+				currentNDVStore: shallowRef(null),
 			});
 			setup();
 
@@ -627,6 +645,7 @@ describe('usePostMessageHandler', () => {
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: storeRef,
+				currentNDVStore: shallowRef(null),
 			});
 			setup();
 
@@ -662,6 +681,7 @@ describe('usePostMessageHandler', () => {
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
 			});
 			setup();
 
@@ -689,6 +709,7 @@ describe('usePostMessageHandler', () => {
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
 			});
 			setup();
 
@@ -730,6 +751,7 @@ describe('usePostMessageHandler', () => {
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
 			});
 			setup();
 
@@ -747,6 +769,7 @@ describe('usePostMessageHandler', () => {
 			const { setup, cleanup } = usePostMessageHandler({
 				workflowState,
 				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
 			});
 			setup();
 

--- a/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.ts
@@ -25,17 +25,20 @@ import {
 	useWorkflowDocumentStore as createWorkflowDocumentStore,
 	createWorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useWorkflowImport } from '@/app/composables/useWorkflowImport';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 
 interface PostMessageHandlerDeps {
 	workflowState: WorkflowState;
 	currentWorkflowDocumentStore: ShallowRef<ReturnType<typeof useWorkflowDocumentStore> | null>;
+	currentNDVStore: ShallowRef<ReturnType<typeof useNDVStore> | null>;
 }
 
 export function usePostMessageHandler({
 	workflowState,
 	currentWorkflowDocumentStore,
+	currentNDVStore,
 }: PostMessageHandlerDeps) {
 	const i18n = useI18n();
 	const toast = useToast();
@@ -52,7 +55,7 @@ export function usePostMessageHandler({
 	const route = useRoute();
 	const workflowsStore = useWorkflowsStore();
 	const { resetWorkspace, openExecution, fitView } = useCanvasOperations();
-	const { importWorkflowExact } = useWorkflowImport(currentWorkflowDocumentStore);
+	const { importWorkflowExact } = useWorkflowImport(currentWorkflowDocumentStore, currentNDVStore);
 
 	function emitPostMessageReady() {
 		if (window.parent) {
@@ -138,9 +141,9 @@ export function usePostMessageHandler({
 
 		const wfId = workflowsStore.workflowId;
 		if (wfId) {
-			currentWorkflowDocumentStore.value = createWorkflowDocumentStore(
-				createWorkflowDocumentId(wfId),
-			);
+			const workflowDocumentId = createWorkflowDocumentId(wfId);
+			currentWorkflowDocumentStore.value = createWorkflowDocumentStore(workflowDocumentId);
+			currentNDVStore.value = useNDVStore(workflowDocumentId);
 		}
 
 		void nextTick(() => {

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowImport.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowImport.test.ts
@@ -52,7 +52,8 @@ describe('useWorkflowImport', () => {
 
 	it('should throw if workflow has no nodes', async () => {
 		const storeRef = shallowRef(null);
-		const { importWorkflowExact } = useWorkflowImport(storeRef);
+		const ndvStoreRef = shallowRef(null);
+		const { importWorkflowExact } = useWorkflowImport(storeRef, ndvStoreRef);
 
 		await expect(
 			importWorkflowExact({ workflow: { connections: {} } as WorkflowDataUpdate }),
@@ -61,7 +62,8 @@ describe('useWorkflowImport', () => {
 
 	it('should throw if workflow has no connections', async () => {
 		const storeRef = shallowRef(null);
-		const { importWorkflowExact } = useWorkflowImport(storeRef);
+		const ndvStoreRef = shallowRef(null);
+		const { importWorkflowExact } = useWorkflowImport(storeRef, ndvStoreRef);
 
 		await expect(
 			importWorkflowExact({ workflow: { nodes: [] } as unknown as WorkflowDataUpdate }),
@@ -70,7 +72,8 @@ describe('useWorkflowImport', () => {
 
 	it('should reset workspace, initialize, and fit view', async () => {
 		const storeRef = shallowRef(null);
-		const { importWorkflowExact } = useWorkflowImport(storeRef);
+		const ndvStoreRef = shallowRef(null);
+		const { importWorkflowExact } = useWorkflowImport(storeRef, ndvStoreRef);
 
 		await importWorkflowExact({ workflow: createWorkflowData() });
 
@@ -88,7 +91,8 @@ describe('useWorkflowImport', () => {
 		});
 
 		const storeRef = shallowRef(null);
-		const { importWorkflowExact } = useWorkflowImport(storeRef);
+		const ndvStoreRef = shallowRef(null);
+		const { importWorkflowExact } = useWorkflowImport(storeRef, ndvStoreRef);
 
 		await importWorkflowExact({ workflow: createWorkflowData() });
 
@@ -100,7 +104,8 @@ describe('useWorkflowImport', () => {
 		mockInitializeWorkspace.mockResolvedValue({ workflowDocumentStore: mockStore });
 
 		const storeRef = shallowRef(null);
-		const { importWorkflowExact } = useWorkflowImport(storeRef);
+		const ndvStoreRef = shallowRef(null);
+		const { importWorkflowExact } = useWorkflowImport(storeRef, ndvStoreRef);
 
 		await importWorkflowExact({ workflow: createWorkflowData() });
 
@@ -111,7 +116,8 @@ describe('useWorkflowImport', () => {
 		mockRoute.name = VIEWS.WORKFLOW;
 
 		const storeRef = shallowRef(null);
-		const { importWorkflowExact } = useWorkflowImport(storeRef);
+		const ndvStoreRef = shallowRef(null);
+		const { importWorkflowExact } = useWorkflowImport(storeRef, ndvStoreRef);
 
 		await importWorkflowExact({ workflow: createWorkflowData({ id: 'my-workflow-id' }) });
 
@@ -124,7 +130,8 @@ describe('useWorkflowImport', () => {
 		mockRoute.name = VIEWS.DEMO;
 
 		const storeRef = shallowRef(null);
-		const { importWorkflowExact } = useWorkflowImport(storeRef);
+		const ndvStoreRef = shallowRef(null);
+		const { importWorkflowExact } = useWorkflowImport(storeRef, ndvStoreRef);
 
 		await importWorkflowExact({ workflow: createWorkflowData({ id: 'real-workflow-id' }) });
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowImport.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowImport.ts
@@ -5,11 +5,16 @@ import { VIEWS } from '@/app/constants';
 import type { INodeUi, IWorkflowDb } from '@/Interface';
 import type { WorkflowDataUpdate } from '@n8n/rest-api-client/api/workflows';
 import { getNodesWithNormalizedPosition } from '@/app/utils/nodeViewUtils';
-import type { useWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import {
+	type useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
 
 export function useWorkflowImport(
 	currentWorkflowDocumentStore: ShallowRef<ReturnType<typeof useWorkflowDocumentStore> | null>,
+	currentNDVStore: ShallowRef<ReturnType<typeof useNDVStore> | null>,
 ) {
 	const route = useRoute();
 	const { resetWorkspace, initializeWorkspace, fitView } = useCanvasOperations();
@@ -33,6 +38,12 @@ export function useWorkflowImport(
 		} as IWorkflowDb);
 
 		currentWorkflowDocumentStore.value = workflowDocumentStore;
+		currentNDVStore.value = useNDVStore(
+			createWorkflowDocumentId(
+				workflowDocumentStore.workflowId,
+				workflowDocumentStore.workflowVersion,
+			),
+		);
 
 		if (isDemoRoute.value) {
 			// VueFlow drops edges when node handles haven't been created yet

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -86,9 +86,8 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 			disposeNDVStore(storeId);
 			disposeWorkflowDocumentStore(storeId);
 			currentWorkflowDocumentStore.value = null;
+			currentNDVStore.value = null;
 		}
-
-		currentNDVStore.value = null;
 	}
 
 	const isNewWorkflowRoute = computed(() => route.query.new === 'true');

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -1,4 +1,4 @@
-import { ref, computed } from 'vue';
+import { ref, computed, shallowRef } from 'vue';
 import { type RouteRecordNameGeneric, useRoute, useRouter } from 'vue-router';
 import { useI18n } from '@n8n/i18n';
 import { useToast } from '@/app/composables/useToast';
@@ -29,6 +29,7 @@ import {
 	createWorkflowDocumentId,
 	disposeWorkflowDocumentStore,
 } from '@/app/stores/workflowDocument.store';
+import { useNDVStore, disposeNDVStore } from '@/features/ndv/shared/ndv.store';
 import { WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
 import { injectStrict } from '@/app/utils/injectStrict';
 import { useWorkflowId } from '@/app/composables/useWorkflowId';
@@ -56,6 +57,7 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 	const telemetry = useTelemetry();
 	const workflowId = useWorkflowId();
 	const currentWorkflowDocumentStore = injectStrict(WorkflowDocumentStoreKey);
+	const currentNDVStore = shallowRef<ReturnType<typeof useNDVStore> | null>(null);
 
 	const DEMO_ROUTES: RouteRecordNameGeneric[] = [VIEWS.DEMO, VIEWS.DEMO_DIFF];
 
@@ -81,9 +83,12 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 				currentWorkflowDocumentStore.value.workflowId,
 				currentWorkflowDocumentStore.value.workflowVersion,
 			);
+			disposeNDVStore(storeId);
 			disposeWorkflowDocumentStore(storeId);
 			currentWorkflowDocumentStore.value = null;
 		}
+
+		currentNDVStore.value = null;
 	}
 
 	const isNewWorkflowRoute = computed(() => route.query.new === 'true');
@@ -158,6 +163,7 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 		if (currentWorkflowId) {
 			const workflowDocumentId = createWorkflowDocumentId(currentWorkflowId);
 			currentWorkflowDocumentStore.value = useWorkflowDocumentStore(workflowDocumentId);
+			currentNDVStore.value = useNDVStore(workflowDocumentId);
 		}
 
 		return true;
@@ -231,6 +237,12 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 
 		const { workflowDocumentStore } = await initializeWorkspace(data);
 		currentWorkflowDocumentStore.value = workflowDocumentStore;
+		currentNDVStore.value = useNDVStore(
+			createWorkflowDocumentId(
+				workflowDocumentStore.workflowId,
+				workflowDocumentStore.workflowVersion,
+			),
+		);
 
 		void externalHooks.run('workflow.open', {
 			workflowId: data.id,
@@ -250,6 +262,7 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 
 		const workflowDocumentId = createWorkflowDocumentId(workflowId.value);
 		currentWorkflowDocumentStore.value = useWorkflowDocumentStore(workflowDocumentId);
+		currentNDVStore.value = useNDVStore(workflowDocumentId);
 
 		// Sync document store name → list cache (mirrors initializeWorkflowDocument)
 		currentWorkflowDocumentStore.value.onNameChange(({ payload }) => {
@@ -417,6 +430,7 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 		initializedWorkflowId,
 		workflowId,
 		currentWorkflowDocumentStore,
+		currentNDVStore,
 		isNewWorkflowRoute,
 		isDemoRoute,
 		isTemplateRoute,

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -78,16 +78,19 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 	const { fetchParentFolder } = useParentFolder();
 
 	function disposeCurrentWorkflowDocumentStore() {
-		if (currentWorkflowDocumentStore.value) {
-			const storeId = createWorkflowDocumentId(
-				currentWorkflowDocumentStore.value.workflowId,
-				currentWorkflowDocumentStore.value.workflowVersion,
-			);
-			disposeNDVStore(storeId);
-			disposeWorkflowDocumentStore(storeId);
-			currentWorkflowDocumentStore.value = null;
-			currentNDVStore.value = null;
+		const ndvStore = currentNDVStore.value;
+		const workflowDocumentStore = currentWorkflowDocumentStore.value;
+
+		if (ndvStore) {
+			disposeNDVStore(ndvStore);
 		}
+
+		if (workflowDocumentStore) {
+			disposeWorkflowDocumentStore(workflowDocumentStore);
+		}
+
+		currentWorkflowDocumentStore.value = null;
+		currentNDVStore.value = null;
 	}
 
 	const isNewWorkflowRoute = computed(() => route.query.new === 'true');

--- a/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
+++ b/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
@@ -8,6 +8,7 @@ import type { ExpressionLocalResolveContext } from '@/app/types/expressions';
 import type { TelemetryContext } from '@/app/types/telemetry';
 import type { WorkflowState } from '@/app/composables/useWorkflowState';
 import type { useWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import type { useNDVStore } from '@/features/ndv/shared/ndv.store';
 
 export const WorkflowIdKey = 'workflowId' as unknown as InjectionKey<ComputedRef<string>>;
 export const CanvasKey = 'canvas' as unknown as InjectionKey<CanvasInjectionData>;
@@ -23,5 +24,7 @@ export const WorkflowStateKey: InjectionKey<WorkflowState> = Symbol('WorkflowSta
 export const WorkflowDocumentStoreKey: InjectionKey<
 	ShallowRef<ReturnType<typeof useWorkflowDocumentStore> | null>
 > = Symbol('WorkflowDocumentStore');
+export const NDVStoreKey: InjectionKey<ShallowRef<ReturnType<typeof useNDVStore> | null>> =
+	Symbol('NDVStore');
 export const ChatHubToolContextKey: InjectionKey<boolean> = Symbol('ChatHubToolContext');
 export const AiBuilderScrollToBottomKey: InjectionKey<() => void> = Symbol('ChatScrollToBottom');

--- a/packages/frontend/editor-ui/src/app/layouts/DemoLayout.test.ts
+++ b/packages/frontend/editor-ui/src/app/layouts/DemoLayout.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createComponentRenderer } from '@/__tests__/render';
 import DemoLayout from './DemoLayout.vue';
-import { computed, ref, shallowRef } from 'vue';
+import { computed, ref } from 'vue';
 import { createTestingPinia } from '@pinia/testing';
 
 const demoLayoutMocks = vi.hoisted(() => ({
@@ -10,6 +10,8 @@ const demoLayoutMocks = vi.hoisted(() => ({
 	cleanupInitialization: vi.fn(),
 	setupPostMessages: vi.fn(),
 	cleanupPostMessages: vi.fn(),
+	currentWorkflowDocumentStore: { value: {} as object | null, __v_isRef: true as const },
+	currentNDVStore: { value: {} as object | null, __v_isRef: true as const },
 }));
 
 vi.mock('vue-router', async (importOriginal) => {
@@ -45,8 +47,8 @@ vi.mock('@/app/composables/useWorkflowInitialization', () => ({
 	useWorkflowInitialization: vi.fn(() => ({
 		isLoading: ref(false),
 		workflowId: computed(() => 'demo'),
-		currentWorkflowDocumentStore: shallowRef(null),
-		currentNDVStore: shallowRef({}),
+		currentWorkflowDocumentStore: demoLayoutMocks.currentWorkflowDocumentStore,
+		currentNDVStore: demoLayoutMocks.currentNDVStore,
 		initializeData: demoLayoutMocks.initializeData,
 		initializeWorkflow: demoLayoutMocks.initializeWorkflow,
 		cleanup: demoLayoutMocks.cleanupInitialization,
@@ -91,6 +93,8 @@ describe('DemoLayout', () => {
 		vi.clearAllMocks();
 		demoLayoutMocks.initializeData.mockResolvedValue(undefined);
 		demoLayoutMocks.initializeWorkflow.mockResolvedValue(undefined);
+		demoLayoutMocks.currentWorkflowDocumentStore.value = {};
+		demoLayoutMocks.currentNDVStore.value = {};
 	});
 
 	it('should render the layout without throwing', () => {
@@ -120,6 +124,22 @@ describe('DemoLayout', () => {
 			},
 		});
 		expect(getByText('Demo Layout Content')).toBeInTheDocument();
+	});
+
+	it('should not render RouterView content until both scoped stores exist', () => {
+		demoLayoutMocks.currentWorkflowDocumentStore.value = null;
+
+		const { queryByText } = renderComponent({
+			global: {
+				stubs: {
+					RouterView: {
+						template: '<div>Demo Layout Content</div>',
+					},
+				},
+			},
+		});
+
+		expect(queryByText('Demo Layout Content')).not.toBeInTheDocument();
 	});
 
 	it('should render DemoFooter component in footer slot', () => {

--- a/packages/frontend/editor-ui/src/app/layouts/DemoLayout.test.ts
+++ b/packages/frontend/editor-ui/src/app/layouts/DemoLayout.test.ts
@@ -38,6 +38,7 @@ vi.mock('@/app/composables/useWorkflowInitialization', () => ({
 		isLoading: ref(false),
 		workflowId: computed(() => 'demo'),
 		currentWorkflowDocumentStore: shallowRef(null),
+		currentNDVStore: shallowRef({}),
 		initializeData: vi.fn().mockResolvedValue(undefined),
 		initializeWorkflow: vi.fn().mockResolvedValue(undefined),
 		cleanup: vi.fn(),

--- a/packages/frontend/editor-ui/src/app/layouts/DemoLayout.test.ts
+++ b/packages/frontend/editor-ui/src/app/layouts/DemoLayout.test.ts
@@ -4,6 +4,14 @@ import DemoLayout from './DemoLayout.vue';
 import { computed, ref, shallowRef } from 'vue';
 import { createTestingPinia } from '@pinia/testing';
 
+const demoLayoutMocks = vi.hoisted(() => ({
+	initializeData: vi.fn(),
+	initializeWorkflow: vi.fn(),
+	cleanupInitialization: vi.fn(),
+	setupPostMessages: vi.fn(),
+	cleanupPostMessages: vi.fn(),
+}));
+
 vi.mock('vue-router', async (importOriginal) => {
 	const actual = (await importOriginal()) as object;
 	return {
@@ -39,16 +47,16 @@ vi.mock('@/app/composables/useWorkflowInitialization', () => ({
 		workflowId: computed(() => 'demo'),
 		currentWorkflowDocumentStore: shallowRef(null),
 		currentNDVStore: shallowRef({}),
-		initializeData: vi.fn().mockResolvedValue(undefined),
-		initializeWorkflow: vi.fn().mockResolvedValue(undefined),
-		cleanup: vi.fn(),
+		initializeData: demoLayoutMocks.initializeData,
+		initializeWorkflow: demoLayoutMocks.initializeWorkflow,
+		cleanup: demoLayoutMocks.cleanupInitialization,
 	})),
 }));
 
 vi.mock('@/app/composables/usePostMessageHandler', () => ({
 	usePostMessageHandler: vi.fn(() => ({
-		setup: vi.fn(),
-		cleanup: vi.fn(),
+		setup: demoLayoutMocks.setupPostMessages,
+		cleanup: demoLayoutMocks.cleanupPostMessages,
 	})),
 }));
 
@@ -81,6 +89,8 @@ describe('DemoLayout', () => {
 	beforeEach(() => {
 		createTestingPinia();
 		vi.clearAllMocks();
+		demoLayoutMocks.initializeData.mockResolvedValue(undefined);
+		demoLayoutMocks.initializeWorkflow.mockResolvedValue(undefined);
 	});
 
 	it('should render the layout without throwing', () => {
@@ -185,6 +195,33 @@ describe('DemoLayout', () => {
 	});
 
 	describe('push connection', () => {
+		it('should set up post messages only after workflow initialization completes', async () => {
+			let resolveInitializeWorkflow: () => void;
+			demoLayoutMocks.initializeWorkflow.mockReturnValueOnce(
+				new Promise<void>((resolve) => {
+					resolveInitializeWorkflow = resolve;
+				}),
+			);
+
+			renderComponent();
+
+			await vi.waitFor(() => {
+				expect(demoLayoutMocks.initializeWorkflow).toHaveBeenCalled();
+			});
+			expect(mockPushInitialize).not.toHaveBeenCalled();
+			expect(demoLayoutMocks.setupPostMessages).not.toHaveBeenCalled();
+
+			resolveInitializeWorkflow!();
+
+			await vi.waitFor(() => {
+				expect(demoLayoutMocks.setupPostMessages).toHaveBeenCalled();
+			});
+			expect(mockPushInitialize).toHaveBeenCalled();
+			expect(mockPushInitialize.mock.invocationCallOrder[0]).toBeLessThan(
+				demoLayoutMocks.setupPostMessages.mock.invocationCallOrder[0],
+			);
+		});
+
 		it('should initialize push handlers on mount', async () => {
 			renderComponent();
 			await vi.waitFor(() => {

--- a/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
@@ -3,7 +3,7 @@ import { computed, provide, onBeforeMount, onBeforeUnmount, onMounted } from 'vu
 import { useRoute, useRouter } from 'vue-router';
 import BaseLayout from './BaseLayout.vue';
 import DemoFooter from '@/features/execution/logs/components/DemoFooter.vue';
-import { WorkflowStateKey } from '@/app/constants/injectionKeys';
+import { NDVStoreKey, WorkflowStateKey } from '@/app/constants/injectionKeys';
 import { useWorkflowState } from '@/app/composables/useWorkflowState';
 import { useWorkflowInitialization } from '@/app/composables/useWorkflowInitialization';
 import { usePostMessageHandler } from '@/app/composables/usePostMessageHandler';
@@ -28,13 +28,18 @@ provide(WorkflowStateKey, workflowState);
 
 const {
 	initializeData,
+	initializeWorkflow,
 	currentWorkflowDocumentStore,
+	currentNDVStore,
 	cleanup: cleanupInitialization,
 } = useWorkflowInitialization(workflowState);
+
+provide(NDVStoreKey, currentNDVStore);
 
 const { setup: setupPostMessages, cleanup: cleanupPostMessages } = usePostMessageHandler({
 	workflowState,
 	currentWorkflowDocumentStore,
+	currentNDVStore,
 });
 
 // Initialize push event handlers so relayed execution events (via postMessage
@@ -59,6 +64,7 @@ onBeforeMount(() => {
 
 onMounted(async () => {
 	await initializeData();
+	await initializeWorkflow();
 	pushConnection.initialize();
 
 	// When canExecute is enabled, establish a real WebSocket/SSE connection
@@ -80,7 +86,7 @@ onBeforeUnmount(() => {
 
 <template>
 	<BaseLayout>
-		<RouterView />
+		<RouterView v-if="currentNDVStore" />
 		<template #footer>
 			<DemoFooter />
 		</template>

--- a/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
@@ -84,7 +84,7 @@ onBeforeUnmount(() => {
 
 <template>
 	<BaseLayout>
-		<RouterView v-if="currentNDVStore" />
+		<RouterView v-if="currentWorkflowDocumentStore && currentNDVStore" />
 		<template #footer>
 			<DemoFooter />
 		</template>

--- a/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, provide, onBeforeMount, onBeforeUnmount, onMounted } from 'vue';
+import { computed, provide, onBeforeUnmount, onMounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import BaseLayout from './BaseLayout.vue';
 import DemoFooter from '@/features/execution/logs/components/DemoFooter.vue';
@@ -58,10 +58,6 @@ if (!canExecute.value) {
 	workflowState.setActiveExecutionId(null);
 }
 
-onBeforeMount(() => {
-	setupPostMessages();
-});
-
 onMounted(async () => {
 	await initializeData();
 	await initializeWorkflow();
@@ -72,6 +68,8 @@ onMounted(async () => {
 	if (canExecute.value) {
 		pushConnectionStore.pushConnect();
 	}
+
+	setupPostMessages();
 });
 
 onBeforeUnmount(() => {

--- a/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
@@ -14,7 +14,7 @@ import AppHeader from '@/app/components/app/AppHeader.vue';
 import AppSidebar from '@/app/components/app/AppSidebar.vue';
 import LogsPanel from '@/features/execution/logs/components/LogsPanel.vue';
 import LoadingView from '@/app/views/LoadingView.vue';
-import { WorkflowStateKey } from '@/app/constants/injectionKeys';
+import { NDVStoreKey, WorkflowStateKey } from '@/app/constants/injectionKeys';
 import { useSettingsStore } from '@/app/stores/settings.store';
 
 const { layoutProps } = useLayoutProps();
@@ -31,6 +31,7 @@ const {
 	isLoading,
 	workflowId,
 	currentWorkflowDocumentStore,
+	currentNDVStore,
 	isDebugRoute,
 	initializeData,
 	initializeWorkflow,
@@ -38,9 +39,12 @@ const {
 	cleanup,
 } = useWorkflowInitialization(workflowState);
 
+provide(NDVStoreKey, currentNDVStore);
+
 const { setup: setupPostMessages, cleanup: cleanupPostMessages } = usePostMessageHandler({
 	workflowState,
 	currentWorkflowDocumentStore,
+	currentNDVStore,
 });
 
 onMounted(async () => {

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.test.ts
@@ -6,13 +6,14 @@
  * Individual composable behavior is tested in their own test files.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { setActivePinia, createPinia } from 'pinia';
+import { setActivePinia, createPinia, getActivePinia } from 'pinia';
 import { NodeConnectionTypes } from 'n8n-workflow';
 import type { ITag, WorkflowHistory } from '@n8n/rest-api-client';
 import type { Scope } from '@n8n/permissions';
 import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
+	disposeWorkflowDocumentStore,
 } from '@/app/stores/workflowDocument.store';
 import { DEFAULT_SETTINGS } from '@/app/stores/workflowDocument/useWorkflowDocumentSettings';
 import { useUIStore } from '@/app/stores/ui.store';
@@ -63,6 +64,27 @@ describe('workflowDocument.store orchestration', () => {
 		expect(workflowDocumentStore.allNodes).toHaveLength(0);
 		expect(workflowDocumentStore.connectionsBySourceNode).toEqual({});
 		expect(workflowDocumentStore.pinData).toEqual({});
+	});
+
+	it('disposeWorkflowDocumentStore disposes the instance and clears scoped state', () => {
+		const workflowDocumentId = createWorkflowDocumentId('test-wf');
+		const workflowDocumentStore = useWorkflowDocumentStore(workflowDocumentId);
+		const pinia = getActivePinia();
+		const disposeSpy = vi.spyOn(workflowDocumentStore, '$dispose');
+
+		workflowDocumentStore.setName('Stale workflow name');
+
+		expect(pinia?.state.value[workflowDocumentStore.$id]).toBeDefined();
+
+		disposeWorkflowDocumentStore(workflowDocumentStore);
+
+		expect(disposeSpy).toHaveBeenCalledOnce();
+		expect(pinia?.state.value[workflowDocumentStore.$id]).toBeUndefined();
+
+		const recreatedWorkflowDocumentStore = useWorkflowDocumentStore(workflowDocumentId);
+
+		expect(recreatedWorkflowDocumentStore).not.toBe(workflowDocumentStore);
+		expect(recreatedWorkflowDocumentStore.name).toBe('');
 	});
 
 	it('node mutation triggers markStateDirty on UI store', () => {

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -1,4 +1,4 @@
-import { defineStore, getActivePinia, type StoreGeneric } from 'pinia';
+import { defineStore, getActivePinia } from 'pinia';
 import { STORES } from '@n8n/stores';
 import { inject } from 'vue';
 import { WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
@@ -43,11 +43,6 @@ export {
 	getPinDataSize,
 	pinDataToExecutionData,
 } from './workflowDocument/useWorkflowDocumentPinData';
-
-// Pinia internal type - _s is the store registry Map
-type PiniaInternal = ReturnType<typeof getActivePinia> & {
-	_s: Map<string, StoreGeneric>;
-};
 
 // ---------------------------------------------------------------------------
 // Compile-time guard: detect key collisions between composable return types.
@@ -365,27 +360,18 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 }
 
 /**
- * Disposes a workflow document store by ID.
+ * Disposes a workflow document store instance.
  * Call this when a workflow document is unloaded (e.g., when navigating away from NodeView).
  *
- * This removes the store from Pinia's internal registry, freeing memory and preventing
- * stale stores from accumulating over time.
+ * Pinia's $dispose removes the store from its registry, but not from pinia.state.
+ * Remove the state entry as well so recreating this scoped store starts clean.
  */
-export function disposeWorkflowDocumentStore(id: string) {
-	const pinia = getActivePinia() as PiniaInternal;
-	if (!pinia) return;
+export function disposeWorkflowDocumentStore(store: ReturnType<typeof useWorkflowDocumentStore>) {
+	const pinia = getActivePinia();
+	store.$dispose();
 
-	const storeId = getWorkflowDocumentStoreId(id);
-
-	// Check if the store exists in the Pinia state
-	if (pinia.state.value[storeId]) {
-		// Get the store instance
-		const store = pinia._s.get(storeId);
-		if (store) {
-			store.$dispose();
-		}
-		// Remove from Pinia's state
-		delete pinia.state.value[storeId];
+	if (pinia) {
+		delete pinia.state.value[store.$id];
 	}
 }
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputWrapper.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputWrapper.test.ts
@@ -2,6 +2,8 @@ import { renderComponent } from '@/__tests__/render';
 import { createTestingPinia } from '@pinia/testing';
 import ParameterInputWrapper from './ParameterInputWrapper.vue';
 import { STORES } from '@n8n/stores';
+import { getNDVStoreId } from '@/features/ndv/shared/ndv.store';
+import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
 import { SETTINGS_STORE_DEFAULT_STATE } from '@/__tests__/utils';
 import { waitFor } from '@testing-library/vue';
 import { createTestNodeProperties } from '@/__tests__/mocks';
@@ -15,7 +17,7 @@ describe('ParameterInputWrapper.vue', () => {
 		const { getByTestId } = renderComponent(ParameterInputWrapper, {
 			pinia: createTestingPinia({
 				initialState: {
-					[STORES.NDV]: {
+					[getNDVStoreId(createWorkflowDocumentId('default'))]: {
 						activeNodeName: 'testNode',
 						input: { nodeName: 'inputNode' },
 					},

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.test.ts
@@ -20,7 +20,7 @@ import type { INodeExecutionData, ITaskData, ITaskMetadata } from 'n8n-workflow'
 import { setActivePinia } from 'pinia';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSchemaPreviewStore } from '@/features/ndv/runData/schemaPreview.store';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { getNDVStoreId, useNDVStore } from '@/features/ndv/shared/ndv.store';
 import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
@@ -1359,7 +1359,7 @@ describe('RunData', () => {
 			stubActions: false,
 			initialState: {
 				[STORES.SETTINGS]: SETTINGS_STORE_DEFAULT_STATE,
-				[STORES.NDV]: {
+				[getNDVStoreId(createWorkflowDocumentId('default'))]: {
 					activeNodeName: 'Test Node',
 				},
 				[STORES.WORKFLOWS]: {

--- a/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setActivePinia, createPinia, getActivePinia } from 'pinia';
+import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
+import { disposeNDVStore, useNDVStore } from './ndv.store';
+
+describe('ndv.store', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+	});
+
+	it('disposeNDVStore disposes the instance and clears scoped state', () => {
+		const ndvStoreId = createWorkflowDocumentId('test-wf');
+		const ndvStore = useNDVStore(ndvStoreId);
+		const pinia = getActivePinia();
+		const disposeSpy = vi.spyOn(ndvStore, '$dispose');
+
+		ndvStore.setActiveNodeName('Stale node', 'other');
+
+		expect(pinia?.state.value[ndvStore.$id]).toBeDefined();
+
+		disposeNDVStore(ndvStore);
+
+		expect(disposeSpy).toHaveBeenCalledOnce();
+		expect(pinia?.state.value[ndvStore.$id]).toBeUndefined();
+
+		const recreatedNDVStore = useNDVStore(ndvStoreId);
+
+		expect(recreatedNDVStore).not.toBe(ndvStore);
+		expect(recreatedNDVStore.activeNodeName).toBeNull();
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.ts
@@ -18,7 +18,7 @@ import {
 import { STORES } from '@n8n/stores';
 import type { INodeIssues } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
-import { defineStore, getActivePinia, type Pinia, type StoreGeneric } from 'pinia';
+import { defineStore, getActivePinia, type Pinia } from 'pinia';
 import { v4 as uuid } from 'uuid';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
@@ -28,10 +28,6 @@ import {
 } from '@/app/stores/workflowDocument.store';
 import { computed, ref } from 'vue';
 import type { TelemetryNdvSource } from '@/app/types/telemetry';
-
-type PiniaInternal = ReturnType<typeof getActivePinia> & {
-	_s: Map<string, StoreGeneric>;
-};
 
 export type NDVStoreId = WorkflowDocumentId;
 
@@ -484,18 +480,11 @@ export function useNDVStore(idOrPinia?: NDVStoreId | Pinia): NDVStore {
 	return defineNDVStore(storeId, !isExplicitStoreId)(pinia);
 }
 
-export function disposeNDVStore(id: NDVStoreId) {
-	const pinia = getActivePinia() as PiniaInternal;
-	if (!pinia) return;
+export function disposeNDVStore(store: NDVStore) {
+	const pinia = getActivePinia();
+	store.$dispose();
 
-	const storeId = getNDVStoreId(id);
-
-	if (pinia.state.value[storeId]) {
-		const store = pinia._s.get(storeId);
-		if (store) {
-			store.$dispose();
-		}
-
-		delete pinia.state.value[storeId];
+	if (pinia) {
+		delete pinia.state.value[store.$id];
 	}
 }

--- a/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.ts
@@ -18,15 +18,24 @@ import {
 import { STORES } from '@n8n/stores';
 import type { INodeIssues } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
-import { defineStore } from 'pinia';
+import { defineStore, getActivePinia, type Pinia, type StoreGeneric } from 'pinia';
 import { v4 as uuid } from 'uuid';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
+	type WorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
 import { computed, ref } from 'vue';
 import type { TelemetryNdvSource } from '@/app/types/telemetry';
+
+type PiniaInternal = ReturnType<typeof getActivePinia> & {
+	_s: Map<string, StoreGeneric>;
+};
+
+export type NDVStoreId = WorkflowDocumentId;
+
+const DEFAULT_NDV_STORE_ID = createWorkflowDocumentId('default');
 
 const DEFAULT_MAIN_PANEL_DIMENSIONS = {
 	relativeLeft: 1,
@@ -34,420 +43,459 @@ const DEFAULT_MAIN_PANEL_DIMENSIONS = {
 	relativeWidth: 1,
 };
 
-export const useNDVStore = defineStore(STORES.NDV, () => {
-	const localStorageMappingIsOnboarded = useStorage(LOCAL_STORAGE_MAPPING_IS_ONBOARDED);
-	const localStorageTableHoverIsOnboarded = useStorage(LOCAL_STORAGE_TABLE_HOVER_IS_ONBOARDED);
-	const localStorageAutoCompleteIsOnboarded = useStorage(LOCAL_STORAGE_AUTOCOMPLETE_IS_ONBOARDED);
+export function getNDVStoreId(id: NDVStoreId) {
+	return `${STORES.NDV}/${id}`;
+}
 
-	const activeNodeName = ref<string | null>(null);
-	const mainPanelDimensions = ref<MainPanelDimensions>({
-		unknown: { ...DEFAULT_MAIN_PANEL_DIMENSIONS },
-		regular: { ...DEFAULT_MAIN_PANEL_DIMENSIONS },
-		dragless: { ...DEFAULT_MAIN_PANEL_DIMENSIONS },
-		inputless: { ...DEFAULT_MAIN_PANEL_DIMENSIONS },
-		wide: { ...DEFAULT_MAIN_PANEL_DIMENSIONS },
-	});
-	const pushRef = ref('');
-	const input = ref<InputPanel>({
-		nodeName: undefined,
-		run: undefined,
-		branch: undefined,
-		data: {
-			isEmpty: true,
-		},
-	});
-	const inputPanelDisplayMode = useLocalStorage<IRunDataDisplayMode>(
-		LOCAL_STORAGE_NDV_INPUT_PANEL_DISPLAY_MODE,
-		'schema',
-	);
-	const output = ref<OutputPanel>({
-		run: undefined,
-		branch: undefined,
-		data: {
-			isEmpty: true,
-		},
-		editMode: {
-			enabled: false,
-			value: '',
-		},
-	});
-	const outputPanelDisplayMode = useLocalStorage<IRunDataDisplayMode>(
-		LOCAL_STORAGE_NDV_OUTPUT_PANEL_DISPLAY_MODE,
-		'table',
-	);
-	const focusedMappableInput = ref('');
-	const focusedInputPath = ref('');
-	const mappingTelemetry = ref<Record<string, string | number | boolean>>({});
-	const hoveringItem = ref<null | TargetItem>(null);
-	const expressionOutputItemIndex = ref(0);
-	const draggable = ref<Draggable>({
-		isDragging: false,
-		type: '',
-		data: '',
-		dimensions: null,
-		activeTarget: null,
-	});
-	const isMappingOnboarded = ref(localStorageMappingIsOnboarded.value === 'true');
-	const isTableHoverOnboarded = ref(localStorageTableHoverIsOnboarded.value === 'true');
+function defineNDVStore(id: NDVStoreId, useCurrentWorkflowDocument = false) {
+	return defineStore(getNDVStoreId(id), () => {
+		const localStorageMappingIsOnboarded = useStorage(LOCAL_STORAGE_MAPPING_IS_ONBOARDED);
+		const localStorageTableHoverIsOnboarded = useStorage(LOCAL_STORAGE_TABLE_HOVER_IS_ONBOARDED);
+		const localStorageAutoCompleteIsOnboarded = useStorage(LOCAL_STORAGE_AUTOCOMPLETE_IS_ONBOARDED);
 
-	const isAutocompleteOnboarded = ref(localStorageAutoCompleteIsOnboarded.value === 'true');
-
-	const highlightDraggables = ref(false);
-	const lastSetActiveNodeSource = ref<TelemetryNdvSource>();
-
-	const workflowsStore = useWorkflowsStore();
-	const workflowDocumentStore = computed(() =>
-		useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId)),
-	);
-	const activeNode = computed(() => {
-		return workflowDocumentStore.value.getNodeByName(activeNodeName.value || '') ?? null;
-	});
-
-	const ndvInputData = computed(() => {
-		const executionData = workflowsStore.getWorkflowExecution;
-		const inputNodeName: string | undefined = input.value.nodeName;
-		const inputRunIndex: number = input.value.run ?? 0;
-		const inputBranchIndex: number = input.value.branch ?? 0;
-
-		if (
-			!executionData ||
-			!inputNodeName ||
-			inputRunIndex === undefined ||
-			inputBranchIndex === undefined
-		) {
-			return [];
-		}
-
-		return (
-			executionData.data?.resultData?.runData?.[inputNodeName]?.[inputRunIndex]?.data?.main?.[
-				inputBranchIndex
-			] ?? []
+		const activeNodeName = ref<string | null>(null);
+		const mainPanelDimensions = ref<MainPanelDimensions>({
+			unknown: { ...DEFAULT_MAIN_PANEL_DIMENSIONS },
+			regular: { ...DEFAULT_MAIN_PANEL_DIMENSIONS },
+			dragless: { ...DEFAULT_MAIN_PANEL_DIMENSIONS },
+			inputless: { ...DEFAULT_MAIN_PANEL_DIMENSIONS },
+			wide: { ...DEFAULT_MAIN_PANEL_DIMENSIONS },
+		});
+		const pushRef = ref('');
+		const input = ref<InputPanel>({
+			nodeName: undefined,
+			run: undefined,
+			branch: undefined,
+			data: {
+				isEmpty: true,
+			},
+		});
+		const inputPanelDisplayMode = useLocalStorage<IRunDataDisplayMode>(
+			LOCAL_STORAGE_NDV_INPUT_PANEL_DISPLAY_MODE,
+			'schema',
 		);
-	});
-
-	const ndvInputNodeName = computed(() => {
-		return input.value.nodeName;
-	});
-
-	const ndvInputDataWithPinnedData = computed(() => {
-		const data = ndvInputData.value;
-		return ndvInputNodeName.value
-			? (workflowDocumentStore.value.pinData?.[ndvInputNodeName.value] ?? data)
-			: data;
-	});
-
-	const hasInputData = computed(() => {
-		return ndvInputDataWithPinnedData.value.length > 0;
-	});
-
-	const isDraggableDragging = computed(() => draggable.value.isDragging);
-
-	const draggableType = computed(() => draggable.value.type);
-
-	const draggableData = computed(() => draggable.value.data);
-
-	const canDraggableDrop = computed(() => draggable.value.activeTarget !== null);
-
-	const outputPanelEditMode = computed(() => output.value.editMode);
-
-	const draggableStickyPos = computed(() => draggable.value.activeTarget?.stickyPosition ?? null);
-
-	const ndvNodeInputNumber = computed(() => {
-		const returnData: { [nodeName: string]: number[] } = {};
-		const activeNodeConections = (
-			workflowDocumentStore.value.connectionsByDestinationNode[activeNode.value?.name || ''] ?? {}
-		).main;
-
-		if (!activeNodeConections || activeNodeConections.length < 2) return returnData;
-
-		for (const [index, connection] of activeNodeConections.entries()) {
-			for (const node of connection ?? []) {
-				if (!returnData[node.node]) {
-					returnData[node.node] = [];
-				}
-				returnData[node.node].push(index + 1);
-			}
-		}
-
-		return returnData;
-	});
-
-	const ndvInputRunIndex = computed(() => input.value.run);
-
-	const ndvInputBranchIndex = computed(() => input.value.branch);
-
-	const isInputPanelEmpty = computed(() => input.value.data.isEmpty);
-
-	const isOutputPanelEmpty = computed(() => output.value.data.isEmpty);
-
-	const isInputParentOfActiveNode = computed(() => {
-		const inputNodeName = ndvInputNodeName.value;
-		if (!activeNode.value || !inputNodeName) {
-			return false;
-		}
-		const parentNodes = workflowDocumentStore.value.getParentNodes(
-			activeNode.value.name,
-			NodeConnectionTypes.Main,
-			1,
+		const output = ref<OutputPanel>({
+			run: undefined,
+			branch: undefined,
+			data: {
+				isEmpty: true,
+			},
+			editMode: {
+				enabled: false,
+				value: '',
+			},
+		});
+		const outputPanelDisplayMode = useLocalStorage<IRunDataDisplayMode>(
+			LOCAL_STORAGE_NDV_OUTPUT_PANEL_DISPLAY_MODE,
+			'table',
 		);
-		return parentNodes?.includes(inputNodeName) ?? false;
-	});
-
-	const getHoveringItem = computed(() => {
-		if (isInputParentOfActiveNode.value) {
-			return hoveringItem.value;
-		}
-
-		return null;
-	});
-
-	const expressionTargetItem = computed(() => {
-		if (getHoveringItem.value) {
-			return getHoveringItem.value;
-		}
-
-		if (expressionOutputItemIndex.value && ndvInputNodeName.value) {
-			return {
-				nodeName: ndvInputNodeName.value,
-				runIndex: ndvInputRunIndex.value ?? 0,
-				outputIndex: ndvInputBranchIndex.value ?? 0,
-				itemIndex: expressionOutputItemIndex.value,
-			};
-		}
-
-		return null;
-	});
-
-	const isNDVOpen = computed(() => activeNodeName.value !== null);
-
-	const unsetActiveNodeName = (): void => {
-		activeNodeName.value = null;
-		lastSetActiveNodeSource.value = undefined;
-	};
-
-	const setActiveNodeName = (nodeName: string, source: TelemetryNdvSource): void => {
-		if (activeNodeName.value === nodeName) {
-			return;
-		}
-
-		activeNodeName.value = nodeName;
-		lastSetActiveNodeSource.value = source;
-	};
-
-	const setInputNodeName = (nodeName: string | undefined): void => {
-		input.value.nodeName = nodeName;
-	};
-
-	const setInputRunIndex = (run?: number): void => {
-		input.value.run = run;
-	};
-
-	const setOutputRunIndex = (run?: number): void => {
-		output.value.run = run;
-	};
-
-	const setMainPanelDimensions = (params: {
-		panelType: MainPanelType;
-		dimensions: { relativeLeft?: number; relativeRight?: number; relativeWidth?: number };
-	}): void => {
-		mainPanelDimensions.value[params.panelType] = {
-			...mainPanelDimensions.value[params.panelType],
-			...params.dimensions,
-		};
-	};
-
-	const setNDVPushRef = (): void => {
-		pushRef.value = `ndv-${uuid()}`;
-	};
-
-	const resetNDVPushRef = (): void => {
-		pushRef.value = '';
-	};
-
-	const setPanelDisplayMode = (params: {
-		pane: NodePanelType;
-		mode: IRunDataDisplayMode;
-	}): void => {
-		if (params.pane === 'input') {
-			inputPanelDisplayMode.value = params.mode;
-		} else {
-			outputPanelDisplayMode.value = params.mode;
-		}
-	};
-
-	const setOutputPanelEditModeEnabled = (isEnabled: boolean): void => {
-		output.value.editMode.enabled = isEnabled;
-	};
-
-	const setOutputPanelEditModeValue = (payload: string): void => {
-		output.value.editMode.value = payload;
-	};
-
-	const setMappableNDVInputFocus = (paramName: string): void => {
-		focusedMappableInput.value = paramName;
-	};
-
-	const draggableStartDragging = ({
-		type,
-		data,
-		dimensions,
-	}: {
-		type: string;
-		data: string;
-		dimensions: DOMRect | null;
-	}): void => {
-		draggable.value = {
-			isDragging: true,
-			type,
-			data,
-			dimensions,
-			activeTarget: null,
-		};
-	};
-
-	const draggableStopDragging = (): void => {
-		draggable.value = {
+		const focusedMappableInput = ref('');
+		const focusedInputPath = ref('');
+		const mappingTelemetry = ref<Record<string, string | number | boolean>>({});
+		const hoveringItem = ref<null | TargetItem>(null);
+		const expressionOutputItemIndex = ref(0);
+		const draggable = ref<Draggable>({
 			isDragging: false,
 			type: '',
 			data: '',
 			dimensions: null,
 			activeTarget: null,
+		});
+		const isMappingOnboarded = ref(localStorageMappingIsOnboarded.value === 'true');
+		const isTableHoverOnboarded = ref(localStorageTableHoverIsOnboarded.value === 'true');
+
+		const isAutocompleteOnboarded = ref(localStorageAutoCompleteIsOnboarded.value === 'true');
+
+		const highlightDraggables = ref(false);
+		const lastSetActiveNodeSource = ref<TelemetryNdvSource>();
+
+		const workflowsStore = useWorkflowsStore();
+		const workflowDocumentStore = computed(() =>
+			useWorkflowDocumentStore(
+				useCurrentWorkflowDocument ? createWorkflowDocumentId(workflowsStore.workflowId) : id,
+			),
+		);
+		const activeNode = computed(() => {
+			return workflowDocumentStore.value.getNodeByName(activeNodeName.value || '') ?? null;
+		});
+
+		const ndvInputData = computed(() => {
+			const executionData = workflowsStore.getWorkflowExecution;
+			const inputNodeName: string | undefined = input.value.nodeName;
+			const inputRunIndex: number = input.value.run ?? 0;
+			const inputBranchIndex: number = input.value.branch ?? 0;
+
+			if (
+				!executionData ||
+				!inputNodeName ||
+				inputRunIndex === undefined ||
+				inputBranchIndex === undefined
+			) {
+				return [];
+			}
+
+			return (
+				executionData.data?.resultData?.runData?.[inputNodeName]?.[inputRunIndex]?.data?.main?.[
+					inputBranchIndex
+				] ?? []
+			);
+		});
+
+		const ndvInputNodeName = computed(() => {
+			return input.value.nodeName;
+		});
+
+		const ndvInputDataWithPinnedData = computed(() => {
+			const data = ndvInputData.value;
+			return ndvInputNodeName.value
+				? (workflowDocumentStore.value.pinData?.[ndvInputNodeName.value] ?? data)
+				: data;
+		});
+
+		const hasInputData = computed(() => {
+			return ndvInputDataWithPinnedData.value.length > 0;
+		});
+
+		const isDraggableDragging = computed(() => draggable.value.isDragging);
+
+		const draggableType = computed(() => draggable.value.type);
+
+		const draggableData = computed(() => draggable.value.data);
+
+		const canDraggableDrop = computed(() => draggable.value.activeTarget !== null);
+
+		const outputPanelEditMode = computed(() => output.value.editMode);
+
+		const draggableStickyPos = computed(() => draggable.value.activeTarget?.stickyPosition ?? null);
+
+		const ndvNodeInputNumber = computed(() => {
+			const returnData: { [nodeName: string]: number[] } = {};
+			const activeNodeConections = (
+				workflowDocumentStore.value.connectionsByDestinationNode[activeNode.value?.name || ''] ?? {}
+			).main;
+
+			if (!activeNodeConections || activeNodeConections.length < 2) return returnData;
+
+			for (const [index, connection] of activeNodeConections.entries()) {
+				for (const node of connection ?? []) {
+					if (!returnData[node.node]) {
+						returnData[node.node] = [];
+					}
+					returnData[node.node].push(index + 1);
+				}
+			}
+
+			return returnData;
+		});
+
+		const ndvInputRunIndex = computed(() => input.value.run);
+
+		const ndvInputBranchIndex = computed(() => input.value.branch);
+
+		const isInputPanelEmpty = computed(() => input.value.data.isEmpty);
+
+		const isOutputPanelEmpty = computed(() => output.value.data.isEmpty);
+
+		const isInputParentOfActiveNode = computed(() => {
+			const inputNodeName = ndvInputNodeName.value;
+			if (!activeNode.value || !inputNodeName) {
+				return false;
+			}
+			const parentNodes = workflowDocumentStore.value.getParentNodes(
+				activeNode.value.name,
+				NodeConnectionTypes.Main,
+				1,
+			);
+			return parentNodes?.includes(inputNodeName) ?? false;
+		});
+
+		const getHoveringItem = computed(() => {
+			if (isInputParentOfActiveNode.value) {
+				return hoveringItem.value;
+			}
+
+			return null;
+		});
+
+		const expressionTargetItem = computed(() => {
+			if (getHoveringItem.value) {
+				return getHoveringItem.value;
+			}
+
+			if (expressionOutputItemIndex.value && ndvInputNodeName.value) {
+				return {
+					nodeName: ndvInputNodeName.value,
+					runIndex: ndvInputRunIndex.value ?? 0,
+					outputIndex: ndvInputBranchIndex.value ?? 0,
+					itemIndex: expressionOutputItemIndex.value,
+				};
+			}
+
+			return null;
+		});
+
+		const isNDVOpen = computed(() => activeNodeName.value !== null);
+
+		const unsetActiveNodeName = (): void => {
+			activeNodeName.value = null;
+			lastSetActiveNodeSource.value = undefined;
 		};
-	};
 
-	const setDraggableTarget = (target: Draggable['activeTarget']): void => {
-		draggable.value.activeTarget = target;
-	};
+		const setActiveNodeName = (nodeName: string, source: TelemetryNdvSource): void => {
+			if (activeNodeName.value === nodeName) {
+				return;
+			}
 
-	const setMappingTelemetry = (telemetry: { [key: string]: string | number | boolean }): void => {
-		mappingTelemetry.value = { ...mappingTelemetry.value, ...telemetry };
-	};
+			activeNodeName.value = nodeName;
+			lastSetActiveNodeSource.value = source;
+		};
 
-	const resetMappingTelemetry = (): void => {
-		mappingTelemetry.value = {};
-	};
+		const setInputNodeName = (nodeName: string | undefined): void => {
+			input.value.nodeName = nodeName;
+		};
 
-	const setHoveringItem = (item: TargetItem | null): void => {
-		if (item) setTableHoverOnboarded();
-		hoveringItem.value = item;
-	};
+		const setInputRunIndex = (run?: number): void => {
+			input.value.run = run;
+		};
 
-	const setNDVBranchIndex = (e: { pane: NodePanelType; branchIndex: number }): void => {
-		if (e.pane === 'input') {
-			input.value.branch = e.branchIndex;
-		} else {
-			output.value.branch = e.branchIndex;
+		const setOutputRunIndex = (run?: number): void => {
+			output.value.run = run;
+		};
+
+		const setMainPanelDimensions = (params: {
+			panelType: MainPanelType;
+			dimensions: { relativeLeft?: number; relativeRight?: number; relativeWidth?: number };
+		}): void => {
+			mainPanelDimensions.value[params.panelType] = {
+				...mainPanelDimensions.value[params.panelType],
+				...params.dimensions,
+			};
+		};
+
+		const setNDVPushRef = (): void => {
+			pushRef.value = `ndv-${uuid()}`;
+		};
+
+		const resetNDVPushRef = (): void => {
+			pushRef.value = '';
+		};
+
+		const setPanelDisplayMode = (params: {
+			pane: NodePanelType;
+			mode: IRunDataDisplayMode;
+		}): void => {
+			if (params.pane === 'input') {
+				inputPanelDisplayMode.value = params.mode;
+			} else {
+				outputPanelDisplayMode.value = params.mode;
+			}
+		};
+
+		const setOutputPanelEditModeEnabled = (isEnabled: boolean): void => {
+			output.value.editMode.enabled = isEnabled;
+		};
+
+		const setOutputPanelEditModeValue = (payload: string): void => {
+			output.value.editMode.value = payload;
+		};
+
+		const setMappableNDVInputFocus = (paramName: string): void => {
+			focusedMappableInput.value = paramName;
+		};
+
+		const draggableStartDragging = ({
+			type,
+			data,
+			dimensions,
+		}: {
+			type: string;
+			data: string;
+			dimensions: DOMRect | null;
+		}): void => {
+			draggable.value = {
+				isDragging: true,
+				type,
+				data,
+				dimensions,
+				activeTarget: null,
+			};
+		};
+
+		const draggableStopDragging = (): void => {
+			draggable.value = {
+				isDragging: false,
+				type: '',
+				data: '',
+				dimensions: null,
+				activeTarget: null,
+			};
+		};
+
+		const setDraggableTarget = (target: Draggable['activeTarget']): void => {
+			draggable.value.activeTarget = target;
+		};
+
+		const setMappingTelemetry = (telemetry: { [key: string]: string | number | boolean }): void => {
+			mappingTelemetry.value = { ...mappingTelemetry.value, ...telemetry };
+		};
+
+		const resetMappingTelemetry = (): void => {
+			mappingTelemetry.value = {};
+		};
+
+		const setHoveringItem = (item: TargetItem | null): void => {
+			if (item) setTableHoverOnboarded();
+			hoveringItem.value = item;
+		};
+
+		const setNDVBranchIndex = (e: { pane: NodePanelType; branchIndex: number }): void => {
+			if (e.pane === 'input') {
+				input.value.branch = e.branchIndex;
+			} else {
+				output.value.branch = e.branchIndex;
+			}
+		};
+
+		const setNDVPanelDataIsEmpty = (params: { panel: NodePanelType; isEmpty: boolean }): void => {
+			if (params.panel === 'input') {
+				input.value.data.isEmpty = params.isEmpty;
+			} else {
+				output.value.data.isEmpty = params.isEmpty;
+			}
+		};
+
+		const setMappingOnboarded = () => {
+			isMappingOnboarded.value = true;
+			localStorageMappingIsOnboarded.value = 'true';
+		};
+
+		const setTableHoverOnboarded = () => {
+			isTableHoverOnboarded.value = true;
+			localStorageTableHoverIsOnboarded.value = 'true';
+		};
+
+		const setAutocompleteOnboarded = () => {
+			isAutocompleteOnboarded.value = true;
+			localStorageAutoCompleteIsOnboarded.value = 'true';
+		};
+
+		const setHighlightDraggables = (highlight: boolean) => {
+			highlightDraggables.value = highlight;
+		};
+
+		const updateNodeParameterIssues = (issues: INodeIssues): void => {
+			const node = workflowDocumentStore.value.getNodeByName(activeNodeName.value || '');
+
+			if (node?.id) {
+				workflowDocumentStore.value.updateNodeById(node.id, {
+					issues: {
+						...node.issues,
+						...issues,
+					},
+				});
+			}
+		};
+
+		const setFocusedInputPath = (path: string) => {
+			focusedInputPath.value = path;
+		};
+
+		return {
+			activeNode,
+			ndvInputData,
+			ndvInputNodeName,
+			ndvInputDataWithPinnedData,
+			hasInputData,
+			inputPanelDisplayMode,
+			outputPanelDisplayMode,
+			isDraggableDragging,
+			draggableType,
+			draggableData,
+			canDraggableDrop,
+			outputPanelEditMode,
+			draggableStickyPos,
+			ndvNodeInputNumber,
+			ndvInputRunIndex,
+			ndvInputBranchIndex,
+			isInputParentOfActiveNode,
+			getHoveringItem,
+			expressionTargetItem,
+			isNDVOpen,
+			isInputPanelEmpty,
+			isOutputPanelEmpty,
+			focusedMappableInput,
+			isMappingOnboarded,
+			pushRef,
+			activeNodeName,
+			focusedInputPath,
+			input,
+			output,
+			hoveringItem,
+			highlightDraggables,
+			mappingTelemetry,
+			draggable,
+			isAutocompleteOnboarded,
+			expressionOutputItemIndex,
+			isTableHoverOnboarded,
+			mainPanelDimensions,
+			lastSetActiveNodeSource,
+			setActiveNodeName,
+			unsetActiveNodeName,
+			setInputNodeName,
+			setInputRunIndex,
+			setOutputRunIndex,
+			setMainPanelDimensions,
+			setNDVPushRef,
+			resetNDVPushRef,
+			setPanelDisplayMode,
+			setOutputPanelEditModeEnabled,
+			setOutputPanelEditModeValue,
+			setMappableNDVInputFocus,
+			draggableStartDragging,
+			draggableStopDragging,
+			setDraggableTarget,
+			setMappingTelemetry,
+			resetMappingTelemetry,
+			setHoveringItem,
+			setNDVBranchIndex,
+			setNDVPanelDataIsEmpty,
+			setMappingOnboarded,
+			setTableHoverOnboarded,
+			setAutocompleteOnboarded,
+			setHighlightDraggables,
+			updateNodeParameterIssues,
+			setFocusedInputPath,
+		};
+	});
+}
+
+type Writable<T> = { -readonly [Key in keyof T]: T[Key] };
+
+export type NDVStore = Writable<ReturnType<ReturnType<typeof defineNDVStore>>>;
+
+export function useNDVStore(id: NDVStoreId): NDVStore;
+export function useNDVStore(pinia: Pinia): NDVStore;
+export function useNDVStore(): NDVStore;
+export function useNDVStore(idOrPinia?: NDVStoreId | Pinia): NDVStore {
+	const pinia = typeof idOrPinia === 'string' ? undefined : idOrPinia;
+	const isExplicitStoreId = typeof idOrPinia === 'string';
+	const storeId = isExplicitStoreId ? idOrPinia : DEFAULT_NDV_STORE_ID;
+
+	return defineNDVStore(storeId, !isExplicitStoreId)(pinia);
+}
+
+export function disposeNDVStore(id: NDVStoreId) {
+	const pinia = getActivePinia() as PiniaInternal;
+	if (!pinia) return;
+
+	const storeId = getNDVStoreId(id);
+
+	if (pinia.state.value[storeId]) {
+		const store = pinia._s.get(storeId);
+		if (store) {
+			store.$dispose();
 		}
-	};
 
-	const setNDVPanelDataIsEmpty = (params: { panel: NodePanelType; isEmpty: boolean }): void => {
-		if (params.panel === 'input') {
-			input.value.data.isEmpty = params.isEmpty;
-		} else {
-			output.value.data.isEmpty = params.isEmpty;
-		}
-	};
-
-	const setMappingOnboarded = () => {
-		isMappingOnboarded.value = true;
-		localStorageMappingIsOnboarded.value = 'true';
-	};
-
-	const setTableHoverOnboarded = () => {
-		isTableHoverOnboarded.value = true;
-		localStorageTableHoverIsOnboarded.value = 'true';
-	};
-
-	const setAutocompleteOnboarded = () => {
-		isAutocompleteOnboarded.value = true;
-		localStorageAutoCompleteIsOnboarded.value = 'true';
-	};
-
-	const setHighlightDraggables = (highlight: boolean) => {
-		highlightDraggables.value = highlight;
-	};
-
-	const updateNodeParameterIssues = (issues: INodeIssues): void => {
-		const node = workflowDocumentStore.value.getNodeByName(activeNodeName.value || '');
-
-		if (node?.id) {
-			workflowDocumentStore.value.updateNodeById(node.id, {
-				issues: {
-					...node.issues,
-					...issues,
-				},
-			});
-		}
-	};
-
-	const setFocusedInputPath = (path: string) => {
-		focusedInputPath.value = path;
-	};
-
-	return {
-		activeNode,
-		ndvInputData,
-		ndvInputNodeName,
-		ndvInputDataWithPinnedData,
-		hasInputData,
-		inputPanelDisplayMode,
-		outputPanelDisplayMode,
-		isDraggableDragging,
-		draggableType,
-		draggableData,
-		canDraggableDrop,
-		outputPanelEditMode,
-		draggableStickyPos,
-		ndvNodeInputNumber,
-		ndvInputRunIndex,
-		ndvInputBranchIndex,
-		isInputParentOfActiveNode,
-		getHoveringItem,
-		expressionTargetItem,
-		isNDVOpen,
-		isInputPanelEmpty,
-		isOutputPanelEmpty,
-		focusedMappableInput,
-		isMappingOnboarded,
-		pushRef,
-		activeNodeName,
-		focusedInputPath,
-		input,
-		output,
-		hoveringItem,
-		highlightDraggables,
-		mappingTelemetry,
-		draggable,
-		isAutocompleteOnboarded,
-		expressionOutputItemIndex,
-		isTableHoverOnboarded,
-		mainPanelDimensions,
-		lastSetActiveNodeSource,
-		setActiveNodeName,
-		unsetActiveNodeName,
-		setInputNodeName,
-		setInputRunIndex,
-		setOutputRunIndex,
-		setMainPanelDimensions,
-		setNDVPushRef,
-		resetNDVPushRef,
-		setPanelDisplayMode,
-		setOutputPanelEditModeEnabled,
-		setOutputPanelEditModeValue,
-		setMappableNDVInputFocus,
-		draggableStartDragging,
-		draggableStopDragging,
-		setDraggableTarget,
-		setMappingTelemetry,
-		resetMappingTelemetry,
-		setHoveringItem,
-		setNDVBranchIndex,
-		setNDVPanelDataIsEmpty,
-		setMappingOnboarded,
-		setTableHoverOnboarded,
-		setAutocompleteOnboarded,
-		setHighlightDraggables,
-		updateNodeParameterIssues,
-		setFocusedInputPath,
-	};
-});
+		delete pinia.state.value[storeId];
+	}
+}

--- a/packages/frontend/editor-ui/src/features/shared/editors/components/SqlEditor/SQLEditor.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/SqlEditor/SQLEditor.test.ts
@@ -1,6 +1,7 @@
 import * as workflowHelpers from '@/app/composables/useWorkflowHelpers';
 import { SETTINGS_STORE_DEFAULT_STATE } from '@/__tests__/utils';
 import { STORES } from '@n8n/stores';
+import { getNDVStoreId } from '@/features/ndv/shared/ndv.store';
 import { createTestingPinia } from '@pinia/testing';
 
 import SqlEditor from '@/features/shared/editors/components/SqlEditor/SqlEditor.vue';
@@ -64,7 +65,7 @@ describe('SqlEditor.vue', () => {
 				[STORES.SETTINGS]: {
 					settings: SETTINGS_STORE_DEFAULT_STATE.settings,
 				},
-				[STORES.NDV]: {
+				[getNDVStoreId(createWorkflowDocumentId('default'))]: {
 					activeNodeName: 'Test Node',
 					hasInputData: true,
 					isInputPanelEmpty: false,


### PR DESCRIPTION
## Summary

Convert the NDV store from a singleton into a per-workflow-document instance keyed by workflow document ID, mirroring the existing workflow document store pattern. The current NDV store is provided via injection (`NDVStoreKey`) and disposed alongside the workflow document store on cleanup, ensuring NDV state (active node, panel dimensions, drag/hover state, etc.) is isolated between workflows opened in the same session.

To test: open a workflow, interact with NDV (open a node, switch panels), navigate to another workflow and confirm NDV state does not leak between them. Verify demo and embedded (postMessage) flows still initialize and dispose correctly.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Add Linear ticket if applicable: https://linear.app/n8n/issue/[TICKET-ID] -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI