### PR TITLE
fix(editor): Make textarea resize handle accessible in NDV

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -2215,6 +2215,26 @@ onUpdated(async () => {
 	}
 }
 
+.input-with-opener .textarea-modal-opener {
+	top: 1px;
+	bottom: auto;
+	border-top: none;
+	border-bottom: var(--border);
+	border-top-left-radius: 0;
+	border-bottom-right-radius: 0;
+	border-top-right-radius: var(--radius);
+	border-bottom-left-radius: var(--radius);
+}
+
+.input-with-opener textarea {
+	resize: both;
+	max-width: 100%;
+}
+
+.input-with-opener .n8n-input__wrapper {
+	gap: 0;
+}
+
 .focused {
 	border-color: var(--color--secondary);
 }


### PR DESCRIPTION
## Summary

In the NDV, the textarea fullscreen ("open in modal") button was absolutely positioned in the bottom-right corner — directly on top of the browser's native textarea resize handle — so the resize affordance was unreachable. This PR moves the fullscreen button to the top-right corner of the plain textarea variant only (code editors that share the same class are unaffected since they have no native resize handle), switches the textarea from `resize: vertical` to `resize: both` with `max-width: 100%` so the resize indicator renders as a corner grip in the bottom-right rather than a horizontal grip in the bottom-center, and zeroes the input wrapper's flex `gap` for this variant so the corner grip sits flush with the visual corner instead of being inset by a spacing unit. Test by opening any string parameter with rows > 1 in NDV: the fullscreen button should sit in the top-right corner and the resize handle should be grabbable from the bottom-right corner.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5155

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI