### PR TITLE
feat(cli): support publishing all workflows with a new `--all` flag

### DIFF
--- a/packages/cli/src/commands/publish/workflow.ts
+++ b/packages/cli/src/commands/publish/workflow.ts
@@ -6,12 +6,12 @@ import { z } from 'zod';
 import { BaseCommand } from '../base-command';
 
 const flagsSchema = z.object({
-	id: z.string().describe('The ID of the workflow to publish'),
+	id: z.string().describe('The ID of the workflow to publish').optional(),
 	versionId: z
 		.string()
 		.describe('The version ID to publish. If not provided, publishes the current version')
 		.optional(),
-	all: z.boolean().describe('(Deprecated) This flag is no longer supported').optional(),
+	all: z.boolean().describe('Publish all workflows').optional(),
 });
 
 @Command({
@@ -25,22 +25,11 @@ export class PublishWorkflowCommand extends BaseCommand<z.infer<typeof flagsSche
 	async run() {
 		const { flags } = this;
 
-		// Educate users who try to use --all flag
 		if (flags.all) {
-			this.logger.error('The --all flag is no longer supported for workflow publishing.');
-			this.logger.error(
-				'Please publish workflows individually using: publish:workflow --id=<workflow-id> [--versionId=<version-id>]',
-			);
-			return;
-		}
-
-		if (flags.versionId) {
-			this.logger.info(`Publishing workflow with ID: ${flags.id}, version: ${flags.versionId}`);
+			await this.publishAllWorkflows();
 		} else {
-			this.logger.info(`Publishing workflow with ID: ${flags.id} (current version)`);
+			await this.publishWorkflow();
 		}
-
-		await Container.get(WorkflowRepository).publishVersion(flags.id, flags.versionId);
 
 		this.logger.info('Note: Changes will not take effect if n8n is running.');
 		this.logger.info('Please restart n8n for changes to take effect if n8n is currently running.');
@@ -52,5 +41,50 @@ export class PublishWorkflowCommand extends BaseCommand<z.infer<typeof flagsSche
 		this.logger.error('====================================');
 		this.logger.error(error.message);
 		this.logger.error(error.stack!);
+	}
+
+	private async publishAllWorkflows() {
+		const { flags } = this;
+
+		if (flags.id) {
+			this.logger.error('The --id flag cannot be used with the --all flag.');
+			return;
+		}
+
+		if (flags.versionId) {
+			this.logger.error('The --versionId flag cannot be used with the --all flag.');
+			return;
+		}
+
+		this.logger.info('Publishing all workflows');
+
+		const workflowRepository = Container.get(WorkflowRepository);
+
+		const workflows = await workflowRepository.find();
+
+		await Promise.all(
+			workflows.map(async (workflow) => {
+				await workflowRepository.publishVersion(workflow.id);
+			}),
+		);
+
+		this.logger.info('All workflows published successfully');
+	}
+
+	private async publishWorkflow() {
+		const { flags } = this;
+
+		if (!flags.id) {
+			this.logger.error('The --id flag is required.');
+			return;
+		}
+
+		if (flags.versionId) {
+			this.logger.info(`Publishing workflow with ID: ${flags.id}, version: ${flags.versionId}`);
+		} else {
+			this.logger.info(`Publishing workflow with ID: ${flags.id} (current version)`);
+		}
+
+		await Container.get(WorkflowRepository).publishVersion(flags.id, flags.versionId);
 	}
 }


### PR DESCRIPTION
## Summary

Add an `--all` parameter to the `publish:workflow` command to publish all workflows at once.

Currently, each workflow must be published manually, or with a shell loop. Since n8n needs to restart with each iteration, the process can take more time than necessary on low-end hardware.

Functionally, publishing all workflows works perfectly and I don't see any reason to prevent this behavior.

Shell loop:

```sh
n8n list:workflow --onlyId --active=false | while read -r workflow_id; do
  [ -n "$workflow_id" ] && n8n publish:workflow --id="$workflow_id"
done
``` 

I didn't submit a doc update yet, but happy to write it once this PR is validated.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

fixes #28609

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
