### PR TITLE
ci: Scope RELEASE env to editor-ui turbo task (no-changelog)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,11 +1,16 @@
 {
-	"globalEnv": ["CI", "BUILD_WITH_COVERAGE", "RELEASE"],
+	"globalEnv": ["CI", "BUILD_WITH_COVERAGE"],
 	"globalPassThroughEnv": ["CODECOV_TOKEN", "COVERAGE_ENABLED", "SENTRY_AUTH_TOKEN"],
 	"tasks": {
 		"clean": { "cache": false },
 		"build": {
 			"dependsOn": ["^build"],
 			"outputs": ["dist/**"]
+		},
+		"n8n-editor-ui#build": {
+			"dependsOn": ["^build"],
+			"outputs": ["dist/**"],
+			"env": ["RELEASE"]
 		},
 		"typecheck": {
 			"dependsOn": ["^typecheck", "^build"]


### PR DESCRIPTION
## Summary

`RELEASE` was configured in turbo's `globalEnv`, which meant every package's build cache was invalidated during `release-publish` — even though only `editor-ui` reads the variable (for minification, sourcemaps, Sentry upload, and legacy polyfills).

This moves `RELEASE` to a package-scoped `n8n-editor-ui#build` task in `turbo.json`, so that:
- All other packages get turbo cache hits from `ci-master` builds during release-publish
- `editor-ui` still correctly rebuilds when the release version changes

This should resolve the npm publish stage cache timeouts in the release workflow.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.