### PR TITLE
feat(Mautic Trigger Node): Add webhook request verification

### DIFF
--- a/packages/nodes-base/nodes/Mautic/MauticTrigger.node.ts
+++ b/packages/nodes-base/nodes/Mautic/MauticTrigger.node.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'crypto';
 import {
 	type IHookFunctions,
 	type IWebhookFunctions,
@@ -12,6 +13,7 @@ import {
 import { parse as urlParse } from 'url';
 
 import { mauticApiRequest } from './GenericFunctions';
+import { verifySignature } from './MauticTriggerHelpers';
 
 export class MauticTrigger implements INodeType {
 	description: INodeTypeDescription = {
@@ -146,16 +148,19 @@ export class MauticTrigger implements INodeType {
 				const events = this.getNodeParameter('events', 0) as string[];
 				const eventsOrder = this.getNodeParameter('eventsOrder', 0) as string;
 				const urlParts = urlParse(webhookUrl);
+				const webhookSecret = randomBytes(32).toString('hex');
 				const body: IDataObject = {
 					name: `n8n-webhook:${urlParts.path}`,
 					description: 'n8n webhook',
 					webhookUrl,
+					secret: webhookSecret,
 					triggers: events,
 					eventsOrderbyDir: eventsOrder,
 					isPublished: true,
 				};
 				const { hook } = await mauticApiRequest.call(this, 'POST', '/hooks/new', body);
 				webhookData.webhookId = hook.id;
+				webhookData.webhookSecret = webhookSecret;
 				return true;
 			},
 			async delete(this: IHookFunctions): Promise<boolean> {
@@ -166,12 +171,21 @@ export class MauticTrigger implements INodeType {
 					return false;
 				}
 				delete webhookData.webhookId;
+				delete webhookData.webhookSecret;
 				return true;
 			},
 		},
 	};
 
 	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
+		if (!verifySignature.call(this)) {
+			const res = this.getResponseObject();
+			res.status(401).send('Unauthorized').end();
+			return {
+				noWebhookResponse: true,
+			};
+		}
+
 		const req = this.getRequestObject();
 		return {
 			workflowData: [this.helpers.returnJsonArray(req.body as IDataObject)],

--- a/packages/nodes-base/nodes/Mautic/MauticTriggerHelpers.ts
+++ b/packages/nodes-base/nodes/Mautic/MauticTriggerHelpers.ts
@@ -1,0 +1,38 @@
+import { createHmac } from 'crypto';
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { verifySignature as verifySignatureGeneric } from '../../utils/webhook-signature-verification';
+
+/**
+ * Verifies the Mautic webhook signature.
+ *
+ * Mautic signs webhooks using HMAC SHA-256:
+ * 1. Create HMAC SHA-256 hash of the raw request body using the secret as key
+ * 2. Encode the hash in base64 format
+ * 3. Compare with the signature in the `Webhook-Signature` header
+ *
+ * @returns true if the signature is valid, false otherwise
+ * @returns true if no secret is configured (backward compatibility with old triggers)
+ */
+export function verifySignature(this: IWebhookFunctions): boolean {
+	const req = this.getRequestObject();
+	const webhookData = this.getWorkflowStaticData('node');
+	const secret = webhookData.webhookSecret;
+
+	return verifySignatureGeneric({
+		getExpectedSignature: () => {
+			if (!secret || typeof secret !== 'string' || !req.rawBody) {
+				return null;
+			}
+			const hmac = createHmac('sha256', secret);
+			const payload = Buffer.isBuffer(req.rawBody) ? req.rawBody : Buffer.from(req.rawBody);
+			hmac.update(payload);
+			return hmac.digest('base64');
+		},
+		skipIfNoExpectedSignature: !secret || typeof secret !== 'string',
+		getActualSignature: () => {
+			const receivedSignature = req.header('webhook-signature');
+			return typeof receivedSignature === 'string' ? receivedSignature : null;
+		},
+	});
+}

--- a/packages/nodes-base/nodes/Mautic/test/MauticTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Mautic/test/MauticTrigger.node.test.ts
@@ -1,0 +1,165 @@
+import { randomBytes } from 'crypto';
+import type { IHookFunctions, IWebhookFunctions } from 'n8n-workflow';
+
+import { mauticApiRequest } from '../GenericFunctions';
+import { MauticTrigger } from '../MauticTrigger.node';
+import { verifySignature } from '../MauticTriggerHelpers';
+
+jest.mock('../GenericFunctions');
+jest.mock('../MauticTriggerHelpers');
+jest.mock('crypto', () => ({
+	...jest.requireActual('crypto'),
+	randomBytes: jest.fn(),
+}));
+
+describe('MauticTrigger', () => {
+	let trigger: MauticTrigger;
+	let mockHookFunctions: Pick<
+		jest.Mocked<IHookFunctions>,
+		'getNodeWebhookUrl' | 'getNodeParameter' | 'getWorkflowStaticData'
+	>;
+	let mockWebhookFunctions: Pick<
+		jest.Mocked<IWebhookFunctions>,
+		'getRequestObject' | 'getResponseObject' | 'helpers'
+	>;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		trigger = new MauticTrigger();
+
+		mockHookFunctions = {
+			getNodeWebhookUrl: jest.fn(),
+			getNodeParameter: jest.fn(),
+			getWorkflowStaticData: jest.fn(),
+		};
+
+		mockWebhookFunctions = {
+			getRequestObject: jest.fn(),
+			getResponseObject: jest.fn(),
+			helpers: {
+				returnJsonArray: jest.fn((data) => [{ json: data }]),
+			} as any,
+		};
+	});
+
+	describe('webhookMethods.default.create', () => {
+		it('should create webhook with auto-generated secret', async () => {
+			const webhookUrl = 'https://example.com/webhook/abc';
+			const webhookSecret = 'a'.repeat(64);
+			const webhookData: any = {};
+
+			mockHookFunctions.getNodeWebhookUrl.mockReturnValue(webhookUrl);
+			mockHookFunctions.getNodeParameter.mockImplementation((name) => {
+				if (name === 'events') return ['mautic.lead_post_save_new'];
+				if (name === 'eventsOrder') return 'ASC';
+				return undefined;
+			});
+			mockHookFunctions.getWorkflowStaticData.mockReturnValue(webhookData);
+
+			(randomBytes as jest.Mock).mockReturnValue({
+				toString: jest.fn().mockReturnValue(webhookSecret),
+			});
+			(mauticApiRequest as jest.Mock).mockResolvedValue({ hook: { id: 42 } });
+
+			const result = await trigger.webhookMethods!.default.create.call(
+				mockHookFunctions as unknown as IHookFunctions,
+			);
+
+			expect(result).toBe(true);
+			expect(randomBytes).toHaveBeenCalledWith(32);
+			expect(mauticApiRequest).toHaveBeenCalledWith(
+				'POST',
+				'/hooks/new',
+				expect.objectContaining({
+					webhookUrl,
+					secret: webhookSecret,
+					triggers: ['mautic.lead_post_save_new'],
+					eventsOrderbyDir: 'ASC',
+					isPublished: true,
+				}),
+			);
+			expect(webhookData.webhookId).toBe(42);
+			expect(webhookData.webhookSecret).toBe(webhookSecret);
+		});
+	});
+
+	describe('webhookMethods.default.delete', () => {
+		it('should delete webhook and clean up secret', async () => {
+			const webhookData: any = {
+				webhookId: 42,
+				webhookSecret: 'test-secret',
+			};
+			mockHookFunctions.getWorkflowStaticData.mockReturnValue(webhookData);
+
+			(mauticApiRequest as jest.Mock).mockResolvedValue({});
+
+			const result = await trigger.webhookMethods!.default.delete.call(
+				mockHookFunctions as unknown as IHookFunctions,
+			);
+
+			expect(result).toBe(true);
+			expect(mauticApiRequest).toHaveBeenCalledWith('DELETE', '/hooks/42/delete');
+			expect(webhookData.webhookId).toBeUndefined();
+			expect(webhookData.webhookSecret).toBeUndefined();
+		});
+
+		it('should return false when deletion fails', async () => {
+			const webhookData: any = {
+				webhookId: 42,
+				webhookSecret: 'test-secret',
+			};
+			mockHookFunctions.getWorkflowStaticData.mockReturnValue(webhookData);
+
+			(mauticApiRequest as jest.Mock).mockRejectedValue(new Error('Delete failed'));
+
+			const result = await trigger.webhookMethods!.default.delete.call(
+				mockHookFunctions as unknown as IHookFunctions,
+			);
+
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('webhook', () => {
+		it('should return 401 when signature verification fails', async () => {
+			const mockResponse = {
+				status: jest.fn().mockReturnThis(),
+				send: jest.fn().mockReturnThis(),
+				end: jest.fn(),
+			};
+
+			(verifySignature as jest.Mock).mockReturnValue(false);
+			mockWebhookFunctions.getResponseObject.mockReturnValue(mockResponse as any);
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(verifySignature).toHaveBeenCalled();
+			expect(mockResponse.status).toHaveBeenCalledWith(401);
+			expect(mockResponse.send).toHaveBeenCalledWith('Unauthorized');
+			expect(result).toEqual({
+				noWebhookResponse: true,
+			});
+		});
+
+		it('should process webhook when signature verification passes', async () => {
+			const bodyData = { 'mautic.lead_post_save_new': [{ id: 1 }] };
+
+			(verifySignature as jest.Mock).mockReturnValue(true);
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				body: bodyData,
+			} as any);
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(verifySignature).toHaveBeenCalled();
+			expect(mockWebhookFunctions.helpers.returnJsonArray).toHaveBeenCalledWith(bodyData);
+			expect(result).toEqual({
+				workflowData: [[{ json: bodyData }]],
+			});
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Mautic/test/MauticTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Mautic/test/MauticTriggerHelpers.test.ts
@@ -1,0 +1,100 @@
+import { createHmac } from 'crypto';
+
+import { verifySignature } from '../MauticTriggerHelpers';
+
+describe('MauticTriggerHelpers', () => {
+	let mockWebhookFunctions: any;
+	const testSecret = 'test-secret-key-12345';
+	const testPayload = Buffer.from('{"mautic.lead_post_save_new":[{"id":1}]}');
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		mockWebhookFunctions = {
+			getRequestObject: jest.fn(),
+			getWorkflowStaticData: jest.fn(),
+		};
+	});
+
+	describe('verifySignature', () => {
+		it('should return true if no secret is configured', () => {
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(null),
+				rawBody: testPayload,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return true if signatures match', () => {
+			const hmac = createHmac('sha256', testSecret);
+			hmac.update(testPayload);
+			const expectedSignature = hmac.digest('base64');
+
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				webhookSecret: testSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'webhook-signature') return expectedSignature;
+					return null;
+				}),
+				rawBody: testPayload,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false if signatures do not match', () => {
+			const wrongSignature = 'wrongsignature1234567890';
+
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				webhookSecret: testSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'webhook-signature') return wrongSignature;
+					return null;
+				}),
+				rawBody: testPayload,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false if signature header is missing', () => {
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				webhookSecret: testSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(null),
+				rawBody: testPayload,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false if raw body is missing', () => {
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				webhookSecret: testSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue('any-signature'),
+				rawBody: undefined,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Add HMAC-SHA256 signature verification to the Mautic Trigger node:

- Auto-generate a 32-byte random secret when registering the webhook with Mautic via `POST /hooks/new`, storing it in the request body's `secret` field.
- Persist the secret in workflow static data so it survives webhook lifecycle events.
- Verify the `Webhook-Signature` header (base64-encoded HMAC-SHA256 of the raw body) on every incoming webhook using the shared `verifySignature` utility. Reject mismatches with `401 Unauthorized`.
- Skip verification when no secret is present so existing workflows continue to work without changes.

Reference: https://devdocs.mautic.org/en/latest/webhooks/getting_started.html#securing-a-webhook

https://linear.app/n8n/issue/NODE-4311

## Test plan

- [x] Unit tests for helpers (`MauticTriggerHelpers.test.ts`): no secret, valid signature, invalid signature, missing header, missing raw body.
- [x] Unit tests for trigger node (`MauticTrigger.node.test.ts`): create webhook generates secret, delete cleans up secret, webhook returns 401 on invalid signature, webhook processes payload on valid signature.
- [x] `pnpm typecheck` passes.
- [x] `pnpm eslint nodes/Mautic/` passes.