### PR TITLE
feat(core): Fix user access control logic

### DIFF
--- a/packages/cli/src/services/__tests__/user.service.test.ts
+++ b/packages/cli/src/services/__tests__/user.service.test.ts
@@ -17,7 +17,6 @@ import { mock } from 'jest-mock-extended';
 import { v4 as uuid } from 'uuid';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
-import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { UrlService } from '@/services/url.service';
 import { UserService } from '@/services/user.service';
@@ -656,15 +655,12 @@ describe('UserService', () => {
 	});
 
 	describe('assertGetUsersAccess', () => {
-		it('should allow project admin to list all users', async () => {
+		it('should allow global member to list all users without project filter', async () => {
 			const member = Object.assign(new User(), { role: GLOBAL_MEMBER_ROLE });
-			projectService.getProjectIdsWithScope.mockResolvedValueOnce(['project-1']);
 
 			await expect(userService.assertGetUsersAccess(member)).resolves.toBeUndefined();
 
-			expect(projectService.getProjectIdsWithScope).toHaveBeenCalledWith(member, [
-				'project:update',
-			]);
+			expect(projectService.getProjectIdsWithScope).not.toHaveBeenCalled();
 		});
 
 		it('should allow non-admin members to list users by projectId', async () => {
@@ -676,13 +672,6 @@ describe('UserService', () => {
 			expect(projectService.getProjectWithScope).toHaveBeenCalledWith(member, 'project-1', [
 				'project:list',
 			]);
-		});
-
-		it('should throw ForbiddenError for member without project admin scope', async () => {
-			const member = Object.assign(new User(), { role: GLOBAL_MEMBER_ROLE });
-			projectService.getProjectIdsWithScope.mockResolvedValueOnce([]);
-
-			await expect(userService.assertGetUsersAccess(member)).rejects.toThrow(ForbiddenError);
 		});
 
 		it('should throw NotFoundError when filtering by unknown projectId', async () => {

--- a/packages/cli/src/services/user.service.ts
+++ b/packages/cli/src/services/user.service.ts
@@ -79,7 +79,6 @@ export class UserService {
 			}
 			return;
 		}
-		// Instance-wide listing is authorized by `user:list` on the REST and Public API routes.
 	}
 
 	async updateSettings(userId: string, newSettings: Partial<IUserSettings>) {

--- a/packages/cli/src/services/user.service.ts
+++ b/packages/cli/src/services/user.service.ts
@@ -23,7 +23,6 @@ import type { IUserSettings } from 'n8n-workflow';
 import { UserError } from 'n8n-workflow';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
-import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { EventService } from '@/events/event.service';
@@ -80,17 +79,7 @@ export class UserService {
 			}
 			return;
 		}
-		const isInstanceAdmin = ['global:owner', 'global:admin'].includes(user.role.slug);
-		if (isInstanceAdmin) {
-			return;
-		}
-		const hasProjectUpdateScope =
-			(await this.projectService.getProjectIdsWithScope(user, ['project:update'])).length > 0;
-		if (!hasProjectUpdateScope) {
-			throw new ForbiddenError(
-				'Listing all users is limited to instance administrators and project admins. Filter by project to list project members.',
-			);
-		}
+		// Instance-wide listing is authorized by `user:list` on the REST and Public API routes.
 	}
 
 	async updateSettings(userId: string, newSettings: Partial<IUserSettings>) {

--- a/packages/cli/test/integration/public-api/users.ee.test.ts
+++ b/packages/cli/test/integration/public-api/users.ee.test.ts
@@ -48,11 +48,13 @@ describe('With license unlimited quota:users', () => {
 			await authOwnerAgent.get('/users').expect(401);
 		});
 
-		test('should forbid global user list for a member API key', async () => {
+		test('should allow global user list for a member API key with user:list scope', async () => {
 			const member = await createMemberWithApiKey();
 			await createUser();
 
-			await testServer.publicApiAgentFor(member).get('/users').expect(403);
+			const response = await testServer.publicApiAgentFor(member).get('/users').expect(200);
+
+			expect(response.body.data.length).toBe(2);
 		});
 
 		test('should allow member to list users of a project they belong to', async () => {


### PR DESCRIPTION
## Summary

Allow listing users for all users with `user:list` scope. 
Permissions based on user roles is not in line with how we model permissions now.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ligo-479](https://linear.app/n8n/issue/LIGO-479/cant-invite-users-to-a-project)


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
