### PR TITLE
fix(agents): Guard agent builder config writes against stale state

### DIFF
--- a/packages/cli/src/modules/agents/__tests__/agent-skills.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-skills.service.test.ts
@@ -41,12 +41,13 @@ describe('AgentSkillsService', () => {
 		service = new AgentSkillsService(mockLogger(), agentRepository);
 	});
 
-	it('creates a skill on the agent', async () => {
+	it('creates a skill without attaching it to the config', async () => {
 		const agent = makeAgent({
 			schema: {
 				name: 'Test Agent',
 				model: 'anthropic/claude-sonnet-4-5',
 				instructions: 'Be helpful',
+				skills: [],
 			},
 		});
 		agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
@@ -58,6 +59,25 @@ describe('AgentSkillsService', () => {
 			skill,
 			versionId: agent.versionId,
 		});
+		expect(agentRepository.save.mock.calls[0][0].skills).toEqual({
+			[result.id]: skill,
+		});
+		expect(agent.schema?.skills).toEqual([]);
+	});
+
+	it('creates and attaches a skill on the agent when requested', async () => {
+		const agent = makeAgent({
+			schema: {
+				name: 'Test Agent',
+				model: 'anthropic/claude-sonnet-4-5',
+				instructions: 'Be helpful',
+				skills: [],
+			},
+		});
+		agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
+
+		const result = await service.createAndAttachSkill(agentId, projectId, skill);
+
 		expect(agentRepository.save.mock.calls[0][0].skills).toEqual({
 			[result.id]: skill,
 		});

--- a/packages/cli/src/modules/agents/__tests__/agents-builder-tools.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-builder-tools.service.test.ts
@@ -256,13 +256,14 @@ describe('AgentsBuilderToolsService', () => {
 				.shared.find((tool) => tool.name === BUILDER_TOOLS.CREATE_SKILL)!;
 		}
 
-		it('is available to the builder with attachment guidance', () => {
+		it('is available to the builder with config attachment guidance', () => {
 			const { service } = makeService();
 
 			const tool = getCreateSkillTool(service);
 
 			expect(tool).toBeDefined();
-			expect(tool.description).toContain('attached to the agent config');
+			expect(tool.description).toContain('does NOT attach the skill to the agent config');
+			expect(tool.description).toContain('patch_config');
 			expect(tool.description).toContain('when to load it');
 		});
 

--- a/packages/cli/src/modules/agents/__tests__/agents-builder-tools.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-builder-tools.service.test.ts
@@ -5,8 +5,13 @@ import { mock } from 'jest-mock-extended';
 
 import type { AgentsToolsService } from '../agents-tools.service';
 import type { AgentsService } from '../agents.service';
-import { AgentsBuilderToolsService } from '../builder/agents-builder-tools.service';
+import {
+	AgentsBuilderToolsService,
+	getAgentConfigHash,
+} from '../builder/agents-builder-tools.service';
 import { BUILDER_TOOLS } from '../builder/builder-tool-names';
+import type { Agent } from '../entities/agent.entity';
+import type { AgentJsonConfig } from '../json-config/agent-json-config';
 import type { AgentSecureRuntime } from '../runtime/agent-secure-runtime';
 
 const ctx = {
@@ -32,6 +37,26 @@ function makeService() {
 	return { service, agentsService, secureRuntime };
 }
 
+const baseConfig: AgentJsonConfig = {
+	name: 'Agent One',
+	model: 'anthropic/claude-sonnet-4-5',
+	credential: 'Anthropic Key',
+	instructions: 'Help the user.',
+	tools: [],
+	skills: [],
+};
+
+function makeAgent(config: AgentJsonConfig = baseConfig): Agent {
+	return {
+		schema: config,
+		integrations: [],
+		updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+		versionId: 'v1',
+		tools: {},
+		skills: {},
+	} as unknown as Agent;
+}
+
 describe('AgentsBuilderToolsService', () => {
 	const agentId = 'agent-1';
 	const projectId = 'project-1';
@@ -39,6 +64,142 @@ describe('AgentsBuilderToolsService', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
+	});
+
+	describe('JSON config tools', () => {
+		function getJsonTool(service: AgentsBuilderToolsService, name: string) {
+			return service
+				.getTools(agentId, projectId, credentialProvider)
+				.json.find((tool) => tool.name === name)!;
+		}
+
+		it('read_config returns the current config snapshot metadata', async () => {
+			const { service, agentsService } = makeService();
+			agentsService.findById.mockResolvedValue(makeAgent());
+
+			const result = await getJsonTool(service, BUILDER_TOOLS.READ_CONFIG).handler!({}, ctx);
+
+			expect(result).toEqual({
+				ok: true,
+				config: { ...baseConfig, integrations: [] },
+				configHash: getAgentConfigHash({ ...baseConfig, integrations: [] }),
+				updatedAt: '2026-01-01T00:00:00.000Z',
+				versionId: 'v1',
+			});
+		});
+
+		it('patch_config applies a patch when baseConfigHash matches', async () => {
+			const { service, agentsService } = makeService();
+			const currentConfig = { ...baseConfig, integrations: [] };
+			const updatedConfig = { ...currentConfig, description: 'Updated description' };
+			agentsService.findById.mockResolvedValue(makeAgent(baseConfig));
+			agentsService.updateConfig.mockResolvedValue({
+				config: updatedConfig,
+				updatedAt: '2026-01-02T00:00:00.000Z',
+				versionId: 'v2',
+			});
+
+			const result = await getJsonTool(service, BUILDER_TOOLS.PATCH_CONFIG).handler!(
+				{
+					baseConfigHash: getAgentConfigHash(currentConfig),
+					operations: JSON.stringify([
+						{ op: 'add', path: '/description', value: 'Updated description' },
+					]),
+				},
+				ctx,
+			);
+
+			expect(agentsService.updateConfig).toHaveBeenCalledWith(agentId, projectId, updatedConfig);
+			expect(result).toEqual({
+				ok: true,
+				config: updatedConfig,
+				configHash: getAgentConfigHash(updatedConfig),
+				updatedAt: '2026-01-02T00:00:00.000Z',
+				versionId: 'v2',
+			});
+		});
+
+		it('patch_config rejects stale baseConfigHash without updating', async () => {
+			const { service, agentsService } = makeService();
+			const currentConfig = { ...baseConfig, integrations: [] };
+			agentsService.findById.mockResolvedValue(makeAgent(baseConfig));
+
+			const result = await getJsonTool(service, BUILDER_TOOLS.PATCH_CONFIG).handler!(
+				{
+					baseConfigHash: 'stale-hash',
+					operations: JSON.stringify([
+						{ op: 'add', path: '/description', value: 'Updated description' },
+					]),
+				},
+				ctx,
+			);
+
+			expect(agentsService.updateConfig).not.toHaveBeenCalled();
+			expect(result).toEqual({
+				ok: false,
+				stage: 'stale',
+				errors: expect.arrayContaining([expect.objectContaining({ path: '(root)' })]),
+				config: currentConfig,
+				configHash: getAgentConfigHash(currentConfig),
+				updatedAt: '2026-01-01T00:00:00.000Z',
+				versionId: 'v1',
+			});
+		});
+
+		it('write_config applies a full config when baseConfigHash matches', async () => {
+			const { service, agentsService } = makeService();
+			const currentConfig = { ...baseConfig, integrations: [] };
+			const updatedConfig = { ...currentConfig, instructions: 'Help with support tickets.' };
+			agentsService.findById.mockResolvedValue(makeAgent(baseConfig));
+			agentsService.updateConfig.mockResolvedValue({
+				config: updatedConfig,
+				updatedAt: '2026-01-02T00:00:00.000Z',
+				versionId: 'v2',
+			});
+
+			const result = await getJsonTool(service, BUILDER_TOOLS.WRITE_CONFIG).handler!(
+				{
+					baseConfigHash: getAgentConfigHash(currentConfig),
+					json: JSON.stringify(updatedConfig),
+				},
+				ctx,
+			);
+
+			expect(agentsService.updateConfig).toHaveBeenCalledWith(agentId, projectId, updatedConfig);
+			expect(result).toEqual({
+				ok: true,
+				config: updatedConfig,
+				configHash: getAgentConfigHash(updatedConfig),
+				updatedAt: '2026-01-02T00:00:00.000Z',
+				versionId: 'v2',
+			});
+		});
+
+		it('write_config rejects stale baseConfigHash without updating', async () => {
+			const { service, agentsService } = makeService();
+			const currentConfig = { ...baseConfig, integrations: [] };
+			const updatedConfig = { ...currentConfig, instructions: 'Help with support tickets.' };
+			agentsService.findById.mockResolvedValue(makeAgent(baseConfig));
+
+			const result = await getJsonTool(service, BUILDER_TOOLS.WRITE_CONFIG).handler!(
+				{
+					baseConfigHash: 'stale-hash',
+					json: JSON.stringify(updatedConfig),
+				},
+				ctx,
+			);
+
+			expect(agentsService.updateConfig).not.toHaveBeenCalled();
+			expect(result).toEqual({
+				ok: false,
+				stage: 'stale',
+				errors: expect.arrayContaining([expect.objectContaining({ path: '(root)' })]),
+				config: currentConfig,
+				configHash: getAgentConfigHash(currentConfig),
+				updatedAt: '2026-01-01T00:00:00.000Z',
+				versionId: 'v1',
+			});
+		});
 	});
 
 	describe('build_custom_tool tool', () => {

--- a/packages/cli/src/modules/agents/agent-skills.service.ts
+++ b/packages/cli/src/modules/agents/agent-skills.service.ts
@@ -42,25 +42,37 @@ export class AgentSkillsService {
 	): Promise<AgentSkillMutationResponse> {
 		const entity = await this.agentRepository.findByIdAndProjectId(agentId, projectId);
 		if (!entity) throw new NotFoundError('Agent not found');
-		if (!entity.schema) throw new UserError('Agent has no JSON config yet.');
 
 		this.validateSkill(skill);
 
-		const skillId = generateAgentResourceId('skill', Object.keys(entity.skills ?? {}));
-
-		entity.skills = {
-			...(entity.skills ?? {}),
-			[skillId]: skill,
-		};
-		entity.schema.skills = [
-			...(entity.schema.skills ?? []).filter((ref) => ref.id !== skillId),
-			{ type: 'skill', id: skillId },
-		];
+		const skillId = this.addSkill(entity, skill);
 
 		markAgentDraftDirty(entity);
 		const saved = await this.agentRepository.save(entity);
 
 		this.logger.debug('Created agent skill', { agentId, projectId, skillId });
+
+		return { id: skillId, skill, versionId: saved.versionId };
+	}
+
+	async createAndAttachSkill(
+		agentId: string,
+		projectId: string,
+		skill: AgentSkill,
+	): Promise<AgentSkillMutationResponse> {
+		const entity = await this.agentRepository.findByIdAndProjectId(agentId, projectId);
+		if (!entity) throw new NotFoundError('Agent not found');
+		if (!entity.schema) throw new UserError('Agent has no JSON config yet.');
+
+		this.validateSkill(skill);
+
+		const skillId = this.addSkill(entity, skill);
+		this.attachSkillRef(entity, skillId);
+
+		markAgentDraftDirty(entity);
+		const saved = await this.agentRepository.save(entity);
+
+		this.logger.debug('Created and attached agent skill', { agentId, projectId, skillId });
 
 		return { id: skillId, skill, versionId: saved.versionId };
 	}
@@ -166,5 +178,25 @@ export class AgentSkillsService {
 				`Invalid agent skill: ${result.error.issues[0]?.message ?? 'Invalid skill'}`,
 			);
 		}
+	}
+
+	private addSkill(entity: Agent, skill: AgentSkill): string {
+		const skillId = generateAgentResourceId('skill', Object.keys(entity.skills ?? {}));
+
+		entity.skills = {
+			...(entity.skills ?? {}),
+			[skillId]: skill,
+		};
+
+		return skillId;
+	}
+
+	private attachSkillRef(entity: Agent, skillId: string): void {
+		if (!entity.schema) throw new UserError('Agent has no JSON config yet.');
+
+		entity.schema.skills = [
+			...(entity.schema.skills ?? []).filter((ref) => ref.id !== skillId),
+			{ type: 'skill', id: skillId },
+		];
 	}
 }

--- a/packages/cli/src/modules/agents/agents.controller.ts
+++ b/packages/cli/src/modules/agents/agents.controller.ts
@@ -190,7 +190,7 @@ export class AgentsController {
 			instructions: payload.instructions,
 		};
 
-		return await this.agentsService.createSkill(agentId, projectId, skill);
+		return await this.agentsService.createAndAttachSkill(agentId, projectId, skill);
 	}
 
 	@Patch('/:agentId/skills/:skillId')

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -1274,6 +1274,16 @@ export class AgentsService {
 		return result;
 	}
 
+	async createAndAttachSkill(
+		agentId: string,
+		projectId: string,
+		skill: AgentSkill,
+	): Promise<AgentSkillMutationResponse> {
+		const result = await this.agentSkillsService.createAndAttachSkill(agentId, projectId, skill);
+		this.clearRuntimes(agentId);
+		return result;
+	}
+
 	async updateSkill(
 		agentId: string,
 		projectId: string,

--- a/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
@@ -345,8 +345,6 @@ Examples:
 
 Path syntax: \`/field\` for top-level fields, \`/nested/field\` for nested, \`/array/0\` for index, \`/array/-\` to append.
 
-For array item edits/removals, include a preceding \`test\` op for an identifying
-field such as \`/tools/1/name\` or \`/skills/0/id\` before replacing/removing.
 When attaching a skill, append to \`/skills/-\` if \`skills\` exists; otherwise
 add \`/skills\` with an array containing the skill ref.
 

--- a/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
@@ -133,9 +133,10 @@ Use skills for reusable instructions, playbooks, style guides, policies, or
 domain knowledge the agent should follow. Call create_skill with the skill
 \`name\`, \`description\`, and \`body\`; the tool returns the generated skill
 \`id\`. Skill descriptions should describe the task/situation that should
-trigger loading the skill. create_skill stores the skill body and attaches
-\`{ "type": "skill", "id": "<returned id>" }\` to the agent config in one
-operation, so do not add a second skill ref afterwards.`;
+trigger loading the skill. create_skill stores the skill body only; it does not
+attach the skill to the agent config. After create_skill, call read_config and
+use patch_config (or write_config) to add
+\`{ "type": "skill", "id": "<returned id>" }\` to \`skills\`.`;
 
 export const INTERACTIVE_TOOLS_SECTION = `\
 ## Interactive tools (user-facing)
@@ -346,6 +347,8 @@ Path syntax: \`/field\` for top-level fields, \`/nested/field\` for nested, \`/a
 
 For array item edits/removals, include a preceding \`test\` op for an identifying
 field such as \`/tools/1/name\` or \`/skills/0/id\` before replacing/removing.
+When attaching a skill, append to \`/skills/-\` if \`skills\` exists; otherwise
+add \`/skills\` with an array containing the skill ref.
 
 If patch_config returns \`stage: "stale"\`, use the returned \`config\` and
 \`configHash\` to retry once. Do not retry from memory.
@@ -368,8 +371,9 @@ If a write_config or patch_config call returns \`stage: "stale"\`, retry once
 from the returned \`config\` and \`configHash\`. For any later independent config
 change, call \`read_config\` again.
 
-\`create_skill\` does not require a follow-up read_config because it attaches the
-skill reference itself and does not need a separate skills patch.`;
+\`create_skill\` stores a skill body but does not attach it. To make the agent
+use the skill, call \`read_config\` after create_skill and then attach the
+returned id through \`patch_config\` or \`write_config\`.`;
 
 export const WORKFLOW_SECTION = `\
 ## Workflow
@@ -383,7 +387,8 @@ export const WORKFLOW_SECTION = `\
 3. Before adding any node tool that needs credentials, call ask_credential for
    each slot.
 4. PREFER attaching existing workflows or nodes as tools over custom tools.
-5. Use create_skill for reusable instruction bundles; it attaches the returned skill id to \`skills\`.
+5. Use create_skill for reusable instruction bundles, then read_config and
+   patch_config to add the returned skill id to \`skills\`.
 6. Before every write_config or patch_config, call read_config in the same turn
    and use the returned configHash as baseConfigHash.
 7. Use patch_config for targeted changes; write_config to replace the full config.`;
@@ -431,7 +436,9 @@ export const FEW_SHOT_FLOWS_SECTION = `\
 ### Adding a skill to an existing agent
 1. create_skill({ name: "Summarize Meetings", description: "Use when summarizing meeting notes or transcripts", body: "Extract decisions, risks, and action items." })
    → { id: "skill_0Ab9ZkLm3Pq7Xy2N", ... }
-2. Reply: "Done. I added the skill."
+2. read_config() → { configHash: "hash1", config: { ... } }
+3. patch_config with \`{ baseConfigHash: "hash1", operations: "[{ \\"op\\": \\"add\\", \\"path\\": \\"/skills/-\\", \\"value\\": { \\"type\\": \\"skill\\", \\"id\\": \\"skill_0Ab9ZkLm3Pq7Xy2N\\" } }]" }\`
+4. Reply: "Done. I added the skill."
 
 ### Ambiguous request: "Make it post somewhere"
 1. ask_question({ question: "Where should the agent post?",
@@ -453,7 +460,7 @@ export const IMPORTANT_SECTION = `\
 - Prefer workflow tools and node tools over custom tools for real-world interactions
 - Memory with storage "n8n" is the default -- always enable it unless told otherwise
 - \`build_custom_tool\` generates an opaque custom tool id, then compiles and stores the tool code. Register the returned id in the config separately by adding a \`{ type: "custom", id }\` entry to \`tools\` via write_config or patch_config
-- \`create_skill\` creates the skill and attaches a \`{ type: "skill", id }\` entry to \`skills\` in one operation. Do not add a second skill ref via patch_config.`;
+- \`create_skill\` stores the skill body only. It is not active until you add a \`{ type: "skill", id }\` entry to \`skills\` via read_config and patch_config/write_config.`;
 
 export const RESPONSE_STYLE_SECTION = `\
 ## Response style

--- a/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
@@ -8,13 +8,26 @@ import { jsonSchemaToCompactText } from '../json-config/schema-text-serializer';
 // Context sections — dynamic, injected at runtime
 // ---------------------------------------------------------------------------
 
-export function getAgentStateSection(configJson: string, toolList: string): string {
+export function getAgentStateSection(
+	configJson: string,
+	configHash: string | null,
+	configUpdatedAt: string | null,
+	toolList: string,
+): string {
 	return `\
 ## Current agent config
+
+configHash: \`${configHash ?? 'null'}\`
+updatedAt: \`${configUpdatedAt ?? 'null'}\`
 
 \`\`\`json
 ${configJson}
 \`\`\`
+
+Treat this config as a starting snapshot only. Before any \`write_config\` or
+\`patch_config\` call, call \`read_config\` in the same turn and use the returned
+\`config\` plus \`configHash\` as the write base. Do not pass the prompt
+\`configHash\` to a write tool.
 
 ## Custom tools
 
@@ -276,21 +289,29 @@ Never invent credential IDs or names. Always go through \`ask_credential\`.`;
 export const WRITE_CONFIG_SECTION = `\
 ## write_config — full replace
 
-Call write_config with the complete agent configuration as a JSON string:
+Before calling write_config, call \`read_config\` and build the full replacement
+from the returned \`config\`. Call write_config with the complete agent
+configuration as a JSON string and the \`baseConfigHash\` from that same
+\`read_config\` result:
 \`\`\`json
 {
-  "name": "My Agent",
-  "model": "anthropic/claude-sonnet-4-5",
-  "credential": "My Anthropic Key",
-  "instructions": "You are a helpful assistant.",
-  "memory": { "enabled": true, "storage": "n8n", "lastMessages": 50 }
+  "baseConfigHash": "<configHash from read_config>",
+  "json": "{ \\"name\\": \\"My Agent\\", \\"model\\": \\"anthropic/claude-sonnet-4-5\\", \\"credential\\": \\"My Anthropic Key\\", \\"instructions\\": \\"You are a helpful assistant.\\", \\"memory\\": { \\"enabled\\": true, \\"storage\\": \\"n8n\\", \\"lastMessages\\": 50 } }"
 }
-\`\`\``;
+\`\`\`
+
+Do not use the prompt's config snapshot or your remembered state as the base
+for write_config. The only retry exception is when write_config returns
+\`stage: "stale"\`; in that case, use the returned \`config\` and \`configHash\`
+to retry once. Do not retry from memory.`;
 
 export const PATCH_CONFIG_SECTION = `\
 ## patch_config — RFC 6902 JSON Patch
 
-Send an array of RFC 6902 patch operations as a JSON string. Each operation targets a field by its JSON Pointer path.
+Before calling patch_config, call \`read_config\` and derive the patch from the
+returned \`config\`. Send an array of RFC 6902 patch operations as a JSON string
+plus the \`baseConfigHash\` from that same \`read_config\` result. Each operation
+targets a field by its JSON Pointer path.
 
 | op      | description                              |
 |---------|------------------------------------------|
@@ -303,32 +324,59 @@ Send an array of RFC 6902 patch operations as a JSON string. Each operation targ
 
 Examples:
 \`\`\`json
-[
-  { "op": "replace", "path": "/model", "value": "anthropic/claude-sonnet-4-5" }
-]
+{
+  "baseConfigHash": "<configHash from read_config>",
+  "operations": "[{ \\"op\\": \\"replace\\", \\"path\\": \\"/model\\", \\"value\\": \\"anthropic/claude-sonnet-4-5\\" }]"
+}
 \`\`\`
 \`\`\`json
-[
-  { "op": "replace", "path": "/memory/lastMessages", "value": 50 },
-  { "op": "add", "path": "/tools/-", "value": { "type": "workflow", "workflow": "Send Email" } }
-]
+{
+  "baseConfigHash": "<configHash from read_config>",
+  "operations": "[{ \\"op\\": \\"replace\\", \\"path\\": \\"/memory/lastMessages\\", \\"value\\": 50 }, { \\"op\\": \\"add\\", \\"path\\": \\"/tools/-\\", \\"value\\": { \\"type\\": \\"workflow\\", \\"workflow\\": \\"Send Email\\" } }]"
+}
 \`\`\`
 \`\`\`json
-[
-  { "op": "remove", "path": "/description" }
-]
+{
+  "baseConfigHash": "<configHash from read_config>",
+  "operations": "[{ \\"op\\": \\"remove\\", \\"path\\": \\"/description\\" }]"
+}
 \`\`\`
 
 Path syntax: \`/field\` for top-level fields, \`/nested/field\` for nested, \`/array/0\` for index, \`/array/-\` to append.
 
-On error, the response includes a \`stage\` field: "parse" (invalid JSON), "patch" (operation failed), or "schema" (config fails validation).`;
+For array item edits/removals, include a preceding \`test\` op for an identifying
+field such as \`/tools/1/name\` or \`/skills/0/id\` before replacing/removing.
+
+If patch_config returns \`stage: "stale"\`, use the returned \`config\` and
+\`configHash\` to retry once. Do not retry from memory.
+
+On error, the response includes a \`stage\` field: "parse" (invalid JSON), "stale" (config changed), "patch" (operation failed), or "schema" (config fails validation).`;
+
+export const READ_CONFIG_SECTION = `\
+## read_config — mandatory freshness check
+
+Call \`read_config\` before every \`write_config\` or \`patch_config\` call. Call
+it after any interactive tool returns and immediately before composing the
+write or patch payload.
+
+Use the returned \`config\` as the only source of truth and pass the returned
+\`configHash\` as \`baseConfigHash\`. Do not patch from memory, the conversation,
+or the prompt snapshot. Do not skip this just because the prompt already
+contains a \`configHash\`.
+
+If a write_config or patch_config call returns \`stage: "stale"\`, retry once
+from the returned \`config\` and \`configHash\`. For any later independent config
+change, call \`read_config\` again.
+
+\`create_skill\` does not require a follow-up read_config because it attaches the
+skill reference itself and does not need a separate skills patch.`;
 
 export const WORKFLOW_SECTION = `\
 ## Workflow
 
 1. If the agent has no \`instructions\` and \`credential\` yet (fresh agent), FIRST call ask_llm to let
-   the user pick the model + credential, then write_config with the chosen
-   \`model\` and \`credential\` plus a draft \`instructions\`.
+   the user pick the model + credential, then call read_config and write_config
+   with the chosen \`model\` and \`credential\` plus a draft \`instructions\`.
 2. Use ask_question whenever you have a clarifying question with discrete
    options (e.g. "Which Slack channel?" → list channels, "Read-only or
    read-write?"). Never put the question in plain text if options are known.
@@ -336,7 +384,9 @@ export const WORKFLOW_SECTION = `\
    each slot.
 4. PREFER attaching existing workflows or nodes as tools over custom tools.
 5. Use create_skill for reusable instruction bundles; it attaches the returned skill id to \`skills\`.
-6. Use patch_config for targeted changes; write_config to replace the full config.`;
+6. Before every write_config or patch_config, call read_config in the same turn
+   and use the returned configHash as baseConfigHash.
+7. Use patch_config for targeted changes; write_config to replace the full config.`;
 
 export const FEW_SHOT_FLOWS_SECTION = `\
 ## Example flows
@@ -351,19 +401,16 @@ export const FEW_SHOT_FLOWS_SECTION = `\
        nodeType: "n8n-nodes-base.slackTool", credentialType: "slackApi",
        slot: "slackApi" })
    → { credentialId: "xyz", credentialName: "Acme Slack" }
-5. write_config({ ...
-     model: "anthropic/claude-sonnet-4-5",
-     credential: "My Anthropic",
-     tools: [{ type: "node", name: "slack_post", node: { ...,
-       credentials: { slackApi: { id: "xyz", name: "Acme Slack" } } } }]
-   })
-6. Reply: "Done."
+5. read_config() → { configHash: "hash1", config: { ... } }
+6. write_config({ baseConfigHash: "hash1", json: "{ ...complete config with model, credential, instructions, and Slack tool... }" })
+7. Reply: "Done."
 
 ### Adding a new node tool to an existing agent
 1. (skip ask_llm — already set)
 2. search_nodes / get_node_types
 3. ask_credential per required slot
-4. patch_config with \`{ op: "add", path: "/tools/-", value: { ... credentials: {...} } }\`
+4. read_config() → { configHash: "hash1", config: { ... } }
+5. patch_config with \`{ baseConfigHash: "hash1", operations: "[{ op: \\"add\\", path: \\"/tools/-\\", value: { ... credentials: {...} } }]" }\`
 
 ### Adding a node tool when credential setup is skipped
 1. search_nodes / get_node_types
@@ -371,13 +418,14 @@ export const FEW_SHOT_FLOWS_SECTION = `\
      nodeType: "n8n-nodes-base.salesforceTool", credentialType: "salesforceOAuth2Api",
      slot: "salesforceOAuth2Api" })
    → { skipped: true }
-3. patch_config with \`{ op: "add", path: "/tools/-", value: { type: "node",
+3. read_config() → { configHash: "hash1", config: { ... } }
+4. patch_config with \`{ baseConfigHash: "hash1", operations: "[{ op: \\"add\\", path: \\"/tools/-\\", value: { type: \\"node\\",
    name: "salesforce_create_lead", description: "...", node: {
    nodeType: "n8n-nodes-base.salesforceTool", nodeTypeVersion: 1,
-   nodeParameters: { ... } } } }\`
+   nodeParameters: { ... } } } }]" }\`
    IMPORTANT: omit \`node.credentials\` or omit only the skipped credential slot.
    Do not stop. Do not say you will not add the tool.
-4. Reply: "Done. I added the Salesforce tool without credentials; configure
+5. Reply: "Done. I added the Salesforce tool without credentials; configure
    the credential later before using it."
 
 ### Adding a skill to an existing agent
@@ -391,7 +439,7 @@ export const FEW_SHOT_FLOWS_SECTION = `\
        { label: "Slack", value: "slack" },
        { label: "Discord", value: "discord" },
        { label: "Email", value: "email" } ] })
-2. Continue with the chosen branch (search_nodes → ask_credential → patch_config).`;
+2. Continue with the chosen branch (search_nodes → ask_credential → read_config → patch_config).`;
 
 export const IMPORTANT_SECTION = `\
 ## Important
@@ -405,7 +453,7 @@ export const IMPORTANT_SECTION = `\
 - Prefer workflow tools and node tools over custom tools for real-world interactions
 - Memory with storage "n8n" is the default -- always enable it unless told otherwise
 - \`build_custom_tool\` generates an opaque custom tool id, then compiles and stores the tool code. Register the returned id in the config separately by adding a \`{ type: "custom", id }\` entry to \`tools\` via write_config or patch_config
-- \`create_skill\` creates the skill and attaches a \`{ type: "skill", id }\` entry to \`skills\` in one operation`;
+- \`create_skill\` creates the skill and attaches a \`{ type: "skill", id }\` entry to \`skills\` in one operation. Do not add a second skill ref via patch_config.`;
 
 export const RESPONSE_STYLE_SECTION = `\
 ## Response style
@@ -455,16 +503,19 @@ ${jsonSchemaText}
 
 export interface BuilderPromptContext {
 	configJson: string;
+	configHash: string | null;
+	configUpdatedAt: string | null;
 	toolList: string;
 	builderModel: string;
 }
 
 export function buildBuilderPrompt(ctx: BuilderPromptContext): string {
-	const { configJson, toolList, builderModel } = ctx;
+	const { configJson, configHash, configUpdatedAt, toolList, builderModel } = ctx;
 
 	return [
 		'You are an expert agent builder. You help users create and configure AI agents by writing raw JSON configuration and building custom tools.',
-		getAgentStateSection(configJson, toolList),
+		getAgentStateSection(configJson, configHash, configUpdatedAt, toolList),
+		READ_CONFIG_SECTION,
 		CONVERSATION_MODE_SECTION,
 		TOOL_TYPES_SECTION,
 		INTERACTIVE_TOOLS_SECTION,

--- a/packages/cli/src/modules/agents/builder/agents-builder-tools.service.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-tools.service.ts
@@ -378,7 +378,8 @@ export class AgentsBuilderToolsService {
 			.description(
 				'Create and store an agent skill. Pass the skill name, a short description, and the full skill body. ' +
 					'The description should help the runtime decide when to load it. ' +
-					'The body is stored as the skill instructions and the skill is attached to the agent config. ' +
+					'The body is stored as the skill instructions, but this does NOT attach the skill to the agent config. ' +
+					'Follow up with read_config and patch_config (or write_config) to add a `{ type: "skill", id }` entry to `skills`. ' +
 					'Returns { ok: true, id, skill } or { ok: false, errors }.',
 			)
 			.input(

--- a/packages/cli/src/modules/agents/builder/agents-builder-tools.service.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-tools.service.ts
@@ -4,10 +4,12 @@ import { agentSkillSchema } from '@n8n/api-types';
 import { WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import type { Operation } from 'fast-json-patch';
+import { createHash } from 'node:crypto';
 import { z } from 'zod';
 
 import { AgentsToolsService } from '../agents-tools.service';
 import { AgentsService } from '../agents.service';
+import { composeJsonConfig } from '../json-config/agent-config-composition';
 import type { AgentJsonConfig, ConfigValidationError } from '../json-config/agent-json-config';
 import {
 	AgentJsonConfigSchema,
@@ -24,6 +26,19 @@ const EMPTY_INSTRUCTIONS_ERROR: ConfigValidationError = {
 		'Refusing to write an agent with empty instructions. Ask the user what the agent should do before calling write_config or patch_config again.',
 };
 
+const STALE_CONFIG_ERROR: ConfigValidationError = {
+	path: '(root)',
+	message:
+		'Agent config changed since you last read it. Call read_config and retry with the returned configHash.',
+};
+
+export interface AgentConfigSnapshot {
+	config: AgentJsonConfig | null;
+	configHash: string | null;
+	updatedAt: string | null;
+	versionId: string | null;
+}
+
 function rejectIfEmptyInstructions(
 	config: AgentJsonConfig,
 ): { errors: ConfigValidationError[] } | null {
@@ -31,6 +46,44 @@ function rejectIfEmptyInstructions(
 		return { errors: [EMPTY_INSTRUCTIONS_ERROR] };
 	}
 	return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function canonicalizeJson(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		return value.map((item) => canonicalizeJson(item));
+	}
+
+	if (!isRecord(value)) return value;
+
+	const sorted: Record<string, unknown> = {};
+	for (const key of Object.keys(value).sort()) {
+		sorted[key] = canonicalizeJson(value[key]);
+	}
+	return sorted;
+}
+
+export function getAgentConfigHash(config: AgentJsonConfig | null): string | null {
+	if (!config) return null;
+	return createHash('sha256')
+		.update(JSON.stringify(canonicalizeJson(config)))
+		.digest('hex');
+}
+
+function snapshotFromConfig(
+	config: AgentJsonConfig | null,
+	updatedAt: string | null,
+	versionId: string | null,
+): AgentConfigSnapshot {
+	return {
+		config,
+		configHash: getAgentConfigHash(config),
+		updatedAt,
+		versionId,
+	};
 }
 
 export interface BuilderTools {
@@ -63,33 +116,16 @@ export class AgentsBuilderToolsService {
 		projectId: string,
 		credentialProvider: CredentialProvider,
 	): BuiltTool[] {
-		const writeConfigTool = new Tool(BUILDER_TOOLS.WRITE_CONFIG)
+		const readConfigTool = new Tool(BUILDER_TOOLS.READ_CONFIG)
 			.description(
-				'Create or replace the agent configuration by writing a complete JSON string. ' +
-					'Returns { ok: true } on success or { ok: false, errors } with path, message, ' +
-					'expected, received fields on validation failure.',
+				'Read the latest persisted agent configuration and freshness metadata. ' +
+					'Returns { ok: true, config, configHash, updatedAt, versionId }. ' +
+					'Call this before every write_config or patch_config and use configHash as baseConfigHash.',
 			)
-			.input(
-				z.object({
-					json: z.string().describe('Complete agent configuration as a JSON string'),
-				}),
-			)
-			.handler(async ({ json }: { json: string }) => {
-				const parsed = tryParseConfigJson(json);
-				if (!parsed.ok) {
-					return { ok: false, errors: parsed.errors };
-				}
-				const zodResult = AgentJsonConfigSchema.safeParse(parsed.data);
-				if (!zodResult.success) {
-					return { ok: false, errors: formatZodErrors(zodResult.error) };
-				}
-				const emptyInstructions = rejectIfEmptyInstructions(zodResult.data);
-				if (emptyInstructions) {
-					return { ok: false, errors: emptyInstructions.errors };
-				}
+			.input(z.object({}))
+			.handler(async () => {
 				try {
-					await this.agentsService.updateConfig(agentId, projectId, zodResult.data);
-					return { ok: true };
+					return { ok: true, ...(await this.getConfigSnapshot(agentId, projectId)) };
 				} catch (e) {
 					return {
 						ok: false,
@@ -99,70 +135,173 @@ export class AgentsBuilderToolsService {
 			})
 			.build();
 
+		const writeConfigTool = new Tool(BUILDER_TOOLS.WRITE_CONFIG)
+			.description(
+				'Create or replace the agent configuration by writing a complete JSON string. ' +
+					'Requires baseConfigHash from the immediately preceding read_config result, or from a stale retry response. ' +
+					'Do not use a configHash copied from the prompt snapshot. ' +
+					'Returns { ok: true, config, configHash, updatedAt, versionId } on success or ' +
+					'{ ok: false, stage, errors } with path, message, expected, received fields on failure.',
+			)
+			.input(
+				z.object({
+					json: z.string().describe('Complete agent configuration as a JSON string'),
+					baseConfigHash: z
+						.string()
+						.nullable()
+						.describe(
+							'configHash from the immediately preceding read_config result; null only if no config exists',
+						),
+				}),
+			)
+			.handler(
+				async ({ json, baseConfigHash }: { json: string; baseConfigHash: string | null }) => {
+					const parsed = tryParseConfigJson(json);
+					if (!parsed.ok) {
+						return { ok: false, errors: parsed.errors };
+					}
+					let snapshot: AgentConfigSnapshot;
+					try {
+						snapshot = await this.getConfigSnapshot(agentId, projectId);
+					} catch (e) {
+						return {
+							ok: false,
+							stage: 'stale',
+							errors: [{ path: '(root)', message: e instanceof Error ? e.message : String(e) }],
+						};
+					}
+					if (baseConfigHash !== snapshot.configHash) {
+						return { ok: false, stage: 'stale', errors: [STALE_CONFIG_ERROR], ...snapshot };
+					}
+					const zodResult = AgentJsonConfigSchema.safeParse(parsed.data);
+					if (!zodResult.success) {
+						return { ok: false, errors: formatZodErrors(zodResult.error) };
+					}
+					const emptyInstructions = rejectIfEmptyInstructions(zodResult.data);
+					if (emptyInstructions) {
+						return { ok: false, errors: emptyInstructions.errors };
+					}
+					try {
+						const result = await this.agentsService.updateConfig(
+							agentId,
+							projectId,
+							zodResult.data,
+						);
+						return {
+							ok: true,
+							...snapshotFromConfig(result.config, result.updatedAt, result.versionId),
+						};
+					} catch (e) {
+						return {
+							ok: false,
+							stage: 'schema',
+							errors: [{ path: '(root)', message: e instanceof Error ? e.message : String(e) }],
+						};
+					}
+				},
+			)
+			.build();
+
 		const patchConfigTool = new Tool(BUILDER_TOOLS.PATCH_CONFIG)
 			.description(
 				'Apply RFC 6902 JSON Patch operations to the current agent configuration. ' +
 					'Pass an array of patch operations as a JSON string. ' +
+					'Requires baseConfigHash from the immediately preceding read_config result, or from a stale retry response. ' +
+					'Do not use a configHash copied from the prompt snapshot. ' +
 					'Supported ops: add, remove, replace, move, copy, test. ' +
-					'Returns { ok: true, config } on success or { ok: false, stage, errors } on failure. ' +
-					'stage is "parse", "patch", or "schema".',
+					'Returns { ok: true, config, configHash, updatedAt, versionId } on success or ' +
+					'{ ok: false, stage, errors } on failure. ' +
+					'stage is "parse", "stale", "patch", or "schema".',
 			)
 			.input(
 				z.object({
 					operations: z.string().describe('RFC 6902 JSON Patch operations array as a JSON string'),
+					baseConfigHash: z
+						.string()
+						.nullable()
+						.describe(
+							'configHash from the immediately preceding read_config result; null only if no config exists',
+						),
 				}),
 			)
-			.handler(async ({ operations }: { operations: string }) => {
-				const parsedOps = tryParseConfigJson(operations);
-				if (!parsedOps.ok) {
-					return { ok: false, stage: 'parse', errors: parsedOps.errors };
-				}
+			.handler(
+				async ({
+					operations,
+					baseConfigHash,
+				}: {
+					operations: string;
+					baseConfigHash: string | null;
+				}) => {
+					const parsedOps = tryParseConfigJson(operations);
+					if (!parsedOps.ok) {
+						return { ok: false, stage: 'parse', errors: parsedOps.errors };
+					}
 
-				let existingConfig: AgentJsonConfig;
-				try {
-					existingConfig = await this.agentsService.getConfig(agentId, projectId);
-				} catch (e) {
-					return {
-						ok: false,
-						stage: 'patch',
-						errors: [{ path: '(root)', message: e instanceof Error ? e.message : String(e) }],
-					};
-				}
-				const jsonpatch = (await import('fast-json-patch')).default;
-				const ops = parsedOps.data as Operation[];
-				const patchError = jsonpatch.validate(ops, existingConfig);
-				if (patchError) {
-					const opPath = (patchError.operation as { path?: string } | undefined)?.path ?? '(root)';
-					return {
-						ok: false,
-						stage: 'patch',
-						errors: [{ path: opPath, message: patchError.message ?? 'Invalid patch operation' }],
-					};
-				}
+					let snapshot: AgentConfigSnapshot;
+					try {
+						snapshot = await this.getConfigSnapshot(agentId, projectId);
+					} catch (e) {
+						return {
+							ok: false,
+							stage: 'stale',
+							errors: [{ path: '(root)', message: e instanceof Error ? e.message : String(e) }],
+						};
+					}
+					if (baseConfigHash !== snapshot.configHash) {
+						return { ok: false, stage: 'stale', errors: [STALE_CONFIG_ERROR], ...snapshot };
+					}
+					if (!snapshot.config) {
+						return {
+							ok: false,
+							stage: 'patch',
+							errors: [{ path: '(root)', message: 'Agent has no JSON config yet.' }],
+						};
+					}
 
-				const patched = jsonpatch.applyPatch(jsonpatch.deepClone(existingConfig), ops)
-					.newDocument as unknown as AgentJsonConfig;
+					const jsonpatch = (await import('fast-json-patch')).default;
+					const ops = parsedOps.data as Operation[];
+					const patchError = jsonpatch.validate(ops, snapshot.config);
+					if (patchError) {
+						const opPath =
+							(patchError.operation as { path?: string } | undefined)?.path ?? '(root)';
+						return {
+							ok: false,
+							stage: 'patch',
+							errors: [{ path: opPath, message: patchError.message ?? 'Invalid patch operation' }],
+						};
+					}
 
-				const zodResult = AgentJsonConfigSchema.safeParse(patched);
-				if (!zodResult.success) {
-					return { ok: false, stage: 'schema', errors: formatZodErrors(zodResult.error) };
-				}
-				const emptyInstructions = rejectIfEmptyInstructions(zodResult.data);
-				if (emptyInstructions) {
-					return { ok: false, stage: 'schema', errors: emptyInstructions.errors };
-				}
+					const patched = jsonpatch.applyPatch(jsonpatch.deepClone(snapshot.config), ops)
+						.newDocument as unknown as AgentJsonConfig;
 
-				try {
-					const result = await this.agentsService.updateConfig(agentId, projectId, zodResult.data);
-					return { ok: true, config: result.config };
-				} catch (e) {
-					return {
-						ok: false,
-						stage: 'schema',
-						errors: [{ path: '(root)', message: e instanceof Error ? e.message : String(e) }],
-					};
-				}
-			})
+					const zodResult = AgentJsonConfigSchema.safeParse(patched);
+					if (!zodResult.success) {
+						return { ok: false, stage: 'schema', errors: formatZodErrors(zodResult.error) };
+					}
+					const emptyInstructions = rejectIfEmptyInstructions(zodResult.data);
+					if (emptyInstructions) {
+						return { ok: false, stage: 'schema', errors: emptyInstructions.errors };
+					}
+
+					try {
+						const result = await this.agentsService.updateConfig(
+							agentId,
+							projectId,
+							zodResult.data,
+						);
+						return {
+							ok: true,
+							...snapshotFromConfig(result.config, result.updatedAt, result.versionId),
+						};
+					} catch (e) {
+						return {
+							ok: false,
+							stage: 'schema',
+							errors: [{ path: '(root)', message: e instanceof Error ? e.message : String(e) }],
+						};
+					}
+				},
+			)
 			.build();
 
 		const listIntegrationTypesTool = new Tool(BUILDER_TOOLS.LIST_INTEGRATION_TYPES)
@@ -185,6 +324,7 @@ export class AgentsBuilderToolsService {
 			.build();
 
 		return [
+			readConfigTool,
 			writeConfigTool,
 			patchConfigTool,
 			listIntegrationTypesTool,
@@ -337,5 +477,16 @@ export class AgentsBuilderToolsService {
 					'into the config.',
 			),
 		];
+	}
+
+	private async getConfigSnapshot(
+		agentId: string,
+		projectId: string,
+	): Promise<AgentConfigSnapshot> {
+		const agent = await this.agentsService.findById(agentId, projectId);
+		if (!agent) throw new Error('Agent not found');
+
+		const config = composeJsonConfig(agent);
+		return snapshotFromConfig(config, agent.updatedAt.toISOString(), agent.versionId);
 	}
 }

--- a/packages/cli/src/modules/agents/builder/agents-builder.service.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder.service.ts
@@ -17,7 +17,7 @@ import { N8nMemory } from '../integrations/n8n-memory';
 import type { AgentJsonConfig } from '../json-config/agent-json-config';
 import { AgentCheckpointRepository } from '../repositories/agent-checkpoint.repository';
 import { buildBuilderPrompt } from './agents-builder-prompts';
-import { AgentsBuilderToolsService } from './agents-builder-tools.service';
+import { AgentsBuilderToolsService, getAgentConfigHash } from './agents-builder-tools.service';
 import { AGENT_THREAD_PREFIX } from './builder-tool-names';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { AgentsBuilderSettingsService } from './agents-builder-settings.service';
@@ -162,6 +162,8 @@ export class AgentsBuilderService {
 		const configJson = currentConfig ? JSON.stringify(currentConfig, null, 2) : '(no config yet)';
 		const instructions = buildBuilderPrompt({
 			configJson,
+			configHash: getAgentConfigHash(currentConfig),
+			configUpdatedAt: agent.updatedAt.toISOString(),
 			toolList,
 			builderModel: BUILDER_MODEL,
 		});

--- a/packages/cli/src/modules/agents/builder/builder-tool-names.ts
+++ b/packages/cli/src/modules/agents/builder/builder-tool-names.ts
@@ -3,6 +3,7 @@
  * routing, and tests can't drift on string typos.
  */
 export const BUILDER_TOOLS = {
+	READ_CONFIG: 'read_config',
 	WRITE_CONFIG: 'write_config',
 	PATCH_CONFIG: 'patch_config',
 	BUILD_CUSTOM_TOOL: 'build_custom_tool',

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatPanel.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+import { computed, ref } from 'vue';
+
+const sendMessageMock = vi.fn();
+const stopGeneratingMock = vi.fn();
+const loadHistoryMock = vi.fn();
+
+vi.mock('@n8n/i18n', () => ({
+	useI18n: () => ({ baseText: (key: string) => key }),
+}));
+
+vi.mock('@n8n/design-system', () => ({
+	N8nButton: { template: '<button><slot /></button>' },
+	N8nCallout: { template: '<div><slot /><slot name="trailingContent" /></div>' },
+	N8nIconButton: { template: '<button />' },
+}));
+
+vi.mock('@/features/ai/shared/components/ChatInputBase.vue', () => ({
+	default: {
+		name: 'ChatInputBase',
+		template:
+			'<form data-testid="chat-input-stub" @submit.prevent="$emit(\'submit\')"><slot name="footer-start" /></form>',
+		props: ['modelValue', 'placeholder', 'isStreaming', 'canSubmit', 'disabled'],
+		emits: ['submit', 'stop', 'update:modelValue'],
+	},
+}));
+
+vi.mock('../components/AgentChatEmptyState.vue', () => ({
+	default: { template: '<div data-testid="empty-state-stub" />', props: ['endpoint'] },
+}));
+
+vi.mock('../components/AgentChatMessageList.vue', () => ({
+	default: { template: '<div data-testid="message-list-stub" />', props: ['messages'] },
+}));
+
+vi.mock('../composables/useAgentChatStream', () => ({
+	useAgentChatStream: () => ({
+		messages: ref([]),
+		isStreaming: ref(false),
+		messagingState: computed(() => 'idle'),
+		fatalError: ref(null),
+		loadHistory: loadHistoryMock,
+		sendMessage: sendMessageMock,
+		stopGenerating: stopGeneratingMock,
+		resume: vi.fn(),
+		dismissFatalError: vi.fn(),
+	}),
+}));
+
+vi.mock('../composables/useAgentTelemetry', () => ({
+	useAgentTelemetry: () => ({ trackSubmittedMessage: vi.fn() }),
+}));
+
+vi.mock('../composables/agentTelemetry.utils', () => ({
+	buildAgentConfigFingerprint: vi.fn().mockResolvedValue({
+		instructions: '',
+		tools: [],
+		skills: [],
+		triggers: [],
+		memory: null,
+		model: null,
+		config_version: 'test-version',
+	}),
+}));
+
+describe('AgentChatPanel', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('awaits beforeSend before sending a build message', async () => {
+		const events: string[] = [];
+		let resolveBeforeSend: () => void = () => {};
+		const beforeSend = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					resolveBeforeSend = () => {
+						events.push('beforeSend');
+						resolve();
+					};
+				}),
+		);
+		sendMessageMock.mockImplementation(async () => {
+			events.push('sendMessage');
+		});
+
+		const { default: AgentChatPanel } = await import('../components/AgentChatPanel.vue');
+		const wrapper = mount(AgentChatPanel, {
+			props: {
+				projectId: 'p1',
+				agentId: 'a1',
+				endpoint: 'build',
+				agentConfig: {
+					name: 'Agent',
+					model: 'anthropic/claude-sonnet-4-5',
+					instructions: 'Help.',
+				},
+				agentStatus: 'draft',
+				connectedTriggers: [],
+				beforeSend,
+			},
+		});
+
+		(
+			wrapper.vm as unknown as { sendMessageFromOutside: (message: string) => void }
+		).sendMessageFromOutside('update config');
+		await flushPromises();
+
+		expect(beforeSend).toHaveBeenCalledTimes(1);
+		expect(sendMessageMock).not.toHaveBeenCalled();
+
+		resolveBeforeSend();
+		await flushPromises();
+
+		expect(sendMessageMock).toHaveBeenCalledWith('update config');
+		expect(events).toEqual(['beforeSend', 'sendMessage']);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatPanel.test.ts
@@ -116,4 +116,32 @@ describe('AgentChatPanel', () => {
 		expect(sendMessageMock).toHaveBeenCalledWith('update config');
 		expect(events).toEqual(['beforeSend', 'sendMessage']);
 	});
+
+	it('does not consume an initial message when beforeSend fails', async () => {
+		const beforeSend = vi.fn().mockRejectedValue(new Error('flush failed'));
+
+		const { default: AgentChatPanel } = await import('../components/AgentChatPanel.vue');
+		const wrapper = mount(AgentChatPanel, {
+			props: {
+				projectId: 'p1',
+				agentId: 'a1',
+				endpoint: 'build',
+				initialMessage: 'seed build prompt',
+				agentConfig: {
+					name: 'Agent',
+					model: 'anthropic/claude-sonnet-4-5',
+					instructions: 'Help.',
+				},
+				agentStatus: 'draft',
+				connectedTriggers: [],
+				beforeSend,
+			},
+		});
+
+		await flushPromises();
+
+		expect(beforeSend).toHaveBeenCalledTimes(1);
+		expect(sendMessageMock).not.toHaveBeenCalled();
+		expect(wrapper.emitted('initial-consumed')).toBeUndefined();
+	});
 });

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/NewAgentView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/NewAgentView.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import source from '../views/NewAgentView.vue?raw';
+
+describe('NewAgentView', () => {
+	it('does not tell the builder to register skill refs after create_skill', () => {
+		expect(source).not.toContain('then register the returned id in the agent config skills array');
+		expect(source).toContain(
+			'For each skill, call create_skill with the name, description, and body.',
+		);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/NewAgentView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/NewAgentView.test.ts
@@ -3,10 +3,13 @@ import { describe, expect, it } from 'vitest';
 import source from '../views/NewAgentView.vue?raw';
 
 describe('NewAgentView', () => {
-	it('does not tell the builder to register skill refs after create_skill', () => {
+	it('tells the builder to attach generated skill refs through config patching', () => {
 		expect(source).not.toContain('then register the returned id in the agent config skills array');
 		expect(source).toContain(
 			'For each skill, call create_skill with the name, description, and body.',
+		);
+		expect(source).toContain(
+			'After creating the skills, call read_config and patch_config to append the returned skill refs to the config skills array.',
 		);
 	});
 });

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentConfigAutosave.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentConfigAutosave.test.ts
@@ -43,4 +43,36 @@ describe('useAgentConfigAutosave', () => {
 		await expect(autosave.flushAutosave()).rejects.toBe(error);
 		expect(onError).toHaveBeenCalledWith(error);
 	});
+
+	it('does not restore a failed flush snapshot over a newer pending snapshot', async () => {
+		vi.useFakeTimers();
+		const error = new Error('save failed');
+		let rejectFirstSave: (error: Error) => void = () => {};
+		const save = vi.fn((snapshot: { value: string }) => {
+			if (snapshot.value === 'old') {
+				return new Promise<void>((_resolve, reject) => {
+					rejectFirstSave = reject;
+				});
+			}
+			return Promise.resolve();
+		});
+		const autosave = useAgentConfigAutosave<{ value: string }>({
+			save,
+			debounceMs: 500,
+		});
+
+		autosave.scheduleAutosave({ value: 'old' });
+		const flushPromise = autosave.flushAutosave();
+		await Promise.resolve();
+
+		autosave.scheduleAutosave({ value: 'new' });
+		rejectFirstSave(error);
+
+		await expect(flushPromise).rejects.toBe(error);
+		await autosave.flushAutosave();
+
+		expect(save).toHaveBeenCalledTimes(2);
+		expect(save).toHaveBeenNthCalledWith(1, { value: 'old' });
+		expect(save).toHaveBeenNthCalledWith(2, { value: 'new' });
+	});
 });

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentConfigAutosave.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentConfigAutosave.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import { useAgentConfigAutosave } from '../composables/useAgentConfigAutosave';
+
+describe('useAgentConfigAutosave', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+		sessionStorage.removeItem('N8N_DEBOUNCE_MULTIPLIER');
+	});
+
+	it('flushAutosave immediately saves a pending debounced snapshot', async () => {
+		vi.useFakeTimers();
+		const save = vi.fn().mockResolvedValue(undefined);
+		const autosave = useAgentConfigAutosave<{ value: string }>({
+			save,
+			debounceMs: 500,
+		});
+
+		autosave.scheduleAutosave({ value: 'latest' });
+		await autosave.flushAutosave();
+
+		expect(save).toHaveBeenCalledTimes(1);
+		expect(save).toHaveBeenCalledWith({ value: 'latest' });
+
+		await vi.advanceTimersByTimeAsync(500);
+		expect(save).toHaveBeenCalledTimes(1);
+	});
+
+	it('flushAutosave rejects when the immediate save fails', async () => {
+		vi.useFakeTimers();
+		const error = new Error('save failed');
+		const save = vi.fn().mockRejectedValue(error);
+		const onError = vi.fn();
+		const autosave = useAgentConfigAutosave<{ value: string }>({
+			save,
+			onError,
+			debounceMs: 500,
+		});
+
+		autosave.scheduleAutosave({ value: 'latest' });
+
+		await expect(autosave.flushAutosave()).rejects.toBe(error);
+		expect(onError).toHaveBeenCalledWith(error);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderChatColumn.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderChatColumn.vue
@@ -32,6 +32,7 @@ const props = defineProps<{
 	isBuilderConfigured: boolean;
 	isBuildChatStreaming: boolean;
 	isPublished: boolean;
+	beforeBuildSend?: () => Promise<void> | void;
 }>();
 
 const emit = defineEmits<{
@@ -149,6 +150,7 @@ const sessionMenuItems = computed<Array<DropdownMenuItemProps<string>>>(() =>
 				:agent-config="localConfig"
 				:agent-status="deriveAgentStatus(agent)"
 				:connected-triggers="connectedTriggers"
+				:before-send="beforeBuildSend"
 				@config-updated="emit('config-updated')"
 				@update:streaming="emit('update:streaming', $event)"
 			>

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChatPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChatPanel.vue
@@ -22,6 +22,7 @@ const props = withDefaults(
 		agentConfig: AgentJsonConfig | null;
 		agentStatus: 'draft' | 'production';
 		connectedTriggers: string[];
+		beforeSend?: () => Promise<void> | void;
 	}>(),
 	{
 		visible: true,
@@ -29,6 +30,7 @@ const props = withDefaults(
 		endpoint: 'chat',
 		initialMessage: undefined,
 		continueSessionId: undefined,
+		beforeSend: undefined,
 	},
 );
 
@@ -47,6 +49,7 @@ const locale = useI18n();
 const agentTelemetry = useAgentTelemetry();
 
 const inputText = ref('');
+const isPreparingToSend = ref(false);
 
 const {
 	messages,
@@ -100,22 +103,39 @@ watch(isStreaming, (v) => emit('update:streaming', v));
 
 async function onSubmit() {
 	const text = inputText.value.trim();
-	if (!text || isStreaming.value) return;
-	inputText.value = '';
+	if (!text || isStreaming.value || isPreparingToSend.value) return;
 
-	const fingerprint = await buildAgentConfigFingerprint(props.agentConfig, props.connectedTriggers);
-	// Raw `message` is sent intentionally — matches the text-to-workflow
-	// builder's `User submitted builder message` event, which also sends the
-	// raw prompt. Revisit if the product-wide privacy posture tightens.
-	agentTelemetry.trackSubmittedMessage({
-		agentId: props.agentId,
-		message: text,
-		mode: props.endpoint === 'build' ? 'build' : 'test',
-		status: props.agentStatus,
-		agentConfig: fingerprint,
-	});
+	isPreparingToSend.value = true;
+	try {
+		await props.beforeSend?.();
+	} catch {
+		// Autosave errors are surfaced by the caller that owns the flush.
+		isPreparingToSend.value = false;
+		return;
+	}
 
-	await sendMessage(text);
+	try {
+		inputText.value = '';
+
+		const fingerprint = await buildAgentConfigFingerprint(
+			props.agentConfig,
+			props.connectedTriggers,
+		);
+		// Raw `message` is sent intentionally — matches the text-to-workflow
+		// builder's `User submitted builder message` event, which also sends the
+		// raw prompt. Revisit if the product-wide privacy posture tightens.
+		agentTelemetry.trackSubmittedMessage({
+			agentId: props.agentId,
+			message: text,
+			mode: props.endpoint === 'build' ? 'build' : 'test',
+			status: props.agentStatus,
+			agentConfig: fingerprint,
+		});
+
+		await sendMessage(text);
+	} finally {
+		isPreparingToSend.value = false;
+	}
 }
 
 function sendMessageFromOutside(message: string) {
@@ -139,8 +159,17 @@ const seedMessage = props.initialMessage;
 // before any await, so calling it here runs the sync prefix (push + set
 // `isStreaming = true` inside streamFromEndpoint) before setup returns. The
 // fetch itself continues to run async in the background.
+async function sendSeedMessage(message: string): Promise<void> {
+	try {
+		await props.beforeSend?.();
+		await sendMessage(message);
+	} catch {
+		// Autosave errors are surfaced by the caller that owns the flush.
+	}
+}
+
 if (seedMessage) {
-	void sendMessage(seedMessage);
+	void sendSeedMessage(seedMessage);
 }
 
 onMounted(() => {
@@ -222,8 +251,8 @@ onBeforeUnmount(() => {
 				v-model="inputText"
 				placeholder="Type a message..."
 				:is-streaming="messagingState === 'receiving'"
-				:can-submit="!isStreaming && inputText.trim().length > 0"
-				:disabled="isStreaming && messagingState !== 'receiving'"
+				:can-submit="!isStreaming && !isPreparingToSend && inputText.trim().length > 0"
+				:disabled="isPreparingToSend || (isStreaming && messagingState !== 'receiving')"
 				data-testid="chat-input"
 				@submit="onSubmit"
 				@stop="stopGenerating"

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChatPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChatPanel.vue
@@ -162,7 +162,9 @@ const seedMessage = props.initialMessage;
 async function sendSeedMessage(message: string): Promise<void> {
 	try {
 		await props.beforeSend?.();
-		await sendMessage(message);
+		const sending = sendMessage(message);
+		emit('initial-consumed');
+		await sending;
 	} catch {
 		// Autosave errors are surfaced by the caller that owns the flush.
 	}
@@ -177,11 +179,8 @@ onMounted(() => {
 	// and wants us to seed it with the first message — there's no thread to
 	// load yet, and hitting the history endpoint would 404. The seed was
 	// already sent synchronously during setup (see the `seedMessage` block
-	// above) — here we just emit `initial-consumed` so the parent can clear
-	// its source ref. This guards against re-sending on HMR / any re-mount
-	// where the parent's prompt ref is still populated.
+	// above).
 	if (seedMessage) {
-		emit('initial-consumed');
 		return;
 	}
 	void loadHistory();

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentConfigAutosave.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentConfigAutosave.ts
@@ -42,6 +42,8 @@ export function useAgentConfigAutosave<TSnapshot>(params: UseAgentConfigAutosave
 	let autosaveInFlight: Promise<void> | null = null;
 	let saveStatusResetTimer: ReturnType<typeof setTimeout> | null = null;
 	let pendingSnapshot: TSnapshot | null = null;
+	let pendingSnapshotRevision = 0;
+	let latestSnapshotRevision = 0;
 	let lastSaveError: Error | null = null;
 
 	function toError(error: unknown): Error {
@@ -94,11 +96,13 @@ export function useAgentConfigAutosave<TSnapshot>(params: UseAgentConfigAutosave
 
 	function scheduleAutosave(snapshot: TSnapshot) {
 		pendingSnapshot = snapshot;
+		pendingSnapshotRevision = ++latestSnapshotRevision;
 		if (autosaveTimer !== null) clearTimeout(autosaveTimer);
 		autosaveTimer = setTimeout(() => {
 			autosaveTimer = null;
 			const target = pendingSnapshot as TSnapshot;
 			pendingSnapshot = null;
+			pendingSnapshotRevision = 0;
 			void chainSave(target, false);
 		}, getDebounceTime(debounceMs));
 	}
@@ -118,13 +122,18 @@ export function useAgentConfigAutosave<TSnapshot>(params: UseAgentConfigAutosave
 		}
 
 		const target = pendingSnapshot;
+		const targetRevision = pendingSnapshotRevision;
 		pendingSnapshot = null;
+		pendingSnapshotRevision = 0;
 
 		if (target !== null) {
 			try {
 				await chainSave(target, true);
 			} catch (error) {
-				pendingSnapshot = target;
+				if (latestSnapshotRevision === targetRevision && pendingSnapshot === null) {
+					pendingSnapshot = target;
+					pendingSnapshotRevision = targetRevision;
+				}
 				throw error;
 			}
 			return;

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentConfigAutosave.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentConfigAutosave.ts
@@ -42,6 +42,55 @@ export function useAgentConfigAutosave<TSnapshot>(params: UseAgentConfigAutosave
 	let autosaveInFlight: Promise<void> | null = null;
 	let saveStatusResetTimer: ReturnType<typeof setTimeout> | null = null;
 	let pendingSnapshot: TSnapshot | null = null;
+	let lastSaveError: Error | null = null;
+
+	function toError(error: unknown): Error {
+		return error instanceof Error ? error : new Error(String(error));
+	}
+
+	async function runSave(snapshot: TSnapshot, rethrow: boolean): Promise<void> {
+		saveStatus.value = 'saving';
+		lastSaveError = null;
+		// A `saved → idle` reset timer from the previous save would otherwise
+		// fire mid-way through this one and flip the indicator back to idle
+		// while the request is still in flight.
+		if (saveStatusResetTimer !== null) {
+			clearTimeout(saveStatusResetTimer);
+			saveStatusResetTimer = null;
+		}
+		try {
+			await params.save(snapshot);
+			params.onSaved?.(snapshot);
+			saveStatus.value = 'saved';
+			saveStatusResetTimer = setTimeout(() => {
+				saveStatus.value = 'idle';
+				saveStatusResetTimer = null;
+			}, savedHoldMs);
+		} catch (error) {
+			lastSaveError = toError(error);
+			params.onError?.(error);
+			saveStatus.value = 'idle';
+			if (rethrow) throw lastSaveError;
+		}
+	}
+
+	async function chainSave(snapshot: TSnapshot, rethrow: boolean): Promise<void> {
+		// Chain onto any in-flight save so two scheduled saves can't run
+		// concurrently — overlapping POSTs would otherwise race the version-id
+		// update and the second `autosaveInFlight` write would hide the first
+		// one from `settleAutosave`.
+		const previous = autosaveInFlight ?? Promise.resolve();
+		const slot = previous.then(async () => await runSave(snapshot, rethrow));
+		const trackedSlot = slot.catch(() => undefined);
+		autosaveInFlight = trackedSlot;
+		void trackedSlot.finally(() => {
+			// Only release the slot if no later save chained behind us; otherwise
+			// leave the newer promise in place so `settleAutosave` awaits the
+			// full tail of pending work.
+			if (autosaveInFlight === trackedSlot) autosaveInFlight = null;
+		});
+		await slot;
+	}
 
 	function scheduleAutosave(snapshot: TSnapshot) {
 		pendingSnapshot = snapshot;
@@ -50,40 +99,7 @@ export function useAgentConfigAutosave<TSnapshot>(params: UseAgentConfigAutosave
 			autosaveTimer = null;
 			const target = pendingSnapshot as TSnapshot;
 			pendingSnapshot = null;
-			// Chain onto any in-flight save so two scheduled saves can't run
-			// concurrently — overlapping POSTs would otherwise race the
-			// version-id update and the second `autosaveInFlight` write would
-			// hide the first one from `settleAutosave`.
-			const previous = autosaveInFlight ?? Promise.resolve();
-			const slot: Promise<void> = previous.then(async () => {
-				saveStatus.value = 'saving';
-				// A `saved → idle` reset timer from the previous save would
-				// otherwise fire mid-way through this one and flip the
-				// indicator back to idle while the request is still in flight.
-				if (saveStatusResetTimer !== null) {
-					clearTimeout(saveStatusResetTimer);
-					saveStatusResetTimer = null;
-				}
-				try {
-					await params.save(target);
-					params.onSaved?.(target);
-					saveStatus.value = 'saved';
-					saveStatusResetTimer = setTimeout(() => {
-						saveStatus.value = 'idle';
-						saveStatusResetTimer = null;
-					}, savedHoldMs);
-				} catch (error) {
-					params.onError?.(error);
-					saveStatus.value = 'idle';
-				}
-			});
-			autosaveInFlight = slot;
-			void slot.finally(() => {
-				// Only release the slot if no later save chained behind us;
-				// otherwise leave the newer promise in place so `settleAutosave`
-				// awaits the full tail of pending work.
-				if (autosaveInFlight === slot) autosaveInFlight = null;
-			});
+			void chainSave(target, false);
 		}, getDebounceTime(debounceMs));
 	}
 
@@ -95,5 +111,28 @@ export function useAgentConfigAutosave<TSnapshot>(params: UseAgentConfigAutosave
 		if (autosaveInFlight) await autosaveInFlight;
 	}
 
-	return { saveStatus, scheduleAutosave, settleAutosave };
+	async function flushAutosave() {
+		if (autosaveTimer !== null) {
+			clearTimeout(autosaveTimer);
+			autosaveTimer = null;
+		}
+
+		const target = pendingSnapshot;
+		pendingSnapshot = null;
+
+		if (target !== null) {
+			try {
+				await chainSave(target, true);
+			} catch (error) {
+				pendingSnapshot = target;
+				throw error;
+			}
+			return;
+		}
+
+		if (autosaveInFlight) await autosaveInFlight;
+		if (lastSaveError) throw lastSaveError;
+	}
+
+	return { saveStatus, scheduleAutosave, settleAutosave, flushAutosave };
 }

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -395,6 +395,10 @@ async function settleAutosave() {
 	await Promise.all([configAutosave.settleAutosave(), skillAutosave.settleAutosave()]);
 }
 
+async function flushAutosave() {
+	await Promise.all([configAutosave.flushAutosave(), skillAutosave.flushAutosave()]);
+}
+
 function onConfigFieldUpdate(updates: Partial<AgentJsonConfig>) {
 	if (!localConfig.value) return;
 	// Record BEFORE assigning so the composable can diff against the pre-update state.
@@ -851,6 +855,7 @@ function onSwitchAgent(nextAgentId: string) {
 					:is-builder-configured="isBuilderConfigured"
 					:is-build-chat-streaming="isBuildChatStreaming"
 					:is-published="Boolean(agent?.publishedVersion)"
+					:before-build-send="flushAutosave"
 					@session-select="onSessionPick"
 					@new-chat="onNewChat"
 					@config-updated="onConfigUpdated"

--- a/packages/frontend/editor-ui/src/features/agents/views/NewAgentView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/NewAgentView.vue
@@ -181,7 +181,7 @@ function buildPromptWithSkills(suggestion: SuggestionTemplate): string {
 
 	return `${suggestion.prompt}
 
-Also create and attach these curated skills to the agent. For each skill, call create_skill with the name, description, and body, then register the returned id in the agent config skills array.
+Also create and attach these curated skills to the agent. For each skill, call create_skill with the name, description, and body.
 
 ${skills}`;
 }

--- a/packages/frontend/editor-ui/src/features/agents/views/NewAgentView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/NewAgentView.vue
@@ -181,7 +181,7 @@ function buildPromptWithSkills(suggestion: SuggestionTemplate): string {
 
 	return `${suggestion.prompt}
 
-Also create and attach these curated skills to the agent. For each skill, call create_skill with the name, description, and body.
+Also create these curated skills and attach them to the agent config. For each skill, call create_skill with the name, description, and body. After creating the skills, call read_config and patch_config to append the returned skill refs to the config skills array.
 
 ${skills}`;
 }


### PR DESCRIPTION
## Summary

- Added a fresh config snapshot helper that returns the current config, SHA-256 config hash, `updatedAt`, and `versionId`.
- Added a new `read_config` builder tool so the agent can explicitly refresh its view of the config before patching.
- Added `baseConfigHash` guards to `write_config` and `patch_config` so stale writes fail softly without mutating the persisted config.
- Updated successful `write_config` and `patch_config` responses to return the latest config snapshot metadata after mutation.
- Removed the New Agent suggestion text that told the builder to manually register returned skill IDs in the config.
- Added frontend `flushAutosave()` support so pending config and skill edits are persisted before build-chat messages are sent.
- Wired build-chat submission to await autosave flushing before POSTing, ensuring the backend prompt starts from the latest UI-edited state.
- Added backend and frontend tests covering config snapshots, stale hash handling, autosave flushing, build-chat send ordering, and the cleaned-up New Agent prompt.


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
