### PR TITLE
fix(ai-builder): Filter LangSmith eval dataset by local file slugs

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -359,9 +359,11 @@ async function runWithLangSmith(config: RunConfig): Promise<MultiRunEvaluation> 
 		`Starting evaluate() with concurrency=${String(args.concurrency)}, builds limited to ${String(MAX_CONCURRENT_BUILDS)}, iterations=${String(args.iterations)}`,
 	);
 
-	const sourceExamples = args.filter
-		? filteredExamplesIterable(lsClient, datasetName, args.filter, logger)
-		: lsClient.listExamples({ datasetName });
+	// Always filter the LangSmith dataset by the local file slugs. The local
+	// JSON files are the source of truth; the dataset accumulates orphans (the
+	// sync is additive — see langsmith/dataset-sync.ts) and we don't want to
+	// run scenarios whose JSON file no longer exists.
+	const sourceExamples = filteredExamplesIterable(lsClient, datasetName, args.filter, logger);
 	const evaluateData =
 		args.iterations > 1
 			? expandExamplesForIterations(sourceExamples, args.iterations)
@@ -454,15 +456,16 @@ async function* expandExamplesForIterations(
 function filteredExamplesIterable(
 	lsClient: Client,
 	datasetName: string,
-	filter: string,
+	filter: string | undefined,
 	logger: EvalLogger,
 ): AsyncIterable<Example> {
 	const slugs = loadWorkflowTestCasesWithFiles(filter).map((tc) => tc.fileSlug);
+	const label = filter ? `Filter "${filter}"` : 'Local test cases';
 	if (slugs.length === 0) {
-		logger.info(`Filter "${filter}" matched no local test case files`);
+		logger.info(`${label} matched no local test case files`);
 		return (async function* () {})();
 	}
-	logger.info(`Filter "${filter}" matched ${String(slugs.length)} split(s): ${slugs.join(', ')}`);
+	logger.info(`${label} matched ${String(slugs.length)} split(s): ${slugs.join(', ')}`);
 	return lsClient.listExamples({ datasetName, splits: slugs });
 }
 


### PR DESCRIPTION
## Summary

The eval CLI was reading scenarios directly from the LangSmith dataset when no `--filter` was given. The dataset is additive (`syncDataset` never deletes — see comment in `evaluations/langsmith/dataset-sync.ts`), so orphans from past branches and deleted test cases accumulate over time. PR runs end up evaluating both current scenarios and the orphans, roughly doubling the workload and pushing recent runs over the 45-minute workflow cap.

This PR always filters by the slugs of the local `data/workflows/*.json` files at query time. Local files are the source of truth; orphans get skipped without any change to the sync logic.

**How to test**

Locally with `LANGSMITH_API_KEY` set:

```bash
cd packages/@n8n/instance-ai
dotenvx run -f ../../../.env.local -- pnpm eval:instance-ai --filter cross-team-linear --iterations 2
```

Look for `Local test cases matched N split(s):` (or `Filter "..." matched N split(s):` when `--filter` is passed) in the log — confirms the filter is being applied.

**Why split out from TRUST-27**

The same fix is already part of [PR #29456](https://github.com/n8n-io/n8n/pull/29456) (TRUST-27 regression detector), but that PR is large. Splitting this small fix lets it merge quickly to unblock anyone whose master CI eval is timing out due to orphan accumulation.

## Related Linear tickets

https://linear.app/n8n/issue/TRUST-27/baseline-diffing-and-regression-detection (downstream consumer)

Follow-up: https://linear.app/n8n/issue/TRUST-69/auto-clean-orphan-examples-from-langsmith-eval-dataset-on-sync — make `syncDataset` prune orphans server-side so the dataset stays tidy in the LangSmith UI as well.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI