### PR TITLE
Ignore peer dependency catalog ranges in code health

### DIFF
--- a/packages/testing/code-health/src/rules/catalog-violations.rule.test.ts
+++ b/packages/testing/code-health/src/rules/catalog-violations.rule.test.ts
@@ -97,6 +97,36 @@ catalogs:
 		expect(violations[0].message).toContain('"catalog:frontend"');
 	});
 
+	it('ignores peer dependency ranges that are also available in the catalog', async () => {
+		writeFile(
+			tmpDir,
+			'pnpm-workspace.yaml',
+			`
+packages:
+  - packages/*
+catalog:
+  ts-morph: ^27.0.0
+`,
+		);
+		writeFile(
+			tmpDir,
+			'packages/janitor/package.json',
+			JSON.stringify(
+				{
+					name: 'janitor',
+					peerDependencies: { 'ts-morph': '>=20.0.0' },
+					devDependencies: { 'ts-morph': 'catalog:' },
+				},
+				null,
+				2,
+			),
+		);
+
+		const violations = await rule.analyze(context());
+
+		expect(violations).toHaveLength(0);
+	});
+
 	it('ignores deps that already use catalog reference', async () => {
 		writeFile(
 			tmpDir,

--- a/packages/testing/code-health/src/rules/catalog-violations.rule.ts
+++ b/packages/testing/code-health/src/rules/catalog-violations.rule.ts
@@ -46,6 +46,7 @@ export class CatalogViolationsRule extends BaseRule<CodeHealthContext> {
 
 		for (const pkgInfo of packages) {
 			for (const dep of pkgInfo.deps) {
+				if (dep.section === 'peerDependencies') continue;
 				if (dep.usesCatalog || dep.version.startsWith('workspace:')) continue;
 
 				const catalogMatch = findInCatalog(catalogData, dep.name);
@@ -78,6 +79,7 @@ export class CatalogViolationsRule extends BaseRule<CodeHealthContext> {
 
 		for (const pkgInfo of packages) {
 			for (const dep of pkgInfo.deps) {
+				if (dep.section === 'peerDependencies') continue;
 				if (dep.usesCatalog || dep.version.startsWith('workspace:')) continue;
 				if (findInCatalog(catalogData, dep.name).found) continue;
 


### PR DESCRIPTION
## Summary

- Skip `peerDependencies` when enforcing pnpm catalog references in the code-health catalog rule
- Add a regression test for a peer range that is intentionally different from the cataloged dev dependency
- Remove the stale `ts-morph` peer-dependency entry from the code-health baseline

Peer dependency ranges describe compatibility with a host package, so they should not be forced to use `catalog:` the same way install-time dependencies are.

## Tests

- `pnpm --filter @n8n/code-health test -- catalog-violations.rule.test.ts`
- `pnpm --filter @n8n/code-health format:check`
- `pnpm --filter @n8n/code-health lint`
- `pnpm --filter @n8n/code-health typecheck`
