### PR TITLE
refactor(API): Use PublicAPIEndpoint type in all public API handlers (no-changelog)

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/audit/audit.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/audit/audit.handler.ts
@@ -13,17 +13,13 @@ const auditHandlers: AuditHandlers = {
 	generateAudit: [
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'securityAudit:generate' }),
 		async (req, res) => {
-			try {
-				const { SecurityAuditService } = await import('@/security-audit/security-audit.service');
-				const result = await Container.get(SecurityAuditService).run(
-					req.body?.additionalOptions?.categories,
-					req.body?.additionalOptions?.daysAbandonedWorkflow,
-				);
+			const { SecurityAuditService } = await import('@/security-audit/security-audit.service');
+			const result = await Container.get(SecurityAuditService).run(
+				req.body?.additionalOptions?.categories,
+				req.body?.additionalOptions?.daysAbandonedWorkflow,
+			);
 
-				return res.json(result);
-			} catch (error) {
-				return res.status(500).json(error);
-			}
+			return res.json(result);
 		},
 	],
 };

--- a/packages/cli/src/public-api/v1/handlers/audit/audit.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/audit/audit.handler.ts
@@ -1,14 +1,18 @@
 import { Container } from '@n8n/di';
-import type { Response } from 'express';
 
 import type { AuditRequest } from '@/public-api/types';
 
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
 import { apiKeyHasScopeWithGlobalScopeFallback } from '../../shared/middlewares/global.middleware';
 
-export = {
+type AuditHandlers = {
+	generateAudit: PublicAPIEndpoint<AuditRequest.Generate>;
+};
+
+const auditHandlers: AuditHandlers = {
 	generateAudit: [
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'securityAudit:generate' }),
-		async (req: AuditRequest.Generate, res: Response): Promise<Response> => {
+		async (req, res) => {
 			try {
 				const { SecurityAuditService } = await import('@/security-audit/security-audit.service');
 				const result = await Container.get(SecurityAuditService).run(
@@ -23,3 +27,5 @@ export = {
 		},
 	],
 };
+
+export = auditHandlers;

--- a/packages/cli/src/public-api/v1/handlers/community-packages/__tests__/community-packages.handler.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/__tests__/community-packages.handler.test.ts
@@ -1,15 +1,16 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import { Container } from '@n8n/di';
 import type { Response } from 'express';
+import { mock } from 'jest-mock-extended';
 
 import { RESPONSE_ERROR_MESSAGES } from '@/constants';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
-import type { InstalledPackages } from '@/modules/community-packages/installed-packages.entity';
 import { CommunityPackagesLifecycleService } from '@/modules/community-packages/community-packages.lifecycle.service';
+import type { InstalledPackages } from '@/modules/community-packages/installed-packages.entity';
 import * as middlewares from '@/public-api/v1/shared/middlewares/global.middleware';
+
 import { mapToCommunityPackage, mapToCommunityPackageList } from '../community-packages.mapper';
-import { mock } from 'jest-mock-extended';
 
 const mockMiddleware = jest.fn(async (_req: unknown, _res: unknown, next: unknown) =>
 	(next as () => void)(),
@@ -85,7 +86,7 @@ describe('CommunityPackages Handler', () => {
 			);
 		});
 
-		it('should return 400 when name is missing', async () => {
+		it('should throw BadRequestError when name is missing', async () => {
 			const req = {
 				body: {},
 				user: mockUser,
@@ -95,12 +96,21 @@ describe('CommunityPackages Handler', () => {
 				new BadRequestError(RESPONSE_ERROR_MESSAGES.PACKAGE_NAME_NOT_PROVIDED),
 			);
 
-			await handler.installPackage[handler.installPackage.length - 1](req, mockResponse);
-
-			expect(mockResponse.status).toHaveBeenCalledWith(400);
+			const handlerFn = handler.installPackage[handler.installPackage.length - 1];
+			let caught: unknown;
+			try {
+				await handlerFn(req, mockResponse);
+			} catch (error) {
+				caught = error;
+			}
+			expect(caught).toBeInstanceOf(BadRequestError);
+			expect(caught).toMatchObject({
+				message: RESPONSE_ERROR_MESSAGES.PACKAGE_NAME_NOT_PROVIDED,
+				httpStatusCode: 400,
+			});
 		});
 
-		it('should return 400 when package is already installed', async () => {
+		it('should throw BadRequestError when package is already installed', async () => {
 			const req = {
 				body: { name: 'n8n-nodes-test' },
 				user: mockUser,
@@ -110,9 +120,18 @@ describe('CommunityPackages Handler', () => {
 				new BadRequestError('Package "n8n-nodes-test" is already installed'),
 			);
 
-			await handler.installPackage[handler.installPackage.length - 1](req, mockResponse);
-
-			expect(mockResponse.status).toHaveBeenCalledWith(400);
+			const handlerFn = handler.installPackage[handler.installPackage.length - 1];
+			let caught: unknown;
+			try {
+				await handlerFn(req, mockResponse);
+			} catch (error) {
+				caught = error;
+			}
+			expect(caught).toBeInstanceOf(BadRequestError);
+			expect(caught).toMatchObject({
+				message: 'Package "n8n-nodes-test" is already installed',
+				httpStatusCode: 400,
+			});
 		});
 	});
 
@@ -171,7 +190,7 @@ describe('CommunityPackages Handler', () => {
 			expect(mockResponse.json).toHaveBeenCalledWith(mapToCommunityPackage(updatedPackage));
 		});
 
-		it('should return 404 when package is not installed', async () => {
+		it('should throw NotFoundError when package is not installed', async () => {
 			const req = {
 				params: { name: 'n8n-nodes-missing' },
 				body: {},
@@ -182,9 +201,18 @@ describe('CommunityPackages Handler', () => {
 				new NotFoundError(RESPONSE_ERROR_MESSAGES.PACKAGE_NOT_INSTALLED),
 			);
 
-			await handler.updatePackage[handler.updatePackage.length - 1](req, mockResponse);
-
-			expect(mockResponse.status).toHaveBeenCalledWith(404);
+			const handlerFn = handler.updatePackage[handler.updatePackage.length - 1];
+			let caught: unknown;
+			try {
+				await handlerFn(req, mockResponse);
+			} catch (error) {
+				caught = error;
+			}
+			expect(caught).toBeInstanceOf(NotFoundError);
+			expect(caught).toMatchObject({
+				message: RESPONSE_ERROR_MESSAGES.PACKAGE_NOT_INSTALLED,
+				httpStatusCode: 404,
+			});
 		});
 	});
 
@@ -203,7 +231,7 @@ describe('CommunityPackages Handler', () => {
 			expect(mockResponse.status).toHaveBeenCalledWith(204);
 		});
 
-		it('should return 404 when package is not installed', async () => {
+		it('should throw NotFoundError when package is not installed', async () => {
 			const req = {
 				params: { name: 'n8n-nodes-missing' },
 				user: mockUser,
@@ -213,9 +241,18 @@ describe('CommunityPackages Handler', () => {
 				new NotFoundError(RESPONSE_ERROR_MESSAGES.PACKAGE_NOT_INSTALLED),
 			);
 
-			await handler.uninstallPackage[handler.uninstallPackage.length - 1](req, mockResponse);
-
-			expect(mockResponse.status).toHaveBeenCalledWith(404);
+			const handlerFn = handler.uninstallPackage[handler.uninstallPackage.length - 1];
+			let caught: unknown;
+			try {
+				await handlerFn(req, mockResponse);
+			} catch (error) {
+				caught = error;
+			}
+			expect(caught).toBeInstanceOf(NotFoundError);
+			expect(caught).toMatchObject({
+				message: RESPONSE_ERROR_MESSAGES.PACKAGE_NOT_INSTALLED,
+				httpStatusCode: 404,
+			});
 		});
 	});
 });

--- a/packages/cli/src/public-api/v1/handlers/community-packages/community-packages.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/community-packages.handler.ts
@@ -1,17 +1,11 @@
 import type { AuthenticatedRequest } from '@n8n/db';
 import { Container } from '@n8n/di';
-import type { Response } from 'express';
 
-import { ResponseError } from '@/errors/response-errors/abstract/response.error';
 import { CommunityPackagesLifecycleService } from '@/modules/community-packages/community-packages.lifecycle.service';
 
 import { mapToCommunityPackage, mapToCommunityPackageList } from './community-packages.mapper';
 import type { PublicAPIEndpoint } from '../../shared/handler.types';
 import { publicApiScope } from '../../shared/middlewares/global.middleware';
-
-function sendResponseError(res: Response, error: ResponseError): Response {
-	return res.status(error.httpStatusCode).json({ message: error.message });
-}
 
 type InstallPackageRequest = AuthenticatedRequest<
 	{},
@@ -38,19 +32,13 @@ const communityPackageHandlers: CommunityPackageHandlers = {
 		async (req, res) => {
 			const lifecycle = Container.get(CommunityPackagesLifecycleService);
 
-			try {
-				const installedPackage = await lifecycle.install(
-					{ name: req.body.name, version: req.body.version, verify: req.body.verify ?? true },
-					req.user,
-					'publicApi',
-				);
-				return res.json(mapToCommunityPackage(installedPackage));
-			} catch (error) {
-				if (error instanceof ResponseError) {
-					return sendResponseError(res, error);
-				}
-				throw error;
-			}
+			const installedPackage = await lifecycle.install(
+				{ name: req.body.name, version: req.body.version, verify: req.body.verify ?? true },
+				req.user,
+				'publicApi',
+			);
+
+			return res.json(mapToCommunityPackage(installedPackage));
 		},
 	],
 
@@ -68,23 +56,16 @@ const communityPackageHandlers: CommunityPackageHandlers = {
 		async (req, res) => {
 			const lifecycle = Container.get(CommunityPackagesLifecycleService);
 
-			try {
-				const updated = await lifecycle.update(
-					{
-						name: req.params.name,
-						version: req.body?.version,
-						verify: req.body?.verify ?? true,
-					},
-					req.user,
-					'notFound',
-				);
-				return res.json(mapToCommunityPackage(updated));
-			} catch (error) {
-				if (error instanceof ResponseError) {
-					return sendResponseError(res, error);
-				}
-				throw error;
-			}
+			const updated = await lifecycle.update(
+				{
+					name: req.params.name,
+					version: req.body?.version,
+					verify: req.body?.verify ?? true,
+				},
+				req.user,
+				'notFound',
+			);
+			return res.json(mapToCommunityPackage(updated));
 		},
 	],
 
@@ -93,15 +74,8 @@ const communityPackageHandlers: CommunityPackageHandlers = {
 		async (req, res) => {
 			const lifecycle = Container.get(CommunityPackagesLifecycleService);
 
-			try {
-				await lifecycle.uninstall(req.params.name, req.user, 'notFound');
-				return res.status(204).send();
-			} catch (error) {
-				if (error instanceof ResponseError) {
-					return sendResponseError(res, error);
-				}
-				throw error;
-			}
+			await lifecycle.uninstall(req.params.name, req.user, 'notFound');
+			return res.status(204).send();
 		},
 	],
 };

--- a/packages/cli/src/public-api/v1/handlers/community-packages/community-packages.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/community-packages.handler.ts
@@ -1,28 +1,41 @@
 import type { AuthenticatedRequest } from '@n8n/db';
 import { Container } from '@n8n/di';
-import type express from 'express';
+import type { Response } from 'express';
 
 import { ResponseError } from '@/errors/response-errors/abstract/response.error';
 import { CommunityPackagesLifecycleService } from '@/modules/community-packages/community-packages.lifecycle.service';
 
 import { mapToCommunityPackage, mapToCommunityPackageList } from './community-packages.mapper';
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
 import { publicApiScope } from '../../shared/middlewares/global.middleware';
 
-function sendResponseError(res: express.Response, error: ResponseError): express.Response {
+function sendResponseError(res: Response, error: ResponseError): Response {
 	return res.status(error.httpStatusCode).json({ message: error.message });
 }
 
-export = {
+type InstallPackageRequest = AuthenticatedRequest<
+	{},
+	{},
+	{ name: string; version?: string; verify?: boolean }
+>;
+
+type UpdatePackageRequest = AuthenticatedRequest<
+	{ name: string },
+	{},
+	{ version?: string; verify?: boolean }
+>;
+
+type CommunityPackageHandlers = {
+	installPackage: PublicAPIEndpoint<InstallPackageRequest>;
+	getInstalledPackages: PublicAPIEndpoint<AuthenticatedRequest>;
+	updatePackage: PublicAPIEndpoint<UpdatePackageRequest>;
+	uninstallPackage: PublicAPIEndpoint<AuthenticatedRequest<{ name: string }>>;
+};
+
+const communityPackageHandlers: CommunityPackageHandlers = {
 	installPackage: [
 		publicApiScope('communityPackage:install'),
-		async (
-			req: AuthenticatedRequest<
-				Record<string, never>,
-				unknown,
-				{ name: string; version?: string; verify?: boolean }
-			>,
-			res: express.Response,
-		): Promise<express.Response> => {
+		async (req, res) => {
 			const lifecycle = Container.get(CommunityPackagesLifecycleService);
 
 			try {
@@ -43,10 +56,7 @@ export = {
 
 	getInstalledPackages: [
 		publicApiScope('communityPackage:list'),
-		async (
-			_req: AuthenticatedRequest<Record<string, never>>,
-			res: express.Response,
-		): Promise<express.Response> => {
+		async (_req, res) => {
 			const lifecycle = Container.get(CommunityPackagesLifecycleService);
 			const packages = await lifecycle.listInstalledPackages();
 			return res.json(mapToCommunityPackageList(packages));
@@ -55,14 +65,7 @@ export = {
 
 	updatePackage: [
 		publicApiScope('communityPackage:update'),
-		async (
-			req: AuthenticatedRequest<
-				{ name: string },
-				Record<string, never>,
-				{ version?: string; verify?: boolean }
-			>,
-			res: express.Response,
-		): Promise<express.Response> => {
+		async (req, res) => {
 			const lifecycle = Container.get(CommunityPackagesLifecycleService);
 
 			try {
@@ -87,10 +90,7 @@ export = {
 
 	uninstallPackage: [
 		publicApiScope('communityPackage:uninstall'),
-		async (
-			req: AuthenticatedRequest<{ name: string }>,
-			res: express.Response,
-		): Promise<express.Response> => {
+		async (req, res) => {
 			const lifecycle = Container.get(CommunityPackagesLifecycleService);
 
 			try {
@@ -105,3 +105,5 @@ export = {
 		},
 	],
 };
+
+export = communityPackageHandlers;

--- a/packages/cli/src/public-api/v1/handlers/credentials/credentials.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/credentials.handler.ts
@@ -1,11 +1,8 @@
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import { LicenseState } from '@n8n/backend-common';
-import type { PublicApiCredentialResponse } from '@n8n/api-types';
 import type { CredentialsEntity } from '@n8n/db';
 import { CredentialsRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { hasGlobalScope } from '@n8n/permissions';
-import type express from 'express';
 import { z } from 'zod';
 
 import { CredentialTypes } from '@/credential-types';
@@ -13,8 +10,11 @@ import { CredentialsService } from '@/credentials/credentials.service';
 import { EnterpriseCredentialsService } from '@/credentials/credentials.service.ee';
 import { CredentialsHelper } from '@/credentials-helper';
 import { CredentialNotFoundError } from '@/errors/credential-not-found.error';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
+import { toPublicApiCredentialResponse } from './credentials.mapper';
 import {
 	validCredentialsProperties,
 	validCredentialType,
@@ -32,8 +32,8 @@ import {
 	toJsonSchema,
 	updateCredential,
 } from './credentials.service';
-import { toPublicApiCredentialResponse } from './credentials.mapper';
 import type { CredentialTypeRequest, CredentialRequest } from '../../../types';
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
 import {
 	publicApiScope,
 	apiKeyHasScopeWithGlobalScopeFallback,
@@ -41,29 +41,23 @@ import {
 	validCursor,
 } from '../../shared/middlewares/global.middleware';
 import { encodeNextCursor } from '../../shared/services/pagination.service';
-import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
-import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 
-export = {
+type CredentialsHandlers = {
+	getCredentials: PublicAPIEndpoint<CredentialRequest.GetAll>;
+	getCredential: PublicAPIEndpoint<CredentialRequest.Get>;
+	testCredential: PublicAPIEndpoint<CredentialRequest.Test>;
+	createCredential: PublicAPIEndpoint<CredentialRequest.Create>;
+	updateCredential: PublicAPIEndpoint<CredentialRequest.Update>;
+	transferCredential: PublicAPIEndpoint<CredentialRequest.Transfer>;
+	deleteCredential: PublicAPIEndpoint<CredentialRequest.Delete>;
+	getCredentialType: PublicAPIEndpoint<CredentialTypeRequest.Get>;
+};
+
+const credentialsHandlers: CredentialsHandlers = {
 	getCredentials: [
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'credential:list' }),
 		validCursor,
-		async (
-			req: CredentialRequest.GetAll,
-			res: express.Response,
-		): Promise<
-			express.Response<{
-				data: Array<{
-					id: string;
-					name: string;
-					type: string;
-					createdAt: Date;
-					updatedAt: Date;
-					shared: ReturnType<typeof buildSharedForCredential>;
-				}>;
-				nextCursor: string | null;
-			}>
-		> => {
+		async (req, res) => {
 			const offset = Number(req.query.offset) || 0;
 			const limit = Math.min(Number(req.query.limit) || 100, 250);
 
@@ -101,10 +95,7 @@ export = {
 	getCredential: [
 		publicApiScope('credential:read'),
 		projectScope('credential:read', 'credential'),
-		async (
-			req: CredentialRequest.Get,
-			res: express.Response,
-		): Promise<express.Response<PublicApiCredentialResponse>> => {
+		async (req, res) => {
 			const { id: credentialId } = req.params;
 
 			const credential = await getCredential(credentialId);
@@ -118,12 +109,7 @@ export = {
 	testCredential: [
 		publicApiScope('credential:read'),
 		projectScope('credential:read', 'credential'),
-		async (
-			req: CredentialRequest.Test,
-			res: express.Response<{ status: 'OK' | 'Error'; message: string } | { message: string }>,
-		): Promise<
-			express.Response<{ status: 'OK' | 'Error'; message: string } | { message: string }>
-		> => {
+		async (req, res) => {
 			const { id: credentialId } = req.params;
 			try {
 				const credentialTestResult = await Container.get(CredentialsService).testById(
@@ -144,10 +130,7 @@ export = {
 		validCredentialType,
 		validCredentialsProperties,
 		publicApiScope('credential:create'),
-		async (
-			req: CredentialRequest.Create,
-			res: express.Response,
-		): Promise<express.Response<PublicApiCredentialResponse>> => {
+		async (req, res) => {
 			const savedCredential = await saveCredential(req.body, req.user);
 			return res.json(savedCredential);
 		},
@@ -157,10 +140,7 @@ export = {
 		validCredentialsPropertiesForUpdate,
 		publicApiScope('credential:update'),
 		projectScope('credential:update', 'credential'),
-		async (
-			req: CredentialRequest.Update,
-			res: express.Response,
-		): Promise<express.Response<PublicApiCredentialResponse>> => {
+		async (req, res) => {
 			const { id: credentialId } = req.params;
 
 			const existingCredential = await getCredential(credentialId);
@@ -197,7 +177,7 @@ export = {
 	transferCredential: [
 		publicApiScope('credential:move'),
 		projectScope('credential:move', 'credential'),
-		async (req: CredentialRequest.Transfer, res: express.Response) => {
+		async (req, res) => {
 			const body = z.object({ destinationProjectId: z.string() }).parse(req.body);
 
 			await Container.get(EnterpriseCredentialsService).transferOne(
@@ -206,16 +186,13 @@ export = {
 				body.destinationProjectId,
 			);
 
-			res.status(204).send();
+			return res.status(204).send();
 		},
 	],
 	deleteCredential: [
 		publicApiScope('credential:delete'),
 		projectScope('credential:delete', 'credential'),
-		async (
-			req: CredentialRequest.Delete,
-			res: express.Response,
-		): Promise<express.Response<Partial<CredentialsEntity>>> => {
+		async (req, res) => {
 			const { id: credentialId } = req.params;
 			let credential: CredentialsEntity | undefined;
 
@@ -239,7 +216,7 @@ export = {
 	],
 
 	getCredentialType: [
-		async (req: CredentialTypeRequest.Get, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const { credentialTypeName } = req.params;
 
 			try {
@@ -256,3 +233,5 @@ export = {
 		},
 	],
 };
+
+export = credentialsHandlers;

--- a/packages/cli/src/public-api/v1/handlers/data-tables/__tests__/data-tables.handler.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/__tests__/data-tables.handler.test.ts
@@ -3,6 +3,8 @@ import { ProjectRelationRepository, ProjectRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import type { Response } from 'express';
 
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { DataTableRepository } from '@/modules/data-table/data-table.repository';
 import { DataTableService } from '@/modules/data-table/data-table.service';
 import { DataTableNotFoundError } from '@/modules/data-table/errors/data-table-not-found.error';
@@ -187,7 +189,7 @@ describe('DataTable Handler', () => {
 			);
 		});
 
-		it('should return 404 when data table not found', async () => {
+		it('should throw NotFoundError when data table not found', async () => {
 			// Arrange
 			const req = {
 				params: { dataTableId },
@@ -200,16 +202,23 @@ describe('DataTable Handler', () => {
 			);
 
 			// Act
-			await handler.getDataTableRows[3](req, mockResponse as Response);
+			const handlerFn = handler.getDataTableRows[3];
+			let caught: unknown;
+			try {
+				await handlerFn(req, mockResponse as Response);
+			} catch (error) {
+				caught = error;
+			}
 
 			// Assert
-			expect(mockResponse.status).toHaveBeenCalledWith(404);
-			expect(mockResponse.json).toHaveBeenCalledWith({
+			expect(caught).toBeInstanceOf(NotFoundError);
+			expect(caught).toMatchObject({
 				message: expect.stringContaining(dataTableId),
+				httpStatusCode: 404,
 			});
 		});
 
-		it('should return 400 for validation errors', async () => {
+		it('should throw BadRequestError for validation errors', async () => {
 			// Arrange
 			const req = {
 				params: { dataTableId },
@@ -218,12 +227,19 @@ describe('DataTable Handler', () => {
 			} as unknown as DataTableRequest.GetRows;
 
 			// Act
-			await handler.getDataTableRows[3](req, mockResponse as Response);
+			const handlerFn = handler.getDataTableRows[3];
+			let caught: unknown;
+			try {
+				await handlerFn(req, mockResponse as Response);
+			} catch (error) {
+				caught = error;
+			}
 
 			// Assert
-			expect(mockResponse.status).toHaveBeenCalledWith(400);
-			expect(mockResponse.json).toHaveBeenCalledWith({
+			expect(caught).toBeInstanceOf(BadRequestError);
+			expect(caught).toMatchObject({
 				message: expect.stringContaining('Invalid'),
+				httpStatusCode: 400,
 			});
 		});
 	});
@@ -302,7 +318,7 @@ describe('DataTable Handler', () => {
 			expect(mockResponse.json).toHaveBeenCalledWith([mockRow]);
 		});
 
-		it('should return 404 when data table not found', async () => {
+		it('should throw NotFoundError when data table not found', async () => {
 			// Arrange
 			const req = {
 				params: { dataTableId },
@@ -315,10 +331,17 @@ describe('DataTable Handler', () => {
 			);
 
 			// Act
-			await handler.insertDataTableRows[2](req, mockResponse as Response);
+			const handlerFn = handler.insertDataTableRows[2];
+			let caught: unknown;
+			try {
+				await handlerFn(req, mockResponse as Response);
+			} catch (error) {
+				caught = error;
+			}
 
 			// Assert
-			expect(mockResponse.status).toHaveBeenCalledWith(404);
+			expect(caught).toBeInstanceOf(NotFoundError);
+			expect(caught).toMatchObject({ httpStatusCode: 404 });
 		});
 	});
 
@@ -544,7 +567,7 @@ describe('DataTable Handler', () => {
 			expect(mockResponse.json).toHaveBeenCalledWith([mockRow]);
 		});
 
-		it('should return 400 when filter is missing', async () => {
+		it('should throw BadRequestError when filter is missing', async () => {
 			// Arrange
 			const req = {
 				params: { dataTableId },
@@ -553,12 +576,19 @@ describe('DataTable Handler', () => {
 			} as unknown as DataTableRequest.DeleteRows;
 
 			// Act
-			await handler.deleteDataTableRows[2](req, mockResponse as Response);
+			const handlerFn = handler.deleteDataTableRows[2];
+			let caught: unknown;
+			try {
+				await handlerFn(req, mockResponse as Response);
+			} catch (error) {
+				caught = error;
+			}
 
 			// Assert
-			expect(mockResponse.status).toHaveBeenCalledWith(400);
-			expect(mockResponse.json).toHaveBeenCalledWith({
+			expect(caught).toBeInstanceOf(BadRequestError);
+			expect(caught).toMatchObject({
 				message: 'Required',
+				httpStatusCode: 400,
 			});
 		});
 
@@ -598,7 +628,7 @@ describe('DataTable Handler', () => {
 	describe('Security - Cross-Project Access', () => {
 		const otherUserDataTableId = 'other-user-data-table-id';
 
-		it('should return 404 when trying to get rows from another users data table', async () => {
+		it('should throw NotFoundError when trying to get rows from another users data table', async () => {
 			// Arrange
 			const req = {
 				params: { dataTableId: otherUserDataTableId },
@@ -617,19 +647,26 @@ describe('DataTable Handler', () => {
 			);
 
 			// Act
-			await handler.getDataTableRows[3](req, mockResponse as Response);
+			const handlerFn = handler.getDataTableRows[3];
+			let caught: unknown;
+			try {
+				await handlerFn(req, mockResponse as Response);
+			} catch (error) {
+				caught = error;
+			}
 
 			// Assert
 			expect(mockDataTableService.getProjectIdForDataTable).toHaveBeenCalledWith(
 				otherUserDataTableId,
 			);
-			expect(mockResponse.status).toHaveBeenCalledWith(404);
-			expect(mockResponse.json).toHaveBeenCalledWith({
+			expect(caught).toBeInstanceOf(NotFoundError);
+			expect(caught).toMatchObject({
 				message: expect.stringContaining(otherUserDataTableId),
+				httpStatusCode: 404,
 			});
 		});
 
-		it('should return 404 when trying to insert rows into another users data table', async () => {
+		it('should throw NotFoundError when trying to insert rows into another users data table', async () => {
 			// Arrange
 			const req = {
 				params: { dataTableId: otherUserDataTableId },
@@ -649,16 +686,23 @@ describe('DataTable Handler', () => {
 			);
 
 			// Act
-			await handler.insertDataTableRows[2](req, mockResponse as Response);
+			const handlerFn = handler.insertDataTableRows[2];
+			let caught: unknown;
+			try {
+				await handlerFn(req, mockResponse as Response);
+			} catch (error) {
+				caught = error;
+			}
 
 			// Assert
-			expect(mockResponse.status).toHaveBeenCalledWith(404);
-			expect(mockResponse.json).toHaveBeenCalledWith({
+			expect(caught).toBeInstanceOf(NotFoundError);
+			expect(caught).toMatchObject({
 				message: expect.stringContaining(otherUserDataTableId),
+				httpStatusCode: 404,
 			});
 		});
 
-		it('should return 404 when trying to update rows in another users data table', async () => {
+		it('should throw NotFoundError when trying to update rows in another users data table', async () => {
 			// Arrange
 			const req = {
 				params: { dataTableId: otherUserDataTableId },
@@ -680,16 +724,23 @@ describe('DataTable Handler', () => {
 			);
 
 			// Act
-			await handler.updateDataTableRows[2](req, mockResponse as Response);
+			const handlerFn = handler.updateDataTableRows[2];
+			let caught: unknown;
+			try {
+				await handlerFn(req, mockResponse as Response);
+			} catch (error) {
+				caught = error;
+			}
 
 			// Assert
-			expect(mockResponse.status).toHaveBeenCalledWith(404);
-			expect(mockResponse.json).toHaveBeenCalledWith({
+			expect(caught).toBeInstanceOf(NotFoundError);
+			expect(caught).toMatchObject({
 				message: expect.stringContaining(otherUserDataTableId),
+				httpStatusCode: 404,
 			});
 		});
 
-		it('should return 404 when trying to upsert row in another users data table', async () => {
+		it('should throw NotFoundError when trying to upsert row in another users data table', async () => {
 			// Arrange
 			const req = {
 				params: { dataTableId: otherUserDataTableId },
@@ -714,16 +765,23 @@ describe('DataTable Handler', () => {
 			);
 
 			// Act
-			await handler.upsertDataTableRow[2](req, mockResponse as Response);
+			const handlerFn = handler.upsertDataTableRow[2];
+			let caught: unknown;
+			try {
+				await handlerFn(req, mockResponse as Response);
+			} catch (error) {
+				caught = error;
+			}
 
 			// Assert
-			expect(mockResponse.status).toHaveBeenCalledWith(404);
-			expect(mockResponse.json).toHaveBeenCalledWith({
+			expect(caught).toBeInstanceOf(NotFoundError);
+			expect(caught).toMatchObject({
 				message: expect.stringContaining(otherUserDataTableId),
+				httpStatusCode: 404,
 			});
 		});
 
-		it('should return 404 when trying to delete rows from another users data table', async () => {
+		it('should throw NotFoundError when trying to delete rows from another users data table', async () => {
 			// Arrange
 			const filterStr = JSON.stringify({
 				type: 'and',
@@ -748,12 +806,19 @@ describe('DataTable Handler', () => {
 			);
 
 			// Act
-			await handler.deleteDataTableRows[2](req, mockResponse as Response);
+			const handlerFn = handler.deleteDataTableRows[2];
+			let caught: unknown;
+			try {
+				await handlerFn(req, mockResponse as Response);
+			} catch (error) {
+				caught = error;
+			}
 
 			// Assert
-			expect(mockResponse.status).toHaveBeenCalledWith(404);
-			expect(mockResponse.json).toHaveBeenCalledWith({
+			expect(caught).toBeInstanceOf(NotFoundError);
+			expect(caught).toMatchObject({
 				message: expect.stringContaining(otherUserDataTableId),
+				httpStatusCode: 404,
 			});
 		});
 
@@ -775,16 +840,23 @@ describe('DataTable Handler', () => {
 			);
 
 			// Act
-			await handler.getDataTableRows[3](req, mockResponse as Response);
+			const handlerFn = handler.getDataTableRows[3];
+			let caught: unknown;
+			try {
+				await handlerFn(req, mockResponse as Response);
+			} catch (error) {
+				caught = error;
+			}
 
 			// Assert
 			// The error message should be the same whether:
 			// 1. The table doesn't exist at all
 			// 2. The table exists but belongs to another user's project
 			// This prevents information leakage
-			expect(mockResponse.status).toHaveBeenCalledWith(404);
-			expect(mockResponse.json).toHaveBeenCalledWith({
+			expect(caught).toBeInstanceOf(NotFoundError);
+			expect(caught).toMatchObject({
 				message: expect.stringContaining(nonExistentDataTableId),
+				httpStatusCode: 404,
 			});
 		});
 	});

--- a/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.columns.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.columns.handler.ts
@@ -1,6 +1,5 @@
 import { AddDataTableColumnDto, updateDataTableColumnSchema } from '@n8n/api-types';
 import { Container } from '@n8n/di';
-import type express from 'express';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
@@ -9,13 +8,21 @@ import { DataTableColumnNameConflictError } from '@/modules/data-table/errors/da
 import { DataTableSystemColumnNameConflictError } from '@/modules/data-table/errors/data-table-system-column-name-conflict.error';
 
 import type { DataTableRequest } from '../../../types';
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
 import { projectScope, publicApiScope } from '../../shared/middlewares/global.middleware';
 
-export = {
+type DataTableColumnsHandlers = {
+	listDataTableColumns: PublicAPIEndpoint<DataTableRequest.ListColumns>;
+	createDataTableColumn: PublicAPIEndpoint<DataTableRequest.CreateColumn>;
+	deleteDataTableColumn: PublicAPIEndpoint<DataTableRequest.DeleteColumn>;
+	updateDataTableColumn: PublicAPIEndpoint<DataTableRequest.UpdateColumn>;
+};
+
+const dataTableColumnsHandlers: DataTableColumnsHandlers = {
 	listDataTableColumns: [
 		publicApiScope('dataTableColumn:read'),
 		projectScope('dataTable:readColumn', 'dataTable'),
-		async (req: DataTableRequest.ListColumns, res: express.Response) => {
+		async (req, res) => {
 			const { dataTableId } = req.params;
 			const projectId = await Container.get(DataTableService).getProjectIdForDataTable(dataTableId);
 			return res.json(await Container.get(DataTableService).getColumns(dataTableId, projectId));
@@ -25,7 +32,7 @@ export = {
 	createDataTableColumn: [
 		publicApiScope('dataTableColumn:create'),
 		projectScope('dataTable:writeColumn', 'dataTable'),
-		async (req: DataTableRequest.CreateColumn, res: express.Response) => {
+		async (req, res) => {
 			const { dataTableId } = req.params;
 			const payload = AddDataTableColumnDto.safeParse(req.body);
 			if (!payload.success) {
@@ -55,7 +62,7 @@ export = {
 	deleteDataTableColumn: [
 		publicApiScope('dataTableColumn:delete'),
 		projectScope('dataTable:writeColumn', 'dataTable'),
-		async (req: DataTableRequest.DeleteColumn, res: express.Response) => {
+		async (req, res) => {
 			const { dataTableId, columnId } = req.params;
 			const projectId = await Container.get(DataTableService).getProjectIdForDataTable(dataTableId);
 			await Container.get(DataTableService).deleteColumn(dataTableId, projectId, columnId);
@@ -66,7 +73,7 @@ export = {
 	updateDataTableColumn: [
 		publicApiScope('dataTableColumn:update'),
 		projectScope('dataTable:writeColumn', 'dataTable'),
-		async (req: DataTableRequest.UpdateColumn, res: express.Response) => {
+		async (req, res) => {
 			try {
 				const { dataTableId, columnId } = req.params;
 				const payload = updateDataTableColumnSchema.safeParse(req.body);
@@ -100,3 +107,5 @@ export = {
 		},
 	],
 };
+
+export = dataTableColumnsHandlers;

--- a/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.columns.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.columns.handler.ts
@@ -11,6 +11,17 @@ import type { DataTableRequest } from '../../../types';
 import type { PublicAPIEndpoint } from '../../shared/handler.types';
 import { projectScope, publicApiScope } from '../../shared/middlewares/global.middleware';
 
+const handleError = (error: unknown) => {
+	if (
+		error instanceof DataTableColumnNameConflictError ||
+		error instanceof DataTableSystemColumnNameConflictError
+	) {
+		throw new ConflictError(error.message);
+	}
+
+	throw error;
+};
+
 type DataTableColumnsHandlers = {
 	listDataTableColumns: PublicAPIEndpoint<DataTableRequest.ListColumns>;
 	createDataTableColumn: PublicAPIEndpoint<DataTableRequest.CreateColumn>;
@@ -48,13 +59,7 @@ const dataTableColumnsHandlers: DataTableColumnsHandlers = {
 				);
 				return res.status(201).json(column);
 			} catch (error) {
-				if (
-					error instanceof DataTableColumnNameConflictError ||
-					error instanceof DataTableSystemColumnNameConflictError
-				) {
-					throw new ConflictError(error.message);
-				}
-				throw error;
+				return handleError(error);
 			}
 		},
 	],
@@ -96,13 +101,7 @@ const dataTableColumnsHandlers: DataTableColumnsHandlers = {
 				const updatedColumn = await service.getColumnById({ projectId, dataTableId, columnId });
 				return res.json(updatedColumn);
 			} catch (error) {
-				if (
-					error instanceof DataTableColumnNameConflictError ||
-					error instanceof DataTableSystemColumnNameConflictError
-				) {
-					throw new ConflictError(error.message);
-				}
-				throw error;
+				return handleError(error);
 			}
 		},
 	],

--- a/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.handler.ts
@@ -4,7 +4,7 @@ import {
 	UpdateDataTableDto,
 } from '@n8n/api-types';
 import { Container } from '@n8n/di';
-import type express from 'express';
+import type { Response } from 'express';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
@@ -17,6 +17,7 @@ import { ProjectService } from '@/services/project.service.ee';
 
 import { getDataTableListFilter, resolveProjectIdForCreate } from './data-tables.service';
 import type { DataTableRequest } from '../../../types';
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
 import {
 	publicApiScope,
 	projectScope,
@@ -24,7 +25,7 @@ import {
 } from '../../shared/middlewares/global.middleware';
 import { encodeNextCursor } from '../../shared/services/pagination.service';
 
-const handleError = (error: unknown, res: express.Response): express.Response => {
+const handleError = (error: unknown, res: Response): Response => {
 	if (error instanceof DataTableNotFoundError) {
 		return res.status(404).json({ message: error.message });
 	}
@@ -57,11 +58,19 @@ const stringifyQuery = (query: Record<string, unknown>): Record<string, string |
 	return result;
 };
 
-export = {
+type DataTableHandlers = {
+	listDataTables: PublicAPIEndpoint<DataTableRequest.List>;
+	createDataTable: PublicAPIEndpoint<DataTableRequest.Create>;
+	getDataTable: PublicAPIEndpoint<DataTableRequest.Get>;
+	updateDataTable: PublicAPIEndpoint<DataTableRequest.Update>;
+	deleteDataTable: PublicAPIEndpoint<DataTableRequest.Delete>;
+};
+
+const dataTableHandlers: DataTableHandlers = {
 	listDataTables: [
 		publicApiScope('dataTable:list'),
 		validCursor,
-		async (req: DataTableRequest.List, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			try {
 				const payload = PublicApiListDataTableQueryDto.safeParse(stringifyQuery(req.query));
 				if (!payload.success) {
@@ -118,7 +127,7 @@ export = {
 
 	createDataTable: [
 		publicApiScope('dataTable:create'),
-		async (req: DataTableRequest.Create, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const payload = PublicApiCreateDataTableDto.safeParse(req.body);
 			if (!payload.success) {
 				throw new BadRequestError(payload.error.errors[0]?.message || 'Invalid request body');
@@ -143,7 +152,7 @@ export = {
 	getDataTable: [
 		publicApiScope('dataTable:read'),
 		projectScope('dataTable:read', 'dataTable'),
-		async (req: DataTableRequest.Get, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			try {
 				const { dataTableId } = req.params;
 
@@ -171,7 +180,7 @@ export = {
 	updateDataTable: [
 		publicApiScope('dataTable:update'),
 		projectScope('dataTable:update', 'dataTable'),
-		async (req: DataTableRequest.Update, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			try {
 				const { dataTableId } = req.params;
 
@@ -208,7 +217,7 @@ export = {
 	deleteDataTable: [
 		publicApiScope('dataTable:delete'),
 		projectScope('dataTable:delete', 'dataTable'),
-		async (req: DataTableRequest.Delete, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			try {
 				const { dataTableId } = req.params;
 
@@ -224,3 +233,5 @@ export = {
 		},
 	],
 };
+
+export = dataTableHandlers;

--- a/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.handler.ts
@@ -4,10 +4,11 @@ import {
 	UpdateDataTableDto,
 } from '@n8n/api-types';
 import { Container } from '@n8n/di';
-import type { Response } from 'express';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { DataTableRepository } from '@/modules/data-table/data-table.repository';
 import { DataTableService } from '@/modules/data-table/data-table.service';
 import { DataTableNameConflictError } from '@/modules/data-table/errors/data-table-name-conflict.error';
@@ -25,22 +26,20 @@ import {
 } from '../../shared/middlewares/global.middleware';
 import { encodeNextCursor } from '../../shared/services/pagination.service';
 
-const handleError = (error: unknown, res: Response): Response => {
-	if (error instanceof DataTableNotFoundError) {
-		return res.status(404).json({ message: error.message });
-	}
-	if (error instanceof DataTableNameConflictError) {
-		return res.status(409).json({ message: error.message });
-	}
+const handleError = (error: unknown) => {
 	if (error instanceof DataTableValidationError) {
-		return res.status(400).json({ message: error.message });
+		throw new BadRequestError(error.message);
+	}
+	if (error instanceof DataTableNotFoundError) {
+		throw new NotFoundError(error.message);
 	}
 	if (error instanceof ForbiddenError) {
-		return res.status(error.httpStatusCode).json({ message: error.message });
+		throw new ForbiddenError(error.message);
 	}
-	if (error instanceof Error) {
-		return res.status(400).json({ message: error.message });
+	if (error instanceof DataTableNameConflictError) {
+		throw new ConflictError(error.message);
 	}
+
 	throw error;
 };
 
@@ -74,9 +73,7 @@ const dataTableHandlers: DataTableHandlers = {
 			try {
 				const payload = PublicApiListDataTableQueryDto.safeParse(stringifyQuery(req.query));
 				if (!payload.success) {
-					return res.status(400).json({
-						message: payload.error.errors[0]?.message || 'Invalid query parameters',
-					});
+					throw new BadRequestError(payload.error.errors[0]?.message || 'Invalid query parameters');
 				}
 
 				const { offset, limit, filter, sortBy } = payload.data;
@@ -120,7 +117,7 @@ const dataTableHandlers: DataTableHandlers = {
 					}),
 				});
 			} catch (error) {
-				return handleError(error, res);
+				return handleError(error);
 			}
 		},
 	],
@@ -144,7 +141,7 @@ const dataTableHandlers: DataTableHandlers = {
 
 				return res.status(201).json(dataTable);
 			} catch (error) {
-				return handleError(error, res);
+				return handleError(error);
 			}
 		},
 	],
@@ -172,7 +169,7 @@ const dataTableHandlers: DataTableHandlers = {
 
 				return res.json(dataTable);
 			} catch (error) {
-				return handleError(error, res);
+				return handleError(error);
 			}
 		},
 	],
@@ -186,9 +183,7 @@ const dataTableHandlers: DataTableHandlers = {
 
 				const payload = UpdateDataTableDto.safeParse(req.body);
 				if (!payload.success) {
-					return res.status(400).json({
-						message: payload.error.errors[0]?.message || 'Invalid request body',
-					});
+					throw new BadRequestError(payload.error.errors[0]?.message || 'Invalid request body');
 				}
 
 				const projectId =
@@ -209,7 +204,7 @@ const dataTableHandlers: DataTableHandlers = {
 
 				return res.json(dataTable);
 			} catch (error) {
-				return handleError(error, res);
+				return handleError(error);
 			}
 		},
 	],
@@ -228,7 +223,7 @@ const dataTableHandlers: DataTableHandlers = {
 
 				return res.status(204).send();
 			} catch (error) {
-				return handleError(error, res);
+				return handleError(error);
 			}
 		},
 	],

--- a/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.rows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.rows.handler.ts
@@ -6,13 +6,14 @@ import {
 	DeleteDataTableRowsDto,
 } from '@n8n/api-types';
 import { Container } from '@n8n/di';
-import type express from 'express';
+import type { Response } from 'express';
 
 import { DataTableService } from '@/modules/data-table/data-table.service';
 import { DataTableNotFoundError } from '@/modules/data-table/errors/data-table-not-found.error';
 import { DataTableValidationError } from '@/modules/data-table/errors/data-table-validation.error';
 
 import type { DataTableRequest } from '../../../types';
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
 import {
 	publicApiScope,
 	projectScope,
@@ -20,7 +21,7 @@ import {
 } from '../../shared/middlewares/global.middleware';
 import { encodeNextCursor } from '../../shared/services/pagination.service';
 
-const handleError = (error: unknown, res: express.Response): express.Response => {
+const handleError = (error: unknown, res: Response): Response => {
 	if (error instanceof DataTableNotFoundError) {
 		return res.status(404).json({ message: error.message });
 	}
@@ -47,12 +48,20 @@ const stringifyQuery = (query: Record<string, unknown>): Record<string, string |
 	return result;
 };
 
-export = {
+type DataTableRowsHandlers = {
+	getDataTableRows: PublicAPIEndpoint<DataTableRequest.GetRows>;
+	insertDataTableRows: PublicAPIEndpoint<DataTableRequest.InsertRows>;
+	updateDataTableRows: PublicAPIEndpoint<DataTableRequest.UpdateRows>;
+	upsertDataTableRow: PublicAPIEndpoint<DataTableRequest.UpsertRow>;
+	deleteDataTableRows: PublicAPIEndpoint<DataTableRequest.DeleteRows>;
+};
+
+const dataTableRowsHandlers: DataTableRowsHandlers = {
 	getDataTableRows: [
 		publicApiScope('dataTableRow:read'),
 		projectScope('dataTable:readRow', 'dataTable'),
 		validCursor,
-		async (req: DataTableRequest.GetRows, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			try {
 				const { dataTableId } = req.params;
 
@@ -97,7 +106,7 @@ export = {
 	insertDataTableRows: [
 		publicApiScope('dataTableRow:create'),
 		projectScope('dataTable:writeRow', 'dataTable'),
-		async (req: DataTableRequest.InsertRows, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			try {
 				const { dataTableId } = req.params;
 
@@ -128,7 +137,7 @@ export = {
 	updateDataTableRows: [
 		publicApiScope('dataTableRow:update'),
 		projectScope('dataTable:writeRow', 'dataTable'),
-		async (req: DataTableRequest.UpdateRows, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			try {
 				const { dataTableId } = req.params;
 
@@ -161,7 +170,7 @@ export = {
 	upsertDataTableRow: [
 		publicApiScope('dataTableRow:upsert'),
 		projectScope('dataTable:writeRow', 'dataTable'),
-		async (req: DataTableRequest.UpsertRow, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			try {
 				const { dataTableId } = req.params;
 
@@ -194,7 +203,7 @@ export = {
 	deleteDataTableRows: [
 		publicApiScope('dataTableRow:delete'),
 		projectScope('dataTable:writeRow', 'dataTable'),
-		async (req: DataTableRequest.DeleteRows, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			try {
 				const { dataTableId } = req.params;
 
@@ -224,3 +233,5 @@ export = {
 		},
 	],
 };
+
+export = dataTableRowsHandlers;

--- a/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.rows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.rows.handler.ts
@@ -6,8 +6,9 @@ import {
 	DeleteDataTableRowsDto,
 } from '@n8n/api-types';
 import { Container } from '@n8n/di';
-import type { Response } from 'express';
 
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { DataTableService } from '@/modules/data-table/data-table.service';
 import { DataTableNotFoundError } from '@/modules/data-table/errors/data-table-not-found.error';
 import { DataTableValidationError } from '@/modules/data-table/errors/data-table-validation.error';
@@ -21,16 +22,14 @@ import {
 } from '../../shared/middlewares/global.middleware';
 import { encodeNextCursor } from '../../shared/services/pagination.service';
 
-const handleError = (error: unknown, res: Response): Response => {
+const handleError = (error: unknown) => {
 	if (error instanceof DataTableNotFoundError) {
-		return res.status(404).json({ message: error.message });
+		throw new NotFoundError(error.message);
 	}
 	if (error instanceof DataTableValidationError) {
-		return res.status(400).json({ message: error.message });
+		throw new BadRequestError(error.message);
 	}
-	if (error instanceof Error) {
-		return res.status(400).json({ message: error.message });
-	}
+
 	throw error;
 };
 
@@ -67,9 +66,7 @@ const dataTableRowsHandlers: DataTableRowsHandlers = {
 
 				const payload = PublicApiListDataTableContentQueryDto.safeParse(stringifyQuery(req.query));
 				if (!payload.success) {
-					return res.status(400).json({
-						message: payload.error.errors[0]?.message || 'Invalid query parameters',
-					});
+					throw new BadRequestError(payload.error.errors[0]?.message || 'Invalid query parameters');
 				}
 
 				const { offset, limit, filter, sortBy, search } = payload.data;
@@ -98,7 +95,7 @@ const dataTableRowsHandlers: DataTableRowsHandlers = {
 					}),
 				});
 			} catch (error) {
-				return handleError(error, res);
+				return handleError(error);
 			}
 		},
 	],
@@ -112,9 +109,7 @@ const dataTableRowsHandlers: DataTableRowsHandlers = {
 
 				const payload = AddDataTableRowsDto.safeParse(req.body);
 				if (!payload.success) {
-					return res.status(400).json({
-						message: payload.error.errors[0]?.message || 'Invalid request body',
-					});
+					throw new BadRequestError(payload.error.errors[0]?.message || 'Invalid request body');
 				}
 
 				const projectId =
@@ -129,7 +124,7 @@ const dataTableRowsHandlers: DataTableRowsHandlers = {
 
 				return res.json(result);
 			} catch (error) {
-				return handleError(error, res);
+				return handleError(error);
 			}
 		},
 	],
@@ -143,9 +138,7 @@ const dataTableRowsHandlers: DataTableRowsHandlers = {
 
 				const payload = UpdateDataTableRowDto.safeParse(req.body);
 				if (!payload.success) {
-					return res.status(400).json({
-						message: payload.error.errors[0]?.message || 'Invalid request body',
-					});
+					throw new BadRequestError(payload.error.errors[0]?.message || 'Invalid request body');
 				}
 
 				const projectId =
@@ -162,7 +155,7 @@ const dataTableRowsHandlers: DataTableRowsHandlers = {
 
 				return res.json(result);
 			} catch (error) {
-				return handleError(error, res);
+				return handleError(error);
 			}
 		},
 	],
@@ -176,9 +169,7 @@ const dataTableRowsHandlers: DataTableRowsHandlers = {
 
 				const payload = UpsertDataTableRowDto.safeParse(req.body);
 				if (!payload.success) {
-					return res.status(400).json({
-						message: payload.error.errors[0]?.message || 'Invalid request body',
-					});
+					throw new BadRequestError(payload.error.errors[0]?.message || 'Invalid request body');
 				}
 
 				const projectId =
@@ -195,7 +186,7 @@ const dataTableRowsHandlers: DataTableRowsHandlers = {
 
 				return res.json(result);
 			} catch (error) {
-				return handleError(error, res);
+				return handleError(error);
 			}
 		},
 	],
@@ -209,9 +200,7 @@ const dataTableRowsHandlers: DataTableRowsHandlers = {
 
 				const payload = DeleteDataTableRowsDto.safeParse(stringifyQuery(req.query));
 				if (!payload.success) {
-					return res.status(400).json({
-						message: payload.error.errors[0]?.message || 'Invalid query parameters',
-					});
+					throw new BadRequestError(payload.error.errors[0]?.message || 'Invalid query parameters');
 				}
 
 				const projectId =
@@ -228,7 +217,7 @@ const dataTableRowsHandlers: DataTableRowsHandlers = {
 
 				return res.json(result);
 			} catch (error) {
-				return handleError(error, res);
+				return handleError(error);
 			}
 		},
 	],

--- a/packages/cli/src/public-api/v1/handlers/discover/__tests__/discover.handler.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/discover/__tests__/discover.handler.test.ts
@@ -1,8 +1,10 @@
 import { mockInstance } from '@n8n/backend-test-utils';
+import type { AuthenticatedRequest } from '@n8n/db';
 import { ApiKeyRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import type { Response } from 'express';
-import type { AuthenticatedRequest } from '@n8n/db';
+
+import { UnauthenticatedError } from '@/errors/response-errors/unauthenticated.error';
 
 import * as discoverService from '../discover.service';
 
@@ -24,25 +26,28 @@ describe('Discover Handler', () => {
 
 		mockResponse = {
 			json: jest.fn().mockReturnThis(),
-			status: jest.fn().mockReturnThis(),
 		};
 	});
 
-	it('should return 401 when API key header is missing', async () => {
+	it('should throw UnauthenticatedError when API key header is missing', async () => {
 		const req = {
 			headers: {},
 			query: {},
 		} as unknown as AuthenticatedRequest;
 
 		const handlerFn = handler.getDiscover[0];
-		await handlerFn(req, mockResponse);
-
-		expect(mockResponse.status).toHaveBeenCalledWith(401);
-		expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Unauthorized' });
+		let caught: unknown;
+		try {
+			await handlerFn(req, mockResponse as Response);
+		} catch (error) {
+			caught = error;
+		}
+		expect(caught).toBeInstanceOf(UnauthenticatedError);
+		expect(caught).toMatchObject({ message: 'Unauthorized', httpStatusCode: 401 });
 		expect(mockApiKeyRepository.findOne).not.toHaveBeenCalled();
 	});
 
-	it('should return 401 when API key not found in DB', async () => {
+	it('should throw UnauthenticatedError when API key not found in DB', async () => {
 		mockApiKeyRepository.findOne.mockResolvedValue(null);
 
 		const req = {
@@ -51,10 +56,14 @@ describe('Discover Handler', () => {
 		} as unknown as AuthenticatedRequest;
 
 		const handlerFn = handler.getDiscover[0];
-		await handlerFn(req, mockResponse);
-
-		expect(mockResponse.status).toHaveBeenCalledWith(401);
-		expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Unauthorized' });
+		let caught: unknown;
+		try {
+			await handlerFn(req, mockResponse as Response);
+		} catch (error) {
+			caught = error;
+		}
+		expect(caught).toBeInstanceOf(UnauthenticatedError);
+		expect(caught).toMatchObject({ message: 'Unauthorized', httpStatusCode: 401 });
 	});
 
 	it('should return discover data when API key is valid', async () => {

--- a/packages/cli/src/public-api/v1/handlers/discover/discover.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/discover/discover.handler.ts
@@ -1,11 +1,17 @@
-import { ApiKeyRepository } from '@n8n/db';
-import type { AuthenticatedRequest } from '@n8n/db';
+import { ApiKeyRepository, type AuthenticatedRequest } from '@n8n/db';
 import { Container } from '@n8n/di';
-import type express from 'express';
 
 import { buildDiscoverResponse } from './discover.service';
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
 
 const API_KEY_AUDIENCE = 'public-api';
+
+type GetDiscoverRequest = AuthenticatedRequest<
+	{},
+	{},
+	{},
+	{ include?: string; resource?: string; operation?: string }
+>;
 
 function firstString(value: unknown): string | undefined {
 	if (typeof value === 'string') return value;
@@ -13,17 +19,13 @@ function firstString(value: unknown): string | undefined {
 	return undefined;
 }
 
-export = {
+type DiscoverHandlers = {
+	getDiscover: PublicAPIEndpoint<GetDiscoverRequest>;
+};
+
+const discoverHandlers: DiscoverHandlers = {
 	getDiscover: [
-		async (
-			req: AuthenticatedRequest<
-				{},
-				{},
-				{},
-				{ include?: string; resource?: string; operation?: string }
-			>,
-			res: express.Response,
-		): Promise<express.Response> => {
+		async (req, res) => {
 			const apiKey = firstString(req.headers['x-n8n-api-key']);
 			if (!apiKey) {
 				return res.status(401).json({ message: 'Unauthorized' });
@@ -48,3 +50,5 @@ export = {
 		},
 	],
 };
+
+export = discoverHandlers;

--- a/packages/cli/src/public-api/v1/handlers/discover/discover.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/discover/discover.handler.ts
@@ -1,6 +1,8 @@
 import { ApiKeyRepository, type AuthenticatedRequest } from '@n8n/db';
 import { Container } from '@n8n/di';
 
+import { UnauthenticatedError } from '@/errors/response-errors/unauthenticated.error';
+
 import { buildDiscoverResponse } from './discover.service';
 import type { PublicAPIEndpoint } from '../../shared/handler.types';
 
@@ -28,7 +30,7 @@ const discoverHandlers: DiscoverHandlers = {
 		async (req, res) => {
 			const apiKey = firstString(req.headers['x-n8n-api-key']);
 			if (!apiKey) {
-				return res.status(401).json({ message: 'Unauthorized' });
+				throw new UnauthenticatedError('Unauthorized');
 			}
 
 			const apiKeyRecord = await Container.get(ApiKeyRepository).findOne({
@@ -37,7 +39,7 @@ const discoverHandlers: DiscoverHandlers = {
 			});
 
 			if (!apiKeyRecord) {
-				return res.status(401).json({ message: 'Unauthorized' });
+				throw new UnauthenticatedError('Unauthorized');
 			}
 
 			const includeSchemas = req.query.include === 'schemas';

--- a/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
@@ -11,7 +11,8 @@ import { ConcurrencyControlService } from '@/concurrency/concurrency-control.ser
 import { AbortedExecutionRetryError } from '@/errors/aborted-execution-retry.error';
 import { MissingExecutionStopError } from '@/errors/missing-execution-stop.error';
 import { QueuedExecutionRetryError } from '@/errors/queued-execution-retry.error';
-import { ResponseError } from '@/errors/response-errors/abstract/response.error';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { EventService } from '@/events/event.service';
 import { ExecutionPersistence } from '@/executions/execution-persistence';
@@ -25,6 +26,17 @@ import type { PublicAPIEndpoint } from '../../shared/handler.types';
 import { publicApiScope, validCursor } from '../../shared/middlewares/global.middleware';
 import { encodeNextCursor } from '../../shared/services/pagination.service';
 import { getSharedWorkflowIds } from '../workflows/workflows.service';
+
+const handleError = (error: unknown) => {
+	if (error instanceof QueuedExecutionRetryError || error instanceof AbortedExecutionRetryError) {
+		throw new ConflictError(error.message);
+	}
+	if (error instanceof MissingExecutionStopError) {
+		throw new NotFoundError(error.message);
+	}
+
+	throw error;
+};
 
 function isRedactableExecution(
 	execution: IExecutionBase,
@@ -52,7 +64,7 @@ const executionHandlers: ExecutionHandlers = {
 			// user does not have workflows hence no executions
 			// or the execution they are trying to access belongs to a workflow they do not own
 			if (!sharedWorkflowsIds.length) {
-				return res.status(404).json({ message: 'Not Found' });
+				throw new NotFoundError('Not Found');
 			}
 
 			const { id } = req.params;
@@ -63,13 +75,11 @@ const executionHandlers: ExecutionHandlers = {
 			).getExecutionInWorkflowsForPublicApi(id, sharedWorkflowsIds, false);
 
 			if (!execution) {
-				return res.status(404).json({ message: 'Not Found' });
+				throw new NotFoundError('Not Found');
 			}
 
 			if (execution.status === 'running') {
-				return res.status(400).json({
-					message: 'Cannot delete a running execution',
-				});
+				throw new BadRequestError('Cannot delete a running execution');
 			}
 
 			if (execution.status === 'new') {
@@ -98,7 +108,7 @@ const executionHandlers: ExecutionHandlers = {
 			// user does not have workflows hence no executions
 			// or the execution they are trying to access belongs to a workflow they do not own
 			if (!sharedWorkflowsIds.length) {
-				return res.status(404).json({ message: 'Not Found' });
+				throw new NotFoundError('Not Found');
 			}
 
 			const { id } = req.params;
@@ -110,7 +120,7 @@ const executionHandlers: ExecutionHandlers = {
 			).getExecutionInWorkflowsForPublicApi(id, sharedWorkflowsIds, includeData);
 
 			if (!execution) {
-				return res.status(404).json({ message: 'Not Found' });
+				throw new NotFoundError('Not Found');
 			}
 
 			if (includeData && isRedactableExecution(execution)) {
@@ -119,24 +129,12 @@ const executionHandlers: ExecutionHandlers = {
 					? redactQuery.data.redactExecutionData
 					: undefined;
 
-				try {
-					await Container.get(ExecutionRedactionServiceProxy).processExecution(execution, {
-						user: req.user,
-						redactExecutionData,
-						ipAddress: req.ip ?? '',
-						userAgent: req.headers['user-agent'] ?? '',
-					});
-				} catch (error) {
-					if (error instanceof ResponseError) {
-						return res.status(error.httpStatusCode).json({
-							code: error.httpStatusCode,
-							message: error.message,
-							hint: error.hint,
-							meta: 'meta' in error ? error.meta : undefined,
-						});
-					}
-					throw error;
-				}
+				await Container.get(ExecutionRedactionServiceProxy).processExecution(execution, {
+					user: req.user,
+					redactExecutionData,
+					ipAddress: req.ip ?? '',
+					userAgent: req.headers['user-agent'] ?? '',
+				});
 			}
 
 			Container.get(EventService).emit('user-retrieved-execution', {
@@ -203,27 +201,15 @@ const executionHandlers: ExecutionHandlers = {
 					: undefined;
 
 				const redactableExecutions = executions.filter(isRedactableExecution);
-				try {
-					await Container.get(ExecutionRedactionServiceProxy).processExecutions(
-						redactableExecutions,
-						{
-							user: req.user,
-							redactExecutionData,
-							ipAddress: req.ip ?? '',
-							userAgent: req.headers['user-agent'] ?? '',
-						},
-					);
-				} catch (error) {
-					if (error instanceof ResponseError) {
-						return res.status(error.httpStatusCode).json({
-							code: error.httpStatusCode,
-							message: error.message,
-							hint: error.hint,
-							meta: 'meta' in error ? error.meta : undefined,
-						});
-					}
-					throw error;
-				}
+				await Container.get(ExecutionRedactionServiceProxy).processExecutions(
+					redactableExecutions,
+					{
+						user: req.user,
+						redactExecutionData,
+						ipAddress: req.ip ?? '',
+						userAgent: req.headers['user-agent'] ?? '',
+					},
+				);
 			}
 
 			Container.get(EventService).emit('user-retrieved-all-executions', {
@@ -249,7 +235,7 @@ const executionHandlers: ExecutionHandlers = {
 			// user does not have workflows hence no executions
 			// or the execution they are trying to access belongs to a workflow they do not own
 			if (!sharedWorkflowsIds.length) {
-				return res.status(404).json({ message: 'Not Found' });
+				throw new NotFoundError('Not Found');
 			}
 
 			try {
@@ -265,16 +251,7 @@ const executionHandlers: ExecutionHandlers = {
 
 				return res.json(replaceCircularReferences(retriedExecution));
 			} catch (error) {
-				if (
-					error instanceof QueuedExecutionRetryError ||
-					error instanceof AbortedExecutionRetryError
-				) {
-					return res.status(409).json({ message: error.message });
-				} else if (error instanceof NotFoundError) {
-					return res.status(404).json({ message: error.message });
-				} else {
-					throw error;
-				}
+				return handleError(error);
 			}
 		},
 	],
@@ -285,7 +262,7 @@ const executionHandlers: ExecutionHandlers = {
 			const sharedWorkflowsIds = await getSharedWorkflowIds(req.user, ['workflow:read']);
 
 			if (!sharedWorkflowsIds.length) {
-				return res.status(404).json({ message: 'Not Found' });
+				throw new NotFoundError('Not Found');
 			}
 
 			const execution = await Container.get(
@@ -293,7 +270,7 @@ const executionHandlers: ExecutionHandlers = {
 			).getExecutionInWorkflowsForPublicApi(id, sharedWorkflowsIds, false);
 
 			if (!execution) {
-				return res.status(404).json({ message: 'Not Found' });
+				throw new NotFoundError('Not Found');
 			}
 
 			const tags = await getExecutionTags(id);
@@ -309,7 +286,7 @@ const executionHandlers: ExecutionHandlers = {
 			const sharedWorkflowsIds = await getSharedWorkflowIds(req.user, ['workflow:update']);
 
 			if (!sharedWorkflowsIds.length) {
-				return res.status(404).json({ message: 'Not Found' });
+				throw new NotFoundError('Not Found');
 			}
 
 			const execution = await Container.get(
@@ -317,7 +294,7 @@ const executionHandlers: ExecutionHandlers = {
 			).getExecutionInWorkflowsForPublicApi(id, sharedWorkflowsIds, false);
 
 			if (!execution) {
-				return res.status(404).json({ message: 'Not Found' });
+				throw new NotFoundError('Not Found');
 			}
 
 			try {
@@ -326,9 +303,9 @@ const executionHandlers: ExecutionHandlers = {
 				return res.json(tags);
 			} catch (error) {
 				if (error instanceof QueryFailedError) {
-					return res.status(404).json({ message: 'Some tags not found' });
+					throw new NotFoundError('Some tags not found');
 				}
-				throw error;
+				return handleError(error);
 			}
 		},
 	],
@@ -340,7 +317,7 @@ const executionHandlers: ExecutionHandlers = {
 			// user does not have workflows hence no executions
 			// or the execution they are trying to access belongs to a workflow they do not own
 			if (!sharedWorkflowsIds.length) {
-				return res.status(404).json({ message: 'Not Found' });
+				throw new NotFoundError('Not Found');
 			}
 
 			const { id } = req.params;
@@ -350,13 +327,7 @@ const executionHandlers: ExecutionHandlers = {
 
 				return res.json(replaceCircularReferences(stopResult));
 			} catch (error) {
-				if (error instanceof MissingExecutionStopError) {
-					return res.status(404).json({ message: 'Not Found' });
-				} else if (error instanceof NotFoundError) {
-					return res.status(404).json({ message: error.message });
-				} else {
-					throw error;
-				}
+				return handleError(error);
 			}
 		},
 	],
@@ -385,7 +356,7 @@ const executionHandlers: ExecutionHandlers = {
 
 			// If workflowId is provided, validate user has access to it
 			if (workflowId && workflowId !== 'all' && !sharedWorkflowsIds.includes(workflowId)) {
-				return res.status(404).json({ message: 'Workflow not found or not accessible' });
+				throw new NotFoundError('Workflow not found or not accessible');
 			}
 
 			const filter = {

--- a/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
@@ -1,10 +1,9 @@
+import { ExecutionRedactionQueryDtoSchema } from '@n8n/api-types';
 import type { IExecutionBase } from '@n8n/db';
 import { ExecutionRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
-import type express from 'express';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { QueryFailedError } from '@n8n/typeorm';
-import { ExecutionRedactionQueryDtoSchema } from '@n8n/api-types';
 import { type ExecutionStatus, replaceCircularReferences } from 'n8n-workflow';
 
 import { ActiveExecutions } from '@/active-executions';
@@ -12,13 +11,20 @@ import { ConcurrencyControlService } from '@/concurrency/concurrency-control.ser
 import { AbortedExecutionRetryError } from '@/errors/aborted-execution-retry.error';
 import { MissingExecutionStopError } from '@/errors/missing-execution-stop.error';
 import { QueuedExecutionRetryError } from '@/errors/queued-execution-retry.error';
-import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { ResponseError } from '@/errors/response-errors/abstract/response.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { EventService } from '@/events/event.service';
 import { ExecutionPersistence } from '@/executions/execution-persistence';
 import type { RedactableExecution } from '@/executions/execution-redaction';
 import { ExecutionRedactionServiceProxy } from '@/executions/execution-redaction-proxy.service';
 import { ExecutionService } from '@/executions/execution.service';
+
+import { getExecutionTags, mapAnnotationTags, updateExecutionTags } from './executions.service';
+import type { ExecutionRequest } from '../../../types';
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
+import { publicApiScope, validCursor } from '../../shared/middlewares/global.middleware';
+import { encodeNextCursor } from '../../shared/services/pagination.service';
+import { getSharedWorkflowIds } from '../workflows/workflows.service';
 
 function isRedactableExecution(
 	execution: IExecutionBase,
@@ -26,16 +32,21 @@ function isRedactableExecution(
 	return 'data' in execution && 'workflowData' in execution;
 }
 
-import type { ExecutionRequest } from '../../../types';
-import { publicApiScope, validCursor } from '../../shared/middlewares/global.middleware';
-import { encodeNextCursor } from '../../shared/services/pagination.service';
-import { getSharedWorkflowIds } from '../workflows/workflows.service';
-import { getExecutionTags, mapAnnotationTags, updateExecutionTags } from './executions.service';
+type ExecutionHandlers = {
+	deleteExecution: PublicAPIEndpoint<ExecutionRequest.Delete>;
+	getExecution: PublicAPIEndpoint<ExecutionRequest.Get>;
+	getExecutions: PublicAPIEndpoint<ExecutionRequest.GetAll>;
+	retryExecution: PublicAPIEndpoint<ExecutionRequest.Retry>;
+	getExecutionTags: PublicAPIEndpoint<ExecutionRequest.GetTags>;
+	updateExecutionTags: PublicAPIEndpoint<ExecutionRequest.UpdateTags>;
+	stopExecution: PublicAPIEndpoint<ExecutionRequest.Stop>;
+	stopManyExecutions: PublicAPIEndpoint<ExecutionRequest.StopMany>;
+};
 
-export = {
+const executionHandlers: ExecutionHandlers = {
 	deleteExecution: [
 		publicApiScope('execution:delete'),
-		async (req: ExecutionRequest.Delete, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const sharedWorkflowsIds = await getSharedWorkflowIds(req.user, ['workflow:delete']);
 
 			// user does not have workflows hence no executions
@@ -81,7 +92,7 @@ export = {
 	],
 	getExecution: [
 		publicApiScope('execution:read'),
-		async (req: ExecutionRequest.Get, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const sharedWorkflowsIds = await getSharedWorkflowIds(req.user, ['workflow:read']);
 
 			// user does not have workflows hence no executions
@@ -139,7 +150,7 @@ export = {
 	getExecutions: [
 		publicApiScope('execution:list'),
 		validCursor,
-		async (req: ExecutionRequest.GetAll, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const {
 				lastId = undefined,
 				limit = 100,
@@ -232,7 +243,7 @@ export = {
 	],
 	retryExecution: [
 		publicApiScope('execution:retry'),
-		async (req: ExecutionRequest.Retry, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const sharedWorkflowsIds = await getSharedWorkflowIds(req.user, ['workflow:read']);
 
 			// user does not have workflows hence no executions
@@ -269,7 +280,7 @@ export = {
 	],
 	getExecutionTags: [
 		publicApiScope('executionTags:list'),
-		async (req: ExecutionRequest.GetTags, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const { id } = req.params;
 			const sharedWorkflowsIds = await getSharedWorkflowIds(req.user, ['workflow:read']);
 
@@ -292,7 +303,7 @@ export = {
 	],
 	updateExecutionTags: [
 		publicApiScope('executionTags:update'),
-		async (req: ExecutionRequest.UpdateTags, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const { id } = req.params;
 			const newTagIds = req.body.map((tag) => tag.id);
 			const sharedWorkflowsIds = await getSharedWorkflowIds(req.user, ['workflow:update']);
@@ -323,7 +334,7 @@ export = {
 	],
 	stopExecution: [
 		publicApiScope('execution:stop'),
-		async (req: ExecutionRequest.Stop, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const sharedWorkflowsIds = await getSharedWorkflowIds(req.user, ['workflow:execute']);
 
 			// user does not have workflows hence no executions
@@ -351,7 +362,7 @@ export = {
 	],
 	stopManyExecutions: [
 		publicApiScope('execution:stop'),
-		async (req: ExecutionRequest.StopMany, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const { status: rawStatus, workflowId, startedAfter, startedBefore } = req.body;
 			const status: ExecutionStatus[] = rawStatus.map((x) => (x === 'queued' ? 'new' : x));
 			// Validate that status is provided and not empty
@@ -390,3 +401,5 @@ export = {
 		},
 	],
 };
+
+export = executionHandlers;

--- a/packages/cli/src/public-api/v1/handlers/folders/folders.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/folders/folders.handler.ts
@@ -19,6 +19,18 @@ import {
 	isLicensed,
 } from '../../shared/middlewares/global.middleware';
 import { assertProjectScope } from '../../shared/services/utils.service';
+
+const handleError = (error: unknown) => {
+	if (error instanceof FolderNotFoundError) {
+		throw new NotFoundError(error.message);
+	}
+	if (error instanceof UserError) {
+		throw new BadRequestError(error.message);
+	}
+
+	throw error;
+};
+
 type FolderHandlers = {
 	createFolder: PublicAPIEndpoint<AuthenticatedRequest<{ projectId: string }>>;
 	getFolders: PublicAPIEndpoint<AuthenticatedRequest<{ projectId: string }>>;
@@ -43,9 +55,8 @@ const folderHandlers: FolderHandlers = {
 			try {
 				const folder = await Container.get(FolderService).createFolder(payload.data, projectId);
 				return res.status(201).json(folder);
-			} catch (e) {
-				if (e instanceof FolderNotFoundError) throw new NotFoundError(e.message);
-				throw e;
+			} catch (error) {
+				return handleError(error);
 			}
 		},
 	],
@@ -83,10 +94,8 @@ const folderHandlers: FolderHandlers = {
 			try {
 				await Container.get(FolderService).deleteFolder(req.user, folderId, projectId, query.data);
 				return res.status(204).send();
-			} catch (e) {
-				if (e instanceof FolderNotFoundError) throw new NotFoundError(e.message);
-				if (e instanceof UserError) throw new BadRequestError(e.message);
-				throw e;
+			} catch (error) {
+				return handleError(error);
 			}
 		},
 	],
@@ -103,9 +112,8 @@ const folderHandlers: FolderHandlers = {
 				).findFolderWithContentCounts(req.params.folderId, projectId);
 
 				return res.json({ ...folder, totalSubFolders, totalWorkflows });
-			} catch (e) {
-				if (e instanceof FolderNotFoundError) throw new NotFoundError(e.message);
-				throw e;
+			} catch (error) {
+				return handleError(error);
 			}
 		},
 	],
@@ -128,10 +136,8 @@ const folderHandlers: FolderHandlers = {
 					payload.data,
 				);
 				return res.json(folder);
-			} catch (e) {
-				if (e instanceof FolderNotFoundError) throw new NotFoundError(e.message);
-				if (e instanceof UserError) throw new BadRequestError(e.message);
-				throw e;
+			} catch (error) {
+				return handleError(error);
 			}
 		},
 	],

--- a/packages/cli/src/public-api/v1/handlers/folders/folders.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/folders/folders.handler.ts
@@ -4,6 +4,7 @@ import {
 	ListFolderQueryDto,
 	UpdateFolderDto,
 } from '@n8n/api-types';
+import type { AuthenticatedRequest } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { UserError } from 'n8n-workflow';
 
@@ -12,25 +13,18 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { FolderService } from '@/services/folder.service';
 
-import type { PublicAPIHandler } from '../../shared/handler.types';
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
 import {
 	apiKeyHasScopeWithGlobalScopeFallback,
 	isLicensed,
 } from '../../shared/middlewares/global.middleware';
 import { assertProjectScope } from '../../shared/services/utils.service';
-
-type FoldersEndpoint<TParams extends Record<string, string>> = readonly [
-	ReturnType<typeof isLicensed>,
-	ReturnType<typeof apiKeyHasScopeWithGlobalScopeFallback>,
-	PublicAPIHandler<TParams>,
-];
-
 type FolderHandlers = {
-	createFolder: FoldersEndpoint<{ projectId: string }>;
-	getFolders: FoldersEndpoint<{ projectId: string }>;
-	deleteFolder: FoldersEndpoint<{ projectId: string; folderId: string }>;
-	getFolder: FoldersEndpoint<{ projectId: string; folderId: string }>;
-	updateFolder: FoldersEndpoint<{ projectId: string; folderId: string }>;
+	createFolder: PublicAPIEndpoint<AuthenticatedRequest<{ projectId: string }>>;
+	getFolders: PublicAPIEndpoint<AuthenticatedRequest<{ projectId: string }>>;
+	deleteFolder: PublicAPIEndpoint<AuthenticatedRequest<{ projectId: string; folderId: string }>>;
+	getFolder: PublicAPIEndpoint<AuthenticatedRequest<{ projectId: string; folderId: string }>>;
+	updateFolder: PublicAPIEndpoint<AuthenticatedRequest<{ projectId: string; folderId: string }>>;
 };
 
 const folderHandlers: FolderHandlers = {

--- a/packages/cli/src/public-api/v1/handlers/insights/insights.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/insights/insights.handler.ts
@@ -1,6 +1,5 @@
 import { InsightsDateFilterDto } from '@n8n/api-types';
 import { Container } from '@n8n/di';
-import type express from 'express';
 import { DateTime } from 'luxon';
 import { UserError } from 'n8n-workflow';
 import { z } from 'zod';
@@ -10,6 +9,7 @@ import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { InsightsService } from '@/modules/insights/insights.service';
 import type { InsightsRequest } from '@/public-api/types';
 
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
 import { publicApiScope } from '../../shared/middlewares/global.middleware';
 
 const dateFilterValidationSchema = z
@@ -31,10 +31,14 @@ const dateFilterValidationSchema = z
 		},
 	);
 
-export = {
+type InsightsHandlers = {
+	getInsightsSummary: PublicAPIEndpoint<InsightsRequest.GetSummary>;
+};
+
+const insightsHandlers: InsightsHandlers = {
 	getInsightsSummary: [
 		publicApiScope('insights:read'),
-		async (req: InsightsRequest.GetSummary, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const query = InsightsDateFilterDto.safeParse(req.query);
 			if (!query.success) {
 				throw new BadRequestError(query.error.errors.map(({ message }) => message).join('; '));
@@ -68,3 +72,5 @@ export = {
 		},
 	],
 };
+
+export = insightsHandlers;

--- a/packages/cli/src/public-api/v1/handlers/insights/insights.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/insights/insights.handler.ts
@@ -12,6 +12,14 @@ import type { InsightsRequest } from '@/public-api/types';
 import type { PublicAPIEndpoint } from '../../shared/handler.types';
 import { publicApiScope } from '../../shared/middlewares/global.middleware';
 
+const handleError = (error: unknown) => {
+	if (error instanceof UserError) {
+		throw new ForbiddenError(error.message);
+	}
+
+	throw error;
+};
+
 const dateFilterValidationSchema = z
 	.object({
 		startDate: z.coerce.date().optional(),
@@ -55,11 +63,7 @@ const insightsHandlers: InsightsHandlers = {
 			try {
 				Container.get(InsightsService).validateDateFiltersLicense({ startDate, endDate });
 			} catch (error) {
-				if (error instanceof UserError) {
-					throw new ForbiddenError(error.message);
-				}
-
-				throw error;
+				return handleError(error);
 			}
 
 			const summary = await Container.get(InsightsService).getInsightsSummary({

--- a/packages/cli/src/public-api/v1/handlers/projects/projects.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/projects/projects.handler.ts
@@ -11,7 +11,7 @@ import { Container } from '@n8n/di';
 import pick from 'lodash/pick';
 
 import { ProjectController } from '@/controllers/project.controller';
-import { ResponseError } from '@/errors/response-errors/abstract/response.error';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import type { PaginatedRequest } from '@/public-api/types';
 import { ProjectService } from '@/services/project.service.ee';
@@ -49,7 +49,7 @@ const projectHandlers: ProjectHandlers = {
 		async (req, res) => {
 			const payload = CreateProjectDto.safeParse(req.body);
 			if (payload.error) {
-				return res.status(400).json(payload.error.errors[0]);
+				throw new BadRequestError(payload.error.errors[0].message);
 			}
 
 			const project = await Container.get(ProjectController).createProject(req, res, payload.data);
@@ -63,7 +63,7 @@ const projectHandlers: ProjectHandlers = {
 		async (req, res) => {
 			const payload = UpdateProjectWithRelationsDto.safeParse(req.body);
 			if (payload.error) {
-				return res.status(400).json(payload.error.errors[0]);
+				throw new BadRequestError(payload.error.errors[0].message);
 			}
 
 			await Container.get(ProjectController).updateProject(
@@ -82,7 +82,7 @@ const projectHandlers: ProjectHandlers = {
 		async (req, res) => {
 			const query = DeleteProjectDto.safeParse(req.query);
 			if (query.error) {
-				return res.status(400).json(query.error.errors[0]);
+				throw new BadRequestError(query.error.errors[0].message);
 			}
 
 			await Container.get(ProjectController).deleteProject(
@@ -126,50 +126,43 @@ const projectHandlers: ProjectHandlers = {
 			const offset = Number(req.query.offset) || 0;
 			const limit = Number(req.query.limit) || 100;
 
-			try {
-				const projectService = Container.get(ProjectService);
-				const project = await projectService.getProjectWithScope(req.user, projectId, [
-					'project:list',
-				]);
-				if (!project) {
-					throw new NotFoundError(`Could not find project with ID "${projectId}"`);
-				}
-
-				const projectRelationRepository = Container.get(ProjectRelationRepository);
-				const [relations, count] = await projectRelationRepository.findAndCount({
-					where: { projectId },
-					relations: { user: true, role: true },
-					skip: offset,
-					take: limit,
-				});
-
-				const memberFields = [
-					'id',
-					'email',
-					'firstName',
-					'lastName',
-					'createdAt',
-					'updatedAt',
-				] as const;
-				const data = relations.map((relation) => ({
-					...pick(relation.user, memberFields),
-					role: relation.role?.slug ?? null,
-				}));
-
-				return res.json({
-					data,
-					nextCursor: encodeNextCursor({
-						offset,
-						limit,
-						numberOfTotalRecords: count,
-					}),
-				});
-			} catch (error) {
-				if (error instanceof ResponseError) {
-					return res.status(error.httpStatusCode).json({ message: error.message });
-				}
-				throw error;
+			const projectService = Container.get(ProjectService);
+			const project = await projectService.getProjectWithScope(req.user, projectId, [
+				'project:list',
+			]);
+			if (!project) {
+				throw new NotFoundError(`Could not find project with ID "${projectId}"`);
 			}
+
+			const projectRelationRepository = Container.get(ProjectRelationRepository);
+			const [relations, count] = await projectRelationRepository.findAndCount({
+				where: { projectId },
+				relations: { user: true, role: true },
+				skip: offset,
+				take: limit,
+			});
+
+			const memberFields = [
+				'id',
+				'email',
+				'firstName',
+				'lastName',
+				'createdAt',
+				'updatedAt',
+			] as const;
+			const data = relations.map((relation) => ({
+				...pick(relation.user, memberFields),
+				role: relation.role?.slug ?? null,
+			}));
+
+			return res.json({
+				data,
+				nextCursor: encodeNextCursor({
+					offset,
+					limit,
+					numberOfTotalRecords: count,
+				}),
+			});
 		},
 	],
 	addUsersToProject: [
@@ -178,20 +171,13 @@ const projectHandlers: ProjectHandlers = {
 		async (req, res) => {
 			const payload = AddUsersToProjectDto.safeParse(req.body);
 			if (payload.error) {
-				return res.status(400).json(payload.error.errors[0]);
+				throw new BadRequestError(payload.error.errors[0].message);
 			}
 
-			try {
-				await Container.get(ProjectService).addUsersToProject(
-					req.params.projectId,
-					payload.data.relations,
-				);
-			} catch (error) {
-				if (error instanceof ResponseError) {
-					return res.status(error.httpStatusCode).send({ message: error.message });
-				}
-				throw error;
-			}
+			await Container.get(ProjectService).addUsersToProject(
+				req.params.projectId,
+				payload.data.relations,
+			);
 
 			return res.status(201).send();
 		},
@@ -202,19 +188,12 @@ const projectHandlers: ProjectHandlers = {
 		async (req, res) => {
 			const payload = ChangeUserRoleInProject.safeParse(req.body);
 			if (payload.error) {
-				return res.status(400).json(payload.error.errors[0]);
+				throw new BadRequestError(payload.error.errors[0].message);
 			}
 
 			const { projectId, userId } = req.params;
 			const { role } = payload.data;
-			try {
-				await Container.get(ProjectService).changeUserRoleInProject(projectId, userId, role);
-			} catch (error) {
-				if (error instanceof ResponseError) {
-					return res.status(error.httpStatusCode).send({ message: error.message });
-				}
-				throw error;
-			}
+			await Container.get(ProjectService).changeUserRoleInProject(projectId, userId, role);
 
 			return res.status(204).send();
 		},
@@ -224,14 +203,9 @@ const projectHandlers: ProjectHandlers = {
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'project:update' }),
 		async (req, res) => {
 			const { projectId, userId } = req.params;
-			try {
-				await Container.get(ProjectService).deleteUserFromProject(projectId, userId);
-			} catch (error) {
-				if (error instanceof ResponseError) {
-					return res.status(error.httpStatusCode).send({ message: error.message });
-				}
-				throw error;
-			}
+
+			await Container.get(ProjectService).deleteUserFromProject(projectId, userId);
+
 			return res.status(204).send();
 		},
 	],

--- a/packages/cli/src/public-api/v1/handlers/projects/projects.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/projects/projects.handler.ts
@@ -9,14 +9,14 @@ import type { AuthenticatedRequest } from '@n8n/db';
 import { ProjectRelationRepository, ProjectRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import pick from 'lodash/pick';
-import type { Response } from 'express';
 
 import { ProjectController } from '@/controllers/project.controller';
-import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { ResponseError } from '@/errors/response-errors/abstract/response.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import type { PaginatedRequest } from '@/public-api/types';
 import { ProjectService } from '@/services/project.service.ee';
 
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
 import {
 	apiKeyHasScopeWithGlobalScopeFallback,
 	isLicensed,
@@ -25,11 +25,28 @@ import {
 import { encodeNextCursor } from '../../shared/services/pagination.service';
 
 type GetAll = PaginatedRequest;
-export = {
+type GetProjectUsersRequest = AuthenticatedRequest<{ projectId: string }> & GetAll;
+
+type ProjectHandlers = {
+	createProject: PublicAPIEndpoint<AuthenticatedRequest>;
+	updateProject: PublicAPIEndpoint<AuthenticatedRequest<{ projectId: string }>>;
+	deleteProject: PublicAPIEndpoint<AuthenticatedRequest<{ projectId: string }>>;
+	getProjects: PublicAPIEndpoint<GetAll>;
+	getProjectUsers: PublicAPIEndpoint<GetProjectUsersRequest>;
+	addUsersToProject: PublicAPIEndpoint<AuthenticatedRequest<{ projectId: string }>>;
+	changeUserRoleInProject: PublicAPIEndpoint<
+		AuthenticatedRequest<{ projectId: string; userId: string }>
+	>;
+	deleteUserFromProject: PublicAPIEndpoint<
+		AuthenticatedRequest<{ projectId: string; userId: string }>
+	>;
+};
+
+const projectHandlers: ProjectHandlers = {
 	createProject: [
 		isLicensed('feat:projectRole:admin'),
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'project:create' }),
-		async (req: AuthenticatedRequest, res: Response) => {
+		async (req, res) => {
 			const payload = CreateProjectDto.safeParse(req.body);
 			if (payload.error) {
 				return res.status(400).json(payload.error.errors[0]);
@@ -43,7 +60,7 @@ export = {
 	updateProject: [
 		isLicensed('feat:projectRole:admin'),
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'project:update' }),
-		async (req: AuthenticatedRequest<{ projectId: string }>, res: Response) => {
+		async (req, res) => {
 			const payload = UpdateProjectWithRelationsDto.safeParse(req.body);
 			if (payload.error) {
 				return res.status(400).json(payload.error.errors[0]);
@@ -62,7 +79,7 @@ export = {
 	deleteProject: [
 		isLicensed('feat:projectRole:admin'),
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'project:delete' }),
-		async (req: AuthenticatedRequest<{ projectId: string }>, res: Response) => {
+		async (req, res) => {
 			const query = DeleteProjectDto.safeParse(req.query);
 			if (query.error) {
 				return res.status(400).json(query.error.errors[0]);
@@ -82,7 +99,7 @@ export = {
 		isLicensed('feat:projectRole:admin'),
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'project:list' }),
 		validCursor,
-		async (req: GetAll, res: Response) => {
+		async (req, res) => {
 			const { offset = 0, limit = 100 } = req.query;
 
 			const [projects, count] = await Container.get(ProjectRepository).findAndCount({
@@ -104,7 +121,7 @@ export = {
 		isLicensed('feat:projectRole:admin'),
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'user:list' }),
 		validCursor,
-		async (req: AuthenticatedRequest<{ projectId: string }> & GetAll, res: Response) => {
+		async (req, res) => {
 			const { projectId } = req.params;
 			const offset = Number(req.query.offset) || 0;
 			const limit = Number(req.query.limit) || 100;
@@ -158,7 +175,7 @@ export = {
 	addUsersToProject: [
 		isLicensed('feat:projectRole:admin'),
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'project:update' }),
-		async (req: AuthenticatedRequest<{ projectId: string }>, res: Response) => {
+		async (req, res) => {
 			const payload = AddUsersToProjectDto.safeParse(req.body);
 			if (payload.error) {
 				return res.status(400).json(payload.error.errors[0]);
@@ -182,7 +199,7 @@ export = {
 	changeUserRoleInProject: [
 		isLicensed('feat:projectRole:admin'),
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'project:update' }),
-		async (req: AuthenticatedRequest<{ projectId: string; userId: string }>, res: Response) => {
+		async (req, res) => {
 			const payload = ChangeUserRoleInProject.safeParse(req.body);
 			if (payload.error) {
 				return res.status(400).json(payload.error.errors[0]);
@@ -205,7 +222,7 @@ export = {
 	deleteUserFromProject: [
 		isLicensed('feat:projectRole:admin'),
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'project:update' }),
-		async (req: AuthenticatedRequest<{ projectId: string; userId: string }>, res: Response) => {
+		async (req, res) => {
 			const { projectId, userId } = req.params;
 			try {
 				await Container.get(ProjectService).deleteUserFromProject(projectId, userId);
@@ -219,3 +236,5 @@ export = {
 		},
 	],
 };
+
+export = projectHandlers;

--- a/packages/cli/src/public-api/v1/handlers/source-control/source-control.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/source-control/source-control.handler.ts
@@ -1,27 +1,26 @@
 import { PullWorkFolderRequestDto } from '@n8n/api-types';
 import type { AuthenticatedRequest } from '@n8n/db';
 import { Container } from '@n8n/di';
-import type express from 'express';
-import type { StatusResult } from 'simple-git';
 
+import { EventService } from '@/events/event.service';
 import {
 	getTrackingInformationFromPullResult,
 	isSourceControlLicensed,
 } from '@/modules/source-control.ee/source-control-helper.ee';
 import { SourceControlPreferencesService } from '@/modules/source-control.ee/source-control-preferences.service.ee';
 import { SourceControlService } from '@/modules/source-control.ee/source-control.service.ee';
-import type { ImportResult } from '@/modules/source-control.ee/types/import-result';
-import { EventService } from '@/events/event.service';
 
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
 import { apiKeyHasScopeWithGlobalScopeFallback } from '../../shared/middlewares/global.middleware';
 
-export = {
+type SourceControlHandlers = {
+	pull: PublicAPIEndpoint<AuthenticatedRequest>;
+};
+
+const sourceControlHandlers: SourceControlHandlers = {
 	pull: [
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'sourceControl:pull' }),
-		async (
-			req: AuthenticatedRequest,
-			res: express.Response,
-		): Promise<ImportResult | StatusResult | Promise<express.Response>> => {
+		async (req, res) => {
 			const sourceControlPreferencesService = Container.get(SourceControlPreferencesService);
 			if (!isSourceControlLicensed()) {
 				return res
@@ -53,3 +52,5 @@ export = {
 		},
 	],
 };
+
+export = sourceControlHandlers;

--- a/packages/cli/src/public-api/v1/handlers/tags/tags.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/tags/tags.handler.ts
@@ -1,9 +1,12 @@
 import type { TagEntity } from '@n8n/db';
 import { TagRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
+
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import type { FindManyOptions } from '@n8n/typeorm';
 
+import { ConflictError } from '@/errors/response-errors/conflict.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { TagService } from '@/services/tag.service';
 
 import type { TagRequest } from '../../../types';
@@ -33,8 +36,8 @@ const tagHandlers: TagHandlers = {
 			try {
 				const createdTag = await Container.get(TagService).save(newTag, 'create');
 				return res.status(201).json(createdTag);
-			} catch (error) {
-				return res.status(409).json({ message: 'Tag already exists' });
+			} catch {
+				throw new ConflictError('Tag already exists');
 			}
 		},
 	],
@@ -47,7 +50,7 @@ const tagHandlers: TagHandlers = {
 			try {
 				await Container.get(TagService).getById(id);
 			} catch (error) {
-				return res.status(404).json({ message: 'Not Found' });
+				throw new NotFoundError('Not Found');
 			}
 
 			const updateTag = Container.get(TagService).toEntity({ id, name: name.trim() });
@@ -55,8 +58,8 @@ const tagHandlers: TagHandlers = {
 			try {
 				const updatedTag = await Container.get(TagService).save(updateTag, 'update');
 				return res.json(updatedTag);
-			} catch (error) {
-				return res.status(409).json({ message: 'Tag already exists' });
+			} catch {
+				throw new ConflictError('Tag already exists');
 			}
 		},
 	],
@@ -69,7 +72,7 @@ const tagHandlers: TagHandlers = {
 			try {
 				tag = await Container.get(TagService).getById(id);
 			} catch (error) {
-				return res.status(404).json({ message: 'Not Found' });
+				throw new NotFoundError('Not Found');
 			}
 
 			await Container.get(TagService).delete(id);
@@ -108,7 +111,7 @@ const tagHandlers: TagHandlers = {
 				const tag = await Container.get(TagService).getById(id);
 				return res.json(tag);
 			} catch (error) {
-				return res.status(404).json({ message: 'Not Found' });
+				throw new NotFoundError('Not Found');
 			}
 		},
 	],

--- a/packages/cli/src/public-api/v1/handlers/tags/tags.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/tags/tags.handler.ts
@@ -3,21 +3,29 @@ import { TagRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import type { FindManyOptions } from '@n8n/typeorm';
-import type express from 'express';
 
 import { TagService } from '@/services/tag.service';
 
 import type { TagRequest } from '../../../types';
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
 import {
 	apiKeyHasScopeWithGlobalScopeFallback,
 	validCursor,
 } from '../../shared/middlewares/global.middleware';
 import { encodeNextCursor } from '../../shared/services/pagination.service';
 
-export = {
+type TagHandlers = {
+	createTag: PublicAPIEndpoint<TagRequest.Create>;
+	updateTag: PublicAPIEndpoint<TagRequest.Update>;
+	deleteTag: PublicAPIEndpoint<TagRequest.Delete>;
+	getTags: PublicAPIEndpoint<TagRequest.GetAll>;
+	getTag: PublicAPIEndpoint<TagRequest.Get>;
+};
+
+const tagHandlers: TagHandlers = {
 	createTag: [
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'tag:create' }),
-		async (req: TagRequest.Create, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const { name } = req.body;
 
 			const newTag = Container.get(TagService).toEntity({ name: name.trim() });
@@ -32,7 +40,7 @@ export = {
 	],
 	updateTag: [
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'tag:update' }),
-		async (req: TagRequest.Update, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const { id } = req.params;
 			const { name } = req.body;
 
@@ -54,7 +62,7 @@ export = {
 	],
 	deleteTag: [
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'tag:delete' }),
-		async (req: TagRequest.Delete, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const { id } = req.params;
 
 			let tag;
@@ -71,7 +79,7 @@ export = {
 	getTags: [
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'tag:list' }),
 		validCursor,
-		async (req: TagRequest.GetAll, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const { offset = 0, limit = 100 } = req.query;
 
 			const query: FindManyOptions<TagEntity> = {
@@ -93,7 +101,7 @@ export = {
 	],
 	getTag: [
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'tag:read' }),
-		async (req: TagRequest.Get, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const { id } = req.params;
 
 			try {
@@ -105,3 +113,5 @@ export = {
 		},
 	],
 };
+
+export = tagHandlers;

--- a/packages/cli/src/public-api/v1/handlers/users/users.handler.ee.ts
+++ b/packages/cli/src/public-api/v1/handlers/users/users.handler.ee.ts
@@ -1,9 +1,7 @@
 import { InviteUsersRequestDto, RoleChangeRequestDto } from '@n8n/api-types';
-import type { AuthenticatedRequest } from '@n8n/db';
-import { ProjectRelationRepository } from '@n8n/db';
+import { ProjectRelationRepository, type AuthenticatedRequest } from '@n8n/db';
 import { Container } from '@n8n/di';
-import type express from 'express';
-import type { Response } from 'express';
+
 import { InvitationController } from '@/controllers/invitation.controller';
 import { UsersController } from '@/controllers/users.controller';
 import { EventService } from '@/events/event.service';
@@ -11,6 +9,7 @@ import type { UserRequest } from '@/requests';
 import { UserService } from '@/services/user.service';
 
 import { clean, getAllUsersAndCount, getUser } from './users.service.ee';
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
 import {
 	apiKeyHasScopeWithGlobalScopeFallback,
 	isLicensed,
@@ -23,11 +22,19 @@ type Create = AuthenticatedRequest<{}, {}, InviteUsersRequestDto>;
 type Delete = UserRequest.Delete;
 type ChangeRole = AuthenticatedRequest<{ id: string }, {}, RoleChangeRequestDto, {}>;
 
-export = {
+type UsersHandlers = {
+	getUser: PublicAPIEndpoint<UserRequest.Get>;
+	getUsers: PublicAPIEndpoint<UserRequest.Get>;
+	createUser: PublicAPIEndpoint<Create>;
+	deleteUser: PublicAPIEndpoint<Delete>;
+	changeRole: PublicAPIEndpoint<ChangeRole>;
+};
+
+const usersHandlers: UsersHandlers = {
 	getUser: [
 		validLicenseWithUserQuota,
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'user:read' }),
-		async (req: UserRequest.Get, res: express.Response) => {
+		async (req, res) => {
 			const { includeRole = false } = req.query;
 			const { id } = req.params;
 
@@ -51,7 +58,7 @@ export = {
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'user:list' }),
 		validLicenseWithUserQuota,
 		validCursor,
-		async (req: UserRequest.Get, res: express.Response) => {
+		async (req, res) => {
 			const { offset = 0, limit = 100, includeRole = false, projectId } = req.query;
 
 			await Container.get(UserService).assertGetUsersAccess(req.user, projectId);
@@ -84,7 +91,7 @@ export = {
 	],
 	createUser: [
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'user:create' }),
-		async (req: Create, res: Response) => {
+		async (req, res) => {
 			const { data, error } = InviteUsersRequestDto.safeParse(req.body);
 			if (error) {
 				return res.status(400).json(error.errors[0]);
@@ -100,7 +107,7 @@ export = {
 	],
 	deleteUser: [
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'user:delete' }),
-		async (req: Delete, res: Response) => {
+		async (req, res) => {
 			await Container.get(UsersController).deleteUser(req);
 
 			return res.status(204).send();
@@ -109,7 +116,7 @@ export = {
 	changeRole: [
 		isLicensed('feat:advancedPermissions'),
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'user:changeRole' }),
-		async (req: ChangeRole, res: Response) => {
+		async (req, res) => {
 			const validation = RoleChangeRequestDto.safeParse(req.body);
 			if (validation.error) {
 				return res.status(400).json({
@@ -128,3 +135,5 @@ export = {
 		},
 	],
 };
+
+export = usersHandlers;

--- a/packages/cli/src/public-api/v1/handlers/users/users.handler.ee.ts
+++ b/packages/cli/src/public-api/v1/handlers/users/users.handler.ee.ts
@@ -4,6 +4,8 @@ import { Container } from '@n8n/di';
 
 import { InvitationController } from '@/controllers/invitation.controller';
 import { UsersController } from '@/controllers/users.controller';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { EventService } from '@/events/event.service';
 import type { UserRequest } from '@/requests';
 import { UserService } from '@/services/user.service';
@@ -41,9 +43,7 @@ const usersHandlers: UsersHandlers = {
 			const user = await getUser({ withIdentifier: id, includeRole });
 
 			if (!user) {
-				return res.status(404).json({
-					message: `Could not find user with id: ${id}`,
-				});
+				throw new NotFoundError(`Could not find user with id: ${id}`);
 			}
 
 			Container.get(EventService).emit('user-retrieved-user', {
@@ -94,7 +94,7 @@ const usersHandlers: UsersHandlers = {
 		async (req, res) => {
 			const { data, error } = InviteUsersRequestDto.safeParse(req.body);
 			if (error) {
-				return res.status(400).json(error.errors[0]);
+				throw new BadRequestError(error.errors[0]?.message ?? 'Invalid request body');
 			}
 
 			const usersInvited = await Container.get(InvitationController).inviteUser(
@@ -119,9 +119,7 @@ const usersHandlers: UsersHandlers = {
 		async (req, res) => {
 			const validation = RoleChangeRequestDto.safeParse(req.body);
 			if (validation.error) {
-				return res.status(400).json({
-					message: validation.error.errors[0],
-				});
+				throw new BadRequestError(validation.error.errors[0]?.message ?? 'Invalid request body');
 			}
 
 			await Container.get(UsersController).changeGlobalRole(

--- a/packages/cli/src/public-api/v1/handlers/variables/variables.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/variables/variables.handler.ts
@@ -4,6 +4,7 @@ import { Container } from '@n8n/di';
 
 import { VariablesController } from '@/environments.ee/variables/variables.controller.ee';
 import { VariablesService } from '@/environments.ee/variables/variables.service.ee';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import type { VariablesRequest } from '@/requests';
 
 import type { PublicAPIEndpoint } from '../../shared/handler.types';
@@ -28,7 +29,7 @@ const variablesHandlers: VariablesHandlers = {
 		async (req, res) => {
 			const payload = CreateVariableRequestDto.safeParse(req.body);
 			if (payload.error) {
-				return res.status(400).json(payload.error.errors[0]);
+				throw new BadRequestError(payload.error.errors[0]?.message ?? 'Invalid request body');
 			}
 			await Container.get(VariablesController).createVariable(req, res, payload.data);
 
@@ -41,7 +42,7 @@ const variablesHandlers: VariablesHandlers = {
 		async (req, res) => {
 			const payload = UpdateVariableRequestDto.safeParse(req.body);
 			if (payload.error) {
-				return res.status(400).json(payload.error.errors[0]);
+				throw new BadRequestError(payload.error.errors[0]?.message ?? 'Invalid request body');
 			}
 			await Container.get(VariablesController).updateVariable(req, res, payload.data);
 

--- a/packages/cli/src/public-api/v1/handlers/variables/variables.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/variables/variables.handler.ts
@@ -1,12 +1,12 @@
 import { CreateVariableRequestDto, UpdateVariableRequestDto } from '@n8n/api-types';
 import type { AuthenticatedRequest } from '@n8n/db';
 import { Container } from '@n8n/di';
-import type { Response } from 'express';
 
 import { VariablesController } from '@/environments.ee/variables/variables.controller.ee';
 import { VariablesService } from '@/environments.ee/variables/variables.service.ee';
 import type { VariablesRequest } from '@/requests';
 
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
 import {
 	apiKeyHasScopeWithGlobalScopeFallback,
 	isLicensed,
@@ -14,11 +14,18 @@ import {
 } from '../../shared/middlewares/global.middleware';
 import { paginateArray } from '../../shared/services/pagination.service';
 
-export = {
+type VariablesHandlers = {
+	createVariable: PublicAPIEndpoint<AuthenticatedRequest>;
+	updateVariable: PublicAPIEndpoint<AuthenticatedRequest<{ id: string }>>;
+	deleteVariable: PublicAPIEndpoint<AuthenticatedRequest<{ id: string }>>;
+	getVariables: PublicAPIEndpoint<VariablesRequest.GetAll>;
+};
+
+const variablesHandlers: VariablesHandlers = {
 	createVariable: [
 		isLicensed('feat:variables'),
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'variable:create' }),
-		async (req: AuthenticatedRequest, res: Response) => {
+		async (req, res) => {
 			const payload = CreateVariableRequestDto.safeParse(req.body);
 			if (payload.error) {
 				return res.status(400).json(payload.error.errors[0]);
@@ -31,7 +38,7 @@ export = {
 	updateVariable: [
 		isLicensed('feat:variables'),
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'variable:update' }),
-		async (req: AuthenticatedRequest<{ id: string }>, res: Response) => {
+		async (req, res) => {
 			const payload = UpdateVariableRequestDto.safeParse(req.body);
 			if (payload.error) {
 				return res.status(400).json(payload.error.errors[0]);
@@ -44,7 +51,7 @@ export = {
 	deleteVariable: [
 		isLicensed('feat:variables'),
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'variable:delete' }),
-		async (req: AuthenticatedRequest<{ id: string }>, res: Response) => {
+		async (req, res) => {
 			await Container.get(VariablesController).deleteVariable(req);
 
 			return res.status(204).send();
@@ -54,7 +61,7 @@ export = {
 		isLicensed('feat:variables'),
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'variable:list' }),
 		validCursor,
-		async (req: VariablesRequest.GetAll, res: Response) => {
+		async (req, res) => {
 			const { offset = 0, limit = 100, projectId, state } = req.query;
 
 			const variables = await Container.get(VariablesService).getAllForUser(req.user, {
@@ -66,3 +73,5 @@ export = {
 		},
 	],
 };
+
+export = variablesHandlers;

--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
@@ -25,6 +25,16 @@ import {
 } from '../../shared/middlewares/global.middleware';
 import { encodeNextCursor } from '../../shared/services/pagination.service';
 
+const handleError = (error: unknown) => {
+	if (error instanceof NotFoundError) {
+		throw error;
+	}
+	if (error instanceof Error) {
+		throw new BadRequestError(error.message);
+	}
+	throw error;
+};
+
 type WorkflowHandlers = {
 	createWorkflow: PublicAPIEndpoint<WorkflowRequest.Create>;
 	transferWorkflow: PublicAPIEndpoint<WorkflowRequest.Transfer>;
@@ -76,7 +86,7 @@ const workflowHandlers: WorkflowHandlers = {
 			if (!workflow) {
 				// user trying to access a workflow they do not own
 				// or workflow does not exist
-				return res.status(404).json({ message: 'Not Found' });
+				throw new NotFoundError('Not Found');
 			}
 
 			return res.json(workflow);
@@ -103,7 +113,7 @@ const workflowHandlers: WorkflowHandlers = {
 				// user trying to access a workflow they do not own
 				// and was not shared to them
 				// Or does not exist.
-				return res.status(404).json({ message: 'Not Found' });
+				throw new NotFoundError('Not Found');
 			}
 
 			if (excludePinnedData) {
@@ -140,8 +150,8 @@ const workflowHandlers: WorkflowHandlers = {
 				const { autosaved, ...versionWithoutInternalFields } = version;
 
 				return res.json(versionWithoutInternalFields);
-			} catch (error) {
-				return res.status(404).json({ message: 'Version not found' });
+			} catch {
+				throw new NotFoundError('Version not found');
 			}
 		},
 	],
@@ -305,13 +315,7 @@ const workflowHandlers: WorkflowHandlers = {
 
 				return res.json(updatedWorkflow);
 			} catch (error) {
-				if (error instanceof NotFoundError) {
-					return res.status(404).json({ message: 'Not Found' });
-				}
-				if (error instanceof Error) {
-					return res.status(400).json({ message: error.message });
-				}
-				throw error;
+				return handleError(error);
 			}
 		},
 	],
@@ -332,13 +336,7 @@ const workflowHandlers: WorkflowHandlers = {
 
 				return res.json(workflow);
 			} catch (error) {
-				if (error instanceof NotFoundError) {
-					return res.status(404).json({ message: 'Not Found' });
-				}
-				if (error instanceof Error) {
-					return res.status(400).json({ message: error.message });
-				}
-				throw error;
+				return handleError(error);
 			}
 		},
 	],
@@ -355,13 +353,7 @@ const workflowHandlers: WorkflowHandlers = {
 
 				return res.json(workflow);
 			} catch (error) {
-				if (error instanceof NotFoundError) {
-					return res.status(404).json({ message: 'Not Found' });
-				}
-				if (error instanceof Error) {
-					return res.status(400).json({ message: error.message });
-				}
-				throw error;
+				return handleError(error);
 			}
 		},
 	],
@@ -372,7 +364,7 @@ const workflowHandlers: WorkflowHandlers = {
 			const { id } = req.params;
 
 			if (Container.get(GlobalConfig).tags.disabled) {
-				return res.status(400).json({ message: 'Workflow Tags Disabled' });
+				throw new BadRequestError('Workflow Tags Disabled');
 			}
 
 			const workflow = await Container.get(WorkflowFinderService).findWorkflowForUser(
@@ -384,7 +376,7 @@ const workflowHandlers: WorkflowHandlers = {
 			if (!workflow) {
 				// user trying to access a workflow he does not own
 				// or workflow does not exist
-				return res.status(404).json({ message: 'Not Found' });
+				throw new NotFoundError('Not Found');
 			}
 
 			const tags = await getWorkflowTags(id);
@@ -400,7 +392,7 @@ const workflowHandlers: WorkflowHandlers = {
 			const newTags = req.body.map((newTag) => newTag.id);
 
 			if (Container.get(GlobalConfig).tags.disabled) {
-				return res.status(400).json({ message: 'Workflow Tags Disabled' });
+				throw new BadRequestError('Workflow Tags Disabled');
 			}
 
 			const sharedWorkflow = await Container.get(WorkflowFinderService).findWorkflowForUser(
@@ -412,7 +404,7 @@ const workflowHandlers: WorkflowHandlers = {
 			if (!sharedWorkflow) {
 				// user trying to access a workflow he does not own
 				// or workflow does not exist
-				return res.status(404).json({ message: 'Not Found' });
+				throw new NotFoundError('Not Found');
 			}
 
 			let tags;
@@ -422,10 +414,10 @@ const workflowHandlers: WorkflowHandlers = {
 			} catch (error) {
 				// TODO: add a `ConstraintFailureError` in typeorm to handle when tags are missing here
 				if (error instanceof QueryFailedError) {
-					return res.status(404).json({ message: 'Some tags not found' });
-				} else {
-					throw error;
+					throw new NotFoundError('Some tags not found');
 				}
+
+				return handleError(error);
 			}
 
 			return res.json(tags);
@@ -443,10 +435,7 @@ const workflowHandlers: WorkflowHandlers = {
 				}
 				return res.json(workflow);
 			} catch (error) {
-				if (error instanceof NotFoundError) {
-					return res.status(404).json({ message: 'Workflow Not Found' });
-				}
-				throw error;
+				return handleError(error);
 			}
 		},
 	],
@@ -462,13 +451,7 @@ const workflowHandlers: WorkflowHandlers = {
 				}
 				return res.json(workflow);
 			} catch (error) {
-				if (error instanceof NotFoundError) {
-					return res.status(404).json({ message: 'Workflow Not Found' });
-				}
-				if (error instanceof BadRequestError) {
-					return res.status(error.httpStatusCode).json({ message: error.message });
-				}
-				throw error;
+				return handleError(error);
 			}
 		},
 	],

--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
@@ -5,7 +5,6 @@ import { Container } from '@n8n/di';
 import { In, IsNull, Like, Not, QueryFailedError } from '@n8n/typeorm';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import type { FindOptionsWhere } from '@n8n/typeorm';
-import type express from 'express';
 import { z } from 'zod';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
@@ -18,16 +17,34 @@ import { EnterpriseWorkflowService } from '@/workflows/workflow.service.ee';
 
 import { createWorkflow, parseTagNames, getWorkflowTags, updateTags } from './workflows.service';
 import type { WorkflowRequest } from '../../../types';
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
 import {
 	publicApiScope,
 	projectScope,
 	validCursor,
 } from '../../shared/middlewares/global.middleware';
 import { encodeNextCursor } from '../../shared/services/pagination.service';
-export = {
+
+type WorkflowHandlers = {
+	createWorkflow: PublicAPIEndpoint<WorkflowRequest.Create>;
+	transferWorkflow: PublicAPIEndpoint<WorkflowRequest.Transfer>;
+	deleteWorkflow: PublicAPIEndpoint<WorkflowRequest.Get>;
+	getWorkflow: PublicAPIEndpoint<WorkflowRequest.Get>;
+	getWorkflowVersion: PublicAPIEndpoint<WorkflowRequest.GetVersion>;
+	getWorkflows: PublicAPIEndpoint<WorkflowRequest.GetAll>;
+	updateWorkflow: PublicAPIEndpoint<WorkflowRequest.Update>;
+	activateWorkflow: PublicAPIEndpoint<WorkflowRequest.Activate>;
+	deactivateWorkflow: PublicAPIEndpoint<WorkflowRequest.Activate>;
+	getWorkflowTags: PublicAPIEndpoint<WorkflowRequest.GetTags>;
+	updateWorkflowTags: PublicAPIEndpoint<WorkflowRequest.UpdateTags>;
+	archiveWorkflow: PublicAPIEndpoint<WorkflowRequest.Get>;
+	unarchiveWorkflow: PublicAPIEndpoint<WorkflowRequest.Get>;
+};
+
+const workflowHandlers: WorkflowHandlers = {
 	createWorkflow: [
 		publicApiScope('workflow:create'),
-		async (req: WorkflowRequest.Create, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const createdWorkflow = await createWorkflow(req.user, req.body);
 			return res.json(createdWorkflow);
 		},
@@ -35,7 +52,7 @@ export = {
 	transferWorkflow: [
 		publicApiScope('workflow:move'),
 		projectScope('workflow:move', 'workflow'),
-		async (req: WorkflowRequest.Transfer, res: express.Response) => {
+		async (req, res) => {
 			const { id: workflowId } = req.params;
 
 			const body = z.object({ destinationProjectId: z.string() }).parse(req.body);
@@ -46,13 +63,13 @@ export = {
 				body.destinationProjectId,
 			);
 
-			res.status(204).send();
+			return res.status(204).send();
 		},
 	],
 	deleteWorkflow: [
 		publicApiScope('workflow:delete'),
 		projectScope('workflow:delete', 'workflow'),
-		async (req: WorkflowRequest.Get, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const { id: workflowId } = req.params;
 
 			const workflow = await Container.get(WorkflowService).delete(req.user, workflowId, true);
@@ -68,7 +85,7 @@ export = {
 	getWorkflow: [
 		publicApiScope('workflow:read'),
 		projectScope('workflow:read', 'workflow'),
-		async (req: WorkflowRequest.Get, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const { id } = req.params;
 			const { excludePinnedData = false } = req.query;
 
@@ -104,7 +121,7 @@ export = {
 	getWorkflowVersion: [
 		publicApiScope('workflow:read'),
 		projectScope('workflow:read', 'workflow'),
-		async (req: WorkflowRequest.GetVersion, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const { id: workflowId, versionId } = req.params;
 
 			try {
@@ -131,7 +148,7 @@ export = {
 	getWorkflows: [
 		publicApiScope('workflow:list'),
 		validCursor,
-		async (req: WorkflowRequest.GetAll, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const {
 				offset = 0,
 				limit = 100,
@@ -268,7 +285,7 @@ export = {
 	updateWorkflow: [
 		publicApiScope('workflow:update'),
 		projectScope('workflow:update', 'workflow'),
-		async (req: WorkflowRequest.Update, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const { id } = req.params;
 			const updateData = new WorkflowEntity();
 			Object.assign(updateData, req.body);
@@ -301,7 +318,7 @@ export = {
 	activateWorkflow: [
 		publicApiScope('workflow:activate'),
 		projectScope('workflow:publish', 'workflow'),
-		async (req: WorkflowRequest.Activate, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const { id } = req.params;
 			const { versionId, name, description } = req.body;
 
@@ -328,7 +345,7 @@ export = {
 	deactivateWorkflow: [
 		publicApiScope('workflow:deactivate'),
 		projectScope('workflow:unpublish', 'workflow'),
-		async (req: WorkflowRequest.Activate, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const { id } = req.params;
 
 			try {
@@ -351,7 +368,7 @@ export = {
 	getWorkflowTags: [
 		publicApiScope('workflowTags:list'),
 		projectScope('workflow:read', 'workflow'),
-		async (req: WorkflowRequest.GetTags, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const { id } = req.params;
 
 			if (Container.get(GlobalConfig).tags.disabled) {
@@ -378,7 +395,7 @@ export = {
 	updateWorkflowTags: [
 		publicApiScope('workflowTags:update'),
 		projectScope('workflow:update', 'workflow'),
-		async (req: WorkflowRequest.UpdateTags, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const { id } = req.params;
 			const newTags = req.body.map((newTag) => newTag.id);
 
@@ -417,7 +434,7 @@ export = {
 	archiveWorkflow: [
 		publicApiScope('workflow:delete'),
 		projectScope('workflow:delete', 'workflow'),
-		async (req: WorkflowRequest.Get, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const { id } = req.params;
 			try {
 				const workflow = await Container.get(WorkflowService).archiveForPublicApi(req.user, id);
@@ -436,7 +453,7 @@ export = {
 	unarchiveWorkflow: [
 		publicApiScope('workflow:delete'),
 		projectScope('workflow:delete', 'workflow'),
-		async (req: WorkflowRequest.Get, res: express.Response): Promise<express.Response> => {
+		async (req, res) => {
 			const { id } = req.params;
 			try {
 				const workflow = await Container.get(WorkflowService).unarchiveForPublicApi(req.user, id);
@@ -456,3 +473,5 @@ export = {
 		},
 	],
 };
+
+export = workflowHandlers;

--- a/packages/cli/src/public-api/v1/shared/handler.types.ts
+++ b/packages/cli/src/public-api/v1/shared/handler.types.ts
@@ -1,7 +1,23 @@
 import type { AuthenticatedRequest } from '@n8n/db';
 import type { Response } from 'express';
 
-export type PublicAPIHandler<TParams extends Record<string, string>> = (
-	req: AuthenticatedRequest<TParams>,
+import type { Middleware } from './middlewares/global.middleware';
+
+/**
+ * Final handler in a public API route tuple. `TReq` must be an `AuthenticatedRequest`
+ * instantiation (including aliases like `WorkflowRequest.Create`).
+ */
+type PublicAPIEndpointHandler<TReq extends AuthenticatedRequest> = (
+	req: TReq,
 	res: Response,
-) => Promise<Response | undefined>;
+) => Promise<Response>;
+
+/**
+ * A public API route: any number of middlewares (see `Middleware` in `global.middleware.ts`),
+ * then a typed handler. Middleware typing is intentionally loose; the handler is what we
+ * type-check strictly.
+ */
+export type PublicAPIEndpoint<TReq extends AuthenticatedRequest> = readonly [
+	...Middleware[],
+	PublicAPIEndpointHandler<TReq>,
+];

--- a/packages/cli/src/public-api/v1/shared/middlewares/global.middleware.ts
+++ b/packages/cli/src/public-api/v1/shared/middlewares/global.middleware.ts
@@ -10,8 +10,8 @@ import { FeatureNotLicensedError } from '@/errors/feature-not-licensed.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { License } from '@/license';
 import { userHasScopes } from '@/permissions.ee/check-access';
+import type { PaginatedRequest } from '@/public-api/types';
 
-import type { PaginatedRequest } from '../../../types';
 import { decodeCursor } from '../services/pagination.service';
 
 const UNLIMITED_USERS_QUOTA = -1;
@@ -61,20 +61,22 @@ export const projectScope = (scopes: Scope | Scope[], resource: ProjectScopeReso
 	buildScopeMiddleware(Array.isArray(scopes) ? scopes : [scopes], resource, { globalOnly: false });
 
 export const validCursor = (
-	req: PaginatedRequest,
+	req: Request,
 	res: express.Response,
 	next: express.NextFunction,
 ): express.Response | void => {
-	if (req.query.cursor) {
-		const { cursor } = req.query;
+	const paginatedReq = req as unknown as PaginatedRequest;
+
+	if (paginatedReq.query.cursor) {
+		const { cursor } = paginatedReq.query;
 		try {
 			const paginationData = decodeCursor(cursor);
 			if ('offset' in paginationData) {
-				req.query.offset = paginationData.offset;
-				req.query.limit = paginationData.limit;
+				paginatedReq.query.offset = paginationData.offset;
+				paginatedReq.query.limit = paginationData.limit;
 			} else {
-				req.query.lastId = paginationData.lastId;
-				req.query.limit = paginationData.limit;
+				paginatedReq.query.lastId = paginationData.lastId;
+				paginatedReq.query.limit = paginationData.limit;
 			}
 		} catch (error) {
 			return res.status(400).json({

--- a/packages/cli/test/integration/execution-redaction.test.ts
+++ b/packages/cli/test/integration/execution-redaction.test.ts
@@ -354,15 +354,8 @@ describe('GET /executions/:id — Execution Redaction', () => {
 				.query({ redactExecutionData: 'false' })
 				.expect(403);
 
-			expect(response.body).toMatchObject({
-				code: 403,
-				message: expect.stringContaining('execution:reveal'),
-				hint: expect.any(String),
-				meta: {
-					errorCode: 'EXECUTION_REVEAL_FORBIDDEN',
-					requiredScope: 'execution:reveal',
-				},
-			});
+			expect(response.status).toBe(403);
+			expect(response.body.message).toContain('execution:reveal');
 		});
 
 		test('project editor without execution:reveal scope can still reveal when policy allows it (policy=none)', async () => {
@@ -733,10 +726,8 @@ describe('GET /api/v1/executions/:id — Execution Redaction', () => {
 				.get(`/executions/${execution.id}?includeData=true&redactExecutionData=false`)
 				.expect(403);
 
-			expect(response.body).toMatchObject({
-				code: 403,
-				message: expect.stringContaining('execution:reveal'),
-			});
+			expect(response.status).toBe(403);
+			expect(response.body.message).toContain('execution:reveal');
 		});
 
 		test('member without execution:reveal scope can still reveal when policy allows it (policy=none)', async () => {
@@ -922,10 +913,8 @@ describe('GET /api/v1/executions — Execution Redaction', () => {
 				.get('/executions?includeData=true&redactExecutionData=false')
 				.expect(403);
 
-			expect(response.body).toMatchObject({
-				code: 403,
-				message: expect.stringContaining('execution:reveal'),
-			});
+			expect(response.status).toBe(403);
+			expect(response.body.message).toContain('execution:reveal');
 		});
 	});
 });

--- a/packages/cli/test/integration/public-api/source-control.test.ts
+++ b/packages/cli/test/integration/public-api/source-control.test.ts
@@ -1,0 +1,163 @@
+import type { SourceControlledFile } from '@n8n/api-types';
+import { mockInstance } from '@n8n/backend-test-utils';
+import type { User } from '@n8n/db';
+import { Container } from '@n8n/di';
+
+import { EventService } from '@/events/event.service';
+import { SourceControlPreferencesService } from '@/modules/source-control.ee/source-control-preferences.service.ee';
+import { SourceControlService } from '@/modules/source-control.ee/source-control.service.ee';
+import { Telemetry } from '@/telemetry';
+import { createMemberWithApiKey, createOwnerWithApiKey } from '@test-integration/db/users';
+import { setupTestServer } from '@test-integration/utils';
+
+describe('POST /source-control/pull (Public API)', () => {
+	const testServer = setupTestServer({ endpointGroups: ['publicApi'] });
+	mockInstance(Telemetry);
+
+	let owner: User;
+
+	beforeAll(async () => {
+		owner = await createOwnerWithApiKey();
+	});
+
+	beforeEach(() => {
+		testServer.license.reset();
+		jest.restoreAllMocks();
+	});
+
+	const pullUrl = '/source-control/pull';
+	const validBody = { autoPublish: 'none' as const };
+
+	const sourceControlledFileFixture = (id: string): SourceControlledFile => ({
+		file: `workflows/${id}.json`,
+		id,
+		name: `Workflow ${id}`,
+		type: 'workflow',
+		status: 'created',
+		location: 'remote',
+		conflict: false,
+		updatedAt: '2024-01-01T00:00:00.000Z',
+	});
+
+	it('should return 401 when API key is missing', async () => {
+		const response = await testServer.publicApiAgentWithoutApiKey().post(pullUrl).send(validBody);
+
+		expect(response.status).toBe(401);
+		expect(response.body).toHaveProperty('message', "'X-N8N-API-KEY' header required");
+	});
+
+	it('should return 401 when API key is invalid', async () => {
+		const response = await testServer
+			.publicApiAgentWithApiKey('not-a-real-api-key')
+			.post(pullUrl)
+			.send(validBody);
+
+		expect(response.status).toBe(401);
+		expect(response.body).toHaveProperty('message');
+	});
+
+	it('should return 403 when API key lacks sourceControl:pull scope', async () => {
+		testServer.license.enable('feat:sourceControl');
+		const member = await createMemberWithApiKey({ scopes: ['tag:list'] });
+
+		const response = await testServer.publicApiAgentFor(member).post(pullUrl).send(validBody);
+
+		expect(response.status).toBe(403);
+		expect(response.body).toEqual({ message: 'Forbidden' });
+	});
+
+	it('should return 401 when Source Control is not licensed', async () => {
+		const response = await testServer.publicApiAgentFor(owner).post(pullUrl).send(validBody);
+
+		expect(response.status).toBe(401);
+		expect(response.body).toEqual({
+			status: 'Error',
+			message: 'Source Control feature is not licensed',
+		});
+	});
+
+	it('should return 400 when licensed but Source Control is not connected', async () => {
+		testServer.license.enable('feat:sourceControl');
+
+		const response = await testServer.publicApiAgentFor(owner).post(pullUrl).send(validBody);
+
+		expect(response.status).toBe(400);
+		expect(response.body).toEqual({
+			status: 'Error',
+			message: 'Source Control is not connected to a repository',
+		});
+	});
+
+	it('should return 200 and import result when pull succeeds', async () => {
+		testServer.license.enable('feat:sourceControl');
+		const preferences = Container.get(SourceControlPreferencesService);
+		jest.spyOn(preferences, 'isSourceControlConnected').mockReturnValue(true);
+
+		const statusResult: SourceControlledFile[] = [
+			sourceControlledFileFixture('wf-1'),
+			sourceControlledFileFixture('wf-2'),
+			sourceControlledFileFixture('wf-3'),
+		];
+		const pullSpy = jest
+			.spyOn(Container.get(SourceControlService), 'pullWorkfolder')
+			.mockResolvedValue({ statusCode: 200, statusResult });
+
+		const emitSpy = jest.spyOn(Container.get(EventService), 'emit').mockImplementation(() => true);
+
+		const response = await testServer.publicApiAgentFor(owner).post(pullUrl).send(validBody);
+
+		expect(response.status).toBe(200);
+		expect(response.body).toEqual(statusResult);
+		expect(pullSpy).toHaveBeenCalled();
+		expect(emitSpy).toHaveBeenCalledWith(
+			'source-control-user-pulled-api',
+			expect.objectContaining({ forced: false }),
+		);
+	});
+
+	it('should return 409 when pull reports conflicts', async () => {
+		testServer.license.enable('feat:sourceControl');
+		const preferences = Container.get(SourceControlPreferencesService);
+		jest.spyOn(preferences, 'isSourceControlConnected').mockReturnValue(true);
+
+		const statusResult: SourceControlledFile[] = [];
+		jest.spyOn(Container.get(SourceControlService), 'pullWorkfolder').mockResolvedValue({
+			statusCode: 409,
+			statusResult,
+		});
+
+		const response = await testServer.publicApiAgentFor(owner).post(pullUrl).send({ force: false });
+
+		expect(response.status).toBe(409);
+		expect(response.body).toEqual(statusResult);
+	});
+
+	it('should return 400 as plain text when pullWorkfolder throws', async () => {
+		testServer.license.enable('feat:sourceControl');
+		const preferences = Container.get(SourceControlPreferencesService);
+		jest.spyOn(preferences, 'isSourceControlConnected').mockReturnValue(true);
+
+		jest
+			.spyOn(Container.get(SourceControlService), 'pullWorkfolder')
+			.mockRejectedValue(new Error('Git operation failed'));
+
+		const response = await testServer.publicApiAgentFor(owner).post(pullUrl).send(validBody);
+
+		expect(response.status).toBe(400);
+		expect(response.text).toBe('Git operation failed');
+	});
+
+	it('should return 400 as plain text when body fails PullWorkFolderRequestDto validation', async () => {
+		testServer.license.enable('feat:sourceControl');
+		const preferences = Container.get(SourceControlPreferencesService);
+		jest.spyOn(preferences, 'isSourceControlConnected').mockReturnValue(true);
+
+		const response = await testServer
+			.publicApiAgentFor(owner)
+			.post(pullUrl)
+			.send({ autoPublish: 'not-a-valid-mode' });
+
+		expect(response.status).toBe(400);
+		expect(response.text.length).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
## Summary

This PR refactors all public API handlers to use the unified `PublicAPIEndpoint<TReq>` type defined in `handler.types.ts`. Previously, each handler returned inconsistent types (some used `Response`, some used `Promise<Response>`, some were untyped). The `PublicAPIEndpoint` type enforces a consistent signature — a tuple of optional middlewares followed by a strictly-typed handler — across all 16 handler files.

Changes:
- Updated `handler.types.ts` to export `PublicAPIEndpoint<TReq>` with a trailing `PublicAPIEndpointHandler<TReq>` tuple type
- Applied the type to all handlers: audit, community-packages, credentials, data-tables (columns, rows, main), discover, executions, folders, insights, projects, source-control, tags, users (EE), variables, workflows
- Standardized error handling patterns in handlers to align with the new type contract
- Added integration tests for the source-control public API handler

> [!TIP]
> Changes in this test [(here)](https://github.com/n8n-io/n8n/pull/29752/changes#r3188283588) describe the ONLY breaking change 

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-490

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI