### PR TITLE
fix(core): Add missing @n8n/tournament alias to Vite config (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -35,6 +35,7 @@ const alias = [
 	// Ensure bare imports resolve to sources (not dist)
 	{ find: '@n8n/i18n', replacement: resolve(packagesDir, 'frontend', '@n8n', 'i18n', 'src') },
 	{ find: '@n8n/chat-hub', replacement: resolve(packagesDir, '@n8n', 'chat-hub', 'src') },
+	{ find: '@n8n/tournament', replacement: resolve(packagesDir, '@n8n', 'tournament', 'src') },
 	{
 		find: /^@n8n\/chat(.+)$/,
 		replacement: resolve(packagesDir, 'frontend', '@n8n', 'chat', 'src$1'),


### PR DESCRIPTION
## Summary

After `@n8n/tournament` was moved into the monorepo (#29358), its Vite alias was never added to `editor-ui/vite.config.mts`. All other monorepo packages have an alias redirecting bare imports to their `src/` directory so Vite serves TypeScript directly in dev mode. Without this alias, Vite resolved `@n8n/tournament` via the `exports` map, which points both `import` and `require` conditions to the CJS `dist/index.js`. CJS re-exports of `recast` named exports (like `astVisit`) don't surface as ESM named imports, causing the dev server crash:

```
Uncaught SyntaxError: The requested module '/@fs/.../packages/@n8n/tournament/dist/index.js'
does not provide an export named 'astVisit'
```

**Fix:** Add one alias entry pointing `@n8n/tournament` → `src/`, consistent with every other monorepo package alias in the file.

**To test:** Run `pnpm dev:fe` -> browser should load without the SyntaxError.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2988

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI