### PR TITLE
fix(core): Clarify 0-based indexing in workflow SDK prompts and JSDoc

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/prompts/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/prompts/index.ts
@@ -99,15 +99,16 @@ startTrigger.to(sourceA.to(sourceB.to(processResults)));
 // Pairs items by index, merging fields from both inputs into one item.
 // @example input0: [{ a: 1 }, { a: 2 }] input1: [{ b: 10, c: 'x' }, { b: 20 }]
 //   output: [{ a: 1, b: 10, c: 'x' }, { a: 2, b: 20, c: undefined }]
+// .input(n) is 0-based: .input(0) = first input, .input(1) = second input.
 const combineResults = merge({
   version: 3.2,
   config: { name: 'Combine Results', parameters: { mode: 'combine', combineBy: 'combineByPosition' } }
 });
 export default workflow('id', 'name')
   .add(startTrigger)
-  .to(sourceA.to(combineResults.input(0)))
+  .to(sourceA.to(combineResults.input(0))) // first input (index 0)
   .add(startTrigger)
-  .to(sourceB.to(combineResults.input(1)))
+  .to(sourceB.to(combineResults.input(1))) // second input (index 1)
   .add(combineResults)
   .to(processResults);
 
@@ -121,9 +122,9 @@ const allResults = merge({
 });
 export default workflow('id', 'name')
   .add(startTrigger)
-  .to(sourceA.to(allResults.input(0)))
+  .to(sourceA.to(allResults.input(0))) // first input (index 0)
   .add(startTrigger)
