### PR TITLE
fix(core): Reject empty webhookMethods in community lint rule

### DIFF
--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.test.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.test.ts
@@ -108,6 +108,19 @@ export class RegularClass {
 			errors: [{ messageId: 'missingWebhookMethods' }],
 		},
 		{
+			name: 'trigger node with empty webhookMethods object (no lifecycle groups)',
+			code: createTriggerNode({ webhookMethods: '{}' }),
+			errors: [
+				{
+					messageId: 'missingLifecycleMethod',
+					data: {
+						group: 'default',
+						missing: '`checkExists`, `create`, `delete`',
+					},
+				},
+			],
+		},
+		{
 			name: 'trigger node with empty webhookMethods group (all three missing)',
 			code: createTriggerNode({
 				webhookMethods: `{

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.test.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.test.ts
@@ -110,15 +110,7 @@ export class RegularClass {
 		{
 			name: 'trigger node with empty webhookMethods object (no lifecycle groups)',
 			code: createTriggerNode({ webhookMethods: '{}' }),
-			errors: [
-				{
-					messageId: 'missingLifecycleMethod',
-					data: {
-						group: 'default',
-						missing: '`checkExists`, `create`, `delete`',
-					},
-				},
-			],
+			errors: [{ messageId: 'emptyWebhookMethods' }],
 		},
 		{
 			name: 'trigger node with empty webhookMethods group (all three missing)',

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.ts
@@ -91,6 +91,18 @@ export const WebhookLifecycleCompleteRule = createRule({
 					return;
 				}
 
+				if (webhookMethodsProperty.value.properties.length === 0) {
+					context.report({
+						node: webhookMethodsProperty.value,
+						messageId: 'missingLifecycleMethod',
+						data: {
+							group: 'default',
+							missing: REQUIRED_METHODS.map((m) => `\`${m}\``).join(', '),
+						},
+					});
+					return;
+				}
+
 				for (const groupProperty of webhookMethodsProperty.value.properties) {
 					if (groupProperty.type !== AST_NODE_TYPES.Property) continue;
 					if (groupProperty.value.type !== AST_NODE_TYPES.ObjectExpression) continue;

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.ts
@@ -56,6 +56,8 @@ export const WebhookLifecycleCompleteRule = createRule({
 		messages: {
 			missingWebhookMethods:
 				'Webhook trigger node is missing the `webhookMethods` property. Implement `checkExists`, `create`, and `delete` to register, verify, and clean up the webhook on the third-party service.',
+			emptyWebhookMethods:
+				'Webhook trigger node has an empty `webhookMethods` object. Define at least one lifecycle group with `checkExists`, `create`, and `delete` methods.',
 			missingLifecycleMethod:
 				'Webhook trigger lifecycle is incomplete. `webhookMethods.{{group}}` is missing: {{missing}}. All of `checkExists`, `create`, and `delete` must be implemented.',
 		},
@@ -93,12 +95,8 @@ export const WebhookLifecycleCompleteRule = createRule({
 
 				if (webhookMethodsProperty.value.properties.length === 0) {
 					context.report({
-						node: webhookMethodsProperty.value,
-						messageId: 'missingLifecycleMethod',
-						data: {
-							group: 'default',
-							missing: REQUIRED_METHODS.map((m) => `\`${m}\``).join(', '),
-						},
+						node: webhookMethodsProperty.key,
+						messageId: 'emptyWebhookMethods',
 					});
 					return;
 				}


### PR DESCRIPTION
## Summary
- Treat an empty top-level `webhookMethods = {}` object as an incomplete webhook lifecycle
- Report the same missing lifecycle methods as an empty `default` lifecycle group
- Add a focused RuleTester invalid case for webhook trigger nodes with no lifecycle groups

## Review notes
The rule already catches missing `webhookMethods` and empty nested lifecycle groups. This closes the adjacent false negative where the property exists but has no groups at all.

## Validation
- `git diff --check`

Not run locally:
- `pnpm --filter @n8n/eslint-plugin-community-nodes test -- webhook-lifecycle-complete.test.ts` (local dependency install did not complete; `vitest` is unavailable in this checkout)
