### PR TITLE
fix(editor): Add proper bg color for hover state with color-mix()

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
@@ -247,6 +247,16 @@ const handleClick = (event: MouseEvent) => {
 
 	&.subtle {
 		--button--color--background: var(--background--surface);
+		--button--color--background-hover: color-mix(
+			in srgb,
+			var(--button--color--background),
+			var(--background--hover)
+		);
+		--button--color--background-active: color-mix(
+			in srgb,
+			var(--button--color--background),
+			var(--background--active)
+		);
 		--button--shadow: var(--shadow--xs);
 		--button--shadow--hover: var(--shadow--xs);
 		--button--shadow--active: var(--shadow--xs);


### PR DESCRIPTION
## Summary
Alpha-based hover/active fills for the `subtle` `N8nButton` produced semi-transparent overlays when the button is positioned above other content so the hover/active fill needs to be derived by blending the variant background with the interaction tokens.

Updated `N8nButton` to use `color-mix()` so it creates a solid color

| Before | After |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/91c5eabd-40d6-42f3-befa-c4b2fc3a1f33" width="960px" alt="Before image" /> | <img src="https://github.com/user-attachments/assets/2d12755b-e28f-4684-8219-33054b90f138" width="960px" alt="After image" /> |

## Related Linear tickets, Github issues, and Community forum posts
[DS-527](https://linear.app/n8n/issue/DS-527/hover-shows-semi-transparent-background)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
