### PR TITLE
fix(editor): Restore read-only mode for archived workflows on canvas

### DIFF
--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -294,7 +294,7 @@ const isCanvasReadOnly = computed(() => {
 		isReadOnlyEnvironment.value ||
 		collaborationStore.shouldBeReadOnly ||
 		!(workflowPermissions.value.update ?? projectPermissions.value.workflow.update) ||
-		editableWorkflow.value.isArchived ||
+		(workflowDocumentStore?.value?.isArchived ?? false) ||
 		(builderStore.streaming && !builderStore.isHelpStreaming)
 	);
 });
@@ -303,7 +303,7 @@ const canExecuteOnCanvas = computed(() => {
 	if (isDemoRoute.value) {
 		return route.query.canExecute === 'true';
 	}
-	if (editableWorkflow.value.isArchived) return false;
+	if (workflowDocumentStore?.value?.isArchived) return false;
 	if (builderStore.streaming) return false;
 	return !!(workflowPermissions.value.execute ?? projectPermissions.value.workflow.execute);
 });

--- a/packages/testing/playwright/pages/CanvasPage.ts
+++ b/packages/testing/playwright/pages/CanvasPage.ts
@@ -163,12 +163,16 @@ export class CanvasPage extends BasePage {
 		await this.nodeDeleteButton(nodeName).click();
 	}
 
