### PR TITLE
fix(core): Defer Instance AI temporary workflow cleanup (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -51,6 +51,33 @@ type ServiceInternals = {
 	logger: { debug: jest.Mock; warn: jest.Mock; error: jest.Mock };
 };
 
+type RunningTask = { taskId: string };
+type MarkedWorkflow = { workflowId: string };
+type ArchiveIfAiTemporary = jest.MockedFunction<(workflowId: string) => Promise<boolean>>;
+
+type TemporaryCleanupService = {
+	reapAiTemporaryFromRun: (
+		threadId: string,
+		user: User,
+		createdWorkflowIds: Set<string> | undefined,
+	) => Promise<string[]>;
+	backgroundTasks: {
+		getRunningTasks: jest.MockedFunction<(threadId: string) => RunningTask[]>;
+	};
+	aiBuilderTemporaryWorkflowRepository: {
+		findByThread: jest.MockedFunction<(threadId: string) => Promise<MarkedWorkflow[]>>;
+	};
+	adapterService: {
+		createContext: jest.MockedFunction<
+			(
+				user: User,
+				options: { threadId: string },
+			) => { workflowService: { archiveIfAiTemporary: ArchiveIfAiTemporary } }
+		>;
+	};
+	logger: { debug: jest.Mock; warn: jest.Mock; error: jest.Mock };
+};
+
 function createCheckpointService(): ServiceInternals {
 	// Bypass the constructor — we only exercise the three pending-reentry helpers
 	// and their direct dependencies. Everything else (scheduler, event bus, etc.)
@@ -75,6 +102,46 @@ function createCheckpointService(): ServiceInternals {
 	};
 
 	return service;
+}
+
+function createTemporaryCleanupService({
+	runningTaskCount = 0,
+	markedWorkflows = [],
+	archivedWorkflowIds = new Set<string>(),
+}: {
+	runningTaskCount?: number;
+	markedWorkflows?: MarkedWorkflow[];
+	archivedWorkflowIds?: Set<string>;
+} = {}): {
+	service: TemporaryCleanupService;
+	archiveIfAiTemporary: ArchiveIfAiTemporary;
+} {
+	const service = Object.create(InstanceAiService.prototype) as unknown as TemporaryCleanupService;
+	const runningTasks = Array.from({ length: runningTaskCount }, (_value, index) => ({
+		taskId: `task-${index}`,
+	}));
+	const archiveIfAiTemporary: ArchiveIfAiTemporary = jest.fn(async (workflowId: string) =>
+		archivedWorkflowIds.has(workflowId),
+	);
+
+	service.backgroundTasks = {
+		getRunningTasks: jest.fn(() => runningTasks),
+	};
+	service.aiBuilderTemporaryWorkflowRepository = {
+		findByThread: jest.fn(async () => markedWorkflows),
+	};
+	service.adapterService = {
+		createContext: jest.fn(() => ({
+			workflowService: { archiveIfAiTemporary },
+		})),
+	};
+	service.logger = {
+		debug: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+	};
+
+	return { service, archiveIfAiTemporary };
 }
 
 const fakeUser = { id: 'user-1' } as User;
@@ -181,5 +248,53 @@ describe('InstanceAiService — pending checkpoint re-entry', () => {
 
 			expect(service.reenterCheckpointById).not.toHaveBeenCalled();
 		});
+	});
+});
+
+describe('InstanceAiService — AI temporary workflow cleanup', () => {
+	it('defers cleanup while background tasks are running', async () => {
+		const { service, archiveIfAiTemporary } = createTemporaryCleanupService({
+			runningTaskCount: 1,
+			markedWorkflows: [{ workflowId: 'wf-marked' }],
+			archivedWorkflowIds: new Set(['wf-marked', 'wf-created']),
+		});
+
+		await expect(
+			service.reapAiTemporaryFromRun('thread-a', fakeUser, new Set(['wf-created'])),
+		).resolves.toEqual([]);
+
+		expect(service.backgroundTasks.getRunningTasks).toHaveBeenCalledWith('thread-a');
+		expect(service.aiBuilderTemporaryWorkflowRepository.findByThread).not.toHaveBeenCalled();
+		expect(service.adapterService.createContext).not.toHaveBeenCalled();
+		expect(archiveIfAiTemporary).not.toHaveBeenCalled();
+		expect(service.logger.debug).toHaveBeenCalledWith(
+			'Deferring AI-builder temporary workflow cleanup until tasks settle',
+			{
+				threadId: 'thread-a',
+				runningTaskCount: 1,
+			},
+		);
+	});
+
+	it('archives marked temporary workflows after background tasks settle', async () => {
+		const { service, archiveIfAiTemporary } = createTemporaryCleanupService({
+			markedWorkflows: [{ workflowId: 'wf-marked' }],
+			archivedWorkflowIds: new Set(['wf-marked', 'wf-created']),
+		});
+
+		await expect(
+			service.reapAiTemporaryFromRun('thread-a', fakeUser, new Set(['wf-created'])),
+		).resolves.toEqual(['wf-marked', 'wf-created']);
+
+		expect(service.backgroundTasks.getRunningTasks).toHaveBeenCalledWith('thread-a');
+		expect(service.aiBuilderTemporaryWorkflowRepository.findByThread).toHaveBeenCalledWith(
+			'thread-a',
+		);
+		expect(service.adapterService.createContext).toHaveBeenCalledWith(fakeUser, {
+			threadId: 'thread-a',
+		});
+		expect(archiveIfAiTemporary).toHaveBeenCalledTimes(2);
+		expect(archiveIfAiTemporary).toHaveBeenNthCalledWith(1, 'wf-marked');
+		expect(archiveIfAiTemporary).toHaveBeenNthCalledWith(2, 'wf-created');
 	});
 });

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -117,7 +117,7 @@ function createTemporaryCleanupService({
 	archiveIfAiTemporary: ArchiveIfAiTemporary;
 } {
 	const service = Object.create(InstanceAiService.prototype) as unknown as TemporaryCleanupService;
-	const runningTasks = Array.from({ length: runningTaskCount }, (_value, index) => ({
+	const runningTasks: RunningTask[] = Array.from({ length: runningTaskCount }, (_value, index) => ({
 		taskId: `task-${index}`,
 	}));
 	const archiveIfAiTemporary: ArchiveIfAiTemporary = jest.fn(async (workflowId: string) =>
@@ -125,13 +125,13 @@ function createTemporaryCleanupService({
 	);
 
 	service.backgroundTasks = {
-		getRunningTasks: jest.fn(() => runningTasks),
+		getRunningTasks: jest.fn((_threadId: string) => runningTasks),
 	};
 	service.aiBuilderTemporaryWorkflowRepository = {
-		findByThread: jest.fn(async () => markedWorkflows),
+		findByThread: jest.fn(async (_threadId: string) => markedWorkflows),
 	};
 	service.adapterService = {
-		createContext: jest.fn(() => ({
+		createContext: jest.fn((_user: User, _options: { threadId: string }) => ({
 			workflowService: { archiveIfAiTemporary },
 		})),
 	};

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -3155,6 +3155,15 @@ export class InstanceAiService {
 		user: User,
 		createdWorkflowIds: Set<string> | undefined,
 	): Promise<string[]> {
+		const runningTaskCount = this.backgroundTasks.getRunningTasks(threadId).length;
+		if (runningTaskCount > 0) {
+			this.logger.debug('Deferring AI-builder temporary workflow cleanup until tasks settle', {
+				threadId,
+				runningTaskCount,
+			});
+			return [];
+		}
+
 		let markedWorkflows: Array<{ workflowId: string }> = [];
 		try {
 			markedWorkflows = await this.aiBuilderTemporaryWorkflowRepository.findByThread(threadId);


### PR DESCRIPTION
## Summary
This PR defers Instance AI temporary workflow cleanup while background tasks are still running for the thread.

Previously, an intermediate orchestrator run could finish while workflow-builder tasks were still verifying submitted workflows. The run-finish cleanup then archived workflows that were still marked as AI temporary before their builder tasks had completed and promoted them.

With this change, cleanup returns early when the thread still has running background tasks. A later run-finish after the tasks settle can still clean up workflows that remain marked as temporary.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/INS-194

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)