### PR TITLE
fix: Require userId for checkpoints and agent builder memory

### DIFF
--- a/packages/@n8n/db/src/migrations/common/1781000000000-AddUserIdToAgentCheckpoints.ts
+++ b/packages/@n8n/db/src/migrations/common/1781000000000-AddUserIdToAgentCheckpoints.ts
@@ -1,0 +1,11 @@
+import type { IrreversibleMigration, MigrationContext } from '../migration-types';
+
+export class AddUserIdToAgentCheckpoints1781000000000 implements IrreversibleMigration {
+	async up({ schemaBuilder: { addColumns, column }, runQuery, tablePrefix }: MigrationContext) {
+		// Checkpoints are transient suspension state. Drop all existing rows so
+		// the new non-nullable userId column can be added without a default value.
+		await runQuery(`DELETE FROM ${tablePrefix}agent_checkpoints`);
+
+		await addColumns('agent_checkpoints', [column('userId').varchar(255).notNull]);
+	}
+}

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -168,6 +168,7 @@ import { AddLangsmithIdsToInstanceAiRunSnapshots1777100000000 } from '../common/
 import { AddToolsColumnToAgents1778000000000 } from '../common/1778000000000-AddToolsColumnToAgents';
 import { DropAgentCodeColumn1779000000000 } from '../common/1779000000000-DropAgentCodeColumn';
 import { AddAgentPublishVersionSupport1780000000000 } from '../common/1780000000000-AddAgentPublishVersionSupport';
+import { AddUserIdToAgentCheckpoints1781000000000 } from '../common/1781000000000-AddUserIdToAgentCheckpoints';
 import { CreateExecutionThreads1780000000000 } from '../common/1780000000000-CreateExecutionThreads';
 import type { Migration } from '../migration-types';
 
