### PR TITLE
fix(editor): Load more executions on tall screens

### DIFF
--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsList.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsList.vue
@@ -16,11 +16,13 @@ const props = withDefaults(
 		executions: ExecutionSummary[];
 		execution?: ExecutionSummary;
 		loadingMore: boolean;
+		hasMore: boolean;
 	}>(),
 	{
 		loading: false,
 		executions: () => [] as ExecutionSummary[],
 		loadingMore: false,
+		hasMore: false,
 	},
 );
 
@@ -84,6 +86,7 @@ onBeforeRouteLeave(async (to, _, next) => {
 			:executions="executions"
 			:loading="loading && !executions.length"
 			:loading-more="loadingMore"
+			:has-more="hasMore"
 			:temporary-execution="temporaryExecution"
 			:workflow="workflow"
 			@update:auto-refresh="emit('update:auto-refresh', $event)"

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsSidebar.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsSidebar.test.ts
@@ -6,16 +6,30 @@ import { useSettingsStore } from '@/app/stores/settings.store';
 import { mockedStore, SETTINGS_STORE_DEFAULT_STATE } from '@/__tests__/utils';
 import { STORES } from '@n8n/stores';
 import merge from 'lodash/merge';
-import { expect, it } from 'vitest';
-import { computed } from 'vue';
+import { expect, it, vi } from 'vitest';
+import { computed, nextTick } from 'vue';
 import { WorkflowIdKey } from '@/app/constants/injectionKeys';
+import type { ExecutionSummary } from 'n8n-workflow';
+
+const observe = vi.fn();
+const disconnect = vi.fn();
+
+vi.mock('@/app/composables/useIntersectionObserver', () => ({
+	useIntersectionObserver: () => ({
+		observe,
+		disconnect,
+		observer: { value: null },
+	}),
+}));
 
 vi.mock('vue-router', () => {
-	const location = {};
 	return {
 		useRouter: vi.fn(),
 		useRoute: () => ({
-			location,
+			params: {},
+			query: {},
+			name: '',
+			path: '',
 		}),
 		RouterLink: {
 			template: '<a><slot /></a>',
@@ -45,11 +59,25 @@ const renderComponent = createComponentRenderer(WorkflowExecutionsSidebar, {
 	}),
 });
 
+const buildExecutions = (count: number): ExecutionSummary[] =>
+	Array.from({ length: count }, (_, index) => ({
+		id: `exec-${index}`,
+		workflowId: 'test-workflow-id',
+		mode: 'manual',
+		status: 'success',
+		createdAt: new Date().toISOString(),
+		startedAt: new Date().toISOString(),
+		stoppedAt: new Date().toISOString(),
+		finished: true,
+	})) as unknown as ExecutionSummary[];
+
 let settingsStore: MockedStore<typeof useSettingsStore>;
 
 describe('WorkflowExecutionsSidebar', () => {
 	beforeEach(() => {
 		settingsStore = mockedStore(useSettingsStore);
+		observe.mockClear();
+		disconnect.mockClear();
 	});
 
 	it('should not throw error when opened', async () => {
@@ -58,6 +86,7 @@ describe('WorkflowExecutionsSidebar', () => {
 				props: {
 					loading: false,
 					loadingMore: false,
+					hasMore: false,
 					executions: [],
 				},
 			}),
@@ -70,10 +99,110 @@ describe('WorkflowExecutionsSidebar', () => {
 			props: {
 				loading: false,
 				loadingMore: false,
+				hasMore: false,
 				executions: [],
 			},
 		});
 
 		expect(getByTestId('concurrent-executions-header')).toBeVisible();
+	});
+
+	describe('infinite scroll sentinel', () => {
+		it('should observe the sentinel when executions are present and more pages exist', async () => {
+			const { getByTestId } = renderComponent({
+				props: {
+					loading: false,
+					loadingMore: false,
+					hasMore: true,
+					executions: buildExecutions(20),
+				},
+			});
+
+			await nextTick();
+
+			const sentinel = getByTestId('executions-load-more-sentinel');
+			expect(observe).toHaveBeenCalledWith(sentinel);
+		});
+
+		it('should not render the sentinel when there are no more pages', async () => {
+			const { queryByTestId } = renderComponent({
+				props: {
+					loading: false,
+					loadingMore: false,
+					hasMore: false,
+					executions: buildExecutions(20),
+				},
+			});
+
+			await nextTick();
+
+			expect(queryByTestId('executions-load-more-sentinel')).toBeNull();
+			expect(observe).not.toHaveBeenCalled();
+		});
+
+		it('should not render the sentinel when the list is empty', async () => {
+			const { queryByTestId } = renderComponent({
+				props: {
+					loading: false,
+					loadingMore: false,
+					hasMore: true,
+					executions: [],
+				},
+			});
+
+			await nextTick();
+
+			expect(queryByTestId('executions-load-more-sentinel')).toBeNull();
+			expect(observe).not.toHaveBeenCalled();
+		});
+
+		it('should re-observe the sentinel after a new batch of executions arrives', async () => {
+			const { rerender, getByTestId } = renderComponent({
+				props: {
+					loading: false,
+					loadingMore: false,
+					hasMore: true,
+					executions: buildExecutions(20),
+				},
+			});
+
+			await nextTick();
+			expect(observe).toHaveBeenCalledTimes(1);
+
+			await rerender({
+				loading: false,
+				loadingMore: false,
+				hasMore: true,
+				executions: buildExecutions(40),
+			});
+			await nextTick();
+
+			expect(observe).toHaveBeenCalledTimes(2);
+			expect(observe).toHaveBeenLastCalledWith(getByTestId('executions-load-more-sentinel'));
+		});
+
+		it('should not re-observe the sentinel while a load is in flight', async () => {
+			const { rerender } = renderComponent({
+				props: {
+					loading: false,
+					loadingMore: false,
+					hasMore: true,
+					executions: buildExecutions(20),
+				},
+			});
+
+			await nextTick();
+			expect(observe).toHaveBeenCalledTimes(1);
+
+			await rerender({
+				loading: false,
+				loadingMore: true,
+				hasMore: true,
+				executions: buildExecutions(20),
+			});
+			await nextTick();
+
+			expect(observe).toHaveBeenCalledTimes(1);
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsSidebar.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsSidebar.vue
@@ -28,6 +28,7 @@ const props = defineProps<{
 	executions: ExecutionSummary[];
 	loading: boolean;
 	loadingMore: boolean;
+	hasMore: boolean;
 	temporaryExecution?: ExecutionSummary;
 }>();
 
@@ -54,12 +55,26 @@ const autoScrollDeps = ref<AutoScrollDeps>({
 });
 const currentWorkflowExecutionsCardRefs = ref<Record<string, ComponentPublicInstance>>({});
 const executionListRef = ref<HTMLElement | null>(null);
+const loadMoreSentinel = ref<HTMLElement | null>(null);
 
 const { observe: observeForLoadMore } = useIntersectionObserver({
 	root: executionListRef,
 	threshold: 0.01,
 	onIntersect: () => emit('loadMore', 20),
 });
+
+// Re-attach the observer whenever the items array grows or hasMore/loadingMore flips.
+// This handles tall screens where the sentinel may already be visible and the previous
+// observer has disconnected itself after firing once.
+watch(
+	[loadMoreSentinel, () => props.executions.length, () => props.hasMore, () => props.loadingMore],
+	([sentinel, , hasMore, loadingMore]) => {
+		if (sentinel && hasMore && !loadingMore) {
+			observeForLoadMore(sentinel);
+		}
+	},
+	{ immediate: true, flush: 'post' },
+);
 
 const workflowPermissions = computed(() => getResourcePermissions(props.workflow?.scopes).workflow);
 
@@ -108,30 +123,9 @@ function addCurrentWorkflowExecutionsCardRef(
 }
 
 function onItemMounted(id: string): void {
-	const index = props.executions.findIndex((execution) => execution.id === id);
-
 	if (executionsStore.activeExecution?.id === id) {
 		autoScrollDeps.value.activeExecutionSet = true;
 		autoScrollDeps.value.cardsMounted = true;
-	}
-
-	// Observe the last item to trigger loading more executions
-	if (index === props.executions.length - 1 && !props.loading && !props.loadingMore) {
-		const cardElement = currentWorkflowExecutionsCardRefs.value[id]?.$el;
-		observeForLoadMore(cardElement);
-	}
-}
-
-function loadMore(limit = 20): void {
-	if (!props.loading) {
-		if (executionListRef.value) {
-			const diff =
-				executionListRef.value.offsetHeight -
-				(executionListRef.value.scrollHeight - executionListRef.value.scrollTop);
-			if (diff > -10 && diff < 10) {
-				emit('loadMore', limit);
-			}
-		}
 	}
 }
 
@@ -209,7 +203,6 @@ const goToUpgrade = () => {
 			ref="executionListRef"
 			:class="$style.executionList"
 			data-test-id="current-executions-list"
-			@scroll="loadMore(20)"
 		>
 			<div v-if="loading" class="mr-l">
 				<N8nLoading variant="rect" />
@@ -244,6 +237,13 @@ const goToUpgrade = () => {
 					@mounted="onItemMounted"
 				/>
 			</TransitionGroup>
+			<div
+				v-if="executions.length && hasMore"
+				ref="loadMoreSentinel"
+				:class="$style.loadMoreSentinel"
+				aria-hidden="true"
+				data-test-id="executions-load-more-sentinel"
+			/>
 			<div v-if="loadingMore" class="mr-m">
 				<N8nLoading variant="p" :rows="1" />
 			</div>
@@ -322,6 +322,11 @@ const goToUpgrade = () => {
 	width: 100%;
 	margin-top: var(--spacing--2xl);
 	text-align: center;
+}
+
+.loadMoreSentinel {
+	height: 1px;
+	width: 100%;
 }
 </style>
 

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsSidebar.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsSidebar.vue
@@ -67,8 +67,8 @@ const { observe: observeForLoadMore } = useIntersectionObserver({
 // This handles tall screens where the sentinel may already be visible and the previous
 // observer has disconnected itself after firing once.
 watch(
-	[loadMoreSentinel, () => props.executions.length, () => props.hasMore, () => props.loadingMore],
-	([sentinel, , hasMore, loadingMore]) => {
+	[loadMoreSentinel, () => props.hasMore, () => props.loadingMore, () => props.executions.length],
+	([sentinel, hasMore, loadingMore]) => {
 		if (sentinel && hasMore && !loadingMore) {
 			observeForLoadMore(sentinel);
 		}

--- a/packages/frontend/editor-ui/src/features/execution/executions/views/WorkflowExecutionsView.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/views/WorkflowExecutionsView.vue
@@ -302,11 +302,14 @@ async function onLoadMore(): Promise<void> {
 	}
 }
 
+const hasMore = computed(
+	() =>
+		!executionsStore.executionsFilters.status?.includes('running') &&
+		executions.value.length < executionsStore.executionsCount,
+);
+
 async function loadMore(): Promise<void> {
-	if (
-		!!executionsStore.executionsFilters.status?.includes('running') ||
-		executions.value.length >= executionsStore.executionsCount
-	) {
+	if (!hasMore.value) {
 		return;
 	}
 
@@ -337,6 +340,7 @@ async function loadMore(): Promise<void> {
 		:workflow="workflow"
 		:loading="loading"
 		:loading-more="loadingMore"
+		:has-more="hasMore"
 		@execution:stop="onExecutionStop"
 		@execution:delete="onExecutionDelete"
 		@execution:retry="onExecutionRetry"

--- a/packages/testing/playwright/tests/e2e/workflows/editor/execution/executions-list-infinite-scroll.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/execution/executions-list-infinite-scroll.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression coverage for LIGO-304: Executions list not loading on longer screens.
+ *
+ * On tall viewports (and at low browser zoom levels) the default 20 executions
+ * fit without overflow, so no scrollbar appears. Without the fix the
+ * IntersectionObserver disconnects after firing once, leaving the user stuck
+ * at 20 executions with no way to load more.
+ */
+
+import { test, expect } from '../../../../../fixtures/base';
+
+test.use({
+	capability: { env: { TEST_ISOLATION: 'ligo-304-executions-list-infinite-scroll' } },
+});
+
+test.describe(
+	'Executions list infinite scroll',
+	{
+		annotation: [{ type: 'issue', description: 'LIGO-304' }],
+	},
+	() => {
+		const TOTAL_EXECUTIONS = 25;
+		const TALL_VIEWPORT = { width: 1920, height: 2000 };
+
+		test.beforeEach(async ({ n8n }) => {
+			await n8n.start.fromImportedWorkflow('Test_workflow_4_executions_view.json');
+		});
+
+		test('should auto-load remaining executions when the sidebar fits without a scrollbar', async ({
+			n8n,
+		}) => {
+			await n8n.executionsComposer.createExecutions(TOTAL_EXECUTIONS);
+			await n8n.canvas.clickExecutionsTab();
+			await n8n.page.setViewportSize(TALL_VIEWPORT);
+
+			await expect(n8n.executions.getExecutionsList()).toBeVisible();
+			await expect(n8n.executions.getExecutionItems().first()).toBeVisible();
+
+			const hasScrollbar = await n8n.executions.getExecutionsList().evaluate((listElement) => {
+				return listElement.scrollHeight > listElement.clientHeight;
+			});
+			expect(hasScrollbar).toBe(false);
+
+			await expect(n8n.executions.getExecutionItems()).toHaveCount(TOTAL_EXECUTIONS, {
+				timeout: 15000,
+			});
+		});
+
+		test('should keep loading on manual scroll on a tall viewport', async ({ n8n }) => {
+			await n8n.executionsComposer.createExecutions(TOTAL_EXECUTIONS);
+			await n8n.canvas.clickExecutionsTab();
+			await n8n.page.setViewportSize(TALL_VIEWPORT);
+
+			await expect(n8n.executions.getExecutionsList()).toBeVisible();
+			await expect(n8n.executions.getExecutionItems().first()).toBeVisible();
+
+			await n8n.executions.scrollExecutionsListToBottom();
+
+			await expect(n8n.executions.getExecutionItems()).toHaveCount(TOTAL_EXECUTIONS, {
+				timeout: 15000,
+			});
+		});
+	},
+);


### PR DESCRIPTION
## Summary

On tall monitors and zoomed-out browsers the workflow Executions sidebar showed only the first 20 entries — no scrollbar appeared, so the infinite-scroll trigger never fired and users could not reach executions 21+. The sidebar's `IntersectionObserver` is now re-armed whenever the items array grows or `loadingMore` settles, so successive pages are fetched automatically until the viewport is filled or no more pages exist.

To verify: open a workflow with 25+ executions, zoom Chrome to ~30% (or use a tall monitor), switch to the Executions tab, and confirm the list loads beyond 20 entries without manual scrolling. At normal zoom, scroll-to-load should continue to work as before.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-304/executions-list-not-loading-on-longer-screens

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use \`(no-changelog)\` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI