### PR TITLE
fix(editor): Align message box button radius with N8nButton

### DIFF
--- a/packages/frontend/@n8n/design-system/src/css/message-box.scss
+++ b/packages/frontend/@n8n/design-system/src/css/message-box.scss
@@ -179,7 +179,7 @@
 
 			height: 2rem;
 			padding: 0 var(--spacing--xs);
-			border-radius: var(--radius--xs);
+			border-radius: var(--radius--3xs);
 			font-size: var(--font-size--sm);
 			font-family: var(--font-family);
 			font-weight: var(--font-weight--medium);


### PR DESCRIPTION
## Summary

Align MessageBox action button rounding with the standard `N8nButton` radius so dialog confirm and cancel buttons no longer appear more rounded than other buttons.

| Before | After |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/d39e0740-f676-40d3-a865-44af36888c89" width="960px" alt="Before" /> | <img src="https://github.com/user-attachments/assets/afa4d43f-00eb-48e4-b775-eeeb225c0f72" width="960px" alt="After" /> |

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DS-524

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
