### PR TITLE
fix(core): Add file path validation to localFile source

### DIFF
--- a/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/GenericFunctions.test.ts
@@ -1,30 +1,64 @@
+import { readFile as fsReadFile } from 'fs/promises';
 import { mockDeep, type DeepMockProxy } from 'jest-mock-extended';
-import type { IExecuteFunctions, ILoadOptionsFunctions, INode } from 'n8n-workflow';
+import type { IExecuteFunctions, INode } from 'n8n-workflow';
 
 import { getWorkflowInfo } from './GenericFunctions';
 
-jest.mock('fs/promises', () => ({
-	readFile: jest.fn().mockResolvedValue('sensitive data'),
-}));
+jest.mock('fs/promises', () => ({ readFile: jest.fn() }));
+
+const mockReadFile = jest.mocked(fsReadFile);
+const enoentError = () => Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
 
 describe('ExecuteWorkflow node - GenericFunctions', () => {
-	let executeFunctionsMock: DeepMockProxy<ILoadOptionsFunctions | IExecuteFunctions>;
+	let executeFunctionsMock: DeepMockProxy<IExecuteFunctions>;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
-		executeFunctionsMock = mockDeep<ILoadOptionsFunctions | IExecuteFunctions>();
+		executeFunctionsMock = mockDeep<IExecuteFunctions>();
+		executeFunctionsMock.helpers.resolvePath.mockResolvedValue('path/to/file' as never);
 	});
 
 	describe('getWorkflowInfo', () => {
-		it('should throw an error without the file content when source is localFile and the file is not json', async () => {
-			executeFunctionsMock.getNode.mockReturnValue({
-				typeVersion: 1,
-			} as INode);
-			executeFunctionsMock.getNodeParameter.mockReturnValue('path/to/file');
+		describe('when source is localFile', () => {
+			it('should throw an error without the file content when the file is not json', async () => {
+				executeFunctionsMock.getNode.mockReturnValue({ typeVersion: 1 } as INode);
+				executeFunctionsMock.getNodeParameter.mockReturnValue('path/to/file');
+				mockReadFile.mockResolvedValueOnce('non-json data');
 
-			await expect(getWorkflowInfo.call(executeFunctionsMock, 'localFile', 0)).rejects.toThrow(
-				'The file content is not valid JSON',
-			);
+				await expect(getWorkflowInfo.call(executeFunctionsMock, 'localFile', 0)).rejects.toThrow(
+					'The file content is not valid JSON',
+				);
+			});
+
+			it('should throw an error when the file is in a blocked path', async () => {
+				executeFunctionsMock.getNode.mockReturnValue({ typeVersion: 1 } as INode);
+				executeFunctionsMock.getNodeParameter.mockReturnValue('path/to/file');
+				executeFunctionsMock.helpers.isFilePathBlocked.mockReturnValue(true);
+
+				await expect(getWorkflowInfo.call(executeFunctionsMock, 'localFile', 0)).rejects.toThrow(
+					'Access to the workflow file path is not allowed',
+				);
+			});
+
+			it('should throw a friendly error when the parent directory does not exist', async () => {
+				executeFunctionsMock.getNode.mockReturnValue({ typeVersion: 1 } as INode);
+				executeFunctionsMock.getNodeParameter.mockReturnValue('/nonexistent/dir/file.json');
+				executeFunctionsMock.helpers.resolvePath.mockRejectedValue(enoentError());
+
+				await expect(getWorkflowInfo.call(executeFunctionsMock, 'localFile', 0)).rejects.toThrow(
+					'The file "/nonexistent/dir/file.json" could not be found, [item 0]',
+				);
+			});
+
+			it('should throw a friendly error when the file does not exist', async () => {
+				executeFunctionsMock.getNode.mockReturnValue({ typeVersion: 1 } as INode);
+				executeFunctionsMock.getNodeParameter.mockReturnValue('/existing/dir/missing.json');
+				mockReadFile.mockRejectedValueOnce(enoentError());
+
+				await expect(getWorkflowInfo.call(executeFunctionsMock, 'localFile', 0)).rejects.toThrow(
+					'The file "/existing/dir/missing.json" could not be found, [item 0]',
+				);
+			});
 		});
 	});
 });

--- a/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/GenericFunctions.ts
@@ -3,16 +3,11 @@ import { NodeOperationError, jsonParse } from 'n8n-workflow';
 import type {
 	IExecuteFunctions,
 	IExecuteWorkflowInfo,
-	ILoadOptionsFunctions,
 	INodeParameterResourceLocator,
 	IRequestOptions,
 } from 'n8n-workflow';
 
-export async function getWorkflowInfo(
-	this: ILoadOptionsFunctions | IExecuteFunctions,
-	source: string,
-	itemIndex = 0,
-) {
+export async function getWorkflowInfo(this: IExecuteFunctions, source: string, itemIndex = 0) {
 	const workflowInfo: IExecuteWorkflowInfo = {};
 	const nodeVersion = this.getNode().typeVersion;
 	if (source === 'database') {
@@ -31,19 +26,28 @@ export async function getWorkflowInfo(
 		// Read workflow from filesystem
 		const workflowPath = this.getNodeParameter('workflowPath', itemIndex) as string;
 
-		let workflowJson;
-		try {
-			workflowJson = await fsReadFile(workflowPath, { encoding: 'utf8' });
-		} catch (error) {
-			if (error.code === 'ENOENT') {
+		const handleFileError = (error: unknown): never => {
+			if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
 				throw new NodeOperationError(
 					this.getNode(),
 					`The file "${workflowPath}" could not be found, [item ${itemIndex}]`,
 				);
 			}
-
 			throw error;
+		};
+
+		const resolvedPath = await this.helpers.resolvePath(workflowPath).catch(handleFileError);
+
+		if (this.helpers.isFilePathBlocked(resolvedPath)) {
+			throw new NodeOperationError(
+				this.getNode(),
+				'Access to the workflow file path is not allowed',
+			);
 		}
+
+		const workflowJson = await fsReadFile(resolvedPath, { encoding: 'utf8' }).catch(
+			handleFileError,
+		);
 
 		workflowInfo.code = jsonParse(workflowJson, {
 			errorMessage: 'The file content is not valid JSON', // pass a custom error message to not expose the file contents


### PR DESCRIPTION
## Summary

The `localFile` source option in the `ExecuteWorkflow` node was missing the path validation checks that other file-reading nodes (e.g. Git) apply. This PR adds `resolvePath()` + `isFilePathBlocked()` validation before reading the workflow file, bringing it in line with the rest of the codebase.

**Changes:**
- Added `resolvePath()` + `isFilePathBlocked()` validation before reading the workflow file in the `localFile` branch
- Narrowed `this` context type from `ILoadOptionsFunctions | IExecuteFunctions` to `IExecuteFunctions`, since `getWorkflowInfo` is only ever called during execution
- Added test coverage for the new validation paths

**How to test:**
1. Start n8n with `N8N_RESTRICT_FILE_ACCESS_TO=/some/allowed/path`
2. Create a v1 `ExecuteWorkflow` node with `Source: Local File`
3. Set the path to a file outside the allowed directory - execution should be blocked with a clear error
4. Set the path to a non-existent file - execution should show a friendly "could not be found" message

## Related tickets

https://linear.app/n8n/issue/CAT-2296

## Checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code
- [x] PR title follows [conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md)
- [x] Docs updated or follow-up ticket created
- [x] Tests included

🤖 PR summary generated by AI