### PR TITLE
fix(Todoist Node): Migrate to Todoist unified API v1 endpoints

### DIFF
--- a/packages/nodes-base/credentials/TodoistApi.credentials.ts
+++ b/packages/nodes-base/credentials/TodoistApi.credentials.ts
@@ -32,7 +32,7 @@ export class TodoistApi implements ICredentialType {
 
 	test: ICredentialTestRequest = {
 		request: {
-			baseURL: 'https://api.todoist.com/rest/v2',
+			baseURL: 'https://api.todoist.com/api/v1',
 			url: '/labels',
 		},
 	};

--- a/packages/nodes-base/nodes/Todoist/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Todoist/GenericFunctions.ts
@@ -56,11 +56,15 @@ export async function todoistSyncRequest(
 ): Promise<any> {
 	const authentication = this.getNodeParameter('authentication', 0, 'oAuth2');
 
+	const nodeVersion = this.getNode().typeVersion;
+	const baseUrl =
+		nodeVersion >= 2.2 ? 'https://api.todoist.com/api/v1' : 'https://api.todoist.com/sync/v9';
+
 	const options: IRequestOptions = {
 		headers: {},
 		method: 'POST',
 		qs,
-		uri: `https://api.todoist.com/sync/v9${endpoint}`,
+		uri: `${baseUrl}${endpoint}`,
 		json: true,
 	};
 

--- a/packages/nodes-base/nodes/Todoist/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Todoist/test/GenericFunctions.test.ts
@@ -2,7 +2,7 @@ import { mock } from 'jest-mock-extended';
 import type { IExecuteFunctions, INode } from 'n8n-workflow';
 
 import type { Context } from '../GenericFunctions';
-import { todoistApiGetAllRequest } from '../GenericFunctions';
+import { todoistApiGetAllRequest, todoistSyncRequest } from '../GenericFunctions';
 
 const createMockContext = (typeVersion: number = 2.2) => {
 	const mockRequestWithAuth = jest.fn();
@@ -28,6 +28,38 @@ const createMockContext = (typeVersion: number = 2.2) => {
 describe('GenericFunctions', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
+	});
+
+	describe('todoistSyncRequest', () => {
+		it('should use api/v1 endpoint for node version >= 2.2', async () => {
+			const { ctx, mockRequestWithAuth } = createMockContext(2.2);
+			mockRequestWithAuth.mockResolvedValue({});
+
+			await todoistSyncRequest.call(ctx, { commands: [] });
+
+			const calledOptions = mockRequestWithAuth.mock.calls[0][2];
+			expect(calledOptions.uri).toBe('https://api.todoist.com/api/v1/sync');
+		});
+
+		it('should use sync/v9 endpoint for node version < 2.2', async () => {
+			const { ctx, mockRequestWithAuth } = createMockContext(2.1);
+			mockRequestWithAuth.mockResolvedValue({});
+
+			await todoistSyncRequest.call(ctx, { commands: [] });
+
+			const calledOptions = mockRequestWithAuth.mock.calls[0][2];
+			expect(calledOptions.uri).toBe('https://api.todoist.com/sync/v9/sync');
+		});
+
+		it('should use api/v1 endpoint for quick/add on version >= 2.2', async () => {
+			const { ctx, mockRequestWithAuth } = createMockContext(2.2);
+			mockRequestWithAuth.mockResolvedValue({});
+
+			await todoistSyncRequest.call(ctx, { text: 'test' }, {}, '/quick/add');
+
+			const calledOptions = mockRequestWithAuth.mock.calls[0][2];
+			expect(calledOptions.uri).toBe('https://api.todoist.com/api/v1/quick/add');
+		});
 	});
 
 	describe('todoistApiGetAllRequest', () => {

--- a/packages/nodes-base/nodes/Todoist/v2/OperationHandler.ts
+++ b/packages/nodes-base/nodes/Todoist/v2/OperationHandler.ts
@@ -869,7 +869,9 @@ export class QuickAddHandler implements OperationHandler {
 			body.auto_reminder = options.auto_reminder;
 		}
 
-		const data = await todoistSyncRequest.call(ctx, body, {}, '/quick/add');
+		const nodeVersion = ctx.getNode().typeVersion;
+		const quickAddEndpoint = nodeVersion >= 2.2 ? '/tasks/quick' : '/quick/add';
+		const data = await todoistSyncRequest.call(ctx, body, {}, quickAddEndpoint);
 
 		return {
 			data,

--- a/packages/nodes-base/nodes/Todoist/v2/test/OperationHandler.test.ts
+++ b/packages/nodes-base/nodes/Todoist/v2/test/OperationHandler.test.ts
@@ -1192,6 +1192,25 @@ describe('OperationHandler', () => {
 				);
 				expect(result).toEqual({ data: expectedResponse });
 			});
+
+			it('should use /tasks/quick endpoint for node version >= 2.2', async () => {
+				const handler = new QuickAddHandler();
+				const mockCtx = createMockContext({
+					text: 'Buy milk',
+					options: {},
+				});
+				mockCtx.getNode.mockReturnValue(mock<INode>({ typeVersion: 2.2 }));
+
+				mockTodoistSyncRequest.mockResolvedValue({ id: '123' });
+
+				await handler.handleOperation(mockCtx, 0);
+
+				expect(mockTodoistSyncRequest).toHaveBeenCalledWith(
+					{ text: 'Buy milk' },
+					{},
+					'/tasks/quick',
+				);
+			});
 		});
 	});
 


### PR DESCRIPTION
## Summary

Todoist deprecated their legacy Sync API (`sync/v9`) and REST API (`rest/v2`) in favor of the unified API v1 (`api/v1`). This broke several Todoist node operations:

- **Move task** — `item_move` sync command hit deprecated `sync/v9/sync` endpoint
- **Quick Add** — `/quick/add` path no longer exists, moved to `/tasks/quick`
- **Credential test** — test request hit deprecated `rest/v2/labels`

### Changes

1. **`GenericFunctions.ts`** — `todoistSyncRequest` now routes to `api.todoist.com/api/v1` for node version ≥ 2.2, keeping `sync/v9` as fallback for older versions
2. **`v2/OperationHandler.ts`** — `QuickAddHandler` uses `/tasks/quick` for v2.2+ (was `/quick/add`)
3. **`credentials/TodoistApi.credentials.ts`** — Credential test URL updated from `rest/v2` to `api/v1`

### How to test

1. Set up Todoist API key credential → should pass validation
2. Create a task via "Get All", then use "Move" to another project → should succeed
3. Use "Quick Add" with natural language → should succeed
4. Verify network requests go to `api.todoist.com/api/v1/...` (not `sync/v9`)

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-4610
- Fixes #26450

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

Made with [Cursor](https://cursor.com)