### PR TITLE
chore: Gitignore .claude/worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ packages/cli/src/commands/export/outputs
 .data/
 .claude/settings.local.json
 .claude/plans/
+.claude/worktrees/
 .cursor/plans/
 .superset
 .conductor


### PR DESCRIPTION
## Summary

Ignore the default [Claude worktree directory](https://code.claude.com/docs/en/common-workflows#run-parallel-claude-code-sessions-with-git-worktrees).

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
