### PR TITLE
fix(instance-ai): Set task status to 'cancelled' in BackgroundTaskMan…

### DIFF
--- a/packages/@n8n/instance-ai/src/runtime/__tests__/background-task-manager.test.ts
+++ b/packages/@n8n/instance-ai/src/runtime/__tests__/background-task-manager.test.ts
@@ -524,6 +524,7 @@ describe('BackgroundTaskManager', () => {
 			const cancelled = manager.cancelAll();
 
 			expect(cancelled).toHaveLength(2);
+			expect(cancelled.every((t) => t.status === 'cancelled')).toBe(true);
 			expect(manager.getRunningTasks('thread-1')).toHaveLength(0);
 			expect(manager.getRunningTasks('thread-2')).toHaveLength(0);
 		});

--- a/packages/@n8n/instance-ai/src/runtime/background-task-manager.ts
+++ b/packages/@n8n/instance-ai/src/runtime/background-task-manager.ts
@@ -210,6 +210,7 @@ export class BackgroundTaskManager {
 		const cancelled: ManagedBackgroundTask[] = [];
 		for (const [taskId, task] of this.tasks) {
 			task.abortController.abort();
+			task.status = 'cancelled';
 			cancelled.push(task);
 			this.tasks.delete(taskId);
 			this.releaseDedupeIndices(task);


### PR DESCRIPTION
…ager.cancelAll()

cancelTask() and cancelThread() both mark returned tasks as 'cancelled', but cancelAll() returned them with the stale 'running' status. This broke the API contract for callers (including the service shutdown path) that inspect task.status after cancellation.

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
