### PR TITLE
fix(editor): Resolve "Workflow not found" error on evaluations tab (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.test.ts
@@ -111,7 +111,7 @@ describe('EvaluationsRootView', () => {
 		usageStore.getLicenseInfo.mockResolvedValue(undefined);
 		evaluationStore.fetchTestRuns.mockResolvedValue([]);
 
-		renderComponent({ props: { name: mockWorkflow.id } });
+		renderComponent({ props: { workflowId: mockWorkflow.id } });
 
 		await flushPromises();
 
@@ -124,7 +124,7 @@ describe('EvaluationsRootView', () => {
 		const evaluationStore = mockedStore(useEvaluationStore);
 		evaluationStore.fetchTestRuns.mockResolvedValue(mockTestRuns);
 
-		renderComponent({ props: { name: mockWorkflow.id } });
+		renderComponent({ props: { workflowId: mockWorkflow.id } });
 
 		await waitFor(() =>
 			expect(evaluationStore.fetchTestRuns).toHaveBeenCalledWith(mockWorkflow.id),
@@ -135,7 +135,7 @@ describe('EvaluationsRootView', () => {
 		const evaluationStore = mockedStore(useEvaluationStore);
 		evaluationStore.testRunsById = { foo: mock<TestRunRecord>({ workflowId: mockWorkflow.id }) };
 
-		const { container } = renderComponent({ props: { name: mockWorkflow.id } });
+		const { container } = renderComponent({ props: { workflowId: mockWorkflow.id } });
 
 		// Check that setupContent is not present
 		await waitFor(() => expect(container.querySelector('.setupContent')).toBeFalsy());
@@ -151,7 +151,7 @@ describe('EvaluationsRootView', () => {
 		evaluationStore.fetchTestRuns.mockResolvedValue([]);
 		evaluationStore.testRunsById = {};
 
-		const { container } = renderComponent({ props: { name: mockWorkflow.id } });
+		const { container } = renderComponent({ props: { workflowId: mockWorkflow.id } });
 
 		await flushPromises();
 		await waitFor(() => expect(container.querySelector('.setupContent')).toBeTruthy());
@@ -169,7 +169,7 @@ describe('EvaluationsRootView', () => {
 		evaluationStore.testRunsById = {};
 		sourceControlStore.preferences = mock<SourceControlPreferences>({ branchReadOnly: true });
 
-		const { container } = renderComponent({ props: { name: mockWorkflow.id } });
+		const { container } = renderComponent({ props: { workflowId: mockWorkflow.id } });
 
 		await flushPromises();
 		await waitFor(() => {
@@ -193,7 +193,7 @@ describe('EvaluationsRootView', () => {
 			// Mock no evaluation nodes in workflow
 			getNodeType.mockReturnValue(null);
 
-			renderComponent({ props: { name: mockWorkflow.id } });
+			renderComponent({ props: { workflowId: mockWorkflow.id } });
 
 			await waitFor(() => {
 				expect(useTelemetry().track).toHaveBeenCalledWith('User viewed tests tab', {
@@ -221,7 +221,7 @@ describe('EvaluationsRootView', () => {
 			usageStore.workflowsWithEvaluationsLimit = 10;
 			usageStore.workflowsWithEvaluationsCount = 1;
 
-			renderComponent({ props: { name: mockWorkflow.id } });
+			renderComponent({ props: { workflowId: mockWorkflow.id } });
 
 			await waitFor(() => {
 				expect(useTelemetry().track).toHaveBeenCalledWith('User viewed tests tab', {
@@ -264,7 +264,7 @@ describe('EvaluationsRootView', () => {
 					: null,
 			);
 
-			renderComponent({ props: { name: mockWorkflow.id } });
+			renderComponent({ props: { workflowId: mockWorkflow.id } });
 
 			await waitFor(() => {
 				expect(useTelemetry().track).toHaveBeenCalledWith('User viewed tests tab', {
@@ -316,7 +316,7 @@ describe('EvaluationsRootView', () => {
 					: null,
 			);
 
-			renderComponent({ props: { name: mockWorkflow.id } });
+			renderComponent({ props: { workflowId: mockWorkflow.id } });
 
 			await waitFor(() => {
 				expect(useTelemetry().track).toHaveBeenCalledWith('User viewed tests tab', {
@@ -368,7 +368,7 @@ describe('EvaluationsRootView', () => {
 					: null,
 			);
 
-			renderComponent({ props: { name: mockWorkflow.id } });
+			renderComponent({ props: { workflowId: mockWorkflow.id } });
 
 			await waitFor(() => {
 				expect(useTelemetry().track).toHaveBeenCalledWith('User viewed tests tab', {
@@ -396,7 +396,7 @@ describe('EvaluationsRootView', () => {
 			// Mock no evaluation nodes in workflow
 			getNodeType.mockReturnValue(null);
 
-			renderComponent({ props: { name: mockWorkflow.id } });
+			renderComponent({ props: { workflowId: mockWorkflow.id } });
 
 			await waitFor(() => {
 				expect(useTelemetry().track).toHaveBeenCalledWith('User viewed tests tab', {

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.vue
@@ -14,7 +14,7 @@ import SetupWizard from '../components/SetupWizard/SetupWizard.vue';
 
 import { N8nCallout, N8nLink, N8nText } from '@n8n/design-system';
 const props = defineProps<{
-	name: string;
+	workflowId: string;
 }>();
 
 const usageStore = useUsageStore();
@@ -34,7 +34,7 @@ const isProtectedEnvironment = computed(() => {
 
 const runs = computed(() => {
 	return Object.values(evaluationStore.testRunsById ?? {}).filter(
-		({ workflowId }) => workflowId === props.name,
+		({ workflowId }) => workflowId === props.workflowId,
 	);
 });
 
@@ -47,13 +47,13 @@ const showWizard = computed(() => !hasRuns.value);
 // Method to run a test - will be used by the SetupWizard component
 async function runTest() {
 	try {
-		await evaluationStore.startTestRun(props.name);
+		await evaluationStore.startTestRun(props.workflowId);
 	} catch (error) {
 		toast.showError(error, locale.baseText('evaluation.listRuns.error.cantStartTestRun'));
 		return;
 	}
 	try {
-		await evaluationStore.fetchTestRuns(props.name);
+		await evaluationStore.fetchTestRuns(props.workflowId);
 	} catch (error) {
 		toast.showError(error, locale.baseText('evaluation.listRuns.error.cantFetchTestRuns'));
 	}
@@ -70,7 +70,7 @@ const evaluationsQuotaExceeded = computed(() => {
 const { isReady } = useAsyncState(async () => {
 	try {
 		await usageStore.getLicenseInfo();
-		await evaluationStore.fetchTestRuns(props.name);
+		await evaluationStore.fetchTestRuns(props.workflowId);
 	} catch (error) {
 		toast.showError(error, locale.baseText('evaluation.listRuns.error.cantFetchTestRuns'));
 	}
@@ -82,7 +82,7 @@ watch(
 		if (ready) {
 			if (showWizard.value) {
 				telemetry.track('User viewed tests tab', {
-					workflow_id: props.name,
+					workflow_id: props.workflowId,
 					test_type: 'evaluation',
 					view: 'setup',
 					trigger_set_up: evaluationStore.evaluationTriggerExists,
@@ -92,7 +92,7 @@ watch(
 				});
 			} else {
 				telemetry.track('User viewed tests tab', {
-					workflow_id: props.name,
+					workflow_id: props.workflowId,
 					test_type: 'evaluation',
 					view: 'overview',
 					run_count: runs.value.length,

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsView.test.ts
@@ -28,7 +28,7 @@ vi.mock('vue-router', () => {
 });
 
 const renderComponent = createComponentRenderer(EvaluationsView, {
-	props: { name: 'workflow-id' },
+	props: { workflowId: 'workflow-id' },
 });
 
 describe('EvaluationsView', () => {

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsView.vue
@@ -9,7 +9,7 @@ import { useToast } from '@/app/composables/useToast';
 
 import { N8nButton } from '@n8n/design-system';
 const props = defineProps<{
-	name: string;
+	workflowId: string;
 }>();
 
 const locale = useI18n();
@@ -24,13 +24,13 @@ const runningTestRun = computed(() => runs.value.find((run) => run.status === 'r
 
 async function runTest() {
 	try {
-		await evaluationStore.startTestRun(props.name);
+		await evaluationStore.startTestRun(props.workflowId);
 	} catch (error) {
 		toast.showError(error, locale.baseText('evaluation.listRuns.error.cantStartTestRun'));
 	}
 
 	try {
-		await evaluationStore.fetchTestRuns(props.name);
+		await evaluationStore.fetchTestRuns(props.workflowId);
 	} catch (error) {
 		toast.showError(error, locale.baseText('evaluation.listRuns.error.cantFetchTestRuns'));
 	}
@@ -54,7 +54,7 @@ async function stopTest() {
 
 const runs = computed(() => {
 	const testRuns = Object.values(evaluationStore.testRunsById ?? {}).filter(
-		({ workflowId }) => workflowId === props.name,
+		({ workflowId }) => workflowId === props.workflowId,
 	);
 
 	return orderBy(testRuns, (record) => new Date(record.runAt), ['asc']).map((record, index) => ({
@@ -100,7 +100,7 @@ watch(runningTestRun, (run) => {
 					v-model:selected-metric="selectedMetric"
 					:class="$style.runs"
 					:runs="runs"
-					:workflow-id="props.name"
+					:workflow-id="props.workflowId"
 				/>
 			</div>
 		</div>


### PR DESCRIPTION
## Summary

The Evaluations tab on a workflow was failing to load with a "Workflow not found" error.

The route was passing the workflow ID under a `name` prop, while the evaluation views expected the prop name to match the underlying value. Renamed the prop from `name` to `workflowId` in `EvaluationsRootView.vue` and `EvaluationsView.vue` (and their tests) so the views receive the workflow ID correctly and the tab loads as expected.

### How to test

1. Open any workflow
2. Navigate to the **Evaluations** tab
3. The tab should load — no "Workflow not found" error

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2433

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI