### PR TITLE
ci(ai-builder): Raise eval scenario concurrency from 4 to 16

### DIFF
--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -91,7 +91,7 @@ jobs:
         run: >-
           pnpm eval:instance-ai
           --base-url http://localhost:5678
-          --concurrency 4
+          --concurrency 16
           --verbose
           --iterations 3
           ${{ inputs.filter && format('--filter "{0}"', inputs.filter) || '' }}


### PR DESCRIPTION
## Summary

The eval workflow's `--concurrency 4` flag was unnecessarily serializing the cheap part of the run.

`--concurrency` controls how many `target()` invocations LangSmith's `evaluate()` runs in parallel. It does **not** control build pressure on n8n — builds are independently capped at `MAX_CONCURRENT_BUILDS = 4` in the CLI (`evaluations/cli/index.ts:57`), which is the comment-blocked safety against n8n degradation.

So the existing `4` only slowed scenario execution, not protect anything.

## Measured impact

Against the latest TRUST-27 CI run that already runs at `--concurrency 16`:
- Build phase: 27 builds × 146s ÷ 4 concurrent ≈ **16 min** (unchanged — build cap is the floor)
- Exec phase: 87 scenarios × ~60s ÷ 16 concurrent ≈ **6 min**  *(vs ÷ 4 ≈ 22 min)*
- **Total wall ≈ 23 min** *(vs ~38 min at concurrency 4)*

This brings PR-level CI well clear of the 45-min workflow cap.

## How to test

The next eval run on this PR (or any PR after merge) will surface this directly — the workflow time should drop from ~38 min to ~23 min on a clean dataset.

## Related

- https://linear.app/n8n/issue/TRUST-27/baseline-diffing-and-regression-detection — original PR (#29456) where this change was first introduced; splitting it out so master gets the speedup independently
- https://github.com/n8n-io/n8n/pull/29507 — sibling fix landing the dataset filter (also from TRUST-27)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI