### PR TITLE
fix(core): Detect conflicting webhook endpoint paths at startup

### DIFF
--- a/packages/@n8n/config/src/configs/endpoints.config.ts
+++ b/packages/@n8n/config/src/configs/endpoints.config.ts
@@ -157,3 +157,49 @@ export class EndpointsConfig {
 	)
 	health: string = '/healthz';
 }
+
+/**
+ * Validates that no webhook-style endpoint is a path-segment prefix of another.
+ *
+ * The form/webhook/mcp/waiting routes are registered with greedy `*path` (or
+ * multi-segment) Express patterns, and Express dispatches in registration
+ * order. If one endpoint value equals or path-segment-prefixes another, the
+ * earlier-registered route silently swallows the later one's traffic.
+ */
+export function validateEndpointPaths(endpoints: EndpointsConfig): void {
+	const routes = [
+		{ envVar: 'N8N_ENDPOINT_FORM', value: endpoints.form },
+		{ envVar: 'N8N_ENDPOINT_WEBHOOK', value: endpoints.webhook },
+		{ envVar: 'N8N_ENDPOINT_FORM_WAIT', value: endpoints.formWaiting },
+		{ envVar: 'N8N_ENDPOINT_WEBHOOK_WAIT', value: endpoints.webhookWaiting },
+		{ envVar: 'N8N_ENDPOINT_MCP', value: endpoints.mcp },
+		{ envVar: 'N8N_ENDPOINT_FORM_TEST', value: endpoints.formTest },
+		{ envVar: 'N8N_ENDPOINT_WEBHOOK_TEST', value: endpoints.webhookTest },
+		{ envVar: 'N8N_ENDPOINT_MCP_TEST', value: endpoints.mcpTest },
+	];
+
+	const isSegmentPrefixOrEqual = (a: string, b: string): boolean =>
+		a === b || b.startsWith(`${a}/`);
+
+	const conflicts: string[] = [];
+	for (let i = 0; i < routes.length; i++) {
+		for (let j = i + 1; j < routes.length; j++) {
+			const a = routes[i];
+			const b = routes[j];
+			if (isSegmentPrefixOrEqual(a.value, b.value)) {
+				conflicts.push(`${a.envVar}="${a.value}" shadows ${b.envVar}="${b.value}"`);
+			} else if (isSegmentPrefixOrEqual(b.value, a.value)) {
+				conflicts.push(`${b.envVar}="${b.value}" shadows ${a.envVar}="${a.value}"`);
+			}
+		}
+	}
+
+	if (conflicts.length > 0) {
+		throw new Error(
+			'Conflicting webhook endpoint configuration: one or more endpoint env vars share a leading path segment with another, ' +
+				"which causes the earlier-registered route to swallow the other's traffic.\n" +
+				conflicts.map((c) => `  - ${c}`).join('\n') +
+				"\nSet values that don't share a leading path segment.",
+		);
+	}
+}

--- a/packages/@n8n/config/src/configs/endpoints.config.ts
+++ b/packages/@n8n/config/src/configs/endpoints.config.ts
@@ -165,6 +165,8 @@ export class EndpointsConfig {
  * multi-segment) Express patterns, and Express dispatches in registration
  * order. If one endpoint value equals or path-segment-prefixes another, the
  * earlier-registered route silently swallows the later one's traffic.
+ *
+ * For example, `prefix` shadows `prefix/test`.
  */
 export function validateEndpointPaths(endpoints: EndpointsConfig): void {
 	const routes = [

--- a/packages/@n8n/config/src/index.ts
+++ b/packages/@n8n/config/src/index.ts
@@ -77,6 +77,7 @@ export { ChatTriggerConfig } from './configs/chat-trigger.config';
 export { InstanceAiConfig } from './configs/instance-ai.config';
 export { ExpressionEngineConfig } from './configs/expression-engine.config';
 export { PasswordConfig } from './configs/password.config';
+export { validateEndpointPaths } from './configs/endpoints.config';
 
 const protocolSchema = z.enum(['http', 'https']);
 

--- a/packages/@n8n/config/test/endpoints.config.test.ts
+++ b/packages/@n8n/config/test/endpoints.config.test.ts
@@ -1,0 +1,71 @@
+import { Container } from '@n8n/di';
+
+import { GlobalConfig, validateEndpointPaths } from '../src/index';
+
+describe('validateEndpointPaths', () => {
+	const baseEndpoints = () => {
+		Container.reset();
+		return Container.get(GlobalConfig).endpoints;
+	};
+
+	it('accepts the default configuration', () => {
+		const endpoints = baseEndpoints();
+
+		expect(() => validateEndpointPaths(endpoints)).not.toThrow();
+	});
+
+	it('rejects when a test endpoint is path-segment-prefixed by the production endpoint', () => {
+		const endpoints = baseEndpoints();
+		endpoints.webhook = 'Aegie7beasha1aighoh4Ihi4ekoh1yee';
+		endpoints.webhookTest = 'Aegie7beasha1aighoh4Ihi4ekoh1yee/test';
+
+		expect(() => validateEndpointPaths(endpoints)).toThrow(
+			/N8N_ENDPOINT_WEBHOOK="Aegie7beasha1aighoh4Ihi4ekoh1yee" shadows N8N_ENDPOINT_WEBHOOK_TEST="Aegie7beasha1aighoh4Ihi4ekoh1yee\/test"/,
+		);
+	});
+
+	it('rejects when two endpoints have the same value', () => {
+		const endpoints = baseEndpoints();
+		endpoints.webhook = 'shared';
+		endpoints.form = 'shared';
+
+		expect(() => validateEndpointPaths(endpoints)).toThrow(/shadows/);
+	});
+
+	it('reports all conflicts together', () => {
+		const endpoints = baseEndpoints();
+		endpoints.webhook = 'wh';
+		endpoints.webhookTest = 'wh/test';
+		endpoints.webhookWaiting = 'wh/wait';
+
+		const error = (() => {
+			try {
+				validateEndpointPaths(endpoints);
+				return null;
+			} catch (e) {
+				return e as Error;
+			}
+		})();
+
+		expect(error).not.toBeNull();
+		expect(error?.message).toContain('N8N_ENDPOINT_WEBHOOK_TEST');
+		expect(error?.message).toContain('N8N_ENDPOINT_WEBHOOK_WAIT');
+	});
+
+	it('does not flag values that share a prefix substring but not a path segment', () => {
+		const endpoints = baseEndpoints();
+		endpoints.webhook = 'webhook';
+		endpoints.webhookTest = 'webhook-test';
+		endpoints.webhookWaiting = 'webhook-waiting';
+
+		expect(() => validateEndpointPaths(endpoints)).not.toThrow();
+	});
+
+	it('allows multi-segment values when no value is a path-segment prefix of another', () => {
+		const endpoints = baseEndpoints();
+		endpoints.webhook = 'a/prod';
+		endpoints.webhookTest = 'a/test';
+
+		expect(() => validateEndpointPaths(endpoints)).not.toThrow();
+	});
+});

--- a/packages/cli/src/abstract-server.ts
+++ b/packages/cli/src/abstract-server.ts
@@ -1,5 +1,5 @@
 import { inTest, inDevelopment, Logger } from '@n8n/backend-common';
-import { GlobalConfig } from '@n8n/config';
+import { GlobalConfig, validateEndpointPaths } from '@n8n/config';
 import { DbConnection } from '@n8n/db';
 import { OnShutdown } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
@@ -82,6 +82,7 @@ export abstract class AbstractServer {
 		this.sslCert = this.globalConfig.ssl_cert;
 
 		const { endpoints } = this.globalConfig;
+		validateEndpointPaths(endpoints);
 		this.restEndpoint = endpoints.rest;
 
 		this.endpointForm = endpoints.form;


### PR DESCRIPTION
## Summary

Fail-fast validation for the `N8N_ENDPOINT_*` env vars used to register webhook-style routes. Throws a clear startup error when one endpoint value is equal to or a path-segment prefix of another, naming the offending env vars.

The form/webhook/mcp/waiting routes are registered on Express with greedy `*path` (or multi-segment) patterns, and Express dispatches in registration order. When one endpoint value path-segment-prefixes another, the earlier-registered route silently swallows the later one's traffic — producing confusing 404s with no warning at boot. The customer report in the linked ticket hit this with `N8N_ENDPOINT_WEBHOOK="…/yee"` and `N8N_ENDPOINT_WEBHOOK_TEST="…/yee/test"`: test-webhook URLs were being routed to the production handler, which then 404'd because the production handler couldn't find a webhook at the (test-webhook) path.

The validator runs once in `AbstractServer`'s constructor before any routes are registered. Default configuration still passes (e.g. `webhook` vs `webhook-test` is fine — no shared path segment). Multi-segment values are still allowed as long as they don't collide (e.g. `a/prod` + `a/test` passes).

### How to test

```bash
N8N_ENDPOINT_WEBHOOK="prefix" \
N8N_ENDPOINT_WEBHOOK_TEST="prefix/test" \
pnpm --filter n8n start
```

Should error at startup with a message naming both env vars. Removing either var (or making them not share a leading segment) lets startup proceed.

Unit tests in `packages/@n8n/config/test/endpoints.config.test.ts` cover the default config, prefix-shadow, equal values, multiple conflicts reported together, prefix-substring (not segment) false-positives, and multi-segment values that don't collide.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2836

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI