### PR TITLE
test: Use identity-based assertion in node search test (no-changelog)

### DIFF
--- a/packages/testing/playwright/pages/CanvasPage.ts
+++ b/packages/testing/playwright/pages/CanvasPage.ts
@@ -488,6 +488,10 @@ export class CanvasPage extends BasePage {
 		return this.page.getByTestId('node-creator-item-name');
 	}
 
+	nodeCreatorNodeItem(name: string): Locator {
+		return this.nodeCreatorNodeItems().getByText(name, { exact: true });
+	}
+
 	nodeCreatorActionItems(): Locator {
 		return this.page.getByTestId('node-creator-action-item');
 	}

--- a/packages/testing/playwright/tests/e2e/building-blocks/canvas-actions.spec.ts
+++ b/packages/testing/playwright/tests/e2e/building-blocks/canvas-actions.spec.ts
@@ -47,8 +47,8 @@ test.describe(
 			test('should clear search and show all nodes', async ({ n8n }) => {
 				await n8n.canvas.clickCanvasPlusButton();
 				await n8n.canvas.fillNodeCreatorSearchBar('Linear');
+				await expect(n8n.canvas.nodeCreatorNodeItem('Linear')).toBeVisible();
 				const searchCount = await n8n.canvas.nodeCreatorNodeItems().count();
-				await expect(n8n.canvas.nodeCreatorNodeItems()).toHaveCount(1);
 
 				await n8n.canvas.nodeCreatorSearchBar().clear();
 				const nodeCount = await n8n.canvas.nodeCreatorNodeItems().count();


### PR DESCRIPTION
## Summary

The "should clear search and show all nodes" E2E test was failing because community nodes also appear in search results, making `toHaveCount(1)` brittle.

**Changes:**
- Replace `toHaveCount(1)` with identity-based assertion (`nodeCreatorNodeItem('Linear').toBeVisible()`)
- Add `nodeCreatorNodeItem(name)` method to `CanvasPage` to keep locator logic in the page object (janitor-compliant)

## Related Linear tickets, Github issues, and Community forum posts

<!-- No associated ticket — test fix identified from Currents CI failures -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)