-  .to(sourceB.to(allResults.input(1)))
+  .to(sourceB.to(allResults.input(1))) // second input (index 1)
   .add(allResults)
   .to(processResults);
 \`\`\`
@@ -180,12 +181,13 @@ const branch1 = node({ type: 'n8n-nodes-base.httpRequest', ... });
 const branch2 = node({ type: 'n8n-nodes-base.httpRequest', ... });
 const processResults = node({ type: 'n8n-nodes-base.set', ... });
 
-// Connect branches to specific merge inputs using .input(n)
+// Connect branches to specific merge inputs using .input(n).
+// Indices are 0-based: .input(0) is the FIRST input, .input(1) is the SECOND.
 export default workflow('id', 'name')
   .add(trigger({ ... }))
-  .to(branch1.to(combineResults.input(0)))  // Connect to input 0
+  .to(branch1.to(combineResults.input(0)))  // first input (index 0)
   .add(trigger({ ... }))
-  .to(branch2.to(combineResults.input(1)))  // Connect to input 1
+  .to(branch2.to(combineResults.input(1)))  // second input (index 1)
   .add(combineResults)
   .to(processResults);  // Process merged results
 \`\`\`

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/additional-functions.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/additional-functions.ts
@@ -14,8 +14,8 @@ export const ADDITIONAL_FUNCTIONS = `Additional SDK functions:
 - \`sticky('content', nodes?, config?)\` — creates a sticky note on the canvas.
   Example: \`sticky('## Data Processing', [httpNode, setNode], { color: 2 })\`
 
-- \`.output(n)\` — selects a specific output index for multi-output nodes. IF and Switch have dedicated methods (\`onTrue/onFalse\`, \`onCase\`), but \`.output(n)\` works as a generic alternative.
-  Example: \`classifier.output(1).to(categoryB)\`
+- \`.output(n)\` — selects a specific output index for multi-output nodes. The index is **0-based**: \`.output(0)\` is the first output, \`.output(1)\` is the second. IF and Switch have dedicated methods (\`onTrue/onFalse\`, \`onCase\`), but \`.output(n)\` works as a generic alternative.
+  Example: \`classifier.output(0).to(categoryA); classifier.output(1).to(categoryB)\`
 
 - \`.onError(handler)\` — connects a node's error output to a handler node. Requires \`onError: 'continueErrorOutput'\` in the node config.
   Example: \`httpNode.onError(errorHandler)\` (with \`config: { onError: 'continueErrorOutput' }\`)

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-patterns-detailed.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-patterns-detailed.ts
@@ -64,15 +64,16 @@ startTrigger.to(sourceA.to(sourceB.to(processResults)));
 // Pairs items by index, merging fields from both inputs into one item.
 // @example input0: [{ a: 1 }, { a: 2 }] input1: [{ b: 10, c: 'x' }, { b: 20 }]
 //   output: [{ a: 1, b: 10, c: 'x' }, { a: 2, b: 20, c: undefined }]
+// .input(n) is 0-based: .input(0) = first input, .input(1) = second input.
 const combineResults = merge({
   version: 3.2,
   config: { name: 'Combine Results', parameters: { mode: 'combine', combineBy: 'combineByPosition' } }
 });
 export default workflow('id', 'name')
   .add(startTrigger)
-  .to(sourceA.to(combineResults.input(0)))
+  .to(sourceA.to(combineResults.input(0))) // first input (index 0)
   .add(startTrigger)
-  .to(sourceB.to(combineResults.input(1)))
+  .to(sourceB.to(combineResults.input(1))) // second input (index 1)
   .add(combineResults)
   .to(processResults);
 
@@ -86,9 +87,9 @@ const allResults = merge({
 });
 export default workflow('id', 'name')
   .add(startTrigger)
-  .to(sourceA.to(allResults.input(0)))
+  .to(sourceA.to(allResults.input(0))) // first input (index 0)
   .add(startTrigger)
-  .to(sourceB.to(allResults.input(1)))
+  .to(sourceB.to(allResults.input(1))) // second input (index 1)
   .add(allResults)
   .to(processResults);
 \`\`\`
@@ -143,12 +144,13 @@ const branch1 = node({ type: 'n8n-nodes-base.httpRequest', ... });
 const branch2 = node({ type: 'n8n-nodes-base.httpRequest', ... });
 const processResults = node({ type: 'n8n-nodes-base.set', ... });
 
-// Connect branches to specific merge inputs using .input(n)
+// Connect branches to specific merge inputs using .input(n).
+// Indices are 0-based: .input(0) is the FIRST input, .input(1) is the SECOND.
 export default workflow('id', 'name')
   .add(trigger({ ... }))
-  .to(branch1.to(combineResults.input(0)))
+  .to(branch1.to(combineResults.input(0)))  // first input (index 0)
   .add(trigger({ ... }))
-  .to(branch2.to(combineResults.input(1)))
+  .to(branch2.to(combineResults.input(1)))  // second input (index 1)
   .add(combineResults)
   .to(processResults);
 \`\`\`

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-patterns.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-patterns.ts
@@ -78,15 +78,16 @@ const sourceB = node({ ..., config: { ..., executeOnce: true } });
 startTrigger.to(sourceA.to(sourceB.to(processResults)));
 
 // FIX 2 - parallel branches + Merge (combine by position)
+// .input(n) is 0-based: .input(0) = first input, .input(1) = second input.
 const combineResults = merge({
   version: 3.2,
   config: { name: 'Combine Results', parameters: { mode: 'combine', combineBy: 'combineByPosition' } }
 });
 export default workflow('id', 'name')
   .add(startTrigger)
-  .to(sourceA.to(combineResults.input(0)))
+  .to(sourceA.to(combineResults.input(0))) // first input (index 0)
   .add(startTrigger)
-  .to(sourceB.to(combineResults.input(1)))
+  .to(sourceB.to(combineResults.input(1))) // second input (index 1)
   .add(combineResults)
   .to(processResults);
 
@@ -97,9 +98,9 @@ const allResults = merge({
 });
 export default workflow('id', 'name')
   .add(startTrigger)
-  .to(sourceA.to(allResults.input(0)))
+  .to(sourceA.to(allResults.input(0))) // first input (index 0)
   .add(startTrigger)
-  .to(sourceB.to(allResults.input(1)))
+  .to(sourceB.to(allResults.input(1))) // second input (index 1)
   .add(allResults)
   .to(processResults);
 \`\`\`
@@ -237,12 +238,13 @@ const branch1 = node({ type: 'n8n-nodes-base.httpRequest', ... });
 const branch2 = node({ type: 'n8n-nodes-base.httpRequest', ... });
 const processResults = node({ type: 'n8n-nodes-base.set', ... });
 
-// Connect branches to specific merge inputs using .input(n)
+// Connect branches to specific merge inputs using .input(n).
+// Indices are 0-based: .input(0) is the FIRST input, .input(1) is the SECOND.
 export default workflow('id', 'name')
   .add(trigger({ ... }))
-  .to(branch1.to(combineResults.input(0)))  // Connect to input 0
+  .to(branch1.to(combineResults.input(0)))  // first input (index 0)
   .add(trigger({ ... }))
-  .to(branch2.to(combineResults.input(1)))  // Connect to input 1
+  .to(branch2.to(combineResults.input(1)))  // second input (index 1)
   .add(combineResults)
   .to(processResults);  // Process merged results
 \`\`\`

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-rules.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-rules.ts
@@ -31,4 +31,12 @@ export const WORKFLOW_RULES = `Follow these rules strictly when generating workf
    - **Drop items that don't match a predicate** → \`filter\`. It emits 0 items when nothing matches, and the chain stops cleanly.
    - **Two mutually exclusive paths that both do real work** → \`IF\` (\`onTrue\` / \`onFalse\`).
    - **Many mutually exclusive paths keyed off a value** → \`switch\` (\`onCase\`).
-   - Nested control flow is supported: \`ifNode.onTrue(loopBuilder)\`, \`switchNode.onCase(0, loopBuilder)\`, and \`splitInBatches(sib).onEachBatch(ifElseBuilder)\` all compile and wire correctly. Use them when the semantics genuinely call for it, not as a workaround for empty-list handling.`;
+   - Nested control flow is supported: \`ifNode.onTrue(loopBuilder)\`, \`switchNode.onCase(0, loopBuilder)\`, and \`splitInBatches(sib).onEachBatch(ifElseBuilder)\` all compile and wire correctly. Use them when the semantics genuinely call for it, not as a workaround for empty-list handling.
+
+5. **Input and output indices are 0-based — \`.input(0)\` is the FIRST input**
+   - \`.input(0)\` and \`.output(0)\` refer to the **first** input/output. \`.input(1)\` and \`.output(1)\` refer to the **second**. \`.input(1)\` is NOT the first input — it is the second one.
+   - This applies everywhere indices are passed: \`.input(n)\`, \`.output(n)\`, \`.onCase(n, ...)\` for switch outputs, and any \`outputIndex\` argument.
+   - When wiring N branches to a Merge node, the indices are \`0, 1, ..., N-1\` — never \`1, 2, ..., N\`.
+   - Counter-examples to AVOID:
+     - WRONG: \`sourceA.to(merge.input(1))\` followed by \`sourceB.to(merge.input(2))\` — this skips input 0 entirely; the first branch is silently dropped.
+     - CORRECT: \`sourceA.to(merge.input(0))\` followed by \`sourceB.to(merge.input(1))\`.`;

--- a/packages/@n8n/workflow-sdk/src/types/base.ts
+++ b/packages/@n8n/workflow-sdk/src/types/base.ts
@@ -533,9 +533,12 @@ export interface NodeInstance<TType extends string, TVersion extends string, TOu
 	 * Create a terminal input target for connecting to a specific input index.
 	 * Use this to connect a node to a specific input of a multi-input node like Merge.
 	 *
+	 * Index is **0-based**: `.input(0)` is the FIRST input, `.input(1)` is the SECOND.
+	 *
 	 * @example
-	 * // Connect to input 1 of a merge node
-	 * nodeA.to(mergeNode.input(1))
+	 * // Wire two sources to a merge node — first source to input 0, second to input 1
+	 * sourceA.to(mergeNode.input(0)) // first input
+	 * sourceB.to(mergeNode.input(1)) // second input
 	 */
 	input(index: number): InputTarget;
 
@@ -543,9 +546,11 @@ export interface NodeInstance<TType extends string, TVersion extends string, TOu
 	 * Create an output selector for connecting from a specific output index.
 	 * Use this for multi-output nodes (like text classifiers) to connect from specific outputs.
 	 *
+	 * Index is **0-based**: `.output(0)` is the FIRST output, `.output(1)` is the SECOND.
+	 *
 	 * @example
-	 * // Connect from output 1 of a classifier
-	 * classifier.output(1).to(categoryB)
+	 * classifier.output(0).to(categoryA) // first output
+	 * classifier.output(1).to(categoryB) // second output
 	 */
 	output(index: number): OutputSelector<TType, TVersion, TOutput>;
 

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/node-builders/node-builder.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/node-builders/node-builder.ts
@@ -233,6 +233,8 @@ class NodeInstanceImpl<TType extends string, TVersion extends string, TOutput = 
 	/**
 	 * Create a terminal input target for connecting to a specific input index.
 	 * Use this to connect a node to a specific input of a multi-input node like Merge.
+	 *
+	 * Index is **0-based**: `.input(0)` is the FIRST input, `.input(1)` is the SECOND.
 	 */
 	input(index: number): InputTarget {
 		return {
@@ -245,6 +247,8 @@ class NodeInstanceImpl<TType extends string, TVersion extends string, TOutput = 
 	/**
 	 * Create an output selector for connecting from a specific output index.
 	 * Use this for multi-output nodes (like text classifiers) to connect from specific outputs.
+	 *
+	 * Index is **0-based**: `.output(0)` is the FIRST output, `.output(1)` is the SECOND.
 	 */
 	output(index: number): OutputSelector<TType, TVersion, TOutput> {
 		return new OutputSelectorImpl(this, index) as unknown as OutputSelector<
@@ -881,14 +885,18 @@ export interface MergeFactoryConfig {
  * Create a Merge node for combining data from multiple branches.
  * Use .input(n) method to connect sources to specific input indices.
  *
+ * Input indices are **0-based**: `.input(0)` is the FIRST input, `.input(1)` is
+ * the SECOND. When wiring N sources, use indices `0, 1, ..., N-1` — never start
+ * at 1.
+ *
  * @param input - Config with version (required) and config object
  * @returns A Merge NodeInstance with .input(n) method for branch connections
  *
  * @example
  * ```typescript
  * const mergeNode = merge({ version: 3, config: { name: 'Combine Data' } });
- * source1.to(mergeNode.input(0));
- * source2.to(mergeNode.input(1));
+ * source1.to(mergeNode.input(0)); // first input
+ * source2.to(mergeNode.input(1)); // second input
  * mergeNode.to(downstream);
  * ```
  */


### PR DESCRIPTION
## Summary

The AI workflow builder occasionally generates workflows where parallel branches are wired to a Merge node starting at `.input(1)` instead of `.input(0)`, silently dropping the first branch. The root cause is ambiguous documentation — `.input(1)` reads naturally as "the first input" if you don't know it's 0-based.

This PR clarifies 0-based semantics everywhere the LLM sees indices:

- **JSDoc** on `NodeInstance.input(n)` / `.output(n)` and the `merge()` factory: explicit "0-based: `.input(0)` is the FIRST input" note, with corrected examples (`sourceA.to(merge.input(0))` rather than `nodeA.to(mergeNode.input(1))`).
- **SDK reference prompts** (`workflow-patterns.ts`, `workflow-patterns-detailed.ts`, `additional-functions.ts`, and the parallel copy in `ai-workflow-builder.ee`): annotate every `.input(n)` example with `// first input (index 0)` / `// second input (index 1)` so the pattern the model copies is unambiguous.
- **`workflow-rules.ts`**: new rule #5 stating the convention explicitly, with a wrong/right counter-example showing the exact off-by-one shape we're trying to prevent.

No runtime behaviour change — all edits are documentation/prompt strings.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5162

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [x] I have seen this code, I have run this code, and I take responsibility for this code.