### PR TITLE
fix(agents): Resolve explicit agent LLM requests without picker

### DIFF
--- a/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
@@ -132,8 +132,10 @@ responds. Treat the resume value as authoritative — it is the user's choice an
 must be persisted into the config exactly as returned.
 
 ### ask_llm
-When: the agent has no \`model\`/\`credential\` yet, or the user asks to change
-either. Call AT MOST ONCE per build turn unless the user changes their mind.
+When: the user must choose a model/credential because the request is ambiguous,
+resolve_llm returned an ambiguous/missing credential result, or the user asks
+to pick/change/use a different model. Call AT MOST ONCE per build turn unless
+the user changes their mind.
 Returns: { provider, model, credentialId, credentialName }.
 After: set \`model = "{provider}/{model}"\` and \`credential = credentialName\`
 via write_config or patch_config.
@@ -166,6 +168,35 @@ ask in prose for that.
   patch_config / next ask_*). Do not narrate the answer back to the user.
 - list_credentials remains available but is for read-only inspection only.
   Never copy ids from it into the config.`;
+
+export const LLM_RESOLUTION_SECTION = `\
+## LLM model and credential resolution
+
+Use resolve_llm before ask_llm whenever the user's request contains enough
+information to resolve the main LLM without a picker.
+
+### resolve_llm
+When: the user explicitly names a provider/model, or a fresh agent needs a
+default LLM and the user did not ask to choose.
+
+Inputs: optional \`provider\`, optional \`model\`.
+- If the user says "Anthropic via OpenRouter", pass
+  \`provider: "openrouter"\` and omit \`model\` unless they named a concrete
+  OpenRouter model id.
+- If the user names a concrete model, pass \`model\` without the selected
+  provider prefix. For OpenRouter, use the routed model id, e.g.
+  \`"anthropic/claude-sonnet-4.6"\`.
+
+On \`{ ok: true, provider, model, credentialId, credentialName }\`: set
+\`model = "{provider}/{model}"\` and \`credential = credentialName\`.
+
+On \`ok: false\`: use ask_llm only when the user needs to choose/configure a
+credential or model. Do not guess credential names from list_credentials.
+
+Rules:
+- Explicit provider/model request → resolve_llm first, not ask_llm.
+- User asks to pick/change/use a different model → ask_llm.
+- No provider specified and resolve_llm reports ambiguity → ask_llm.`;
 
 export const N8N_EXPRESSIONS_SECTION = `\
 ## n8n expressions
@@ -326,9 +357,11 @@ On error, the response includes a \`stage\` field: "parse" (invalid JSON), "patc
 export const WORKFLOW_SECTION = `\
 ## Workflow
 
-1. If the agent has no \`instructions\` and \`credential\` yet (fresh agent), FIRST call ask_llm to let
-   the user pick the model + credential, then write_config with the chosen
-   \`model\` and \`credential\` plus a draft \`instructions\`.
+1. If the agent has no \`instructions\` and \`credential\` yet (fresh agent), FIRST call resolve_llm
+   when the user specified a provider/model or did not ask to choose. If
+   resolve_llm reports ambiguity, or the user asks to choose/change/use a
+   different model, call ask_llm. Then write_config with the chosen \`model\`
+   and \`credential\` plus a draft \`instructions\`.
 2. Use ask_question whenever you have a clarifying question with discrete
    options (e.g. "Which Slack channel?" → list channels, "Read-only or
    read-write?"). Never put the question in plain text if options are known.
@@ -342,8 +375,8 @@ export const FEW_SHOT_FLOWS_SECTION = `\
 ## Example flows
 
 ### New agent (no instructions yet), user says "Build me a Slack triage agent"
-1. ask_llm({ purpose: "Main LLM for the Slack triage agent" })
-   → { provider: "anthropic", model: "claude-sonnet-4-5",
+1. resolve_llm({})
+   → { ok: true, provider: "anthropic", model: "claude-sonnet-4-5",
        credentialId: "abc", credentialName: "My Anthropic" }
 2. search_nodes({ query: "slack" }) → ...
 3. get_node_types({ nodeType: "n8n-nodes-base.slackTool" }) → ...
@@ -358,6 +391,19 @@ export const FEW_SHOT_FLOWS_SECTION = `\
        credentials: { slackApi: { id: "xyz", name: "Acme Slack" } } } }]
    })
 6. Reply: "Done."
+
+### New agent, user says "Use Anthropic via OpenRouter"
+1. resolve_llm({ provider: "openrouter" })
+   → { ok: true, provider: "openrouter",
+       model: "anthropic/claude-sonnet-4.6",
+       credentialId: "or1", credentialName: "OpenRouter" }
+2. write_config with \`model: "openrouter/anthropic/claude-sonnet-4.6"\`,
+   \`credential: "OpenRouter"\`, and the requested instructions.
+
+### User says "Use a different OpenRouter model"
+1. ask_llm({ purpose: "Choose a different OpenRouter model" })
+2. patch_config with the returned \`model: "{provider}/{model}"\` and
+   \`credential: credentialName\`.
 
 ### Adding a new node tool to an existing agent
 1. (skip ask_llm — already set)
@@ -397,7 +443,8 @@ export const IMPORTANT_SECTION = `\
 ## Important
 
 - Credentials are user-controlled. ALWAYS use ask_llm (for the agent's main
-  LLM credential) and ask_credential (for every node-tool credential slot).
+  LLM picker), resolve_llm (for explicit/default main LLM resolution), and
+  ask_credential (for every node-tool credential slot).
   Never read credential ids from list_credentials into the config.
 - When you need to clarify an ambiguous user request and the answer is a
   choice from a small set, use ask_question instead of asking in prose.
@@ -430,11 +477,11 @@ export function getConfigRulesSection(builderModel: string): string {
 ## Agent config rules
 
 - \`model\` must be "provider/model-name" format (e.g. "anthropic/claude-sonnet-4-5")
-- \`credential\` must be the \`name\` returned by a prior ask_llm tool call. Do not guess.
+- \`credential\` must be the \`credentialName\` returned by a prior resolve_llm or ask_llm tool call. Do not guess.
 - \`memory.storage\` is a preset: "n8n" (recommended, persists in n8n DB), "sqlite", or "postgres"
 - \`memory.lastMessages\` default: 50
 - Use "n8n" as the default memory storage for all agents
-- If the agent has no \`model\`/\`credential\` yet, call ask_llm before defaulting; only fall back to '${builderModel}' as the in-config placeholder string when the user explicitly declines to pick.`;
+- If the agent has no \`model\`/\`credential\` yet, call resolve_llm or ask_llm before defaulting; only fall back to '${builderModel}' as the in-config placeholder string when the user explicitly declines to pick.`;
 }
 
 export function getSchemaReferenceSection(): string {
@@ -467,6 +514,7 @@ export function buildBuilderPrompt(ctx: BuilderPromptContext): string {
 		getAgentStateSection(configJson, toolList),
 		CONVERSATION_MODE_SECTION,
 		TOOL_TYPES_SECTION,
+		LLM_RESOLUTION_SECTION,
 		INTERACTIVE_TOOLS_SECTION,
 		N8N_EXPRESSIONS_SECTION,
 		PROVIDER_TOOLS_SECTION,

--- a/packages/cli/src/modules/agents/builder/agents-builder-tools.service.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-tools.service.ts
@@ -15,7 +15,12 @@ import {
 	tryParseConfigJson,
 } from '../json-config/agent-json-config';
 import { AgentSecureRuntime } from '../runtime/agent-secure-runtime';
-import { buildAskCredentialTool, buildAskLlmTool, buildAskQuestionTool } from './interactive';
+import {
+	buildAskCredentialTool,
+	buildAskLlmTool,
+	buildAskQuestionTool,
+	buildResolveLlmTool,
+} from './interactive';
 import { BUILDER_TOOLS } from './builder-tool-names';
 
 const EMPTY_INSTRUCTIONS_ERROR: ConfigValidationError = {
@@ -188,8 +193,9 @@ export class AgentsBuilderToolsService {
 			writeConfigTool,
 			patchConfigTool,
 			listIntegrationTypesTool,
+			buildResolveLlmTool({ credentialProvider }),
 			buildAskCredentialTool({ credentialProvider }),
-			buildAskLlmTool({ credentialProvider }),
+			buildAskLlmTool(),
 			buildAskQuestionTool(),
 		];
 	}

--- a/packages/cli/src/modules/agents/builder/builder-tool-names.ts
+++ b/packages/cli/src/modules/agents/builder/builder-tool-names.ts
@@ -8,6 +8,7 @@ export const BUILDER_TOOLS = {
 	BUILD_CUSTOM_TOOL: 'build_custom_tool',
 	CREATE_SKILL: 'create_skill',
 	LIST_INTEGRATION_TYPES: 'list_integration_types',
+	RESOLVE_LLM: 'resolve_llm',
 } as const;
 
 export type BuilderToolName = (typeof BUILDER_TOOLS)[keyof typeof BUILDER_TOOLS];

--- a/packages/cli/src/modules/agents/builder/interactive/__tests__/ask-llm.tool.test.ts
+++ b/packages/cli/src/modules/agents/builder/interactive/__tests__/ask-llm.tool.test.ts
@@ -1,4 +1,3 @@
-import type { CredentialListItem, CredentialProvider } from '@n8n/agents';
 import { buildAskLlmTool } from '../ask-llm.tool';
 
 interface TestCtx {
@@ -10,65 +9,16 @@ function makeCtx(overrides?: { resumeData?: unknown }): TestCtx {
 	return { resumeData: overrides?.resumeData, suspend: jest.fn(async (x: unknown) => x) };
 }
 
-function makeProvider(creds: CredentialListItem[]): CredentialProvider {
-	return {
-		list: jest.fn(async () => creds),
-		resolve: jest.fn(async () => ({})),
-	};
-}
-
 describe('ask_llm tool', () => {
-	it('auto-resolves when exactly one LLM-provider credential exists', async () => {
-		const credentialProvider = makeProvider([
-			{ id: 'c1', name: 'My Anthropic', type: 'anthropicApi' },
-			// Non-LLM credential — must be ignored.
-			{ id: 'c2', name: 'My Slack', type: 'slackApi' },
-		]);
-		const tool = buildAskLlmTool({ credentialProvider });
-		const ctx = makeCtx();
-		const result = await tool.handler!({ purpose: 'Main LLM' }, ctx as never);
-		expect(ctx.suspend).not.toHaveBeenCalled();
-		expect(result).toEqual({
-			provider: 'anthropic',
-			model: 'claude-sonnet-4-6',
-			credentialId: 'c1',
-			credentialName: 'My Anthropic',
-		});
-	});
-
-	it('suspends when multiple LLM-provider credentials exist (different providers)', async () => {
-		const credentialProvider = makeProvider([
-			{ id: 'c1', name: 'My Anthropic', type: 'anthropicApi' },
-			{ id: 'c2', name: 'My OpenAI', type: 'openAiApi' },
-		]);
-		const tool = buildAskLlmTool({ credentialProvider });
+	it('suspends on first invocation so the user can choose', async () => {
+		const tool = buildAskLlmTool();
 		const ctx = makeCtx();
 		await tool.handler!({ purpose: 'Main LLM' }, ctx as never);
-		expect(ctx.suspend).toHaveBeenCalledTimes(1);
+		expect(ctx.suspend).toHaveBeenCalledWith({ purpose: 'Main LLM' });
 	});
 
-	it('suspends when two creds of the same provider type exist', async () => {
-		const credentialProvider = makeProvider([
-			{ id: 'c1', name: 'Personal Anthropic', type: 'anthropicApi' },
-			{ id: 'c2', name: 'Work Anthropic', type: 'anthropicApi' },
-		]);
-		const tool = buildAskLlmTool({ credentialProvider });
-		const ctx = makeCtx();
-		await tool.handler!({ purpose: 'Main LLM' }, ctx as never);
-		expect(ctx.suspend).toHaveBeenCalledTimes(1);
-	});
-
-	it('suspends when no LLM-provider credentials exist', async () => {
-		const credentialProvider = makeProvider([{ id: 'c1', name: 'Slack', type: 'slackApi' }]);
-		const tool = buildAskLlmTool({ credentialProvider });
-		const ctx = makeCtx();
-		await tool.handler!({ purpose: 'Main LLM' }, ctx as never);
-		expect(ctx.suspend).toHaveBeenCalledTimes(1);
-	});
-
-	it('returns resumeData verbatim after resume without consulting the provider', async () => {
-		const credentialProvider = makeProvider([]);
-		const tool = buildAskLlmTool({ credentialProvider });
+	it('returns resumeData verbatim after resume', async () => {
+		const tool = buildAskLlmTool();
 		const ctx = makeCtx({
 			resumeData: {
 				provider: 'anthropic',
@@ -79,7 +29,6 @@ describe('ask_llm tool', () => {
 		});
 		const result = await tool.handler!({ purpose: 'Main LLM' }, ctx as never);
 		expect(ctx.suspend).not.toHaveBeenCalled();
-		expect(credentialProvider.list).not.toHaveBeenCalled();
 		expect(result).toEqual({
 			provider: 'anthropic',
 			model: 'claude-sonnet-4-6',

--- a/packages/cli/src/modules/agents/builder/interactive/__tests__/resolve-llm.tool.test.ts
+++ b/packages/cli/src/modules/agents/builder/interactive/__tests__/resolve-llm.tool.test.ts
@@ -49,7 +49,7 @@ describe('resolve_llm tool', () => {
 		]);
 		const tool = buildResolveLlmTool({ credentialProvider });
 		const result = await tool.handler!(
-			{ provider: 'openrouter', model: 'openrouter/meta-llama/llama-3.1-70b-instruct' },
+			{ provider: 'openrouter', model: 'meta-llama/llama-3.1-70b-instruct' },
 			{},
 		);
 

--- a/packages/cli/src/modules/agents/builder/interactive/__tests__/resolve-llm.tool.test.ts
+++ b/packages/cli/src/modules/agents/builder/interactive/__tests__/resolve-llm.tool.test.ts
@@ -1,0 +1,118 @@
+import type { CredentialListItem, CredentialProvider } from '@n8n/agents';
+import { buildResolveLlmTool } from '../resolve-llm.tool';
+
+function makeProvider(creds: CredentialListItem[]): CredentialProvider {
+	return {
+		list: jest.fn(async () => creds),
+		resolve: jest.fn(async () => ({})),
+	};
+}
+
+describe('resolve_llm tool', () => {
+	it('auto-resolves when exactly one LLM-provider credential exists', async () => {
+		const credentialProvider = makeProvider([
+			{ id: 'c1', name: 'My Anthropic', type: 'anthropicApi' },
+			{ id: 'c2', name: 'My Slack', type: 'slackApi' },
+		]);
+		const tool = buildResolveLlmTool({ credentialProvider });
+		const result = await tool.handler!({}, {});
+
+		expect(result).toEqual({
+			ok: true,
+			provider: 'anthropic',
+			model: 'claude-sonnet-4-6',
+			credentialId: 'c1',
+			credentialName: 'My Anthropic',
+		});
+	});
+
+	it('auto-resolves the requested provider when multiple LLM-provider credentials exist', async () => {
+		const credentialProvider = makeProvider([
+			{ id: 'c1', name: 'My Anthropic', type: 'anthropicApi' },
+			{ id: 'c2', name: 'My OpenRouter', type: 'openRouterApi' },
+		]);
+		const tool = buildResolveLlmTool({ credentialProvider });
+		const result = await tool.handler!({ provider: 'openrouter' }, {});
+
+		expect(result).toEqual({
+			ok: true,
+			provider: 'openrouter',
+			model: 'anthropic/claude-sonnet-4.6',
+			credentialId: 'c2',
+			credentialName: 'My OpenRouter',
+		});
+	});
+
+	it('uses the requested model for the requested provider', async () => {
+		const credentialProvider = makeProvider([
+			{ id: 'c1', name: 'My OpenRouter', type: 'openRouterApi' },
+		]);
+		const tool = buildResolveLlmTool({ credentialProvider });
+		const result = await tool.handler!(
+			{ provider: 'openrouter', model: 'openrouter/meta-llama/llama-3.1-70b-instruct' },
+			{},
+		);
+
+		expect(result).toEqual({
+			ok: true,
+			provider: 'openrouter',
+			model: 'meta-llama/llama-3.1-70b-instruct',
+			credentialId: 'c1',
+			credentialName: 'My OpenRouter',
+		});
+	});
+
+	it('returns missing_credential when the requested provider has no credentials', async () => {
+		const credentialProvider = makeProvider([
+			{ id: 'c1', name: 'My Anthropic', type: 'anthropicApi' },
+		]);
+		const tool = buildResolveLlmTool({ credentialProvider });
+		const result = await tool.handler!({ provider: 'openrouter' }, {});
+
+		expect(result).toEqual({
+			ok: false,
+			reason: 'missing_credential',
+			provider: 'openrouter',
+			credentialType: 'openRouterApi',
+			credentials: [],
+		});
+	});
+
+	it('returns ambiguous_credential when the requested provider has multiple credentials', async () => {
+		const credentialProvider = makeProvider([
+			{ id: 'c1', name: 'Personal OpenRouter', type: 'openRouterApi' },
+			{ id: 'c2', name: 'Work OpenRouter', type: 'openRouterApi' },
+		]);
+		const tool = buildResolveLlmTool({ credentialProvider });
+		const result = await tool.handler!({ provider: 'openrouter' }, {});
+
+		expect(result).toEqual({
+			ok: false,
+			reason: 'ambiguous_credential',
+			provider: 'openrouter',
+			credentialType: 'openRouterApi',
+			credentials: [
+				{ id: 'c1', name: 'Personal OpenRouter' },
+				{ id: 'c2', name: 'Work OpenRouter' },
+			],
+		});
+	});
+
+	it('returns ambiguous_provider_or_credential when no provider is requested and multiple credentials exist', async () => {
+		const credentialProvider = makeProvider([
+			{ id: 'c1', name: 'My Anthropic', type: 'anthropicApi' },
+			{ id: 'c2', name: 'My OpenAI', type: 'openAiApi' },
+		]);
+		const tool = buildResolveLlmTool({ credentialProvider });
+		const result = await tool.handler!({}, {});
+
+		expect(result).toEqual({
+			ok: false,
+			reason: 'ambiguous_provider_or_credential',
+			credentials: [
+				{ id: 'c1', name: 'My Anthropic', type: 'anthropicApi', provider: 'anthropic' },
+				{ id: 'c2', name: 'My OpenAI', type: 'openAiApi', provider: 'openai' },
+			],
+		});
+	});
+});

--- a/packages/cli/src/modules/agents/builder/interactive/ask-llm.tool.ts
+++ b/packages/cli/src/modules/agents/builder/interactive/ask-llm.tool.ts
@@ -1,5 +1,5 @@
 import { Tool } from '@n8n/agents';
-import type { BuiltTool, CredentialProvider, InterruptibleToolContext } from '@n8n/agents';
+import type { BuiltTool, InterruptibleToolContext } from '@n8n/agents';
 import {
 	ASK_LLM_TOOL_NAME,
 	askLlmInputSchema,
@@ -8,21 +8,15 @@ import {
 	type AskLlmResume,
 } from '@n8n/api-types';
 
-import { LLM_PROVIDER_DEFAULTS } from './llm-provider-defaults';
-
-export interface AskLlmToolDeps {
-	credentialProvider: CredentialProvider;
-}
-
-export function buildAskLlmTool(deps: AskLlmToolDeps): BuiltTool {
+export function buildAskLlmTool(): BuiltTool {
 	return new Tool(ASK_LLM_TOOL_NAME)
 		.description(
 			'Show a model + credential picker card in the chat UI and suspend until the user ' +
-				'selects a provider, model and credential. Call AT MOST ONCE per build turn unless ' +
-				'the user explicitly asks to change the model. ' +
+				'selects a provider, model and credential. Use only when resolve_llm returns an ' +
+				'ambiguous result, when credentials are missing and the user must choose/configure one, ' +
+				'or when the user explicitly asks to pick/change the model. ' +
 				'After resume: set model = "{provider}/{model}" and credential = credentialName ' +
-				'via write_config or patch_config. Auto-resolves without rendering a card when the ' +
-				'user has exactly one LLM-provider credential.',
+				'via write_config or patch_config.',
 		)
 		.input(askLlmInputSchema)
 		.suspend(askLlmInputSchema)
@@ -30,22 +24,6 @@ export function buildAskLlmTool(deps: AskLlmToolDeps): BuiltTool {
 		.handler(
 			async (input: AskLlmInput, ctx: InterruptibleToolContext<AskLlmInput, AskLlmResume>) => {
 				if (ctx.resumeData !== undefined) return ctx.resumeData;
-				const all = await deps.credentialProvider.list();
-				// Keep only credentials whose type maps to a known LLM provider.
-				const llmCreds = all.filter((c) => LLM_PROVIDER_DEFAULTS[c.type]);
-				// Auto-resolve only when there's exactly one — if the user has
-				// multiple LLM credentials (or two of the same type), the choice is
-				// real and the card must render.
-				if (llmCreds.length === 1) {
-					const cred = llmCreds[0];
-					const def = LLM_PROVIDER_DEFAULTS[cred.type];
-					return {
-						provider: def.provider,
-						model: def.defaultModel,
-						credentialId: cred.id,
-						credentialName: cred.name,
-					};
-				}
 				return await ctx.suspend(input);
 			},
 		)

--- a/packages/cli/src/modules/agents/builder/interactive/index.ts
+++ b/packages/cli/src/modules/agents/builder/interactive/index.ts
@@ -1,3 +1,4 @@
 export { buildAskCredentialTool } from './ask-credential.tool';
 export { buildAskLlmTool } from './ask-llm.tool';
 export { buildAskQuestionTool } from './ask-question.tool';
+export { buildResolveLlmTool } from './resolve-llm.tool';

--- a/packages/cli/src/modules/agents/builder/interactive/llm-provider-defaults.ts
+++ b/packages/cli/src/modules/agents/builder/interactive/llm-provider-defaults.ts
@@ -18,11 +18,12 @@ export interface LlmProviderDefault {
 
 export const LLM_PROVIDER_DEFAULTS: Record<string, LlmProviderDefault> = {
 	anthropicApi: { provider: 'anthropic', defaultModel: 'claude-sonnet-4-6' },
-	openAiApi: { provider: 'openai', defaultModel: 'gpt-4o' },
-	googlePalmApi: { provider: 'google', defaultModel: 'gemini-1.5-pro' },
-	xAiApi: { provider: 'xai', defaultModel: 'grok-2' },
+	openAiApi: { provider: 'openai', defaultModel: 'gpt-5' },
+	googlePalmApi: { provider: 'google', defaultModel: 'gemini-2.5-pro' },
+	xAiApi: { provider: 'xai', defaultModel: 'grok-4' },
 	groqApi: { provider: 'groq', defaultModel: 'llama-3.1-70b-versatile' },
 	mistralCloudApi: { provider: 'mistral', defaultModel: 'mistral-large-latest' },
 	deepSeekApi: { provider: 'deepseek', defaultModel: 'deepseek-chat' },
 	cohereApi: { provider: 'cohere', defaultModel: 'command-r-plus' },
+	openRouterApi: { provider: 'openrouter', defaultModel: 'anthropic/claude-sonnet-4.6' },
 };

--- a/packages/cli/src/modules/agents/builder/interactive/resolve-llm.tool.ts
+++ b/packages/cli/src/modules/agents/builder/interactive/resolve-llm.tool.ts
@@ -1,0 +1,146 @@
+import { Tool } from '@n8n/agents';
+import type { BuiltTool, CredentialListItem, CredentialProvider } from '@n8n/agents';
+import { z } from 'zod';
+
+import { BUILDER_TOOLS } from '../builder-tool-names';
+import { LLM_PROVIDER_DEFAULTS, type LlmProviderDefault } from './llm-provider-defaults';
+
+export interface ResolveLlmToolDeps {
+	credentialProvider: CredentialProvider;
+}
+
+type LlmCredentialEntry = [credentialType: string, defaults: LlmProviderDefault];
+
+function normalizeProviderId(value: string) {
+	return value
+		.trim()
+		.toLowerCase()
+		.replace(/[\s_-]+/g, '');
+}
+
+function findProviderDefault(provider: string): LlmCredentialEntry | undefined {
+	const normalizedProvider = normalizeProviderId(provider);
+
+	return Object.entries(LLM_PROVIDER_DEFAULTS).find(
+		([credentialType, defaults]) =>
+			normalizeProviderId(defaults.provider) === normalizedProvider ||
+			normalizeProviderId(credentialType) === normalizedProvider,
+	);
+}
+
+function normalizeRequestedModel(provider: string, model: string | undefined) {
+	const trimmed = model?.trim();
+	if (!trimmed) return undefined;
+
+	const providerPrefix = `${provider}/`;
+	if (trimmed.toLowerCase().startsWith(providerPrefix.toLowerCase())) {
+		return trimmed.slice(providerPrefix.length);
+	}
+
+	return trimmed;
+}
+
+function toLlmResolution(
+	credential: CredentialListItem,
+	defaults: LlmProviderDefault,
+	model?: string,
+) {
+	return {
+		ok: true as const,
+		provider: defaults.provider,
+		model: normalizeRequestedModel(defaults.provider, model) ?? defaults.defaultModel,
+		credentialId: credential.id,
+		credentialName: credential.name,
+	};
+}
+
+export function buildResolveLlmTool(deps: ResolveLlmToolDeps): BuiltTool {
+	return new Tool(BUILDER_TOOLS.RESOLVE_LLM)
+		.description(
+			'Resolve the agent main LLM without showing a picker. Use this when the user ' +
+				'explicitly requests a provider/model, or when a fresh agent needs a default LLM. ' +
+				'If provider is given, resolves only that provider; if model is omitted, uses the ' +
+				'provider default model. For "Anthropic via OpenRouter", pass provider="openrouter" ' +
+				'and omit model unless the user named a concrete OpenRouter model id. Returns ok=false ' +
+				'when credentials are missing, unsupported, or ambiguous; use ask_llm only when the ' +
+				'user must choose.',
+		)
+		.input(
+			z.object({
+				provider: z
+					.string()
+					.optional()
+					.describe('Requested provider, e.g. "anthropic", "openai", or "openrouter".'),
+				model: z
+					.string()
+					.optional()
+					.describe(
+						'Requested model without the selected provider prefix. For OpenRouter use the routed id, e.g. "anthropic/claude-sonnet-4.6".',
+					),
+			}),
+		)
+		.handler(async ({ provider, model }: { provider?: string; model?: string }) => {
+			const all = await deps.credentialProvider.list();
+			const llmCredentials = all.filter((credential) => LLM_PROVIDER_DEFAULTS[credential.type]);
+
+			if (provider) {
+				const providerEntry = findProviderDefault(provider);
+				if (!providerEntry) {
+					return {
+						ok: false as const,
+						reason: 'unsupported_provider' as const,
+						provider,
+						supportedProviders: Object.values(LLM_PROVIDER_DEFAULTS).map(
+							(defaults) => defaults.provider,
+						),
+					};
+				}
+
+				const [credentialType, defaults] = providerEntry;
+				const matchingCredentials = llmCredentials.filter(
+					(credential) => credential.type === credentialType,
+				);
+
+				if (matchingCredentials.length === 1) {
+					return toLlmResolution(matchingCredentials[0], defaults, model);
+				}
+
+				return {
+					ok: false as const,
+					reason:
+						matchingCredentials.length === 0
+							? ('missing_credential' as const)
+							: ('ambiguous_credential' as const),
+					provider: defaults.provider,
+					credentialType,
+					credentials: matchingCredentials.map((credential) => ({
+						id: credential.id,
+						name: credential.name,
+					})),
+				};
+			}
+
+			if (llmCredentials.length === 1) {
+				const credential = llmCredentials[0];
+				return toLlmResolution(credential, LLM_PROVIDER_DEFAULTS[credential.type], model);
+			}
+
+			return {
+				ok: false as const,
+				reason:
+					llmCredentials.length === 0
+						? ('missing_credential' as const)
+						: ('ambiguous_provider_or_credential' as const),
+				credentials: llmCredentials.map((credential) => {
+					const defaults = LLM_PROVIDER_DEFAULTS[credential.type];
+					return {
+						id: credential.id,
+						name: credential.name,
+						type: credential.type,
+						provider: defaults.provider,
+					};
+				}),
+			};
+		})
+		.build();
+}

--- a/packages/cli/src/modules/agents/builder/interactive/resolve-llm.tool.ts
+++ b/packages/cli/src/modules/agents/builder/interactive/resolve-llm.tool.ts
@@ -11,33 +11,11 @@ export interface ResolveLlmToolDeps {
 
 type LlmCredentialEntry = [credentialType: string, defaults: LlmProviderDefault];
 
-function normalizeProviderId(value: string) {
-	return value
-		.trim()
-		.toLowerCase()
-		.replace(/[\s_-]+/g, '');
-}
-
 function findProviderDefault(provider: string): LlmCredentialEntry | undefined {
-	const normalizedProvider = normalizeProviderId(provider);
-
+	const requestedProvider = provider.trim();
 	return Object.entries(LLM_PROVIDER_DEFAULTS).find(
-		([credentialType, defaults]) =>
-			normalizeProviderId(defaults.provider) === normalizedProvider ||
-			normalizeProviderId(credentialType) === normalizedProvider,
+		([, defaults]) => defaults.provider === requestedProvider,
 	);
-}
-
-function normalizeRequestedModel(provider: string, model: string | undefined) {
-	const trimmed = model?.trim();
-	if (!trimmed) return undefined;
-
-	const providerPrefix = `${provider}/`;
-	if (trimmed.toLowerCase().startsWith(providerPrefix.toLowerCase())) {
-		return trimmed.slice(providerPrefix.length);
-	}
-
-	return trimmed;
 }
 
 function toLlmResolution(
@@ -48,7 +26,7 @@ function toLlmResolution(
 	return {
 		ok: true as const,
 		provider: defaults.provider,
-		model: normalizeRequestedModel(defaults.provider, model) ?? defaults.defaultModel,
+		model: model?.trim() || defaults.defaultModel,
 		credentialId: credential.id,
 		credentialName: credential.name,
 	};


### PR DESCRIPTION
## Summary

- Added a new non-interactive `resolve_llm` builder tool for explicit/default main LLM resolution.
- Kept `ask_llm` focused on the UI picker flow, so it only suspends for user choice/resume.
- Updated builder guidance so explicit provider/model requests use `resolve_llm`, while ambiguous or “choose/change model” requests use `ask_llm`.
- Added OpenRouter-aware resolution via `LLM_PROVIDER_DEFAULTS`, including default model support.
- Registered `resolve_llm` in the builder tool set and centralized tool names.
- Updated `ask_llm` tests for picker-only behavior.
- Added focused `resolve_llm` tests for single credential, provider-specific resolution, custom model, missing credential, and ambiguity cases.
- Verified with focused Jest tests and `packages/cli` typecheck.


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-37/feature-refresh-llm-provider-defaults-and-add-openrouter-support-to

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
