### PR TITLE
feat(core): Add preAuthentication support to requestOAuth2 pipeline

### DIFF
--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -212,6 +212,25 @@ export class CredentialsHelper extends ICredentialsHelper {
 	}
 
 	/**
+	 * Invokes a credential's `preAuthentication` hook for in-memory transformation,
+	 * without the expirable-property guard or DB persistence. Used by `requestOAuth2`
+	 * to transform `oauthTokenData` on every request (e.g. extracting a claim from a
+	 * decrypted JWE/JWT) without writing to the database on every call.
+	 */
+	async runPreAuthentication(
+		helpers: IHttpRequestHelper,
+		credentials: ICredentialDataDecryptedObject,
+		typeName: string,
+	): Promise<ICredentialDataDecryptedObject | undefined> {
+		const credentialType = this.credentialTypes.getByName(typeName);
+		if (typeof credentialType.preAuthentication !== 'function') {
+			return undefined;
+		}
+		const output = await credentialType.preAuthentication.call(helpers, credentials);
+		return (output as ICredentialDataDecryptedObject) ?? undefined;
+	}
+
+	/**
 	 * Resolves the given value in case it is an expression
 	 */
 	private resolveValue(

--- a/packages/core/nodes-testing/credentials-helper.ts
+++ b/packages/core/nodes-testing/credentials-helper.ts
@@ -50,6 +50,14 @@ export class CredentialsHelper extends ICredentialsHelper {
 		return undefined;
 	}
 
+	async runPreAuthentication(
+		_helpers: IHttpRequestHelper,
+		_credentials: ICredentialDataDecryptedObject,
+		_typeName: string,
+	): Promise<ICredentialDataDecryptedObject | undefined> {
+		return undefined;
+	}
+
 	getParentTypes(_name: string): string[] {
 		return [];
 	}

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
@@ -1658,6 +1658,217 @@ describe('Request Helper Functions', () => {
 		});
 	});
 
+	describe('requestOAuth2 - preAuthentication', () => {
+		const baseUrl = 'https://api.example.com';
+		const tokenUrl = 'https://auth.example.com';
+		const mockThis = mockDeep<IAllExecuteFunctions>();
+		const mockNode = mockDeep<INode>();
+		const mockAdditionalData = mockDeep<IWorkflowExecuteAdditionalData>();
+
+		const credentialData = () => ({
+			clientId: 'client-id',
+			clientSecret: 'client-secret',
+			grantType: 'authorizationCode',
+			authUrl: `${tokenUrl}/auth`,
+			accessTokenUrl: `${tokenUrl}/token`,
+			authentication: 'body',
+			scope: 'openid',
+			oauthTokenData: {
+				access_token: 'raw-token',
+				refresh_token: 'old-refresh',
+				token_type: 'bearer',
+			},
+		});
+
+		beforeEach(() => {
+			nock.cleanAll();
+			jest.resetAllMocks();
+			mockNode.name = 'test-node';
+			mockNode.credentials = {
+				testOAuth2: { id: 'cred-id', name: 'cred-name' },
+			};
+		});
+
+		test('initial path: signs request with token transformed by preAuthentication', async () => {
+			mockThis.getCredentials.mockResolvedValue(credentialData());
+			mockAdditionalData.credentialsHelper.preAuthentication.mockResolvedValue({
+				oauthTokenData: {
+					access_token: 'transformed-token',
+					token_type: 'bearer',
+				},
+			});
+
+			mockThis.helpers.httpRequest.mockResolvedValueOnce({ ok: true });
+
+			await requestOAuth2.call(
+				mockThis,
+				'testOAuth2',
+				{ method: 'GET', url: `${baseUrl}/data` },
+				mockNode,
+				mockAdditionalData,
+				undefined,
+				true,
+			);
+
+			expect(mockAdditionalData.credentialsHelper.preAuthentication).toHaveBeenCalled();
+			const preAuthCall = mockAdditionalData.credentialsHelper.preAuthentication.mock.calls[0];
+			expect(preAuthCall[2]).toBe('testOAuth2');
+			expect(preAuthCall[4]).toBe(true);
+			expect(mockThis.helpers.httpRequest).toHaveBeenCalledWith(
+				expect.objectContaining({
+					headers: expect.objectContaining({ Authorization: 'Bearer transformed-token' }),
+				}),
+			);
+		});
+
+		test('initial path: undefined preAuthentication leaves request untouched', async () => {
+			mockThis.getCredentials.mockResolvedValue(credentialData());
+			mockAdditionalData.credentialsHelper.preAuthentication.mockResolvedValue(undefined);
+			mockThis.helpers.httpRequest.mockResolvedValueOnce({ ok: true });
+
+			await requestOAuth2.call(
+				mockThis,
+				'testOAuth2',
+				{ method: 'GET', url: `${baseUrl}/data` },
+				mockNode,
+				mockAdditionalData,
+				undefined,
+				true,
+			);
+
+			expect(mockThis.helpers.httpRequest).toHaveBeenCalledWith(
+				expect.objectContaining({
+					headers: expect.objectContaining({ Authorization: 'Bearer raw-token' }),
+				}),
+			);
+		});
+
+		test('refresh path: retry signs with preAuthentication-transformed refreshed token and persists it', async () => {
+			mockThis.getCredentials.mockResolvedValue(credentialData());
+
+			// preAuthentication is called twice (initial + refresh). Initial returns undefined
+			// so the 401 fires; refresh returns a transformed token.
+			mockAdditionalData.credentialsHelper.preAuthentication
+				.mockResolvedValueOnce(undefined)
+				.mockResolvedValueOnce({
+					oauthTokenData: {
+						access_token: 'transformed-refreshed',
+						refresh_token: 'new-refresh',
+						token_type: 'bearer',
+					},
+				});
+
+			nock(tokenUrl).post('/token').reply(200, {
+				access_token: 'raw-refreshed',
+				refresh_token: 'new-refresh',
+				token_type: 'bearer',
+			});
+
+			mockThis.helpers.httpRequest.mockRejectedValueOnce(
+				Object.assign(new Error('401'), { response: { status: 401 } }),
+			);
+			mockThis.helpers.httpRequest.mockResolvedValueOnce({ ok: true });
+
+			const result = await requestOAuth2.call(
+				mockThis,
+				'testOAuth2',
+				{ method: 'GET', url: `${baseUrl}/data` },
+				mockNode,
+				mockAdditionalData,
+				undefined,
+				true,
+			);
+
+			expect(result).toEqual({ ok: true });
+			expect(mockThis.helpers.httpRequest).toHaveBeenNthCalledWith(
+				2,
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: 'Bearer transformed-refreshed',
+					}),
+				}),
+			);
+			expect(
+				mockAdditionalData.credentialsHelper.updateCredentialsOauthTokenData,
+			).toHaveBeenCalledWith(
+				mockNode.credentials!.testOAuth2,
+				'testOAuth2',
+				expect.objectContaining({
+					oauthTokenData: expect.objectContaining({ access_token: 'transformed-refreshed' }),
+				}),
+				mockAdditionalData,
+			);
+		});
+
+		test('refresh path: undefined preAuthentication signs retry with raw refreshed token', async () => {
+			mockThis.getCredentials.mockResolvedValue(credentialData());
+			mockAdditionalData.credentialsHelper.preAuthentication.mockResolvedValue(undefined);
+
+			nock(tokenUrl).post('/token').reply(200, {
+				access_token: 'raw-refreshed',
+				token_type: 'bearer',
+			});
+
+			mockThis.helpers.httpRequest.mockRejectedValueOnce(
+				Object.assign(new Error('401'), { response: { status: 401 } }),
+			);
+			mockThis.helpers.httpRequest.mockResolvedValueOnce({ ok: true });
+
+			await requestOAuth2.call(
+				mockThis,
+				'testOAuth2',
+				{ method: 'GET', url: `${baseUrl}/data` },
+				mockNode,
+				mockAdditionalData,
+				undefined,
+				true,
+			);
+
+			expect(mockThis.helpers.httpRequest).toHaveBeenNthCalledWith(
+				2,
+				expect.objectContaining({
+					headers: expect.objectContaining({ Authorization: 'Bearer raw-refreshed' }),
+				}),
+			);
+		});
+
+		test('refreshOAuth2Token: returns transformed data after preAuthentication', async () => {
+			mockThis.getCredentials.mockResolvedValue(credentialData());
+			mockAdditionalData.credentialsHelper.preAuthentication.mockResolvedValue({
+				oauthTokenData: {
+					access_token: 'transformed-refreshed',
+					refresh_token: 'new-refresh',
+					token_type: 'bearer',
+				},
+			});
+
+			nock(tokenUrl).post('/token').reply(200, {
+				access_token: 'raw-refreshed',
+				refresh_token: 'new-refresh',
+				token_type: 'bearer',
+			});
+
+			const result = await refreshOAuth2Token.call(
+				mockThis,
+				'testOAuth2',
+				mockNode,
+				mockAdditionalData,
+			);
+
+			expect(result).toEqual(expect.objectContaining({ access_token: 'transformed-refreshed' }));
+			expect(
+				mockAdditionalData.credentialsHelper.updateCredentialsOauthTokenData,
+			).toHaveBeenCalledWith(
+				mockNode.credentials!.testOAuth2,
+				'testOAuth2',
+				expect.objectContaining({
+					oauthTokenData: expect.objectContaining({ access_token: 'transformed-refreshed' }),
+				}),
+				mockAdditionalData,
+			);
+		});
+	});
+
 	describe('SSRF protection wiring', () => {
 		const baseUrl = 'https://example.com';
 		const workflow = mock<Workflow>();

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
@@ -1691,7 +1691,7 @@ describe('Request Helper Functions', () => {
 
 		test('initial path: signs request with token transformed by preAuthentication', async () => {
 			mockThis.getCredentials.mockResolvedValue(credentialData());
-			mockAdditionalData.credentialsHelper.preAuthentication.mockResolvedValue({
+			mockAdditionalData.credentialsHelper.runPreAuthentication.mockResolvedValue({
 				oauthTokenData: {
 					access_token: 'transformed-token',
 					token_type: 'bearer',
@@ -1710,10 +1710,11 @@ describe('Request Helper Functions', () => {
 				true,
 			);
 
-			expect(mockAdditionalData.credentialsHelper.preAuthentication).toHaveBeenCalled();
-			const preAuthCall = mockAdditionalData.credentialsHelper.preAuthentication.mock.calls[0];
+			expect(mockAdditionalData.credentialsHelper.runPreAuthentication).toHaveBeenCalled();
+			const preAuthCall = mockAdditionalData.credentialsHelper.runPreAuthentication.mock.calls[0];
 			expect(preAuthCall[2]).toBe('testOAuth2');
-			expect(preAuthCall[4]).toBe(true);
+			// runPreAuthentication is the non-persisting variant — must not call updateCredentials
+			expect(mockAdditionalData.credentialsHelper.updateCredentials).not.toHaveBeenCalled();
 			expect(mockThis.helpers.httpRequest).toHaveBeenCalledWith(
 				expect.objectContaining({
 					headers: expect.objectContaining({ Authorization: 'Bearer transformed-token' }),
@@ -1723,7 +1724,7 @@ describe('Request Helper Functions', () => {
 
 		test('initial path: undefined preAuthentication leaves request untouched', async () => {
 			mockThis.getCredentials.mockResolvedValue(credentialData());
-			mockAdditionalData.credentialsHelper.preAuthentication.mockResolvedValue(undefined);
+			mockAdditionalData.credentialsHelper.runPreAuthentication.mockResolvedValue(undefined);
 			mockThis.helpers.httpRequest.mockResolvedValueOnce({ ok: true });
 
 			await requestOAuth2.call(
@@ -1748,7 +1749,7 @@ describe('Request Helper Functions', () => {
 
 			// preAuthentication is called twice (initial + refresh). Initial returns undefined
 			// so the 401 fires; refresh returns a transformed token.
-			mockAdditionalData.credentialsHelper.preAuthentication
+			mockAdditionalData.credentialsHelper.runPreAuthentication
 				.mockResolvedValueOnce(undefined)
 				.mockResolvedValueOnce({
 					oauthTokenData: {
@@ -1802,7 +1803,7 @@ describe('Request Helper Functions', () => {
 
 		test('refresh path: undefined preAuthentication signs retry with raw refreshed token', async () => {
 			mockThis.getCredentials.mockResolvedValue(credentialData());
-			mockAdditionalData.credentialsHelper.preAuthentication.mockResolvedValue(undefined);
+			mockAdditionalData.credentialsHelper.runPreAuthentication.mockResolvedValue(undefined);
 
 			nock(tokenUrl).post('/token').reply(200, {
 				access_token: 'raw-refreshed',
@@ -1834,7 +1835,7 @@ describe('Request Helper Functions', () => {
 
 		test('refreshOAuth2Token: returns transformed data after preAuthentication', async () => {
 			mockThis.getCredentials.mockResolvedValue(credentialData());
-			mockAdditionalData.credentialsHelper.preAuthentication.mockResolvedValue({
+			mockAdditionalData.credentialsHelper.runPreAuthentication.mockResolvedValue({
 				oauthTokenData: {
 					access_token: 'transformed-refreshed',
 					refresh_token: 'new-refresh',

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
@@ -729,6 +729,23 @@ function createOAuth2Client(credentials: OAuth2CredentialData): ClientOAuth2 {
 	});
 }
 
+function buildSigningToken(
+	client: ClientOAuth2,
+	tokenData: ClientOAuth2TokenData,
+	oAuth2Options?: IOAuth2Options,
+): ClientOAuth2Token {
+	const accessToken = get(tokenData, oAuth2Options?.property as string) || tokenData.accessToken;
+	const refreshToken = tokenData.refreshToken;
+	return client.createToken(
+		{
+			...tokenData,
+			...(accessToken ? { access_token: accessToken } : {}),
+			...(refreshToken ? { refresh_token: refreshToken } : {}),
+		},
+		oAuth2Options?.tokenType || tokenData.tokenType,
+	);
+}
+
 interface RefreshOAuth2TokenContext {
 	credentials: OAuth2CredentialData;
 	token: ClientOAuth2Token;
@@ -737,10 +754,20 @@ interface RefreshOAuth2TokenContext {
 	additionalData: IWorkflowExecuteAdditionalData;
 	oAuth2Options?: IOAuth2Options;
 	logger: WorkflowLogger;
+	helpers: IAllExecuteFunctions['helpers'];
 }
 
 async function refreshOrFetchToken(ctx: RefreshOAuth2TokenContext): Promise<ClientOAuth2Token> {
-	const { credentials, token, credentialsType, node, additionalData, oAuth2Options, logger } = ctx;
+	const {
+		credentials,
+		token,
+		credentialsType,
+		node,
+		additionalData,
+		oAuth2Options,
+		logger,
+		helpers,
+	} = ctx;
 	const tokenRefreshOptions: IDataObject = {};
 	if (oAuth2Options?.includeCredentialsOnRefreshOnBody) {
 		const body: IDataObject = {
@@ -769,6 +796,28 @@ async function refreshOrFetchToken(ctx: RefreshOAuth2TokenContext): Promise<Clie
 	);
 
 	credentials.oauthTokenData = newToken.data;
+
+	// Re-run preAuthentication so custom credential types extending oAuth2Api can transform
+	// refreshed token data (e.g. extracting a claim from a decrypted JWE/JWT) before signing.
+	// credentialsExpired=true bypasses the expirable-property guard since the transformation
+	// must run on every refresh, not only when the cached value is empty.
+	const preAuthData = await additionalData.credentialsHelper.preAuthentication(
+		{ helpers },
+		credentials as unknown as ICredentialDataDecryptedObject,
+		credentialsType,
+		node,
+		true,
+	);
+	let signingToken = newToken;
+	if (preAuthData) {
+		Object.assign(credentials, preAuthData);
+		signingToken = buildSigningToken(
+			token.client,
+			credentials.oauthTokenData as ClientOAuth2TokenData,
+			oAuth2Options,
+		);
+	}
+
 	if (!node.credentials?.[credentialsType]) {
 		throw new ApplicationError('Node does not have credential type', {
 			extra: { nodeName: node.name, credentialType: credentialsType },
@@ -783,7 +832,7 @@ async function refreshOrFetchToken(ctx: RefreshOAuth2TokenContext): Promise<Clie
 		additionalData,
 	);
 
-	return newToken;
+	return signingToken;
 }
 
 function resolveTokenExpiredStatusCode(
@@ -856,17 +905,23 @@ export async function requestOAuth2(
 		oauthTokenData = data;
 	}
 
-	const accessToken =
-		get(oauthTokenData, oAuth2Options?.property as string) || oauthTokenData.accessToken;
-	const refreshToken = oauthTokenData.refreshToken;
-	const token = oAuthClient.createToken(
-		{
-			...oauthTokenData,
-			...(accessToken ? { access_token: accessToken } : {}),
-			...(refreshToken ? { refresh_token: refreshToken } : {}),
-		},
-		oAuth2Options?.tokenType || oauthTokenData.tokenType,
+	// Support preAuthentication for custom OAuth2 credential types extending oAuth2Api.
+	// Enables transforming token data on every request (e.g. extracting a claim from a
+	// decrypted JWE/JWT). credentialsExpired=true bypasses the expirable-property guard,
+	// which would otherwise skip the call once the cached value is populated.
+	const preAuthData = await additionalData.credentialsHelper.preAuthentication(
+		{ helpers: this.helpers },
+		credentials as unknown as ICredentialDataDecryptedObject,
+		credentialsType,
+		node,
+		true,
 	);
+	if (preAuthData) {
+		Object.assign(credentials, preAuthData);
+		oauthTokenData = credentials.oauthTokenData as ClientOAuth2TokenData;
+	}
+
+	const token = buildSigningToken(oAuthClient, oauthTokenData, oAuth2Options);
 
 	(requestOptions as IRequestOptions).rejectUnauthorized = !credentials.ignoreSSLIssues;
 
@@ -894,6 +949,7 @@ export async function requestOAuth2(
 		additionalData,
 		oAuth2Options,
 		logger: this.logger,
+		helpers: this.helpers,
 	};
 
 	const retryWithNewToken = async (
@@ -1032,17 +1088,7 @@ export async function refreshOAuth2Token(
 
 	const oAuthClient = createOAuth2Client(credentials);
 	const oauthTokenData = credentials.oauthTokenData as ClientOAuth2TokenData;
-	const accessToken =
-		get(oauthTokenData, oAuth2Options?.property as string) || oauthTokenData.accessToken;
-	const refreshToken = oauthTokenData.refreshToken;
-	const token = oAuthClient.createToken(
-		{
-			...oauthTokenData,
-			...(accessToken ? { access_token: accessToken } : {}),
-			...(refreshToken ? { refresh_token: refreshToken } : {}),
-		},
-		oAuth2Options?.tokenType || oauthTokenData.tokenType,
-	);
+	const token = buildSigningToken(oAuthClient, oauthTokenData, oAuth2Options);
 
 	const newToken = await refreshOrFetchToken({
 		credentials,
@@ -1052,6 +1098,7 @@ export async function refreshOAuth2Token(
 		additionalData,
 		oAuth2Options,
 		logger: this.logger,
+		helpers: this.helpers,
 	});
 
 	return newToken.data;

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
@@ -797,16 +797,14 @@ async function refreshOrFetchToken(ctx: RefreshOAuth2TokenContext): Promise<Clie
 
 	credentials.oauthTokenData = newToken.data;
 
-	// Re-run preAuthentication so custom credential types extending oAuth2Api can transform
+	// Apply preAuthentication so custom credential types extending oAuth2Api can transform
 	// refreshed token data (e.g. extracting a claim from a decrypted JWE/JWT) before signing.
-	// credentialsExpired=true bypasses the expirable-property guard since the transformation
-	// must run on every refresh, not only when the cached value is empty.
-	const preAuthData = await additionalData.credentialsHelper.preAuthentication(
+	// runPreAuthentication runs on every refresh without persisting — the transformed
+	// oauthTokenData is persisted by the updateCredentialsOauthTokenData call below.
+	const preAuthData = await additionalData.credentialsHelper.runPreAuthentication(
 		{ helpers },
 		credentials as unknown as ICredentialDataDecryptedObject,
 		credentialsType,
-		node,
-		true,
 	);
 	let signingToken = newToken;
 	if (preAuthData) {
@@ -905,16 +903,13 @@ export async function requestOAuth2(
 		oauthTokenData = data;
 	}
 
-	// Support preAuthentication for custom OAuth2 credential types extending oAuth2Api.
+	// Apply preAuthentication for custom OAuth2 credential types extending oAuth2Api.
 	// Enables transforming token data on every request (e.g. extracting a claim from a
-	// decrypted JWE/JWT). credentialsExpired=true bypasses the expirable-property guard,
-	// which would otherwise skip the call once the cached value is populated.
-	const preAuthData = await additionalData.credentialsHelper.preAuthentication(
+	// decrypted JWE/JWT) as a pure in-memory transform — no DB write per request.
+	const preAuthData = await additionalData.credentialsHelper.runPreAuthentication(
 		{ helpers: this.helpers },
 		credentials as unknown as ICredentialDataDecryptedObject,
 		credentialsType,
-		node,
-		true,
 	);
 	if (preAuthData) {
 		Object.assign(credentials, preAuthData);

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -227,6 +227,12 @@ export abstract class ICredentialsHelper {
 		credentialsExpired: boolean,
 	): Promise<ICredentialDataDecryptedObject | undefined>;
 
+	abstract runPreAuthentication(
+		helpers: IHttpRequestHelper,
+		credentials: ICredentialDataDecryptedObject,
+		typeName: string,
+	): Promise<ICredentialDataDecryptedObject | undefined>;
+
 	abstract getCredentials(
 		nodeCredentials: INodeCredentialsDetails,
 		type: string,


### PR DESCRIPTION
## Summary

The `requestOAuth2` pipeline previously bypassed `preAuthentication` entirely, which prevented custom credential types extending `oAuth2Api` (e.g. for OIDC/JWE/JWT-claim extraction) from transforming token data before signing. This PR wires `preAuthentication` into both the initial request path and the centralized `refreshOrFetchToken` helper, so the retry-with-new-token path and the standalone `refreshOAuth2Token` helper inherit the transformation. `credentialsExpired=true` is passed to bypass the expirable-property guard, since OAuth2 credentials need transformation on every request. Token construction is extracted into a `buildSigningToken` helper to remove duplication across the three call sites. Behavior is unchanged for credentials that do not declare `preAuthentication`.

## How to test

1. Unit tests: `pnpm --filter n8n-core test request-helper-functions.test.ts` — covers initial path, refresh-via-retry, standalone `refreshOAuth2Token`, and the no-op path when `preAuthentication` returns `undefined`.

2. Manual: create a custom OAuth2 credential extending `oAuth2Api` with a `preAuthentication` hook so you can observe the transformation end-to-end:

   ```ts
   import type {
     ICredentialType,
     INodeProperties,
     IAuthenticateGeneric,
     ICredentialDataDecryptedObject,
     IHttpRequestHelper,
   } from 'n8n-workflow';

   export class TestPreAuthOAuth2Api implements ICredentialType {
     name = 'testPreAuthOAuth2Api';
     displayName = 'Test PreAuth OAuth2 API';
     extends = ['oAuth2Api'];

     properties: INodeProperties[] = [
       {
         displayName: 'Grant Type',
         name: 'grantType',
         type: 'hidden',
         default: 'authorizationCode',
       },
       // Required: an expirable hidden property is what enables preAuthentication
       {
         displayName: 'Session Token',
         name: 'sessionToken',
         type: 'hidden',
         typeOptions: { expirable: true },
         default: '',
       },
     ];

     async preAuthentication(this: IHttpRequestHelper, credentials: ICredentialDataDecryptedObject) {
       const tokenData = (credentials.oauthTokenData ?? {}) as { access_token?: string };
       // Transform the token however you need (e.g. decrypt JWE, extract a claim, etc.)
       const transformed = `transformed-${tokenData.access_token ?? ''}`;
       return {
         sessionToken: transformed,
         oauthTokenData: { ...tokenData, access_token: transformed },
       };
     }
   }
   ```

   Connect the credential, then run an HTTP Request node (or any node using `requestOAuth2`) and verify the outgoing `Authorization` header carries the transformed token. Force a refresh (expire the token) and confirm the retried request also uses the transformed value and that the persisted credential reflects it.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-570

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI