### PR TITLE
fix(editor): Preserve Form Trigger custom path on import and duplication

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -4629,7 +4629,7 @@ describe('useCanvasOperations', () => {
 						position: [200, 200] as [number, number],
 						webhookId: 'first-webhook',
 						parameters: {
-							path: 'some-path',
+							path: 'first-webhook',
 						},
 					},
 					{
@@ -4641,7 +4641,7 @@ describe('useCanvasOperations', () => {
 						webhookId: 'second-webhook',
 						parameters: {
 							options: {
-								path: 'some-path',
+								path: 'second-webhook',
 							},
 						},
 					},
@@ -4658,17 +4658,72 @@ describe('useCanvasOperations', () => {
 
 				const canvasOperations = useCanvasOperations();
 
-				// This should not throw even when nodes can't be added due to maxNodes limit
 				const workflow = await canvasOperations.importWorkflowData(workflowDataToImport, 'paste');
 
 				expect(workflow.nodes).toHaveLength(2);
 				expect(workflow.nodes![0].name).toBe('Execute Workflow Trigger 1');
 				expect(workflow.nodes![0].webhookId).not.toBe('first-webhook');
-				expect(workflow.nodes![0].parameters.path).not.toBe('some-path');
+				expect(workflow.nodes![0].parameters.path).toBe(workflow.nodes![0].webhookId);
 				expect(workflow.nodes![1].name).toBe('Execute Workflow Trigger 2');
 				expect(workflow.nodes![1].webhookId).not.toBe('second-webhook');
-				expect((workflow.nodes![1].parameters.options as { path: string }).path).not.toBe(
-					'some-path',
+				expect((workflow.nodes![1].parameters.options as { path: string }).path).toBe(
+					workflow.nodes![1].webhookId,
+				);
+			},
+		);
+
+		it.each(UPDATE_WEBHOOK_ID_NODE_TYPES)(
+			'should preserve custom paths for node type "%s" on pasting into canvas',
+			async (type) => {
+				vi.mocked(workflowDocumentStoreInstance.createWorkflowObject).mockReturnValue({
+					nodes: {},
+					connections: {},
+					connectionsBySourceNode: {},
+					renameNode: vi.fn(),
+				} as unknown as Workflow);
+
+				const nodesToImport = [
+					{
+						id: 'import-1',
+						name: 'Execute Workflow Trigger 1',
+						type,
+						typeVersion: 1,
+						position: [200, 200] as [number, number],
+						webhookId: 'first-webhook',
+						parameters: {
+							path: 'custom-path-1',
+						},
+					},
+					{
+						id: 'import-2',
+						name: 'Execute Workflow Trigger 2',
+						type,
+						typeVersion: 1,
+						position: [300, 300] as [number, number],
+						webhookId: 'second-webhook',
+						parameters: {
+							options: {
+								path: 'custom-path-2',
+							},
+						},
+					},
+				];
+
+				const workflowDataToImport = {
+					nodes: nodesToImport,
+					connections: {},
+				};
+
+				const canvasOperations = useCanvasOperations();
+
+				const workflow = await canvasOperations.importWorkflowData(workflowDataToImport, 'paste');
+
+				expect(workflow.nodes).toHaveLength(2);
+				expect(workflow.nodes![0].webhookId).not.toBe('first-webhook');
+				expect(workflow.nodes![0].parameters.path).toBe('custom-path-1');
+				expect(workflow.nodes![1].webhookId).not.toBe('second-webhook');
+				expect((workflow.nodes![1].parameters.options as { path: string }).path).toBe(
+					'custom-path-2',
 				);
 			},
 		);

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -4640,6 +4640,7 @@ describe('useCanvasOperations', () => {
 						position: [300, 300] as [number, number],
 						webhookId: 'second-webhook',
 						parameters: {
+							path: 'second-webhook',
 							options: {
 								path: 'second-webhook',
 							},
@@ -4666,6 +4667,7 @@ describe('useCanvasOperations', () => {
 				expect(workflow.nodes![0].parameters.path).toBe(workflow.nodes![0].webhookId);
 				expect(workflow.nodes![1].name).toBe('Execute Workflow Trigger 2');
 				expect(workflow.nodes![1].webhookId).not.toBe('second-webhook');
+				expect(workflow.nodes![1].parameters.path).toBe(workflow.nodes![1].webhookId);
 				expect((workflow.nodes![1].parameters.options as { path: string }).path).toBe(
 					workflow.nodes![1].webhookId,
 				);

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -1510,7 +1510,8 @@ export function useCanvasOperations() {
 		// if it's a webhook and the path is empty set the UUID as the default path
 		if (
 			[WEBHOOK_NODE_TYPE, FORM_TRIGGER_NODE_TYPE, MCP_TRIGGER_NODE_TYPE].includes(node.type) &&
-			node.parameters.path === ''
+			node.parameters.path === '' &&
+			!(node.parameters.options as IDataObject)?.path
 		) {
 			node.parameters.path = node.webhookId as string;
 		}
@@ -2638,14 +2639,13 @@ export function useCanvasOperations() {
 
 					// Generate new webhookId
 					if (node.webhookId && UPDATE_WEBHOOK_ID_NODE_TYPES.includes(node.type)) {
-						if (node.webhookId) {
-							nodeHelpers.assignWebhookId(node);
+						const oldWebhookId = node.webhookId;
+						nodeHelpers.assignWebhookId(node);
 
-							if (node.parameters.path) {
-								node.parameters.path = node.webhookId;
-							} else if ((node.parameters.options as IDataObject)?.path) {
-								(node.parameters.options as IDataObject).path = node.webhookId;
-							}
+						if (node.parameters.path === oldWebhookId) {
+							node.parameters.path = node.webhookId;
+						} else if ((node.parameters.options as IDataObject)?.path === oldWebhookId) {
+							(node.parameters.options as IDataObject).path = node.webhookId;
 						}
 					}
 

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -2644,7 +2644,9 @@ export function useCanvasOperations() {
 
 						if (node.parameters.path === oldWebhookId) {
 							node.parameters.path = node.webhookId;
-						} else if ((node.parameters.options as IDataObject)?.path === oldWebhookId) {
+						}
+
+						if ((node.parameters.options as IDataObject)?.path === oldWebhookId) {
 							(node.parameters.options as IDataObject).path = node.webhookId;
 						}
 					}


### PR DESCRIPTION
Previously, custom webhook paths in Form Trigger nodes (v2.2+) were overwritten by randomly generated UUIDs during workflow import, node duplication, or canvas initialization. This occurred because the editor-ui was unconditionally regenerating the path parameter for specific node types.

This change:
- Updates `importWorkflowData` to only regenerate the path if it matches the old `webhookId` (the default behavior).
- Updates `resolveNodeWebhook` to respect an existing `options.path` before falling back to a default `webhookId`.
- Updates and adds tests in `useCanvasOperations.test.ts` to ensure custom paths are preserved while default behavior is maintained.


##Tests
Added regression test covering Form Trigger custom formPath persistence during import/duplication.

Fixes #29596 
