### PR TITLE
fix(ai-builder): Stop builder from adding auth to inbound trigger nodes by default

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/inbound-trigger-auth-defaults.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/inbound-trigger-auth-defaults.ts
@@ -1,0 +1,48 @@
+import type { WorkflowNodeResponse } from '../../clients/n8n-client';
+import type { BinaryCheck } from '../types';
+
+const INBOUND_TRIGGER_TYPES = new Set([
+	'n8n-nodes-base.webhook',
+	'n8n-nodes-base.formTrigger',
+	'@n8n/n8n-nodes-langchain.chatTrigger',
+	'@n8n/n8n-nodes-langchain.mcpTrigger',
+]);
+
+const EXPLICIT_INBOUND_AUTH_PATTERNS = [
+	/\bauthenticated\s+(?:webhook|form|chat|mcp)\b/i,
+	/\b(?:webhook|form|chat|mcp|inbound|incoming)\b.{0,80}\b(?:auth|authenticated|authentication|authorization|bearer|jwt|basic auth|header auth|api key|token|password)\b/i,
+	/\b(?:require|requires|requiring|protect|secure|authenticate)\b.{0,80}\b(?:webhook|form|chat|mcp|inbound|incoming)\b/i,
+	/\b(?:webhook|form|chat|mcp|inbound|incoming)\b.{0,80}\b(?:require|protect|secure|authenticate)\b/i,
+];
+
+function explicitlyRequestsInboundAuth(prompt: string): boolean {
+	return EXPLICIT_INBOUND_AUTH_PATTERNS.some((pattern) => pattern.test(prompt));
+}
+
+function hasNonDefaultAuthentication(node: WorkflowNodeResponse): boolean {
+	const auth = node.parameters?.authentication;
+	return typeof auth === 'string' && auth !== 'none';
+}
+
+function getAuthentication(node: WorkflowNodeResponse): string {
+	const auth = node.parameters?.authentication;
+	return typeof auth === 'string' ? auth : '';
+}
+
+export const inboundTriggerAuthDefaults: BinaryCheck = {
+	name: 'inbound_trigger_auth_defaults',
+	description: 'Inbound trigger nodes keep authentication disabled unless the user asks for it',
+	kind: 'deterministic',
+	run(workflow, ctx) {
+		if (explicitlyRequestsInboundAuth(ctx.prompt)) return { pass: true };
+
+		const issues = (workflow.nodes ?? [])
+			.filter((node) => INBOUND_TRIGGER_TYPES.has(node.type) && hasNonDefaultAuthentication(node))
+			.map((node) => `"${node.name}" sets authentication to "${getAuthentication(node)}"`);
+
+		return {
+			pass: issues.length === 0,
+			...(issues.length > 0 ? { comment: issues.join('; ') } : {}),
+		};
+	},
+};

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/index.ts
@@ -14,6 +14,7 @@ import { handlesMultipleItems } from './handles-multiple-items';
 import { hasNodes } from './has-nodes';
 import { hasStartNode } from './has-start-node';
 import { hasTrigger } from './has-trigger';
+import { inboundTriggerAuthDefaults } from './inbound-trigger-auth-defaults';
 import { memoryProperlyConnected } from './memory-properly-connected';
 import { memorySessionKeyExpression } from './memory-session-key-expression';
 import { noDisabledNodes } from './no-disabled-nodes';
@@ -48,6 +49,7 @@ export const DETERMINISTIC_CHECKS: BinaryCheck[] = [
 	noInvalidFromAi,
 	toolsHaveParameters,
 	noUnreachableNodes,
+	inboundTriggerAuthDefaults,
 	validNodeConfig,
 ];
 

--- a/packages/@n8n/instance-ai/src/__tests__/binary-checks.test.ts
+++ b/packages/@n8n/instance-ai/src/__tests__/binary-checks.test.ts
@@ -95,6 +95,45 @@ describe('binary checks', () => {
 		expect(check?.score).toBe(0);
 	});
 
+	it('fails inbound_trigger_auth_defaults when webhook auth is enabled without user intent', async () => {
+		const workflow = makeWorkflow({
+			nodes: [
+				{
+					name: 'Webhook',
+					type: 'n8n-nodes-base.webhook',
+					parameters: { authentication: 'basicAuth' },
+				},
+				{ name: 'Set', type: 'n8n-nodes-base.set', parameters: {} },
+			],
+		});
+
+		const feedback = await runBinaryChecks(workflow, ctx);
+		const check = feedback.find((f) => f.metric === 'inbound_trigger_auth_defaults');
+
+		expect(check?.score).toBe(0);
+		expect(check?.comment).toContain('"Webhook" sets authentication to "basicAuth"');
+	});
+
+	it('passes inbound_trigger_auth_defaults when user asks for authenticated inbound traffic', async () => {
+		const workflow = makeWorkflow({
+			nodes: [
+				{
+					name: 'Webhook',
+					type: 'n8n-nodes-base.webhook',
+					parameters: { authentication: 'headerAuth' },
+				},
+				{ name: 'Set', type: 'n8n-nodes-base.set', parameters: {} },
+			],
+		});
+
+		const feedback = await runBinaryChecks(workflow, {
+			prompt: 'Create a workflow with a webhook and require header auth for inbound requests',
+		});
+		const check = feedback.find((f) => f.metric === 'inbound_trigger_auth_defaults');
+
+		expect(check?.score).toBe(1);
+	});
+
 	it('supports --only filter', async () => {
 		const feedback = await runBinaryChecks(makeWorkflow(), ctx, { only: ['has_nodes'] });
 		const metrics = feedback.filter((f) => f.kind === 'metric');

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/credential-guardrails.prompt.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/credential-guardrails.prompt.test.ts
@@ -22,6 +22,17 @@ describe('credential guardrail prompts', () => {
 		expect(prompt).not.toContain('copied and ready to paste into n8n');
 	});
 
+	it('keeps inbound trigger authentication disabled unless explicitly requested', () => {
+		const prompt = createSandboxBuilderAgentPrompt('/tmp/workspace');
+
+		expect(prompt).toContain(
+			'The credential-selection guidance above applies to outbound service calls.',
+		);
+		expect(prompt).toContain(
+			'keep authentication at its default `none` unless the user explicitly asks to authenticate inbound traffic',
+		);
+	});
+
 	it('tells the planner to ask when a required service has more than one credential of the same type', () => {
 		expect(PLANNER_AGENT_PROMPT).toContain(
 			'Do ask when a required service has more than one credential of the same type',

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.prompt.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.prompt.ts
@@ -589,6 +589,8 @@ The key (\`openWeatherMapApi\`) is the credential **type** from the node type de
 
 If the required credential type is not in \`credentials(action="list")\` results, call \`credentials(action="search-types")\` with the service name (e.g. "linear", "notion") to discover available dedicated credential types. Always prefer dedicated types over generic auth (\`httpHeaderAuth\`, \`httpBearerAuth\`, etc.). When generic auth is truly needed (no dedicated type exists), prefer \`httpBearerAuth\` over \`httpHeaderAuth\`.
 
+The credential-selection guidance above applies to outbound service calls. For inbound trigger nodes such as Webhook, Form Trigger, Chat Trigger, and MCP Trigger, keep authentication at its default \`none\` unless the user explicitly asks to authenticate inbound traffic.
+
 ## Data Tables
 
 n8n normalizes column names to snake_case (e.g., \`dayName\` → \`day_name\`). Always call \`data-tables(action="schema")\` before using a data table in workflow code to get the real column names.

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
@@ -92,6 +92,10 @@ export class McpTrigger extends Node {
 				],
 				default: 'none',
 				description: 'The way to authenticate',
+				builderHint: {
+					message:
+						"Default to 'none'. n8n exposes inbound trigger URLs publicly by design. Only select an authentication method when the user explicitly asks to authenticate inbound traffic.",
+				},
 			},
 			{
 				displayName: 'Path',

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__tests__/McpTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__tests__/McpTrigger.node.test.ts
@@ -5,6 +5,9 @@ import { createMockLogger, createMockRequest, createMockResponse } from './helpe
 import { McpTrigger } from '../McpTrigger.node';
 import { McpServer } from '../McpServer';
 
+const INBOUND_TRIGGER_AUTHENTICATION_BUILDER_HINT =
+	"Default to 'none'. n8n exposes inbound trigger URLs publicly by design. Only select an authentication method when the user explicitly asks to authenticate inbound traffic.";
+
 // Mock the McpServer
 jest.mock('../McpServer', () => ({
 	McpServer: {
@@ -78,7 +81,11 @@ describe('McpTrigger', () => {
 			const authParam = mcpTrigger.description.properties?.find((p) => p.name === 'authentication');
 			expect(authParam).toBeDefined();
 			expect(authParam?.type).toBe('options');
+			expect(authParam?.default).toBe('none');
 			expect(authParam?.options).toHaveLength(3);
+			expect(authParam?.builderHint).toEqual({
+				message: INBOUND_TRIGGER_AUTHENTICATION_BUILDER_HINT,
+			});
 		});
 
 		it('should define webhook endpoints', () => {

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -402,6 +402,10 @@ export class ChatTrigger extends Node {
 				],
 				default: 'none',
 				description: 'The way to authenticate',
+				builderHint: {
+					message:
+						"Default to 'none'. n8n exposes inbound trigger URLs publicly by design. Only select an authentication method when the user explicitly asks to authenticate inbound traffic.",
+				},
 			},
 			{
 				displayName: 'Initial Message(s)',

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
@@ -11,6 +11,9 @@ jest.mock('../GenericFunctions', () => ({
 	validateAuth: jest.fn().mockResolvedValue(undefined as never),
 }));
 
+const INBOUND_TRIGGER_AUTHENTICATION_BUILDER_HINT =
+	"Default to 'none'. n8n exposes inbound trigger URLs publicly by design. Only select an authentication method when the user explicitly asks to authenticate inbound traffic.";
+
 describe('ChatTrigger Node', () => {
 	const mockContext = mock<IWebhookFunctions>();
 	const mockRequest = mock<Request>();
@@ -65,6 +68,21 @@ describe('ChatTrigger Node', () => {
 				return defaultValue;
 			},
 		);
+	});
+
+	describe('description', () => {
+		it('should tell builders to keep inbound authentication disabled unless requested', () => {
+			const authParam = chatTrigger.description.properties.find(
+				(property) => property.name === 'authentication',
+			);
+
+			expect(authParam).toMatchObject({
+				default: 'none',
+				builderHint: {
+					message: INBOUND_TRIGGER_AUTHENTICATION_BUILDER_HINT,
+				},
+			});
+		});
 	});
 
 	describe('webhook method', () => {

--- a/packages/nodes-base/nodes/Form/test/FormTriggerV2.node.test.ts
+++ b/packages/nodes-base/nodes/Form/test/FormTriggerV2.node.test.ts
@@ -4,11 +4,37 @@ import { NodeOperationError, type INode } from 'n8n-workflow';
 
 import { testVersionedWebhookTriggerNode } from '@test/nodes/TriggerHelpers';
 
+import { FORM_TRIGGER_AUTHENTICATION_PROPERTY } from '../interfaces';
 import { FormTrigger } from '../FormTrigger.node';
+import { FormTriggerV2 } from '../v2/FormTriggerV2.node';
+
+const INBOUND_TRIGGER_AUTHENTICATION_BUILDER_HINT =
+	"Default to 'none'. n8n exposes inbound trigger URLs publicly by design. Only select an authentication method when the user explicitly asks to authenticate inbound traffic.";
 
 describe('FormTrigger', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
+	});
+
+	it('should tell builders to keep inbound authentication disabled unless requested', () => {
+		const formTriggerV2 = new FormTriggerV2({
+			displayName: 'n8n Form Trigger',
+			name: 'formTrigger',
+			group: ['trigger'],
+			description: 'Generate webforms in n8n and pass their responses to the workflow',
+			defaultVersion: 2.5,
+		});
+
+		const authParam = formTriggerV2.description.properties.find(
+			(property) => property.name === FORM_TRIGGER_AUTHENTICATION_PROPERTY,
+		);
+
+		expect(authParam).toMatchObject({
+			default: 'none',
+			builderHint: {
+				message: INBOUND_TRIGGER_AUTHENTICATION_BUILDER_HINT,
+			},
+		});
 	});
 
 	it('should render a form template with correct fields', async () => {

--- a/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
+++ b/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
@@ -109,6 +109,10 @@ const descriptionV2: INodeTypeDescription = {
 				},
 			],
 			default: 'none',
+			builderHint: {
+				message:
+					"Default to 'none'. n8n exposes inbound trigger URLs publicly by design. Only select an authentication method when the user explicitly asks to authenticate inbound traffic.",
+			},
 		},
 		{ ...webhookPath, displayOptions: { show: { '@version': [{ _cnd: { lte: 2.1 } }] } } },
 		formTitle,

--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -20,6 +20,7 @@ import {
 	credentialsProperty,
 	defaultWebhookDescription,
 	httpMethodsProperty,
+	inboundTriggerAuthenticationBuilderHint,
 	optionsProperty,
 	responseBinaryPropertyNameProperty,
 	responseCodeOption,
@@ -141,7 +142,10 @@ export class Webhook extends Node {
 				description:
 					"The path to listen to, dynamic values could be specified by using ':', e.g. 'your-path/:dynamic-value'. If dynamic values are set 'webhookId' would be prepended to path.",
 			},
-			authenticationProperty(this.authPropertyName),
+			{
+				...authenticationProperty(this.authPropertyName),
+				builderHint: inboundTriggerAuthenticationBuilderHint,
+			},
 			responseModeProperty,
 			responseModePropertyStreaming,
 			{

--- a/packages/nodes-base/nodes/Webhook/description.ts
+++ b/packages/nodes-base/nodes/Webhook/description.ts
@@ -48,6 +48,11 @@ export const credentialsProperty = (
 	},
 ];
 
+export const inboundTriggerAuthenticationBuilderHint = {
+	message:
+		"Default to 'none'. n8n exposes inbound trigger URLs publicly by design. Only select an authentication method when the user explicitly asks to authenticate inbound traffic.",
+};
+
 export const authenticationProperty = (propertyName = 'authentication'): INodeProperties => ({
 	displayName: 'Authentication',
 	name: propertyName,

--- a/packages/nodes-base/nodes/Webhook/test/Webhook.test.ts
+++ b/packages/nodes-base/nodes/Webhook/test/Webhook.test.ts
@@ -9,8 +9,27 @@ import { Webhook } from '../Webhook.node';
 jest.mock('fs/promises');
 const mockFs = jest.mocked(fs);
 
+const INBOUND_TRIGGER_AUTHENTICATION_BUILDER_HINT =
+	"Default to 'none'. n8n exposes inbound trigger URLs publicly by design. Only select an authentication method when the user explicitly asks to authenticate inbound traffic.";
+
 describe('Test Webhook Node', () => {
 	new NodeTestHarness().setupTests();
+
+	describe('description', () => {
+		it('should tell builders to keep inbound authentication disabled unless requested', () => {
+			const node = new Webhook();
+			const authParam = node.description.properties.find(
+				(property) => property.name === 'authentication',
+			);
+
+			expect(authParam).toMatchObject({
+				default: 'none',
+				builderHint: {
+					message: INBOUND_TRIGGER_AUTHENTICATION_BUILDER_HINT,
+				},
+			});
+		});
+	});
 
 	describe('handleFormData', () => {
 		const node = new Webhook();


### PR DESCRIPTION
## Summary

Adds parameter-level builder guidance so inbound trigger nodes keep authentication disabled by default unless the user explicitly asks for authenticated inbound traffic.

Also hardens the sandbox builder prompt so outbound credential-selection guidance is not applied to inbound triggers, and adds a deterministic binary-check evaluation guard for generated workflows.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-168

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created. Not applicable: internal builder metadata, prompt, and eval guardrail only.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)