### PR TITLE
test: Use identity-based assertion in node search test (backport to release-candidate/2.19.x) (no-changelog)

### DIFF
--- a/packages/testing/playwright/pages/CanvasPage.ts
+++ b/packages/testing/playwright/pages/CanvasPage.ts
@@ -488,6 +488,10 @@ export class CanvasPage extends BasePage {
 		return this.page.getByTestId('node-creator-item-name');
 	}
 
+	nodeCreatorNodeItem(name: string): Locator {
+		return this.nodeCreatorNodeItems().getByText(name, { exact: true });
+	}
+
 	nodeCreatorActionItems(): Locator {
 		return this.page.getByTestId('node-creator-action-item');
 	}

--- a/packages/testing/playwright/tests/e2e/building-blocks/canvas-actions.spec.ts
+++ b/packages/testing/playwright/tests/e2e/building-blocks/canvas-actions.spec.ts
@@ -47,8 +47,8 @@ test.describe(
 			test('should clear search and show all nodes', async ({ n8n }) => {
 				await n8n.canvas.clickCanvasPlusButton();
 				await n8n.canvas.fillNodeCreatorSearchBar('Linear');
+				await expect(n8n.canvas.nodeCreatorNodeItem('Linear')).toBeVisible();
 				const searchCount = await n8n.canvas.nodeCreatorNodeItems().count();
-				await expect(n8n.canvas.nodeCreatorNodeItems()).toHaveCount(1);
 
 				await n8n.canvas.nodeCreatorSearchBar().clear();
 				const nodeCount = await n8n.canvas.nodeCreatorNodeItems().count();


### PR DESCRIPTION
## Summary

Backport of #29426 (commit `d461ec3e9b`) to `release-candidate/2.19.x`.

The E2E test `Canvas Node Actions › Node Search and Add › should clear search and show all nodes` is consistently failing on the 2.19.x release-candidate CI shard `multi-main:e2e` because it asserts `toHaveCount(1)` after searching "Linear" in the node creator — but the search legitimately returns two items (`Linear` and `Linear Trigger`). The trigger merging only happens in subcategory views, not in root search.

This was already fixed on master by replacing the brittle count assertion with an identity-based one. The fix needs to be on the 2.19.x line as well so the share-dropdown backport (#29537) and any further backports can land on green CI.

## Changes (cherry-pick of `d461ec3e9b`)

- `packages/testing/playwright/pages/CanvasPage.ts` — adds `nodeCreatorNodeItem(name)` helper that scopes to a specific item by exact text.
- `packages/testing/playwright/tests/e2e/building-blocks/canvas-actions.spec.ts` — replaces `expect(nodeCreatorNodeItems()).toHaveCount(1)` with `expect(nodeCreatorNodeItem('Linear')).toBeVisible()`.

Net: 5 lines added, 1 line removed, no behavior change for the test's intent (still proves Linear shows up in search and that clearing search returns more results).

## Related

- Master PR: https://github.com/n8n-io/n8n/pull/29426
- Master commit: `d461ec3e9b`

## Test plan

- [x] Cherry-pick applies cleanly with no conflicts
- [x] `CanvasPage.ts` and `canvas-actions.spec.ts` compile clean (pre-existing typecheck errors on this branch are in unrelated files: `wait.spec.ts`, `list.spec.ts`, `Types.ts`, `benchmark/*`, `chat-hub/fixtures.ts`)
- [ ] CI passes — including the previously-failing `multi-main:e2e` shard