### PR TITLE
ci: Fix licensed test filter for fork PR e2e runs

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -215,7 +215,7 @@ jobs:
     with:
       branch: ${{ needs.install-and-build.outputs.commit_sha }}
       test-mode: docker-artifact
-      test-command: ${{ github.event.pull_request.head.repo.fork == true && 'pnpm --filter=n8n-playwright test:container:sqlite:e2e --grep-invert="@licensed"' || 'pnpm --filter=n8n-playwright test:container:multi-main:e2e' }}
+      test-command: ${{ github.event.pull_request.head.repo.fork == true && 'pnpm --filter=n8n-playwright test:container:sqlite:e2e --grep-invert=@licensed' || 'pnpm --filter=n8n-playwright test:container:multi-main:e2e' }}
       workers: '1'
       pre-generated-matrix: ${{ needs.install-and-build.outputs.matrix }}
       upload-failure-artifacts: ${{ github.event.pull_request.head.repo.fork == true }}


### PR DESCRIPTION
## Summary

Fork PRs were running `@licensed` tests despite the CI command having a `--grep-invert="@licensed"` filter. Caused by shell quoting — the literal double quotes inside the YAML expression were preserved as part of the argv value, so Playwright received the regex `"@licensed"` (with quote characters) instead of `@licensed`, matched zero tests, and filtered nothing.

Evidence from a failing fork PR run — note the literal quotes in the resolved command:

```
playwright test --project='sqlite:e2e' '--grep-invert="@licensed"' --workers=1 ...
```

## Root cause

`.github/workflows/ci-pull-requests.yml:218` defined the fork-PR test command as:

```yaml
'pnpm --filter=n8n-playwright test:container:sqlite:e2e --grep-invert="@licensed"'
```

When `test-e2e-reusable.yml` later runs `$TEST_COMMAND --workers="$WORKERS" $SHARD_ARGS`, bash word-splits the variable but does not re-process the embedded `"` characters, so Playwright receives the literal value `"@licensed"`.

## Fix

Drop the inner double quotes — `@licensed` has no spaces and doesn't need them:

```diff
- ... --grep-invert="@licensed"
+ ... --grep-invert=@licensed
```

- [x] I have seen this code, I have run this code, and I take responsibility for this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)