### PR TITLE
fix(editor): Rename canvas header dropdown action to Description

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1642,7 +1642,7 @@
 	"menuActions.duplicate": "Duplicate",
 	"menuActions.download": "Download",
 	"menuActions.push": "Push to git",
-	"menuActions.editDescription": "Edit description",
+	"menuActions.editDescription": "Description",
 	"menuActions.importFromUrl": "Import from URL...",
 	"menuActions.importFromFile": "Import from file...",
 	"menuActions.delete": "Delete",


### PR DESCRIPTION
## Summary

This came up months ago but we forgot to actually align this with the other items.

Renames the canvas header Actions dropdown item from "Edit description" to "Description".

To test: open a workflow, click the actions menu (`...`) in the canvas header, and verify the menu entry now reads "Description".

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI