### PR TITLE
fix(Extract From File Node): Parse date-only RRULE UNTIL values

### DIFF
--- a/packages/nodes-base/nodes/Files/ExtractFromFile/actions/moveTo.operation.ts
+++ b/packages/nodes-base/nodes/Files/ExtractFromFile/actions/moveTo.operation.ts
@@ -15,10 +15,11 @@ import {
 	jsonParse,
 	BINARY_MODE_COMBINED,
 } from 'n8n-workflow';
-import { icsCalendarToObject } from 'ts-ics';
 
 import { encodeDecodeOptions } from '@utils/descriptions';
 import { updateDisplayOptions } from '@utils/utilities';
+
+import { parseIcsCalendar } from './parseIcsCalendar';
 
 export const properties: INodeProperties[] = [
 	{
@@ -152,7 +153,7 @@ export async function execute(
 			}
 
 			if (operation === 'fromIcs') {
-				convertedValue = icsCalendarToObject(convertedValue as string);
+				convertedValue = parseIcsCalendar(convertedValue as string);
 			}
 
 			const destinationKey = this.getNodeParameter('destinationKey', itemIndex, '') as string;

--- a/packages/nodes-base/nodes/Files/ExtractFromFile/actions/parseIcsCalendar.ts
+++ b/packages/nodes-base/nodes/Files/ExtractFromFile/actions/parseIcsCalendar.ts
@@ -1,0 +1,10 @@
+import { icsCalendarToObject } from 'ts-ics';
+import type { VCalendar } from 'ts-ics';
+
+export function parseIcsCalendar(calendarString: string): VCalendar {
+	const normalizedCalendar = calendarString.replace(
+		/(^|\r?\n)(RRULE[^\r\n]*?\bUNTIL=)(\d{8})(?=;|\r?\n|$)/g,
+		'$1$2$3T000000Z',
+	);
+	return icsCalendarToObject(normalizedCalendar);
+}

--- a/packages/nodes-base/nodes/Files/ExtractFromFile/actions/parseIcsCalendar.ts
+++ b/packages/nodes-base/nodes/Files/ExtractFromFile/actions/parseIcsCalendar.ts
@@ -2,6 +2,7 @@ import { icsCalendarToObject } from 'ts-ics';
 import type { VCalendar } from 'ts-ics';
 
 export function parseIcsCalendar(calendarString: string): VCalendar {
+	// ts-ics < 2.4.5 does not parse date-only RRULE UNTIL values. Remove this after upgrading.
 	const normalizedCalendar = calendarString.replace(
 		/(^|\r?\n)(RRULE[^\r\n]*?\bUNTIL=)(\d{8})(?=;|\r?\n|$)/g,
 		'$1$2$3T000000Z',

--- a/packages/nodes-base/nodes/Files/ExtractFromFile/test/parseIcsCalendar.test.ts
+++ b/packages/nodes-base/nodes/Files/ExtractFromFile/test/parseIcsCalendar.test.ts
@@ -1,0 +1,45 @@
+import { parseIcsCalendar } from '../actions/parseIcsCalendar';
+
+describe('parseIcsCalendar', () => {
+	it('parses date-only RRULE UNTIL values', () => {
+		const calendar = parseIcsCalendar(`BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//n8n test//EN
+BEGIN:VEVENT
+UID:mDceAWXluoi-MADvoh-u2SFjv3jv@proton.me
+DTSTAMP:20250915T225621Z
+SUMMARY:test recurring
+DTSTART;VALUE=DATE:20250917
+DTEND;VALUE=DATE:20250918
+SEQUENCE:1
+RRULE:FREQ=WEEKLY;UNTIL=20250926
+STATUS:CONFIRMED
+END:VEVENT
+END:VCALENDAR`);
+
+		const until = calendar.events?.[0]?.recurrenceRule?.until?.date;
+
+		expect(until).toBeInstanceOf(Date);
+		expect(until?.toISOString()).toBe('2025-09-26T00:00:00.000Z');
+	});
+
+	it('keeps date-time RRULE UNTIL values valid', () => {
+		const calendar = parseIcsCalendar(`BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//n8n test//EN
+BEGIN:VEVENT
+UID:test
+DTSTAMP:20250915T225621Z
+SUMMARY:test recurring
+DTSTART:20250917T100000Z
+DTEND:20250917T110000Z
+RRULE:FREQ=WEEKLY;UNTIL=20250926T120000Z
+END:VEVENT
+END:VCALENDAR`);
+
+		const until = calendar.events?.[0]?.recurrenceRule?.until?.date;
+
+		expect(until).toBeInstanceOf(Date);
+		expect(until?.toISOString()).toBe('2025-09-26T12:00:00.000Z');
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #19571.

The Extract From File node returns an invalid `recurrenceRule.until.date` for valid ICS recurrence rules using a date-only `UNTIL` value.

For example:

  ```ics
  RRULE:FREQ=WEEKLY;UNTIL=20250926
  ```

This normalizes date-only RRULE UNTIL values before parsing the calendar, so the extracted recurrenceRule.until.date is returned as a valid date.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/GHC-4415

Fixes #19571


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created.  Not needed for this behavior-only bug fix.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
