### PR TITLE
fix: Merge tool-result and tool-call content blocks into one

### DIFF
--- a/packages/@n8n/agents/src/__tests__/agent-runtime.test.ts
+++ b/packages/@n8n/agents/src/__tests__/agent-runtime.test.ts
@@ -6,7 +6,7 @@ import { isLlmMessage } from '../sdk/message';
 import { Tool, Tool as ToolBuilder } from '../sdk/tool';
 import { AgentEvent } from '../types/runtime/event';
 import type { StreamChunk } from '../types/sdk/agent';
-import type { ContentToolResult, Message } from '../types/sdk/message';
+import type { ContentToolCall, Message } from '../types/sdk/message';
 import type { BuiltTool, InterruptibleToolContext } from '../types/sdk/tool';
 import type { BuiltTelemetry } from '../types/telemetry';
 
@@ -903,7 +903,7 @@ describe('AgentRuntime — concurrent tool execution', () => {
 	it('tool error produces an error tool-result in the message list and loop continues', async () => {
 		type ToolOutputContent = {
 			type: string;
-			output?: { type: string; value?: { error?: string } };
+			output?: { type: string; value?: unknown };
 		};
 		type ToolMessage = { role: string; content: ToolOutputContent[] };
 		const receivedMessages: unknown[] = [];
@@ -930,13 +930,15 @@ describe('AgentRuntime — concurrent tool execution', () => {
 		expect(result.finishReason).toBe('stop');
 		// LLM was called a second time — it saw the error tool result and continued
 		expect(generateText).toHaveBeenCalledTimes(2);
-		// The second LLM call received a tool message whose output carries the error description
+		// The second LLM call received a tool message whose output carries the error description.
 		const toolMsg = receivedMessages.find(
 			(m): m is ToolMessage =>
 				typeof m === 'object' && m !== null && (m as ToolMessage).role === 'tool',
 		);
 		expect(toolMsg).toBeDefined();
-		const hasErrorOutput = toolMsg!.content.some((c) => !!c.output?.value?.error);
+		const hasErrorOutput = toolMsg!.content.some(
+			(c) => c.output?.type === 'error-text' || c.output?.type === 'error-json',
+		);
 		expect(hasErrorOutput).toBe(true);
 	});
 
@@ -1552,17 +1554,14 @@ describe('AgentRuntime — runtime input schema validation', () => {
 		// the LLM responds with 'done' on the next turn.
 		expect(result.finishReason).toBe('stop');
 
-		const toolErrorMessage = result.messages.find(
-			(m) => isLlmMessage(m) && m.role === 'tool' && m.content[0].type === 'tool-result',
+		const assistantMsg = result.messages.find(
+			(m) =>
+				isLlmMessage(m) && m.role === 'assistant' && m.content.some((c) => c.type === 'tool-call'),
 		) as Message;
-		expect(toolErrorMessage).toBeDefined();
-		const content = toolErrorMessage.content[0] as ContentToolResult;
-		expect(content.result).toEqual(
-			expect.objectContaining({
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-				error: expect.stringContaining('Expected string, received number'),
-			}),
-		);
+		expect(assistantMsg).toBeDefined();
+		const call = assistantMsg.content.find((c) => c.type === 'tool-call') as ContentToolCall;
+		expect(call.state).toBe('rejected');
+		expect(call.state === 'rejected' && call.error).toContain('Expected string, received number');
 	});
 });
 
@@ -1601,13 +1600,14 @@ describe('AgentRuntime — runtime JSON Schema input validation', () => {
 		const result = await runtime.generate('go');
 		expect(result.finishReason).toBe('stop');
 
-		// No tool-result error — the tool ran successfully
-		const toolResultMsg = result.messages.find(
-			(m) => isLlmMessage(m) && m.role === 'tool',
+		// No error — the tool ran successfully
+		const assistantMsg = result.messages.find(
+			(m) =>
+				isLlmMessage(m) && m.role === 'assistant' && m.content.some((c) => c.type === 'tool-call'),
 		) as Message;
-		expect(toolResultMsg).toBeDefined();
-		const content = toolResultMsg.content[0] as ContentToolResult;
-		expect(content.isError).toBeFalsy();
+		expect(assistantMsg).toBeDefined();
+		const call = assistantMsg.content.find((c) => c.type === 'tool-call') as ContentToolCall;
+		expect(call.state).toBe('resolved');
 	});
 
 	it('surfaces a validation error as a tool error outcome when LLM provides the wrong type', async () => {
@@ -1637,13 +1637,14 @@ describe('AgentRuntime — runtime JSON Schema input validation', () => {
 		const result = await runtime.generate('go');
 		expect(result.finishReason).toBe('stop');
 
-		const toolResultMsg = result.messages.find(
-			(m) => isLlmMessage(m) && m.role === 'tool',
+		const assistantMsg = result.messages.find(
+			(m) =>
+				isLlmMessage(m) && m.role === 'assistant' && m.content.some((c) => c.type === 'tool-call'),
 		) as Message;
-		expect(toolResultMsg).toBeDefined();
-		const content = toolResultMsg.content[0] as ContentToolResult;
-		expect(content.isError).toBe(true);
-		expect(JSON.stringify(content.result)).toContain('Invalid tool input');
+		expect(assistantMsg).toBeDefined();
+		const call = assistantMsg.content.find((c) => c.type === 'tool-call') as ContentToolCall;
+		expect(call.state).toBe('rejected');
+		expect(call.state === 'rejected' && call.error).toContain('Invalid tool input');
 	});
 
 	it('surfaces a validation error when a required property is missing', async () => {
@@ -1676,12 +1677,13 @@ describe('AgentRuntime — runtime JSON Schema input validation', () => {
 		const result = await runtime.generate('go');
 		expect(result.finishReason).toBe('stop');
 
-		const toolResultMsg = result.messages.find(
-			(m) => isLlmMessage(m) && m.role === 'tool',
+		const assistantMsg = result.messages.find(
+			(m) =>
+				isLlmMessage(m) && m.role === 'assistant' && m.content.some((c) => c.type === 'tool-call'),
 		) as Message;
-		const content = toolResultMsg.content[0] as ContentToolResult;
-		expect(content.isError).toBe(true);
-		expect(JSON.stringify(content.result)).toContain('Invalid tool input');
+		const call = assistantMsg.content.find((c) => c.type === 'tool-call') as ContentToolCall;
+		expect(call.state).toBe('rejected');
+		expect(call.state === 'rejected' && call.error).toContain('Invalid tool input');
 	});
 
 	it('does not invoke the handler when JSON Schema validation fails', async () => {
@@ -1758,11 +1760,12 @@ describe('AgentRuntime — Tool builder with JSON Schema input', () => {
 			expect.anything(),
 		);
 
-		const toolResultMsg = result.messages.find(
-			(m) => isLlmMessage(m) && m.role === 'tool',
+		const assistantMsg = result.messages.find(
+			(m) =>
+				isLlmMessage(m) && m.role === 'assistant' && m.content.some((c) => c.type === 'tool-call'),
 		) as Message;
-		const content = toolResultMsg.content[0] as ContentToolResult;
-		expect(content.isError).toBeFalsy();
+		const call = assistantMsg.content.find((c) => c.type === 'tool-call') as ContentToolCall;
+		expect(call.state).toBe('resolved');
 	});
 
 	it('produces a tool error when the LLM sends input that fails JSON Schema validation', async () => {
@@ -1799,12 +1802,13 @@ describe('AgentRuntime — Tool builder with JSON Schema input', () => {
 		// Handler must not be called — validation should block execution
 		expect(handlerFn).not.toHaveBeenCalled();
 
-		const toolResultMsg = result.messages.find(
-			(m) => isLlmMessage(m) && m.role === 'tool',
+		const assistantMsg = result.messages.find(
+			(m) =>
+				isLlmMessage(m) && m.role === 'assistant' && m.content.some((c) => c.type === 'tool-call'),
 		) as Message;
-		const content = toolResultMsg.content[0] as ContentToolResult;
-		expect(content.isError).toBe(true);
-		expect(JSON.stringify(content.result)).toContain('Invalid tool input');
+		const call = assistantMsg.content.find((c) => c.type === 'tool-call') as ContentToolCall;
+		expect(call.state).toBe('rejected');
+		expect(call.state === 'rejected' && call.error).toContain('Invalid tool input');
 	});
 
 	it('validates enum and pattern constraints defined in JSON Schema', async () => {

--- a/packages/@n8n/agents/src/__tests__/inmemory-working-memory.test.ts
+++ b/packages/@n8n/agents/src/__tests__/inmemory-working-memory.test.ts
@@ -1,5 +1,5 @@
 import { InMemoryMemory } from '../runtime/memory-store';
-import type { AgentDbMessage } from '../types/sdk/message';
+import type { AgentDbMessage, Message } from '../types/sdk/message';
 
 describe('InMemoryMemory working memory', () => {
 	it('returns null for unknown key', async () => {
@@ -115,5 +115,61 @@ describe('InMemoryMemory — message createdAt', () => {
 		expect(loaded[0].createdAt.getTime()).toBe(t1.getTime());
 		expect(loaded[1].createdAt).toBeInstanceOf(Date);
 		expect(loaded[1].createdAt.getTime()).toBe(t2.getTime());
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Upsert contract
+// ---------------------------------------------------------------------------
+
+describe('InMemoryMemory — saveMessages upsert by id', () => {
+	it('upserts by id (no duplicate rows after a re-save)', async () => {
+		const mem = new InMemoryMemory();
+		const t1 = new Date('2020-01-01T00:00:01.000Z');
+
+		await mem.saveMessages({
+			threadId: 't1',
+			messages: [makeDbMsg('msg-1', t1, 'original')],
+		});
+
+		const updated = { ...makeDbMsg('msg-1', t1, 'updated content') };
+		await mem.saveMessages({ threadId: 't1', messages: [updated] });
+
+		const result = await mem.getMessages('t1');
+		expect(result).toHaveLength(1);
+		expect(((result[0] as Message).content[0] as { type: string; text: string }).text).toBe(
+			'updated content',
+		);
+	});
+
+	it('preserves insertion order on upsert', async () => {
+		const mem = new InMemoryMemory();
+		const t1 = new Date('2020-01-01T00:00:01.000Z');
+		const t2 = new Date('2020-01-01T00:00:02.000Z');
+		const t3 = new Date('2020-01-01T00:00:03.000Z');
+
+		await mem.saveMessages({
+			threadId: 't1',
+			messages: [
+				makeDbMsg('m1', t1, 'first'),
+				makeDbMsg('m2', t2, 'second'),
+				makeDbMsg('m3', t3, 'third'),
+			],
+		});
+
+		// Update m2 in place
+		await mem.saveMessages({
+			threadId: 't1',
+			messages: [makeDbMsg('m2', t2, 'second-updated')],
+		});
+
+		const result = await mem.getMessages('t1');
+		expect(result).toHaveLength(3);
+		// Original order preserved
+		expect(result[0].id).toBe('m1');
+		expect(result[1].id).toBe('m2');
+		expect(result[2].id).toBe('m3');
+		// Updated content
+		expect(((result[1] as Message).content[0] as { text: string }).text).toBe('second-updated');
 	});
 });

--- a/packages/@n8n/agents/src/__tests__/integration/agent-runtime-conversion.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/agent-runtime-conversion.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Round-trip conversion tests: toAiMessages ↔ fromAiMessages
+ *
+ * These tests exercise the message split/merge logic without making real LLM
+ * calls. They lock down the structural invariants that the agent runtime relies
+ * on, including the key interim-message ordering guarantee described in the
+ * plan:
+ *
+ *   input:  [assistant{tool-call resolved}, user{x}, assistant{y}]
+ *   output: [assistant{tool-call}, tool{tool-result}, user{x}, assistant{y}]
+ *
+ * The tool-result is inserted right after its tool-call, regardless of what
+ * messages follow it in the n8n list.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { toAiMessages, fromAiMessages } from '../../runtime/messages';
+import type { Message } from '../../types/sdk/message';
+
+describe('toAiMessages + fromAiMessages — round-trip', () => {
+	it('splits a resolved tool-call into assistant + tool ModelMessages', () => {
+		const input: Message[] = [
+			{
+				role: 'assistant',
+				content: [
+					{
+						type: 'tool-call',
+						toolCallId: 'tc-1',
+						toolName: 'add',
+						input: { a: 1, b: 2 },
+						state: 'resolved',
+						output: { result: 3 },
+					},
+				],
+			},
+		];
+
+		const aiMessages = toAiMessages(input);
+
+		expect(aiMessages).toHaveLength(2);
+		expect(aiMessages[0].role).toBe('assistant');
+		expect(aiMessages[1].role).toBe('tool');
+
+		const toolCallPart = (
+			aiMessages[0] as { role: string; content: Array<{ type: string; toolCallId: string }> }
+		).content[0];
+		expect(toolCallPart.type).toBe('tool-call');
+		expect(toolCallPart.toolCallId).toBe('tc-1');
+
+		const toolResultPart = (
+			aiMessages[1] as {
+				role: string;
+				content: Array<{
+					type: string;
+					toolCallId: string;
+					output: { type: string; value: unknown };
+				}>;
+			}
+		).content[0];
+		expect(toolResultPart.type).toBe('tool-result');
+		expect(toolResultPart.toolCallId).toBe('tc-1');
+		expect(toolResultPart.output.type).toBe('json');
+		expect(toolResultPart.output.value).toEqual({ result: 3 });
+	});
+
+	it('encodes rejected tool-call as error-text in the tool ModelMessage', () => {
+		const input: Message[] = [
+			{
+				role: 'assistant',
+				content: [
+					{
+						type: 'tool-call',
+						toolCallId: 'tc-1',
+						toolName: 'do_it',
+						input: {},
+						state: 'rejected',
+						error: 'Error: something went wrong',
+					},
+				],
+			},
+		];
+
+		const aiMessages = toAiMessages(input);
+		expect(aiMessages).toHaveLength(2);
+
+		const toolResultPart = (
+			aiMessages[1] as { role: string; content: Array<{ output: { type: string; value: string } }> }
+		).content[0];
+		expect(toolResultPart.output.type).toBe('error-text');
+		expect(toolResultPart.output.value).toBe('Error: something went wrong');
+	});
+
+	it('drops pending tool-call blocks from both assistant and tool ModelMessages', () => {
+		const input: Message[] = [
+			{
+				role: 'assistant',
+				content: [
+					{ type: 'text', text: 'Thinking...' },
+					{
+						type: 'tool-call',
+						toolCallId: 'tc-1',
+						toolName: 'do_it',
+						input: {},
+						state: 'pending',
+					},
+				],
+			},
+		];
+
+		const aiMessages = toAiMessages(input);
+
+		// Only the assistant text part remains; no tool-result emitted for pending
+		expect(aiMessages).toHaveLength(1);
+		expect(aiMessages[0].role).toBe('assistant');
+		const content = (aiMessages[0] as { role: string; content: Array<{ type: string }> }).content;
+		expect(content).toHaveLength(1);
+		expect(content[0].type).toBe('text');
+	});
+
+	it('emits one tool ModelMessage per settled block in the same assistant turn', () => {
+		const input: Message[] = [
+			{
+				role: 'assistant',
+				content: [
+					{
+						type: 'tool-call',
+						toolCallId: 'tc-1',
+						toolName: 'add',
+						input: { a: 1, b: 2 },
+						state: 'resolved',
+						output: { result: 3 },
+					},
+					{
+						type: 'tool-call',
+						toolCallId: 'tc-2',
+						toolName: 'mul',
+						input: { a: 4, b: 5 },
+						state: 'resolved',
+						output: { result: 20 },
+					},
+				],
+			},
+		];
+
+		const aiMessages = toAiMessages(input);
+
+		// assistant{tc-1, tc-2} + tool{tc-1} + tool{tc-2}
+		expect(aiMessages).toHaveLength(3);
+		expect(aiMessages[0].role).toBe('assistant');
+		const assistantContent = (
+			aiMessages[0] as { content: Array<{ type: string; toolCallId: string }> }
+		).content;
+		expect(assistantContent).toHaveLength(2);
+		expect(assistantContent[0].toolCallId).toBe('tc-1');
+		expect(assistantContent[1].toolCallId).toBe('tc-2');
+
+		expect(aiMessages[1].role).toBe('tool');
+		expect(aiMessages[2].role).toBe('tool');
+	});
+
+	it('merges role:tool ModelMessages into the preceding assistant tool-call block', () => {
+		// Simulate AI SDK output: [assistant{tool-call}, tool{tool-result}]
+		const aiMessages = [
+			{
+				role: 'assistant' as const,
+				content: [
+					{
+						type: 'tool-call' as const,
+						toolCallId: 'tc-1',
+						toolName: 'add',
+						input: { a: 1, b: 2 },
+						providerExecuted: undefined,
+					},
+				],
+			},
+			{
+				role: 'tool' as const,
+				content: [
+					{
+						type: 'tool-result' as const,
+						toolCallId: 'tc-1',
+						toolName: 'add',
+						output: { type: 'json' as const, value: { result: 3 } },
+					},
+				],
+			},
+		];
+
+		const n8nMessages = fromAiMessages(aiMessages);
+
+		// Should produce a single assistant message with the resolved block
+		expect(n8nMessages).toHaveLength(1);
+		expect((n8nMessages[0] as Message).role).toBe('assistant');
+		const block = (n8nMessages[0] as Message).content[0];
+		expect(block.type).toBe('tool-call');
+		expect((block as { state: string }).state).toBe('resolved');
+		expect((block as { output: unknown }).output).toEqual({ result: 3 });
+	});
+
+	it('round-trip is structurally equivalent for a resolved tool-call', () => {
+		const original: Message[] = [
+			{
+				role: 'assistant',
+				content: [
+					{
+						type: 'tool-call',
+						toolCallId: 'tc-1',
+						toolName: 'echo',
+						input: { text: 'hello' },
+						state: 'resolved',
+						output: { echoed: 'hello' },
+					},
+				],
+			},
+		];
+
+		const aiMessages = toAiMessages(original);
+		const roundTripped = fromAiMessages(aiMessages);
+
+		expect(roundTripped).toHaveLength(1);
+		expect((roundTripped[0] as Message).role).toBe('assistant');
+		const block = (roundTripped[0] as Message).content[0];
+		expect(block.type).toBe('tool-call');
+		expect((block as { state: string }).state).toBe('resolved');
+		expect((block as { output: unknown }).output).toEqual({ echoed: 'hello' });
+		expect((block as { toolCallId: string }).toolCallId).toBe('tc-1');
+	});
+
+	it('interim-message ordering: tool-result is inserted right after its tool-call', () => {
+		// This is the key regression test for the interim-message scenario.
+		// Input n8n list: [assistant{tool-call resolved}, user{x}, assistant{y}]
+		// Expected AI SDK output: [assistant{tc}, tool{tr}, user{x}, assistant{y}]
+		const input: Message[] = [
+			{
+				role: 'assistant',
+				content: [
+					{
+						type: 'tool-call',
+						toolCallId: 'tc-1',
+						toolName: 'delete_file',
+						input: { path: 'foo.txt' },
+						state: 'resolved',
+						output: { deleted: true },
+					},
+				],
+			},
+			{
+				role: 'user',
+				content: [{ type: 'text', text: 'Actually, what is 2+2?' }],
+			},
+			{
+				role: 'assistant',
+				content: [{ type: 'text', text: 'It is 4.' }],
+			},
+		];
+
+		const aiMessages = toAiMessages(input);
+
+		// 4 messages: assistant{tool-call}, tool{tool-result}, user, assistant
+		expect(aiMessages).toHaveLength(4);
+		expect(aiMessages[0].role).toBe('assistant');
+		expect(aiMessages[1].role).toBe('tool');
+		expect(aiMessages[2].role).toBe('user');
+		expect(aiMessages[3].role).toBe('assistant');
+
+		// tool-result is immediately after the assistant tool-call message
+		const toolResultContent = (aiMessages[1] as { content: Array<{ toolCallId: string }> })
+			.content[0];
+		expect(toolResultContent.toolCallId).toBe('tc-1');
+
+		// user interim message is after the tool-result
+		const userContent = (aiMessages[2] as { content: Array<{ type: string; text: string }> })
+			.content[0];
+		expect(userContent.text).toBe('Actually, what is 2+2?');
+	});
+});

--- a/packages/@n8n/agents/src/__tests__/integration/agent-runtime-conversion.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/agent-runtime-conversion.test.ts
@@ -117,6 +117,57 @@ describe('toAiMessages + fromAiMessages — round-trip', () => {
 		expect(content[0].type).toBe('text');
 	});
 
+	it('emits nothing for an assistant message whose only blocks are all pending', () => {
+		const input: Message[] = [
+			{
+				role: 'assistant',
+				content: [
+					{
+						type: 'tool-call',
+						toolCallId: 'tc-1',
+						toolName: 'do_it',
+						input: {},
+						state: 'pending',
+					},
+					{
+						type: 'tool-call',
+						toolCallId: 'tc-2',
+						toolName: 'do_more',
+						input: {},
+						state: 'pending',
+					},
+				],
+			},
+		];
+
+		const aiMessages = toAiMessages(input);
+
+		// No empty-content assistant message — the whole message is suppressed
+		expect(aiMessages).toHaveLength(0);
+	});
+
+	it('skips legacy tool-call blocks that have no state field and emits nothing when they are the only content', () => {
+		const input: Message[] = [
+			{
+				role: 'assistant',
+				content: [
+					// Simulate a DB row written before the state field was introduced
+					{
+						type: 'tool-call',
+						toolCallId: 'tc-legacy',
+						toolName: 'old_tool',
+						input: {},
+					} as unknown as Message['content'][number],
+				],
+			},
+		];
+
+		const aiMessages = toAiMessages(input);
+
+		// No empty-content assistant message and no spurious error-json tool message
+		expect(aiMessages).toHaveLength(0);
+	});
+
 	it('emits one tool ModelMessage per settled block in the same assistant turn', () => {
 		const input: Message[] = [
 			{

--- a/packages/@n8n/agents/src/__tests__/integration/helpers.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/helpers.ts
@@ -7,7 +7,6 @@ import { z } from 'zod';
 import {
 	Agent,
 	type ContentToolCall,
-	type ContentToolResult,
 	filterLlmMessages,
 	Tool,
 	type StreamChunk,
@@ -404,10 +403,10 @@ export const findAllToolCalls = (messages: AgentMessage[]): ContentToolCall[] =>
 		.map((m) => m.content.filter((c) => c.type === 'tool-call'))
 		.flat();
 };
-export const findAllToolResults = (messages: AgentMessage[]): ContentToolResult[] => {
-	return filterLlmMessages(messages)
-		.filter((m) => m.content.find((c) => c.type === 'tool-result'))
-		.map((m) => m.content.find((c) => c.type === 'tool-result') as ContentToolResult);
+export const findAllToolResults = (messages: AgentMessage[]): ContentToolCall[] => {
+	return filterLlmMessages(messages).flatMap((m) =>
+		m.content.filter((c): c is ContentToolCall => c.type === 'tool-call' && c.state !== 'pending'),
+	);
 };
 export const collectTextDeltas = (chunks: StreamChunk[]): string => {
 	return chunks

--- a/packages/@n8n/agents/src/__tests__/integration/interim-user-message-during-suspend.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/interim-user-message-during-suspend.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Regression test: interim user message while a tool-call is suspended.
+ *
+ * Old architecture bug: if a user sent a new message between a tool-call
+ * suspension and its eventual resume, the message list would contain:
+ *
+ *   assistant{tool-call}  →  user{interim}  →  tool{tool-result}
+ *
+ * This order is invalid for AI SDK providers (tool-result must immediately
+ * follow its tool-call). The new architecture stores the result ON the
+ * tool-call block, so toAiMessages always emits:
+ *
+ *   assistant{tool-call}  →  tool{tool-result}  →  user{interim}  →  assistant{reply}
+ *
+ * The tool-result is always adjacent to its tool-call regardless of what n8n
+ * messages come after it in the list.
+ *
+ * This test drives the full scenario end-to-end and asserts that:
+ *  1. The final result has finishReason 'stop' (no provider error).
+ *  2. The tool-call block on the originating assistant message transitions to
+ *     state 'resolved' with the expected output.
+ *  3. The interim user/assistant messages are still present in memory.
+ */
+import { afterEach, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { describeIf, createSqliteMemory, getModel } from './helpers';
+import { Agent, filterLlmMessages, Memory, Tool } from '../../index';
+import type { AgentDbMessage } from '../../index';
+import type { ContentToolCall, Message } from '../../types/sdk/message';
+
+const describe = describeIf('anthropic');
+
+describe('interim user message during tool suspension', () => {
+	const cleanups: Array<() => void> = [];
+
+	afterEach(() => {
+		for (const fn of cleanups) fn();
+		cleanups.length = 0;
+	});
+
+	function buildInterruptibleAgent(mem: Memory): Agent {
+		const deleteTool = new Tool('delete_file')
+			.description('Delete a file at the given path')
+			.input(z.object({ path: z.string().describe('File path to delete') }))
+			.output(z.object({ deleted: z.boolean(), path: z.string() }))
+			.suspend(z.object({ message: z.string(), severity: z.string() }))
+			.resume(z.object({ approved: z.boolean() }))
+			.handler(async ({ path }, ctx) => {
+				if (!ctx.resumeData) {
+					return await ctx.suspend({ message: `Delete "${path}"?`, severity: 'destructive' });
+				}
+				if (!ctx.resumeData.approved) return { deleted: false, path };
+				return { deleted: true, path };
+			});
+
+		return new Agent('interim-test-agent')
+			.model(getModel('anthropic'))
+			.instructions(
+				'You are a file manager. When asked to delete a file, use the delete_file tool. Be concise.',
+			)
+			.tool(deleteTool)
+			.memory(mem)
+			.checkpoint('memory');
+	}
+
+	for (const method of ['generate', 'stream'] as const) {
+		it(`[${method}] interim message does not break provider message ordering`, async () => {
+			const { memory, cleanup } = createSqliteMemory();
+			cleanups.push(cleanup);
+
+			const threadId = `thread-interim-${method}`;
+			const resourceId = 'res-interim';
+			const persistence = { threadId, resourceId };
+			const mem = new Memory().storage(memory);
+
+			const agent = buildInterruptibleAgent(mem);
+
+			// ----------------------------------------------------------------
+			// Turn 1: trigger the tool suspension
+			// ----------------------------------------------------------------
+			const suspendResult = await agent.generate('Please delete /tmp/interim-test.txt', {
+				persistence,
+			});
+
+			expect(suspendResult.finishReason).toBe('tool-calls');
+			expect(suspendResult.pendingSuspend).toBeDefined();
+			const { runId, toolCallId } = suspendResult.pendingSuspend![0];
+
+			// ----------------------------------------------------------------
+			// Interim turn: send a new message while the tool is suspended.
+			// Build a fresh agent instance to simulate a separate request.
+			// ----------------------------------------------------------------
+			const interimAgent = new Agent('interim-agent')
+				.model(getModel('anthropic'))
+				.instructions('You are helpful. Answer questions concisely.')
+				.memory(mem);
+
+			const interimResult = await interimAgent.generate('What is 1 + 1?', { persistence });
+			expect(interimResult.finishReason).toBe('stop');
+
+			// ----------------------------------------------------------------
+			// Resume turn: approve the suspended tool call
+			// ----------------------------------------------------------------
+			let resumeFinishReason: string;
+			if (method === 'generate') {
+				const result = await agent.resume(
+					'generate',
+					{ approved: true },
+					{
+						runId,
+						toolCallId,
+					},
+				);
+				resumeFinishReason = result.finishReason ?? 'stop';
+			} else {
+				const { stream } = await agent.resume(
+					'stream',
+					{ approved: true },
+					{
+						runId,
+						toolCallId,
+					},
+				);
+				// Drain the stream
+				const reader = stream.getReader();
+				let finishReason = 'stop';
+				while (true) {
+					const { done, value } = await reader.read();
+					if (done) break;
+					if ((value as { type: string }).type === 'finish') {
+						finishReason = (value as { finishReason?: string }).finishReason ?? 'stop';
+					}
+				}
+				resumeFinishReason = finishReason;
+			}
+
+			// ----------------------------------------------------------------
+			// Assertions
+			// ----------------------------------------------------------------
+			// 1. No provider error — the ordering was valid
+			expect(resumeFinishReason).toBe('stop');
+
+			// 2. The originating assistant message's tool-call block is resolved
+			const allMessages = await memory.getMessages(threadId);
+			const llmMessages = filterLlmMessages(allMessages);
+
+			const ourBlock = llmMessages
+				.flatMap((m) => m.content.filter((c): c is ContentToolCall => c.type === 'tool-call'))
+				.find((b) => b.toolCallId === toolCallId);
+
+			expect(ourBlock).toBeDefined();
+			expect(ourBlock!.state).toBe('resolved');
+
+			// 3. The interim user/assistant exchange is present in memory
+			const userMessages = allMessages.filter(
+				(m): m is AgentDbMessage & Message => 'role' in m && m.role === 'user',
+			);
+			// Turn-1 user + interim user (at minimum)
+			expect(userMessages.length).toBeGreaterThanOrEqual(2);
+		});
+	}
+
+	it('preserves chronological ordering of messages in memory after resume', async () => {
+		const { memory, cleanup } = createSqliteMemory();
+		cleanups.push(cleanup);
+
+		const threadId = 'thread-interim-ordering';
+		const resourceId = 'res-ordering';
+		const persistence = { threadId, resourceId };
+		const mem = new Memory().storage(memory);
+
+		const agent = buildInterruptibleAgent(mem);
+
+		// Turn 1: suspend
+		const suspendResult = await agent.generate('Delete /tmp/order-test.txt', { persistence });
+		expect(suspendResult.finishReason).toBe('tool-calls');
+		const { runId, toolCallId } = suspendResult.pendingSuspend![0];
+
+		// Interim turn
+		const interimAgent = new Agent('interim-ordering')
+			.model(getModel('anthropic'))
+			.instructions('Answer concisely.')
+			.memory(mem);
+		await interimAgent.generate('Say hi', { persistence });
+
+		// Resume
+		const resumeResult = await agent.resume(
+			'generate',
+			{ approved: true },
+			{
+				runId,
+				toolCallId,
+			},
+		);
+		expect(resumeResult.finishReason).toBe('stop');
+
+		// The tool-call is resolved
+		const allMessages = await memory.getMessages(threadId);
+		const llmMessages = filterLlmMessages(allMessages);
+		const ourBlock = llmMessages
+			.flatMap((m) => m.content.filter((c): c is ContentToolCall => c.type === 'tool-call'))
+			.find((b) => b.toolCallId === toolCallId);
+
+		expect(ourBlock).toBeDefined();
+		expect(ourBlock!.state).toBe('resolved');
+
+		// Messages are in chronological order (createdAt ascending)
+		const timestamps = allMessages.map((m) => m.createdAt.getTime());
+		for (let i = 1; i < timestamps.length; i++) {
+			expect(timestamps[i]).toBeGreaterThanOrEqual(timestamps[i - 1]);
+		}
+	});
+});

--- a/packages/@n8n/agents/src/__tests__/integration/json-schema-validation.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/json-schema-validation.test.ts
@@ -72,12 +72,12 @@ describe('JSON Schema validation — non-MCP tools with raw JSON Schema', () => 
 		// The handler should have been called with valid data
 		expect(handler).toHaveBeenCalledWith(expect.objectContaining({ age: 25 }), expect.anything());
 
-		// No tool-result should carry an error flag
+		// No tool-call block should have state 'rejected'
 		const allMessages = filterLlmMessages(result.messages);
-		const toolResults = allMessages.flatMap((m) =>
-			m.content.filter((c) => c.type === 'tool-result'),
+		const toolCallBlocks = allMessages.flatMap((m) =>
+			m.content.filter((c) => c.type === 'tool-call'),
 		);
-		expect(toolResults.every((r) => !r.isError)).toBe(true);
+		expect(toolCallBlocks.every((c) => (c as { state: string }).state !== 'rejected')).toBe(true);
 	});
 
 	it('allows the LLM to self-correct after receiving a JSON Schema validation error', async () => {
@@ -105,12 +105,12 @@ describe('JSON Schema validation — non-MCP tools with raw JSON Schema', () => 
 		expect(result.finishReason).toBe('stop');
 		expect(result.error).toBeUndefined();
 
-		// There should be at least two tool-result messages: one error, one success
+		// There should be at least two tool-call messages: one rejected, one resolved
 		const allMessages = filterLlmMessages(result.messages);
-		const toolResultMessages = allMessages.filter((m) =>
-			m.content.some((c) => c.type === 'tool-result'),
+		const toolCallMessages = allMessages.filter((m) =>
+			m.content.some((c) => c.type === 'tool-call'),
 		);
-		expect(toolResultMessages.length).toBeGreaterThanOrEqual(2);
+		expect(toolCallMessages.length).toBeGreaterThanOrEqual(2);
 
 		// The successful handler call should have received a valid age
 		expect(callCount).toBeGreaterThanOrEqual(1);

--- a/packages/@n8n/agents/src/__tests__/integration/orphaned-tool-messages.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/orphaned-tool-messages.test.ts
@@ -28,95 +28,92 @@ describe('orphaned tool messages in memory', () => {
 	}
 
 	/**
-	 * Seed memory with a conversation that has tool-call / tool-result pairs
-	 * surrounded by plain user/assistant exchanges.
+	 * Seed memory with a conversation that has settled tool-call blocks
+	 * (state: 'resolved') surrounded by plain user/assistant exchanges.
 	 *
-	 * Message layout (indices 0–7):
-	 *   0: user   "How many widgets?"
-	 *   1: assistant  text + tool-call(call_1)
-	 *   2: tool   tool-result(call_1)
-	 *   3: assistant  "There are 10 widgets"
-	 *   4: user   "What about gadgets?"
-	 *   5: assistant  text + tool-call(call_2)
-	 *   6: tool   tool-result(call_2)
-	 *   7: assistant  "There are 5 gadgets"
+	 * Message layout (indices 0–5):
+	 *   0: user      "How many widgets?"
+	 *   1: assistant  text + tool-call(call_1, state:'resolved', output:{count:10})
+	 *   2: assistant  "There are 10 widgets"
+	 *   3: user      "What about gadgets?"
+	 *   4: assistant  text + tool-call(call_2, state:'resolved', output:{count:5})
+	 *   5: assistant  "There are 5 gadgets"
 	 */
 	function buildSeedMessages(): AgentDbMessage[] {
+		const now = Date.now();
 		return [
 			{
 				id: 'm1',
-				createdAt: new Date(),
+				createdAt: new Date(now),
 				role: 'user',
 				content: [{ type: 'text', text: 'How many widgets do we have?' }],
 			},
 			{
 				id: 'm2',
-				createdAt: new Date(),
+				createdAt: new Date(now + 1),
 				role: 'assistant',
 				content: [
 					{ type: 'text', text: 'Let me look that up.' },
-					{ type: 'tool-call', toolCallId: 'call_1', toolName: 'lookup', input: { id: 'widgets' } },
+					{
+						type: 'tool-call',
+						toolCallId: 'call_1',
+						toolName: 'lookup',
+						input: { id: 'widgets' },
+						state: 'resolved',
+						output: { count: 10 },
+					},
 				],
 			},
 			{
 				id: 'm3',
-				createdAt: new Date(),
-				role: 'tool',
-				content: [
-					{ type: 'tool-result', toolCallId: 'call_1', toolName: 'lookup', result: { count: 10 } },
-				],
-			},
-			{
-				id: 'm4',
-				createdAt: new Date(),
+				createdAt: new Date(now + 2),
 				role: 'assistant',
 				content: [{ type: 'text', text: 'There are 10 widgets in stock.' }],
 			},
 			{
-				id: 'm5',
-				createdAt: new Date(),
+				id: 'm4',
+				createdAt: new Date(now + 3),
 				role: 'user',
 				content: [{ type: 'text', text: 'What about gadgets?' }],
 			},
 			{
-				id: 'm6',
-				createdAt: new Date(),
+				id: 'm5',
+				createdAt: new Date(now + 4),
 				role: 'assistant',
 				content: [
 					{ type: 'text', text: 'Let me check.' },
-					{ type: 'tool-call', toolCallId: 'call_2', toolName: 'lookup', input: { id: 'gadgets' } },
+					{
+						type: 'tool-call',
+						toolCallId: 'call_2',
+						toolName: 'lookup',
+						input: { id: 'gadgets' },
+						state: 'resolved',
+						output: { count: 5 },
+					},
 				],
 			},
 			{
-				id: 'm7',
-				createdAt: new Date(),
-				role: 'tool',
-				content: [
-					{ type: 'tool-result', toolCallId: 'call_2', toolName: 'lookup', result: { count: 5 } },
-				],
-			},
-			{
-				id: 'm8',
-				createdAt: new Date(),
+				id: 'm6',
+				createdAt: new Date(now + 5),
 				role: 'assistant',
 				content: [{ type: 'text', text: 'There are 5 gadgets in stock.' }],
 			},
 		];
 	}
 
-	it('handles orphaned tool results when tool-call message is truncated from history', async () => {
+	it('handles partial history window when earlier messages are truncated', async () => {
 		const { memory, cleanup } = createSqliteMemory();
 		cleanups.push(cleanup);
 
 		const threadId = 'thread-orphan-result';
 
-		// Seed 8 messages into the thread
+		// Seed 6 messages into the thread
 		await memory.saveMessages({ threadId, messages: buildSeedMessages() });
 
-		// lastMessages=6 → loads messages 2–7
-		// Message at index 2 is a tool-result for call_1, but the matching
-		// assistant+tool-call (index 1) is truncated. This is an orphaned tool result.
-		const mem = new Memory().storage(memory).lastMessages(6);
+		// lastMessages=4 → loads messages 2–5
+		// Each tool-call block carries its own result (state:'resolved'), so there
+		// are no orphan issues regardless of window boundaries.
+		const mem = new Memory().storage(memory).lastMessages(4);
 
 		const agent = new Agent('orphan-result-test')
 			.model(getModel('anthropic'))
@@ -132,7 +129,7 @@ describe('orphaned tool messages in memory', () => {
 		expect(result.finishReason).toBe('stop');
 	});
 
-	it('handles orphaned tool calls when tool-result message is truncated from history', async () => {
+	it('handles pending tool-call blocks (interrupted turn) in history', async () => {
 		const { memory, cleanup } = createSqliteMemory();
 		cleanups.push(cleanup);
 
@@ -140,8 +137,9 @@ describe('orphaned tool messages in memory', () => {
 		const now = Date.now();
 
 		// Store a conversation where the last saved message is an assistant
-		// with a tool-call but the tool-result was never persisted (simulating
-		// a partial save / interrupted turn).
+		// with a pending tool-call block (simulating a partial save / interrupted turn).
+		// stripOrphanedToolMessages will drop the pending block so the LLM receives
+		// only the user message.
 		const messages: AgentDbMessage[] = [
 			{
 				id: 'm1',
@@ -160,6 +158,7 @@ describe('orphaned tool messages in memory', () => {
 						toolCallId: 'call_orphan',
 						toolName: 'lookup',
 						input: { id: 'widgets' },
+						state: 'pending',
 					},
 				],
 			},

--- a/packages/@n8n/agents/src/__tests__/integration/to-model-output.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/to-model-output.test.ts
@@ -63,11 +63,12 @@ describe('toModelOutput integration', () => {
 		expect(rawOutput.total).toBe(3);
 		expect(rawOutput.records[0].data).toBe('x'.repeat(200));
 
-		// ContentToolResult in messages stores the transformed output (what the LLM saw)
+		// Tool-call block in messages stores the transformed output (what the LLM saw)
 		const toolResults = findAllToolResults(result.messages);
 		const searchToolResult = toolResults.find((tr) => tr.toolName === 'search_db');
 		expect(searchToolResult).toBeDefined();
-		const modelOutput = searchToolResult!.result as { summary: string };
+		expect(searchToolResult!.state).toBe('resolved');
+		const modelOutput = (searchToolResult as unknown as { output: { summary: string } }).output;
 		expect(modelOutput.summary).toContain('Found 3 records');
 		expect(modelOutput.summary).toContain('Widget A');
 	});
@@ -139,11 +140,14 @@ describe('toModelOutput integration', () => {
 
 		const result = await agent.generate('Echo the message "hello world"');
 
-		// Without toModelOutput, tool result in messages should have the raw output
+		// Without toModelOutput, tool-call block in messages has the raw output
 		const toolResults = findAllToolResults(result.messages);
 		const echoResult = toolResults.find((tr) => tr.toolName === 'echo');
 		expect(echoResult).toBeDefined();
-		expect((echoResult!.result as { echoed: string }).echoed).toBe('hello world');
+		expect(echoResult!.state).toBe('resolved');
+		expect((echoResult as unknown as { output: { echoed: string } }).output.echoed).toBe(
+			'hello world',
+		);
 
 		// And toolCalls should also have the same raw output
 		expect(result.toolCalls).toBeDefined();
@@ -195,11 +199,14 @@ describe('toModelOutput integration', () => {
 		expect(multiplyEntry).toBeDefined();
 		expect((multiplyEntry!.output as { result: number }).result).toBe(56);
 
-		// Tool result in messages stores the transformed output for the LLM
+		// Tool-call block in messages stores the transformed output for the LLM
 		const toolResults = findAllToolResults(result.messages);
 		const multiplyToolResult = toolResults.find((tr) => tr.toolName === 'multiply');
 		expect(multiplyToolResult).toBeDefined();
-		const modelOutput = multiplyToolResult!.result as { answer: number; note: string };
+		expect(multiplyToolResult!.state).toBe('resolved');
+		const modelOutput = (
+			multiplyToolResult as unknown as { output: { answer: number; note: string } }
+		).output;
 		expect(modelOutput.answer).toBe(56);
 		expect(modelOutput.note).toBe('multiplication complete');
 

--- a/packages/@n8n/agents/src/__tests__/integration/tool-call-upsert.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/tool-call-upsert.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Upsert contract: after a HITL suspend/resume cycle backed by SqliteMemory,
+ * the thread must contain exactly ONE assistant message with the tool-call
+ * block (no duplicate rows), and that block must have state: 'resolved'.
+ *
+ * The upsert matters because on resume the runtime calls saveToMemory with
+ * turnDelta() which includes the now-resolved assistant message restored from
+ * the checkpoint. Without upsert-by-id, a second row would be inserted for
+ * the same message, breaking the thread ordering contract.
+ *
+ * Note: messages with state:'pending' are transient and are NOT written to
+ * memory during suspension — they only live in the checkpoint. Memory only
+ * receives the final settled state after resume completes.
+ */
+import { afterEach, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { describeIf, createSqliteMemory, getModel } from './helpers';
+import { Agent, filterLlmMessages, Memory, Tool } from '../../index';
+import type { AgentDbMessage } from '../../index';
+import type { ContentToolCall, Message } from '../../types/sdk/message';
+
+const describe = describeIf('anthropic');
+
+describe('tool-call upsert via suspend/resume (SqliteMemory)', () => {
+	const cleanups: Array<() => void> = [];
+
+	afterEach(() => {
+		for (const fn of cleanups) fn();
+		cleanups.length = 0;
+	});
+
+	function extractToolCallBlocks(messages: AgentDbMessage[]): ContentToolCall[] {
+		return filterLlmMessages(messages).flatMap((m) =>
+			m.content.filter((c): c is ContentToolCall => c.type === 'tool-call'),
+		);
+	}
+
+	function buildInterruptibleAgent(memory: ReturnType<typeof createSqliteMemory>['memory']): Agent {
+		const deleteTool = new Tool('delete_file')
+			.description('Delete a file at the given path')
+			.input(z.object({ path: z.string().describe('File path to delete') }))
+			.output(z.object({ deleted: z.boolean(), path: z.string() }))
+			.suspend(z.object({ message: z.string(), severity: z.string() }))
+			.resume(z.object({ approved: z.boolean() }))
+			.handler(async ({ path }, ctx) => {
+				if (!ctx.resumeData) {
+					return await ctx.suspend({ message: `Delete "${path}"?`, severity: 'destructive' });
+				}
+				if (!ctx.resumeData.approved) return { deleted: false, path };
+				return { deleted: true, path };
+			});
+
+		return new Agent('upsert-test-agent')
+			.model(getModel('anthropic'))
+			.instructions(
+				'You are a file manager. When asked to delete a file, use the delete_file tool. Be concise.',
+			)
+			.tool(deleteTool)
+			.memory(new Memory().storage(memory))
+			.checkpoint('memory');
+	}
+
+	it('after resume, thread has exactly one resolved tool-call block (no duplicate rows)', async () => {
+		const { memory, cleanup } = createSqliteMemory();
+		cleanups.push(cleanup);
+
+		const threadId = 'thread-upsert-resolved';
+		const resourceId = 'res-1';
+		const persistence = { threadId, resourceId };
+
+		const agent = buildInterruptibleAgent(memory);
+
+		// Turn 1: trigger the suspend — messages with pending tool-call are
+		// stored in the checkpoint only, NOT in SqliteMemory yet.
+		const suspendResult = await agent.generate('Please delete /tmp/foo.txt', {
+			persistence,
+		});
+
+		expect(suspendResult.finishReason).toBe('tool-calls');
+		expect(suspendResult.pendingSuspend).toBeDefined();
+		const { runId, toolCallId } = suspendResult.pendingSuspend![0];
+
+		// Before resume: no tool-call blocks in memory (pending stays in checkpoint)
+		const msgsBefore = await memory.getMessages(threadId);
+		const blocksBefore = extractToolCallBlocks(msgsBefore);
+		expect(blocksBefore).toHaveLength(0);
+
+		// Turn 2: resume with approval — on completion saveToMemory is called and
+		// the assistant message (now resolved) is written for the first time.
+		const resumeResult = await agent.resume(
+			'generate',
+			{ approved: true },
+			{
+				runId,
+				toolCallId,
+			},
+		);
+
+		expect(resumeResult.finishReason).toBe('stop');
+
+		// After resume: exactly one resolved tool-call block, no duplicate rows
+		const msgsAfter = await memory.getMessages(threadId);
+		const blocksAfter = extractToolCallBlocks(msgsAfter);
+
+		expect(blocksAfter).toHaveLength(1);
+		expect(blocksAfter[0].state).toBe('resolved');
+		expect(blocksAfter[0].toolCallId).toBe(toolCallId);
+		expect((blocksAfter[0] as ContentToolCall & { state: 'resolved' }).output).toMatchObject({
+			deleted: true,
+		});
+
+		// No duplicate assistant messages with tool-call blocks
+		const assistantMsgsWithToolCalls = filterLlmMessages(msgsAfter).filter(
+			(m) => m.role === 'assistant' && m.content.some((c) => c.type === 'tool-call'),
+		);
+		expect(assistantMsgsWithToolCalls).toHaveLength(1);
+	});
+
+	it('after resume with denial, thread has exactly one resolved tool-call block', async () => {
+		const { memory, cleanup } = createSqliteMemory();
+		cleanups.push(cleanup);
+
+		const threadId = 'thread-upsert-denied';
+		const resourceId = 'res-2';
+		const persistence = { threadId, resourceId };
+
+		const agent = buildInterruptibleAgent(memory);
+
+		const suspendResult = await agent.generate('Please delete /tmp/bar.txt', {
+			persistence,
+		});
+		expect(suspendResult.finishReason).toBe('tool-calls');
+		const { runId, toolCallId } = suspendResult.pendingSuspend![0];
+
+		// Before resume: no messages in memory
+		const msgsBefore = await memory.getMessages(threadId);
+		expect(extractToolCallBlocks(msgsBefore)).toHaveLength(0);
+
+		const resumeResult = await agent.resume(
+			'generate',
+			{ approved: false },
+			{
+				runId,
+				toolCallId,
+			},
+		);
+		expect(resumeResult.finishReason).toBe('stop');
+
+		const msgsAfter = await memory.getMessages(threadId);
+		const blocksAfter = extractToolCallBlocks(msgsAfter);
+
+		// Tool ran and returned {deleted: false} — still resolved, not rejected
+		expect(blocksAfter).toHaveLength(1);
+		expect(blocksAfter[0].state).toBe('resolved');
+		const output = (blocksAfter[0] as ContentToolCall & { state: 'resolved' }).output;
+		expect(output).toMatchObject({ deleted: false });
+
+		// No duplicate rows
+		const assistantMsgsWithToolCalls = filterLlmMessages(msgsAfter).filter(
+			(m) => m.role === 'assistant' && m.content.some((c) => c.type === 'tool-call'),
+		);
+		expect(assistantMsgsWithToolCalls).toHaveLength(1);
+	});
+
+	it('if same thread is resumed twice (re-suspend then resume again), still no duplicate rows', async () => {
+		const { memory, cleanup } = createSqliteMemory();
+		cleanups.push(cleanup);
+
+		const threadId = 'thread-upsert-double';
+		const resourceId = 'res-3';
+		const persistence = { threadId, resourceId };
+
+		// Use a tool that always re-suspends on first call and approves on second
+		let callCount = 0;
+		const confirmTool = new Tool('confirm')
+			.description('Confirm an action')
+			.input(z.object({ action: z.string() }))
+			.output(z.object({ done: z.boolean() }))
+			.suspend(z.object({ question: z.string() }))
+			.resume(z.object({ yes: z.boolean() }))
+			.handler(async ({ action }, ctx) => {
+				callCount++;
+				if (!ctx.resumeData) {
+					return await ctx.suspend({ question: `Confirm: ${action}?` });
+				}
+				return { done: ctx.resumeData.yes };
+			});
+
+		const agent = new Agent('double-upsert-agent')
+			.model(getModel('anthropic'))
+			.instructions('Use confirm tool for every action. Be concise.')
+			.tool(confirmTool)
+			.memory(new Memory().storage(memory))
+			.checkpoint('memory');
+
+		// Turn 1: suspend
+		const r1 = await agent.generate('confirm action: foo', { persistence });
+		expect(r1.finishReason).toBe('tool-calls');
+		const { runId, toolCallId } = r1.pendingSuspend![0];
+
+		// No messages in memory yet
+		expect(await memory.getMessages(threadId)).toHaveLength(0);
+
+		// Resume: completes
+		const r2 = await agent.resume('generate', { yes: true }, { runId, toolCallId });
+		expect(r2.finishReason).toBe('stop');
+
+		const finalMessages = await memory.getMessages(threadId);
+		const toolCallBlocks = extractToolCallBlocks(finalMessages);
+
+		// Exactly one tool-call block, no duplicates
+		expect(toolCallBlocks).toHaveLength(1);
+		expect(toolCallBlocks[0].state).toBe('resolved');
+
+		// And the assistant message with the tool-call appears exactly once
+		const assistantMsgsWithCalls = filterLlmMessages(finalMessages).filter(
+			(m): m is Message => m.role === 'assistant' && m.content.some((c) => c.type === 'tool-call'),
+		);
+		expect(assistantMsgsWithCalls).toHaveLength(1);
+	});
+});

--- a/packages/@n8n/agents/src/__tests__/integration/workspace/workspace-agent.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/workspace/workspace-agent.test.ts
@@ -69,7 +69,10 @@ describe('workspace agent integration', () => {
 
 		const readResult = toolResults.find((tr) => tr.toolName === 'workspace_read_file');
 		expect(readResult).toBeDefined();
-		expect((readResult!.result as { content: string }).content).toContain('Hello from n8n!');
+		expect(readResult!.state).toBe('resolved');
+		expect((readResult as unknown as { output: { content: string } }).output.content).toContain(
+			'Hello from n8n!',
+		);
 
 		expect(memFs.getFileContent('/greeting.txt')).toBe('Hello from n8n!');
 	});
@@ -103,7 +106,8 @@ describe('workspace agent integration', () => {
 		const toolResults = findAllToolResults(result.messages);
 		const execResult = toolResults.find((tr) => tr.toolName === 'workspace_execute_command');
 		expect(execResult).toBeDefined();
-		expect((execResult!.result as { success: boolean }).success).toBe(true);
+		expect(execResult!.state).toBe('resolved');
+		expect((execResult as unknown as { output: { success: boolean } }).output.success).toBe(true);
 	});
 
 	it('agent uses workspace_mkdir and workspace_list_files together', async () => {
@@ -130,7 +134,8 @@ describe('workspace agent integration', () => {
 		const toolResults = findAllToolResults(result.messages);
 		const listResult = toolResults.find((tr) => tr.toolName === 'workspace_list_files');
 		expect(listResult).toBeDefined();
-		const entries = (listResult!.result as unknown as { entries: FileEntry[] }).entries;
+		expect(listResult!.state).toBe('resolved');
+		const entries = (listResult as unknown as { output: { entries: FileEntry[] } }).output.entries;
 		const names = entries.map((e) => e.name);
 		expect(names).toContain('index.ts');
 		expect(names).toContain('README.md');
@@ -201,7 +206,8 @@ describe('workspace agent integration', () => {
 		const toolResults = findAllToolResults(result.messages);
 		const statResult = toolResults.find((tr) => tr.toolName === 'workspace_file_stat');
 		expect(statResult).toBeDefined();
-		const stat = statResult!.result as { type: string; size: number };
+		expect(statResult!.state).toBe('resolved');
+		const stat = (statResult as unknown as { output: { type: string; size: number } }).output;
 		expect(stat.type).toBe('file');
 		expect(stat.size).toBe(29);
 	});
@@ -233,7 +239,10 @@ describe('workspace agent integration', () => {
 
 		const readResult = toolResults.find((tr) => tr.toolName === 'workspace_read_file');
 		expect(readResult).toBeDefined();
-		expect((readResult!.result as { content: string }).content).toContain('export default {}');
+		expect(readResult!.state).toBe('resolved');
+		expect((readResult as unknown as { output: { content: string } }).output.content).toContain(
+			'export default {}',
+		);
 
 		expect(memFs.getFileContent('/app/config.ts')).toBe('export default {}');
 	});

--- a/packages/@n8n/agents/src/__tests__/integration/zod-validation-error.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/zod-validation-error.test.ts
@@ -45,12 +45,12 @@ describe('Zod validation errors surface to LLM and allow self-correction', () =>
 		expect(result.finishReason).toBe('stop');
 		expect(result.error).toBeUndefined();
 
-		// At least two tool-result messages: one error, one success
+		// At least two tool-call messages: one rejected, one resolved
 		const allMessages = filterLlmMessages(result.messages);
-		const toolResultMessages = allMessages.filter((m) =>
-			m.content.some((c) => c.type === 'tool-result'),
+		const toolCallMessages = allMessages.filter((m) =>
+			m.content.some((c) => c.type === 'tool-call'),
 		);
-		expect(toolResultMessages.length).toBeGreaterThanOrEqual(2);
+		expect(toolCallMessages.length).toBeGreaterThanOrEqual(2);
 
 		// The final response should mention a user (age 25 or similar)
 		const text = findLastTextContent(result.messages);

--- a/packages/@n8n/agents/src/__tests__/message-list.test.ts
+++ b/packages/@n8n/agents/src/__tests__/message-list.test.ts
@@ -1,6 +1,6 @@
 import { AgentMessageList } from '../runtime/message-list';
 import { isLlmMessage } from '../sdk/message';
-import type { AgentDbMessage, AgentMessage, Message } from '../types/sdk/message';
+import type { AgentDbMessage, AgentMessage, ContentToolCall, Message } from '../types/sdk/message';
 
 function makeUserMsg(text: string): AgentMessage {
 	return { role: 'user', content: [{ type: 'text', text }] };
@@ -172,5 +172,120 @@ describe('AgentMessageList — deserialize', () => {
 		const [newMsg] = list2.turnDelta();
 		expect(newMsg.createdAt).toBeInstanceOf(Date);
 		expect(newMsg.createdAt.getTime()).toBeGreaterThan(futureTs.getTime());
+	});
+});
+
+// ---------------------------------------------------------------------------
+// setToolCallResult / setToolCallError
+// ---------------------------------------------------------------------------
+
+function makePendingToolCallMsg(toolCallId: string): AgentMessage {
+	return {
+		role: 'assistant',
+		content: [
+			{
+				type: 'tool-call',
+				toolCallId,
+				toolName: 'my_tool',
+				input: { x: 1 },
+				state: 'pending',
+			},
+		],
+	};
+}
+
+describe('AgentMessageList — setToolCallResult', () => {
+	it('sets state and output on the matching tool-call block', () => {
+		const list = new AgentMessageList();
+		list.addResponse([makePendingToolCallMsg('id-1')]);
+
+		const host = list.setToolCallResult('id-1', { ok: true });
+		expect(host).toBeDefined();
+
+		const block = (host as Message).content.find((c) => c.type === 'tool-call') as ContentToolCall;
+		expect(block.state).toBe('resolved');
+		expect((block as ContentToolCall & { state: 'resolved' }).output).toEqual({ ok: true });
+	});
+
+	it('promotes a history-only message into responseDelta after setToolCallResult', () => {
+		const list = new AgentMessageList();
+		const histMsg: AgentDbMessage = {
+			id: 'hist-1',
+			createdAt: new Date('2024-01-01T00:00:01.000Z'),
+			role: 'assistant',
+			content: [
+				{
+					type: 'tool-call',
+					toolCallId: 'tc-hist',
+					toolName: 'my_tool',
+					input: {},
+					state: 'pending',
+				},
+			],
+		};
+		list.addHistory([histMsg]);
+
+		// Before: not in responseDelta (history only)
+		expect(list.responseDelta()).toHaveLength(0);
+
+		list.setToolCallResult('tc-hist', { done: true });
+
+		// After: promoted to responseDelta
+		const delta = list.responseDelta();
+		expect(delta).toHaveLength(1);
+		const block = (delta[0] as Message).content.find(
+			(c) => c.type === 'tool-call',
+		) as ContentToolCall;
+		expect(block.state).toBe('resolved');
+	});
+
+	it('is a no-op when toolCallId is unknown', () => {
+		const list = new AgentMessageList();
+		list.addResponse([makePendingToolCallMsg('id-1')]);
+
+		const result = list.setToolCallResult('unknown-id', { x: 1 });
+		expect(result).toBeUndefined();
+		// List unchanged
+		expect(list.responseDelta()).toHaveLength(1);
+	});
+
+	it('Set semantics make repeated calls idempotent (no duplicate messages)', () => {
+		const list = new AgentMessageList();
+		list.addResponse([makePendingToolCallMsg('id-1')]);
+
+		list.setToolCallResult('id-1', { ok: true });
+		list.setToolCallResult('id-1', { ok: true });
+
+		expect(list.responseDelta()).toHaveLength(1);
+	});
+});
+
+describe('AgentMessageList — setToolCallError', () => {
+	it('stringifies errors and clears any prior output', () => {
+		const list = new AgentMessageList();
+		list.addResponse([
+			{
+				role: 'assistant',
+				content: [
+					{
+						type: 'tool-call',
+						toolCallId: 'id-1',
+						toolName: 'my_tool',
+						input: {},
+						state: 'resolved',
+						output: { prev: true },
+					},
+				],
+			},
+		]);
+
+		const host = list.setToolCallError('id-1', new Error('boom'));
+		expect(host).toBeDefined();
+
+		const block = (host as Message).content.find((c) => c.type === 'tool-call') as ContentToolCall;
+		expect(block.state).toBe('rejected');
+		expect((block as ContentToolCall & { state: 'rejected' }).error).toBe('Error: boom');
+		// output should be gone
+		expect((block as unknown as { output?: unknown }).output).toBeUndefined();
 	});
 });

--- a/packages/@n8n/agents/src/__tests__/strip-orphaned-tool-messages.test.ts
+++ b/packages/@n8n/agents/src/__tests__/strip-orphaned-tool-messages.test.ts
@@ -2,52 +2,38 @@ import { stripOrphanedToolMessages } from '../runtime/strip-orphaned-tool-messag
 import type { AgentMessage, Message } from '../types/sdk/message';
 
 describe('stripOrphanedToolMessages', () => {
-	it('returns messages unchanged when all tool pairs are complete', () => {
+	it('returns messages unchanged when all tool-calls are settled', () => {
 		const messages: AgentMessage[] = [
 			{ role: 'user', content: [{ type: 'text', text: 'Hello' }] },
 			{
 				role: 'assistant',
 				content: [
 					{ type: 'text', text: 'Looking up...' },
-					{ type: 'tool-call', toolCallId: 'c1', toolName: 'lookup', input: {} },
+					{
+						type: 'tool-call',
+						toolCallId: 'c1',
+						toolName: 'lookup',
+						input: {},
+						state: 'resolved',
+						output: 42,
+					},
 				],
-			},
-			{
-				role: 'tool',
-				content: [{ type: 'tool-result', toolCallId: 'c1', toolName: 'lookup', result: 42 }],
 			},
 			{ role: 'assistant', content: [{ type: 'text', text: 'Done.' }] },
 		];
 
 		const result = stripOrphanedToolMessages(messages);
-		expect(result).toBe(messages);
+		expect(result).toEqual(messages);
 	});
 
-	it('strips orphaned tool-result when matching tool-call is missing', () => {
-		const messages: AgentMessage[] = [
-			{
-				role: 'tool',
-				content: [{ type: 'tool-result', toolCallId: 'c1', toolName: 'lookup', result: 42 }],
-			},
-			{ role: 'assistant', content: [{ type: 'text', text: 'There are 42.' }] },
-			{ role: 'user', content: [{ type: 'text', text: 'Thanks' }] },
-		];
-
-		const result = stripOrphanedToolMessages(messages) as Message[];
-
-		expect(result).toHaveLength(2);
-		expect(result[0].role).toBe('assistant');
-		expect(result[1].role).toBe('user');
-	});
-
-	it('strips orphaned tool-call when matching tool-result is missing', () => {
+	it('drops pending tool-call blocks while preserving sibling content', () => {
 		const messages: AgentMessage[] = [
 			{ role: 'user', content: [{ type: 'text', text: 'Check it' }] },
 			{
 				role: 'assistant',
 				content: [
 					{ type: 'text', text: 'Checking...' },
-					{ type: 'tool-call', toolCallId: 'c1', toolName: 'lookup', input: {} },
+					{ type: 'tool-call', toolCallId: 'c1', toolName: 'lookup', input: {}, state: 'pending' },
 				],
 			},
 		];
@@ -61,12 +47,14 @@ describe('stripOrphanedToolMessages', () => {
 		expect(assistantMsg.content[0].type).toBe('text');
 	});
 
-	it('drops assistant message entirely if it only contained an orphaned tool-call', () => {
+	it('drops empty messages after pending strip', () => {
 		const messages: AgentMessage[] = [
 			{ role: 'user', content: [{ type: 'text', text: 'Do it' }] },
 			{
 				role: 'assistant',
-				content: [{ type: 'tool-call', toolCallId: 'c1', toolName: 'action', input: {} }],
+				content: [
+					{ type: 'tool-call', toolCallId: 'c1', toolName: 'action', input: {}, state: 'pending' },
+				],
 			},
 		];
 
@@ -76,44 +64,45 @@ describe('stripOrphanedToolMessages', () => {
 		expect(result[0].role).toBe('user');
 	});
 
-	it('handles mixed scenario: one complete pair and one orphaned result', () => {
+	it('mixed scenario — only pending blocks are removed', () => {
 		const messages: AgentMessage[] = [
-			{
-				role: 'tool',
-				content: [
-					{ type: 'tool-result', toolCallId: 'orphan', toolName: 'lookup', result: 'stale' },
-				],
-			},
-			{ role: 'assistant', content: [{ type: 'text', text: 'Old result' }] },
-			{ role: 'user', content: [{ type: 'text', text: 'New question' }] },
 			{
 				role: 'assistant',
 				content: [
-					{ type: 'text', text: 'Looking up...' },
-					{ type: 'tool-call', toolCallId: 'c2', toolName: 'lookup', input: {} },
+					{
+						type: 'tool-call',
+						toolCallId: 'c1',
+						toolName: 'lookup',
+						input: {},
+						state: 'resolved',
+						output: 99,
+					},
+					{
+						type: 'tool-call',
+						toolCallId: 'c2',
+						toolName: 'delete',
+						input: {},
+						state: 'pending',
+					},
+					{
+						type: 'tool-call',
+						toolCallId: 'c3',
+						toolName: 'create',
+						input: {},
+						state: 'rejected',
+						error: 'boom',
+					},
 				],
 			},
-			{
-				role: 'tool',
-				content: [{ type: 'tool-result', toolCallId: 'c2', toolName: 'lookup', result: 99 }],
-			},
-			{ role: 'assistant', content: [{ type: 'text', text: '99 items' }] },
 		];
 
 		const result = stripOrphanedToolMessages(messages) as Message[];
 
-		expect(result).toHaveLength(5);
-		expect(result[0].role).toBe('assistant');
-		expect(result[0].content[0]).toEqual(
-			expect.objectContaining({ type: 'text', text: 'Old result' }),
-		);
-
-		const toolCallMsg = result.find(
-			(m) => m.role === 'assistant' && m.content.some((c) => c.type === 'tool-call'),
-		);
-		expect(toolCallMsg).toBeDefined();
-		const toolResultMsg = result.find((m) => m.role === 'tool');
-		expect(toolResultMsg).toBeDefined();
+		expect(result).toHaveLength(1);
+		const blocks = result[0].content;
+		// c2 (pending) should be removed; c1 (resolved) and c3 (rejected) stay
+		expect(blocks).toHaveLength(2);
+		expect(blocks.map((b) => (b as { toolCallId: string }).toolCallId)).toEqual(['c1', 'c3']);
 	});
 
 	it('preserves custom (non-LLM) messages', () => {
@@ -127,8 +116,16 @@ describe('stripOrphanedToolMessages', () => {
 		const messages: AgentMessage[] = [
 			customMsg,
 			{
-				role: 'tool',
-				content: [{ type: 'tool-result', toolCallId: 'orphan', toolName: 'x', result: null }],
+				role: 'assistant',
+				content: [
+					{
+						type: 'tool-call',
+						toolCallId: 'c1',
+						toolName: 'x',
+						input: {},
+						state: 'pending',
+					},
+				],
 			},
 		];
 
@@ -136,15 +133,5 @@ describe('stripOrphanedToolMessages', () => {
 
 		expect(result).toHaveLength(1);
 		expect(result[0]).toBe(customMsg);
-	});
-
-	it('returns same array reference when no orphans exist (no-op fast path)', () => {
-		const messages: AgentMessage[] = [
-			{ role: 'user', content: [{ type: 'text', text: 'Hi' }] },
-			{ role: 'assistant', content: [{ type: 'text', text: 'Hello!' }] },
-		];
-
-		const result = stripOrphanedToolMessages(messages);
-		expect(result).toBe(messages);
 	});
 });

--- a/packages/@n8n/agents/src/index.ts
+++ b/packages/@n8n/agents/src/index.ts
@@ -75,7 +75,6 @@ export type {
 	ContentReasoning,
 	ContentText,
 	ContentToolCall,
-	ContentToolResult,
 	Message,
 	MessageContent,
 	MessageRole,

--- a/packages/@n8n/agents/src/runtime/agent-runtime.ts
+++ b/packages/@n8n/agents/src/runtime/agent-runtime.ts
@@ -38,10 +38,8 @@ import { generateRunId, RunStateManager } from './run-state';
 import {
 	accumulateUsage,
 	applySubAgentUsage,
-	extractToolResults,
+	extractSettledToolCalls,
 	makeErrorStream,
-	makeErrorToolResultMessage,
-	makeToolResultMessage,
 	normalizeInput,
 } from './runtime-helpers';
 import { convertChunk } from './stream';
@@ -65,12 +63,7 @@ import type {
 	PersistedExecutionOptions,
 	ToolResultEntry,
 } from '../types/sdk/agent';
-import type {
-	AgentDbMessage,
-	AgentMessage,
-	ContentToolResult,
-	Message,
-} from '../types/sdk/message';
+import type { AgentDbMessage, AgentMessage, ContentToolCall, Message } from '../types/sdk/message';
 import type { JSONObject, JSONValue } from '../types/utils/json';
 import { parseWithSchema } from '../utils/parse';
 import { isZodSchema } from '../utils/zod';
@@ -136,7 +129,7 @@ type ToolCallOutcome =
 			customMessage?: AgentMessage;
 	  }
 	| { outcome: 'suspended'; payload: unknown; resumeSchema: JsonSchema7Type }
-	| { outcome: 'error'; error: unknown; message: AgentMessage }
+	| { outcome: 'error'; error: unknown }
 	| { outcome: 'noop' }; // tool call shouldn't be saved or logged anywhere, usually means that if was executed by AI SDK
 
 /** A tool call that completed successfully. */
@@ -166,7 +159,6 @@ interface ToolCallError {
 	toolName: string;
 	input: JSONValue;
 	error: unknown;
-	message: AgentMessage;
 }
 
 /** Result of executing a batch of tool calls (before persistence). */
@@ -708,7 +700,7 @@ export class AgentRuntime {
 				if (outputSpec) {
 					structuredOutput = result.output;
 				}
-				this.emitTurnEnd(newMessages, extractToolResults(newMessages));
+				this.emitTurnEnd(newMessages, extractSettledToolCalls(newMessages));
 				break;
 			}
 
@@ -747,7 +739,7 @@ export class AgentRuntime {
 			}
 
 			// Emit TurnEnd after all tool calls in this iteration are processed
-			this.emitTurnEnd(newMessages, extractToolResults(list.responseDelta()));
+			this.emitTurnEnd(newMessages, extractSettledToolCalls(list.responseDelta()));
 		}
 
 		if (lastFinishReason === 'tool-calls') {
@@ -985,7 +977,7 @@ export class AgentRuntime {
 				if (outputSpec) {
 					structuredOutput = await result.output;
 				}
-				this.emitTurnEnd(newMessages, extractToolResults(newMessages));
+				this.emitTurnEnd(newMessages, extractSettledToolCalls(newMessages));
 				break;
 			}
 
@@ -1049,7 +1041,7 @@ export class AgentRuntime {
 			}
 
 			// Emit TurnEnd after all tool calls in this iteration are processed
-			this.emitTurnEnd(newMessages, extractToolResults(list.responseDelta()));
+			this.emitTurnEnd(newMessages, extractSettledToolCalls(list.responseDelta()));
 		}
 
 		const costUsage = this.applyCost(totalUsage);
@@ -1297,12 +1289,12 @@ export class AgentRuntime {
 				const toolInput = tc.input as JSONValue;
 
 				if (result.status === 'rejected') {
+					list.setToolCallError(tc.toolCallId, result.reason);
 					errors.push({
 						toolCallId: tc.toolCallId,
 						toolName: tc.toolName,
 						input: toolInput,
 						error: result.reason,
-						message: makeErrorToolResultMessage(tc.toolCallId, tc.toolName, result.reason),
 					});
 				} else if (result.value.outcome === 'suspended') {
 					hasSuspension = true;
@@ -1338,7 +1330,6 @@ export class AgentRuntime {
 						toolName: tc.toolName,
 						input: toolInput,
 						error: result.value.error,
-						message: result.value.message,
 					});
 				} else if (result.value.outcome === 'noop') {
 					// noop
@@ -1430,7 +1421,6 @@ export class AgentRuntime {
 				toolName: resumedToolName,
 				input: resumedEntry.input,
 				error: processResult.error,
-				message: processResult.message,
 			});
 		} else if (processResult.outcome === 'noop') {
 			// noop
@@ -1518,30 +1508,38 @@ export class AgentRuntime {
 				result: error,
 				isError: true,
 			});
-			const errorMsg = makeErrorToolResultMessage(toolCallId, toolName, error);
-			list.addResponse([errorMsg]);
-			return { outcome: 'error', error, message: errorMsg };
+			list.setToolCallError(toolCallId, error);
+			return { outcome: 'error', error };
 		};
 
 		if (!builtTool) {
 			return makeToolError(new Error(`Tool ${toolName} not found`));
 		}
 
-		// AI SDK automatically parses tool input and creates a tool-result message for it.
-		// If the tool-result message is an error, we don't need to execute the tool again.
-		const existingToolResults = list
+		// Check if this tool-call block was already settled (e.g. by provider-executed tools).
+		// If so, emit ToolExecutionEnd and skip re-execution.
+		type SettledToolCall = ContentToolCall & { state: 'resolved' | 'rejected' };
+		const settledBlock = list
 			.responseDelta()
-			.filter((m) => isLlmMessage(m) && m.role === 'tool')
-			.flatMap((m) => (m as Message).content.filter((content) => content.type === 'tool-result'));
-		const existingToolResult = existingToolResults.find((r) => r.toolCallId === toolCallId);
+			.flatMap((m) => (isLlmMessage(m) && 'content' in m ? (m as Message).content : []))
+			.find(
+				(c): c is SettledToolCall =>
+					c.type === 'tool-call' && c.toolCallId === toolCallId && c.state !== 'pending',
+			);
 
-		if (existingToolResult) {
+		if (settledBlock) {
+			let settledResult: unknown;
+			if (settledBlock.state === 'resolved') {
+				settledResult = settledBlock.output;
+			} else {
+				settledResult = settledBlock.error;
+			}
 			this.eventBus.emit({
 				type: AgentEvent.ToolExecutionEnd,
 				toolCallId,
 				toolName,
-				result: existingToolResult.result,
-				isError: !!existingToolResult.isError,
+				result: settledResult,
+				isError: settledBlock.state === 'rejected',
 			});
 			return { outcome: 'noop' };
 		}
@@ -1603,8 +1601,7 @@ export class AgentRuntime {
 			? builtTool.toModelOutput(actualResult)
 			: actualResult;
 
-		const toolResultMsg = makeToolResultMessage(toolCallId, toolName, modelResult);
-		list.addResponse([toolResultMsg]);
+		list.setToolCallResult(toolCallId, modelResult as JSONValue);
 
 		const customMessage = builtTool?.toMessage?.(actualResult);
 		if (customMessage) {
@@ -1702,7 +1699,7 @@ export class AgentRuntime {
 	}
 
 	/** Emit a TurnEnd event when an assistant message is present in `newMessages`. */
-	private emitTurnEnd(newMessages: AgentMessage[], toolResults: ContentToolResult[]): void {
+	private emitTurnEnd(newMessages: AgentMessage[], toolResults: ContentToolCall[]): void {
 		const assistantMsg = newMessages.find((m) => 'role' in m && m.role === 'assistant');
 		if (assistantMsg) {
 			this.eventBus.emit({ type: AgentEvent.TurnEnd, message: assistantMsg, toolResults });

--- a/packages/@n8n/agents/src/runtime/memory-store.ts
+++ b/packages/@n8n/agents/src/runtime/memory-store.ts
@@ -78,6 +78,8 @@ export class InMemoryMemory implements BuiltMemory {
 	/**
 	 * Save messages to the thread established by the most recent `saveThread` call.
 	 * Always call `saveThread` before `saveMessages` to set the thread context.
+	 * Upserts by message id — if a message with the same id already exists, it is
+	 * replaced in place (preserving insertion order). New messages are appended.
 	 */
 	// eslint-disable-next-line @typescript-eslint/require-await
 	async saveMessages(args: {
@@ -86,8 +88,16 @@ export class InMemoryMemory implements BuiltMemory {
 		messages: AgentDbMessage[];
 	}): Promise<void> {
 		const existing = this.messagesByThread.get(args.threadId) ?? [];
+		const byId = new Map(existing.map((s, i) => [s.message.id, i]));
 		for (const msg of args.messages) {
-			existing.push({ message: msg, createdAt: msg.createdAt });
+			const entry: StoredMessage = { message: msg, createdAt: msg.createdAt };
+			const idx = byId.get(msg.id);
+			if (idx !== undefined) {
+				existing[idx] = entry;
+			} else {
+				byId.set(msg.id, existing.length);
+				existing.push(entry);
+			}
 		}
 		this.messagesByThread.set(args.threadId, existing);
 	}

--- a/packages/@n8n/agents/src/runtime/message-list.ts
+++ b/packages/@n8n/agents/src/runtime/message-list.ts
@@ -2,11 +2,13 @@ import type { ProviderOptions } from '@ai-sdk/provider-utils';
 import type { ModelMessage } from 'ai';
 
 import { toAiMessages } from './messages';
+import { stringifyError } from './runtime-helpers';
 import { stripOrphanedToolMessages } from './strip-orphaned-tool-messages';
 import { buildWorkingMemoryInstruction } from './working-memory';
 import { filterLlmMessages, getCreatedAt } from '../sdk/message';
 import type { SerializedMessageList } from '../types/runtime/message-list';
-import type { AgentDbMessage, AgentMessage } from '../types/sdk/message';
+import type { AgentDbMessage, AgentMessage, ContentToolCall } from '../types/sdk/message';
+import type { JSONValue } from '../types/utils/json';
 
 export type { SerializedMessageList };
 
@@ -132,6 +134,70 @@ export class AgentMessageList {
 			this.responseSet.add(dbMsg);
 		}
 		this.sortAllByCreatedAt();
+	}
+
+	/**
+	 * Locate the assistant message hosting the given toolCallId and mark the
+	 * block as resolved with the supplied output.
+	 *
+	 * Returns the mutated host message, or `undefined` if the toolCallId is
+	 * not found (internal invariant violation — caller should log/throw).
+	 */
+	setToolCallResult(toolCallId: string, output: JSONValue): AgentDbMessage | undefined {
+		const host = this.findToolCallHost(toolCallId);
+		if (!host) return undefined;
+
+		const block = this.findToolCallBlock(host, toolCallId);
+		if (!block) return undefined;
+
+		const mutableBlock = block;
+		mutableBlock.state = 'resolved';
+		(mutableBlock as Extract<ContentToolCall, { state: 'resolved' }>).output = output;
+		if ('error' in mutableBlock) {
+			delete (mutableBlock as { error: unknown }).error;
+		}
+
+		this.responseSet.add(host);
+		return host;
+	}
+
+	/**
+	 * Locate the assistant message hosting the given toolCallId and mark the
+	 * block as rejected with the supplied error.
+	 *
+	 * Returns the mutated host message, or `undefined` if the toolCallId is
+	 * not found (internal invariant violation — caller should log/throw).
+	 */
+	setToolCallError(toolCallId: string, error: unknown): AgentDbMessage | undefined {
+		const host = this.findToolCallHost(toolCallId);
+		if (!host) return undefined;
+
+		const block = this.findToolCallBlock(host, toolCallId)!;
+		const mutableBlock = block;
+		mutableBlock.state = 'rejected';
+		(mutableBlock as Extract<ContentToolCall, { state: 'rejected' }>).error = stringifyError(error);
+		if ('output' in mutableBlock) {
+			delete (mutableBlock as { output: unknown }).output;
+		}
+
+		this.responseSet.add(host);
+		return host;
+	}
+
+	private findToolCallHost(toolCallId: string): AgentDbMessage | undefined {
+		return this.all.find(
+			(m) =>
+				'content' in m &&
+				Array.isArray(m.content) &&
+				m.content.some((c) => c.type === 'tool-call' && c.toolCallId === toolCallId),
+		);
+	}
+
+	private findToolCallBlock(host: AgentDbMessage, toolCallId: string): ContentToolCall | undefined {
+		if (!('content' in host) || !Array.isArray(host.content)) return undefined;
+		return host.content.find(
+			(c): c is ContentToolCall => c.type === 'tool-call' && c.toolCallId === toolCallId,
+		);
 	}
 
 	/**

--- a/packages/@n8n/agents/src/runtime/message-list.ts
+++ b/packages/@n8n/agents/src/runtime/message-list.ts
@@ -185,12 +185,18 @@ export class AgentMessageList {
 	}
 
 	private findToolCallHost(toolCallId: string): AgentDbMessage | undefined {
-		return this.all.find(
-			(m) =>
+		// Start from the last message and go backwards to find the host message
+		for (let i = this.all.length - 1; i >= 0; i--) {
+			const m = this.all[i];
+			if (
 				'content' in m &&
 				Array.isArray(m.content) &&
-				m.content.some((c) => c.type === 'tool-call' && c.toolCallId === toolCallId),
-		);
+				m.content.some((c) => c.type === 'tool-call' && c.toolCallId === toolCallId)
+			) {
+				return m;
+			}
+		}
+		return undefined;
 	}
 
 	private findToolCallBlock(host: AgentDbMessage, toolCallId: string): ContentToolCall | undefined {

--- a/packages/@n8n/agents/src/runtime/messages.ts
+++ b/packages/@n8n/agents/src/runtime/messages.ts
@@ -212,6 +212,10 @@ function toAiMessageList(msg: Message): ModelMessage[] {
 
 			for (const block of msg.content) {
 				if (block.type === 'tool-call') {
+					if (!('state' in block)) {
+						// Legacy DB block - skip it
+						continue;
+					}
 					if (block.state === 'pending') {
 						// Skip pending blocks — defense-in-depth (strip step removes them first)
 						continue;
@@ -233,16 +237,25 @@ function toAiMessageList(msg: Message): ModelMessage[] {
 				}
 			}
 
-			const assistantBase: ModelMessage = {
-				role: 'assistant',
-				content: assistantParts as Array<
-					TextPart | ReasoningPart | ToolCallPart | ToolResultPart | FilePart
-				>,
-			};
-			const assistantMsg: ModelMessage = msg.providerOptions
-				? { ...assistantBase, providerOptions: msg.providerOptions }
-				: assistantBase;
-			return [assistantMsg, ...resultMessages];
+			const transformedMessages: ModelMessage[] = [];
+
+			if (assistantParts.length > 0) {
+				const assistantBase: ModelMessage = {
+					role: 'assistant',
+					content: assistantParts as Array<
+						TextPart | ReasoningPart | ToolCallPart | ToolResultPart | FilePart
+					>,
+				};
+				const assistantMsg: ModelMessage = msg.providerOptions
+					? { ...assistantBase, providerOptions: msg.providerOptions }
+					: assistantBase;
+				transformedMessages.push(assistantMsg);
+			}
+			if (resultMessages.length > 0) {
+				transformedMessages.push(...resultMessages);
+			}
+
+			return transformedMessages;
 		}
 
 		case 'tool': {

--- a/packages/@n8n/agents/src/runtime/messages.ts
+++ b/packages/@n8n/agents/src/runtime/messages.ts
@@ -11,13 +11,13 @@ import type {
 } from 'ai';
 
 import type { FinishReason } from '../types';
+import { stringifyError } from './runtime-helpers';
 import type {
 	AgentMessage,
 	ContentFile,
 	ContentReasoning,
 	ContentText,
 	ContentToolCall,
-	ContentToolResult,
 	Message,
 	MessageContent,
 } from '../types/sdk/message';
@@ -54,10 +54,6 @@ function isToolCall(block: MessageContent): block is ContentToolCall {
 	return block.type === 'tool-call';
 }
 
-function isToolResult(block: MessageContent): block is ContentToolResult {
-	return block.type === 'tool-result';
-}
-
 /**
  * Parse a JSONValue that may be a stringified JSON object back into
  * its parsed form. Non-string values pass through unchanged.
@@ -92,32 +88,6 @@ function toAiContent(block: MessageContent): AiContentPart | undefined {
 			input: parseJsonValue(block.input),
 			providerExecuted: block.providerExecuted,
 		};
-	}
-	if (isToolResult(block)) {
-		if (block.isError) {
-			if (typeof block.result === 'string') {
-				base = {
-					type: 'tool-result',
-					toolCallId: block.toolCallId,
-					toolName: block.toolName,
-					output: { type: 'error-text', value: block.result },
-				};
-			} else {
-				base = {
-					type: 'tool-result',
-					toolCallId: block.toolCallId,
-					toolName: block.toolName,
-					output: { type: 'error-json', value: block.result },
-				};
-			}
-		} else {
-			base = {
-				type: 'tool-result',
-				toolCallId: block.toolCallId,
-				toolName: block.toolName,
-				output: { type: 'json', value: block.result },
-			};
-		}
 	} else if (isReasoning(block)) {
 		base = { type: 'reasoning', text: block.text };
 	}
@@ -126,6 +96,36 @@ function toAiContent(block: MessageContent): AiContentPart | undefined {
 		return { ...base, providerOptions: block.providerOptions } as AiContentPart;
 	}
 	return base;
+}
+
+/** Build an AI SDK ToolResultPart from a resolved/rejected ContentToolCall. */
+function toolCallToResultPart(
+	block: ContentToolCall & { state: 'resolved' | 'rejected' },
+): ToolResultPart {
+	if (block.state === 'resolved') {
+		return {
+			type: 'tool-result',
+			toolCallId: block.toolCallId,
+			toolName: block.toolName,
+			output: { type: 'json', value: block.output },
+		};
+	}
+	// rejected
+	const errorValue = block.error;
+	if (typeof errorValue === 'string') {
+		return {
+			type: 'tool-result',
+			toolCallId: block.toolCallId,
+			toolName: block.toolName,
+			output: { type: 'error-text', value: errorValue },
+		};
+	}
+	return {
+		type: 'tool-result',
+		toolCallId: block.toolCallId,
+		toolName: block.toolName,
+		output: { type: 'error-json', value: errorValue as JSONValue },
+	};
 }
 
 /** Convert a single AI SDK content part to an n8n MessageContent block. */
@@ -159,35 +159,11 @@ function fromAiContent(part: AiContentPart): MessageContent | undefined {
 				toolName: part.toolName,
 				input: part.input as JSONValue,
 				providerExecuted: part.providerExecuted,
+				state: 'pending',
 			};
 			break;
-		case 'tool-result': {
-			const { output } = part;
-			let result: JSONValue;
-			let isError: boolean | undefined;
-			if (output.type === 'json') {
-				result = output.value;
-			} else if (output.type === 'text') {
-				result = output.value;
-			} else if (output.type === 'error-json') {
-				result = output.value;
-				isError = true;
-			} else if (output.type === 'error-text') {
-				result = output.value;
-				isError = true;
-			} else {
-				result = null;
-				isError = true;
-			}
-			base = {
-				type: 'tool-result',
-				toolCallId: part.toolCallId,
-				toolName: part.toolName,
-				result,
-				isError,
-			};
-			break;
-		}
+		case 'tool-result':
+			return undefined;
 		// Ignore these types, because HITL is handled by our runtime
 		case 'tool-approval-request':
 		case 'tool-approval-response':
@@ -201,82 +177,159 @@ function fromAiContent(part: AiContentPart): MessageContent | undefined {
 	return base;
 }
 
-/** Convert a single n8n Message to an AI SDK ModelMessage. */
-export function toAiMessage(msg: Message): ModelMessage {
-	let base: ModelMessage;
+/**
+ * Convert a single n8n Message to one or more AI SDK ModelMessages.
+ *
+ * For assistant messages with resolved/rejected tool-call blocks, this emits:
+ *  1. The assistant ModelMessage (tool-call parts only, no result fields)
+ *  2. One tool ModelMessage per settled tool-call block (resolved or rejected)
+ *
+ * Pending tool-call blocks are silently skipped (defense-in-depth; the strip
+ * step should already have removed them before forLlm() calls toAiMessages).
+ */
+function toAiMessageList(msg: Message): ModelMessage[] {
 	switch (msg.role) {
 		case 'system': {
 			const text = msg.content
 				.filter(isText)
 				.map((b) => b.text)
 				.join('');
-			base = { role: 'system', content: text };
-			break;
+			const base: ModelMessage = { role: 'system', content: text };
+			return [msg.providerOptions ? { ...base, providerOptions: msg.providerOptions } : base];
 		}
 
 		case 'user': {
 			const parts = msg.content
 				.map(toAiContent)
 				.filter((p): p is TextPart | FilePart => p?.type === 'text' || p?.type === 'file');
-			base = { role: 'user', content: parts };
-			break;
+			const base: ModelMessage = { role: 'user', content: parts };
+			return [msg.providerOptions ? { ...base, providerOptions: msg.providerOptions } : base];
 		}
 
 		case 'assistant': {
-			const parts = msg.content
-				.map(toAiContent)
-				.filter(
-					(p): p is TextPart | ReasoningPart | ToolCallPart | ToolResultPart | FilePart =>
-						p?.type === 'text' ||
-						p?.type === 'reasoning' ||
-						p?.type === 'tool-call' ||
-						p?.type === 'tool-result' ||
-						p?.type === 'file',
-				);
-			base = { role: 'assistant', content: parts };
-			break;
+			const assistantParts: AiContentPart[] = [];
+			const resultMessages: ModelMessage[] = [];
+
+			for (const block of msg.content) {
+				if (block.type === 'tool-call') {
+					if (block.state === 'pending') {
+						// Skip pending blocks — defense-in-depth (strip step removes them first)
+						continue;
+					}
+					// Emit tool-call part (without result fields)
+					assistantParts.push({
+						type: 'tool-call',
+						toolCallId: block.toolCallId,
+						toolName: block.toolName,
+						input: parseJsonValue(block.input),
+						providerExecuted: block.providerExecuted,
+					});
+					// Emit corresponding tool-result message immediately after
+					const resultPart = toolCallToResultPart(block);
+					resultMessages.push({ role: 'tool', content: [resultPart] });
+				} else {
+					const part = toAiContent(block);
+					if (part) assistantParts.push(part);
+				}
+			}
+
+			const assistantBase: ModelMessage = {
+				role: 'assistant',
+				content: assistantParts as Array<
+					TextPart | ReasoningPart | ToolCallPart | ToolResultPart | FilePart
+				>,
+			};
+			const assistantMsg: ModelMessage = msg.providerOptions
+				? { ...assistantBase, providerOptions: msg.providerOptions }
+				: assistantBase;
+			return [assistantMsg, ...resultMessages];
 		}
 
 		case 'tool': {
-			const parts = msg.content
-				.map(toAiContent)
-				.filter((p): p is ToolResultPart => p?.type === 'tool-result');
-			base = { role: 'tool', content: parts };
-			break;
+			// Legacy role: 'tool' messages (from old DB rows). Don't emit them.
+			return [];
 		}
 
 		default:
 			throw new Error(`Unknown role: ${msg.role as string}`);
 	}
-
-	if (msg.providerOptions) {
-		return { ...base, providerOptions: msg.providerOptions };
-	}
-	return base;
 }
 
 /** Convert n8n Messages to AI SDK ModelMessages for passing to stream/generateText. */
 export function toAiMessages(messages: Message[]): ModelMessage[] {
-	return messages.map(toAiMessage);
+	return messages.flatMap(toAiMessageList);
 }
 
-/** Convert a single AI SDK ModelMessage to an n8n AgentDbMessage (with a generated id). */
-export function fromAiMessage(msg: ModelMessage): AgentMessage {
-	const rawContent = msg.content;
-	const content: MessageContent[] =
-		typeof rawContent === 'string'
-			? [{ type: 'text', text: rawContent }]
-			: rawContent.map(fromAiContent).filter((p): p is MessageContent => p !== undefined);
-	const message: AgentMessage = { role: msg.role, content };
-	if ('providerOptions' in msg && msg.providerOptions) {
-		message.providerOptions = msg.providerOptions;
-	}
-	return message;
-}
-
-/** Convert AI SDK ModelMessages to n8n AgentDbMessages (each with a generated id). */
+/**
+ * Convert AI SDK ModelMessages to n8n AgentMessages.
+ *
+ * This is a stateful walk: when a role:'tool' ModelMessage is encountered,
+ * the matching tool-call block on the preceding assistant message is mutated
+ * to 'resolved' or 'rejected'. The tool message itself is not emitted as a
+ * separate n8n message.
+ *
+ * If a tool-result references a toolCallId not in the index (orphan), it is
+ * silently dropped.
+ */
 export function fromAiMessages(messages: ModelMessage[]): AgentMessage[] {
-	return messages.map(fromAiMessage);
+	// Map from toolCallId → ContentToolCall block (mutable ref inside the n8n message)
+	const toolCallIndex = new Map<string, ContentToolCall>();
+	const result: AgentMessage[] = [];
+
+	for (const msg of messages) {
+		if (msg.role === 'tool') {
+			// Merge tool results back into the matching tool-call blocks
+			const toolParts = msg.content as ToolResultPart[];
+			for (const part of toolParts) {
+				const block = toolCallIndex.get(part.toolCallId);
+				if (!block) continue; // orphan — drop
+
+				const { output } = part;
+				if (output.type === 'json' || output.type === 'text') {
+					const mutableBlock = block as Extract<ContentToolCall, { state: 'resolved' }>;
+					mutableBlock.state = 'resolved';
+					mutableBlock.output = output.value as JSONValue;
+				} else if (output.type === 'error-json') {
+					const mutableBlock = block as Extract<ContentToolCall, { state: 'rejected' }>;
+					mutableBlock.state = 'rejected';
+					mutableBlock.error = stringifyError(output.value);
+				} else if (output.type === 'error-text') {
+					const mutableBlock = block as Extract<ContentToolCall, { state: 'rejected' }>;
+					mutableBlock.state = 'rejected';
+					mutableBlock.error = output.value;
+				} else {
+					const mutableBlock = block as Extract<ContentToolCall, { state: 'rejected' }>;
+					mutableBlock.state = 'rejected';
+					mutableBlock.error = JSON.stringify(output);
+				}
+			}
+			// Do not emit a separate n8n message for tool results
+			continue;
+		}
+
+		const rawContent = msg.content;
+		const content: MessageContent[] =
+			typeof rawContent === 'string'
+				? [{ type: 'text', text: rawContent }]
+				: rawContent.map(fromAiContent).filter((p): p is MessageContent => p !== undefined);
+
+		const agentMsg: AgentMessage = { role: msg.role, content };
+		if ('providerOptions' in msg && msg.providerOptions) {
+			agentMsg.providerOptions = msg.providerOptions;
+		}
+		result.push(agentMsg);
+
+		// Index any tool-call blocks for later merging with tool-result messages
+		if (msg.role === 'assistant') {
+			for (const block of content) {
+				if (block.type === 'tool-call' && block.toolCallId) {
+					toolCallIndex.set(block.toolCallId, block);
+				}
+			}
+		}
+	}
+
+	return result;
 }
 
 export function fromAiFinishReason(reason: AiFinishReason): FinishReason {

--- a/packages/@n8n/agents/src/runtime/messages.ts
+++ b/packages/@n8n/agents/src/runtime/messages.ts
@@ -11,7 +11,6 @@ import type {
 } from 'ai';
 
 import type { FinishReason } from '../types';
-import { stringifyError } from './runtime-helpers';
 import type {
 	AgentMessage,
 	ContentFile,
@@ -305,7 +304,7 @@ export function fromAiMessages(messages: ModelMessage[]): AgentMessage[] {
 				} else if (output.type === 'error-json') {
 					const mutableBlock = block as Extract<ContentToolCall, { state: 'rejected' }>;
 					mutableBlock.state = 'rejected';
-					mutableBlock.error = stringifyError(output.value);
+					mutableBlock.error = JSON.stringify(output.value);
 				} else if (output.type === 'error-text') {
 					const mutableBlock = block as Extract<ContentToolCall, { state: 'rejected' }>;
 					mutableBlock.state = 'rejected';

--- a/packages/@n8n/agents/src/runtime/runtime-helpers.ts
+++ b/packages/@n8n/agents/src/runtime/runtime-helpers.ts
@@ -4,8 +4,7 @@
  */
 import type { GenerateResult, StreamChunk, TokenUsage } from '../types';
 import { toTokenUsage } from './stream';
-import type { AgentMessage, ContentToolResult } from '../types/sdk/message';
-import type { JSONValue } from '../types/utils/json';
+import type { AgentMessage, ContentToolCall } from '../types/sdk/message';
 
 /**
  * Normalize caller input to `AgentMessage[]` for the runtime. String input becomes a
@@ -18,55 +17,16 @@ export function normalizeInput(input: AgentMessage[] | string): AgentMessage[] {
 	return input;
 }
 
-/** Build an AI SDK tool ModelMessage for a tool execution result. */
-export function makeToolResultMessage(
-	toolCallId: string,
-	toolName: string,
-	result: unknown,
-): AgentMessage {
-	return {
-		role: 'tool',
-		content: [
-			{
-				type: 'tool-result',
-				toolCallId,
-				toolName,
-				result: result as JSONValue,
-			},
-		],
-	};
+/** Stringify an error value for use in a rejected tool-call block. */
+export function stringifyError(error: unknown): string {
+	return error instanceof Error ? `${error.name}: ${error.message}` : String(error);
 }
 
-/**
- * Build an AI SDK tool ModelMessage for a tool execution error.
- * The LLM receives this as a tool result so it can self-correct on the next iteration.
- * The error is surfaced via the output json value so the LLM can read and reason about it.
- */
-export function makeErrorToolResultMessage(
-	toolCallId: string,
-	toolName: string,
-	error: unknown,
-): AgentMessage {
-	const message = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
-	return {
-		role: 'tool',
-		content: [
-			{
-				type: 'tool-result',
-				toolCallId,
-				toolName,
-				result: { error: message } as JSONValue,
-				isError: true,
-			},
-		],
-	};
-}
-
-/** Extract all tool-result content parts from a flat list of agent messages. */
-export function extractToolResults(messages: AgentMessage[]): ContentToolResult[] {
+/** Extract all settled (resolved or rejected) tool-call blocks from a flat list of agent messages. */
+export function extractSettledToolCalls(messages: AgentMessage[]): ContentToolCall[] {
 	return messages
 		.flatMap((m) => ('content' in m ? m.content : []))
-		.filter((c): c is ContentToolResult => c.type === 'tool-result');
+		.filter((c): c is ContentToolCall => c.type === 'tool-call' && c.state !== 'pending');
 }
 
 /**

--- a/packages/@n8n/agents/src/runtime/strip-orphaned-tool-messages.ts
+++ b/packages/@n8n/agents/src/runtime/strip-orphaned-tool-messages.ts
@@ -2,43 +2,17 @@ import { isLlmMessage } from '../sdk/message';
 import type { AgentMessage, MessageContent } from '../types/sdk/message';
 
 /**
- * Strip orphaned tool-call and tool-result content from a message list.
- *
- * When memory loads the last N messages, the window boundary can split
- * tool-call / tool-result pairs, leaving one side without its counterpart.
- * Sending these orphans to the LLM causes provider errors because tool
- * calls and results must always be paired.
+ * Strip pending tool-call blocks from a message list before sending to the LLM.
  *
  * This function:
- *  1. Collects all toolCallIds present in tool-call and tool-result blocks.
- *  2. Identifies orphans — calls without a matching result and vice-versa.
- *  3. Strips orphaned content blocks from their messages.
- *  4. Drops messages that become empty after stripping (e.g. a tool message
- *     whose only content was the orphaned result).
- *  5. Preserves non-tool content (text, reasoning, files) in mixed messages.
+ *  1. Drops any tool-call block whose state is 'pending'.
+ *  2. If a message becomes empty after stripping, drops the message entirely.
+ *  3. Preserves all other content (text, reasoning, files, resolved/rejected
+ *     tool-call blocks, and non-LLM custom messages).
+ *  4. Returns the original array reference when no pending blocks exist (no-op
+ *     fast path — avoids allocations on the common case).
  */
 export function stripOrphanedToolMessages<T extends AgentMessage>(messages: T[]): T[] {
-	const callIds = new Set<string>();
-	const resultIds = new Set<string>();
-
-	for (const msg of messages) {
-		if (!isLlmMessage(msg)) continue;
-		for (const block of msg.content) {
-			if (block.type === 'tool-call' && block.toolCallId) {
-				callIds.add(block.toolCallId);
-			} else if (block.type === 'tool-result' && block.toolCallId) {
-				resultIds.add(block.toolCallId);
-			}
-		}
-	}
-
-	const orphanedCallIds = new Set([...callIds].filter((id) => !resultIds.has(id)));
-	const orphanedResultIds = new Set([...resultIds].filter((id) => !callIds.has(id)));
-
-	if (orphanedCallIds.size === 0 && orphanedResultIds.size === 0) {
-		return messages;
-	}
-
 	const result: T[] = [];
 
 	for (const msg of messages) {
@@ -48,14 +22,7 @@ export function stripOrphanedToolMessages<T extends AgentMessage>(messages: T[])
 		}
 
 		const filtered = msg.content.filter((block: MessageContent) => {
-			if (block.type === 'tool-call' && block.toolCallId && orphanedCallIds.has(block.toolCallId)) {
-				return false;
-			}
-			if (
-				block.type === 'tool-result' &&
-				block.toolCallId &&
-				orphanedResultIds.has(block.toolCallId)
-			) {
+			if (block.type === 'tool-call' && block.state === 'pending') {
 				return false;
 			}
 			return true;

--- a/packages/@n8n/agents/src/runtime/strip-orphaned-tool-messages.ts
+++ b/packages/@n8n/agents/src/runtime/strip-orphaned-tool-messages.ts
@@ -9,8 +9,6 @@ import type { AgentMessage, MessageContent } from '../types/sdk/message';
  *  2. If a message becomes empty after stripping, drops the message entirely.
  *  3. Preserves all other content (text, reasoning, files, resolved/rejected
  *     tool-call blocks, and non-LLM custom messages).
- *  4. Returns the original array reference when no pending blocks exist (no-op
- *     fast path — avoids allocations on the common case).
  */
 export function stripOrphanedToolMessages<T extends AgentMessage>(messages: T[]): T[] {
 	const result: T[] = [];

--- a/packages/@n8n/agents/src/types/index.ts
+++ b/packages/@n8n/agents/src/types/index.ts
@@ -9,7 +9,6 @@ export type {
 	ContentReasoning,
 	ContentFile,
 	ContentToolCall,
-	ContentToolResult,
 	ContentInvalidToolCall,
 	ContentProvider,
 	Message,

--- a/packages/@n8n/agents/src/types/runtime/event.ts
+++ b/packages/@n8n/agents/src/types/runtime/event.ts
@@ -1,4 +1,4 @@
-import type { AgentMessage, ContentToolResult } from '../sdk/message';
+import type { AgentMessage, ContentToolCall } from '../sdk/message';
 
 export const enum AgentEvent {
 	AgentStart = 'agent_start',
@@ -14,7 +14,7 @@ export type AgentEventData =
 	| { type: AgentEvent.AgentStart }
 	| { type: AgentEvent.AgentEnd; messages: AgentMessage[] }
 	| { type: AgentEvent.TurnStart }
-	| { type: AgentEvent.TurnEnd; message: AgentMessage; toolResults: ContentToolResult[] }
+	| { type: AgentEvent.TurnEnd; message: AgentMessage; toolResults: ContentToolCall[] }
 	| { type: AgentEvent.ToolExecutionStart; toolCallId: string; toolName: string; args: unknown }
 	| {
 			type: AgentEvent.ToolExecutionEnd;

--- a/packages/@n8n/agents/src/types/sdk/message.ts
+++ b/packages/@n8n/agents/src/types/sdk/message.ts
@@ -8,7 +8,6 @@ export type MessageContent =
 	| ContentText
 	| ContentToolCall
 	| ContentInvalidToolCall
-	| ContentToolResult
 	| ContentReasoning
 	| ContentFile
 	| ContentCitation
@@ -104,31 +103,11 @@ export type ContentToolCall = ContentMetadata & {
 	input: JSONValue;
 
 	providerExecuted?: boolean;
-};
-
-export type ContentToolResult = ContentMetadata & {
-	type: 'tool-result';
-
-	/**
-	 * The name of the tool that was called.
-	 */
-	toolName: string;
-
-	/**
-	 * The ID of the tool call that this result is associated with.
-	 */
-	toolCallId: string;
-
-	/**
-	 * Result of the tool call. This is a JSON-serializable object.
-	 */
-	result: JSONValue;
-
-	/**
-	 * Optional flag if the result is an error or an error message.
-	 */
-	isError?: boolean;
-};
+} & (
+		| { state: 'pending' }
+		| { state: 'resolved'; output: JSONValue }
+		| { state: 'rejected'; error: string }
+	);
 
 export type ContentInvalidToolCall = ContentMetadata & {
 	type: 'invalid-tool-call';

--- a/packages/@n8n/api-types/src/agents.ts
+++ b/packages/@n8n/api-types/src/agents.ts
@@ -129,12 +129,14 @@ export interface AgentPublishedVersionDto {
  * introduce additional kinds.
  */
 export interface AgentPersistedMessageContentPart {
-	type: 'text' | 'reasoning' | 'tool-call' | 'tool-result' | (string & {});
+	type: 'text' | 'reasoning' | 'tool-call' | (string & {});
 	text?: string;
 	toolName?: string;
 	toolCallId?: string;
 	input?: unknown;
-	result?: unknown;
+	state?: string;
+	output?: unknown;
+	error?: string;
 }
 
 /**
@@ -148,7 +150,7 @@ export interface AgentPersistedMessageContentPart {
  */
 export interface AgentPersistedMessageDto {
 	id: string;
-	role: 'user' | 'assistant' | 'tool' | (string & {});
+	role: 'user' | 'assistant' | (string & {});
 	content: AgentPersistedMessageContentPart[];
 }
 

--- a/packages/cli/src/modules/agents/agent-message-mapper.ts
+++ b/packages/cli/src/modules/agents/agent-message-mapper.ts
@@ -9,7 +9,9 @@ export function contentPartToDto(part: MessageContent): AgentPersistedMessageCon
 		dto.toolCallId = part.toolCallId;
 	}
 	if ('input' in part) dto.input = part.input;
-	if ('result' in part) dto.result = part.result;
+	if ('state' in part && typeof part.state === 'string') dto.state = part.state;
+	if ('output' in part) dto.output = part.output;
+	if ('error' in part && typeof part.error === 'string') dto.error = part.error;
 	return dto;
 }
 

--- a/packages/cli/src/modules/agents/integrations/n8n-memory.ts
+++ b/packages/cli/src/modules/agents/integrations/n8n-memory.ts
@@ -8,8 +8,9 @@ import type {
 import { Service } from '@n8n/di';
 import type { FindOptionsWhere } from '@n8n/typeorm';
 import { LessThan } from '@n8n/typeorm';
+import type { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
 
-import { AgentMessageEntity } from '../entities/agent-message.entity';
+import type { AgentMessageEntity } from '../entities/agent-message.entity';
 import { AgentThreadEntity } from '../entities/agent-thread.entity';
 import { AgentMessageRepository } from '../repositories/agent-message.repository';
 import { AgentResourceRepository } from '../repositories/agent-resource.repository';
@@ -114,20 +115,27 @@ export class N8nMemory implements BuiltMemory {
 	}): Promise<void> {
 		if (args.messages.length === 0) return;
 
+		// Upsert by id — bulk INSERT … ON CONFLICT (id) DO UPDATE avoids the
+		// per-row SELECT that save() performs. createdAt is passed explicitly so
+		// the column is preserved on conflict; updatedAt is set manually because
+		// the @BeforeUpdate hook does not fire during upsert.
+		const now = new Date();
 		const entities = args.messages.map((dbMsg) => {
 			const role = 'role' in dbMsg ? (dbMsg.role as string) : 'custom';
 			const type = 'type' in dbMsg ? (dbMsg.type as string) : null;
-			return this.messageRepository.create({
+			return {
 				id: dbMsg.id,
 				threadId: args.threadId,
 				resourceId: args.resourceId,
 				role,
 				type: type ?? null,
 				content: dbMsg as unknown as Record<string, unknown>,
-			});
+				createdAt: dbMsg.createdAt,
+				updatedAt: now,
+			} as QueryDeepPartialEntity<AgentMessageEntity>;
 		});
 
-		await this.messageRepository.save(entities);
+		await this.messageRepository.upsert(entities, ['id']);
 	}
 
 	async deleteMessages(messageIds: string[]): Promise<void> {

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/agentChatMessages.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/agentChatMessages.test.ts
@@ -79,7 +79,7 @@ describe('rebuildInteractiveFromHistory', () => {
 });
 
 describe('convertDbMessages — interactive turn synthesis', () => {
-	it('reconstructs an OPEN interactive card when only the assistant message is persisted (suspended turn from checkpoint)', () => {
+	it('reconstructs an OPEN interactive card when tool-call block has state:pending', () => {
 		const dbMessages: AgentPersistedMessageDto[] = [
 			{
 				id: 'm1',
@@ -95,6 +95,7 @@ describe('convertDbMessages — interactive turn synthesis', () => {
 						toolName: ASK_LLM_TOOL_NAME,
 						toolCallId: 'call-llm-1',
 						input: { purpose: 'main' },
+						state: 'pending',
 					},
 				],
 			},
@@ -110,7 +111,7 @@ describe('convertDbMessages — interactive turn synthesis', () => {
 		expect(assistant.toolCalls?.[0].state).toBe('suspended');
 	});
 
-	it('reconstructs a RESOLVED interactive card when both assistant + tool-result are persisted', () => {
+	it('reconstructs a RESOLVED interactive card when tool-call block has state:resolved', () => {
 		const dbMessages: AgentPersistedMessageDto[] = [
 			{
 				id: 'm1',
@@ -127,31 +128,71 @@ describe('convertDbMessages — interactive turn synthesis', () => {
 								{ label: 'Discord', value: 'discord' },
 							],
 						},
-					},
-				],
-			},
-			{
-				id: 'm2',
-				role: 'tool',
-				content: [
-					{
-						type: 'tool-result',
-						toolName: ASK_QUESTION_TOOL_NAME,
-						toolCallId: 'q-1',
-						result: { values: ['slack'] },
+						state: 'resolved',
+						output: { values: ['slack'] },
 					},
 				],
 			},
 		];
 
 		const chat = convertDbMessages(dbMessages);
-		// Tool messages don't produce their own ChatMessage — they patch the assistant.
 		expect(chat).toHaveLength(1);
 		const assistant = chat[0];
 		expect(assistant.toolCalls?.[0].state).toBe('done');
+		expect(assistant.toolCalls?.[0].output).toEqual({ values: ['slack'] });
 		expect(assistant.interactive?.toolName).toBe(ASK_QUESTION_TOOL_NAME);
 		expect(assistant.interactive?.resolvedAt).toBeDefined();
 		expect(assistant.interactive?.resolvedValue).toEqual({ values: ['slack'] });
+	});
+
+	it('sets state:error when tool-call block is rejected', () => {
+		const dbMessages: AgentPersistedMessageDto[] = [
+			{
+				id: 'm1',
+				role: 'assistant',
+				content: [
+					{
+						type: 'tool-call',
+						toolName: 'delete_file',
+						toolCallId: 'tc-1',
+						input: { path: '/tmp/foo.txt' },
+						state: 'rejected',
+						error: 'Error: permission denied',
+					},
+				],
+			},
+		];
+
+		const chat = convertDbMessages(dbMessages);
+		expect(chat).toHaveLength(1);
+		const tc = chat[0].toolCalls?.[0];
+		expect(tc?.state).toBe('error');
+		expect(tc?.output).toBe('Error: permission denied');
+	});
+
+	it('treats state:resolved non-interactive tool call as done with output', () => {
+		const dbMessages: AgentPersistedMessageDto[] = [
+			{
+				id: 'm1',
+				role: 'assistant',
+				content: [
+					{
+						type: 'tool-call',
+						toolName: 'search_nodes',
+						toolCallId: 'tc-2',
+						input: { query: 'Slack' },
+						state: 'resolved',
+						output: [{ name: 'Slack' }],
+					},
+				],
+			},
+		];
+
+		const chat = convertDbMessages(dbMessages);
+		expect(chat).toHaveLength(1);
+		const tc = chat[0].toolCalls?.[0];
+		expect(tc?.state).toBe('done');
+		expect(tc?.output).toEqual([{ name: 'Slack' }]);
 	});
 });
 

--- a/packages/frontend/editor-ui/src/features/agents/composables/agentChatMessages.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/agentChatMessages.ts
@@ -258,9 +258,6 @@ export function rebuildInteractiveFromHistory(tc: ToolCall): InteractivePayload 
 /**
  * Convert persisted agent messages into the frontend ChatMessage format.
  *
- * Tool results are persisted in separate `role: 'tool'` messages. We walk
- * forward, attaching results back to the matching tool call by `toolCallId`.
- *
  * Whenever a tool call is interactive (one of the ask_* tools), we attach a
  * reconstructed `InteractivePayload` so the UI re-renders the card in either
  * its open (awaiting user) or resolved (disabled) state.
@@ -268,38 +265,8 @@ export function rebuildInteractiveFromHistory(tc: ToolCall): InteractivePayload 
 export function convertDbMessages(dbMessages: AgentPersistedMessageDto[]): ChatMessage[] {
 	const result: ChatMessage[] = [];
 
-	const applyToolResult = (toolName: string, toolCallId: string | undefined, output: unknown) => {
-		for (let i = result.length - 1; i >= 0; i--) {
-			const tcs = result[i].toolCalls;
-			if (!tcs) continue;
-			const match = tcs.find((t) =>
-				toolCallId ? t.toolCallId === toolCallId : t.tool === toolName && t.output === undefined,
-			);
-			if (match) {
-				match.output = output;
-				match.state = 'done';
-				// If this tool was an interactive one, refresh the parent message's
-				// `interactive` payload so the card flips to its resolved state.
-				if (isInteractiveToolName(match.tool)) {
-					const rebuilt = rebuildInteractiveFromHistory(match);
-					if (rebuilt) result[i].interactive = rebuilt;
-				}
-				return;
-			}
-		}
-	};
-
 	for (const msg of dbMessages) {
 		if (!msg.role || !Array.isArray(msg.content)) continue;
-
-		if (msg.role === 'tool') {
-			for (const part of msg.content) {
-				if (part.type === 'tool-result' && part.toolName) {
-					applyToolResult(part.toolName, part.toolCallId, part.result);
-				}
-			}
-			continue;
-		}
 
 		const role: ChatMessage['role'] | null =
 			msg.role === 'user' ? 'user' : msg.role === 'assistant' ? 'assistant' : null;
@@ -315,18 +282,25 @@ export function convertDbMessages(dbMessages: AgentPersistedMessageDto[]): ChatM
 			} else if (part.type === 'reasoning' && part.text) {
 				thinking += part.text;
 			} else if (part.type === 'tool-call' && part.toolName) {
+				let state: ToolCallState;
+				let output: unknown;
+				if (part.state === 'resolved') {
+					state = TOOL_CALL_STATE.DONE;
+					output = part.output;
+				} else if (part.state === 'rejected') {
+					state = TOOL_CALL_STATE.ERROR;
+					output = part.error;
+				} else {
+					state = TOOL_CALL_STATE.RUNNING;
+					output = undefined;
+				}
 				toolCalls.push({
 					tool: part.toolName,
 					toolCallId: part.toolCallId ?? '',
 					input: part.input,
-					state: 'running',
+					...(output !== undefined && { output }),
+					state,
 				});
-			} else if (part.type === 'tool-result' && part.toolName) {
-				const existing = toolCalls.find((t) => t.tool === part.toolName && t.output === undefined);
-				if (existing) {
-					existing.output = part.result;
-					existing.state = 'done';
-				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

This PR makes a breaking but needed change in @n8n/agents package. Now tool-call content blocks also contain tool results. Previous implementation stored tool result blocks as a separate content block, but it leads to some problems because AI SDK expects tool-result to always go after tool-call block. This change guarantees that this will always be the case

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-41/bug-tool-result-is-missing-for-tool-call-when-tool-result-arrives


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
