### PR TITLE
fix: Add sequence prefix to proxy expectation recordings (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/docs/e2e-tests.md
+++ b/packages/@n8n/instance-ai/docs/e2e-tests.md
@@ -210,15 +210,16 @@ Each test's HTTP exchanges are stored as individual JSON files:
 
 ```
 expectations/instance-ai/should-send-message-and-receive-assistant-response/
-  1775805992870-unknown-host-POST-_v1_messages-8a23f6c2.json    ← Anthropic API call
-  1775805993100-api-staging.n8n.io-GET-_api_community_nodes-272f77d5.json  ← Node catalog
+  0000-1775805992870-unknown-host-POST-_v1_messages-8a23f6c2.json    ← Anthropic API call
+  0001-1775805993100-api-staging.n8n.io-GET-_api_community_nodes-272f77d5.json  ← Node catalog
   trace.jsonl                                                     ← Tool trace
 ```
 
 ### File Naming
 
-`<timestamp>-<host>-<method>-<path_slugified>-<8char_sha256>.json`
+`<sequence>-<timestamp>-<host>-<method>-<path_slugified>-<8char_sha256>.json`
 
+- `sequence` = zero-padded write order within the recording, used to keep replay deterministic when multiple matching requests are recorded in the same millisecond
 - `unknown-host` = Anthropic API (CONNECT tunneling hides the real host)
 - `api-staging.n8n.io` = n8n community nodes API
 

--- a/packages/testing/containers/services/proxy.ts
+++ b/packages/testing/containers/services/proxy.ts
@@ -341,7 +341,7 @@ export class ProxyServer {
 			await fs.mkdir(targetDir, { recursive: true });
 			const seenRequests = new Set<string>();
 
-			for (const expectation of recordedExpectations) {
+			for (const [index, expectation] of recordedExpectations.entries()) {
 				if (
 					!expectation.httpRequest ||
 					!(
@@ -413,7 +413,8 @@ export class ProxyServer {
 					.digest('hex')
 					.substring(0, 8);
 
-				const filename = `${Date.now()}-${hostName}-${method}-${expectation.httpRequest.path.replace(/[^a-zA-Z0-9]/g, '_')}-${hash}.json`;
+				const sequence = String(index).padStart(4, '0');
+				const filename = `${sequence}-${Date.now()}-${hostName}-${method}-${expectation.httpRequest.path.replace(/[^a-zA-Z0-9]/g, '_')}-${hash}.json`;
 				processedExpectation.id = filename;
 				const filePath = join(targetDir, filename);
 


### PR DESCRIPTION
## Summary

There were duplicate request files in the instance-ai fixture/recordings because of same timestamp.

Split out from https://github.com/n8n-io/n8n/pull/29340

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