@@ -343,4 +344,5 @@ export const postgresMigrations: Migration[] = [
 	DropAgentCodeColumn1779000000000,
 	AddAgentPublishVersionSupport1780000000000,
 	CreateExecutionThreads1780000000000,
+	AddUserIdToAgentCheckpoints1781000000000,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -162,6 +162,7 @@ import { AddLangsmithIdsToInstanceAiRunSnapshots1777100000000 } from '../common/
 import { AddToolsColumnToAgents1778000000000 } from '../common/1778000000000-AddToolsColumnToAgents';
 import { DropAgentCodeColumn1779000000000 } from '../common/1779000000000-DropAgentCodeColumn';
 import { AddAgentPublishVersionSupport1780000000000 } from '../common/1780000000000-AddAgentPublishVersionSupport';
+import { AddUserIdToAgentCheckpoints1781000000000 } from '../common/1781000000000-AddUserIdToAgentCheckpoints';
 import { CreateExecutionThreads1780000000000 } from '../common/1780000000000-CreateExecutionThreads';
 import type { Migration } from '../migration-types';
 
@@ -331,6 +332,7 @@ const sqliteMigrations: Migration[] = [
 	DropAgentCodeColumn1779000000000,
 	AddAgentPublishVersionSupport1780000000000,
 	CreateExecutionThreads1780000000000,
+	AddUserIdToAgentCheckpoints1781000000000,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/modules/agents/__tests__/agent.repository.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent.repository.test.ts
@@ -3,10 +3,10 @@ import { mock } from 'jest-mock-extended';
 
 import { mockEntityManager } from '@test/mocking';
 
-import { Agent } from '../entities/agent.entity';
+import { AgentEntity } from '../entities/agent.entity';
 import { AgentRepository } from '../repositories/agent.repository';
 
-const entityManager = mockEntityManager(Agent);
+const entityManager = mockEntityManager(AgentEntity);
 const mockDataSource = { manager: entityManager };
 
 describe('AgentRepository', () => {
@@ -19,7 +19,7 @@ describe('AgentRepository', () => {
 
 	describe('findByIdAndProjectId', () => {
 		it('calls findOne with id, projectId, and the publishedVersion relation', async () => {
-			const agent = mock<Agent>({ id: 'agent-1', projectId: 'project-1' });
+			const agent = mock<AgentEntity>({ id: 'agent-1', projectId: 'project-1' });
 			jest.spyOn(repository, 'findOne').mockResolvedValue(agent);
 
 			const result = await repository.findByIdAndProjectId('agent-1', 'project-1');
@@ -42,7 +42,7 @@ describe('AgentRepository', () => {
 
 	describe('findByProjectId', () => {
 		it('calls find ordered by updatedAt descending with the publishedVersion relation', async () => {
-			const agents = [mock<Agent>(), mock<Agent>()];
+			const agents = [mock<AgentEntity>(), mock<AgentEntity>()];
 			jest.spyOn(repository, 'find').mockResolvedValue(agents);
 
 			const result = await repository.findByProjectId('project-1');
@@ -66,7 +66,7 @@ describe('AgentRepository', () => {
 
 	describe('findByIntegrationCredential', () => {
 		const makeAgent = (id: string, integrations: Array<{ type: string; credentialId: string }>) =>
-			({ id, integrations }) as Agent;
+			({ id, integrations }) as AgentEntity;
 
 		it('returns agents that have a matching type + credentialId, excluding the given agentId', async () => {
 			const agents = [
@@ -108,8 +108,8 @@ describe('AgentRepository', () => {
 		it('handles agents whose integrations column is null / undefined without crashing', async () => {
 			const agents = [
 				makeAgent('agent-a', [{ type: 'telegram', credentialId: 'cred-1' }]),
-				{ id: 'agent-null', integrations: null } as unknown as Agent,
-				{ id: 'agent-undef' } as unknown as Agent,
+				{ id: 'agent-null', integrations: null } as unknown as AgentEntity,
+				{ id: 'agent-undef' } as unknown as AgentEntity,
 			];
 			jest.spyOn(repository, 'find').mockResolvedValue(agents);
 

--- a/packages/cli/src/modules/agents/__tests__/agents-service-reconstruct-gating.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-service-reconstruct-gating.test.ts
@@ -18,7 +18,7 @@ import type { WorkflowFinderService } from '@/workflows/workflow-finder.service'
 import type { AgentExecutionService } from '../agent-execution.service';
 import type { AgentsToolsService } from '../agents-tools.service';
 import { AgentsService } from '../agents.service';
-import type { Agent } from '../entities/agent.entity';
+import type { AgentEntity } from '../entities/agent.entity';
 import type { N8NCheckpointStorage } from '../integrations/n8n-checkpoint-storage';
 import type { N8nMemory } from '../integrations/n8n-memory';
 import type { AgentJsonConfig } from '../json-config/agent-json-config';
@@ -61,7 +61,7 @@ function makeService(agentsToolsService: AgentsToolsService): AgentsService {
 	);
 }
 
-function makeAgentEntity(schemaConfig?: AgentJsonConfig['config']): Agent {
+function makeAgentEntity(schemaConfig?: AgentJsonConfig['config']): AgentEntity {
 	const schema: AgentJsonConfig = {
 		name: 'Test',
 		model: 'anthropic/claude-sonnet-4-5',
@@ -73,13 +73,13 @@ function makeAgentEntity(schemaConfig?: AgentJsonConfig['config']): Agent {
 		projectId: 'project-1',
 		schema,
 		tools: {},
-	} as unknown as Agent;
+	} as unknown as AgentEntity;
 }
 
 // reconstructFromConfig is private; cast to invoke directly.
 type Reconstructable = {
 	reconstructFromConfig(
-		agentEntity: Agent,
+		agentEntity: AgentEntity,
 		credentialProvider: CredentialProvider,
 		userId?: string,
 	): Promise<agents.Agent>;

--- a/packages/cli/src/modules/agents/__tests__/agents-service-sync.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-service-sync.test.ts
@@ -16,14 +16,14 @@ import type { WorkflowFinderService } from '@/workflows/workflow-finder.service'
 
 import type { AgentExecutionService } from '../agent-execution.service';
 import { AgentsService } from '../agents.service';
-import type { Agent } from '../entities/agent.entity';
+import type { AgentEntity } from '../entities/agent.entity';
 import type { N8NCheckpointStorage } from '../integrations/n8n-checkpoint-storage';
 import type { N8nMemory } from '../integrations/n8n-memory';
 import type { AgentJsonConfig } from '../json-config/agent-json-config';
 import type { AgentRepository } from '../repositories/agent.repository';
 import type { AgentSecureRuntime } from '../runtime/agent-secure-runtime';
 
-function makeAgent(overrides: Partial<Agent> = {}): Agent {
+function makeAgent(overrides: Partial<AgentEntity> = {}): AgentEntity {
 	return {
 		id: 'agent-1',
 		name: 'Old Name',
@@ -43,7 +43,7 @@ function makeAgent(overrides: Partial<Agent> = {}): Agent {
 		createdAt: new Date('2026-01-01'),
 		updatedAt: new Date('2026-01-01'),
 		...overrides,
-	} as Agent;
+	} as AgentEntity;
 }
 
 describe('AgentsService — updateName / updateDescription schema sync', () => {
@@ -52,7 +52,7 @@ describe('AgentsService — updateName / updateDescription schema sync', () => {
 
 	beforeEach(() => {
 		agentRepository = mock<AgentRepository>();
-		agentRepository.save.mockImplementation(async (entity) => entity as Agent);
+		agentRepository.save.mockImplementation(async (entity) => entity as AgentEntity);
 
 		service = new AgentsService(
 			mock<Logger>(),
@@ -99,7 +99,7 @@ describe('AgentsService — updateName / updateDescription schema sync', () => {
 		});
 
 		it('handles agent with null schema', async () => {
-			const agent = makeAgent({ schema: null } as unknown as Partial<Agent>);
+			const agent = makeAgent({ schema: null } as unknown as Partial<AgentEntity>);
 			agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
 
 			const result = await service.updateName('agent-1', 'project-1', 'New Name');
@@ -141,7 +141,7 @@ describe('AgentsService — updateName / updateDescription schema sync', () => {
 		});
 
 		it('handles agent with null schema', async () => {
-			const agent = makeAgent({ schema: null } as unknown as Partial<Agent>);
+			const agent = makeAgent({ schema: null } as unknown as Partial<AgentEntity>);
 			agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
 
 			const result = await service.updateDescription('agent-1', 'project-1', 'New desc');

--- a/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
@@ -5,9 +5,9 @@ import { mock } from 'jest-mock-extended';
 
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
-import { AgentsService, chatThreadId } from '../agents.service';
+import { AgentsService } from '../agents.service';
 import type { AgentPublishedVersion } from '../entities/agent-published-version.entity';
-import type { Agent } from '../entities/agent.entity';
+import type { AgentEntity } from '../entities/agent.entity';
 import { ChatIntegrationService } from '../integrations/chat-integration.service';
 import {
 	AgentChatIntegration,
@@ -18,13 +18,14 @@ import type { N8nMemory } from '../integrations/n8n-memory';
 import type { AgentJsonConfig } from '../json-config/agent-json-config';
 import type { AgentPublishedVersionRepository } from '../repositories/agent-published-version.repository';
 import type { AgentRepository } from '../repositories/agent.repository';
+import { testChatThreadId } from '../builder/thread';
 
 const agentId = 'agent-1';
 const projectId = 'project-1';
 const userId = 'user-1';
 const versionId = 'v1';
 
-function makeAgent(overrides: Partial<Agent> = {}): Agent {
+function makeAgent(overrides: Partial<AgentEntity> = {}): AgentEntity {
 	return {
 		id: agentId,
 		versionId,
@@ -36,7 +37,7 @@ function makeAgent(overrides: Partial<Agent> = {}): Agent {
 		tools: {},
 		updatedAt: new Date(),
 		...overrides,
-	} as unknown as Agent;
+	} as unknown as AgentEntity;
 }
 
 function makePublishedVersion(
@@ -95,7 +96,7 @@ describe('AgentsService', () => {
 
 		beforeEach(() => {
 			jest.spyOn(service, 'validateConfig').mockResolvedValue({ valid: true, config });
-			agentRepository.save.mockImplementation(async (a) => a as Agent);
+			agentRepository.save.mockImplementation(async (a) => a as AgentEntity);
 		});
 
 		it('does not bump versionId when agent has never been published', async () => {
@@ -266,7 +267,7 @@ describe('AgentsService', () => {
 
 			await service.getTestChatMessages(agentId, userId);
 
-			expect(n8nMemory.getMessages).toHaveBeenCalledWith(chatThreadId(agentId), {
+			expect(n8nMemory.getMessages).toHaveBeenCalledWith(testChatThreadId(agentId), {
 				resourceId: userId,
 			});
 		});
@@ -285,7 +286,10 @@ describe('AgentsService', () => {
 		it('deletes only the caller’s messages on the shared test-chat thread', async () => {
 			await service.clearTestChatMessages(agentId, userId);
 
-			expect(n8nMemory.deleteMessagesByThread).toHaveBeenCalledWith(chatThreadId(agentId), userId);
+			expect(n8nMemory.deleteMessagesByThread).toHaveBeenCalledWith(
+				testChatThreadId(agentId),
+				userId,
+			);
 			// Must not wipe the thread row — other users share it.
 			expect(n8nMemory.deleteThread).not.toHaveBeenCalled();
 		});
@@ -295,10 +299,10 @@ describe('AgentsService', () => {
 		it('deletes every message and the thread row itself', async () => {
 			await service.clearAllTestChatMessages(agentId);
 
-			expect(n8nMemory.deleteMessagesByThread).toHaveBeenCalledWith(chatThreadId(agentId));
+			expect(n8nMemory.deleteMessagesByThread).toHaveBeenCalledWith(testChatThreadId(agentId));
 			// Second arg must be absent — undefined means "all users".
 			expect(n8nMemory.deleteMessagesByThread.mock.calls[0]).toHaveLength(1);
-			expect(n8nMemory.deleteThread).toHaveBeenCalledWith(chatThreadId(agentId));
+			expect(n8nMemory.deleteThread).toHaveBeenCalledWith(testChatThreadId(agentId));
 		});
 	});
 
@@ -349,8 +353,8 @@ describe('AgentsService', () => {
 			await service.delete(agentId, projectId);
 
 			expect(agentRepository.remove).toHaveBeenCalledWith(agent);
-			expect(n8nMemory.deleteMessagesByThread).toHaveBeenCalledWith(chatThreadId(agentId));
-			expect(n8nMemory.deleteThread).toHaveBeenCalledWith(chatThreadId(agentId));
+			expect(n8nMemory.deleteMessagesByThread).toHaveBeenCalledWith(testChatThreadId(agentId));
+			expect(n8nMemory.deleteThread).toHaveBeenCalledWith(testChatThreadId(agentId));
 		});
 
 		it('still returns true when chat cleanup fails — agent removal is the primary intent', async () => {

--- a/packages/cli/src/modules/agents/agents.controller.ts
+++ b/packages/cli/src/modules/agents/agents.controller.ts
@@ -353,7 +353,7 @@ export class AgentsController {
 		if (!thread || !threadBelongsTo(thread, projectId, agentId)) {
 			throw new NotFoundError(`Thread "${threadId}" not found`);
 		}
-		return await this.agentsService.getChatMessages(threadId);
+		return await this.agentsService.getChatMessages(threadId, req.user.id);
 	}
 
 	@Get('/:agentId/build/messages')
@@ -363,29 +363,10 @@ export class AgentsController {
 		const { projectId, agentId } = req.params;
 		const agent = await this.agentsService.findById(agentId, projectId);
 		if (!agent) throw new NotFoundError(`Agent "${agentId}" not found`);
-
-		// Merge persisted thread memory with any open suspension's checkpoint
-		// so a refresh during a suspended turn still returns the suspended
-		// assistant message (the SDK only saveToMemory's on completion).
-		const memory = await this.agentsBuilderService.getBuilderMessages(agentId);
-		const checkpoint = await this.agentsBuilderService.findOpenCheckpoint(agentId);
-		const openSuspensions = Object.values(checkpoint?.pendingToolCalls ?? {})
-			.filter((tc) => tc.suspended)
-			.map((tc) => ({
-				toolCallId: tc.toolCallId,
-				runId: tc.runId,
-			}));
-
-		let messages: AgentPersistedMessageDto[];
-		if (!checkpoint) {
-			messages = messagesToDto(memory);
-		} else {
-			const memoryIds = new Set(memory.map((m) => m.id));
-			const newFromCheckpoint = checkpoint.messageList.messages.filter((m) => !memoryIds.has(m.id));
-			messages = messagesToDto([...memory, ...newFromCheckpoint]);
-		}
-
-		return { messages, openSuspensions };
+		return await this.agentsBuilderService.getBuilderMessageHistory({
+			agentId,
+			userId: req.user.id,
+		});
 	}
 
 	@Delete('/:agentId/build/messages')
@@ -393,7 +374,7 @@ export class AgentsController {
 		const { projectId, agentId } = req.params;
 		const agent = await this.agentsService.findById(agentId, projectId);
 		if (!agent) throw new NotFoundError(`Agent "${agentId}" not found`);
-		await this.agentsBuilderService.clearBuilderMessages(agentId);
+		await this.agentsBuilderService.clearBuilderMessages(agentId, req.user.id);
 		return { ok: true };
 	}
 
@@ -439,13 +420,13 @@ export class AgentsController {
 
 		try {
 			const suspended = await pumpChunks(
-				this.agentsBuilderService.buildAgent(
-					agentId,
+				this.agentsBuilderService.buildAgent({
+					agent,
 					projectId,
 					message,
 					credentialProvider,
-					req.user.id,
-				),
+					userId: req.user.id,
+				}),
 				send,
 				makeBuilderToolEvents(send),
 			);
@@ -483,14 +464,15 @@ export class AgentsController {
 
 		try {
 			const suspended = await pumpChunks(
-				this.agentsBuilderService.resumeBuild(
-					agentId,
+				this.agentsBuilderService.resumeBuild({
+					agent,
 					projectId,
 					runId,
 					toolCallId,
 					resumeData,
 					credentialProvider,
-				),
+					userId: req.user.id,
+				}),
 				send,
 				makeBuilderToolEvents(send),
 			);

--- a/packages/cli/src/modules/agents/agents.module.ts
+++ b/packages/cli/src/modules/agents/agents.module.ts
@@ -62,7 +62,7 @@ export class AgentsModule implements ModuleInterface {
 	}
 
 	async entities() {
-		const { Agent } = await import('./entities/agent.entity');
+		const { AgentEntity } = await import('./entities/agent.entity');
 		const { AgentCheckpoint } = await import('./entities/agent-checkpoint.entity');
 		const { AgentResourceEntity } = await import('./entities/agent-resource.entity');
 		const { AgentThreadEntity } = await import('./entities/agent-thread.entity');
@@ -71,7 +71,7 @@ export class AgentsModule implements ModuleInterface {
 		const { AgentPublishedVersion } = await import('./entities/agent-published-version.entity');
 
 		return [
-			Agent,
+			AgentEntity,
 			AgentCheckpoint,
 			AgentResourceEntity,
 			AgentThreadEntity,

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -5,8 +5,8 @@ import type {
 	StreamChunk,
 	ToolDescriptor,
 } from '@n8n/agents';
-import type { ChatIntegrationDescriptor } from '@n8n/api-types';
 import * as agents from '@n8n/agents';
+import type { ChatIntegrationDescriptor } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { Time } from '@n8n/constants';
 import {
@@ -20,6 +20,30 @@ import { In } from '@n8n/typeorm';
 import { OperationalError, UserError } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
 
+import { AgentsCredentialProvider } from './adapters/agents-credential-provider';
+import { AgentExecutionService } from './agent-execution.service';
+import { AgentsToolsService } from './agents-tools.service';
+import { builderThreadId, testChatThreadId } from './builder/thread';
+import { AgentEntity } from './entities/agent.entity';
+import { ExecutionRecorder } from './execution-recorder';
+import { ChatIntegrationRegistry } from './integrations/agent-chat-integration';
+import { N8NCheckpointStorage } from './integrations/n8n-checkpoint-storage';
+import { N8nMemory } from './integrations/n8n-memory';
+import type {
+	AgentJsonConfig,
+	AgentJsonMemoryConfig,
+	AgentJsonToolConfig,
+} from './json-config/agent-json-config';
+import { AgentJsonConfigSchema, isNodeToolsEnabled } from './json-config/agent-json-config';
+import {
+	buildFromJson,
+	type MemoryFactory,
+	type ToolResolver,
+} from './json-config/from-json-config';
+import { AgentPublishedVersionRepository } from './repositories/agent-published-version.repository';
+import { AgentRepository } from './repositories/agent.repository';
+import { AgentSecureRuntime } from './runtime/agent-secure-runtime';
+
 import { ActiveExecutions } from '@/active-executions';
 import { CredentialsService } from '@/credentials/credentials.service';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
@@ -31,43 +55,15 @@ import { TtlMap } from '@/utils/ttl-map';
 import { WorkflowRunner } from '@/workflow-runner';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
-import { AgentsCredentialProvider } from './adapters/agents-credential-provider';
-import { AgentExecutionService } from './agent-execution.service';
-import { AgentsToolsService } from './agents-tools.service';
-import { Agent } from './entities/agent.entity';
-import { ExecutionRecorder } from './execution-recorder';
-import { ChatIntegrationRegistry } from './integrations/agent-chat-integration';
-import { N8NCheckpointStorage } from './integrations/n8n-checkpoint-storage';
-import { N8nMemory } from './integrations/n8n-memory';
-import { AgentJsonConfigSchema, isNodeToolsEnabled } from './json-config/agent-json-config';
-import type {
-	AgentJsonConfig,
-	AgentJsonMemoryConfig,
-	AgentJsonToolConfig,
-} from './json-config/agent-json-config';
-import {
-	buildFromJson,
-	type MemoryFactory,
-	type ToolResolver,
-} from './json-config/from-json-config';
-import { AgentPublishedVersionRepository } from './repositories/agent-published-version.repository';
-import { AgentRepository } from './repositories/agent.repository';
-import { AgentSecureRuntime } from './runtime/agent-secure-runtime';
-import { AGENT_THREAD_PREFIX } from './builder/builder-tool-names';
-
 interface InjectRuntimeDependenciesParams {
 	agent: agents.Agent;
 	agentId: string;
 	projectId: string;
+	userId: string;
 	credentialProvider: CredentialProvider;
 	nodeToolsEnabled: boolean;
 	/** Chat platform the runtime is being reconstructed for — drives the rich_interaction tool's capability profile. */
 	integrationType?: string;
-}
-
-/** Derive a stable thread ID for the test-chat of a given agent. */
-export function chatThreadId(agentId: string): string {
-	return `${AGENT_THREAD_PREFIX.TEST}${agentId}`;
 }
 
 export interface ExecuteAgentData {
@@ -119,7 +115,7 @@ export class AgentsService {
 	 * Any mutation that changes how the agent would run must call this so that
 	 * `hasUnpublishedChanges` (derived from versionId vs publishedFromVersionId) stays accurate.
 	 */
-	private markDraftDirty(agent: Agent): void {
+	private markDraftDirty(agent: AgentEntity): void {
 		if (
 			agent.versionId !== null &&
 			agent.versionId === agent.publishedVersion?.publishedFromVersionId
@@ -163,7 +159,7 @@ export class AgentsService {
 			}));
 	}
 
-	async create(projectId: string, name: string): Promise<Agent> {
+	async create(projectId: string, name: string): Promise<AgentEntity> {
 		// New agents start with no instructions so the home screen routes the
 		// first user message to the builder (/build) instead of to the chat
 		// endpoint. The builder fills in instructions and credentials.
@@ -188,15 +184,15 @@ export class AgentsService {
 		return saved;
 	}
 
-	async findByProjectId(projectId: string): Promise<Agent[]> {
+	async findByProjectId(projectId: string): Promise<AgentEntity[]> {
 		return await this.agentRepository.findByProjectId(projectId);
 	}
 
-	async findById(agentId: string, projectId: string): Promise<Agent | null> {
+	async findById(agentId: string, projectId: string): Promise<AgentEntity | null> {
 		return await this.agentRepository.findByIdAndProjectId(agentId, projectId);
 	}
 
-	async updateName(agentId: string, projectId: string, name: string): Promise<Agent | null> {
+	async updateName(agentId: string, projectId: string, name: string): Promise<AgentEntity | null> {
 		const agent = await this.agentRepository.findByIdAndProjectId(agentId, projectId);
 
 		if (!agent) {
@@ -220,7 +216,7 @@ export class AgentsService {
 		projectId: string,
 		description: string,
 		updatedAt?: string,
-	): Promise<Agent | null> {
+	): Promise<AgentEntity | null> {
 		const agent = await this.agentRepository.findByIdAndProjectId(agentId, projectId);
 
 		if (!agent) {
@@ -241,7 +237,7 @@ export class AgentsService {
 		return saved;
 	}
 
-	async findByUser(userId: string): Promise<Agent[]> {
+	async findByUser(userId: string): Promise<AgentEntity[]> {
 		const projectRelations = await this.projectRelationRepository.findAllByUser(userId);
 		const projectIds = projectRelations.map((pr) => pr.projectId);
 
@@ -253,7 +249,7 @@ export class AgentsService {
 		});
 	}
 
-	async publishAgent(agentId: string, projectId: string, userId: string): Promise<Agent> {
+	async publishAgent(agentId: string, projectId: string, userId: string): Promise<AgentEntity> {
 		const agent = await this.agentRepository.findByIdAndProjectId(agentId, projectId);
 		if (!agent) {
 			throw new NotFoundError(`Agent "${agentId}" not found`);
@@ -289,7 +285,7 @@ export class AgentsService {
 		return agent;
 	}
 
-	async unpublishAgent(agentId: string, projectId: string): Promise<Agent> {
+	async unpublishAgent(agentId: string, projectId: string): Promise<AgentEntity> {
 		const agent = await this.agentRepository.findByIdAndProjectId(agentId, projectId);
 		if (!agent) {
 			throw new NotFoundError(`Agent "${agentId}" not found`);
@@ -323,19 +319,20 @@ export class AgentsService {
 		await this.agentRepository.remove(agent);
 
 		this.clearRuntimes(agentId);
-
-		// Remove the test-chat thread + its messages so deleting an agent
-		// doesn't leave orphaned rows in agents_threads / agents_messages.
-		// Swallow errors — the agent is already gone; best-effort cleanup.
-		// Log at warn level so orphaned rows are observable in production.
-		try {
-			await this.clearAllTestChatMessages(agentId);
-		} catch (error) {
-			this.logger.warn('Failed to clear test chat on agent delete', {
-				agentId,
-				error: error instanceof Error ? error.message : error,
-			});
-		}
+		await Promise.all([
+			this.clearAllTestChatMessages(agentId, agent.schema?.memory).catch((error) => {
+				this.logger.warn('Failed to clear test chat on agent delete', {
+					agentId,
+					error: error instanceof Error ? error.message : error,
+				});
+			}),
+			this.clearAllBuilderChatMessages(agentId).catch((error) => {
+				this.logger.warn('Failed to clear builder chat on agent delete', {
+					agentId,
+					error: error instanceof Error ? error.message : error,
+				});
+			}),
+		]);
 
 		this.logger.debug('Deleted SDK agent', { agentId, projectId });
 
@@ -363,8 +360,8 @@ export class AgentsService {
 	}
 
 	/** Return persisted chat messages for a given session/thread. */
-	async getChatMessages(threadId: string) {
-		return await this.n8nMemory.getMessages(threadId);
+	async getChatMessages(threadId: string, userId: string) {
+		return await this.n8nMemory.getMessages(threadId, { resourceId: userId });
 	}
 
 	private getMemoryFactory(): MemoryFactory {
@@ -428,8 +425,15 @@ export class AgentsService {
 	 * (opt-in, defaults to false) — see {@link isNodeToolsEnabled}.
 	 */
 	private async injectRuntimeDependencies(params: InjectRuntimeDependenciesParams): Promise<void> {
-		const { agent, agentId, projectId, credentialProvider, nodeToolsEnabled, integrationType } =
-			params;
+		const {
+			agent,
+			agentId,
+			projectId,
+			credentialProvider,
+			nodeToolsEnabled,
+			integrationType,
+			userId,
+		} = params;
 
 		// Inject the rich_interaction tool only for platforms that can actually
 		// render its suspend/resume HITL cards. Two gates:
@@ -463,7 +467,7 @@ export class AgentsService {
 
 		// Inject checkpoint storage
 		if (!agent.hasCheckpointStorage()) {
-			agent.checkpoint(this.n8nCheckpointStorage);
+			agent.checkpoint(this.n8nCheckpointStorage.getStorage(agentId, userId));
 		}
 	}
 
@@ -648,15 +652,15 @@ export class AgentsService {
 			if (!runtime) throw new Error(`Agent ${agentId} failed to reconstruct`);
 		}
 
-		yield* this.streamChatResponse(
-			runtime.agent,
+		yield* this.streamChatResponse({
+			agentInstance: runtime.agent,
 			agentId,
 			message,
 			threadId,
 			userId,
 			projectId,
-			integrationType,
-		);
+			source: integrationType,
+		});
 	}
 
 	/**
@@ -666,7 +670,7 @@ export class AgentsService {
 	 * we filter here to give every user their own private conversation view.
 	 */
 	async getTestChatMessages(agentId: string, userId: string) {
-		return await this.n8nMemory.getMessages(chatThreadId(agentId), { resourceId: userId });
+		return await this.n8nMemory.getMessages(testChatThreadId(agentId), { resourceId: userId });
 	}
 
 	/**
@@ -674,13 +678,23 @@ export class AgentsService {
 	 * stays so other users' histories on the same thread are preserved.
 	 */
 	async clearTestChatMessages(agentId: string, userId: string) {
-		await this.n8nMemory.deleteMessagesByThread(chatThreadId(agentId), userId);
+		await this.n8nMemory.deleteMessagesByThread(testChatThreadId(agentId), userId);
 	}
 
 	/** Delete all test-chat messages + the thread row — used when the agent itself is deleted. */
-	async clearAllTestChatMessages(agentId: string) {
-		const threadId = chatThreadId(agentId);
-		await this.n8nMemory.deleteMessagesByThread(threadId);
+	async clearAllTestChatMessages(agentId: string, memoryConfig?: AgentJsonMemoryConfig) {
+		const threadId = testChatThreadId(agentId);
+		if (!memoryConfig || memoryConfig.storage === 'n8n') {
+			await this.n8nMemory.deleteAllThreadMessages(threadId);
+			await this.n8nMemory.deleteThread(threadId);
+		} else {
+			// TODO: Implement for other memory storages
+		}
+	}
+
+	async clearAllBuilderChatMessages(agentId: string) {
+		const threadId = builderThreadId(agentId);
+		await this.n8nMemory.deleteAllThreadMessages(threadId);
 		await this.n8nMemory.deleteThread(threadId);
 	}
 
@@ -714,7 +728,7 @@ export class AgentsService {
 		const key = this.runtimeKey(agentId, userId, integrationType);
 		let runtime = this.runtimes.get(key);
 		if (!runtime) {
-			const publishedAgentData = { ...agentEntity, schema: publishedSchema } as Agent;
+			const publishedAgentData = { ...agentEntity, schema: publishedSchema } as AgentEntity;
 			const agentInstance = await this.reconstructFromConfig(
 				publishedAgentData,
 				credentialProvider,
@@ -726,15 +740,15 @@ export class AgentsService {
 			if (!runtime) throw new Error(`Agent ${agentId} failed to reconstruct`);
 		}
 
-		yield* this.streamChatResponse(
-			runtime.agent,
+		yield* this.streamChatResponse({
+			agentInstance: runtime.agent,
 			agentId,
 			message,
 			threadId,
 			userId,
 			projectId,
-			integrationType,
-		);
+			source: integrationType,
+		});
 	}
 
 	/**
@@ -743,15 +757,16 @@ export class AgentsService {
 	 * and persists the full message record via `AgentExecutionService` so chat
 	 * history shows up in the executions view.
 	 */
-	private async *streamChatResponse(
-		agentInstance: agents.Agent,
-		agentId: string,
-		message: string,
-		threadId: string,
-		userId: string,
-		projectId: string,
-		source?: string,
-	): AsyncGenerator<StreamChunk> {
+	private async *streamChatResponse(opts: {
+		agentInstance: agents.Agent;
+		agentId: string;
+		message: string;
+		threadId: string;
+		userId: string;
+		projectId: string;
+		source?: string;
+	}): AsyncGenerator<StreamChunk> {
+		const { agentInstance, agentId, message, threadId, userId, projectId, source } = opts;
 		const recorder = new ExecutionRecorder();
 
 		const resultStream = await agentInstance.stream(message, {
@@ -811,9 +826,9 @@ export class AgentsService {
 	 * are not affected.
 	 */
 	private async compileIsolated(
-		agentEntity: Agent,
+		agentEntity: AgentEntity,
 		credentialProvider: CredentialProvider,
-		userId?: string,
+		userId: string,
 	): Promise<{ ok: boolean; agent?: BuiltAgent; error?: string }> {
 		if (!agentEntity.schema) {
 			return { ok: false, error: 'Agent has no JSON config. Create a config first.' };
@@ -1135,9 +1150,9 @@ export class AgentsService {
 	 * This is the new execution path for JSON-config agents.
 	 */
 	private async reconstructFromConfig(
-		agentEntity: Agent,
+		agentEntity: AgentEntity,
 		credentialProvider: CredentialProvider,
-		userId?: string,
+		userId: string,
 		integrationType?: string,
 	): Promise<agents.Agent> {
 		const config = agentEntity.schema;
@@ -1177,6 +1192,7 @@ export class AgentsService {
 			credentialProvider,
 			nodeToolsEnabled: isNodeToolsEnabled(config.config),
 			integrationType,
+			userId,
 		});
 
 		return reconstructed;

--- a/packages/cli/src/modules/agents/builder/agents-builder-tools.service.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-tools.service.ts
@@ -7,6 +7,8 @@ import { z } from 'zod';
 
 import { AgentsToolsService } from '../agents-tools.service';
 import { AgentsService } from '../agents.service';
+import { BUILDER_TOOLS } from './builder-tool-names';
+import { buildAskCredentialTool, buildAskLlmTool, buildAskQuestionTool } from './interactive';
 import type { AgentJsonConfig, ConfigValidationError } from '../json-config/agent-json-config';
 import {
 	AgentJsonConfigSchema,
@@ -14,8 +16,6 @@ import {
 	tryParseConfigJson,
 } from '../json-config/agent-json-config';
 import { AgentSecureRuntime } from '../runtime/agent-secure-runtime';
-import { buildAskCredentialTool, buildAskLlmTool, buildAskQuestionTool } from './interactive';
-import { BUILDER_TOOLS } from './builder-tool-names';
 
 const EMPTY_INSTRUCTIONS_ERROR: ConfigValidationError = {
 	path: '/instructions',

--- a/packages/cli/src/modules/agents/builder/agents-builder.service.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder.service.ts
@@ -5,26 +5,22 @@ import type {
 	StreamResult,
 } from '@n8n/agents';
 import { Agent, Memory, providerTools } from '@n8n/agents';
+import { AgentBuilderMessagesResponse, AgentPersistedMessageDto } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
 import { jsonParse, OperationalError, UserError } from 'n8n-workflow';
 
-import { AgentsService } from '../agents.service';
+import { messagesToDto } from '../agent-message-mapper';
+import { buildBuilderPrompt } from './agents-builder-prompts';
+import { AgentsBuilderToolsService } from './agents-builder-tools.service';
+import { builderThreadId } from './thread';
+import { AgentEntity } from '../entities/agent.entity';
 import { N8NCheckpointStorage } from '../integrations/n8n-checkpoint-storage';
 import { N8nMemory } from '../integrations/n8n-memory';
 import type { AgentJsonConfig } from '../json-config/agent-json-config';
 import { AgentCheckpointRepository } from '../repositories/agent-checkpoint.repository';
-import { buildBuilderPrompt } from './agents-builder-prompts';
-import { AgentsBuilderToolsService } from './agents-builder-tools.service';
-import { AGENT_THREAD_PREFIX } from './builder-tool-names';
-import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
 const BUILDER_MODEL = 'anthropic/claude-sonnet-4-5';
-
-/** Derive a stable thread ID for the builder chat of a given agent. */
-function builderThreadId(agentId: string): string {
-	return `${AGENT_THREAD_PREFIX.BUILDER}${agentId}`;
-}
 
 /** Read an Anthropic key from env, preferring the n8n-specific variable. */
 function readEnvAnthropicKey(): string | null {
@@ -36,51 +32,42 @@ function readEnvAnthropicKey(): string | null {
 export class AgentsBuilderService {
 	constructor(
 		private readonly logger: Logger,
-		private readonly agentsService: AgentsService,
 		private readonly agentsBuilderToolsService: AgentsBuilderToolsService,
 		private readonly n8nMemory: N8nMemory,
 		private readonly n8nCheckpointStorage: N8NCheckpointStorage,
 		private readonly agentCheckpointRepository: AgentCheckpointRepository,
 	) {}
 
-	// ---------------------------------------------------------------------------
-	// Public — message storage
-	// ---------------------------------------------------------------------------
-
 	/**
-	 * Return persisted builder chat messages for an agent.
+	 * Clear persisted builder chat messages for the calling user on an agent.
 	 */
-	async getBuilderMessages(agentId: string) {
+	async clearBuilderMessages(agentId: string, userId: string) {
 		const threadId = builderThreadId(agentId);
-		return await this.n8nMemory.getMessages(threadId);
-	}
-
-	/**
-	 * Clear persisted builder chat messages for an agent.
-	 */
-	async clearBuilderMessages(agentId: string) {
-		const threadId = builderThreadId(agentId);
-		await this.n8nMemory.deleteMessagesByThread(threadId);
-		await this.n8nMemory.deleteThread(threadId);
+		await this.n8nMemory.deleteMessagesByThread(threadId, userId);
 	}
 	// ---------------------------------------------------------------------------
 	// Public — streaming
 	// ---------------------------------------------------------------------------
 
-	async *buildAgent(
-		agentId: string,
-		projectId: string,
-		message: string,
-		credentialProvider: CredentialProvider,
-		userId?: string,
-	): AsyncGenerator<StreamChunk> {
-		const builder = await this.createBuilderAgent(agentId, projectId, credentialProvider);
+	async *buildAgent(opts: {
+		agent: AgentEntity;
+		projectId: string;
+		message: string;
+		credentialProvider: CredentialProvider;
+		userId: string;
+	}): AsyncGenerator<StreamChunk> {
+		const { agent, projectId, message, credentialProvider, userId } = opts;
+		const builder = await this.createBuilderAgent({
+			agent,
+			projectId,
+			credentialProvider,
+			userId,
+		});
 
-		this.logger.debug('Starting builder agent stream', { agentId, projectId });
+		this.logger.debug('Starting builder agent stream', { agentId: agent.id, projectId });
 
-		const resourceId = userId ?? agentId;
 		const resultStream = await builder.stream(message, {
-			persistence: { threadId: builderThreadId(agentId), resourceId },
+			persistence: { threadId: builderThreadId(agent.id), resourceId: userId },
 		});
 
 		yield* this.streamFromAgent(resultStream);
@@ -96,14 +83,17 @@ export class AgentsBuilderService {
 	 * `agent.resume(...)` rehydrates the suspended state from the persisted
 	 * checkpoint, so the new instance picks up where the old one left off.
 	 */
-	async *resumeBuild(
-		agentId: string,
-		projectId: string,
-		runId: string,
-		toolCallId: string,
-		resumeData: unknown,
-		credentialProvider: CredentialProvider,
-	): AsyncGenerator<StreamChunk> {
+	async *resumeBuild(opts: {
+		agent: AgentEntity;
+		projectId: string;
+		runId: string;
+		toolCallId: string;
+		resumeData: unknown;
+		credentialProvider: CredentialProvider;
+		userId: string;
+	}): AsyncGenerator<StreamChunk> {
+		const { agent, projectId, runId, toolCallId, resumeData, credentialProvider, userId } = opts;
+
 		const checkpointStatus = await this.n8nCheckpointStorage.getStatus(runId);
 		if (checkpointStatus === 'expired') {
 			throw new UserError(`Builder checkpoint ${runId} has expired and cannot be resumed`);
@@ -112,9 +102,9 @@ export class AgentsBuilderService {
 			throw new UserError(`Builder checkpoint ${runId} not found`);
 		}
 
-		const builder = await this.createBuilderAgent(agentId, projectId, credentialProvider);
+		const builder = await this.createBuilderAgent({ agent, projectId, credentialProvider, userId });
 
-		this.logger.debug('Resuming builder agent', { agentId, runId, toolCallId });
+		this.logger.debug('Resuming builder agent', { agentdId: agent.id, runId, toolCallId });
 
 		const resultStream = await builder.resume('stream', resumeData, {
 			runId,
@@ -122,6 +112,37 @@ export class AgentsBuilderService {
 		});
 
 		yield* this.streamFromAgent(resultStream);
+	}
+
+	async getBuilderMessageHistory(opts: {
+		agentId: string;
+		userId: string;
+	}): Promise<AgentBuilderMessagesResponse> {
+		const { agentId, userId } = opts;
+
+		// Merge persisted thread memory with any open suspension's checkpoint
+		// so a refresh during a suspended turn still returns the suspended
+		// assistant message (the SDK only saveToMemory's on completion).
+		const threadId = builderThreadId(agentId);
+		const memory = await this.n8nMemory.getMessages(threadId, { resourceId: userId });
+		const checkpoint = await this.findOpenCheckpoint(agentId, userId);
+		const openSuspensions = Object.values(checkpoint?.pendingToolCalls ?? {})
+			.filter((tc) => tc.suspended)
+			.map((tc) => ({
+				toolCallId: tc.toolCallId,
+				runId: tc.runId,
+			}));
+
+		let messages: AgentPersistedMessageDto[];
+		if (!checkpoint) {
+			messages = messagesToDto(memory);
+		} else {
+			const memoryIds = new Set(memory.map((m) => m.id));
+			const newFromCheckpoint = checkpoint.messageList.messages.filter((m) => !memoryIds.has(m.id));
+			messages = messagesToDto([...memory, ...newFromCheckpoint]);
+		}
+
+		return { messages, openSuspensions };
 	}
 
 	// ---------------------------------------------------------------------------
@@ -137,15 +158,13 @@ export class AgentsBuilderService {
 	 * persisted checkpoint via the SDK, so the new instance picks up where
 	 * the previous one left off.
 	 */
-	private async createBuilderAgent(
-		agentId: string,
-		projectId: string,
-		credentialProvider: CredentialProvider,
-	): Promise<Agent> {
-		const agent = await this.agentsService.findById(agentId, projectId);
-		if (!agent) {
-			throw new NotFoundError(`Agent "${agentId}" not found`);
-		}
+	private async createBuilderAgent(opts: {
+		agent: AgentEntity;
+		projectId: string;
+		credentialProvider: CredentialProvider;
+		userId: string;
+	}): Promise<Agent> {
+		const { agent, projectId, credentialProvider, userId } = opts;
 
 		// The builder is a built-in, system-level agent — it is driven by an
 		// env-var Anthropic key and never uses project credentials. This keeps
@@ -175,7 +194,7 @@ export class AgentsBuilderService {
 			builderModel: BUILDER_MODEL,
 		});
 
-		const tools = this.agentsBuilderToolsService.getTools(agentId, projectId, credentialProvider);
+		const tools = this.agentsBuilderToolsService.getTools(agent.id, projectId, credentialProvider);
 
 		const builderMemory = new Memory().storage(this.n8nMemory).lastMessages(40);
 
@@ -183,7 +202,7 @@ export class AgentsBuilderService {
 			.model({ id: BUILDER_MODEL, apiKey: envAnthropicKey })
 			.instructions(instructions)
 			.memory(builderMemory)
-			.checkpoint(this.n8nCheckpointStorage.getStorage(agentId))
+			.checkpoint(this.n8nCheckpointStorage.getStorage(agent.id, userId))
 			.providerTool(providerTools.anthropicWebSearch({ maxUses: 5 }));
 
 		for (const tool of [...tools.json, ...tools.shared]) {
@@ -211,19 +230,18 @@ export class AgentsBuilderService {
 		}
 	}
 
-	// ---------------------------------------------------------------------------
-	// Private — open-suspension lookup
-	// ---------------------------------------------------------------------------
-
 	/**
 	 * Return the parsed state of the most recent non-expired suspended
 	 * checkpoint for this agent, or `null` if there isn't one. Each pending
 	 * tool call inside the state already carries its own `runId`, so callers
 	 * don't need a separate runId from this helper.
 	 */
-	async findOpenCheckpoint(agentId: string): Promise<SerializableAgentState | null> {
+	async findOpenCheckpoint(
+		agentId: string,
+		userId: string,
+	): Promise<SerializableAgentState | null> {
 		const rows = await this.agentCheckpointRepository.find({
-			where: { agentId, expired: false },
+			where: { agentId, userId, expired: false },
 			order: { updatedAt: 'DESC' },
 			take: 5,
 		});

--- a/packages/cli/src/modules/agents/builder/agents-builder.service.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder.service.ts
@@ -104,7 +104,7 @@ export class AgentsBuilderService {
 
 		const builder = await this.createBuilderAgent({ agent, projectId, credentialProvider, userId });
 
-		this.logger.debug('Resuming builder agent', { agentdId: agent.id, runId, toolCallId });
+		this.logger.debug('Resuming builder agent', { agentId: agent.id, runId, toolCallId });
 
 		const resultStream = await builder.resume('stream', resumeData, {
 			runId,

--- a/packages/cli/src/modules/agents/builder/builder-tool-names.ts
+++ b/packages/cli/src/modules/agents/builder/builder-tool-names.ts
@@ -9,9 +9,3 @@ export const BUILDER_TOOLS = {
 } as const;
 
 export type BuilderToolName = (typeof BUILDER_TOOLS)[keyof typeof BUILDER_TOOLS];
-
-/** Thread-id prefixes scoping different chat surfaces of the same agent. */
-export const AGENT_THREAD_PREFIX = {
-	TEST: 'test-',
-	BUILDER: 'builder:',
-} as const;

--- a/packages/cli/src/modules/agents/builder/thread.ts
+++ b/packages/cli/src/modules/agents/builder/thread.ts
@@ -1,0 +1,15 @@
+/** Thread-id prefixes scoping different chat surfaces of the same agent. */
+export const AGENT_THREAD_PREFIX = {
+	TEST: 'test:',
+	BUILDER: 'builder:',
+} as const;
+
+/** Derive a stable thread ID for the builder chat of a given agent. */
+export function builderThreadId(agentId: string): string {
+	return `${AGENT_THREAD_PREFIX.BUILDER}${agentId}`;
+}
+
+/** Derive a stable thread ID for the test-chat of a given agent. */
+export function testChatThreadId(agentId: string): string {
+	return `${AGENT_THREAD_PREFIX.TEST}${agentId}`;
+}

--- a/packages/cli/src/modules/agents/entities/agent-checkpoint.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-checkpoint.entity.ts
@@ -1,19 +1,22 @@
 import { WithTimestamps } from '@n8n/db';
 import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from '@n8n/typeorm';
 
-import { Agent } from './agent.entity';
+import { AgentEntity } from './agent.entity';
 
 @Entity({ name: 'agent_checkpoints' })
 export class AgentCheckpoint extends WithTimestamps {
 	@PrimaryColumn({ type: 'varchar', length: 255 })
 	runId: string;
 
-	@ManyToOne(() => Agent, { nullable: true, onDelete: 'CASCADE' })
+	@ManyToOne(() => AgentEntity, { nullable: true, onDelete: 'CASCADE' })
 	@JoinColumn({ name: 'agentId' })
-	agent: Agent | null;
+	agent: AgentEntity | null;
 
 	@Column({ type: 'varchar', length: 255, nullable: true })
 	agentId: string | null;
+
+	@Column({ type: 'varchar', length: 255 })
+	userId: string;
 
 	@Column({ type: 'text', nullable: true })
 	state: string | null;

--- a/packages/cli/src/modules/agents/entities/agent-published-version.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-published-version.entity.ts
@@ -9,7 +9,7 @@ import {
 	type Relation,
 } from '@n8n/typeorm';
 
-import type { Agent } from './agent.entity';
+import { AgentEntity } from './agent.entity';
 import type { AgentJsonConfig } from '../json-config/agent-json-config';
 
 @Entity({ name: 'agent_published_version' })
@@ -17,9 +17,9 @@ export class AgentPublishedVersion extends WithTimestamps {
 	@PrimaryColumn({ type: 'varchar', length: 36 })
 	agentId: string;
 
-	@OneToOne('Agent', { onDelete: 'CASCADE' })
+	@OneToOne(() => AgentEntity, { onDelete: 'CASCADE' })
 	@JoinColumn({ name: 'agentId' })
-	agent: Relation<Agent>;
+	agent: Relation<AgentEntity>;
 
 	@JsonColumn({ nullable: true, default: null })
 	schema: AgentJsonConfig | null;

--- a/packages/cli/src/modules/agents/entities/agent.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent.entity.ts
@@ -6,7 +6,7 @@ import type { AgentPublishedVersion } from './agent-published-version.entity';
 import type { AgentJsonConfig } from '../json-config/agent-json-config';
 
 @Entity({ name: 'agents' })
-export class Agent extends WithTimestampsAndStringId {
+export class AgentEntity extends WithTimestampsAndStringId {
 	@Column({ type: 'varchar', length: 128 })
 	name: string;
 

--- a/packages/cli/src/modules/agents/entities/execution-thread.entity.ts
+++ b/packages/cli/src/modules/agents/entities/execution-thread.entity.ts
@@ -1,13 +1,13 @@
 import { Project, WithTimestampsAndStringId } from '@n8n/db';
 import { Column, Entity, Index, JoinColumn, ManyToOne } from '@n8n/typeorm';
 
-import { Agent } from './agent.entity';
+import { AgentEntity } from './agent.entity';
 
 @Entity({ name: 'execution_threads' })
 export class ExecutionThread extends WithTimestampsAndStringId {
-	@ManyToOne(() => Agent, { onDelete: 'CASCADE' })
+	@ManyToOne(() => AgentEntity, { onDelete: 'CASCADE' })
 	@JoinColumn({ name: 'agentId' })
-	agent: Agent;
+	agent: AgentEntity;
 
 	@Index()
 	@Column({ type: 'varchar', length: 36 })

--- a/packages/cli/src/modules/agents/integrations/__tests__/n8n-memory.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/n8n-memory.test.ts
@@ -138,9 +138,10 @@ describe('N8nMemory', () => {
 		});
 
 		it('deletes every message on the thread when resourceId is omitted', async () => {
-			await memory.deleteMessagesByThread('thread-1');
-
-			expect(messageRepository.delete).toHaveBeenCalledWith({ threadId: 'thread-1' });
+			await expect(memory.deleteMessagesByThread('thread-1', undefined as any)).rejects.toThrow(
+				'Resource ID and thread ID are required',
+			);
+			expect(messageRepository.delete).not.toHaveBeenCalled();
 		});
 
 		it('does not widen the delete to all users when resourceId is an empty string', async () => {

--- a/packages/cli/src/modules/agents/integrations/n8n-checkpoint-storage.ts
+++ b/packages/cli/src/modules/agents/integrations/n8n-checkpoint-storage.ts
@@ -32,8 +32,8 @@ export class N8NCheckpointStorage {
 	getStorage(agentId: string, userId: string): CheckpointStore {
 		return {
 			save: async (key, state) => await this.save(key, state, agentId, userId),
-			load: async (key) => await this.load(key),
-			delete: async (key) => await this.delete(key),
+			load: async (key) => await this.load(key, userId),
+			delete: async (key) => await this.delete(key, userId),
 		};
 	}
 
@@ -67,8 +67,8 @@ export class N8NCheckpointStorage {
 		}
 	}
 
-	async load(key: string): Promise<SerializableAgentState | undefined> {
-		const checkpoint = await this.agentCheckpointRepository.findOneBy({ runId: key });
+	async load(key: string, userId: string): Promise<SerializableAgentState | undefined> {
+		const checkpoint = await this.agentCheckpointRepository.findOneBy({ runId: key, userId });
 
 		if (!checkpoint) return undefined;
 
@@ -86,8 +86,11 @@ export class N8NCheckpointStorage {
 		return 'active';
 	}
 
-	async delete(key: string): Promise<void> {
-		await this.agentCheckpointRepository.update({ runId: key }, { expired: true, state: null });
+	async delete(key: string, userId: string): Promise<void> {
+		await this.agentCheckpointRepository.update(
+			{ runId: key, userId },
+			{ expired: true, state: null },
+		);
 	}
 
 	@OnLeaderTakeover()

--- a/packages/cli/src/modules/agents/integrations/n8n-checkpoint-storage.ts
+++ b/packages/cli/src/modules/agents/integrations/n8n-checkpoint-storage.ts
@@ -29,9 +29,9 @@ export class N8NCheckpointStorage {
 		this.isInitialized = this.moduleRegistry.isActive('agents');
 	}
 
-	getStorage(agentId: string): CheckpointStore {
+	getStorage(agentId: string, userId: string): CheckpointStore {
 		return {
-			save: async (key, state) => await this.save(key, state, agentId),
+			save: async (key, state) => await this.save(key, state, agentId, userId),
 			load: async (key) => await this.load(key),
 			delete: async (key) => await this.delete(key),
 		};
@@ -47,6 +47,7 @@ export class N8NCheckpointStorage {
 		key: string,
 		state: SerializableAgentState,
 		agentId: string | null = null,
+		userId: string,
 	): Promise<void> {
 		const existing = await this.agentCheckpointRepository.findOneBy({ runId: key });
 
@@ -58,6 +59,7 @@ export class N8NCheckpointStorage {
 			const checkpoint = this.agentCheckpointRepository.create({
 				runId: key,
 				agentId,
+				userId,
 				state: JSON.stringify(state),
 				expired: false,
 			});

--- a/packages/cli/src/modules/agents/integrations/n8n-memory.ts
+++ b/packages/cli/src/modules/agents/integrations/n8n-memory.ts
@@ -85,13 +85,11 @@ export class N8nMemory implements BuiltMemory {
 		opts?: { limit?: number; before?: Date; resourceId?: string },
 	): Promise<AgentDbMessage[]> {
 		// `resourceId` is the per-user scope for shared threads (e.g. the test-chat
-		// thread is keyed by agentId but each message carries the originating user's
-		// id). Use an explicit `!== undefined` check — a falsy (empty-string) value
-		// would otherwise drop the filter and leak other users' messages.
+		// thread is keyed by agentId but each message carries the originating user's id).
 		const where: FindOptionsWhere<AgentMessageEntity> = {
 			threadId,
 			...(opts?.before && { createdAt: LessThan(opts.before) }),
-			...(opts?.resourceId !== undefined && { resourceId: opts.resourceId }),
+			...(!!opts?.resourceId?.length && { resourceId: opts.resourceId }),
 		};
 
 		const entities = await this.messageRepository.find({
@@ -135,14 +133,23 @@ export class N8nMemory implements BuiltMemory {
 		await this.messageRepository.delete(messageIds);
 	}
 
-	async deleteMessagesByThread(threadId: string, resourceId?: string): Promise<void> {
-		// Mirrors `getMessages`: explicit `!== undefined` check so that a falsy
-		// (empty-string) `resourceId` cannot accidentally delete every user's
-		// messages on a shared thread.
+	async deleteMessagesByThread(threadId: string, resourceId: string): Promise<void> {
+		if (!resourceId || !threadId) {
+			throw new Error('Resource ID and thread ID are required');
+		}
 		await this.messageRepository.delete({
 			threadId,
-			...(resourceId !== undefined && { resourceId }),
+			...(!!resourceId?.length && { resourceId }),
 		});
+	}
+
+	/**
+	 * Delete all messages of a thread not matching on resourceId.
+	 * Use deleteMessagesByThread for deleting messages of a specific resourceId.
+	 * @param threadId - The ID of the thread to delete messages from.
+	 */
+	async deleteAllThreadMessages(threadId: string): Promise<void> {
+		await this.messageRepository.delete({ threadId });
 	}
 
 	// ── Working memory ───────────────────────────────────────────────────

--- a/packages/cli/src/modules/agents/integrations/platforms/__tests__/telegram-integration.test.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/__tests__/telegram-integration.test.ts
@@ -5,7 +5,7 @@ import { mock } from 'jest-mock-extended';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import type { UrlService } from '@/services/url.service';
 
-import type { Agent } from '../../../entities/agent.entity';
+import type { AgentEntity } from '../../../entities/agent.entity';
 import type { AgentRepository } from '../../../repositories/agent.repository';
 import type { AgentChatIntegrationContext } from '../../agent-chat-integration';
 import { TelegramIntegration } from '../telegram-integration';
@@ -14,7 +14,7 @@ const makeAgent = (
 	id: string,
 	name: string,
 	integrations: Array<{ type: string; credentialId: string }>,
-) => ({ id, name, integrations }) as Agent;
+) => ({ id, name, integrations }) as AgentEntity;
 
 const makeContext = (
 	overrides: Partial<AgentChatIntegrationContext> = {},

--- a/packages/cli/src/modules/agents/repositories/agent.repository.ts
+++ b/packages/cli/src/modules/agents/repositories/agent.repository.ts
@@ -1,15 +1,15 @@
 import { Service } from '@n8n/di';
 import { DataSource, Repository } from '@n8n/typeorm';
 
-import { Agent } from '../entities/agent.entity';
+import { AgentEntity } from '../entities/agent.entity';
 
 @Service()
-export class AgentRepository extends Repository<Agent> {
+export class AgentRepository extends Repository<AgentEntity> {
 	constructor(dataSource: DataSource) {
-		super(Agent, dataSource.manager);
+		super(AgentEntity, dataSource.manager);
 	}
 
-	async findByProjectId(projectId: string): Promise<Agent[]> {
+	async findByProjectId(projectId: string): Promise<AgentEntity[]> {
 		return await this.find({
 			where: { projectId },
 			relations: { publishedVersion: true },
@@ -26,14 +26,14 @@ export class AgentRepository extends Repository<Agent> {
 	 * published snapshot (or `null`) in a single query, which is what the publish button uses
 	 * to compute its state (published vs. unpublished, has changes vs. up to date).
 	 */
-	async findByIdAndProjectId(id: string, projectId: string): Promise<Agent | null> {
+	async findByIdAndProjectId(id: string, projectId: string): Promise<AgentEntity | null> {
 		return await this.findOne({
 			where: { id, projectId },
 			relations: { publishedVersion: true },
 		});
 	}
 
-	async findPublished(): Promise<Agent[]> {
+	async findPublished(): Promise<AgentEntity[]> {
 		return await this.createQueryBuilder('agent')
 			.innerJoinAndSelect('agent.publishedVersion', 'publishedVersion')
 			.getMany();
@@ -56,7 +56,7 @@ export class AgentRepository extends Repository<Agent> {
 		credentialId: string,
 		projectId: string,
 		excludeAgentId: string,
-	): Promise<Agent[]> {
+	): Promise<AgentEntity[]> {
 		const agents = await this.find({ where: { projectId } });
 		return agents.filter(
 			(agent) =>


### PR DESCRIPTION
## Summary

This PR changes agent builder messages and checkpoints to be always scoped by user id to prevent sharing chat history

There is another issue which this PR doesn't touch: Test chat sessions can be accessed by all users [inside the project](https://linear.app/n8n/issue/AGENT-52/bug-users-can-access-other-user-chats).

This PR adds a new migration which drops some data, but it's temporary and the migration should be removed before we merge to main

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-40/bug-checkpoints-and-agent-builder-memory-can-be-accessed-by-any-user


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
