### PR TITLE
feat(Pipedrive Node): Allow selecting custom fields when creating/updating records

### DIFF
--- a/packages/nodes-base/nodes/Pipedrive/test/v2/customFields.test.ts
+++ b/packages/nodes-base/nodes/Pipedrive/test/v2/customFields.test.ts
@@ -1,6 +1,10 @@
 import type { IDataObject, INodeExecutionData } from 'n8n-workflow';
 
-import { encodeCustomFieldsV2, resolveCustomFieldsV2 } from '../../v2/helpers/customFields';
+import {
+	encodeCustomFieldsV2,
+	resolveCustomFieldsV2,
+	applyCustomFieldsMapping,
+} from '../../v2/helpers/customFields';
 import { addFieldsToBody } from '../../v2/helpers/fields';
 import { coerceToBoolean, coerceToNumber, toRfc3339 } from '../../v2/helpers/typeCoercion';
 import type { ICustomProperties } from '../../v2/transport';
@@ -386,6 +390,41 @@ describe('Pipedrive v2 Type Coercion', () => {
 		});
 		it('should pass through date-only format unchanged', () => {
 			expect(toRfc3339('2024-01-15')).toBe('2024-01-15');
+		});
+	});
+
+	describe('applyCustomFieldsMapping', () => {
+		it('is a no-op when mappingValue is null/undefined/empty', () => {
+			const a: IDataObject = { foo: 1 };
+			applyCustomFieldsMapping(a, null);
+			applyCustomFieldsMapping(a, undefined);
+			applyCustomFieldsMapping(a, {});
+			expect(a).toEqual({ foo: 1 });
+		});
+
+		it('initialises body.custom_fields when missing', () => {
+			const body: IDataObject = {};
+			applyCustomFieldsMapping(body, { abc123_text: 'Hello' });
+			expect(body.custom_fields).toEqual({ abc123_text: 'Hello' });
+		});
+
+		it('mapper values override legacy custom_fields entries on key conflict', () => {
+			const body: IDataObject = {
+				custom_fields: { abc123_text: 'from-legacy' },
+			};
+			applyCustomFieldsMapping(body, { abc123_text: 'from-mapper' });
+			expect(body.custom_fields).toEqual({ abc123_text: 'from-mapper' });
+		});
+
+		it('merges non-conflicting keys from both sources', () => {
+			const body: IDataObject = {
+				custom_fields: { abc123_text: 'A' },
+			};
+			applyCustomFieldsMapping(body, { def456_enum: 20 });
+			expect(body.custom_fields).toEqual({
+				abc123_text: 'A',
+				def456_enum: 20,
+			});
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Pipedrive/test/v2/customFields.test.ts
+++ b/packages/nodes-base/nodes/Pipedrive/test/v2/customFields.test.ts
@@ -175,6 +175,44 @@ describe('Pipedrive v2 Custom Fields', () => {
 
 			expect(item.custom_fields).toEqual({ unknown_key: 'some value' });
 		});
+
+		describe('clearing enum/set fields', () => {
+			it('encodes empty string to null for enum', () => {
+				const item: IDataObject = { custom_fields: { def456_enum: '' } };
+				encodeCustomFieldsV2(customProperties, item);
+				expect(item.custom_fields).toEqual({ def456_enum: null });
+			});
+
+			it('encodes null to null for enum', () => {
+				const item: IDataObject = { custom_fields: { def456_enum: null } };
+				encodeCustomFieldsV2(customProperties, item);
+				expect(item.custom_fields).toEqual({ def456_enum: null });
+			});
+
+			it('encodes empty string to null for visible_to', () => {
+				const item: IDataObject = { custom_fields: { jkl012_visible: '' } };
+				encodeCustomFieldsV2(customProperties, item);
+				expect(item.custom_fields).toEqual({ jkl012_visible: null });
+			});
+
+			it('encodes empty string to [] for set', () => {
+				const item: IDataObject = { custom_fields: { ghi789_set: '' } };
+				encodeCustomFieldsV2(customProperties, item);
+				expect(item.custom_fields).toEqual({ ghi789_set: [] });
+			});
+
+			it('encodes null to [] for set', () => {
+				const item: IDataObject = { custom_fields: { ghi789_set: null } };
+				encodeCustomFieldsV2(customProperties, item);
+				expect(item.custom_fields).toEqual({ ghi789_set: [] });
+			});
+
+			it('drops trailing empty entries from set CSV', () => {
+				const item: IDataObject = { custom_fields: { ghi789_set: 'Tag One,, Tag Three,' } };
+				encodeCustomFieldsV2(customProperties, item);
+				expect(item.custom_fields).toEqual({ ghi789_set: [1, 3] });
+			});
+		});
 	});
 
 	describe('resolveCustomFieldsV2', () => {

--- a/packages/nodes-base/nodes/Pipedrive/test/v2/methods/resourceMapping.test.ts
+++ b/packages/nodes-base/nodes/Pipedrive/test/v2/methods/resourceMapping.test.ts
@@ -138,6 +138,7 @@ describe('Pipedrive v2 Resource Mapping', () => {
 			expect(byId.hex_date.type).toBe('dateTime');
 			expect(byId.hex_enum.type).toBe('options');
 			expect(byId.hex_enum.options).toEqual([
+				{ name: '— Clear value —', value: '' },
 				{ name: 'Low', value: 1 },
 				{ name: 'High', value: 2 },
 			]);

--- a/packages/nodes-base/nodes/Pipedrive/test/v2/methods/resourceMapping.test.ts
+++ b/packages/nodes-base/nodes/Pipedrive/test/v2/methods/resourceMapping.test.ts
@@ -1,0 +1,234 @@
+import { mockDeep } from 'jest-mock-extended';
+import type { ILoadOptionsFunctions } from 'n8n-workflow';
+
+import { mapPipedriveFieldType } from '../../../v2/helpers/customFields';
+import { getCustomFieldsMappingColumns } from '../../../v2/methods/resourceMapping';
+
+function makeLoadOptionsMock(currentResource: string | undefined) {
+	const ctx = mockDeep<ILoadOptionsFunctions>();
+	ctx.getCurrentNodeParameter.mockReturnValue(currentResource as string);
+	ctx.getNodeParameter.mockReturnValue('apiToken');
+	ctx.getNode.mockReturnValue({
+		id: 'test-node-id',
+		name: 'Pipedrive',
+		type: 'n8n-nodes-base.pipedrive',
+		typeVersion: 2,
+		position: [0, 0],
+		parameters: {},
+	});
+	return ctx;
+}
+
+function mockApiResponse(
+	ctx: ReturnType<typeof makeLoadOptionsMock>,
+	fields: Array<Record<string, unknown>>,
+) {
+	ctx.helpers.requestWithAuthentication.mockResolvedValue({
+		success: true,
+		data: fields,
+		additional_data: {},
+	});
+}
+
+describe('Pipedrive v2 Resource Mapping', () => {
+	describe('getCustomFieldsMappingColumns', () => {
+		it('returns empty fields with notice when resource is missing', async () => {
+			const ctx = makeLoadOptionsMock(undefined);
+			const result = await getCustomFieldsMappingColumns.call(ctx);
+
+			expect(result.fields).toEqual([]);
+			expect(result.emptyFieldsNotice).toContain('Select a resource');
+			expect(ctx.helpers.requestWithAuthentication).not.toHaveBeenCalled();
+		});
+
+		it('returns empty fields with notice when resource is unsupported', async () => {
+			const ctx = makeLoadOptionsMock('note');
+			const result = await getCustomFieldsMappingColumns.call(ctx);
+
+			expect(result.fields).toEqual([]);
+			expect(result.emptyFieldsNotice).toBeDefined();
+			expect(ctx.helpers.requestWithAuthentication).not.toHaveBeenCalled();
+		});
+
+		it('filters out built-in fields with is_custom_field=false', async () => {
+			const ctx = makeLoadOptionsMock('deal');
+			mockApiResponse(ctx, [
+				{
+					field_code: 'label',
+					field_name: 'Label',
+					field_type: 'set',
+					is_custom_field: false,
+				},
+				{
+					field_code: 'status',
+					field_name: 'Status',
+					field_type: 'enum',
+					is_custom_field: false,
+				},
+				{
+					field_code: 'abc123',
+					field_name: 'My Custom Text',
+					field_type: 'text',
+					is_custom_field: true,
+				},
+			]);
+
+			const result = await getCustomFieldsMappingColumns.call(ctx);
+
+			expect(result.fields).toHaveLength(1);
+			expect(result.fields[0]).toMatchObject({
+				id: 'abc123',
+				displayName: 'My Custom Text',
+				type: 'string',
+			});
+		});
+
+		it('maps deal custom fields with correct types', async () => {
+			const ctx = makeLoadOptionsMock('deal');
+			mockApiResponse(ctx, [
+				{
+					field_code: 'hex_text',
+					field_name: 'Text Field',
+					field_type: 'text',
+					is_custom_field: true,
+				},
+				{
+					field_code: 'hex_num',
+					field_name: 'Number Field',
+					field_type: 'double',
+					is_custom_field: true,
+				},
+				{
+					field_code: 'hex_bool',
+					field_name: 'Active',
+					field_type: 'boolean',
+					is_custom_field: true,
+				},
+				{
+					field_code: 'hex_date',
+					field_name: 'Due Date',
+					field_type: 'date',
+					is_custom_field: true,
+				},
+				{
+					field_code: 'hex_enum',
+					field_name: 'Priority',
+					field_type: 'enum',
+					is_custom_field: true,
+					options: [
+						{ id: 1, label: 'Low' },
+						{ id: 2, label: 'High' },
+					],
+				},
+				{
+					field_code: 'hex_set',
+					field_name: 'Tags',
+					field_type: 'set',
+					is_custom_field: true,
+					options: [{ id: 5, label: 'Tag One' }],
+				},
+			]);
+
+			const result = await getCustomFieldsMappingColumns.call(ctx);
+
+			const byId = Object.fromEntries(result.fields.map((f) => [f.id, f]));
+			expect(byId.hex_text.type).toBe('string');
+			expect(byId.hex_num.type).toBe('number');
+			expect(byId.hex_bool.type).toBe('boolean');
+			expect(byId.hex_date.type).toBe('dateTime');
+			expect(byId.hex_enum.type).toBe('options');
+			expect(byId.hex_enum.options).toEqual([
+				{ name: 'Low', value: 1 },
+				{ name: 'High', value: 2 },
+			]);
+			expect(byId.hex_set.type).toBe('string');
+		});
+
+		it('uses v1 key/name when v2 field_code/field_name is missing (lead)', async () => {
+			const ctx = makeLoadOptionsMock('lead');
+			ctx.helpers.requestWithAuthentication.mockResolvedValue({
+				success: true,
+				data: [
+					{
+						key: 'v1_hex',
+						name: 'Lead Custom',
+						field_type: 'text',
+						is_custom_field: true,
+					},
+				],
+				additional_data: {
+					pagination: { more_items_in_collection: false },
+				},
+			});
+
+			const result = await getCustomFieldsMappingColumns.call(ctx);
+
+			expect(result.fields).toHaveLength(1);
+			expect(result.fields[0]).toMatchObject({
+				id: 'v1_hex',
+				displayName: 'Lead Custom',
+				type: 'string',
+			});
+		});
+
+		it('returns empty fields with notice on transport failure', async () => {
+			const ctx = makeLoadOptionsMock('deal');
+			ctx.helpers.requestWithAuthentication.mockRejectedValue(new Error('boom'));
+
+			const result = await getCustomFieldsMappingColumns.call(ctx);
+
+			expect(result.fields).toEqual([]);
+			expect(result.emptyFieldsNotice).toContain('Could not load');
+		});
+
+		it('sorts fields alphabetically by displayName', async () => {
+			const ctx = makeLoadOptionsMock('deal');
+			mockApiResponse(ctx, [
+				{ field_code: 'a', field_name: 'Zeta', field_type: 'text', is_custom_field: true },
+				{ field_code: 'b', field_name: 'Alpha', field_type: 'text', is_custom_field: true },
+				{ field_code: 'c', field_name: 'Mike', field_type: 'text', is_custom_field: true },
+			]);
+
+			const result = await getCustomFieldsMappingColumns.call(ctx);
+
+			expect(result.fields.map((f) => f.displayName)).toEqual(['Alpha', 'Mike', 'Zeta']);
+		});
+	});
+
+	describe('mapPipedriveFieldType', () => {
+		it.each([
+			['varchar', 'string'],
+			['varchar_auto', 'string'],
+			['text', 'string'],
+			['phone', 'string'],
+			['address', 'string'],
+			['int', 'number'],
+			['double', 'number'],
+			['monetary', 'number'],
+			['boolean', 'boolean'],
+			['date', 'dateTime'],
+			['daterange', 'dateTime'],
+			['time', 'time'],
+			['timerange', 'time'],
+			['enum', 'options'],
+			['visible_to', 'options'],
+			['set', 'string'],
+			['org', 'number'],
+			['people', 'number'],
+			['person', 'number'],
+			['user', 'number'],
+			['deal', 'number'],
+			['product', 'number'],
+		])('maps %s -> %s', (input, expected) => {
+			expect(mapPipedriveFieldType(input)).toBe(expected);
+		});
+
+		it('falls through unknown types to string', () => {
+			expect(mapPipedriveFieldType('mystery')).toBe('string');
+		});
+
+		it('handles undefined input', () => {
+			expect(mapPipedriveFieldType(undefined)).toBe('string');
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Pipedrive/test/v2/methods/resourceMapping.test.ts
+++ b/packages/nodes-base/nodes/Pipedrive/test/v2/methods/resourceMapping.test.ts
@@ -144,6 +144,23 @@ describe('Pipedrive v2 Resource Mapping', () => {
 			expect(byId.hex_set.type).toBe('string');
 		});
 
+		it('falls back to edit_flag when is_custom_field is absent (legacy v1)', async () => {
+			const ctx = makeLoadOptionsMock('lead');
+			ctx.helpers.requestWithAuthentication.mockResolvedValue({
+				success: true,
+				data: [
+					{ key: 'builtin', name: 'Built-in', field_type: 'text', edit_flag: false },
+					{ key: 'legacy_custom', name: 'Legacy Custom', field_type: 'text', edit_flag: true },
+				],
+				additional_data: { pagination: { more_items_in_collection: false } },
+			});
+
+			const result = await getCustomFieldsMappingColumns.call(ctx);
+
+			expect(result.fields).toHaveLength(1);
+			expect(result.fields[0].id).toBe('legacy_custom');
+		});
+
 		it('uses v1 key/name when v2 field_code/field_name is missing (lead)', async () => {
 			const ctx = makeLoadOptionsMock('lead');
 			ctx.helpers.requestWithAuthentication.mockResolvedValue({

--- a/packages/nodes-base/nodes/Pipedrive/test/v2/node/deal/createMapping.test.ts
+++ b/packages/nodes-base/nodes/Pipedrive/test/v2/node/deal/createMapping.test.ts
@@ -1,0 +1,65 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../credentials';
+import { mockFieldsApi } from '../fieldsApiMock';
+
+describe('Test PipedriveV2, deal => create with customFieldsMapping', () => {
+	mockFieldsApi('deal', {
+		test_multi: {
+			field_type: 'set',
+			options: [
+				{ id: 1, label: 'Tag One' },
+				{ id: 2, label: 'Tag Two' },
+				{ id: 3, label: 'Tag Three' },
+			],
+		},
+	});
+
+	// Mapper-only: hex-keyed value goes through to API under custom_fields
+	nock('https://api.pipedrive.com/api/v2')
+		.post('/deals', {
+			title: 'Mapping Test Deal',
+			org_id: 7,
+			custom_fields: {
+				f5ed368466cf0477371c6ee076252f49a188848e: 'from-mapper',
+			},
+		})
+		.reply(200, {
+			success: true,
+			data: {
+				id: 9,
+				title: 'Mapping Test Deal',
+				org_id: 7,
+				custom_fields: {
+					f5ed368466cf0477371c6ee076252f49a188848e: 'from-mapper',
+				},
+			},
+		});
+
+	// Set mapping: CSV string is resolved to ID array via encodeCustomFieldsV2
+	nock('https://api.pipedrive.com/api/v2')
+		.post('/deals', {
+			title: 'Set Mapping Deal',
+			org_id: 7,
+			custom_fields: {
+				febf5dbb0f1e95d60876abc4638483291b8ef18b: [1, 3],
+			},
+		})
+		.reply(200, {
+			success: true,
+			data: {
+				id: 10,
+				title: 'Set Mapping Deal',
+				org_id: 7,
+				custom_fields: {
+					febf5dbb0f1e95d60876abc4638483291b8ef18b: [1, 3],
+				},
+			},
+		});
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['createMapping.workflow.json', 'createMappingSet.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Pipedrive/test/v2/node/deal/createMapping.workflow.json
+++ b/packages/nodes-base/nodes/Pipedrive/test/v2/node/deal/createMapping.workflow.json
@@ -1,0 +1,70 @@
+{
+	"name": "Pipedrive v2 deal create with mapping",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "aa111111-bb22-cc33-dd44-ee5555555556",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0]
+		},
+		{
+			"parameters": {
+				"authentication": "apiToken",
+				"resource": "deal",
+				"operation": "create",
+				"title": "Mapping Test Deal",
+				"associateWith": "organization",
+				"org_id": 7,
+				"customFieldsMapping": {
+					"mappingMode": "defineBelow",
+					"value": {
+						"f5ed368466cf0477371c6ee076252f49a188848e": "from-mapper"
+					}
+				}
+			},
+			"id": "bb222222-cc33-dd44-ee55-ff6666666667",
+			"name": "Pipedrive",
+			"type": "n8n-nodes-base.pipedrive",
+			"typeVersion": 2,
+			"position": [200, 0],
+			"credentials": {
+				"pipedriveApi": {
+					"id": "cred-1",
+					"name": "Pipedrive API"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "cc333333-dd44-ee55-ff66-aa7777777778",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [400, 0]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"id": 9,
+					"title": "Mapping Test Deal",
+					"org_id": 7,
+					"custom_fields": {
+						"test_string": "from-mapper"
+					}
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [[{ "node": "Pipedrive", "type": "main", "index": 0 }]]
+		},
+		"Pipedrive": {
+			"main": [[{ "node": "No Operation, do nothing", "type": "main", "index": 0 }]]
+		}
+	}
+}

--- a/packages/nodes-base/nodes/Pipedrive/test/v2/node/deal/createMappingSet.workflow.json
+++ b/packages/nodes-base/nodes/Pipedrive/test/v2/node/deal/createMappingSet.workflow.json
@@ -1,0 +1,70 @@
+{
+	"name": "Pipedrive v2 deal create with set mapping",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "aa111111-bb22-cc33-dd44-ee5555555557",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0]
+		},
+		{
+			"parameters": {
+				"authentication": "apiToken",
+				"resource": "deal",
+				"operation": "create",
+				"title": "Set Mapping Deal",
+				"associateWith": "organization",
+				"org_id": 7,
+				"customFieldsMapping": {
+					"mappingMode": "defineBelow",
+					"value": {
+						"febf5dbb0f1e95d60876abc4638483291b8ef18b": "Tag One, Tag Three"
+					}
+				}
+			},
+			"id": "bb222222-cc33-dd44-ee55-ff6666666668",
+			"name": "Pipedrive",
+			"type": "n8n-nodes-base.pipedrive",
+			"typeVersion": 2,
+			"position": [200, 0],
+			"credentials": {
+				"pipedriveApi": {
+					"id": "cred-1",
+					"name": "Pipedrive API"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "cc333333-dd44-ee55-ff66-aa7777777779",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [400, 0]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"id": 10,
+					"title": "Set Mapping Deal",
+					"org_id": 7,
+					"custom_fields": {
+						"test_multi": ["Tag One", "Tag Three"]
+					}
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [[{ "node": "Pipedrive", "type": "main", "index": 0 }]]
+		},
+		"Pipedrive": {
+			"main": [[{ "node": "No Operation, do nothing", "type": "main", "index": 0 }]]
+		}
+	}
+}

--- a/packages/nodes-base/nodes/Pipedrive/test/v2/node/fieldsApiMock.ts
+++ b/packages/nodes-base/nodes/Pipedrive/test/v2/node/fieldsApiMock.ts
@@ -12,22 +12,37 @@ const fieldEndpoints: Record<ResourceType, string> = {
 	product: '/productFields',
 };
 
+interface FieldOverride {
+	field_type?: string;
+	options?: Array<{ id: number; label: string }>;
+	is_custom_field?: boolean;
+}
+
 /**
  * Registers a nock mock for the v2 Fields API endpoint so that
  * custom field resolution/encoding works in workflow tests.
+ *
+ * `overrides` keys are the friendly names (matching mock-data.json),
+ * letting tests upgrade specific fields to enum/set/etc.
  */
-export function mockFieldsApi(resource: ResourceType): void {
+export function mockFieldsApi(
+	resource: ResourceType,
+	overrides: Record<string, FieldOverride> = {},
+): void {
 	const customFieldKeys = (mockData.customFieldKeys as Record<string, Record<string, string>>)[
 		resource
 	];
 
-	const fields = Object.entries(customFieldKeys ?? {}).map(([name, code]) => ({
-		field_name: name,
-		field_code: code,
-		field_type: 'text',
-		options: null,
-		is_custom_field: true,
-	}));
+	const fields = Object.entries(customFieldKeys ?? {}).map(([name, code]) => {
+		const override = overrides[name] ?? {};
+		return {
+			field_name: name,
+			field_code: code,
+			field_type: override.field_type ?? 'text',
+			options: override.options ?? null,
+			is_custom_field: override.is_custom_field ?? true,
+		};
+	});
 
 	nock('https://api.pipedrive.com/api/v2')
 		.get(fieldEndpoints[resource])

--- a/packages/nodes-base/nodes/Pipedrive/v2/PipedriveV2.node.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/PipedriveV2.node.ts
@@ -8,7 +8,7 @@ import type {
 
 import { router } from './actions/router';
 import { versionDescription } from './actions/versionDescription';
-import { loadOptions } from './methods';
+import { loadOptions, resourceMapping } from './methods';
 
 export class PipedriveV2 implements INodeType {
 	description: INodeTypeDescription;
@@ -23,6 +23,7 @@ export class PipedriveV2 implements INodeType {
 
 	methods = {
 		loadOptions,
+		resourceMapping,
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/activity/create.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/activity/create.operation.ts
@@ -13,8 +13,13 @@ import {
 	coerceToBoolean,
 	toRfc3339,
 	addFieldsToBody,
+	applyCustomFieldsMapping,
 } from '../../helpers';
-import { customFieldsCollection, rawCustomFieldKeysOption } from '../common.description';
+import {
+	customFieldsCollection,
+	customFieldsMappingProperty,
+	rawCustomFieldKeysOption,
+} from '../common.description';
 
 const properties: INodeProperties[] = [
 	{
@@ -104,6 +109,7 @@ const properties: INodeProperties[] = [
 			customFieldsCollection,
 		],
 	},
+	customFieldsMappingProperty,
 	rawCustomFieldKeysOption,
 ];
 
@@ -136,6 +142,11 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 
 			const additionalFields = this.getNodeParameter('additionalFields', i);
 			addFieldsToBody(body, additionalFields);
+
+			const mapping = this.getNodeParameter('customFieldsMapping', i, {}) as {
+				value?: IDataObject | null;
+			};
+			applyCustomFieldsMapping(body, mapping?.value);
 
 			if (body.due_date) {
 				body.due_date = toRfc3339(body.due_date as string);

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/activity/update.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/activity/update.operation.ts
@@ -13,8 +13,13 @@ import {
 	coerceToBoolean,
 	toRfc3339,
 	addFieldsToBody,
+	applyCustomFieldsMapping,
 } from '../../helpers';
-import { customFieldsCollection, rawCustomFieldKeysOption } from '../common.description';
+import {
+	customFieldsCollection,
+	customFieldsMappingProperty,
+	rawCustomFieldKeysOption,
+} from '../common.description';
 
 const properties: INodeProperties[] = [
 	{
@@ -125,6 +130,7 @@ const properties: INodeProperties[] = [
 			customFieldsCollection,
 		],
 	},
+	customFieldsMappingProperty,
 	rawCustomFieldKeysOption,
 ];
 
@@ -154,6 +160,11 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 
 			const updateFields = this.getNodeParameter('updateFields', i);
 			addFieldsToBody(body, updateFields);
+
+			const mapping = this.getNodeParameter('customFieldsMapping', i, {}) as {
+				value?: IDataObject | null;
+			};
+			applyCustomFieldsMapping(body, mapping?.value);
 
 			// Coerce done to boolean for v2 API
 			if (body.done !== undefined) {

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/common.description.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/common.description.ts
@@ -1,7 +1,35 @@
 import type { INodeProperties } from 'n8n-workflow';
 
-export const customFieldsCollection: INodeProperties = {
+export const customFieldsMappingProperty: INodeProperties = {
 	displayName: 'Custom Fields',
+	name: 'customFieldsMapping',
+	type: 'resourceMapper',
+	default: {
+		mappingMode: 'defineBelow',
+		value: null,
+	},
+	noDataExpression: true,
+	description:
+		'Pick custom fields loaded from Pipedrive and enter values with the right input type for each field',
+	typeOptions: {
+		loadOptionsDependsOn: ['resource'],
+		resourceMapper: {
+			resourceMapperMethod: 'getCustomFieldsMappingColumns',
+			mode: 'add',
+			valuesLabel: 'Custom Fields to Send',
+			fieldWords: {
+				singular: 'custom field',
+				plural: 'custom fields',
+			},
+			addAllFields: false,
+			multiKeyMatch: false,
+			supportAutoMap: false,
+		},
+	},
+};
+
+export const customFieldsCollection: INodeProperties = {
+	displayName: 'Custom Fields (Manual Entry)',
 	name: 'customFields',
 	type: 'fixedCollection',
 	typeOptions: {
@@ -9,6 +37,8 @@ export const customFieldsCollection: INodeProperties = {
 	},
 	default: {},
 	placeholder: 'Add Custom Field',
+	description:
+		'Reference custom fields by display name or hex field_code. Use this for fields not yet visible in the picker above (e.g. just-created fields). If the same field appears in both, the picker takes precedence.',
 	options: [
 		{
 			displayName: 'Property',

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/deal/create.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/deal/create.operation.ts
@@ -13,9 +13,11 @@ import {
 	coerceToNumber,
 	toRfc3339,
 	addFieldsToBody,
+	applyCustomFieldsMapping,
 } from '../../helpers';
 import {
 	customFieldsCollection,
+	customFieldsMappingProperty,
 	rawCustomFieldKeysOption,
 	visibleToOption,
 } from '../common.description';
@@ -207,6 +209,7 @@ const properties: INodeProperties[] = [
 			customFieldsCollection,
 		],
 	},
+	customFieldsMappingProperty,
 	rawCustomFieldKeysOption,
 ];
 
@@ -245,6 +248,11 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 
 			const additionalFields = this.getNodeParameter('additionalFields', i);
 			addFieldsToBody(body, additionalFields);
+
+			const mapping = this.getNodeParameter('customFieldsMapping', i, {}) as {
+				value?: IDataObject | null;
+			};
+			applyCustomFieldsMapping(body, mapping?.value);
 
 			if (body.expected_close_date) {
 				body.expected_close_date = toRfc3339(body.expected_close_date as string);

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/deal/update.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/deal/update.operation.ts
@@ -13,9 +13,11 @@ import {
 	coerceToNumber,
 	toRfc3339,
 	addFieldsToBody,
+	applyCustomFieldsMapping,
 } from '../../helpers';
 import {
 	customFieldsCollection,
+	customFieldsMappingProperty,
 	rawCustomFieldKeysOption,
 	visibleToOption,
 } from '../common.description';
@@ -164,6 +166,7 @@ const properties: INodeProperties[] = [
 			customFieldsCollection,
 		],
 	},
+	customFieldsMappingProperty,
 	rawCustomFieldKeysOption,
 ];
 
@@ -193,6 +196,11 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 
 			const updateFields = this.getNodeParameter('updateFields', i);
 			addFieldsToBody(body, updateFields);
+
+			const mapping = this.getNodeParameter('customFieldsMapping', i, {}) as {
+				value?: IDataObject | null;
+			};
+			applyCustomFieldsMapping(body, mapping?.value);
 
 			// Clear label when set to 'null' string
 			if (body.label === 'null') {

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/lead/create.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/lead/create.operation.ts
@@ -6,8 +6,9 @@ import type {
 } from 'n8n-workflow';
 
 import { updateDisplayOptions } from '../../../../../utils/utilities';
-import { pipedriveApiRequest } from '../../transport';
-import { visibleToOption } from '../common.description';
+import { pipedriveApiRequest, pipedriveGetCustomProperties } from '../../transport';
+import { encodeCustomFieldsV2 } from '../../helpers';
+import { customFieldsMappingProperty, visibleToOption } from '../common.description';
 import { currencies } from '../../../utils';
 
 const properties: INodeProperties[] = [
@@ -161,6 +162,7 @@ const properties: INodeProperties[] = [
 			},
 		],
 	},
+	customFieldsMappingProperty,
 ];
 
 const displayOptions = {
@@ -175,6 +177,13 @@ export const description = updateDisplayOptions(displayOptions, properties);
 export async function execute(this: IExecuteFunctions): Promise<INodeExecutionData[]> {
 	const items = this.getInputData();
 	const returnData: INodeExecutionData[] = [];
+
+	let leadCustomProperties;
+	try {
+		leadCustomProperties = await pipedriveGetCustomProperties.call(this, 'lead');
+	} catch {
+		leadCustomProperties = undefined;
+	}
 
 	for (let i = 0; i < items.length; i++) {
 		try {
@@ -214,6 +223,20 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 
 			if (expected_close_date) {
 				body.expected_close_date = expected_close_date.split('T')[0];
+			}
+
+			const mapping = this.getNodeParameter('customFieldsMapping', i, {}) as {
+				value?: IDataObject | null;
+			};
+			const mappingValue = mapping?.value;
+			if (mappingValue && Object.keys(mappingValue).length > 0) {
+				if (leadCustomProperties) {
+					const wrapper: IDataObject = { custom_fields: { ...mappingValue } };
+					encodeCustomFieldsV2(leadCustomProperties, wrapper);
+					Object.assign(body, (wrapper.custom_fields as IDataObject) ?? {});
+				} else {
+					Object.assign(body, mappingValue);
+				}
 			}
 
 			const responseData = await pipedriveApiRequest.call(

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/lead/update.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/lead/update.operation.ts
@@ -6,8 +6,9 @@ import type {
 } from 'n8n-workflow';
 
 import { updateDisplayOptions } from '../../../../../utils/utilities';
-import { pipedriveApiRequest } from '../../transport';
-import { visibleToOption } from '../common.description';
+import { pipedriveApiRequest, pipedriveGetCustomProperties } from '../../transport';
+import { encodeCustomFieldsV2 } from '../../helpers';
+import { customFieldsMappingProperty, visibleToOption } from '../common.description';
 import { currencies } from '../../../utils';
 
 const properties: INodeProperties[] = [
@@ -118,6 +119,7 @@ const properties: INodeProperties[] = [
 			},
 		],
 	},
+	customFieldsMappingProperty,
 ];
 
 const displayOptions = {
@@ -132,6 +134,13 @@ export const description = updateDisplayOptions(displayOptions, properties);
 export async function execute(this: IExecuteFunctions): Promise<INodeExecutionData[]> {
 	const items = this.getInputData();
 	const returnData: INodeExecutionData[] = [];
+
+	let leadCustomProperties;
+	try {
+		leadCustomProperties = await pipedriveGetCustomProperties.call(this, 'lead');
+	} catch {
+		leadCustomProperties = undefined;
+	}
 
 	for (let i = 0; i < items.length; i++) {
 		try {
@@ -160,6 +169,20 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 
 			if (expected_close_date) {
 				body.expected_close_date = expected_close_date.split('T')[0];
+			}
+
+			const mapping = this.getNodeParameter('customFieldsMapping', i, {}) as {
+				value?: IDataObject | null;
+			};
+			const mappingValue = mapping?.value;
+			if (mappingValue && Object.keys(mappingValue).length > 0) {
+				if (leadCustomProperties) {
+					const wrapper: IDataObject = { custom_fields: { ...mappingValue } };
+					encodeCustomFieldsV2(leadCustomProperties, wrapper);
+					Object.assign(body, (wrapper.custom_fields as IDataObject) ?? {});
+				} else {
+					Object.assign(body, mappingValue);
+				}
 			}
 
 			const responseData = await pipedriveApiRequest.call(

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/organization/create.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/organization/create.operation.ts
@@ -7,9 +7,15 @@ import type {
 
 import { updateDisplayOptions } from '../../../../../utils/utilities';
 import { pipedriveApiRequest, pipedriveGetCustomProperties } from '../../transport';
-import { encodeCustomFieldsV2, resolveCustomFieldsV2, addFieldsToBody } from '../../helpers';
+import {
+	encodeCustomFieldsV2,
+	resolveCustomFieldsV2,
+	addFieldsToBody,
+	applyCustomFieldsMapping,
+} from '../../helpers';
 import {
 	customFieldsCollection,
+	customFieldsMappingProperty,
 	rawCustomFieldKeysOption,
 	visibleToOption,
 } from '../common.description';
@@ -56,6 +62,7 @@ const properties: INodeProperties[] = [
 			customFieldsCollection,
 		],
 	},
+	customFieldsMappingProperty,
 	rawCustomFieldKeysOption,
 ];
 
@@ -86,6 +93,11 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 
 			const additionalFields = this.getNodeParameter('additionalFields', i);
 			addFieldsToBody(body, additionalFields);
+
+			const mapping = this.getNodeParameter('customFieldsMapping', i, {}) as {
+				value?: IDataObject | null;
+			};
+			applyCustomFieldsMapping(body, mapping?.value);
 
 			if (customProperties) {
 				encodeCustomFieldsV2(customProperties, body);

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/organization/update.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/organization/update.operation.ts
@@ -7,9 +7,15 @@ import type {
 
 import { updateDisplayOptions } from '../../../../../utils/utilities';
 import { pipedriveApiRequest, pipedriveGetCustomProperties } from '../../transport';
-import { encodeCustomFieldsV2, resolveCustomFieldsV2, addFieldsToBody } from '../../helpers';
+import {
+	encodeCustomFieldsV2,
+	resolveCustomFieldsV2,
+	addFieldsToBody,
+	applyCustomFieldsMapping,
+} from '../../helpers';
 import {
 	customFieldsCollection,
+	customFieldsMappingProperty,
 	rawCustomFieldKeysOption,
 	visibleToOption,
 } from '../common.description';
@@ -63,6 +69,7 @@ const properties: INodeProperties[] = [
 			customFieldsCollection,
 		],
 	},
+	customFieldsMappingProperty,
 	rawCustomFieldKeysOption,
 ];
 
@@ -92,6 +99,11 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 
 			const updateFields = this.getNodeParameter('updateFields', i);
 			addFieldsToBody(body, updateFields);
+
+			const mapping = this.getNodeParameter('customFieldsMapping', i, {}) as {
+				value?: IDataObject | null;
+			};
+			applyCustomFieldsMapping(body, mapping?.value);
 
 			// Clear label when set to 'null' string
 			if (body.label === 'null') {

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/person/create.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/person/create.operation.ts
@@ -7,9 +7,15 @@ import type {
 
 import { updateDisplayOptions } from '../../../../../utils/utilities';
 import { pipedriveApiRequest, pipedriveGetCustomProperties } from '../../transport';
-import { encodeCustomFieldsV2, resolveCustomFieldsV2, addFieldsToBody } from '../../helpers';
+import {
+	encodeCustomFieldsV2,
+	resolveCustomFieldsV2,
+	addFieldsToBody,
+	applyCustomFieldsMapping,
+} from '../../helpers';
 import {
 	customFieldsCollection,
+	customFieldsMappingProperty,
 	rawCustomFieldKeysOption,
 	visibleToOption,
 } from '../common.description';
@@ -149,6 +155,7 @@ const properties: INodeProperties[] = [
 			customFieldsCollection,
 		],
 	},
+	customFieldsMappingProperty,
 	rawCustomFieldKeysOption,
 ];
 
@@ -179,6 +186,11 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 
 			const additionalFields = this.getNodeParameter('additionalFields', i);
 			addFieldsToBody(body, additionalFields);
+
+			const mapping = this.getNodeParameter('customFieldsMapping', i, {}) as {
+				value?: IDataObject | null;
+			};
+			applyCustomFieldsMapping(body, mapping?.value);
 
 			// Transform fixedCollection emails to API array format
 			if (body.emails && (body.emails as IDataObject).emailProperties) {

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/person/update.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/person/update.operation.ts
@@ -7,9 +7,15 @@ import type {
 
 import { updateDisplayOptions } from '../../../../../utils/utilities';
 import { pipedriveApiRequest, pipedriveGetCustomProperties } from '../../transport';
-import { encodeCustomFieldsV2, resolveCustomFieldsV2, addFieldsToBody } from '../../helpers';
+import {
+	encodeCustomFieldsV2,
+	resolveCustomFieldsV2,
+	addFieldsToBody,
+	applyCustomFieldsMapping,
+} from '../../helpers';
 import {
 	customFieldsCollection,
+	customFieldsMappingProperty,
 	rawCustomFieldKeysOption,
 	visibleToOption,
 } from '../common.description';
@@ -156,6 +162,7 @@ const properties: INodeProperties[] = [
 			customFieldsCollection,
 		],
 	},
+	customFieldsMappingProperty,
 	rawCustomFieldKeysOption,
 ];
 
@@ -185,6 +192,11 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 
 			const updateFields = this.getNodeParameter('updateFields', i);
 			addFieldsToBody(body, updateFields);
+
+			const mapping = this.getNodeParameter('customFieldsMapping', i, {}) as {
+				value?: IDataObject | null;
+			};
+			applyCustomFieldsMapping(body, mapping?.value);
 
 			// Transform fixedCollection emails to API array format
 			if (body.emails && (body.emails as IDataObject).emailProperties) {

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/product/create.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/product/create.operation.ts
@@ -7,9 +7,15 @@ import type {
 
 import { updateDisplayOptions } from '../../../../../utils/utilities';
 import { pipedriveApiRequest, pipedriveGetCustomProperties } from '../../transport';
-import { encodeCustomFieldsV2, resolveCustomFieldsV2, addFieldsToBody } from '../../helpers';
+import {
+	encodeCustomFieldsV2,
+	resolveCustomFieldsV2,
+	addFieldsToBody,
+	applyCustomFieldsMapping,
+} from '../../helpers';
 import {
 	customFieldsCollection,
+	customFieldsMappingProperty,
 	rawCustomFieldKeysOption,
 	visibleToOption,
 } from '../common.description';
@@ -111,6 +117,7 @@ const properties: INodeProperties[] = [
 			customFieldsCollection,
 		],
 	},
+	customFieldsMappingProperty,
 	rawCustomFieldKeysOption,
 ];
 
@@ -141,6 +148,11 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 
 			const additionalFields = this.getNodeParameter('additionalFields', i);
 			addFieldsToBody(body, additionalFields);
+
+			const mapping = this.getNodeParameter('customFieldsMapping', i, {}) as {
+				value?: IDataObject | null;
+			};
+			applyCustomFieldsMapping(body, mapping?.value);
 
 			// Unpack the prices fixed-collection into the format the API expects
 			if (body.prices && (body.prices as IDataObject).pricesValues) {

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/product/update.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/product/update.operation.ts
@@ -7,9 +7,15 @@ import type {
 
 import { updateDisplayOptions } from '../../../../../utils/utilities';
 import { pipedriveApiRequest, pipedriveGetCustomProperties } from '../../transport';
-import { encodeCustomFieldsV2, resolveCustomFieldsV2, addFieldsToBody } from '../../helpers';
+import {
+	encodeCustomFieldsV2,
+	resolveCustomFieldsV2,
+	addFieldsToBody,
+	applyCustomFieldsMapping,
+} from '../../helpers';
 import {
 	customFieldsCollection,
+	customFieldsMappingProperty,
 	rawCustomFieldKeysOption,
 	visibleToOption,
 } from '../common.description';
@@ -118,6 +124,7 @@ const properties: INodeProperties[] = [
 			customFieldsCollection,
 		],
 	},
+	customFieldsMappingProperty,
 	rawCustomFieldKeysOption,
 ];
 
@@ -147,6 +154,11 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 
 			const body: IDataObject = {};
 			addFieldsToBody(body, updateFields);
+
+			const mapping = this.getNodeParameter('customFieldsMapping', i, {}) as {
+				value?: IDataObject | null;
+			};
+			applyCustomFieldsMapping(body, mapping?.value);
 
 			// Unpack the prices fixed-collection into the format the API expects
 			if (body.prices && (body.prices as IDataObject).pricesValues) {

--- a/packages/nodes-base/nodes/Pipedrive/v2/helpers/customFields.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/helpers/customFields.ts
@@ -43,19 +43,30 @@ export function encodeCustomFieldsV2(customProperties: ICustomProperties, item: 
 		const customPropertyData = nameMap.get(key) ?? customProperties[key];
 
 		if (customPropertyData !== undefined) {
+			const isSet = customPropertyData.field_type === 'set';
+			const isEnumLike = ['enum', 'visible_to'].includes(customPropertyData.field_type);
+
+			// Empty/null normalization: send [] for set, null for enum-like
+			if ((isSet || isEnumLike) && (value === null || value === undefined || value === '')) {
+				resolved[customPropertyData.key] = isSet ? [] : null;
+				continue;
+			}
+
 			if (
 				value !== null &&
 				value !== undefined &&
 				customPropertyData.options !== undefined &&
 				Array.isArray(customPropertyData.options)
 			) {
-				if (customPropertyData.field_type === 'set') {
-					// Set fields: resolve each label to its option ID
-					const labels: string[] = Array.isArray(value)
-						? (value as string[]).map(String)
-						: String(value)
-								.split(',')
-								.map((s) => s.trim());
+				if (isSet) {
+					// Set fields: resolve each label to its option ID, skip empty entries
+					const labels: string[] = (
+						Array.isArray(value)
+							? (value as string[]).map(String)
+							: String(value)
+									.split(',')
+									.map((s) => s.trim())
+					).filter((s) => s !== '');
 					const ids = labels.map((label) => {
 						const opt = customPropertyData.options!.find(
 							(option) => option.label.toString() === label,

--- a/packages/nodes-base/nodes/Pipedrive/v2/helpers/customFields.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/helpers/customFields.ts
@@ -1,4 +1,4 @@
-import type { IDataObject, INodeExecutionData } from 'n8n-workflow';
+import type { FieldType, IDataObject, INodeExecutionData } from 'n8n-workflow';
 
 import type { ICustomProperties, ICustomInterface } from '../transport';
 
@@ -149,4 +149,47 @@ export function resolveCustomFieldsV2(
 
 	json.custom_fields = resolved;
 	item.json = json;
+}
+
+const PIPEDRIVE_FIELD_TYPE_TO_N8N: Record<string, FieldType> = {
+	varchar: 'string',
+	varchar_auto: 'string',
+	text: 'string',
+	phone: 'string',
+	address: 'string',
+	int: 'number',
+	double: 'number',
+	monetary: 'number',
+	boolean: 'boolean',
+	date: 'dateTime',
+	daterange: 'dateTime',
+	time: 'time',
+	timerange: 'time',
+	enum: 'options',
+	visible_to: 'options',
+	set: 'string',
+	org: 'number',
+	people: 'number',
+	person: 'number',
+	user: 'number',
+	deal: 'number',
+	product: 'number',
+};
+
+export function mapPipedriveFieldType(fieldType: string | undefined): FieldType {
+	if (!fieldType) return 'string';
+	return PIPEDRIVE_FIELD_TYPE_TO_N8N[fieldType] ?? 'string';
+}
+
+export function applyCustomFieldsMapping(
+	body: IDataObject,
+	mappingValue: IDataObject | null | undefined,
+): void {
+	if (!mappingValue || typeof mappingValue !== 'object') return;
+	if (Object.keys(mappingValue).length === 0) return;
+
+	body.custom_fields = {
+		...((body.custom_fields as IDataObject) ?? {}),
+		...mappingValue,
+	};
 }

--- a/packages/nodes-base/nodes/Pipedrive/v2/helpers/index.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/helpers/index.ts
@@ -1,4 +1,9 @@
-export { encodeCustomFieldsV2, resolveCustomFieldsV2 } from './customFields';
+export {
+	encodeCustomFieldsV2,
+	resolveCustomFieldsV2,
+	mapPipedriveFieldType,
+	applyCustomFieldsMapping,
+} from './customFields';
 
 export { coerceToBoolean, coerceToNumber, toRfc3339 } from './typeCoercion';
 

--- a/packages/nodes-base/nodes/Pipedrive/v2/methods/index.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/methods/index.ts
@@ -1,1 +1,2 @@
 export * as loadOptions from './loadOptions';
+export * as resourceMapping from './resourceMapping';

--- a/packages/nodes-base/nodes/Pipedrive/v2/methods/resourceMapping.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/methods/resourceMapping.ts
@@ -95,10 +95,15 @@ export async function getCustomFieldsMappingColumns(
 		};
 
 		if (type === 'options' && Array.isArray(raw.options)) {
-			field.options = raw.options.map((option) => ({
-				name: String(option.label),
-				value: option.id,
-			}));
+			// Prepend a synthetic "Clear value" option so users can null-out
+			// enum/visible_to fields. encodeCustomFieldsV2 maps '' → null.
+			field.options = [
+				{ name: '— Clear value —', value: '' },
+				...raw.options.map((option) => ({
+					name: String(option.label),
+					value: option.id,
+				})),
+			];
 		}
 
 		fields.push(field);

--- a/packages/nodes-base/nodes/Pipedrive/v2/methods/resourceMapping.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/methods/resourceMapping.ts
@@ -27,6 +27,7 @@ interface RawPipedriveField {
 	name?: string;
 	field_type?: string;
 	is_custom_field?: boolean;
+	edit_flag?: boolean;
 	options?: Array<{ id: number; label: string }>;
 }
 
@@ -73,7 +74,9 @@ export async function getCustomFieldsMappingColumns(
 	const fields: ResourceMapperField[] = [];
 
 	for (const raw of rawFields as RawPipedriveField[]) {
-		if (raw.is_custom_field !== true) continue;
+		// v2 endpoints set `is_custom_field`; older v1 leadFields responses
+		// only set `edit_flag`. Treat either as the custom-field marker.
+		if (raw.is_custom_field !== true && raw.edit_flag !== true) continue;
 
 		const id = raw.field_code ?? raw.key;
 		const displayName = raw.field_name ?? raw.name;

--- a/packages/nodes-base/nodes/Pipedrive/v2/methods/resourceMapping.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/methods/resourceMapping.ts
@@ -1,0 +1,107 @@
+import type {
+	IDataObject,
+	ILoadOptionsFunctions,
+	ResourceMapperField,
+	ResourceMapperFields,
+} from 'n8n-workflow';
+
+import { mapPipedriveFieldType } from '../helpers';
+import { pipedriveApiRequestAllItemsCursor, pipedriveApiRequestAllItemsOffset } from '../transport';
+
+const FIELD_ENDPOINTS_V2: Record<string, string> = {
+	activity: '/activityFields',
+	deal: '/dealFields',
+	organization: '/organizationFields',
+	person: '/personFields',
+	product: '/productFields',
+};
+
+const FIELD_ENDPOINTS_V1: Record<string, string> = {
+	lead: '/leadFields',
+};
+
+interface RawPipedriveField {
+	field_code?: string;
+	key?: string;
+	field_name?: string;
+	name?: string;
+	field_type?: string;
+	is_custom_field?: boolean;
+	options?: Array<{ id: number; label: string }>;
+}
+
+export async function getCustomFieldsMappingColumns(
+	this: ILoadOptionsFunctions,
+): Promise<ResourceMapperFields> {
+	const resource = this.getCurrentNodeParameter('resource') as string | undefined;
+
+	if (!resource || (!FIELD_ENDPOINTS_V2[resource] && !FIELD_ENDPOINTS_V1[resource])) {
+		return {
+			fields: [],
+			emptyFieldsNotice: 'Select a resource to load custom fields.',
+		};
+	}
+
+	let rawFields: IDataObject[];
+	try {
+		if (FIELD_ENDPOINTS_V2[resource]) {
+			const { data } = await pipedriveApiRequestAllItemsCursor.call(
+				this,
+				'GET',
+				FIELD_ENDPOINTS_V2[resource],
+				{},
+			);
+			rawFields = data;
+		} else {
+			const { data } = await pipedriveApiRequestAllItemsOffset.call(
+				this,
+				'GET',
+				FIELD_ENDPOINTS_V1[resource],
+				{},
+			);
+			rawFields = data;
+		}
+	} catch (error) {
+		const message =
+			error instanceof Error ? error.message : typeof error === 'string' ? error : 'unknown error';
+		return {
+			fields: [],
+			emptyFieldsNotice: `Could not load custom fields: ${message}`,
+		};
+	}
+
+	const fields: ResourceMapperField[] = [];
+
+	for (const raw of rawFields as RawPipedriveField[]) {
+		if (raw.is_custom_field !== true) continue;
+
+		const id = raw.field_code ?? raw.key;
+		const displayName = raw.field_name ?? raw.name;
+		if (!id || !displayName) continue;
+
+		const type = mapPipedriveFieldType(raw.field_type);
+
+		const field: ResourceMapperField = {
+			id,
+			displayName,
+			defaultMatch: false,
+			canBeUsedToMatch: false,
+			display: true,
+			required: false,
+			type,
+		};
+
+		if (type === 'options' && Array.isArray(raw.options)) {
+			field.options = raw.options.map((option) => ({
+				name: String(option.label),
+				value: option.id,
+			}));
+		}
+
+		fields.push(field);
+	}
+
+	fields.sort((a, b) => a.displayName.localeCompare(b.displayName));
+
+	return { fields };
+}

--- a/packages/nodes-base/nodes/Pipedrive/v2/transport/pipedrive.api.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/transport/pipedrive.api.ts
@@ -94,7 +94,7 @@ export async function pipedriveApiRequest(
 }
 
 export async function pipedriveApiRequestAllItemsCursor(
-	this: IHookFunctions | IExecuteFunctions,
+	this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions,
 	method: IHttpRequestMethods,
 	endpoint: string,
 	body: IDataObject,
@@ -124,7 +124,7 @@ export async function pipedriveApiRequestAllItemsCursor(
 }
 
 export async function pipedriveApiRequestAllItemsOffset(
-	this: IHookFunctions | IExecuteFunctions,
+	this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions,
 	method: IHttpRequestMethods,
 	endpoint: string,
 	body: IDataObject,
@@ -168,7 +168,7 @@ export async function pipedriveApiRequestAllItemsOffset(
 }
 
 export async function pipedriveGetCustomProperties(
-	this: IHookFunctions | IExecuteFunctions,
+	this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions,
 	resource: string,
 ): Promise<ICustomProperties> {
 	const v2Endpoints: Record<string, string> = {


### PR DESCRIPTION
## Summary

When using the Base Pipedrive Nodes to create

- Activities
- Deals
- Organizations
- Persons
- Products

custom fields needed to be referenced by exact name or hex id.

This change introduces a dropdown to select available Pipedrive custom fields fetched through the fields API endpoints.

## Related Linear tickets, Github issues, and Community forum posts

None


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.
