### PR TITLE
fix(core): Add timeout to external secrets provider refresh

### DIFF
--- a/packages/cli/src/modules/external-secrets.ee/__tests__/secrets-cache.service.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/secrets-cache.service.test.ts
@@ -2,6 +2,7 @@ import { mockLogger } from '@n8n/backend-test-utils';
 
 import { AnotherDummyProvider, DummyProvider } from '@test/external-secrets/utils';
 
+import { EXTERNAL_SECRETS_REFRESH_TIMEOUT_MS } from '../constants';
 import { ExternalSecretsProviderRegistry } from '../provider-registry.service';
 import { ExternalSecretsSecretsCache } from '../secrets-cache.service';
 
@@ -52,6 +53,22 @@ describe('SecretsCache', () => {
 			jest.spyOn(dummyProvider, 'update').mockRejectedValue(new Error('Update failed'));
 
 			await expect(cache.refreshProvider('dummy', dummyProvider)).resolves.not.toThrow();
+		});
+
+		it('should not hang when update exceeds refresh timeout', async () => {
+			jest.useFakeTimers();
+			try {
+				jest
+					.spyOn(dummyProvider, 'update')
+					.mockImplementation(async () => await new Promise(() => {}));
+
+				const refreshPromise = cache.refreshProvider('dummy', dummyProvider);
+				await jest.advanceTimersByTimeAsync(EXTERNAL_SECRETS_REFRESH_TIMEOUT_MS);
+
+				await expect(refreshPromise).resolves.toBeUndefined();
+			} finally {
+				jest.useRealTimers();
+			}
 		});
 	});
 

--- a/packages/cli/src/modules/external-secrets.ee/constants.ts
+++ b/packages/cli/src/modules/external-secrets.ee/constants.ts
@@ -3,8 +3,7 @@ import type { INodeProperties } from 'n8n-workflow';
 export const EXTERNAL_SECRETS_DB_KEY = 'feature.externalSecrets';
 export const EXTERNAL_SECRETS_INITIAL_BACKOFF = 10 * 1000;
 export const EXTERNAL_SECRETS_MAX_BACKOFF = 5 * 60 * 1000;
-/** Max wait for a single provider refresh (startup and periodic refresh) */
-export const EXTERNAL_SECRETS_REFRESH_TIMEOUT_MS = 120 * 1000;
+export const EXTERNAL_SECRETS_REFRESH_TIMEOUT_MS = 20_000;
 
 export const DOCS_HELP_NOTICE: INodeProperties = {
 	displayName:

--- a/packages/cli/src/modules/external-secrets.ee/constants.ts
+++ b/packages/cli/src/modules/external-secrets.ee/constants.ts
@@ -3,6 +3,8 @@ import type { INodeProperties } from 'n8n-workflow';
 export const EXTERNAL_SECRETS_DB_KEY = 'feature.externalSecrets';
 export const EXTERNAL_SECRETS_INITIAL_BACKOFF = 10 * 1000;
 export const EXTERNAL_SECRETS_MAX_BACKOFF = 5 * 60 * 1000;
+/** Max wait for a single provider refresh (startup and periodic refresh) */
+export const EXTERNAL_SECRETS_REFRESH_TIMEOUT_MS = 120 * 1000;
 
 export const DOCS_HELP_NOTICE: INodeProperties = {
 	displayName:

--- a/packages/cli/src/modules/external-secrets.ee/secrets-cache.service.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-cache.service.ts
@@ -1,7 +1,8 @@
 import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
-import { ensureError } from 'n8n-workflow';
+import { ensureError, OperationalError } from 'n8n-workflow';
 
+import { EXTERNAL_SECRETS_REFRESH_TIMEOUT_MS } from './constants';
 import { ExternalSecretsProviderRegistry } from './provider-registry.service';
 import type { SecretsProvider } from './types';
 
@@ -41,12 +42,33 @@ export class ExternalSecretsSecretsCache {
 		}
 
 		try {
-			await provider.update();
+			await this.refreshProviderWithTimeout(provider);
 			this.logger.debug(`Refreshed secrets from provider ${name}`);
 		} catch (error) {
 			this.logger.error(`Error refreshing secrets from provider ${name}`, {
 				error: ensureError(error),
 			});
+		}
+	}
+
+	private async refreshProviderWithTimeout(provider: SecretsProvider): Promise<void> {
+		let timeoutId: NodeJS.Timeout | undefined;
+		const timeoutPromise = new Promise<never>((_, reject) => {
+			timeoutId = setTimeout(() => {
+				reject(
+					new OperationalError(
+						`Timed out refreshing secrets after ${EXTERNAL_SECRETS_REFRESH_TIMEOUT_MS}ms`,
+					),
+				);
+			}, EXTERNAL_SECRETS_REFRESH_TIMEOUT_MS);
+		});
+
+		try {
+			await Promise.race([provider.update(), timeoutPromise]);
+		} finally {
+			if (timeoutId !== undefined) {
+				clearTimeout(timeoutId);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

https://www.loom.com/share/50d1b99ee6fb464783fafa67dbe05ec3

An unresponsive external secrets provider (e.g. Vault, AWS Secrets Manager) could cause `provider.update()` to hang indefinitely, blocking instance startup and periodic refresh cycles.

This PR wraps each provider refresh in a `Promise.race` against a 20-second timeout. If the provider does not respond within that window, the refresh is aborted with an `OperationalError` and the error is logged — the instance continues normally instead of hanging.

**How to test:**
1. Configure an external secrets store that is unreachable or slow to respond.
2. Start the n8n instance and verify it starts up within the timeout window rather than hanging indefinitely.
3. Check logs for the timeout error message on the affected provider.

***OR test the failure/timeout with:***
1. Replicate a never-ending promise with `await new Promise(() => {});`
2. Start the n8n instance

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-522

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI