### PR TITLE
feat(Formstack Trigger Node): Add webhook request verification

### DIFF
--- a/packages/nodes-base/nodes/Formstack/FormstackTrigger.node.ts
+++ b/packages/nodes-base/nodes/Formstack/FormstackTrigger.node.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'crypto';
 import type {
 	IHookFunctions,
 	IWebhookFunctions,
@@ -8,6 +9,7 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 
+import { verifySignature } from './FormstackTriggerHelpers';
 import type { IFormstackWebhookResponseBody } from './GenericFunctions';
 import { apiRequest, getForms } from './GenericFunctions';
 
@@ -127,18 +129,21 @@ export class FormstackTrigger implements INodeType {
 
 				const endpoint = `form/${formId}/webhook.json`;
 
-				// TODO: Add handshake key support
+				const webhookSecret = randomBytes(32).toString('hex');
+
 				const body = {
 					url: webhookUrl,
 					standardize_field_values: true,
 					include_field_type: true,
 					content_type: 'json',
+					hmac_secret: webhookSecret,
 				};
 
 				const response = await apiRequest.call(this, 'POST', endpoint, body);
 
 				const webhookData = this.getWorkflowStaticData('node');
 				webhookData.webhookId = response.id;
+				webhookData.webhookSecret = webhookSecret;
 				return true;
 			},
 			async delete(this: IHookFunctions): Promise<boolean> {
@@ -156,6 +161,7 @@ export class FormstackTrigger implements INodeType {
 					// Remove from the static workflow data so that it is clear
 					// that no webhooks are registered anymore
 					delete webhookData.webhookId;
+					delete webhookData.webhookSecret;
 				}
 
 				return true;
@@ -164,6 +170,14 @@ export class FormstackTrigger implements INodeType {
 	};
 
 	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
+		if (!verifySignature.call(this)) {
+			const res = this.getResponseObject();
+			res.status(401).send('Unauthorized').end();
+			return {
+				noWebhookResponse: true,
+			};
+		}
+
 		const bodyData = this.getBodyData() as unknown as IFormstackWebhookResponseBody;
 		const simple = this.getNodeParameter('simple') as string;
 

--- a/packages/nodes-base/nodes/Formstack/FormstackTrigger.node.ts
+++ b/packages/nodes-base/nodes/Formstack/FormstackTrigger.node.ts
@@ -136,7 +136,7 @@ export class FormstackTrigger implements INodeType {
 					standardize_field_values: true,
 					include_field_type: true,
 					content_type: 'json',
-					hmac_key: webhookSecret,
+					hmac_secret: webhookSecret,
 				};
 
 				const response = await apiRequest.call(this, 'POST', endpoint, body);

--- a/packages/nodes-base/nodes/Formstack/FormstackTrigger.node.ts
+++ b/packages/nodes-base/nodes/Formstack/FormstackTrigger.node.ts
@@ -136,7 +136,7 @@ export class FormstackTrigger implements INodeType {
 					standardize_field_values: true,
 					include_field_type: true,
 					content_type: 'json',
-					hmac_secret: webhookSecret,
+					hmac_key: webhookSecret,
 				};
 
 				const response = await apiRequest.call(this, 'POST', endpoint, body);

--- a/packages/nodes-base/nodes/Formstack/FormstackTriggerHelpers.ts
+++ b/packages/nodes-base/nodes/Formstack/FormstackTriggerHelpers.ts
@@ -1,0 +1,38 @@
+import { createHmac } from 'crypto';
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { verifySignature as verifySignatureGeneric } from '../../utils/webhook-signature-verification';
+
+/**
+ * Verifies the Formstack webhook signature.
+ *
+ * Formstack signs webhooks using HMAC SHA-256 over the raw request body, with
+ * the resulting hex digest sent in the `X-FS-Signature` header in the format
+ * `sha256=<hex>`.
+ *
+ * @returns true if the signature is valid, or no secret is configured
+ *          (backward compatibility with webhooks created before signing was
+ *          supported)
+ */
+export function verifySignature(this: IWebhookFunctions): boolean {
+	const req = this.getRequestObject();
+	const webhookData = this.getWorkflowStaticData('node');
+	const secret = webhookData.webhookSecret;
+
+	return verifySignatureGeneric({
+		getExpectedSignature: () => {
+			if (!secret || typeof secret !== 'string' || !req.rawBody) {
+				return null;
+			}
+			const hmac = createHmac('sha256', secret);
+			const payload = Buffer.isBuffer(req.rawBody) ? req.rawBody : Buffer.from(req.rawBody);
+			hmac.update(payload);
+			return `sha256=${hmac.digest('hex')}`;
+		},
+		skipIfNoExpectedSignature: !secret || typeof secret !== 'string',
+		getActualSignature: () => {
+			const sig = req.header('x-fs-signature');
+			return typeof sig === 'string' ? sig : null;
+		},
+	});
+}

--- a/packages/nodes-base/nodes/Formstack/test/FormstackTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Formstack/test/FormstackTrigger.node.test.ts
@@ -1,0 +1,163 @@
+import { randomBytes } from 'crypto';
+import type { IHookFunctions, IWebhookFunctions } from 'n8n-workflow';
+
+import { FormstackTrigger } from '../FormstackTrigger.node';
+import { verifySignature } from '../FormstackTriggerHelpers';
+import { apiRequest } from '../GenericFunctions';
+
+jest.mock('../GenericFunctions');
+jest.mock('../FormstackTriggerHelpers');
+jest.mock('crypto', () => ({
+	...jest.requireActual('crypto'),
+	randomBytes: jest.fn(),
+}));
+
+describe('FormstackTrigger', () => {
+	let trigger: FormstackTrigger;
+	let mockHookFunctions: Pick<
+		jest.Mocked<IHookFunctions>,
+		'getNodeWebhookUrl' | 'getNodeParameter' | 'getWorkflowStaticData'
+	>;
+	let mockWebhookFunctions: Pick<
+		jest.Mocked<IWebhookFunctions>,
+		| 'getNodeParameter'
+		| 'getBodyData'
+		| 'getRequestObject'
+		| 'getResponseObject'
+		| 'getWorkflowStaticData'
+		| 'helpers'
+	>;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		trigger = new FormstackTrigger();
+
+		mockHookFunctions = {
+			getNodeWebhookUrl: jest.fn(),
+			getNodeParameter: jest.fn(),
+			getWorkflowStaticData: jest.fn(),
+		};
+
+		mockWebhookFunctions = {
+			getNodeParameter: jest.fn(),
+			getBodyData: jest.fn(),
+			getRequestObject: jest.fn(),
+			getResponseObject: jest.fn(),
+			getWorkflowStaticData: jest.fn(),
+			helpers: {
+				returnJsonArray: jest.fn((data) => data),
+			} as any,
+		};
+	});
+
+	describe('webhookMethods.default.create', () => {
+		it('should create webhook with hmac_secret and persist secret in static data', async () => {
+			const webhookUrl = 'https://example.com/webhook';
+			const formId = 'form-123';
+			const webhookId = 'webhook-456';
+			const webhookSecret = 'a'.repeat(64);
+
+			mockHookFunctions.getNodeWebhookUrl.mockReturnValue(webhookUrl);
+			mockHookFunctions.getNodeParameter.mockReturnValue(formId);
+
+			const webhookData: any = {};
+			mockHookFunctions.getWorkflowStaticData.mockReturnValue(webhookData);
+
+			(randomBytes as jest.Mock).mockReturnValue({
+				toString: jest.fn().mockReturnValue(webhookSecret),
+			});
+			(apiRequest as jest.Mock).mockResolvedValue({ id: webhookId });
+
+			const result = await trigger.webhookMethods.default.create.call(
+				mockHookFunctions as unknown as IHookFunctions,
+			);
+
+			expect(result).toBe(true);
+			expect(randomBytes).toHaveBeenCalledWith(32);
+			expect(apiRequest).toHaveBeenCalledWith('POST', `form/${formId}/webhook.json`, {
+				url: webhookUrl,
+				standardize_field_values: true,
+				include_field_type: true,
+				content_type: 'json',
+				hmac_secret: webhookSecret,
+			});
+			expect(webhookData.webhookId).toBe(webhookId);
+			expect(webhookData.webhookSecret).toBe(webhookSecret);
+		});
+	});
+
+	describe('webhookMethods.default.delete', () => {
+		it('should clean up webhookSecret from static data on delete', async () => {
+			const webhookId = 'webhook-456';
+			const webhookData: any = {
+				webhookId,
+				webhookSecret: 'stored-secret',
+			};
+
+			mockHookFunctions.getWorkflowStaticData.mockReturnValue(webhookData);
+			(apiRequest as jest.Mock).mockResolvedValue({});
+
+			const result = await trigger.webhookMethods.default.delete.call(
+				mockHookFunctions as unknown as IHookFunctions,
+			);
+
+			expect(result).toBe(true);
+			expect(apiRequest).toHaveBeenCalledWith('DELETE', `webhook/${webhookId}.json`, {});
+			expect(webhookData.webhookId).toBeUndefined();
+			expect(webhookData.webhookSecret).toBeUndefined();
+		});
+
+		it('should return true when no webhookId is set', async () => {
+			mockHookFunctions.getWorkflowStaticData.mockReturnValue({});
+
+			const result = await trigger.webhookMethods.default.delete.call(
+				mockHookFunctions as unknown as IHookFunctions,
+			);
+
+			expect(result).toBe(true);
+			expect(apiRequest).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('webhook', () => {
+		it('should return 401 when signature verification fails', async () => {
+			const mockResponse = {
+				status: jest.fn().mockReturnThis(),
+				send: jest.fn().mockReturnThis(),
+				end: jest.fn(),
+			};
+
+			(verifySignature as jest.Mock).mockReturnValue(false);
+			mockWebhookFunctions.getResponseObject.mockReturnValue(mockResponse as any);
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(verifySignature).toHaveBeenCalled();
+			expect(mockResponse.status).toHaveBeenCalledWith(401);
+			expect(mockResponse.send).toHaveBeenCalledWith('Unauthorized');
+			expect(mockResponse.end).toHaveBeenCalled();
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		it('should process webhook when signature verification passes', async () => {
+			const bodyData = {
+				FormID: '123',
+				UniqueID: 'abc',
+				field1: { value: 'foo' },
+			};
+
+			(verifySignature as jest.Mock).mockReturnValue(true);
+			mockWebhookFunctions.getNodeParameter.mockReturnValue(true);
+			mockWebhookFunctions.getBodyData.mockReturnValue(bodyData as any);
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(verifySignature).toHaveBeenCalled();
+			expect(result.workflowData).toBeDefined();
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Formstack/test/FormstackTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Formstack/test/FormstackTrigger.node.test.ts
@@ -51,7 +51,7 @@ describe('FormstackTrigger', () => {
 	});
 
 	describe('webhookMethods.default.create', () => {
-		it('should create webhook with hmac_secret and persist secret in static data', async () => {
+		it('should create webhook with hmac_key and persist secret in static data', async () => {
 			const webhookUrl = 'https://example.com/webhook';
 			const formId = 'form-123';
 			const webhookId = 'webhook-456';
@@ -79,7 +79,7 @@ describe('FormstackTrigger', () => {
 				standardize_field_values: true,
 				include_field_type: true,
 				content_type: 'json',
-				hmac_secret: webhookSecret,
+				hmac_key: webhookSecret,
 			});
 			expect(webhookData.webhookId).toBe(webhookId);
 			expect(webhookData.webhookSecret).toBe(webhookSecret);

--- a/packages/nodes-base/nodes/Formstack/test/FormstackTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Formstack/test/FormstackTrigger.node.test.ts
@@ -51,7 +51,7 @@ describe('FormstackTrigger', () => {
 	});
 
 	describe('webhookMethods.default.create', () => {
-		it('should create webhook with hmac_key and persist secret in static data', async () => {
+		it('should create webhook with hmac_secret and persist secret in static data', async () => {
 			const webhookUrl = 'https://example.com/webhook';
 			const formId = 'form-123';
 			const webhookId = 'webhook-456';
@@ -79,7 +79,7 @@ describe('FormstackTrigger', () => {
 				standardize_field_values: true,
 				include_field_type: true,
 				content_type: 'json',
-				hmac_key: webhookSecret,
+				hmac_secret: webhookSecret,
 			});
 			expect(webhookData.webhookId).toBe(webhookId);
 			expect(webhookData.webhookSecret).toBe(webhookSecret);

--- a/packages/nodes-base/nodes/Formstack/test/FormstackTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Formstack/test/FormstackTriggerHelpers.test.ts
@@ -96,27 +96,5 @@ describe('FormstackTriggerHelpers', () => {
 
 			expect(result).toBe(false);
 		});
-
-		it('should handle a string raw body', () => {
-			const stringBody = '{"FormID":"123","UniqueID":"abc"}';
-			const hmac = createHmac('sha256', testSecret);
-			hmac.update(Buffer.from(stringBody));
-			const expectedSignature = `sha256=${hmac.digest('hex')}`;
-
-			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
-				webhookSecret: testSecret,
-			});
-			mockWebhookFunctions.getRequestObject.mockReturnValue({
-				header: jest.fn().mockImplementation((header) => {
-					if (header === 'x-fs-signature') return expectedSignature;
-					return null;
-				}),
-				rawBody: stringBody,
-			});
-
-			const result = verifySignature.call(mockWebhookFunctions);
-
-			expect(result).toBe(true);
-		});
 	});
 });

--- a/packages/nodes-base/nodes/Formstack/test/FormstackTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Formstack/test/FormstackTriggerHelpers.test.ts
@@ -1,0 +1,122 @@
+import { createHmac } from 'crypto';
+
+import { verifySignature } from '../FormstackTriggerHelpers';
+
+describe('FormstackTriggerHelpers', () => {
+	let mockWebhookFunctions: any;
+	const testSecret = 'test-secret-key-12345';
+	const testPayload = Buffer.from('{"FormID":"123","UniqueID":"abc"}');
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		mockWebhookFunctions = {
+			getRequestObject: jest.fn(),
+			getWorkflowStaticData: jest.fn(),
+		};
+	});
+
+	describe('verifySignature', () => {
+		it('should return true when no secret is configured', () => {
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(null),
+				rawBody: testPayload,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return true when signatures match', () => {
+			const hmac = createHmac('sha256', testSecret);
+			hmac.update(testPayload);
+			const expectedSignature = `sha256=${hmac.digest('hex')}`;
+
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				webhookSecret: testSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'x-fs-signature') return expectedSignature;
+					return null;
+				}),
+				rawBody: testPayload,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false when signatures do not match', () => {
+			const wrongSignature = `sha256=${'0'.repeat(64)}`;
+
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				webhookSecret: testSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'x-fs-signature') return wrongSignature;
+					return null;
+				}),
+				rawBody: testPayload,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when signature header is missing', () => {
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				webhookSecret: testSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(null),
+				rawBody: testPayload,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when raw body is missing', () => {
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				webhookSecret: testSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue('sha256=anything'),
+				rawBody: undefined,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should handle a string raw body', () => {
+			const stringBody = '{"FormID":"123","UniqueID":"abc"}';
+			const hmac = createHmac('sha256', testSecret);
+			hmac.update(Buffer.from(stringBody));
+			const expectedSignature = `sha256=${hmac.digest('hex')}`;
+
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				webhookSecret: testSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'x-fs-signature') return expectedSignature;
+					return null;
+				}),
+				rawBody: stringBody,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds webhook request verification for the Formstack Trigger node using HMAC SHA-256 signing.

- On webhook creation, generates a secret and registers it with Formstack via the `hmac_secret` parameter; stored in the workflow's static data.
- Incoming requests are verified against the `X-FS-Signature` header using the shared `verifySignature` utility.
- Backward compatible: existing webhooks without a stored secret skip verification.
- Cleans up the stored secret when the webhook is deleted.

<img width="2502" height="1304" alt="2026-04-30 12 53 12" src="https://github.com/user-attachments/assets/9e308f2d-c9ea-432c-b33c-6e742419adda" />

### Verification

Tested with [n8n-node-mocker](https://github.com/DawidMyslak/n8n-node-mocker):
- ✅ Correct secret → 200 OK
- ✅ Wrong secret → 401 Unauthorized

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4307

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI