### PR TITLE
fix(agents):Remove overlap of N8nRadioButtons with Panel Header

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/components/AgentIdentityHeader.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentIdentityHeader.vue
@@ -37,7 +37,7 @@ function onDescriptionUpdate(value: string) {
 			:model-value="name"
 			:placeholder="i18n.baseText('agents.builder.agent.name.placeholder')"
 			:disabled="props.disabled"
-			:max-width="640"
+			:max-width="240"
 			:min-width="96"
 			:class="$style.title"
 			data-testid="agent-name-inline-edit"
@@ -47,8 +47,8 @@ function onDescriptionUpdate(value: string) {
 			:model-value="description"
 			:placeholder="i18n.baseText('agents.builder.agent.description.placeholder')"
 			:disabled="props.disabled"
-			:max-width="720"
-			:min-width="160"
+			:max-width="240"
+			:min-width="96"
 			:class="$style.description"
 			data-testid="agent-description-inline-edit"
 			@update:model-value="onDescriptionUpdate"
@@ -77,5 +77,6 @@ function onDescriptionUpdate(value: string) {
 	font-weight: var(--font-weight--regular);
 	line-height: var(--line-height--md);
 	color: var(--text-color--light);
+	max-width: 100px;
 }
 </style>


### PR DESCRIPTION
## Summary

Fixes [AGENT-99](https://linear.app/n8n/issue/AGENT-99/bug-ui-mini-tabs-conflict-with-agent-description)

FYI Works only on larger screen sizes as we don't support mobile layouts in this anyway

| Before | After |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/2e30222a-bdcb-477b-a857-c2c57e36e28c" width="960px" alt="before image" /> | <img src="https://github.com/user-attachments/assets/9c599ef6-1522-4acd-8644-3e6671870081" width="960px" alt="after image" /> |


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
