### PR TITLE
feat(Mautic Trigger Node): Add webhook request verification

### DIFF
--- a/packages/nodes-base/nodes/Mautic/MauticTrigger.node.ts
+++ b/packages/nodes-base/nodes/Mautic/MauticTrigger.node.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from 'crypto';
+
 import {
 	type IHookFunctions,
 	type IWebhookFunctions,
@@ -12,6 +14,7 @@ import {
 import { parse as urlParse } from 'url';
 
 import { mauticApiRequest } from './GenericFunctions';
+import { verifySignature } from './MauticTriggerHelpers';
 
 export class MauticTrigger implements INodeType {
 	description: INodeTypeDescription = {
@@ -146,16 +149,19 @@ export class MauticTrigger implements INodeType {
 				const events = this.getNodeParameter('events', 0) as string[];
 				const eventsOrder = this.getNodeParameter('eventsOrder', 0) as string;
 				const urlParts = urlParse(webhookUrl);
+				const webhookSecret = randomBytes(32).toString('hex');
 				const body: IDataObject = {
 					name: `n8n-webhook:${urlParts.path}`,
 					description: 'n8n webhook',
 					webhookUrl,
+					secret: webhookSecret,
 					triggers: events,
 					eventsOrderbyDir: eventsOrder,
 					isPublished: true,
 				};
 				const { hook } = await mauticApiRequest.call(this, 'POST', '/hooks/new', body);
 				webhookData.webhookId = hook.id;
+				webhookData.webhookSecret = webhookSecret;
 				return true;
 			},
 			async delete(this: IHookFunctions): Promise<boolean> {
@@ -166,12 +172,19 @@ export class MauticTrigger implements INodeType {
 					return false;
 				}
 				delete webhookData.webhookId;
+				delete webhookData.webhookSecret;
 				return true;
 			},
 		},
 	};
 
 	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
+		if (!verifySignature.call(this)) {
+			const res = this.getResponseObject();
+			res.status(401).send('Unauthorized').end();
+			return { noWebhookResponse: true };
+		}
+
 		const req = this.getRequestObject();
 		return {
 			workflowData: [this.helpers.returnJsonArray(req.body as IDataObject)],

--- a/packages/nodes-base/nodes/Mautic/MauticTriggerHelpers.ts
+++ b/packages/nodes-base/nodes/Mautic/MauticTriggerHelpers.ts
@@ -1,0 +1,38 @@
+import { createHmac } from 'crypto';
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { verifySignature as verifySignatureGeneric } from '../../utils/webhook-signature-verification';
+
+/**
+ * Verifies the Mautic webhook signature.
+ *
+ * Mautic signs webhooks using HMAC SHA-256:
+ * 1. Create HMAC SHA-256 hash of the raw body using the secret as key
+ * 2. Encode the hash in base64 format
+ * 3. Compare with the signature in the `Webhook-Signature` header
+ *
+ * @returns true if the signature is valid, false otherwise
+ * @returns true if no secret is configured (backward compatibility with old triggers)
+ */
+export function verifySignature(this: IWebhookFunctions): boolean {
+	const req = this.getRequestObject();
+	const webhookData = this.getWorkflowStaticData('node');
+	const secret = webhookData.webhookSecret;
+
+	return verifySignatureGeneric({
+		getExpectedSignature: () => {
+			if (!secret || typeof secret !== 'string' || !req.rawBody) {
+				return null;
+			}
+			const hmac = createHmac('sha256', secret);
+			const payload = Buffer.isBuffer(req.rawBody) ? req.rawBody : Buffer.from(req.rawBody);
+			hmac.update(payload);
+			return hmac.digest('base64');
+		},
+		skipIfNoExpectedSignature: !secret || typeof secret !== 'string',
+		getActualSignature: () => {
+			const sig = req.header('webhook-signature');
+			return typeof sig === 'string' ? sig : null;
+		},
+	});
+}

--- a/packages/nodes-base/nodes/Mautic/test/MauticTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Mautic/test/MauticTrigger.node.test.ts
@@ -1,0 +1,163 @@
+import { randomBytes } from 'crypto';
+import type { IHookFunctions, IWebhookFunctions } from 'n8n-workflow';
+
+import { mauticApiRequest } from '../GenericFunctions';
+import { MauticTrigger } from '../MauticTrigger.node';
+import { verifySignature } from '../MauticTriggerHelpers';
+
+jest.mock('../GenericFunctions');
+jest.mock('../MauticTriggerHelpers');
+jest.mock('crypto', () => ({
+	...jest.requireActual('crypto'),
+	randomBytes: jest.fn(),
+}));
+
+describe('MauticTrigger', () => {
+	let trigger: MauticTrigger;
+	let mockHookFunctions: Pick<
+		jest.Mocked<IHookFunctions>,
+		'getNodeWebhookUrl' | 'getNodeParameter' | 'getWorkflowStaticData'
+	>;
+	let mockWebhookFunctions: Pick<
+		jest.Mocked<IWebhookFunctions>,
+		'getRequestObject' | 'getResponseObject' | 'getWorkflowStaticData' | 'helpers'
+	>;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		trigger = new MauticTrigger();
+
+		mockHookFunctions = {
+			getNodeWebhookUrl: jest.fn(),
+			getNodeParameter: jest.fn(),
+			getWorkflowStaticData: jest.fn(),
+		};
+
+		mockWebhookFunctions = {
+			getRequestObject: jest.fn(),
+			getResponseObject: jest.fn(),
+			getWorkflowStaticData: jest.fn(),
+			helpers: {
+				returnJsonArray: jest.fn((data) => data),
+			} as any,
+		};
+	});
+
+	describe('webhookMethods.default.create', () => {
+		it('should create webhook with secret', async () => {
+			const webhookUrl = 'https://example.com/webhook/path';
+			const webhookSecret = 'a'.repeat(64);
+
+			mockHookFunctions.getNodeWebhookUrl.mockReturnValue(webhookUrl);
+			mockHookFunctions.getNodeParameter.mockImplementation((name: string) => {
+				if (name === 'events') return ['mautic.lead_post_save_new'];
+				if (name === 'eventsOrder') return 'ASC';
+				return null;
+			});
+			mockHookFunctions.getWorkflowStaticData.mockReturnValue({});
+
+			(randomBytes as jest.Mock).mockReturnValue({
+				toString: jest.fn().mockReturnValue(webhookSecret),
+			});
+			(mauticApiRequest as jest.Mock).mockResolvedValue({ hook: { id: 'hook-123' } });
+
+			const result = await trigger.webhookMethods!.default.create.call(
+				mockHookFunctions as unknown as IHookFunctions,
+			);
+
+			expect(result).toBe(true);
+			expect(randomBytes).toHaveBeenCalledWith(32);
+			expect(mauticApiRequest).toHaveBeenCalledWith(
+				'POST',
+				'/hooks/new',
+				expect.objectContaining({
+					secret: webhookSecret,
+					webhookUrl,
+				}),
+			);
+
+			const webhookData = mockHookFunctions.getWorkflowStaticData('node');
+			expect(webhookData.webhookId).toBe('hook-123');
+			expect(webhookData.webhookSecret).toBe(webhookSecret);
+		});
+	});
+
+	describe('webhookMethods.default.delete', () => {
+		it('should delete webhook and clean up secret', async () => {
+			const webhookData: any = {
+				webhookId: 'hook-123',
+				webhookSecret: 'test-secret',
+			};
+			mockHookFunctions.getWorkflowStaticData.mockReturnValue(webhookData);
+			(mauticApiRequest as jest.Mock).mockResolvedValue({});
+
+			const result = await trigger.webhookMethods!.default.delete.call(
+				mockHookFunctions as unknown as IHookFunctions,
+			);
+
+			expect(result).toBe(true);
+			expect(mauticApiRequest).toHaveBeenCalledWith('DELETE', '/hooks/hook-123/delete');
+			expect(webhookData.webhookId).toBeUndefined();
+			expect(webhookData.webhookSecret).toBeUndefined();
+		});
+	});
+
+	describe('webhook', () => {
+		it('should return 401 when signature verification fails', async () => {
+			const mockResponse = {
+				status: jest.fn().mockReturnThis(),
+				send: jest.fn().mockReturnThis(),
+				end: jest.fn(),
+			};
+
+			(verifySignature as jest.Mock).mockReturnValue(false);
+			mockWebhookFunctions.getResponseObject.mockReturnValue(mockResponse as any);
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(verifySignature).toHaveBeenCalled();
+			expect(mockResponse.status).toHaveBeenCalledWith(401);
+			expect(mockResponse.send).toHaveBeenCalledWith('Unauthorized');
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		it('should process webhook when signature verification passes', async () => {
+			const bodyData = {
+				'mautic.lead_post_save_new': [{ contact: { id: 1, name: 'Test' } }],
+			};
+
+			(verifySignature as jest.Mock).mockReturnValue(true);
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				body: bodyData,
+			} as any);
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(verifySignature).toHaveBeenCalled();
+			expect(result).toBeDefined();
+			expect(result.workflowData).toBeDefined();
+		});
+
+		it('should process webhook when no secret is configured (backward compat)', async () => {
+			const bodyData = {
+				'mautic.lead_post_save_new': [{ contact: { id: 1 } }],
+			};
+
+			(verifySignature as jest.Mock).mockReturnValue(true);
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				body: bodyData,
+			} as any);
+
+			const result = await trigger.webhook.call(
+				mockWebhookFunctions as unknown as IWebhookFunctions,
+			);
+
+			expect(verifySignature).toHaveBeenCalled();
+			expect(result.workflowData).toBeDefined();
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Mautic/test/MauticTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Mautic/test/MauticTrigger.node.test.ts
@@ -141,23 +141,5 @@ describe('MauticTrigger', () => {
 			expect(result).toBeDefined();
 			expect(result.workflowData).toBeDefined();
 		});
-
-		it('should process webhook when no secret is configured (backward compat)', async () => {
-			const bodyData = {
-				'mautic.lead_post_save_new': [{ contact: { id: 1 } }],
-			};
-
-			(verifySignature as jest.Mock).mockReturnValue(true);
-			mockWebhookFunctions.getRequestObject.mockReturnValue({
-				body: bodyData,
-			} as any);
-
-			const result = await trigger.webhook.call(
-				mockWebhookFunctions as unknown as IWebhookFunctions,
-			);
-
-			expect(verifySignature).toHaveBeenCalled();
-			expect(result.workflowData).toBeDefined();
-		});
 	});
 });

--- a/packages/nodes-base/nodes/Mautic/test/MauticTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Mautic/test/MauticTriggerHelpers.test.ts
@@ -1,0 +1,84 @@
+import { createHmac } from 'crypto';
+
+import { verifySignature } from '../MauticTriggerHelpers';
+
+describe('MauticTriggerHelpers', () => {
+	let mockWebhookFunctions: any;
+	const testSecret = 'test-secret-key-12345';
+	const testPayload = Buffer.from('{"mautic.lead_post_save_new":[{"contact":{"id":1}}]}');
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		mockWebhookFunctions = {
+			getRequestObject: jest.fn(),
+			getWorkflowStaticData: jest.fn(),
+		};
+	});
+
+	describe('verifySignature', () => {
+		it('should return true when no secret is configured', () => {
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(null),
+				rawBody: testPayload,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return true when signatures match', () => {
+			const hmac = createHmac('sha256', testSecret);
+			hmac.update(testPayload);
+			const expectedSignature = hmac.digest('base64');
+
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				webhookSecret: testSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header: string) => {
+					if (header === 'webhook-signature') return expectedSignature;
+					return null;
+				}),
+				rawBody: testPayload,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false when signatures do not match', () => {
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				webhookSecret: testSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header: string) => {
+					if (header === 'webhook-signature') return 'invalidsignature';
+					return null;
+				}),
+				rawBody: testPayload,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when signature header is missing', () => {
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				webhookSecret: testSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(null),
+				rawBody: testPayload,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Add webhook request verification to the Mautic Trigger node using the shared `verifySignature` utility:

- Generate an HMAC-SHA256 signing secret (`randomBytes(32)`) on webhook creation and pass it to the Mautic API via the `secret` field
- Verify the `Webhook-Signature` header on incoming requests using constant-time comparison
- Return 401 for requests with invalid signatures
- Existing webhooks without a stored secret continue to work unchanged (backward compatible)

<img width="2502" height="1304" alt="2026-05-03 23 11 31" src="https://github.com/user-attachments/assets/3104bc51-3dff-4bd0-b6a0-56e9452a3a7c" />

### Verification

Tested with [n8n-node-mocker](https://github.com/DawidMyslak/n8n-node-mocker):
- ✅ Correct secret → 200 OK
- ✅ Wrong secret → 401 Unauthorized

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4311

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.


Made with [Cursor](https://cursor.com)