### PR TITLE
fix(core): Check npm provenance in community package scanner

### DIFF
--- a/packages/@n8n/scan-community-package/README.md
+++ b/packages/@n8n/scan-community-package/README.md
@@ -1,5 +1,7 @@
 ## n8n community-package static analysis tool
 
+Checks npm provenance and runs static analysis for n8n community packages.
+
 ### How to use this
 
 ```

--- a/packages/@n8n/scan-community-package/package.json
+++ b/packages/@n8n/scan-community-package/package.json
@@ -4,6 +4,9 @@
   "description": "Static code analyser for n8n community packages",
   "license": "none",
   "bin": "scanner/cli.mjs",
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  },
   "files": [
     "scanner"
   ],

--- a/packages/@n8n/scan-community-package/scanner/provenance.mjs
+++ b/packages/@n8n/scan-community-package/scanner/provenance.mjs
@@ -1,0 +1,31 @@
+const NPM_PROVENANCE_PREDICATE_TYPE = 'https://slsa.dev/provenance/v1';
+const N8N_COMMUNITY_NODE_PUBLISH_DOCS_URL =
+	'https://docs.n8n.io/integrations/creating-nodes/deploy/submit-community-nodes/';
+
+export const checkPackageProvenance = (packageMetadata, version) => {
+	const packageVersion = packageMetadata.versions?.[version];
+	const provenance = packageVersion?.dist?.attestations?.provenance;
+
+	if (!packageVersion) {
+		return {
+			passed: false,
+			message: `No package metadata found for version ${version}`,
+		};
+	}
+
+	if (!provenance) {
+		return {
+			passed: false,
+			message: `Package was not published with npm provenance. Learn how to publish community nodes with provenance: ${N8N_COMMUNITY_NODE_PUBLISH_DOCS_URL}`,
+		};
+	}
+
+	if (provenance.predicateType !== NPM_PROVENANCE_PREDICATE_TYPE) {
+		return {
+			passed: false,
+			message: `Unsupported npm provenance predicate type: ${provenance.predicateType ?? 'unknown'}`,
+		};
+	}
+
+	return { passed: true };
+};

--- a/packages/@n8n/scan-community-package/scanner/scanner.mjs
+++ b/packages/@n8n/scan-community-package/scanner/scanner.mjs
@@ -11,6 +11,8 @@ import glob from 'fast-glob';
 import { fileURLToPath } from 'url';
 import { defineConfig } from 'eslint/config';
 
+import { checkPackageProvenance } from './provenance.mjs';
+
 const { stdout } = process;
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMP_DIR = tmp.dirSync({ unsafeCleanup: true }).name;
@@ -164,10 +166,12 @@ const analyzePackage = async (packageDir) => {
 export const analyzePackageByName = async (packageName, version) => {
 	try {
 		let exactVersion = version;
+		let packageMetadata;
 
 		// If version is a range, get the latest matching version
 		if (version && semver.validRange(version) && !semver.valid(version)) {
 			const { data } = await axios.get(`${registry}/${packageName}`);
+			packageMetadata = data;
 			const versions = Object.keys(data.versions);
 			exactVersion = semver.maxSatisfying(versions, version);
 
@@ -179,10 +183,32 @@ export const analyzePackageByName = async (packageName, version) => {
 		// If no version specified, get the latest
 		if (!exactVersion) {
 			const { data } = await axios.get(`${registry}/${packageName}`);
+			packageMetadata = data;
 			exactVersion = data['dist-tags'].latest;
 		}
 
+		packageMetadata ??= (await axios.get(`${registry}/${packageName}`)).data;
+		exactVersion = packageMetadata['dist-tags']?.[exactVersion] ?? exactVersion;
 		const label = `${packageName}@${exactVersion}`;
+
+		stdout.write(`Checking provenance for ${label}...`);
+		const provenanceResult = checkPackageProvenance(packageMetadata, exactVersion);
+		if (stdout.TTY) {
+			stdout.clearLine(0);
+			stdout.cursorTo(0);
+		}
+
+		if (!provenanceResult.passed) {
+			stdout.write(`❌ Provenance check failed for ${label} \n`);
+
+			return {
+				packageName,
+				version: exactVersion,
+				...provenanceResult,
+			};
+		}
+
+		stdout.write(`✅ Provenance check passed for ${label} \n`);
 
 		stdout.write(`Downloading ${label}...`);
 		const packageDir = await downloadAndExtractPackage(packageName, exactVersion);

--- a/packages/@n8n/scan-community-package/test/provenance.test.mjs
+++ b/packages/@n8n/scan-community-package/test/provenance.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { checkPackageProvenance } from '../scanner/provenance.mjs';
+
+test('checkPackageProvenance passes when npm provenance metadata is present', () => {
+	assert.deepEqual(
+		checkPackageProvenance(
+			{
+				versions: {
+					'1.0.0': {
+						dist: {
+							attestations: {
+								provenance: {
+									predicateType: 'https://slsa.dev/provenance/v1',
+								},
+							},
+						},
+					},
+				},
+			},
+			'1.0.0',
+		),
+		{ passed: true },
+	);
+});
+
+test('checkPackageProvenance fails when npm provenance metadata is missing', () => {
+	assert.deepEqual(
+		checkPackageProvenance(
+			{
+				versions: {
+					'1.0.0': { dist: {} },
+				},
+			},
+			'1.0.0',
+		),
+		{
+			passed: false,
+			message:
+				'Package was not published with npm provenance. Learn how to publish community nodes with provenance: https://docs.n8n.io/integrations/creating-nodes/deploy/submit-community-nodes/',
+		},
+	);
+});
+
+test('checkPackageProvenance fails when lint checks pass but npm provenance is missing', () => {
+	const lintResult = { passed: true };
+	const provenanceResult = checkPackageProvenance(
+		{
+			versions: {
+				'1.0.0': { dist: {} },
+			},
+		},
+		'1.0.0',
+	);
+
+	assert.equal(lintResult.passed, true);
+	assert.equal(provenanceResult.passed, false);
+	assert.match(provenanceResult.message, /Package was not published with npm provenance/);
+});
+
+test('checkPackageProvenance fails for unsupported provenance predicate types', () => {
+	assert.deepEqual(
+		checkPackageProvenance(
+			{
+				versions: {
+					'1.0.0': {
+						dist: {
+							attestations: {
+								provenance: {
+									predicateType: 'https://example.com/provenance/v1',
+								},
+							},
+						},
+					},
+				},
+			},
+			'1.0.0',
+		),
+		{
+			passed: false,
+			message: 'Unsupported npm provenance predicate type: https://example.com/provenance/v1',
+		},
+	);
+});


### PR DESCRIPTION
## Summary

Adds an npm provenance check to `@n8n/scan-community-package` before downloading and linting package contents.

How to test:
- `pnpm --filter @n8n/scan-community-package test`
- `node packages/@n8n/scan-community-package/scanner/cli.mjs n8n-nodes-openpix@0.3.0`

Test output:

```
➜  hvdq git:(cursor/d0e5ab81) ✗ node packages/@n8n/scan-community-package/scanner/cli.mjs @apify/n8n-nodes-apify

Checking provenance for @apify/n8n-nodes-apify@0.6.5...✅ Provenance check passed for @apify/n8n-nodes-apify@0.6.5 
Downloading @apify/n8n-nodes-apify@0.6.5...✅ Downloaded @apify/n8n-nodes-apify@0.6.5 
Analyzing @apify/n8n-nodes-apify@0.6.5...✅ Analyzed @apify/n8n-nodes-apify@0.6.5 
✅ Package @apify/n8n-nodes-apify@0.6.5 has passed all security checks


➜  hvdq git:(cursor/d0e5ab81) ✗ node packages/@n8n/scan-community-package/scanner/cli.mjs n8n-nodes-openpix     
Checking provenance for n8n-nodes-openpix@0.3.0...❌ Provenance check failed for n8n-nodes-openpix@0.3.0 
❌ Package n8n-nodes-openpix@0.3.0 has failed security checks
Reason: Package was not published with npm provenance. Learn how to publish community nodes with provenance: https://docs.n8n.io/integrations/creating-nodes/deploy/submit-community-nodes/
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CE-999/add-provenance-check-to-n8nscan-community-package

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)