### PR TITLE
fix(Schedule Node): Cap day-of-month jitter at 28

### DIFF
--- a/packages/nodes-base/nodes/Schedule/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Schedule/GenericFunctions.ts
@@ -126,7 +126,9 @@ export const toCronExpression = (interval: ScheduleInterval, nodeKey: string): C
 		return `${second} ${minute} ${hour} * * ${daysOfWeek}` as CronExpression;
 	}
 
-	const dayOfMonth = interval.triggerAtDayOfMonth ?? stableInt(nodeKey, 'dayOfMonth', 1, 31);
+	// Cap at 29 (exclusive) so jitter yields 1-28: any higher day would silently
+	// skip months that don't contain it (e.g. day 30 skips February every year).
+	const dayOfMonth = interval.triggerAtDayOfMonth ?? stableInt(nodeKey, 'dayOfMonth', 1, 29);
 	return `${second} ${minute} ${hour} ${dayOfMonth} */${interval.monthsInterval} *`;
 };
 

--- a/packages/nodes-base/nodes/Schedule/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Schedule/test/GenericFunctions.test.ts
@@ -33,7 +33,7 @@ function mockMomentTz(values: {
 // from the input interval.
 //
 // For `seed = 'test-key'`, `stableInt` produces:
-//   second=56, minute=19, hour=14, dayOfMonth=4
+//   second=56, minute=19, hour=14, dayOfMonth=22
 const TEST_SEED = 'test-key';
 
 describe('toCronExpression', () => {
@@ -158,7 +158,7 @@ describe('toCronExpression', () => {
 			TEST_SEED,
 		);
 		expect(result).toEqual('56 0 0 1 */3 *');
-		// Nothing pinned, so sec=56 / min=19 / hr=14 / dom=4 are all filler.
+		// Nothing pinned, so sec=56 / min=19 / hr=14 / dom=22 are all filler.
 		const result1 = toCronExpression(
 			{
 				field: 'months',
@@ -166,7 +166,7 @@ describe('toCronExpression', () => {
 			},
 			TEST_SEED,
 		);
-		expect(result1).toEqual('56 19 14 4 */3 *');
+		expect(result1).toEqual('56 19 14 22 */3 *');
 	});
 });
 


### PR DESCRIPTION
## Summary

Cap the day-of-month jitter at 28 to prevent skipping executions in February.

Previously, when you created a Schedule trigger to run at a monthly interval, we would pick a random day. We picked from the range 1-30. This means that if we picked 29 or 30, the February execution would just get skipped.

The simplest solution is just to cap at 28. We lose some of the spread of executions because we will no longer schedule for the 29, 30, or 31, but this is quite marginal compared to skipping executions.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4968

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
