### PR TITLE
fix: Correct connect.html path in browser extension

### DIFF
--- a/packages/@n8n/mcp-browser-extension/manifest.json
+++ b/packages/@n8n/mcp-browser-extension/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "n8n Browser Use",
 	"key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvRoWEdJjhgP9qs6R1jcemywrw+I91EJZtYur5C97hjjUc5nPao4jSv1qXFksdKuMddb9IEvzBElr5EYsXSaiVqdbRl8Gge0xYV1gGga653T2d9BuXL7NKv/wZxJ2i/coHSjhhIULQUBAVwu0JFMbHY5T8LfqrzBljuY7u1Xa7jmLmx0QrsoKLbGUoOBVZz4ztEGKEQHEelgg+ph2LrcYJczMBZ80PaHQAaWrvbCYF4vnZLd++Svy70ZCt7gr93L8BXHc8j1c3VojQTk+Uvqhm/4nZdYHlEmruQkd0pE+zTyegbcDlw0oc+6sLbsc0CqmJz8zH0OvSTfSVK7h6LNwbQIDAQAB",
-	"version": "0.0.1",
+	"version": "0.0.3",
 	"description": "Let n8n AI set up credentials, fill out forms, and automate anything in your browser",
 	"permissions": ["debugger", "activeTab", "tabs", "storage", "webNavigation"],
 	"host_permissions": ["<all_urls>"],

--- a/packages/@n8n/mcp-browser-extension/package.json
+++ b/packages/@n8n/mcp-browser-extension/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@n8n/mcp-browser-extension",
-	"version": "0.0.1",
+	"version": "0.0.3",
 	"private": true,
 	"description": "Chrome extension that lets n8n AI control browser tabs via CDP",
 	"scripts": {

--- a/packages/@n8n/mcp-browser-extension/src/background.ts
+++ b/packages/@n8n/mcp-browser-extension/src/background.ts
@@ -37,7 +37,7 @@ async function loadSettings(): Promise<TabManagementSettings> {
 // Relay URL storage (for deduplicating connect.html tabs)
 // ---------------------------------------------------------------------------
 
-const CONNECT_PAGE = '/dist/connect.html';
+const CONNECT_PAGE = 'connect.html';
 const RELAY_URL_KEY = 'pendingRelayUrl';
 
 // ---------------------------------------------------------------------------
@@ -122,7 +122,7 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
 	if (!changeInfo.url) return;
 
 	const extOrigin = chrome.runtime.getURL('');
-	if (!changeInfo.url.startsWith(extOrigin) || !changeInfo.url.includes(CONNECT_PAGE)) return;
+	if (!changeInfo.url.startsWith(extOrigin)) return;
 
 	const parsed = new URL(changeInfo.url);
 	const relayUrl = parsed.searchParams.get('mcpRelayUrl');
@@ -141,7 +141,7 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
 		await chrome.storage.session.set({ [RELAY_URL_KEY]: relayUrl });
 
 		// Check for an existing connect.html tab to reuse
-		const connectUrl = chrome.runtime.getURL('dist/connect.html');
+		const connectUrl = chrome.runtime.getURL(CONNECT_PAGE);
 		const allConnectTabs = await chrome.tabs.query({ url: `${connectUrl}*` });
 		const existing = allConnectTabs.find((t) => t.id !== tabId && t.id !== undefined);
 
@@ -378,7 +378,7 @@ chrome.action.onClicked.addListener(() => {
 });
 
 async function openOrFocusConnectTab(): Promise<void> {
-	const connectUrl = chrome.runtime.getURL('dist/connect.html');
+	const connectUrl = chrome.runtime.getURL(CONNECT_PAGE);
 	const existing = await chrome.tabs.query({ url: `${connectUrl}*` });
 
 	if (existing.length > 0 && existing[0].id !== undefined) {


### PR DESCRIPTION
## Summary

Fixes the resolved URL for the MCP browser extension's connect page. The packaged `connect.html` is emitted at the extension root, so the previous `/dist/connect.html` path didn't resolve. This switches to `connect.html` and bumps the extension version to `0.0.3`.

### How to test

1. Build the extension: `pnpm --filter @n8n/mcp-browser-extension build`.
2. Load the unpacked extension in Chrome from the build output.
3. Click the extension, the connect tab should open without a 404

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI