### PR TITLE
feat(Customer.io Trigger Node): Add webhook request verification

### DIFF
--- a/packages/nodes-base/credentials/CustomerIoApi.credentials.ts
+++ b/packages/nodes-base/credentials/CustomerIoApi.credentials.ts
@@ -57,6 +57,15 @@ export class CustomerIoApi implements ICredentialType {
 			default: '',
 			description: 'Required for App API',
 		},
+		{
+			displayName: 'Webhook Signing Key',
+			name: 'webhookSigningKey',
+			type: 'string',
+			typeOptions: { password: true },
+			default: '',
+			description:
+				'Used to verify webhook authenticity. Found in Customer.io under Integrations → Reporting Webhooks.',
+		},
 	];
 
 	async authenticate(

--- a/packages/nodes-base/credentials/CustomerIoApi.credentials.ts
+++ b/packages/nodes-base/credentials/CustomerIoApi.credentials.ts
@@ -57,6 +57,15 @@ export class CustomerIoApi implements ICredentialType {
 			default: '',
 			description: 'Required for App API',
 		},
+		{
+			displayName: 'Webhook Signing Key',
+			name: 'webhookSigningKey',
+			type: 'string',
+			typeOptions: { password: true },
+			default: '',
+			description:
+				'Used to verify the authenticity of Reporting Webhook requests. Find it in your Customer.io dashboard under Integrations > Reporting webhooks.',
+		},
 	];
 
 	async authenticate(

--- a/packages/nodes-base/nodes/CustomerIo/CustomerIoTrigger.node.ts
+++ b/packages/nodes-base/nodes/CustomerIo/CustomerIoTrigger.node.ts
@@ -7,6 +7,7 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 
+import { verifySignature } from './CustomerIoTriggerHelpers';
 import { customerIoApiRequest, eventExists, toApiEventName } from './GenericFunctions';
 
 export class CustomerIoTrigger implements INodeType {
@@ -281,6 +282,15 @@ export class CustomerIoTrigger implements INodeType {
 	};
 
 	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
+		const isSignatureValid = await verifySignature.call(this);
+		if (!isSignatureValid) {
+			const res = this.getResponseObject();
+			res.status(401).send('Unauthorized').end();
+			return {
+				noWebhookResponse: true,
+			};
+		}
+
 		const bodyData = this.getBodyData();
 		return {
 			workflowData: [this.helpers.returnJsonArray(bodyData)],

--- a/packages/nodes-base/nodes/CustomerIo/CustomerIoTriggerHelpers.ts
+++ b/packages/nodes-base/nodes/CustomerIo/CustomerIoTriggerHelpers.ts
@@ -1,0 +1,57 @@
+import { createHmac } from 'crypto';
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { verifySignature as verifySignatureGeneric } from '../../utils/webhook-signature-verification';
+
+/**
+ * Verifies the Customer.io reporting webhook signature.
+ *
+ * Customer.io signs reporting webhooks using HMAC SHA-256:
+ * 1. Combine the version, timestamp, and raw body as `v0:<timestamp>:<body>`
+ * 2. Compute the HMAC SHA-256 hash using the webhook signing key
+ * 3. Compare hex digest with the `X-CIO-Signature` header
+ *
+ * @returns true if the signature is valid, false otherwise
+ * @returns true if no signing key is configured (backward compatibility)
+ */
+export async function verifySignature(this: IWebhookFunctions): Promise<boolean> {
+	try {
+		const credential = await this.getCredentials('customerIoApi');
+		const req = this.getRequestObject();
+
+		const signingKey = credential?.webhookSigningKey;
+		const hasSigningKey = typeof signingKey === 'string' && signingKey.length > 0;
+
+		const timestamp = req.header('x-cio-timestamp');
+
+		return verifySignatureGeneric({
+			getExpectedSignature: () => {
+				if (!hasSigningKey || !timestamp || !req.rawBody) {
+					return null;
+				}
+
+				const hmac = createHmac('sha256', signingKey);
+
+				if (Buffer.isBuffer(req.rawBody)) {
+					hmac.update(`v0:${timestamp}:`);
+					hmac.update(req.rawBody);
+				} else {
+					const rawBodyString =
+						typeof req.rawBody === 'string' ? req.rawBody : JSON.stringify(req.rawBody);
+					hmac.update(`v0:${timestamp}:${rawBodyString}`);
+				}
+
+				return hmac.digest('hex');
+			},
+			skipIfNoExpectedSignature: !hasSigningKey,
+			getActualSignature: () => {
+				const actualSignature = req.header('x-cio-signature');
+				return typeof actualSignature === 'string' ? actualSignature : null;
+			},
+			getTimestamp: () => (typeof timestamp === 'string' ? timestamp : null),
+			skipIfNoTimestamp: !hasSigningKey,
+		});
+	} catch (error) {
+		return false;
+	}
+}

--- a/packages/nodes-base/nodes/CustomerIo/test/CustomerIoTrigger.test.ts
+++ b/packages/nodes-base/nodes/CustomerIo/test/CustomerIoTrigger.test.ts
@@ -1,0 +1,67 @@
+import { mock } from 'jest-mock-extended';
+import type { IWebhookFunctions, INodeType } from 'n8n-workflow';
+
+import { CustomerIoTrigger } from '../CustomerIoTrigger.node';
+
+jest.mock('../CustomerIoTriggerHelpers', () => ({
+	verifySignature: jest.fn(),
+}));
+
+import { verifySignature } from '../CustomerIoTriggerHelpers';
+
+describe('CustomerIoTrigger Node', () => {
+	let customerIoTrigger: INodeType;
+	let mockWebhookFunctions: ReturnType<typeof mock<IWebhookFunctions>>;
+
+	const mockBody = {
+		event_id: '01E4E0XXXXXXXXX',
+		event_type: 'email_delivered',
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		customerIoTrigger = new CustomerIoTrigger();
+		mockWebhookFunctions = mock<IWebhookFunctions>();
+
+		mockWebhookFunctions.helpers = {
+			returnJsonArray: jest.fn().mockImplementation((data) => [{ json: data }]),
+		} as any;
+
+		mockWebhookFunctions.getBodyData.mockReturnValue(mockBody);
+
+		mockWebhookFunctions.getResponseObject.mockReturnValue({
+			status: jest.fn().mockReturnThis(),
+			send: jest.fn().mockReturnThis(),
+			end: jest.fn(),
+		} as any);
+	});
+
+	describe('webhook method', () => {
+		it('should trigger workflow when signature is valid', async () => {
+			(verifySignature as jest.Mock).mockResolvedValue(true);
+
+			const result = await customerIoTrigger.webhook!.call(mockWebhookFunctions);
+
+			expect(result.workflowData).toBeDefined();
+			expect(result.workflowData![0][0].json).toEqual(mockBody);
+		});
+
+		it('should respond with 401 when signature is invalid', async () => {
+			(verifySignature as jest.Mock).mockResolvedValue(false);
+
+			const mockResponse = {
+				status: jest.fn().mockReturnThis(),
+				send: jest.fn().mockReturnThis(),
+				end: jest.fn(),
+			};
+			mockWebhookFunctions.getResponseObject.mockReturnValue(mockResponse as any);
+
+			const result = await customerIoTrigger.webhook!.call(mockWebhookFunctions);
+
+			expect(result).toEqual({ noWebhookResponse: true });
+			expect(mockResponse.status).toHaveBeenCalledWith(401);
+			expect(mockResponse.send).toHaveBeenCalledWith('Unauthorized');
+			expect(mockResponse.end).toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/nodes-base/nodes/CustomerIo/test/CustomerIoTrigger.test.ts
+++ b/packages/nodes-base/nodes/CustomerIo/test/CustomerIoTrigger.test.ts
@@ -1,0 +1,76 @@
+import { mock } from 'jest-mock-extended';
+import type { IWebhookFunctions, INodeType } from 'n8n-workflow';
+
+import { CustomerIoTrigger } from '../CustomerIoTrigger.node';
+
+jest.mock('../CustomerIoTriggerHelpers', () => ({
+	verifySignature: jest.fn(),
+}));
+
+import { verifySignature } from '../CustomerIoTriggerHelpers';
+
+describe('CustomerIoTrigger Node', () => {
+	let customerIoTrigger: INodeType;
+	let mockWebhookFunctions: ReturnType<typeof mock<IWebhookFunctions>>;
+
+	const mockBody = {
+		event_id: '01E4E0XXXXXXXXX',
+		event_type: 'email_delivered',
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		customerIoTrigger = new CustomerIoTrigger();
+		mockWebhookFunctions = mock<IWebhookFunctions>();
+
+		mockWebhookFunctions.helpers = {
+			returnJsonArray: jest.fn().mockImplementation((data) => [{ json: data }]),
+		} as any;
+
+		mockWebhookFunctions.getBodyData.mockReturnValue(mockBody);
+
+		mockWebhookFunctions.getResponseObject.mockReturnValue({
+			status: jest.fn().mockReturnThis(),
+			send: jest.fn().mockReturnThis(),
+			end: jest.fn(),
+		} as any);
+	});
+
+	describe('webhook method', () => {
+		it('should trigger workflow when signature is valid', async () => {
+			(verifySignature as jest.Mock).mockResolvedValue(true);
+
+			const result = await customerIoTrigger.webhook!.call(mockWebhookFunctions);
+
+			expect(result.workflowData).toBeDefined();
+			expect(result.workflowData![0][0].json).toEqual(mockBody);
+		});
+
+		it('should trigger workflow when no signing key is configured (backward compatibility)', async () => {
+			(verifySignature as jest.Mock).mockResolvedValue(true);
+
+			const result = await customerIoTrigger.webhook!.call(mockWebhookFunctions);
+
+			expect(result.workflowData).toBeDefined();
+			expect(result.workflowData![0][0].json).toEqual(mockBody);
+		});
+
+		it('should respond with 401 when signature is invalid', async () => {
+			(verifySignature as jest.Mock).mockResolvedValue(false);
+
+			const mockResponse = {
+				status: jest.fn().mockReturnThis(),
+				send: jest.fn().mockReturnThis(),
+				end: jest.fn(),
+			};
+			mockWebhookFunctions.getResponseObject.mockReturnValue(mockResponse as any);
+
+			const result = await customerIoTrigger.webhook!.call(mockWebhookFunctions);
+
+			expect(result).toEqual({ noWebhookResponse: true });
+			expect(mockResponse.status).toHaveBeenCalledWith(401);
+			expect(mockResponse.send).toHaveBeenCalledWith('Unauthorized');
+			expect(mockResponse.end).toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/nodes-base/nodes/CustomerIo/test/CustomerIoTrigger.test.ts
+++ b/packages/nodes-base/nodes/CustomerIo/test/CustomerIoTrigger.test.ts
@@ -46,15 +46,6 @@ describe('CustomerIoTrigger Node', () => {
 			expect(result.workflowData![0][0].json).toEqual(mockBody);
 		});
 
-		it('should trigger workflow when no signing key is configured (backward compatibility)', async () => {
-			(verifySignature as jest.Mock).mockResolvedValue(true);
-
-			const result = await customerIoTrigger.webhook!.call(mockWebhookFunctions);
-
-			expect(result.workflowData).toBeDefined();
-			expect(result.workflowData![0][0].json).toEqual(mockBody);
-		});
-
 		it('should respond with 401 when signature is invalid', async () => {
 			(verifySignature as jest.Mock).mockResolvedValue(false);
 

--- a/packages/nodes-base/nodes/CustomerIo/test/CustomerIoTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/CustomerIo/test/CustomerIoTriggerHelpers.test.ts
@@ -1,0 +1,189 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+
+import { verifySignature } from '../CustomerIoTriggerHelpers';
+
+jest.mock('crypto', () => ({
+	...jest.requireActual('crypto'),
+	createHmac: jest.fn().mockReturnValue({
+		update: jest.fn().mockReturnThis(),
+		digest: jest
+			.fn()
+			.mockReturnValue('a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503'),
+	}),
+	timingSafeEqual: jest.fn(),
+}));
+
+describe('CustomerIoTriggerHelpers', () => {
+	let mockWebhookFunctions: any;
+	const testSigningKey = 'test-signing-key';
+	const testTimestamp = '1531420618';
+	const testBody = '{"event_id":"01E4E0XXXXXXXXX","event_type":"email_delivered"}';
+	const testSignature = 'a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503';
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		// Mock Date.now() to return a fixed timestamp within the replay window
+		const fixedDate = new Date(parseInt(testTimestamp, 10) * 1000);
+		jest.spyOn(Date, 'now').mockImplementation(() => fixedDate.getTime());
+
+		mockWebhookFunctions = {
+			getCredentials: jest.fn(),
+			getRequestObject: jest.fn(),
+			getNode: jest.fn().mockReturnValue({ name: 'Customer.io Trigger' }),
+		};
+
+		mockWebhookFunctions.getRequestObject.mockReturnValue({
+			header: jest.fn().mockImplementation((header) => {
+				if (header === 'x-cio-signature') return testSignature;
+				if (header === 'x-cio-timestamp') return testTimestamp;
+				return null;
+			}),
+			rawBody: testBody,
+		});
+	});
+
+	describe('verifySignature', () => {
+		it('should return true when no signing key is configured (backward compatibility)', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+			expect(mockWebhookFunctions.getCredentials).toHaveBeenCalledWith('customerIoApi');
+		});
+
+		it('should return true when signing key is empty string (backward compatibility)', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				webhookSigningKey: '',
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return true when signature is valid', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				webhookSigningKey: testSigningKey,
+			});
+
+			(timingSafeEqual as jest.Mock).mockReturnValue(true);
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+			expect(createHmac).toHaveBeenCalledWith('sha256', testSigningKey);
+			expect(timingSafeEqual).toHaveBeenCalled();
+		});
+
+		it('should return false when signature is invalid', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				webhookSigningKey: testSigningKey,
+			});
+
+			(timingSafeEqual as jest.Mock).mockReturnValue(false);
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+			expect(createHmac).toHaveBeenCalledWith('sha256', testSigningKey);
+			expect(timingSafeEqual).toHaveBeenCalled();
+		});
+
+		it('should return false when signature header is missing', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				webhookSigningKey: testSigningKey,
+			});
+
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'x-cio-timestamp') return testTimestamp;
+					return null;
+				}),
+				rawBody: testBody,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when timestamp header is missing', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				webhookSigningKey: testSigningKey,
+			});
+
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'x-cio-signature') return testSignature;
+					return null;
+				}),
+				rawBody: testBody,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when timestamp is too old', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				webhookSigningKey: testSigningKey,
+			});
+
+			const futureDate = new Date((parseInt(testTimestamp, 10) + 301) * 1000);
+			jest.spyOn(Date, 'now').mockImplementation(() => futureDate.getTime());
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should build the signing string as v0:<timestamp>:<body>', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				webhookSigningKey: testSigningKey,
+			});
+
+			(timingSafeEqual as jest.Mock).mockReturnValue(true);
+
+			await verifySignature.call(mockWebhookFunctions);
+
+			expect(createHmac).toHaveBeenCalledWith('sha256', testSigningKey);
+			const mockHmac = createHmac('sha256', testSigningKey);
+			expect(mockHmac.update).toHaveBeenCalledWith(`v0:${testTimestamp}:${testBody}`);
+		});
+
+		it('should update HMAC with raw buffer when rawBody is a Buffer', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				webhookSigningKey: testSigningKey,
+			});
+
+			const rawBuffer = Buffer.from(testBody);
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'x-cio-signature') return testSignature;
+					if (header === 'x-cio-timestamp') return testTimestamp;
+					return null;
+				}),
+				rawBody: rawBuffer,
+			});
+
+			(timingSafeEqual as jest.Mock).mockReturnValue(true);
+
+			await verifySignature.call(mockWebhookFunctions);
+
+			const mockHmac = createHmac('sha256', testSigningKey);
+			expect(mockHmac.update).toHaveBeenCalledWith(`v0:${testTimestamp}:`);
+			expect(mockHmac.update).toHaveBeenCalledWith(rawBuffer);
+		});
+
+		it('should return false when getCredentials throws', async () => {
+			mockWebhookFunctions.getCredentials.mockRejectedValue(new Error('cred error'));
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds HMAC-SHA256 verification of the `X-CIO-Signature` header on incoming Customer.io reporting webhook requests.

- Adds an optional `Webhook Signing Key` field to the `Customer.io API` credential. The key can be found in the Customer.io dashboard under Integrations > Reporting webhooks.
- The trigger now computes `HMAC-SHA256("v0:<x-cio-timestamp>:<rawBody>", signingKey)` and compares (constant-time) it against `X-CIO-Signature`.
- Replay protection is enforced via the shared `verifySignature` utility (5 minute window on `X-CIO-Timestamp`).
- Invalid requests respond with `401 Unauthorized` and do not trigger the workflow.
- Backward compatible: when no signing key is set on the credential, verification is skipped so existing workflows keep running unchanged.

<img width="2502" height="1304" alt="2026-04-29 15 13 52" src="https://github.com/user-attachments/assets/474c0d5b-0175-4306-a0bf-a8c3d616c2a1" />

### Verification

Tested with [n8n-node-mocker](https://github.com/DawidMyslak/n8n-node-mocker):
- ✅ Correct secret → 200 OK
- ✅ Wrong secret → 401 Unauthorized

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4305

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.