### PR TITLE
refactor(editor): Replace el-dialog with N8nDialog in Modal component (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nDialog/Dialog.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDialog/Dialog.vue
@@ -65,6 +65,18 @@ export interface DialogProps {
 	 */
 	ariaDescription?: string;
 	/**
+	 * Additional class applied to the dialog content element.
+	 */
+	contentClass?: unknown;
+	/**
+	 * Additional styles applied to the dialog content element.
+	 */
+	contentStyle?: unknown;
+	/**
+	 * Test id applied to the dialog content element.
+	 */
+	contentTestId?: string;
+	/**
 	 * Shorthand for rendering a dialog header with a title.
 	 * Alternative to using N8nDialogHeader and N8nDialogTitle as children.
 	 */
@@ -116,6 +128,9 @@ const handleOpenChange = (value: boolean) => {
 				:show-close-button="showCloseButton"
 				:aria-label="ariaLabel"
 				:aria-description="ariaDescription"
+				:class="contentClass"
+				:style="contentStyle"
+				:data-test-id="contentTestId"
 				@escape-key-down="emit('escapeKeyDown', $event)"
 				@interact-outside="emit('interactOutside', $event)"
 				@open-auto-focus="emit('openAutoFocus', $event)"

--- a/packages/frontend/@n8n/design-system/src/components/N8nDialog/DialogContent.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDialog/DialogContent.vue
@@ -57,7 +57,7 @@ export interface DialogContentEmits {
 }
 
 const props = withDefaults(defineProps<DialogContentProps>(), {
-	size: 'medium',
+	size: 'large',
 	trapFocus: true,
 	disableOutsidePointerEvents: true,
 	showCloseButton: true,
@@ -156,7 +156,7 @@ function handleInteractOutside(e: Event) {
 	top: 50%;
 	left: 50%;
 	transform: translate(-50%, -50%);
-	width: 100%;
+	width: var(--dialog--width, 100%);
 	padding: var(--spacing--lg);
 	border-radius: var(--radius--lg);
 	background-color: light-dark(var(--color--neutral-white), var(--color--neutral-800));
@@ -185,7 +185,7 @@ function handleInteractOutside(e: Event) {
 .small {
 	--dialog--max-width: calc(100dvw - var(--spacing--lg));
 
-	@media (min-width: 640px) {
+	@media (min-width: 768px) {
 		--dialog--max-width: 360px;
 	}
 }
@@ -193,7 +193,7 @@ function handleInteractOutside(e: Event) {
 .medium {
 	--dialog--max-width: calc(100dvw - var(--spacing--lg));
 
-	@media (min-width: 640px) {
+	@media (min-width: 768px) {
 		--dialog--max-width: 480px;
 	}
 }
@@ -201,7 +201,7 @@ function handleInteractOutside(e: Event) {
 .large {
 	--dialog--max-width: calc(100dvw - var(--spacing--lg));
 
-	@media (min-width: 640px) {
+	@media (min-width: 768px) {
 		--dialog--max-width: 564px;
 	}
 }
@@ -209,15 +209,15 @@ function handleInteractOutside(e: Event) {
 .xlarge {
 	--dialog--max-width: calc(100dvw - var(--spacing--lg));
 
-	@media (min-width: 640px) {
-		--dialog--max-width: 640px;
+	@media (min-width: 768px) {
+		--dialog--max-width: 768px;
 	}
 }
 
 .\32xlarge {
 	--dialog--max-width: calc(100dvw - var(--spacing--lg));
 
-	@media (min-width: 640px) {
+	@media (min-width: 768px) {
 		--dialog--max-width: 780px;
 	}
 }

--- a/packages/frontend/editor-ui/src/app/components/Modal.vue
+++ b/packages/frontend/editor-ui/src/app/components/Modal.vue
@@ -38,6 +38,7 @@ const props = withDefaults(
 		closeOnPressEscape?: boolean;
 		appendToBody?: boolean;
 		lockScroll?: boolean;
+		modal?: boolean;
 	}>(),
 	{
 		title: '',
@@ -54,6 +55,7 @@ const props = withDefaults(
 		closeOnPressEscape: true,
 		appendToBody: false,
 		lockScroll: true,
+		modal: true,
 	},
 );
 
@@ -162,7 +164,7 @@ function onInteractOutside(event: Event) {
 <template>
 	<N8nDialog
 		:open="uiStore.modalsById[name]?.open"
-		:modal="lockScroll"
+		:modal="modal"
 		:disable-outside-pointer-events="closeOnClickModal"
 		:show-close-button="showClose"
 		:content-test-id="`${name}-modal`"
@@ -173,7 +175,7 @@ function onInteractOutside(event: Event) {
 			[getCustomClass()]: true,
 		}"
 		:content-style="styles"
-		:aria-label="title || name"
+		:aria-label="$slots.header || title ? undefined : name"
 		:aria-description="subtitle"
 		@update:open="onUpdateOpen"
 		@escape-key-down="onEscapeKeyDown"

--- a/packages/frontend/editor-ui/src/app/components/Modal.vue
+++ b/packages/frontend/editor-ui/src/app/components/Modal.vue
@@ -3,11 +3,18 @@ import { computed, onMounted, onBeforeUnmount } from 'vue';
 import type { EventBus } from '@n8n/utils/event-bus';
 import { useUIStore } from '@/app/stores/ui.store';
 import type { ModalKey } from '@/Interface';
-import { APP_MODALS_ELEMENT_ID } from '@/app/constants';
 import { useStyles } from '@/app/composables/useStyles';
 
-import { ElDialog } from 'element-plus';
-import { N8nHeading, N8nSpinner } from '@n8n/design-system';
+import {
+	N8nDialog,
+	N8nDialogContent,
+	N8nDialogDescription,
+	N8nDialogFooter,
+	N8nDialogHeader,
+	N8nDialogTitle,
+	N8nHeading,
+	N8nSpinner,
+} from '@n8n/design-system';
 const props = withDefaults(
 	defineProps<{
 		name: ModalKey;
@@ -57,26 +64,27 @@ const emit = defineEmits<{ enter: [] }>();
 const { APP_Z_INDEXES } = useStyles();
 
 const styles = computed(() => {
-	const styles: { [prop: string]: string } = {};
+	const modalStyles: { [prop: string]: string } = {};
+	if (props.width) {
+		modalStyles['--dialog--width'] = props.width;
+	}
 	if (props.height) {
-		styles['--dialog--height'] = props.height;
+		modalStyles['--dialog--height'] = props.height;
 	}
 	if (props.minHeight) {
-		styles['--dialog--min-height'] = props.minHeight;
+		modalStyles['--dialog--min-height'] = props.minHeight;
 	}
 	if (props.maxHeight) {
-		styles['--dialog--max-height'] = props.maxHeight;
+		modalStyles['--dialog--max-height'] = props.maxHeight;
 	}
 	if (props.maxWidth) {
-		styles['--dialog--max-width'] = props.maxWidth;
+		modalStyles['--dialog--max-width'] = props.maxWidth;
 	}
 	if (props.minWidth) {
-		styles['--dialog--min-width'] = props.minWidth;
+		modalStyles['--dialog--min-width'] = props.minWidth;
 	}
-	return styles;
+	return modalStyles;
 });
-
-const appModalsId = `#${APP_MODALS_ELEMENT_ID}`;
 
 onMounted(() => {
 	window.addEventListener('keydown', onWindowKeydown);
@@ -100,21 +108,17 @@ function handleEnter() {
 }
 
 function onOpened() {
-	// Triggers when the Dialog opening animation ends.
-	// This can be helpful at positioning dropdowns etc correctly,
-	// as the dialog doesn't now move anymore at this point.
 	props.eventBus?.emit('opened');
 }
 
 function onWindowKeydown(event: KeyboardEvent) {
-	if (event?.keyCode === 13) handleEnter();
+	if (event?.key === 'Enter') handleEnter();
 }
 
 async function closeDialog(returnData?: unknown) {
 	if (props.beforeClose) {
 		const shouldClose = await props.beforeClose();
 		if (shouldClose === false) {
-			// must be strictly false to stop modal from closing
 			return;
 		}
 	}
@@ -135,79 +139,93 @@ function getCustomClass() {
 
 	return classes;
 }
+
+async function onUpdateOpen(isOpen: boolean) {
+	if (isOpen) {
+		onOpened();
+		return;
+	}
+
+	await onCloseDialog();
+}
+
+function onEscapeKeyDown(event: KeyboardEvent) {
+	if (!props.closeOnPressEscape) {
+		event.preventDefault();
+	}
+}
+
+function onInteractOutside(event: Event) {
+	if (!props.closeOnClickModal) {
+		event.preventDefault();
+	}
+}
 </script>
 
 <template>
-	<ElDialog
-		:model-value="uiStore.modalsById[name]?.open"
-		:before-close="onCloseDialog"
-		:class="{
-			'dialog-wrapper': true,
-			scrollable: scrollable,
-			[getCustomClass()]: true,
-		}"
-		:center="center"
-		:width="width"
-		:show-close="showClose"
-		:close-on-click-modal="closeOnClickModal"
-		:close-on-press-escape="closeOnPressEscape"
-		:style="styles"
-		:append-to="appendToBody ? undefined : appModalsId"
-		:lock-scroll="lockScroll"
-		:append-to-body="appendToBody"
-		:data-test-id="`${name}-modal`"
-		:modal-class="center ? $style.center : ''"
-		:z-index="APP_Z_INDEXES.MODALS"
-		@opened="onOpened"
+	<N8nDialog
+		:open="uiStore.modalsById[name]?.open"
+		:modal="lockScroll"
+		:disable-outside-pointer-events="closeOnClickModal"
+		:show-close-button="showClose"
+		@update:open="onUpdateOpen"
+		@escape-key-down="onEscapeKeyDown"
+		@interact-outside="onInteractOutside"
 	>
-		<template v-if="$slots.header" #header>
-			<slot v-if="!loading" name="header" v-bind="{ closeDialog }" />
-		</template>
-		<template v-else-if="title" #title>
-			<div :class="centerTitle ? $style.centerTitle : ''">
-				<div v-if="title">
-					<N8nHeading tag="h1" size="xlarge">{{ title }}</N8nHeading>
-				</div>
-				<div v-if="subtitle" :class="$style.subtitle">
-					<N8nHeading tag="h3" size="small" color="text-light">{{ subtitle }}</N8nHeading>
-				</div>
-			</div>
-		</template>
-		<div
-			class="modal-content"
-			@keydown.stop
-			@keydown.enter="handleEnter"
-			@keydown.esc="onCloseDialog"
+		<N8nDialogContent
+			:data-test-id="`${name}-modal`"
+			:class="{
+				'dialog-wrapper': true,
+				scrollable: scrollable,
+				centered: center,
+				[getCustomClass()]: true,
+			}"
+			:style="styles"
+			:z-index="APP_Z_INDEXES.MODALS"
 		>
-			<slot v-if="!loading" name="content" />
-			<div v-else :class="$style.loader">
-				<N8nSpinner />
+			<template v-if="$slots.header">
+				<slot v-if="!loading" name="header" v-bind="{ closeDialog }" />
+			</template>
+			<N8nDialogHeader v-else-if="title">
+				<div :class="centerTitle ? $style.centerTitle : ''">
+					<div v-if="title">
+						<N8nDialogTitle>
+							<N8nHeading tag="h1" size="xlarge">{{ title }}</N8nHeading>
+						</N8nDialogTitle>
+					</div>
+					<N8nDialogDescription v-if="subtitle" :class="$style.subtitle">
+						<N8nHeading tag="h3" size="small" color="text-light">{{ subtitle }}</N8nHeading>
+					</N8nDialogDescription>
+				</div>
+			</N8nDialogHeader>
+			<div
+				class="modal-content"
+				@keydown.stop
+				@keydown.enter="handleEnter"
+				@keydown.esc="onCloseDialog"
+			>
+				<slot v-if="!loading" name="content" />
+				<div v-else :class="$style.loader">
+					<N8nSpinner />
+				</div>
 			</div>
-		</div>
-		<div v-if="!loading && $slots.footer" :class="$style.footer">
-			<slot name="footer" :close="closeDialog" />
-		</div>
-	</ElDialog>
+			<N8nDialogFooter v-if="!loading && $slots.footer" :class="$style.footer">
+				<slot name="footer" :close="closeDialog" />
+			</N8nDialogFooter>
+		</N8nDialogContent>
+	</N8nDialog>
 </template>
 
 <style lang="scss">
 .dialog-wrapper {
-	&.el-dialog {
-		display: flex;
-		flex-direction: column;
-		max-width: var(--dialog--max-width, 80%);
-		min-width: var(--dialog--min-width, 420px);
-		height: var(--dialog--height);
-		min-height: var(--dialog--min-height);
-		max-height: var(--dialog--max-height);
-	}
-
-	.el-dialog__body {
-		overflow: hidden;
-		display: flex;
-		flex-direction: column;
-		flex-grow: 1;
-	}
+	max-width: var(--dialog--max-width, 80%);
+	min-width: var(--dialog--min-width, 420px);
+	width: var(--dialog--width);
+	height: var(--dialog--height);
+	min-height: var(--dialog--min-height);
+	max-height: var(--dialog--max-height);
+	display: flex;
+	flex-direction: column;
 
 	.modal-content {
 		overflow: hidden;
@@ -220,14 +238,14 @@ function getCustomClass() {
 	&.scrollable .modal-content {
 		overflow-y: auto;
 	}
+
+	&.centered {
+		margin-inline: auto;
+	}
 }
 </style>
 
 <style lang="scss" module>
-.center > div {
-	justify-content: center;
-}
-
 .loader {
 	display: flex;
 	align-items: center;

--- a/packages/frontend/editor-ui/src/app/components/Modal.vue
+++ b/packages/frontend/editor-ui/src/app/components/Modal.vue
@@ -3,11 +3,9 @@ import { computed, onMounted, onBeforeUnmount } from 'vue';
 import type { EventBus } from '@n8n/utils/event-bus';
 import { useUIStore } from '@/app/stores/ui.store';
 import type { ModalKey } from '@/Interface';
-import { useStyles } from '@/app/composables/useStyles';
 
 import {
 	N8nDialog,
-	N8nDialogContent,
 	N8nDialogDescription,
 	N8nDialogFooter,
 	N8nDialogHeader,
@@ -61,12 +59,11 @@ const props = withDefaults(
 
 const emit = defineEmits<{ enter: [] }>();
 
-const { APP_Z_INDEXES } = useStyles();
-
 const styles = computed(() => {
 	const modalStyles: { [prop: string]: string } = {};
 	if (props.width) {
 		modalStyles['--dialog--width'] = props.width;
+		modalStyles['--dialog--max-width'] = props.width;
 	}
 	if (props.height) {
 		modalStyles['--dialog--height'] = props.height;
@@ -168,51 +165,49 @@ function onInteractOutside(event: Event) {
 		:modal="lockScroll"
 		:disable-outside-pointer-events="closeOnClickModal"
 		:show-close-button="showClose"
+		:content-test-id="`${name}-modal`"
+		:content-class="{
+			'dialog-wrapper': true,
+			scrollable: scrollable,
+			centered: center,
+			[getCustomClass()]: true,
+		}"
+		:content-style="styles"
+		:aria-label="title || name"
+		:aria-description="subtitle"
 		@update:open="onUpdateOpen"
 		@escape-key-down="onEscapeKeyDown"
 		@interact-outside="onInteractOutside"
 	>
-		<N8nDialogContent
-			:data-test-id="`${name}-modal`"
-			:class="{
-				'dialog-wrapper': true,
-				scrollable: scrollable,
-				centered: center,
-				[getCustomClass()]: true,
-			}"
-			:style="styles"
-			:z-index="APP_Z_INDEXES.MODALS"
-		>
-			<template v-if="$slots.header">
-				<slot v-if="!loading" name="header" v-bind="{ closeDialog }" />
-			</template>
-			<N8nDialogHeader v-else-if="title">
-				<div :class="centerTitle ? $style.centerTitle : ''">
-					<div v-if="title">
-						<N8nDialogTitle>
-							<N8nHeading tag="h1" size="xlarge">{{ title }}</N8nHeading>
-						</N8nDialogTitle>
-					</div>
-					<N8nDialogDescription v-if="subtitle" :class="$style.subtitle">
-						<N8nHeading tag="h3" size="small" color="text-light">{{ subtitle }}</N8nHeading>
-					</N8nDialogDescription>
+		<template v-if="$slots.header">
+			<slot v-if="!loading" name="header" v-bind="{ closeDialog }" />
+		</template>
+		<N8nDialogHeader v-else-if="title">
+			<div :class="centerTitle ? $style.centerTitle : ''">
+				<div v-if="title">
+					<N8nDialogTitle>
+						<N8nHeading tag="h1" size="xlarge">{{ title }}</N8nHeading>
+					</N8nDialogTitle>
 				</div>
-			</N8nDialogHeader>
-			<div
-				class="modal-content"
-				@keydown.stop
-				@keydown.enter="handleEnter"
-				@keydown.esc="onCloseDialog"
-			>
-				<slot v-if="!loading" name="content" />
-				<div v-else :class="$style.loader">
-					<N8nSpinner />
-				</div>
+				<N8nDialogDescription v-if="subtitle" :class="$style.subtitle">
+					<N8nHeading tag="h3" size="small" color="text-light">{{ subtitle }}</N8nHeading>
+				</N8nDialogDescription>
 			</div>
-			<N8nDialogFooter v-if="!loading && $slots.footer" :class="$style.footer">
-				<slot name="footer" :close="closeDialog" />
-			</N8nDialogFooter>
-		</N8nDialogContent>
+		</N8nDialogHeader>
+		<div
+			class="modal-content"
+			@keydown.stop
+			@keydown.enter="handleEnter"
+			@keydown.esc="onCloseDialog"
+		>
+			<slot v-if="!loading" name="content" />
+			<div v-else :class="$style.loader">
+				<N8nSpinner />
+			</div>
+		</div>
+		<N8nDialogFooter v-if="!loading && $slots.footer" :class="$style.footer">
+			<slot name="footer" :close="closeDialog" />
+		</N8nDialogFooter>
 	</N8nDialog>
 </template>
 
@@ -265,5 +260,11 @@ function onInteractOutside(event: Event) {
 
 .footer {
 	margin-top: var(--spacing--lg);
+	width: 100%;
+
+	/** If in it's own container, makes sure the footer takes all the available space and pushes the content to the top if needed */
+	> div:only-child {
+		flex: 1;
+	}
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/AgentEditorModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/AgentEditorModal.test.ts
@@ -9,7 +9,7 @@ import { usePostHog } from '@/app/stores/posthog.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { TOOLS_MANAGER_MODAL_KEY } from '@/features/ai/chatHub/constants';
 import AgentEditorModal from './AgentEditorModal.vue';
-import { waitFor, fireEvent, within } from '@testing-library/vue';
+import { cleanup, waitFor, fireEvent, within } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import { MODAL_CONFIRM } from '@/app/constants';
 import { ref } from 'vue';
@@ -112,35 +112,21 @@ const MOCK_AGENT_MODEL: ChatModelDto = {
 	groupIcon: null,
 };
 
-const ElDialogStub = {
+const ModalStub = {
 	template: `
 		<div role="dialog">
 			<slot name="header" />
+			<div v-if="loading" class="loader" />
+			<slot v-else name="content" />
+			<slot v-if="!loading" name="footer" />
 			<slot />
-			<slot name="footer" />
 		</div>
 	`,
-	props: [
-		'modelValue',
-		'beforeClose',
-		'class',
-		'center',
-		'width',
-		'showClose',
-		'closeOnClickModal',
-		'closeOnPressEscape',
-		'style',
-		'appendTo',
-		'lockScroll',
-		'appendToBody',
-		'dataTestId',
-		'modalClass',
-		'zIndex',
-	],
+	props: ['name', 'title', 'loading', 'width', 'showClose', 'customClass'],
 };
 
 const sharedStubs = {
-	ElDialog: ElDialogStub,
+	Modal: ModalStub,
 	ModelSelector: {
 		template: '<div data-test-id="model-selector" />',
 		props: [
@@ -194,6 +180,7 @@ describe('AgentEditorModal', () => {
 	let nodeTypesStore: ReturnType<typeof mockedStore<typeof useNodeTypesStore>>;
 
 	beforeEach(() => {
+		cleanup();
 		vi.clearAllMocks();
 
 		createTestingPinia({ stubActions: false });
@@ -235,10 +222,10 @@ describe('AgentEditorModal', () => {
 		});
 
 		it('should not show delete button', () => {
-			const { queryByText, container } = renderModal();
+			const { queryByText, baseElement } = renderModal();
 
 			// No delete button (only shown in edit mode)
-			const deleteButton = container.querySelector('.deleteButton');
+			const deleteButton = baseElement.querySelector('.deleteButton');
 			expect(deleteButton).toBeNull();
 			// But cancel and save are shown
 			expect(queryByText('chatHub.tools.editor.cancel')).toBeTruthy();
@@ -282,23 +269,25 @@ describe('AgentEditorModal', () => {
 		});
 
 		it('should show delete button', () => {
-			const { container } = renderModal({ agentId: 'agent-1' });
+			const { baseElement } = renderModal({ agentId: 'agent-1' });
 
-			const deleteButton = container.querySelector('.deleteButton');
+			const deleteButton = baseElement.querySelector('.deleteButton');
 			expect(deleteButton).toBeTruthy();
 		});
 
 		it('should populate form from existing agent', async () => {
-			const { container } = renderModal({ agentId: 'agent-1' });
+			const { baseElement } = renderModal({ agentId: 'agent-1' });
 
 			await waitFor(() => {
-				const nameInput = container.querySelector('#agent-name') as HTMLInputElement;
+				const nameInput = baseElement.querySelector('#agent-name') as HTMLInputElement;
 				expect(nameInput?.value).toBe('Test Agent');
 
-				const descInput = container.querySelector('#agent-description') as HTMLTextAreaElement;
+				const descInput = baseElement.querySelector('#agent-description') as HTMLTextAreaElement;
 				expect(descInput?.value).toBe('A test agent');
 
-				const promptInput = container.querySelector('#agent-system-prompt') as HTMLTextAreaElement;
+				const promptInput = baseElement.querySelector(
+					'#agent-system-prompt',
+				) as HTMLTextAreaElement;
 				expect(promptInput?.value).toBe('You are a helpful assistant');
 			});
 		});
@@ -383,12 +372,12 @@ describe('AgentEditorModal', () => {
 		it('should delete agent after confirmation', async () => {
 			mockConfirm.mockResolvedValue(MODAL_CONFIRM);
 
-			const { container } = renderModal({
+			const { baseElement } = renderModal({
 				agentId: 'agent-1',
 				credentials: { openai: 'cred-1' },
 			});
 
-			const deleteButton = container.querySelector('.deleteButton') as HTMLElement;
+			const deleteButton = baseElement.querySelector('.deleteButton') as HTMLElement;
 			await userEvent.click(deleteButton);
 
 			await waitFor(() => {
@@ -404,9 +393,9 @@ describe('AgentEditorModal', () => {
 		it('should not delete when confirmation is cancelled', async () => {
 			mockConfirm.mockResolvedValue('cancel');
 
-			const { container } = renderModal({ agentId: 'agent-1' });
+			const { baseElement } = renderModal({ agentId: 'agent-1' });
 
-			const deleteButton = container.querySelector('.deleteButton') as HTMLElement;
+			const deleteButton = baseElement.querySelector('.deleteButton') as HTMLElement;
 			await userEvent.click(deleteButton);
 
 			await waitFor(() => {
@@ -420,12 +409,12 @@ describe('AgentEditorModal', () => {
 			const error = new Error('Delete failed');
 			chatStore.deleteCustomAgent = vi.fn().mockRejectedValue(error);
 
-			const { container } = renderModal({
+			const { baseElement } = renderModal({
 				agentId: 'agent-1',
 				credentials: { openai: 'cred-1' },
 			});
 
-			const deleteButton = container.querySelector('.deleteButton') as HTMLElement;
+			const deleteButton = baseElement.querySelector('.deleteButton') as HTMLElement;
 			await userEvent.click(deleteButton);
 
 			await waitFor(() => {
@@ -443,10 +432,10 @@ describe('AgentEditorModal', () => {
 				customAgent: ref(undefined),
 			});
 
-			const { container, queryByText } = renderModal({ agentId: 'agent-1' });
+			const { baseElement, queryByText } = renderModal({ agentId: 'agent-1' });
 
 			// Spinner should be visible, form fields should not
-			expect(container.querySelector('.loader')).toBeTruthy();
+			expect(baseElement.querySelector('.loader')).toBeTruthy();
 			expect(queryByText('chatHub.agent.editor.name.label')).toBeNull();
 		});
 	});
@@ -474,7 +463,7 @@ describe('AgentEditorModal', () => {
 				},
 				global: {
 					stubs: {
-						ElDialog: ElDialogStub,
+						Modal: ModalStub,
 						ModelSelector: sharedStubs.ModelSelector,
 						N8nIconPicker: sharedStubs.N8nIconPicker,
 						NodeIcon: { template: '<div />' },
@@ -609,7 +598,7 @@ describe('AgentEditorModal', () => {
 		});
 
 		it('should call the upload endpoint once per chunk when multiple files exceed the chunk size', async () => {
-			const { container, getByRole, findByRole } = renderModal({
+			const { baseElement, getByRole, findByRole } = renderModal({
 				agentId: 'agent-1',
 				credentials: { openai: 'cred-1' },
 			});
@@ -622,7 +611,7 @@ describe('AgentEditorModal', () => {
 				new File(['ab'], 'doc3.pdf', { type: 'application/pdf' }),
 			];
 
-			const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+			const fileInput = baseElement.querySelector('input[type="file"]') as HTMLInputElement;
 
 			Object.defineProperty(fileInput, 'files', { value: files, configurable: true });
 

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ToolSettingsModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ToolSettingsModal.test.ts
@@ -5,7 +5,7 @@ import { mockedStore } from '@/__tests__/utils';
 import { useUIStore } from '@/app/stores/ui.store';
 import ToolSettingsModal from './ToolSettingsModal.vue';
 import type { INode } from 'n8n-workflow';
-import { waitFor } from '@testing-library/vue';
+import { cleanup, waitFor } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import { defineComponent, onMounted, ref } from 'vue';
 
@@ -72,35 +72,20 @@ function createToolSettingsStub(emitValid: boolean) {
 	});
 }
 
-const ElDialogStub = {
+const ModalStub = {
 	template: `
 		<div role="dialog">
 			<slot name="header" />
-			<slot />
+			<slot name="content" />
 			<slot name="footer" />
+			<slot />
 		</div>
 	`,
-	props: [
-		'modelValue',
-		'beforeClose',
-		'class',
-		'center',
-		'width',
-		'showClose',
-		'closeOnClickModal',
-		'closeOnPressEscape',
-		'style',
-		'appendTo',
-		'lockScroll',
-		'appendToBody',
-		'dataTestId',
-		'modalClass',
-		'zIndex',
-	],
+	props: ['name', 'title', 'loading', 'width', 'showClose', 'customClass'],
 };
 
 const sharedStubs = {
-	ElDialog: ElDialogStub,
+	Modal: ModalStub,
 	NodeIcon: { template: '<div />' },
 };
 
@@ -130,6 +115,7 @@ describe('ToolSettingsModal', () => {
 	let uiStore: ReturnType<typeof mockedStore<typeof useUIStore>>;
 
 	beforeEach(() => {
+		cleanup();
 		vi.clearAllMocks();
 
 		createTestingPinia({ stubActions: false });

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ToolsManagerModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ToolsManagerModal.test.ts
@@ -7,7 +7,7 @@ import { useUIStore } from '@/app/stores/ui.store';
 import { useChatStore } from '@/features/ai/chatHub/chat.store';
 import ToolsManagerModal from './ToolsManagerModal.vue';
 import { NodeConnectionTypes, type INode, type INodeTypeDescription } from 'n8n-workflow';
-import { fireEvent, waitFor } from '@testing-library/vue';
+import { cleanup, fireEvent, waitFor } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import { MODAL_CONFIRM } from '@/app/constants';
 import type { ChatHubToolDto } from '@n8n/api-types';
@@ -119,31 +119,16 @@ function createMockToolDto(overrides: Partial<INode> = {}, enabled = true): Chat
 	};
 }
 
-const ElDialogStub = {
+const ModalStub = {
 	template: `
 		<div role="dialog">
 			<slot name="header" />
-			<slot />
+			<slot name="content" />
 			<slot name="footer" />
+			<slot />
 		</div>
 	`,
-	props: [
-		'modelValue',
-		'beforeClose',
-		'class',
-		'center',
-		'width',
-		'showClose',
-		'closeOnClickModal',
-		'closeOnPressEscape',
-		'style',
-		'appendTo',
-		'lockScroll',
-		'appendToBody',
-		'dataTestId',
-		'modalClass',
-		'zIndex',
-	],
+	props: ['name', 'title', 'loading', 'width', 'showClose', 'customClass'],
 };
 
 const MODAL_NAME = 'ToolsManagerModal';
@@ -152,7 +137,7 @@ const onConfirmMock = vi.fn();
 const renderComponent = createComponentRenderer(ToolsManagerModal, {
 	global: {
 		stubs: {
-			ElDialog: ElDialogStub,
+			Modal: ModalStub,
 			ToolSettingsContent: {
 				template: '<div data-test-id="tool-settings-content" />',
 				props: ['initialNode', 'existingToolNames'],
@@ -162,12 +147,12 @@ const renderComponent = createComponentRenderer(ToolsManagerModal, {
 	},
 });
 
-function getConfiguredItems(container: Element) {
-	return Array.from(container.querySelectorAll('.item.configured'));
+function getConfiguredItems(baseElement: Element) {
+	return Array.from(baseElement.querySelectorAll('.item.configured'));
 }
 
-function getAvailableItems(container: Element) {
-	return Array.from(container.querySelectorAll('.item:not(.configured)'));
+function getAvailableItems(baseElement: Element) {
+	return Array.from(baseElement.querySelectorAll('.item:not(.configured)'));
 }
 
 function getActionButtons(item: Element) {
@@ -184,6 +169,7 @@ describe('ToolsManagerModal', () => {
 	let chatStore: ReturnType<typeof mockedStore<typeof useChatStore>>;
 
 	beforeEach(() => {
+		cleanup();
 		vi.clearAllMocks();
 
 		createTestingPinia({ stubActions: false });
@@ -217,6 +203,7 @@ describe('ToolsManagerModal', () => {
 	function defaultProps() {
 		return {
 			modalName: MODAL_NAME,
+			modal: false,
 			data: {
 				tools: [],
 				onConfirm: onConfirmMock,
@@ -231,27 +218,27 @@ describe('ToolsManagerModal', () => {
 	});
 
 	it('should render search input', () => {
-		const { container } = renderComponent({ props: defaultProps() });
+		const { baseElement } = renderComponent({ props: defaultProps() });
 
-		const input = container.querySelector('input');
+		const input = baseElement.querySelector('input');
 		expect(input).toBeTruthy();
 	});
 
 	it('should render available tools from node types store', () => {
-		const { getByText, container } = renderComponent({ props: defaultProps() });
+		const { getByText, baseElement } = renderComponent({ props: defaultProps() });
 
 		expect(getByText('Tool A')).toBeTruthy();
 		expect(getByText('Tool B')).toBeTruthy();
-		expect(getAvailableItems(container)).toHaveLength(2);
+		expect(getAvailableItems(baseElement)).toHaveLength(2);
 	});
 
 	it('should render configured tools section when tools exist', () => {
 		chatStore.configuredTools = [createMockToolDto()];
 
-		const { getByText, container } = renderComponent({ props: defaultProps() });
+		const { getByText, baseElement } = renderComponent({ props: defaultProps() });
 
 		expect(getByText('Configured Tool A')).toBeTruthy();
-		expect(getConfiguredItems(container)).toHaveLength(1);
+		expect(getConfiguredItems(baseElement)).toHaveLength(1);
 	});
 
 	it('should show empty state when no tools are available', () => {
@@ -263,9 +250,9 @@ describe('ToolsManagerModal', () => {
 	});
 
 	it('should sort available tools by popularity', () => {
-		const { container } = renderComponent({ props: defaultProps() });
+		const { baseElement } = renderComponent({ props: defaultProps() });
 
-		const availableItems = getAvailableItems(container);
+		const availableItems = getAvailableItems(baseElement);
 		expect(availableItems).toHaveLength(2);
 		// Tool A (popularity 100) should come before Tool B (popularity 50)
 		expect(availableItems[0].textContent).toContain('Tool A');
@@ -277,9 +264,9 @@ describe('ToolsManagerModal', () => {
 			[NodeConnectionTypes.AiTool]: ['n8n-nodes-base.toolA', 'n8n-nodes-base.toolWithInputs'],
 		};
 
-		const { container, getByText, queryByText } = renderComponent({ props: defaultProps() });
+		const { baseElement, getByText, queryByText } = renderComponent({ props: defaultProps() });
 
-		const availableItems = getAvailableItems(container);
+		const availableItems = getAvailableItems(baseElement);
 		// Only toolA should appear (toolWithInputs has inputs and is excluded)
 		expect(availableItems).toHaveLength(1);
 		expect(getByText('Tool A')).toBeTruthy();
@@ -301,9 +288,9 @@ describe('ToolsManagerModal', () => {
 		it('should switch to settings view when configuring a tool', async () => {
 			chatStore.configuredTools = [createMockToolDto()];
 
-			const { container, getByTestId } = renderComponent({ props: defaultProps() });
+			const { baseElement, getByTestId } = renderComponent({ props: defaultProps() });
 
-			const configuredItem = getConfiguredItems(container)[0];
+			const configuredItem = getConfiguredItems(baseElement)[0];
 			const [configureBtn] = getActionButtons(configuredItem);
 			await userEvent.click(configureBtn);
 
@@ -317,9 +304,9 @@ describe('ToolsManagerModal', () => {
 			chatStore.configuredTools = [tool];
 			mockConfirm.mockResolvedValue(MODAL_CONFIRM);
 
-			const { container } = renderComponent({ props: defaultProps() });
+			const { baseElement } = renderComponent({ props: defaultProps() });
 
-			const configuredItem = getConfiguredItems(container)[0];
+			const configuredItem = getConfiguredItems(baseElement)[0];
 			const [, removeBtn] = getActionButtons(configuredItem);
 			await userEvent.click(removeBtn);
 
@@ -334,9 +321,9 @@ describe('ToolsManagerModal', () => {
 			chatStore.configuredTools = [tool];
 			mockConfirm.mockResolvedValue('cancel');
 
-			const { container } = renderComponent({ props: defaultProps() });
+			const { baseElement } = renderComponent({ props: defaultProps() });
 
-			const configuredItem = getConfiguredItems(container)[0];
+			const configuredItem = getConfiguredItems(baseElement)[0];
 			const [, removeBtn] = getActionButtons(configuredItem);
 			await userEvent.click(removeBtn);
 
@@ -350,9 +337,9 @@ describe('ToolsManagerModal', () => {
 			const tool = createMockToolDto({ id: 'tool-toggle' }, false);
 			chatStore.configuredTools = [tool];
 
-			const { container } = renderComponent({ props: defaultProps() });
+			const { baseElement } = renderComponent({ props: defaultProps() });
 
-			const configuredItem = getConfiguredItems(container)[0];
+			const configuredItem = getConfiguredItems(baseElement)[0];
 			const toggle = getToggle(configuredItem);
 			await fireEvent.click(toggle);
 
@@ -368,14 +355,14 @@ describe('ToolsManagerModal', () => {
 				'agent-1': { name: 'Test Agent', toolIds: ['tool-agent-toggle'] } as never,
 			};
 
-			const { container } = renderComponent({
+			const { baseElement } = renderComponent({
 				props: {
 					...defaultProps(),
 					data: { ...defaultProps().data, customAgentId: 'agent-1' },
 				},
 			});
 
-			const configuredItem = getConfiguredItems(container)[0];
+			const configuredItem = getConfiguredItems(baseElement)[0];
 			const toggle = getToggle(configuredItem);
 			await fireEvent.click(toggle);
 
@@ -390,19 +377,19 @@ describe('ToolsManagerModal', () => {
 
 	describe('settings view', () => {
 		it('should show back button in settings view', async () => {
-			const { getAllByText, container } = renderComponent({ props: defaultProps() });
+			const { getAllByText, baseElement } = renderComponent({ props: defaultProps() });
 
 			const addButtons = getAllByText('chatHub.toolsManager.add');
 			await userEvent.click(addButtons[0]);
 
 			await waitFor(() => {
-				const backButton = container.querySelector('.backButton');
+				const backButton = baseElement.querySelector('.backButton');
 				expect(backButton).toBeTruthy();
 			});
 		});
 
 		it('should return to list view when back button is clicked', async () => {
-			const { getAllByText, queryByTestId, container } = renderComponent({
+			const { getAllByText, queryByTestId, baseElement } = renderComponent({
 				props: defaultProps(),
 			});
 
@@ -414,7 +401,7 @@ describe('ToolsManagerModal', () => {
 			});
 
 			// Click back - use fireEvent to bypass pointer-events check on body
-			const backButton = container.querySelector('.backButton') as HTMLElement;
+			const backButton = baseElement.querySelector('.backButton') as HTMLElement;
 			await fireEvent.click(backButton);
 
 			await waitFor(() => {
@@ -448,9 +435,9 @@ describe('ToolsManagerModal', () => {
 			const error = new Error('Remove failed');
 			chatStore.removeConfiguredTool = vi.fn().mockRejectedValue(error);
 
-			const { container } = renderComponent({ props: defaultProps() });
+			const { baseElement } = renderComponent({ props: defaultProps() });
 
-			const configuredItem = getConfiguredItems(container)[0];
+			const configuredItem = getConfiguredItems(baseElement)[0];
 			const [, removeBtn] = getActionButtons(configuredItem);
 			await userEvent.click(removeBtn);
 
@@ -465,9 +452,9 @@ describe('ToolsManagerModal', () => {
 			const error = new Error('Toggle failed');
 			chatStore.toggleToolEnabled = vi.fn().mockRejectedValue(error);
 
-			const { container } = renderComponent({ props: defaultProps() });
+			const { baseElement } = renderComponent({ props: defaultProps() });
 
-			const configuredItem = getConfiguredItems(container)[0];
+			const configuredItem = getConfiguredItems(baseElement)[0];
 			const toggle = getToggle(configuredItem);
 			await fireEvent.click(toggle);
 

--- a/packages/frontend/editor-ui/src/features/core/auth/components/__snapshots__/ChangePasswordModal.test.ts.snap
+++ b/packages/frontend/editor-ui/src/features/core/auth/components/__snapshots__/ChangePasswordModal.test.ts.snap
@@ -1,6 +1,3 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ChangePasswordModal > should render correctly 1`] = `
-"<!--teleport start-->
-<!--teleport end-->"
-`;
+exports[`ChangePasswordModal > should render correctly 1`] = `"<!--v-if-->"`;

--- a/packages/frontend/editor-ui/src/features/core/auth/components/__snapshots__/ConfirmPasswordModal.test.ts.snap
+++ b/packages/frontend/editor-ui/src/features/core/auth/components/__snapshots__/ConfirmPasswordModal.test.ts.snap
@@ -1,6 +1,3 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ConfirmPasswordModal > should render correctly 1`] = `
-"<!--teleport start-->
-<!--teleport end-->"
-`;
+exports[`ConfirmPasswordModal > should render correctly 1`] = `"<!--v-if-->"`;

--- a/packages/frontend/editor-ui/src/features/core/folders/components/MoveToFolderModal.vue
+++ b/packages/frontend/editor-ui/src/features/core/folders/components/MoveToFolderModal.vue
@@ -423,6 +423,7 @@ onMounted(async () => {
 		width="500"
 		:class="$style.container"
 		:event-bus="modalBus"
+		:modal="false"
 	>
 		<template #content>
 			<p


### PR DESCRIPTION
## Summary
- Migrate the modal implementation from `ElDialog` (Element Plus) to the app design system's `N8nDialog` components to unify UI primitives and behavior.
- Simplify and standardize modal sizing and interaction handling via CSS variables and explicit event handlers for outside interaction and escape key behavior.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
