### PR TITLE
chore: Upgrade nock to 14.0.13 to fix Node.js 24+ compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "jest-mock-extended": "^3.0.4",
     "lefthook": "^1.7.15",
     "license-checker": "^25.0.1",
-    "nock": "^14.0.1",
+    "nock": "^14.0.13",
     "nodemon": "^3.0.1",
     "npm-run-all2": "^7.0.2",
     "p-limit": "^3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -530,8 +530,8 @@ importers:
         specifier: ^25.0.1
         version: 25.0.1
       nock:
-        specifier: ^14.0.1
-        version: 14.0.1
+        specifier: ^14.0.13
+        version: 14.0.13
       nodemon:
         specifier: ^3.0.1
         version: 3.0.1
@@ -8174,8 +8174,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@mswjs/interceptors@0.37.5':
-    resolution: {integrity: sha512-AAwRb5vXFcY4L+FvZ7LZusDuZ0vEe0Zm8ohn1FM6/X7A3bj4mqmkAcGRWuvC2JwSygNwHAAmMnAI73vPHeqsHA==}
+  '@mswjs/interceptors@0.41.6':
+    resolution: {integrity: sha512-qmDvJIjcNsZ6tXWy2G9yuCgMPTTn35GMA3dPpSLm7QJVpbQzYdw0ALy1bKoivXnEM3U93/OrK+/M719b+fg84Q==}
     engines: {node: '>=18'}
 
   '@n8n/typeorm@0.3.20-16':
@@ -18080,8 +18080,8 @@ packages:
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
-  nock@14.0.1:
-    resolution: {integrity: sha512-IJN4O9pturuRdn60NjQ7YkFt6Rwei7ZKaOwb1tvUIIqTgeD0SDDAX3vrqZD4wcXczeEy/AsUXxpGpP/yHqV7xg==}
+  nock@14.0.13:
+    resolution: {integrity: sha512-SCPsQmGVNY8h1rfS3aU0MzOGYY+wKIFukHEsoSIwPRCYocZkya7MFIlWIEYPWQZj+Gaksg6EyUaY255ZDqpQuA==}
     engines: {node: '>=18.20.0 <20 || >=20.12.1'}
 
   node-abi@3.75.0:
@@ -27952,7 +27952,7 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.2':
     optional: true
 
-  '@mswjs/interceptors@0.37.5':
+  '@mswjs/interceptors@0.41.6':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/logger': 0.3.0
@@ -40288,9 +40288,9 @@ snapshots:
       lower-case: 2.0.2
       tslib: 2.8.1
 
-  nock@14.0.1:
+  nock@14.0.13:
     dependencies:
-      '@mswjs/interceptors': 0.37.5
+      '@mswjs/interceptors': 0.41.6
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
 


### PR DESCRIPTION
## Summary

Upgrades `nock` from `^14.0.1` to `^14.0.13`.

`nock@14.0.1` depends on `@mswjs/interceptors@0.37.5`, which calls `_getSession()` — an internal TLS socket API removed in Node.js 24. This causes `TypeError: this._getSession is not a function` across any test suite using `nock` on Node.js 24 or 25.

`nock@14.0.13` bumps the transitive dependency to `@mswjs/interceptors@^0.41.0`, which removes the `_getSession` call entirely.

## Related Linear tickets, Github issues, and Community forum posts

<!--
No Linear ticket — standalone CI compatibility fix.
-->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
