### PR TITLE
fix(core): Generate array types for properties with multipleValues                  

### DIFF
--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-types.test.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-types.test.ts
@@ -543,6 +543,20 @@ describe('generate-types', () => {
 			expect(result).toBe('AssignmentCollectionValue');
 		});
 
+		it('should map string type with multipleValues to an array type', () => {
+			const prop: NodeProperty = {
+				name: 'attendees',
+				displayName: 'Attendees',
+				type: 'string',
+				default: '',
+				typeOptions: {
+					multipleValues: true,
+				},
+			};
+			const result = generateTypes.mapPropertyType(prop);
+			expect(result).toBe('Array<string | Expression<string> | PlaceholderValue>');
+		});
+
 		it('should map fixedCollection type to proper nested interface', () => {
 			const prop: NodeProperty = {
 				name: 'queryParameters',
@@ -565,6 +579,34 @@ describe('generate-types', () => {
 			expect(result).toContain('parameters?:');
 			expect(result).toContain('name?:');
 			expect(result).toContain('value?:');
+		});
+
+		it('should map nested string fields with multipleValues to array types', () => {
+			const prop: NodeProperty = {
+				name: 'attendeesUi',
+				displayName: 'Attendees',
+				type: 'fixedCollection',
+				default: {},
+				options: [
+					{
+						displayName: 'Values',
+						name: 'values',
+						values: [
+							{
+								displayName: 'Attendees',
+								name: 'attendees',
+								type: 'string',
+								default: '',
+								typeOptions: {
+									multipleValues: true,
+								},
+							},
+						],
+					},
+				],
+			};
+			const result = generateTypes.mapPropertyType(prop);
+			expect(result).toContain('attendees?: Array<string | Expression<string> | PlaceholderValue>');
 		});
 
 		it('should map fixedCollection with multipleValues to array type', () => {

--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-types.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-types.ts
@@ -715,10 +715,8 @@ function mapNestedPropertyType(
 	discriminatorContext?: DiscriminatorCombination,
 ): string {
 	const result = mapNestedPropertyTypeInner(prop, discriminatorContext);
-	if (prop.noDataExpression) {
-		return stripExpressionFromType(result);
-	}
-	return result;
+	const expressionAwareResult = prop.noDataExpression ? stripExpressionFromType(result) : result;
+	return wrapMultipleValuesType(prop, expressionAwareResult);
 }
 
 function mapNestedPropertyTypeInner(
@@ -1275,10 +1273,16 @@ export function mapPropertyType(
 	discriminatorContext?: DiscriminatorCombination,
 ): string {
 	const result = mapPropertyTypeInner(prop, discriminatorContext);
-	if (prop.noDataExpression) {
-		return stripExpressionFromType(result);
+	const expressionAwareResult = prop.noDataExpression ? stripExpressionFromType(result) : result;
+	return wrapMultipleValuesType(prop, expressionAwareResult);
+}
+
+function wrapMultipleValuesType(prop: NodeProperty, typeStr: string): string {
+	if (!typeStr || prop.type === 'fixedCollection' || prop.type === 'multiOptions') {
+		return typeStr;
 	}
-	return result;
+
+	return prop.typeOptions?.multipleValues === true ? `Array<${typeStr}>` : typeStr;
 }
 
 function mapPropertyTypeInner(

--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.test.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.test.ts
@@ -490,6 +490,71 @@ describe('extractDefaultsForDisplayOptions', () => {
 	});
 });
 
+describe('mapPropertyToZodSchema for multipleValues', () => {
+	it('wraps repeatable string fields in an array schema', () => {
+		const prop: NodeProperty = {
+			name: 'attendees',
+			displayName: 'Attendees',
+			type: 'string',
+			default: '',
+			typeOptions: {
+				multipleValues: true,
+			},
+		};
+
+		const schema = mapPropertyToZodSchema(prop);
+
+		expect(schema).toBe('z.array(stringOrExpression)');
+	});
+
+	it('applies noDataExpression to repeatable fields before wrapping the array schema', () => {
+		const prop: NodeProperty = {
+			name: 'resource',
+			displayName: 'Resource',
+			type: 'string',
+			default: '',
+			noDataExpression: true,
+			typeOptions: {
+				multipleValues: true,
+			},
+		};
+
+		const schema = mapPropertyToZodSchema(prop);
+
+		expect(schema).toBe('z.array(z.string())');
+	});
+
+	it('wraps nested repeatable string fields in an array schema', () => {
+		const prop: NodeProperty = {
+			name: 'attendeesUi',
+			displayName: 'Attendees',
+			type: 'fixedCollection',
+			default: {},
+			options: [
+				{
+					name: 'values',
+					displayName: 'Values',
+					values: [
+						{
+							name: 'attendees',
+							displayName: 'Attendees',
+							type: 'string',
+							default: '',
+							typeOptions: {
+								multipleValues: true,
+							},
+						},
+					],
+				},
+			],
+		};
+
+		const schema = mapPropertyToZodSchema(prop);
+
+		expect(schema).toContain('attendees: z.array(stringOrExpression).optional()');
+	});
+});
+
 describe('stripDiscriminatorKeysFromDisplayOptions', () => {
 	it('removes discriminator keys from show conditions', () => {
 		const result = stripDiscriminatorKeysFromDisplayOptions(

--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.ts
@@ -419,10 +419,10 @@ function generateResourceLocatorZodSchema(prop: NodeProperty): string {
  */
 function mapNestedPropertyToZodSchema(prop: NodeProperty): string {
 	const result = mapNestedPropertyToZodSchemaInner(prop);
-	if (prop.noDataExpression) {
-		return stripExpressionFromZodSchema(result);
-	}
-	return result;
+	const expressionAwareResult = prop.noDataExpression
+		? stripExpressionFromZodSchema(result)
+		: result;
+	return wrapMultipleValuesZodSchema(prop, expressionAwareResult);
 }
 
 function mapNestedPropertyToZodSchemaInner(prop: NodeProperty): string {
@@ -626,10 +626,10 @@ function generateCollectionZodSchema(prop: NodeProperty): string {
  */
 export function mapPropertyToZodSchema(prop: NodeProperty): string {
 	const result = mapPropertyToZodSchemaInner(prop);
-	if (prop.noDataExpression) {
-		return stripExpressionFromZodSchema(result);
-	}
-	return result;
+	const expressionAwareResult = prop.noDataExpression
+		? stripExpressionFromZodSchema(result)
+		: result;
+	return wrapMultipleValuesZodSchema(prop, expressionAwareResult);
 }
 
 /**
@@ -643,6 +643,14 @@ function stripExpressionFromZodSchema(schema: string): string {
 	if (schema === 'booleanOrExpression') return 'z.boolean()';
 	// Remove expressionSchema from z.union([..., expressionSchema])
 	return schema.replace(/,\s*expressionSchema/g, '');
+}
+
+function wrapMultipleValuesZodSchema(prop: NodeProperty, schema: string): string {
+	if (!schema || prop.type === 'fixedCollection' || prop.type === 'multiOptions') {
+		return schema;
+	}
+
+	return prop.typeOptions?.multipleValues === true ? `z.array(${schema})` : schema;
 }
 
 function mapPropertyToZodSchemaInner(prop: NodeProperty): string {


### PR DESCRIPTION
## Summary

Properties declared with `typeOptions: { multipleValues: true }` on simple
types (`string`, `number`, `boolean`, `dateTime`, `color`, `options`, etc.)
were emitted in the generated node type definitions and Zod schemas as their
**singular** type, even though the runtime treats them as arrays.

For example, the Google Calendar node's `additionalFields.attendees` field
(`type: 'string'`, `multipleValues: true`, consumed at
`GoogleCalendar.node.ts:243-253` as `string[]`) was generated as:

```ts
attendees?: string | Expression<string> | PlaceholderValue;
```

The AI workflow builder, reading that signature, produced a single-string
expression for the entire array:

```jsonc
// Wrong (what the builder generated)
"attendees": "={{ [{ email: $json.email }] }}"
```

instead of the array shape the runtime actually requires:

```jsonc
// Correct
"attendees": ["={{ $json.email }}"]
```

This caused `forEach`/`split(',')` calls inside the node implementation to
silently mangle the value at execution time.

### Fix

In `packages/@n8n/workflow-sdk/src/generate-types/`:

- Add a `wrapMultipleValuesType` helper that wraps the inner type with
  `Array<…>` whenever `prop.typeOptions?.multipleValues === true`.
- Apply it at the wrapper level in both `mapPropertyType` and
  `mapNestedPropertyType` (after the `noDataExpression` strip, so
  `Array<string>` is produced correctly when expressions are disabled).
- Mirror the same logic in `mapPropertyToZodSchema` via
  `wrapMultipleValuesZodSchema`, so runtime validation matches the
  emitted TypeScript.
- Skip `fixedCollection` (already handles `multipleValues` internally via
  `generateFixedCollectionType`) and `multiOptions` (already an array by
  definition) to avoid double-wrapping.

After the fix, the same Google Calendar property is emitted as:

```ts
attendees?: Array<string | Expression<string> | PlaceholderValue>;
```

…which the builder uses to produce the correct array shape.

This affects every node that uses `multipleValues: true` on a simple-typed
property, not just Google Calendar.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Add Linear ticket link here -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
