### PR TITLE
feat(Cal Trigger Node): Add webhook request verification

### DIFF
--- a/packages/nodes-base/nodes/Cal/CalTrigger.node.ts
+++ b/packages/nodes-base/nodes/Cal/CalTrigger.node.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'crypto';
 import {
 	type IDataObject,
 	type IHookFunctions,
@@ -10,6 +11,7 @@ import {
 	NodeConnectionTypes,
 } from 'n8n-workflow';
 
+import { verifySignature } from './CalTriggerHelpers';
 import { calApiRequest, sortOptionParameters } from './GenericFunctions';
 
 export class CalTrigger implements INodeType {
@@ -209,10 +211,13 @@ export class CalTrigger implements INodeType {
 				const options = this.getNodeParameter('options');
 				const active = true;
 
+				const webhookSecret = randomBytes(32).toString('hex');
+
 				const body = {
 					subscriberUrl,
 					eventTriggers,
 					active,
+					secret: webhookSecret,
 					...(options as object),
 				};
 
@@ -227,6 +232,7 @@ export class CalTrigger implements INodeType {
 				}
 
 				webhookData.webhookId = responseData.webhook.id as string;
+				webhookData.webhookSecret = webhookSecret;
 				return true;
 			},
 			async delete(this: IHookFunctions): Promise<boolean> {
@@ -247,6 +253,7 @@ export class CalTrigger implements INodeType {
 					// Remove from the static workflow data so that it is clear
 					// that no webhooks are registered anymore
 					delete webhookData.webhookId;
+					delete webhookData.webhookSecret;
 				}
 				return true;
 			},
@@ -254,6 +261,14 @@ export class CalTrigger implements INodeType {
 	};
 
 	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
+		if (!verifySignature.call(this)) {
+			const res = this.getResponseObject();
+			res.status(401).send('Unauthorized').end();
+			return {
+				noWebhookResponse: true,
+			};
+		}
+
 		const req = this.getRequestObject();
 		return {
 			workflowData: [

--- a/packages/nodes-base/nodes/Cal/CalTriggerHelpers.ts
+++ b/packages/nodes-base/nodes/Cal/CalTriggerHelpers.ts
@@ -1,0 +1,38 @@
+import { createHmac } from 'crypto';
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { verifySignature as verifySignatureGeneric } from '../../utils/webhook-signature-verification';
+
+/**
+ * Verifies the Cal.com webhook signature.
+ *
+ * Cal.com signs webhooks using HMAC SHA-256:
+ * 1. Create HMAC SHA-256 hash of the raw payload using the secret as key
+ * 2. Encode the hash as a hex string
+ * 3. Compare with the value in the `X-Cal-Signature-256` header
+ *
+ * @returns true if the signature is valid, false otherwise
+ * @returns true if no secret is configured (backward compatibility with old triggers)
+ */
+export function verifySignature(this: IWebhookFunctions): boolean {
+	const req = this.getRequestObject();
+	const webhookData = this.getWorkflowStaticData('node');
+	const secret = webhookData.webhookSecret;
+
+	return verifySignatureGeneric({
+		getExpectedSignature: () => {
+			if (!secret || typeof secret !== 'string' || !req.rawBody) {
+				return null;
+			}
+			const hmac = createHmac('sha256', secret);
+			const payload = Buffer.isBuffer(req.rawBody) ? req.rawBody : Buffer.from(req.rawBody);
+			hmac.update(payload);
+			return hmac.digest('hex');
+		},
+		skipIfNoExpectedSignature: !secret || typeof secret !== 'string',
+		getActualSignature: () => {
+			const receivedSignature = req.header('x-cal-signature-256');
+			return typeof receivedSignature === 'string' ? receivedSignature : null;
+		},
+	});
+}

--- a/packages/nodes-base/nodes/Cal/test/CalTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Cal/test/CalTrigger.node.test.ts
@@ -1,0 +1,260 @@
+import { randomBytes } from 'crypto';
+import type { IHookFunctions, IWebhookFunctions } from 'n8n-workflow';
+
+import { CalTrigger } from '../CalTrigger.node';
+import { verifySignature } from '../CalTriggerHelpers';
+import { calApiRequest } from '../GenericFunctions';
+
+jest.mock('../GenericFunctions');
+jest.mock('../CalTriggerHelpers');
+jest.mock('crypto', () => ({
+	...jest.requireActual('crypto'),
+	randomBytes: jest.fn(),
+}));
+
+describe('CalTrigger', () => {
+	let trigger: CalTrigger;
+	let mockHookFunctions: Pick<
+		jest.Mocked<IHookFunctions>,
+		'getNodeWebhookUrl' | 'getNodeParameter' | 'getWorkflowStaticData' | 'helpers'
+	>;
+	let mockWebhookFunctions: Pick<
+		jest.Mocked<IWebhookFunctions>,
+		'getRequestObject' | 'getResponseObject' | 'helpers'
+	>;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		trigger = new CalTrigger();
+
+		mockHookFunctions = {
+			getNodeWebhookUrl: jest.fn(),
+			getNodeParameter: jest.fn(),
+			getWorkflowStaticData: jest.fn(),
+			helpers: {} as any,
+		};
+
+		mockWebhookFunctions = {
+			getRequestObject: jest.fn(),
+			getResponseObject: jest.fn(),
+			helpers: {
+				returnJsonArray: jest.fn((data) => data),
+			} as any,
+		};
+	});
+
+	describe('webhookMethods.default.create', () => {
+		it('should create webhook with auto-generated secret on v2', async () => {
+			const subscriberUrl = 'https://example.com/webhook';
+			const events = ['BOOKING_CREATED'];
+			const webhookSecret = 'a'.repeat(64);
+			const webhookId = 'webhook-123';
+
+			mockHookFunctions.getNodeWebhookUrl.mockReturnValue(subscriberUrl);
+			mockHookFunctions.getNodeParameter.mockImplementation((name) => {
+				if (name === 'version') return 2;
+				if (name === 'events') return events;
+				if (name === 'options') return {};
+				return undefined;
+			});
+
+			const webhookData: any = {};
+			mockHookFunctions.getWorkflowStaticData.mockReturnValue(webhookData);
+
+			(randomBytes as jest.Mock).mockReturnValue({
+				toString: jest.fn().mockReturnValue(webhookSecret),
+			});
+			(calApiRequest as jest.Mock).mockResolvedValue({
+				webhook: { id: webhookId },
+			});
+
+			const result = await trigger.webhookMethods!.default.create.call(
+				mockHookFunctions as unknown as IHookFunctions,
+			);
+
+			expect(result).toBe(true);
+			expect(randomBytes).toHaveBeenCalledWith(32);
+			expect(calApiRequest).toHaveBeenCalledWith('POST', '/webhooks', {
+				subscriberUrl,
+				eventTriggers: events,
+				active: true,
+				secret: webhookSecret,
+			});
+			expect(webhookData.webhookId).toBe(webhookId);
+			expect(webhookData.webhookSecret).toBe(webhookSecret);
+		});
+
+		it('should create webhook with auto-generated secret on v1', async () => {
+			const subscriberUrl = 'https://example.com/webhook';
+			const events = ['BOOKING_CREATED'];
+			const webhookSecret = 'b'.repeat(64);
+			const webhookId = 'webhook-321';
+
+			mockHookFunctions.getNodeWebhookUrl.mockReturnValue(subscriberUrl);
+			mockHookFunctions.getNodeParameter.mockImplementation((name) => {
+				if (name === 'version') return 1;
+				if (name === 'events') return events;
+				if (name === 'options') return {};
+				return undefined;
+			});
+
+			const webhookData: any = {};
+			mockHookFunctions.getWorkflowStaticData.mockReturnValue(webhookData);
+
+			(randomBytes as jest.Mock).mockReturnValue({
+				toString: jest.fn().mockReturnValue(webhookSecret),
+			});
+			(calApiRequest as jest.Mock).mockResolvedValue({
+				webhook: { id: webhookId },
+			});
+
+			const result = await trigger.webhookMethods!.default.create.call(
+				mockHookFunctions as unknown as IHookFunctions,
+			);
+
+			expect(result).toBe(true);
+			expect(calApiRequest).toHaveBeenCalledWith('POST', '/hooks', {
+				subscriberUrl,
+				eventTriggers: events,
+				active: true,
+				secret: webhookSecret,
+			});
+			expect(webhookData.webhookId).toBe(webhookId);
+			expect(webhookData.webhookSecret).toBe(webhookSecret);
+		});
+
+		it('should return false when API does not return a webhook id', async () => {
+			mockHookFunctions.getNodeWebhookUrl.mockReturnValue('https://example.com/webhook');
+			mockHookFunctions.getNodeParameter.mockImplementation((name) => {
+				if (name === 'version') return 2;
+				if (name === 'events') return ['BOOKING_CREATED'];
+				if (name === 'options') return {};
+				return undefined;
+			});
+
+			const webhookData: any = {};
+			mockHookFunctions.getWorkflowStaticData.mockReturnValue(webhookData);
+
+			(randomBytes as jest.Mock).mockReturnValue({
+				toString: jest.fn().mockReturnValue('secret'),
+			});
+			(calApiRequest as jest.Mock).mockResolvedValue({ webhook: {} });
+
+			const result = await trigger.webhookMethods!.default.create.call(
+				mockHookFunctions as unknown as IHookFunctions,
+			);
+
+			expect(result).toBe(false);
+			expect(webhookData.webhookId).toBeUndefined();
+			expect(webhookData.webhookSecret).toBeUndefined();
+		});
+	});
+
+	describe('webhookMethods.default.delete', () => {
+		it('should delete webhook and clean up secret', async () => {
+			const webhookId = 'webhook-123';
+
+			mockHookFunctions.getNodeParameter.mockReturnValue(2);
+
+			const webhookData: any = {
+				webhookId,
+				webhookSecret: 'test-secret',
+			};
+			mockHookFunctions.getWorkflowStaticData.mockReturnValue(webhookData);
+
+			(calApiRequest as jest.Mock).mockResolvedValue({});
+
+			const result = await trigger.webhookMethods!.default.delete.call(
+				mockHookFunctions as unknown as IHookFunctions,
+			);
+
+			expect(result).toBe(true);
+			expect(calApiRequest).toHaveBeenCalledWith('DELETE', `/webhooks/${webhookId}`);
+			expect(webhookData.webhookId).toBeUndefined();
+			expect(webhookData.webhookSecret).toBeUndefined();
+		});
+
+		it('should return true when no webhookId is set', async () => {
+			mockHookFunctions.getNodeParameter.mockReturnValue(2);
+			mockHookFunctions.getWorkflowStaticData.mockReturnValue({});
+
+			const result = await trigger.webhookMethods!.default.delete.call(
+				mockHookFunctions as unknown as IHookFunctions,
+			);
+
+			expect(result).toBe(true);
+			expect(calApiRequest).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('webhook', () => {
+		it('should return 401 when signature verification fails', async () => {
+			const mockResponse = {
+				status: jest.fn().mockReturnThis(),
+				send: jest.fn().mockReturnThis(),
+				end: jest.fn(),
+			};
+
+			(verifySignature as jest.Mock).mockReturnValue(false);
+			mockWebhookFunctions.getResponseObject.mockReturnValue(mockResponse as any);
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(verifySignature).toHaveBeenCalled();
+			expect(mockResponse.status).toHaveBeenCalledWith(401);
+			expect(mockResponse.send).toHaveBeenCalledWith('Unauthorized');
+			expect(result).toEqual({
+				noWebhookResponse: true,
+			});
+		});
+
+		it('should process webhook when signature verification passes', async () => {
+			const requestBody = {
+				triggerEvent: 'BOOKING_CREATED',
+				createdAt: '2024-01-01T00:00:00Z',
+				payload: { bookingId: 'abc-123' },
+			};
+
+			(verifySignature as jest.Mock).mockReturnValue(true);
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				body: requestBody,
+			} as any);
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(verifySignature).toHaveBeenCalled();
+			expect(result.workflowData).toEqual([
+				{
+					triggerEvent: 'BOOKING_CREATED',
+					createdAt: '2024-01-01T00:00:00Z',
+					bookingId: 'abc-123',
+				},
+			]);
+		});
+
+		it('should process webhook when no secret is configured (backward compatibility)', async () => {
+			const requestBody = {
+				triggerEvent: 'BOOKING_CREATED',
+				createdAt: '2024-01-01T00:00:00Z',
+				payload: {},
+			};
+
+			// verifySignature returns true when no secret is configured (skip behaviour)
+			(verifySignature as jest.Mock).mockReturnValue(true);
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				body: requestBody,
+			} as any);
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(verifySignature).toHaveBeenCalled();
+			expect(result.workflowData).toBeDefined();
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Cal/test/CalTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Cal/test/CalTrigger.node.test.ts
@@ -235,26 +235,5 @@ describe('CalTrigger', () => {
 				},
 			]);
 		});
-
-		it('should process webhook when no secret is configured (backward compatibility)', async () => {
-			const requestBody = {
-				triggerEvent: 'BOOKING_CREATED',
-				createdAt: '2024-01-01T00:00:00Z',
-				payload: {},
-			};
-
-			// verifySignature returns true when no secret is configured (skip behaviour)
-			(verifySignature as jest.Mock).mockReturnValue(true);
-			mockWebhookFunctions.getRequestObject.mockReturnValue({
-				body: requestBody,
-			} as any);
-
-			const result = await trigger.webhook.call(
-				mockWebhookFunctions as unknown as IWebhookFunctions,
-			);
-
-			expect(verifySignature).toHaveBeenCalled();
-			expect(result.workflowData).toBeDefined();
-		});
 	});
 });

--- a/packages/nodes-base/nodes/Cal/test/CalTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Cal/test/CalTriggerHelpers.test.ts
@@ -1,0 +1,122 @@
+import { createHmac } from 'crypto';
+
+import { verifySignature } from '../CalTriggerHelpers';
+
+describe('CalTriggerHelpers', () => {
+	let mockWebhookFunctions: any;
+	const testSecret = 'test-secret-key-12345';
+	const testPayload = Buffer.from('{"triggerEvent":"BOOKING_CREATED"}');
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		mockWebhookFunctions = {
+			getRequestObject: jest.fn(),
+			getWorkflowStaticData: jest.fn(),
+		};
+	});
+
+	describe('verifySignature', () => {
+		it('should return true if no secret is configured', () => {
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(null),
+				rawBody: testPayload,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return true if signatures match', () => {
+			const hmac = createHmac('sha256', testSecret);
+			hmac.update(testPayload);
+			const expectedSignature = hmac.digest('hex');
+
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				webhookSecret: testSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'x-cal-signature-256') return expectedSignature;
+					return null;
+				}),
+				rawBody: testPayload,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false if signatures do not match', () => {
+			const wrongSignature = 'a'.repeat(64);
+
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				webhookSecret: testSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'x-cal-signature-256') return wrongSignature;
+					return null;
+				}),
+				rawBody: testPayload,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false if signature header is missing', () => {
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				webhookSecret: testSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(null),
+				rawBody: testPayload,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false if rawBody is missing but secret is configured', () => {
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				webhookSecret: testSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue('any-signature'),
+				rawBody: undefined,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should accept rawBody as a string', () => {
+			const stringPayload = '{"triggerEvent":"BOOKING_CREATED"}';
+			const hmac = createHmac('sha256', testSecret);
+			hmac.update(Buffer.from(stringPayload));
+			const expectedSignature = hmac.digest('hex');
+
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				webhookSecret: testSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'x-cal-signature-256') return expectedSignature;
+					return null;
+				}),
+				rawBody: stringPayload,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Add HMAC SHA-256 signature verification for incoming Cal.com webhook requests using the `X-Cal-Signature-256` header. A signing secret is auto-generated on webhook creation and persisted in workflow static data. Existing webhooks without a stored secret continue to work unchanged.

<img width="2502" height="1304" alt="2026-04-29 16 17 10" src="https://github.com/user-attachments/assets/54902e2d-33a9-4dd0-a0b6-650a7229d995" />

### Verification

Tested with [n8n-node-mocker](https://github.com/DawidMyslak/n8n-node-mocker):
- ✅ Correct secret → 200 OK
- ✅ Wrong secret → 401 Unauthorized

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4303

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.