### PR TITLE
fix(agents): Postgres migrations

### DIFF
--- a/packages/@n8n/db/src/migrations/common/1783000000000-CreateAgentTables.ts
+++ b/packages/@n8n/db/src/migrations/common/1783000000000-CreateAgentTables.ts
@@ -49,14 +49,14 @@ export class CreateAgentTables1783000000000 implements ReversibleMigration {
 		await createTable('agents')
 			.withColumns(
 				column('id').varchar(36).primary.notNull,
-				column('name').varchar(255).notNull,
-				column('description').varchar(255),
+				column('name').varchar(128).notNull,
+				column('description').varchar(512),
 				column('projectId').varchar(255).notNull,
 				column('credentialId').varchar(255),
 				column('provider').varchar(128),
 				column('model').varchar(128),
-				column('integrations').text.notNull.default("'[]'"),
-				column('schema').text,
+				column('integrations').json.notNull.default("'[]'"),
+				column('schema').json,
 				column('tools').json.notNull.default("'{}'"),
 				column('skills').json.notNull.default("'{}'"),
 				column('versionId').varchar(36),
@@ -124,7 +124,7 @@ export class CreateAgentTables1783000000000 implements ReversibleMigration {
 				column('resourceId').varchar(255).notNull,
 				column('role').varchar(36).notNull,
 				column('type').varchar(36),
-				column('content').text.notNull,
+				column('content').json.notNull,
 			)
 			.withIndexOn(['threadId', 'createdAt'])
 			.withForeignKey('threadId', {
@@ -145,7 +145,7 @@ export class CreateAgentTables1783000000000 implements ReversibleMigration {
 		await createTable('agent_published_version')
 			.withColumns(
 				column('agentId').varchar(36).primary.notNull,
-				column('schema').text,
+				column('schema').json,
 				column('publishedFromVersionId').varchar(36).notNull,
 				column('model').varchar(128),
 				column('provider').varchar(128),

--- a/packages/cli/src/modules/agents/entities/agent-published-version.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-published-version.entity.ts
@@ -54,7 +54,7 @@ export class AgentPublishedVersion extends WithTimestamps {
 	@Column({ type: 'varchar', length: 36, nullable: true })
 	credentialId: string | null;
 
-	@Column({ type: 'varchar', length: 36, nullable: true })
+	@Column({ type: 'uuid', nullable: true })
 	publishedById: string | null;
 
 	@ManyToOne(() => User, { onDelete: 'SET NULL', nullable: true })

--- a/packages/cli/src/modules/agents/entities/agent.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent.entity.ts
@@ -11,7 +11,7 @@ export class Agent extends WithTimestampsAndStringId {
 	@Column({ type: 'varchar', length: 128 })
 	name: string;
 
-	@Column({ type: 'varchar', nullable: true })
+	@Column({ type: 'varchar', length: 512, nullable: true })
 	description: string | null;
 
 	@ManyToOne(() => Project, { onDelete: 'CASCADE' })


### PR DESCRIPTION
## Summary

- Updated the agents table migration to use real JSON columns on Postgres:
  - `agents.integrations`
  - `agents.schema`
  - `agents_messages.content`
  - `agent_published_version.schema`

- Fixed `agent_published_version.publishedById` to use `uuid`, matching `user.id` and the FK target.

- Aligned agent description storage with the JSON config limit:
  - `agents.description` is now `varchar(512)`
  - `Agent.description` entity now uses `length: 512`

- Aligned `agents.name` migration length with the entity/config limit:
  - `varchar(255)` → `varchar(128)`

## Why

- Agents were developed against SQLite, where JSON-backed fields can behave like text.
- In Postgres, the old migration created some agent JSON fields as `text`, causing runtime values like `agent.integrations` and message `content` to come back as strings.
- This broke backend flows with errors like:
  - `(agent.integrations ?? []).filter is not a function`
  - `(agent.integrations ?? []).find is not a function`
  - `Cannot create property 'id' on string ...`

## Verification

- Rebuilt and ran n8n against Docker Postgres with a wiped volume.
- Verified live Postgres schema has the expected `json` and `uuid` column types.
- Passed:
  - `pnpm --filter @n8n/db typecheck`
  - `pnpm --filter @n8n/db lint`
  - `pnpm --filter n8n typecheck`

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
