### PR TITLE
fix(editor): Fix OAuth2 credential showing "Needs first setup" after connecting

### DIFF
--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -1183,6 +1183,7 @@ async function deleteCredential() {
 async function oAuthCredentialAuthorize() {
 	let url;
 
+	credentialsStore.pendingOAuthRefresh = true;
 	const credential = await saveCredential();
 	if (!credential) {
 		return;

--- a/packages/frontend/editor-ui/src/features/credentials/credentials.store.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/credentials.store.ts
@@ -44,6 +44,8 @@ export const useCredentialsStore = defineStore(STORES.CREDENTIALS, () => {
 	type CredentialTestStatus = 'pending' | 'success' | 'error';
 	const credentialTestResults = ref(new Map<string, CredentialTestStatus>());
 
+	const pendingOAuthRefresh = ref(false);
+
 	const isCredentialTestedOk = (id: string): boolean => {
 		return credentialTestResults.value.get(id) === 'success';
 	};
@@ -520,6 +522,7 @@ export const useCredentialsStore = defineStore(STORES.CREDENTIALS, () => {
 		getCredentialTranslation,
 		setCredentialSharedWith,
 		claimFreeAiCredits,
+		pendingOAuthRefresh,
 	};
 });
 

--- a/packages/frontend/editor-ui/src/features/credentials/views/CredentialsView.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/views/CredentialsView.vue
@@ -145,6 +145,13 @@ listenForModalChanges({
 		if ([CREDENTIAL_SELECT_MODAL_KEY, CREDENTIAL_EDIT_MODAL_KEY].includes(modalName as string)) {
 			void router.replace({ params: { credentialId: '' }, query: route.query });
 		}
+		if (modalName === CREDENTIAL_EDIT_MODAL_KEY) {
+			void credentialsStore.fetchAllCredentials({
+				projectId: route?.params?.projectId as string | undefined,
+				includeScopes: true,
+				externalSecretsStore: filters.value.externalSecretsStore,
+			});
+		}
 	},
 });
 

--- a/packages/frontend/editor-ui/src/features/credentials/views/CredentialsView.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/views/CredentialsView.vue
@@ -145,7 +145,8 @@ listenForModalChanges({
 		if ([CREDENTIAL_SELECT_MODAL_KEY, CREDENTIAL_EDIT_MODAL_KEY].includes(modalName as string)) {
 			void router.replace({ params: { credentialId: '' }, query: route.query });
 		}
-		if (modalName === CREDENTIAL_EDIT_MODAL_KEY) {
+		if (modalName === CREDENTIAL_EDIT_MODAL_KEY && credentialsStore.pendingOAuthRefresh) {
+			credentialsStore.pendingOAuthRefresh = false;
 			void credentialsStore.fetchAllCredentials({
 				projectId: route?.params?.projectId as string | undefined,
 				includeScopes: true,


### PR DESCRIPTION
## Summary

When setting up an OAuth2 credential (e.g. Slack), the credential card in the list would continue to show the "Needs first setup" warning badge immediately after closing the modal, even though the OAuth flow had completed successfully. A page refresh would clear the badge correctly, confirming this was a stale state issue rather than a real setup problem.

**Root cause:** The credential list performs a `fetchAllCredentials` via a `$onAction` listener when `saveCredential()` is called — but this happens *before* the OAuth popup opens. By the time the user completes the OAuth flow in the popup and closes the modal, the list holds pre-OAuth data from that earlier fetch, with no mechanism to re-sync.

**Fix:** A `pendingOAuthRefresh` flag is added to the credentials store and set to `true` when the OAuth connect flow is initiated in `CredentialEdit`. When the credential edit modal closes, `CredentialsView` checks this flag and only triggers a `fetchAllCredentials` if it is set (resetting it immediately after). This ensures:

- The credential list reflects the post-OAuth server state when the modal closes.
- Regular (non-OAuth) credential saves are unaffected — they continue to use the existing single `$onAction` refetch with no extra calls.

**To test:**

1. Go to **Credentials** and create a new Slack OAuth2 credential (or any OAuth2 type).
2. Complete the OAuth flow in the popup.
3. Close the modal.
4. Verify the credential card no longer shows "Needs first setup".

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-602

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
