### PR TITLE
fix(editor): Suppress execution error toasts for AI-initiated test runs

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/WorkflowPreview.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowPreview.test.ts
@@ -186,7 +186,30 @@ describe('WorkflowPreview', () => {
 				executionId,
 				executionMode: '',
 				canOpenNDV: true,
+				suppressExecutionErrorToast: false,
 				projectId: 'test-project-id',
+			});
+		});
+	});
+
+	it('should pass suppressExecutionErrorToast using PostMessage when enabled', async () => {
+		const executionId = '123';
+		renderComponent({
+			pinia,
+			props: {
+				executionId,
+				mode: 'execution',
+				suppressExecutionErrorToast: true,
+			},
+		});
+
+		sendPostMessageCommand('n8nReady');
+
+		await waitFor(() => {
+			expectIframePostMessage({
+				command: 'openExecution',
+				executionId,
+				suppressExecutionErrorToast: true,
 			});
 		});
 	});
@@ -213,6 +236,7 @@ describe('WorkflowPreview', () => {
 				executionId,
 				executionMode: '',
 				canOpenNDV: true,
+				suppressExecutionErrorToast: false,
 				projectId: 'test-project-id',
 			});
 

--- a/packages/frontend/editor-ui/src/app/components/WorkflowPreview.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowPreview.vue
@@ -23,6 +23,7 @@ const props = withDefaults(
 		hideControls?: boolean;
 		suppressNotifications?: boolean;
 		allowErrorNotifications?: boolean;
+		suppressExecutionErrorToast?: boolean;
 		canExecute?: boolean;
 	}>(),
 	{
@@ -39,6 +40,7 @@ const props = withDefaults(
 		hideControls: false,
 		suppressNotifications: false,
 		allowErrorNotifications: false,
+		suppressExecutionErrorToast: false,
 		canExecute: false,
 	},
 );
@@ -121,6 +123,7 @@ const loadExecution = () => {
 				executionMode: props.executionMode ?? '',
 				nodeId: props.nodeId,
 				canOpenNDV: props.canOpenNDV,
+				suppressExecutionErrorToast: props.suppressExecutionErrorToast,
 				projectId: projectsStore.currentProjectId,
 			}),
 			'*',

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -4180,6 +4180,36 @@ describe('useCanvasOperations', () => {
 				type: 'error',
 			});
 		});
+
+		it('should not show an error notification for failed executions when suppressed', async () => {
+			const workflowsStore = mockedStore(useWorkflowsStore);
+			const { openExecution } = useCanvasOperations();
+			const toast = useToast();
+
+			const executionId = '123';
+			const executionData: IExecutionResponse = {
+				id: executionId,
+				finished: true,
+				status: 'error',
+				startedAt: new Date(),
+				createdAt: new Date(),
+				workflowData: createTestWorkflow({ id: workflowId }),
+				mode: 'manual',
+				data: {
+					resultData: {
+						error: { message: 'Crashed', node: { name: 'Step1' } },
+						lastNodeExecuted: 'Last Node',
+					},
+				} as IExecutionResponse['data'],
+			};
+
+			workflowsStore.getExecution.mockResolvedValue(executionData);
+
+			await openExecution(executionId, undefined, { suppressExecutionErrorToast: true });
+
+			expect(toast.showMessage).not.toHaveBeenCalled();
+		});
+
 		it('should set active node when nodeId is provided and node exists', async () => {
 			const workflowsStore = mockedStore(useWorkflowsStore);
 			const ndvStore = mockedStore(useNDVStore);

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -2928,7 +2928,11 @@ export function useCanvasOperations() {
 		deleteNodes(ids);
 	}
 
-	async function openExecution(executionId: string, nodeId?: string) {
+	async function openExecution(
+		executionId: string,
+		nodeId?: string,
+		options?: { suppressExecutionErrorToast?: boolean },
+	) {
 		let data: IExecutionResponse | undefined;
 		try {
 			data = await workflowsStore.getExecution(executionId);
@@ -2941,7 +2945,11 @@ export function useCanvasOperations() {
 			throw new Error(`Execution with id "${executionId}" could not be found!`);
 		}
 
-		if (data.status === 'error' && data.data?.resultData.error) {
+		if (
+			options?.suppressExecutionErrorToast !== true &&
+			data.status === 'error' &&
+			data.data?.resultData.error
+		) {
 			const { title, message } = getExecutionErrorToastConfiguration({
 				error: data.data.resultData.error,
 				lastNodeExecuted: data.data.resultData.lastNodeExecuted,

--- a/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.test.ts
@@ -71,6 +71,13 @@ vi.mock('@/features/workflows/canvas/canvas.eventBus', () => ({
 	},
 }));
 
+const mockPushOnMessageReceivedHandlers = vi.hoisted(() => [] as Array<(event: unknown) => void>);
+vi.mock('@/app/stores/pushConnection.store', () => ({
+	usePushConnectionStore: vi.fn(() => ({
+		onMessageReceivedHandlers: mockPushOnMessageReceivedHandlers,
+	})),
+}));
+
 const mockBuildExecutionResponseFromSchema = vi.hoisted(() =>
 	vi.fn().mockReturnValue({ workflowData: { id: 'w1' } } as unknown as IExecutionResponse),
 );
@@ -517,6 +524,31 @@ describe('usePostMessageHandler', () => {
 			cleanup();
 		});
 
+		it('should pass suppressExecutionErrorToast to openExecution when requested', async () => {
+			mockOpenExecution.mockResolvedValue(null);
+
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
+			});
+			setup();
+
+			dispatchPostMessage({
+				command: 'openExecution',
+				executionId: 'exec-1',
+				suppressExecutionErrorToast: true,
+			});
+
+			await vi.waitFor(() => {
+				expect(mockOpenExecution).toHaveBeenCalledWith('exec-1', undefined, {
+					suppressExecutionErrorToast: true,
+				});
+			});
+
+			cleanup();
+		});
+
 		it('should show an error toast when opening execution fails with error allowance enabled', async () => {
 			setActivePinia(createTestingPinia({ stubActions: false }));
 			const uiStore = useUIStore();
@@ -741,6 +773,65 @@ describe('usePostMessageHandler', () => {
 					type: 'error',
 				});
 			});
+
+			cleanup();
+		});
+	});
+
+	describe('executionEvent command', () => {
+		beforeEach(() => {
+			mockPushOnMessageReceivedHandlers.length = 0;
+		});
+
+		it('marks execution as AI-initiated when relayed with source "ai"', async () => {
+			setActivePinia(createTestingPinia({ stubActions: false }));
+			const uiStore = useUIStore();
+			const handler = vi.fn();
+			mockPushOnMessageReceivedHandlers.push(handler);
+
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
+			});
+			setup();
+
+			dispatchPostMessage({
+				command: 'executionEvent',
+				event: { type: 'executionStarted', data: { executionId: 'exec-ai-99' } },
+				source: 'ai',
+			});
+
+			await vi.waitFor(() => {
+				expect(handler).toHaveBeenCalled();
+			});
+			expect(uiStore.isExecutionAiInitiated('exec-ai-99')).toBe(true);
+
+			cleanup();
+		});
+
+		it('does not mark execution as AI-initiated when source is missing', async () => {
+			setActivePinia(createTestingPinia({ stubActions: false }));
+			const uiStore = useUIStore();
+			const handler = vi.fn();
+			mockPushOnMessageReceivedHandlers.push(handler);
+
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
+			});
+			setup();
+
+			dispatchPostMessage({
+				command: 'executionEvent',
+				event: { type: 'executionStarted', data: { executionId: 'exec-user-1' } },
+			});
+
+			await vi.waitFor(() => {
+				expect(handler).toHaveBeenCalled();
+			});
+			expect(uiStore.isExecutionAiInitiated('exec-user-1')).toBe(false);
 
 			cleanup();
 		});

--- a/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.ts
@@ -121,6 +121,7 @@ export function usePostMessageHandler({
 		executionMode?: string;
 		nodeId?: string;
 		projectId?: string;
+		suppressExecutionErrorToast?: boolean;
 	}) {
 		if (json.projectId) {
 			await projectsStore.fetchAndSetProject(json.projectId);
@@ -132,7 +133,9 @@ export function usePostMessageHandler({
 		canvasStore.startLoading();
 		resetWorkspace();
 
-		const data = await openExecution(json.executionId, json.nodeId);
+		const data = await openExecution(json.executionId, json.nodeId, {
+			suppressExecutionErrorToast: json.suppressExecutionErrorToast === true,
+		});
 		if (!data) {
 			return;
 		}
@@ -262,6 +265,10 @@ export function usePostMessageHandler({
 				// the event to all registered listeners — same pattern the store uses internally.
 				const { usePushConnectionStore } = await import('@/app/stores/pushConnection.store');
 				const pushStore = usePushConnectionStore();
+				const relayedExecutionId = json.source === 'ai' ? json.event?.data?.executionId : undefined;
+				if (typeof relayedExecutionId === 'string') {
+					uiStore.markExecutionAsAiInitiated(relayedExecutionId);
+				}
 				for (const handler of pushStore.onMessageReceivedHandlers) {
 					handler(json.event);
 				}

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.test.ts
@@ -824,5 +824,57 @@ describe('manual execution stats tracking', () => {
 
 			expect(incrementSpy).not.toHaveBeenCalled();
 		});
+
+		it('shows error toast for user-initiated executions', () => {
+			const pinia = createTestingPinia();
+			setActivePinia(pinia);
+
+			mockShowMessage.mockClear();
+
+			const execution = mock<SimplifiedExecution>({
+				id: 'exec-user-1',
+				status: 'error',
+				data: {
+					resultData: {
+						error: { message: 'boom', name: 'Error' },
+					},
+				},
+			});
+
+			handleExecutionFinishedWithErrorOrCanceled(
+				execution,
+				mock<IRunExecutionData>({ resultData: { error: { message: 'boom', name: 'Error' } } }),
+			);
+
+			expect(mockShowMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+		});
+
+		it('suppresses error toast for AI-initiated executions', () => {
+			const pinia = createTestingPinia();
+			setActivePinia(pinia);
+
+			const uiStore = mockedStore(useUIStore);
+			uiStore.isExecutionAiInitiated.mockReturnValue(true);
+
+			mockShowMessage.mockClear();
+
+			const execution = mock<SimplifiedExecution>({
+				id: 'exec-ai-1',
+				status: 'error',
+				data: {
+					resultData: {
+						error: { message: 'boom', name: 'Error' },
+					},
+				},
+			});
+
+			handleExecutionFinishedWithErrorOrCanceled(
+				execution,
+				mock<IRunExecutionData>({ resultData: { error: { message: 'boom', name: 'Error' } } }),
+			);
+
+			expect(mockShowMessage).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+			expect(uiStore.isExecutionAiInitiated).toHaveBeenCalledWith('exec-ai-1');
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -370,8 +370,7 @@ export function handleExecutionFinishedWithErrorOrCanceled(
 			type: 'success',
 		});
 	} else if (execution.data?.resultData.error) {
-		// AI-initiated test executions surface failures in the builder UI, so the
-		// editor-level toast is redundant and confusing for the user.
+		// AI-initiated runs surface failures in the builder UI.
 		if (!useUIStore().isExecutionAiInitiated(execution.id)) {
 			const { message, title } = getExecutionErrorToastConfiguration({
 				error: execution.data.resultData.error,

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -138,6 +138,7 @@ export async function executionFinished(
 	if (!execution) {
 		options.workflowState.setActiveExecutionId(undefined);
 		uiStore.setProcessingExecutionResults(false);
+		uiStore.clearAiInitiatedExecution(data.executionId);
 		return;
 	}
 
@@ -157,6 +158,8 @@ export async function executionFinished(
 	}
 
 	setRunExecutionData(execution, runExecutionData, options.workflowState);
+
+	uiStore.clearAiInitiatedExecution(data.executionId);
 
 	continueEvaluationLoop(execution, options);
 }
@@ -367,12 +370,16 @@ export function handleExecutionFinishedWithErrorOrCanceled(
 			type: 'success',
 		});
 	} else if (execution.data?.resultData.error) {
-		const { message, title } = getExecutionErrorToastConfiguration({
-			error: execution.data.resultData.error,
-			lastNodeExecuted: execution.data?.resultData.lastNodeExecuted,
-		});
+		// AI-initiated test executions surface failures in the builder UI, so the
+		// editor-level toast is redundant and confusing for the user.
+		if (!useUIStore().isExecutionAiInitiated(execution.id)) {
+			const { message, title } = getExecutionErrorToastConfiguration({
+				error: execution.data.resultData.error,
+				lastNodeExecuted: execution.data?.resultData.lastNodeExecuted,
+			});
 
-		toast.showMessage({ title, message, type: 'error', duration: 0 });
+			toast.showMessage({ title, message, type: 'error', duration: 0 });
+		}
 
 		useBuilderStore().incrementManualExecutionStats('error');
 	}

--- a/packages/frontend/editor-ui/src/app/stores/ui.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/ui.store.ts
@@ -772,7 +772,6 @@ export const useUIStore = defineStore(STORES.UI, () => {
 		pendingNotificationsForViews,
 		areNotificationsSuppressed,
 		allowErrorNotificationsWhenSuppressed,
-		aiInitiatedExecutionIds,
 		activeModals,
 		isProcessingExecutionResults,
 		setTheme,

--- a/packages/frontend/editor-ui/src/app/stores/ui.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/ui.store.ts
@@ -300,6 +300,7 @@ export const useUIStore = defineStore(STORES.UI, () => {
 	const pendingNotificationsForViews = ref<{ [key in VIEWS]?: NotificationOptions[] }>({});
 	const areNotificationsSuppressed = ref(false);
 	const allowErrorNotificationsWhenSuppressed = ref(false);
+	const aiInitiatedExecutionIds = ref<Set<string>>(new Set());
 	const processingExecutionResults = ref<boolean>(false);
 	const isBlankRedirect = ref<boolean>(false);
 
@@ -635,6 +636,18 @@ export const useUIStore = defineStore(STORES.UI, () => {
 		allowErrorNotificationsWhenSuppressed.value = suppressed && options?.allowErrors === true;
 	};
 
+	const markExecutionAsAiInitiated = (executionId: string) => {
+		aiInitiatedExecutionIds.value.add(executionId);
+	};
+
+	const isExecutionAiInitiated = (executionId: string) => {
+		return aiInitiatedExecutionIds.value.has(executionId);
+	};
+
+	const clearAiInitiatedExecution = (executionId: string) => {
+		aiInitiatedExecutionIds.value.delete(executionId);
+	};
+
 	function resetLastInteractedWith() {
 		lastInteractedWithNodeConnection.value = undefined;
 		lastInteractedWithNodeHandle.value = null;
@@ -759,6 +772,7 @@ export const useUIStore = defineStore(STORES.UI, () => {
 		pendingNotificationsForViews,
 		areNotificationsSuppressed,
 		allowErrorNotificationsWhenSuppressed,
+		aiInitiatedExecutionIds,
 		activeModals,
 		isProcessingExecutionResults,
 		setTheme,
@@ -776,6 +790,9 @@ export const useUIStore = defineStore(STORES.UI, () => {
 		toggleSidebarMenuCollapse,
 		setNotificationsForView,
 		setNotificationsSuppressed,
+		markExecutionAsAiInitiated,
+		isExecutionAiInitiated,
+		clearAiInitiatedExecution,
 		resetLastInteractedWith,
 		setProcessingExecutionResults,
 		markStateDirty,

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowPreview.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowPreview.test.ts
@@ -17,7 +17,7 @@ const renderComponent = createComponentRenderer(InstanceAiWorkflowPreview, {
 		stubs: {
 			WorkflowPreview: {
 				template:
-					'<div data-test-id="workflow-preview" :data-can-execute="canExecute" :data-suppress-notifications="suppressNotifications" :data-allow-error-notifications="allowErrorNotifications" />',
+					'<div data-test-id="workflow-preview" :data-can-execute="canExecute" :data-suppress-notifications="suppressNotifications" :data-allow-error-notifications="allowErrorNotifications" :data-suppress-execution-error-toast="suppressExecutionErrorToast" />',
 				props: [
 					'mode',
 					'workflow',
@@ -27,6 +27,7 @@ const renderComponent = createComponentRenderer(InstanceAiWorkflowPreview, {
 					'hideControls',
 					'suppressNotifications',
 					'allowErrorNotifications',
+					'suppressExecutionErrorToast',
 					'loaderType',
 				],
 			},
@@ -96,6 +97,7 @@ describe('InstanceAiWorkflowPreview', () => {
 			expect(preview).toHaveAttribute('data-can-execute', 'true');
 			expect(preview).toHaveAttribute('data-suppress-notifications', 'true');
 			expect(preview).toHaveAttribute('data-allow-error-notifications', 'true');
+			expect(preview).toHaveAttribute('data-suppress-execution-error-toast', 'true');
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowPreview.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowPreview.vue
@@ -54,7 +54,7 @@ function relayPushEvent(event: PushMessage) {
 		?.iframeRef;
 	if (!iframe?.contentWindow) return;
 	iframe.contentWindow.postMessage(
-		JSON.stringify({ command: 'executionEvent', event }),
+		JSON.stringify({ command: 'executionEvent', event, source: 'ai' }),
 		window.location.origin,
 	);
 }
@@ -194,6 +194,7 @@ defineExpose({ relayPushEvent });
 			:hide-controls="false"
 			:suppress-notifications="true"
 			:allow-error-notifications="true"
+			:suppress-execution-error-toast="true"
 			loader-type="spinner"
 		/>
 


### PR DESCRIPTION
## Summary

Builds on [INS-122](https://linear.app/n8n/issue/INS-122/error-toasts-not-appearing-on-canvas-when-running-workflow), which introduced execution error toasts in the Instance AI builder canvas. The toasts also fire for AI-driven test runs, which is confusing — the user didn't trigger them and the AI surfaces failures in its own UI.

This change differentiates the two cases by tagging events relayed from the AI builder so the editor's error toast is suppressed for those, while user-triggered manual runs from inside the canvas still surface the toast. It also suppresses the separate failed-execution toast emitted when the AI preview reloads the completed execution after polling.

### How it works
1. `InstanceAiWorkflowPreview.relayPushEvent` tags relayed events with `source: 'ai'`.
2. `usePostMessageHandler` records the relayed `executionId` in a new `aiInitiatedExecutionIds` set on the UI store before dispatching the event.
3. `handleExecutionFinishedWithErrorOrCanceled` checks the set and skips the error toast when the execution was AI-initiated.
4. `WorkflowPreview` can pass `suppressExecutionErrorToast` to the iframe when loading an execution.
5. `useCanvasOperations.openExecution` skips its failed-execution toast only when that explicit option is set.
6. The set entry is cleared once the execution finishes so it doesn't leak.

### Test plan
- [ ] Open the Instance AI builder and ask the AI to build/test a workflow that fails (e.g. missing credential). Verify no error toast appears.
- [ ] In the same builder canvas, click "Test workflow" manually so it fails. Verify the error toast still shows.
- [ ] Run unit tests: `pnpm --filter n8n-editor-ui test src/app/components/WorkflowPreview.test.ts src/features/ai/instanceAi/__tests__/InstanceAiWorkflowPreview.test.ts src/app/composables/usePostMessageHandler.test.ts src/app/composables/useCanvasOperations.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/INS-195
- Builds on https://linear.app/n8n/issue/INS-122

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created — N/A (internal behavior change).
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)