### PR TITLE
feat(core): Add migration for postgres variable values

### DIFF
--- a/packages/@n8n/db/src/migrations/postgresdb/1772800000000-ExpandVariablesValueColumnToText.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/1772800000000-ExpandVariablesValueColumnToText.ts
@@ -1,0 +1,21 @@
+import type { IrreversibleMigration, MigrationContext } from '../migration-types';
+
+/** Must stay in sync with `VALUE_MAX_LENGTH` in `@n8n/api-types` `dto/variables/base.dto`. */
+const VARIABLE_VALUE_MAX_LENGTH = 1000;
+
+/**
+ * Widens `variables.value` to TEXT and enforces the API max length at the database layer.
+ */
+export class ExpandVariablesValueColumnToText1772800000000 implements IrreversibleMigration {
+	async up({ escape, queryRunner, tablePrefix }: MigrationContext) {
+		const tableName = escape.tableName('variables');
+		const valueColumn = escape.columnName('value');
+		const constraintName = `${tablePrefix}variables_value_max_len`;
+
+		await queryRunner.query(`ALTER TABLE ${tableName} ALTER COLUMN ${valueColumn} TYPE TEXT;`);
+
+		await queryRunner.query(
+			`ALTER TABLE ${tableName} ADD CONSTRAINT "${constraintName}" CHECK ("value" IS NULL OR char_length("value") <= ${VARIABLE_VALUE_MAX_LENGTH});`,
+		);
+	}
+}

--- a/packages/@n8n/db/src/migrations/postgresdb/1777420800000-ExpandVariablesValueColumnToText.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/1777420800000-ExpandVariablesValueColumnToText.ts
@@ -6,7 +6,7 @@ const VARIABLE_VALUE_MAX_LENGTH = 1000;
 /**
  * Widens `variables.value` to TEXT and enforces the API max length at the database layer.
  */
-export class ExpandVariablesValueColumnToText1772800000000 implements IrreversibleMigration {
+export class ExpandVariablesValueColumnToText1777420800000 implements IrreversibleMigration {
 	async up({ escape, queryRunner, tablePrefix }: MigrationContext) {
 		const tableName = escape.tableName('variables');
 		const valueColumn = escape.columnName('value');
@@ -15,7 +15,7 @@ export class ExpandVariablesValueColumnToText1772800000000 implements Irreversib
 		await queryRunner.query(`ALTER TABLE ${tableName} ALTER COLUMN ${valueColumn} TYPE TEXT;`);
 
 		await queryRunner.query(
-			`ALTER TABLE ${tableName} ADD CONSTRAINT "${constraintName}" CHECK ("value" IS NULL OR char_length("value") <= ${VARIABLE_VALUE_MAX_LENGTH});`,
+			`ALTER TABLE ${tableName} ADD CONSTRAINT "${constraintName}" CHECK (${valueColumn} IS NULL OR char_length(${valueColumn}) <= ${VARIABLE_VALUE_MAX_LENGTH});`,
 		);
 	}
 }

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -49,7 +49,7 @@ import { ChangeDefaultForIdInUserTable1762771264000 } from './1762771264000-Chan
 import { ConvertAgentIdToUuid1765804780000 } from './1765804780000-ConvertAgentIdToUuid';
 import { ExpandInsightsWorkflowIdLength1766500000000 } from './1766500000000-ExpandInsightsWorkflowIdLength';
 import { ChangeWorkflowStatisticsFKToNoAction1767018516000 } from './1767018516000-ChangeWorkflowStatisticsFKToNoAction';
-import { ExpandVariablesValueColumnToText1772800000000 } from './1772800000000-ExpandVariablesValueColumnToText';
+import { ExpandVariablesValueColumnToText1777420800000 } from './1777420800000-ExpandVariablesValueColumnToText';
 import { CreateLdapEntities1674509946020 } from '../common/1674509946020-CreateLdapEntities';
 import { PurgeInvalidWorkflowConnections1675940580449 } from '../common/1675940580449-PurgeInvalidWorkflowConnections';
 import { RemoveResetPasswordColumns1690000000030 } from '../common/1690000000030-RemoveResetPasswordColumns';
@@ -326,7 +326,6 @@ export const postgresMigrations: Migration[] = [
 	ChangeWorkflowPublishedVersionFKsToRestrict1772619247762,
 	AddTypeToChatHubSessions1772700000000,
 	CreateRoleMappingRuleTable1772800000000,
-	ExpandVariablesValueColumnToText1772800000000,
 	CreateCredentialDependencyTable1773000000000,
 	AddRestoreFieldsToWorkflowBuilderSession1774280963551,
 	CreateInstanceVersionHistoryTable1774854660000,
@@ -341,4 +340,5 @@ export const postgresMigrations: Migration[] = [
 	AddExecutionDeduplicationKey1778000000000,
 	AddTracingContextToExecution1777045000000,
 	CreateAiBuilderTemporaryWorkflowTable1777281990043,
+	ExpandVariablesValueColumnToText1777420800000,
 ];

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -49,6 +49,7 @@ import { ChangeDefaultForIdInUserTable1762771264000 } from './1762771264000-Chan
 import { ConvertAgentIdToUuid1765804780000 } from './1765804780000-ConvertAgentIdToUuid';
 import { ExpandInsightsWorkflowIdLength1766500000000 } from './1766500000000-ExpandInsightsWorkflowIdLength';
 import { ChangeWorkflowStatisticsFKToNoAction1767018516000 } from './1767018516000-ChangeWorkflowStatisticsFKToNoAction';
+import { ExpandVariablesValueColumnToText1772800000000 } from './1772800000000-ExpandVariablesValueColumnToText';
 import { CreateLdapEntities1674509946020 } from '../common/1674509946020-CreateLdapEntities';
 import { PurgeInvalidWorkflowConnections1675940580449 } from '../common/1675940580449-PurgeInvalidWorkflowConnections';
 import { RemoveResetPasswordColumns1690000000030 } from '../common/1690000000030-RemoveResetPasswordColumns';
@@ -325,6 +326,7 @@ export const postgresMigrations: Migration[] = [
 	ChangeWorkflowPublishedVersionFKsToRestrict1772619247762,
 	AddTypeToChatHubSessions1772700000000,
 	CreateRoleMappingRuleTable1772800000000,
+	ExpandVariablesValueColumnToText1772800000000,
 	CreateCredentialDependencyTable1773000000000,
 	AddRestoreFieldsToWorkflowBuilderSession1774280963551,
 	CreateInstanceVersionHistoryTable1774854660000,


### PR DESCRIPTION
## Summary

When v1.118.0 introduced "The maximum character limit has been [increased to 1,000](https://github.com/n8n-io/n8n-docs/commit/8e81cb307e9b3c609532295ff3289fe1fea41f92#diff-9b66fbfa649bf40afda37e523c03e8733fb1646ea9e6689aff6b695fe3fa7934R32)", only the frontend/application-layer validation was changed. No database migration was shipped to match.

## Related Linear tickets, Github issues, and Community forum posts

Fixes [LIGO-403](https://linear.app/n8n/issue/LIGO-403/community-issue-bugdb-missing-migration-to-expand-variablesvalue-from)


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
