### PR TITLE
feat(editor): Add envFeatureFlag and copyButton property options

### DIFF
--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -596,6 +596,76 @@ describe('FrontendService', () => {
 
 			expect(credential.__skipManagedCreation).toBeUndefined();
 		});
+
+		describe('JWKS URI injection', () => {
+			const expectedJwksUri = 'http://localhost:5678/rest/.well-known/jwks.json';
+
+			const makeJwksUriProperty = () => ({
+				displayName: 'JWKS URI',
+				name: 'jwksUri',
+				type: 'string' as const,
+				default: '',
+			});
+
+			it('should inject the instance JWKS URI on oAuth2Api', () => {
+				const credential = {
+					name: 'oAuth2Api',
+					displayName: 'OAuth2 API',
+					properties: [makeJwksUriProperty()],
+				} as unknown as ICredentialType;
+
+				loadNodesAndCredentials.types = { credentials: [credential], nodes: [] };
+				(credentialTypes.getParentTypes as jest.Mock).mockReturnValue([]);
+
+				const { service } = createMockService();
+				(service as any).overwriteCredentialsProperties();
+
+				const jwksProperty = credential.properties?.find((p) => p.name === 'jwksUri');
+				expect(jwksProperty?.default).toBe(expectedJwksUri);
+			});
+
+			it('should inject the instance JWKS URI on credentials extending oAuth2Api', () => {
+				const credential = {
+					name: 'slackOAuth2Api',
+					displayName: 'Slack OAuth2 API',
+					properties: [makeJwksUriProperty()],
+				} as unknown as ICredentialType;
+
+				loadNodesAndCredentials.types = { credentials: [credential], nodes: [] };
+				(credentialTypes.getParentTypes as jest.Mock).mockReturnValue(['oAuth2Api']);
+
+				const { service } = createMockService();
+				(service as any).overwriteCredentialsProperties();
+
+				const jwksProperty = credential.properties?.find((p) => p.name === 'jwksUri');
+				expect(jwksProperty?.default).toBe(expectedJwksUri);
+			});
+
+			it('should leave non-OAuth2 credentials untouched', () => {
+				const credential = {
+					name: 'httpBasicAuth',
+					displayName: 'Basic Auth',
+					properties: [
+						{
+							displayName: 'User',
+							name: 'user',
+							type: 'string' as const,
+							default: '',
+						},
+					],
+				} as unknown as ICredentialType;
+
+				loadNodesAndCredentials.types = { credentials: [credential], nodes: [] };
+				(credentialTypes.getParentTypes as jest.Mock).mockReturnValue([]);
+
+				const { service } = createMockService();
+				(service as any).overwriteCredentialsProperties();
+
+				expect(credential.properties).toEqual([
+					{ displayName: 'User', name: 'user', type: 'string', default: '' },
+				]);
+			});
+		});
 	});
 
 	describe('generateTypes', () => {

--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -623,26 +623,24 @@ describe('FrontendService', () => {
 				expect(jwksProperty?.default).toBe(expectedJwksUri);
 			});
 
-			it('should inject the instance JWKS URI on credentials extending oAuth2Api', () => {
-				// `jwksUri` is inheritable so an extending credential that
-				// re-declares `jweEnabled` (opting into JWE) gets the runtime URL
-				// for free. Without a re-declared `jweEnabled`, the field's
-				// `displayOptions` keeps it hidden anyway — but the default is
-				// still populated server-side.
+			it('should leave credentials extending oAuth2Api untouched (jwksUri is doNotInherit)', () => {
+				// Both `jweEnabled` and `jwksUri` carry `doNotInherit: true` because
+				// inheriting `jwksUri` alone breaks `getParameterResolveOrder` on
+				// the child (its `displayOptions` references a missing field).
+				// So extending credentials don't carry `jwksUri` in the first place
+				// and the injection is correctly scoped to the bare `oAuth2Api`.
 				const credential = {
 					name: 'slackOAuth2Api',
 					displayName: 'Slack OAuth2 API',
-					properties: [makeJwksUriProperty()],
+					properties: [],
 				} as unknown as ICredentialType;
 
 				loadNodesAndCredentials.types = { credentials: [credential], nodes: [] };
-				(credentialTypes.getParentTypes as jest.Mock).mockReturnValue(['oAuth2Api']);
 
 				const { service } = createMockService();
 				(service as any).overwriteCredentialsProperties();
 
-				const jwksProperty = credential.properties?.find((p) => p.name === 'jwksUri');
-				expect(jwksProperty?.default).toBe(expectedJwksUri);
+				expect(credential.properties).toEqual([]);
 			});
 
 			it('should leave non-OAuth2 credentials untouched', () => {

--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -623,12 +623,11 @@ describe('FrontendService', () => {
 				expect(jwksProperty?.default).toBe(expectedJwksUri);
 			});
 
-			it('should leave credentials extending oAuth2Api untouched (jwksUri is doNotInherit)', () => {
-				// Both `jweEnabled` and `jwksUri` carry `doNotInherit: true` because
-				// inheriting `jwksUri` alone breaks `getParameterResolveOrder` on
-				// the child (its `displayOptions` references a missing field).
-				// So extending credentials don't carry `jwksUri` in the first place
-				// and the injection is correctly scoped to the bare `oAuth2Api`.
+			it('should not touch standard OAuth2-extending credentials (jwksUri not inherited)', () => {
+				// Both `jweEnabled` and `jwksUri` carry `doNotInherit: true` so
+				// provider-specific OAuth2 credentials (Google, Slack, GitHub, ...)
+				// don't inherit them. Without a `jwksUri` property in scope, the
+				// injection has nothing to mutate.
 				const credential = {
 					name: 'slackOAuth2Api',
 					displayName: 'Slack OAuth2 API',
@@ -641,6 +640,28 @@ describe('FrontendService', () => {
 				(service as any).overwriteCredentialsProperties();
 
 				expect(credential.properties).toEqual([]);
+			});
+
+			it('should inject the JWKS URI on JWE-aware OAuth2 extensions that re-declare jwksUri', () => {
+				// Custom credentials extending oAuth2Api can opt into the JWE flow
+				// by re-declaring both `jweEnabled` and `jwksUri`. The runtime URL
+				// injection must reach those credentials so the user sees the
+				// instance JWKS endpoint without the credential class hardcoding
+				// it (which would be impossible per-instance).
+				const credential = {
+					name: 'metaOAuth2Api',
+					displayName: 'Meta OAuth2 API',
+					properties: [makeJwksUriProperty()],
+				} as unknown as ICredentialType;
+
+				loadNodesAndCredentials.types = { credentials: [credential], nodes: [] };
+				(credentialTypes.getParentTypes as jest.Mock).mockReturnValue(['oAuth2Api']);
+
+				const { service } = createMockService();
+				(service as any).overwriteCredentialsProperties();
+
+				const jwksProperty = credential.properties?.find((p) => p.name === 'jwksUri');
+				expect(jwksProperty?.default).toBe(expectedJwksUri);
 			});
 
 			it('should leave non-OAuth2 credentials untouched', () => {

--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -615,7 +615,6 @@ describe('FrontendService', () => {
 				} as unknown as ICredentialType;
 
 				loadNodesAndCredentials.types = { credentials: [credential], nodes: [] };
-				(credentialTypes.getParentTypes as jest.Mock).mockReturnValue([]);
 
 				const { service } = createMockService();
 				(service as any).overwriteCredentialsProperties();
@@ -625,6 +624,11 @@ describe('FrontendService', () => {
 			});
 
 			it('should inject the instance JWKS URI on credentials extending oAuth2Api', () => {
+				// `jwksUri` is inheritable so an extending credential that
+				// re-declares `jweEnabled` (opting into JWE) gets the runtime URL
+				// for free. Without a re-declared `jweEnabled`, the field's
+				// `displayOptions` keeps it hidden anyway — but the default is
+				// still populated server-side.
 				const credential = {
 					name: 'slackOAuth2Api',
 					displayName: 'Slack OAuth2 API',
@@ -656,7 +660,6 @@ describe('FrontendService', () => {
 				} as unknown as ICredentialType;
 
 				loadNodesAndCredentials.types = { credentials: [credential], nodes: [] };
-				(credentialTypes.getParentTypes as jest.Mock).mockReturnValue([]);
 
 				const { service } = createMockService();
 				(service as any).overwriteCredentialsProperties();

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -695,11 +695,13 @@ export class FrontendService {
 				credential.__skipManagedCreation = true;
 			}
 
-			// Inject the per-instance JWKS URI as the default of `jwksUri` for
-			// `oAuth2Api` and any credential that extends it. The field is hidden
-			// behind the `jweEnabled` toggle (and the toggle itself is gated by
-			// the OAuth2 JWE feature flag on the frontend), so the value only
-			// surfaces when the feature is in use.
+			// Inject the per-instance JWKS URI as the default of `jwksUri` on
+			// `oAuth2Api` and any credential that extends it. The field stays
+			// hidden by the `jweEnabled` toggle's `displayOptions`, which only
+			// resolves on credentials that explicitly re-declare `jweEnabled`
+			// (it carries `doNotInherit: true`). Net effect: bare `oAuth2Api`
+			// surfaces the JWE flow today, future JWE-aware extending
+			// credentials get the URL injected automatically when they opt in.
 			const isOAuth2Credential =
 				credential.name === 'oAuth2Api' ||
 				this.credentialTypes.getParentTypes(credential.name).includes('oAuth2Api');

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -695,26 +695,19 @@ export class FrontendService {
 				credential.__skipManagedCreation = true;
 			}
 
-			// JWE fields on `oAuth2Api` are baked into nodes-base's pre-rendered
-			// credentials.json by lazy loading, so feature gating and the
-			// instance-specific JWKS URI have to be applied here at runtime.
-			if (credential.name === 'oAuth2Api' && credential.properties) {
-				const isOAuth2JweEnabled = process.env.N8N_ENV_FEAT_OAUTH2_JWE === 'true';
-				if (!isOAuth2JweEnabled) {
-					credential.properties = credential.properties.filter(
-						(property) => property.name !== 'jweEnabled' && property.name !== 'jwksUriNotice',
-					);
-				} else {
-					const jwksUri = `${this.urlService.getInstanceBaseUrl()}/${this.globalConfig.endpoints.rest}/.well-known/jwks.json`;
-					credential.properties = credential.properties.map((property) =>
-						property.name === 'jwksUriNotice'
-							? {
-									...property,
-									displayName: `Provide this JWKS URI to your IdP so it can encrypt tokens to this instance's public key: \`${jwksUri}\``,
-								}
-							: property,
-					);
-				}
+			// Inject the per-instance JWKS URI as the default of `jwksUri` for
+			// `oAuth2Api` and any credential that extends it. The field is hidden
+			// behind the `jweEnabled` toggle (and the toggle itself is gated by
+			// the OAuth2 JWE feature flag on the frontend), so the value only
+			// surfaces when the feature is in use.
+			const isOAuth2Credential =
+				credential.name === 'oAuth2Api' ||
+				this.credentialTypes.getParentTypes(credential.name).includes('oAuth2Api');
+			if (isOAuth2Credential && credential.properties) {
+				const jwksUri = `${this.urlService.getInstanceBaseUrl()}/${this.globalConfig.endpoints.rest}/.well-known/jwks.json`;
+				credential.properties = credential.properties.map((property) =>
+					property.name === 'jwksUri' ? { ...property, default: jwksUri } : property,
+				);
 			}
 		}
 	}

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -695,12 +695,17 @@ export class FrontendService {
 				credential.__skipManagedCreation = true;
 			}
 
-			// Inject the per-instance JWKS URI as the default of `oAuth2Api.jwksUri`.
-			// The field is hidden behind the `jweEnabled` toggle (and the toggle
-			// itself is gated by the OAuth2 JWE feature flag on the frontend), so
-			// the value only surfaces when the feature is in use. Both fields
-			// are non-inheritable, so this only fires for the bare `oAuth2Api`.
-			if (credential.name === 'oAuth2Api' && credential.properties) {
+			// Inject the per-instance JWKS URI as the default of any `jwksUri`
+			// property on `oAuth2Api` itself or any credential that extends it
+			// and explicitly re-declares the field. Inheritance is blocked by
+			// `doNotInherit: true` on both `jweEnabled` and `jwksUri` so that
+			// extending credentials don't silently inherit half a dependency
+			// pair (which would crash `getParameterResolveOrder`); custom
+			// JWE-aware OAuth2 extensions can re-declare both fields together.
+			const isOAuth2Credential =
+				credential.name === 'oAuth2Api' ||
+				this.credentialTypes.getParentTypes(credential.name).includes('oAuth2Api');
+			if (isOAuth2Credential && credential.properties) {
 				const jwksUri = `${this.urlService.getInstanceBaseUrl()}/${this.globalConfig.endpoints.rest}/.well-known/jwks.json`;
 				credential.properties = credential.properties.map((property) =>
 					property.name === 'jwksUri' ? { ...property, default: jwksUri } : property,

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -695,17 +695,12 @@ export class FrontendService {
 				credential.__skipManagedCreation = true;
 			}
 
-			// Inject the per-instance JWKS URI as the default of `jwksUri` on
-			// `oAuth2Api` and any credential that extends it. The field stays
-			// hidden by the `jweEnabled` toggle's `displayOptions`, which only
-			// resolves on credentials that explicitly re-declare `jweEnabled`
-			// (it carries `doNotInherit: true`). Net effect: bare `oAuth2Api`
-			// surfaces the JWE flow today, future JWE-aware extending
-			// credentials get the URL injected automatically when they opt in.
-			const isOAuth2Credential =
-				credential.name === 'oAuth2Api' ||
-				this.credentialTypes.getParentTypes(credential.name).includes('oAuth2Api');
-			if (isOAuth2Credential && credential.properties) {
+			// Inject the per-instance JWKS URI as the default of `oAuth2Api.jwksUri`.
+			// The field is hidden behind the `jweEnabled` toggle (and the toggle
+			// itself is gated by the OAuth2 JWE feature flag on the frontend), so
+			// the value only surfaces when the feature is in use. Both fields
+			// are non-inheritable, so this only fires for the bare `oAuth2Api`.
+			if (credential.name === 'oAuth2Api' && credential.properties) {
 				const jwksUri = `${this.urlService.getInstanceBaseUrl()}/${this.globalConfig.endpoints.rest}/.well-known/jwks.json`;
 				credential.properties = credential.properties.map((property) =>
 					property.name === 'jwksUri' ? { ...property, default: jwksUri } : property,

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialInputs.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialInputs.vue
@@ -5,7 +5,9 @@ import type {
 	NodeParameterValueType,
 } from 'n8n-workflow';
 import type { IUpdateInformation } from '@/Interface';
+import CopyInput from '@/app/components/CopyInput.vue';
 import ParameterInputExpanded from '@/features/ndv/parameters/components/ParameterInputExpanded.vue';
+import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
 import { computed } from 'vue';
 
 import { N8nNotice } from '@n8n/design-system';
@@ -18,8 +20,16 @@ type Props = {
 
 const props = defineProps<Props>();
 
+const { check: envFeatureFlag } = useEnvFeatureFlag();
+
 const credentialDataValues = computed(
 	() => props.credentialData as Record<string, NodeParameterValueType>,
+);
+
+const visibleProperties = computed(() =>
+	props.credentialProperties.filter(
+		(parameter) => !parameter.envFeatureFlag || envFeatureFlag.value(parameter.envFeatureFlag),
+	),
 );
 
 const emit = defineEmits<{
@@ -32,9 +42,9 @@ function valueChanged(parameterData: IUpdateInformation) {
 </script>
 
 <template>
-	<div v-if="credentialProperties.length" :class="$style.container" @keydown.stop>
+	<div v-if="visibleProperties.length" :class="$style.container" @keydown.stop>
 		<form
-			v-for="parameter in credentialProperties"
+			v-for="parameter in visibleProperties"
 			:key="parameter.name"
 			autocomplete="off"
 			data-test-id="credential-connection-parameter"
@@ -42,6 +52,12 @@ function valueChanged(parameterData: IUpdateInformation) {
 		>
 			<!-- Why form? to break up inputs, to prevent Chrome autofill -->
 			<N8nNotice v-if="parameter.type === 'notice'" :content="parameter.displayName" />
+			<CopyInput
+				v-else-if="parameter.type === 'string' && parameter.typeOptions?.copyButton"
+				:label="parameter.displayName"
+				:hint="parameter.description"
+				:value="String(credentialDataValues[parameter.name] ?? parameter.default ?? '')"
+			/>
 			<ParameterInputExpanded
 				v-else
 				:parameter="parameter"

--- a/packages/nodes-base/credentials/OAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/OAuth2Api.credentials.ts
@@ -214,11 +214,11 @@ export class OAuth2Api implements ICredentialType {
 			doNotInherit: true,
 		},
 		{
-			// `jwksUri` is inheritable so future JWE-aware credentials extending
-			// `oAuth2Api` can opt in by simply re-declaring `jweEnabled` and the
-			// JWKS URI surfaces for free. `displayOptions.show.jweEnabled` keeps
-			// this field hidden on extending credentials that don't re-declare
-			// the toggle, so no UI noise.
+			// `doNotInherit` matches `jweEnabled` above. Inheriting just `jwksUri`
+			// without `jweEnabled` breaks `getParameterResolveOrder` on every
+			// extending credential because `jwksUri.displayOptions` references a
+			// field the child doesn't have, leaving the dependency unresolved.
+			// Future JWE-aware OAuth2 extensions can re-declare both fields.
 			displayName: 'JWKS URI',
 			name: 'jwksUri',
 			type: 'string',
@@ -233,6 +233,7 @@ export class OAuth2Api implements ICredentialType {
 					jweEnabled: [true],
 				},
 			},
+			doNotInherit: true,
 		},
 	];
 }

--- a/packages/nodes-base/credentials/OAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/OAuth2Api.credentials.ts
@@ -214,6 +214,11 @@ export class OAuth2Api implements ICredentialType {
 			doNotInherit: true,
 		},
 		{
+			// `jwksUri` is inheritable so future JWE-aware credentials extending
+			// `oAuth2Api` can opt in by simply re-declaring `jweEnabled` and the
+			// JWKS URI surfaces for free. `displayOptions.show.jweEnabled` keeps
+			// this field hidden on extending credentials that don't re-declare
+			// the toggle, so no UI noise.
 			displayName: 'JWKS URI',
 			name: 'jwksUri',
 			type: 'string',
@@ -228,7 +233,6 @@ export class OAuth2Api implements ICredentialType {
 					jweEnabled: [true],
 				},
 			},
-			doNotInherit: true,
 		},
 	];
 }

--- a/packages/nodes-base/credentials/OAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/OAuth2Api.credentials.ts
@@ -209,17 +209,20 @@ export class OAuth2Api implements ICredentialType {
 			type: 'boolean',
 			default: false,
 			description:
-				'Whether the IdP returns tokens encrypted as JWE to the public key at this instance’s JWKS endpoint. The response must contain at least one JWE-encrypted token (access or ID token); fully plaintext responses are rejected. The field is hidden by the server unless the OAuth2 JWE feature is enabled.',
+				'Whether the IdP returns tokens encrypted as JWE to the public key at this instance’s JWKS endpoint. The response must contain at least one JWE-encrypted token (access or ID token); fully plaintext responses are rejected.',
+			envFeatureFlag: 'OAUTH2_JWE',
 			doNotInherit: true,
 		},
 		{
-			// `displayName` is filled in at runtime by FrontendService with the
-			// instance JWKS URI. Server-side gating drops both this notice and
-			// the toggle above when the OAuth2 JWE feature flag is off.
-			displayName: '',
-			name: 'jwksUriNotice',
-			type: 'notice',
+			displayName: 'JWKS URI',
+			name: 'jwksUri',
+			type: 'string',
+			typeOptions: {
+				copyButton: true,
+			},
 			default: '',
+			description:
+				'Provide this URL to your IdP so it can fetch the public key used to encrypt access and ID tokens for this instance.',
 			displayOptions: {
 				show: {
 					jweEnabled: [true],

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1646,6 +1646,7 @@ export interface INodePropertyTypeOptions {
 		layout?: 'inline'; // Render sub-parameters side-by-side in a row
 	};
 	password?: boolean; // Supported by: string
+	copyButton?: boolean; // Supported by: string — renders a readonly value with a click-to-copy affordance
 	redactJsonLeaves?: boolean; // Supported by: json (credential fields only) — redacts leaf values instead of the whole field
 	rows?: number; // Supported by: string
 	showAlpha?: boolean; // Supported by: color
@@ -1773,6 +1774,11 @@ export interface INodeProperties {
 	builderHint?: IParameterBuilderHint;
 	disabledOptions?: IDisplayOptions;
 	displayOptions?: IDisplayOptions;
+	/**
+	 * Hides the property unless the named instance-level env feature flag is
+	 * truthy. The value is the flag suffix without the `N8N_ENV_FEAT_` prefix
+	 */
+	envFeatureFlag?: Uppercase<string>;
 	options?: Array<INodePropertyOptions | INodeProperties | INodePropertyCollection>;
 	placeholder?: string;
 	isNodeSetting?: boolean;


### PR DESCRIPTION
## Summary

Adds two declarative knobs on `INodeProperties` so credential forms can hide fields behind instance-level env feature flags and surface readonly, click-to-copy values without bespoke Vue plumbing:

- **`envFeatureFlag?: Uppercase<string>`** on `INodeProperties` — hides the field on credential forms unless the named `N8N_ENV_FEAT_*` flag is truthy. Honoured by `CredentialInputs.vue` via `useEnvFeatureFlag`. The value is the suffix only (e.g. `'OAUTH2_JWE'`), matching the existing `<EnvFeatureFlag name=\"...\">` component convention.
- **`typeOptions.copyButton?: boolean`** on string properties — renders the value as a `CopyInput` (label + monospace value + click-to-copy with toast) instead of the standard text input + Fixed/Expression toolbar. Useful for system-generated values the user needs to paste somewhere external.

Wired both into `OAuth2Api`: the `jweEnabled` toggle gates on `OAUTH2_JWE` and the `jwksUri` field renders as a copy-button string. `FrontendService.overwriteCredentialsProperties` injects the per-instance JWKS URI into the field's `default` at runtime.

**How to test:** with `N8N_ENV_FEAT_OAUTH2_JWE=true pnpm start`, open an OAuth2 credential — the \"Encrypted Tokens (JWE)\" toggle is visible; toggling it on reveals a JWKS URI field with a click-to-copy affordance and the live instance URL. Without the flag, neither field appears.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI