### PR TITLE
fix(core): Skip disabled tool nodes when mapping AI Agent tool sources

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/helpers.ts
+++ b/packages/@n8n/nodes-langchain/utils/helpers.ts
@@ -200,13 +200,17 @@ export const getConnectedTools = async (
 		0,
 	)) as SupplyDataToolResponse[];
 
-	// Get parent nodes to map toolkits to their source nodes
+	// Get parent nodes to map toolkits to their source nodes.
+	// getInputConnectionData filters out disabled nodes, so parents must be filtered
+	// the same way to keep the index alignment between toolkitConnections and parentNodes.
 	const parentNodes =
 		'getParentNodes' in ctx
-			? ctx.getParentNodes(ctx.getNode().name, {
-					connectionType: NodeConnectionTypes.AiTool,
-					depth: 1,
-				})
+			? ctx
+					.getParentNodes(ctx.getNode().name, {
+						connectionType: NodeConnectionTypes.AiTool,
+						depth: 1,
+					})
+					.filter((node) => !node.disabled)
 			: [];
 
 	const connectedTools = (toolkitConnections ?? [])

--- a/packages/@n8n/nodes-langchain/utils/tests/helpers.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/tests/helpers.test.ts
@@ -341,6 +341,38 @@ describe('getConnectedTools', () => {
 			sourceNodeName: 'MCP Client Tool',
 		});
 	});
+
+	it('should map source node names correctly when a disabled tool node is still connected', async () => {
+		// getParentNodes returns ALL parents including disabled ones,
+		// while getInputConnectionData filters disabled nodes out.
+		// getConnectedTools must skip disabled parents to keep the index in sync.
+		const mockParentNodes = [
+			{ name: 'Tool Alpha', disabled: false },
+			{ name: 'Tool Bravo', disabled: true },
+			{ name: 'Tool Charlie', disabled: false },
+		];
+		const mockTools = [
+			{ name: 'alpha', description: 'desc-alpha' },
+			{ name: 'charlie', description: 'desc-charlie' },
+		];
+
+		mockExecuteFunctions.getInputConnectionData = jest.fn().mockResolvedValue(mockTools);
+		mockExecuteFunctions.getParentNodes = jest.fn().mockReturnValue(mockParentNodes);
+
+		const tools = await getConnectedTools(mockExecuteFunctions, false);
+
+		expect(tools).toHaveLength(2);
+		expect(tools[0].name).toBe('alpha');
+		expect(tools[0].metadata).toEqual({
+			isFromToolkit: false,
+			sourceNodeName: 'Tool Alpha',
+		});
+		expect(tools[1].name).toBe('charlie');
+		expect(tools[1].metadata).toEqual({
+			isFromToolkit: false,
+			sourceNodeName: 'Tool Charlie',
+		});
+	});
 });
 
 describe('unwrapNestedOutput', () => {


### PR DESCRIPTION
## Summary

When a tool node connected to an AI Agent was disabled but kept its connection wire, tool calls for tools after the disabled node in the connection order were routed to the wrong node.

In `getConnectedTools` (`packages/@n8n/nodes-langchain/utils/helpers.ts`), two arrays were zipped together by index to assign each tool its `sourceNodeName`:

- `toolkitConnections` — from `getInputConnectionData`, which **excludes** disabled nodes (it internally calls `getConnectedNodes`, which filters via `node.disabled !== true`).
- `parentNodes` — from `getParentNodes`, which **includes** disabled nodes and only annotates them with a `disabled` flag.

Once a disabled-but-connected node was present, `parentNodes[index]` shifted out of alignment with `toolkitConnections[index]`, and every tool after the disabled one was tagged with the previous parent's name — sending its execution to the wrong node.

The fix filters disabled entries out of `parentNodes` so both arrays stay in sync.

### How to test

1. Create a workflow with an AI Agent and three Code Tools: Tool Alpha, Tool Bravo, Tool Charlie.
2. Connect all three tools to the agent.
3. Disable Tool Bravo (keep the wire).
4. Ask the agent to call Tool Alpha or Tool Charlie.
5. Before the fix: Tool Bravo executes for Charlie's call. After the fix: each call routes to the correct tool.

A unit test in `helpers.test.ts` covers the regression.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2376

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI