### PR TITLE
fix(editor): Use text-color to stop color-scheme override on N8nButton (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
@@ -149,7 +149,7 @@ const handleClick = (event: MouseEvent) => {
 	--button--color--background: transparent;
 	--button--color--background-hover: var(--background--hover);
 	--button--color--background-active: var(--background--active);
-	--button--color: light-dark(var(--color--neutral-900), var(--color--neutral-100));
+	--button--color: var(--text-color);
 	--button--shadow: 0 0 0 0 transparent;
 	--button--shadow--hover: 0 0 0 0 transparent;
 	--button--shadow--active: 0 0 0 0 transparent;


### PR DESCRIPTION
## Summary

Fixes [this](https://n8nio.slack.com/archives/C03594NKD7W/p1777452332851619)

- Replace the `light-dark(...)` fallback with the semantic token to follow the design-system guideline of using `var(--text-color)` for component text colors.

| Before | After |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/b5f27845-840b-4dd8-88f9-9239f275b9d2" width="960px" alt="Before image" /> | <img src="https://github.com/user-attachments/assets/88cd0fdc-70d2-4152-aaea-f82cc05b0fab" width="960px" alt="After image" /> |



## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

