### PR TITLE
fix/docker permission error on community node installation due to missing tar flag

### DIFF
--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts
@@ -451,7 +451,7 @@ describe('CommunityPackagesService', () => {
 			expect(execFile).toHaveBeenCalledTimes(1);
 			expect(execFile).toHaveBeenCalledWith(
 				'tar',
-				['-xzf', testBlockTarballName, '-C', testBlockPackageDir, '--strip-components=1'],
+				['-xzf', testBlockTarballName, '-C', testBlockPackageDir, '--strip-components=1', '--no-same-owner'],
 				{ cwd: testBlockDownloadDir },
 				expect.any(Function),
 			);

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts
@@ -451,7 +451,14 @@ describe('CommunityPackagesService', () => {
 			expect(execFile).toHaveBeenCalledTimes(1);
 			expect(execFile).toHaveBeenCalledWith(
 				'tar',
-				['-xzf', testBlockTarballName, '-C', testBlockPackageDir, '--strip-components=1', '--no-same-owner'],
+				[
+					'-xzf',
+					testBlockTarballName,
+					'-C',
+					testBlockPackageDir,
+					'--strip-components=1',
+					'--no-same-owner',
+				],
 				{ cwd: testBlockDownloadDir },
 				expect.any(Function),
 			);
@@ -504,12 +511,71 @@ describe('CommunityPackagesService', () => {
 	});
 
 	describe('installPackage', () => {
+		const PACKAGE_NAME = 'n8n-nodes-test';
+		const packageDirectory = `${nodesDownloadDir}/node_modules/${PACKAGE_NAME}`;
+		const tarballName = `${PACKAGE_NAME}-1.0.0.tgz`;
+
+		const packageDirectoryLoader = mock<PackageDirectoryLoader>({
+			loadedNodes: [{ name: 'a-node-from-the-loader', version: 1 }],
+		});
+		const installedPackage = mock<InstalledPackages>({ packageName: PACKAGE_NAME });
+
+		beforeEach(() => {
+			config.unverifiedEnabled = true;
+			config.registry = 'some.random.host';
+			license.isCustomNpmRegistryEnabled.mockReturnValue(true);
+
+			mocked(execFile).mockImplementation(execMock);
+			mocked(executeNpmCommand).mockImplementation(async (args: string[]) =>
+				args[0] === 'pack' ? tarballName : 'Done',
+			);
+			mocked(readFile).mockResolvedValue(
+				JSON.stringify({
+					name: PACKAGE_NAME,
+					version: '1.0.0',
+					dependencies: { 'some-actual-dep': '1.2.3' },
+				}),
+			);
+
+			loadNodesAndCredentials.loadPackage.mockResolvedValue(packageDirectoryLoader);
+			installedPackageRepository.saveInstalledPackageWithNodes.mockResolvedValue(installedPackage);
+		});
+
 		test('should throw when installation of not vetted packages is forbidden', async () => {
 			config.unverifiedEnabled = false;
 			config.registry = 'https://registry.npmjs.org';
 			await expect(communityPackagesService.installPackage('package', '0.1.0')).rejects.toThrow(
 				'Installation of unverified community packages is forbidden!',
 			);
+		});
+
+		test('should extract the tarball without applying file ownership stored in the archive', async () => {
+			await communityPackagesService.installPackage(PACKAGE_NAME, '1.0.0');
+
+			// npm tarballs store uid=0/gid=0 in their entry headers; busybox tar (Alpine
+			// docker image) applies that ownership even as non-root unless --no-same-owner
+			// is passed, leaving the extracted files unreadable for the runtime user
+			expect(execFile).toHaveBeenCalledTimes(1);
+			expect(execFile).toHaveBeenCalledWith(
+				'tar',
+				['-xzf', tarballName, '-C', packageDirectory, '--strip-components=1', '--no-same-owner'],
+				{ cwd: nodesDownloadDir },
+				expect.any(Function),
+			);
+		});
+
+		test('should propagate the error and still delete the tarball when extraction fails', async () => {
+			mocked(execFile).mockImplementation(((...args) => {
+				const callback = args[args.length - 1] as ExecFileCallback;
+				callback(new Error('tar: invalid option'), '', '');
+			}) as typeof execFile);
+
+			await expect(communityPackagesService.installPackage(PACKAGE_NAME, '1.0.0')).rejects.toThrow(
+				'tar: invalid option',
+			);
+
+			expect(rm).toHaveBeenCalledWith(path.join(nodesDownloadDir, tarballName));
+			expect(loadNodesAndCredentials.loadPackage).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/modules/community-packages/community-packages.service.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.service.ts
@@ -527,7 +527,7 @@ export class CommunityPackagesService {
 		try {
 			await asyncExecFile(
 				'tar',
-				['-xzf', tarballName, '-C', packageDirectory, '--strip-components=1'],
+				['-xzf', tarballName, '-C', packageDirectory, '--strip-components=1', '--no-same-owner'],
 				{ cwd: this.downloadFolder },
 			);
 


### PR DESCRIPTION
## Summary

Busybox `tar` (used in the Alpine-based n8n Docker image) preserves UID/GID from archive headers even for non-root users. npm tarballs carry `uid=0/gid=0` headers, so extracted files end up owned by `root` when n8n runs as a custom UID — causing `EACCES` on the subsequent `package.json` read.

**Fix:** add `--no-same-owner` to the `tar` invocation in `downloadPackage`. Both GNU tar and busybox tar honour this flag, instructing tar to use the current process UID/GID instead of the archive's stored ownership.

## Root cause

The official n8n Docker image is Alpine-based, where `tar` is provided by busybox. Busybox `tar`, unlike GNU `tar`, by default preserves UID/GID metadata from the tarball even when extracting as a non-root user. npm-published tarballs typically contain `uid=0/gid=0` in their headers, so files end up owned by `root`. When n8n then tries to read `package.json` as the runtime UID, it gets `EACCES`.

This only surfaces when overriding the user via `docker run --user <UID>:<GID>`, which is the documented and recommended way to control file ownership on bind-mounted volumes.

## Changes

- `community-packages.service.ts` — adds `--no-same-owner` to the `tar` args
- `community-packages.service.test.ts` — updates the `execFile` assertion to match

No behaviour change for users running as `root` or the default `node` user (UID 1000).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
