### PR TITLE
feat(Onfleet Trigger Node): Add webhook request verification

### DIFF
--- a/packages/nodes-base/credentials/OnfleetApi.credentials.ts
+++ b/packages/nodes-base/credentials/OnfleetApi.credentials.ts
@@ -15,5 +15,14 @@ export class OnfleetApi implements ICredentialType {
 			typeOptions: { password: true },
 			default: '',
 		},
+		{
+			displayName: 'Signing Secret',
+			name: 'signingSecret',
+			type: 'string',
+			typeOptions: { password: true },
+			default: '',
+			description:
+				'Used to verify webhook authenticity. Found in Onfleet under Settings → API & Webhooks.',
+		},
 	];
 }

--- a/packages/nodes-base/credentials/OnfleetApi.credentials.ts
+++ b/packages/nodes-base/credentials/OnfleetApi.credentials.ts
@@ -15,5 +15,14 @@ export class OnfleetApi implements ICredentialType {
 			typeOptions: { password: true },
 			default: '',
 		},
+		{
+			displayName: 'Signing Secret',
+			name: 'signingSecret',
+			type: 'string',
+			typeOptions: { password: true },
+			default: '',
+			description:
+				'Used to verify webhook authenticity. Find it in your Onfleet dashboard under Configuration → API & Webhooks → Show Secret.',
+		},
 	];
 }

--- a/packages/nodes-base/nodes/Onfleet/OnfleetTrigger.node.ts
+++ b/packages/nodes-base/nodes/Onfleet/OnfleetTrigger.node.ts
@@ -11,6 +11,7 @@ import { NodeApiError, NodeConnectionTypes, NodeOperationError } from 'n8n-workf
 
 import { eventDisplay, eventNameField } from './descriptions/OnfleetWebhookDescription';
 import { onfleetApiRequest } from './GenericFunctions';
+import { verifySignature } from './OnfleetTriggerHelpers';
 import { webhookMapping } from './WebhookMapping';
 
 export class OnfleetTrigger implements INodeType {
@@ -139,6 +140,13 @@ export class OnfleetTrigger implements INodeType {
 			/* -------------------------------------------------------------------------- */
 			const res = this.getResponseObject();
 			res.status(200).type('text/plain').send(req.query.check);
+			return { noWebhookResponse: true };
+		}
+
+		const isSignatureValid = await verifySignature.call(this);
+		if (!isSignatureValid) {
+			const res = this.getResponseObject();
+			res.status(401).send('Unauthorized').end();
 			return { noWebhookResponse: true };
 		}
 

--- a/packages/nodes-base/nodes/Onfleet/OnfleetTriggerHelpers.ts
+++ b/packages/nodes-base/nodes/Onfleet/OnfleetTriggerHelpers.ts
@@ -1,0 +1,33 @@
+import { createHmac } from 'crypto';
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { verifySignature as verifySignatureGeneric } from '../../utils/webhook-signature-verification';
+
+export async function verifySignature(this: IWebhookFunctions): Promise<boolean> {
+	try {
+		const credential = await this.getCredentials('onfleetApi');
+		const req = this.getRequestObject();
+		const signingSecret = credential.signingSecret;
+
+		return verifySignatureGeneric({
+			getExpectedSignature: () => {
+				if (!signingSecret || typeof signingSecret !== 'string' || !req.rawBody) {
+					return null;
+				}
+
+				const secretBuffer = Buffer.from(signingSecret, 'hex');
+				const hmac = createHmac('sha512', secretBuffer);
+				const payload = Buffer.isBuffer(req.rawBody) ? req.rawBody : Buffer.from(req.rawBody);
+				hmac.update(payload);
+				return hmac.digest('hex');
+			},
+			skipIfNoExpectedSignature: !signingSecret || typeof signingSecret !== 'string',
+			getActualSignature: () => {
+				const sig = req.header('x-onfleet-signature');
+				return typeof sig === 'string' ? sig : null;
+			},
+		});
+	} catch (error) {
+		return false;
+	}
+}

--- a/packages/nodes-base/nodes/Onfleet/test/OnfleetTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Onfleet/test/OnfleetTrigger.node.test.ts
@@ -1,3 +1,4 @@
+import { createHmac } from 'crypto';
 import type { IWebhookFunctions } from 'n8n-workflow';
 
 import { OnfleetTrigger } from '../OnfleetTrigger.node';
@@ -6,6 +7,15 @@ describe('Onfleet Trigger Node', () => {
 	let node: OnfleetTrigger;
 	let mockWebhookFunctions: IWebhookFunctions;
 
+	const testSecretHex = 'a'.repeat(64);
+	const testBody = '{"taskId":"task123","actionContext":"COMPLETE"}';
+
+	const computeSignature = (secretHex: string, body: string): string => {
+		const hmac = createHmac('sha512', Buffer.from(secretHex, 'hex'));
+		hmac.update(Buffer.from(body));
+		return hmac.digest('hex');
+	};
+
 	beforeEach(() => {
 		node = new OnfleetTrigger();
 		mockWebhookFunctions = {
@@ -13,6 +23,7 @@ describe('Onfleet Trigger Node', () => {
 			getRequestObject: jest.fn(),
 			getResponseObject: jest.fn(),
 			getBodyData: jest.fn(),
+			getCredentials: jest.fn(),
 			helpers: {
 				returnJsonArray: jest.fn().mockImplementation((data) => [{ json: data }]),
 			},
@@ -48,19 +59,24 @@ describe('Onfleet Trigger Node', () => {
 		});
 
 		describe('default webhook', () => {
-			it('should process incoming webhook data', async () => {
-				const mockRequestData = {
-					taskId: 'task123',
-					workerId: 'worker456',
-					actionContext: 'COMPLETE',
-				};
+			const mockRequestData = {
+				taskId: 'task123',
+				workerId: 'worker456',
+				actionContext: 'COMPLETE',
+			};
 
+			it('should process the request when no signing secret is configured (backward compatibility)', async () => {
 				const mockRequest = {
 					query: {},
+					header: jest.fn().mockReturnValue(undefined),
+					rawBody: Buffer.from(testBody),
 				};
 
 				(mockWebhookFunctions.getWebhookName as jest.Mock).mockReturnValue('default');
 				(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue(mockRequest);
+				(mockWebhookFunctions.getCredentials as jest.Mock).mockResolvedValue({
+					apiKey: 'test-api-key',
+				});
 				(mockWebhookFunctions.getBodyData as jest.Mock).mockReturnValue(mockRequestData);
 
 				const result = await node.webhook.call(mockWebhookFunctions);
@@ -68,7 +84,65 @@ describe('Onfleet Trigger Node', () => {
 				expect(result).toEqual({
 					workflowData: [[{ json: mockRequestData }]],
 				});
-				expect(mockWebhookFunctions.helpers.returnJsonArray).toHaveBeenCalledWith(mockRequestData);
+			});
+
+			it('should process the request when the signature is valid', async () => {
+				const validSignature = computeSignature(testSecretHex, testBody);
+				const mockRequest = {
+					query: {},
+					header: jest.fn().mockImplementation((header: string) => {
+						if (header === 'x-onfleet-signature') return validSignature;
+						return undefined;
+					}),
+					rawBody: Buffer.from(testBody),
+				};
+
+				(mockWebhookFunctions.getWebhookName as jest.Mock).mockReturnValue('default');
+				(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue(mockRequest);
+				(mockWebhookFunctions.getCredentials as jest.Mock).mockResolvedValue({
+					apiKey: 'test-api-key',
+					signingSecret: testSecretHex,
+				});
+				(mockWebhookFunctions.getBodyData as jest.Mock).mockReturnValue(mockRequestData);
+
+				const result = await node.webhook.call(mockWebhookFunctions);
+
+				expect(result).toEqual({
+					workflowData: [[{ json: mockRequestData }]],
+				});
+			});
+
+			it('should respond with 401 and not trigger the workflow when the signature is invalid', async () => {
+				const mockRequest = {
+					query: {},
+					header: jest.fn().mockImplementation((header: string) => {
+						if (header === 'x-onfleet-signature') return 'f'.repeat(128);
+						return undefined;
+					}),
+					rawBody: Buffer.from(testBody),
+				};
+
+				const mockResponse = {
+					status: jest.fn().mockReturnThis(),
+					send: jest.fn().mockReturnThis(),
+					end: jest.fn().mockReturnThis(),
+				};
+
+				(mockWebhookFunctions.getWebhookName as jest.Mock).mockReturnValue('default');
+				(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue(mockRequest);
+				(mockWebhookFunctions.getResponseObject as jest.Mock).mockReturnValue(mockResponse);
+				(mockWebhookFunctions.getCredentials as jest.Mock).mockResolvedValue({
+					apiKey: 'test-api-key',
+					signingSecret: testSecretHex,
+				});
+
+				const result = await node.webhook.call(mockWebhookFunctions);
+
+				expect(mockResponse.status).toHaveBeenCalledWith(401);
+				expect(mockResponse.send).toHaveBeenCalledWith('Unauthorized');
+				expect(mockResponse.end).toHaveBeenCalled();
+				expect(result).toEqual({ noWebhookResponse: true });
+				expect(mockWebhookFunctions.getBodyData).not.toHaveBeenCalled();
 			});
 		});
 	});

--- a/packages/nodes-base/nodes/Onfleet/test/OnfleetTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Onfleet/test/OnfleetTriggerHelpers.test.ts
@@ -1,0 +1,123 @@
+import { createHmac } from 'crypto';
+
+import { verifySignature } from '../OnfleetTriggerHelpers';
+
+describe('OnfleetTriggerHelpers', () => {
+	const testSecretHex = 'a'.repeat(64);
+	const testBody = '{"taskId":"task123","actionContext":"COMPLETE"}';
+
+	const computeSignature = (secretHex: string, body: string): string => {
+		const hmac = createHmac('sha512', Buffer.from(secretHex, 'hex'));
+		hmac.update(Buffer.from(body));
+		return hmac.digest('hex');
+	};
+
+	const validSignature = computeSignature(testSecretHex, testBody);
+
+	let mockWebhookFunctions: any;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		mockWebhookFunctions = {
+			getCredentials: jest.fn(),
+			getRequestObject: jest.fn(),
+		};
+
+		mockWebhookFunctions.getRequestObject.mockReturnValue({
+			header: jest.fn().mockImplementation((header: string) => {
+				if (header === 'x-onfleet-signature') return validSignature;
+				return undefined;
+			}),
+			rawBody: Buffer.from(testBody),
+		});
+	});
+
+	describe('verifySignature', () => {
+		it('returns true when no credentials are provided (backward compatibility)', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+			expect(mockWebhookFunctions.getCredentials).toHaveBeenCalledWith('onfleetApi');
+		});
+
+		it('returns true when no signing secret is configured (backward compatibility)', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				apiKey: 'test-api-key',
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('returns true when signature is valid', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				apiKey: 'test-api-key',
+				signingSecret: testSecretHex,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('returns false when signature is invalid', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				signingSecret: testSecretHex,
+			});
+
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header: string) => {
+					if (header === 'x-onfleet-signature') return 'f'.repeat(128);
+					return undefined;
+				}),
+				rawBody: Buffer.from(testBody),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('returns false when signature header is missing', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				signingSecret: testSecretHex,
+			});
+
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(undefined),
+				rawBody: Buffer.from(testBody),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('returns false when raw body is missing', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				signingSecret: testSecretHex,
+			});
+
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(validSignature),
+				rawBody: undefined,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('returns false when getCredentials throws', async () => {
+			mockWebhookFunctions.getCredentials.mockRejectedValue(new Error('credentials not found'));
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Onfleet/test/OnfleetTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Onfleet/test/OnfleetTriggerHelpers.test.ts
@@ -1,0 +1,144 @@
+import { createHmac } from 'crypto';
+
+import { verifySignature } from '../OnfleetTriggerHelpers';
+
+describe('OnfleetTriggerHelpers', () => {
+	const testSecretHex = 'a'.repeat(64);
+	const testBody = '{"taskId":"task123","actionContext":"COMPLETE"}';
+
+	const computeSignature = (secretHex: string, body: string): string => {
+		const hmac = createHmac('sha512', Buffer.from(secretHex, 'hex'));
+		hmac.update(Buffer.from(body));
+		return hmac.digest('hex');
+	};
+
+	const validSignature = computeSignature(testSecretHex, testBody);
+
+	let mockWebhookFunctions: any;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		mockWebhookFunctions = {
+			getCredentials: jest.fn(),
+			getRequestObject: jest.fn(),
+		};
+
+		mockWebhookFunctions.getRequestObject.mockReturnValue({
+			header: jest.fn().mockImplementation((header: string) => {
+				if (header === 'x-onfleet-signature') return validSignature;
+				return undefined;
+			}),
+			rawBody: Buffer.from(testBody),
+		});
+	});
+
+	describe('verifySignature', () => {
+		it('returns true when no credentials are provided (backward compatibility)', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+			expect(mockWebhookFunctions.getCredentials).toHaveBeenCalledWith('onfleetApi');
+		});
+
+		it('returns true when no signing secret is configured (backward compatibility)', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				apiKey: 'test-api-key',
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('returns true when signature is valid', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				apiKey: 'test-api-key',
+				signingSecret: testSecretHex,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('returns false when signature is invalid', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				signingSecret: testSecretHex,
+			});
+
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header: string) => {
+					if (header === 'x-onfleet-signature') return 'f'.repeat(128);
+					return undefined;
+				}),
+				rawBody: Buffer.from(testBody),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('returns false when signature header is missing', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				signingSecret: testSecretHex,
+			});
+
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(undefined),
+				rawBody: Buffer.from(testBody),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('returns false when raw body is missing', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				signingSecret: testSecretHex,
+			});
+
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(validSignature),
+				rawBody: undefined,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('returns false when getCredentials throws', async () => {
+			mockWebhookFunctions.getCredentials.mockRejectedValue(new Error('credentials not found'));
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('uses HMAC-SHA512 with hex-decoded secret over the raw body', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				signingSecret: testSecretHex,
+			});
+
+			const customBody = '{"foo":"bar"}';
+			const expectedSig = computeSignature(testSecretHex, customBody);
+
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header: string) => {
+					if (header === 'x-onfleet-signature') return expectedSig;
+					return undefined;
+				}),
+				rawBody: Buffer.from(customBody),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds optional HMAC-SHA512 verification of incoming webhook requests in the Onfleet Trigger node, using the `X-Onfleet-Signature` header.

- New optional `Signing Secret` field on the Onfleet API credential. When set, every incoming webhook is verified against the request body using the secret (hex-decoded) and HMAC-SHA512; mismatches are rejected with `401 Unauthorized`.
- When no signing secret is configured, verification is skipped to keep existing workflows working without changes.
- The setup (validation) request that Onfleet sends with `?check=...` continues to bypass signature checks.

<img width="2502" height="1304" alt="2026-04-30 11 33 03" src="https://github.com/user-attachments/assets/1e8b65da-cfc1-49c6-a2f2-27dbcddee7ed" />


### Verification

Tested with [n8n-node-mocker](https://github.com/DawidMyslak/n8n-node-mocker):
- ✅ Correct secret → 200 OK
- ✅ Wrong secret → 401 Unauthorized

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4314

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

🤖 PR Summary generated by AI