### PR TITLE
fix: Telegram thread handling, memory scopes

### DIFF
--- a/packages/cli/src/modules/agents/__tests__/agent-skills.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-skills.service.test.ts
@@ -3,8 +3,8 @@ import { mockLogger } from '@n8n/backend-test-utils';
 import { mock } from 'jest-mock-extended';
 
 import type { Agent } from '../entities/agent.entity';
-import type { AgentRepository } from '../repositories/agent.repository';
 import { AgentSkillsService } from '../agent-skills.service';
+import type { AgentRepository } from '../repositories/agent.repository';
 
 const agentId = 'agent-1';
 const projectId = 'project-1';

--- a/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
@@ -18,7 +18,9 @@ import {
 	ChatIntegrationRegistry,
 	type AgentChatIntegrationContext,
 } from '../integrations/agent-chat-integration';
+import type { N8NCheckpointStorage } from '../integrations/n8n-checkpoint-storage';
 import type { N8nMemory } from '../integrations/n8n-memory';
+import type { AgentExecutionService } from '../agent-execution.service';
 import type { AgentJsonConfig } from '../json-config/agent-json-config';
 import type { AgentPublishedVersionRepository } from '../repositories/agent-published-version.repository';
 import type { AgentRepository } from '../repositories/agent.repository';
@@ -67,6 +69,8 @@ describe('AgentsService', () => {
 	let agentRepository: jest.Mocked<AgentRepository>;
 	let agentPublishedVersionRepository: jest.Mocked<AgentPublishedVersionRepository>;
 	let n8nMemory: jest.Mocked<N8nMemory>;
+	let n8nCheckpointStorage: jest.Mocked<N8NCheckpointStorage>;
+	let agentExecutionService: jest.Mocked<AgentExecutionService>;
 	let scheduleService: jest.Mocked<AgentScheduleService>;
 
 	beforeEach(() => {
@@ -75,6 +79,9 @@ describe('AgentsService', () => {
 		agentRepository = mock<AgentRepository>();
 		agentPublishedVersionRepository = mock<AgentPublishedVersionRepository>();
 		n8nMemory = mock<N8nMemory>();
+		n8nCheckpointStorage = mock<N8NCheckpointStorage>();
+		agentExecutionService = mock<AgentExecutionService>();
+		agentExecutionService.recordMessage.mockResolvedValue('exec-id');
 		scheduleService = mock<AgentScheduleService>();
 		const logger = mockLogger();
 
@@ -89,12 +96,12 @@ describe('AgentsService', () => {
 			mock(),
 			mock(),
 			mock(),
-			mock(),
+			n8nCheckpointStorage,
 			mock(),
 			mock(),
 			mock(),
 			n8nMemory,
-			mock(),
+			agentExecutionService,
 			agentPublishedVersionRepository,
 			new AgentSkillsService(logger, agentRepository),
 		);
@@ -466,19 +473,26 @@ describe('AgentsService', () => {
 				publishedVersion: makePublishedVersion({
 					schema,
 					skills: { summarize_notes: publishedSkill },
+					publishedById: userId,
 				}),
 			});
 			agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
 
+			jest.spyOn(service as never, 'createCredentialProvider').mockReturnValue(mock());
 			const reconstructSpy = jest
 				.spyOn(service as never, 'reconstructFromConfig')
-				.mockResolvedValue({} as never);
+				.mockResolvedValue({ agent: {}, toolRegistry: {} } as never);
 			jest
 				.spyOn(service as never, 'streamChatResponse')
 				.mockImplementation(async function* () {} as never);
 
 			await service
-				.executeForChatPublished(agentId, 'hello', 'thread-1', userId, projectId, mock())
+				.executeForChatPublished({
+					agentId,
+					projectId,
+					message: 'hello',
+					memory: { threadId: 'thread-1', resourceId: 'platform-user-1' },
+				})
 				.next();
 
 			expect(reconstructSpy.mock.calls[0][0]).toEqual(
@@ -486,7 +500,42 @@ describe('AgentsService', () => {
 					skills: { summarize_notes: publishedSkill },
 				}),
 			);
-			expect(reconstructSpy.mock.calls[0][2]).toBe(userId);
+		});
+
+		it('passes resourceId (not n8n userId) to streamChatResponse', async () => {
+			const schema: AgentJsonConfig = {
+				name: 'Test Agent',
+				model: 'anthropic/claude-sonnet-4-5',
+				instructions: 'Be helpful',
+			};
+			const n8nPublisherId = 'n8n-user-publisher';
+			const chatUserId = 'slack-user-abc';
+			const agent = makeAgent({
+				schema,
+				publishedVersion: makePublishedVersion({ schema, publishedById: n8nPublisherId }),
+			});
+			agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
+
+			jest.spyOn(service as never, 'createCredentialProvider').mockReturnValue(mock());
+			jest
+				.spyOn(service as never, 'reconstructFromConfig')
+				.mockResolvedValue({ agent: {}, toolRegistry: {} } as never);
+			const streamSpy = jest
+				.spyOn(service as never, 'streamChatResponse')
+				.mockImplementation(async function* () {} as never);
+
+			await service
+				.executeForChatPublished({
+					agentId,
+					projectId,
+					message: 'hello',
+					memory: { threadId: 'thread-1', resourceId: chatUserId },
+				})
+				.next();
+
+			const streamConfig = (streamSpy.mock.calls[0] as [{ memory: { resourceId: string } }])[0];
+			expect(streamConfig.memory.resourceId).toBe(chatUserId);
+			expect(streamConfig.memory.resourceId).not.toBe(n8nPublisherId);
 		});
 	});
 
@@ -812,6 +861,61 @@ describe('AgentsService', () => {
 			);
 
 			expect(result.missing.filter((m) => m.startsWith('skill:'))).toEqual([]);
+		});
+	});
+
+	describe('resumeForChat', () => {
+		it('does not use n8n userId as resourceId — resume passes no resourceId to agentInstance.resume', async () => {
+			const n8nPublisherId = 'n8n-user-publisher';
+			const runId = 'run-abc';
+			const toolCallId = 'tool-xyz';
+			const schema: AgentJsonConfig = {
+				name: 'Test Agent',
+				model: 'anthropic/claude-sonnet-4-5',
+				instructions: 'Be helpful',
+			};
+			const agent = makeAgent({
+				schema,
+				publishedVersion: makePublishedVersion({ schema, publishedById: n8nPublisherId }),
+			});
+			agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
+
+			// Configure the named checkpoint storage mock injected in beforeEach
+			n8nCheckpointStorage.getStatus.mockResolvedValue({
+				status: 'ok',
+				checkpoint: { persistence: { threadId: 'thread-1', resourceId: 'platform-user-1' } },
+			} as never);
+
+			const mockAgentInstance = {
+				name: 'Test Agent',
+				resume: jest.fn().mockResolvedValue({
+					stream: {
+						getReader: () => ({
+							read: jest.fn().mockResolvedValue({ done: true, value: undefined }),
+							releaseLock: jest.fn(),
+						}),
+					},
+				}),
+			};
+
+			jest.spyOn(service as never, 'createCredentialProvider').mockReturnValue(mock());
+			jest
+				.spyOn(service as never, 'reconstructFromConfig')
+				.mockResolvedValue({ agent: mockAgentInstance, toolRegistry: {} } as never);
+
+			await service
+				.resumeForChat({ agentId, projectId, runId, toolCallId, resumeData: { value: 'yes' } })
+				.next();
+
+			// resume() takes runId and toolCallId — no resourceId or userId is passed
+			expect(mockAgentInstance.resume).toHaveBeenCalledWith(
+				'stream',
+				{ value: 'yes' },
+				{ runId, toolCallId },
+			);
+			// The n8n publisher ID must not appear in the resume args
+			const resumeArgs = mockAgentInstance.resume.mock.calls[0];
+			expect(JSON.stringify(resumeArgs)).not.toContain(n8nPublisherId);
 		});
 	});
 

--- a/packages/cli/src/modules/agents/agent-execution.service.ts
+++ b/packages/cli/src/modules/agents/agent-execution.service.ts
@@ -19,7 +19,6 @@ export interface RecordMessageParams {
 	agentId: string;
 	agentName: string;
 	projectId: string;
-	userId: string;
 	userMessage: string;
 	record: MessageRecord;
 	/** Set to 'suspended' or 'resumed' for HITL tool call flows. */

--- a/packages/cli/src/modules/agents/agents.controller.ts
+++ b/packages/cli/src/modules/agents/agents.controller.ts
@@ -436,15 +436,13 @@ export class AgentsController {
 
 		try {
 			await pumpChunks(
-				this.agentsService.executeForChat(
+				this.agentsService.executeForChat({
 					agentId,
-					message,
-					threadId,
-					req.user.id,
 					projectId,
-					credentialProvider,
-					'chat',
-				),
+					message,
+					userId: req.user.id,
+					memory: { threadId, resourceId: req.user.id },
+				}),
 				send,
 			);
 			send({ type: 'done', sessionId: threadId });

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -94,14 +94,6 @@ export function chatThreadId(agentId: string): string {
 	return `${AGENT_THREAD_PREFIX.TEST}${agentId}`;
 }
 
-export interface ExecuteAgentData {
-	response: string;
-	structuredOutput: unknown;
-	usage: { promptTokens: number; completionTokens: number; totalTokens: number } | null;
-	toolCalls: Array<{ toolName: string; input: unknown; result: unknown }>;
-	finishReason: string;
-}
-
 /** Scopes the agent's memory to a specific conversation context. */
 export interface AgentMemoryScope {
 	threadId: string;

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -655,7 +655,7 @@ export class AgentsService {
 		const integration = integrationType
 			? Container.get(ChatIntegrationRegistry).get(integrationType)
 			: undefined;
-		if (integration?.supportedComponents !== undefined) {
+		if (integrationType && integration?.supportedComponents !== undefined) {
 			try {
 				const { createRichInteractionTool } = await import('./integrations/rich-interaction-tool');
 				agent.tool(createRichInteractionTool(integrationType));
@@ -695,10 +695,6 @@ export class AgentsService {
 	 * Resume a suspended tool call and yield the resulting stream chunks.
 	 * Used by chat integration handlers to continue an agent run after
 	 * a human-in-the-loop action (button click, modal submission).
-	 *
-	 * `projectId` is not required — it is resolved from the agent entity.
-	 * If the runtime is no longer cached (e.g. after a server restart) it is
-	 * reconstructed from the published snapshot before resuming.
 	 */
 	async *resumeForChat(config: ResumeForChatConfig): AsyncGenerator<StreamChunk> {
 		const { agentId, projectId, runId, toolCallId, resumeData } = config;

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -94,16 +94,87 @@ export function chatThreadId(agentId: string): string {
 	return `${AGENT_THREAD_PREFIX.TEST}${agentId}`;
 }
 
+export interface ExecuteAgentData {
+	response: string;
+	structuredOutput: unknown;
+	usage: { promptTokens: number; completionTokens: number; totalTokens: number } | null;
+	toolCalls: Array<{ toolName: string; input: unknown; result: unknown }>;
+	finishReason: string;
+}
+
+/** Scopes the agent's memory to a specific conversation context. */
+export interface AgentMemoryScope {
+	threadId: string;
+	resourceId: string;
+}
+
+export interface ExecuteForChatConfig {
+	agentId: string;
+	projectId: string;
+	message: string;
+	/** n8n user ID — used for RBAC / credential resolution. */
+	userId: string;
+	/** Memory scope — resourceId is the chat platform user (e.g. Slack / Telegram user ID). */
+	memory: AgentMemoryScope;
+}
+
+export interface ExecuteForChatPublishedConfig {
+	agentId: string;
+	projectId: string;
+	message: string;
+	/** Memory scope — resourceId is the chat platform user (e.g. Slack / Telegram user ID). */
+	memory: AgentMemoryScope;
+	integrationType?: string;
+}
+
+export interface ResumeForChatConfig {
+	agentId: string;
+	projectId: string;
+	runId: string;
+	toolCallId: string;
+	resumeData: unknown;
+}
+
+export interface ExecuteForSchedulePublishedConfig {
+	agentId: string;
+	projectId: string;
+	message: string;
+	/** Memory scope — resourceId isolates per-run memory. */
+	memory: AgentMemoryScope;
+}
+
+interface StreamChatResponseConfig {
+	agentInstance: agents.Agent;
+	toolRegistry: ToolRegistry;
+	agentId: string;
+	message: string;
+	memory: AgentMemoryScope;
+	projectId: string;
+	source?: string;
+}
+
+interface GetOrReconstructRuntimeParams {
+	agentId: string;
+	projectId: string;
+	n8nUserId?: string;
+	integrationType?: string;
+	/** When true, load the published snapshot; n8nUserId is derived from publishedById when omitted. */
+	usePublishedVersion?: boolean;
+}
+
 @Service()
 export class AgentsService {
 	/**
-	 * Cached agent runtimes keyed by `agentId` or `agentId:userId`.
+	 * Cached agent runtimes.  Keys follow the pattern:
+	 *   Draft:     `{agentId}:draft:{n8nUserId}`
+	 *   Published: `{agentId}:published[:{integrationType}]`
+	 *
 	 * TTL = 30 minutes — entries are evicted when the agent is idle so that
 	 * memory is freed without requiring an explicit shutdown step.
 	 */
 	private readonly runtimes = new TtlMap<
 		string,
-		{ agent: agents.Agent; agentId: string; userId?: string; toolRegistry: ToolRegistry }
+		{ agent: agents.Agent; agentId: string; toolRegistry: ToolRegistry; projectId: string }
 	>(30 * Time.minutes.toMilliseconds);
 
 	/**
@@ -113,11 +184,23 @@ export class AgentsService {
 	 */
 	private readonly pendingUserMessages = new Map<string, string>();
 
-	/** Build a cache key that includes the user and integration type so different contexts get isolated runtimes. */
-	private runtimeKey(agentId: string, userId?: string, integrationType?: string): string {
-		const parts = [agentId];
-		if (userId) parts.push(userId);
-		if (integrationType) parts.push(integrationType);
+	/**
+	 * Compute a deterministic runtime cache key.
+	 *
+	 * - Draft runtimes: `{agentId}:draft:{n8nUserId}`
+	 * - Published runtimes: `{agentId}:published[:{resourceId}[:{integrationType}]]`
+	 *
+	 * Separating draft and published with explicit prefixes prevents a draft
+	 * runtime from being mistakenly returned to a published-agent execution.
+	 */
+	private computeRuntimeCacheKey(params: GetOrReconstructRuntimeParams): string {
+		if (params.usePublishedVersion) {
+			const parts = [params.agentId, 'published'];
+			if (params.integrationType) parts.push(params.integrationType);
+			return parts.join(':');
+		}
+		const parts = [params.agentId, 'draft'];
+		if (params.n8nUserId) parts.push(params.n8nUserId);
 		return parts.join(':');
 	}
 
@@ -436,14 +519,14 @@ export class AgentsService {
 		return this.findRuntimeForAgent(agentId) !== undefined;
 	}
 
-	/** Find any cached runtime for an agent (regardless of user). */
+	/** Find any cached runtime for an agent */
 	private findRuntimeForAgent(
 		agentId: string,
 	):
-		| { agent: agents.Agent; agentId: string; userId?: string; toolRegistry: ToolRegistry }
+		| { agent: agents.Agent; agentId: string; toolRegistry: ToolRegistry; projectId: string }
 		| undefined {
 		for (const [key, runtime] of this.runtimes) {
-			if (key === agentId || key.startsWith(`${agentId}:`)) {
+			if (key.startsWith(`${agentId}:`)) {
 				return runtime;
 			}
 		}
@@ -465,6 +548,67 @@ export class AgentsService {
 			}
 			throw new Error(`Unsupported memory storage: ${params.storage}`);
 		};
+	}
+
+	/** Create a credential provider scoped to a project. */
+	private createCredentialProvider(projectId: string): AgentsCredentialProvider {
+		return new AgentsCredentialProvider(Container.get(CredentialsService), projectId);
+	}
+
+	/**
+	 * Return a cached runtime, or reconstruct one from the DB.
+	 */
+	private async getOrReconstructRuntime(params: GetOrReconstructRuntimeParams): Promise<{
+		agent: agents.Agent;
+		agentId: string;
+		toolRegistry: ToolRegistry;
+		projectId: string;
+	}> {
+		const { agentId, projectId, integrationType, usePublishedVersion } = params;
+
+		const cacheKey = this.computeRuntimeCacheKey(params);
+
+		const cached = this.runtimes.get(cacheKey);
+		if (cached) return cached;
+
+		const agentEntity = await this.agentRepository.findByIdAndProjectId(agentId, projectId);
+		if (!agentEntity) throw new NotFoundError(`Agent ${agentId} not found`);
+
+		let n8nUserId = params.n8nUserId;
+		let agentData: Agent = agentEntity;
+
+		if (usePublishedVersion) {
+			const publishedSchema = agentEntity.publishedVersion?.schema;
+			if (!publishedSchema) {
+				throw new NotFoundError(`Agent ${agentId} is not published`);
+			}
+			agentData = {
+				...agentEntity,
+				schema: publishedSchema,
+				tools: agentEntity.publishedVersion?.tools ?? agentEntity.tools ?? {},
+				skills: agentEntity.publishedVersion?.skills ?? agentEntity.skills ?? {},
+			} as Agent;
+
+			// Resolve n8n user from publishedById when not provided by the caller.
+			n8nUserId ??= agentEntity.publishedVersion?.publishedById ?? undefined;
+		}
+
+		if (!n8nUserId) {
+			throw new UserError('Agent user owner id is required');
+		}
+
+		const credentialProvider = this.createCredentialProvider(projectId);
+		const { agent: agentInstance, toolRegistry } = await this.reconstructFromConfig(
+			agentData,
+			credentialProvider,
+			n8nUserId,
+			integrationType,
+		);
+
+		this.runtimes.set(cacheKey, { agent: agentInstance, agentId, toolRegistry, projectId });
+		const runtime = this.runtimes.get(cacheKey);
+		if (!runtime) throw new Error(`Agent ${agentId} failed to reconstruct`);
+		return runtime;
 	}
 
 	/**
@@ -533,7 +677,7 @@ export class AgentsService {
 		const integration = integrationType
 			? Container.get(ChatIntegrationRegistry).get(integrationType)
 			: undefined;
-		if (integration && integration.supportedComponents !== undefined) {
+		if (integration?.supportedComponents !== undefined) {
 			try {
 				const { createRichInteractionTool } = await import('./integrations/rich-interaction-tool');
 				agent.tool(createRichInteractionTool(integrationType));
@@ -573,33 +717,40 @@ export class AgentsService {
 	 * Resume a suspended tool call and yield the resulting stream chunks.
 	 * Used by chat integration handlers to continue an agent run after
 	 * a human-in-the-loop action (button click, modal submission).
+	 *
+	 * `projectId` is not required — it is resolved from the agent entity.
+	 * If the runtime is no longer cached (e.g. after a server restart) it is
+	 * reconstructed from the published snapshot before resuming.
 	 */
-	async *resumeForChat(
-		agentId: string,
-		runId: string,
-		toolCallId: string,
-		resumeData: unknown,
-		threadId?: string,
-		userId?: string,
-		projectId?: string,
-	): AsyncGenerator<StreamChunk> {
-		const runtime = this.findRuntimeForAgent(agentId);
-		if (!runtime) {
-			throw new UserError(`Agent ${agentId} is not compiled — cannot resume`);
-		}
-
-		const agentInstance = runtime.agent;
+	async *resumeForChat(config: ResumeForChatConfig): AsyncGenerator<StreamChunk> {
+		const { agentId, projectId, runId, toolCallId, resumeData } = config;
 
 		const checkpointStatus = await this.n8nCheckpointStorage.getStatus(runId);
-		if (checkpointStatus === 'expired') {
+		if (checkpointStatus.status === 'expired') {
 			throw new UserError(`Checkpoint ${runId} is expired and cannot be resumed`);
 		}
 
-		if (checkpointStatus === 'not-found') {
+		if (checkpointStatus.status === 'not-found') {
 			throw new UserError(`Checkpoint ${runId} not found and cannot be resumed`);
 		}
 
-		const recorder = new ExecutionRecorder(runtime.toolRegistry);
+		const memoryScope = checkpointStatus.checkpoint?.persistence;
+		if (!memoryScope) {
+			throw new UserError(`Checkpoint ${runId} has no memory data and cannot be resumed`);
+		}
+
+		const threadId = memoryScope.threadId;
+
+		// Prefer a cached runtime (correct integrationType already injected).
+		// Fall back to reconstruction from the published snapshot on cache miss
+		// (e.g. server restart).  n8nUserId is derived from publishedById inside
+		// getOrReconstructRuntime.  projectId is always available on the runtime entry.
+		const runtime =
+			this.findRuntimeForAgent(agentId) ??
+			(await this.getOrReconstructRuntime({ agentId, projectId, usePublishedVersion: true }));
+
+		const { agent: agentInstance, toolRegistry } = runtime;
+		const recorder = new ExecutionRecorder(toolRegistry);
 
 		const resultStream = await agentInstance.resume('stream', resumeData, {
 			runId,
@@ -620,30 +771,27 @@ export class AgentsService {
 
 		// Always record resumed executions — even if they suspend again (chained HITL).
 		// Don't repeat the original user message — the pre-suspension execution already has it.
-		if (threadId && userId && projectId) {
-			if (!recorder.suspended) {
-				this.pendingUserMessages.delete(agentId);
-			}
-			const messageRecord = recorder.getMessageRecord();
-			void this.agentExecutionService
-				.recordMessage({
-					threadId,
-					agentId,
-					agentName: agentInstance.name,
-					projectId,
-					userId,
-					userMessage: '',
-					record: messageRecord,
-					hitlStatus: 'resumed',
-				})
-				.catch((error) => {
-					this.logger.warn('Failed to record resumed agent execution', {
-						agentId,
-						threadId,
-						error: error instanceof Error ? error.message : String(error),
-					});
-				});
+		if (!recorder.suspended) {
+			this.pendingUserMessages.delete(agentId);
 		}
+		const messageRecord = recorder.getMessageRecord();
+		void this.agentExecutionService
+			.recordMessage({
+				threadId,
+				agentId,
+				agentName: agentInstance.name,
+				projectId,
+				userMessage: '',
+				record: messageRecord,
+				hitlStatus: 'resumed',
+			})
+			.catch((error) => {
+				this.logger.warn('Failed to record resumed agent execution', {
+					agentId,
+					threadId,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			});
 	}
 
 	/**
@@ -674,7 +822,7 @@ export class AgentsService {
 			return { missing: ['instructions', 'model'] };
 		}
 
-		if (!config.instructions || !config.instructions.trim()) {
+		if (!config.instructions?.trim()) {
 			missing.push('instructions');
 		}
 
@@ -707,55 +855,26 @@ export class AgentsService {
 	}
 
 	/**
-	 * Execute a compiled SDK agent for a chat integration and yield stream chunks.
-	 * Uses userId as the resourceId so each user gets their own memory context.
+	 * Execute an agent for the in-app test chat and yield stream chunks.
 	 *
-	 * When the runtime is not cached (e.g. after server restart), it loads the
-	 * agent from DB and reconstructs from the persisted schema — no compile() call.
+	 * `userId` is the authenticated n8n user (used for RBAC / credential
+	 * resolution).  `memory.resourceId` scopes the agent's memory so each
+	 * user sees their own conversation; for test-chat both equal userId.
+	 *
 	 */
-	async *executeForChat(
-		agentId: string,
-		message: string,
-		threadId: string,
-		userId: string,
-		projectId: string,
-		credentialProvider: CredentialProvider,
-		integrationType?: string,
-	): AsyncGenerator<StreamChunk> {
-		const key = this.runtimeKey(agentId, userId, integrationType);
-		let runtime = this.runtimes.get(key);
-		if (!runtime) {
-			// Scope the lookup to the project so an agent from a different project
-			// cannot be driven by supplying an arbitrary agentId (IDOR).
-			const agentEntity = await this.agentRepository.findByIdAndProjectId(agentId, projectId);
-			if (!agentEntity) throw new NotFoundError(`Agent ${agentId} not found`);
+	async *executeForChat(config: ExecuteForChatConfig): AsyncGenerator<StreamChunk> {
+		const { agentId, projectId, message, userId, memory } = config;
 
-			const { agent: reconstructed, toolRegistry } = await this.reconstructFromConfig(
-				agentEntity,
-				credentialProvider,
-				userId,
-				integrationType,
-			);
+		const runtime = await this.getOrReconstructRuntime({ agentId, projectId, n8nUserId: userId });
 
-			// Cache the runtime for subsequent calls
-			this.runtimes.set(key, { agent: reconstructed, agentId, userId, toolRegistry });
-			runtime = this.runtimes.get(key);
-			if (!runtime) throw new Error(`Agent ${agentId} failed to reconstruct`);
-		}
-
-		yield* this.streamChatResponse(
-			runtime.agent,
-			runtime.toolRegistry,
+		yield* this.streamChatResponse({
+			agentInstance: runtime.agent,
+			toolRegistry: runtime.toolRegistry,
 			agentId,
 			message,
-			threadId,
-			userId,
-			projectId,
-			{
-				source: integrationType,
-				resourceId: userId,
-			},
-		);
+			memory,
+			projectId: runtime.projectId,
+		});
 	}
 
 	/**
@@ -784,143 +903,77 @@ export class AgentsService {
 	}
 
 	/**
-	 * Execute a published agent for a chat integration (Slack, Discord, etc.).
+	 * Execute a published agent for a chat integration (Slack, Telegram, …).
 	 *
-	 * Mirrors the live-webhooks pattern: load the published snapshot and run that,
-	 * never the current draft. Throws NotFoundError if the agent is not published.
+	 * Loads the published snapshot — never the draft.
 	 */
 	async *executeForChatPublished(
-		agentId: string,
-		message: string,
-		threadId: string,
-		userId: string,
-		projectId: string,
-		credentialProvider: CredentialProvider,
-		integrationType?: string,
+		config: ExecuteForChatPublishedConfig,
 	): AsyncGenerator<StreamChunk> {
-		const agentEntity = await this.agentRepository.findByIdAndProjectId(agentId, projectId);
-		if (!agentEntity) throw new NotFoundError(`Agent ${agentId} not found`);
+		const { agentId, projectId, message, memory, integrationType } = config;
 
-		const publishedSchema = agentEntity.publishedVersion?.schema;
-		if (!publishedSchema) {
-			throw new NotFoundError(`Agent ${agentId} is not published`);
-		}
-		const publishedTools = agentEntity.publishedVersion?.tools ?? agentEntity.tools;
-		const publishedSkills = agentEntity.publishedVersion?.skills ?? agentEntity.skills;
+		const runtime = await this.getOrReconstructRuntime({
+			agentId,
+			projectId,
+			integrationType,
+			usePublishedVersion: true,
+		});
 
-		// Reconstruct from the published snapshot and cache the runtime so that
-		// a follow-up `resumeForChat` (HITL button click) can find it via
-		// `findRuntimeForAgent`. Integration traffic only ever runs the published
-		// version — drafts stay in their own cache under different keys.
-		const key = this.runtimeKey(agentId, userId, integrationType);
-		let runtime = this.runtimes.get(key);
-		if (!runtime) {
-			const publishedAgentData = {
-				...agentEntity,
-				schema: publishedSchema,
-				tools: publishedTools ?? {},
-				skills: publishedSkills ?? {},
-			} as Agent;
-			const { agent: agentInstance, toolRegistry } = await this.reconstructFromConfig(
-				publishedAgentData,
-				credentialProvider,
-				userId,
-				integrationType,
-			);
-			this.runtimes.set(key, { agent: agentInstance, agentId, userId, toolRegistry });
-			runtime = this.runtimes.get(key);
-			if (!runtime) throw new Error(`Agent ${agentId} failed to reconstruct`);
-		}
-
-		yield* this.streamChatResponse(
-			runtime.agent,
-			runtime.toolRegistry,
+		yield* this.streamChatResponse({
+			agentInstance: runtime.agent,
+			toolRegistry: runtime.toolRegistry,
 			agentId,
 			message,
-			threadId,
-			userId,
-			projectId,
-			{
-				source: integrationType,
-				resourceId: userId,
-			},
-		);
+			memory,
+			projectId: runtime.projectId,
+			source: integrationType,
+		});
 	}
 
 	/**
 	 * Execute a published agent for the local schedule trigger.
 	 *
-	 * Scheduled runs compile with a project user identity for RBAC/tool access,
-	 * but persist against a per-run resourceId so no memory is shared across runs.
+	 * The n8n user identity for RBAC is resolved from
+	 * `publishedVersion.publishedById`.  Each scheduled run uses its own
+	 * memory scope so no conversation history is shared across runs.
+	 * `projectId` is resolved from the agent entity.
 	 */
 	async *executeForSchedulePublished(
-		agentId: string,
-		message: string,
-		threadId: string,
-		userId: string,
-		projectId: string,
-		credentialProvider: CredentialProvider,
-		resourceId: string,
+		config: ExecuteForSchedulePublishedConfig,
 	): AsyncGenerator<StreamChunk> {
-		const agentEntity = await this.agentRepository.findByIdAndProjectId(agentId, projectId);
-		if (!agentEntity) throw new NotFoundError(`Agent ${agentId} not found`);
+		const { agentId, projectId, message, memory } = config;
 
-		const publishedSchema = agentEntity.publishedVersion?.schema;
-		if (!publishedSchema) {
-			throw new NotFoundError(`Agent ${agentId} is not published`);
-		}
+		// One shared compiled runtime per agent for all schedule runs.
+		const runtime = await this.getOrReconstructRuntime({
+			agentId,
+			projectId,
+			integrationType: AGENT_SCHEDULE_TRIGGER_TYPE,
+			usePublishedVersion: true,
+		});
 
-		const key = this.runtimeKey(agentId, userId, AGENT_SCHEDULE_TRIGGER_TYPE);
-		let runtime = this.runtimes.get(key);
-		if (!runtime) {
-			const publishedAgentData = { ...agentEntity, schema: publishedSchema } as Agent;
-			const { agent: agentInstance, toolRegistry } = await this.reconstructFromConfig(
-				publishedAgentData,
-				credentialProvider,
-				userId,
-				AGENT_SCHEDULE_TRIGGER_TYPE,
-			);
-			this.runtimes.set(key, { agent: agentInstance, agentId, userId, toolRegistry });
-			runtime = this.runtimes.get(key);
-			if (!runtime) throw new Error(`Agent ${agentId} failed to reconstruct`);
-		}
-
-		yield* this.streamChatResponse(
-			runtime.agent,
-			runtime.toolRegistry,
+		yield* this.streamChatResponse({
+			agentInstance: runtime.agent,
+			toolRegistry: runtime.toolRegistry,
 			agentId,
 			message,
-			threadId,
-			userId,
-			projectId,
-			{
-				source: AGENT_SCHEDULE_TRIGGER_TYPE,
-				resourceId,
-			},
-		);
+			memory,
+			projectId: runtime.projectId,
+			source: AGENT_SCHEDULE_TRIGGER_TYPE,
+		});
 	}
 
 	/**
-	 * Read from an agent's streaming response, record it, and yield each chunk.
-	 * Logs `tool-call-suspended` chunks so we can observe human-in-the-loop pauses,
-	 * and persists the full message record via `AgentExecutionService` so chat
-	 * history shows up in the executions view.
+	 * Stream an agent response, record it, and yield each chunk.
+	 *
+	 * `config.memory.resourceId` is passed as `persistence.resourceId` to
+	 * `agentInstance.stream()` to scope memory per chat user — it is
+	 * deliberately distinct from the n8n user ID used for RBAC.
 	 */
-	private async *streamChatResponse(
-		agentInstance: agents.Agent,
-		toolRegistry: ToolRegistry,
-		agentId: string,
-		message: string,
-		threadId: string,
-		userId: string,
-		projectId: string,
-		options?: {
-			source?: string;
-			resourceId?: string;
-		},
-	): AsyncGenerator<StreamChunk> {
+	private async *streamChatResponse(config: StreamChatResponseConfig): AsyncGenerator<StreamChunk> {
+		const { agentInstance, toolRegistry, agentId, message, memory, projectId, source } = config;
+		const { threadId, resourceId } = memory;
+
 		const recorder = new ExecutionRecorder(toolRegistry);
-		const resourceId = options?.resourceId ?? userId;
 
 		const resultStream = await agentInstance.stream(message, {
 			persistence: { threadId, resourceId },
@@ -958,11 +1011,10 @@ export class AgentsService {
 				agentId,
 				agentName: agentInstance.name,
 				projectId,
-				userId,
 				userMessage: message,
 				record: messageRecord,
 				hitlStatus: recorder.suspended ? 'suspended' : undefined,
-				source: options?.source,
+				source,
 			})
 			.catch((error) => {
 				this.logger.warn('Failed to record agent execution', {
@@ -981,7 +1033,7 @@ export class AgentsService {
 	private async compileIsolated(
 		agentEntity: Agent,
 		credentialProvider: CredentialProvider,
-		userId?: string,
+		userId: string,
 	): Promise<{ ok: boolean; agent?: BuiltAgent; error?: string }> {
 		if (!agentEntity.schema) {
 			return { ok: false, error: 'Agent has no JSON config. Create a config first.' };
@@ -1436,7 +1488,7 @@ export class AgentsService {
 	private async reconstructFromConfig(
 		agentEntity: Agent,
 		credentialProvider: CredentialProvider,
-		userId?: string,
+		userId: string,
 		integrationType?: string,
 	): Promise<{ agent: agents.Agent; toolRegistry: ToolRegistry }> {
 		const config = agentEntity.schema;

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -171,6 +171,9 @@ export class AgentsService {
 	 *
 	 * TTL = 30 minutes — entries are evicted when the agent is idle so that
 	 * memory is freed without requiring an explicit shutdown step.
+	 *
+	 * Separating draft and published with explicit prefixes prevents a draft
+	 * runtime from being mistakenly returned to a published-agent execution.
 	 */
 	private readonly runtimes = new TtlMap<
 		string,
@@ -184,15 +187,6 @@ export class AgentsService {
 	 */
 	private readonly pendingUserMessages = new Map<string, string>();
 
-	/**
-	 * Compute a deterministic runtime cache key.
-	 *
-	 * - Draft runtimes: `{agentId}:draft:{n8nUserId}`
-	 * - Published runtimes: `{agentId}:published[:{integrationType}]`
-	 *
-	 * Separating draft and published with explicit prefixes prevents a draft
-	 * runtime from being mistakenly returned to a published-agent execution.
-	 */
 	private computeRuntimeCacheKey(params: GetRuntimeParams): string {
 		if (params.usePublishedVersion) {
 			const parts = [params.agentId, 'published'];
@@ -655,7 +649,7 @@ export class AgentsService {
 		const integration = integrationType
 			? Container.get(ChatIntegrationRegistry).get(integrationType)
 			: undefined;
-		if (integrationType && integration?.supportedComponents !== undefined) {
+		if (integration?.supportedComponents !== undefined) {
 			try {
 				const { createRichInteractionTool } = await import('./integrations/rich-interaction-tool');
 				agent.tool(createRichInteractionTool(integrationType));

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -188,7 +188,7 @@ export class AgentsService {
 	 * Compute a deterministic runtime cache key.
 	 *
 	 * - Draft runtimes: `{agentId}:draft:{n8nUserId}`
-	 * - Published runtimes: `{agentId}:published[:{resourceId}[:{integrationType}]]`
+	 * - Published runtimes: `{agentId}:published[:{integrationType}]`
 	 *
 	 * Separating draft and published with explicit prefixes prevents a draft
 	 * runtime from being mistakenly returned to a published-agent execution.

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -153,7 +153,7 @@ interface StreamChatResponseConfig {
 	source?: string;
 }
 
-interface GetOrReconstructRuntimeParams {
+interface GetRuntimeParams {
 	agentId: string;
 	projectId: string;
 	n8nUserId?: string;
@@ -193,7 +193,7 @@ export class AgentsService {
 	 * Separating draft and published with explicit prefixes prevents a draft
 	 * runtime from being mistakenly returned to a published-agent execution.
 	 */
-	private computeRuntimeCacheKey(params: GetOrReconstructRuntimeParams): string {
+	private computeRuntimeCacheKey(params: GetRuntimeParams): string {
 		if (params.usePublishedVersion) {
 			const parts = [params.agentId, 'published'];
 			if (params.integrationType) parts.push(params.integrationType);
@@ -511,28 +511,6 @@ export class AgentsService {
 		return true;
 	}
 
-	getRuntime(agentId: string): { agent: agents.Agent; agentId: string } | undefined {
-		return this.findRuntimeForAgent(agentId);
-	}
-
-	hasRuntime(agentId: string): boolean {
-		return this.findRuntimeForAgent(agentId) !== undefined;
-	}
-
-	/** Find any cached runtime for an agent */
-	private findRuntimeForAgent(
-		agentId: string,
-	):
-		| { agent: agents.Agent; agentId: string; toolRegistry: ToolRegistry; projectId: string }
-		| undefined {
-		for (const [key, runtime] of this.runtimes) {
-			if (key.startsWith(`${agentId}:`)) {
-				return runtime;
-			}
-		}
-		return undefined;
-	}
-
 	/** Return persisted chat messages for a given session/thread. */
 	async getChatMessages(threadId: string) {
 		return await this.n8nMemory.getMessages(threadId);
@@ -558,7 +536,7 @@ export class AgentsService {
 	/**
 	 * Return a cached runtime, or reconstruct one from the DB.
 	 */
-	private async getOrReconstructRuntime(params: GetOrReconstructRuntimeParams): Promise<{
+	private async getRuntime(params: GetRuntimeParams): Promise<{
 		agent: agents.Agent;
 		agentId: string;
 		toolRegistry: ToolRegistry;
@@ -741,13 +719,11 @@ export class AgentsService {
 
 		const threadId = memoryScope.threadId;
 
-		// Prefer a cached runtime (correct integrationType already injected).
-		// Fall back to reconstruction from the published snapshot on cache miss
-		// (e.g. server restart).  n8nUserId is derived from publishedById inside
-		// getOrReconstructRuntime.  projectId is always available on the runtime entry.
-		const runtime =
-			this.findRuntimeForAgent(agentId) ??
-			(await this.getOrReconstructRuntime({ agentId, projectId, usePublishedVersion: true }));
+		const runtime = await this.getRuntime({
+			agentId,
+			projectId,
+			usePublishedVersion: true,
+		});
 
 		const { agent: agentInstance, toolRegistry } = runtime;
 		const recorder = new ExecutionRecorder(toolRegistry);
@@ -865,7 +841,7 @@ export class AgentsService {
 	async *executeForChat(config: ExecuteForChatConfig): AsyncGenerator<StreamChunk> {
 		const { agentId, projectId, message, userId, memory } = config;
 
-		const runtime = await this.getOrReconstructRuntime({ agentId, projectId, n8nUserId: userId });
+		const runtime = await this.getRuntime({ agentId, projectId, n8nUserId: userId });
 
 		yield* this.streamChatResponse({
 			agentInstance: runtime.agent,
@@ -912,7 +888,7 @@ export class AgentsService {
 	): AsyncGenerator<StreamChunk> {
 		const { agentId, projectId, message, memory, integrationType } = config;
 
-		const runtime = await this.getOrReconstructRuntime({
+		const runtime = await this.getRuntime({
 			agentId,
 			projectId,
 			integrationType,
@@ -944,7 +920,7 @@ export class AgentsService {
 		const { agentId, projectId, message, memory } = config;
 
 		// One shared compiled runtime per agent for all schedule runs.
-		const runtime = await this.getOrReconstructRuntime({
+		const runtime = await this.getRuntime({
 			agentId,
 			projectId,
 			integrationType: AGENT_SCHEDULE_TRIGGER_TYPE,

--- a/packages/cli/src/modules/agents/builder/agents-builder.service.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder.service.ts
@@ -104,10 +104,10 @@ export class AgentsBuilderService {
 		user: User,
 	): AsyncGenerator<StreamChunk> {
 		const checkpointStatus = await this.n8nCheckpointStorage.getStatus(runId);
-		if (checkpointStatus === 'expired') {
+		if (checkpointStatus.status === 'expired') {
 			throw new UserError(`Builder checkpoint ${runId} has expired and cannot be resumed`);
 		}
-		if (checkpointStatus === 'not-found') {
+		if (checkpointStatus.status === 'not-found') {
 			throw new UserError(`Builder checkpoint ${runId} not found`);
 		}
 

--- a/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
@@ -1,4 +1,4 @@
-import type { CredentialProvider, StreamChunk } from '@n8n/agents';
+import type { StreamChunk } from '@n8n/agents';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import type { Logger } from 'n8n-workflow';
@@ -92,7 +92,6 @@ class StreamingTestIntegration extends AgentChatIntegration {
 
 describe('AgentChatBridge — consumeStream', () => {
 	let registry: ChatIntegrationRegistry;
-	const credentialProvider = mock<CredentialProvider>();
 	const componentMapper = mock<ComponentMapper>();
 	const logger = mock<Logger>();
 
@@ -129,10 +128,8 @@ describe('AgentChatBridge — consumeStream', () => {
 				bot as unknown as ChatBotLike,
 				'agent-1',
 				agentExecutor as never,
-				credentialProvider,
 				componentMapper,
 				logger,
-				'user-1',
 				'project-1',
 				'test-buffered',
 			);
@@ -165,10 +162,8 @@ describe('AgentChatBridge — consumeStream', () => {
 				bot as unknown as ChatBotLike,
 				'agent-1',
 				agentExecutor as never,
-				credentialProvider,
 				componentMapper,
 				logger,
-				'user-1',
 				'project-1',
 				'test-buffered',
 			);
@@ -193,10 +188,8 @@ describe('AgentChatBridge — consumeStream', () => {
 				bot as unknown as ChatBotLike,
 				'agent-1',
 				agentExecutor as never,
-				credentialProvider,
 				componentMapper,
 				logger,
-				'user-1',
 				'project-1',
 				'test-buffered',
 			);
@@ -221,10 +214,8 @@ describe('AgentChatBridge — consumeStream', () => {
 				bot as unknown as ChatBotLike,
 				'agent-1',
 				agentExecutor as never,
-				credentialProvider,
 				componentMapper,
 				logger,
-				'user-1',
 				'project-1',
 				'test-streaming',
 			);

--- a/packages/cli/src/modules/agents/integrations/__tests__/agent-schedule.service.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/agent-schedule.service.test.ts
@@ -7,7 +7,6 @@ import { mock } from 'jest-mock-extended';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 
-import { AgentsCredentialProvider } from '../../adapters/agents-credential-provider';
 import type { AgentsService } from '../../agents.service';
 import type { Agent } from '../../entities/agent.entity';
 import { AgentScheduleService } from '../agent-schedule.service';
@@ -62,9 +61,8 @@ describe('AgentScheduleService', () => {
 				generic: { timezone: 'Europe/Berlin' },
 			}),
 			agentRepository as never,
-			projectRelationRepository as never,
-			mock(),
 			agentsService,
+			projectRelationRepository as never,
 		);
 	});
 
@@ -217,19 +215,20 @@ describe('AgentScheduleService', () => {
 		);
 
 		expect(agentsService.executeForSchedulePublished).toHaveBeenCalledWith(
-			'agent-1',
-			expect.stringContaining('Wake up and check the queue.'),
-			expect.stringMatching(/^schedule-agent-1-/),
-			'user-1',
-			'project-1',
-			expect.any(AgentsCredentialProvider),
-			expect.stringMatching(/^schedule-agent-1-/),
+			expect.objectContaining({
+				agentId: 'agent-1',
+				projectId: 'project-1',
+				message: expect.stringContaining('Wake up and check the queue.'),
+				memory: {
+					threadId: expect.stringMatching(/^schedule-agent-1-/),
+					resourceId: expect.stringMatching(/^user-1/),
+				},
+			}),
 		);
 
-		const call = agentsService.executeForSchedulePublished.mock.calls[0];
-		expect(call[1]).toContain('Current date and time:');
-		expect(call[1]).toContain('(timezone: Europe/Berlin)');
-		expect(call[2]).toBe(call[6]);
+		const config = agentsService.executeForSchedulePublished.mock.calls[0][0];
+		expect(config.message).toContain('Current date and time:');
+		expect(config.message).toContain('(timezone: Europe/Berlin)');
 	});
 
 	it('reconnectAll restores only active published schedules', async () => {

--- a/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
@@ -605,7 +605,7 @@ export class AgentChatBridge {
 	 */
 	private async handleDisplayOnly(
 		chunk: Extract<StreamChunk, { type: 'tool-result' }>,
-		thread: ChatThread,
+		thread: Thread,
 	): Promise<void> {
 		const { toolCallId } = chunk;
 		const input = this.richInteractionInputs.get(toolCallId);

--- a/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
@@ -1,89 +1,33 @@
-import type { AgentMessage, CredentialProvider, StreamChunk } from '@n8n/agents';
+import type { AgentMessage, StreamChunk } from '@n8n/agents';
 import { Container } from '@n8n/di';
+import type { ActionEvent, Chat, Message, Thread } from 'chat';
 import type { Logger } from 'n8n-workflow';
 
 import type { AgentsService } from '../agents.service';
 import type { RichSuspendPayload } from '../types';
+import type { AgentChatIntegration } from './agent-chat-integration';
 import { ChatIntegrationRegistry } from './agent-chat-integration';
 import { CallbackStore } from './callback-store';
 import type { ComponentMapper } from './component-mapper';
+import { type TextEndFn, type TextYieldFn, type InternalThread, toInternalThreadId } from './types';
 
-/**
- * Subset of `AgentsService` consumed by the bridge.
- * Defined as an interface to avoid circular imports and simplify testing.
- */
 interface AgentExecutor {
-	executeForChat(
-		agentId: string,
-		message: string,
-		threadId: string,
-		userId: string,
-		projectId: string,
-		credentialProvider: CredentialProvider,
-		integrationType?: string,
-	): AsyncGenerator<StreamChunk>;
+	executeForChatPublished(config: {
+		agentId: string;
+		projectId: string;
+		message: string;
+		memory: { threadId: InternalThread; resourceId: string };
+		integrationType?: string;
+	}): AsyncGenerator<StreamChunk>;
 
-	executeForChatPublished(
-		agentId: string,
-		message: string,
-		threadId: string,
-		userId: string,
-		projectId: string,
-		credentialProvider: CredentialProvider,
-		integrationType?: string,
-	): AsyncGenerator<StreamChunk>;
-
-	resumeForChat(
-		agentId: string,
-		runId: string,
-		toolCallId: string,
-		resumeData: unknown,
-		threadId?: string,
-		userId?: string,
-		projectId?: string,
-	): AsyncGenerator<StreamChunk>;
+	resumeForChat(config: {
+		agentId: string;
+		projectId: string;
+		runId: string;
+		toolCallId: string;
+		resumeData: unknown;
+	}): AsyncGenerator<StreamChunk>;
 }
-
-// ---------------------------------------------------------------------------
-// Chat SDK local interfaces
-//
-// The `chat` package is ESM-only so we cannot use top-level imports.
-// These interfaces mirror the subset of the Chat SDK API we consume.
-// ---------------------------------------------------------------------------
-
-interface ChatBot {
-	onNewMention: (handler: (thread: ChatThread, message: ChatMessage) => Promise<void>) => void;
-	onSubscribedMessage: (
-		handler: (thread: ChatThread, message: ChatMessage) => Promise<void>,
-	) => void;
-	onAction: (handler: (event: ChatActionEvent) => Promise<void>) => void;
-}
-
-interface ChatThread {
-	id: string;
-	subscribe: () => Promise<void>;
-	post: (content: unknown) => Promise<unknown>;
-}
-
-interface ChatMessage {
-	text: string;
-	author: { userId: string };
-}
-
-interface ChatActionEvent {
-	actionId: string;
-	value: string;
-	thread: ChatThread;
-	threadId: string;
-	messageId: string;
-	adapter: { deleteMessage(threadId: string, messageId: string): Promise<void> };
-	userId: string;
-}
-
-/** Callback that pushes a text fragment into the streaming iterable. */
-type TextYieldFn = (text: string) => void;
-/** Callback that signals the end of the streaming iterable. */
-type TextEndFn = () => void;
 
 /**
  * Bridges Chat SDK events to the agent execution pipeline.
@@ -115,6 +59,9 @@ export class AgentChatBridge {
 	/** When true, buffer deltas and post as a single message (see integration flag). */
 	private readonly disableStreaming: boolean;
 
+	/** Resolved integration for this platform (may be undefined for unknown types). */
+	private readonly integration: AgentChatIntegration | undefined;
+
 	/**
 	 * In-flight `rich_interaction` tool inputs keyed by toolCallId. Populated on
 	 * the `tool-call` chunk; consumed on the matching `tool-result` chunk when
@@ -130,47 +77,55 @@ export class AgentChatBridge {
 	private readonly richInteractionInputs = new Map<string, unknown>();
 
 	constructor(
-		private readonly bot: ChatBot,
+		private readonly chat: Chat,
 		private readonly agentId: string,
 		private readonly agentService: AgentExecutor,
-		private readonly credentialProvider: CredentialProvider,
 		private readonly componentMapper: ComponentMapper,
 		private readonly logger: Logger,
-		private readonly n8nUserId: string,
 		private readonly n8nProjectId: string,
 		private readonly integrationType: string,
 	) {
-		const integration = Container.get(ChatIntegrationRegistry).get(integrationType);
-		if (integration?.needsShortCallbackData) {
+		this.integration = Container.get(ChatIntegrationRegistry).get(integrationType);
+		if (this.integration?.needsShortCallbackData) {
 			this.callbackStore = new CallbackStore();
 		}
-		this.disableStreaming = integration?.disableStreaming ?? false;
+		this.disableStreaming = this.integration?.disableStreaming ?? false;
 		this.registerHandlers();
 	}
 
 	// ---------------------------------------------------------------------------
-	// Static factory — validates that the bot has expected handler methods
+	// Static factory
 	// ---------------------------------------------------------------------------
 
 	static create(
-		bot: unknown,
+		chat: Chat,
 		agentId: string,
 		agentService: AgentsService,
-		credentialProvider: CredentialProvider,
 		componentMapper: ComponentMapper,
 		logger: Logger,
-		n8nUserId: string,
 		n8nProjectId: string,
 		integrationType: string,
 	): AgentChatBridge {
+		const agentExecutor: AgentExecutor = {
+			async *executeForChatPublished({ memory, agentId: aid, message, integrationType }) {
+				yield* agentService.executeForChatPublished({
+					agentId: aid,
+					projectId: n8nProjectId,
+					message,
+					memory: { threadId: memory.threadId.id, resourceId: memory.resourceId },
+					integrationType,
+				});
+			},
+			async *resumeForChat(config) {
+				yield* agentService.resumeForChat(config);
+			},
+		};
 		return new AgentChatBridge(
-			bot as ChatBot,
+			chat,
 			agentId,
-			agentService,
-			credentialProvider,
+			agentExecutor,
 			componentMapper,
 			logger,
-			n8nUserId,
 			n8nProjectId,
 			integrationType,
 		);
@@ -181,7 +136,7 @@ export class AgentChatBridge {
 	// ---------------------------------------------------------------------------
 
 	private registerHandlers(): void {
-		this.bot.onNewMention(async (thread, message) => {
+		this.chat.onNewMention(async (thread, message) => {
 			try {
 				await thread.subscribe();
 				await this.executeAndStream(thread, message);
@@ -190,7 +145,7 @@ export class AgentChatBridge {
 			}
 		});
 
-		this.bot.onSubscribedMessage(async (thread, message) => {
+		this.chat.onSubscribedMessage(async (thread, message) => {
 			try {
 				await this.executeAndStream(thread, message);
 			} catch (error) {
@@ -198,7 +153,7 @@ export class AgentChatBridge {
 			}
 		});
 
-		this.bot.onAction(async (event) => {
+		this.chat.onAction(async (event) => {
 			try {
 				await this.handleAction(event);
 			} catch (error) {
@@ -210,6 +165,24 @@ export class AgentChatBridge {
 	/** Release long-lived resources (callback store timer). */
 	dispose(): void {
 		this.callbackStore?.dispose();
+	}
+
+	// ---------------------------------------------------------------------------
+	// Thread ID resolution — single place to apply per-platform formatting
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Resolve the thread ID to pass to the agents service.
+	 *
+	 * Delegates to `integration.formatThreadId.fromSdk` when the platform
+	 * provides one (e.g. Slack encodes channel + ts), otherwise falls back
+	 * to the raw Chat SDK `thread.id`.
+	 *
+	 * Every call site that hands a threadId to `AgentExecutor` MUST use this
+	 * helper so platform-specific formatting is never accidentally skipped.
+	 */
+	private resolveThreadId(thread: Thread<unknown, unknown>) {
+		return toInternalThreadId(this.integration?.formatThreadId?.fromSdk(thread) ?? thread.id);
 	}
 
 	/**
@@ -231,22 +204,22 @@ export class AgentChatBridge {
 	// Core execution pipeline
 	// ---------------------------------------------------------------------------
 
-	private async executeAndStream(thread: ChatThread, message: ChatMessage): Promise<void> {
+	private async executeAndStream(thread: Thread, message: Message): Promise<void> {
 		const text = message.text?.trim();
 		if (!text) return;
 
-		// Use the n8n user ID (who connected the integration) for agent compilation
-		// and RBAC, and the platform user ID for memory/thread context.
+		const threadId = this.resolveThreadId(thread);
+		// threadId.id already encodes platform + user identity (e.g. Telegram:
+		// "chat:botId-userId") so it serves as a per-chat-user resourceId that
+		// scopes memory correctly without leaking the n8n user identity.
 		// Always run the published snapshot — integrations are production traffic.
-		const stream = this.agentService.executeForChatPublished(
-			this.agentId,
-			text,
-			thread.id,
-			this.n8nUserId,
-			this.n8nProjectId,
-			this.credentialProvider,
-			this.integrationType,
-		);
+		const stream = this.agentService.executeForChatPublished({
+			agentId: this.agentId,
+			projectId: this.n8nProjectId,
+			message: text,
+			memory: { threadId, resourceId: message.author.userId },
+			integrationType: this.integrationType,
+		});
 
 		await this.consumeStream(stream, thread);
 	}
@@ -267,10 +240,7 @@ export class AgentChatBridge {
 	 * In both strategies, non-text chunks (`tool-call-suspended`, `message`,
 	 * `error`) flush any pending text first, then get handled in order.
 	 */
-	private async consumeStream(
-		stream: AsyncGenerator<StreamChunk>,
-		thread: ChatThread,
-	): Promise<void> {
+	private async consumeStream(stream: AsyncGenerator<StreamChunk>, thread: Thread): Promise<void> {
 		if (this.disableStreaming) {
 			await this.consumeStreamBuffered(stream, thread);
 			return;
@@ -412,7 +382,7 @@ export class AgentChatBridge {
 	 */
 	private async consumeStreamBuffered(
 		stream: AsyncGenerator<StreamChunk>,
-		thread: ChatThread,
+		thread: Thread,
 	): Promise<void> {
 		let buffer = '';
 
@@ -428,6 +398,7 @@ export class AgentChatBridge {
 				// shape the streaming path uses under the hood.
 				await thread.post({ markdown: text });
 			} catch (postError: unknown) {
+				await this.postErrorToThread(thread, postError);
 				this.logger.error('[AgentChatBridge] Buffered post failed', {
 					error: postError instanceof Error ? postError.message : String(postError),
 				});
@@ -480,7 +451,7 @@ export class AgentChatBridge {
 
 	private async handleSuspension(
 		chunk: Extract<StreamChunk, { type: 'tool-call-suspended' }>,
-		thread: ChatThread,
+		thread: Thread,
 	): Promise<void> {
 		const { runId, toolCallId, suspendPayload } = chunk;
 
@@ -552,7 +523,7 @@ export class AgentChatBridge {
 
 	private async handleRichInteraction(
 		chunk: Extract<StreamChunk, { type: 'tool-call-suspended' }>,
-		thread: ChatThread,
+		thread: Thread,
 	): Promise<void> {
 		const { runId, toolCallId, suspendPayload } = chunk;
 
@@ -590,7 +561,7 @@ export class AgentChatBridge {
 				this.getShortenCallback(),
 				this.integrationType,
 			);
-			await thread.post({ card });
+			await thread.post(card);
 		} catch (error) {
 			this.logger.error('[AgentChatBridge] Failed to post rich interaction card', {
 				error: error instanceof Error ? error.message : String(error),
@@ -685,7 +656,7 @@ export class AgentChatBridge {
 
 	private async handleMessage(
 		chunk: Extract<StreamChunk, { type: 'message' }>,
-		thread: ChatThread,
+		thread: Thread,
 	): Promise<void> {
 		const agentMessage: AgentMessage = chunk.message;
 
@@ -719,146 +690,192 @@ export class AgentChatBridge {
 	// Button interaction handling (HITL resume)
 	// ---------------------------------------------------------------------------
 
+	/** Parsed result from an action ID. */
+	private parseActionId(
+		actionId: string,
+		value: string | undefined,
+	): { runId: string; toolCallId: string; resumeData: unknown } | null {
+		if (actionId.startsWith('ri-btn:')) {
+			const parts = actionId.split(':');
+			if (parts.length < 4) {
+				this.logger.warn('[AgentChatBridge] Malformed ri-btn action ID', { actionId });
+				return null;
+			}
+			let resumeData: unknown;
+			try {
+				resumeData = JSON.parse(value ?? '');
+			} catch {
+				resumeData = { type: 'button', value };
+			}
+			return { runId: parts[1], toolCallId: parts.slice(2, -1).join(':'), resumeData };
+		}
+
+		if (actionId.startsWith('ri-sel:')) {
+			const parts = actionId.split(':');
+			if (parts.length < 4) {
+				this.logger.warn('[AgentChatBridge] Malformed ri-sel action ID', { actionId });
+				return null;
+			}
+			return {
+				runId: parts[2],
+				toolCallId: parts.slice(3).join(':'),
+				resumeData: { type: 'select', id: parts[1], value },
+			};
+		}
+
+		if (actionId.startsWith('resume:')) {
+			const parts = actionId.split(':');
+			if (parts.length < 4) {
+				this.logger.warn('[AgentChatBridge] Malformed action ID', { actionId });
+				return null;
+			}
+			let resumeData: unknown;
+			try {
+				resumeData = JSON.parse(value ?? '');
+			} catch {
+				resumeData = { value };
+			}
+			return { runId: parts[1], toolCallId: parts.slice(2, -1).join(':'), resumeData };
+		}
+
+		return null;
+	}
+
+	/**
+	 * Resolve short callback keys when the platform uses them (e.g. Telegram).
+	 * Returns the resolved `{ actionId, value }` or `null` if expired/missing.
+	 */
+	private async resolveCallbackData(
+		actionId: string,
+		value: string | undefined,
+		thread: Thread<unknown, unknown>,
+	): Promise<{ actionId: string; value: string | undefined } | null> {
+		if (!this.callbackStore) return { actionId, value };
+
+		const resolved = await this.callbackStore.resolve(actionId);
+		if (!resolved) {
+			this.logger.warn('[AgentChatBridge] Callback key not found or expired', { actionId });
+			await thread.post(
+				'This action is no longer available. The link may have expired or already been used.',
+			);
+			return null;
+		}
+		return { actionId: resolved.actionId, value: resolved.value };
+	}
+
+	/**
+	 * Delete the card message and apply platform-specific workarounds before
+	 * resuming the agent.
+	 */
+	private async cleanUpBeforeResume(event: ActionEvent): Promise<void> {
+		try {
+			await event.adapter.deleteMessage(event.threadId, event.messageId);
+		} catch (deleteError) {
+			this.logger.warn('[AgentChatBridge] Failed to delete card message', {
+				error: deleteError instanceof Error ? deleteError.message : String(deleteError),
+			});
+		}
+
+		// TODO(chat-sdk-bug): Remove when Chat SDK normalises Slack interaction
+		// payloads. Slack sends `team: { id: "T..." }` (object) but Chat SDK's
+		// streaming path expects `team_id: "T..."` (string) on the raw message.
+		interface ThreadWithRaw {
+			_currentMessage?: { raw?: Record<string, unknown> };
+		}
+		const threadInternal = event.thread as unknown as ThreadWithRaw;
+		if (threadInternal?._currentMessage?.raw) {
+			const raw = threadInternal._currentMessage.raw;
+			if (raw.team && typeof raw.team === 'object' && !raw.team_id) {
+				raw.team_id = (raw.team as Record<string, string>).id;
+			}
+		}
+	}
+
+	/**
+	 * Guard against double resumption, then resume the agent and stream the
+	 * response back into the thread.
+	 */
+	private async executeResume(
+		thread: Thread<unknown, unknown>,
+		runId: string,
+		toolCallId: string,
+		resumeData: unknown,
+	): Promise<void> {
+		if (this.activeResumedRuns.has(runId)) {
+			this.logger.warn('[AgentChatBridge] Run is already active', { runId, toolCallId });
+			await thread.post('This action has already been handled');
+			return;
+		}
+
+		this.activeResumedRuns.add(runId);
+		try {
+			const stream = this.agentService.resumeForChat({
+				agentId: this.agentId,
+				projectId: this.n8nProjectId,
+				runId,
+				toolCallId,
+				resumeData,
+			});
+			await this.consumeStream(stream, thread as Thread);
+		} finally {
+			this.activeResumedRuns.delete(runId);
+		}
+	}
+
 	/**
 	 * Handle a button/select action. Action IDs use one of three prefixes:
 	 * - `ri-btn:{runId}:{toolCallId}:{index}` — rich interaction button
 	 * - `ri-sel:{selectId}:{runId}:{toolCallId}` — rich interaction select
 	 * - `resume:{runId}:{toolCallId}:{index}` — generic per-tool resume button
 	 */
-	private async handleAction(event: ChatActionEvent): Promise<void> {
-		let { actionId, value } = event;
+	private async handleAction(event: ActionEvent): Promise<void> {
 		const { thread } = event;
 
-		// Resolve short callback keys back to full action data. If the key is
-		// missing the action was already handled or the entry expired — let the
-		// user know rather than silently swallowing the click.
-		if (this.callbackStore) {
-			const resolved = await this.callbackStore.resolve(actionId);
-			if (!resolved) {
-				this.logger.warn('[AgentChatBridge] Callback key not found or expired', {
-					actionId,
-				});
-				await thread.post(
-					'This action is no longer available. The link may have expired or already been used.',
-				);
-				return;
-			}
-			actionId = resolved.actionId;
-			value = resolved.value;
-		}
-
-		let runId: string;
-		let toolCallId: string;
-		let resumeData: unknown;
-
-		if (actionId.startsWith('ri-btn:')) {
-			// Rich interaction button: ri-btn:{runId}:{toolCallId}:{index}
-			const parts = actionId.split(':');
-			if (parts.length < 4) {
-				this.logger.warn('[AgentChatBridge] Malformed ri-btn action ID', { actionId });
-				return;
-			}
-			runId = parts[1];
-			toolCallId = parts.slice(2, -1).join(':');
-			try {
-				resumeData = JSON.parse(value);
-			} catch {
-				resumeData = { type: 'button', value };
-			}
-		} else if (actionId.startsWith('ri-sel:')) {
-			// Rich interaction select: ri-sel:{selectId}:{runId}:{toolCallId}
-			const parts = actionId.split(':');
-			if (parts.length < 4) {
-				this.logger.warn('[AgentChatBridge] Malformed ri-sel action ID', { actionId });
-				return;
-			}
-			const selectId = parts[1];
-			runId = parts[2];
-			toolCallId = parts.slice(3).join(':');
-			resumeData = { type: 'select', id: selectId, value };
-		} else if (actionId.startsWith('resume:')) {
-			// Existing per-tool resume: resume:{runId}:{toolCallId}:{index}
-			const parts = actionId.split(':');
-			if (parts.length < 4) {
-				this.logger.warn('[AgentChatBridge] Malformed action ID', { actionId });
-				return;
-			}
-			runId = parts[1];
-			toolCallId = parts.slice(2, -1).join(':');
-			try {
-				resumeData = JSON.parse(value);
-			} catch {
-				resumeData = { value };
-			}
-		} else {
+		if (!thread) {
+			this.logger.warn('[AgentChatBridge] Thread is not set for event', {
+				threadId: event.threadId,
+				actionId: event.actionId,
+			});
 			return;
 		}
 
-		// --- Everything below is the same for all prefixes ---
+		const callbackData = await this.resolveCallbackData(event.actionId, event.value, thread);
+		if (!callbackData) return;
 
-		const isRunActive = this.activeResumedRuns.has(runId);
+		const parsed = this.parseActionId(callbackData.actionId, callbackData.value);
+		if (!parsed) return;
 
-		if (isRunActive) {
-			this.logger.warn('[AgentChatBridge] Run is already active', { runId, toolCallId });
-			await thread.post('This action has already been handled');
-			return;
-		}
-		this.activeResumedRuns.add(runId);
-		try {
-			// Delete the card message
-			try {
-				await event.adapter.deleteMessage(event.threadId, event.messageId);
-			} catch (deleteError) {
-				this.logger.warn('[AgentChatBridge] Failed to delete card message', {
-					error: deleteError instanceof Error ? deleteError.message : String(deleteError),
-				});
-			}
-
-			// TODO(chat-sdk-bug): Remove when Chat SDK normalises Slack interaction
-			// payloads. Slack sends `team: { id: "T..." }` (object) but Chat SDK's
-			// streaming path expects `team_id: "T..."` (string) on the raw message.
-			// We patch the thread's internal `_currentMessage.raw` to bridge this.
-			interface ThreadWithRaw {
-				_currentMessage?: { raw?: Record<string, unknown> };
-			}
-			const threadInternal = thread as unknown as ThreadWithRaw;
-			if (threadInternal._currentMessage?.raw) {
-				const raw = threadInternal._currentMessage.raw;
-				if (raw.team && typeof raw.team === 'object' && !raw.team_id) {
-					raw.team_id = (raw.team as Record<string, string>).id;
-				}
-			}
-
-			// Resume the agent and stream the response
-			const stream = this.agentService.resumeForChat(
-				this.agentId,
-				runId,
-				toolCallId,
-				resumeData,
-				thread.id,
-				this.n8nUserId,
-				this.n8nProjectId,
-			);
-			await this.consumeStream(stream, thread);
-		} finally {
-			this.activeResumedRuns.delete(runId);
-		}
+		await this.cleanUpBeforeResume(event);
+		await this.executeResume(thread, parsed.runId, parsed.toolCallId, parsed.resumeData);
 	}
 
 	// ---------------------------------------------------------------------------
 	// Error posting
 	// ---------------------------------------------------------------------------
 
-	private async postErrorToThread(thread: ChatThread, error: unknown): Promise<void> {
+	private async postErrorToThread(
+		thread: Thread<unknown, unknown> | null,
+		error: unknown,
+	): Promise<void> {
 		const message = error instanceof Error ? error.message : 'An unexpected error occurred';
 
 		this.logger.error('[AgentChatBridge] Error in handler', {
 			agentId: this.agentId,
-			threadId: thread.id,
+			threadId: thread?.id,
 			error: message,
 		});
 
 		try {
+			if (!thread) {
+				this.logger.warn(
+					"[AgentChatBridge] Couldn't post error message because thread is not set",
+					{
+						agentId: this.agentId,
+						error: message,
+					},
+				);
+				return;
+			}
 			await thread.post('⚠️ Something went wrong while processing your request. Please try again.');
 		} catch (postError) {
 			this.logger.error('[AgentChatBridge] Failed to post error message', {

--- a/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
@@ -1,4 +1,5 @@
 import { Service } from '@n8n/di';
+import type { Thread } from 'chat';
 
 import type { SuspendComponent } from './component-mapper';
 
@@ -79,6 +80,15 @@ export abstract class AgentChatIntegration {
 	 * turns select options into individual buttons.
 	 */
 	normalizeComponents?(components: SuspendComponent[]): SuspendComponent[];
+
+	/**
+	 * Optional per-platform thread ID formatting.
+	 * Used to convert between the Chat SDK thread and our format.
+	 */
+	formatThreadId?: {
+		fromSdk: (thread: Thread<unknown, unknown>) => string;
+		toSdk: (threadId: string) => string;
+	};
 }
 
 /**

--- a/packages/cli/src/modules/agents/integrations/agent-schedule.service.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-schedule.service.ts
@@ -5,20 +5,18 @@ import {
 	type AgentScheduleIntegration,
 	isAgentScheduleIntegration,
 } from '@n8n/api-types';
+import { ProjectRelationRepository } from '@n8n/db';
 import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
-import { ProjectRelationRepository } from '@n8n/db';
 import { OnShutdown } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import { CronJob } from 'cron';
 import { randomUUID } from 'crypto';
 import { DateTime } from 'luxon';
 
-import { CredentialsService } from '@/credentials/credentials.service';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 
-import { AgentsCredentialProvider } from '../adapters/agents-credential-provider';
 import { AgentsService } from '../agents.service';
 import type { Agent } from '../entities/agent.entity';
 import { AgentRepository } from '../repositories/agent.repository';
@@ -32,9 +30,8 @@ export class AgentScheduleService {
 		private readonly logger: Logger,
 		private readonly globalConfig: GlobalConfig,
 		private readonly agentRepository: AgentRepository,
-		private readonly projectRelationRepository: ProjectRelationRepository,
-		private readonly credentialsService: CredentialsService,
 		private readonly agentsService: AgentsService,
+		private readonly projectRelationRepository: ProjectRelationRepository,
 	) {}
 
 	getConfig(agent: Agent): AgentScheduleConfig {
@@ -316,10 +313,6 @@ export class AgentScheduleService {
 				return;
 			}
 
-			const credentialProvider = new AgentsCredentialProvider(
-				this.credentialsService,
-				agent.projectId,
-			);
 			threadId = `schedule-${agentId}-${randomUUID()}`;
 			const timezone = this.globalConfig.generic.timezone;
 			const timestamp = DateTime.now().setZone(timezone).toISO() ?? new Date().toISOString();
@@ -330,7 +323,6 @@ export class AgentScheduleService {
 				projectId,
 				threadId,
 				cronExpression: schedule.cronExpression,
-				executionUserId,
 				timezone,
 			});
 			this.logger.debug('[AgentScheduleService] Starting scheduled agent run', {
@@ -341,15 +333,12 @@ export class AgentScheduleService {
 			});
 
 			let chunkCount = 0;
-			for await (const _chunk of this.agentsService.executeForSchedulePublished(
-				agent.id,
+			for await (const _chunk of this.agentsService.executeForSchedulePublished({
+				agentId: agent.id,
+				projectId: agent.projectId,
 				message,
-				threadId,
-				executionUserId,
-				agent.projectId,
-				credentialProvider,
-				threadId,
-			)) {
+				memory: { threadId, resourceId: executionUserId },
+			})) {
 				chunkCount += 1;
 			}
 

--- a/packages/cli/src/modules/agents/integrations/chat-integration.service.ts
+++ b/packages/cli/src/modules/agents/integrations/chat-integration.service.ts
@@ -19,7 +19,6 @@ import {
 } from './agent-chat-integration';
 import { ComponentMapper } from './component-mapper';
 import { loadChatSdk, loadMemoryState } from './esm-loader';
-import { AgentsCredentialProvider } from '../adapters/agents-credential-provider';
 import type { Agent } from '../entities/agent.entity';
 import { AgentRepository } from '../repositories/agent.repository';
 
@@ -97,9 +96,6 @@ export class ChatIntegrationService {
 
 		const user = await this.resolveUser(userId);
 
-		// Create credential provider scoped to this agent's project
-		const credentialProvider = new AgentsCredentialProvider(this.credentialsService, projectId);
-
 		// Decrypt the integration credential to get platform tokens
 		const decryptedData = await this.decryptCredential(credentialId, user);
 
@@ -145,10 +141,8 @@ export class ChatIntegrationService {
 			chat,
 			agentId,
 			agentService,
-			credentialProvider,
 			componentMapper,
 			this.logger,
-			userId,
 			projectId,
 			integrationType,
 		);

--- a/packages/cli/src/modules/agents/integrations/component-mapper.ts
+++ b/packages/cli/src/modules/agents/integrations/component-mapper.ts
@@ -2,6 +2,7 @@ import { Container } from '@n8n/di';
 
 import { ChatIntegrationRegistry } from './agent-chat-integration';
 import { loadChatSdk } from './esm-loader';
+import type { CardElement } from 'chat';
 
 /**
  * Component type from agent SDK suspend/toMessage payloads.
@@ -72,7 +73,7 @@ export class ComponentMapper {
 		resumeSchema?: unknown,
 		shortenCallback?: (actionId: string, value: string) => Promise<{ id: string; value: string }>,
 		platform?: string,
-	): Promise<unknown> {
+	): Promise<CardElement> {
 		const sdk = await loadChatSdk();
 
 		// Delegate per-platform normalization to the Integration implementation.

--- a/packages/cli/src/modules/agents/integrations/n8n-checkpoint-storage.ts
+++ b/packages/cli/src/modules/agents/integrations/n8n-checkpoint-storage.ts
@@ -10,6 +10,16 @@ import { strict } from 'node:assert';
 
 import { AgentCheckpointRepository } from '../repositories/agent-checkpoint.repository';
 
+type CheckpointStatus =
+	| {
+			status: 'expired';
+	  }
+	| { status: 'not-found' }
+	| {
+			status: 'active';
+			checkpoint: SerializableAgentState;
+	  };
+
 @Service()
 export class N8NCheckpointStorage {
 	private pruneTimeout: NodeJS.Timeout | undefined;
@@ -77,11 +87,11 @@ export class N8NCheckpointStorage {
 		return jsonParse<SerializableAgentState>(checkpoint.state);
 	}
 
-	async getStatus(key: string): Promise<'expired' | 'active' | 'not-found'> {
+	async getStatus(key: string): Promise<CheckpointStatus> {
 		const checkpoint = await this.agentCheckpointRepository.findOneBy({ runId: key });
-		if (!checkpoint) return 'not-found';
-		if (checkpoint.expired || checkpoint.state === null) return 'expired';
-		return 'active';
+		if (!checkpoint) return { status: 'not-found' };
+		if (checkpoint.expired || checkpoint.state === null) return { status: 'expired' };
+		return { status: 'active', checkpoint: jsonParse<SerializableAgentState>(checkpoint.state) };
 	}
 
 	async delete(key: string): Promise<void> {

--- a/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
@@ -55,7 +55,7 @@ export class TelegramIntegration extends AgentChatIntegration {
 			if (!threadId.includes('-')) {
 				return threadId;
 			}
-			return threadId.split('-')[1];
+			return threadId.split('-').slice(1).join('-');
 		},
 	};
 

--- a/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
@@ -1,5 +1,6 @@
 import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
+import type { Thread } from 'chat';
 
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { UrlService } from '@/services/url.service';
@@ -39,6 +40,24 @@ export class TelegramIntegration extends AgentChatIntegration {
 	readonly needsShortCallbackData = true;
 
 	readonly disableStreaming = true;
+
+	readonly formatThreadId = {
+		fromSdk: (thread: Thread<unknown, unknown>) => {
+			const adapter = thread.adapter;
+			const botUserId = adapter.botUserId;
+			if (!botUserId) {
+				throw new Error('Telegram bot user ID is not set');
+			}
+			// thread.id is simply user id, which means connecting agent to another bot user will result in the same thread id
+			return `chat:${botUserId}-${thread.id}`;
+		},
+		toSdk: (threadId: string) => {
+			if (!threadId.includes('-')) {
+				return threadId;
+			}
+			return threadId.split('-')[1];
+		},
+	};
 
 	constructor(
 		private readonly logger: Logger,

--- a/packages/cli/src/modules/agents/integrations/types.ts
+++ b/packages/cli/src/modules/agents/integrations/types.ts
@@ -1,0 +1,21 @@
+/** Callback that pushes a text fragment into the streaming iterable. */
+export type TextYieldFn = (text: string) => void;
+/** Callback that signals the end of the streaming iterable. */
+export type TextEndFn = () => void;
+
+export const INTERNAL_THREAD_ID_SYMBOL = Symbol('internal-thread-id');
+
+/**
+ * The symbol is required to prevent accidental mixing of internal and chat SDK thread IDs as they may be different
+ */
+export interface InternalThread {
+	[INTERNAL_THREAD_ID_SYMBOL]: boolean;
+	id: string;
+}
+
+export const toInternalThreadId = (id: string): InternalThread => {
+	return {
+		[INTERNAL_THREAD_ID_SYMBOL]: true,
+		id,
+	};
+};

--- a/packages/cli/src/modules/agents/repositories/agent-published-version.repository.ts
+++ b/packages/cli/src/modules/agents/repositories/agent-published-version.repository.ts
@@ -29,7 +29,7 @@ export class AgentPublishedVersionRepository extends Repository<AgentPublishedVe
 			model: string | null;
 			provider: string | null;
 			credentialId: string | null;
-			publishedById: string | null;
+			publishedById: string;
 		},
 		trx?: EntityManager,
 	): Promise<AgentPublishedVersion> {


### PR DESCRIPTION
## Summary

This PR does a bunch of medium-high priority fixes for chate integration related logic:
- Use Chat SDK imports instead of mocks
- Use thread `botId-userId` instead of `userId` for telegram chats. Previously different telegram chat integrations would use same message history
- Clearly define n8n user id and user id that is used for resourceId. That lead to several bugs where chat user id was used as n8n user id for checking permissions. Now the implementation always uses user id from published_agents or from http request
- Use different cache key for published agents and draft agents to avoid using draft agent for published agent request handling
- refactor handleAction to keep it readable

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-64/bug-telegram-chats-share-same-message-history-and-threadid

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
