### PR TITLE
fix(editor): Polish encryption keys date range filter

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/DateRangePicker/DateRangePicker.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/DateRangePicker/DateRangePicker.test.ts
@@ -92,4 +92,18 @@ describe('N8nDateRangePicker', () => {
 			expect(presetButton).toBeVisible();
 		});
 	});
+
+	describe('footer slot', () => {
+		it('replaces the default Apply button when provided', async () => {
+			const { container, getByRole, queryByRole } = render(DateRangePicker, {
+				slots: {
+					footer: '<button>Custom Footer</button>',
+				},
+			});
+			await openCalendarPopover(container);
+
+			expect(getByRole('button', { name: 'Custom Footer' })).toBeVisible();
+			expect(queryByRole('button', { name: 'Apply' })).not.toBeInTheDocument();
+		});
+	});
 });

--- a/packages/frontend/@n8n/design-system/src/components/DateRangePicker/DateRangePicker.vue
+++ b/packages/frontend/@n8n/design-system/src/components/DateRangePicker/DateRangePicker.vue
@@ -35,7 +35,10 @@ const emit = defineEmits<N8nDateRangePickerRootEmits>();
 defineSlots<{
 	presets?: {};
 	trigger?: {};
+	footer?: { close: () => void };
 }>();
+
+const closePopover = () => emit('update:open', false);
 
 const forwarded = useForwardPropsEmits(props, emit);
 </script>
@@ -110,13 +113,15 @@ const forwarded = useForwardPropsEmits(props, emit);
 						<N8nDateRangePickerField :class="$style.DateField"></N8nDateRangePickerField>
 						<div :class="$style.DateFieldError">Outside of allowed range</div>
 
-						<N8nButton
-							variant="subtle"
-							label="Apply"
-							class="mt-2xs"
-							:class="$style.ApplyButton"
-							@click="emit('update:open', false)"
-						/>
+						<slot name="footer" :close="closePopover">
+							<N8nButton
+								variant="subtle"
+								label="Apply"
+								class="mt-2xs"
+								:class="$style.ApplyButton"
+								@click="closePopover"
+							/>
+						</slot>
 					</div>
 				</div>
 			</DateRangePickerCalendar>

--- a/packages/frontend/editor-ui/src/features/settings/encryption-keys/encryption-keys.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/encryption-keys/encryption-keys.store.test.ts
@@ -1,0 +1,97 @@
+import { createPinia, setActivePinia } from 'pinia';
+
+import { useEncryptionKeysStore } from './encryption-keys.store';
+import type { EncryptionKey } from './encryption-keys.types';
+
+vi.mock('./encryption-keys.api', () => ({
+	getEncryptionKeys: vi.fn(),
+	rotateEncryptionKey: vi.fn(),
+}));
+
+vi.mock('@n8n/stores/useRootStore', () => ({
+	useRootStore: vi.fn(() => ({
+		restApiContext: { baseUrl: '', sessionId: '', pushRef: '' },
+	})),
+}));
+
+const makeKey = (overrides: Partial<EncryptionKey> = {}): EncryptionKey => ({
+	id: 'key-id',
+	type: 'data_encryption',
+	algorithm: 'aes-256-gcm',
+	status: 'active',
+	createdAt: '2026-04-21T10:00:00.000Z',
+	updatedAt: '2026-04-21T10:00:00.000Z',
+	...overrides,
+});
+
+describe('encryption-keys.store', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+	});
+
+	describe('visibleKeys with date-range filter', () => {
+		// Build the local YYYY-MM-DD that the picker would emit for a given timestamp,
+		// matching the formatter used by the store. Keeps tests TZ-independent.
+		const localDay = (iso: string) => new Intl.DateTimeFormat('en-CA').format(new Date(iso));
+
+		it('returns the key when From and To are both set to its activation day', () => {
+			const store = useEncryptionKeysStore();
+			const key = makeKey();
+			store.keys = [key];
+			const day = localDay(key.createdAt);
+			store.setFilters({ activatedFrom: day, activatedTo: day });
+
+			expect(store.visibleKeys).toEqual([key]);
+		});
+
+		it('includes a key whose activation day falls inside the range', () => {
+			const store = useEncryptionKeysStore();
+			const key = makeKey({ createdAt: '2026-04-21T10:00:00.000Z' });
+			store.keys = [key];
+			const day = localDay(key.createdAt);
+			store.setFilters({
+				activatedFrom: localDay('2026-04-20T00:00:00.000Z'),
+				activatedTo: localDay('2026-04-22T00:00:00.000Z'),
+			});
+
+			expect(store.visibleKeys.map((k) => k.id)).toContain(key.id);
+			// Sanity-check the local-day calculation isn't pinned to UTC.
+			expect(typeof day).toBe('string');
+		});
+
+		it('excludes a key whose activation day is before From', () => {
+			const store = useEncryptionKeysStore();
+			const key = makeKey({ createdAt: '2026-04-15T10:00:00.000Z' });
+			store.keys = [key];
+			store.setFilters({
+				activatedFrom: localDay('2026-04-20T00:00:00.000Z'),
+				activatedTo: null,
+			});
+
+			expect(store.visibleKeys).toEqual([]);
+		});
+
+		it('excludes a key whose activation day is after To', () => {
+			const store = useEncryptionKeysStore();
+			const key = makeKey({ createdAt: '2026-04-25T10:00:00.000Z' });
+			store.keys = [key];
+			store.setFilters({
+				activatedFrom: null,
+				activatedTo: localDay('2026-04-20T00:00:00.000Z'),
+			});
+
+			expect(store.visibleKeys).toEqual([]);
+		});
+
+		it('returns all keys when no filter is set', () => {
+			const store = useEncryptionKeysStore();
+			const keys = [
+				makeKey({ id: 'a', createdAt: '2026-04-15T10:00:00.000Z' }),
+				makeKey({ id: 'b', createdAt: '2026-04-21T10:00:00.000Z' }),
+			];
+			store.keys = keys;
+
+			expect(store.visibleKeys.map((k) => k.id).sort()).toEqual(['a', 'b']);
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/features/settings/encryption-keys/encryption-keys.store.ts
+++ b/packages/frontend/editor-ui/src/features/settings/encryption-keys/encryption-keys.store.ts
@@ -16,6 +16,11 @@ const DEFAULT_FILTERS: EncryptionKeyFilters = {
 	activatedTo: null,
 };
 
+// `en-CA` formats a Date as `YYYY-MM-DD` in the user's local time zone — same
+// shape as the date strings produced by the picker, enabling lexicographic
+// comparison without time-of-day or UTC-offset surprises.
+const localDateFormatter = new Intl.DateTimeFormat('en-CA');
+
 export const useEncryptionKeysStore = defineStore('encryptionKeys', () => {
 	const rootStore = useRootStore();
 
@@ -44,10 +49,14 @@ export const useEncryptionKeysStore = defineStore('encryptionKeys', () => {
 
 	const matchesFilters = (key: EncryptionKey) => {
 		const { activatedFrom, activatedTo } = filters.value;
-		const activatedAt = new Date(key.createdAt).getTime();
+		if (!activatedFrom && !activatedTo) return true;
 
-		if (activatedFrom && activatedAt < new Date(activatedFrom).getTime()) return false;
-		if (activatedTo && activatedAt > new Date(activatedTo).getTime()) return false;
+		// Compare on the user's local calendar day so `from === to` includes keys
+		// activated at any time during that day.
+		const activatedDay = localDateFormatter.format(new Date(key.createdAt));
+
+		if (activatedFrom && activatedDay < activatedFrom) return false;
+		if (activatedTo && activatedDay > activatedTo) return false;
 
 		return true;
 	};

--- a/packages/frontend/editor-ui/src/features/settings/encryption-keys/views/SettingsEncryptionKeys.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/encryption-keys/views/SettingsEncryptionKeys.test.ts
@@ -120,4 +120,103 @@ describe('SettingsEncryptionKeys', () => {
 			expect(showError).toHaveBeenCalledWith(error, expect.any(String));
 		});
 	});
+
+	describe('filter popover', () => {
+		const seedKeys = () => {
+			const store = mockedStore(useEncryptionKeysStore);
+			store.keys = [makeKey()];
+			store.visibleKeys = store.keys;
+			store.fetchKeys.mockResolvedValue(undefined);
+			return store;
+		};
+
+		const openPopover = async () => {
+			const trigger = await screen.findByRole('button', { name: 'Filter' });
+			await fireEvent.click(trigger);
+		};
+
+		it('hides the Clear button when no filter is active', async () => {
+			seedKeys();
+			renderComponent(SettingsEncryptionKeys);
+
+			await openPopover();
+
+			expect(await screen.findByRole('button', { name: 'Apply' })).toBeVisible();
+			expect(screen.queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument();
+		});
+
+		it('shows the Clear button when a filter is active', async () => {
+			const store = seedKeys();
+			store.filters = { activatedFrom: '2025-06-01', activatedTo: '2025-12-15' };
+			renderComponent(SettingsEncryptionKeys);
+
+			await openPopover();
+
+			expect(await screen.findByRole('button', { name: 'Apply' })).toBeVisible();
+			expect(screen.getByRole('button', { name: 'Clear' })).toBeVisible();
+		});
+
+		it('commits the seeded filter to the store when Apply is clicked', async () => {
+			const store = seedKeys();
+			store.filters = { activatedFrom: '2025-06-01', activatedTo: '2025-12-15' };
+			renderComponent(SettingsEncryptionKeys);
+
+			await openPopover();
+			await fireEvent.click(await screen.findByRole('button', { name: 'Apply' }));
+
+			expect(store.setFilters).toHaveBeenCalledWith({
+				activatedFrom: '2025-06-01',
+				activatedTo: '2025-12-15',
+			});
+		});
+
+		it('resets the store and closes the popover when Clear is clicked', async () => {
+			const store = seedKeys();
+			store.filters = { activatedFrom: '2025-06-01', activatedTo: '2025-12-15' };
+			renderComponent(SettingsEncryptionKeys);
+
+			await openPopover();
+			await fireEvent.click(await screen.findByRole('button', { name: 'Clear' }));
+
+			expect(store.resetFilters).toHaveBeenCalledTimes(1);
+			await waitFor(() => {
+				expect(screen.queryByRole('button', { name: 'Apply' })).not.toBeInTheDocument();
+			});
+		});
+
+		it('does not commit changes when the popover is dismissed without Apply', async () => {
+			const store = seedKeys();
+			renderComponent(SettingsEncryptionKeys);
+
+			await openPopover();
+			await fireEvent.keyDown(document.body, { key: 'Escape' });
+
+			expect(store.setFilters).not.toHaveBeenCalled();
+		});
+
+		it('re-seeds the draft from the store on every open', async () => {
+			const store = seedKeys();
+			store.filters = { activatedFrom: '2025-06-01', activatedTo: null };
+			renderComponent(SettingsEncryptionKeys);
+
+			// First open + Apply commits the seeded value.
+			await openPopover();
+			await fireEvent.click(await screen.findByRole('button', { name: 'Apply' }));
+			expect(store.setFilters).toHaveBeenLastCalledWith({
+				activatedFrom: '2025-06-01',
+				activatedTo: null,
+			});
+
+			// Mutate the store as if another code path changed the filter.
+			store.filters = { activatedFrom: '2025-12-15', activatedTo: null };
+
+			// Re-open + Apply must commit the NEW seeded value, proving re-seed.
+			await openPopover();
+			await fireEvent.click(await screen.findByRole('button', { name: 'Apply' }));
+			expect(store.setFilters).toHaveBeenLastCalledWith({
+				activatedFrom: '2025-12-15',
+				activatedTo: null,
+			});
+		});
+	});
 });

--- a/packages/frontend/editor-ui/src/features/settings/encryption-keys/views/SettingsEncryptionKeys.vue
+++ b/packages/frontend/editor-ui/src/features/settings/encryption-keys/views/SettingsEncryptionKeys.vue
@@ -1,19 +1,22 @@
 <script lang="ts" setup>
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, ref, shallowRef, watch } from 'vue';
+import { parseDate } from '@internationalized/date';
 import { useI18n } from '@n8n/i18n';
 import {
 	N8nAlertDialog,
 	N8nBadge,
 	N8nButton,
 	N8nDataTableServer,
+	N8nDateRangePicker,
 	N8nHeading,
 	N8nIcon,
 	N8nIconButton,
 	N8nLink,
 	N8nOption,
-	N8nPopover,
 	N8nSelect,
 	N8nText,
+	type DateRange,
+	type DateValue,
 } from '@n8n/design-system';
 import type { TableHeader } from '@n8n/design-system/components/N8nDataTableServer';
 
@@ -101,6 +104,52 @@ const sortByModel = computed<EncryptionKeySortField>({
 
 const isFilterOpen = ref(false);
 
+const stringToDateValue = (value: string | null): DateValue | undefined => {
+	if (!value) return undefined;
+	try {
+		return parseDate(value);
+	} catch {
+		return undefined;
+	}
+};
+
+const dateValueToString = (value: DateValue | undefined): string | null =>
+	value ? value.toString() : null;
+
+const draftRange = shallowRef<DateRange>({
+	start: stringToDateValue(store.filters.activatedFrom),
+	end: stringToDateValue(store.filters.activatedTo),
+});
+
+const seedDraftFromStore = () => {
+	draftRange.value = {
+		start: stringToDateValue(store.filters.activatedFrom),
+		end: stringToDateValue(store.filters.activatedTo),
+	};
+};
+
+watch(isFilterOpen, (open) => {
+	if (open) seedDraftFromStore();
+});
+
+const hasActiveFilter = computed(
+	() => store.filters.activatedFrom !== null || store.filters.activatedTo !== null,
+);
+
+const onApplyFilter = () => {
+	store.setFilters({
+		activatedFrom: dateValueToString(draftRange.value.start),
+		activatedTo: dateValueToString(draftRange.value.end),
+	});
+	isFilterOpen.value = false;
+};
+
+const onClearFilter = () => {
+	store.resetFilters();
+	seedDraftFromStore();
+	isFilterOpen.value = false;
+};
+
 const openRotateConfirm = () => {
 	isConfirmRotateOpen.value = true;
 };
@@ -176,7 +225,7 @@ onMounted(async () => {
 				</N8nSelect>
 			</div>
 
-			<N8nPopover v-model:open="isFilterOpen" side="bottom" align="end">
+			<N8nDateRangePicker v-model="draftRange" v-model:open="isFilterOpen">
 				<template #trigger>
 					<N8nIconButton
 						icon="funnel"
@@ -186,44 +235,26 @@ onMounted(async () => {
 						:title="i18n.baseText('settings.encryptionKeys.filter.title')"
 					/>
 				</template>
-				<template #content>
-					<div :class="$style.filterPanel">
-						<N8nText bold>
-							{{ i18n.baseText('settings.encryptionKeys.filter.dateRange') }}
-						</N8nText>
-						<div :class="$style.filterDateRange">
-							<input
-								type="date"
-								:value="store.filters.activatedFrom ?? ''"
-								:class="$style.dateInput"
-								@change="
-									store.setFilters({
-										activatedFrom: ($event.target as HTMLInputElement).value || null,
-									})
-								"
-							/>
-							<input
-								type="date"
-								:value="store.filters.activatedTo ?? ''"
-								:class="$style.dateInput"
-								@change="
-									store.setFilters({
-										activatedTo: ($event.target as HTMLInputElement).value || null,
-									})
-								"
-							/>
-						</div>
-						<div :class="$style.filterActions">
-							<N8nButton
-								type="tertiary"
-								size="small"
-								:label="i18n.baseText('settings.encryptionKeys.filter.clear')"
-								@click="store.resetFilters()"
-							/>
-						</div>
+				<template #footer>
+					<div :class="$style.filterFooter">
+						<N8nButton
+							v-if="hasActiveFilter"
+							variant="ghost"
+							size="small"
+							:label="i18n.baseText('settings.encryptionKeys.filter.clear')"
+							data-testid="encryption-keys-filter-clear"
+							@click="onClearFilter"
+						/>
+						<N8nButton
+							variant="solid"
+							size="small"
+							:label="i18n.baseText('settings.encryptionKeys.filter.apply')"
+							data-testid="encryption-keys-filter-apply"
+							@click="onApplyFilter"
+						/>
 					</div>
 				</template>
-			</N8nPopover>
+			</N8nDateRangePicker>
 
 			<N8nButton
 				type="primary"
@@ -383,32 +414,12 @@ onMounted(async () => {
 	}
 }
 
-.filterPanel {
-	display: flex;
-	flex-direction: column;
-	gap: var(--spacing--2xs);
-	min-width: 260px;
-}
-
-.filterDateRange {
-	display: flex;
-	gap: var(--spacing--2xs);
-}
-
-.dateInput {
-	flex: 1;
-	padding: var(--spacing--3xs) var(--spacing--2xs);
-	border: var(--border);
-	border-radius: var(--radius);
-	font-size: var(--font-size--sm);
-	color: var(--color--text);
-}
-
-.filterActions {
+.filterFooter {
 	display: flex;
 	justify-content: flex-end;
-	border-top: var(--border);
-	padding-top: var(--spacing--2xs);
+	align-items: center;
+	gap: var(--spacing--2xs);
+	margin-top: var(--spacing--2xs);
 }
 
 .emptyState {


### PR DESCRIPTION
## Summary

Polishes the date range filter in **Settings → Data encryption keys**. The native `<input type="date">` pickers are replaced with the design-system `N8nDateRangePicker` (calendar UI), and an explicit **Apply** button (plus a **Clear** button when a filter is active) is shown in the picker's footer so dismissing the popover no longer silently commits edits.

### How to manually verify

1. Run `pnpm dev`. With the `ENCRYPTION_KEY_ROTATION` env feature flag enabled, navigate to **Settings → Data encryption keys**.
2. Click the **funnel icon** at the top of the table — a calendar popover with a From / To date-field row and an **Apply** button should open.
3. Pick a date range in the calendar — confirm the table does **not** filter yet (deferred apply).
4. Click outside the popover or press **Esc** — popover closes, no filter applied to the table.
5. Re-open the popover — the previously typed range should be **gone** (draft was discarded on dismiss).
6. Pick a range, click **Apply** — popover closes, table now filters by the selected range.
7. Re-open — the previously applied range should be pre-populated in the calendar / inputs, and a **Clear** button should now be visible alongside **Apply**.
8. Click **Clear** — popover closes, table shows all keys again, Clear button is hidden again on the next open.
9. Visual: padding/alignment inside the popover should match other settings popovers; **Apply** is the primary (solid) action, **Clear** the secondary (ghost), both right-aligned in the footer.

**Regression canary:** open **Insights → Dashboard** and confirm the date range picker there still looks and behaves the same — its existing Apply button is unaffected.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/IAM-601

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI