### PR TITLE
fix(Notion Node): Support app.notion.com URL format for page and block ID extraction

### DIFF
--- a/packages/nodes-base/nodes/Notion/shared/constants.ts
+++ b/packages/nodes-base/nodes/Notion/shared/constants.ts
@@ -3,7 +3,8 @@ const notionIdRegexp = '[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9
 export const idExtractionRegexp = `^(${notionIdRegexp})`;
 export const idValidationRegexp = `${idExtractionRegexp}.*`;
 
-const baseUrlRegexp = '(?:https|http)://www\\.notion\\.so/(?:[a-z0-9-]{2,}/)?';
+const baseUrlRegexp =
+	'(?:https|http)://(?:www\\.notion\\.so|app\\.notion\\.com)/(?:p/)?(?:[a-z0-9-]{2,}/)?';
 
 export const databaseUrlExtractionRegexp = `${baseUrlRegexp}(${notionIdRegexp})`;
 export const databaseUrlValidationRegexp = `${databaseUrlExtractionRegexp}.*`;

--- a/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
@@ -105,6 +105,22 @@ describe('Test Notion', () => {
 				expect(result).toBe(testId);
 			}
 		});
+
+		test('should extract page ID from new app.notion.com/p/ URL format', () => {
+			for (const testId of testIds) {
+				const page = `https://app.notion.com/p/Handbook-${testId}?source=copy_link`;
+				const result = extractPageId(extractIdFromUrl(page));
+				expect(result).toBe(testId);
+			}
+		});
+
+		test('should extract page ID from new app.notion.com/p/ URL without query string', () => {
+			for (const testId of testIds) {
+				const page = `https://app.notion.com/p/My-Page-Title-${testId}`;
+				const result = extractPageId(extractIdFromUrl(page));
+				expect(result).toBe(testId);
+			}
+		});
 	});
 });
 
@@ -149,6 +165,18 @@ describe('Test Notion, getPageId', () => {
 		const page = {
 			mode: 'url',
 			value: `https://www.notion.so/page-name-${id}`,
+		} as INodeParameterResourceLocator;
+
+		mockExecuteFunctions.getNodeParameter.mockReturnValue(page);
+
+		const result = getPageId.call(mockExecuteFunctions, 0);
+		expect(result).toBe(id);
+	});
+
+	it('should extract page ID from new app.notion.com/p/ URL', () => {
+		const page = {
+			mode: 'url',
+			value: `https://app.notion.com/p/Handbook-${id}?source=copy_link`,
 		} as INodeParameterResourceLocator;
 
 		mockExecuteFunctions.getNodeParameter.mockReturnValue(page);


### PR DESCRIPTION
## Summary

Notion is migrating its primary web domain from `notion.so` to `app.notion.com`. The new URL format (`https://app.notion.com/p/<Title>-<id>`) is already being returned by the Notion API, but n8n's Notion node failed to parse it, throwing `Invalid URL, could not find block ID or page ID` on any \"By URL\" mode operation (reading blocks, updating pages, etc.).

The fix updates `baseUrlRegexp` in `constants.ts` to also accept `app.notion.com` as a valid domain and the optional `/p/` path prefix. All five URL extraction/validation regexps used by the node are derived from this one constant, so the single change fixes all affected operations.

**To test:**
1. In the Notion node, set Resource to **Block**, Operation to **Get Child Blocks**, Block to **By URL**
2. Enter a new-format URL such as `https://app.notion.com/p/some-document-name?source=copy_link`
3. Execute — it should return child blocks instead of throwing `Invalid URL`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4942

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI