### PR TITLE
fix(editor): Always show running/cap in concurrent executions header

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1271,7 +1271,6 @@
 	"executionsLandingPage.emptyState.accordion.footer.tooltipLink": "Save your workflow",
 	"executionsLandingPage.emptyState.accordion.footer.tooltipText": "in order to access workflow settings",
 	"executionsLandingPage.noResults": "No executions found",
-	"executionsList.activeExecutions.none": "No active executions",
 	"executionsList.activeExecutions.header": "{running}/{cap} active",
 	"executionsList.activeExecutions.tooltip": "Current active executions: {running} out of {cap}. This instance is limited to {cap} concurrent production executions.",
 	"executionsList.activeExecutions.evaluationNote": "Evaluation runs appear in the list of executions but do not count towards your execution concurrency.",

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/ConcurrentExecutionsHeader.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/ConcurrentExecutionsHeader.test.ts
@@ -31,7 +31,7 @@ describe('ConcurrentExecutionsHeader', () => {
 	});
 
 	test.each([
-		[0, 5, 'No active executions'],
+		[0, 5, '0/5 active'],
 		[2, 5, '2/5 active'],
 	])(
 		'shows the correct text when there are %i running executions of %i',

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/ConcurrentExecutionsHeader.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/ConcurrentExecutionsHeader.vue
@@ -28,17 +28,14 @@ const tooltipText = computed(() => {
 	return text;
 });
 
-const headerText = computed(() => {
-	if (props.runningExecutionsCount === 0) {
-		return i18n.baseText('executionsList.activeExecutions.none');
-	}
-	return i18n.baseText('executionsList.activeExecutions.header', {
+const headerText = computed(() =>
+	i18n.baseText('executionsList.activeExecutions.header', {
 		interpolate: {
 			running: props.runningExecutionsCount,
 			cap: props.concurrencyCap,
 		},
-	});
-});
+	}),
+);
 </script>
 
 <template>


### PR DESCRIPTION
## Summary

Removes the special-case copy when there are 0 running executions in the concurrent executions header. The header now always renders as `{running}/{cap} active` (e.g. `0/20 active`) for a more consistent display. Drops the now-unused `executionsList.activeExecutions.none` i18n key and updates the existing unit test.

To test: open the executions list with concurrency configured and confirm the header reads `0/<cap> active` when no executions are running.

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI