### PR TITLE
ci: Bump safe-chain to v1.5.1 and use safe-mode retry (no-changelog)

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -46,12 +46,11 @@ runs:
         fi
 
     - name: Install Aikido SafeChain
-      if: runner.os != 'Windows'
       run: |
-        VERSION="1.4.1"
-        EXPECTED_SHA256="628235987175072a4255aa3f5f0128f31795b63970f1970ae8a04d07bf8527b0"
-        node .github/scripts/retry.mjs --attempts 3 --delay 10 \
-          "curl -fsSL -o install-safe-chain.sh https://github.com/AikidoSec/safe-chain/releases/download/${VERSION}/install-safe-chain.sh"
+        VERSION="1.5.1"
+        EXPECTED_SHA256="7c910fff717649c86cc8ca960e6c054d3734da2d660050e3bcfc54029e3b485b"
+        node .github/scripts/retry.mjs --attempts 3 --delay 10 -- \
+          curl -fsSL -o install-safe-chain.sh "https://github.com/AikidoSec/safe-chain/releases/download/${VERSION}/install-safe-chain.sh"
         echo "${EXPECTED_SHA256}  install-safe-chain.sh" | sha256sum -c -
         sh install-safe-chain.sh --ci
         rm install-safe-chain.sh
@@ -60,14 +59,9 @@ runs:
     - name: Install Dependencies
       if: ${{ inputs.install-command != '' }}
       env:
-        INSTALL_COMMAND: ${{ inputs.install-command }}
+        INSTALL_COMMAND: ${{ inputs.install-command }}
       run: |
         $INSTALL_COMMAND
-      shell: bash
-
-    - name: Disable safe-chain
-      if: runner.os != 'Windows'
-      run: safe-chain teardown
       shell: bash
 
     - name: Configure Turborepo Cache


### PR DESCRIPTION
## Summary

- Bump Aikido SafeChain from v1.4.1 to v1.5.1 with updated SHA256 checksum
- Switch retry script to safe mode (`--` separator) so `curl` is spawned directly without shell interpolation
- Remove `if: runner.os != 'Windows'` guards (no longer needed in v1.5.1)
- Remove `safe-chain teardown` step (no longer needed in v1.5.1)
- Fix stray non-breaking space character in the YAML

## Related Linear tickets, Github issues, and Community forum posts

<!-- N/A - maintenance improvement -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)