### PR TITLE
feat(agents): Make columns in agent view resizable

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
@@ -4,9 +4,11 @@ import { mount, flushPromises } from '@vue/test-utils';
 import { nextTick, ref } from 'vue';
 
 const routerPush = vi.fn();
+const routerReplace = vi.fn();
+const routeQuery: Record<string, string | undefined> = {};
 vi.mock('vue-router', () => ({
-	useRouter: () => ({ push: routerPush, replace: vi.fn() }),
-	useRoute: () => ({ params: { projectId: 'p1', agentId: 'a1' }, query: {} }),
+	useRouter: () => ({ push: routerPush, replace: routerReplace }),
+	useRoute: () => ({ params: { projectId: 'p1', agentId: 'a1' }, query: routeQuery }),
 	onBeforeRouteLeave: vi.fn(),
 	onBeforeRouteUpdate: vi.fn(),
 	RouterLink: { template: '<a><slot/></a>' },
@@ -53,6 +55,7 @@ vi.mock('@/app/stores/ui.store', () => ({
 const updateAgentMock = vi.fn();
 const getIntegrationStatusMock = vi.fn();
 const publishAgentMock = vi.fn();
+const sessionThreads: Array<{ id: string; updatedAt: string }> = [];
 
 vi.mock('../composables/useAgentApi', () => ({
 	getAgent: vi.fn().mockResolvedValue({
@@ -111,7 +114,7 @@ vi.mock('../composables/useAgentConfig', () => ({
 
 vi.mock('../agentSessions.store', () => ({
 	useAgentSessionsStore: () => ({
-		threads: [],
+		threads: sessionThreads,
 		loading: false,
 		fetchThreads: vi.fn().mockResolvedValue(undefined),
 		startAutoRefresh: vi.fn(),
@@ -267,6 +270,9 @@ describe('AgentBuilderView — chat mode toggle', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		routerPush.mockReset();
+		routerReplace.mockReset();
+		for (const key of Object.keys(routeQuery)) delete routeQuery[key];
+		sessionThreads.length = 0;
 		// Reset to a built agent; tests that need an unbuilt agent override locally.
 		intendedConfig = {
 			name: 'Agent One',
@@ -394,6 +400,21 @@ describe('AgentBuilderView — chat mode toggle', () => {
 		expect((testPanel.element as HTMLElement).style.display).not.toBe('none');
 	});
 
+	it('keeps a known continued session selected even when it has no persisted messages', async () => {
+		routeQuery.continueSessionId = 'faulty-thread';
+		sessionThreads.push({ id: 'faulty-thread', updatedAt: '2026-01-01T00:00:00Z' });
+
+		const wrapper = await renderView();
+		routerReplace.mockClear();
+
+		(wrapper.vm as unknown as { onContinueLoaded: (count: number) => void }).onContinueLoaded(0);
+		await nextTick();
+		await flushPromises();
+
+		expect(routerReplace).not.toHaveBeenCalled();
+		expect((wrapper.vm as unknown as { chatMode: string }).chatMode).toBe('test');
+	});
+
 	it('navigates directly to build chat on startChat for an unbuilt agent', async () => {
 		intendedConfig = { name: 'Agent One', instructions: '' };
 		mockConfig.value = { ...intendedConfig };
@@ -428,6 +449,9 @@ describe('AgentBuilderView — three-column shell', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		routerPush.mockReset();
+		routerReplace.mockReset();
+		for (const key of Object.keys(routeQuery)) delete routeQuery[key];
+		sessionThreads.length = 0;
 		intendedConfig = {
 			name: 'Agent One',
 			instructions: 'You are a helpful assistant.',

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentBuilderLayout.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentBuilderLayout.test.ts
@@ -1,0 +1,43 @@
+import { nextTick } from 'vue';
+import { useAgentBuilderLayout } from '../composables/useAgentBuilderLayout';
+
+describe('useAgentBuilderLayout', () => {
+	const chatCollapsedKey = 'agentBuilder.chatColumnCollapsed';
+	const chatWidthKey = 'agentBuilder.chatColumnWidth';
+	const treeWidthKey = 'agentBuilder.treeColumnWidth';
+
+	let container: HTMLElement;
+
+	beforeEach(() => {
+		window.localStorage.removeItem(chatCollapsedKey);
+		window.localStorage.removeItem(chatWidthKey);
+		window.localStorage.removeItem(treeWidthKey);
+
+		container = document.createElement('div');
+		Object.defineProperty(container, 'offsetWidth', {
+			configurable: true,
+			get() {
+				return 1200;
+			},
+		});
+	});
+
+	it('reserves chat width while collapsed so expanding keeps the editor above minimum width', async () => {
+		window.localStorage.setItem(chatCollapsedKey, '1');
+		window.localStorage.setItem(chatWidthKey, '460');
+		window.localStorage.setItem(treeWidthKey, '780');
+
+		const layout = useAgentBuilderLayout();
+		layout.builderRef.value = container;
+		await nextTick();
+
+		expect(layout.chatColumnCollapsed.value).toBe(true);
+		expect(layout.treeColumnWidth.value).toBe(320);
+
+		layout.onToggleChatColumn();
+		await nextTick();
+
+		expect(layout.chatColumnCollapsed.value).toBe(false);
+		expect(layout.gridColumns.value).toBe('460px minmax(420px, 1fr) 320px');
+	});
+});

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentBuilderLayout.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentBuilderLayout.ts
@@ -1,4 +1,6 @@
+import { useDebounceFn, useElementSize } from '@vueuse/core';
 import { computed, ref, watch } from 'vue';
+import { DEBOUNCE_TIME, getDebounceTime } from '@/app/constants/durations';
 
 const CHAT_COLLAPSED_KEY = 'agentBuilder.chatColumnCollapsed';
 const CHAT_WIDTH_KEY = 'agentBuilder.chatColumnWidth';
@@ -17,21 +19,28 @@ const RESIZE_GRID_SIZE = 8;
  */
 export function useAgentBuilderLayout() {
 	const builderRef = ref<HTMLElement | null>(null);
-	const builderWidth = ref(0);
+	const { width: observedBuilderWidth } = useElementSize(builderRef);
+	const builderWidth = computed(
+		() => observedBuilderWidth.value || builderRef.value?.offsetWidth || 0,
+	);
 	const chatColumnCollapsed = ref(
 		typeof window !== 'undefined' && window.localStorage?.getItem(CHAT_COLLAPSED_KEY) === '1',
 	);
 	const chatColumnWidth = ref(readStoredNumber(CHAT_WIDTH_KEY, DEFAULT_CHAT_WIDTH));
 	const treeColumnWidth = ref(readStoredNumber(TREE_WIDTH_KEY, DEFAULT_TREE_WIDTH));
+	const writeChatColumnWidth = useDebounceFn((width: number) => {
+		writeStoredNumber(CHAT_WIDTH_KEY, width);
+	}, getDebounceTime(DEBOUNCE_TIME.UI.RESIZE));
+	const writeTreeColumnWidth = useDebounceFn((width: number) => {
+		writeStoredNumber(TREE_WIDTH_KEY, width);
+	}, getDebounceTime(DEBOUNCE_TIME.UI.RESIZE));
 
 	const maxChatWidth = computed(() =>
 		Math.max(MIN_CHAT_WIDTH, builderWidth.value - treeColumnWidth.value - MIN_EDITOR_WIDTH),
 	);
-	const maxTreeWidth = computed(() => {
-		const visibleChatWidth = chatColumnCollapsed.value ? 0 : chatColumnWidth.value;
-
-		return Math.max(MIN_TREE_WIDTH, builderWidth.value - visibleChatWidth - MIN_EDITOR_WIDTH);
-	});
+	const maxTreeWidth = computed(() =>
+		Math.max(MIN_TREE_WIDTH, builderWidth.value - chatColumnWidth.value - MIN_EDITOR_WIDTH),
+	);
 
 	watch(chatColumnCollapsed, (v) => {
 		try {
@@ -42,32 +51,14 @@ export function useAgentBuilderLayout() {
 	});
 
 	watch(chatColumnWidth, (width) => {
-		writeStoredNumber(CHAT_WIDTH_KEY, width);
+		void writeChatColumnWidth(width);
 	});
 
 	watch(treeColumnWidth, (width) => {
-		writeStoredNumber(TREE_WIDTH_KEY, width);
+		void writeTreeColumnWidth(width);
 	});
 
-	watch(
-		builderRef,
-		(el, _, onCleanup) => {
-			if (!el) return;
-
-			const updateWidth = () => {
-				builderWidth.value = el.offsetWidth;
-				chatColumnWidth.value = clamp(chatColumnWidth.value, MIN_CHAT_WIDTH, maxChatWidth.value);
-				treeColumnWidth.value = clamp(treeColumnWidth.value, MIN_TREE_WIDTH, maxTreeWidth.value);
-			};
-
-			const observer = new ResizeObserver(updateWidth);
-			observer.observe(el);
-			updateWidth();
-
-			onCleanup(() => observer.disconnect());
-		},
-		{ immediate: true },
-	);
+	watch([builderRef, builderWidth], () => clampPanelWidths(), { immediate: true });
 
 	const gridColumns = computed(() =>
 		chatColumnCollapsed.value
@@ -77,15 +68,24 @@ export function useAgentBuilderLayout() {
 
 	function onToggleChatColumn() {
 		chatColumnCollapsed.value = !chatColumnCollapsed.value;
+		clampPanelWidths();
 	}
 
 	function onChatColumnResize({ width }: { width: number }) {
 		chatColumnCollapsed.value = false;
 		chatColumnWidth.value = clamp(width, MIN_CHAT_WIDTH, maxChatWidth.value);
+		clampPanelWidths();
 	}
 
 	function onTreeColumnResize({ width }: { width: number }) {
 		treeColumnWidth.value = clamp(width, MIN_TREE_WIDTH, maxTreeWidth.value);
+	}
+
+	function clampPanelWidths() {
+		if (builderWidth.value <= 0) return;
+
+		treeColumnWidth.value = clamp(treeColumnWidth.value, MIN_TREE_WIDTH, maxTreeWidth.value);
+		chatColumnWidth.value = clamp(chatColumnWidth.value, MIN_CHAT_WIDTH, maxChatWidth.value);
 	}
 
 	return {

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentBuilderLayout.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentBuilderLayout.ts
@@ -1,16 +1,37 @@
 import { computed, ref, watch } from 'vue';
 
 const CHAT_COLLAPSED_KEY = 'agentBuilder.chatColumnCollapsed';
+const CHAT_WIDTH_KEY = 'agentBuilder.chatColumnWidth';
+const TREE_WIDTH_KEY = 'agentBuilder.treeColumnWidth';
+const DEFAULT_CHAT_WIDTH = 460;
+const DEFAULT_TREE_WIDTH = 260;
+const MIN_CHAT_WIDTH = 320;
+const MIN_EDITOR_WIDTH = 420;
+const MIN_TREE_WIDTH = 220;
+const RESIZE_GRID_SIZE = 8;
 
 /**
- * Three-column shell layout state for the agent builder. Owns the chat-column
- * collapse toggle (persisted to localStorage) and the corresponding
+ * Three-column shell layout state for the agent builder. Owns persisted panel
+ * widths, the chat-column collapse toggle, and the corresponding
  * `grid-template-columns` value.
  */
 export function useAgentBuilderLayout() {
+	const builderRef = ref<HTMLElement | null>(null);
+	const builderWidth = ref(0);
 	const chatColumnCollapsed = ref(
 		typeof window !== 'undefined' && window.localStorage?.getItem(CHAT_COLLAPSED_KEY) === '1',
 	);
+	const chatColumnWidth = ref(readStoredNumber(CHAT_WIDTH_KEY, DEFAULT_CHAT_WIDTH));
+	const treeColumnWidth = ref(readStoredNumber(TREE_WIDTH_KEY, DEFAULT_TREE_WIDTH));
+
+	const maxChatWidth = computed(() =>
+		Math.max(MIN_CHAT_WIDTH, builderWidth.value - treeColumnWidth.value - MIN_EDITOR_WIDTH),
+	);
+	const maxTreeWidth = computed(() => {
+		const visibleChatWidth = chatColumnCollapsed.value ? 0 : chatColumnWidth.value;
+
+		return Math.max(MIN_TREE_WIDTH, builderWidth.value - visibleChatWidth - MIN_EDITOR_WIDTH);
+	});
 
 	watch(chatColumnCollapsed, (v) => {
 		try {
@@ -20,15 +41,87 @@ export function useAgentBuilderLayout() {
 		}
 	});
 
+	watch(chatColumnWidth, (width) => {
+		writeStoredNumber(CHAT_WIDTH_KEY, width);
+	});
+
+	watch(treeColumnWidth, (width) => {
+		writeStoredNumber(TREE_WIDTH_KEY, width);
+	});
+
+	watch(
+		builderRef,
+		(el, _, onCleanup) => {
+			if (!el) return;
+
+			const updateWidth = () => {
+				builderWidth.value = el.offsetWidth;
+				chatColumnWidth.value = clamp(chatColumnWidth.value, MIN_CHAT_WIDTH, maxChatWidth.value);
+				treeColumnWidth.value = clamp(treeColumnWidth.value, MIN_TREE_WIDTH, maxTreeWidth.value);
+			};
+
+			const observer = new ResizeObserver(updateWidth);
+			observer.observe(el);
+			updateWidth();
+
+			onCleanup(() => observer.disconnect());
+		},
+		{ immediate: true },
+	);
+
 	const gridColumns = computed(() =>
 		chatColumnCollapsed.value
-			? '0 1fr minmax(200px, 260px)'
-			: 'minmax(400px, 500px) 1fr minmax(200px, 260px)',
+			? `0 minmax(${MIN_EDITOR_WIDTH}px, 1fr) ${treeColumnWidth.value}px`
+			: `${chatColumnWidth.value}px minmax(${MIN_EDITOR_WIDTH}px, 1fr) ${treeColumnWidth.value}px`,
 	);
 
 	function onToggleChatColumn() {
 		chatColumnCollapsed.value = !chatColumnCollapsed.value;
 	}
 
-	return { chatColumnCollapsed, gridColumns, onToggleChatColumn };
+	function onChatColumnResize({ width }: { width: number }) {
+		chatColumnCollapsed.value = false;
+		chatColumnWidth.value = clamp(width, MIN_CHAT_WIDTH, maxChatWidth.value);
+	}
+
+	function onTreeColumnResize({ width }: { width: number }) {
+		treeColumnWidth.value = clamp(width, MIN_TREE_WIDTH, maxTreeWidth.value);
+	}
+
+	return {
+		builderRef,
+		chatColumnCollapsed,
+		chatColumnWidth,
+		treeColumnWidth,
+		gridColumns,
+		onChatColumnResize,
+		onTreeColumnResize,
+		onToggleChatColumn,
+		resizeGridSize: RESIZE_GRID_SIZE,
+	};
+}
+
+function readStoredNumber(key: string, fallback: number) {
+	if (typeof window === 'undefined') return fallback;
+
+	try {
+		const storedValue = Number(window.localStorage?.getItem(key));
+
+		return Number.isFinite(storedValue) && storedValue > 0 ? storedValue : fallback;
+	} catch {
+		// localStorage may throw in private-browsing modes; silently ignore.
+		return fallback;
+	}
+}
+
+function writeStoredNumber(key: string, value: number) {
+	try {
+		window.localStorage?.setItem(key, String(Math.round(value)));
+	} catch {
+		// localStorage may throw in private-browsing modes; silently ignore.
+	}
+}
+
+function clamp(value: number, min: number, max: number) {
+	return Math.max(min, Math.min(value, max));
 }

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -12,6 +12,7 @@ import {
 	N8nIcon,
 	N8nNavigationDropdown,
 	N8nRadioButtons,
+	N8nResizeWrapper,
 	N8nText,
 	N8nTooltip,
 } from '@n8n/design-system';
@@ -117,7 +118,17 @@ const {
 	onNewChat,
 } = useAgentBuilderSession();
 
-const { chatColumnCollapsed, gridColumns, onToggleChatColumn } = useAgentBuilderLayout();
+const {
+	builderRef,
+	chatColumnCollapsed,
+	chatColumnWidth,
+	treeColumnWidth,
+	gridColumns,
+	onChatColumnResize,
+	onTreeColumnResize,
+	onToggleChatColumn,
+	resizeGridSize,
+} = useAgentBuilderLayout();
 
 // Config
 const { config, fetchConfig, updateConfig } = useAgentConfig();
@@ -760,183 +771,193 @@ function onSwitchAgent(nextAgentId: string) {
 			@unpublished="onUnpublished"
 			@switch-agent="onSwitchAgent"
 		/>
-		<div :class="$style.builder" :style="{ gridTemplateColumns: gridColumns }">
+		<div ref="builderRef" :class="$style.builder" :style="{ gridTemplateColumns: gridColumns }">
 			<!-- Column 1: chat -->
-			<aside
-				:class="$style.chatColumn"
-				:aria-label="locale.baseText('agents.builder.chatColumn.ariaLabel')"
-				data-testid="agent-builder-chat-column"
+			<N8nResizeWrapper
+				:class="$style.chatColumnResizeWrapper"
+				:width="chatColumnWidth"
+				:min-width="320"
+				:grid-size="resizeGridSize"
+				:supported-directions="chatColumnCollapsed ? [] : ['right']"
+				:is-resizing-enabled="!chatColumnCollapsed"
+				@resize="onChatColumnResize"
 			>
-				<div
-					v-if="initialized && chatMode === 'test' && effectiveSessionId"
-					:class="$style.sessionHeader"
-					data-testid="agent-chat-session-header"
+				<aside
+					:class="$style.chatColumn"
+					:aria-label="locale.baseText('agents.builder.chatColumn.ariaLabel')"
+					data-testid="agent-builder-chat-column"
 				>
-					<N8nNavigationDropdown
-						:menu="sessionMenu"
-						submenu-class="agent-chat-session-menu"
-						data-testid="agent-chat-session-picker"
-						@select="onSessionPick"
+					<div
+						v-if="initialized && chatMode === 'test' && effectiveSessionId"
+						:class="$style.sessionHeader"
+						data-testid="agent-chat-session-header"
 					>
-						<button
-							type="button"
-							:class="$style.sessionTitleBtn"
-							:aria-label="locale.baseText('agents.builder.chat.sessionPicker.ariaLabel')"
-							data-testid="agent-chat-session-picker-btn"
+						<N8nNavigationDropdown
+							:menu="sessionMenu"
+							submenu-class="agent-chat-session-menu"
+							data-testid="agent-chat-session-picker"
+							@select="onSessionPick"
 						>
-							<N8nIcon icon="history" :size="14" />
-							<span :class="$style.sessionTitleText">{{ currentSessionTitle }}</span>
-							<N8nIcon icon="chevron-down" :size="12" />
+							<button
+								type="button"
+								:class="$style.sessionTitleBtn"
+								:aria-label="locale.baseText('agents.builder.chat.sessionPicker.ariaLabel')"
+								data-testid="agent-chat-session-picker-btn"
+							>
+								<N8nIcon icon="history" :size="14" />
+								<span :class="$style.sessionTitleText">{{ currentSessionTitle }}</span>
+								<N8nIcon icon="chevron-down" :size="12" />
+							</button>
+							<template v-for="item in sessionMenu" :key="item.id" #[`item.append.${item.id}`]>
+								<span v-if="item.label" :class="$style.sessionItemLabel">{{ item.label }}</span>
+								<span v-if="item.when" :class="$style.sessionItemWhen">{{ item.when }}</span>
+							</template>
+						</N8nNavigationDropdown>
+						<button
+							v-if="currentSessionHasMessages"
+							type="button"
+							:class="$style.newChatBtn"
+							:aria-label="locale.baseText('agents.builder.chat.newChat.ariaLabel')"
+							data-testid="agent-chat-new-chat-btn"
+							@click="onNewChat"
+						>
+							<N8nIcon icon="plus" :size="14" />
+							<span>{{ locale.baseText('agents.builder.chat.newChat.label') }}</span>
 						</button>
-						<template v-for="item in sessionMenu" :key="item.id" #[`item.append.${item.id}`]>
-							<span v-if="item.label" :class="$style.sessionItemLabel">{{ item.label }}</span>
-							<span v-if="item.when" :class="$style.sessionItemWhen">{{ item.when }}</span>
-						</template>
-					</N8nNavigationDropdown>
-					<button
-						v-if="currentSessionHasMessages"
-						type="button"
-						:class="$style.newChatBtn"
-						:aria-label="locale.baseText('agents.builder.chat.newChat.ariaLabel')"
-						data-testid="agent-chat-new-chat-btn"
-						@click="onNewChat"
-					>
-						<N8nIcon icon="plus" :size="14" />
-						<span>{{ locale.baseText('agents.builder.chat.newChat.label') }}</span>
-					</button>
-				</div>
-				<div :class="$style.chatBody">
-					<AgentChatPanel
-						v-if="initialized && chatModeOpened.test && effectiveSessionId"
-						v-show="chatMode === 'test'"
-						:key="`test-${effectiveSessionId}`"
-						:project-id="projectId"
-						:agent-id="agentId"
-						mode="inline"
-						endpoint="chat"
-						:initial-message="initialPrompt"
-						:continue-session-id="effectiveSessionId"
-						:agent-config="localConfig"
-						:agent-status="deriveAgentStatus(agent)"
-						:connected-triggers="connectedTriggers"
-						@config-updated="onConfigUpdated"
-						@continue-loaded="onContinueLoaded"
-						@open-build="onOpenBuildFromChat"
-					>
-						<template #above-input>
-							<div :class="$style.quickActionsRow">
-								<div :class="$style.quickActionsStart"></div>
-								<N8nTooltip
-									v-if="initialized"
-									:class="$style.chatModeToggle"
-									:disabled="isBuilt"
-									:content="locale.baseText('agents.builder.chatMode.test.lockedTooltip')"
-									:show-after="100"
-									placement="top"
-								>
-									<N8nRadioButtons
-										:model-value="chatMode"
-										:options="chatModeOptions"
-										:aria-label="locale.baseText('agents.builder.chatMode.ariaLabel')"
-										data-testid="agent-chat-mode-toggle"
-										@update:model-value="setChatMode"
+					</div>
+					<div :class="$style.chatBody">
+						<AgentChatPanel
+							v-if="initialized && chatModeOpened.test && effectiveSessionId"
+							v-show="chatMode === 'test'"
+							:key="`test-${effectiveSessionId}`"
+							:project-id="projectId"
+							:agent-id="agentId"
+							mode="inline"
+							endpoint="chat"
+							:initial-message="initialPrompt"
+							:continue-session-id="effectiveSessionId"
+							:agent-config="localConfig"
+							:agent-status="deriveAgentStatus(agent)"
+							:connected-triggers="connectedTriggers"
+							@config-updated="onConfigUpdated"
+							@continue-loaded="onContinueLoaded"
+							@open-build="onOpenBuildFromChat"
+						>
+							<template #above-input>
+								<div :class="$style.quickActionsRow">
+									<div :class="$style.quickActionsStart"></div>
+									<N8nTooltip
+										v-if="initialized"
+										:class="$style.chatModeToggle"
+										:disabled="isBuilt"
+										:content="locale.baseText('agents.builder.chatMode.test.lockedTooltip')"
+										:show-after="100"
+										placement="top"
 									>
-										<template #option="option">
-											<span :class="$style.chatModeOption">
-												<N8nIcon
-													v-if="option.value === 'build' && isBuildChatStreaming"
-													icon="loader-circle"
-													:size="14"
-													:spin="true"
-												/>
-												<N8nIcon
-													v-else-if="option.value === 'test' && !isBuilt"
-													icon="triangle-alert"
-													:size="14"
-													:class="$style.chatModeLockedIcon"
-												/>
-												<N8nIcon
-													v-else
-													:icon="option.value === 'build' ? 'wand-sparkles' : 'message-square'"
-													:size="14"
-												/>
-												<span>{{ option.label }}</span>
-											</span>
-										</template>
-									</N8nRadioButtons>
-								</N8nTooltip>
-							</div>
-						</template>
-					</AgentChatPanel>
-					<AgentChatPanel
-						v-if="initialized && chatModeOpened.build"
-						v-show="chatMode === 'build'"
-						:project-id="projectId"
-						:agent-id="agentId"
-						mode="inline"
-						endpoint="build"
-						:initial-message="chatMode === 'build' ? initialPrompt : undefined"
-						:agent-config="localConfig"
-						:agent-status="deriveAgentStatus(agent)"
-						:connected-triggers="connectedTriggers"
-						@config-updated="onConfigUpdated"
-						@update:streaming="onBuildChatStreamingChange"
-					>
-						<template #above-input>
-							<div :class="$style.quickActionsRow">
-								<AgentChatQuickActions
-									:tools="localConfig?.tools ?? []"
-									:project-id="projectId"
-									:agent-id="agentId"
-									:connected-triggers="connectedTriggers"
-									@update:tools="onQuickActionAddTool"
-									@update:connected-triggers="onConnectedTriggersUpdate"
-									@trigger-added="onTriggerAdded"
-								/>
-								<N8nTooltip
-									v-if="initialized"
-									:class="$style.chatModeToggle"
-									:disabled="isBuilt"
-									:content="locale.baseText('agents.builder.chatMode.test.lockedTooltip')"
-									:show-after="100"
-									placement="top"
-								>
-									<N8nRadioButtons
-										:model-value="chatMode"
-										:options="chatModeOptions"
-										:aria-label="locale.baseText('agents.builder.chatMode.ariaLabel')"
-										data-testid="agent-chat-mode-toggle"
-										@update:model-value="setChatMode"
+										<N8nRadioButtons
+											:model-value="chatMode"
+											:options="chatModeOptions"
+											:aria-label="locale.baseText('agents.builder.chatMode.ariaLabel')"
+											data-testid="agent-chat-mode-toggle"
+											@update:model-value="setChatMode"
+										>
+											<template #option="option">
+												<span :class="$style.chatModeOption">
+													<N8nIcon
+														v-if="option.value === 'build' && isBuildChatStreaming"
+														icon="loader-circle"
+														:size="14"
+														:spin="true"
+													/>
+													<N8nIcon
+														v-else-if="option.value === 'test' && !isBuilt"
+														icon="triangle-alert"
+														:size="14"
+														:class="$style.chatModeLockedIcon"
+													/>
+													<N8nIcon
+														v-else
+														:icon="option.value === 'build' ? 'wand-sparkles' : 'message-square'"
+														:size="14"
+													/>
+													<span>{{ option.label }}</span>
+												</span>
+											</template>
+										</N8nRadioButtons>
+									</N8nTooltip>
+								</div>
+							</template>
+						</AgentChatPanel>
+						<AgentChatPanel
+							v-if="initialized && chatModeOpened.build"
+							v-show="chatMode === 'build'"
+							:project-id="projectId"
+							:agent-id="agentId"
+							mode="inline"
+							endpoint="build"
+							:initial-message="chatMode === 'build' ? initialPrompt : undefined"
+							:agent-config="localConfig"
+							:agent-status="deriveAgentStatus(agent)"
+							:connected-triggers="connectedTriggers"
+							@config-updated="onConfigUpdated"
+							@update:streaming="onBuildChatStreamingChange"
+						>
+							<template #above-input>
+								<div :class="$style.quickActionsRow">
+									<AgentChatQuickActions
+										:tools="localConfig?.tools ?? []"
+										:project-id="projectId"
+										:agent-id="agentId"
+										:connected-triggers="connectedTriggers"
+										@update:tools="onQuickActionAddTool"
+										@update:connected-triggers="onConnectedTriggersUpdate"
+										@trigger-added="onTriggerAdded"
+									/>
+									<N8nTooltip
+										v-if="initialized"
+										:class="$style.chatModeToggle"
+										:disabled="isBuilt"
+										:content="locale.baseText('agents.builder.chatMode.test.lockedTooltip')"
+										:show-after="100"
+										placement="top"
 									>
-										<template #option="option">
-											<span :class="$style.chatModeOption">
-												<N8nIcon
-													v-if="option.value === 'build' && isBuildChatStreaming"
-													icon="loader-circle"
-													:size="14"
-													:spin="true"
-												/>
-												<N8nIcon
-													v-else-if="option.value === 'test' && !isBuilt"
-													icon="triangle-alert"
-													:size="14"
-													:class="$style.chatModeLockedIcon"
-												/>
-												<N8nIcon
-													v-else
-													:icon="option.value === 'build' ? 'wand-sparkles' : 'message-square'"
-													:size="14"
-												/>
-												<span>{{ option.label }}</span>
-											</span>
-										</template>
-									</N8nRadioButtons>
-								</N8nTooltip>
-							</div>
-						</template>
-					</AgentChatPanel>
-				</div>
-			</aside>
+										<N8nRadioButtons
+											:model-value="chatMode"
+											:options="chatModeOptions"
+											:aria-label="locale.baseText('agents.builder.chatMode.ariaLabel')"
+											data-testid="agent-chat-mode-toggle"
+											@update:model-value="setChatMode"
+										>
+											<template #option="option">
+												<span :class="$style.chatModeOption">
+													<N8nIcon
+														v-if="option.value === 'build' && isBuildChatStreaming"
+														icon="loader-circle"
+														:size="14"
+														:spin="true"
+													/>
+													<N8nIcon
+														v-else-if="option.value === 'test' && !isBuilt"
+														icon="triangle-alert"
+														:size="14"
+														:class="$style.chatModeLockedIcon"
+													/>
+													<N8nIcon
+														v-else
+														:icon="option.value === 'build' ? 'wand-sparkles' : 'message-square'"
+														:size="14"
+													/>
+													<span>{{ option.label }}</span>
+												</span>
+											</template>
+										</N8nRadioButtons>
+									</N8nTooltip>
+								</div>
+							</template>
+						</AgentChatPanel>
+					</div>
+				</aside>
+			</N8nResizeWrapper>
 
 			<!-- Column 2: editor -->
 			<section
@@ -1094,18 +1115,27 @@ function onSwitchAgent(nextAgentId: string) {
 			</section>
 
 			<!-- Column 3: tree -->
-			<aside
-				:class="[$style.treeColumn, shared.scrollbarThin]"
-				data-testid="agent-builder-tree-column"
+			<N8nResizeWrapper
+				:class="$style.treeColumnResizeWrapper"
+				:width="treeColumnWidth"
+				:min-width="220"
+				:grid-size="resizeGridSize"
+				:supported-directions="['left']"
+				@resize="onTreeColumnResize"
 			>
-				<AgentConfigTree
-					:config="localConfig"
-					:selected-key="selectedSection"
-					:connected-triggers="connectedTriggers"
-					:executions-count="sessionsStore.threads.length"
-					@select="onTreeSelect"
-				/>
-			</aside>
+				<aside
+					:class="[$style.treeColumn, shared.scrollbarThin]"
+					data-testid="agent-builder-tree-column"
+				>
+					<AgentConfigTree
+						:config="localConfig"
+						:selected-key="selectedSection"
+						:connected-triggers="connectedTriggers"
+						:executions-count="sessionsStore.threads.length"
+						@select="onTreeSelect"
+					/>
+				</aside>
+			</N8nResizeWrapper>
 		</div>
 	</div>
 </template>
@@ -1125,11 +1155,19 @@ function onSwitchAgent(nextAgentId: string) {
 	overflow: hidden;
 }
 
+.chatColumnResizeWrapper,
+.treeColumnResizeWrapper {
+	min-width: 0;
+	min-height: 0;
+	overflow: hidden;
+}
+
 .chatColumn {
 	position: relative;
 	display: flex;
 	flex-direction: column;
 	border-right: var(--border);
+	height: 100%;
 	min-height: 0;
 	min-width: 0;
 	overflow: hidden;
@@ -1303,6 +1341,7 @@ function onSwitchAgent(nextAgentId: string) {
 	display: flex;
 	flex-direction: column;
 	border-left: var(--border);
+	height: 100%;
 	min-height: 0;
 	overflow: auto;
 }
@@ -1311,6 +1350,7 @@ function onSwitchAgent(nextAgentId: string) {
 	display: flex;
 	flex-direction: column;
 	min-height: 0;
+	min-width: 0;
 }
 
 .triggersTab {

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -723,10 +723,15 @@ function onTriggerAdded(payload: { triggerType: string; triggers: string[] }) {
 }
 
 function onContinueLoaded(count: number) {
-	// Only kick back to home for a URL-supplied session that turned out to be
-	// empty/stale. Ephemeral in-tab sessions always start empty and fill in as
-	// the user chats, so the zero-count signal is expected there.
-	if (count === 0 && continueSessionId.value) {
+	// Only kick away from a URL-supplied session when the URL points at a
+	// missing/stale thread. A real thread can legitimately have zero persisted
+	// chat messages if its execution failed before history was saved.
+	const requestedSessionId = continueSessionId.value;
+	const knownThread = requestedSessionId
+		? sessionsStore.threads.some((thread) => thread.id === requestedSessionId)
+		: false;
+
+	if (count === 0 && requestedSessionId && !knownThread) {
 		exitContinueMode();
 		// `exitContinueMode` only drops the query param; the chat panel would
 		// otherwise sit blank waiting for a session to bind. Once the route


### PR DESCRIPTION
## Summary

- Added drag resizing for the chat and sidebar/tree columns using N8nResizeWrapper.
- Persisted chat/sidebar widths and chat collapsed state in localStorage.
- Added width clamping so the editor area remains usable across viewport changes.
- Hardened localStorage reads/writes to safely fall back when storage is unavailable.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
