### PR TITLE
fix(core): Increase default task runner grant token TTL to 30s

### DIFF
--- a/packages/@n8n/config/src/configs/runners.config.ts
+++ b/packages/@n8n/config/src/configs/runners.config.ts
@@ -70,7 +70,7 @@ export class TaskRunnersConfig {
 	 * Increase on slow hardware where the runner needs more time to start.
 	 */
 	@Env('N8N_RUNNERS_GRANT_TOKEN_TTL', positiveIntSchema)
-	grantTokenTtl: number = 15;
+	grantTokenTtl: number = 30;
 
 	/**
 	 * Whether to disable all security measures in the task runner. **Discouraged for production use.**

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -338,7 +338,7 @@ describe('GlobalConfig', () => {
 			taskTimeout: 300,
 			taskRequestTimeout: 60,
 			heartbeatInterval: 30,
-			grantTokenTtl: 15,
+			grantTokenTtl: 30,
 			insecureMode: false,
 		},
 		sentry: {


### PR DESCRIPTION
## Summary

Continuation of #29357

Increases the default task runner grant token TTL from 15s to 30s. The previous default was too short for slower environments where the runner needs more time to start, causing connection failures.

- [x] I have seen this code, I have run this code, and I take responsibility for this code.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI