### PR TITLE
feat(core): Dynamic 'one year' preset based on date range of data

### DIFF
--- a/packages/@n8n/api-types/src/frontend-settings.ts
+++ b/packages/@n8n/api-types/src/frontend-settings.ts
@@ -263,6 +263,9 @@ export type FrontendModuleSettings = {
 		summary: boolean;
 		dashboard: boolean;
 		dateRanges: InsightsDateRange[];
+		insightsPresetAvailability?: {
+			oneYearRange: boolean;
+		};
 	};
 
 	/**

--- a/packages/cli/src/modules/insights/__tests__/insights-data-availability.util.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-data-availability.util.test.ts
@@ -1,0 +1,35 @@
+import { DateTime } from 'luxon';
+
+import { keyRangeToDays } from '../insights.constants';
+import { buildInsightsPresetAvailability } from '../insights-data-availability.util';
+
+describe('buildInsightsPresetAvailability', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+		jest.setSystemTime(new Date('2026-05-04T12:00:00Z'));
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('returns oneYearRange true when oldest is null', () => {
+		expect(buildInsightsPresetAvailability(null)).toEqual({ oneYearRange: true });
+	});
+
+	it('oneYearRange false when oldest is one day after the 365-day threshold', () => {
+		const threshold = DateTime.utc().startOf('day').minus({ days: keyRangeToDays.year });
+		const oldest = threshold.plus({ days: 1 }).toJSDate();
+		expect(buildInsightsPresetAvailability(oldest)).toEqual({ oneYearRange: false });
+	});
+
+	it('oneYearRange true when oldest is exactly on the 365-day threshold', () => {
+		const oldest = DateTime.utc().startOf('day').minus({ days: keyRangeToDays.year }).toJSDate();
+		expect(buildInsightsPresetAvailability(oldest)).toEqual({ oneYearRange: true });
+	});
+
+	it('oneYearRange false when data spans less than a year', () => {
+		const oldest = DateTime.utc().startOf('day').minus({ days: 100 }).toJSDate();
+		expect(buildInsightsPresetAvailability(oldest)).toEqual({ oneYearRange: false });
+	});
+});

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -408,6 +408,23 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 		return aggregatedInsightsByTimeParser.parse(rawRows);
 	}
 
+	async getOldestPeriodStart(): Promise<Date | null> {
+		const result = await this.createQueryBuilder('insights')
+			.select('MIN(insights.periodStart)', 'oldest')
+			.getRawOne<{ oldest: Date | string | null }>();
+
+		if (result?.oldest === null || result?.oldest === undefined) {
+			return null;
+		}
+
+		const oldest =
+			result.oldest instanceof Date
+				? result.oldest
+				: new Date(result.oldest.replace(' ', 'T') + 'Z');
+
+		return Number.isNaN(oldest.getTime()) ? null : oldest;
+	}
+
 	async pruneOldData(maxAgeInDays: number): Promise<{ affected: number | null | undefined }> {
 		const thresholdDate = DateTime.now().minus({ days: maxAgeInDays }).startOf('day').toJSDate();
 		const result = await this.delete({

--- a/packages/cli/src/modules/insights/insights-data-availability.util.ts
+++ b/packages/cli/src/modules/insights/insights-data-availability.util.ts
@@ -1,0 +1,22 @@
+import { DateTime } from 'luxon';
+
+import { keyRangeToDays } from './insights.constants';
+
+export type InsightsPresetAvailabilityPayload = {
+	oneYearRange: boolean;
+};
+
+export function buildInsightsPresetAvailability(
+	oldestPeriodStart: Date | null,
+): InsightsPresetAvailabilityPayload {
+	if (!oldestPeriodStart) {
+		return { oneYearRange: true };
+	}
+
+	const today = DateTime.utc().startOf('day');
+	const oldest = DateTime.fromJSDate(oldestPeriodStart, { zone: 'utc' }).startOf('day');
+
+	return {
+		oneYearRange: oldest <= today.minus({ days: keyRangeToDays.year }),
+	};
+}

--- a/packages/cli/src/modules/insights/insights.module.ts
+++ b/packages/cli/src/modules/insights/insights.module.ts
@@ -1,6 +1,7 @@
 import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule, OnShutdown } from '@n8n/decorators';
 import { Container } from '@n8n/di';
+import { InstanceSettings } from 'n8n-core';
 
 /**
  * Only main- and webhook-type instances collect insights because
@@ -25,8 +26,23 @@ export class InsightsModule implements ModuleInterface {
 
 	async settings() {
 		const { InsightsSettings } = await import('./insights.settings');
+		const { InsightsByPeriodRepository } = await import(
+			'./database/repositories/insights-by-period.repository'
+		);
+		const { buildInsightsPresetAvailability } = await import('./insights-data-availability.util');
 
-		return Container.get(InsightsSettings).settings();
+		const base = Container.get(InsightsSettings).settings();
+		const instanceType = Container.get(InstanceSettings).instanceType;
+
+		const oldestPeriodStart =
+			instanceType === 'worker'
+				? null
+				: await Container.get(InsightsByPeriodRepository).getOldestPeriodStart();
+
+		return {
+			...base,
+			insightsPresetAvailability: buildInsightsPresetAvailability(oldestPeriodStart),
+		};
 	}
 
 	@OnShutdown()

--- a/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.test.ts
@@ -13,12 +13,14 @@ import {
 } from '@/__tests__/utils';
 import { within, screen, waitFor } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
+import { useSettingsStore } from '@/app/stores/settings.store';
 import { createProjectListItem } from '@/features/collaboration/projects/__tests__/utils';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import type {
 	FrontendModuleSettings,
 	InsightsByTime,
 	InsightsByWorkflow,
+	InsightsDateRange,
 	InsightsSummaryType,
 } from '@n8n/api-types';
 import { INSIGHT_TYPES } from '@/features/execution/insights/insights.constants';
@@ -81,6 +83,9 @@ const moduleSettings: FrontendModuleSettings = {
 	insights: {
 		summary: true,
 		dashboard: true,
+		insightsPresetAvailability: {
+			oneYearRange: true,
+		},
 		dateRanges: [
 			{
 				key: 'day',
@@ -104,6 +109,24 @@ const moduleSettings: FrontendModuleSettings = {
 			},
 		],
 	},
+};
+
+const fullLicensedDateRanges: InsightsDateRange[] = [
+	{ key: 'day', licensed: true, granularity: 'hour' },
+	{ key: 'week', licensed: true, granularity: 'day' },
+	{ key: '2weeks', licensed: true, granularity: 'day' },
+	{ key: 'month', licensed: true, granularity: 'day' },
+	{ key: 'quarter', licensed: true, granularity: 'week' },
+	{ key: '6months', licensed: true, granularity: 'week' },
+	{ key: 'year', licensed: true, granularity: 'week' },
+];
+
+const setInsightsModuleSettings = (insights: FrontendModuleSettings['insights']) => {
+	const settingsStore = useSettingsStore();
+	settingsStore.moduleSettings = {
+		...settingsStore.moduleSettings,
+		insights,
+	};
 };
 
 const mockSummaryData: InsightsSummaryDisplay = [
@@ -464,6 +487,46 @@ describe('InsightsDashboard', () => {
 					...expectedRange,
 				},
 			});
+		});
+	});
+
+	describe('Insights date preset availability', () => {
+		it('shows all presets including one year when oneYearRange is true', async () => {
+			setInsightsModuleSettings({
+				summary: true,
+				dashboard: true,
+				dateRanges: fullLicensedDateRanges,
+				insightsPresetAvailability: { oneYearRange: true },
+			});
+
+			const { getByRole } = renderComponent({
+				props: { insightType: INSIGHT_TYPES.TOTAL },
+			});
+
+			const picker = await openDatePicker(getByRole);
+
+			expect(within(picker).getByText('One year')).toBeInTheDocument();
+			expect(within(picker).getByText('6 months')).toBeInTheDocument();
+			expect(within(picker).getByText('Last 30 days')).toBeInTheDocument();
+		});
+
+		it('hides one year only when oneYearRange is false; six months stays visible', async () => {
+			setInsightsModuleSettings({
+				summary: true,
+				dashboard: true,
+				dateRanges: fullLicensedDateRanges,
+				insightsPresetAvailability: { oneYearRange: false },
+			});
+
+			const { getByRole } = renderComponent({
+				props: { insightType: INSIGHT_TYPES.TOTAL },
+			});
+
+			const picker = await openDatePicker(getByRole);
+
+			expect(within(picker).getByText('Last 30 days')).toBeInTheDocument();
+			expect(within(picker).getByText('6 months')).toBeInTheDocument();
+			expect(within(picker).queryByText('One year')).not.toBeInTheDocument();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.vue
+++ b/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.vue
@@ -21,6 +21,7 @@ import {
 	watch,
 } from 'vue';
 import { useRoute } from 'vue-router';
+import { useSettingsStore } from '@/app/stores/settings.store';
 import { INSIGHT_TYPES } from '../insights.constants';
 import { getAdjustedDateRange, getTimeRangeLabels, timeRangeMappings } from '../insights.utils';
 import InsightsDataRangePicker from './InsightsDataRangePicker.vue';
@@ -60,6 +61,7 @@ const props = defineProps<{
 
 const route = useRoute();
 const i18n = useI18n();
+const settingsStore = useSettingsStore();
 
 const insightsStore = useInsightsStore();
 const projectsStore = useProjectsStore();
@@ -99,15 +101,19 @@ const maxLicensedDate =
 	insightsStore.dateRanges.toReversed().find((dateRange) => dateRange.licensed)?.key ?? 'week';
 
 const timeRangeLabels = getTimeRangeLabels();
-const presets = computed(() =>
-	insightsStore.dateRanges.map((item) => {
-		return {
+
+const presets = computed(() => {
+	const hasOneYearPreset =
+		settingsStore.moduleSettings.insights?.insightsPresetAvailability?.oneYearRange ?? true;
+
+	return insightsStore.dateRanges
+		.filter((item) => item.key !== 'year' || hasOneYearPreset)
+		.map((item) => ({
 			value: timeRangeMappings[item.key],
 			label: timeRangeLabels[item.key],
 			disabled: !item.licensed,
-		};
-	}),
-);
+		}));
+});
 
 const maximumValue = shallowRef(maxDate.copy());
 const minimumValue = shallowRef(


### PR DESCRIPTION
## Summary
- Adds `insightsPresetAvailability` in insights module settings (`oneYearRange`) so the editor can hide the **One year** date preset when `insights_by_period` data does not reach a full year of data
- Insights dashboard presets: hide **One year** when `oneYearRange` is `false`;
- Worker instances skip querying period metadata and use the same “no oldest row” path so `settings()` does not touch TypeORM entities that are not loaded there.

**How to test**
1. Instance with **&lt; 365 days** of compacted insights: open **Insights**, open the date range picker → **One year** should not appear (others unchanged).
2. Instance with **≥ 365 days** of history (or edge aligned with `keyRangeToDays.year`): **One year** should appear.
3. Optional: after pruning old periods, reload or refetch module settings and confirm the preset list updates if data span drops below a year.
## Related Linear tickets, Github issues, and Community forum posts
- https://linear.app/n8n/issue/LIGO-498


## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
