### PR TITLE
fix(editor): Ignore paste events on read-only canvas

### DIFF
--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -518,6 +518,7 @@ async function onCopyNodes(ids: string[]) {
 
 async function onClipboardPaste(plainTextData: string): Promise<void> {
 	if (
+		isCanvasReadOnly.value ||
 		getNodeViewTab(route) !== MAIN_HEADER_TABS.WORKFLOW ||
 		!keyBindingsEnabled.value ||
 		!checkIfEditingIsAllowed()

--- a/packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/archive.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/archive.spec.ts
@@ -97,6 +97,48 @@ test.describe(
 			expect(saveRequestDetected).toBe(false);
 		});
 
+		test('should not trigger autosave when pasting nodes on an archived workflow', async ({
+			n8n,
+		}) => {
+			const workflowId = await addNodeAndGetWorkflowId(n8n);
+
+			await n8n.workflowSettingsModal.getWorkflowMenu().click();
+			await n8n.workflowSettingsModal.clickArchiveMenuItem();
+			await expect(n8n.notifications.getSuccessNotifications().first()).toBeVisible();
+			await expect(n8n.page).toHaveURL(/\/workflows$/);
+
+			await goToWorkflow(n8n, workflowId);
+			await expect(n8n.canvas.getArchivedTag()).toBeVisible();
+
+			let saveRequestDetected = false;
+			n8n.page.on('request', (request) => {
+				if (request.url().includes('/rest/workflows/') && request.method() === 'PATCH') {
+					saveRequestDetected = true;
+				}
+			});
+
+			const workflowData = JSON.stringify({
+				nodes: [
+					{
+						parameters: {},
+						id: 'paste-test-node',
+						name: 'No Operation, do nothing',
+						type: 'n8n-nodes-base.noOp',
+						typeVersion: 1,
+						position: [300, 300],
+					},
+				],
+				connections: {},
+			});
+			await n8n.clipboard.paste(workflowData);
+
+			// eslint-disable-next-line playwright/no-wait-for-timeout
+			await n8n.page.waitForTimeout(2000);
+
+			expect(saveRequestDetected).toBe(false);
+			await expect(n8n.notifications.getErrorNotifications().first()).not.toBeAttached();
+		});
+
 		test('should not be able to archive or delete unsaved workflow', async ({ n8n }) => {
 			await expect(n8n.workflowSettingsModal.getWorkflowMenu()).toBeVisible();
 			await n8n.workflowSettingsModal.getWorkflowMenu().click();


### PR DESCRIPTION
## Summary

Pasting nodes (Ctrl/Cmd+V) on an archived workflow was bypassing the canvas read-only guard, triggering autosave attempts that failed with repeated 403/404 toast errors.

**Root cause:** `onClipboardPaste` in `NodeView.vue` guarded execution via `checkIfEditingIsAllowed()`, which does not account for the archived state. By contrast, `isCanvasReadOnly` (which already includes the archived check, added in #29559) was not consulted.

**Fix:** Add `isCanvasReadOnly.value` as the first condition in `onClipboardPaste`'s early-return guard — the same pattern already used by `onCutNodes`.

**How to test:**
1. Create and save a workflow with at least one node
2. Copy the node (Ctrl/Cmd+C)
3. Archive the workflow via the workflow menu
4. Open the archived workflow — canvas should be in read-only mode
5. Press Ctrl/Cmd+V — no nodes should appear, no autosave should fire, no error toasts should appear

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2995

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI