### PR TITLE
fix(Extract from File Node): Correct typo in binaryToProperty operation value

### DIFF
--- a/packages/nodes-base/nodes/Files/ExtractFromFile/ExtractFromFile.node.ts
+++ b/packages/nodes-base/nodes/Files/ExtractFromFile/ExtractFromFile.node.ts
@@ -101,7 +101,7 @@ export class ExtractFromFile implements INodeType {
 					},
 					{
 						name: 'Move File to Base64 String',
-						value: 'binaryToPropery',
+						value: 'binaryToProperty',
 						action: 'Move file to base64 string',
 						description: 'Convert a file into a base64-encoded string',
 					},
@@ -126,7 +126,8 @@ export class ExtractFromFile implements INodeType {
 			});
 		}
 
-		if (['binaryToPropery', 'fromJson', 'text', 'fromIcs', 'xml'].includes(operation)) {
+		// 'binaryToPropery' is the legacy misspelling kept for backward compatibility with persisted workflows
+		if (['binaryToProperty', 'binaryToPropery', 'fromJson', 'text', 'fromIcs', 'xml'].includes(operation)) {
 			returnData = await moveTo.execute.call(this, items, operation);
 		}
 

--- a/packages/nodes-base/nodes/Files/ExtractFromFile/actions/moveTo.operation.ts
+++ b/packages/nodes-base/nodes/Files/ExtractFromFile/actions/moveTo.operation.ts
@@ -96,7 +96,8 @@ export const properties: INodeProperties[] = [
 
 const displayOptions = {
 	show: {
-		operation: ['binaryToPropery', 'fromJson', 'text', 'fromIcs', 'xml'],
+		// 'binaryToPropery' is the legacy misspelling kept for backward compatibility with persisted workflows
+		operation: ['binaryToProperty', 'binaryToPropery', 'fromJson', 'text', 'fromIcs', 'xml'],
 	},
 };
 
@@ -135,7 +136,7 @@ export async function execute(
 			}
 
 			let convertedValue: string | IDataObject;
-			if (operation !== 'binaryToPropery') {
+			if (operation !== 'binaryToProperty' && operation !== 'binaryToPropery') {
 				convertedValue = iconv.decode(buffer, encoding, {
 					stripBOM: options.stripBOM as boolean,
 				});


### PR DESCRIPTION
## Summary

Fixes a typo in the `ExtractFromFile` node where the operation value `'binaryToPropery'` was missing the letter `t` — it should be `'binaryToProperty'`.

**Changes:**
- `ExtractFromFile.node.ts`: Fixed typo in the `options` array value and the `includes()` check
- `moveTo.operation.ts`: Fixed typo in the `displayOptions` show condition and the `!==` guard

**How to test:**
1. Open a workflow and add the **Extract from File** node
2. Select the **Move File to Base64 String** operation
3. Run the node with a binary input — it should execute without errors

## Related Linear tickets, Github issues, and Community forum posts

<!-- No Linear ticket for this minor typo fix -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

---
🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)