### PR TITLE
fix(editor): Show permission-aware message on redacted input/output panels

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1714,6 +1714,7 @@
 	"ndv.redacted.description.sentence1": "Execution data has been redacted.",
 	"ndv.redacted.description.sentence2": "Adjust redaction rules in {link}.",
 	"ndv.redacted.description.link": "workflow settings",
+	"ndv.redacted.noPermission.description": "Execution data has been redacted. You do not have the permissions to reveal it.",
 	"ndv.redacted.dynamicCredentials.description": "This execution used dynamic credentials. Data from dynamic credential executions cannot be revealed.",
 	"ndv.redacted.revealButton": "Reveal data",
 	"ndv.redacted.revealModal.title": "Reveal redacted data",

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/RedactedDataState.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/RedactedDataState.test.ts
@@ -26,9 +26,20 @@ describe('RedactedDataState', () => {
 		expect(queryByText('Execution data has been redacted.')).not.toBeInTheDocument();
 	});
 
-	it('should show standard description with workflow settings link when isDynamicCredentials is false', () => {
-		const { getByText } = renderComponent({
+	it('should show no-permission description when isDynamicCredentials is false and canReveal is false', () => {
+		const { getByText, queryByText } = renderComponent({
 			props: { title: 'Redacted', isDynamicCredentials: false, canReveal: false },
+		});
+
+		expect(
+			getByText('Execution data has been redacted. You do not have the permissions to reveal it.'),
+		).toBeInTheDocument();
+		expect(queryByText('workflow settings')).not.toBeInTheDocument();
+	});
+
+	it('should show standard description with workflow settings link when isDynamicCredentials is false and canReveal is true', () => {
+		const { getByText } = renderComponent({
+			props: { title: 'Redacted', isDynamicCredentials: false, canReveal: true },
 		});
 
 		expect(getByText('Execution data has been redacted.')).toBeInTheDocument();
@@ -63,7 +74,7 @@ describe('RedactedDataState', () => {
 
 	it('should emit "openSettings" when workflow settings link is clicked', async () => {
 		const { getByText, emitted } = renderComponent({
-			props: { title: 'Redacted', isDynamicCredentials: false, canReveal: false },
+			props: { title: 'Redacted', isDynamicCredentials: false, canReveal: true },
 		});
 
 		getByText('workflow settings').click();

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/RedactedDataState.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/RedactedDataState.vue
@@ -26,7 +26,7 @@ const i18n = useI18n();
 		<template v-if="isDynamicCredentials">
 			{{ i18n.baseText('ndv.redacted.dynamicCredentials.description') }}
 		</template>
-		<template v-else>
+		<template v-else-if="canReveal">
 			{{ i18n.baseText('ndv.redacted.description.sentence1') }}<br />
 			<I18nT keypath="ndv.redacted.description.sentence2" tag="span" scope="global">
 				<template #link>
@@ -35,6 +35,9 @@ const i18n = useI18n();
 					}}</N8nLink>
 				</template>
 			</I18nT>
+		</template>
+		<template v-else>
+			{{ i18n.baseText('ndv.redacted.noPermission.description') }}
 		</template>
 		<template v-if="canReveal" #actions>
 			<N8nButton


### PR DESCRIPTION
## Summary

When execution data is redacted, the input and output panels in the NDV now show a different empty-state message depending on whether the current user has the `reveal redacted data` permission.

**Before:** all users saw "Execution data has been redacted. Adjust redaction rules in workflow settings." — including users who have no ability to change those settings or reveal the data.

**After:**
- Users **with** the reveal permission: current behaviour unchanged (settings link + reveal button shown).
- Users **without** the reveal permission: "Execution data has been redacted. You do not have the permissions to reveal it." — no settings link, no reveal button.

### Changes
- `RedactedDataState.vue` — description block is now conditional on `canReveal`; the settings link branch is only rendered when `canReveal` is `true`.
- `en.json` — new i18n key `ndv.redacted.noPermission.description`.
- `RedactedDataState.test.ts` — tests updated to cover both permission states.

### Manual testing steps

**Setup:** you need two users — one with the "reveal redacted data" permission (owner/admin) and one without (a member with restricted permissions). You also need a workflow with execution data redaction enabled (Workflow Settings → Save execution data → Redact).

1. Trigger a production execution of the workflow so data is redacted.
2. Open the execution in the editor and click on any node to open the NDV.
3. **As a user with reveal permission:** confirm the input and output panels show "Execution data has been redacted. Adjust redaction rules in workflow settings." with a link, and a "Reveal data" button.
4. **As a user without reveal permission:** confirm the panels show "Execution data has been redacted. You do not have the permissions to reveal it." with no settings link and no reveal button.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-513

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
