### PR TITLE
fix(chat): Guard runData access in getMessage against missing node ru…

### DIFF
--- a/packages/cli/src/chat/utils.ts
+++ b/packages/cli/src/chat/utils.ts
@@ -111,8 +111,10 @@ export function getMessage(execution: IExecutionResponse) {
 		return getToolExecutorSendMessage(execution.data);
 	}
 
-	const runIndex = execution.data.resultData.runData[lastNodeExecuted].length - 1;
-	const data = execution.data.resultData.runData[lastNodeExecuted][runIndex]?.data;
+	const nodeRunData = execution.data.resultData.runData?.[lastNodeExecuted];
+	if (!nodeRunData?.length) return undefined;
+	const runIndex = nodeRunData.length - 1;
+	const data = nodeRunData[runIndex]?.data;
 	const outputs = data?.main ?? data?.[AI_TOOL];
 
 	// Check all main output branches for a message


### PR DESCRIPTION
…n data

getMessage() accessed runData[lastNodeExecuted] without checking whether the key exists. In corrupted/partially-written execution states (CAT-752 pattern) runData can be undefined or missing the lastNodeExecuted entry, causing a TypeError that aborts the chat response path.

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
