### PR TITLE
fix(ai-builder): Handle properties with contradicting displayOptions as OR alternatives instead of AND

### DIFF
--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-types.test.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-types.test.ts
@@ -1983,6 +1983,191 @@ describe('generate-types', () => {
 			expect(result).toMatch(/fieldToSplitOut:\s*string\s*\|/);
 			expect(result).not.toMatch(/fieldToSplitOut\?:/);
 		});
+
+		// BigQuery declares `sqlQuery` twice — show iff useLegacySql=true and
+		// hide iff useLegacySql=true. The two together cover every value of
+		// useLegacySql, so the JSDoc must drop the key entirely.
+		it('collapses BigQuery-style UX-fork sqlQuery variants into a single honest predicate', () => {
+			const bigQueryShape: NodeTypeDescription = {
+				name: 'n8n-nodes-base.googleBigQuery',
+				displayName: 'Google BigQuery',
+				description: 'Run BigQuery queries',
+				group: ['transform'],
+				version: 2.1,
+				inputs: ['main'],
+				outputs: ['main'],
+				properties: [
+					{
+						name: 'sqlQuery',
+						displayName: 'SQL Query',
+						type: 'string',
+						default: '',
+						displayOptions: {
+							show: { resource: ['database'], operation: ['executeQuery'] },
+							hide: { '/options.useLegacySql': [true] },
+						},
+					},
+					{
+						name: 'sqlQuery',
+						displayName: 'SQL Query',
+						type: 'string',
+						default: '',
+						displayOptions: {
+							show: {
+								resource: ['database'],
+								operation: ['executeQuery'],
+								'/options.useLegacySql': [true],
+							},
+						},
+					},
+				],
+			};
+
+			const result = generateTypes.generateNodeTypeFile(bigQueryShape);
+
+			// The simplified JSDoc must keep the resource/operation guard but
+			// not mention useLegacySql — the two variants partition that key.
+			expect(result).toMatch(
+				/@displayOptions\.show \{ resource: \["database"\], operation: \["executeQuery"\] \}/,
+			);
+			expect(result).not.toMatch(/@displayOptions\.hide.*useLegacySql/);
+			expect(result).not.toMatch(/@displayOptions\.show \{[^}]*useLegacySql/);
+		});
+
+		// Pushbullet's `value` declares variant A `hide: target=[default,
+		// device_iden]` and variant B `show: target=[device_iden]`. OR-semantics
+		// = target ≠ default; the JSDoc must drop `device_iden` from the hide.
+		it('simplifies Pushbullet-style "show ⊆ hide" to drop the rescued values', () => {
+			const pushbulletShape: NodeTypeDescription = {
+				name: 'n8n-nodes-base.pushbullet',
+				displayName: 'Pushbullet',
+				description: 'Send pushes',
+				group: ['transform'],
+				version: 1,
+				inputs: ['main'],
+				outputs: ['main'],
+				properties: [
+					{
+						name: 'resource',
+						displayName: 'Resource',
+						type: 'options',
+						default: 'push',
+						options: [{ name: 'Push', value: 'push' }],
+						noDataExpression: true,
+					},
+					{
+						name: 'operation',
+						displayName: 'Operation',
+						type: 'options',
+						default: 'create',
+						displayOptions: { show: { resource: ['push'] } },
+						options: [{ name: 'Create', value: 'create' }],
+						noDataExpression: true,
+					},
+					{
+						name: 'value',
+						displayName: 'Value',
+						type: 'string',
+						required: true,
+						default: '',
+						displayOptions: {
+							show: { resource: ['push'], operation: ['create'] },
+							hide: { target: ['default', 'device_iden'] },
+						},
+					},
+					{
+						name: 'value',
+						displayName: 'Value Name or ID',
+						type: 'string',
+						required: true,
+						default: '',
+						displayOptions: {
+							show: { resource: ['push'], operation: ['create'], target: ['device_iden'] },
+						},
+					},
+				],
+			};
+
+			const result = generateTypes.generateNodeTypeFile(pushbulletShape);
+
+			// Hide line should keep only `default`; `device_iden` is rescued
+			// by variant B's show.
+			expect(result).toMatch(/@displayOptions\.hide \{ target: \["default"\] \}/);
+			expect(result).not.toMatch(/@displayOptions\.hide \{[^}]*device_iden/);
+			expect(result).not.toMatch(/@displayOptions\.show \{[^}]*target.*device_iden/);
+		});
+
+		// `show: K=[a]` + `hide: K=[b]` (a ≠ b) collapses to `hide: K=[b]` —
+		// the second clause already covers the first.
+		it('also simplifies CoinGecko-style "show K=[a] + hide K=[b]" to the OR predicate', () => {
+			const coinGeckoShape: NodeTypeDescription = {
+				name: 'n8n-nodes-base.coinGecko',
+				displayName: 'CoinGecko',
+				description: 'Coin data',
+				group: ['transform'],
+				version: 1,
+				inputs: ['main'],
+				outputs: ['main'],
+				properties: [
+					{
+						name: 'tickerField',
+						displayName: 'Ticker Field',
+						type: 'string',
+						default: '',
+						displayOptions: { show: { searchBy: ['coinId'] } },
+					},
+					{
+						name: 'tickerField',
+						displayName: 'Ticker Field',
+						type: 'string',
+						default: '',
+						displayOptions: { hide: { searchBy: ['contractAddress'] } },
+					},
+				],
+			};
+
+			const result = generateTypes.generateNodeTypeFile(coinGeckoShape);
+
+			expect(result).toMatch(/@displayOptions\.hide \{ searchBy: \["contractAddress"\] \}/);
+			expect(result).not.toMatch(/@displayOptions\.show \{ searchBy:/);
+		});
+
+		// Two variants gating on different keys aren't a fork — no single key
+		// is partitioned, so the simplifier bails and "first wins" stands.
+		it('falls back to first-declaration-wins when the variants are not a UX fork', () => {
+			const unrelatedShape: NodeTypeDescription = {
+				name: 'n8n-nodes-base.dummy',
+				displayName: 'Dummy',
+				description: 'Dummy',
+				group: ['transform'],
+				version: 1,
+				inputs: ['main'],
+				outputs: ['main'],
+				properties: [
+					{
+						name: 'field',
+						displayName: 'Field',
+						type: 'string',
+						default: '',
+						displayOptions: { show: { mode: ['a'] } },
+					},
+					{
+						name: 'field',
+						displayName: 'Field',
+						type: 'string',
+						default: '',
+						displayOptions: { show: { resource: ['x'] } },
+					},
+				],
+			};
+
+			const result = generateTypes.generateNodeTypeFile(unrelatedShape);
+
+			// First declaration's displayOptions still appear; second is
+			// dropped (existing behaviour, no regression).
+			expect(result).toMatch(/@displayOptions\.show \{ mode: \["a"\] \}/);
+			expect(result).not.toMatch(/@displayOptions\.show \{ resource:/);
+		});
 	});
 
 	describe('generateIndexFile', () => {

--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-types.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-types.ts
@@ -1152,9 +1152,89 @@ export function narrowDisplayOptionsByDisabled(prop: NodeProperty): {
 }
 
 /**
- * Merge properties with the same name for collection/fixedCollection types.
- * When multiple properties have the same name (e.g., multiple 'options' collections
- * with different displayOptions), their nested options should be merged.
+ * Compute the OR-simplified displayOptions for two same-named declarations
+ * that form a "UX fork" — variants A and B differ only in a single key K,
+ * one gating it on hide and the other on show.
+ *
+ * With H = A.hide[K], S = B.show[K], the OR is:
+ *   K ∈ S  OR  K ∉ H   ≡   K ∉ (H \ S)
+ *
+ * - H \ S empty (S ⊇ H, e.g. BigQuery `show:[true]` + `hide:[true]`):
+ *   drop K — no constraint.
+ * - H \ S non-empty (e.g. Pushbullet `show:[device_iden]` +
+ *   `hide:[default, device_iden]`): keep `hide: K = [default]`.
+ *
+ * Returns `undefined` when the shape doesn't fit (other show/hide entries
+ * differ between variants, more than two variants, etc.); callers fall
+ * back to "first declaration wins".
+ */
+function tryMergeUxForkVariants(
+	a: NodeProperty,
+	b: NodeProperty,
+): NonNullable<NodeProperty['displayOptions']> | undefined {
+	const aDO = a.displayOptions;
+	const bDO = b.displayOptions;
+	if (!aDO || !bDO) return undefined;
+
+	const stripKey = (
+		dispOpts: { show?: Record<string, unknown[]>; hide?: Record<string, unknown[]> },
+		key: string,
+	): { show: Record<string, unknown[]>; hide: Record<string, unknown[]> } => {
+		const showRest = dispOpts.show ? { ...dispOpts.show } : {};
+		const hideRest = dispOpts.hide ? { ...dispOpts.hide } : {};
+		delete showRest[key];
+		delete hideRest[key];
+		return { show: showRest, hide: hideRest };
+	};
+
+	const setDifference = (a: unknown[], b: unknown[]): unknown[] => {
+		const bSet = new Set(b.map((v) => JSON.stringify(v)));
+		return a.filter((v) => !bSet.has(JSON.stringify(v)));
+	};
+
+	// Try both directions: A may hide-K while B shows-K, or vice versa.
+	for (const [first, second] of [
+		[aDO, bDO],
+		[bDO, aDO],
+	] as const) {
+		const firstHide = first.hide ?? {};
+		const secondShow = second.show ?? {};
+		for (const k of Object.keys(firstHide)) {
+			const secondShowVals = secondShow[k];
+			if (!secondShowVals) continue;
+
+			const firstStripped = stripKey(first, k);
+			const secondStripped = stripKey(second, k);
+			if (
+				JSON.stringify(firstStripped.show) !== JSON.stringify(secondStripped.show) ||
+				JSON.stringify(firstStripped.hide) !== JSON.stringify(secondStripped.hide)
+			) {
+				continue;
+			}
+
+			const remainingHide = setDifference(firstHide[k], secondShowVals);
+
+			const mergedShow: Record<string, unknown[]> = { ...firstStripped.show };
+			const mergedHide: Record<string, unknown[]> = { ...firstStripped.hide };
+			if (remainingHide.length > 0) {
+				mergedHide[k] = remainingHide;
+			}
+
+			const merged: NonNullable<NodeProperty['displayOptions']> = {};
+			if (Object.keys(mergedShow).length > 0) merged.show = mergedShow;
+			if (Object.keys(mergedHide).length > 0) merged.hide = mergedHide;
+			return merged;
+		}
+	}
+
+	return undefined;
+}
+
+/**
+ * Merge properties with the same name. Nested options of collection /
+ * fixedCollection types are union-merged; displayOptions are
+ * UX-fork-simplified when applicable (see tryMergeUxForkVariants), otherwise
+ * the first declaration's displayOptions wins.
  *
  * @param properties - Array of node properties, possibly with duplicates
  * @returns Array of properties with duplicates merged
@@ -1196,7 +1276,14 @@ function mergeCollectionProperties(properties: NodeProperty[]): NodeProperty[] {
 					}
 				}
 			}
-			// Don't add duplicate to output - we've merged into existing
+
+			// If the two declarations form a UX fork, replace the surviving
+			// displayOptions with the OR-simplified predicate.
+			const simplified = tryMergeUxForkVariants(existingProp, normalizedProp);
+			if (simplified !== undefined) {
+				existingProp.displayOptions = Object.keys(simplified).length > 0 ? simplified : undefined;
+			}
+
 			continue;
 		}
 
@@ -1728,13 +1815,10 @@ export function generateDiscriminatedUnion(node: NodeTypeDescription): string {
 			}
 		}
 
-		// Track seen property names to avoid duplicates
-		const seenNames = new Set<string>();
-		for (const prop of props) {
-			if (seenNames.has(prop.name)) {
-				continue; // Skip duplicate property names
-			}
-			seenNames.add(prop.name);
+		// Route through mergeCollectionProperties so duplicate-named
+		// declarations get UX-fork-simplified instead of silently dropped.
+		const mergedProps = mergeCollectionProperties(props);
+		for (const prop of mergedProps) {
 			// Pass combo as discriminator context to filter redundant displayOptions
 			const propLine = generatePropertyLine(prop, isPropertyOptional(prop), combo);
 			if (propLine) {
@@ -2391,11 +2475,10 @@ export function generateDiscriminatorFile(
 		}
 	}
 
-	// Add properties
-	const seenNames = new Set<string>();
-	for (const prop of props) {
-		if (seenNames.has(prop.name)) continue;
-		seenNames.add(prop.name);
+	// Route through mergeCollectionProperties so duplicate-named declarations
+	// get UX-fork-simplified instead of silently dropped.
+	const mergedProps = mergeCollectionProperties(props);
+	for (const prop of mergedProps) {
 		// Pass combo as discriminator context to filter redundant displayOptions
 		const propLine = generatePropertyLine(prop, isPropertyOptional(prop), combo);
 		if (propLine) {
@@ -3249,13 +3332,10 @@ function generateDiscriminatedUnionForEntry(
 			}
 		}
 
-		// Track seen property names to avoid duplicates
-		const seenNames = new Set<string>();
-		for (const prop of props) {
-			if (seenNames.has(prop.name)) {
-				continue; // Skip duplicate property names
-			}
-			seenNames.add(prop.name);
+		// Route through mergeCollectionProperties so duplicate-named
+		// declarations get UX-fork-simplified instead of silently dropped.
+		const mergedProps = mergeCollectionProperties(props);
+		for (const prop of mergedProps) {
 			// Pass combo as discriminator context to filter redundant displayOptions
 			const propLine = generatePropertyLine(prop, isPropertyOptional(prop), combo);
 			if (propLine) {

--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.test.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.test.ts
@@ -1581,10 +1581,8 @@ describe('mergePropertiesByName with disabledOptions', () => {
 });
 
 describe('mergePropertiesByName with multi-declaration variants', () => {
-	// Real-world repro: BigQuery v2 declares `sqlQuery` twice — one variant for
-	// standard SQL (`hide: useLegacySql=[true]`) and one for legacy SQL
-	// (`show: useLegacySql=[true]`). The two predicates are mutually exclusive,
-	// so the variants must reach codegen as separate entries to be OR-evaluated.
+	// BigQuery declares `sqlQuery` twice — `hide: useLegacySql=[true]` (standard)
+	// and `show: useLegacySql=[true]` (legacy). Mutually exclusive predicates.
 	const standardSql: NodeProperty = {
 		name: 'sqlQuery',
 		displayName: 'SQL Query',
@@ -1666,10 +1664,9 @@ describe('mergePropertiesByName with multi-declaration variants', () => {
 		const { resolveOneOfSchemas } = await import('../validation/resolve-schema');
 		const { z } = await import('zod');
 
-		// Hypothetical: variantA is required when mode=a, variantB is optional
-		// when mode=b. With OR-of-resolveSchema, the inactive variant's
-		// "must-be-undefined" branch would silently mask the required check —
-		// resolveOneOfSchemas must instead use the active variant's required flag.
+		// A naive z.union of resolveSchema calls would let the inactive variant's
+		// "must-be-undefined" branch mask the active variant's required flag —
+		// resolveOneOfSchemas must use the visible variant's required flag.
 		const variants = [
 			{
 				schema: z.string(),
@@ -1739,9 +1736,6 @@ describe('mergePropertiesByName with multi-declaration variants', () => {
 				{
 					schema: z.string(),
 					required: false,
-					// Also not visible because hide checks against actual value 'maybe'
-					// but actual value is 'maybe' so hide doesn't fire — still visible.
-					// Adjust: make this also impossible.
 					displayOptions: { show: { '/options.useLegacySql': [false] } },
 				},
 			],
@@ -1755,11 +1749,10 @@ describe('mergePropertiesByName with multi-declaration variants', () => {
 		}
 	});
 
+	// Agent-style: three `text` declarations differing only in promptType
+	// show-values. Each lands as its own variant; the runtime resolver picks
+	// whichever matches.
 	it('OR alternatives still merge cleanly when the existing union behaviour suffices', () => {
-		// Three Agent-style text declarations differing only in promptType show
-		// values. Each variant lands as its own group entry; the runtime
-		// resolver picks whichever matches, so the visible behaviour matches
-		// the historical "show: { promptType: [a, b, c] }" merge.
 		const a: NodeProperty = {
 			name: 'text',
 			displayName: 'Text',
@@ -1792,16 +1785,10 @@ describe('mergePropertiesByName with multi-declaration variants', () => {
 		]);
 	});
 
+	// CoinGecko-shape: `show: K=[a]` + `hide: K=[b]`, distinct values. Naive
+	// union-merge would collapse to "K=a", silently dropping every other value
+	// from settable. Variants must stay split for the runtime to OR them.
 	it('preserves OR semantics for show-on-one-value + hide-on-another-value (CoinGecko shape)', async () => {
-		// Real-world repro: CoinGecko v1 declares this shape on a coin/market
-		// chart parameter — `show: searchBy=['coinId']` and
-		// `hide: searchBy=['contractAddress']`. The two predicates aren't
-		// literally contradictory (no value overlap), but the naive union-merge
-		// produces `searchBy='coinId' AND searchBy≠'contractAddress'`, which
-		// equals just "searchBy='coinId'" — wrong, since the OR semantic is
-		// "searchBy='coinId' OR searchBy≠'contractAddress'" = "searchBy ≠
-		// 'contractAddress'". With the fix in place the variants stay separate
-		// and the runtime resolver evaluates OR.
 		const showOnA: NodeProperty = {
 			name: 'tickerField',
 			displayName: 'Ticker Field',
@@ -1837,23 +1824,18 @@ describe('mergePropertiesByName with multi-declaration variants', () => {
 			},
 		];
 
-		// searchBy='coinId': variantA visible (variantB also visible since hide
-		// doesn't fire) → settable. The naive merge would also accept this.
+		// searchBy='coinId': variantA visible → settable.
 		expect(
 			resolveOneOfSchemas({ parameters: { searchBy: 'coinId' }, variants }).safeParse('AAPL')
 				.success,
 		).toBe(true);
-
 		// searchBy='other': variantA hidden, variantB visible → settable. The
-		// naive merge would have REJECTED this — that's the bug the OR fix
-		// addresses.
+		// naive merge would have rejected this — the bug the OR fix addresses.
 		expect(
 			resolveOneOfSchemas({ parameters: { searchBy: 'other' }, variants }).safeParse('AAPL')
 				.success,
 		).toBe(true);
-
-		// searchBy='contractAddress': variantA hidden, variantB hidden by its
-		// own `hide` rule → field must be unset.
+		// searchBy='contractAddress': both variants hidden → must be unset.
 		expect(
 			resolveOneOfSchemas({
 				parameters: { searchBy: 'contractAddress' },

--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.test.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.test.ts
@@ -15,6 +15,7 @@ import {
 	mergePropertiesByName,
 	extractDefaultsForDisplayOptions,
 } from './generate-zod-schemas';
+import type { SchemaVariant } from '../validation/resolve-schema';
 
 describe('mapPropertyToZodSchema for resourceLocator', () => {
 	it('returns resourceLocatorValueSchema when no modes are specified', () => {
@@ -679,8 +680,10 @@ describe('generateDiscriminatorSchemaFile with displayOptions', () => {
 			[],
 		);
 
-		// CommonJS: resolveSchema is included in the require destructure
-		expect(code).toContain('resolveSchema }');
+		// resolveSchema and resolveOneOfSchemas are added together when
+		// conditional resolution is needed; asserting on the trailing helper
+		// confirms both made it into the factory's parameter destructure.
+		expect(code).toContain('resolveSchema, resolveOneOfSchemas }');
 	});
 
 	it('uses resolveSchema for properties with remaining displayOptions', () => {
@@ -778,9 +781,9 @@ describe('generateDiscriminatorSchemaFile with displayOptions', () => {
 			[],
 		);
 
-		// CommonJS module.exports for factory function with all helpers as parameters
+		// CommonJS module.exports for factory function with all helpers as parameters.
 		expect(code).toContain('module.exports = function getSchema({ parameters, z,');
-		expect(code).toContain('resolveSchema }');
+		expect(code).toContain('resolveSchema, resolveOneOfSchemas }');
 		expect(code).toContain('return z.object({');
 	});
 
@@ -919,9 +922,9 @@ describe('generateSingleVersionSchemaFile', () => {
 
 		const code = generateSingleVersionSchemaFile(node, 1);
 
-		// Should generate a factory function with all helpers as parameters (CommonJS)
+		// Should generate a factory function with all helpers as parameters (CommonJS).
 		expect(code).toContain('module.exports = function getSchema({ parameters, z,');
-		expect(code).toContain('resolveSchema }');
+		expect(code).toContain('resolveSchema, resolveOneOfSchemas }');
 		expect(code).toContain('return z.object({');
 	});
 
@@ -1488,9 +1491,10 @@ describe('mergePropertiesByName with disabledOptions', () => {
 
 		const merged = mergePropertiesByName([expressionSessionKey, editableSessionKey]);
 
-		const prop = merged.get('sessionKey');
-		expect(prop).toBeDefined();
-		expect(prop?.displayOptions).toEqual({ show: { sessionIdType: ['customKey'] } });
+		const group = merged.get('sessionKey');
+		expect(group).toBeDefined();
+		expect(group).toHaveLength(1);
+		expect(group?.[0].displayOptions).toEqual({ show: { sessionIdType: ['customKey'] } });
 	});
 
 	it('produces the same narrowed result regardless of property ordering', () => {
@@ -1513,10 +1517,10 @@ describe('mergePropertiesByName with disabledOptions', () => {
 		const mergedA = mergePropertiesByName([expressionSessionKey, editableSessionKey]);
 		const mergedB = mergePropertiesByName([editableSessionKey, expressionSessionKey]);
 
-		expect(mergedA.get('sessionKey')?.displayOptions).toEqual({
+		expect(mergedA.get('sessionKey')?.[0].displayOptions).toEqual({
 			show: { sessionIdType: ['customKey'] },
 		});
-		expect(mergedB.get('sessionKey')?.displayOptions).toEqual({
+		expect(mergedB.get('sessionKey')?.[0].displayOptions).toEqual({
 			show: { sessionIdType: ['customKey'] },
 		});
 	});
@@ -1562,7 +1566,7 @@ describe('mergePropertiesByName with disabledOptions', () => {
 		};
 
 		const merged = mergePropertiesByName([expressionSessionKey, editableSessionKey]);
-		const line = generateConditionalSchemaLine(merged.get('sessionKey')!, [
+		const line = generateConditionalSchemaLine(merged.get('sessionKey')![0], [
 			{
 				name: 'sessionIdType',
 				displayName: 'Session ID',
@@ -1573,6 +1577,311 @@ describe('mergePropertiesByName with disabledOptions', () => {
 
 		expect(line).toContain('displayOptions: {"show":{"sessionIdType":["customKey"]}}');
 		expect(line).not.toMatch(/"show":\{[^}]*"fromInput"/);
+	});
+});
+
+describe('mergePropertiesByName with multi-declaration variants', () => {
+	// Real-world repro: BigQuery v2 declares `sqlQuery` twice — one variant for
+	// standard SQL (`hide: useLegacySql=[true]`) and one for legacy SQL
+	// (`show: useLegacySql=[true]`). The two predicates are mutually exclusive,
+	// so the variants must reach codegen as separate entries to be OR-evaluated.
+	const standardSql: NodeProperty = {
+		name: 'sqlQuery',
+		displayName: 'SQL Query',
+		type: 'string',
+		default: '',
+		displayOptions: { hide: { '/options.useLegacySql': [true] } },
+	};
+	const legacySql: NodeProperty = {
+		name: 'sqlQuery',
+		displayName: 'SQL Query',
+		type: 'string',
+		default: '',
+		displayOptions: { show: { '/options.useLegacySql': [true] } },
+	};
+
+	it('keeps mutually-exclusive declarations as separate variants', () => {
+		const merged = mergePropertiesByName([standardSql, legacySql]);
+		const group = merged.get('sqlQuery');
+
+		expect(group).toHaveLength(2);
+		expect(group?.[0].displayOptions).toEqual({ hide: { '/options.useLegacySql': [true] } });
+		expect(group?.[1].displayOptions).toEqual({ show: { '/options.useLegacySql': [true] } });
+	});
+
+	it('emits a resolveOneOfSchemas line when codegen runs on a multi-variant group', () => {
+		const node: NodeTypeDescription = {
+			name: 'n8n-nodes-base.dummy',
+			displayName: 'Dummy',
+			version: 1,
+			group: ['transform'],
+			inputs: ['main'],
+			outputs: ['main'],
+			properties: [standardSql, legacySql],
+		};
+		const code = generateSingleVersionSchemaFile(node, 1);
+
+		expect(code).toContain('resolveOneOfSchemas({');
+		expect(code).toContain('"hide":{"/options.useLegacySql":[true]}');
+		expect(code).toContain('"show":{"/options.useLegacySql":[true]}');
+		expect(code).toContain('resolveOneOfSchemas }');
+	});
+
+	it('runtime: accepts sqlQuery for every value of useLegacySql via resolveOneOfSchemas', async () => {
+		const { resolveOneOfSchemas } = await import('../validation/resolve-schema');
+		const { z } = await import('zod');
+
+		const variants = [
+			{
+				schema: z.string(),
+				required: false,
+				displayOptions: standardSql.displayOptions!,
+			},
+			{
+				schema: z.string(),
+				required: false,
+				displayOptions: legacySql.displayOptions!,
+			},
+		];
+
+		const schemaWhenLegacy = resolveOneOfSchemas({
+			parameters: { options: { useLegacySql: true } },
+			variants,
+		});
+		const schemaWhenStandard = resolveOneOfSchemas({
+			parameters: { options: { useLegacySql: false } },
+			variants,
+		});
+		const schemaWhenUnset = resolveOneOfSchemas({
+			parameters: { options: {} },
+			variants,
+		});
+
+		expect(schemaWhenLegacy.safeParse('SELECT 1').success).toBe(true);
+		expect(schemaWhenStandard.safeParse('SELECT 1').success).toBe(true);
+		expect(schemaWhenUnset.safeParse('SELECT 1').success).toBe(true);
+	});
+
+	it('runtime: enforces required when the visible variant is required', async () => {
+		const { resolveOneOfSchemas } = await import('../validation/resolve-schema');
+		const { z } = await import('zod');
+
+		// Hypothetical: variantA is required when mode=a, variantB is optional
+		// when mode=b. With OR-of-resolveSchema, the inactive variant's
+		// "must-be-undefined" branch would silently mask the required check —
+		// resolveOneOfSchemas must instead use the active variant's required flag.
+		const variants = [
+			{
+				schema: z.string(),
+				required: true,
+				displayOptions: { show: { mode: ['a'] } },
+			},
+			{
+				schema: z.string(),
+				required: false,
+				displayOptions: { show: { mode: ['b'] } },
+			},
+		];
+
+		const whenA = resolveOneOfSchemas({ parameters: { mode: 'a' }, variants });
+		const whenB = resolveOneOfSchemas({ parameters: { mode: 'b' }, variants });
+		const whenC = resolveOneOfSchemas({ parameters: { mode: 'c' }, variants });
+
+		expect(whenA.safeParse(undefined).success).toBe(false); // required
+		expect(whenA.safeParse('value').success).toBe(true);
+		expect(whenB.safeParse(undefined).success).toBe(true); // optional
+		expect(whenB.safeParse('value').success).toBe(true);
+		expect(whenC.safeParse(undefined).success).toBe(true); // hidden, must be undefined
+		expect(whenC.safeParse('value').success).toBe(false);
+	});
+
+	it('runtime: full DSL — @version, _cnd operators, root paths — work per variant', async () => {
+		const { resolveOneOfSchemas } = await import('../validation/resolve-schema');
+		const { z } = await import('zod');
+
+		const variants: SchemaVariant[] = [
+			{
+				schema: z.string(),
+				required: false,
+				displayOptions: { show: { '/modelId': [{ _cnd: { includes: 'gpt-image' } }] } },
+			},
+			{
+				schema: z.string(),
+				required: false,
+				displayOptions: { show: { '/model': ['dall-e-2'] } },
+			},
+		];
+
+		const whenGptImage = resolveOneOfSchemas({
+			parameters: { modelId: 'gpt-image-1-2024' },
+			variants,
+		});
+		const whenDallE = resolveOneOfSchemas({ parameters: { model: 'dall-e-2' }, variants });
+		const whenNeither = resolveOneOfSchemas({ parameters: {}, variants });
+
+		expect(whenGptImage.safeParse('hello').success).toBe(true);
+		expect(whenDallE.safeParse('hello').success).toBe(true);
+		expect(whenNeither.safeParse('hello').success).toBe(false);
+	});
+
+	it('runtime: refuses settings when no variant is visible, with a combined OR error message', async () => {
+		const { resolveOneOfSchemas } = await import('../validation/resolve-schema');
+		const { z } = await import('zod');
+
+		const schema = resolveOneOfSchemas({
+			parameters: { options: { useLegacySql: 'maybe' } },
+			variants: [
+				{
+					schema: z.string(),
+					required: false,
+					displayOptions: { show: { '/options.useLegacySql': [true] } },
+				},
+				{
+					schema: z.string(),
+					required: false,
+					// Also not visible because hide checks against actual value 'maybe'
+					// but actual value is 'maybe' so hide doesn't fire — still visible.
+					// Adjust: make this also impossible.
+					displayOptions: { show: { '/options.useLegacySql': [false] } },
+				},
+			],
+		});
+
+		const result = schema.safeParse('SELECT 1');
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const message = result.error.issues[0]?.message ?? '';
+			expect(message).toContain('OR');
+		}
+	});
+
+	it('OR alternatives still merge cleanly when the existing union behaviour suffices', () => {
+		// Three Agent-style text declarations differing only in promptType show
+		// values. Each variant lands as its own group entry; the runtime
+		// resolver picks whichever matches, so the visible behaviour matches
+		// the historical "show: { promptType: [a, b, c] }" merge.
+		const a: NodeProperty = {
+			name: 'text',
+			displayName: 'Text',
+			type: 'string',
+			default: '',
+			displayOptions: { show: { promptType: ['guardrails'] } },
+		};
+		const b: NodeProperty = {
+			name: 'text',
+			displayName: 'Text',
+			type: 'string',
+			default: '',
+			displayOptions: { show: { promptType: ['auto'] } },
+		};
+		const c: NodeProperty = {
+			name: 'text',
+			displayName: 'Text',
+			type: 'string',
+			default: '',
+			displayOptions: { show: { promptType: ['define'] } },
+		};
+		const merged = mergePropertiesByName([a, b, c]);
+		const group = merged.get('text');
+
+		expect(group).toHaveLength(3);
+		expect(group?.map((g) => g.displayOptions)).toEqual([
+			{ show: { promptType: ['guardrails'] } },
+			{ show: { promptType: ['auto'] } },
+			{ show: { promptType: ['define'] } },
+		]);
+	});
+
+	it('preserves OR semantics for show-on-one-value + hide-on-another-value (CoinGecko shape)', async () => {
+		// Real-world repro: CoinGecko v1 declares this shape on a coin/market
+		// chart parameter — `show: searchBy=['coinId']` and
+		// `hide: searchBy=['contractAddress']`. The two predicates aren't
+		// literally contradictory (no value overlap), but the naive union-merge
+		// produces `searchBy='coinId' AND searchBy≠'contractAddress'`, which
+		// equals just "searchBy='coinId'" — wrong, since the OR semantic is
+		// "searchBy='coinId' OR searchBy≠'contractAddress'" = "searchBy ≠
+		// 'contractAddress'". With the fix in place the variants stay separate
+		// and the runtime resolver evaluates OR.
+		const showOnA: NodeProperty = {
+			name: 'tickerField',
+			displayName: 'Ticker Field',
+			type: 'string',
+			default: '',
+			displayOptions: { show: { searchBy: ['coinId'] } },
+		};
+		const hideOnB: NodeProperty = {
+			name: 'tickerField',
+			displayName: 'Ticker Field',
+			type: 'string',
+			default: '',
+			displayOptions: { hide: { searchBy: ['contractAddress'] } },
+		};
+
+		const merged = mergePropertiesByName([showOnA, hideOnB]);
+		const group = merged.get('tickerField');
+
+		// Variants stay separate — no lossy union-merge.
+		expect(group).toHaveLength(2);
+		expect(group?.[0].displayOptions).toEqual({ show: { searchBy: ['coinId'] } });
+		expect(group?.[1].displayOptions).toEqual({ hide: { searchBy: ['contractAddress'] } });
+
+		// Runtime: the field must be settable in every state OR-semantics demands.
+		const { resolveOneOfSchemas } = await import('../validation/resolve-schema');
+		const { z } = await import('zod');
+		const variants: SchemaVariant[] = [
+			{ schema: z.string(), required: false, displayOptions: { show: { searchBy: ['coinId'] } } },
+			{
+				schema: z.string(),
+				required: false,
+				displayOptions: { hide: { searchBy: ['contractAddress'] } },
+			},
+		];
+
+		// searchBy='coinId': variantA visible (variantB also visible since hide
+		// doesn't fire) → settable. The naive merge would also accept this.
+		expect(
+			resolveOneOfSchemas({ parameters: { searchBy: 'coinId' }, variants }).safeParse('AAPL')
+				.success,
+		).toBe(true);
+
+		// searchBy='other': variantA hidden, variantB visible → settable. The
+		// naive merge would have REJECTED this — that's the bug the OR fix
+		// addresses.
+		expect(
+			resolveOneOfSchemas({ parameters: { searchBy: 'other' }, variants }).safeParse('AAPL')
+				.success,
+		).toBe(true);
+
+		// searchBy='contractAddress': variantA hidden, variantB hidden by its
+		// own `hide` rule → field must be unset.
+		expect(
+			resolveOneOfSchemas({
+				parameters: { searchBy: 'contractAddress' },
+				variants,
+			}).safeParse('AAPL').success,
+		).toBe(false);
+	});
+
+	it('collapses to a single unconditional declaration when any variant is unconditional', () => {
+		const conditional: NodeProperty = {
+			name: 'field',
+			displayName: 'Field',
+			type: 'string',
+			default: '',
+			displayOptions: { show: { mode: ['advanced'] } },
+		};
+		const unconditional: NodeProperty = {
+			name: 'field',
+			displayName: 'Field',
+			type: 'string',
+			default: '',
+		};
+
+		const merged = mergePropertiesByName([conditional, unconditional]);
+		const group = merged.get('field');
+
+		expect(group).toHaveLength(1);
+		expect(group?.[0].displayOptions).toBeUndefined();
 	});
 });
 

--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.ts
@@ -878,33 +878,18 @@ export function mergeDisplayOptions(
 /**
  * Group properties by name and resolve duplicate declarations.
  *
- * In n8n, multiple property declarations sharing a name represent OR
- * alternatives (only one is "active" at a time, depending on the user's other
- * parameter values). Wherever the alternatives have *compatible* visibility
- * predicates, this function union-merges them into a single declaration —
- * preserving the historical merge behaviour that existing tests and downstream
- * consumers expect (e.g. the Agent node's three `text` declarations differ
- * only in `promptType` show-values and merge cleanly to
- * `show: { promptType: ['guardrails', 'auto', 'define'] }`).
+ * Multiple declarations sharing a name represent OR alternatives — only one
+ * is active at a time. The codegen treats them with OR semantics via
+ * `resolveOneOfSchemas`, so this function does NOT try to union-merge
+ * displayOptions across variants (see collapseDeclarations for why).
  *
- * When the alternatives have *incompatible* predicates — typical example:
- * BigQuery's two `sqlQuery` declarations, one shown when `useLegacySql=true`
- * and one hidden when `useLegacySql=true` — the naive union-merge produces a
- * self-contradicting `{show, hide}` that rejects every configuration. In
- * those cases the declarations are kept as separate entries in the returned
- * array so the codegen can emit a `resolveOneOfSchemas(...)` call that
- * OR-evaluates the variants at runtime.
- *
- * Properties whose displayOptions are fully covered by disabledOptions (the
- * field is rendered read-only in all its visible states, e.g. the
- * expression-prefilled variant of a sessionKey) contribute no settable states
- * and are skipped, so the generated schema only accepts values in states
+ * Fully disabledOptions-covered variants are dropped — they contribute no
+ * settable states, so the generated schema only accepts values in states
  * where the field is actually user-editable.
  *
- * @param properties - Array of node properties, possibly with duplicates
  * @returns Map of property name to its declaration group. Single-element
- *   arrays are the common case (one declaration, or several that merged
- *   cleanly). Multi-element arrays are mutually-exclusive variants.
+ *   arrays are the common case; multi-element arrays are
+ *   mutually-exclusive variants kept for the runtime resolver.
  */
 export function mergePropertiesByName(properties: NodeProperty[]): Map<string, NodeProperty[]> {
 	// Pass 1: bucket the raw declarations by name, after dropping
@@ -941,28 +926,20 @@ export function mergePropertiesByName(properties: NodeProperty[]): Map<string, N
 }
 
 /**
- * Resolve a list of same-named declarations into the form the codegen will
- * emit:
+ * Resolve same-named declarations into the form the codegen will emit:
+ * - 1 declaration → as-is.
+ * - Any unconditional declaration → single unconditional (OR short-circuits
+ *   to "always visible").
+ * - 2+ conditional declarations → kept split as variants for
+ *   `resolveOneOfSchemas`. We deliberately do NOT union-merge their
+ *   `{show, hide}` — that's only equivalent to OR in narrow cases and
+ *   silently produces a more restrictive predicate otherwise (e.g.
+ *   CoinGecko's `show: searchBy=[coinId]` + `hide: searchBy=[contractAddress]`
+ *   collapses to `searchBy=coinId`, dropping every other value).
  *
- * - 1 declaration: returned as-is (codegen emits a single `resolveSchema`).
- * - Any declaration is unconditional (no displayOptions): the OR short-circuits
- *   to "always visible" — emit a single declaration without displayOptions.
- *   Inner options (for collection/fixedCollection) are unioned across all
- *   declarations so the schema accepts any inner option from any variant.
- * - All declarations are conditional and there are 2+ of them: keep them as
- *   separate variants (codegen emits `resolveOneOfSchemas`). We deliberately
- *   do NOT union-merge them into a single show/hide object — the merge is
- *   only equivalent to OR in narrow cases, and silently produces a *more
- *   restrictive* predicate the rest of the time (e.g. CoinGecko's
- *   `show: searchBy=['coinId']` + `hide: searchBy=['contractAddress']`
- *   collapses to "searchBy=coinId" instead of the intended
- *   "searchBy≠contractAddress").
- *
- *   Inner options for collection/fixedCollection variants are still unioned
- *   onto the *first* variant — at runtime the parameter has a single key/value
- *   slot, so the schema must accept any inner option from any variant. The
- *   first variant carries the merged inner options; later variants share the
- *   same `options` reference for emit consistency.
+ * Inner options of collection/fixedCollection variants are unioned across
+ * declarations — at runtime the parameter has one key/value slot, so the
+ * schema must accept any inner option from any variant.
  */
 function collapseDeclarations(decls: NodeProperty[]): NodeProperty[] {
 	if (decls.length === 1) return decls;

--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.ts
@@ -876,73 +876,139 @@ export function mergeDisplayOptions(
 }
 
 /**
- * Merge duplicate properties by name, combining displayOptions and nested options.
- * When multiple properties have the same name (e.g., multiple 'options' collections
- * with different displayOptions), their displayOptions and nested options are merged.
+ * Group properties by name and resolve duplicate declarations.
  *
- * Properties whose displayOptions are fully covered by disabledOptions (the field
- * is rendered read-only in all its visible states, e.g. the expression-prefilled
- * variant of a sessionKey) contribute no settable states and are skipped, so the
- * generated schema only accepts values in states where the field is actually
- * user-editable.
+ * In n8n, multiple property declarations sharing a name represent OR
+ * alternatives (only one is "active" at a time, depending on the user's other
+ * parameter values). Wherever the alternatives have *compatible* visibility
+ * predicates, this function union-merges them into a single declaration —
+ * preserving the historical merge behaviour that existing tests and downstream
+ * consumers expect (e.g. the Agent node's three `text` declarations differ
+ * only in `promptType` show-values and merge cleanly to
+ * `show: { promptType: ['guardrails', 'auto', 'define'] }`).
+ *
+ * When the alternatives have *incompatible* predicates — typical example:
+ * BigQuery's two `sqlQuery` declarations, one shown when `useLegacySql=true`
+ * and one hidden when `useLegacySql=true` — the naive union-merge produces a
+ * self-contradicting `{show, hide}` that rejects every configuration. In
+ * those cases the declarations are kept as separate entries in the returned
+ * array so the codegen can emit a `resolveOneOfSchemas(...)` call that
+ * OR-evaluates the variants at runtime.
+ *
+ * Properties whose displayOptions are fully covered by disabledOptions (the
+ * field is rendered read-only in all its visible states, e.g. the
+ * expression-prefilled variant of a sessionKey) contribute no settable states
+ * and are skipped, so the generated schema only accepts values in states
+ * where the field is actually user-editable.
  *
  * @param properties - Array of node properties, possibly with duplicates
- * @returns Map of property name to merged property
+ * @returns Map of property name to its declaration group. Single-element
+ *   arrays are the common case (one declaration, or several that merged
+ *   cleanly). Multi-element arrays are mutually-exclusive variants.
  */
-export function mergePropertiesByName(properties: NodeProperty[]): Map<string, NodeProperty> {
-	const propsByName = new Map<string, NodeProperty>();
-
+export function mergePropertiesByName(properties: NodeProperty[]): Map<string, NodeProperty[]> {
+	// Pass 1: bucket the raw declarations by name, after dropping
+	// display-only types and fully-disabled variants.
+	const declsByName = new Map<string, NodeProperty[]>();
 	for (const prop of properties) {
-		// Skip display-only types
 		if (DISPLAY_ONLY_PROPERTY_TYPES.has(prop.type)) {
 			continue;
 		}
-
 		const { displayOptions: narrowedDisplayOptions, fullyDisabled } =
 			narrowDisplayOptionsByDisabled(prop);
 		if (fullyDisabled) {
 			continue;
 		}
-
-		const normalizedProp: NodeProperty = { ...prop, displayOptions: narrowedDisplayOptions };
-
-		const existing = propsByName.get(normalizedProp.name);
-		if (existing) {
-			// Merge displayOptions from duplicate property
-			if (normalizedProp.displayOptions && existing.displayOptions) {
-				existing.displayOptions = mergeDisplayOptions(
-					existing.displayOptions,
-					normalizedProp.displayOptions,
-				);
-			} else if (normalizedProp.displayOptions && !existing.displayOptions) {
-				// If only the new one has displayOptions, the existing one has no condition
-				// which means it's always visible - keep existing as-is (no condition)
-			}
-
-			// For collection/fixedCollection types, merge nested options
-			if (
-				(normalizedProp.type === 'collection' || normalizedProp.type === 'fixedCollection') &&
-				normalizedProp.options &&
-				existing.options
-			) {
-				const existingOptionNames = new Set(existing.options.map((o) => o.name));
-				for (const opt of normalizedProp.options) {
-					if (!existingOptionNames.has(opt.name)) {
-						existing.options.push(opt);
-					}
-				}
-			}
-			// Keep the first property's other attributes (type, required, etc.)
+		const normalized: NodeProperty = {
+			...prop,
+			displayOptions: narrowedDisplayOptions,
+			options: prop.options ? [...prop.options] : undefined,
+		};
+		const list = declsByName.get(normalized.name);
+		if (list) {
+			list.push(normalized);
 		} else {
-			// Create a shallow copy to avoid mutating the original when merging
-			propsByName.set(normalizedProp.name, {
-				...normalizedProp,
-				options: normalizedProp.options ? [...normalizedProp.options] : undefined,
-			});
+			declsByName.set(normalized.name, [normalized]);
 		}
 	}
 
-	return propsByName;
+	// Pass 2: collapse compatible declarations and keep incompatible ones split.
+	const result = new Map<string, NodeProperty[]>();
+	for (const [name, decls] of declsByName) {
+		result.set(name, collapseDeclarations(decls));
+	}
+	return result;
+}
+
+/**
+ * Resolve a list of same-named declarations into the form the codegen will
+ * emit:
+ *
+ * - 1 declaration: returned as-is (codegen emits a single `resolveSchema`).
+ * - Any declaration is unconditional (no displayOptions): the OR short-circuits
+ *   to "always visible" — emit a single declaration without displayOptions.
+ *   Inner options (for collection/fixedCollection) are unioned across all
+ *   declarations so the schema accepts any inner option from any variant.
+ * - All declarations are conditional and there are 2+ of them: keep them as
+ *   separate variants (codegen emits `resolveOneOfSchemas`). We deliberately
+ *   do NOT union-merge them into a single show/hide object — the merge is
+ *   only equivalent to OR in narrow cases, and silently produces a *more
+ *   restrictive* predicate the rest of the time (e.g. CoinGecko's
+ *   `show: searchBy=['coinId']` + `hide: searchBy=['contractAddress']`
+ *   collapses to "searchBy=coinId" instead of the intended
+ *   "searchBy≠contractAddress").
+ *
+ *   Inner options for collection/fixedCollection variants are still unioned
+ *   onto the *first* variant — at runtime the parameter has a single key/value
+ *   slot, so the schema must accept any inner option from any variant. The
+ *   first variant carries the merged inner options; later variants share the
+ *   same `options` reference for emit consistency.
+ */
+function collapseDeclarations(decls: NodeProperty[]): NodeProperty[] {
+	if (decls.length === 1) return decls;
+
+	// Any unconditional declaration short-circuits the OR to "always visible".
+	const unconditional = decls.find((d) => !d.displayOptions);
+	if (unconditional) {
+		return [
+			{
+				...unconditional,
+				displayOptions: undefined,
+				options: mergeNestedOptions(decls),
+			},
+		];
+	}
+
+	// All declarations have displayOptions — keep them separate as variants
+	// so the runtime resolver OR-combines them. Union the nested options so
+	// every variant carries the same complete option set.
+	const mergedOptions = mergeNestedOptions(decls);
+	return decls.map((d) => ({ ...d, options: mergedOptions }));
+}
+
+/**
+ * For collection/fixedCollection declarations sharing a name, union the inner
+ * options arrays by inner-option name (first declaration wins on conflicts).
+ * Mirrors the previous in-place merge behaviour.
+ */
+function mergeNestedOptions(decls: NodeProperty[]): NodeProperty['options'] {
+	const first = decls[0];
+	if (first.type !== 'collection' && first.type !== 'fixedCollection') {
+		return first.options ? [...first.options] : undefined;
+	}
+	const merged = first.options ? [...first.options] : [];
+	const seen = new Set(merged.map((o) => o.name));
+	for (let i = 1; i < decls.length; i++) {
+		const opts = decls[i].options;
+		if (!opts) continue;
+		for (const opt of opts) {
+			if (!seen.has(opt.name)) {
+				merged.push(opt);
+				seen.add(opt.name);
+			}
+		}
+	}
+	return merged.length > 0 ? merged : undefined;
 }
 
 /**
@@ -974,6 +1040,144 @@ export function generateConditionalSchemaLine(
 		Object.keys(defaults).length > 0 ? `, defaults: ${JSON.stringify(defaults)}` : '';
 
 	return `${INDENT}${propName}: resolveSchema({ parameters, schema: ${zodSchema}, required: ${required}, displayOptions: ${displayOptionsStr}${defaultsStr} }),`;
+}
+
+/**
+ * Emit one or more lines of generated code for a single property group from
+ * `mergePropertiesByName`. A group is either:
+ *
+ * - 1 declaration → emit a single `resolveSchema` (or static schema) line.
+ * - 2+ declarations → emit one `resolveOneOfSchemas` line covering all
+ *   variants.
+ *
+ * Discriminator keys (e.g. `@version`, or `resource`/`operation` for
+ * discriminator-split files) are stripped from each variant's displayOptions
+ * since the discriminator file split already enforces them. If every variant
+ * strips down to an empty displayOptions, the field is unconditional and
+ * codegen falls back to a static schema line.
+ */
+function emitPropertyGroup(
+	group: NodeProperty[],
+	allDeclarations: NodeProperty[],
+	discriminatorKeys: string[],
+	indent: string,
+	out: string[],
+): void {
+	if (group.length === 0) return;
+
+	if (group.length === 1) {
+		const prop = group[0];
+		if (prop.displayOptions) {
+			const stripped = stripDiscriminatorKeysFromDisplayOptions(
+				prop.displayOptions,
+				discriminatorKeys,
+			);
+			if (stripped) {
+				const line = generateConditionalSchemaLine(
+					{ ...prop, displayOptions: stripped },
+					allDeclarations,
+				);
+				if (line) out.push(indent + line);
+				return;
+			}
+		}
+		const line = generateSchemaPropertyLine(prop, isPropertyOptional(prop));
+		if (line) out.push(indent + line);
+		return;
+	}
+
+	// Multi-variant group. Strip discriminator keys from each variant; drop
+	// variants that strip down to nothing (they were entirely discriminated).
+	const strippedVariants: NodeProperty[] = [];
+	for (const variant of group) {
+		if (!variant.displayOptions) {
+			// Should not happen — collapseDeclarations resolves unconditional
+			// short-circuits to a single declaration. Be defensive anyway.
+			strippedVariants.push(variant);
+			continue;
+		}
+		const stripped = stripDiscriminatorKeysFromDisplayOptions(
+			variant.displayOptions,
+			discriminatorKeys,
+		);
+		if (stripped) {
+			strippedVariants.push({ ...variant, displayOptions: stripped });
+		}
+	}
+
+	if (strippedVariants.length === 0) {
+		// Every variant was wholly discriminated away. Emit a static schema
+		// line using the first declaration's shape.
+		const line = generateSchemaPropertyLine(group[0], isPropertyOptional(group[0]));
+		if (line) out.push(indent + line);
+		return;
+	}
+
+	if (strippedVariants.length === 1) {
+		// Only one variant survived stripping — emit it as a single
+		// `resolveSchema` call.
+		const line = generateConditionalSchemaLine(strippedVariants[0], allDeclarations);
+		if (line) out.push(indent + line);
+		return;
+	}
+
+	const line = generateOneOfSchemasLine(strippedVariants, allDeclarations);
+	if (line) out.push(indent + line);
+}
+
+/**
+ * Generate a `resolveOneOfSchemas(...)` line for a property whose visibility
+ * is described by multiple mutually-exclusive variants. Each variant gets its
+ * own `{ schema, required, displayOptions }` entry; the runtime evaluator
+ * picks the visible variant via the same `matchesDisplayOptions` matcher
+ * `resolveSchema` uses, so the full DSL (`@version`, `@tool`, `_cnd`
+ * operators, root-paths, regex paths, defaults, expressions) is honoured per
+ * variant.
+ *
+ * All variants are expected to share a name (callers feed them straight from
+ * `mergePropertiesByName`). Each variant carries its own `required` flag, so
+ * "required when visible" is enforced correctly even when some other variant
+ * is the one currently active.
+ */
+export function generateOneOfSchemasLine(
+	variants: NodeProperty[],
+	allProperties: NodeProperty[] = [],
+): string {
+	if (variants.length === 0) return '';
+
+	const propName = quotePropertyName(variants[0].name);
+
+	const variantEntries: string[] = [];
+	const referencedProperties: MergeableDisplayOptions[] = [];
+	for (const variant of variants) {
+		const zodSchema = mapPropertyToZodSchema(variant);
+		if (!zodSchema) continue;
+		const required = !isPropertyOptional(variant);
+		const displayOptionsStr = JSON.stringify(variant.displayOptions ?? {});
+		variantEntries.push(
+			`{ schema: ${zodSchema}, required: ${required}, displayOptions: ${displayOptionsStr} }`,
+		);
+		if (variant.displayOptions) {
+			referencedProperties.push(variant.displayOptions);
+		}
+	}
+
+	if (variantEntries.length === 0) return '';
+
+	// Defaults are extracted from every variant's referenced property names,
+	// so the runtime resolver can fall back to declared defaults when checking
+	// whether a variant matches.
+	const defaults: Record<string, unknown> = {};
+	for (const dispOpts of referencedProperties) {
+		const partial = extractDefaultsForDisplayOptions(dispOpts, allProperties);
+		for (const [k, v] of Object.entries(partial)) {
+			if (!(k in defaults)) defaults[k] = v;
+		}
+	}
+	const defaultsStr =
+		Object.keys(defaults).length > 0 ? `, defaults: ${JSON.stringify(defaults)}` : '';
+
+	return `${INDENT}${propName}: resolveOneOfSchemas({ parameters, variants: [${variantEntries.join(', ')}]${defaultsStr} }),`;
 }
 
 // =============================================================================
@@ -1168,9 +1372,14 @@ export function generateSingleVersionSchemaFile(
 		'iDataObjectSchema',
 	];
 
-	// Add resolveSchema if we need it
+	// Add resolveSchema (and the multi-variant counterpart) if we need it.
+	// resolveOneOfSchemas is only used when a property name has multiple
+	// declarations with mutually-exclusive displayOptions, but we surface both
+	// helpers together — schema-helpers.ts exports them as a pair and the cost
+	// of an unused destructured binding is nothing.
 	if (needsResolveSchema) {
 		helpers.push('resolveSchema');
+		helpers.push('resolveOneOfSchemas');
 	}
 
 	// Add subnode schema imports if this is an AI node
@@ -1269,36 +1478,10 @@ export function generateSingleVersionSchemaFile(
 
 	// Group properties by name, merging displayOptions and nested options for duplicates
 	const propsByName = mergePropertiesByName(filteredProperties);
-	const allPropsArray = Array.from(propsByName.values());
+	const allDeclarations = Array.from(propsByName.values()).flat();
 
-	for (const prop of allPropsArray) {
-		if (prop.displayOptions) {
-			// Strip @version since it's implicit in the file path
-			const strippedDisplayOptions = stripDiscriminatorKeysFromDisplayOptions(prop.displayOptions, [
-				'@version',
-			]);
-			if (strippedDisplayOptions) {
-				const propWithStripped: NodeProperty = {
-					...prop,
-					displayOptions: strippedDisplayOptions,
-				};
-				const propLine = generateConditionalSchemaLine(propWithStripped, allPropsArray);
-				if (propLine) {
-					lines.push(INDENT + propLine);
-				}
-			} else {
-				// No remaining conditions after stripping @version - use static schema
-				const propLine = generateSchemaPropertyLine(prop, isPropertyOptional(prop));
-				if (propLine) {
-					lines.push(INDENT + propLine);
-				}
-			}
-		} else {
-			const propLine = generateSchemaPropertyLine(prop, isPropertyOptional(prop));
-			if (propLine) {
-				lines.push(INDENT + propLine);
-			}
-		}
+	for (const group of propsByName.values()) {
+		emitPropertyGroup(group, allDeclarations, ['@version'], INDENT, lines);
 	}
 
 	lines.push(`${INDENT}});`);
@@ -1428,6 +1611,7 @@ export function generateDiscriminatorSchemaFile(
 	// Add resolveSchema if properties have displayOptions OR AI inputs have displayOptions
 	if (hasRemainingDisplayOptions || hasConditionalAiInputs) {
 		helpers.push('resolveSchema');
+		helpers.push('resolveOneOfSchemas');
 	}
 
 	// Add subnode schema imports if this combo has AI inputs
@@ -1543,37 +1727,10 @@ export function generateDiscriminatorSchemaFile(
 
 	// Group properties by name, merging displayOptions and nested options for duplicates
 	const propsByName = mergePropertiesByName(props);
+	const allDeclarations = Array.from(propsByName.values()).flat();
 
-	// Generate schema for each merged property
-	// Convert propsByName to array for extractDefaultsForDisplayOptions
-	const allPropsArray = Array.from(propsByName.values());
-	for (const prop of allPropsArray) {
-		if (prop.displayOptions) {
-			const strippedDisplayOptions = stripDiscriminatorKeysFromDisplayOptions(
-				prop.displayOptions,
-				discriminatorKeys,
-			);
-			if (strippedDisplayOptions) {
-				const propWithStrippedOptions: NodeProperty = {
-					...prop,
-					displayOptions: strippedDisplayOptions,
-				};
-				const propLine = generateConditionalSchemaLine(propWithStrippedOptions, allPropsArray);
-				if (propLine) {
-					lines.push(INDENT.repeat(2) + propLine);
-				}
-			} else {
-				const propLine = generateSchemaPropertyLine(prop, isPropertyOptional(prop));
-				if (propLine) {
-					lines.push(INDENT.repeat(2) + propLine);
-				}
-			}
-		} else {
-			const propLine = generateSchemaPropertyLine(prop, isPropertyOptional(prop));
-			if (propLine) {
-				lines.push(INDENT.repeat(2) + propLine);
-			}
-		}
+	for (const group of propsByName.values()) {
+		emitPropertyGroup(group, allDeclarations, discriminatorKeys, INDENT.repeat(2), lines);
 	}
 
 	lines.push(`${INDENT.repeat(2)}}).optional(),`);

--- a/packages/@n8n/workflow-sdk/src/validation/display-options.ts
+++ b/packages/@n8n/workflow-sdk/src/validation/display-options.ts
@@ -187,17 +187,26 @@ export function checkConditions(conditions: unknown[], actualValues: unknown[]):
 					const { from, to } = targetValue as { from: number; to: number };
 					return (propertyValue as number) >= from && (propertyValue as number) <= to;
 				}
+				// String operators (`includes` / `startsWith` / `endsWith` / `regex`)
+				// require a string property value. When the referenced parameter is
+				// absent — common for fresh nodes where optional fields like
+				// `modelId` aren't in `parameters` — propertyValue is `undefined`.
+				// Treat that as "condition not met" rather than crashing.
 				if (key === 'includes') {
-					return (propertyValue as string).includes(targetValue as string);
+					if (typeof propertyValue !== 'string') return false;
+					return propertyValue.includes(targetValue as string);
 				}
 				if (key === 'startsWith') {
-					return (propertyValue as string).startsWith(targetValue as string);
+					if (typeof propertyValue !== 'string') return false;
+					return propertyValue.startsWith(targetValue as string);
 				}
 				if (key === 'endsWith') {
-					return (propertyValue as string).endsWith(targetValue as string);
+					if (typeof propertyValue !== 'string') return false;
+					return propertyValue.endsWith(targetValue as string);
 				}
 				if (key === 'regex') {
-					return new RegExp(targetValue as string).test(propertyValue as string);
+					if (typeof propertyValue !== 'string') return false;
+					return new RegExp(targetValue as string).test(propertyValue);
 				}
 				if (key === 'exists') {
 					return propertyValue !== null && propertyValue !== undefined && propertyValue !== '';

--- a/packages/@n8n/workflow-sdk/src/validation/resolve-schema.ts
+++ b/packages/@n8n/workflow-sdk/src/validation/resolve-schema.ts
@@ -170,3 +170,75 @@ export function resolveSchema({
 		});
 	}
 }
+
+/**
+ * One variant of a parameter that has multiple declarations sharing a name —
+ * e.g. BigQuery's two `sqlQuery` declarations (one shown for standard SQL,
+ * one for legacy). At runtime the resolver picks the variant whose
+ * displayOptions match the current parameters.
+ */
+export type SchemaVariant = {
+	schema: z.ZodTypeAny;
+	required: boolean;
+	displayOptions: DisplayOptions;
+};
+
+export type ResolveOneOfSchemasConfig = {
+	parameters: Record<string, unknown>;
+	variants: SchemaVariant[];
+	defaults?: Record<string, unknown>;
+	isToolNode?: boolean;
+};
+
+/**
+ * Resolve a property whose visibility is described by multiple alternative
+ * variants (OR semantics). Used when a node declares the same property name
+ * more than once with mutually-exclusive `displayOptions`.
+ *
+ * Logic:
+ * - 0 visible variants → field must be `undefined` (returns refinement with a
+ *   combined "A OR B …" message).
+ * - 1 visible variant → that variant's schema (required, or `.optional()`).
+ * - ≥2 visible variants → `z.union` of their schemas, optional iff every
+ *   visible variant is optional. Required-when-visible is honoured: if any
+ *   currently-visible variant is required, the field cannot be `undefined`.
+ */
+export function resolveOneOfSchemas({
+	parameters,
+	variants,
+	defaults = {},
+	isToolNode,
+}: ResolveOneOfSchemasConfig): z.ZodTypeAny {
+	const context: DisplayOptionsContext = { parameters, defaults, isToolNode };
+	const visible = variants.filter((v) => matchesDisplayOptionsCore(context, v.displayOptions));
+
+	if (visible.length === 0) {
+		const requirementParts = variants
+			.map((v) => formatDisplayOptionsRequirements(v.displayOptions))
+			.filter((s) => s.length > 0);
+		const requirements =
+			requirementParts.length > 0
+				? requirementParts.length === 1
+					? requirementParts[0]
+					: requirementParts.map((s) => `(${s})`).join(' OR ')
+				: '';
+		return z.any().refine((val) => val === undefined, {
+			message: requirements
+				? `This field is only allowed when: ${requirements}`
+				: 'This field is not applicable for the current configuration',
+		});
+	}
+
+	if (visible.length === 1) {
+		const v = visible[0];
+		return v.required ? v.schema : v.schema.optional();
+	}
+
+	// 2+ variants visible at once — rare; happens when overlapping show/hide
+	// conditions are simultaneously satisfied. Combine into a union and only
+	// allow `undefined` if every visible variant is itself optional.
+	const allOptional = visible.every((v) => !v.required);
+	const [first, second, ...rest] = visible;
+	const union = z.union([first.schema, second.schema, ...rest.map((v) => v.schema)]);
+	return allOptional ? union.optional() : union;
+}

--- a/packages/@n8n/workflow-sdk/src/validation/schema-helpers.ts
+++ b/packages/@n8n/workflow-sdk/src/validation/schema-helpers.ts
@@ -29,7 +29,7 @@ export {
 	multiOptionsSchema,
 } from '../generate-types/zod-helpers';
 
-// Re-export resolveSchema and types from resolve-schema
+// Re-export resolvers and types from resolve-schema
 export { resolveSchema, resolveOneOfSchemas } from './resolve-schema';
 export type {
 	ResolveSchemaConfig,

--- a/packages/@n8n/workflow-sdk/src/validation/schema-helpers.ts
+++ b/packages/@n8n/workflow-sdk/src/validation/schema-helpers.ts
@@ -30,8 +30,13 @@ export {
 } from '../generate-types/zod-helpers';
 
 // Re-export resolveSchema and types from resolve-schema
-export { resolveSchema } from './resolve-schema';
-export type { ResolveSchemaConfig, ResolveSchemaFn } from './resolve-schema';
+export { resolveSchema, resolveOneOfSchemas } from './resolve-schema';
+export type {
+	ResolveSchemaConfig,
+	ResolveSchemaFn,
+	ResolveOneOfSchemasConfig,
+	SchemaVariant,
+} from './resolve-schema';
 
 // =============================================================================
 // Resource Mapper Schema


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
