### PR TITLE
feat: Include updatedAt in encryption key response DTO

### DIFF
--- a/packages/@n8n/api-types/src/dto/encryption/encryption-key-response.dto.ts
+++ b/packages/@n8n/api-types/src/dto/encryption/encryption-key-response.dto.ts
@@ -4,4 +4,5 @@ export type EncryptionKeyResponseDto = {
 	algorithm: string | null;
 	status: string;
 	createdAt: string;
+	updatedAt: string;
 };

--- a/packages/cli/src/modules/encryption-key-manager/__tests__/encryption-key.controller.test.ts
+++ b/packages/cli/src/modules/encryption-key-manager/__tests__/encryption-key.controller.test.ts
@@ -41,6 +41,7 @@ describe('EncryptionKeyController', () => {
 					algorithm: 'aes-256-cbc',
 					status: 'inactive',
 					createdAt: '2026-01-15T00:00:00.000Z',
+					updatedAt: '2026-01-15T00:00:00.000Z',
 				},
 				{
 					id: 'k2',
@@ -48,6 +49,7 @@ describe('EncryptionKeyController', () => {
 					algorithm: 'aes-256-gcm',
 					status: 'active',
 					createdAt: '2026-01-15T00:00:00.000Z',
+					updatedAt: '2026-01-15T00:00:00.000Z',
 				},
 			]);
 		});
@@ -114,6 +116,7 @@ describe('EncryptionKeyController', () => {
 				algorithm: 'aes-256-gcm',
 				status: 'active',
 				createdAt: '2026-01-15T00:00:00.000Z',
+				updatedAt: '2026-01-15T00:00:00.000Z',
 			});
 			expect(result).not.toHaveProperty('value');
 		});

--- a/packages/cli/src/modules/encryption-key-manager/encryption-key.controller.ts
+++ b/packages/cli/src/modules/encryption-key-manager/encryption-key.controller.ts
@@ -15,6 +15,7 @@ function toResponseDto(row: DeploymentKey): EncryptionKeyResponseDto {
 		algorithm: row.algorithm,
 		status: row.status,
 		createdAt: row.createdAt.toISOString(),
+		updatedAt: row.updatedAt.toISOString(),
 	};
 }
 

--- a/packages/cli/test/integration/encryption-keys.api.test.ts
+++ b/packages/cli/test/integration/encryption-keys.api.test.ts
@@ -46,7 +46,7 @@ const seedKey = async (
 	);
 
 describe('GET /encryption/keys', () => {
-	test('returns all keys for owner with id/type/algorithm/status/createdAt (never value)', async () => {
+	test('returns all keys for owner with id/type/algorithm/status/createdAt/updatedAt (never value)', async () => {
 		const legacy = await seedKey({ algorithm: 'aes-256-cbc', status: 'inactive', value: 'legacy' });
 		const active = await seedKey({
 			algorithm: 'aes-256-gcm',
@@ -69,6 +69,7 @@ describe('GET /encryption/keys', () => {
 				algorithm: expect.any(String),
 				status: expect.any(String),
 				createdAt: expect.any(String),
+				updatedAt: expect.any(String),
 			});
 			expect(row).not.toHaveProperty('value');
 		}
@@ -117,6 +118,7 @@ describe('POST /encryption/keys', () => {
 			algorithm: 'aes-256-gcm',
 			status: 'active',
 			createdAt: expect.any(String),
+			updatedAt: expect.any(String),
 		});
 		expect(response.body.data).not.toHaveProperty('value');
 


### PR DESCRIPTION
## Summary

Adds `updatedAt` to the response shape of the `GET /encryption/keys` and `POST /encryption/keys` endpoints.

The `DeploymentKey` entity already exposes `updatedAt` via its `WithTimestampsAndStringId` base class — it was simply missing from the response DTO and the `toResponseDto` mapper in the controller.

Changes:
- Added `updatedAt: string` to `EncryptionKeyResponseDto` in `@n8n/api-types`
- Added `updatedAt: row.updatedAt.toISOString()` to the mapper in `EncryptionKeyController`
- Updated integration test assertions to expect the new field

<!--
https://linear.app/n8n/issue/[TICKET-ID]
-->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
