### PR TITLE
ci: Ignore .md & .mdx files on check-pr-size

### DIFF
--- a/.github/scripts/quality/check-pr-size.mjs
+++ b/.github/scripts/quality/check-pr-size.mjs
@@ -40,6 +40,8 @@ export const EXCLUDE_PATTERNS = [
 	'packages/testing/**',
 	// Lock file (can produce massive diffs on dependency changes)
 	'pnpm-lock.yaml',
+	'**/*.md',
+	'**/*.mdx'
 ];
 
 const BOT_MARKER = '<!-- pr-size-check -->';

--- a/.github/scripts/quality/check-pr-size.test.mjs
+++ b/.github/scripts/quality/check-pr-size.test.mjs
@@ -203,4 +203,13 @@ describe('countFilteredAdditions', () => {
 		];
 		assert.equal(countFilteredAdditions(files, EXCLUDE_PATTERNS), 50);
 	});
+
+	it('applies EXCLUDE_PATTERNS to markdown files', () => {
+		const files = [
+			{ filename: 'packages/cli/src/service.ts', additions: 50 },
+			{ filename: 'packages/cli/AGENTS.md', additions: 100 },
+			{ filename: 'packages/frontend/STORIES.mdx', additions: 100 },
+		];
+		assert.equal(countFilteredAdditions(files, EXCLUDE_PATTERNS), 50);
+	});
 });


### PR DESCRIPTION
## Summary

Ignore markdown files in check-pr-size checks. Usually these are agent skills or documentation for the design system that won't break anything and can rack up lines quite easily.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
