### PR TITLE
refactor(agents): Refactor styles on Executions Timeline

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nRecycleScroller/RecycleScroller.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nRecycleScroller/RecycleScroller.vue
@@ -9,12 +9,10 @@ interface RecycleScrollerProps {
 	items: Item[];
 	itemKey: Key;
 	offset?: number;
-	scrollPadding?: number;
 }
 
 const props = withDefaults(defineProps<RecycleScrollerProps>(), {
 	offset: 2,
-	scrollPadding: 0,
 });
 
 const wrapperRef = ref<HTMLElement | null>(null);
@@ -184,28 +182,6 @@ function onScroll() {
 
 	scrollTop.value = wrapperRef.value.scrollTop;
 }
-
-function scrollItemIntoView(itemKey: Item[Key]) {
-	if (!wrapperRef.value) return;
-
-	const itemPosition = itemPositionCache.value[itemKey];
-	const itemSize = itemSizeCache.value[itemKey] ?? props.itemSize;
-	if (itemPosition === undefined) return;
-
-	const viewportTop = wrapperRef.value.scrollTop;
-	const viewportBottom = viewportTop + wrapperRef.value.clientHeight;
-	const itemBottom = itemPosition + itemSize;
-
-	if (itemPosition - props.scrollPadding < viewportTop) {
-		wrapperRef.value.scrollTop = Math.max(0, itemPosition - props.scrollPadding);
-	} else if (itemBottom + props.scrollPadding > viewportBottom) {
-		wrapperRef.value.scrollTop = itemBottom + props.scrollPadding - wrapperRef.value.clientHeight;
-	}
-
-	scrollTop.value = wrapperRef.value.scrollTop;
-}
-
-defineExpose({ scrollItemIntoView });
 </script>
 
 <template>

--- a/packages/frontend/@n8n/design-system/src/components/N8nRecycleScroller/RecycleScroller.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nRecycleScroller/RecycleScroller.vue
@@ -9,10 +9,12 @@ interface RecycleScrollerProps {
 	items: Item[];
 	itemKey: Key;
 	offset?: number;
+	scrollPadding?: number;
 }
 
 const props = withDefaults(defineProps<RecycleScrollerProps>(), {
 	offset: 2,
+	scrollPadding: 0,
 });
 
 const wrapperRef = ref<HTMLElement | null>(null);
@@ -182,6 +184,28 @@ function onScroll() {
 
 	scrollTop.value = wrapperRef.value.scrollTop;
 }
+
+function scrollItemIntoView(itemKey: Item[Key]) {
+	if (!wrapperRef.value) return;
+
+	const itemPosition = itemPositionCache.value[itemKey];
+	const itemSize = itemSizeCache.value[itemKey] ?? props.itemSize;
+	if (itemPosition === undefined) return;
+
+	const viewportTop = wrapperRef.value.scrollTop;
+	const viewportBottom = viewportTop + wrapperRef.value.clientHeight;
+	const itemBottom = itemPosition + itemSize;
+
+	if (itemPosition - props.scrollPadding < viewportTop) {
+		wrapperRef.value.scrollTop = Math.max(0, itemPosition - props.scrollPadding);
+	} else if (itemBottom + props.scrollPadding > viewportBottom) {
+		wrapperRef.value.scrollTop = itemBottom + props.scrollPadding - wrapperRef.value.clientHeight;
+	}
+
+	scrollTop.value = wrapperRef.value.scrollTop;
+}
+
+defineExpose({ scrollItemIntoView });
 </script>
 
 <template>

--- a/packages/frontend/@n8n/design-system/src/css/mixins/index.scss
+++ b/packages/frontend/@n8n/design-system/src/css/mixins/index.scss
@@ -3,5 +3,6 @@
 @forward 'config';
 @forward 'focus';
 @forward 'function';
+@forward 'markdown';
 @forward 'mixins';
 @forward 'utils';

--- a/packages/frontend/@n8n/design-system/src/css/mixins/markdown.scss
+++ b/packages/frontend/@n8n/design-system/src/css/mixins/markdown.scss
@@ -99,7 +99,7 @@
 		font-size: var(--font-size--sm);
 		padding: calc(var(--markdown--spacing) * 0.25) calc(var(--markdown--spacing) * 0.5);
 		line-height: var(--line-height--lg);
-		background-color: var(--chat--message--pre--background);
+		background-color: var(--background--subtle);
 		border-radius: var(--radius--sm);
 		font-variant-ligatures: none;
 	}
@@ -117,7 +117,7 @@
 		white-space: pre-wrap;
 		box-sizing: border-box;
 		padding: calc(var(--markdown--spacing) * 2);
-		background: var(--chat--message--pre--background);
+		background: var(--background--subtle);
 		border-radius: var(--radius--lg);
 		position: relative;
 
@@ -219,7 +219,7 @@
 	}
 
 	thead {
-		border-bottom-width: 1px;
+		border-bottom-width: var(--border-width);
 		border-bottom-style: solid;
 		border-bottom-color: var(--color--neutral-300);
 	}
@@ -243,7 +243,7 @@
 	}
 
 	tbody tr {
-		border-bottom-width: 1px;
+		border-bottom-width: var(--border-width);
 		border-bottom-style: solid;
 		border-bottom-color: var(--color--neutral-200);
 	}
@@ -269,7 +269,7 @@
 	}
 
 	tfoot {
-		border-top-width: 1px;
+		border-top-width: var(--border-width);
 		border-top-style: solid;
 		border-top-color: var(--color--neutral-300);
 	}

--- a/packages/frontend/@n8n/design-system/src/css/mixins/markdown.scss
+++ b/packages/frontend/@n8n/design-system/src/css/mixins/markdown.scss
@@ -1,0 +1,313 @@
+@mixin markdown-content {
+	--markdown--spacing: var(--spacing--2xs);
+
+	display: block;
+	color: inherit;
+
+	p,
+	li {
+		font-size: inherit;
+		line-height: inherit;
+		margin: calc(var(--markdown--spacing) * 2) 0;
+
+		&:first-child {
+			margin-top: 0;
+		}
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	li {
+		margin: 0;
+	}
+
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6 {
+		margin: 0;
+		color: var(--color--text--shade-1);
+		line-height: var(--line-height--md);
+		font-weight: var(--font-weight--bold);
+		scroll-margin-top: calc(var(--markdown--spacing) * 4);
+	}
+
+	h1 {
+		font-size: var(--font-size--xl);
+		margin-top: calc(var(--markdown--spacing) * 3);
+	}
+
+	h2 {
+		font-size: var(--font-size--lg);
+		margin-top: calc(var(--markdown--spacing) * 4);
+	}
+
+	h3 {
+		font-size: var(--font-size--md);
+		margin-top: calc(var(--markdown--spacing) * 4);
+	}
+
+	h4 {
+		font-size: var(--font-size--sm);
+		margin-top: calc(var(--markdown--spacing) * 4);
+	}
+
+	h5,
+	h6 {
+		font-size: var(--font-size--sm);
+		margin-top: calc(var(--markdown--spacing) * 3);
+	}
+
+	h2 + h3 {
+		margin-top: calc(var(--markdown--spacing) * 3);
+	}
+
+	li > :is(h1, h2, h3, h4, h5, h6, p, strong):first-child {
+		margin-top: 0;
+	}
+
+	strong,
+	b {
+		color: var(--color--text--shade-1);
+		font-weight: var(--font-weight--bold);
+	}
+
+	a:not(:where(h1, h2, h3, h4, h5, h6) *) {
+		color: var(--color--text--shade-1);
+		font-weight: var(--font-weight--medium);
+		text-decoration: underline;
+		text-underline-offset: 3px;
+		text-decoration-thickness: 1px;
+		transition: color var(--duration--snappy) var(--easing--ease-out);
+
+		&:hover {
+			color: var(--color--primary);
+		}
+
+		code {
+			font-weight: var(--font-weight--medium);
+		}
+	}
+
+	:not(pre) > code {
+		font-family: var(--font-family--monospace);
+		font-weight: var(--font-weight--medium);
+		font-size: var(--font-size--sm);
+		padding: calc(var(--markdown--spacing) * 0.25) calc(var(--markdown--spacing) * 0.5);
+		line-height: var(--line-height--lg);
+		background-color: var(--chat--message--pre--background);
+		border-radius: var(--radius--sm);
+		font-variant-ligatures: none;
+	}
+
+	:is(h1, h2, h3, h4, h5, h6) code {
+		font-weight: var(--font-weight--bold);
+	}
+
+	pre {
+		width: 100%;
+		font-family: var(--font-family--monospace);
+		font-size: var(--font-size--sm);
+		line-height: var(--line-height--xl);
+		margin: var(--markdown--spacing) 0 calc(var(--markdown--spacing) * 2.5);
+		white-space: pre-wrap;
+		box-sizing: border-box;
+		padding: calc(var(--markdown--spacing) * 2);
+		background: var(--chat--message--pre--background);
+		border-radius: var(--radius--lg);
+		position: relative;
+
+		code {
+			font-family: var(--font-family--monospace);
+			font-variant-ligatures: none;
+
+			&::before,
+			&::after {
+				content: none;
+			}
+		}
+
+		code:last-of-type {
+			padding-bottom: 0;
+		}
+
+		code * + * {
+			margin-top: 0;
+		}
+
+		& ~ pre {
+			margin-bottom: calc(var(--markdown--spacing) * 2.5);
+		}
+	}
+
+	blockquote {
+		font-style: italic;
+		border-left: calc(var(--markdown--spacing) * 0.5) solid var(--color--foreground--shade-1);
+		padding-left: calc(var(--markdown--spacing) * 2);
+		margin: calc(var(--markdown--spacing) * 2) 0;
+		color: var(--color--text--tint-1);
+
+		p:first-of-type::before {
+			content: open-quote;
+		}
+
+		p:last-of-type::after {
+			content: close-quote;
+		}
+	}
+
+	hr {
+		border: none;
+		border-top: var(--border-width) var(--border-style) var(--color--foreground);
+		margin: calc(var(--markdown--spacing) * 3) 0;
+
+		& + h2 {
+			margin-top: calc(var(--markdown--spacing) * 3);
+		}
+	}
+
+	ol {
+		padding-left: calc(var(--markdown--spacing) * 4);
+		list-style-type: decimal;
+		list-style-position: outside;
+		margin: calc(var(--markdown--spacing) * 2) 0;
+
+		li + li {
+			margin-top: calc(var(--markdown--spacing) * 1.5);
+		}
+
+		li::marker {
+			font-family: var(--font-family--monospace);
+			color: var(--color--text);
+		}
+	}
+
+	ul {
+		padding-left: calc(var(--markdown--spacing) * 4);
+		list-style-type: disc;
+		list-style-position: outside;
+		margin: calc(var(--markdown--spacing) * 2) 0;
+
+		li + li {
+			margin-top: var(--markdown--spacing);
+		}
+
+		li::marker {
+			color: var(--color--foreground--shade-1);
+		}
+	}
+
+	ul ul,
+	ol ol,
+	ul ol,
+	ol ul {
+		margin-top: var(--markdown--spacing);
+		margin-bottom: 0;
+		padding-left: calc(var(--markdown--spacing) * 3);
+	}
+
+	table {
+		width: 100%;
+		table-layout: auto;
+		margin: calc(var(--markdown--spacing) * 2) 0;
+		font-size: var(--font-size--sm);
+		line-height: var(--line-height--lg);
+	}
+
+	thead {
+		border-bottom-width: 1px;
+		border-bottom-style: solid;
+		border-bottom-color: var(--color--neutral-300);
+	}
+
+	thead th {
+		color: var(--color--text--shade-1);
+		font-weight: var(--font-weight--bold);
+		vertical-align: bottom;
+		padding-inline-start: 0.6em;
+		padding-inline-end: 0.6em;
+		padding-bottom: 0.8em;
+		text-align: start;
+	}
+
+	thead th:first-child {
+		padding-inline-start: 0;
+	}
+
+	thead th:last-child {
+		padding-inline-end: 0;
+	}
+
+	tbody tr {
+		border-bottom-width: 1px;
+		border-bottom-style: solid;
+		border-bottom-color: var(--color--neutral-200);
+	}
+
+	tbody tr:last-child {
+		border-bottom-width: 0;
+	}
+
+	tbody td {
+		vertical-align: baseline;
+		padding-top: 0.8em;
+		padding-inline-start: 0.6em;
+		padding-inline-end: 0.6em;
+		padding-bottom: 0.8em;
+	}
+
+	tbody td:first-child {
+		padding-inline-start: 0;
+	}
+
+	tbody td:last-child {
+		padding-inline-end: 0;
+	}
+
+	tfoot {
+		border-top-width: 1px;
+		border-top-style: solid;
+		border-top-color: var(--color--neutral-300);
+	}
+
+	tfoot td {
+		vertical-align: top;
+		padding-top: 0.8em;
+		padding-inline-start: 0.6em;
+		padding-inline-end: 0.6em;
+		padding-bottom: 0.8em;
+	}
+
+	tfoot td:first-child {
+		padding-inline-start: 0;
+	}
+
+	tfoot td:last-child {
+		padding-inline-end: 0;
+	}
+
+	td code {
+		font-size: var(--font-size--xs);
+	}
+
+	th,
+	td {
+		text-align: start;
+	}
+
+	figure {
+		margin: calc(var(--markdown--spacing) * 2) 0;
+	}
+
+	figcaption {
+		margin-top: calc(var(--markdown--spacing) * 1.5);
+		text-align: center;
+		font-size: var(--font-size--sm);
+		font-style: italic;
+		color: var(--color--text--tint-1);
+	}
+}

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.test.ts
@@ -23,8 +23,7 @@ vi.mock('@n8n/permissions', () => ({
 }));
 
 vi.mock('vue-router', async (importOriginal) => ({
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-	...(await importOriginal<typeof import('vue-router')>()),
+	...(await importOriginal()),
 	useRoute: vi.fn().mockReturnValue({
 		params: { workflowId: 'test' },
 		query: {},

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.ts
@@ -32,8 +32,7 @@ import {
 } from '@/app/stores/workflowDocument.store';
 
 vi.mock('vue-router', async (importOriginal) => ({
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-	...(await importOriginal<typeof import('vue-router')>()),
+	...(await importOriginal()),
 	useRoute: vi.fn().mockReturnValue({
 		params: { workflowId: 'test' },
 		query: { parentFolderId: '1' },

--- a/packages/frontend/editor-ui/src/app/components/WorkflowProductionChecklist.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowProductionChecklist.test.ts
@@ -36,7 +36,7 @@ import { useUsersStore } from '@/features/settings/users/users.store';
 import { MCP_DOCS_PAGE_URL, MCP_SETTINGS_VIEW } from '@/features/ai/mcpAccess/mcp.constants';
 
 vi.mock('vue-router', async (importOriginal) => {
-	const actual = await importOriginal();
+	const actual = await importOriginal<typeof import('vue-router')>();
 	return {
 		...actual,
 		useRouter: vi.fn(),
@@ -58,7 +58,7 @@ vi.mock('@/app/composables/useTelemetry', () => ({
 vi.mock('@/features/ai/mcpAccess/composables/useMcp', () => ({}));
 
 vi.mock('@n8n/i18n', async (importOriginal) => {
-	const actual = await importOriginal();
+	const actual = await importOriginal<typeof import('@n8n/i18n')>();
 	return {
 		...actual,
 		useI18n: () => ({

--- a/packages/frontend/editor-ui/src/app/components/WorkflowProductionChecklist.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowProductionChecklist.test.ts
@@ -36,8 +36,7 @@ import { useUsersStore } from '@/features/settings/users/users.store';
 import { MCP_DOCS_PAGE_URL, MCP_SETTINGS_VIEW } from '@/features/ai/mcpAccess/mcp.constants';
 
 vi.mock('vue-router', async (importOriginal) => {
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-	const actual = await importOriginal<typeof import('vue-router')>();
+	const actual = await importOriginal();
 	return {
 		...actual,
 		useRouter: vi.fn(),
@@ -59,8 +58,7 @@ vi.mock('@/app/composables/useTelemetry', () => ({
 vi.mock('@/features/ai/mcpAccess/composables/useMcp', () => ({}));
 
 vi.mock('@n8n/i18n', async (importOriginal) => {
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-	const actual = await importOriginal<typeof import('@n8n/i18n')>();
+	const actual = await importOriginal();
 	return {
 		...actual,
 		useI18n: () => ({

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -80,7 +80,7 @@ const mockRoute = reactive({
 const mockRouterReplace = vi.fn();
 
 vi.mock('vue-router', async (importOriginal) => ({
-	...(await importOriginal()),
+	...(await importOriginal<typeof import('vue-router')>()),
 	useRoute: () => mockRoute,
 	useRouter: () => ({
 		replace: mockRouterReplace,
@@ -91,7 +91,7 @@ import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 import { GRID_SIZE, PUSH_NODES_OFFSET } from '@/app/utils/nodeViewUtils';
 
 vi.mock('n8n-workflow', async (importOriginal) => {
-	const actual = await importOriginal();
+	const actual = await importOriginal<typeof import('n8n-workflow')>();
 	return {
 		...actual,
 		TelemetryHelpers: {
@@ -109,7 +109,7 @@ vi.mock('n8n-workflow', async (importOriginal) => {
 });
 
 vi.mock('@vueuse/core', async (importOriginal) => {
-	const original = await importOriginal();
+	const original = await importOriginal<typeof import('@vueuse/core')>();
 	const copySpy = vi.fn();
 	return {
 		...original,

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -91,8 +91,7 @@ import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 import { GRID_SIZE, PUSH_NODES_OFFSET } from '@/app/utils/nodeViewUtils';
 
 vi.mock('n8n-workflow', async (importOriginal) => {
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-	const actual = await importOriginal<typeof import('n8n-workflow')>();
+	const actual = await importOriginal();
 	return {
 		...actual,
 		TelemetryHelpers: {
@@ -110,8 +109,7 @@ vi.mock('n8n-workflow', async (importOriginal) => {
 });
 
 vi.mock('@vueuse/core', async (importOriginal) => {
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-	const original = await importOriginal<typeof import('@vueuse/core')>();
+	const original = await importOriginal();
 	const copySpy = vi.fn();
 	return {
 		...original,

--- a/packages/frontend/editor-ui/src/app/stores/rbac.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/rbac.store.test.ts
@@ -4,7 +4,7 @@ import type { Scope } from '@n8n/permissions';
 import { hasScope } from '@n8n/permissions';
 
 vi.mock('@n8n/permissions', async () => {
-	const { hasScope } = await vi.importActual('@n8n/permissions');
+	const { hasScope } = await vi.importActual<typeof import('@n8n/permissions')>('@n8n/permissions');
 	return {
 		hasScope: vi.fn().mockImplementation(hasScope),
 	};

--- a/packages/frontend/editor-ui/src/app/stores/rbac.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/rbac.store.test.ts
@@ -4,8 +4,7 @@ import type { Scope } from '@n8n/permissions';
 import { hasScope } from '@n8n/permissions';
 
 vi.mock('@n8n/permissions', async () => {
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-	const { hasScope } = await vi.importActual<typeof import('@n8n/permissions')>('@n8n/permissions');
+	const { hasScope } = await vi.importActual('@n8n/permissions');
 	return {
 		hasScope: vi.fn().mockImplementation(hasScope),
 	};

--- a/packages/frontend/editor-ui/src/app/stores/settings.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/settings.store.test.ts
@@ -55,8 +55,7 @@ vi.mock('@/app/stores/versions.store', () => ({
 }));
 
 vi.mock('@vueuse/core', async () => {
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-	const originalModule = await vi.importActual<typeof import('@vueuse/core')>('@vueuse/core');
+	const originalModule = await vi.importActual('@vueuse/core');
 
 	return {
 		...originalModule,

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/SessionEventFilter.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/SessionEventFilter.spec.ts
@@ -5,6 +5,13 @@ import SessionEventFilter from '../components/SessionEventFilter.vue';
 import type { FilterOption } from '../session-timeline.types';
 
 vi.mock('@n8n/design-system', () => ({
+	N8nButton: { template: '<button><slot /></button>' },
+	N8nPopover: {
+		props: ['open'],
+		emits: ['update:open'],
+		template:
+			'<div><div @click="$emit(\'update:open\', true)"><slot name="trigger" /></div><div v-if="open"><slot name="content" /></div></div>',
+	},
 	N8nIcon: { template: '<span />' },
 }));
 

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/SessionTimelineTable.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/SessionTimelineTable.spec.ts
@@ -6,7 +6,7 @@ import SessionTimelineTable from '../components/SessionTimelineTable.vue';
 import type { TimelineItem } from '../session-timeline.types';
 
 vi.mock('@n8n/design-system', async (importOriginal) => ({
-	...(await importOriginal<typeof import('@n8n/design-system')>()),
+	...(await importOriginal()),
 	N8nRecycleScroller: {
 		name: 'N8nRecycleScroller',
 		props: ['items'],

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/SessionTimelineTable.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/SessionTimelineTable.spec.ts
@@ -1,9 +1,23 @@
 /* eslint-disable import-x/no-extraneous-dependencies -- test-only patterns */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createRouter, createMemoryHistory, type Router } from 'vue-router';
 import SessionTimelineTable from '../components/SessionTimelineTable.vue';
 import type { TimelineItem } from '../session-timeline.types';
+
+vi.mock('@n8n/design-system', async (importOriginal) => ({
+	...(await importOriginal<typeof import('@n8n/design-system')>()),
+	N8nRecycleScroller: {
+		name: 'N8nRecycleScroller',
+		props: ['items'],
+		template:
+			'<div class="recycle-scroller-wrapper"><slot v-for="item in items" :item="item" /></div>',
+	},
+	N8nTooltip: {
+		name: 'N8nTooltip',
+		template: '<span><slot /></span>',
+	},
+}));
 
 function makeRouter(): Router {
 	return createRouter({
@@ -37,31 +51,37 @@ function makeItems(): TimelineItem[] {
 	];
 }
 
+function mountTable(props: InstanceType<typeof SessionTimelineTable>['$props']) {
+	return mount(SessionTimelineTable, {
+		props,
+		global: { plugins: [makeRouter()] },
+	});
+}
+
 describe('SessionTimelineTable', () => {
 	it('renders one row per item when no filter is active', () => {
-		const w = mount(SessionTimelineTable, {
-			props: { items: makeItems(), selectedIndex: null, visibleKinds: new Set<string>() },
-			global: { plugins: [makeRouter()] },
+		const w = mountTable({
+			items: makeItems(),
+			selectedIndex: null,
+			visibleKinds: new Set<string>(),
 		});
 		expect(w.findAll('[data-test-id="timeline-row"]')).toHaveLength(4);
 	});
 
 	it('hides items whose filterKey is not in visibleKinds', () => {
-		const w = mount(SessionTimelineTable, {
-			props: {
-				items: makeItems(),
-				selectedIndex: null,
-				visibleKinds: new Set<string>(['workflow']),
-			},
-			global: { plugins: [makeRouter()] },
+		const w = mountTable({
+			items: makeItems(),
+			selectedIndex: null,
+			visibleKinds: new Set<string>(['workflow']),
 		});
 		expect(w.findAll('[data-test-id="timeline-row"]')).toHaveLength(1);
 	});
 
 	it('emits select with the absolute (pre-filter) index when a row is clicked', async () => {
-		const w = mount(SessionTimelineTable, {
-			props: { items: makeItems(), selectedIndex: null, visibleKinds: new Set<string>() },
-			global: { plugins: [makeRouter()] },
+		const w = mountTable({
+			items: makeItems(),
+			selectedIndex: null,
+			visibleKinds: new Set<string>(),
 		});
 		// Click the 3rd row (tool at index 2)
 		await w.findAll('[data-test-id="timeline-row"]')[2].trigger('click');
@@ -69,13 +89,10 @@ describe('SessionTimelineTable', () => {
 	});
 
 	it('emits select with the absolute index even when rows are filtered', async () => {
-		const w = mount(SessionTimelineTable, {
-			props: {
-				items: makeItems(),
-				selectedIndex: null,
-				visibleKinds: new Set<string>(['workflow']),
-			},
-			global: { plugins: [makeRouter()] },
+		const w = mountTable({
+			items: makeItems(),
+			selectedIndex: null,
+			visibleKinds: new Set<string>(['workflow']),
 		});
 		// Only the workflow row is visible, at absolute index 3.
 		await w.findAll('[data-test-id="timeline-row"]')[0].trigger('click');
@@ -83,9 +100,10 @@ describe('SessionTimelineTable', () => {
 	});
 
 	it('renders a workflow hyperlink with target="_blank"', () => {
-		const w = mount(SessionTimelineTable, {
-			props: { items: makeItems(), selectedIndex: null, visibleKinds: new Set<string>() },
-			global: { plugins: [makeRouter()] },
+		const w = mountTable({
+			items: makeItems(),
+			selectedIndex: null,
+			visibleKinds: new Set<string>(),
 		});
 		const links = w.findAll('a[target="_blank"]');
 		expect(links.length).toBeGreaterThan(0);
@@ -93,9 +111,10 @@ describe('SessionTimelineTable', () => {
 	});
 
 	it('does not emit select when the workflow hyperlink is clicked', async () => {
-		const w = mount(SessionTimelineTable, {
-			props: { items: makeItems(), selectedIndex: null, visibleKinds: new Set<string>() },
-			global: { plugins: [makeRouter()] },
+		const w = mountTable({
+			items: makeItems(),
+			selectedIndex: null,
+			visibleKinds: new Set<string>(),
 		});
 		await w.find('a[target="_blank"]').trigger('click');
 		expect(w.emitted('select')).toBeUndefined();

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionDetailPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionDetailPanel.vue
@@ -3,7 +3,7 @@ import { computed } from 'vue';
 import { useRouter } from 'vue-router';
 import { useI18n } from '@n8n/i18n';
 import VueMarkdown from 'vue-markdown-render';
-import { N8nButton, N8nIconButton } from '@n8n/design-system';
+import { N8nButton, N8nIconButton, N8nText, N8nCard } from '@n8n/design-system';
 import { convertToDisplayDate } from '@/app/utils/formatters/dateFormatter';
 import { VIEWS } from '@/app/constants/navigation';
 import RichInteractionCard from './RichInteractionCard.vue';
@@ -114,7 +114,7 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 	<div :class="$style.panel">
 		<template v-if="item">
 			<div :class="$style.header">
-				<span>
+				<N8nText bold>
 					<template v-if="item.kind === 'workflow'">{{
 						item.workflowName ?? formatToolNameForDisplay(item.toolName)
 					}}</template>
@@ -132,7 +132,7 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 						i18n.baseText('agentSessions.timeline.agent')
 					}}</template>
 					<template v-else>{{ i18n.baseText('agentSessions.timeline.suspended') }}</template>
-				</span>
+				</N8nText>
 				<N8nIconButton
 					icon="x"
 					variant="ghost"
@@ -141,93 +141,98 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 					@click="emit('close')"
 				/>
 			</div>
+			<div :class="$style.container">
+				<N8nCard>
+					<dl v-if="item.timestamp" :class="$style.infoRow">
+						<dt :class="$style.label">{{ i18n.baseText('agentSessions.timeline.created') }}</dt>
+						<dd :class="$style.value">{{ formatTimestamp(item.timestamp) }}</dd>
+					</dl>
+					<div :class="$style.executionButton" v-if="fullExecutionHref">
+						<N8nButton
+							variant="outline"
+							size="small"
+							:label="i18n.baseText('agentSessions.workflowLog.openFull')"
+							data-test-id="open-full-execution"
+							@click="openFullExecution"
+						/>
+					</div>
+				</N8nCard>
 
-			<div :class="$style.info">
-				<div v-if="item.timestamp" :class="$style.infoRow">
-					<span :class="$style.label">{{ i18n.baseText('agentSessions.timeline.created') }}</span>
-					<span :class="$style.value">{{ formatTimestamp(item.timestamp) }}</span>
-				</div>
-				<div :class="$style.executionButton">
-					<N8nButton
-						v-if="fullExecutionHref"
-						variant="outline"
-						size="small"
-						:label="i18n.baseText('agentSessions.workflowLog.openFull')"
-						data-test-id="open-full-execution"
-						@click="openFullExecution"
-					/>
+				<div :class="$style.output">
+					<N8nText bold color="text-light">Output</N8nText>
+					<template v-if="item.kind === 'workflow'">
+						<WorkflowExecutionLogViewer
+							v-if="item.workflowExecutionId && item.workflowId"
+							:key="`${item.workflowId}:${item.workflowExecutionId}`"
+							:workflow-id="item.workflowId"
+							:workflow-execution-id="item.workflowExecutionId"
+						/>
+						<div
+							v-else-if="item.workflowTriggerType === 'form' && workflowFormOutput"
+							data-test-id="wf-form-card"
+							:class="$style.formCard"
+						>
+							<p>{{ workflowFormOutput.message }}</p>
+							<a
+								:href="workflowFormOutput.formUrl"
+								target="_blank"
+								rel="noopener"
+								:class="$style.formLink"
+								>{{ i18n.baseText('agentSessions.timeline.openForm') }}</a
+							>
+						</div>
+						<div v-else data-test-id="wf-error-fallback" :class="$style.errorFallback">
+							<div :class="$style.errorBanner">
+								{{ i18n.baseText('agentSessions.timeline.workflowError') }}
+							</div>
+							<!-- eslint-disable vue/no-v-html -->
+							<pre :class="$style.json" v-html="highlightJson(ensureParsed(item.toolOutput))" />
+							<!-- eslint-enable vue/no-v-html -->
+						</div>
+					</template>
+
+					<template v-else-if="item.kind === 'tool'">
+						<template v-if="item.toolName === 'rich_interaction'">
+							<RichInteractionCard :input="item.toolInput" :output="item.toolOutput" />
+						</template>
+						<template v-else>
+							<div>
+								<div :class="$style.label">{{ i18n.baseText('agentSessions.timeline.input') }}</div>
+								<!-- eslint-disable vue/no-v-html -->
+								<pre :class="$style.json" v-html="highlightJson(ensureParsed(item.toolInput))" />
+								<!-- eslint-enable vue/no-v-html -->
+							</div>
+							<div>
+								<div :class="$style.label">
+									{{ i18n.baseText('agentSessions.timeline.output') }}
+								</div>
+								<!-- eslint-disable vue/no-v-html -->
+								<pre :class="$style.json" v-html="highlightJson(ensureParsed(item.toolOutput))" />
+								<!-- eslint-enable vue/no-v-html -->
+							</div>
+						</template>
+					</template>
+
+					<template v-else-if="item.kind === 'node'">
+						<ToolIoView
+							:name="(item.nodeDisplayName ?? formatToolNameForDisplay(item.toolName)) || 'node'"
+							:input="item.toolInput"
+							:output="item.toolOutput"
+							:node-type="item.nodeType"
+							:node-type-version="item.nodeTypeVersion"
+							:node-parameters="item.nodeParameters"
+						/>
+					</template>
+
+					<template v-else-if="item.kind === 'working-memory'">
+						<pre :class="$style.json">{{ item.content }}</pre>
+					</template>
+
+					<template v-else-if="item.kind === 'user' || item.kind === 'agent'">
+						<VueMarkdown :source="item.content ?? ''" :class="$style.markdown" />
+					</template>
 				</div>
 			</div>
-
-			<template v-if="item.kind === 'workflow'">
-				<WorkflowExecutionLogViewer
-					v-if="item.workflowExecutionId && item.workflowId"
-					:key="`${item.workflowId}:${item.workflowExecutionId}`"
-					:workflow-id="item.workflowId"
-					:workflow-execution-id="item.workflowExecutionId"
-				/>
-				<div
-					v-else-if="item.workflowTriggerType === 'form' && workflowFormOutput"
-					data-test-id="wf-form-card"
-					:class="$style.formCard"
-				>
-					<p>{{ workflowFormOutput.message }}</p>
-					<a
-						:href="workflowFormOutput.formUrl"
-						target="_blank"
-						rel="noopener"
-						:class="$style.formLink"
-						>{{ i18n.baseText('agentSessions.timeline.openForm') }}</a
-					>
-				</div>
-				<div v-else data-test-id="wf-error-fallback" :class="$style.errorFallback">
-					<div :class="$style.errorBanner">
-						{{ i18n.baseText('agentSessions.timeline.workflowError') }}
-					</div>
-					<!-- eslint-disable vue/no-v-html -->
-					<pre :class="$style.json" v-html="highlightJson(ensureParsed(item.toolOutput))" />
-					<!-- eslint-enable vue/no-v-html -->
-				</div>
-			</template>
-
-			<template v-else-if="item.kind === 'tool'">
-				<template v-if="item.toolName === 'rich_interaction'">
-					<RichInteractionCard :input="item.toolInput" :output="item.toolOutput" />
-				</template>
-				<template v-else>
-					<div>
-						<div :class="$style.label">{{ i18n.baseText('agentSessions.timeline.input') }}</div>
-						<!-- eslint-disable vue/no-v-html -->
-						<pre :class="$style.json" v-html="highlightJson(ensureParsed(item.toolInput))" />
-						<!-- eslint-enable vue/no-v-html -->
-					</div>
-					<div>
-						<div :class="$style.label">{{ i18n.baseText('agentSessions.timeline.output') }}</div>
-						<!-- eslint-disable vue/no-v-html -->
-						<pre :class="$style.json" v-html="highlightJson(ensureParsed(item.toolOutput))" />
-						<!-- eslint-enable vue/no-v-html -->
-					</div>
-				</template>
-			</template>
-
-			<template v-else-if="item.kind === 'node'">
-				<ToolIoView
-					:name="(item.nodeDisplayName ?? formatToolNameForDisplay(item.toolName)) || 'node'"
-					:input="item.toolInput"
-					:output="item.toolOutput"
-					:node-type="item.nodeType"
-					:node-type-version="item.nodeTypeVersion"
-					:node-parameters="item.nodeParameters"
-				/>
-			</template>
-
-			<template v-else-if="item.kind === 'working-memory'">
-				<pre :class="$style.json">{{ item.content }}</pre>
-			</template>
-
-			<template v-else-if="item.kind === 'user' || item.kind === 'agent'">
-				<VueMarkdown :source="item.content ?? ''" :class="$style.markdown" />
-			</template>
 		</template>
 
 		<div v-else :class="$style.empty">{{ i18n.baseText('agentSessions.timeline.selectItem') }}</div>
@@ -235,20 +240,41 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 </template>
 
 <style module lang="scss">
+@use '@n8n/design-system/css/mixins' as ds-mixins;
+
 .panel {
 	display: flex;
 	flex-direction: column;
-	gap: var(--spacing--sm);
-	padding: var(--spacing--sm);
-	overflow-y: auto;
+	height: 100%;
+	min-height: 0;
 }
 
 .header {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	font-weight: var(--font-weight--bold);
-	color: var(--color--text);
+	gap: var(--spacing--2xs);
+	padding: var(--spacing--xs) var(--spacing--sm);
+	background-color: var(--background--surface);
+	border-bottom: var(--border);
+	flex-shrink: 0;
+	height: var(--height--4xl);
+}
+
+.container {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--sm);
+	padding: var(--spacing--sm);
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+}
+
+.output {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--2xs);
 }
 
 .info {
@@ -280,7 +306,7 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 .executionButton {
 	padding-top: var(--spacing--xs);
 	display: flex;
-	justify-content: end;
+	justify-content: start;
 }
 
 .json {
@@ -324,105 +350,19 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 	padding: var(--spacing--sm);
 }
 
-/*
- * Markdown rendering for User/Agent message content. Surrounding global resets
- * zero out list padding, which collapsed nested bullets to the same x-position
- * as their parents — restore sensible spacing and indents for lists, headings,
- * paragraphs, and inline code so multi-level bullet output reads correctly.
- */
 .markdown {
-	color: inherit;
-	font-size: var(--font-size--xs);
+	@include ds-mixins.markdown-content;
+
+	color: var(--color--text--shade-1);
+	font-size: var(--font-size--sm);
 	line-height: var(--line-height--xl);
 
-	p,
-	ul,
-	ol,
-	pre,
-	blockquote {
-		margin: var(--spacing--2xs) 0;
-
-		&:first-child {
-			margin-top: 0;
-		}
-
-		&:last-child {
-			margin-bottom: 0;
-		}
-	}
-
-	ul,
-	ol {
-		padding-left: var(--spacing--md);
-		list-style-position: outside;
-	}
-
-	ul {
-		list-style-type: disc;
-	}
-
-	ol {
-		list-style-type: decimal;
-	}
-
-	li {
-		margin: var(--spacing--5xs) 0;
-	}
-
-	ul ul,
-	ol ol,
-	ul ol,
-	ol ul {
-		margin-top: var(--spacing--5xs);
+	> *:last-child {
 		margin-bottom: 0;
-		padding-left: var(--spacing--sm);
 	}
 
-	ul ul {
-		list-style-type: circle;
-	}
-
-	ul ul ul {
-		list-style-type: square;
-	}
-
-	strong,
-	b {
-		font-weight: var(--font-weight--bold);
-		color: var(--color--text--shade-1);
-	}
-
-	a {
-		color: var(--color--primary);
-		text-decoration: underline;
-	}
-
-	code {
-		font-family: monospace;
-		font-size: var(--font-size--2xs);
-		padding: 0 var(--spacing--5xs);
-		background-color: var(--color--foreground--tint-2);
-		border-radius: var(--radius--sm);
-	}
-
-	pre {
-		font-family: monospace;
-		font-size: var(--font-size--2xs);
-		padding: var(--spacing--2xs);
-		background-color: var(--color--foreground--tint-2);
-		border-radius: var(--radius);
-		overflow-x: auto;
-
-		code {
-			padding: 0;
-			background: none;
-		}
-	}
-
-	blockquote {
-		border-left: 2px solid var(--color--foreground--shade-1);
-		padding-left: var(--spacing--2xs);
-		color: var(--color--text--tint-1);
+	> *:first-child {
+		margin-top: 0;
 	}
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionDetailPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionDetailPanel.vue
@@ -1,9 +1,17 @@
 <script lang="ts" setup>
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { useI18n } from '@n8n/i18n';
 import VueMarkdown from 'vue-markdown-render';
-import { N8nButton, N8nIconButton, N8nText, N8nCard } from '@n8n/design-system';
+import {
+	N8nButton,
+	N8nIconButton,
+	N8nText,
+	N8nCard,
+	N8nIcon,
+	N8nTooltip,
+} from '@n8n/design-system';
+import type { IconName } from '@n8n/design-system/components/N8nIcon/icons';
 import { convertToDisplayDate } from '@/app/utils/formatters/dateFormatter';
 import { VIEWS } from '@/app/constants/navigation';
 import RichInteractionCard from './RichInteractionCard.vue';
@@ -17,6 +25,8 @@ const i18n = useI18n();
 const router = useRouter();
 
 const props = defineProps<{ item: TimelineItem | null }>();
+const copiedBlock = ref<string | null>(null);
+let copiedResetTimer: ReturnType<typeof setTimeout> | null = null;
 
 const fullExecutionHref = computed((): string => {
 	if (
@@ -59,6 +69,24 @@ function ensureParsed(value: unknown): unknown {
 	return value;
 }
 
+function stringifyJson(value: unknown): string {
+	const parsed = ensureParsed(value);
+	if (typeof parsed === 'string') return parsed;
+	return JSON.stringify(parsed, null, 2) ?? String(parsed);
+}
+
+async function copyJsonBlock(id: string, value: unknown): Promise<void> {
+	try {
+		await navigator.clipboard.writeText(stringifyJson(value));
+		copiedBlock.value = id;
+		if (copiedResetTimer) clearTimeout(copiedResetTimer);
+		copiedResetTimer = setTimeout(() => {
+			copiedBlock.value = null;
+			copiedResetTimer = null;
+		}, 1500);
+	} catch {}
+}
+
 function escapeHtml(text: string): string {
 	return text
 		.replace(/&/g, '&amp;')
@@ -98,6 +126,30 @@ const toolDisplayName = computed((): string => {
 	return key ? i18n.baseText(key) : formatToolNameForDisplay(props.item.toolName);
 });
 
+const headerTitle = computed((): string => {
+	const item = props.item;
+	if (!item) return '';
+	if (item.kind === 'workflow') return item.workflowName ?? formatToolNameForDisplay(item.toolName);
+	if (item.kind === 'tool') return toolDisplayName.value;
+	if (item.kind === 'node') return item.nodeDisplayName ?? formatToolNameForDisplay(item.toolName);
+	if (item.kind === 'working-memory') return i18n.baseText('agentSessions.timeline.memory');
+	if (item.kind === 'user') return i18n.baseText('agentSessions.timeline.user');
+	if (item.kind === 'agent') return i18n.baseText('agentSessions.timeline.agent');
+	return i18n.baseText('agentSessions.timeline.suspended');
+});
+
+const headerIcon = computed((): IconName => {
+	const item = props.item;
+	if (!item) return 'info';
+	if (item.kind === 'workflow') return 'workflow';
+	if (item.kind === 'tool') return 'wrench';
+	if (item.kind === 'node') return 'box';
+	if (item.kind === 'working-memory') return 'brain';
+	if (item.kind === 'user') return 'user';
+	if (item.kind === 'agent') return 'bot';
+	return 'clock';
+});
+
 const workflowFormOutput = computed((): { formUrl: string; message: string } | null => {
 	const o = props.item?.toolOutput;
 	if (typeof o !== 'object' || o === null) return null;
@@ -114,29 +166,13 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 	<div :class="$style.panel">
 		<template v-if="item">
 			<div :class="$style.header">
-				<N8nText bold>
-					<template v-if="item.kind === 'workflow'">{{
-						item.workflowName ?? formatToolNameForDisplay(item.toolName)
-					}}</template>
-					<template v-else-if="item.kind === 'tool'">{{ toolDisplayName }}</template>
-					<template v-else-if="item.kind === 'node'">{{
-						item.nodeDisplayName ?? formatToolNameForDisplay(item.toolName)
-					}}</template>
-					<template v-else-if="item.kind === 'working-memory'">{{
-						i18n.baseText('agentSessions.timeline.memory')
-					}}</template>
-					<template v-else-if="item.kind === 'user'">{{
-						i18n.baseText('agentSessions.timeline.user')
-					}}</template>
-					<template v-else-if="item.kind === 'agent'">{{
-						i18n.baseText('agentSessions.timeline.agent')
-					}}</template>
-					<template v-else>{{ i18n.baseText('agentSessions.timeline.suspended') }}</template>
-				</N8nText>
+				<div :class="$style.headerTitle">
+					<N8nIcon :icon="headerIcon" :size="16" />
+					<N8nText bold>{{ headerTitle }}</N8nText>
+				</div>
 				<N8nIconButton
 					icon="x"
 					variant="ghost"
-					size="small"
 					data-test-id="detail-close"
 					@click="emit('close')"
 				/>
@@ -159,7 +195,6 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 				</N8nCard>
 
 				<div :class="$style.output">
-					<N8nText bold color="text-light">Output</N8nText>
 					<template v-if="item.kind === 'workflow'">
 						<WorkflowExecutionLogViewer
 							v-if="item.workflowExecutionId && item.workflowId"
@@ -185,9 +220,33 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 							<div :class="$style.errorBanner">
 								{{ i18n.baseText('agentSessions.timeline.workflowError') }}
 							</div>
-							<!-- eslint-disable vue/no-v-html -->
-							<pre :class="$style.json" v-html="highlightJson(ensureParsed(item.toolOutput))" />
-							<!-- eslint-enable vue/no-v-html -->
+							<div :class="$style.codeBlock">
+								<div :class="$style.codeBlockCopy">
+									<N8nTooltip
+										:content="
+											copiedBlock === 'workflow-output'
+												? i18n.baseText('agents.builder.addTrigger.copied')
+												: i18n.baseText('agents.builder.addTrigger.copy')
+										"
+									>
+										<N8nButton
+											variant="outline"
+											size="small"
+											icon-only
+											:icon="copiedBlock === 'workflow-output' ? 'check' : 'copy'"
+											:aria-label="
+												copiedBlock === 'workflow-output'
+													? i18n.baseText('agents.builder.addTrigger.copied')
+													: i18n.baseText('agents.builder.addTrigger.copy')
+											"
+											@click="copyJsonBlock('workflow-output', item.toolOutput)"
+										/>
+									</N8nTooltip>
+								</div>
+								<!-- eslint-disable vue/no-v-html -->
+								<pre :class="$style.json" v-html="highlightJson(ensureParsed(item.toolOutput))" />
+								<!-- eslint-enable vue/no-v-html -->
+							</div>
 						</div>
 					</template>
 
@@ -198,17 +257,65 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 						<template v-else>
 							<div>
 								<div :class="$style.label">{{ i18n.baseText('agentSessions.timeline.input') }}</div>
-								<!-- eslint-disable vue/no-v-html -->
-								<pre :class="$style.json" v-html="highlightJson(ensureParsed(item.toolInput))" />
-								<!-- eslint-enable vue/no-v-html -->
+								<div :class="$style.codeBlock">
+									<div :class="$style.codeBlockCopy">
+										<N8nTooltip
+											:content="
+												copiedBlock === 'tool-input'
+													? i18n.baseText('agents.builder.addTrigger.copied')
+													: i18n.baseText('agents.builder.addTrigger.copy')
+											"
+										>
+											<N8nButton
+												variant="outline"
+												size="small"
+												icon-only
+												:icon="copiedBlock === 'tool-input' ? 'check' : 'copy'"
+												:aria-label="
+													copiedBlock === 'tool-input'
+														? i18n.baseText('agents.builder.addTrigger.copied')
+														: i18n.baseText('agents.builder.addTrigger.copy')
+												"
+												@click="copyJsonBlock('tool-input', item.toolInput)"
+											/>
+										</N8nTooltip>
+									</div>
+									<!-- eslint-disable vue/no-v-html -->
+									<pre :class="$style.json" v-html="highlightJson(ensureParsed(item.toolInput))" />
+									<!-- eslint-enable vue/no-v-html -->
+								</div>
 							</div>
 							<div>
 								<div :class="$style.label">
 									{{ i18n.baseText('agentSessions.timeline.output') }}
 								</div>
-								<!-- eslint-disable vue/no-v-html -->
-								<pre :class="$style.json" v-html="highlightJson(ensureParsed(item.toolOutput))" />
-								<!-- eslint-enable vue/no-v-html -->
+								<div :class="$style.codeBlock">
+									<div :class="$style.codeBlockCopy">
+										<N8nTooltip
+											:content="
+												copiedBlock === 'tool-output'
+													? i18n.baseText('agents.builder.addTrigger.copied')
+													: i18n.baseText('agents.builder.addTrigger.copy')
+											"
+										>
+											<N8nButton
+												variant="outline"
+												size="small"
+												icon-only
+												:icon="copiedBlock === 'tool-output' ? 'check' : 'copy'"
+												:aria-label="
+													copiedBlock === 'tool-output'
+														? i18n.baseText('agents.builder.addTrigger.copied')
+														: i18n.baseText('agents.builder.addTrigger.copy')
+												"
+												@click="copyJsonBlock('tool-output', item.toolOutput)"
+											/>
+										</N8nTooltip>
+									</div>
+									<!-- eslint-disable vue/no-v-html -->
+									<pre :class="$style.json" v-html="highlightJson(ensureParsed(item.toolOutput))" />
+									<!-- eslint-enable vue/no-v-html -->
+								</div>
 							</div>
 						</template>
 					</template>
@@ -225,7 +332,31 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 					</template>
 
 					<template v-else-if="item.kind === 'working-memory'">
-						<pre :class="$style.json">{{ item.content }}</pre>
+						<div :class="$style.codeBlock">
+							<div :class="$style.codeBlockCopy">
+								<N8nTooltip
+									:content="
+										copiedBlock === 'working-memory'
+											? i18n.baseText('agents.builder.addTrigger.copied')
+											: i18n.baseText('agents.builder.addTrigger.copy')
+									"
+								>
+									<N8nButton
+										variant="outline"
+										size="small"
+										icon-only
+										:icon="copiedBlock === 'working-memory' ? 'check' : 'copy'"
+										:aria-label="
+											copiedBlock === 'working-memory'
+												? i18n.baseText('agents.builder.addTrigger.copied')
+												: i18n.baseText('agents.builder.addTrigger.copy')
+										"
+										@click="copyJsonBlock('working-memory', item.content)"
+									/>
+								</N8nTooltip>
+							</div>
+							<pre :class="$style.json">{{ item.content }}</pre>
+						</div>
 					</template>
 
 					<template v-else-if="item.kind === 'user' || item.kind === 'agent'">
@@ -259,6 +390,21 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 	border-bottom: var(--border);
 	flex-shrink: 0;
 	height: var(--height--4xl);
+}
+
+.headerTitle {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing--2xs);
+	min-width: 0;
+	color: var(--text-color);
+}
+
+.headerTitle > span:last-child {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .container {
@@ -309,14 +455,38 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 	justify-content: start;
 }
 
+.codeBlock {
+	position: relative;
+}
+
+.codeBlockCopy {
+	position: absolute;
+	top: var(--spacing--sm);
+	right: var(--spacing--lg);
+	z-index: 1;
+	opacity: 0;
+	transition: opacity var(--duration--snappy) var(--easing--ease-out);
+
+	.codeBlock:hover &,
+	.codeBlock:focus-within & {
+		opacity: 1;
+	}
+}
+
 .json {
-	font-family: monospace;
-	font-size: var(--font-size--2xs);
-	white-space: pre;
-	background-color: var(--color--foreground--tint-2);
-	padding: var(--spacing--2xs);
-	border-radius: var(--radius);
+	font-family: var(--font-family--monospace);
+	font-size: var(--font-size--sm);
+	line-height: var(--line-height--xl);
+	white-space: pre-wrap;
+	word-break: break-word;
+	margin: 0;
+	background-color: var(--background--subtle);
+	padding: var(--spacing--sm);
+	padding-right: calc(var(--spacing--2xl) + var(--spacing--lg));
+	border-radius: var(--radius--3xs);
 	overflow-x: auto;
+	color: var(--color--text--tint-1);
+	margin-top: var(--spacing--2xs);
 }
 
 .formCard {
@@ -364,5 +534,24 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 	> *:first-child {
 		margin-top: 0;
 	}
+}
+</style>
+
+<style lang="scss">
+.json-key {
+	color: var(--color--primary);
+}
+
+.json-string {
+	color: var(--color--success);
+}
+
+.json-number {
+	color: var(--color--warning);
+}
+
+.json-bool {
+	color: var(--color--text--tint-1);
+	font-style: italic;
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionEventFilter.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionEventFilter.vue
@@ -1,8 +1,7 @@
 <script lang="ts" setup>
-import { ref, useTemplateRef } from 'vue';
-import { onClickOutside } from '@vueuse/core';
+import { ref } from 'vue';
 import { useI18n } from '@n8n/i18n';
-import { N8nIcon } from '@n8n/design-system';
+import { N8nButton, N8nPopover } from '@n8n/design-system';
 import type { FilterOption } from '../session-timeline.types';
 import { swatchBackground } from '../session-timeline.styles';
 
@@ -16,11 +15,6 @@ const emit = defineEmits<{ update: [next: Set<string>] }>();
 const i18n = useI18n();
 
 const open = ref(false);
-const rootRef = useTemplateRef<HTMLElement>('rootRef');
-
-onClickOutside(rootRef, () => {
-	open.value = false;
-});
 
 function toggle(key: string, checked: boolean): void {
 	const next = new Set(props.selected);
@@ -35,18 +29,14 @@ function clearAll(): void {
 </script>
 
 <template>
-	<div ref="rootRef" :class="$style.root">
-		<button
-			type="button"
-			data-test-id="filter-trigger"
-			:class="$style.trigger"
-			@click="open = !open"
-		>
-			<N8nIcon icon="funnel" :size="12" />
-			<span>{{ i18n.baseText('agentSessions.timeline.events') }}</span>
-			<span v-if="props.selected.size > 0">&nbsp;({{ props.selected.size }})</span>
-		</button>
-		<div v-if="open" :class="$style.panel">
+	<N8nPopover v-model:open="open" side="bottom" align="end" :content-class="$style.panel">
+		<template #trigger>
+			<N8nButton variant="outline" icon="funnel" data-test-id="filter-trigger">
+				<span>{{ i18n.baseText('agentSessions.timeline.events') }}</span>
+				<span v-if="props.selected.size > 0">&nbsp;({{ props.selected.size }})</span>
+			</N8nButton>
+		</template>
+		<template #content>
 			<label
 				v-for="opt in props.available"
 				:key="opt.key"
@@ -71,39 +61,13 @@ function clearAll(): void {
 			>
 				{{ i18n.baseText('agentSessions.timeline.clearFilter') }}
 			</button>
-		</div>
-	</div>
+		</template>
+	</N8nPopover>
 </template>
 
 <style module lang="scss">
-.root {
-	position: relative;
-}
-.trigger {
-	display: inline-flex;
-	align-items: center;
-	gap: var(--spacing--4xs);
-	padding: var(--spacing--4xs) var(--spacing--2xs);
-	background: none;
-	border: var(--border-width) var(--border-style) var(--color--foreground);
-	border-radius: var(--radius);
-	font-size: var(--font-size--2xs);
-	color: var(--color--text);
-	cursor: pointer;
-	&:hover {
-		background-color: var(--color--foreground--tint-1);
-	}
-}
 .panel {
-	position: absolute;
-	left: 0;
-	top: calc(100% + var(--spacing--3xs));
-	background-color: var(--color--foreground--tint-2);
-	border: var(--border-width) var(--border-style) var(--color--foreground);
-	border-radius: var(--radius);
 	padding: var(--spacing--sm) var(--spacing--md);
-	min-width: 280px;
-	z-index: 10;
 }
 .option {
 	display: flex;

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineChart.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineChart.vue
@@ -199,7 +199,6 @@ function onClick(index: number, item: TimelineItem): void {
 	gap: 1px;
 	height: 28px;
 	width: 100%;
-	background-color: var(--color--foreground--tint-2);
 	border-radius: var(--radius);
 }
 
@@ -213,6 +212,13 @@ function onClick(index: number, item: TimelineItem): void {
 	display: flex;
 	align-items: stretch;
 	min-width: 24px;
+	transition:
+		opacity,
+		transform var(--duration--snappy) var(--easing--ease-out);
+}
+
+.chart:has(.block:hover, .block.selected) .block:not(:hover):not(.selected) {
+	opacity: 0.6;
 }
 
 .cell > span {
@@ -262,16 +268,13 @@ function onClick(index: number, item: TimelineItem): void {
 	border: none;
 	border-radius: var(--radius--sm);
 	padding: 0;
+	background-color: var(--session-timeline-chart-block-color);
 	cursor: pointer;
 	transition: filter 0.15s;
-
-	&:hover {
-		filter: brightness(1.1);
-	}
 }
 
 .selected {
-	outline: 2px solid var(--color--warning);
+	outline: 2px solid var(--session-timeline-chart-block-color);
 	outline-offset: 1px;
 	/* Lift above neighbouring idle stripes so the highlight outline doesn't
 	   get covered by the adjacent .idle background. */

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineChart.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineChart.vue
@@ -1,14 +1,15 @@
 <script lang="ts" setup>
-import { computed } from 'vue';
+import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue';
 import { truncate } from '@n8n/utils';
 import { useI18n } from '@n8n/i18n';
-import { N8nTooltip } from '@n8n/design-system';
+import { HoverCardContent, HoverCardPortal, HoverCardRoot, HoverCardTrigger } from 'reka-ui';
 import { convertToDisplayDate } from '@/app/utils/formatters/dateFormatter';
 import type { CSSProperties } from 'vue';
 import type { IdleRange, TimelineItem } from '../session-timeline.types';
 import { builtinToolLabelKey, formatDuration, itemFilterKey } from '../session-timeline.utils';
-import { chartBlockStyle, pillStyle as kindPillStyle } from '../session-timeline.styles';
+import { chartBlockStyle } from '../session-timeline.styles';
 import { formatToolNameForDisplay } from '../utils/toolDisplayName';
+import SessionTimelinePill from './SessionTimelinePill.vue';
 
 const props = defineProps<{
 	items: TimelineItem[];
@@ -19,11 +20,18 @@ const props = defineProps<{
 	selectedIndex: number | null;
 }>();
 
+const SCROLL_PADDING = 48;
+
 const emit = defineEmits<{ select: [index: number] }>();
 
 const i18n = useI18n();
+const chartRef = ref<HTMLElement | null>(null);
+const activePopover = ref<{ segment: Segment; reference: HTMLElement } | null>(null);
+const popoverOpen = ref(false);
 
 const INSTANT_MS = 100;
+const POPOVER_SHOW_DELAY_MS = 300;
+let showPopoverTimer: ReturnType<typeof setTimeout> | null = null;
 
 type Segment =
 	| { kind: 'event'; item: TimelineItem; index: number; duration: number }
@@ -67,10 +75,6 @@ function eventStyle(item: TimelineItem): CSSProperties {
 		style.pointerEvents = 'none';
 	}
 	return style;
-}
-
-function pillStyle(item: TimelineItem): CSSProperties {
-	return kindPillStyle(item.kind);
 }
 
 function popoverLabel(item: TimelineItem): string {
@@ -142,10 +146,125 @@ function onClick(index: number, item: TimelineItem): void {
 	if (isDimmed(item)) return;
 	emit('select', index);
 }
+
+function showPopover(segment: Segment, event: MouseEvent | FocusEvent): void {
+	if (!(event.currentTarget instanceof HTMLElement)) return;
+	const reference = event.currentTarget;
+	clearShowPopoverTimer();
+	showPopoverTimer = setTimeout(() => {
+		activePopover.value = { segment, reference };
+		popoverOpen.value = true;
+	}, POPOVER_SHOW_DELAY_MS);
+}
+
+function clearShowPopoverTimer(): void {
+	if (!showPopoverTimer) return;
+	clearTimeout(showPopoverTimer);
+	showPopoverTimer = null;
+}
+
+function showSelectedPopover(): void {
+	const selectedIndex = props.selectedIndex;
+	if (selectedIndex === null) {
+		popoverOpen.value = false;
+		activePopover.value = null;
+		return;
+	}
+
+	const segment = segments.value.find((seg) => seg.kind === 'event' && seg.index === selectedIndex);
+	const reference = chartRef.value?.querySelector<HTMLElement>(
+		`[data-timeline-index="${selectedIndex}"]`,
+	);
+
+	if (segment && reference) {
+		activePopover.value = { segment, reference };
+		popoverOpen.value = true;
+	}
+}
+
+function scrollSelectedIntoView(): void {
+	const selectedIndex = props.selectedIndex;
+	const chart = chartRef.value;
+	if (selectedIndex === null || !chart) return;
+
+	const selectedBlock = chart.querySelector<HTMLElement>(
+		`[data-timeline-index="${selectedIndex}"]`,
+	);
+	if (!selectedBlock) return;
+
+	const blockLeft = selectedBlock.offsetLeft;
+	const blockRight = blockLeft + selectedBlock.offsetWidth;
+	const viewportLeft = chart.scrollLeft;
+	const viewportRight = viewportLeft + chart.clientWidth;
+
+	if (blockLeft - SCROLL_PADDING < viewportLeft) {
+		chart.scrollLeft = Math.max(0, blockLeft - SCROLL_PADDING);
+	} else if (blockRight + SCROLL_PADDING > viewportRight) {
+		chart.scrollLeft = blockRight + SCROLL_PADDING - chart.clientWidth;
+	}
+}
+
+function hidePopover(segment: Segment): void {
+	clearShowPopoverTimer();
+	if (segment.kind === 'event' && segment.index === props.selectedIndex) {
+		showSelectedPopover();
+		return;
+	}
+
+	popoverOpen.value = false;
+	activePopover.value = null;
+}
+
+watch(
+	() => props.selectedIndex,
+	() => {
+		clearShowPopoverTimer();
+		void nextTick(() => {
+			scrollSelectedIntoView();
+			showSelectedPopover();
+		});
+	},
+);
+
+onBeforeUnmount(clearShowPopoverTimer);
 </script>
 
 <template>
-	<div :class="$style.chart">
+	<div ref="chartRef" :class="$style.chart">
+		<HoverCardRoot :open="popoverOpen" :close-delay="0">
+			<!-- One shared HoverCard avoids hundreds of tooltip instances; segment handlers set content and reference. -->
+			<HoverCardTrigger as="span" :class="$style.popoverTrigger" />
+			<HoverCardPortal>
+				<HoverCardContent
+					:reference="activePopover?.reference"
+					side="top"
+					align="center"
+					:side-offset="8"
+					:class="$style.tooltipContent"
+				>
+					<div v-if="activePopover?.segment.kind === 'idle'" :class="$style.popoverInner">
+						<SessionTimelinePill
+							kind="idle"
+							:label="i18n.baseText('agentSessions.timeline.idle')"
+							show-label
+						/>
+						<span :class="$style.popoverMeta">{{ idleDuration(activePopover.segment.range) }}</span>
+					</div>
+					<div v-else-if="activePopover" :class="$style.popoverInner">
+						<SessionTimelinePill
+							:kind="activePopover.segment.item.kind"
+							:label="popoverLabel(activePopover.segment.item)"
+							show-label
+						/>
+						<span :class="$style.popoverName">{{ popoverName(activePopover.segment.item) }}</span>
+						<span v-if="popoverDuration(activePopover.segment.item)" :class="$style.popoverMeta">
+							{{ popoverDuration(activePopover.segment.item) }}
+						</span>
+						<span :class="$style.popoverMeta">{{ popoverTime(activePopover.segment.item) }}</span>
+					</div>
+				</HoverCardContent>
+			</HoverCardPortal>
+		</HoverCardRoot>
 		<div
 			v-for="(seg, segIdx) in segments"
 			:key="segIdx"
@@ -153,41 +272,29 @@ function onClick(index: number, item: TimelineItem): void {
 			:class="$style.cell"
 			:style="cellStyle(seg)"
 		>
-			<N8nTooltip placement="top" :show-after="100" :content-class="$style.tooltipContent">
-				<template v-if="seg.kind === 'idle'">
-					<div data-test-id="timeline-idle" :class="$style.idle">
-						<span :class="$style.idleFill">{{ i18n.baseText('agentSessions.timeline.idle') }}</span>
-					</div>
-				</template>
-				<template v-else>
-					<button
-						type="button"
-						data-test-id="timeline-block"
-						:class="[$style.block, props.selectedIndex === seg.index && $style.selected]"
-						:data-selected="props.selectedIndex === seg.index ? 'true' : undefined"
-						:style="eventStyle(seg.item)"
-						@click="onClick(seg.index, seg.item)"
-					/>
-				</template>
-				<template #content>
-					<div v-if="seg.kind === 'idle'" :class="$style.popoverInner">
-						<span :class="[$style.popoverPill, $style.idlePill]">
-							{{ i18n.baseText('agentSessions.timeline.idle') }}
-						</span>
-						<span :class="$style.popoverMeta">{{ idleDuration(seg.range) }}</span>
-					</div>
-					<div v-else :class="$style.popoverInner">
-						<span :class="$style.popoverPill" :style="pillStyle(seg.item)">
-							{{ popoverLabel(seg.item) }}
-						</span>
-						<span :class="$style.popoverName">{{ popoverName(seg.item) }}</span>
-						<span v-if="popoverDuration(seg.item)" :class="$style.popoverMeta">
-							{{ popoverDuration(seg.item) }}
-						</span>
-						<span :class="$style.popoverMeta">{{ popoverTime(seg.item) }}</span>
-					</div>
-				</template>
-			</N8nTooltip>
+			<div
+				v-if="seg.kind === 'idle'"
+				data-test-id="timeline-idle"
+				:class="$style.idle"
+				@mouseenter="showPopover(seg, $event)"
+				@mouseleave="hidePopover(seg)"
+			>
+				<span :class="$style.idleFill">{{ i18n.baseText('agentSessions.timeline.idle') }}</span>
+			</div>
+			<button
+				v-else
+				type="button"
+				data-test-id="timeline-block"
+				:data-timeline-index="seg.index"
+				:class="[$style.block, props.selectedIndex === seg.index && $style.selected]"
+				:data-selected="props.selectedIndex === seg.index ? 'true' : undefined"
+				:style="eventStyle(seg.item)"
+				@mouseenter="showPopover(seg, $event)"
+				@mouseleave="hidePopover(seg)"
+				@focus="showPopover(seg, $event)"
+				@blur="hidePopover(seg)"
+				@click="onClick(seg.index, seg.item)"
+			/>
 		</div>
 	</div>
 </template>
@@ -199,19 +306,26 @@ function onClick(index: number, item: TimelineItem): void {
 	gap: 1px;
 	height: 28px;
 	width: 100%;
+	overflow-x: auto;
+	scrollbar-width: none;
+	scroll-padding-inline: var(--spacing--lg);
 	border-radius: var(--radius);
+
+	&::-webkit-scrollbar {
+		display: none;
+	}
 }
 
 /*
  * Each segment lives inside a flex .cell that owns the inline flex sizing.
- * The TooltipTrigger span (a real DOM element with a measurable bounding rect
- * — required by reka-ui's positioning) fills the cell, and the block/idle
- * inside fills the span.
+ * Hover/focus popover positioning is handled by one shared HoverCard above,
+ * anchored to the active block/idle element.
  */
 .cell {
 	display: flex;
 	align-items: stretch;
 	min-width: 24px;
+	flex-shrink: 0;
 	transition:
 		opacity,
 		transform var(--duration--snappy) var(--easing--ease-out);
@@ -219,13 +333,6 @@ function onClick(index: number, item: TimelineItem): void {
 
 .chart:has(.block:hover, .block.selected) .block:not(:hover):not(.selected) {
 	opacity: 0.6;
-}
-
-.cell > span {
-	display: flex;
-	flex: 1 0 0;
-	align-items: stretch;
-	min-width: 0;
 }
 
 .idle {
@@ -256,11 +363,6 @@ function onClick(index: number, item: TimelineItem): void {
 	letter-spacing: 0.02em;
 }
 
-.idlePill {
-	background-color: var(--color--foreground--tint-1);
-	color: var(--color--text--tint-1);
-}
-
 .block {
 	position: relative;
 	flex: 1 0 0;
@@ -287,33 +389,34 @@ function onClick(index: number, item: TimelineItem): void {
  * mode. Also remove the 180px max-width so our single-line row layout
  * (pill · name · duration · time) doesn't wrap.
  */
+.popoverTrigger {
+	display: none;
+}
+
 .tooltipContent {
 	max-width: none;
-	/* foreground--tint-2 is a raised surface (also used by the chart strip
-	   and top bar) that stands out from page bg in BOTH light and dark mode. */
-	background: var(--color--foreground--tint-2);
+	min-height: var(--height--sm);
+	font-size: var(--font-size--xs);
+	font-weight: var(--font-weight--medium);
+	line-height: var(--line-height--md);
+	border-radius: var(--radius--xs);
+	box-shadow: var(--shadow--sm);
+	word-wrap: break-word;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 999;
+	background: var(--background--surface);
 	border: var(--border);
 	color: var(--color--text);
-
-	/* Match the arrow fill to the tooltip bg so the pointer doesn't show
-	   as the wrong color against the panel. */
-	svg {
-		fill: var(--color--foreground--tint-2);
-	}
 }
 
 .popoverInner {
 	display: inline-flex;
 	align-items: center;
 	gap: var(--spacing--2xs);
+	padding: var(--spacing--4xs) var(--spacing--3xs);
 	white-space: nowrap;
-}
-
-.popoverPill {
-	font-size: var(--font-size--3xs);
-	font-weight: var(--font-weight--bold);
-	padding: var(--spacing--4xs) var(--spacing--2xs);
-	border-radius: var(--radius--lg);
 }
 
 .popoverName {

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionTimelinePill.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionTimelinePill.vue
@@ -1,0 +1,73 @@
+<script lang="ts" setup>
+import { computed } from 'vue';
+import { N8nIcon, type IconName } from '@n8n/design-system';
+import type { EventKind } from '../session-timeline.types';
+import { pillColors } from '../session-timeline.styles';
+
+const props = withDefaults(
+	defineProps<{
+		kind: EventKind | 'idle';
+		label?: string;
+		showLabel?: boolean;
+	}>(),
+	{
+		label: '',
+		showLabel: false,
+	},
+);
+
+const icon = computed((): IconName => {
+	switch (props.kind) {
+		case 'user':
+			return 'user';
+		case 'agent':
+			return 'bot';
+		case 'tool':
+			return 'wrench';
+		case 'workflow':
+			return 'workflow';
+		case 'node':
+			return 'box';
+		case 'working-memory':
+			return 'brain';
+		case 'suspension':
+		case 'idle':
+			return 'clock';
+		default:
+			return 'info';
+	}
+});
+
+const iconStyle = computed(() => pillColors(props.kind));
+</script>
+
+<template>
+	<span :class="[$style.pill, showLabel && $style.withLabel]" :style="iconStyle">
+		<N8nIcon :icon="icon" size="small" />
+		<span v-if="showLabel && label" :class="$style.label">{{ label }}</span>
+	</span>
+</template>
+
+<style module lang="scss">
+.pill {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: var(--height--2xs);
+	height: var(--height--2xs);
+	border-radius: var(--radius--lg);
+	flex-shrink: 0;
+}
+
+.withLabel {
+	width: auto;
+	gap: var(--spacing--4xs);
+	padding: 0 var(--spacing--2xs);
+}
+
+.label {
+	font-size: var(--font-size--3xs);
+	font-weight: var(--font-weight--bold);
+	line-height: 1;
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineRow.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineRow.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { N8nIcon, N8nTooltip, type IconName } from '@n8n/design-system';
 import { computed } from 'vue';
 import { useRouter } from 'vue-router';
 import { useI18n } from '@n8n/i18n';
@@ -8,10 +9,7 @@ import { VIEWS } from '@/app/constants/navigation';
 import type { TimelineItem } from '../session-timeline.types';
 import { builtinToolLabelKey } from '../session-timeline.utils';
 import { formatToolNameForDisplay } from '../utils/toolDisplayName';
-import {
-	pillStyle as kindPillStyle,
-	rowBorderColor as kindRowBorderColor,
-} from '../session-timeline.styles';
+import { rowBorderColor as kindRowBorderColor } from '../session-timeline.styles';
 
 const props = defineProps<{
 	item: TimelineItem;
@@ -38,7 +36,7 @@ const infoText = computed((): string => {
 	switch (it.kind) {
 		case 'user':
 		case 'agent':
-			return truncate(it.content ?? '', 120);
+			return truncate(it.content ?? '', 500);
 		case 'tool': {
 			const key = builtinToolLabelKey(it.toolName, it.toolOutput);
 			return key ? i18n.baseText(key) : formatToolNameForDisplay(it.toolName);
@@ -77,17 +75,57 @@ const label = computed((): string => {
 	}
 });
 
-const pillStyle = computed(() => kindPillStyle(props.item.kind));
+const icon = computed((): IconName => {
+	switch (props.item.kind) {
+		case 'user':
+			return 'user';
+		case 'agent':
+			return 'bot';
+		case 'tool':
+			return 'wrench';
+		case 'workflow':
+			return 'workflow';
+		case 'node':
+			return 'box';
+		case 'working-memory':
+			return 'brain';
+		case 'suspension':
+			return 'clock';
+		default:
+			return 'info';
+	}
+});
+
+const iconStyle = computed(() => {
+	switch (props.item.kind) {
+		case 'user':
+			return { backgroundColor: 'var(--color--blue-200)', color: 'var(--color--blue-950)' };
+		case 'agent':
+			return { backgroundColor: 'var(--color--purple-200)', color: 'var(--color--purple-950)' };
+		case 'tool':
+			return { backgroundColor: 'var(--color--green-200)', color: 'var(--color--green-950)' };
+		case 'workflow':
+			return { backgroundColor: 'var(--color--orange-200)', color: 'var(--color--orange-950)' };
+		case 'node':
+			return { backgroundColor: 'var(--color--neutral-200)', color: 'var(--color--neutral-950)' };
+		case 'working-memory':
+			return { backgroundColor: 'var(--color--mint-200)', color: 'var(--color--mint-950)' };
+		case 'suspension':
+			return { backgroundColor: 'var(--color--yellow-200)', color: 'var(--color--yellow-950)' };
+		default:
+			return { backgroundColor: 'var(--color--neutral-200)', color: 'var(--color--neutral-950)' };
+	}
+});
 const rowBorderColor = computed(() => kindRowBorderColor(props.item.kind));
 </script>
 
 <template>
-	<div
-		:class="[$style.row, selected && $style.selected]"
-		:style="{ borderLeftColor: rowBorderColor }"
-		@click="emit('select')"
-	>
-		<span :class="$style.pill" :style="pillStyle">{{ label }}</span>
+	<div :class="[$style.row, selected && $style.selected]" @click="emit('select')">
+		<N8nTooltip :content="label" placement="top">
+			<span :class="$style.iconWrapper" :style="iconStyle">
+				<N8nIcon :icon="icon" size="small" />
+			</span>
+		</N8nTooltip>
 		<div :class="$style.info">
 			<template v-if="item.kind === 'workflow' && workflowHref">
 				<a
@@ -110,39 +148,32 @@ const rowBorderColor = computed(() => kindRowBorderColor(props.item.kind));
 <style module lang="scss">
 .row {
 	display: grid;
-	/* Fixed pill column wide enough to fit the widest label ("Workflow",
-	   "Suspended", "Assistant") at 3xs/bold with horizontal padding. */
-	grid-template-columns: 88px 1fr auto;
+	grid-template-columns: auto 1fr auto;
 	align-items: center;
-	gap: var(--spacing--2xs);
+	gap: var(--spacing--xs);
 	padding: var(--spacing--2xs) var(--spacing--sm);
-	border-left: 3px solid transparent;
+	height: var(--height--xl);
 	cursor: pointer;
 	font-size: var(--font-size--sm);
-	line-height: var(--line-height--lg);
+	border-radius: var(--radius--3xs);
 
 	&:hover {
-		background-color: var(--color--foreground--tint-2);
+		background-color: var(--background--hover);
 	}
 }
 
 .selected {
-	background-color: var(--color--foreground--tint-2);
-	outline: 2px solid var(--color--warning);
-	outline-offset: -2px;
+	background-color: var(--background--active);
 }
 
-.pill {
-	/* justify-self: start keeps the pill anchored to the left of the fixed
-	   pill column; the inline-flex sizes the pill to its text content only. */
+.iconWrapper {
 	justify-self: start;
 	display: inline-flex;
 	align-items: center;
-	font-size: var(--font-size--3xs);
-	font-weight: var(--font-weight--bold);
-	padding: var(--spacing--4xs) var(--spacing--2xs);
+	justify-content: center;
+	width: var(--height--2xs);
+	height: var(--height--2xs);
 	border-radius: var(--radius--lg);
-	white-space: nowrap;
 }
 
 .info {
@@ -159,6 +190,7 @@ const rowBorderColor = computed(() => kindRowBorderColor(props.item.kind));
 	> span {
 		overflow: hidden;
 		text-overflow: ellipsis;
+		line-height: 1.2; /* restore normal line height so descenders aren't clipped */
 	}
 }
 

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineRow.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineRow.vue
@@ -135,7 +135,7 @@ const label = computed((): string => {
 	> span {
 		overflow: hidden;
 		text-overflow: ellipsis;
-		line-height: 1.2; /* restore normal line height so descenders aren't clipped */
+		line-height: var(--line-height--sm);
 	}
 }
 

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineRow.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineRow.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { N8nIcon, N8nTooltip, type IconName } from '@n8n/design-system';
+import { N8nTooltip } from '@n8n/design-system';
 import { computed } from 'vue';
 import { useRouter } from 'vue-router';
 import { useI18n } from '@n8n/i18n';
@@ -9,7 +9,7 @@ import { VIEWS } from '@/app/constants/navigation';
 import type { TimelineItem } from '../session-timeline.types';
 import { builtinToolLabelKey } from '../session-timeline.utils';
 import { formatToolNameForDisplay } from '../utils/toolDisplayName';
-import { rowBorderColor as kindRowBorderColor } from '../session-timeline.styles';
+import SessionTimelinePill from './SessionTimelinePill.vue';
 
 const props = defineProps<{
 	item: TimelineItem;
@@ -74,57 +74,12 @@ const label = computed((): string => {
 			return '';
 	}
 });
-
-const icon = computed((): IconName => {
-	switch (props.item.kind) {
-		case 'user':
-			return 'user';
-		case 'agent':
-			return 'bot';
-		case 'tool':
-			return 'wrench';
-		case 'workflow':
-			return 'workflow';
-		case 'node':
-			return 'box';
-		case 'working-memory':
-			return 'brain';
-		case 'suspension':
-			return 'clock';
-		default:
-			return 'info';
-	}
-});
-
-const iconStyle = computed(() => {
-	switch (props.item.kind) {
-		case 'user':
-			return { backgroundColor: 'var(--color--blue-200)', color: 'var(--color--blue-950)' };
-		case 'agent':
-			return { backgroundColor: 'var(--color--purple-200)', color: 'var(--color--purple-950)' };
-		case 'tool':
-			return { backgroundColor: 'var(--color--green-200)', color: 'var(--color--green-950)' };
-		case 'workflow':
-			return { backgroundColor: 'var(--color--orange-200)', color: 'var(--color--orange-950)' };
-		case 'node':
-			return { backgroundColor: 'var(--color--neutral-200)', color: 'var(--color--neutral-950)' };
-		case 'working-memory':
-			return { backgroundColor: 'var(--color--mint-200)', color: 'var(--color--mint-950)' };
-		case 'suspension':
-			return { backgroundColor: 'var(--color--yellow-200)', color: 'var(--color--yellow-950)' };
-		default:
-			return { backgroundColor: 'var(--color--neutral-200)', color: 'var(--color--neutral-950)' };
-	}
-});
-const rowBorderColor = computed(() => kindRowBorderColor(props.item.kind));
 </script>
 
 <template>
 	<div :class="[$style.row, selected && $style.selected]" @click="emit('select')">
 		<N8nTooltip :content="label" placement="top">
-			<span :class="$style.iconWrapper" :style="iconStyle">
-				<N8nIcon :icon="icon" size="small" />
-			</span>
+			<SessionTimelinePill :kind="item.kind" />
 		</N8nTooltip>
 		<div :class="$style.info">
 			<template v-if="item.kind === 'workflow' && workflowHref">
@@ -164,16 +119,6 @@ const rowBorderColor = computed(() => kindRowBorderColor(props.item.kind));
 
 .selected {
 	background-color: var(--background--active);
-}
-
-.iconWrapper {
-	justify-self: start;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	width: var(--height--2xs);
-	height: var(--height--2xs);
-	border-radius: var(--radius--lg);
 }
 
 .info {

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineTable.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineTable.vue
@@ -86,7 +86,11 @@ const rows = computed<Row[]>(() => {
 });
 
 function updateScrollMask() {
-	if (!scrollContainer) return;
+	if (!scrollContainer) {
+		canScrollUp.value = false;
+		canScrollDown.value = false;
+		return;
+	}
 	canScrollUp.value = scrollContainer.scrollTop > 0;
 	canScrollDown.value =
 		scrollContainer.scrollTop + scrollContainer.clientHeight < scrollContainer.scrollHeight - 1;
@@ -144,6 +148,7 @@ watch(
 		]"
 	>
 		<N8nRecycleScroller
+			v-if="rows.length > 0"
 			ref="scrollerRef"
 			:items="rows"
 			:item-size="ROW_HEIGHT"
@@ -167,6 +172,9 @@ watch(
 				</div>
 			</template>
 		</N8nRecycleScroller>
+		<div v-else data-test-id="timeline-empty" :class="$style.empty">
+			{{ i18n.baseText('executionsLandingPage.noResults') }}
+		</div>
 	</div>
 </template>
 
@@ -179,6 +187,15 @@ watch(
 
 .rowWrapper {
 	width: 100%;
+}
+
+.empty {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	color: var(--text-color--subtler);
+	font-size: var(--font-size--sm);
 }
 
 .table :global(.recycle-scroller-wrapper) {

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineTable.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineTable.vue
@@ -1,10 +1,14 @@
 <script lang="ts" setup>
-import { computed } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import type { ComponentPublicInstance } from 'vue';
 import { useI18n } from '@n8n/i18n';
+import { N8nRecycleScroller } from '@n8n/design-system';
 import SessionTimelineRow from './SessionTimelineRow.vue';
 import type { IdleRange, TimelineItem } from '../session-timeline.types';
-import { builtinToolLabelKey, formatDuration, itemFilterKey } from '../session-timeline.utils';
-import { formatToolNameForDisplay } from '../utils/toolDisplayName';
+import { filteredTimelineItemIndexes, formatDuration } from '../session-timeline.utils';
+
+const ROW_HEIGHT = 40;
+const SCROLL_PADDING = 24;
 
 const props = defineProps<{
 	items: TimelineItem[];
@@ -17,77 +21,62 @@ const props = defineProps<{
 const emit = defineEmits<{ select: [index: number] }>();
 
 const i18n = useI18n();
+const tableRef = ref<HTMLElement | null>(null);
+const scrollerRef = ref<
+	ComponentPublicInstance<{ scrollItemIntoView: (itemKey: string) => void }> | undefined
+>();
+const canScrollUp = ref(false);
+const canScrollDown = ref(false);
+let scrollContainer: HTMLElement | null = null;
 
-/**
- * Build the haystack of searchable text per item — includes the pill label
- * (e.g. "Workflow", "Agent"), the built-in display name (e.g. "Feedback
- * requested from user"), the raw tool/workflow name, and any free text content.
- * Lowercased once for case-insensitive substring matching.
- */
-function searchableText(item: TimelineItem): string {
-	const parts: Array<string | undefined> = [];
-
-	// Pill / kind label
-	switch (item.kind) {
+function labelForKey(key: string): string {
+	switch (key) {
 		case 'user':
-			parts.push(i18n.baseText('agentSessions.timeline.user'));
-			break;
+			return i18n.baseText('agentSessions.timeline.user');
 		case 'agent':
-			parts.push(i18n.baseText('agentSessions.timeline.agent'));
-			break;
+			return i18n.baseText('agentSessions.timeline.agent');
 		case 'tool':
-			parts.push(i18n.baseText('agentSessions.timeline.tool'));
-			break;
+			return i18n.baseText('agentSessions.timeline.tool');
 		case 'workflow':
-			parts.push(i18n.baseText('agentSessions.timeline.workflow'));
-			break;
+			return i18n.baseText('agentSessions.timeline.workflow');
 		case 'node':
-			parts.push(i18n.baseText('agentSessions.timeline.node'));
-			break;
+			return i18n.baseText('agentSessions.timeline.node');
 		case 'working-memory':
-			parts.push(i18n.baseText('agentSessions.timeline.memory'));
-			parts.push(i18n.baseText('agentSessions.timeline.memoryUpdated'));
-			break;
+			return i18n.baseText('agentSessions.timeline.memory');
+		case 'working-memory-updated':
+			return i18n.baseText('agentSessions.timeline.memoryUpdated');
 		case 'suspension':
-			parts.push(i18n.baseText('agentSessions.timeline.suspended'));
-			parts.push(i18n.baseText('agentSessions.timeline.waitingForUser'));
-			break;
+			return i18n.baseText('agentSessions.timeline.suspended');
+		case 'suspension-waiting':
+			return i18n.baseText('agentSessions.timeline.waitingForUser');
+		case 'agentSessions.timeline.tool.richInteraction':
+		case 'agentSessions.timeline.tool.richInteractionDisplay':
+			return i18n.baseText(key);
+		default:
+			return key;
 	}
-
-	// Free text + raw identifiers
-	parts.push(item.content, item.toolName, item.workflowName, item.nodeDisplayName);
-	if (item.toolName) parts.push(formatToolNameForDisplay(item.toolName));
-
-	// Built-in tool friendly label
-	const toolKey = builtinToolLabelKey(item.toolName, item.toolOutput);
-	if (toolKey) parts.push(i18n.baseText(toolKey));
-
-	return parts
-		.filter((p): p is string => typeof p === 'string')
-		.join(' ')
-		.toLowerCase();
-}
-
-function matchesSearch(item: TimelineItem, query: string): boolean {
-	if (!query) return true;
-	return searchableText(item).includes(query.toLowerCase());
 }
 
 type Row =
-	| { kind: 'event'; item: TimelineItem; index: number; sortKey: number }
-	| { kind: 'idle'; range: IdleRange; sortKey: number };
+	| { id: string; kind: 'event'; item: TimelineItem; index: number; sortKey: number }
+	| { id: string; kind: 'idle'; range: IdleRange; sortKey: number };
 
 const rows = computed<Row[]>(() => {
-	const events: Row[] = props.items
-		.map((item, index) => ({ item, index }))
-		.filter(
-			({ item }) =>
-				(props.visibleKinds.size === 0 || props.visibleKinds.has(itemFilterKey(item))) &&
-				matchesSearch(item, (props.searchQuery ?? '').trim()),
-		)
-		.map(({ item, index }) => ({ kind: 'event', item, index, sortKey: item.timestamp }));
+	const events: Row[] = filteredTimelineItemIndexes(
+		props.items,
+		props.visibleKinds,
+		props.searchQuery ?? '',
+		labelForKey,
+	).map((index) => ({
+		id: `event-${index}`,
+		kind: 'event',
+		item: props.items[index],
+		index,
+		sortKey: props.items[index].timestamp,
+	}));
 
-	const idles: Row[] = (props.idleRanges ?? []).map((range) => ({
+	const idles: Row[] = (props.idleRanges ?? []).map((range, index) => ({
+		id: `idle-${range.start}-${range.end}-${index}`,
 		kind: 'idle',
 		range,
 		sortKey: range.start,
@@ -95,35 +84,122 @@ const rows = computed<Row[]>(() => {
 
 	return [...events, ...idles].sort((a, b) => a.sortKey - b.sortKey);
 });
+
+function updateScrollMask() {
+	if (!scrollContainer) return;
+	canScrollUp.value = scrollContainer.scrollTop > 0;
+	canScrollDown.value =
+		scrollContainer.scrollTop + scrollContainer.clientHeight < scrollContainer.scrollHeight - 1;
+}
+
+function bindScrollContainer() {
+	const nextScrollContainer = tableRef.value?.querySelector<HTMLElement>(
+		'.recycle-scroller-wrapper',
+	);
+	if (nextScrollContainer === scrollContainer) return;
+
+	scrollContainer?.removeEventListener('scroll', updateScrollMask);
+	scrollContainer = nextScrollContainer ?? null;
+	scrollContainer?.addEventListener('scroll', updateScrollMask, { passive: true });
+	updateScrollMask();
+}
+
+watch(
+	() => rows.value.length,
+	() => {
+		void nextTick(() => {
+			bindScrollContainer();
+			updateScrollMask();
+		});
+	},
+);
+
+onMounted(() => {
+	void nextTick(bindScrollContainer);
+});
+
+onBeforeUnmount(() => {
+	scrollContainer?.removeEventListener('scroll', updateScrollMask);
+});
+
+watch(
+	() => props.selectedIndex,
+	(selectedIndex) => {
+		if (selectedIndex === null) return;
+		void nextTick(() => {
+			scrollerRef.value?.scrollItemIntoView(`event-${selectedIndex}`);
+			updateScrollMask();
+		});
+	},
+);
 </script>
 
 <template>
-	<div :class="$style.table">
-		<template v-for="(row, idx) in rows" :key="idx">
-			<div
-				v-if="row.kind === 'event'"
-				data-test-id="timeline-row"
-				@click="emit('select', row.index)"
-			>
-				<SessionTimelineRow :item="row.item" :selected="props.selectedIndex === row.index" />
-			</div>
-			<div v-else data-test-id="timeline-idle-row" :class="$style.idleRow">
-				<span :class="$style.idlePill">
-					{{ i18n.baseText('agentSessions.timeline.idle') }} ·
-					{{ formatDuration(row.range.end - row.range.start) }}
-				</span>
-			</div>
-		</template>
+	<div
+		ref="tableRef"
+		:class="[
+			$style.table,
+			canScrollUp && $style.canScrollUp,
+			canScrollDown && $style.canScrollDown,
+		]"
+	>
+		<N8nRecycleScroller
+			ref="scrollerRef"
+			:items="rows"
+			:item-size="ROW_HEIGHT"
+			:scroll-padding="SCROLL_PADDING"
+			item-key="id"
+		>
+			<template #default="{ item: row }">
+				<div
+					v-if="row.kind === 'event'"
+					data-test-id="timeline-row"
+					:class="$style.rowWrapper"
+					@click="emit('select', row.index)"
+				>
+					<SessionTimelineRow :item="row.item" :selected="props.selectedIndex === row.index" />
+				</div>
+				<div v-else data-test-id="timeline-idle-row" :class="$style.idleRow">
+					<span :class="$style.idlePill">
+						{{ i18n.baseText('agentSessions.timeline.idle') }} ·
+						{{ formatDuration(row.range.end - row.range.start) }}
+					</span>
+				</div>
+			</template>
+		</N8nRecycleScroller>
 	</div>
 </template>
 
 <style module lang="scss">
 .table {
-	display: flex;
-	flex-direction: column;
 	background-color: var(--background--surface);
 	padding: var(--spacing--4xs);
 	height: 100%;
+}
+
+.rowWrapper {
+	width: 100%;
+}
+
+.table :global(.recycle-scroller-wrapper) {
+	scrollbar-width: none;
+	scroll-padding-block: var(--spacing--lg);
+
+	&::-webkit-scrollbar {
+		display: none;
+	}
+}
+
+.canScrollDown :global(.recycle-scroller-wrapper) {
+	mask-image: linear-gradient(to bottom, black 0%, black 95%, transparent 100%);
+}
+
+.canScrollUp :global(.recycle-scroller-wrapper) {
+	mask-image: linear-gradient(to bottom, transparent 0%, black 2%, black 100%);
+}
+
+.canScrollUp.canScrollDown :global(.recycle-scroller-wrapper) {
+	mask-image: linear-gradient(to bottom, transparent 0%, black 2%, black 95%, transparent 100%);
 }
 
 .idleRow {
@@ -131,6 +207,7 @@ const rows = computed<Row[]>(() => {
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	height: var(--height--xl);
 	padding: var(--spacing--2xs) var(--spacing--sm);
 	font-size: var(--font-size--2xs);
 	color: var(--color--text--tint-1);

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineTable.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineTable.vue
@@ -121,6 +121,9 @@ const rows = computed<Row[]>(() => {
 .table {
 	display: flex;
 	flex-direction: column;
+	background-color: var(--background--surface);
+	padding: var(--spacing--4xs);
+	height: 100%;
 }
 
 .idleRow {

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineTable.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineTable.vue
@@ -1,6 +1,5 @@
 <script lang="ts" setup>
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
-import type { ComponentPublicInstance } from 'vue';
 import { useI18n } from '@n8n/i18n';
 import { N8nRecycleScroller } from '@n8n/design-system';
 import SessionTimelineRow from './SessionTimelineRow.vue';
@@ -22,9 +21,6 @@ const emit = defineEmits<{ select: [index: number] }>();
 
 const i18n = useI18n();
 const tableRef = ref<HTMLElement | null>(null);
-const scrollerRef = ref<
-	ComponentPublicInstance<{ scrollItemIntoView: (itemKey: string) => void }> | undefined
->();
 const canScrollUp = ref(false);
 const canScrollDown = ref(false);
 let scrollContainer: HTMLElement | null = null;
@@ -108,6 +104,54 @@ function bindScrollContainer() {
 	updateScrollMask();
 }
 
+function visibleRowElement(rowId: string): HTMLElement | undefined {
+	const visibleRows = tableRef.value?.querySelectorAll<HTMLElement>('[data-timeline-row-id]');
+
+	return Array.from(visibleRows ?? []).find((element) => element.dataset.timelineRowId === rowId);
+}
+
+function scrollVisibleRowIntoView(rowId: string): boolean {
+	if (!scrollContainer) return false;
+
+	const rowElement = visibleRowElement(rowId);
+	if (!rowElement) return false;
+
+	const containerRect = scrollContainer.getBoundingClientRect();
+	const rowRect = rowElement.getBoundingClientRect();
+
+	if (rowRect.top - SCROLL_PADDING < containerRect.top) {
+		scrollContainer.scrollTop -= containerRect.top - rowRect.top + SCROLL_PADDING;
+	} else if (rowRect.bottom + SCROLL_PADDING > containerRect.bottom) {
+		scrollContainer.scrollTop += rowRect.bottom - containerRect.bottom + SCROLL_PADDING;
+	}
+
+	return true;
+}
+
+function scrollRowIntoView(rowId: string) {
+	if (!scrollContainer) return;
+	if (scrollVisibleRowIntoView(rowId)) return;
+
+	const rowIndex = rows.value.findIndex((row) => row.id === rowId);
+	if (rowIndex === -1) return;
+
+	const rowTop = rowIndex * ROW_HEIGHT;
+	const rowBottom = rowTop + ROW_HEIGHT;
+	const viewportTop = scrollContainer.scrollTop;
+	const viewportBottom = viewportTop + scrollContainer.clientHeight;
+
+	if (rowTop - SCROLL_PADDING < viewportTop) {
+		scrollContainer.scrollTop = Math.max(0, rowTop - SCROLL_PADDING);
+	} else if (rowBottom + SCROLL_PADDING > viewportBottom) {
+		scrollContainer.scrollTop = rowBottom + SCROLL_PADDING - scrollContainer.clientHeight;
+	}
+
+	void nextTick(() => {
+		scrollVisibleRowIntoView(rowId);
+		updateScrollMask();
+	});
+}
+
 watch(
 	() => rows.value.length,
 	() => {
@@ -131,7 +175,7 @@ watch(
 	(selectedIndex) => {
 		if (selectedIndex === null) return;
 		void nextTick(() => {
-			scrollerRef.value?.scrollItemIntoView(`event-${selectedIndex}`);
+			scrollRowIntoView(`event-${selectedIndex}`);
 			updateScrollMask();
 		});
 	},
@@ -147,24 +191,23 @@ watch(
 			canScrollDown && $style.canScrollDown,
 		]"
 	>
-		<N8nRecycleScroller
-			v-if="rows.length > 0"
-			ref="scrollerRef"
-			:items="rows"
-			:item-size="ROW_HEIGHT"
-			:scroll-padding="SCROLL_PADDING"
-			item-key="id"
-		>
+		<N8nRecycleScroller v-if="rows.length > 0" :items="rows" :item-size="ROW_HEIGHT" item-key="id">
 			<template #default="{ item: row }">
 				<div
 					v-if="row.kind === 'event'"
 					data-test-id="timeline-row"
+					:data-timeline-row-id="row.id"
 					:class="$style.rowWrapper"
 					@click="emit('select', row.index)"
 				>
 					<SessionTimelineRow :item="row.item" :selected="props.selectedIndex === row.index" />
 				</div>
-				<div v-else data-test-id="timeline-idle-row" :class="$style.idleRow">
+				<div
+					v-else
+					data-test-id="timeline-idle-row"
+					:data-timeline-row-id="row.id"
+					:class="$style.idleRow"
+				>
 					<span :class="$style.idlePill">
 						{{ i18n.baseText('agentSessions.timeline.idle') }} ·
 						{{ formatDuration(row.range.end - row.range.start) }}

--- a/packages/frontend/editor-ui/src/features/agents/session-timeline.styles.ts
+++ b/packages/frontend/editor-ui/src/features/agents/session-timeline.styles.ts
@@ -1,5 +1,6 @@
 import type { CSSProperties } from 'vue';
 import type { EventKind } from './session-timeline.types';
+import { chartBlockColor } from './session-timeline.utils';
 type TimelinePillKind = EventKind | 'idle';
 
 export function pillColors(
@@ -23,27 +24,6 @@ export function pillColors(
 			return { backgroundColor: 'var(--color--yellow-200)', color: 'var(--color--yellow-950)' };
 		default:
 			return { backgroundColor: 'var(--color--neutral-200)', color: 'var(--color--neutral-950)' };
-	}
-}
-
-function chartBlockColor(kind: EventKind): string {
-	switch (kind) {
-		case 'user':
-			return 'var(--color--blue-600)';
-		case 'agent':
-			return 'var(--color--purple-600)';
-		case 'tool':
-			return 'var(--color--green-600)';
-		case 'workflow':
-			return 'var(--color--orange-600)';
-		case 'node':
-			return 'var(--color--neutral-600)';
-		case 'working-memory':
-			return 'var(--color--mint-600)';
-		case 'suspension':
-			return 'var(--color--yellow-600)';
-		default:
-			return 'var(--color--neutral-600)';
 	}
 }
 

--- a/packages/frontend/editor-ui/src/features/agents/session-timeline.styles.ts
+++ b/packages/frontend/editor-ui/src/features/agents/session-timeline.styles.ts
@@ -1,35 +1,56 @@
 import type { CSSProperties } from 'vue';
 import type { EventKind } from './session-timeline.types';
-import { kindColorToken } from './session-timeline.utils';
+type TimelinePillKind = EventKind | 'idle';
 
-/**
- * Shared kind-based colour treatments for the session timeline. Centralises
- * the `color-mix` recipes that previously lived inline in the row, chart
- * block, chart popover, and filter swatch — so adjusting the look (e.g.
- * stronger colours in light mode) only needs to happen in one place.
- *
- * The alpha percentages are exposed as CSS variables (`--color--session-timeline-pill-bg-alpha`,
- * `--color--session-timeline-block-bg-alpha`, `--color--session-timeline-row-border-alpha`, `--color--session-timeline-pill-text`)
- * defined globally on `body` by `AgentSessionTimelineView.vue` and switched
- * per theme there. Components just consume these helpers and don't think
- * about per-mode tuning.
- */
+export function pillColors(
+	kind: TimelinePillKind,
+): Pick<CSSProperties, 'backgroundColor' | 'color'> {
+	switch (kind) {
+		case 'user':
+			return { backgroundColor: 'var(--color--blue-200)', color: 'var(--color--blue-950)' };
+		case 'agent':
+			return { backgroundColor: 'var(--color--purple-200)', color: 'var(--color--purple-950)' };
+		case 'tool':
+			return { backgroundColor: 'var(--color--green-200)', color: 'var(--color--green-950)' };
+		case 'workflow':
+			return { backgroundColor: 'var(--color--orange-200)', color: 'var(--color--orange-950)' };
+		case 'node':
+			return { backgroundColor: 'var(--color--neutral-200)', color: 'var(--color--neutral-950)' };
+		case 'working-memory':
+			return { backgroundColor: 'var(--color--mint-200)', color: 'var(--color--mint-950)' };
+		case 'suspension':
+		case 'idle':
+			return { backgroundColor: 'var(--color--yellow-200)', color: 'var(--color--yellow-950)' };
+		default:
+			return { backgroundColor: 'var(--color--neutral-200)', color: 'var(--color--neutral-950)' };
+	}
+}
 
-export function pillStyle(kind: EventKind): CSSProperties {
-	return {
-		backgroundColor: `color-mix(in srgb, ${kindColorToken(kind)} var(--color--session-timeline-pill-bg-alpha), transparent)`,
-		color: 'var(--color--session-timeline-pill-text)',
-	};
+function chartBlockColor(kind: EventKind): string {
+	switch (kind) {
+		case 'user':
+			return 'var(--color--blue-600)';
+		case 'agent':
+			return 'var(--color--purple-600)';
+		case 'tool':
+			return 'var(--color--green-600)';
+		case 'workflow':
+			return 'var(--color--orange-600)';
+		case 'node':
+			return 'var(--color--neutral-600)';
+		case 'working-memory':
+			return 'var(--color--mint-600)';
+		case 'suspension':
+			return 'var(--color--yellow-600)';
+		default:
+			return 'var(--color--neutral-600)';
+	}
 }
 
 export function chartBlockStyle(kind: EventKind): CSSProperties {
 	return {
-		'--session-timeline-chart-block-color': `color-mix(in srgb, ${kindColorToken(kind)} var(--color--session-timeline-block-bg-alpha), transparent)`,
+		'--session-timeline-chart-block-color': chartBlockColor(kind),
 	};
-}
-
-export function rowBorderColor(kind: EventKind): string {
-	return `color-mix(in srgb, ${kindColorToken(kind)} var(--color--session-timeline-row-border-alpha), transparent)`;
 }
 
 /**

--- a/packages/frontend/editor-ui/src/features/agents/session-timeline.styles.ts
+++ b/packages/frontend/editor-ui/src/features/agents/session-timeline.styles.ts
@@ -24,7 +24,7 @@ export function pillStyle(kind: EventKind): CSSProperties {
 
 export function chartBlockStyle(kind: EventKind): CSSProperties {
 	return {
-		backgroundColor: `color-mix(in srgb, ${kindColorToken(kind)} var(--color--session-timeline-block-bg-alpha), transparent)`,
+		'--session-timeline-chart-block-color': `color-mix(in srgb, ${kindColorToken(kind)} var(--color--session-timeline-block-bg-alpha), transparent)`,
 	};
 }
 

--- a/packages/frontend/editor-ui/src/features/agents/session-timeline.utils.ts
+++ b/packages/frontend/editor-ui/src/features/agents/session-timeline.utils.ts
@@ -1,5 +1,6 @@
 import type { EventKind, IdleRange, TimelineItem } from './session-timeline.types';
 import type { ThreadExecution } from './composables/useAgentThreadsApi';
+import { formatToolNameForDisplay } from './utils/toolDisplayName';
 
 export const IDLE_THRESHOLD_MS = 10 * 60 * 1000;
 
@@ -27,6 +28,58 @@ export function itemFilterKey(item: TimelineItem): string {
 	// stays compact regardless of how many distinct tools the agent uses; the
 	// search input handles per-tool drill-down.
 	return item.kind;
+}
+
+export type TimelineLabelResolver = (key: string) => string;
+
+export function timelineItemSearchText(
+	item: TimelineItem,
+	labelForKey: TimelineLabelResolver,
+): string {
+	const parts: Array<string | undefined> = [];
+
+	parts.push(labelForKey(itemFilterKey(item)));
+	if (item.kind === 'working-memory') {
+		parts.push(labelForKey('working-memory-updated'));
+	} else if (item.kind === 'suspension') {
+		parts.push(labelForKey('suspension-waiting'));
+	}
+
+	parts.push(item.content, item.toolName, item.workflowName, item.nodeDisplayName);
+	if (item.toolName) parts.push(formatToolNameForDisplay(item.toolName));
+
+	const toolKey = builtinToolLabelKey(item.toolName, item.toolOutput);
+	if (toolKey) parts.push(labelForKey(toolKey));
+
+	return parts
+		.filter((part): part is string => typeof part === 'string')
+		.join(' ')
+		.toLowerCase();
+}
+
+export function matchesSearch(
+	item: TimelineItem,
+	query: string,
+	labelForKey: TimelineLabelResolver,
+): boolean {
+	if (!query) return true;
+	return timelineItemSearchText(item, labelForKey).includes(query.toLowerCase());
+}
+
+export function filteredTimelineItemIndexes(
+	items: TimelineItem[],
+	visibleKinds: Set<string>,
+	searchQuery: string,
+	labelForKey: TimelineLabelResolver,
+): number[] {
+	return items
+		.map((item, index) => ({ item, index }))
+		.filter(
+			({ item }) =>
+				(visibleKinds.size === 0 || visibleKinds.has(itemFilterKey(item))) &&
+				matchesSearch(item, searchQuery.trim(), labelForKey),
+		)
+		.map(({ index }) => index);
 }
 
 export function sessionBounds(items: TimelineItem[]): { start: number; end: number } {

--- a/packages/frontend/editor-ui/src/features/agents/session-timeline.utils.ts
+++ b/packages/frontend/editor-ui/src/features/agents/session-timeline.utils.ts
@@ -109,6 +109,20 @@ export function kindColorToken(kind: EventKind): string {
 	return COLOR_MAP[kind];
 }
 
+const CHART_BLOCK_COLOR_MAP: Record<EventKind, string> = {
+	user: 'var(--color--blue-600)',
+	agent: 'var(--color--purple-600)',
+	tool: 'var(--color--green-600)',
+	node: 'var(--color--neutral-600)',
+	workflow: 'var(--color--orange-600)',
+	'working-memory': 'var(--color--mint-600)',
+	suspension: 'var(--color--yellow-600)',
+};
+
+export function chartBlockColor(kind: EventKind): string {
+	return CHART_BLOCK_COLOR_MAP[kind];
+}
+
 /**
  * i18n keys for built-in tools that should render as a friendly label rather
  * than their raw machine name. Returns `null` for any tool not in the map so

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentSessionTimelineView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentSessionTimelineView.vue
@@ -25,13 +25,16 @@ import {
 	sessionBounds,
 	itemFilterKey,
 	kindColorToken,
+	filteredTimelineItemIndexes,
 } from '@/features/agents/session-timeline.utils';
+import { shouldIgnoreCanvasShortcut } from '@/features/workflows/canvas/canvas.utils';
 import type { FilterOption, TimelineItem } from '@/features/agents/session-timeline.types';
 import { useI18n } from '@n8n/i18n';
 import { N8nBreadcrumbs, N8nButton, N8nDropdownMenu, N8nIcon, N8nInput } from '@n8n/design-system';
 import type { PathItem } from '@n8n/design-system/components/N8nBreadcrumbs/Breadcrumbs.vue';
 import type { DropdownMenuItemProps } from '@n8n/design-system';
 import { computed, onMounted, ref } from 'vue';
+import { useActiveElement, useEventListener } from '@vueuse/core';
 import { useRoute, useRouter, type RouteLocationRaw } from 'vue-router';
 
 const i18n = useI18n();
@@ -41,6 +44,7 @@ const router = useRouter();
 const toast = useToast();
 const sessionsStore = useAgentSessionsStore();
 const projectsStore = useProjectsStore();
+const activeElement = useActiveElement();
 
 const projectId = computed(() => route.params.projectId as string);
 const agentId = computed(() => route.params.agentId as string);
@@ -50,6 +54,7 @@ const thread = ref<ExecutionThread | null>(null);
 const executions = ref<ThreadExecution[]>([]);
 const loading = ref(true);
 const selectedIndex = ref<number | null>(null);
+const highlightedIndex = ref<number | null>(null);
 const selectedFilters = ref<Set<string>>(new Set());
 const searchQuery = ref('');
 
@@ -71,8 +76,15 @@ function labelForKey(key: string): string {
 			return i18n.baseText('agentSessions.timeline.node');
 		case 'working-memory':
 			return i18n.baseText('agentSessions.timeline.memory');
+		case 'working-memory-updated':
+			return i18n.baseText('agentSessions.timeline.memoryUpdated');
 		case 'suspension':
 			return i18n.baseText('agentSessions.timeline.suspension');
+		case 'suspension-waiting':
+			return i18n.baseText('agentSessions.timeline.waitingForUser');
+		case 'agentSessions.timeline.tool.richInteraction':
+		case 'agentSessions.timeline.tool.richInteractionDisplay':
+			return i18n.baseText(key);
 		default:
 			return key;
 	}
@@ -179,6 +191,76 @@ const sessionOptions = computed<Array<DropdownMenuItemProps<string, SessionDropd
 const selectedItem = computed<TimelineItem | null>(() =>
 	selectedIndex.value !== null ? (items.value[selectedIndex.value] ?? null) : null,
 );
+
+const visibleItemIndexes = computed(() =>
+	filteredTimelineItemIndexes(items.value, selectedFilters.value, searchQuery.value, labelForKey),
+);
+
+function moveSelectedIndex(direction: 1 | -1) {
+	const indexes = visibleItemIndexes.value;
+	if (indexes.length === 0) return;
+
+	if (highlightedIndex.value === null || !indexes.includes(highlightedIndex.value)) {
+		highlightedIndex.value = direction === 1 ? indexes[0] : indexes[indexes.length - 1];
+		return;
+	}
+
+	const currentVisibleIndex = indexes.indexOf(highlightedIndex.value);
+	const nextVisibleIndex = currentVisibleIndex + direction;
+	if (nextVisibleIndex < 0 || nextVisibleIndex >= indexes.length) return;
+	highlightedIndex.value = indexes[nextVisibleIndex];
+}
+
+function moveSelectedIndexToBoundary(direction: 1 | -1) {
+	const indexes = visibleItemIndexes.value;
+	if (indexes.length === 0) return;
+	highlightedIndex.value = direction === 1 ? indexes[indexes.length - 1] : indexes[0];
+}
+
+function selectTimelineItem(index: number | null) {
+	selectedIndex.value = index;
+	highlightedIndex.value = index;
+}
+
+function onKeyDown(event: KeyboardEvent) {
+	if (activeElement.value && shouldIgnoreCanvasShortcut(activeElement.value)) return;
+
+	if (event.key === 'Escape') {
+		if (selectedIndex.value !== null || highlightedIndex.value !== null) {
+			event.preventDefault();
+			selectTimelineItem(null);
+		}
+		return;
+	}
+
+	if (event.key === 'ArrowDown') {
+		event.preventDefault();
+		if (event.metaKey) {
+			moveSelectedIndexToBoundary(1);
+		} else {
+			moveSelectedIndex(1);
+		}
+	} else if (event.key === 'ArrowUp') {
+		event.preventDefault();
+		if (event.metaKey) {
+			moveSelectedIndexToBoundary(-1);
+		} else {
+			moveSelectedIndex(-1);
+		}
+	}
+}
+
+useEventListener(document, 'keydown', onKeyDown);
+
+function onKeyUp(event: KeyboardEvent) {
+	if (activeElement.value && shouldIgnoreCanvasShortcut(activeElement.value)) return;
+	if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
+	if (highlightedIndex.value === selectedIndex.value) return;
+	event.preventDefault();
+	selectedIndex.value = highlightedIndex.value;
+}
+
+useEventListener(document, 'keyup', onKeyUp);
 
 onMounted(async () => {
 	try {
@@ -330,8 +412,8 @@ function onSessionSelect(nextThreadId: string) {
 				:session-start="bounds.start"
 				:session-end="bounds.end"
 				:visible-kinds="selectedFilters"
-				:selected-index="selectedIndex"
-				@select="(idx) => (selectedIndex = idx)"
+				:selected-index="highlightedIndex"
+				@select="selectTimelineItem"
 			/>
 		</div>
 
@@ -342,46 +424,29 @@ function onSessionSelect(nextThreadId: string) {
 					v-else
 					:items="items"
 					:idle-ranges="idleRanges"
-					:selected-index="selectedIndex"
+					:selected-index="highlightedIndex"
 					:visible-kinds="selectedFilters"
 					:search-query="searchQuery"
-					@select="(idx) => (selectedIndex = idx)"
+					@select="selectTimelineItem"
 				/>
 			</div>
 			<div v-if="selectedItem" :class="$style.detailPanel">
-				<SessionDetailPanel :item="selectedItem" @close="selectedIndex = null" />
+				<SessionDetailPanel :item="selectedItem" @close="selectTimelineItem(null)" />
 			</div>
 		</div>
 	</div>
 </template>
 
 <style module lang="scss">
-/*
- * Theme-aware colour intensity variables for the session timeline. Defined on
- * `body` (rather than `.view`) so that content teleported out of the component
- * subtree — e.g. the chart's `N8nTooltip` popovers — picks them up too.
- *
- * Light mode: high alpha so kind colours read as solid pills/blocks.
- * Dark mode: lower alpha so the colours sit naturally on the dark surface.
- */
 :global(body) {
-	--color--session-timeline-pill-bg-alpha: 70%;
 	--color--session-timeline-block-bg-alpha: 75%;
-	--color--session-timeline-row-border-alpha: 70%;
-	--color--session-timeline-pill-text: white;
 }
 :global(body[data-theme='dark']) {
-	--color--session-timeline-pill-bg-alpha: 40%;
 	--color--session-timeline-block-bg-alpha: 45%;
-	--color--session-timeline-row-border-alpha: 45%;
-	--color--session-timeline-pill-text: white;
 }
 @media (prefers-color-scheme: dark) {
 	:global(body:not([data-theme])) {
-		--color--session-timeline-pill-bg-alpha: 40%;
 		--color--session-timeline-block-bg-alpha: 45%;
-		--color--session-timeline-row-border-alpha: 45%;
-		--color--session-timeline-pill-text: white;
 	}
 }
 
@@ -411,7 +476,9 @@ function onSessionSelect(nextThreadId: string) {
 	display: flex;
 	align-items: center;
 	gap: var(--spacing--3xs);
-	font-size: var(--font-size--2xs);
+	font-size: var(--font-size--xs);
+	font-weight: var(--font-weight--medium);
+	user-select: none;
 	color: var(--text-color--subtler);
 	margin-left: auto;
 }

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentSessionTimelineView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentSessionTimelineView.vue
@@ -108,8 +108,7 @@ const triggerIcon = computed((): 'slack' | 'bolt-filled' => {
 const triggerLabel = computed((): string => {
 	const source = triggerSource.value;
 	if (!source) return '';
-	const name = source.charAt(0).toUpperCase() + source.slice(1);
-	return i18n.baseText('agentSessions.timeline.triggeredVia', { interpolate: { source: name } });
+	return source.charAt(0).toUpperCase() + source.slice(1);
 });
 
 const sessionTitle = computed(() => {
@@ -275,14 +274,24 @@ function onSessionSelect(nextThreadId: string) {
 				</N8nBreadcrumbs>
 			</div>
 			<div v-if="thread" :class="$style.topBarRight">
-				<span>
-					{{ (thread.totalPromptTokens + thread.totalCompletionTokens).toLocaleString() }}
-					{{ i18n.baseText('agentSessions.drawer.tokens').toLowerCase() }}
+				<span v-if="triggerSource" :class="$style.metricItem">
+					<N8nIcon :icon="triggerIcon" :size="12" />
+					<span>{{ triggerLabel }}</span>
 				</span>
 				<span :class="$style.sep">·</span>
-				<span>${{ thread.totalCost.toFixed(4) }}</span>
+				<span :class="$style.metricItem">
+					<N8nIcon icon="circle-dollar-sign" :size="12" />
+					<span>
+						{{ (thread.totalPromptTokens + thread.totalCompletionTokens).toLocaleString() }}t (${{
+							thread.totalCost.toFixed(4)
+						}})
+					</span>
+				</span>
 				<span :class="$style.sep">·</span>
-				<span>{{ formatDuration(thread.totalDuration) }}</span>
+				<span :class="$style.metricItem">
+					<N8nIcon icon="clock" :size="12" />
+					<span>{{ formatDuration(thread.totalDuration) }}</span>
+				</span>
 				<button
 					v-if="triggerSource === 'chat'"
 					:class="$style.continueButton"
@@ -295,20 +304,10 @@ function onSessionSelect(nextThreadId: string) {
 		</div>
 
 		<div v-if="!loading" :class="$style.subHeader">
-			<div v-if="triggerSource" :class="$style.triggerInfo">
-				<N8nIcon :icon="triggerIcon" :size="12" />
-				<span>{{ triggerLabel }}</span>
-			</div>
-			<span v-if="triggerSource" :class="$style.divider" aria-hidden="true" />
-			<SessionEventFilter
-				:available="filterOptions"
-				:selected="selectedFilters"
-				@update="(next) => (selectedFilters = next)"
-			/>
 			<div :class="$style.search">
 				<N8nInput
+					size="medium"
 					v-model="searchQuery"
-					size="mini"
 					:placeholder="i18n.baseText('agentSessions.timeline.searchPlaceholder')"
 					clearable
 				>
@@ -317,6 +316,11 @@ function onSessionSelect(nextThreadId: string) {
 					</template>
 				</N8nInput>
 			</div>
+			<SessionEventFilter
+				:available="filterOptions"
+				:selected="selectedFilters"
+				@update="(next) => (selectedFilters = next)"
+			/>
 		</div>
 
 		<div v-if="!loading && items.length > 0" :class="$style.chartRow">
@@ -414,6 +418,12 @@ function onSessionSelect(nextThreadId: string) {
 .sep {
 	color: var(--text-color--subtler);
 }
+.metricItem {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--spacing--4xs);
+	white-space: nowrap;
+}
 .crumbSeparator {
 	color: var(--border-color);
 	margin: 0 var(--spacing--4xs);
@@ -478,32 +488,21 @@ function onSessionSelect(nextThreadId: string) {
 .subHeader {
 	display: flex;
 	align-items: center;
-	gap: var(--spacing--xs);
-	padding: var(--spacing--2xs) var(--spacing--sm);
-	background-color: var(--background--subtle);
-	flex-shrink: 0;
-}
-.triggerInfo {
-	display: inline-flex;
-	align-items: center;
-	gap: var(--spacing--4xs);
-	font-size: var(--font-size--2xs);
-	color: var(--text-color);
-	white-space: nowrap;
-}
-.divider {
-	width: 1px;
-	height: 16px;
-	background-color: var(--border-color);
+	gap: var(--spacing--2xs);
+	padding: var(--spacing--xs) var(--spacing--md);
+	background-color: var(--background--surface);
+	border-bottom: var(--border);
 	flex-shrink: 0;
 }
 .search {
-	width: 220px;
+	flex: 1;
+	min-width: 0;
 }
 .chartRow {
 	padding: var(--spacing--sm) var(--spacing--lg);
 	border-bottom: var(--border);
 	flex-shrink: 0;
+	background-color: var(--background--surface);
 }
 .panels {
 	display: flex;

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentSessionTimelineView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentSessionTimelineView.vue
@@ -33,7 +33,7 @@ import { useI18n } from '@n8n/i18n';
 import { N8nBreadcrumbs, N8nButton, N8nDropdownMenu, N8nIcon, N8nInput } from '@n8n/design-system';
 import type { PathItem } from '@n8n/design-system/components/N8nBreadcrumbs/Breadcrumbs.vue';
 import type { DropdownMenuItemProps } from '@n8n/design-system';
-import { computed, onMounted, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useActiveElement, useEventListener } from '@vueuse/core';
 import { useRoute, useRouter, type RouteLocationRaw } from 'vue-router';
 
@@ -57,6 +57,7 @@ const selectedIndex = ref<number | null>(null);
 const highlightedIndex = ref<number | null>(null);
 const selectedFilters = ref<Set<string>>(new Set());
 const searchQuery = ref('');
+let loadThreadDetailRequestId = 0;
 
 const items = computed<TimelineItem[]>(() => flattenExecutionsToTimelineItems(executions.value));
 const idleRanges = computed(() => computeIdleRanges(items.value));
@@ -262,22 +263,41 @@ function onKeyUp(event: KeyboardEvent) {
 
 useEventListener(document, 'keyup', onKeyUp);
 
-onMounted(async () => {
+async function loadThreadDetail() {
+	const currentProjectId = projectId.value;
+	const currentAgentId = agentId.value;
+	const currentThreadId = threadId.value;
+	const requestId = ++loadThreadDetailRequestId;
+
+	thread.value = null;
+	executions.value = [];
+	selectedFilters.value = new Set();
+	searchQuery.value = '';
+	selectTimelineItem(null);
+	loading.value = true;
+
+	void sessionsStore.fetchThreads(currentProjectId, currentAgentId);
+
 	try {
-		void sessionsStore.fetchThreads(projectId.value, agentId.value);
 		const result = await sessionsStore.getThreadDetail(
-			projectId.value,
-			threadId.value,
-			agentId.value,
+			currentProjectId,
+			currentThreadId,
+			currentAgentId,
 		);
+		if (requestId !== loadThreadDetailRequestId) return;
 		thread.value = result.thread;
 		executions.value = result.executions;
 	} catch (error) {
+		if (requestId !== loadThreadDetailRequestId) return;
 		toast.showError(error, i18n.baseText('agentSessions.showError.load'));
 	} finally {
-		loading.value = false;
+		if (requestId === loadThreadDetailRequestId) {
+			loading.value = false;
+		}
 	}
-});
+}
+
+watch([projectId, agentId, threadId], loadThreadDetail, { immediate: true });
 
 function formatDuration(ms: number): string {
 	if (!ms || ms <= 0) return '0ms';

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentSessionTimelineView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentSessionTimelineView.vue
@@ -430,9 +430,11 @@ function onSessionSelect(nextThreadId: string) {
 					@select="selectTimelineItem"
 				/>
 			</div>
-			<div v-if="selectedItem" :class="$style.detailPanel">
-				<SessionDetailPanel :item="selectedItem" @close="selectTimelineItem(null)" />
-			</div>
+			<Transition name="session-detail-panel">
+				<div v-if="selectedItem" :class="$style.detailPanel">
+					<SessionDetailPanel :item="selectedItem" @close="selectTimelineItem(null)" />
+				</div>
+			</Transition>
 		</div>
 	</div>
 </template>
@@ -582,11 +584,39 @@ function onSessionSelect(nextThreadId: string) {
 	height: 100%;
 }
 .detailPanel {
-	flex: 4;
+	flex: 0 0 40%;
+	min-width: 0;
 	overflow-y: auto;
-	/* Border on the panel boundary when present; if the panel is hidden
-	   (no selection) the table fills the full width without any divider. */
 	border-left: var(--border);
+	background-color: var(--background--surface);
+}
+
+:global(.session-detail-panel-enter-active),
+:global(.session-detail-panel-leave-active) {
+	transition:
+		flex-basis var(--duration--snappy) var(--easing--ease-out),
+		opacity var(--duration--snappy) var(--easing--ease-out),
+		transform var(--duration--snappy) var(--easing--ease-out);
+	overflow: hidden;
+}
+:global(.session-detail-panel-enter-from),
+:global(.session-detail-panel-leave-to) {
+	flex-basis: 0;
+	opacity: 0;
+	transform: translateX(var(--spacing--sm));
+	border-left-color: transparent;
+}
+:global(.session-detail-panel-enter-to),
+:global(.session-detail-panel-leave-from) {
+	flex-basis: 40%;
+	opacity: 1;
+	transform: translateX(0);
+}
+@media (prefers-reduced-motion: reduce) {
+	:global(.session-detail-panel-enter-active),
+	:global(.session-detail-panel-leave-active) {
+		transition: none;
+	}
 }
 .loading {
 	padding: var(--spacing--sm);

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentSessionTimelineView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentSessionTimelineView.vue
@@ -24,7 +24,7 @@ import {
 	computeIdleRanges,
 	sessionBounds,
 	itemFilterKey,
-	kindColorToken,
+	chartBlockColor,
 	filteredTimelineItemIndexes,
 } from '@/features/agents/session-timeline.utils';
 import { shouldIgnoreCanvasShortcut } from '@/features/workflows/canvas/canvas.utils';
@@ -96,7 +96,7 @@ const filterOptions = computed<FilterOption[]>(() => {
 	for (const item of items.value) {
 		const key = itemFilterKey(item);
 		counts.set(key, (counts.get(key) ?? 0) + 1);
-		if (!colorByKey.has(key)) colorByKey.set(key, kindColorToken(item.kind));
+		if (!colorByKey.has(key)) colorByKey.set(key, chartBlockColor(item.kind));
 	}
 	return Array.from(counts.entries()).map(([key, count]) => ({
 		key,

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentSessionTimelineView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentSessionTimelineView.vue
@@ -512,7 +512,7 @@ function onSessionSelect(nextThreadId: string) {
 .tablePanel {
 	flex: 6;
 	overflow-y: auto;
-	padding: var(--spacing--sm) 0;
+	height: 100%;
 }
 .detailPanel {
 	flex: 4;

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentSessionTimelineView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentSessionTimelineView.vue
@@ -1,11 +1,14 @@
 <script lang="ts" setup>
 import { truncate } from '@n8n/utils';
 import { useToast } from '@/app/composables/useToast';
+import { VIEWS } from '@/app/constants';
+import { convertToDisplayDate } from '@/app/utils/formatters/dateFormatter';
+import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { useAgentSessionsStore } from '@/features/agents/agentSessions.store';
 import {
 	AGENT_BUILDER_VIEW,
 	CONTINUE_SESSION_ID_PARAM,
-	EXECUTIONS_SECTION_KEY,
+	AGENT_SESSION_DETAIL_VIEW,
 } from '@/features/agents/constants';
 import { useThreadTitle } from '@/features/agents/utils/thread-title';
 import type {
@@ -25,9 +28,11 @@ import {
 } from '@/features/agents/session-timeline.utils';
 import type { FilterOption, TimelineItem } from '@/features/agents/session-timeline.types';
 import { useI18n } from '@n8n/i18n';
-import { N8nIcon, N8nIconButton, N8nInput } from '@n8n/design-system';
+import { N8nBreadcrumbs, N8nButton, N8nDropdownMenu, N8nIcon, N8nInput } from '@n8n/design-system';
+import type { PathItem } from '@n8n/design-system/components/N8nBreadcrumbs/Breadcrumbs.vue';
+import type { DropdownMenuItemProps } from '@n8n/design-system';
 import { computed, onMounted, ref } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
+import { useRoute, useRouter, type RouteLocationRaw } from 'vue-router';
 
 const i18n = useI18n();
 const threadTitleOf = useThreadTitle();
@@ -35,6 +40,7 @@ const route = useRoute();
 const router = useRouter();
 const toast = useToast();
 const sessionsStore = useAgentSessionsStore();
+const projectsStore = useProjectsStore();
 
 const projectId = computed(() => route.params.projectId as string);
 const agentId = computed(() => route.params.agentId as string);
@@ -83,7 +89,7 @@ const filterOptions = computed<FilterOption[]>(() => {
 	return Array.from(counts.entries()).map(([key, count]) => ({
 		key,
 		label: labelForKey(key),
-		color: colorByKey.get(key) ?? 'var(--color--foreground)',
+		color: colorByKey.get(key) ?? 'var(--border-color)',
 		count,
 	}));
 });
@@ -111,12 +117,73 @@ const sessionTitle = computed(() => {
 	return truncate(threadTitleOf(thread.value), 64);
 });
 
+const projectName = computed<string | null>(() => {
+	if (projectsStore.personalProject?.id === projectId.value) {
+		return i18n.baseText('projects.menu.personal');
+	}
+	const current = projectsStore.currentProject;
+	if (current && current.id === projectId.value) return current.name ?? null;
+	const match = projectsStore.myProjects.find((p) => p.id === projectId.value);
+	return match?.name ?? null;
+});
+
+const projectRoute = computed<RouteLocationRaw>(() => ({
+	name: VIEWS.PROJECTS_WORKFLOWS,
+	params: { projectId: projectId.value },
+}));
+
+const agentRoute = computed<RouteLocationRaw>(() => ({
+	name: AGENT_BUILDER_VIEW,
+	params: { projectId: projectId.value, agentId: agentId.value },
+}));
+
+const breadcrumbItems = computed<PathItem[]>(() => [
+	{
+		id: projectId.value,
+		label: projectName.value ?? i18n.baseText('agents.builder.header.projectFallback'),
+		href: router.resolve(projectRoute.value).href,
+	},
+	{
+		id: agentId.value,
+		label: thread.value?.agentName ?? '…',
+		href: router.resolve(agentRoute.value).href,
+	},
+]);
+
+interface SessionDropdownData {
+	date: string;
+	active: boolean;
+}
+
+const sessionOptions = computed<Array<DropdownMenuItemProps<string, SessionDropdownData>>>(() => {
+	const sessions = sessionsStore.threads;
+	if (sessions.length === 0) {
+		return [
+			{
+				id: '__empty__',
+				label: i18n.baseText('agentSessions.empty'),
+				disabled: true,
+			},
+		];
+	}
+	return sessions.map((session) => ({
+		id: session.id,
+		label: truncate(threadTitleOf(session), 64),
+		class: session.id === threadId.value ? 'session-dropdown-item-active' : undefined,
+		data: {
+			date: formatDate(session.updatedAt),
+			active: session.id === threadId.value,
+		},
+	}));
+});
+
 const selectedItem = computed<TimelineItem | null>(() =>
 	selectedIndex.value !== null ? (items.value[selectedIndex.value] ?? null) : null,
 );
 
 onMounted(async () => {
 	try {
+		void sessionsStore.fetchThreads(projectId.value, agentId.value);
 		const result = await sessionsStore.getThreadDetail(
 			projectId.value,
 			threadId.value,
@@ -137,12 +204,10 @@ function formatDuration(ms: number): string {
 	return `${(ms / 1000).toFixed(1)}s`;
 }
 
-function goBack() {
-	void router.push({
-		name: AGENT_BUILDER_VIEW,
-		params: { projectId: projectId.value, agentId: agentId.value },
-		query: { section: EXECUTIONS_SECTION_KEY },
-	});
+function formatDate(fullDate: string): string {
+	if (!fullDate) return '';
+	const { date, time } = convertToDisplayDate(fullDate);
+	return `${date} ${time}`;
 }
 
 function continueChat() {
@@ -152,21 +217,62 @@ function continueChat() {
 		query: { [CONTINUE_SESSION_ID_PARAM]: threadId.value },
 	});
 }
+
+function onBreadcrumbSelect(item: PathItem) {
+	if (item.id === projectId.value) {
+		void router.push(projectRoute.value);
+	} else if (item.id === agentId.value) {
+		void router.push(agentRoute.value);
+	}
+}
+
+function onSessionSelect(nextThreadId: string) {
+	if (nextThreadId === '__empty__' || nextThreadId === threadId.value) return;
+	void router.push({
+		name: AGENT_SESSION_DETAIL_VIEW,
+		params: { projectId: projectId.value, agentId: agentId.value, threadId: nextThreadId },
+	});
+}
 </script>
 
 <template>
 	<div :class="$style.view">
 		<div :class="$style.topBar">
 			<div :class="$style.topBarLeft">
-				<N8nIconButton
-					icon="arrow-left"
-					variant="ghost"
-					size="small"
-					:aria-label="i18n.baseText('agentSessions.timeline.backToAgent')"
-					data-test-id="session-timeline-back"
-					@click="goBack"
-				/>
-				<span :class="$style.sessionTitle">{{ sessionTitle }}</span>
+				<N8nBreadcrumbs :items="breadcrumbItems" theme="medium" @item-selected="onBreadcrumbSelect">
+					<template #append>
+						<span :class="$style.crumbSeparator" aria-hidden="true">/</span>
+						<N8nDropdownMenu
+							:items="sessionOptions"
+							placement="bottom-start"
+							:extra-popper-class="$style.sessionDropdownMenu"
+							data-testid="session-header-switcher"
+							@select="onSessionSelect"
+						>
+							<template #trigger>
+								<N8nButton
+									variant="ghost"
+									size="small"
+									:class="$style.switcherButton"
+									:aria-label="i18n.baseText('agentSessions.sessionName')"
+								>
+									<span :class="$style.switcherLabel">{{ sessionTitle }}</span>
+									<N8nIcon icon="chevron-down" :size="14" />
+								</N8nButton>
+							</template>
+							<template #item-label="{ item }">
+								<span :class="$style.sessionDropdownName">
+									{{ item.label }}
+								</span>
+							</template>
+							<template #item-trailing="{ item }">
+								<span v-if="item.data?.date" :class="$style.sessionDropdownDate">
+									{{ item.data.date }}
+								</span>
+							</template>
+						</N8nDropdownMenu>
+					</template>
+				</N8nBreadcrumbs>
 			</div>
 			<div v-if="thread" :class="$style.topBarRight">
 				<span>
@@ -284,12 +390,12 @@ function continueChat() {
 .topBar {
 	display: flex;
 	align-items: center;
-	justify-content: space-between;
-	padding: var(--spacing--2xs) var(--spacing--sm);
-	background-color: var(--color--foreground--tint-2);
+	gap: var(--spacing--2xs);
+	padding: var(--spacing--xs) var(--spacing--md);
+	background-color: var(--background--surface);
+	border-bottom: var(--border);
 	flex-shrink: 0;
-	box-sizing: content-box;
-	height: var(--height--sm);
+	height: var(--height--4xl);
 }
 .topBarLeft {
 	display: flex;
@@ -302,15 +408,55 @@ function continueChat() {
 	align-items: center;
 	gap: var(--spacing--3xs);
 	font-size: var(--font-size--2xs);
-	color: var(--color--text);
+	color: var(--text-color--subtler);
+	margin-left: auto;
 }
 .sep {
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtler);
+}
+.crumbSeparator {
+	color: var(--border-color);
+	margin: 0 var(--spacing--4xs);
+	user-select: none;
+}
+.switcherButton {
+	font-size: var(--font-size--sm);
+	gap: var(--spacing--4xs);
+	margin-top: var(--spacing--5xs);
+}
+.switcherLabel {
+	max-width: 200px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.sessionDropdownMenu {
+	min-width: 360px;
+}
+:global(.session-dropdown-item-active),
+:global(.session-dropdown-item-active:hover),
+:global(.session-dropdown-item-active:focus),
+:global(.session-dropdown-item-active[data-highlighted]) {
+	background-color: var(--background--active);
+}
+.sessionDropdownName {
+	display: block;
+	max-width: 60%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.sessionDropdownDate {
+	color: var(--text-color--subtler);
+	font-size: var(--font-size--3xs);
+	text-align: right;
+	white-space: nowrap;
+	margin-left: auto;
 }
 .sessionTitle {
 	font-size: var(--font-size--sm);
 	font-weight: var(--font-weight--bold);
-	color: var(--color--text);
+	color: var(--text-color);
 }
 .continueButton {
 	display: inline-flex;
@@ -319,14 +465,14 @@ function continueChat() {
 	margin-left: var(--spacing--2xs);
 	padding: var(--spacing--4xs) var(--spacing--2xs);
 	background: none;
-	border: var(--border-width) var(--border-style) var(--color--foreground);
+	border: var(--border);
 	border-radius: var(--radius);
-	color: var(--color--primary);
+	color: var(--background--brand);
 	font-size: var(--font-size--2xs);
 	font-weight: var(--font-weight--bold);
 	cursor: pointer;
 	&:hover {
-		background-color: var(--color--foreground--tint-1);
+		background-color: var(--background--hover);
 	}
 }
 .subHeader {
@@ -334,7 +480,7 @@ function continueChat() {
 	align-items: center;
 	gap: var(--spacing--xs);
 	padding: var(--spacing--2xs) var(--spacing--sm);
-	background-color: var(--color--foreground--tint-2);
+	background-color: var(--background--subtle);
 	flex-shrink: 0;
 }
 .triggerInfo {
@@ -342,13 +488,13 @@ function continueChat() {
 	align-items: center;
 	gap: var(--spacing--4xs);
 	font-size: var(--font-size--2xs);
-	color: var(--color--text);
+	color: var(--text-color);
 	white-space: nowrap;
 }
 .divider {
 	width: 1px;
 	height: 16px;
-	background-color: var(--color--foreground);
+	background-color: var(--border-color);
 	flex-shrink: 0;
 }
 .search {
@@ -378,6 +524,6 @@ function continueChat() {
 }
 .loading {
 	padding: var(--spacing--sm);
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtler);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
@@ -54,8 +54,7 @@ vi.mock('@n8n/i18n', () => ({
 
 // Mock workflowHistory API
 vi.mock('@n8n/rest-api-client/api/workflowHistory', async (importOriginal) => {
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-	const actual = await importOriginal<typeof import('@n8n/rest-api-client/api/workflowHistory')>();
+	const actual = await importOriginal();
 	return {
 		...actual,
 		getWorkflowVersionsByIds: vi.fn(),

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
@@ -54,7 +54,7 @@ vi.mock('@n8n/i18n', () => ({
 
 // Mock workflowHistory API
 vi.mock('@n8n/rest-api-client/api/workflowHistory', async (importOriginal) => {
-	const actual = await importOriginal();
+	const actual = await importOriginal<typeof import('@n8n/rest-api-client/api/workflowHistory')>();
 	return {
 		...actual,
 		getWorkflowVersionsByIds: vi.fn(),

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.test.ts
@@ -110,7 +110,7 @@ const mockRouterPush = vi.fn((route) => {
 });
 
 vi.mock('vue-router', async (importOriginal) => {
-	const actual = await importOriginal();
+	const actual = await importOriginal<typeof import('vue-router')>();
 
 	return {
 		...actual,

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.test.ts
@@ -110,8 +110,7 @@ const mockRouterPush = vi.fn((route) => {
 });
 
 vi.mock('vue-router', async (importOriginal) => {
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-	const actual = await importOriginal<typeof import('vue-router')>();
+	const actual = await importOriginal();
 
 	return {
 		...actual,

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/AgentEditorModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/AgentEditorModal.test.ts
@@ -17,7 +17,7 @@ import type { ChatModelDto, FrontendModuleSettings } from '@n8n/api-types';
 import { createMockAgentDto, createMockKnowledgeItem } from '@/features/ai/chatHub/__test__/data';
 
 vi.mock('@n8n/i18n', async (importOriginal) => {
-	const actual = await importOriginal();
+	const actual = await importOriginal<typeof import('@n8n/i18n')>();
 	const i18n = {
 		baseText: (key: string) => key,
 		nodeText: () => ({

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/AgentEditorModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/AgentEditorModal.test.ts
@@ -17,8 +17,7 @@ import type { ChatModelDto, FrontendModuleSettings } from '@n8n/api-types';
 import { createMockAgentDto, createMockKnowledgeItem } from '@/features/ai/chatHub/__test__/data';
 
 vi.mock('@n8n/i18n', async (importOriginal) => {
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-	const actual = await importOriginal<typeof import('@n8n/i18n')>();
+	const actual = await importOriginal();
 	const i18n = {
 		baseText: (key: string) => key,
 		nodeText: () => ({

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMarkdownChunk.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMarkdownChunk.vue
@@ -92,6 +92,8 @@ defineExpose({
 </template>
 
 <style lang="scss" module>
+@use '@n8n/design-system/css/mixins' as ds-mixins;
+
 .container {
 	display: flex;
 	flex-direction: column;
@@ -102,155 +104,9 @@ defineExpose({
 }
 
 .chatMessageMarkdown {
-	--markdown--spacing: var(--spacing--2xs);
+	@include ds-mixins.markdown-content;
 
-	display: block;
-	color: inherit;
-
-	// Paragraphs and normal text
-	p,
-	li {
-		font-size: inherit;
-		line-height: inherit;
-		margin: calc(var(--markdown--spacing) * 2) 0;
-
-		&:first-child {
-			margin-top: 0;
-		}
-
-		&:last-child {
-			margin-bottom: 0;
-		}
-	}
-
-	li {
-		margin: 0;
-	}
-
-	// Headings - with scroll margin for anchor navigation
-	h1,
-	h2,
-	h3,
-	h4,
-	h5,
-	h6 {
-		margin: 0;
-		color: var(--color--text--shade-1);
-		line-height: var(--line-height--md);
-		font-weight: var(--font-weight--bold);
-		scroll-margin-top: calc(var(--markdown--spacing) * 4);
-	}
-
-	h1 {
-		font-size: var(--font-size--xl);
-		margin-top: calc(var(--markdown--spacing) * 3);
-	}
-
-	h2 {
-		font-size: var(--font-size--lg);
-		margin-top: calc(var(--markdown--spacing) * 4);
-	}
-
-	h3 {
-		font-size: var(--font-size--md);
-		margin-top: calc(var(--markdown--spacing) * 4);
-	}
-
-	h4 {
-		font-size: var(--font-size--sm);
-		margin-top: calc(var(--markdown--spacing) * 4);
-	}
-
-	h5,
-	h6 {
-		font-size: var(--font-size--sm);
-		margin-top: calc(var(--markdown--spacing) * 3);
-	}
-
-	h2 + h3 {
-		margin-top: calc(var(--markdown--spacing) * 3);
-	}
-
-	// Headings inside list items should have no top margin
-	li > :is(h1, h2, h3, h4, h5, h6, p, strong):first-child {
-		margin-top: 0;
-	}
-
-	// Strong/bold text
-	strong,
-	b {
-		color: var(--color--text--shade-1);
-		font-weight: var(--font-weight--bold);
-	}
-
-	// Links
-	a:not(:where(h1, h2, h3, h4, h5, h6) *) {
-		color: var(--color--text--shade-1);
-		font-weight: var(--font-weight--medium);
-		text-decoration: underline;
-		text-underline-offset: 3px;
-		text-decoration-thickness: 1px;
-		transition: color 0.15s ease;
-
-		&:hover {
-			color: var(--color--primary);
-		}
-
-		code {
-			font-weight: var(--font-weight--medium);
-		}
-	}
-
-	// Inline code (not in pre blocks)
-	:not(pre) > code {
-		font-family: var(--font-family--monospace);
-		font-weight: var(--font-weight--medium);
-		font-size: var(--font-size--sm);
-		padding: calc(var(--markdown--spacing) * 0.25) calc(var(--markdown--spacing) * 0.5);
-		line-height: var(--line-height--lg);
-		background-color: var(--chat--message--pre--background);
-		border-radius: var(--radius--sm);
-		font-variant-ligatures: none;
-	}
-
-	// Code in headings
-	:is(h1, h2, h3, h4, h5, h6) code {
-		font-weight: var(--font-weight--bold);
-	}
-
-	// Code blocks
 	pre {
-		width: 100%;
-		font-family: var(--font-family--monospace);
-		font-size: var(--font-size--sm);
-		line-height: var(--line-height--xl);
-		margin: var(--markdown--spacing) 0 calc(var(--markdown--spacing) * 2.5);
-		white-space: pre-wrap;
-		box-sizing: border-box;
-		padding: calc(var(--markdown--spacing) * 2);
-		background: var(--chat--message--pre--background);
-		border-radius: var(--radius--lg);
-		position: relative;
-
-		code {
-			font-family: var(--font-family--monospace);
-			font-variant-ligatures: none;
-
-			&::before,
-			&::after {
-				content: none;
-			}
-		}
-
-		code:last-of-type {
-			padding-bottom: 0;
-		}
-
-		// Reset spacing inside code blocks
-		code * + * {
-			margin-top: 0;
-		}
-
 		& .codeBlockActions {
 			position: sticky;
 			top: var(--markdown--spacing);
@@ -265,10 +121,6 @@ defineExpose({
 				pointer-events: auto;
 			}
 		}
-
-		& ~ pre {
-			margin-bottom: calc(var(--markdown--spacing) * 2.5);
-		}
 	}
 
 	&.singlePre pre {
@@ -276,78 +128,6 @@ defineExpose({
 		margin: 0;
 		border-radius: 0;
 	}
-
-	// Blockquotes
-	blockquote {
-		font-style: italic;
-		border-left: calc(var(--markdown--spacing) * 0.5) solid var(--color--foreground--shade-1);
-		padding-left: calc(var(--markdown--spacing) * 2);
-		margin: calc(var(--markdown--spacing) * 2) 0;
-		color: var(--color--text--tint-1);
-
-		p:first-of-type::before {
-			content: open-quote;
-		}
-
-		p:last-of-type::after {
-			content: close-quote;
-		}
-	}
-
-	// Horizontal rules
-	hr {
-		border: none;
-		border-top: var(--border-width) var(--border-style) var(--color--foreground);
-		margin: calc(var(--markdown--spacing) * 3) 0;
-
-		& + h2 {
-			margin-top: calc(var(--markdown--spacing) * 3);
-		}
-	}
-
-	// Ordered lists
-	ol {
-		padding-left: calc(var(--markdown--spacing) * 4);
-		list-style-type: decimal;
-		list-style-position: outside;
-		margin: calc(var(--markdown--spacing) * 2) 0;
-
-		li + li {
-			margin-top: calc(var(--markdown--spacing) * 1.5);
-		}
-
-		li::marker {
-			font-family: var(--font-family--monospace);
-			color: var(--color--text);
-		}
-	}
-
-	// Unordered lists
-	ul {
-		padding-left: calc(var(--markdown--spacing) * 4);
-		list-style-type: disc;
-		list-style-position: outside;
-		margin: calc(var(--markdown--spacing) * 2) 0;
-
-		li + li {
-			margin-top: var(--markdown--spacing);
-		}
-
-		li::marker {
-			color: var(--color--foreground--shade-1);
-		}
-	}
-
-	// Nested lists
-	ul ul,
-	ol ol,
-	ul ol,
-	ol ul {
-		margin-top: var(--markdown--spacing);
-		margin-bottom: 0;
-		padding-left: calc(var(--markdown--spacing) * 3);
-	}
-
 	// Footnote pill
 	.footnoteRef {
 		display: inline-block;
@@ -367,108 +147,6 @@ defineExpose({
 	.tableContainer {
 		width: 100%;
 		overflow-x: auto;
-	}
-
-	table {
-		width: 100%;
-		table-layout: auto;
-		margin: calc(var(--markdown--spacing) * 2) 0;
-		font-size: var(--font-size--sm);
-		line-height: var(--line-height--lg);
-	}
-
-	thead {
-		border-bottom-width: 1px;
-		border-bottom-style: solid;
-		border-bottom-color: var(--color--neutral-300);
-	}
-
-	thead th {
-		color: var(--color--text--shade-1);
-		font-weight: var(--font-weight--bold);
-		vertical-align: bottom;
-		padding-inline-start: 0.6em;
-		padding-inline-end: 0.6em;
-		padding-bottom: 0.8em;
-		text-align: start;
-	}
-
-	thead th:first-child {
-		padding-inline-start: 0;
-	}
-
-	thead th:last-child {
-		padding-inline-end: 0;
-	}
-
-	tbody tr {
-		border-bottom-width: 1px;
-		border-bottom-style: solid;
-		border-bottom-color: var(--color--neutral-200);
-	}
-
-	tbody tr:last-child {
-		border-bottom-width: 0;
-	}
-
-	tbody td {
-		vertical-align: baseline;
-		padding-top: 0.8em;
-		padding-inline-start: 0.6em;
-		padding-inline-end: 0.6em;
-		padding-bottom: 0.8em;
-	}
-
-	tbody td:first-child {
-		padding-inline-start: 0;
-	}
-
-	tbody td:last-child {
-		padding-inline-end: 0;
-	}
-
-	tfoot {
-		border-top-width: 1px;
-		border-top-style: solid;
-		border-top-color: var(--color--neutral-300);
-	}
-
-	tfoot td {
-		vertical-align: top;
-		padding-top: 0.8em;
-		padding-inline-start: 0.6em;
-		padding-inline-end: 0.6em;
-		padding-bottom: 0.8em;
-	}
-
-	tfoot td:first-child {
-		padding-inline-start: 0;
-	}
-
-	tfoot td:last-child {
-		padding-inline-end: 0;
-	}
-
-	td code {
-		font-size: var(--font-size--xs);
-	}
-
-	th,
-	td {
-		text-align: start;
-	}
-
-	// Figures and captions
-	figure {
-		margin: calc(var(--markdown--spacing) * 2) 0;
-	}
-
-	figcaption {
-		margin-top: calc(var(--markdown--spacing) * 1.5);
-		text-align: center;
-		font-size: var(--font-size--sm);
-		font-style: italic;
-		color: var(--color--text--tint-1);
 	}
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatHubMarkdownOptions.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatHubMarkdownOptions.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 import { type HLJSApi } from 'highlight.js';
-import type { default as HighlightModule } from 'highlight.js';
 import { computed, ref } from 'vue';
 import type MarkdownIt from 'markdown-it';
 import markdownLink from 'markdown-it-link-attributes';
@@ -15,7 +14,7 @@ let hljsInstance: HLJSApi | undefined;
 let asyncImport:
 	| {
 			status: 'inProgress';
-			promise: Promise<[typeof HighlightModule, typeof LanguageModules]>;
+			promise: Promise<[HLJSApi, typeof LanguageModules]>;
 	  }
 	| { status: 'uninitialized' }
 	| { status: 'done' } = { status: 'uninitialized' };
@@ -104,14 +103,17 @@ export function useChatHubMarkdownOptions(
 		}
 
 		try {
-			const promise = Promise.all([import('highlight.js'), import('./languageModules')]);
+			const promise = Promise.all([
+				import('highlight.js').then(({ default: highlight }) => highlight),
+				import('./languageModules'),
+			]);
 
 			asyncImport = { status: 'inProgress', promise };
 
-			const [hljs, languages] = await asyncImport.promise;
+			const [hljs, languages] = await promise;
 
 			asyncImport = { status: 'done' };
-			hljsInstance = hljs.default.newInstance();
+			hljsInstance = hljs.newInstance();
 
 			for (const [lang, module] of Object.entries(languages)) {
 				hljsInstance.registerLanguage(lang, module);

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatHubMarkdownOptions.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatHubMarkdownOptions.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 import { type HLJSApi } from 'highlight.js';
+import type { default as HighlightModule } from 'highlight.js';
 import { computed, ref } from 'vue';
 import type MarkdownIt from 'markdown-it';
 import markdownLink from 'markdown-it-link-attributes';
@@ -8,12 +9,13 @@ import markdownItFootnote from 'markdown-it-footnote';
 import { truncateBeforeLast } from '@n8n/utils/string/truncate';
 import 'katex/dist/katex.min.css';
 import type StateCore from 'markdown-it/lib/rules_core/state_core';
+import type * as LanguageModules from './languageModules';
 
 let hljsInstance: HLJSApi | undefined;
 let asyncImport:
 	| {
 			status: 'inProgress';
-			promise: Promise<[typeof import('highlight.js'), typeof import('./languageModules')]>;
+			promise: Promise<[typeof HighlightModule, typeof LanguageModules]>;
 	  }
 	| { status: 'uninitialized' }
 	| { status: 'done' } = { status: 'uninitialized' };

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/composables/useFavoriteNavItems.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/composables/useFavoriteNavItems.test.ts
@@ -9,8 +9,7 @@ import { VIEWS } from '@/app/constants';
 import { DATA_TABLE_DETAILS } from '@/features/core/dataTable/constants';
 
 vi.mock('vue-router', async (importOriginal) => {
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-	const actual = await importOriginal<typeof import('vue-router')>();
+	const actual = await importOriginal();
 	return {
 		...actual,
 		useRouter: vi.fn().mockReturnValue({ push: vi.fn() }),

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/composables/useFavoriteNavItems.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/composables/useFavoriteNavItems.test.ts
@@ -9,7 +9,7 @@ import { VIEWS } from '@/app/constants';
 import { DATA_TABLE_DETAILS } from '@/features/core/dataTable/constants';
 
 vi.mock('vue-router', async (importOriginal) => {
-	const actual = await importOriginal();
+	const actual = await importOriginal<typeof import('vue-router')>();
 	return {
 		...actual,
 		useRouter: vi.fn().mockReturnValue({ push: vi.fn() }),

--- a/packages/frontend/editor-ui/src/features/core/folders/components/FolderBreadcrumbs.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/folders/components/FolderBreadcrumbs.test.ts
@@ -13,8 +13,7 @@ import { useFoldersStore } from '../folders.store';
 import type { IUser } from 'n8n-workflow';
 
 vi.mock('vue-router', async (importOriginal) => ({
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-	...(await importOriginal<typeof import('vue-router')>()),
+	...(await importOriginal()),
 	useRoute: vi.fn().mockReturnValue({}),
 	useRouter: vi.fn(() => ({
 		replace: vi.fn(),

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataJson.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataJson.test.ts
@@ -6,8 +6,7 @@ import { createComponentRenderer } from '@/__tests__/render';
 import { useElementSize } from '@vueuse/core'; // Import the composable to mock
 
 vi.mock('@vueuse/core', async () => {
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-	const originalModule = await vi.importActual<typeof import('@vueuse/core')>('@vueuse/core');
+	const originalModule = await vi.importActual('@vueuse/core');
 
 	return {
 		...originalModule, // Keep all original exports

--- a/packages/frontend/editor-ui/src/features/workflows/readyToRun/components/ReadyToRunButton.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/readyToRun/components/ReadyToRunButton.test.ts
@@ -21,8 +21,7 @@ vi.mock('@/features/collaboration/projects/composables/useProjectPages', () => (
 }));
 
 vi.mock('vue-router', async () => {
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-	const actual = await vi.importActual<typeof import('vue-router')>('vue-router');
+	const actual = await vi.importActual('vue-router');
 	return {
 		...actual,
 		useRoute: () => ({


### PR DESCRIPTION
## Summary
- Refresh the Executions Timeline UI to match the Agents experience, including the top bar, breadcrumbs, session switcher, spacing, and design-system-aligned styling.
- Add keyboard navigation for timeline items with `ArrowUp` / `ArrowDown`, boundary jumps with modifier keys, and `Esc` to clear the selection and close the detail panel.
- Improve performance for large sessions by virtualizing the timeline table with `N8nRecycleScroller`, adding scroll-to-selection behavior, and replacing per-segment tooltips with a shared chart popover.
- Standardize markdown rendering across chat and execution surfaces by extracting shared markdown styles into the design system and reusing them in both panels.
- Polish the detail experience with reusable event pills, better metadata display, copy-to-clipboard actions for JSON blocks, and cleaner row/chart selection states

<img width="1623" height="1007" alt="CleanShot 2026-05-02 at 16 08 45@2x" src="https://github.com/user-attachments/assets/f197fd5b-1260-494d-a0cb-70031817ab9e" />

## Related Linear tickets, Github issues, and Community forum posts
[AGENT-95](https://linear.app/n8n/issue/AGENT-95/p05-style-executions-detail)


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
