### PR TITLE
Fixed GHC-8065

### DIFF
--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/activity/create.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/activity/create.operation.ts
@@ -91,8 +91,8 @@ const properties: INodeProperties[] = [
 				description: 'ID of the person this activity will be associated with',
 			},
 			{
-				displayName: 'User Name or ID',
-				name: 'user_id',
+				displayName: 'Owner Name or ID',
+				name: 'owner_id',
 				type: 'options',
 				typeOptions: {
 					loadOptionsMethod: 'getUserIds',

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/activity/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/activity/getAll.operation.ts
@@ -78,7 +78,7 @@ const properties: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'The ID of the Filter to use (will narrow down results if used together with user_id parameter). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The ID of the Filter to use (will narrow down results if used together with owner_id parameter). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Start Date',
@@ -100,15 +100,15 @@ const properties: INodeProperties[] = [
 					'Type of the Activity. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 			},
 			{
-				displayName: 'User Name or ID',
-				name: 'user_id',
+				displayName: 'Owner Name or ID',
+				name: 'owner_id',
 				type: 'options',
 				typeOptions: {
 					loadOptionsMethod: 'getUserIds',
 				},
 				default: '',
 				description:
-					'The ID of the User whose Activities will be fetched. If omitted, the User associated with the API token will be used. If 0, Activities for all company Users will be fetched based on the permission sets. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'The ID of the owner whose Activities will be fetched. If omitted, the User associated with the API token will be used. If 0, Activities for all company Users will be fetched based on the permission sets. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -152,8 +152,8 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 				qs.type = (filters.type as string[]).join(',');
 			}
 
-			if (filters.user_id) {
-				qs.user_id = filters.user_id;
+			if (filters.owner_id) {
+				qs.owner_id = filters.owner_id;
 			}
 
 			if (filters.done !== undefined) {

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/activity/update.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/activity/update.operation.ts
@@ -112,8 +112,8 @@ const properties: INodeProperties[] = [
 				description: 'Type of the activity like "call", "meeting", etc',
 			},
 			{
-				displayName: 'User Name or ID',
-				name: 'user_id',
+				displayName: 'Owner Name or ID',
+				name: 'owner_id',
 				type: 'options',
 				typeOptions: {
 					loadOptionsMethod: 'getUserIds',

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/deal/create.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/deal/create.operation.ts
@@ -186,8 +186,8 @@ const properties: INodeProperties[] = [
 					'The status of the deal. If not provided it will automatically be set to "open".',
 			},
 			{
-				displayName: 'User Name or ID',
-				name: 'user_id',
+				displayName: 'Owner Name or ID',
+				name: 'owner_id',
 				type: 'options',
 				typeOptions: {
 					loadOptionsMethod: 'getUserIds',

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/deal/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/deal/getAll.operation.ts
@@ -98,15 +98,15 @@ const properties: INodeProperties[] = [
 				description: 'Status to filter deals by. Defaults to <code>all_not_deleted</code>',
 			},
 			{
-				displayName: 'User Name or ID',
-				name: 'user_id',
+				displayName: 'Owner Name or ID',
+				name: 'owner_id',
 				type: 'options',
 				typeOptions: {
 					loadOptionsMethod: 'getUserIds',
 				},
 				default: '',
 				description:
-					'ID of the user to filter deals by. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the owner to filter deals by. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 			},
 		],
 	},
@@ -154,8 +154,8 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 				qs.status = filters.status;
 			}
 
-			if (filters.user_id) {
-				qs.user_id = filters.user_id;
+			if (filters.owner_id) {
+				qs.owner_id = filters.owner_id;
 			}
 
 			let responseData;

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/deal/update.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/deal/update.operation.ts
@@ -143,8 +143,8 @@ const properties: INodeProperties[] = [
 				description: 'The title of the deal',
 			},
 			{
-				displayName: 'User Name or ID',
-				name: 'user_id',
+				displayName: 'Owner Name or ID',
+				name: 'owner_id',
 				type: 'options',
 				typeOptions: {
 					loadOptionsMethod: 'getUserIds',


### PR DESCRIPTION
Fixed Pipedrive v2 API drift with user_id -> owner_id for deal.create, deal.update, deal.getAll, activity.create, activity.update, activity.getAll

## Summary

The Pipedrive node drifted from the Pipedrive v2 API spec regarding `user_id` being renamed to `owner_id`. Fixed these params in the node definitions.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/issues/29519 closes #29519
https://linear.app/n8n/issue/GHC-8065

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.