### PR TITLE
feat(editor): Expand Instance AI agent step timeline by default on cloud (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/AgentSection.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/AgentSection.vue
@@ -6,13 +6,16 @@ import AnimatedCollapsibleContent from './AnimatedCollapsibleContent.vue';
 import { computed, ref, watch } from 'vue';
 import SubagentStepTimeline from './SubagentStepTimeline.vue';
 import TimelineStepButton from './TimelineStepButton.vue';
+import { useSettingsStore } from '@/app/stores/settings.store';
 
 const props = defineProps<{
 	agentNode: InstanceAiAgentNode;
 }>();
 
+const settingsStore = useSettingsStore();
+
 const isActive = computed(() => props.agentNode.status === 'active');
-const isExpanded = ref(false);
+const isExpanded = ref(settingsStore.isCloudDeployment);
 
 const isError = computed(() => props.agentNode.status === 'error');
 


### PR DESCRIPTION
## Summary

Default the `AgentSection` (orchestrator step timeline in the Instance AI sidebar) to expanded on cloud deployments. Self-hosted keeps the previous collapsed-by-default behavior.

**Why:** Cloud users get more value from seeing the orchestrator's reasoning steps inline as they happen — it surfaces the value of the new orchestrator-with-planner flow without an extra click.

**What changed**

- `AgentSection.vue`: `isExpanded` initial value flips to `settingsStore.isCloudDeployment`.

**How to test**

1. Cloud deployment (or with `isCloudDeployment` mocked to `true`): open Instance AI, run a request — agent step timeline is expanded by default.
2. Self-hosted: open Instance AI, run a request — agent step timeline is collapsed by default; clicking the section header expands it.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Split out from #29408 — no separate Linear ticket -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)