### PR TITLE
fix(ai-builder): Resolve HitlTool variants to base node in get_node_types

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/tools/code-builder-get.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/tools/code-builder-get.tool.ts
@@ -62,26 +62,34 @@ function getGeneratedNodesPaths(nodeDefinitionDirs?: string[]): string[] {
 }
 
 /**
+ * Synthetic suffixes appended to base node names when tool variants are generated at runtime.
+ * Listed most-specific-first so "slackHitlTool" strips to "slack" rather than "slackHitl".
+ *  - "HitlTool":  appended by createHitlTools() in @n8n/cli/src/tool-generation/hitl-tools.ts
+ *  - "Tool":      appended by createAiTools() in @n8n/cli/src/tool-generation/ai-tools.ts
+ */
+const TOOL_VARIANT_SUFFIXES = ['HitlTool', 'Tool'] as const;
+
+/**
  * Find the first nodes path that contains the given node directory.
  * Returns { nodesPath, nodeDir } or null if not found in any dir.
+ *
+ * For tool variants (no on-disk type files of their own), falls back to the base node's
+ * directory by stripping known synthetic suffixes.
  */
 function findNodeDir(
 	parsed: { packageName: string; nodeName: string },
 	nodesPaths: string[],
 ): { nodesPath: string; nodeDir: string } | null {
-	for (const nodesPath of nodesPaths) {
-		const nodeDir = join(nodesPath, parsed.packageName, parsed.nodeName);
-		if (existsSync(nodeDir)) {
-			return { nodesPath, nodeDir };
+	const candidateNames: string[] = [parsed.nodeName];
+	for (const suffix of TOOL_VARIANT_SUFFIXES) {
+		if (parsed.nodeName.endsWith(suffix)) {
+			candidateNames.push(parsed.nodeName.slice(0, -suffix.length));
 		}
 	}
 
-	// Tool variant fallback: e.g. "httpRequestTool" -> "httpRequest"
-	// Tool variants share type definitions with their base node
-	if (parsed.nodeName.endsWith('Tool')) {
-		const baseName = parsed.nodeName.slice(0, -4);
+	for (const candidate of candidateNames) {
 		for (const nodesPath of nodesPaths) {
-			const nodeDir = join(nodesPath, parsed.packageName, baseName);
+			const nodeDir = join(nodesPath, parsed.packageName, candidate);
 			if (existsSync(nodeDir)) {
 				return { nodesPath, nodeDir };
 			}
@@ -355,10 +363,16 @@ function resolveModePath(
 }
 
 /**
- * Try to resolve file path for a specific node ID
- * This is the core resolution logic used by getNodeFilePath
+ * Get the file path for a node ID, optionally for a specific version and discriminators.
+ * If no version specified, returns the latest version. If the node uses split structure,
+ * discriminators are required.
+ *
+ * Tool variants share their base node's type definition. The suffix-to-base mapping lives
+ * in findNodeDir, which strips known synthetic suffixes ("HitlTool", then "Tool") to reach
+ * the base directory. Error messages always reference the original nodeId, never a stripped
+ * intermediate name.
  */
-function tryGetNodeFilePath(
+function getNodeFilePath(
 	nodeId: string,
 	version: string | undefined,
 	nodeDefinitionDirs: string[] | undefined,
@@ -453,35 +467,6 @@ function tryGetNodeFilePath(
 	}
 
 	return { filePath };
-}
-
-/**
- * Get the file path for a node ID, optionally for a specific version and discriminators
- * If no version specified, returns the latest version
- * If node uses split structure, discriminators are required
- *
- * For tool variants (e.g., "googleCalendarTool"), falls back to the base node
- * (e.g., "googleCalendar") since tool variants don't have separate type files.
- */
-function getNodeFilePath(
-	nodeId: string,
-	version?: string,
-	nodeDefinitionDirs?: string[],
-	discriminators?: { resource?: string; operation?: string; mode?: string },
-): PathResolutionResult {
-	// Try exact node ID first
-	let result = tryGetNodeFilePath(nodeId, version, nodeDefinitionDirs, discriminators);
-
-	// If not found and node name ends with 'Tool', try base node as fallback
-	// (e.g., n8n-nodes-base.googleCalendarTool -> n8n-nodes-base.googleCalendar)
-	// Note: Some nodes legitimately end in Tool (agentTool, mcpClientTool) but those
-	// have their own type files, so this fallback only triggers when no file is found
-	if (result.error && nodeId.endsWith('Tool')) {
-		const baseNodeId = nodeId.slice(0, -4);
-		result = tryGetNodeFilePath(baseNodeId, version, nodeDefinitionDirs, discriminators);
-	}
-
-	return result;
 }
 
 /**

--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/tools/code-builder-get.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/tools/code-builder-get.tool.ts
@@ -62,32 +62,22 @@ function getGeneratedNodesPaths(nodeDefinitionDirs?: string[]): string[] {
 }
 
 /**
- * Synthetic suffixes appended to base node names when tool variants are generated at runtime.
- * Listed most-specific-first so "slackHitlTool" strips to "slack" rather than "slackHitl".
- *  - "HitlTool":  appended by createHitlTools() in @n8n/cli/src/tool-generation/hitl-tools.ts
- *  - "Tool":      appended by createAiTools() in @n8n/cli/src/tool-generation/ai-tools.ts
- */
-const TOOL_VARIANT_SUFFIXES = ['HitlTool', 'Tool'] as const;
-
-/**
  * Find the first nodes path that contains the given node directory.
  * Returns { nodesPath, nodeDir } or null if not found in any dir.
  *
- * For tool variants (no on-disk type files of their own), falls back to the base node's
- * directory by stripping known synthetic suffixes.
+ * Tool variants (e.g. "slackHitlTool", "httpRequestTool") have no on-disk type files;
+ * fall back to the base node by stripping the suffix. The regex tries "HitlTool" before
+ * "Tool" so "slackHitlTool" resolves to "slack", not "slackHitl".
  */
 function findNodeDir(
 	parsed: { packageName: string; nodeName: string },
 	nodesPaths: string[],
 ): { nodesPath: string; nodeDir: string } | null {
-	const candidateNames: string[] = [parsed.nodeName];
-	for (const suffix of TOOL_VARIANT_SUFFIXES) {
-		if (parsed.nodeName.endsWith(suffix)) {
-			candidateNames.push(parsed.nodeName.slice(0, -suffix.length));
-		}
-	}
+	const candidates = [parsed.nodeName];
+	const baseName = parsed.nodeName.replace(/(?:HitlTool|Tool)$/, '');
+	if (baseName !== parsed.nodeName) candidates.push(baseName);
 
-	for (const candidate of candidateNames) {
+	for (const candidate of candidates) {
 		for (const nodesPath of nodesPaths) {
 			const nodeDir = join(nodesPath, parsed.packageName, candidate);
 			if (existsSync(nodeDir)) {
@@ -365,12 +355,7 @@ function resolveModePath(
 /**
  * Get the file path for a node ID, optionally for a specific version and discriminators.
  * If no version specified, returns the latest version. If the node uses split structure,
- * discriminators are required.
- *
- * Tool variants share their base node's type definition. The suffix-to-base mapping lives
- * in findNodeDir, which strips known synthetic suffixes ("HitlTool", then "Tool") to reach
- * the base directory. Error messages always reference the original nodeId, never a stripped
- * intermediate name.
+ * discriminators are required. Tool-variant fallback is handled in findNodeDir.
  */
 function getNodeFilePath(
 	nodeId: string,

--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/tools/test/code-builder-get.tool.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/tools/test/code-builder-get.tool.test.ts
@@ -437,29 +437,16 @@ describe('CodeBuilderGetTool', () => {
 			expect(result).not.toContain('not found');
 		});
 
-		it('should report the original node ID in the error when no fallback resolves', async () => {
+		it.each([
+			['n8n-nodes-base.unknownThingHitlTool', 'n8n-nodes-base.unknownThing'],
+			['n8n-nodes-base.unknownThingTool', 'n8n-nodes-base.unknownThing'],
+		])('should report the original node ID in the error: %s', async (nodeId, strippedName) => {
 			const tool = createCodeBuilderGetTool({ nodeDefinitionDirs: [tempDir] });
 
-			const result = await tool.invoke({
-				nodeIds: ['n8n-nodes-base.unknownThingHitlTool'],
-			});
+			const result = await tool.invoke({ nodeIds: [nodeId] });
 
-			// The error should reference the original ID the caller asked about,
-			// not an intermediate stripped name like 'unknownThingHitl' or 'unknownThing'.
-			expect(result).toContain("'n8n-nodes-base.unknownThingHitlTool'");
-			expect(result).not.toContain("'n8n-nodes-base.unknownThingHitl'");
-			expect(result).not.toContain("'n8n-nodes-base.unknownThing'");
-		});
-
-		it('should report the original node ID in the error for plain Tool variants too', async () => {
-			const tool = createCodeBuilderGetTool({ nodeDefinitionDirs: [tempDir] });
-
-			const result = await tool.invoke({
-				nodeIds: ['n8n-nodes-base.unknownThingTool'],
-			});
-
-			expect(result).toContain("'n8n-nodes-base.unknownThingTool'");
-			expect(result).not.toContain("'n8n-nodes-base.unknownThing'");
+			expect(result).toContain(`'${nodeId}'`);
+			expect(result).not.toContain(`'${strippedName}'`);
 		});
 	});
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/tools/test/code-builder-get.tool.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/tools/test/code-builder-get.tool.test.ts
@@ -355,6 +355,114 @@ describe('CodeBuilderGetTool', () => {
 		});
 	});
 
+	describe('tool variant fallback', () => {
+		let tempDir: string;
+
+		beforeAll(() => {
+			tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tool-variant-test-'));
+
+			// Base node with flat version (e.g. emailSend)
+			const emailSendDir = path.join(tempDir, 'nodes/n8n-nodes-base/emailSend');
+			fs.mkdirSync(emailSendDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(emailSendDir, 'v21.ts'),
+				'export type EmailSendV21Config = { to: string; subject: string };',
+			);
+			fs.writeFileSync(path.join(emailSendDir, 'index.ts'), "export * from './v21';");
+
+			// Base node with split structure (e.g. slack)
+			const slackV24Dir = path.join(tempDir, 'nodes/n8n-nodes-base/slack/v24');
+			fs.mkdirSync(slackV24Dir, { recursive: true });
+			const slackMessageDir = path.join(slackV24Dir, 'resource_message');
+			fs.mkdirSync(slackMessageDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(slackMessageDir, 'operation_post.ts'),
+				"export type SlackV24MessagePostConfig = { resource: 'message'; operation: 'post'; channel: string };",
+			);
+			fs.writeFileSync(
+				path.join(tempDir, 'nodes/n8n-nodes-base/slack/index.ts'),
+				"export * from './v24';",
+			);
+
+			// Langchain-style base node (e.g. chat)
+			const chatDir = path.join(tempDir, 'nodes/n8n-nodes-langchain/chat');
+			fs.mkdirSync(chatDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(chatDir, 'v13.ts'),
+				'export type ChatV13Config = { mode: string };',
+			);
+			fs.writeFileSync(path.join(chatDir, 'index.ts'), "export * from './v13';");
+		});
+
+		afterAll(() => {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		});
+
+		it('should resolve a HitlTool variant to its base node (flat structure)', async () => {
+			const tool = createCodeBuilderGetTool({ nodeDefinitionDirs: [tempDir] });
+
+			const result = await tool.invoke({
+				nodeIds: ['n8n-nodes-base.emailSendHitlTool'],
+			});
+
+			expect(result).toContain('EmailSendV21Config');
+			expect(result).not.toContain('not found');
+		});
+
+		it('should resolve a HitlTool variant to its base node for langchain packages', async () => {
+			const tool = createCodeBuilderGetTool({ nodeDefinitionDirs: [tempDir] });
+
+			const result = await tool.invoke({
+				nodeIds: ['@n8n/n8n-nodes-langchain.chatHitlTool'],
+			});
+
+			expect(result).toContain('ChatV13Config');
+			expect(result).not.toContain('not found');
+		});
+
+		it('should resolve a HitlTool variant to a split-structure base node when discriminators are provided', async () => {
+			const tool = createCodeBuilderGetTool({ nodeDefinitionDirs: [tempDir] });
+
+			const result = await tool.invoke({
+				nodeIds: [
+					{
+						nodeId: 'n8n-nodes-base.slackHitlTool',
+						resource: 'message',
+						operation: 'post',
+					},
+				],
+			});
+
+			expect(result).toContain('SlackV24MessagePostConfig');
+			expect(result).not.toContain('not found');
+		});
+
+		it('should report the original node ID in the error when no fallback resolves', async () => {
+			const tool = createCodeBuilderGetTool({ nodeDefinitionDirs: [tempDir] });
+
+			const result = await tool.invoke({
+				nodeIds: ['n8n-nodes-base.unknownThingHitlTool'],
+			});
+
+			// The error should reference the original ID the caller asked about,
+			// not an intermediate stripped name like 'unknownThingHitl' or 'unknownThing'.
+			expect(result).toContain("'n8n-nodes-base.unknownThingHitlTool'");
+			expect(result).not.toContain("'n8n-nodes-base.unknownThingHitl'");
+			expect(result).not.toContain("'n8n-nodes-base.unknownThing'");
+		});
+
+		it('should report the original node ID in the error for plain Tool variants too', async () => {
+			const tool = createCodeBuilderGetTool({ nodeDefinitionDirs: [tempDir] });
+
+			const result = await tool.invoke({
+				nodeIds: ['n8n-nodes-base.unknownThingTool'],
+			});
+
+			expect(result).toContain("'n8n-nodes-base.unknownThingTool'");
+			expect(result).not.toContain("'n8n-nodes-base.unknownThing'");
+		});
+	});
+
 	describe('path traversal security', () => {
 		describe('isValidPathComponent', () => {
 			it('should accept valid alphanumeric components', () => {


### PR DESCRIPTION
## Summary

`get_node_types` failed for every HITL tool variant (`slackHitlTool`, `chatHitlTool`, `emailSendHitlTool`, etc.) because:

1. HITL tools are synthesized at runtime by `createHitlTools()` and have no static type-definition files.
2. The existing `*Tool`-suffix fallback stripped only 4 chars, producing nonsense intermediate names (`slackHitlTool` → `slackHitl`) that don't exist either.
3. The error message reported the *last attempted* (stripped) ID rather than the original request — so users saw an error mentioning a name they never typed.

This change adds a `HitlTool` (8-char) fallback in `findNodeDir` and in `getNodeFilePath`'s outer fallback so HITL variants resolve to their base node (`slackHitlTool` → `slack`). When all fallbacks fail, the original node ID is preserved in the error message.

### How to test

```bash
pushd packages/@n8n/ai-workflow-builder.ee
pnpm test code-builder-get.tool.test
popd
```

The new `tool variant fallback` describe block covers:
- HITL → flat-structure base (`emailSendHitlTool` → `emailSend`)
- HITL → langchain base (`@n8n/n8n-nodes-langchain.chatHitlTool` → `chat`)
- HITL → split-structure base with discriminators (`slackHitlTool` + resource/operation)
- Original ID preserved in error for unresolved `HitlTool` and plain `Tool` variants

End-to-end smoke test against the live MCP server confirmed all four scenarios resolve correctly through `mcp__n8n-mcp__get_node_types`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5170

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
- [x] I have seen this code, I have run this code, and I take responsibility for this code.