### PR TITLE
fix: prevent fixedCollection multipleValues from iterating expression string characters

### DIFF
--- a/packages/workflow/src/node-helpers.ts
+++ b/packages/workflow/src/node-helpers.ts
@@ -941,9 +941,11 @@ export function getNodeParameters(
 					}
 
 					// Iterate over all items as it contains multiple ones
-					for (const nodeValue of (propertyValues as INodeParameters)[
-						itemName
-					] as INodeParameters[]) {
+					const itemValues = (propertyValues as INodeParameters)[itemName];
+					if (!Array.isArray(itemValues)) {
+						continue;
+					}
+					for (const nodeValue of itemValues as INodeParameters[]) {
 						tempNodePropertiesArray = nodePropertyOptions.values!;
 						tempValue = getNodeParameters(
 							tempNodePropertiesArray,


### PR DESCRIPTION
## Problem

When a node parameter is declared as a `fixedCollection` with `typeOptions: { multipleValues: true }`, and the user sets that parameter via an expression (e.g. `={{ $json.items }}`) instead of typing items literally into the UI, `NodeHelpers.getNodeParameters` iterates the **expression string's characters** instead of the resolved array, producing N schema-default items where N is the string's character length.

For example, setting `itemValues` to `={{ $json.items }}` (18 characters) produces 18 default-filled items instead of the expected real items.

Reported in [#29619](https://github.com/n8n-io/n8n/issues/29619).

## Root Cause

In `packages/workflow/src/node-helpers.ts` (line ~933), the code does:

```js
for (const nodeValue of (propertyValues as INodeParameters)[itemName] as INodeParameters[]) {
```

When `propertyValues[itemName]` is a string (an unresolved expression), `for...of` iterates the string's characters. Each character is treated as a fixedCollection row and processed with schema defaults.

## Fix

Added an `Array.isArray` check before the iteration loop to skip non-array values:

```js
const itemValues = (propertyValues as INodeParameters)[itemName];
if (!Array.isArray(itemValues)) {
    continue;  // skip unresolved expression strings
}
for (const nodeValue of itemValues as INodeParameters[]) {
```

This prevents the character-iteration bug while preserving the expression string in the raw parameters for later evaluation by the workflow runtime.

## Testing

1. Define a custom node with a `multipleValues: true` fixedCollection parameter
2. Set the parameter to an expression like `={{ $json.items }}`
3. Verify the node does not receive N default items (where N = expression string length)
