### PR TITLE
fix(ai-builder): Allow skipping final ask-user question

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiQuestions.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiQuestions.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent } from '@testing-library/vue';
+import { createComponentRenderer } from '@/__tests__/render';
+import InstanceAiQuestions, { type QuestionItem } from '../components/InstanceAiQuestions.vue';
+
+const textQuestion: QuestionItem = {
+	id: 'q-text',
+	question: 'Leave blank for no filter',
+	type: 'text',
+};
+
+const singleQuestion: QuestionItem = {
+	id: 'q-single',
+	question: 'Which credential should I use?',
+	type: 'single',
+	options: ['Production', 'Staging'],
+};
+
+const multiQuestion: QuestionItem = {
+	id: 'q-multi',
+	question: 'Which fields should I include?',
+	type: 'multi',
+	options: ['Name', 'Email', 'Phone'],
+};
+
+const renderComponent = createComponentRenderer(InstanceAiQuestions);
+
+function render(questions: QuestionItem[]) {
+	return renderComponent({
+		props: {
+			questions,
+		},
+	});
+}
+
+describe('InstanceAiQuestions', () => {
+	it('submits the final empty text question as skipped', async () => {
+		const { emitted, getByTestId } = render([textQuestion]);
+
+		const submitButton = getByTestId('instance-ai-questions-next');
+
+		expect(submitButton).toHaveTextContent('Submit');
+		expect(submitButton).not.toHaveAttribute('disabled');
+
+		await fireEvent.click(submitButton);
+
+		expect(emitted().submit).toEqual([
+			[
+				[
+					{
+						questionId: 'q-text',
+						question: 'Leave blank for no filter',
+						selectedOptions: [],
+						customText: '',
+						skipped: true,
+					},
+				],
+			],
+		]);
+	});
+
+	it('shows enabled Submit for the final empty single-select question', async () => {
+		const { emitted, getByTestId, queryByTestId } = render([singleQuestion]);
+
+		expect(queryByTestId('instance-ai-questions-skip')).toBeNull();
+
+		const submitButton = getByTestId('instance-ai-questions-next');
+
+		expect(submitButton).toHaveTextContent('Submit');
+		expect(submitButton).not.toHaveAttribute('disabled');
+
+		await fireEvent.click(submitButton);
+
+		expect(emitted().submit).toEqual([
+			[
+				[
+					{
+						questionId: 'q-single',
+						question: 'Which credential should I use?',
+						selectedOptions: [],
+						customText: '',
+						skipped: true,
+					},
+				],
+			],
+		]);
+	});
+
+	it('submits the final empty multi-select question as skipped', async () => {
+		const { emitted, getByTestId, queryByTestId } = render([multiQuestion]);
+
+		expect(queryByTestId('instance-ai-questions-skip')).toBeNull();
+
+		const submitButton = getByTestId('instance-ai-questions-next');
+
+		expect(submitButton).toHaveTextContent('Submit');
+		expect(submitButton).not.toHaveAttribute('disabled');
+
+		await fireEvent.click(submitButton);
+
+		expect(emitted().submit).toEqual([
+			[
+				[
+					{
+						questionId: 'q-multi',
+						question: 'Which fields should I include?',
+						selectedOptions: [],
+						customText: '',
+						skipped: true,
+					},
+				],
+			],
+		]);
+	});
+
+	it('keeps an empty non-final text question skippable but not nextable', () => {
+		const { getByTestId } = render([textQuestion, singleQuestion]);
+
+		const nextButton = getByTestId('instance-ai-questions-next');
+
+		expect(getByTestId('instance-ai-questions-skip')).toBeInTheDocument();
+		expect(nextButton).toHaveTextContent('Next');
+		expect(nextButton).toHaveAttribute('disabled');
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiQuestions.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiQuestions.vue
@@ -88,6 +88,7 @@ const showSkipButton = computed(() => {
 });
 
 const showNextButton = computed(() => {
+	if (isLastQuestion.value) return true;
 	if (currentQuestion.value?.type === 'single') return hasCustomText.value;
 	return true;
 });
@@ -95,6 +96,7 @@ const showNextButton = computed(() => {
 const isNextEnabled = computed(() => {
 	const q = currentQuestion.value;
 	if (!q) return false;
+	if (isLastQuestion.value) return true;
 	if (q.type === 'single') return hasCustomText.value;
 	if (q.type === 'multi') {
 		const answer = currentAnswer.value;
@@ -326,7 +328,7 @@ function handleEnterKey(event: KeyboardEvent, type: string, optionCount: number)
 		} else if (isNextEnabled.value) {
 			goToNextInternal();
 		}
-	} else if (type === 'text' && hasCustomText.value) {
+	} else if (type === 'text' && isNextEnabled.value) {
 		goToNextInternal();
 	}
 	return true;


### PR DESCRIPTION
## Summary

Allow the final Instance AI ask-user question to be submitted with an empty answer. The existing submit pipeline already marks empty answers as skipped, so this removes the last-step button gating that trapped users when the prompt allowed a blank answer.

Add focused component coverage for final empty text and single-select questions, plus unchanged non-final text behavior.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-175

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created. Not needed for this frontend bug fix.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

## Validation

- `pnpm test InstanceAiQuestions`
- `pnpm lint`
- `pnpm typecheck`
