### PR TITLE
feat(core): Add configurable event log path per process

### DIFF
--- a/packages/@n8n/config/src/configs/event-bus.config.ts
+++ b/packages/@n8n/config/src/configs/event-bus.config.ts
@@ -20,8 +20,9 @@ class LogWriterConfig {
 	 * Absolute path to the primary event log file (must end in `.log`). When set,
 	 * used verbatim with no process-type suffix; the operator owns per-pod
 	 * uniqueness (e.g. via Kubernetes Downward API or per-pod PVC). Parent
-	 * directory is auto-created. Rotation siblings (`.log-1`, `.log-2`, …) and
-	 * the `.recoveryInProgress` marker colocate with this path. Empty (default)
+	 * directory is auto-created. Rotation siblings (e.g. `myEventLog-1.log`,
+	 * `myEventLog-2.log`, …, derived from the configured `logFullPath`) and the
+	 * `.recoveryInProgress` marker colocate with this path. Empty (default)
 	 * preserves the legacy `${N8N_USER_FOLDER}/n8nEventLog[-worker|-webhook-processor]`
 	 * behavior.
 	 */

--- a/packages/@n8n/config/src/configs/event-bus.config.ts
+++ b/packages/@n8n/config/src/configs/event-bus.config.ts
@@ -17,6 +17,18 @@ class LogWriterConfig {
 	logBaseName: string = 'n8nEventLog';
 
 	/**
+	 * Absolute path to the primary event log file (must end in `.log`). When set,
+	 * used verbatim with no process-type suffix; the operator owns per-pod
+	 * uniqueness (e.g. via Kubernetes Downward API or per-pod PVC). Parent
+	 * directory is auto-created. Rotation siblings (`.log-1`, `.log-2`, …) and
+	 * the `.recoveryInProgress` marker colocate with this path. Empty (default)
+	 * preserves the legacy `${N8N_USER_FOLDER}/n8nEventLog[-worker|-webhook-processor]`
+	 * behavior.
+	 */
+	@Env('N8N_EVENTBUS_LOGWRITER_LOGFULLPATH')
+	logFullPath: string = '';
+
+	/**
 	 * Safety tripwire: per-file cap on concurrently unconfirmed messages held in memory
 	 * during startup log parsing. Aborts the file if exceeded, to prevent OOM on legacy
 	 * logs with many orphaned messages. Tune up if healthy workloads hit false positives.

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -161,6 +161,7 @@ describe('GlobalConfig', () => {
 			logWriter: {
 				keepLogCount: 3,
 				logBaseName: 'n8nEventLog',
+				logFullPath: '',
 				maxFileSizeInKB: 10240,
 				maxMessagesPerParse: 10_000,
 				maxTotalMessagesPerFile: 500_000,

--- a/packages/cli/src/eventbus/message-event-bus-writer/__tests__/message-event-bus-log-writer.test.ts
+++ b/packages/cli/src/eventbus/message-event-bus-writer/__tests__/message-event-bus-log-writer.test.ts
@@ -2,6 +2,7 @@ import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
+import { InstanceSettings } from 'n8n-core';
 import { EventMessageTypeNames } from 'n8n-workflow';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -295,5 +296,55 @@ describe('MessageEventBusLogWriter.readLoggedMessagesFromFile', () => {
 		const sampleMatch = warnCall?.match(/Sample \(truncated\): (.*)$/);
 		expect(sampleMatch).not.toBeNull();
 		expect(sampleMatch![1].length).toBeLessThanOrEqual(200);
+	});
+});
+
+describe('MessageEventBusLogWriter.getInstance path resolution', () => {
+	let tempDir: string;
+	let startThreadSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), 'eventbus-log-writer-getinstance-'));
+		Container.set(Logger, mock<Logger>());
+		Container.set(
+			GlobalConfig,
+			mock<GlobalConfig>({
+				eventBus: {
+					logWriter: {
+						logBaseName: 'n8nEventLog',
+						keepLogCount: 3,
+						maxFileSizeInKB: 10240,
+					},
+				},
+			}),
+		);
+		Container.set(InstanceSettings, mock<InstanceSettings>({ n8nFolder: tempDir }));
+		startThreadSpy = jest
+			.spyOn(MessageEventBusLogWriter.prototype as never, 'startThread')
+			.mockResolvedValue(undefined as never);
+	});
+
+	afterEach(() => {
+		(MessageEventBusLogWriter as unknown as { instance: undefined }).instance = undefined;
+		startThreadSpy.mockRestore();
+		rmSync(tempDir, { recursive: true, force: true });
+		Container.reset();
+	});
+
+	it.each<{ name: string; resolvedPath?: { logFullBasePath: string }; expected: () => string }>([
+		{
+			name: 'uses resolvedPath verbatim when supplied',
+			resolvedPath: { logFullBasePath: '/var/log/custom-events' },
+			expected: () => '/var/log/custom-events',
+		},
+		{
+			name: 'falls back to <n8nFolder>/<logBaseName> when no options supplied',
+			resolvedPath: undefined,
+			expected: () => join(tempDir, 'n8nEventLog'),
+		},
+	])('$name', async ({ resolvedPath, expected }) => {
+		await MessageEventBusLogWriter.getInstance(resolvedPath ? { resolvedPath } : undefined);
+
+		expect(MessageEventBusLogWriter.options.logFullBasePath).toBe(expected());
 	});
 });

--- a/packages/cli/src/eventbus/message-event-bus-writer/__tests__/resolve-event-log-path.test.ts
+++ b/packages/cli/src/eventbus/message-event-bus-writer/__tests__/resolve-event-log-path.test.ts
@@ -1,0 +1,97 @@
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { resolveEventLogPath, type EventLogProcessType } from '../resolve-event-log-path';
+
+jest.unmock('node:fs');
+
+describe('resolveEventLogPath', () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), 'resolve-event-log-path-'));
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	describe('path resolution', () => {
+		it.each<{
+			processType: EventLogProcessType;
+			logFullPath: string;
+			expectedBase: (dir: string) => string;
+			expectedFile: (dir: string) => string;
+		}>([
+			{
+				processType: 'main',
+				logFullPath: '',
+				expectedBase: (dir) => join(dir, 'n8nEventLog'),
+				expectedFile: (dir) => join(dir, 'n8nEventLog.log'),
+			},
+			{
+				processType: 'worker',
+				logFullPath: '',
+				expectedBase: (dir) => join(dir, 'n8nEventLog-worker'),
+				expectedFile: (dir) => join(dir, 'n8nEventLog-worker.log'),
+			},
+			{
+				processType: 'webhook-processor',
+				logFullPath: '',
+				expectedBase: (dir) => join(dir, 'n8nEventLog-webhook-processor'),
+				expectedFile: (dir) => join(dir, 'n8nEventLog-webhook-processor.log'),
+			},
+			{
+				processType: 'worker',
+				logFullPath: '__OVERRIDE__',
+				expectedBase: (dir) => join(dir, 'custom'),
+				expectedFile: (dir) => join(dir, 'custom.log'),
+			},
+		])(
+			'resolves processType=$processType, logFullPath=$logFullPath',
+			({ processType, logFullPath, expectedBase, expectedFile }) => {
+				const overridePath = join(tempDir, 'custom.log');
+				const resolved = resolveEventLogPath({
+					logFullPath: logFullPath === '__OVERRIDE__' ? overridePath : '',
+					logBaseName: 'n8nEventLog',
+					instanceDir: tempDir,
+					processType,
+				});
+
+				expect(resolved.logFullBasePath).toBe(expectedBase(tempDir));
+				expect(resolved.logFileName).toBe(expectedFile(tempDir));
+			},
+		);
+	});
+
+	describe('validation', () => {
+		it.each([
+			{ value: 'relative/path.log', match: /absolute/ },
+			{ value: '/tmp/foo.txt', match: /\.log/ },
+		])('rejects logFullPath=$value', ({ value, match }) => {
+			expect(() =>
+				resolveEventLogPath({
+					logFullPath: value,
+					logBaseName: 'n8nEventLog',
+					instanceDir: tempDir,
+					processType: 'worker',
+				}),
+			).toThrow(match);
+		});
+	});
+
+	it('creates the parent directory when it does not exist', () => {
+		const nestedPath = join(tempDir, 'deep', 'nested', 'path', 'events.log');
+		expect(existsSync(dirname(nestedPath))).toBe(false);
+
+		resolveEventLogPath({
+			logFullPath: nestedPath,
+			logBaseName: 'n8nEventLog',
+			instanceDir: tempDir,
+			processType: 'main',
+		});
+
+		expect(existsSync(dirname(nestedPath))).toBe(true);
+	});
+});

--- a/packages/cli/src/eventbus/message-event-bus-writer/message-event-bus-log-writer.ts
+++ b/packages/cli/src/eventbus/message-event-bus-writer/message-event-bus-log-writer.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-
 import { inTest, Logger, safeJoinPath } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { Container } from '@n8n/di';
@@ -31,6 +29,9 @@ import { EventMessageWorkflow } from '../event-message-classes/event-message-wor
 import type { EventMessageReturnMode } from '../message-event-bus/message-event-bus';
 
 interface MessageEventBusLogWriterConstructorOptions {
+	/** Resolved authoritative log file base path (without `.log`). When set,
+	 *  takes precedence over `logBaseName`/`logBasePath`. */
+	resolvedPath?: { logFullBasePath: string };
 	logBaseName?: string;
 	logBasePath?: string;
 	keepNumberOfFiles?: number;
@@ -83,11 +84,14 @@ export class MessageEventBusLogWriter {
 	): Promise<MessageEventBusLogWriter> {
 		if (!MessageEventBusLogWriter.instance) {
 			MessageEventBusLogWriter.instance = new MessageEventBusLogWriter();
-			MessageEventBusLogWriter.options = {
-				logFullBasePath: safeJoinPath(
+			const logFullBasePath =
+				options?.resolvedPath?.logFullBasePath ??
+				safeJoinPath(
 					options?.logBasePath ?? Container.get(InstanceSettings).n8nFolder,
 					options?.logBaseName ?? Container.get(GlobalConfig).eventBus.logWriter.logBaseName,
-				),
+				);
+			MessageEventBusLogWriter.options = {
+				logFullBasePath,
 				keepNumberOfFiles:
 					options?.keepNumberOfFiles ?? Container.get(GlobalConfig).eventBus.logWriter.keepLogCount,
 				maxFileSizeInKB:
@@ -284,7 +288,6 @@ export class MessageEventBusLogWriter {
 		return results;
 	}
 
-	// eslint-disable-next-line complexity
 	private processLoggedLine(
 		line: string,
 		results: ReadMessagesFromLogFileResult,

--- a/packages/cli/src/eventbus/message-event-bus-writer/resolve-event-log-path.ts
+++ b/packages/cli/src/eventbus/message-event-bus-writer/resolve-event-log-path.ts
@@ -1,0 +1,51 @@
+import { safeJoinPath } from '@n8n/backend-common';
+import { UserError } from 'n8n-workflow';
+import { existsSync, mkdirSync } from 'node:fs';
+import { dirname, isAbsolute } from 'node:path';
+
+export type EventLogProcessType = 'main' | 'worker' | 'webhook-processor';
+
+export interface ResolveEventLogPathInput {
+	logFullPath: string;
+	logBaseName: string;
+	instanceDir: string;
+	processType: EventLogProcessType;
+}
+
+export interface ResolvedEventLogPath {
+	logFullBasePath: string;
+	logFileName: string;
+}
+
+const LOG_FILE_EXTENSION = '.log';
+const ENV_VAR = 'N8N_EVENTBUS_LOGWRITER_LOGFULLPATH';
+
+export function resolveEventLogPath(input: ResolveEventLogPathInput): ResolvedEventLogPath {
+	const { logFullPath, logBaseName, instanceDir, processType } = input;
+
+	if (logFullPath) {
+		if (!isAbsolute(logFullPath)) {
+			throw new UserError(`${ENV_VAR} must be an absolute path, got: ${logFullPath}`);
+		}
+		if (!logFullPath.endsWith(LOG_FILE_EXTENSION)) {
+			throw new UserError(`${ENV_VAR} must end in '${LOG_FILE_EXTENSION}', got: ${logFullPath}`);
+		}
+
+		const parent = dirname(logFullPath);
+		if (!existsSync(parent)) {
+			mkdirSync(parent, { recursive: true });
+		}
+
+		const logFullBasePath = logFullPath.slice(0, -LOG_FILE_EXTENSION.length);
+		return { logFullBasePath, logFileName: logFullPath };
+	}
+
+	const suffix =
+		processType === 'worker'
+			? '-worker'
+			: processType === 'webhook-processor'
+				? '-webhook-processor'
+				: '';
+	const logFullBasePath = safeJoinPath(instanceDir, `${logBaseName}${suffix}`);
+	return { logFullBasePath, logFileName: `${logFullBasePath}${LOG_FILE_EXTENSION}` };
+}

--- a/packages/cli/src/eventbus/message-event-bus/__tests__/message-event-bus.test.ts
+++ b/packages/cli/src/eventbus/message-event-bus/__tests__/message-event-bus.test.ts
@@ -1,0 +1,115 @@
+import type { Logger } from '@n8n/backend-common';
+import type { GlobalConfig } from '@n8n/config';
+import { mock } from 'jest-mock-extended';
+import type { InstanceSettings } from 'n8n-core';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { MessageEventBusLogWriter } from '../../message-event-bus-writer/message-event-bus-log-writer';
+import { MessageEventBus, type MessageEventBusInitializeOptions } from '../message-event-bus';
+
+jest.unmock('@/eventbus/message-event-bus/message-event-bus');
+jest.unmock('node:fs');
+
+interface BusConfigOverrides {
+	logFullPath?: string;
+	logBaseName?: string;
+	keepLogCount?: number;
+}
+
+const buildGlobalConfig = (overrides: BusConfigOverrides = {}) =>
+	mock<GlobalConfig>({
+		eventBus: {
+			logWriter: {
+				logBaseName: overrides.logBaseName ?? 'n8nEventLog',
+				logFullPath: overrides.logFullPath ?? '',
+				keepLogCount: overrides.keepLogCount ?? 3,
+				maxFileSizeInKB: 10240,
+				maxMessagesPerParse: 10_000,
+				maxTotalMessagesPerFile: 500_000,
+			},
+			checkUnsentInterval: 0,
+			crashRecoveryMode: 'extensive',
+		},
+		executions: { mode: 'regular', recovery: { workflowDeactivationEnabled: false } },
+	});
+
+describe('MessageEventBus.initialize', () => {
+	let tempDir: string;
+	let logger: ReturnType<typeof mock<Logger>>;
+	let getInstanceSpy: jest.SpyInstance;
+	const mockedWriter = mock<MessageEventBusLogWriter>();
+
+	const buildBus = (globalConfig: GlobalConfig) =>
+		new MessageEventBus(
+			logger,
+			mock(),
+			mock(),
+			mock(),
+			globalConfig,
+			mock<InstanceSettings>({ n8nFolder: tempDir }),
+		);
+
+	const initOpts = (
+		extra: Partial<MessageEventBusInitializeOptions> = {},
+	): MessageEventBusInitializeOptions => ({ skipRecoveryPass: true, ...extra });
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), 'message-event-bus-test-'));
+		logger = mock<Logger>();
+		getInstanceSpy = jest
+			.spyOn(MessageEventBusLogWriter, 'getInstance')
+			.mockResolvedValue(mockedWriter);
+	});
+
+	afterEach(() => {
+		getInstanceSpy.mockRestore();
+		rmSync(tempDir, { recursive: true, force: true });
+		jest.clearAllMocks();
+	});
+
+	describe('path routing', () => {
+		it.each<{
+			name: string;
+			workerId?: string;
+			webhookProcessorId?: string;
+			expectedBase: (dir: string) => string;
+		}>([
+			{
+				name: 'worker default appends -worker suffix',
+				workerId: 'host-1',
+				expectedBase: (dir) => join(dir, 'n8nEventLog-worker'),
+			},
+			{
+				name: 'webhook processor default appends -webhook-processor suffix',
+				webhookProcessorId: 'host-2',
+				expectedBase: (dir) => join(dir, 'n8nEventLog-webhook-processor'),
+			},
+			{
+				name: 'main default has no suffix',
+				expectedBase: (dir) => join(dir, 'n8nEventLog'),
+			},
+		])('$name', async ({ workerId, webhookProcessorId, expectedBase }) => {
+			const bus = buildBus(buildGlobalConfig({ logFullPath: '' }));
+
+			await bus.initialize(initOpts({ workerId, webhookProcessorId }));
+
+			expect(getInstanceSpy).toHaveBeenCalledWith({
+				resolvedPath: { logFullBasePath: expectedBase(tempDir) },
+			});
+		});
+	});
+
+	it('warns when logFullPath is set and a default-location log exists', async () => {
+		const stalePath = join(tempDir, 'n8nEventLog-worker.log');
+		writeFileSync(stalePath, '');
+		const customLog = join(tempDir, 'custom.log');
+		const bus = buildBus(buildGlobalConfig({ logFullPath: customLog }));
+
+		await bus.initialize(initOpts({ workerId: 'host-1' }));
+
+		expect(logger.warn).toHaveBeenCalledTimes(1);
+		expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining(stalePath));
+	});
+});

--- a/packages/cli/src/eventbus/message-event-bus/__tests__/message-event-bus.test.ts
+++ b/packages/cli/src/eventbus/message-event-bus/__tests__/message-event-bus.test.ts
@@ -1,5 +1,6 @@
 import type { Logger } from '@n8n/backend-common';
 import type { GlobalConfig } from '@n8n/config';
+import type { ExecutionRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
@@ -7,7 +8,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { MessageEventBusLogWriter } from '../../message-event-bus-writer/message-event-bus-log-writer';
-import { MessageEventBus, type MessageEventBusInitializeOptions } from '../message-event-bus';
+import { MessageEventBus } from '../message-event-bus';
 
 jest.unmock('@/eventbus/message-event-bus/message-event-bus');
 jest.unmock('node:fs');
@@ -40,20 +41,17 @@ describe('MessageEventBus.initialize', () => {
 	let logger: ReturnType<typeof mock<Logger>>;
 	let getInstanceSpy: jest.SpyInstance;
 	const mockedWriter = mock<MessageEventBusLogWriter>();
+	const executionRepository = mock<ExecutionRepository>();
 
 	const buildBus = (globalConfig: GlobalConfig) =>
 		new MessageEventBus(
 			logger,
-			mock(),
+			executionRepository,
 			mock(),
 			mock(),
 			globalConfig,
 			mock<InstanceSettings>({ n8nFolder: tempDir }),
 		);
-
-	const initOpts = (
-		extra: Partial<MessageEventBusInitializeOptions> = {},
-	): MessageEventBusInitializeOptions => ({ skipRecoveryPass: true, ...extra });
 
 	beforeEach(() => {
 		tempDir = mkdtempSync(join(tmpdir(), 'message-event-bus-test-'));
@@ -61,6 +59,13 @@ describe('MessageEventBus.initialize', () => {
 		getInstanceSpy = jest
 			.spyOn(MessageEventBusLogWriter, 'getInstance')
 			.mockResolvedValue(mockedWriter);
+		mockedWriter.getUnsentAndUnfinishedExecutions.mockResolvedValue({
+			unsentMessages: [],
+			unfinishedExecutions: {},
+		});
+		mockedWriter.getLogFileName.mockReturnValue('mocked.log');
+		mockedWriter.isRecoveryProcessRunning.mockReturnValue(false);
+		executionRepository.find.mockResolvedValue([]);
 	});
 
 	afterEach(() => {
@@ -93,7 +98,7 @@ describe('MessageEventBus.initialize', () => {
 		])('$name', async ({ workerId, webhookProcessorId, expectedBase }) => {
 			const bus = buildBus(buildGlobalConfig({ logFullPath: '' }));
 
-			await bus.initialize(initOpts({ workerId, webhookProcessorId }));
+			await bus.initialize({ workerId, webhookProcessorId });
 
 			expect(getInstanceSpy).toHaveBeenCalledWith({
 				resolvedPath: { logFullBasePath: expectedBase(tempDir) },
@@ -107,7 +112,7 @@ describe('MessageEventBus.initialize', () => {
 		const customLog = join(tempDir, 'custom.log');
 		const bus = buildBus(buildGlobalConfig({ logFullPath: customLog }));
 
-		await bus.initialize(initOpts({ workerId: 'host-1' }));
+		await bus.initialize({ workerId: 'host-1' });
 
 		expect(logger.warn).toHaveBeenCalledTimes(1);
 		expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining(stalePath));

--- a/packages/cli/src/eventbus/message-event-bus/message-event-bus.ts
+++ b/packages/cli/src/eventbus/message-event-bus/message-event-bus.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@n8n/backend-common';
+import { Logger, safeJoinPath } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { ExecutionRepository, WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
@@ -6,6 +6,8 @@ import { Service } from '@n8n/di';
 import { In, IsNull, Not } from '@n8n/typeorm';
 import EventEmitter from 'events';
 import uniqby from 'lodash/uniqBy';
+import { InstanceSettings } from 'n8n-core';
+import { existsSync } from 'node:fs';
 
 import { ExecutionRecoveryService } from '../../executions/execution-recovery.service';
 import type { EventMessageTypes } from '../event-message-classes/';
@@ -27,6 +29,10 @@ import { EventMessageRunner } from '../event-message-classes/event-message-runne
 import type { EventMessageWorkflowOptions } from '../event-message-classes/event-message-workflow';
 import { EventMessageWorkflow } from '../event-message-classes/event-message-workflow';
 import { MessageEventBusLogWriter } from '../message-event-bus-writer/message-event-bus-log-writer';
+import {
+	resolveEventLogPath,
+	type EventLogProcessType,
+} from '../message-event-bus-writer/resolve-event-log-path';
 
 export type EventMessageReturnMode = 'sent' | 'unsent' | 'all' | 'unfinished';
 
@@ -56,6 +62,7 @@ export class MessageEventBus extends EventEmitter {
 		private readonly workflowRepository: WorkflowRepository,
 		private readonly recoveryService: ExecutionRecoveryService,
 		private readonly globalConfig: GlobalConfig,
+		private readonly instanceSettings: InstanceSettings,
 	) {
 		super();
 	}
@@ -76,18 +83,26 @@ export class MessageEventBus extends EventEmitter {
 		this.logger.debug('Initializing event bus...');
 
 		this.logger.debug('Initializing event writer');
-		if (options?.workerId || options?.webhookProcessorId) {
-			// only add 'worker' or 'webhook-processor' to log file name since the ID changes on every start and we
-			// would not be able to recover the log files from the previous run not knowing it
-			const logBaseName =
-				this.globalConfig.eventBus.logWriter.logBaseName +
-				(options.workerId ? '-worker' : '-webhook-processor');
-			this.logWriter = await MessageEventBusLogWriter.getInstance({
-				logBaseName,
-			});
-		} else {
-			this.logWriter = await MessageEventBusLogWriter.getInstance();
+		const processType: EventLogProcessType = options?.workerId
+			? 'worker'
+			: options?.webhookProcessorId
+				? 'webhook-processor'
+				: 'main';
+
+		const resolved = resolveEventLogPath({
+			logFullPath: this.globalConfig.eventBus.logWriter.logFullPath,
+			logBaseName: this.globalConfig.eventBus.logWriter.logBaseName,
+			instanceDir: this.instanceSettings.n8nFolder,
+			processType,
+		});
+
+		if (this.globalConfig.eventBus.logWriter.logFullPath) {
+			this.warnIfDefaultLocationEventLogsCoexist(processType);
 		}
+
+		this.logWriter = await MessageEventBusLogWriter.getInstance({
+			resolvedPath: { logFullBasePath: resolved.logFullBasePath },
+		});
 
 		if (!this.logWriter) {
 			this.logger.warn('Could not initialize event writer');
@@ -107,6 +122,34 @@ export class MessageEventBus extends EventEmitter {
 
 		this.logger.debug('MessageEventBus initialized');
 		this.isInitialized = true;
+	}
+
+	private warnIfDefaultLocationEventLogsCoexist(processType: EventLogProcessType): void {
+		const suffix =
+			processType === 'worker'
+				? '-worker'
+				: processType === 'webhook-processor'
+					? '-webhook-processor'
+					: '';
+		const defaultBase = safeJoinPath(
+			this.instanceSettings.n8nFolder,
+			`${this.globalConfig.eventBus.logWriter.logBaseName}${suffix}`,
+		);
+		const candidates = [
+			`${defaultBase}.log`,
+			...Array.from(
+				{ length: this.globalConfig.eventBus.logWriter.keepLogCount },
+				(_, i) => `${defaultBase}-${i + 1}.log`,
+			),
+		];
+		const stale = candidates.filter((p) => existsSync(p));
+		if (stale.length > 0) {
+			this.logger.warn(
+				`N8N_EVENTBUS_LOGWRITER_LOGFULLPATH is set, but event log file(s) at the default location still exist: ${stale.join(', ')}. ` +
+					'These files are no longer being written to and may contain unsent events from a previous run. ' +
+					'Drain or relocate them as part of the migration.',
+			);
+		}
 	}
 
 	private async trySendingUnsent(msgs?: EventMessageTypes[]) {

--- a/packages/cli/src/eventbus/message-event-bus/message-event-bus.ts
+++ b/packages/cli/src/eventbus/message-event-bus/message-event-bus.ts
@@ -1,4 +1,4 @@
-import { Logger, safeJoinPath } from '@n8n/backend-common';
+import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { ExecutionRepository, WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
@@ -125,18 +125,14 @@ export class MessageEventBus extends EventEmitter {
 	}
 
 	private warnIfDefaultLocationEventLogsCoexist(processType: EventLogProcessType): void {
-		const suffix =
-			processType === 'worker'
-				? '-worker'
-				: processType === 'webhook-processor'
-					? '-webhook-processor'
-					: '';
-		const defaultBase = safeJoinPath(
-			this.instanceSettings.n8nFolder,
-			`${this.globalConfig.eventBus.logWriter.logBaseName}${suffix}`,
-		);
+		const { logFullBasePath: defaultBase, logFileName: defaultLogFile } = resolveEventLogPath({
+			logFullPath: '',
+			logBaseName: this.globalConfig.eventBus.logWriter.logBaseName,
+			instanceDir: this.instanceSettings.n8nFolder,
+			processType,
+		});
 		const candidates = [
-			`${defaultBase}.log`,
+			defaultLogFile,
 			...Array.from(
 				{ length: this.globalConfig.eventBus.logWriter.keepLogCount },
 				(_, i) => `${defaultBase}-${i + 1}.log`,

--- a/packages/cli/src/eventbus/message-event-bus/message-event-bus.ts
+++ b/packages/cli/src/eventbus/message-event-bus/message-event-bus.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@n8n/backend-common';
+import { Logger, safeJoinPath } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { ExecutionRepository, WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
@@ -6,6 +6,8 @@ import { Service } from '@n8n/di';
 import { In, IsNull, Not } from '@n8n/typeorm';
 import EventEmitter from 'events';
 import uniqby from 'lodash/uniqBy';
+import { InstanceSettings } from 'n8n-core';
+import { existsSync } from 'node:fs';
 
 import { ExecutionRecoveryService } from '../../executions/execution-recovery.service';
 import type { EventMessageTypes } from '../event-message-classes/';
@@ -27,6 +29,10 @@ import { EventMessageRunner } from '../event-message-classes/event-message-runne
 import type { EventMessageWorkflowOptions } from '../event-message-classes/event-message-workflow';
 import { EventMessageWorkflow } from '../event-message-classes/event-message-workflow';
 import { MessageEventBusLogWriter } from '../message-event-bus-writer/message-event-bus-log-writer';
+import {
+	resolveEventLogPath,
+	type EventLogProcessType,
+} from '../message-event-bus-writer/resolve-event-log-path';
 
 export type EventMessageReturnMode = 'sent' | 'unsent' | 'all' | 'unfinished';
 
@@ -57,6 +63,7 @@ export class MessageEventBus extends EventEmitter {
 		private readonly workflowRepository: WorkflowRepository,
 		private readonly recoveryService: ExecutionRecoveryService,
 		private readonly globalConfig: GlobalConfig,
+		private readonly instanceSettings: InstanceSettings,
 	) {
 		super();
 	}
@@ -78,18 +85,26 @@ export class MessageEventBus extends EventEmitter {
 		this.logger.debug('Initializing event bus...');
 
 		this.logger.debug('Initializing event writer');
-		if (options?.workerId || options?.webhookProcessorId) {
-			// only add 'worker' or 'webhook-processor' to log file name since the ID changes on every start and we
-			// would not be able to recover the log files from the previous run not knowing it
-			const logBaseName =
-				this.globalConfig.eventBus.logWriter.logBaseName +
-				(options.workerId ? '-worker' : '-webhook-processor');
-			this.logWriter = await MessageEventBusLogWriter.getInstance({
-				logBaseName,
-			});
-		} else {
-			this.logWriter = await MessageEventBusLogWriter.getInstance();
+		const processType: EventLogProcessType = options?.workerId
+			? 'worker'
+			: options?.webhookProcessorId
+				? 'webhook-processor'
+				: 'main';
+
+		const resolved = resolveEventLogPath({
+			logFullPath: this.globalConfig.eventBus.logWriter.logFullPath,
+			logBaseName: this.globalConfig.eventBus.logWriter.logBaseName,
+			instanceDir: this.instanceSettings.n8nFolder,
+			processType,
+		});
+
+		if (this.globalConfig.eventBus.logWriter.logFullPath) {
+			this.warnIfDefaultLocationEventLogsCoexist(processType);
 		}
+
+		this.logWriter = await MessageEventBusLogWriter.getInstance({
+			resolvedPath: { logFullBasePath: resolved.logFullBasePath },
+		});
 
 		if (!this.logWriter) {
 			this.logger.warn('Could not initialize event writer');
@@ -198,6 +213,34 @@ export class MessageEventBus extends EventEmitter {
 
 		this.logger.debug('MessageEventBus initialized');
 		this.isInitialized = true;
+	}
+
+	private warnIfDefaultLocationEventLogsCoexist(processType: EventLogProcessType): void {
+		const suffix =
+			processType === 'worker'
+				? '-worker'
+				: processType === 'webhook-processor'
+					? '-webhook-processor'
+					: '';
+		const defaultBase = safeJoinPath(
+			this.instanceSettings.n8nFolder,
+			`${this.globalConfig.eventBus.logWriter.logBaseName}${suffix}`,
+		);
+		const candidates = [
+			`${defaultBase}.log`,
+			...Array.from(
+				{ length: this.globalConfig.eventBus.logWriter.keepLogCount },
+				(_, i) => `${defaultBase}-${i + 1}.log`,
+			),
+		];
+		const stale = candidates.filter((p) => existsSync(p));
+		if (stale.length > 0) {
+			this.logger.warn(
+				`N8N_EVENTBUS_LOGWRITER_LOGFULLPATH is set, but event log file(s) at the default location still exist: ${stale.join(', ')}. ` +
+					'These files are no longer being written to and may contain unsent events from a previous run. ' +
+					'Drain or relocate them as part of the migration.',
+			);
+		}
 	}
 
 	private async trySendingUnsent(msgs?: EventMessageTypes[]) {

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.unmocked.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.unmocked.test.ts
@@ -22,7 +22,7 @@ const eventService = mock<EventService>();
 const instanceSettings = mock<InstanceSettings>({ instanceType: 'main' });
 const workflowRepository = mock<WorkflowRepository>();
 const app = mock<express.Application>();
-const eventBus = new MessageEventBus(mock(), mock(), mock(), mock(), mock());
+const eventBus = new MessageEventBus(mock(), mock(), mock(), mock(), mock(), mock());
 
 describe('workflow_success_total', () => {
 	test('support workflow id labels', async () => {


### PR DESCRIPTION
## Summary

Adds a new opt-in env var `N8N_EVENTBUS_LOGWRITER_LOGFULLPATH` that lets operators route the event log to a specific absolute path — used verbatim, with no process-type suffix appended. When the env is unset, behavior is byte-identical to today (default path under `${N8N_USER_FOLDER}` with the existing `-worker` / `-webhook-processor` / no-suffix derivation).

## Why

In multi-pod deployments backed by a shared RWX volume, every worker pod resolves to the same `${N8N_USER_FOLDER}/n8nEventLog-worker.log` because the `-worker` suffix discards the per-pod `hostId`. Concurrent unguarded `appendFileSync` writes from N pods to that single file produce interleaved bytes and rotation races, which then destabilizes startup recovery.

The companion read-side fix (bounded skip-and-warn parser + total-messages guard) shipped earlier. This PR addresses the write-side root cause: give operators a knob to put each pod on its own durable per-pod path (typically templated via the Kubernetes Downward API or a per-pod PVC). The operator owns per-pod uniqueness — n8n does not auto-suffix when the env is set.

## What changed

- New config field `LogWriterConfig.logFullPath` (env: `N8N_EVENTBUS_LOGWRITER_LOGFULLPATH`), default empty
- New pure helper `resolveEventLogPath()` co-located with the writer — handles validation, parent-dir auto-create, and legacy fallback in one place
- `MessageEventBusLogWriter.getInstance` accepts a new `resolvedPath` option that takes precedence over the legacy `logBasePath`/`logBaseName` derivation
- `MessageEventBus.initialize` calls the helper, threads the resolved path into the writer, and emits an advisory `logger.warn` when the operator opts into a configured path while files at the default location still exist (non-blocking)
- Worker thread (`message-event-bus-log-writer-worker.ts`) untouched — it already derives all rotation siblings (`.log-N`) and the `.recoveryInProgress` marker purely from `logFullBasePath`

## How to test manually

1. **Configured path is honored**
   ```bash
   N8N_EVENTBUS_LOGWRITER_LOGFULLPATH=/tmp/n8n-events/custom.log n8n start
   ```
   Verify writes land at `/tmp/n8n-events/custom.log`. Trigger a few rotations (lower `N8N_EVENTBUS_LOGWRITER_MAXFILESIZEINKB` to e.g. `1`) and confirm siblings appear at `/tmp/n8n-events/custom-1.log`, `custom-2.log`, …, with no `-worker` suffix anywhere.

2. **Default behavior unchanged when env unset**
   Start a worker without the env. Confirm it still writes to `${N8N_USER_FOLDER}/n8nEventLog-worker.log` (existing behavior).

3. **Validation**
   - `N8N_EVENTBUS_LOGWRITER_LOGFULLPATH=relative/path.log` → startup fails with a clear message about the path needing to be absolute
   - `N8N_EVENTBUS_LOGWRITER_LOGFULLPATH=/tmp/foo.txt` → startup fails about needing `.log` extension

4. **Parent dir auto-create**
   Point the env at a path whose parent does not exist (e.g. `/tmp/does/not/exist/yet/events.log`). Start a worker; confirm the parent dir is created and the file is written.

5. **Default-location coexistence advisory**
   Pre-create `${N8N_USER_FOLDER}/n8nEventLog-worker.log` (e.g. `touch`), then start a worker with `N8N_EVENTBUS_LOGWRITER_LOGFULLPATH=/tmp/elsewhere/events.log`. Confirm a single `WARN` log lists the stale default-location file.

## Key implementation decisions

- **Pure helper, service-layer validation.** `resolveEventLogPath` is a synchronous pure function with one filesystem side-effect (`mkdirSync({ recursive: true })`). Validation throws `UserError` from inside the helper rather than from a config decorator, matching the n8n convention (config decorators stay declarative; service `initialize()` is the validation point).
- **Verbatim when set, no auto-suffix.** When the env is set, the configured path is used as-is for main, worker, and webhook processes alike. The operator templates uniqueness (Downward API `$(POD_NAME)`, per-pod PVC `subPathExpr`, etc.). Auto-suffixing would fight that templating.
- **Worker thread untouched.** The corruption isn't in the worker code — it's in the path collision. Threading a unique `logFullBasePath` through to the worker resolves it without modifying any of the rotation / append / recovery-marker logic.
- **Default-location coexistence is advisory, not destructive.** Lists stale files in a single `WARN` log; never deletes anything. Operators handle drainage as part of their migration.

## Related Links

- Linear: https://linear.app/n8n/issue/IAM-579

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
