### PR TITLE
feat(Taiga Trigger Node): Add webhook request verification

### DIFF
--- a/packages/nodes-base/nodes/Taiga/TaigaTrigger.node.ts
+++ b/packages/nodes-base/nodes/Taiga/TaigaTrigger.node.ts
@@ -11,11 +11,8 @@ import {
 } from 'n8n-workflow';
 
 import { getAutomaticSecret, taigaApiRequest } from './GenericFunctions';
+import { verifySignature } from './TaigaTriggerHelpers';
 import type { Operations, Resources, WebhookPayload } from './types';
-
-// import {
-// 	createHmac,
-// } from 'crypto';
 
 export class TaigaTrigger implements INodeType {
 	description: INodeTypeDescription = {
@@ -204,6 +201,12 @@ export class TaigaTrigger implements INodeType {
 	};
 
 	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
+		if (!verifySignature.call(this)) {
+			const res = this.getResponseObject();
+			res.status(401).send('Unauthorized').end();
+			return { noWebhookResponse: true };
+		}
+
 		const body = this.getRequestObject().body as WebhookPayload;
 
 		const operations = this.getNodeParameter('operations', []) as Operations[];
@@ -216,25 +219,6 @@ export class TaigaTrigger implements INodeType {
 		if (!resources.includes('all') && !resources.includes(body.type)) {
 			return {};
 		}
-
-		// TODO: Signature does not match payload hash
-		// https://github.com/taigaio/taiga-back/issues/1031
-
-		// const webhookData = this.getWorkflowStaticData('node');
-		// const headerData = this.getHeaderData();
-
-		// // @ts-ignore
-		// const requestSignature = headerData['x-taiga-webhook-signature'];
-
-		// if (requestSignature === undefined) {
-		// 	return {};
-		// }
-
-		// const computedSignature = createHmac('sha1', webhookData.key as string).update(JSON.stringify(body)).digest('hex');
-
-		// if (requestSignature !== computedSignature) {
-		// 	return {};
-		// }
 
 		return {
 			workflowData: [this.helpers.returnJsonArray(body)],

--- a/packages/nodes-base/nodes/Taiga/TaigaTriggerHelpers.ts
+++ b/packages/nodes-base/nodes/Taiga/TaigaTriggerHelpers.ts
@@ -1,0 +1,36 @@
+import { createHmac } from 'crypto';
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { verifySignature as verifySignatureGeneric } from '../../utils/webhook-signature-verification';
+
+/**
+ * Verifies the Taiga webhook signature.
+ *
+ * Taiga signs the raw request body with HMAC-SHA1 (hex) using the webhook key
+ * and sends it in the `X-TAIGA-WEBHOOK-SIGNATURE` header.
+ *
+ * @returns true if the signature is valid, or if no key is stored (backward
+ *   compatibility with webhooks created before signing was enabled).
+ */
+export function verifySignature(this: IWebhookFunctions): boolean {
+	const req = this.getRequestObject();
+	const webhookData = this.getWorkflowStaticData('node');
+	const key = webhookData.key;
+
+	return verifySignatureGeneric({
+		getExpectedSignature: () => {
+			if (!key || typeof key !== 'string' || !req.rawBody) {
+				return null;
+			}
+			const hmac = createHmac('sha1', key);
+			const payload = Buffer.isBuffer(req.rawBody) ? req.rawBody : Buffer.from(req.rawBody);
+			hmac.update(payload);
+			return hmac.digest('hex');
+		},
+		skipIfNoExpectedSignature: !key || typeof key !== 'string',
+		getActualSignature: () => {
+			const receivedSignature = req.header('x-taiga-webhook-signature');
+			return typeof receivedSignature === 'string' ? receivedSignature : null;
+		},
+	});
+}

--- a/packages/nodes-base/nodes/Taiga/test/TaigaTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Taiga/test/TaigaTrigger.node.test.ts
@@ -93,41 +93,5 @@ describe('TaigaTrigger', () => {
 			expect(result.workflowData).toBeDefined();
 			expect(mockResponse.status).not.toHaveBeenCalled();
 		});
-
-		it('should filter out events with non-matching action', async () => {
-			const body = { action: 'delete', type: 'issue' };
-
-			(verifySignature as jest.Mock).mockReturnValue(true);
-			mockWebhookFunctions.getRequestObject.mockReturnValue({ body } as any);
-			mockWebhookFunctions.getNodeParameter.mockImplementation((name: string) => {
-				if (name === 'operations') return ['create'];
-				if (name === 'resources') return ['all'];
-				return null;
-			});
-
-			const result = await trigger.webhook.call(
-				mockWebhookFunctions as unknown as IWebhookFunctions,
-			);
-
-			expect(result).toEqual({});
-		});
-
-		it('should filter out events with non-matching resource', async () => {
-			const body = { action: 'create', type: 'wikipage' };
-
-			(verifySignature as jest.Mock).mockReturnValue(true);
-			mockWebhookFunctions.getRequestObject.mockReturnValue({ body } as any);
-			mockWebhookFunctions.getNodeParameter.mockImplementation((name: string) => {
-				if (name === 'operations') return ['all'];
-				if (name === 'resources') return ['issue'];
-				return null;
-			});
-
-			const result = await trigger.webhook.call(
-				mockWebhookFunctions as unknown as IWebhookFunctions,
-			);
-
-			expect(result).toEqual({});
-		});
 	});
 });

--- a/packages/nodes-base/nodes/Taiga/test/TaigaTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Taiga/test/TaigaTrigger.node.test.ts
@@ -1,0 +1,133 @@
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { TaigaTrigger } from '../TaigaTrigger.node';
+import { verifySignature } from '../TaigaTriggerHelpers';
+
+jest.mock('../TaigaTriggerHelpers');
+
+describe('TaigaTrigger', () => {
+	let trigger: TaigaTrigger;
+	let mockResponse: { status: jest.Mock; send: jest.Mock; end: jest.Mock };
+	let mockWebhookFunctions: Pick<
+		jest.Mocked<IWebhookFunctions>,
+		| 'getNodeParameter'
+		| 'getRequestObject'
+		| 'getResponseObject'
+		| 'getWorkflowStaticData'
+		| 'helpers'
+	>;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		trigger = new TaigaTrigger();
+
+		mockResponse = {
+			status: jest.fn().mockReturnThis(),
+			send: jest.fn().mockReturnThis(),
+			end: jest.fn(),
+		};
+
+		mockWebhookFunctions = {
+			getNodeParameter: jest.fn(),
+			getRequestObject: jest.fn(),
+			getResponseObject: jest.fn().mockReturnValue(mockResponse),
+			getWorkflowStaticData: jest.fn(),
+			helpers: {
+				returnJsonArray: jest.fn((data) => [{ json: data }]),
+			} as any,
+		};
+	});
+
+	describe('webhook', () => {
+		it('should return 401 when signature verification fails', async () => {
+			(verifySignature as jest.Mock).mockReturnValue(false);
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(verifySignature).toHaveBeenCalled();
+			expect(mockResponse.status).toHaveBeenCalledWith(401);
+			expect(mockResponse.send).toHaveBeenCalledWith('Unauthorized');
+			expect(mockResponse.end).toHaveBeenCalled();
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		it('should process webhook when signature verification passes', async () => {
+			const body = { action: 'create', type: 'issue', data: { id: 1 } };
+
+			(verifySignature as jest.Mock).mockReturnValue(true);
+			mockWebhookFunctions.getRequestObject.mockReturnValue({ body } as any);
+			mockWebhookFunctions.getNodeParameter.mockImplementation((name: string) => {
+				if (name === 'operations') return ['all'];
+				if (name === 'resources') return ['all'];
+				return null;
+			});
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(verifySignature).toHaveBeenCalled();
+			expect(mockResponse.status).not.toHaveBeenCalled();
+			expect(result.workflowData).toBeDefined();
+			expect(mockWebhookFunctions.helpers.returnJsonArray).toHaveBeenCalledWith(body);
+		});
+
+		it('should process webhook when no key is stored (backward compatibility)', async () => {
+			const body = { action: 'change', type: 'task', data: { id: 2 } };
+
+			// helper returns true when key is missing — simulate by returning true
+			(verifySignature as jest.Mock).mockReturnValue(true);
+			mockWebhookFunctions.getRequestObject.mockReturnValue({ body } as any);
+			mockWebhookFunctions.getNodeParameter.mockImplementation((name: string) => {
+				if (name === 'operations') return ['all'];
+				if (name === 'resources') return ['all'];
+				return null;
+			});
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(result.workflowData).toBeDefined();
+			expect(mockResponse.status).not.toHaveBeenCalled();
+		});
+
+		it('should filter out events with non-matching action', async () => {
+			const body = { action: 'delete', type: 'issue' };
+
+			(verifySignature as jest.Mock).mockReturnValue(true);
+			mockWebhookFunctions.getRequestObject.mockReturnValue({ body } as any);
+			mockWebhookFunctions.getNodeParameter.mockImplementation((name: string) => {
+				if (name === 'operations') return ['create'];
+				if (name === 'resources') return ['all'];
+				return null;
+			});
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(result).toEqual({});
+		});
+
+		it('should filter out events with non-matching resource', async () => {
+			const body = { action: 'create', type: 'wikipage' };
+
+			(verifySignature as jest.Mock).mockReturnValue(true);
+			mockWebhookFunctions.getRequestObject.mockReturnValue({ body } as any);
+			mockWebhookFunctions.getNodeParameter.mockImplementation((name: string) => {
+				if (name === 'operations') return ['all'];
+				if (name === 'resources') return ['issue'];
+				return null;
+			});
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(result).toEqual({});
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Taiga/test/TaigaTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Taiga/test/TaigaTriggerHelpers.test.ts
@@ -74,21 +74,5 @@ describe('TaigaTriggerHelpers', () => {
 
 			expect(verifySignature.call(mockWebhookFunctions)).toBe(false);
 		});
-
-		it('should accept rawBody passed as a string', () => {
-			const rawBodyString = '{"action":"change","type":"task"}';
-			const expectedSignature = createHmac('sha1', testKey).update(rawBodyString).digest('hex');
-
-			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({ key: testKey });
-			mockWebhookFunctions.getRequestObject.mockReturnValue({
-				header: jest.fn().mockImplementation((name: string) => {
-					if (name === 'x-taiga-webhook-signature') return expectedSignature;
-					return null;
-				}),
-				rawBody: rawBodyString,
-			});
-
-			expect(verifySignature.call(mockWebhookFunctions)).toBe(true);
-		});
 	});
 });

--- a/packages/nodes-base/nodes/Taiga/test/TaigaTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Taiga/test/TaigaTriggerHelpers.test.ts
@@ -1,0 +1,94 @@
+import { createHmac } from 'crypto';
+
+import { verifySignature } from '../TaigaTriggerHelpers';
+
+describe('TaigaTriggerHelpers', () => {
+	let mockWebhookFunctions: any;
+	const testKey = 'taiga-webhook-key-abc123';
+	const testPayload = Buffer.from('{"action":"create","type":"issue"}');
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		mockWebhookFunctions = {
+			getRequestObject: jest.fn(),
+			getWorkflowStaticData: jest.fn(),
+		};
+	});
+
+	describe('verifySignature', () => {
+		it('should return true if no key is stored (backward compatibility)', () => {
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(null),
+				rawBody: testPayload,
+			});
+
+			expect(verifySignature.call(mockWebhookFunctions)).toBe(true);
+		});
+
+		it('should return true when signatures match', () => {
+			const expectedSignature = createHmac('sha1', testKey).update(testPayload).digest('hex');
+
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({ key: testKey });
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((name: string) => {
+					if (name === 'x-taiga-webhook-signature') return expectedSignature;
+					return null;
+				}),
+				rawBody: testPayload,
+			});
+
+			expect(verifySignature.call(mockWebhookFunctions)).toBe(true);
+		});
+
+		it('should return false when signatures do not match', () => {
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({ key: testKey });
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((name: string) => {
+					if (name === 'x-taiga-webhook-signature') return 'a'.repeat(40);
+					return null;
+				}),
+				rawBody: testPayload,
+			});
+
+			expect(verifySignature.call(mockWebhookFunctions)).toBe(false);
+		});
+
+		it('should return false when signature header is missing', () => {
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({ key: testKey });
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(null),
+				rawBody: testPayload,
+			});
+
+			expect(verifySignature.call(mockWebhookFunctions)).toBe(false);
+		});
+
+		it('should return false when raw body is missing', () => {
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({ key: testKey });
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue('a'.repeat(40)),
+				rawBody: undefined,
+			});
+
+			expect(verifySignature.call(mockWebhookFunctions)).toBe(false);
+		});
+
+		it('should accept rawBody passed as a string', () => {
+			const rawBodyString = '{"action":"change","type":"task"}';
+			const expectedSignature = createHmac('sha1', testKey).update(rawBodyString).digest('hex');
+
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({ key: testKey });
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((name: string) => {
+					if (name === 'x-taiga-webhook-signature') return expectedSignature;
+					return null;
+				}),
+				rawBody: rawBodyString,
+			});
+
+			expect(verifySignature.call(mockWebhookFunctions)).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Verify the `X-TAIGA-WEBHOOK-SIGNATURE` header on incoming Taiga webhooks using the existing per-webhook key stored in workflow static data. Requests that fail verification receive a 401; existing workflows without a stored key skip verification (backward compatible).

<img width="2502" height="1304" alt="2026-04-30 09 30 54" src="https://github.com/user-attachments/assets/daa5d044-1d1c-4683-9854-c7d13fa9adc5" />

### Verification

Tested with [n8n-node-mocker](https://github.com/DawidMyslak/n8n-node-mocker):
- ✅ Correct secret → 200 OK
- ✅ Wrong secret → 401 Unauthorized

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4315

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI