### PR TITLE
feat(GmailTrigger node): add option to include archived self-sent emails

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -363,6 +363,7 @@ export class GmailTrigger implements INodeType {
 			includeDrafts = filters.includeDrafts ?? true;
 		}
 		const includeSelfSentArchivedEmails = options.includeSelfSentArchivedEmails ?? false;
+		delete options.includeSelfSentArchivedEmails;
 
 		const fetchAndProcessMessage = async (
 			messageId: string,

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -239,6 +239,19 @@ export class GmailTrigger implements INodeType {
 						default: false,
 						description: "Whether the email's attachments will be downloaded",
 					},
+					{
+						displayName: 'Include Auto-Archived Self-Sent Emails',
+						name: 'includeSelfSentArchivedEmails',
+						type: 'boolean',
+						default: false,
+						description:
+							'Whether self-sent emails that have been archived will be returned',
+						displayOptions: {
+							show: {
+								'@version': [{ _cnd: { gte: 1.3 } }],
+							},
+						},
+					},
 				],
 			},
 		],
@@ -349,6 +362,7 @@ export class GmailTrigger implements INodeType {
 		} else {
 			includeDrafts = filters.includeDrafts ?? true;
 		}
+		const includeSelfSentArchivedEmails = options.includeSelfSentArchivedEmails ?? false;
 
 		const fetchAndProcessMessage = async (
 			messageId: string,
@@ -372,6 +386,7 @@ export class GmailTrigger implements INodeType {
 			}
 			if (
 				node.typeVersion > 1.2 &&
+				!includeSelfSentArchivedEmails &&
 				fullMessage.labelIds?.includes('SENT') &&
 				!fullMessage.labelIds?.includes('INBOX')
 			) {

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -438,6 +438,87 @@ describe('GmailTrigger', () => {
 		]);
 	});
 
+	it('should include self-sent archived emails when opted in', async () => {
+		const messageListResponse: MessageListResponse = {
+			messages: [createListMessage({ id: '1' }), createListMessage({ id: '2' })],
+			resultSizeEstimate: 2,
+		};
+		nock(baseUrl)
+			.get('/gmail/v1/users/me/labels')
+			.reply(200, {
+				labels: [
+					{ id: 'INBOX', name: 'INBOX' },
+					{ id: 'SENT', name: 'SENT' },
+				],
+			});
+		nock(baseUrl).get(new RegExp('/gmail/v1/users/me/messages?.*')).reply(200, messageListResponse);
+		nock(baseUrl)
+			.get(new RegExp('/gmail/v1/users/me/messages/1?.*'))
+			.reply(200, createMessage({ id: '1', labelIds: ['INBOX'] }));
+		nock(baseUrl)
+			.get(new RegExp('/gmail/v1/users/me/messages/2?.*'))
+			.reply(200, createMessage({ id: '2', labelIds: ['SENT'] }));
+
+		const { response } = await testPollingTriggerNode(GmailTrigger, {
+			node: {
+				typeVersion: 1.3,
+				parameters: { options: { includeSelfSentArchivedEmails: true } },
+			},
+		});
+		expect(response).toEqual([
+			[
+				{
+					binary: undefined,
+					json: {
+						attachements: undefined,
+						date: '2024-08-31T00:00:00.000Z',
+						from: {
+							html: 'from@example.com',
+							text: 'from@example.com',
+							value: [{ address: 'from@example.com', name: 'From' }],
+						},
+						headerlines: undefined,
+						headers: { headerKey: 'headerValue' },
+						html: '<p>test</p>',
+						id: '1',
+						labelIds: ['INBOX'],
+						sizeEstimate: 4,
+						threadId: 'testThreadId',
+						to: {
+							html: 'to@example.com',
+							text: 'to@example.com',
+							value: [{ address: 'to@example.com', name: 'To' }],
+						},
+					},
+				},
+				{
+					binary: undefined,
+					json: {
+						attachements: undefined,
+						date: '2024-08-31T00:00:00.000Z',
+						from: {
+							html: 'from@example.com',
+							text: 'from@example.com',
+							value: [{ address: 'from@example.com', name: 'From' }],
+						},
+						headerlines: undefined,
+						headers: { headerKey: 'headerValue' },
+						html: '<p>test</p>',
+						id: '2',
+						labelIds: ['SENT'],
+						sizeEstimate: 4,
+						threadId: 'testThreadId',
+						to: {
+							html: 'to@example.com',
+							text: 'to@example.com',
+							value: [{ address: 'to@example.com', name: 'To' }],
+						},
+					},
+				},
+			],
+		]);
+	});
+
 	it('should exclude scheduled emails from query on v1.4', async () => {
 		const messageListResponse: MessageListResponse = {
 			messages: [createListMessage({ id: '1' })],

--- a/packages/nodes-base/nodes/Google/Gmail/types.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/types.ts
@@ -64,6 +64,7 @@ export type GmailWorkflowStaticDataDictionary = Record<string, GmailWorkflowStat
 export type GmailTriggerOptions = Partial<{
 	dataPropertyAttachmentsPrefixName: string;
 	downloadAttachments: boolean;
+	includeSelfSentArchivedEmails: boolean;
 }>;
 
 export type GmailTriggerFilters = Partial<{


### PR DESCRIPTION
## Summary

This PR adds a new Gmail Trigger option to allow including self-sent emails that were archived (i.e., labeled SENT but not INBOX) for node type version >= 1.3. It keeps the existing default behavior (excluding these emails) unless the new option is enabled. A unit test is included to verify the opt-in behavior.

## Related Linear tickets, Github issues, and Community forum posts

Addresses latest comments on #19351 

## Review / Merge checklist

- [x] I have seen this code, I have NOT run this code, and I take responsibility for this code.
> I could not run it on my own machine due to some windows setup issues.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) 
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
> If PR approved, will update docs. For now, the code is self-docummenting and the UI will show a small description for the new field as well.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
