### PR TITLE
fix(core): Respect global admin scope when listing favorites

### DIFF
--- a/packages/cli/src/modules/favorites/__tests__/favorites.controller.test.ts
+++ b/packages/cli/src/modules/favorites/__tests__/favorites.controller.test.ts
@@ -21,7 +21,7 @@ describe('FavoritesController', () => {
 
 			const result = await controller.getFavorites(req);
 
-			expect(favoritesService.getEnrichedFavorites).toHaveBeenCalledWith('user1');
+			expect(favoritesService.getEnrichedFavorites).toHaveBeenCalledWith(req.user);
 			expect(result).toBe(favorites);
 		});
 	});

--- a/packages/cli/src/modules/favorites/__tests__/favorites.service.test.ts
+++ b/packages/cli/src/modules/favorites/__tests__/favorites.service.test.ts
@@ -1,9 +1,12 @@
 import { mock } from 'jest-mock-extended';
-import type {
-	FolderRepository,
-	ProjectRepository,
-	SharedWorkflowRepository,
-	WorkflowRepository,
+import {
+	GLOBAL_ADMIN_ROLE,
+	GLOBAL_MEMBER_ROLE,
+	type FolderRepository,
+	type ProjectRepository,
+	type SharedWorkflowRepository,
+	type User,
+	type WorkflowRepository,
 } from '@n8n/db';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
@@ -22,6 +25,20 @@ const makeUserFavorite = (overrides: Partial<UserFavorite> = {}): UserFavorite =
 		resourceType: 'workflow',
 		...overrides,
 	}) as UserFavorite;
+
+const makeUser = (overrides: Partial<User> = {}): User =>
+	({
+		id: 'user1',
+		role: GLOBAL_MEMBER_ROLE,
+		...overrides,
+	}) as unknown as User;
+
+const makeAdmin = (overrides: Partial<User> = {}): User =>
+	makeUser({
+		id: 'admin1',
+		role: GLOBAL_ADMIN_ROLE,
+		...overrides,
+	});
 
 describe('FavoritesService', () => {
 	const repo = mock<UserFavoriteRepository>();
@@ -45,7 +62,7 @@ describe('FavoritesService', () => {
 		it('should return empty array when user has no favorites', async () => {
 			repo.findByUser.mockResolvedValue([]);
 
-			const result = await service.getEnrichedFavorites('user1');
+			const result = await service.getEnrichedFavorites(makeUser());
 
 			expect(repo.findByUser).toHaveBeenCalledWith('user1');
 			expect(result).toEqual([]);
@@ -60,7 +77,7 @@ describe('FavoritesService', () => {
 			workflowRepository.findByIds.mockResolvedValue([{ id: 'wf1', name: 'My Workflow' } as never]);
 			sharedWorkflowRepository.find.mockResolvedValue([{ workflowId: 'wf1' } as never]);
 
-			const result = await service.getEnrichedFavorites('user1');
+			const result = await service.getEnrichedFavorites(makeUser());
 
 			expect(result).toHaveLength(1);
 			expect(result[0]).toMatchObject({ resourceId: 'wf1', resourceName: 'My Workflow' });
@@ -76,7 +93,7 @@ describe('FavoritesService', () => {
 			// Not in accessible workflows via SharedWorkflow
 			sharedWorkflowRepository.find.mockResolvedValue([]);
 
-			const result = await service.getEnrichedFavorites('user1');
+			const result = await service.getEnrichedFavorites(makeUser());
 
 			expect(result).toHaveLength(0);
 		});
@@ -86,7 +103,7 @@ describe('FavoritesService', () => {
 			repo.findByUser.mockResolvedValue([favorite]);
 			projectRepository.getAccessibleProjects.mockResolvedValue([]);
 
-			const result = await service.getEnrichedFavorites('user1');
+			const result = await service.getEnrichedFavorites(makeUser());
 
 			expect(workflowRepository.findByIds).not.toHaveBeenCalled();
 			expect(result).toHaveLength(0);
@@ -99,7 +116,7 @@ describe('FavoritesService', () => {
 				{ id: 'proj1', name: 'My Project' } as never,
 			]);
 
-			const result = await service.getEnrichedFavorites('user1');
+			const result = await service.getEnrichedFavorites(makeUser());
 
 			expect(result).toHaveLength(1);
 			expect(result[0]).toMatchObject({ resourceId: 'proj1', resourceName: 'My Project' });
@@ -112,7 +129,7 @@ describe('FavoritesService', () => {
 				{ id: 'proj1', name: 'My Project' } as never,
 			]);
 
-			const result = await service.getEnrichedFavorites('user1');
+			const result = await service.getEnrichedFavorites(makeUser());
 
 			expect(result).toHaveLength(0);
 		});
@@ -127,7 +144,7 @@ describe('FavoritesService', () => {
 				{ id: 'dt1', name: 'My Table', projectId: 'proj1' } as never,
 			]);
 
-			const result = await service.getEnrichedFavorites('user1');
+			const result = await service.getEnrichedFavorites(makeUser());
 
 			expect(result).toHaveLength(1);
 			expect(result[0]).toMatchObject({
@@ -147,7 +164,7 @@ describe('FavoritesService', () => {
 				{ id: 'dt1', name: 'My Table', projectId: 'proj-other' } as never,
 			]);
 
-			const result = await service.getEnrichedFavorites('user1');
+			const result = await service.getEnrichedFavorites(makeUser());
 
 			expect(result).toHaveLength(0);
 		});
@@ -166,7 +183,7 @@ describe('FavoritesService', () => {
 				} as never,
 			]);
 
-			const result = await service.getEnrichedFavorites('user1');
+			const result = await service.getEnrichedFavorites(makeUser());
 
 			expect(result).toHaveLength(1);
 			expect(result[0]).toMatchObject({
@@ -190,7 +207,7 @@ describe('FavoritesService', () => {
 				} as never,
 			]);
 
-			const result = await service.getEnrichedFavorites('user1');
+			const result = await service.getEnrichedFavorites(makeUser());
 
 			expect(result).toHaveLength(0);
 		});
@@ -209,7 +226,7 @@ describe('FavoritesService', () => {
 				} as never,
 			]);
 
-			const result = await service.getEnrichedFavorites('user1');
+			const result = await service.getEnrichedFavorites(makeUser());
 
 			expect(result).toHaveLength(0);
 		});
@@ -233,9 +250,97 @@ describe('FavoritesService', () => {
 				{ id: 'folder1', name: 'My Folder', homeProject: { id: 'proj1' } } as never,
 			]);
 
-			const result = await service.getEnrichedFavorites('user1');
+			const result = await service.getEnrichedFavorites(makeUser());
 
 			expect(result).toHaveLength(4);
+		});
+
+		describe('global admin access', () => {
+			it('should enrich workflow favorites without explicit project membership', async () => {
+				const favorite = makeUserFavorite({ resourceId: 'wf1', resourceType: 'workflow' });
+				repo.findByUser.mockResolvedValue([favorite]);
+				projectRepository.getAccessibleProjects.mockResolvedValue([]);
+				workflowRepository.findByIds.mockResolvedValue([
+					{ id: 'wf1', name: 'My Workflow' } as never,
+				]);
+
+				const result = await service.getEnrichedFavorites(makeAdmin());
+
+				expect(result).toHaveLength(1);
+				expect(result[0]).toMatchObject({ resourceId: 'wf1', resourceName: 'My Workflow' });
+				expect(sharedWorkflowRepository.find).not.toHaveBeenCalled();
+			});
+
+			it('should enrich project favorites without explicit project membership', async () => {
+				const favorite = makeUserFavorite({ resourceId: 'proj-other', resourceType: 'project' });
+				repo.findByUser.mockResolvedValue([favorite]);
+				projectRepository.getAccessibleProjects.mockResolvedValue([]);
+				projectRepository.find.mockResolvedValue([
+					{ id: 'proj-other', name: 'Other Project' } as never,
+				]);
+
+				const result = await service.getEnrichedFavorites(makeAdmin());
+
+				expect(result).toHaveLength(1);
+				expect(result[0]).toMatchObject({
+					resourceId: 'proj-other',
+					resourceName: 'Other Project',
+				});
+			});
+
+			it('should enrich dataTable favorites without explicit project membership', async () => {
+				const favorite = makeUserFavorite({ resourceId: 'dt1', resourceType: 'dataTable' });
+				repo.findByUser.mockResolvedValue([favorite]);
+				projectRepository.getAccessibleProjects.mockResolvedValue([]);
+				dataTableRepository.find.mockResolvedValue([
+					{ id: 'dt1', name: 'My Table', projectId: 'proj-other' } as never,
+				]);
+
+				const result = await service.getEnrichedFavorites(makeAdmin());
+
+				expect(result).toHaveLength(1);
+				expect(result[0]).toMatchObject({
+					resourceId: 'dt1',
+					resourceName: 'My Table',
+					resourceProjectId: 'proj-other',
+				});
+			});
+
+			it('should enrich folder favorites without explicit project membership', async () => {
+				const favorite = makeUserFavorite({ resourceId: 'folder1', resourceType: 'folder' });
+				repo.findByUser.mockResolvedValue([favorite]);
+				projectRepository.getAccessibleProjects.mockResolvedValue([]);
+				folderRepository.find.mockResolvedValue([
+					{
+						id: 'folder1',
+						name: 'My Folder',
+						homeProject: { id: 'proj-other' },
+					} as never,
+				]);
+
+				const result = await service.getEnrichedFavorites(makeAdmin());
+
+				expect(result).toHaveLength(1);
+				expect(result[0]).toMatchObject({
+					resourceId: 'folder1',
+					resourceName: 'My Folder',
+					resourceProjectId: 'proj-other',
+				});
+			});
+
+			it('should not query for additional projects when admin already has membership', async () => {
+				const favorite = makeUserFavorite({ resourceId: 'proj1', resourceType: 'project' });
+				repo.findByUser.mockResolvedValue([favorite]);
+				projectRepository.getAccessibleProjects.mockResolvedValue([
+					{ id: 'proj1', name: 'My Project' } as never,
+				]);
+
+				const result = await service.getEnrichedFavorites(makeAdmin());
+
+				expect(projectRepository.find).not.toHaveBeenCalled();
+				expect(result).toHaveLength(1);
+				expect(result[0]).toMatchObject({ resourceId: 'proj1', resourceName: 'My Project' });
+			});
 		});
 	});
 

--- a/packages/cli/src/modules/favorites/favorites.controller.ts
+++ b/packages/cli/src/modules/favorites/favorites.controller.ts
@@ -17,7 +17,7 @@ export class FavoritesController {
 
 	@Get('/')
 	async getFavorites(req: AuthenticatedRequest) {
-		return await this.favoritesService.getEnrichedFavorites(req.user.id);
+		return await this.favoritesService.getEnrichedFavorites(req.user);
 	}
 
 	@Post('/')

--- a/packages/cli/src/modules/favorites/favorites.service.ts
+++ b/packages/cli/src/modules/favorites/favorites.service.ts
@@ -4,7 +4,10 @@ import {
 	ProjectRepository,
 	SharedWorkflowRepository,
 	WorkflowRepository,
+	type Project,
+	type User,
 } from '@n8n/db';
+import { hasGlobalScope } from '@n8n/permissions';
 import { In } from '@n8n/typeorm';
 
 import { UserFavoriteRepository } from './database/repositories/user-favorite.repository';
@@ -14,6 +17,27 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { DataTableRepository } from '@/modules/data-table/data-table.repository';
 
 import type { FavoriteResourceType } from '@n8n/api-types';
+
+type ResourceMeta = { name: string; projectId: string };
+
+type Favorite = { resourceId: string; resourceType: FavoriteResourceType };
+
+const idsOfType = (favorites: Favorite[], type: FavoriteResourceType): string[] =>
+	favorites.filter((f) => f.resourceType === type).map((f) => f.resourceId);
+
+const enrichWithName = <F>(
+	fav: F,
+	name: string | undefined,
+): Array<F & { resourceName: string }> =>
+	name === undefined ? [] : [{ ...fav, resourceName: name }];
+
+const enrichWithMeta = <F>(
+	fav: F,
+	meta: ResourceMeta | undefined,
+): Array<F & { resourceName: string; resourceProjectId: string }> =>
+	meta === undefined
+		? []
+		: [{ ...fav, resourceName: meta.name, resourceProjectId: meta.projectId }];
 
 @Service()
 export class FavoritesService {
@@ -27,103 +51,137 @@ export class FavoritesService {
 		private readonly folderRepository: FolderRepository,
 	) {}
 
-	async getEnrichedFavorites(userId: string) {
-		const favorites = await this.userFavoriteRepository.findByUser(userId);
+	async getEnrichedFavorites(user: User) {
+		const favorites = await this.userFavoriteRepository.findByUser(user.id);
 		if (favorites.length === 0) return [];
 
-		const workflowIds = favorites
-			.filter((f) => f.resourceType === 'workflow')
-			.map((f) => f.resourceId);
-		const dataTableIds = favorites
-			.filter((f) => f.resourceType === 'dataTable')
-			.map((f) => f.resourceId);
-		const folderIds = favorites.filter((f) => f.resourceType === 'folder').map((f) => f.resourceId);
+		const ids = {
+			workflow: idsOfType(favorites, 'workflow'),
+			project: idsOfType(favorites, 'project'),
+			dataTable: idsOfType(favorites, 'dataTable'),
+			folder: idsOfType(favorites, 'folder'),
+		};
 
-		// Get accessible projects for user
-		const accessibleProjects = await this.projectRepository.getAccessibleProjects(userId);
+		const accessibleProjects = await this.projectRepository.getAccessibleProjects(user.id);
 		const accessibleProjectIds = new Set(accessibleProjects.map((p) => p.id));
-		const projectNameMap = new Map(accessibleProjects.map((p) => [p.id, p.name ?? '']));
 
-		// Workflow, data table, and folder enrichment run in parallel
-		const [workflows, sharedWorkflows, dataTables, folders] = await Promise.all([
-			workflowIds.length > 0 && accessibleProjectIds.size > 0
-				? this.workflowRepository.findByIds(workflowIds, { fields: ['id', 'name'] })
-				: [],
-			workflowIds.length > 0 && accessibleProjectIds.size > 0
-				? this.sharedWorkflowRepository.find({
-						select: { workflowId: true },
-						where: { workflowId: In(workflowIds), projectId: In([...accessibleProjectIds]) },
-					})
-				: [],
-			dataTableIds.length > 0
-				? this.dataTableRepository.find({ where: { id: In(dataTableIds) } })
-				: [],
-			folderIds.length > 0
-				? this.folderRepository.find({
-						where: { id: In(folderIds) },
-						relations: { homeProject: true },
-					})
-				: [],
+		const [workflowNames, projectNames, dataTableMeta, folderMeta] = await Promise.all([
+			this.enrichWorkflowFavorites(user, ids.workflow, accessibleProjectIds),
+			this.enrichProjectFavorites(user, ids.project, accessibleProjects),
+			this.enrichDataTableFavorites(user, ids.dataTable, accessibleProjectIds),
+			this.enrichFolderFavorites(user, ids.folder, accessibleProjectIds),
 		]);
 
-		// Workflow enrichment with access control
-		const workflowNameMap = new Map<string, string>();
-		if (workflowIds.length > 0 && accessibleProjectIds.size > 0) {
-			const wfMap = new Map(workflows.map((wf) => [wf.id, wf.name]));
-			const accessibleWfIds = new Set(sharedWorkflows.map((sw) => sw.workflowId));
-			for (const id of workflowIds) {
-				const name = wfMap.get(id);
-				if (accessibleWfIds.has(id) && name !== undefined) {
-					workflowNameMap.set(id, name);
-				}
+		return favorites.flatMap((fav) => {
+			switch (fav.resourceType) {
+				case 'workflow':
+					return enrichWithName(fav, workflowNames.get(fav.resourceId));
+				case 'project':
+					return enrichWithName(fav, projectNames.get(fav.resourceId));
+				case 'dataTable':
+					return enrichWithMeta(fav, dataTableMeta.get(fav.resourceId));
+				case 'folder':
+					return enrichWithMeta(fav, folderMeta.get(fav.resourceId));
+				default:
+					return [];
 			}
-		}
+		});
+	}
 
-		// Data table enrichment with access control
-		const dataTableMetaMap = new Map<string, { name: string; projectId: string }>();
+	private async enrichWorkflowFavorites(
+		user: User,
+		workflowIds: string[],
+		accessibleProjectIds: Set<string>,
+	): Promise<Map<string, string>> {
+		const result = new Map<string, string>();
+		if (workflowIds.length === 0) return result;
+
+		const hasGlobalAccess = hasGlobalScope(user, 'workflow:read');
+		if (!hasGlobalAccess && accessibleProjectIds.size === 0) return result;
+
+		const [workflows, sharedWorkflows] = await Promise.all([
+			this.workflowRepository.findByIds(workflowIds, { fields: ['id', 'name'] }),
+			hasGlobalAccess
+				? Promise.resolve([])
+				: this.sharedWorkflowRepository.find({
+						select: { workflowId: true },
+						where: { workflowId: In(workflowIds), projectId: In([...accessibleProjectIds]) },
+					}),
+		]);
+
+		const accessibleIds = hasGlobalAccess
+			? new Set(workflows.map((wf) => wf.id))
+			: new Set(sharedWorkflows.map((sw) => sw.workflowId));
+
+		for (const wf of workflows) {
+			if (accessibleIds.has(wf.id)) result.set(wf.id, wf.name);
+		}
+		return result;
+	}
+
+	private async enrichProjectFavorites(
+		user: User,
+		projectFavoriteIds: string[],
+		accessibleProjects: Project[],
+	): Promise<Map<string, string>> {
+		const result = new Map(accessibleProjects.map((p) => [p.id, p.name ?? '']));
+		if (projectFavoriteIds.length === 0) return result;
+
+		if (!hasGlobalScope(user, 'project:read')) return result;
+
+		const missingIds = projectFavoriteIds.filter((id) => !result.has(id));
+		if (missingIds.length === 0) return result;
+
+		const additional = await this.projectRepository.find({
+			where: { id: In(missingIds) },
+			select: { id: true, name: true },
+		});
+		for (const p of additional) {
+			result.set(p.id, p.name ?? '');
+		}
+		return result;
+	}
+
+	private async enrichDataTableFavorites(
+		user: User,
+		dataTableIds: string[],
+		accessibleProjectIds: Set<string>,
+	): Promise<Map<string, ResourceMeta>> {
+		const result = new Map<string, ResourceMeta>();
+		if (dataTableIds.length === 0) return result;
+
+		const hasGlobalAccess = hasGlobalScope(user, 'dataTable:read');
+		const dataTables = await this.dataTableRepository.find({ where: { id: In(dataTableIds) } });
+
 		for (const dt of dataTables) {
-			if (accessibleProjectIds.has(dt.projectId)) {
-				dataTableMetaMap.set(dt.id, { name: dt.name, projectId: dt.projectId });
+			if (hasGlobalAccess || accessibleProjectIds.has(dt.projectId)) {
+				result.set(dt.id, { name: dt.name, projectId: dt.projectId });
 			}
 		}
+		return result;
+	}
 
-		// Folder enrichment with access control
-		const folderMetaMap = new Map<string, { name: string; projectId: string }>();
+	private async enrichFolderFavorites(
+		user: User,
+		folderIds: string[],
+		accessibleProjectIds: Set<string>,
+	): Promise<Map<string, ResourceMeta>> {
+		const result = new Map<string, ResourceMeta>();
+		if (folderIds.length === 0) return result;
+
+		const hasGlobalAccess = hasGlobalScope(user, 'folder:read');
+		const folders = await this.folderRepository.find({
+			where: { id: In(folderIds) },
+			relations: { homeProject: true },
+		});
+
 		for (const folder of folders) {
 			const projectId = folder.homeProject?.id;
-			if (projectId && accessibleProjectIds.has(projectId)) {
-				folderMetaMap.set(folder.id, { name: folder.name, projectId });
+			if (projectId && (hasGlobalAccess || accessibleProjectIds.has(projectId))) {
+				result.set(folder.id, { name: folder.name, projectId });
 			}
 		}
-
-		// Build enriched result, filtering out inaccessible resources
-		const enriched: Array<
-			(typeof favorites)[0] & { resourceName: string; resourceProjectId?: string }
-		> = [];
-
-		for (const fav of favorites) {
-			if (fav.resourceType === 'workflow') {
-				const name = workflowNameMap.get(fav.resourceId);
-				if (name !== undefined) enriched.push({ ...fav, resourceName: name });
-			} else if (fav.resourceType === 'project') {
-				const name = projectNameMap.get(fav.resourceId);
-				if (name !== undefined) {
-					enriched.push({ ...fav, resourceName: name });
-				}
-			} else if (fav.resourceType === 'dataTable') {
-				const meta = dataTableMetaMap.get(fav.resourceId);
-				if (meta !== undefined) {
-					enriched.push({ ...fav, resourceName: meta.name, resourceProjectId: meta.projectId });
-				}
-			} else if (fav.resourceType === 'folder') {
-				const meta = folderMetaMap.get(fav.resourceId);
-				if (meta !== undefined) {
-					enriched.push({ ...fav, resourceName: meta.name, resourceProjectId: meta.projectId });
-				}
-			}
-		}
-
-		return enriched;
+		return result;
 	}
 
 	async addFavorite(userId: string, resourceId: string, resourceType: FavoriteResourceType) {


### PR DESCRIPTION
## Summary

Global admins who hadn't been added as explicit project members couldn't see their favorited workflows, projects, data tables, or folders — `getEnrichedFavorites` filtered everything by `getAccessibleProjects(userId)` (project-membership-only) before returning. This change makes the service consult `hasGlobalScope` per resource type, so admins with `workflow:read` / `project:read` / `dataTable:read` / `folder:read` see all their favorites regardless of explicit membership. The function was also split into per-resource enrichment helpers so each one stays under the cyclomatic-complexity threshold.

To test: as a global admin, favorite a workflow / project / data table / folder in a project you aren't a member of, then GET `/favorites` and confirm the items appear.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5147

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI