### PR TITLE
fix(core): Include stack trace in error logs for non-ApplicationError errors

### DIFF
--- a/packages/core/src/errors/__tests__/error-reporter.test.ts
+++ b/packages/core/src/errors/__tests__/error-reporter.test.ts
@@ -209,5 +209,23 @@ describe('ErrorReporter', () => {
 			errorReporter.error(error, { shouldBeLogged: false });
 			expect(logger.error).toHaveBeenCalledTimes(0);
 		});
+
+		it('should include stack trace for generic `Error`', () => {
+			const genericError = new Error('Something broke');
+			errorReporter.error(genericError);
+			expect(logger.error).toHaveBeenCalledWith(
+				`Something broke\n${genericError.stack}\n`,
+				undefined,
+			);
+		});
+
+		it('should include stack trace for generic error cause chain', () => {
+			const cause = new Error('root cause');
+			const outer = new Error('outer', { cause });
+			errorReporter.error(outer);
+			expect(logger.error).toHaveBeenCalledTimes(2);
+			expect(logger.error).toHaveBeenNthCalledWith(1, `outer\n${outer.stack}\n`, undefined);
+			expect(logger.error).toHaveBeenNthCalledWith(2, `root cause\n${cause.stack}\n`, undefined);
+		});
 	});
 });

--- a/packages/core/src/errors/error-reporter.ts
+++ b/packages/core/src/errors/error-reporter.ts
@@ -87,6 +87,8 @@ export class ErrorReporter {
 						stack = `\n${e.stack}\n`;
 					}
 					meta = e.extra;
+				} else if (e.stack) {
+					stack = `\n${e.stack}\n`;
 				}
 				const msg = [e.message + context, stack].join('');
 				// Default to logging the error if option is not specified


### PR DESCRIPTION
## Summary

The motivation for this is to get better error information.

Previously, `ErrorReporter.defaultReport` only included stack traces for `ApplicationError`/`BaseError` with `level === 'error'`. All other error types (e.g. native `Error`, `TypeError`) had their stacks silently dropped from logs, making debugging harder. This adds an `else` branch so non-n8n errors also get their stack traces logged.

- [x] I have seen this code, I have run this code, and I take responsibility for this code.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)