### PR TITLE
feat(core): Broadcast workflow settings updates

### DIFF
--- a/packages/cli/src/collaboration/collaboration.service.ts
+++ b/packages/cli/src/collaboration/collaboration.service.ts
@@ -266,16 +266,29 @@ export class CollaborationService {
 
 		for (let start = 0; start < uniqueWorkflowIds.length; start += OPEN_WORKFLOW_CHECK_BATCH_SIZE) {
 			const chunk = uniqueWorkflowIds.slice(start, start + OPEN_WORKFLOW_CHECK_BATCH_SIZE);
-			const openIdsInChunk = await Promise.all(
+			const collaboratorLookups = await Promise.allSettled(
 				chunk.map(async (workflowId) => {
 					const collaborators = await this.state.getCollaborators(workflowId);
-					return collaborators.length > 0 ? workflowId : undefined;
+					return { workflowId, isOpen: collaborators.length > 0 };
 				}),
 			);
+			const failedWorkflowIds: Array<Workflow['id']> = [];
 
-			openWorkflowIds.push(
-				...openIdsInChunk.filter((id): id is Workflow['id'] => id !== undefined),
-			);
+			for (const [index, result] of collaboratorLookups.entries()) {
+				if (result.status === 'fulfilled') {
+					if (result.value.isOpen) openWorkflowIds.push(result.value.workflowId);
+				} else {
+					const workflowId = chunk[index];
+					if (workflowId) failedWorkflowIds.push(workflowId);
+				}
+			}
+
+			if (failedWorkflowIds.length > 0) {
+				this.logger.warn('Failed to resolve collaborators while filtering open workflows', {
+					workflowCount: failedWorkflowIds.length,
+					workflowIds: failedWorkflowIds.slice(0, 10),
+				});
+			}
 		}
 
 		return openWorkflowIds;

--- a/packages/cli/src/collaboration/collaboration.service.ts
+++ b/packages/cli/src/collaboration/collaboration.service.ts
@@ -23,6 +23,8 @@ import { Push } from '@/push';
 import type { OnPushMessage } from '@/push/types';
 import { AccessService } from '@/services/access.service';
 
+const OPEN_WORKFLOW_CHECK_BATCH_SIZE = 100;
+
 /**
  * Service for managing collaboration feature between users. E.g. keeping
  * track of active users for a workflow.
@@ -256,6 +258,27 @@ export class CollaborationService {
 		};
 
 		this.push.sendToUsers({ type: 'workflowUpdated', data: msgData }, userIds);
+	}
+
+	async filterOpenWorkflowIds(workflowIds: Array<Workflow['id']>): Promise<Array<Workflow['id']>> {
+		const uniqueWorkflowIds = [...new Set(workflowIds)];
+		const openWorkflowIds: Array<Workflow['id']> = [];
+
+		for (let start = 0; start < uniqueWorkflowIds.length; start += OPEN_WORKFLOW_CHECK_BATCH_SIZE) {
+			const chunk = uniqueWorkflowIds.slice(start, start + OPEN_WORKFLOW_CHECK_BATCH_SIZE);
+			const openIdsInChunk = await Promise.all(
+				chunk.map(async (workflowId) => {
+					const collaborators = await this.state.getCollaborators(workflowId);
+					return collaborators.length > 0 ? workflowId : undefined;
+				}),
+			);
+
+			openWorkflowIds.push(
+				...openIdsInChunk.filter((id): id is Workflow['id'] => id !== undefined),
+			);
+		}
+
+		return openWorkflowIds;
 	}
 
 	/**

--- a/packages/cli/src/modules/mcp/__tests__/mcp.settings.controller.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.settings.controller.test.ts
@@ -314,6 +314,19 @@ describe('McpSettingsController', () => {
 				updatedIds: ['wf-1', 'wf-2'],
 				skippedCount: 0,
 				failedCount: 0,
+				changedIds: ['wf-1', 'wf-2'],
+				changedWorkflows: [
+					{
+						workflowId: 'wf-1',
+						settings: { availableInMCP: true },
+						checksum: 'checksum-wf-1',
+					},
+					{
+						workflowId: 'wf-2',
+						settings: { availableInMCP: true },
+						checksum: 'checksum-wf-2',
+					},
+				],
 			};
 			mcpSettingsService.bulkSetAvailableInMCP.mockResolvedValue(bulkResult);
 
@@ -322,7 +335,15 @@ describe('McpSettingsController', () => {
 
 			expect(mcpSettingsService.bulkSetAvailableInMCP).toHaveBeenCalledTimes(1);
 			expect(mcpSettingsService.bulkSetAvailableInMCP).toHaveBeenCalledWith(user, dto);
-			expect(result).toEqual(bulkResult);
+			expect(mcpSettingsService.broadcastWorkflowMCPAvailabilityChanged).toHaveBeenCalledWith(
+				bulkResult.changedWorkflows,
+			);
+			expect(result).toEqual({
+				updatedCount: 2,
+				updatedIds: ['wf-1', 'wf-2'],
+				skippedCount: 0,
+				failedCount: 0,
+			});
 		});
 	});
 

--- a/packages/cli/src/modules/mcp/__tests__/mcp.settings.controller.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.settings.controller.test.ts
@@ -314,7 +314,6 @@ describe('McpSettingsController', () => {
 				updatedIds: ['wf-1', 'wf-2'],
 				skippedCount: 0,
 				failedCount: 0,
-				changedIds: ['wf-1', 'wf-2'],
 				changedWorkflows: [
 					{
 						workflowId: 'wf-1',

--- a/packages/cli/src/modules/mcp/__tests__/mcp.settings.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.settings.service.test.ts
@@ -196,7 +196,6 @@ describe('McpSettingsService', () => {
 				// wf-unauthorized was in the request but filtered out — counts as skipped.
 				skippedCount: 1,
 				failedCount: 0,
-				changedIds: ['wf-1', 'wf-2'],
 				changedWorkflows: [
 					{
 						workflowId: 'wf-1',
@@ -240,7 +239,6 @@ describe('McpSettingsService', () => {
 				updatedIds: ['wf-1'],
 				skippedCount: 1,
 				failedCount: 0,
-				changedIds: ['wf-1'],
 				changedWorkflows: [
 					{
 						workflowId: 'wf-1',
@@ -282,7 +280,6 @@ describe('McpSettingsService', () => {
 				updatedIds: ['wf-1', 'wf-2'],
 				skippedCount: 0,
 				failedCount: 0,
-				changedIds: ['wf-1'],
 				changedWorkflows: [
 					{
 						workflowId: 'wf-1',
@@ -317,7 +314,6 @@ describe('McpSettingsService', () => {
 				updatedIds: ['wf-1', 'wf-2'],
 				skippedCount: 0,
 				failedCount: 0,
-				changedIds: [],
 				changedWorkflows: [],
 			});
 		});
@@ -366,7 +362,6 @@ describe('McpSettingsService', () => {
 				updatedCount: 0,
 				skippedCount: 0,
 				failedCount: 0,
-				changedIds: [],
 				changedWorkflows: [],
 			});
 		});
@@ -389,7 +384,6 @@ describe('McpSettingsService', () => {
 				updatedCount: 2,
 				skippedCount: 0,
 				failedCount: 0,
-				changedIds: ['wf-1', 'wf-2'],
 				changedWorkflows: [
 					{
 						workflowId: 'wf-1',
@@ -421,7 +415,6 @@ describe('McpSettingsService', () => {
 				updatedCount: 1,
 				skippedCount: 0,
 				failedCount: 0,
-				changedIds: ['wf-1'],
 				changedWorkflows: [
 					{
 						workflowId: 'wf-1',
@@ -476,7 +469,6 @@ describe('McpSettingsService', () => {
 				updatedCount: 0,
 				skippedCount: 0,
 				failedCount: 0,
-				changedIds: [],
 				changedWorkflows: [],
 			});
 		});
@@ -497,7 +489,6 @@ describe('McpSettingsService', () => {
 				updatedCount: 0,
 				skippedCount: 0,
 				failedCount: 0,
-				changedIds: [],
 				changedWorkflows: [],
 			});
 			expect(result).not.toHaveProperty('updatedIds');
@@ -518,7 +509,6 @@ describe('McpSettingsService', () => {
 				updatedCount: 0,
 				skippedCount: 2,
 				failedCount: 0,
-				changedIds: [],
 				changedWorkflows: [],
 				updatedIds: [],
 			});
@@ -610,7 +600,6 @@ describe('McpSettingsService', () => {
 				updatedCount: 0,
 				skippedCount: 0,
 				failedCount: 1,
-				changedIds: [],
 				changedWorkflows: [],
 				updatedIds: [],
 			});

--- a/packages/cli/src/modules/mcp/__tests__/mcp.settings.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.settings.service.test.ts
@@ -5,6 +5,7 @@ import { WorkflowEntity } from '@n8n/db';
 import type { EntityManager } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
 
+import type { CollaborationService } from '@/collaboration/collaboration.service';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import type { CacheService } from '@/services/cache/cache.service';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
@@ -21,6 +22,7 @@ describe('McpSettingsService', () => {
 	const workflowRepository = mock<WorkflowRepository>();
 	const workflowFinderService = mock<WorkflowFinderService>();
 	const logger = mock<Logger>();
+	const collaborationService = mock<CollaborationService>();
 	const globalConfig = {
 		executions: { timeout: -1 },
 	} as unknown as GlobalConfig;
@@ -30,6 +32,10 @@ describe('McpSettingsService', () => {
 		findByKey = jest.fn<Promise<Settings | null>, [string]>();
 		upsert = jest.fn();
 		settingsRepository = { findByKey, upsert } as unknown as SettingsRepository;
+		collaborationService.filterOpenWorkflowIds.mockImplementation(
+			async (workflowIds) => workflowIds,
+		);
+		collaborationService.broadcastWorkflowSettingsUpdated.mockResolvedValue(undefined);
 		workflowFinderService.hasProjectScopeForUser.mockResolvedValue(true);
 		workflowFinderService.findProjectIdForFolder.mockResolvedValue('project-1');
 
@@ -40,6 +46,7 @@ describe('McpSettingsService', () => {
 			workflowFinderService,
 			globalConfig,
 			logger,
+			collaborationService,
 		);
 	});
 
@@ -92,9 +99,7 @@ describe('McpSettingsService', () => {
 		const user = mock<User>({ id: 'user-1' });
 
 		// Minimal `find`/`update` stub that behaves like an `EntityManager`
-		// scoped to WorkflowEntity rows the test sets up. Mirrors the
-		// production `select: ['id', 'settings']` — nothing more is needed
-		// since we no longer compute checksums or emit events here.
+		// scoped to WorkflowEntity rows the test sets up.
 		const createTransactionStubs = (seeded: Array<Partial<WorkflowEntity> & { id: string }>) => {
 			const storage = new Map(
 				seeded.map((w) => [w.id, { ...w, isArchived: w.isArchived ?? false }]),
@@ -112,7 +117,7 @@ describe('McpSettingsService', () => {
 							(row): row is Partial<WorkflowEntity> & { id: string; isArchived: boolean } =>
 								!!row && row.isArchived === options.where.isArchived,
 						)
-						.map((row) => ({ id: row.id, settings: row.settings }));
+						.map((row) => ({ ...row }));
 				},
 			);
 
@@ -188,6 +193,19 @@ describe('McpSettingsService', () => {
 				// wf-unauthorized was in the request but filtered out — counts as skipped.
 				skippedCount: 1,
 				failedCount: 0,
+				changedIds: ['wf-1', 'wf-2'],
+				changedWorkflows: [
+					{
+						workflowId: 'wf-1',
+						settings: { availableInMCP: true },
+						checksum: expect.stringMatching(/^[a-f0-9]{64}$/),
+					},
+					{
+						workflowId: 'wf-2',
+						settings: { availableInMCP: true },
+						checksum: expect.stringMatching(/^[a-f0-9]{64}$/),
+					},
+				],
 			});
 		});
 
@@ -219,6 +237,14 @@ describe('McpSettingsService', () => {
 				updatedIds: ['wf-1'],
 				skippedCount: 1,
 				failedCount: 0,
+				changedIds: ['wf-1'],
+				changedWorkflows: [
+					{
+						workflowId: 'wf-1',
+						settings: { availableInMCP: true },
+						checksum: expect.stringMatching(/^[a-f0-9]{64}$/),
+					},
+				],
 			});
 		});
 
@@ -250,6 +276,14 @@ describe('McpSettingsService', () => {
 				updatedIds: ['wf-1', 'wf-2'],
 				skippedCount: 0,
 				failedCount: 0,
+				changedIds: ['wf-1'],
+				changedWorkflows: [
+					{
+						workflowId: 'wf-1',
+						settings: { availableInMCP: true },
+						checksum: expect.stringMatching(/^[a-f0-9]{64}$/),
+					},
+				],
 			});
 		});
 
@@ -276,6 +310,8 @@ describe('McpSettingsService', () => {
 				updatedIds: ['wf-1', 'wf-2'],
 				skippedCount: 0,
 				failedCount: 0,
+				changedIds: [],
+				changedWorkflows: [],
 			});
 		});
 
@@ -323,6 +359,8 @@ describe('McpSettingsService', () => {
 				updatedCount: 0,
 				skippedCount: 0,
 				failedCount: 0,
+				changedIds: [],
+				changedWorkflows: [],
 			});
 		});
 
@@ -340,7 +378,24 @@ describe('McpSettingsService', () => {
 
 			const result = await service.bulkSetAvailableInMCP(user, dto);
 
-			expect(result).toEqual({ updatedCount: 2, skippedCount: 0, failedCount: 0 });
+			expect(result).toEqual({
+				updatedCount: 2,
+				skippedCount: 0,
+				failedCount: 0,
+				changedIds: ['wf-1', 'wf-2'],
+				changedWorkflows: [
+					{
+						workflowId: 'wf-1',
+						settings: { availableInMCP: true },
+						checksum: expect.stringMatching(/^[a-f0-9]{64}$/),
+					},
+					{
+						workflowId: 'wf-2',
+						settings: { availableInMCP: true },
+						checksum: expect.stringMatching(/^[a-f0-9]{64}$/),
+					},
+				],
+			});
 			expect(result).not.toHaveProperty('updatedIds');
 		});
 
@@ -355,7 +410,19 @@ describe('McpSettingsService', () => {
 
 			const result = await service.bulkSetAvailableInMCP(user, dto);
 
-			expect(result).toEqual({ updatedCount: 1, skippedCount: 0, failedCount: 0 });
+			expect(result).toEqual({
+				updatedCount: 1,
+				skippedCount: 0,
+				failedCount: 0,
+				changedIds: ['wf-1'],
+				changedWorkflows: [
+					{
+						workflowId: 'wf-1',
+						settings: { availableInMCP: true },
+						checksum: expect.stringMatching(/^[a-f0-9]{64}$/),
+					},
+				],
+			});
 			expect(result).not.toHaveProperty('updatedIds');
 		});
 
@@ -402,6 +469,8 @@ describe('McpSettingsService', () => {
 				updatedCount: 0,
 				skippedCount: 0,
 				failedCount: 0,
+				changedIds: [],
+				changedWorkflows: [],
 			});
 		});
 
@@ -421,6 +490,8 @@ describe('McpSettingsService', () => {
 				updatedCount: 0,
 				skippedCount: 0,
 				failedCount: 0,
+				changedIds: [],
+				changedWorkflows: [],
 			});
 			expect(result).not.toHaveProperty('updatedIds');
 		});
@@ -440,6 +511,8 @@ describe('McpSettingsService', () => {
 				updatedCount: 0,
 				skippedCount: 2,
 				failedCount: 0,
+				changedIds: [],
+				changedWorkflows: [],
 				updatedIds: [],
 			});
 		});
@@ -530,6 +603,8 @@ describe('McpSettingsService', () => {
 				updatedCount: 0,
 				skippedCount: 0,
 				failedCount: 1,
+				changedIds: [],
+				changedWorkflows: [],
 				updatedIds: [],
 			});
 		});
@@ -581,6 +656,98 @@ describe('McpSettingsService', () => {
 				user,
 				['workflow:update'],
 			);
+		});
+	});
+
+	describe('broadcastWorkflowMCPAvailabilityChanged', () => {
+		const change = (workflowId: string, availableInMCP: boolean) => ({
+			workflowId,
+			settings: { availableInMCP },
+			checksum: `checksum-${workflowId}`,
+		});
+
+		test('broadcasts a precomputed settings update with checksum', async () => {
+			await service.broadcastWorkflowMCPAvailabilityChanged([change('wf-1', true)]);
+
+			expect(collaborationService.filterOpenWorkflowIds).toHaveBeenCalledWith(['wf-1']);
+			expect(workflowRepository.findByIds).not.toHaveBeenCalled();
+			expect(collaborationService.broadcastWorkflowSettingsUpdated).toHaveBeenCalledTimes(1);
+			expect(collaborationService.broadcastWorkflowSettingsUpdated).toHaveBeenCalledWith(
+				'wf-1',
+				{ availableInMCP: true },
+				'checksum-wf-1',
+			);
+		});
+
+		test('broadcasts only changed workflows that are open', async () => {
+			collaborationService.filterOpenWorkflowIds.mockResolvedValueOnce(['wf-2']);
+
+			await service.broadcastWorkflowMCPAvailabilityChanged([
+				change('wf-1', true),
+				change('wf-2', true),
+			]);
+
+			expect(workflowRepository.findByIds).not.toHaveBeenCalled();
+			expect(collaborationService.broadcastWorkflowSettingsUpdated).toHaveBeenCalledTimes(1);
+			expect(collaborationService.broadcastWorkflowSettingsUpdated).toHaveBeenCalledWith(
+				'wf-2',
+				{ availableInMCP: true },
+				'checksum-wf-2',
+			);
+		});
+
+		test('does not fail when one workflow broadcast throws', async () => {
+			collaborationService.broadcastWorkflowSettingsUpdated
+				.mockRejectedValueOnce(new Error('push down'))
+				.mockResolvedValueOnce(undefined);
+
+			await expect(
+				service.broadcastWorkflowMCPAvailabilityChanged([
+					change('wf-1', false),
+					change('wf-2', false),
+				]),
+			).resolves.toBeUndefined();
+
+			expect(collaborationService.broadcastWorkflowSettingsUpdated).toHaveBeenCalledTimes(2);
+			expect(logger.warn).toHaveBeenCalledWith('Failed to broadcast workflow settings update', {
+				workflowId: 'wf-1',
+				cause: 'push down',
+			});
+		});
+
+		test('does not load workflows when there are no changes', async () => {
+			await service.broadcastWorkflowMCPAvailabilityChanged([]);
+
+			expect(collaborationService.filterOpenWorkflowIds).not.toHaveBeenCalled();
+			expect(workflowRepository.findByIds).not.toHaveBeenCalled();
+			expect(collaborationService.broadcastWorkflowSettingsUpdated).not.toHaveBeenCalled();
+		});
+
+		test('does not load workflows when none of the changed workflows are open', async () => {
+			collaborationService.filterOpenWorkflowIds.mockResolvedValueOnce([]);
+
+			await service.broadcastWorkflowMCPAvailabilityChanged([change('wf-1', true)]);
+
+			expect(workflowRepository.findByIds).not.toHaveBeenCalled();
+			expect(collaborationService.broadcastWorkflowSettingsUpdated).not.toHaveBeenCalled();
+		});
+
+		test('logs and returns when open workflow filtering fails', async () => {
+			collaborationService.filterOpenWorkflowIds.mockRejectedValueOnce(new Error('cache down'));
+
+			await expect(
+				service.broadcastWorkflowMCPAvailabilityChanged([change('wf-1', true)]),
+			).resolves.toBeUndefined();
+
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Failed to resolve open workflows for settings update broadcast',
+				{
+					workflowCount: 1,
+					cause: 'cache down',
+				},
+			);
+			expect(workflowRepository.findByIds).not.toHaveBeenCalled();
+			expect(collaborationService.broadcastWorkflowSettingsUpdated).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/cli/src/modules/mcp/__tests__/mcp.settings.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.settings.service.test.ts
@@ -743,6 +743,7 @@ describe('McpSettingsService', () => {
 				'Failed to resolve open workflows for settings update broadcast',
 				{
 					workflowCount: 1,
+					workflowIds: ['wf-1'],
 					cause: 'cache down',
 				},
 			);

--- a/packages/cli/src/modules/mcp/__tests__/mcp.settings.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.settings.service.test.ts
@@ -4,6 +4,7 @@ import type { Settings, SettingsRepository, User, WorkflowRepository } from '@n8
 import { WorkflowEntity } from '@n8n/db';
 import type { EntityManager, FindOperator } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
+import { calculateWorkflowChecksum } from 'n8n-workflow';
 
 import type { CollaborationService } from '@/collaboration/collaboration.service';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
@@ -209,6 +210,53 @@ describe('McpSettingsService', () => {
 					},
 				],
 			});
+		});
+
+		test('computes checksum from the full persisted workflow snapshot with updated settings', async () => {
+			const workflow = {
+				id: 'wf-1',
+				name: 'Workflow with checksum fields',
+				description: 'Description included in checksum',
+				nodes: [
+					{
+						id: 'node-1',
+						name: 'Manual Trigger',
+						type: 'n8n-nodes-base.manualTrigger',
+						typeVersion: 1,
+						position: [0, 0] as [number, number],
+						parameters: {},
+					},
+				],
+				connections: {},
+				settings: { saveManualExecutions: true, availableInMCP: false },
+				meta: { templateCredsSetupCompleted: true },
+				pinData: { 'Manual Trigger': [{ json: { value: 1 } }] },
+				isArchived: false,
+				activeVersionId: 'version-1',
+			};
+			setupRepository([workflow]);
+			workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(new Set(['wf-1']));
+			const expectedSettings = { saveManualExecutions: true, availableInMCP: true };
+			const expectedChecksum = await calculateWorkflowChecksum({
+				...workflow,
+				settings: expectedSettings,
+			});
+
+			const result = await service.bulkSetAvailableInMCP(
+				user,
+				new UpdateWorkflowsAvailabilityDto({
+					availableInMCP: true,
+					workflowIds: ['wf-1'],
+				}),
+			);
+
+			expect(result.changedWorkflows).toEqual([
+				{
+					workflowId: 'wf-1',
+					settings: { availableInMCP: true },
+					checksum: expectedChecksum,
+				},
+			]);
 		});
 
 		test('skips archived workflows and reports them as skipped', async () => {

--- a/packages/cli/src/modules/mcp/__tests__/mcp.settings.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.settings.service.test.ts
@@ -2,7 +2,7 @@ import type { Logger } from '@n8n/backend-common';
 import type { GlobalConfig } from '@n8n/config';
 import type { Settings, SettingsRepository, User, WorkflowRepository } from '@n8n/db';
 import { WorkflowEntity } from '@n8n/db';
-import type { EntityManager } from '@n8n/typeorm';
+import type { EntityManager, FindOperator } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
 
 import type { CollaborationService } from '@/collaboration/collaboration.service';
@@ -108,9 +108,9 @@ describe('McpSettingsService', () => {
 			const find = jest.fn(
 				async (
 					_entity: unknown,
-					options: { where: { id: { _value: string[] }; isArchived: boolean } },
+					options: { where: { id: FindOperator<string[]>; isArchived: boolean } },
 				) => {
-					const ids = options.where.id._value;
+					const ids = options.where.id.value;
 					return ids
 						.map((id) => storage.get(id))
 						.filter(

--- a/packages/cli/src/modules/mcp/__tests__/mcp.settings.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.settings.service.test.ts
@@ -714,7 +714,7 @@ describe('McpSettingsService', () => {
 			await service.broadcastWorkflowMCPAvailabilityChanged([change('wf-1', true)]);
 
 			expect(collaborationService.filterOpenWorkflowIds).toHaveBeenCalledWith(['wf-1']);
-			expect(workflowRepository.findByIds).not.toHaveBeenCalled();
+			expect(workflowRepository.find).not.toHaveBeenCalled();
 			expect(collaborationService.broadcastWorkflowSettingsUpdated).toHaveBeenCalledTimes(1);
 			expect(collaborationService.broadcastWorkflowSettingsUpdated).toHaveBeenCalledWith(
 				'wf-1',
@@ -731,7 +731,7 @@ describe('McpSettingsService', () => {
 				change('wf-2', true),
 			]);
 
-			expect(workflowRepository.findByIds).not.toHaveBeenCalled();
+			expect(workflowRepository.find).not.toHaveBeenCalled();
 			expect(collaborationService.broadcastWorkflowSettingsUpdated).toHaveBeenCalledTimes(1);
 			expect(collaborationService.broadcastWorkflowSettingsUpdated).toHaveBeenCalledWith(
 				'wf-2',
@@ -763,7 +763,7 @@ describe('McpSettingsService', () => {
 			await service.broadcastWorkflowMCPAvailabilityChanged([]);
 
 			expect(collaborationService.filterOpenWorkflowIds).not.toHaveBeenCalled();
-			expect(workflowRepository.findByIds).not.toHaveBeenCalled();
+			expect(workflowRepository.find).not.toHaveBeenCalled();
 			expect(collaborationService.broadcastWorkflowSettingsUpdated).not.toHaveBeenCalled();
 		});
 
@@ -772,7 +772,7 @@ describe('McpSettingsService', () => {
 
 			await service.broadcastWorkflowMCPAvailabilityChanged([change('wf-1', true)]);
 
-			expect(workflowRepository.findByIds).not.toHaveBeenCalled();
+			expect(workflowRepository.find).not.toHaveBeenCalled();
 			expect(collaborationService.broadcastWorkflowSettingsUpdated).not.toHaveBeenCalled();
 		});
 
@@ -791,7 +791,7 @@ describe('McpSettingsService', () => {
 					cause: 'cache down',
 				},
 			);
-			expect(workflowRepository.findByIds).not.toHaveBeenCalled();
+			expect(workflowRepository.find).not.toHaveBeenCalled();
 			expect(collaborationService.broadcastWorkflowSettingsUpdated).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/cli/src/modules/mcp/__tests__/mcp.settings.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.settings.service.test.ts
@@ -108,7 +108,10 @@ describe('McpSettingsService', () => {
 			const find = jest.fn(
 				async (
 					_entity: unknown,
-					options: { where: { id: FindOperator<string[]>; isArchived: boolean } },
+					options: {
+						where: { id: FindOperator<string[]>; isArchived: boolean };
+						select?: Array<keyof WorkflowEntity>;
+					},
 				) => {
 					const ids = options.where.id.value;
 					return ids
@@ -269,6 +272,9 @@ describe('McpSettingsService', () => {
 
 			// Only wf-1 needed a real write. wf-2 was already in the target state.
 			expect(stubs.update).toHaveBeenCalledTimes(1);
+			expect(stubs.find).toHaveBeenCalledTimes(2);
+			expect(stubs.find.mock.calls[0][1].select).toEqual(['id', 'settings']);
+			expect(stubs.find.mock.calls[1][1].where.id.value).toEqual(['wf-1']);
 			// Both ids are reported as updated (the DB is in the requested state
 			// for both). No-ops go last in the list.
 			expect(result).toEqual({
@@ -305,6 +311,7 @@ describe('McpSettingsService', () => {
 			const result = await service.bulkSetAvailableInMCP(user, dto);
 
 			expect(stubs.update).not.toHaveBeenCalled();
+			expect(stubs.find).toHaveBeenCalledTimes(1);
 			expect(result).toEqual({
 				updatedCount: 2,
 				updatedIds: ['wf-1', 'wf-2'],
@@ -534,9 +541,9 @@ describe('McpSettingsService', () => {
 
 			const result = await service.bulkSetAvailableInMCP(user, dto);
 
-			// Two transactions (one per chunk), each with its own find call.
+			// Two transactions (one per chunk), each with a settings pass and checksum pass.
 			expect(stubs.manager.transaction).toHaveBeenCalledTimes(2);
-			expect(stubs.find).toHaveBeenCalledTimes(2);
+			expect(stubs.find).toHaveBeenCalledTimes(4);
 			expect(result.updatedCount).toBe(600);
 			expect(result.failedCount).toBe(0);
 		});

--- a/packages/cli/src/modules/mcp/mcp.settings.controller.ts
+++ b/packages/cli/src/modules/mcp/mcp.settings.controller.ts
@@ -2,7 +2,6 @@ import { ModuleRegistry, Logger } from '@n8n/backend-common';
 import { type AuthenticatedRequest } from '@n8n/db';
 import { Body, Post, Get, Patch, RestController, GlobalScope } from '@n8n/decorators';
 import type { Response } from 'express';
-
 import { listQueryMiddleware } from '@/middlewares';
 import type { ListQuery } from '@/requests';
 import { WorkflowService } from '@/workflows/workflow.service';
@@ -83,6 +82,14 @@ export class McpSettingsController {
 		_res: Response,
 		@Body dto: UpdateWorkflowsAvailabilityDto,
 	) {
-		return await this.mcpSettingsService.bulkSetAvailableInMCP(req.user, dto);
+		const {
+			changedIds: _changedIds,
+			changedWorkflows,
+			...result
+		} = await this.mcpSettingsService.bulkSetAvailableInMCP(req.user, dto);
+
+		void this.mcpSettingsService.broadcastWorkflowMCPAvailabilityChanged(changedWorkflows);
+
+		return result;
 	}
 }

--- a/packages/cli/src/modules/mcp/mcp.settings.controller.ts
+++ b/packages/cli/src/modules/mcp/mcp.settings.controller.ts
@@ -82,11 +82,10 @@ export class McpSettingsController {
 		_res: Response,
 		@Body dto: UpdateWorkflowsAvailabilityDto,
 	) {
-		const {
-			changedIds: _changedIds,
-			changedWorkflows,
-			...result
-		} = await this.mcpSettingsService.bulkSetAvailableInMCP(req.user, dto);
+		const { changedWorkflows, ...result } = await this.mcpSettingsService.bulkSetAvailableInMCP(
+			req.user,
+			dto,
+		);
 
 		void this.mcpSettingsService.broadcastWorkflowMCPAvailabilityChanged(changedWorkflows);
 

--- a/packages/cli/src/modules/mcp/mcp.settings.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.settings.service.ts
@@ -4,7 +4,9 @@ import type { User } from '@n8n/db';
 import { SettingsRepository, WorkflowEntity, WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { In } from '@n8n/typeorm';
+import { calculateWorkflowChecksum, type IWorkflowSettings } from 'n8n-workflow';
 
+import { CollaborationService } from '@/collaboration/collaboration.service';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { CacheService } from '@/services/cache/cache.service';
 import { removeDefaultValues } from '@/workflow-helpers';
@@ -16,11 +18,32 @@ const KEY = 'mcp.access.enabled';
 
 const BULK_CHUNK_SIZE = 500;
 
+const WORKFLOW_CHECKSUM_FIELDS: Array<keyof WorkflowEntity> = [
+	'id',
+	'name',
+	'description',
+	'nodes',
+	'connections',
+	'settings',
+	'meta',
+	'pinData',
+	'isArchived',
+	'activeVersionId',
+];
+
 type BulkSetAvailableInMCPResult = {
 	updatedCount: number;
 	skippedCount: number;
 	failedCount: number;
+	changedIds: string[];
+	changedWorkflows: WorkflowMCPAvailabilityChange[];
 	updatedIds?: string[];
+};
+
+type WorkflowMCPAvailabilityChange = {
+	workflowId: string;
+	settings: Pick<IWorkflowSettings, 'availableInMCP'>;
+	checksum: string;
 };
 
 @Service()
@@ -32,6 +55,7 @@ export class McpSettingsService {
 		private readonly workflowFinderService: WorkflowFinderService,
 		private readonly globalConfig: GlobalConfig,
 		private readonly logger: Logger,
+		private readonly collaborationService: CollaborationService,
 	) {}
 
 	async getEnabled(): Promise<boolean> {
@@ -84,11 +108,14 @@ export class McpSettingsService {
 				updatedCount: 0,
 				skippedCount: baselineSize,
 				failedCount: 0,
+				changedIds: [],
+				changedWorkflows: [],
 				...(isWorkflowIdsScope ? { updatedIds: [] } : {}),
 			};
 		}
 
 		const writtenIds: string[] = [];
+		const changedWorkflows: WorkflowMCPAvailabilityChange[] = [];
 		const noOpIds: string[] = [];
 		let failedCount = 0;
 
@@ -97,13 +124,13 @@ export class McpSettingsService {
 
 			try {
 				const chunkResult = await this.workflowRepository.manager.transaction(async (trx) => {
-					const chunkWritten: string[] = [];
+					const chunkWritten: WorkflowMCPAvailabilityChange[] = [];
 					const chunkNoOp: string[] = [];
 					const now = new Date();
 
 					const rows = await trx.find(WorkflowEntity, {
 						where: { id: In(chunk), isArchived: false },
-						select: ['id', 'settings'],
+						select: WORKFLOW_CHECKSUM_FIELDS,
 					});
 
 					for (const row of rows) {
@@ -122,14 +149,23 @@ export class McpSettingsService {
 							{ id: row.id },
 							{ settings: nextSettings, updatedAt: now },
 						);
+						const checksum = await calculateWorkflowChecksum({
+							...row,
+							settings: nextSettings,
+						});
 
-						chunkWritten.push(row.id);
+						chunkWritten.push({
+							workflowId: row.id,
+							settings: { availableInMCP },
+							checksum,
+						});
 					}
 
 					return { written: chunkWritten, noOp: chunkNoOp };
 				});
 
-				writtenIds.push(...chunkResult.written);
+				writtenIds.push(...chunkResult.written.map(({ workflowId }) => workflowId));
+				changedWorkflows.push(...chunkResult.written);
 				noOpIds.push(...chunkResult.noOp);
 			} catch (error) {
 				failedCount += chunk.length;
@@ -148,8 +184,53 @@ export class McpSettingsService {
 			updatedCount: confirmedIds.length,
 			skippedCount: Math.max(0, baselineSize - confirmedIds.length - failedCount),
 			failedCount,
+			changedIds: writtenIds,
+			changedWorkflows,
 			...(isWorkflowIdsScope ? { updatedIds: confirmedIds } : {}),
 		};
+	}
+
+	async broadcastWorkflowMCPAvailabilityChanged(
+		changes: WorkflowMCPAvailabilityChange[],
+	): Promise<void> {
+		if (changes.length === 0) return;
+
+		const workflowIds = changes.map(({ workflowId }) => workflowId);
+
+		let openWorkflowIds: string[];
+		try {
+			openWorkflowIds = await this.collaborationService.filterOpenWorkflowIds(workflowIds);
+		} catch (error) {
+			this.logger.warn('Failed to resolve open workflows for settings update broadcast', {
+				workflowCount: changes.length,
+				cause: error instanceof Error ? error.message : String(error),
+			});
+			return;
+		}
+
+		if (openWorkflowIds.length === 0) return;
+
+		const changesByWorkflowId = new Map(changes.map((change) => [change.workflowId, change]));
+
+		await Promise.allSettled(
+			openWorkflowIds.map(async (workflowId) => {
+				const change = changesByWorkflowId.get(workflowId);
+				if (!change) return;
+
+				try {
+					await this.collaborationService.broadcastWorkflowSettingsUpdated(
+						workflowId,
+						change.settings,
+						change.checksum,
+					);
+				} catch (error) {
+					this.logger.warn('Failed to broadcast workflow settings update', {
+						workflowId,
+						cause: error instanceof Error ? error.message : String(error),
+					});
+				}
+			}),
+		);
 	}
 
 	private async resolveCandidateIds(

--- a/packages/cli/src/modules/mcp/mcp.settings.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.settings.service.ts
@@ -166,6 +166,8 @@ export class McpSettingsService {
 							{ id: row.id },
 							{ settings: nextSettings, updatedAt: now },
 						);
+						// Matches this settings update
+						// Later concurrent writes may supersede it but acceptable for a settings-toggle use case,
 						const checksum = await calculateWorkflowChecksum({
 							...row,
 							settings: nextSettings,

--- a/packages/cli/src/modules/mcp/mcp.settings.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.settings.service.ts
@@ -212,12 +212,12 @@ export class McpSettingsService {
 
 		const changesByWorkflowId = new Map(changes.map((change) => [change.workflowId, change]));
 
-		await Promise.allSettled(
+		await Promise.all(
 			openWorkflowIds.map(async (workflowId) => {
-				const change = changesByWorkflowId.get(workflowId);
-				if (!change) return;
-
 				try {
+					const change = changesByWorkflowId.get(workflowId);
+					if (!change) return;
+
 					await this.collaborationService.broadcastWorkflowSettingsUpdated(
 						workflowId,
 						change.settings,

--- a/packages/cli/src/modules/mcp/mcp.settings.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.settings.service.ts
@@ -166,8 +166,8 @@ export class McpSettingsService {
 							{ id: row.id },
 							{ settings: nextSettings, updatedAt: now },
 						);
-						// Matches this settings update
-						// Later concurrent writes may supersede it but acceptable for a settings-toggle use case,
+						// Checksum reflects this transaction's post-commit state.
+						// A concurrent write after commit may make it stale, which is acceptable for a settings-only toggle.
 						const checksum = await calculateWorkflowChecksum({
 							...row,
 							settings: nextSettings,

--- a/packages/cli/src/modules/mcp/mcp.settings.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.settings.service.ts
@@ -37,7 +37,6 @@ type BulkSetAvailableInMCPResult = {
 	updatedCount: number;
 	skippedCount: number;
 	failedCount: number;
-	changedIds: string[];
 	changedWorkflows: WorkflowMCPAvailabilityChange[];
 	updatedIds?: string[];
 };
@@ -110,7 +109,6 @@ export class McpSettingsService {
 				updatedCount: 0,
 				skippedCount: baselineSize,
 				failedCount: 0,
-				changedIds: [],
 				changedWorkflows: [],
 				...(isWorkflowIdsScope ? { updatedIds: [] } : {}),
 			};
@@ -203,7 +201,6 @@ export class McpSettingsService {
 			updatedCount: confirmedIds.length,
 			skippedCount: Math.max(0, baselineSize - confirmedIds.length - failedCount),
 			failedCount,
-			changedIds: writtenIds,
 			changedWorkflows,
 			...(isWorkflowIdsScope ? { updatedIds: confirmedIds } : {}),
 		};

--- a/packages/cli/src/modules/mcp/mcp.settings.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.settings.service.ts
@@ -4,7 +4,11 @@ import type { User } from '@n8n/db';
 import { SettingsRepository, WorkflowEntity, WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { In } from '@n8n/typeorm';
-import { calculateWorkflowChecksum, type IWorkflowSettings } from 'n8n-workflow';
+import {
+	calculateWorkflowChecksum,
+	WORKFLOW_CHECKSUM_FIELDS,
+	type IWorkflowSettings,
+} from 'n8n-workflow';
 
 import { CollaborationService } from '@/collaboration/collaboration.service';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
@@ -19,19 +23,6 @@ const KEY = 'mcp.access.enabled';
 const BULK_CHUNK_SIZE = 500;
 
 const WORKFLOW_SETTINGS_FIELDS: Array<keyof WorkflowEntity> = ['id', 'settings'];
-
-const WORKFLOW_CHECKSUM_FIELDS: Array<keyof WorkflowEntity> = [
-	'id',
-	'name',
-	'description',
-	'nodes',
-	'connections',
-	'settings',
-	'meta',
-	'pinData',
-	'isArchived',
-	'activeVersionId',
-];
 
 type BulkSetAvailableInMCPResult = {
 	updatedCount: number;
@@ -154,7 +145,7 @@ export class McpSettingsService {
 
 					const rows = await trx.find(WorkflowEntity, {
 						where: { id: In([...nextSettingsByWorkflowId.keys()]), isArchived: false },
-						select: WORKFLOW_CHECKSUM_FIELDS,
+						select: ['id', ...WORKFLOW_CHECKSUM_FIELDS],
 					});
 
 					for (const row of rows) {

--- a/packages/cli/src/modules/mcp/mcp.settings.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.settings.service.ts
@@ -203,6 +203,7 @@ export class McpSettingsService {
 		} catch (error) {
 			this.logger.warn('Failed to resolve open workflows for settings update broadcast', {
 				workflowCount: changes.length,
+				workflowIds: workflowIds.slice(0, 10),
 				cause: error instanceof Error ? error.message : String(error),
 			});
 			return;

--- a/packages/cli/src/modules/mcp/mcp.settings.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.settings.service.ts
@@ -18,6 +18,8 @@ const KEY = 'mcp.access.enabled';
 
 const BULK_CHUNK_SIZE = 500;
 
+const WORKFLOW_SETTINGS_FIELDS: Array<keyof WorkflowEntity> = ['id', 'settings'];
+
 const WORKFLOW_CHECKSUM_FIELDS: Array<keyof WorkflowEntity> = [
 	'id',
 	'name',
@@ -128,12 +130,13 @@ export class McpSettingsService {
 					const chunkNoOp: string[] = [];
 					const now = new Date();
 
-					const rows = await trx.find(WorkflowEntity, {
+					const settingsRows = await trx.find(WorkflowEntity, {
 						where: { id: In(chunk), isArchived: false },
-						select: WORKFLOW_CHECKSUM_FIELDS,
+						select: WORKFLOW_SETTINGS_FIELDS,
 					});
+					const nextSettingsByWorkflowId = new Map<string, IWorkflowSettings>();
 
-					for (const row of rows) {
+					for (const row of settingsRows) {
 						if (row.settings?.availableInMCP === availableInMCP) {
 							chunkNoOp.push(row.id);
 							continue;
@@ -143,6 +146,22 @@ export class McpSettingsService {
 							{ ...(row.settings ?? {}), availableInMCP },
 							this.globalConfig.executions.timeout,
 						);
+
+						nextSettingsByWorkflowId.set(row.id, nextSettings);
+					}
+
+					if (nextSettingsByWorkflowId.size === 0) {
+						return { written: chunkWritten, noOp: chunkNoOp };
+					}
+
+					const rows = await trx.find(WorkflowEntity, {
+						where: { id: In([...nextSettingsByWorkflowId.keys()]), isArchived: false },
+						select: WORKFLOW_CHECKSUM_FIELDS,
+					});
+
+					for (const row of rows) {
+						const nextSettings = nextSettingsByWorkflowId.get(row.id);
+						if (nextSettings === undefined) continue;
 
 						await trx.update(
 							WorkflowEntity,

--- a/packages/cli/test/integration/collaboration/collaboration.service.test.ts
+++ b/packages/cli/test/integration/collaboration/collaboration.service.test.ts
@@ -15,6 +15,7 @@ import type {
 	WriteAccessRequestedMessage,
 	WriteAccessReleaseRequestedMessage,
 } from '@/collaboration/collaboration.message';
+import { CollaborationState } from '@/collaboration/collaboration.state';
 import { CollaborationService } from '@/collaboration/collaboration.service';
 import { Push } from '@/push';
 import { CacheService } from '@/services/cache/cache.service';
@@ -29,12 +30,14 @@ describe('CollaborationService', () => {
 	let memberWithAccess: User;
 	let workflow: IWorkflowBase;
 	let cacheService: CacheService;
+	let collaborationState: CollaborationState;
 
 	beforeAll(async () => {
 		await testDb.init();
 
 		pushService = Container.get(Push);
 		collaborationService = Container.get(CollaborationService);
+		collaborationState = Container.get(CollaborationState);
 		cacheService = Container.get(CacheService);
 
 		await cacheService.init();
@@ -374,6 +377,33 @@ describe('CollaborationService', () => {
 
 			// Assert
 			expect(lockHolder).toBeNull();
+		});
+	});
+
+	describe('filterOpenWorkflowIds', () => {
+		it('should skip failed collaborator lookups and return resolved open workflows', async () => {
+			jest.spyOn(collaborationState, 'getCollaborators').mockImplementation(async (workflowId) => {
+				if (workflowId === 'workflow-failing') throw new Error('cache down');
+				if (workflowId === 'workflow-open') {
+					return [
+						{
+							clientId: 'client-1',
+							userId: owner.id,
+							lastSeen: new Date().toISOString(),
+						},
+					];
+				}
+
+				return [];
+			});
+
+			await expect(
+				collaborationService.filterOpenWorkflowIds([
+					'workflow-open',
+					'workflow-failing',
+					'workflow-closed',
+				]),
+			).resolves.toEqual(['workflow-open']);
 		});
 	});
 });

--- a/packages/workflow/src/workflow-checksum.ts
+++ b/packages/workflow/src/workflow-checksum.ts
@@ -19,7 +19,7 @@ export interface WorkflowSnapshot {
 	activeVersionId?: string | null;
 }
 
-const CHECKSUM_FIELDS = [
+export const WORKFLOW_CHECKSUM_FIELDS = [
 	'name',
 	'description',
 	'nodes',
@@ -66,7 +66,7 @@ function sortObjectKeys(value: unknown): unknown {
 export async function calculateWorkflowChecksum(workflow: WorkflowSnapshot): Promise<string> {
 	const checksumPayload: Record<string, unknown> = {};
 
-	for (const field of CHECKSUM_FIELDS) {
+	for (const field of WORKFLOW_CHECKSUM_FIELDS) {
 		const value = workflow[field];
 		if (value !== undefined) {
 			checksumPayload[field] = value;


### PR DESCRIPTION
## Summary
Fixes a bug where a workflow's `checksum` would be out of sync (causing autosave to break) if mcp access is toggle from another browser tab/window.
As a fix, we are broadcasting `workflowSettingsUpdated` event for all open workflows. 

## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-5111

## How to test
Check [steps to reproduce](https://linear.app/n8n/issue/ADO-5111/bug-workflow-autosave-breaks-if-mcp-toggle-is-updated-from-another) in the linear ticket and make sure autosave still works.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