-	async waitForSaveWorkflowCompleted() {
+	/**
+	 * @param options - Configuration options for waiting for save workflow completion.
+	 * @param options.timeout - Timeout in milliseconds. Defaults to 2000ms to account for the 1500ms autosave debounce.
+	 */
+	async waitForSaveWorkflowCompleted({ timeout = 2000 }: { timeout?: number } = {}) {
 		return await this.page.waitForResponse(
 			(response) =>
 				response.url().includes('/rest/workflows') &&
 				(response.request().method() === 'POST' || response.request().method() === 'PATCH'),
-			{ timeout: 2000 }, // Wait longer than autosave debounce (1500ms)
+			{ timeout },
 		);
 	}
 

--- a/packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/archive.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/archive.spec.ts
@@ -27,10 +27,75 @@ test.describe(
 		annotation: [{ type: 'owner', description: 'Adore' }],
 	},
 	() => {
-		test.fixme();
-
 		test.beforeEach(async ({ n8n }) => {
 			await n8n.start.fromBlankCanvas();
+		});
+
+		test('should display archived workflow in read-only mode on canvas', async ({ n8n }) => {
+			// Create and save a workflow
+			await n8n.canvas.addNode(SCHEDULE_TRIGGER_NODE_NAME, { closeNDV: true });
+			const workflowId = await getWorkflowIdAfterSave(n8n);
+
+			// Archive the workflow
+			await n8n.workflowSettingsModal.getWorkflowMenu().click();
+			await n8n.workflowSettingsModal.clickArchiveMenuItem();
+			await expect(n8n.notifications.getSuccessNotifications().first()).toBeVisible();
+			await expect(n8n.page).toHaveURL(/\/workflows$/);
+
+			// Open the archived workflow
+			await goToWorkflow(n8n, workflowId);
+
+			// Verify archived tag is visible
+			await expect(n8n.canvas.getArchivedTag()).toBeVisible();
+
+			// Verify canvas is in read-only mode - node creator should not be available
+			await expect(n8n.canvas.getNodeCreatorPlusButton()).not.toBeAttached();
+
+			// Try to click on the canvas where plus button would be - should not open node creator
+			const canvasPlusButtonArea = n8n.page.getByTestId('node-creator-plus-button');
+			await expect(canvasPlusButtonArea).not.toBeAttached();
+
+			// Try to interact with a node - clicking should not allow editing
+			const scheduleNode = n8n.canvas.nodeByName('Schedule Trigger');
+			await expect(scheduleNode).toBeVisible();
+
+			// Click the node - in read-only mode, this should not trigger edit mode
+			await scheduleNode.click();
+
+			// Node toolbar (with delete, disable buttons) should not appear in read-only mode
+			const nodeToolbar = n8n.canvas.nodeToolbar('Schedule Trigger');
+			await expect(nodeToolbar).not.toBeVisible();
+
+			// Try to drag a node - this should not work in read-only mode
+			// Get the node's initial position
+			const nodeBox = await scheduleNode.boundingBox();
+			if (nodeBox) {
+				// Try to drag the node
+				await scheduleNode.hover();
+				await n8n.page.mouse.down();
+				await n8n.page.mouse.move(nodeBox.x + 100, nodeBox.y + 100);
+				await n8n.page.mouse.up();
+
+				// Verify the node hasn't moved (should still be at the same position)
+				const newNodeBox = await scheduleNode.boundingBox();
+				expect(newNodeBox?.x).toBe(nodeBox.x);
+				expect(newNodeBox?.y).toBe(nodeBox.y);
+			}
+
+			// Verify that autosave does NOT trigger when attempting to edit
+			// Listen for save requests - there should be none
+			let saveRequestDetected = false;
+			n8n.page.on('request', (request) => {
+				if (request.url().includes('/rest/workflows/') && request.method() === 'PATCH') {
+					saveRequestDetected = true;
+				}
+			});
+
+			// Wait a bit to ensure no autosave is triggered
+			await n8n.page.waitForTimeout(2000);
+
+			// Verify no save request was made
+			expect(saveRequestDetected).toBe(false);
 		});
 
 		test('should not be able to archive or delete unsaved workflow', async ({ n8n }) => {

--- a/packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/archive.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/archive.spec.ts
@@ -2,11 +2,12 @@ import { SCHEDULE_TRIGGER_NODE_NAME } from '../../../../../config/constants';
 import { test, expect } from '../../../../../fixtures/base';
 import type { n8nPage } from '../../../../../pages/n8nPage';
 
-async function getWorkflowIdAfterSave(n8n: n8nPage): Promise<string> {
-	const saveResponse = await n8n.canvas.waitForSaveWorkflowCompleted();
+async function addNodeAndGetWorkflowId(n8n: n8nPage): Promise<string> {
+	const saveResponsePromise = n8n.canvas.waitForSaveWorkflowCompleted({ timeout: 5000 });
+	await n8n.canvas.addNode(SCHEDULE_TRIGGER_NODE_NAME, { closeNDV: true });
 	const {
 		data: { id },
-	} = await saveResponse.json();
+	} = await saveResponsePromise.then((r) => r.json());
 	return id;
 }
 
@@ -33,8 +34,7 @@ test.describe(
 
 		test('should display archived workflow in read-only mode on canvas', async ({ n8n }) => {
 			// Create and save a workflow
-			await n8n.canvas.addNode(SCHEDULE_TRIGGER_NODE_NAME, { closeNDV: true });
-			const workflowId = await getWorkflowIdAfterSave(n8n);
+			const workflowId = await addNodeAndGetWorkflowId(n8n);
 
 			// Archive the workflow
 			await n8n.workflowSettingsModal.getWorkflowMenu().click();
@@ -62,25 +62,23 @@ test.describe(
 			// Click the node - in read-only mode, this should not trigger edit mode
 			await scheduleNode.click();
 
-			// Node toolbar (with delete, disable buttons) should not appear in read-only mode
-			const nodeToolbar = n8n.canvas.nodeToolbar('Schedule Trigger');
-			await expect(nodeToolbar).not.toBeVisible();
+			// Node toolbar action buttons should not be present in read-only mode
+			await expect(n8n.page.getByTestId('execute-node-button')).not.toBeAttached();
+			await expect(n8n.page.getByTestId('delete-node-button')).not.toBeAttached();
+			await expect(n8n.page.getByTestId('disable-node-button')).not.toBeAttached();
 
 			// Try to drag a node - this should not work in read-only mode
-			// Get the node's initial position
 			const nodeBox = await scheduleNode.boundingBox();
-			if (nodeBox) {
-				// Try to drag the node
-				await scheduleNode.hover();
-				await n8n.page.mouse.down();
-				await n8n.page.mouse.move(nodeBox.x + 100, nodeBox.y + 100);
-				await n8n.page.mouse.up();
+			expect(nodeBox).not.toBeNull();
 
-				// Verify the node hasn't moved (should still be at the same position)
-				const newNodeBox = await scheduleNode.boundingBox();
-				expect(newNodeBox?.x).toBe(nodeBox.x);
-				expect(newNodeBox?.y).toBe(nodeBox.y);
-			}
+			await scheduleNode.hover();
+			await n8n.page.mouse.down();
+			await n8n.page.mouse.move(nodeBox!.x + 100, nodeBox!.y + 100);
+			await n8n.page.mouse.up();
+
+			const newNodeBox = await scheduleNode.boundingBox();
+			expect(newNodeBox?.x).toBe(nodeBox!.x);
+			expect(newNodeBox?.y).toBe(nodeBox!.y);
 
 			// Verify that autosave does NOT trigger when attempting to edit
 			// Listen for save requests - there should be none
@@ -92,6 +90,7 @@ test.describe(
 			});
 
 			// Wait a bit to ensure no autosave is triggered
+			// eslint-disable-next-line playwright/no-wait-for-timeout
 			await n8n.page.waitForTimeout(2000);
 
 			// Verify no save request was made
@@ -109,8 +108,7 @@ test.describe(
 		});
 
 		test('should archive nonactive workflow and then delete it', async ({ n8n }) => {
-			await n8n.canvas.addNode(SCHEDULE_TRIGGER_NODE_NAME, { closeNDV: true });
-			const workflowId = await getWorkflowIdAfterSave(n8n);
+			const workflowId = await addNodeAndGetWorkflowId(n8n);
 			await expect(n8n.canvas.getArchivedTag()).not.toBeAttached();
 
 			await expect(n8n.workflowSettingsModal.getWorkflowMenu()).toBeVisible();
@@ -137,8 +135,7 @@ test.describe(
 
 		// Flaky in multi-main mode
 		test.fixme('should archive published workflow and then delete it', async ({ n8n }) => {
-			await n8n.canvas.addNode(SCHEDULE_TRIGGER_NODE_NAME, { closeNDV: true });
-			const workflowId = await getWorkflowIdAfterSave(n8n);
+			const workflowId = await addNodeAndGetWorkflowId(n8n);
 			await n8n.canvas.publishWorkflow();
 			await n8n.page.keyboard.press('Escape');
 
@@ -169,8 +166,7 @@ test.describe(
 		});
 
 		test('should archive nonactive workflow and then unarchive it', async ({ n8n }) => {
-			await n8n.canvas.addNode(SCHEDULE_TRIGGER_NODE_NAME, { closeNDV: true });
-			const workflowId = await getWorkflowIdAfterSave(n8n);
+			const workflowId = await addNodeAndGetWorkflowId(n8n);
 			await expect(n8n.canvas.getArchivedTag()).not.toBeAttached();
 
 			await expect(n8n.workflowSettingsModal.getWorkflowMenu()).toBeVisible();
@@ -196,8 +192,7 @@ test.describe(
 		});
 
 		test('should not show unpublish menu item for non-published workflow', async ({ n8n }) => {
-			await n8n.canvas.addNode(SCHEDULE_TRIGGER_NODE_NAME, { closeNDV: true });
-			await n8n.canvas.waitForSaveWorkflowCompleted();
+			await addNodeAndGetWorkflowId(n8n);
 
 			await expect(n8n.canvas.getPublishedIndicator()).toBeHidden();
 
@@ -225,8 +220,7 @@ test.describe(
 
 		// Flaky in multi-main mode
 		test.fixme('should unpublish published workflow on archive', async ({ n8n }) => {
-			await n8n.canvas.addNode(SCHEDULE_TRIGGER_NODE_NAME, { closeNDV: true });
-			const workflowId = await getWorkflowIdAfterSave(n8n);
+			const workflowId = await addNodeAndGetWorkflowId(n8n);
 			await n8n.canvas.publishWorkflow();
 			await n8n.page.keyboard.press('Escape');
 


### PR DESCRIPTION
## Summary

Archived workflows were incorrectly rendered as editable on the canvas after a refactor of `workflowDocument.store.ts`. This caused autosave to fire and fail with repeated 403/404 toast errors, since the backend correctly rejects writes to archived workflows.

**Root cause:** `isCanvasReadOnly` and `canExecuteOnCanvas` in `NodeView.vue` were reading `isArchived` from `editableWorkflow` (always `false` after the refactor) instead of `workflowDocumentStore`, which is the correct source of truth.

**Changes:**
- `NodeView.vue`: Read `isArchived` from `workflowDocumentStore` in both `isCanvasReadOnly` and `canExecuteOnCanvas`
- `CanvasNode.vue`: Skip rendering the toolbar entirely when `readOnly && !canExecute`, so the toolbar DOM element is absent (not just opacity-hidden)
- `CanvasNodeToolbar.vue`: Hide the overflow "⋯" button when `readOnly`

**How to test:**
1. Create and save a workflow
2. Archive it via the workflow menu
3. Open the archived workflow — canvas should be in read-only mode (no plus button, no toolbar actions)
4. Verify no autosave requests fire

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2632

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI