### PR TITLE
fix(core): Show AI Builder draft workflows in workflow list

### DIFF
--- a/packages/@n8n/db/src/repositories/__tests__/workflow.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/workflow.repository.test.ts
@@ -2,7 +2,7 @@ import { GlobalConfig } from '@n8n/config';
 import { In, type SelectQueryBuilder } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
 
-import { AiBuilderTemporaryWorkflow, WorkflowEntity } from '../../entities';
+import { WorkflowEntity } from '../../entities';
 import { mockEntityManager } from '../../utils/test-utils/mock-entity-manager';
 import { mockInstance } from '../../utils/test-utils/mock-instance';
 import { FolderRepository } from '../folder.repository';
@@ -32,17 +32,9 @@ describe('WorkflowRepository', () => {
 		jest.resetAllMocks();
 
 		queryBuilder = mock<SelectQueryBuilder<WorkflowEntity>>();
-		const subQueryBuilder = mock<SelectQueryBuilder<AiBuilderTemporaryWorkflow>>();
-		subQueryBuilder.select.mockReturnThis();
-		subQueryBuilder.from.mockReturnThis();
-		subQueryBuilder.where.mockReturnThis();
-		subQueryBuilder.getQuery.mockReturnValue(
-			'(SELECT 1 FROM "ai_builder_temporary_workflow" "aitw" WHERE aitw."workflowId" = workflow.id)',
-		);
 
 		queryBuilder.where.mockReturnThis();
 		queryBuilder.andWhere.mockReturnThis();
-		queryBuilder.subQuery.mockReturnValue(subQueryBuilder);
 		queryBuilder.orWhere.mockReturnThis();
 		queryBuilder.select.mockReturnThis();
 		queryBuilder.addSelect.mockReturnThis();
@@ -63,18 +55,6 @@ describe('WorkflowRepository', () => {
 		});
 
 		jest.spyOn(workflowRepository, 'createQueryBuilder').mockReturnValue(queryBuilder);
-	});
-
-	describe('applyAiBuilderTemporaryFilter', () => {
-		it('hides marker-table rows through a prefix-safe entity subquery', async () => {
-			await workflowRepository.getMany(['workflow1']);
-
-			expect(queryBuilder.subQuery).toHaveBeenCalled();
-			expect(queryBuilder.subQuery().from).toHaveBeenCalledWith(AiBuilderTemporaryWorkflow, 'aitw');
-			expect(queryBuilder.andWhere).toHaveBeenCalledWith(
-				expect.stringContaining('NOT EXISTS (SELECT 1 FROM "ai_builder_temporary_workflow"'),
-			);
-		});
 	});
 
 	describe('applyNameFilter', () => {

--- a/packages/@n8n/db/src/repositories/workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow.repository.ts
@@ -18,7 +18,6 @@ import { SharedWorkflowRepository } from './shared-workflow.repository';
 import { WorkflowHistoryRepository } from './workflow-history.repository';
 import {
 	WebhookEntity,
-	AiBuilderTemporaryWorkflow,
 	TagEntity,
 	WorkflowEntity,
 	WorkflowTagMapping,
@@ -883,23 +882,6 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 		this.applyParentFolderFilter(qb, filter);
 		this.applyNodeTypesFilter(qb, filter);
 		this.applyAvailableInMCPFilter(qb, filter);
-		this.applyAiBuilderTemporaryFilter(qb);
-	}
-
-	/**
-	 * Hide workflows the AI builder created and has not yet promoted to the
-	 * main deliverable. The orchestrator clears the marker on the main at
-	 * build-time and reaps the rest at run-finish, but in the window between
-	 * create and reap, marked rows must not surface in the workflows list.
-	 */
-	private applyAiBuilderTemporaryFilter(qb: SelectQueryBuilder<WorkflowEntity>): void {
-		const markerSubquery = qb
-			.subQuery()
-			.select('1')
-			.from(AiBuilderTemporaryWorkflow, 'aitw')
-			.where('aitw."workflowId" = workflow.id')
-			.getQuery();
-		qb.andWhere(`NOT EXISTS ${markerSubquery}`);
 	}
 
 	private applyAvailableInMCPFilter(


### PR DESCRIPTION
## Summary

When the AI Builder creates a workflow, it inserts a row into `ai_builder_temporary_workflow` to mark it as a draft. The orchestrator clears the marker on success (`clearAiTemporary`) or archives the workflow at run-finish (`reapAiTemporaryFromRun`). Both paths require the orchestrator to reach a terminal state.

If the run never finalizes (LangSmith proxy 401 cascade, OOM, kill, tampering throw mid-build, …), the marker stays in place and the workflows-listing filter — a `NOT EXISTS` subquery in `WorkflowRepository.applyFilters` — hides the workflow until the thread expires by TTL. On David's instance this left **11 workflows** invisible with no self-recovery path.

This PR removes the `applyAiBuilderTemporaryFilter` so the marker becomes pure metadata. Mark / promote / reap logic in `instance-ai` is **unchanged** — the table still drives `archiveIfAiTemporary` at run-finish — it just no longer hides the row from listings. Crashed-run workflows immediately become recoverable, and David's 11 zombie workflows reappear with no DB intervention after deploy.

The trade-off is that drafts are visible in the workflows list during a build. Worth a follow-up for a "draft" badge if it turns out to be confusing.

### Follow-ups (not in this PR)

- Unconditional startup sweep that archives orphaned markers whose threads have no active orchestrator (instead of waiting for `threadTtlDays`).
- Investigate the LangSmith proxy 401 cascade that brought the process down on David's instance (separate ticket).
- Audit `validateWorkflowCredentialUsage` scoping for AI-authored builds — the "Blocked workflow update due to tampering attempt" log line on a fresh build looks suspect.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-194

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)