### PR TITLE
refactor(core): Simplify message event bus recovery (no-changelog)

### DIFF
--- a/packages/cli/src/eventbus/event-message-classes/index.ts
+++ b/packages/cli/src/eventbus/event-message-classes/index.ts
@@ -158,3 +158,6 @@ export type EventMessageTypes =
 	| EventMessageAiNode
 	| EventMessageQueue
 	| EventMessageRunner;
+
+export const isNodeEventMessage = (message: EventMessageTypes): message is EventMessageNode =>
+	message.eventName.startsWith('n8n.node.');

--- a/packages/cli/src/eventbus/message-event-bus/message-event-bus.ts
+++ b/packages/cli/src/eventbus/message-event-bus/message-event-bus.ts
@@ -36,7 +36,6 @@ export interface MessageWithCallback {
 }
 
 export interface MessageEventBusInitializeOptions {
-	skipRecoveryPass?: boolean;
 	workerId?: string;
 	webhookProcessorId?: string;
 }
@@ -69,7 +68,6 @@ export class MessageEventBus extends EventEmitter {
 	 *
 	 * Sets `isInitialized` to `true` once finished.
 	 */
-	// eslint-disable-next-line complexity
 	async initialize(options?: MessageEventBusInitializeOptions): Promise<void> {
 		if (this.isInitialized) {
 			return;
@@ -95,97 +93,8 @@ export class MessageEventBus extends EventEmitter {
 			this.logger.warn('Could not initialize event writer');
 		}
 
-		if (options?.skipRecoveryPass) {
-			this.logger.debug('Skipping unsent event check');
-		} else {
-			// unsent event check:
-			// - find unsent messages in current event log(s)
-			// - cycle event logs and start the logging to a fresh file
-			// - retry sending events
-			this.logger.debug('Checking for unsent event messages');
-			const unsentAndUnfinished = await this.getUnsentAndUnfinishedExecutions();
-			this.logger.debug(
-				`Start logging into ${this.logWriter?.getLogFileName() ?? 'unknown filename'} `,
-			);
-			this.logWriter?.startLogging();
-			await this.send(unsentAndUnfinished.unsentMessages);
+		await this.performStartupRecovery();
 
-			let unfinishedExecutionIds = Object.keys(unsentAndUnfinished.unfinishedExecutions);
-
-			// if we are in queue mode, running jobs may still be running on a worker despite the main process
-			// crashing, so we can't just mark them as crashed
-			if (this.globalConfig.executions.mode !== 'queue') {
-				const dbUnfinishedExecutionIds = (
-					await this.executionRepository.find({
-						where: {
-							status: In(['running', 'unknown']),
-						},
-						select: ['id'],
-					})
-				).map((e) => e.id);
-				unfinishedExecutionIds = Array.from(
-					new Set<string>([...unfinishedExecutionIds, ...dbUnfinishedExecutionIds]),
-				);
-			}
-
-			if (unfinishedExecutionIds.length > 0) {
-				const activeWorkflows = await this.workflowRepository.find({
-					where: { activeVersionId: Not(IsNull()) },
-					select: ['id', 'name'],
-				});
-				if (activeWorkflows.length > 0) {
-					this.logger.info('Currently active workflows:');
-					for (const workflowData of activeWorkflows) {
-						this.logger.info(`   - ${workflowData.name} (ID: ${workflowData.id})`);
-					}
-				}
-				const recoveryAlreadyAttempted = this.logWriter?.isRecoveryProcessRunning();
-				if (recoveryAlreadyAttempted || this.globalConfig.eventBus.crashRecoveryMode === 'simple') {
-					await this.executionRepository.markAsCrashed(unfinishedExecutionIds);
-					// if we end up here, it means that the previous recovery process did not finish
-					// a possible reason would be that recreating the workflow data itself caused e.g an OOM error
-					// in that case, we do not want to retry the recovery process, but rather mark the executions as crashed
-					if (recoveryAlreadyAttempted)
-						this.logger.warn('Skipped recovery process since it previously failed.');
-				} else {
-					// start actual recovery process and write recovery process flag file
-					this.logWriter?.startRecoveryProcess();
-					const recoveredIds: string[] = [];
-					const crashedWorkflowIds: Set<string> = new Set();
-
-					for (const executionId of unfinishedExecutionIds) {
-						const logMessages = unsentAndUnfinished.unfinishedExecutions[executionId];
-						const recoveredExecution = await this.recoveryService.recoverFromLogs(
-							executionId,
-							logMessages ?? [],
-						);
-						if (recoveredExecution) {
-							if (recoveredExecution.status === 'crashed') {
-								crashedWorkflowIds.add(recoveredExecution.workflowId);
-							}
-							recoveredIds.push(executionId);
-						}
-					}
-
-					if (recoveredIds.length > 0) {
-						this.logger.warn(`Found unfinished executions: ${recoveredIds.join(', ')}`);
-						this.logger.info(
-							'This could be due to a crash of an active workflow or a restart of n8n',
-						);
-					}
-
-					if (
-						this.globalConfig.executions.recovery.workflowDeactivationEnabled &&
-						crashedWorkflowIds.size > 0
-					) {
-						await this.recoveryService.autoDeactivateWorkflowsIfNeeded(crashedWorkflowIds);
-					}
-				}
-
-				// remove the recovery process flag file
-				this.logWriter?.endRecoveryProcess();
-			}
-		}
 		// if configured, run this test every n ms
 		if (this.globalConfig.eventBus.checkUnsentInterval > 0) {
 			if (this.pushIntervalTimer) {
@@ -325,5 +234,96 @@ export class MessageEventBus extends EventEmitter {
 
 	async sendQueueEvent(options: EventMessageQueueOptions) {
 		await this.send(new EventMessageQueue(options));
+	}
+
+	// eslint-disable-next-line complexity
+	private async performStartupRecovery() {
+		// unsent event check:
+		// - find unsent messages in current event log(s)
+		// - cycle event logs and start the logging to a fresh file
+		// - retry sending events
+		this.logger.debug('Checking for unsent event messages');
+		const unsentAndUnfinished = await this.getUnsentAndUnfinishedExecutions();
+		this.logger.debug(
+			`Start logging into ${this.logWriter?.getLogFileName() ?? 'unknown filename'} `,
+		);
+		this.logWriter?.startLogging();
+		await this.send(unsentAndUnfinished.unsentMessages);
+
+		let unfinishedExecutionIds = Object.keys(unsentAndUnfinished.unfinishedExecutions);
+
+		// if we are in queue mode, running jobs may still be running on a worker despite the main process
+		// crashing, so we can't just mark them as crashed
+		if (this.globalConfig.executions.mode !== 'queue') {
+			const dbUnfinishedExecutionIds = (
+				await this.executionRepository.find({
+					where: {
+						status: In(['running', 'unknown']),
+					},
+					select: ['id'],
+				})
+			).map((e) => e.id);
+			unfinishedExecutionIds = Array.from(
+				new Set<string>([...unfinishedExecutionIds, ...dbUnfinishedExecutionIds]),
+			);
+		}
+
+		if (unfinishedExecutionIds.length > 0) {
+			const activeWorkflows = await this.workflowRepository.find({
+				where: { activeVersionId: Not(IsNull()) },
+				select: ['id', 'name'],
+			});
+			if (activeWorkflows.length > 0) {
+				this.logger.info('Currently active workflows:');
+				for (const workflowData of activeWorkflows) {
+					this.logger.info(`   - ${workflowData.name} (ID: ${workflowData.id})`);
+				}
+			}
+			const recoveryAlreadyAttempted = this.logWriter?.isRecoveryProcessRunning();
+			if (recoveryAlreadyAttempted || this.globalConfig.eventBus.crashRecoveryMode === 'simple') {
+				await this.executionRepository.markAsCrashed(unfinishedExecutionIds);
+				// if we end up here, it means that the previous recovery process did not finish
+				// a possible reason would be that recreating the workflow data itself caused e.g an OOM error
+				// in that case, we do not want to retry the recovery process, but rather mark the executions as crashed
+				if (recoveryAlreadyAttempted)
+					this.logger.warn('Skipped recovery process since it previously failed.');
+			} else {
+				// start actual recovery process and write recovery process flag file
+				this.logWriter?.startRecoveryProcess();
+				const recoveredIds: string[] = [];
+				const crashedWorkflowIds: Set<string> = new Set();
+
+				for (const executionId of unfinishedExecutionIds) {
+					const logMessages = unsentAndUnfinished.unfinishedExecutions[executionId];
+					const recoveredExecution = await this.recoveryService.recoverFromLogs(
+						executionId,
+						logMessages ?? [],
+					);
+					if (recoveredExecution) {
+						if (recoveredExecution.status === 'crashed') {
+							crashedWorkflowIds.add(recoveredExecution.workflowId);
+						}
+						recoveredIds.push(executionId);
+					}
+				}
+
+				if (recoveredIds.length > 0) {
+					this.logger.warn(`Found unfinished executions: ${recoveredIds.join(', ')}`);
+					this.logger.info(
+						'This could be due to a crash of an active workflow or a restart of n8n',
+					);
+				}
+
+				if (
+					this.globalConfig.executions.recovery.workflowDeactivationEnabled &&
+					crashedWorkflowIds.size > 0
+				) {
+					await this.recoveryService.autoDeactivateWorkflowsIfNeeded(crashedWorkflowIds);
+				}
+			}
+
+			// remove the recovery process flag file
+			this.logWriter?.endRecoveryProcess();
+		}
 	}
 }

--- a/packages/cli/src/executions/__tests__/execution-recovery.service.integration.test.ts
+++ b/packages/cli/src/executions/__tests__/execution-recovery.service.integration.test.ts
@@ -276,7 +276,7 @@ describe('ExecutionRecoveryService', () => {
 				 */
 				assert(amendedExecution);
 				expect(amendedExecution.stoppedAt).not.toBe(execution.stoppedAt);
-				expect(amendedExecution.data).toEqual({ resultData: { runData: {} } });
+				expect(amendedExecution.data).toEqual({ version: 1, resultData: { runData: {} } });
 				expect(amendedExecution.status).toBe('crashed');
 			});
 

--- a/packages/cli/src/executions/execution-recovery.service.ts
+++ b/packages/cli/src/executions/execution-recovery.service.ts
@@ -23,7 +23,7 @@ import { Push } from '@/push';
 import { OwnershipService } from '@/services/ownership.service';
 import { UserManagementMailer } from '@/user-management/email/user-management-mailer';
 
-import type { EventMessageTypes } from '../eventbus/event-message-classes';
+import { isNodeEventMessage, type EventMessageTypes } from '../eventbus/event-message-classes';
 
 /**
  * Service for recovering key properties in executions.
@@ -128,9 +128,9 @@ export class ExecutionRecoveryService {
 	private async amend(executionId: string, messages: EventMessageTypes[]) {
 		if (messages.length === 0) return await this.amendWithoutLogs(executionId);
 
-		const { nodeMessages, workflowMessages } = this.toRelevantMessages(messages);
+		const { nodeMessagesByName, workflowMessages } = this.toRelevantMessages(messages);
 
-		if (nodeMessages.length === 0) return null;
+		if (Object.keys(nodeMessagesByName).length === 0) return null;
 
 		const execution = await this.executionRepository.findSingleExecution(executionId, {
 			includeData: true,
@@ -154,6 +154,7 @@ export class ExecutionRecoveryService {
 		let lastNodeRunTimestamp: DateTime | undefined;
 
 		for (const node of execution.workflowData.nodes) {
+			const nodeMessages = nodeMessagesByName[node.name] ?? [];
 			const nodeStartedMessage = nodeMessages.find(
 				(m) => m.payload.nodeName === node.name && m.eventName === 'n8n.node.started',
 			);
@@ -217,19 +218,21 @@ export class ExecutionRecoveryService {
 
 	private toRelevantMessages(messages: EventMessageTypes[]) {
 		return messages.reduce<{
-			nodeMessages: EventMessageTypes[];
+			nodeMessagesByName: Record<string, EventMessageTypes[]>;
 			workflowMessages: EventMessageTypes[];
 		}>(
 			(acc, cur) => {
-				if (cur.eventName.startsWith('n8n.node.')) {
-					acc.nodeMessages.push(cur);
+				if (isNodeEventMessage(cur)) {
+					const nodeName = cur.payload.nodeName;
+					acc.nodeMessagesByName[nodeName] ??= [];
+					acc.nodeMessagesByName[nodeName].push(cur);
 				} else if (cur.eventName.startsWith('n8n.workflow.')) {
 					acc.workflowMessages.push(cur);
 				}
 
 				return acc;
 			},
-			{ nodeMessages: [], workflowMessages: [] },
+			{ nodeMessagesByName: {}, workflowMessages: [] },
 		);
 	}
 

--- a/packages/cli/src/executions/execution-recovery.service.ts
+++ b/packages/cli/src/executions/execution-recovery.service.ts
@@ -149,7 +149,7 @@ export class ExecutionRecoveryService {
 			return null;
 		}
 
-		const runExecutionData = execution.data ?? { resultData: { runData: {} } };
+		const runExecutionData = execution.data ?? createEmptyRunExecutionData();
 
 		let lastNodeRunTimestamp: DateTime | undefined;
 


### PR DESCRIPTION
## Summary

A small code cleanup before fixing an issue in the crash recovery

- Extract the startup recovery path in `MessageEventBus` into a dedicated method and remove the unused `skipRecoveryPass` initialize option.
- Group execution recovery node events by node name and centralize node-event detection with `isNodeEventMessage`.
- Initialize recovered execution data with `createEmptyRunExecutionData()` and update the integration test expectation.
- Test with `pushd packages/cli && pnpm test src/executions/__tests__/execution-recovery.service.integration.test.ts && popd`.

- [x] I have seen this code, I have run this code, and I take responsibility for this code.

## Related Linear tickets, Github issues, and Community forum posts

- No Linear ticket or GitHub issue was provided for this workspace.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
