### PR TITLE
fix(editor): Keep publish actions menu enabled for published workflows

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
@@ -509,6 +509,29 @@ describe('WorkflowHeaderDraftPublishActions', () => {
 			expect(getByTestId('version-menu-button')).not.toBeDisabled();
 		});
 
+		it('should keep the version menu enabled when workflow is published with no changes and unpublish is unavailable', () => {
+			workflowsStore.workflowTriggerNodes = [triggerNode];
+			workflowsStore.workflow.versionId = 'version-1';
+			workflowDocumentStore.setActiveState({
+				activeVersionId: 'version-1',
+				activeVersion: createMockActiveVersion('version-1'),
+			});
+			uiStore.markStateClean();
+
+			const { getByTestId } = renderComponent({
+				props: {
+					...defaultWorkflowProps,
+					workflowPermissions: {
+						...defaultWorkflowProps.workflowPermissions,
+						unpublish: false,
+					},
+				},
+			});
+
+			expect(getByTestId('workflow-open-publish-modal-button')).toBeDisabled();
+			expect(getByTestId('version-menu-button')).not.toBeDisabled();
+		});
+
 		it('should show publish button enabled when workflow has never been published (no active version)', () => {
 			workflowsStore.workflowTriggerNodes = [triggerNode];
 			workflowsStore.workflow.versionId = 'version-1';

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
@@ -353,6 +353,10 @@ const versionMenuActions = computed<Array<ActionDropdownItem<VERSION_ACTIONS>>>(
 });
 
 const shouldDisableActionDropdown = computed(() => {
+	if (activeVersion.value) {
+		return false;
+	}
+
 	return versionMenuActions.value.every((action) => action.disabled);
 });
 


### PR DESCRIPTION
### Summary

The version dropdown was being disabled when all menu items were disabled, which caused the `Unpublish` option to be greyed out for published workflows with no pending changes.

- Update `shouldDisableActionDropdown` in `WorkflowHeaderDraftPublishActions.vue` to return `false` when an `activeVersion` exists so the chevron activator remains enabled.
- Add a regression test in `WorkflowHeaderDraftPublishActions.test.ts` that asserts the version menu stays enabled for a published workflow with no changes when `workflowPermissions.unpublish` is `false`.
- Ensure the `Unpublish` menu item remains present and disabled while the dropdown activator itself stays enabled.

| Before | After |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/3f053d60-679c-4721-994d-b2dd4ef72227" width="960px" /> | <img src="https://github.com/user-attachments/assets/c69db051-dab3-4aa2-8dde-27400855776a" width="960px" /> |


## Related Linear tickets, Github issues, and Community forum posts

[ADO-5144](https://linear.app/n8n/issue/ADO-5144/impossible-to-unpublish-a-workflow-unless-you-change-it)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
