### PR TITLE
feat(core): Add eval-data agent tool and quality evaluation suite (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -946,6 +946,7 @@ const BUILDER_RENDER_HINT_TOOLS = new Set(['build-workflow-with-agent', 'workflo
 const DATA_TABLE_RENDER_HINT_TOOLS = new Set([
 	'manage-data-tables-with-agent',
 	'agent-data-table-manager',
+	'eval-data',
 ]);
 const RESEARCH_RENDER_HINT_TOOLS = new Set(['research-with-agent']);
 const PLANNER_RENDER_HINT_TOOLS = new Set(['plan']);

--- a/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
+++ b/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
@@ -59,6 +59,49 @@ export interface ExecutionDetail {
 	data: string;
 }
 
+export interface WorkflowTag {
+	id: string;
+	name: string;
+}
+
+/** Subset of fields accepted by POST /rest/workflows. */
+export interface WorkflowCreatePayload {
+	name: string;
+	nodes: Array<WorkflowNodeResponse & Record<string, unknown>>;
+	connections: Record<string, unknown>;
+	settings?: Record<string, unknown> | null;
+	staticData?: Record<string, unknown> | null;
+	meta?: Record<string, unknown> | null;
+	pinData?: Record<string, unknown> | null;
+	tags?: string[] | WorkflowTag[];
+	projectId?: string;
+}
+
+export interface DataTableCreateColumn {
+	name: string;
+	type: 'string' | 'number' | 'boolean' | 'date';
+}
+
+export interface DataTableCreatePayload {
+	name: string;
+	columns: DataTableCreateColumn[];
+}
+
+export interface DataTableResponse {
+	id: string;
+	name: string;
+	columns?: Array<{ id?: string; name: string; type: string }>;
+}
+
+export type DataTableRowInput = Record<string, string | number | boolean | null>;
+
+export type DataTableRowOutput = Record<string, unknown>;
+
+export interface DataTableRowsResponse {
+	count: number;
+	data: DataTableRowOutput[];
+}
+
 // -- Thread types ------------------------------------------------------------
 
 interface ThreadStatus {
@@ -182,6 +225,18 @@ export class N8nClient {
 	 */
 	async listWorkflows(): Promise<WorkflowListItem[]> {
 		const result = (await this.fetch('/rest/workflows')) as { data: WorkflowListItem[] };
+		return result.data;
+	}
+
+	/**
+	 * Create a workflow from a fixture or generated payload.
+	 * POST /rest/workflows
+	 */
+	async createWorkflow(workflow: WorkflowCreatePayload): Promise<WorkflowResponse> {
+		const result = (await this.fetch('/rest/workflows', {
+			method: 'POST',
+			body: workflow,
+		})) as { data: WorkflowResponse };
 		return result.data;
 	}
 
@@ -373,6 +428,54 @@ export class N8nClient {
 			data: Array<{ id: string; name: string }>;
 		};
 		return Array.isArray(result.data) ? result.data : [];
+	}
+
+	/**
+	 * Create a data table in a project.
+	 * POST /rest/projects/:projectId/data-tables
+	 */
+	async createDataTable(
+		projectId: string,
+		payload: DataTableCreatePayload,
+	): Promise<DataTableResponse> {
+		const result = (await this.fetch(`/rest/projects/${projectId}/data-tables`, {
+			method: 'POST',
+			body: payload,
+		})) as { data: DataTableResponse };
+		return result.data;
+	}
+
+	/**
+	 * Insert rows into a data table.
+	 * POST /rest/projects/:projectId/data-tables/:dataTableId/insert
+	 */
+	async insertDataTableRows(
+		projectId: string,
+		dataTableId: string,
+		rows: DataTableRowInput[],
+	): Promise<void> {
+		await this.fetch(`/rest/projects/${projectId}/data-tables/${dataTableId}/insert`, {
+			method: 'POST',
+			body: { data: rows, returnType: 'count' },
+		});
+	}
+
+	/**
+	 * Fetch rows from a data table.
+	 * GET /rest/projects/:projectId/data-tables/:dataTableId/rows
+	 */
+	async getDataTableRows(
+		projectId: string,
+		dataTableId: string,
+		options: { take?: number; skip?: number } = {},
+	): Promise<DataTableRowsResponse> {
+		const params = new URLSearchParams();
+		if (options.take !== undefined) params.set('take', String(options.take));
+		if (options.skip !== undefined) params.set('skip', String(options.skip));
+		const query = params.toString();
+		const path = `/rest/projects/${projectId}/data-tables/${dataTableId}/rows${query ? `?${query}` : ''}`;
+		const result = (await this.fetch(path)) as { data: DataTableRowsResponse };
+		return result.data;
 	}
 
 	/**

--- a/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
+++ b/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
@@ -59,21 +59,12 @@ export interface ExecutionDetail {
 	data: string;
 }
 
-export interface WorkflowTag {
-	id: string;
-	name: string;
-}
-
 /** Subset of fields accepted by POST /rest/workflows. */
 export interface WorkflowCreatePayload {
 	name: string;
 	nodes: Array<WorkflowNodeResponse & Record<string, unknown>>;
 	connections: Record<string, unknown>;
-	settings?: Record<string, unknown> | null;
-	staticData?: Record<string, unknown> | null;
-	meta?: Record<string, unknown> | null;
 	pinData?: Record<string, unknown> | null;
-	tags?: string[] | WorkflowTag[];
 	projectId?: string;
 }
 
@@ -92,8 +83,6 @@ export interface DataTableResponse {
 	name: string;
 	columns?: Array<{ id?: string; name: string; type: string }>;
 }
-
-export type DataTableRowInput = Record<string, string | number | boolean | null>;
 
 export type DataTableRowOutput = Record<string, unknown>;
 
@@ -443,21 +432,6 @@ export class N8nClient {
 			body: payload,
 		})) as { data: DataTableResponse };
 		return result.data;
-	}
-
-	/**
-	 * Insert rows into a data table.
-	 * POST /rest/projects/:projectId/data-tables/:dataTableId/insert
-	 */
-	async insertDataTableRows(
-		projectId: string,
-		dataTableId: string,
-		rows: DataTableRowInput[],
-	): Promise<void> {
-		await this.fetch(`/rest/projects/${projectId}/data-tables/${dataTableId}/insert`, {
-			method: 'POST',
-			body: { data: rows, returnType: 'count' },
-		});
 	}
 
 	/**

--- a/packages/@n8n/instance-ai/evaluations/eval-data-quality/__tests__/dataset-verifier.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/eval-data-quality/__tests__/dataset-verifier.test.ts
@@ -1,0 +1,274 @@
+import { verifyDataset } from '../dataset-verifier';
+import { datasetSidecarSchema, type DatasetSidecar, type SemanticJudgeFn } from '../types';
+
+const baseColumns = [
+	{ name: 'input', type: 'string' as const },
+	{ name: 'expected_output', type: 'string' as const },
+	{ name: 'actual_output', type: 'string' as const },
+];
+
+function sidecar(overrides: Partial<DatasetSidecar> = {}): DatasetSidecar {
+	return datasetSidecarSchema.parse({
+		minRowCount: 3,
+		columns: baseColumns,
+		inputColumns: ['input'],
+		expectedOutputColumns: ['expected_output'],
+		actualOutputColumns: ['actual_output'],
+		...overrides,
+	});
+}
+
+describe('verifyDataset', () => {
+	it('passes when row count, columns, and required cells are all valid', async () => {
+		const result = await verifyDataset({
+			rows: [
+				{ input: 'a', expected_output: 'X', actual_output: null },
+				{ input: 'b', expected_output: 'Y', actual_output: null },
+				{ input: 'c', expected_output: 'Z', actual_output: null },
+			],
+			dataTableColumns: baseColumns,
+			sidecar: sidecar(),
+			requestedRowCount: 3,
+		});
+
+		expect(result.passed).toBe(true);
+		expect(result.findings).toEqual([]);
+		expect(result.rowCount).toBe(3);
+	});
+
+	it('fails when row count is below minRowCount', async () => {
+		const result = await verifyDataset({
+			rows: [{ input: 'a', expected_output: 'X', actual_output: null }],
+			dataTableColumns: baseColumns,
+			sidecar: sidecar({ minRowCount: 3 }),
+			requestedRowCount: 3,
+		});
+
+		expect(result.passed).toBe(false);
+		expect(result.findings).toEqual(
+			expect.arrayContaining([expect.objectContaining({ code: 'row_count_below_minimum' })]),
+		);
+	});
+
+	it('emits a warning (not error) when below requested but above minimum', async () => {
+		const result = await verifyDataset({
+			rows: [
+				{ input: 'a', expected_output: 'X', actual_output: null },
+				{ input: 'b', expected_output: 'Y', actual_output: null },
+				{ input: 'c', expected_output: 'Z', actual_output: null },
+			],
+			dataTableColumns: baseColumns,
+			sidecar: sidecar({ minRowCount: 3 }),
+			requestedRowCount: 25,
+		});
+
+		const warning = result.findings.find((f) => f.code === 'row_count_below_request');
+		expect(warning).toMatchObject({ severity: 'warning' });
+		expect(result.passed).toBe(true);
+	});
+
+	it('flags missing required columns', async () => {
+		const result = await verifyDataset({
+			rows: [
+				{ input: 'a', expected_output: 'X' },
+				{ input: 'b', expected_output: 'Y' },
+				{ input: 'c', expected_output: 'Z' },
+			],
+			dataTableColumns: [
+				{ name: 'input', type: 'string' },
+				{ name: 'expected_output', type: 'string' },
+			],
+			sidecar: sidecar(),
+			requestedRowCount: 3,
+		});
+
+		expect(result.findings).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ code: 'missing_column', column: 'actual_output' }),
+			]),
+		);
+		expect(result.passed).toBe(false);
+	});
+
+	it('flags type mismatches', async () => {
+		const result = await verifyDataset({
+			rows: [
+				{ input: 'a', expected_output: 'X', actual_output: null },
+				{ input: 'b', expected_output: 'Y', actual_output: null },
+				{ input: 'c', expected_output: 'Z', actual_output: null },
+			],
+			dataTableColumns: [
+				{ name: 'input', type: 'number' },
+				{ name: 'expected_output', type: 'string' },
+				{ name: 'actual_output', type: 'string' },
+			],
+			sidecar: sidecar(),
+			requestedRowCount: 3,
+		});
+
+		expect(result.findings).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ code: 'column_type_mismatch', column: 'input' }),
+			]),
+		);
+	});
+
+	it('warns about unexpected columns but does not fail', async () => {
+		const result = await verifyDataset({
+			rows: [
+				{ input: 'a', expected_output: 'X', actual_output: null },
+				{ input: 'b', expected_output: 'Y', actual_output: null },
+				{ input: 'c', expected_output: 'Z', actual_output: null },
+			],
+			dataTableColumns: [...baseColumns, { name: 'extra', type: 'string' }],
+			sidecar: sidecar(),
+			requestedRowCount: 3,
+		});
+
+		expect(result.passed).toBe(true);
+		expect(result.findings).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ code: 'unexpected_column', severity: 'warning' }),
+			]),
+		);
+	});
+
+	it('ignores DataTable system columns when comparing', async () => {
+		const result = await verifyDataset({
+			rows: [
+				{ input: 'a', expected_output: 'X', actual_output: null },
+				{ input: 'b', expected_output: 'Y', actual_output: null },
+				{ input: 'c', expected_output: 'Z', actual_output: null },
+			],
+			dataTableColumns: [
+				{ name: 'id', type: 'number' },
+				{ name: 'createdAt', type: 'date' },
+				{ name: 'updatedAt', type: 'date' },
+				...baseColumns,
+			],
+			sidecar: sidecar(),
+			requestedRowCount: 3,
+		});
+
+		expect(result.passed).toBe(true);
+		expect(result.findings).toEqual([]);
+	});
+
+	it('flags empty values in required columns', async () => {
+		const result = await verifyDataset({
+			rows: [
+				{ input: '', expected_output: 'X', actual_output: null },
+				{ input: 'b', expected_output: null, actual_output: null },
+				{ input: 'c', expected_output: 'Z', actual_output: null },
+			],
+			dataTableColumns: baseColumns,
+			sidecar: sidecar(),
+			requestedRowCount: 3,
+		});
+
+		expect(result.findings).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ code: 'required_cell_empty', column: 'input', rowIndex: 0 }),
+				expect.objectContaining({
+					code: 'required_cell_empty',
+					column: 'expected_output',
+					rowIndex: 1,
+				}),
+			]),
+		);
+	});
+
+	it('flags reserved actual_* columns when they are populated by generation', async () => {
+		const result = await verifyDataset({
+			rows: [
+				{ input: 'a', expected_output: 'X', actual_output: 'leaked' },
+				{ input: 'b', expected_output: 'Y', actual_output: null },
+				{ input: 'c', expected_output: 'Z', actual_output: null },
+			],
+			dataTableColumns: baseColumns,
+			sidecar: sidecar(),
+			requestedRowCount: 3,
+		});
+
+		expect(result.findings).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					code: 'reserved_cell_populated',
+					column: 'actual_output',
+					rowIndex: 0,
+				}),
+			]),
+		);
+	});
+
+	it('runs the LLM judge for each declared semantic criterion', async () => {
+		const judge = jest.fn<ReturnType<SemanticJudgeFn>, Parameters<SemanticJudgeFn>>(
+			async ({ column }) => {
+				await Promise.resolve();
+				if (column === 'input') {
+					return { failures: [{ rowIndex: 1, reason: 'not a question' }] };
+				}
+				return { failures: [] };
+			},
+		);
+
+		const result = await verifyDataset(
+			{
+				rows: [
+					{ input: 'What is X?', expected_output: 'X', actual_output: null },
+					{ input: 'banana', expected_output: 'Y', actual_output: null },
+					{ input: 'When?', expected_output: 'Z', actual_output: null },
+				],
+				dataTableColumns: baseColumns,
+				sidecar: sidecar({
+					semanticCriteria: [
+						{ column: 'input', criterion: 'Each input is a question.', allowEmpty: false },
+						{ column: 'expected_output', criterion: 'Each output is a label.', allowEmpty: false },
+					],
+				}),
+				requestedRowCount: 3,
+			},
+			{ judge },
+		);
+
+		expect(judge).toHaveBeenCalledTimes(2);
+		expect(result.findings).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					code: 'semantic_criterion_failed',
+					column: 'input',
+					rowIndex: 1,
+				}),
+			]),
+		);
+		expect(result.passed).toBe(false);
+	});
+
+	it('skips empty values when judge criterion does not allow empty', async () => {
+		const judge = jest.fn<ReturnType<SemanticJudgeFn>, Parameters<SemanticJudgeFn>>(
+			async ({ samples }) => {
+				await Promise.resolve();
+				expect(samples.map((sample) => sample.rowIndex)).toEqual([0, 2]);
+				return { failures: [] };
+			},
+		);
+
+		await verifyDataset(
+			{
+				rows: [
+					{ input: 'a', expected_output: 'X', actual_output: null },
+					{ input: 'a', expected_output: '', actual_output: null },
+					{ input: 'b', expected_output: 'Z', actual_output: null },
+				],
+				dataTableColumns: baseColumns,
+				sidecar: sidecar({
+					semanticCriteria: [
+						{ column: 'expected_output', criterion: 'Output is a label.', allowEmpty: false },
+					],
+				}),
+				requestedRowCount: 3,
+			},
+			{ judge },
+		);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/eval-data-quality/__tests__/exit-policy.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/eval-data-quality/__tests__/exit-policy.test.ts
@@ -1,7 +1,0 @@
-import { shouldFailProcessForCompletedRun } from '../exit-policy';
-
-describe('shouldFailProcessForCompletedRun', () => {
-	it('does not fail the process when the run completed', () => {
-		expect(shouldFailProcessForCompletedRun({ passed: false, results: [] })).toBe(false);
-	});
-});

--- a/packages/@n8n/instance-ai/evaluations/eval-data-quality/__tests__/exit-policy.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/eval-data-quality/__tests__/exit-policy.test.ts
@@ -1,0 +1,7 @@
+import { shouldFailProcessForCompletedRun } from '../exit-policy';
+
+describe('shouldFailProcessForCompletedRun', () => {
+	it('does not fail the process when the run completed', () => {
+		expect(shouldFailProcessForCompletedRun({ passed: false, results: [] })).toBe(false);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/eval-data-quality/__tests__/fixtures.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/eval-data-quality/__tests__/fixtures.test.ts
@@ -1,0 +1,93 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { loadEvalDataQualityCases } from '../fixtures';
+
+function makeRoot(): string {
+	const root = mkdtempSync(join(tmpdir(), 'eval-data-quality-'));
+	mkdirSync(join(root, 'workflows'), { recursive: true });
+	mkdirSync(join(root, 'expectations'), { recursive: true });
+	return root;
+}
+
+function writeJson(path: string, data: unknown): void {
+	writeFileSync(path, JSON.stringify(data, null, 2));
+}
+
+const validWorkflow = {
+	name: 'Sample',
+	nodes: [{ name: 'Eval Trigger', type: 'n8n-nodes-base.evaluationTrigger', typeVersion: 4.7 }],
+	connections: {},
+};
+
+const validSidecar = {
+	minRowCount: 5,
+	columns: [
+		{ name: 'input', type: 'string' },
+		{ name: 'expected_output', type: 'string' },
+	],
+	inputColumns: ['input'],
+	expectedOutputColumns: ['expected_output'],
+};
+
+describe('loadEvalDataQualityCases', () => {
+	it('returns an empty list when the workflows directory does not exist', () => {
+		expect(loadEvalDataQualityCases({ rootDir: '/nonexistent-eval-quality-path' })).toEqual([]);
+	});
+
+	it('loads workflow + sidecar pairs sorted alphabetically', () => {
+		const root = makeRoot();
+		try {
+			writeJson(join(root, 'workflows', 'b-second.json'), { ...validWorkflow, name: 'B' });
+			writeJson(join(root, 'workflows', 'a-first.json'), { ...validWorkflow, name: 'A' });
+			writeJson(join(root, 'expectations', 'a-first.dataset.json'), validSidecar);
+			writeJson(join(root, 'expectations', 'b-second.dataset.json'), validSidecar);
+
+			const cases = loadEvalDataQualityCases({ rootDir: root });
+
+			expect(cases.map((c) => c.slug)).toEqual(['a-first', 'b-second']);
+			expect(cases[0].workflow.name).toBe('A');
+		} finally {
+			rmSync(root, { recursive: true });
+		}
+	});
+
+	it('throws when a sidecar is missing for a workflow fixture', () => {
+		const root = makeRoot();
+		try {
+			writeJson(join(root, 'workflows', 'orphan.json'), validWorkflow);
+
+			expect(() => loadEvalDataQualityCases({ rootDir: root })).toThrow(/Missing dataset sidecar/);
+		} finally {
+			rmSync(root, { recursive: true });
+		}
+	});
+
+	it('throws when a sidecar fails schema validation', () => {
+		const root = makeRoot();
+		try {
+			writeJson(join(root, 'workflows', 'sample.json'), validWorkflow);
+			writeJson(join(root, 'expectations', 'sample.dataset.json'), { minRowCount: 'oops' });
+
+			expect(() => loadEvalDataQualityCases({ rootDir: root })).toThrow(/Invalid dataset sidecar/);
+		} finally {
+			rmSync(root, { recursive: true });
+		}
+	});
+
+	it('applies the filter option', () => {
+		const root = makeRoot();
+		try {
+			writeJson(join(root, 'workflows', 'alpha.json'), validWorkflow);
+			writeJson(join(root, 'workflows', 'beta.json'), validWorkflow);
+			writeJson(join(root, 'expectations', 'alpha.dataset.json'), validSidecar);
+			writeJson(join(root, 'expectations', 'beta.dataset.json'), validSidecar);
+
+			const cases = loadEvalDataQualityCases({ rootDir: root, filter: 'alpha' });
+			expect(cases.map((c) => c.slug)).toEqual(['alpha']);
+		} finally {
+			rmSync(root, { recursive: true });
+		}
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/eval-data-quality/__tests__/runner.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/eval-data-quality/__tests__/runner.test.ts
@@ -1,0 +1,393 @@
+import type { N8nClient } from '../../clients/n8n-client';
+import { consumeSseStream } from '../../clients/sse-client';
+import type { EvalLogger } from '../../harness/logger';
+import type { CapturedEvent } from '../../types';
+import {
+	approveEvalDataConfirmation,
+	buildEvalPrompt,
+	buildWorkflowCreatePayload,
+	extractConfirmationRequestId,
+	isEvalDataConfirmation,
+	rewriteDataTableId,
+	runEvalDataQualityCase,
+	startSseConnection,
+	waitForThreadToSettle,
+} from '../runner';
+import { datasetSidecarSchema, type EvalDataQualityCase } from '../types';
+
+jest.mock('../../clients/sse-client', () => ({
+	consumeSseStream: jest.fn(),
+}));
+
+const sidecar = datasetSidecarSchema.parse({
+	requestedRowCount: 5,
+	minRowCount: 3,
+	columns: [
+		{ name: 'input', type: 'string' },
+		{ name: 'expected_output', type: 'string' },
+		{ name: 'actual_output', type: 'string' },
+	],
+	inputColumns: ['input'],
+	expectedOutputColumns: ['expected_output'],
+	actualOutputColumns: ['actual_output'],
+	dataTableNodeName: 'Eval Trigger',
+});
+
+function makeTestCase(overrides: Partial<EvalDataQualityCase> = {}): EvalDataQualityCase {
+	return {
+		slug: 'chat-agent',
+		workflowPath: '/fixtures/chat-agent.json',
+		sidecarPath: '/fixtures/chat-agent.dataset.json',
+		workflow: {
+			id: 'fixture-id',
+			name: 'Fixture Workflow',
+			active: false,
+			nodes: [
+				{
+					name: 'Eval Trigger',
+					type: 'n8n-nodes-base.evaluationTrigger',
+					typeVersion: 4.7,
+					parameters: {
+						source: 'dataTable',
+						dataTableId: { __rl: true, mode: 'id', value: 'PLACEHOLDER' },
+					},
+				},
+			],
+			connections: {},
+			pinData: {},
+		},
+		sidecar,
+		...overrides,
+	};
+}
+
+function logger(): EvalLogger {
+	return {
+		info: jest.fn(),
+		verbose: jest.fn(),
+		success: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+		isVerbose: false,
+	};
+}
+
+describe('rewriteDataTableId', () => {
+	it('rewrites the resource locator on the named node', () => {
+		const result = rewriteDataTableId(makeTestCase().workflow, 'Eval Trigger', 'dt-real');
+		const node = result.nodes.find((n) => n.name === 'Eval Trigger');
+		expect(node?.parameters?.dataTableId).toEqual({ __rl: true, mode: 'id', value: 'dt-real' });
+	});
+
+	it('rewrites a plain string dataTableId', () => {
+		const original = makeTestCase().workflow;
+		original.nodes[0].parameters = { dataTableId: 'old' };
+
+		const result = rewriteDataTableId(original, 'Eval Trigger', 'dt-real');
+		expect(result.nodes[0].parameters?.dataTableId).toBe('dt-real');
+	});
+
+	it('falls back to any node with a dataTableId param when no name is provided', () => {
+		const result = rewriteDataTableId(makeTestCase().workflow, undefined, 'dt-real');
+		expect(result.nodes[0].parameters?.dataTableId).toMatchObject({ value: 'dt-real' });
+	});
+
+	it('does not mutate the original workflow', () => {
+		const original = makeTestCase().workflow;
+		const cloned = structuredClone(original);
+		rewriteDataTableId(original, 'Eval Trigger', 'dt-real');
+		expect(original).toEqual(cloned);
+	});
+});
+
+describe('buildWorkflowCreatePayload', () => {
+	it('strips credentials and tags name with the slug', () => {
+		const wf = makeTestCase().workflow;
+		wf.nodes[0].credentials = { someCred: 'cred-id' };
+		const payload = buildWorkflowCreatePayload(wf, 'my-slug', 'project-1');
+		expect(payload.name).toContain('eval-data-quality-my-slug-');
+		expect(payload.projectId).toBe('project-1');
+		expect(payload.nodes[0].credentials).toBeUndefined();
+	});
+});
+
+describe('buildEvalPrompt', () => {
+	it('mentions workflow id, DataTable id, and requested row count', () => {
+		const prompt = buildEvalPrompt({
+			workflowId: 'w-1',
+			workflowName: 'Support Writer',
+			dataTableId: 'dt-1',
+			requestedRowCount: 10,
+		});
+		expect(prompt).toContain('w-1');
+		expect(prompt).toContain('Support Writer');
+		expect(prompt).toContain('dt-1');
+		expect(prompt).toContain('10 synthetic eval rows');
+	});
+
+	it('includes the target agent node when provided', () => {
+		const prompt = buildEvalPrompt({
+			workflowId: 'w-1',
+			workflowName: 'wf',
+			dataTableId: 'dt-1',
+			requestedRowCount: 10,
+			targetAgentNodeName: 'Classifier',
+		});
+		expect(prompt).toContain('Classifier');
+	});
+});
+
+describe('isEvalDataConfirmation', () => {
+	it('matches confirmation-request events with payload.toolName=eval-data', () => {
+		expect(
+			isEvalDataConfirmation({
+				timestamp: 1,
+				type: 'confirmation-request',
+				data: { payload: { toolName: 'eval-data' } },
+			}),
+		).toBe(true);
+	});
+
+	it('matches confirmation-request events with top-level toolName=eval-data', () => {
+		expect(
+			isEvalDataConfirmation({
+				timestamp: 1,
+				type: 'confirmation-request',
+				data: { toolName: 'eval-data' },
+			}),
+		).toBe(true);
+	});
+
+	it('rejects non-confirmation events', () => {
+		expect(
+			isEvalDataConfirmation({
+				timestamp: 1,
+				type: 'tool-call',
+				data: { toolName: 'eval-data' },
+			}),
+		).toBe(false);
+	});
+});
+
+describe('extractConfirmationRequestId', () => {
+	it('reads requestId from the top-level event data', () => {
+		expect(
+			extractConfirmationRequestId({
+				timestamp: 1,
+				type: 'confirmation-request',
+				data: { requestId: 'req-1' },
+			}),
+		).toBe('req-1');
+	});
+
+	it('reads requestId from a nested payload', () => {
+		expect(
+			extractConfirmationRequestId({
+				timestamp: 1,
+				type: 'confirmation-request',
+				data: { payload: { requestId: 'req-2' } },
+			}),
+		).toBe('req-2');
+	});
+
+	it('returns undefined when not present', () => {
+		expect(
+			extractConfirmationRequestId({ timestamp: 1, type: 'confirmation-request', data: {} }),
+		).toBeUndefined();
+	});
+});
+
+describe('startSseConnection', () => {
+	beforeEach(() => {
+		jest.mocked(consumeSseStream).mockImplementation(async (_url, _cookie, handler) => {
+			await Promise.resolve();
+			handler({ type: 'message', data: JSON.stringify({ type: 'tool-call', x: 1 }) });
+			handler({ type: 'message', data: '{not-json' });
+			handler({ type: 'message', data: JSON.stringify('string-value') });
+		});
+	});
+
+	it('captures structured events and ignores malformed payloads', async () => {
+		const events: CapturedEvent[] = [];
+		await startSseConnection(
+			{ getEventsUrl: () => 'http://x', cookie: 'cookie' } as unknown as Pick<
+				N8nClient,
+				'getEventsUrl' | 'cookie'
+			>,
+			'thread-1',
+			events,
+			new AbortController().signal,
+		);
+		expect(events).toHaveLength(1);
+		expect(events[0].type).toBe('tool-call');
+	});
+});
+
+describe('approveEvalDataConfirmation', () => {
+	it('approves only eval-data confirmations and dedupes by requestId', async () => {
+		const confirmAction = jest.fn().mockResolvedValue(undefined);
+		const events: CapturedEvent[] = [
+			{
+				timestamp: 1,
+				type: 'confirmation-request',
+				data: { requestId: 'req-1', payload: { toolName: 'eval-data' } },
+			},
+			{
+				timestamp: 2,
+				type: 'confirmation-request',
+				data: { requestId: 'req-2', payload: { toolName: 'workflows' } },
+			},
+		];
+		const approvedRequestIds = new Set<string>();
+
+		await approveEvalDataConfirmation({
+			client: { confirmAction },
+			events,
+			approvedRequestIds,
+			logger: logger(),
+		});
+		await approveEvalDataConfirmation({
+			client: { confirmAction },
+			events,
+			approvedRequestIds,
+			logger: logger(),
+		});
+
+		expect(confirmAction).toHaveBeenCalledTimes(1);
+		expect(confirmAction).toHaveBeenCalledWith('req-1', { kind: 'approval', approved: true });
+	});
+});
+
+describe('waitForThreadToSettle', () => {
+	beforeEach(() => {
+		jest.useFakeTimers({ doNotFake: ['nextTick'] });
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('returns once the thread has no active run, suspended state, or background tasks', async () => {
+		const getThreadStatus = jest
+			.fn()
+			.mockResolvedValueOnce({ hasActiveRun: true, isSuspended: false, backgroundTasks: [] })
+			.mockResolvedValue({ hasActiveRun: false, isSuspended: false, backgroundTasks: [] });
+		const confirmAction = jest.fn();
+		const promise = waitForThreadToSettle({
+			client: { getThreadStatus, confirmAction },
+			threadId: 'thread-1',
+			events: [],
+			approvedRequestIds: new Set(),
+			logger: logger(),
+			timeoutMs: 5_000,
+		});
+		await jest.runOnlyPendingTimersAsync();
+		await jest.runOnlyPendingTimersAsync();
+		await expect(promise).resolves.toBeUndefined();
+	});
+
+	it('throws when the timeout elapses', async () => {
+		const getThreadStatus = jest
+			.fn()
+			.mockResolvedValue({ hasActiveRun: true, isSuspended: false, backgroundTasks: [] });
+		const confirmAction = jest.fn();
+		const promise = waitForThreadToSettle({
+			client: { getThreadStatus, confirmAction },
+			threadId: 'thread-1',
+			events: [],
+			approvedRequestIds: new Set(),
+			logger: logger(),
+			timeoutMs: 50,
+		});
+		const captured = promise.catch((reason: unknown) => reason);
+		await jest.advanceTimersByTimeAsync(2_000);
+		const settled = await captured;
+		expect(settled).toBeInstanceOf(Error);
+		expect((settled as Error).message).toMatch(/Timed out/);
+	});
+});
+
+describe('runEvalDataQualityCase', () => {
+	beforeEach(() => {
+		jest.mocked(consumeSseStream).mockImplementation(async () => {});
+	});
+
+	it('runs end-to-end against a mocked client and returns a verifier result', async () => {
+		const dataTable = {
+			id: 'dt-real',
+			name: 'dt',
+			columns: [
+				{ name: 'input', type: 'string' },
+				{ name: 'expected_output', type: 'string' },
+				{ name: 'actual_output', type: 'string' },
+			],
+		};
+		const client = {
+			getPersonalProjectId: jest.fn().mockResolvedValue('project-1'),
+			createDataTable: jest.fn().mockResolvedValue(dataTable),
+			createWorkflow: jest
+				.fn()
+				.mockResolvedValue({ id: 'wf-1', name: 'wf', active: false, nodes: [], connections: {} }),
+			sendMessage: jest.fn().mockResolvedValue({ runId: 'run-1' }),
+			getThreadStatus: jest
+				.fn()
+				.mockResolvedValue({ hasActiveRun: false, isSuspended: false, backgroundTasks: [] }),
+			getThreadMessages: jest.fn().mockResolvedValue(undefined),
+			getDataTableRows: jest.fn().mockResolvedValue({
+				count: 3,
+				data: [
+					{ input: 'a', expected_output: 'X', actual_output: null },
+					{ input: 'b', expected_output: 'Y', actual_output: null },
+					{ input: 'c', expected_output: 'Z', actual_output: null },
+				],
+			}),
+			confirmAction: jest.fn().mockResolvedValue(undefined),
+			cancelRun: jest.fn().mockResolvedValue(undefined),
+			deleteWorkflow: jest.fn().mockResolvedValue(undefined),
+			deleteDataTable: jest.fn().mockResolvedValue(undefined),
+			getEventsUrl: () => 'http://x',
+			cookie: 'cookie',
+		} as unknown as N8nClient;
+
+		const result = await runEvalDataQualityCase({
+			client,
+			testCase: makeTestCase(),
+			logger: logger(),
+			timeoutMs: 10_000,
+		});
+
+		expect(client.createDataTable).toHaveBeenCalledWith(
+			'project-1',
+			expect.objectContaining({ columns: sidecar.columns }),
+		);
+		expect(client.createWorkflow).toHaveBeenCalled();
+		expect(client.deleteWorkflow).toHaveBeenCalledWith('wf-1');
+		expect(client.deleteDataTable).toHaveBeenCalledWith('project-1', 'dt-real');
+		expect(result.workflowId).toBe('wf-1');
+		expect(result.dataTableId).toBe('dt-real');
+		expect(result.dataset.passed).toBe(true);
+	});
+
+	it('captures runner errors as findings and still cleans up', async () => {
+		const client = {
+			getPersonalProjectId: jest.fn().mockResolvedValue('project-1'),
+			createDataTable: jest.fn().mockRejectedValue(new Error('boom')),
+			deleteWorkflow: jest.fn(),
+			deleteDataTable: jest.fn(),
+			cancelRun: jest.fn(),
+			getEventsUrl: () => 'http://x',
+			cookie: 'cookie',
+		} as unknown as N8nClient;
+
+		const result = await runEvalDataQualityCase({
+			client,
+			testCase: makeTestCase(),
+			logger: logger(),
+			timeoutMs: 1_000,
+		});
+
+		expect(result.passed).toBe(false);
+		expect(result.error).toBe('boom');
+		expect(result.dataset.findings[0].code).toBe('runner_error');
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/eval-data-quality/__tests__/summary.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/eval-data-quality/__tests__/summary.test.ts
@@ -1,0 +1,24 @@
+import { formatRunSummary } from '../summary';
+import type { EvalDataQualityCaseResult } from '../types';
+
+const caseResult = (passed: boolean): EvalDataQualityCaseResult => ({
+	caseSlug: 'slug',
+	toolSelection: { evalDataToolCalled: passed, findings: [] },
+	dataset: { passed, findings: [], rowCount: 0 },
+	passed,
+});
+
+describe('formatRunSummary', () => {
+	it('reports passed/total/failed counts', () => {
+		expect(
+			formatRunSummary({
+				passed: false,
+				results: [caseResult(true), caseResult(false), caseResult(true)],
+			}),
+		).toBe('Summary: 2/3 passed, 1 failed');
+	});
+
+	it('handles an empty run', () => {
+		expect(formatRunSummary({ passed: true, results: [] })).toBe('Summary: 0/0 passed, 0 failed');
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/eval-data-quality/__tests__/tool-selection.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/eval-data-quality/__tests__/tool-selection.test.ts
@@ -1,0 +1,133 @@
+import type { InstanceAiRichMessagesResponse } from '@n8n/api-types';
+
+import type { CapturedEvent } from '../../types';
+import { extractToolSelection } from '../tool-selection';
+
+function capturedEvent(data: Record<string, unknown>, type = 'tool-call'): CapturedEvent {
+	return { timestamp: 1, type, data };
+}
+
+function richMessagesWithToolCalls(toolNames: string[]): InstanceAiRichMessagesResponse {
+	return {
+		threadId: 'thread-1',
+		nextEventId: 1,
+		messages: [
+			{
+				id: 'message-1',
+				role: 'assistant',
+				createdAt: '2026-04-29T00:00:00.000Z',
+				content: '',
+				reasoning: '',
+				isStreaming: false,
+				agentTree: {
+					agentId: 'agent-1',
+					role: 'orchestrator',
+					status: 'completed',
+					textContent: '',
+					reasoning: '',
+					toolCalls: toolNames.map((toolName, index) => ({
+						toolCallId: `tool-call-${index}`,
+						toolName,
+						args: {},
+						isLoading: false,
+					})),
+					children: [],
+					timeline: [],
+				},
+			},
+		],
+	};
+}
+
+describe('extractToolSelection', () => {
+	it('returns a finding when no tool call or agent spawn is observed', () => {
+		const result = extractToolSelection({ events: [] });
+
+		expect(result).toEqual({
+			evalDataToolCalled: false,
+			findings: [expect.objectContaining({ code: 'eval_data_tool_not_called', severity: 'error' })],
+		});
+	});
+
+	it('detects tool call from a tool-call event', () => {
+		const result = extractToolSelection({
+			events: [capturedEvent({ payload: { toolName: 'eval-data' } })],
+		});
+
+		expect(result.evalDataToolCalled).toBe(true);
+		expect(result.findings).toEqual([]);
+	});
+
+	it('detects an eval-data agent spawn event when no tool-call event is present', () => {
+		const result = extractToolSelection({
+			events: [
+				capturedEvent(
+					{ runId: 'r1', agentId: 'a1', payload: { role: 'eval-data' } },
+					'agent-spawned',
+				),
+			],
+		});
+
+		expect(result.evalDataToolCalled).toBe(true);
+	});
+
+	it('detects tool call via thread messages when SSE missed it', () => {
+		const result = extractToolSelection({
+			events: [],
+			threadMessages: richMessagesWithToolCalls(['eval-data']),
+		});
+
+		expect(result.evalDataToolCalled).toBe(true);
+	});
+
+	it('does not match arbitrary string occurrences in non-tool events', () => {
+		const result = extractToolSelection({
+			events: [capturedEvent({ note: 'eval-data was discussed' }, 'message')],
+		});
+
+		expect(result.evalDataToolCalled).toBe(false);
+	});
+
+	it('walks rich-message child agent trees', () => {
+		const messages: InstanceAiRichMessagesResponse = {
+			threadId: 'thread-1',
+			nextEventId: 1,
+			messages: [
+				{
+					id: 'message-1',
+					role: 'assistant',
+					createdAt: '2026-04-29T00:00:00.000Z',
+					content: '',
+					reasoning: '',
+					isStreaming: false,
+					agentTree: {
+						agentId: 'parent',
+						role: 'orchestrator',
+						status: 'completed',
+						textContent: '',
+						reasoning: '',
+						toolCalls: [],
+						timeline: [],
+						children: [
+							{
+								agentId: 'child',
+								role: 'eval-data',
+								status: 'completed',
+								textContent: '',
+								reasoning: '',
+								toolCalls: [
+									{ toolCallId: 'tc-1', toolName: 'eval-data', args: {}, isLoading: false },
+								],
+								timeline: [],
+								children: [],
+							},
+						],
+					},
+				},
+			],
+		};
+
+		const result = extractToolSelection({ events: [], threadMessages: messages });
+		expect(result.evalDataToolCalled).toBe(true);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/eval-data-quality/cli.ts
+++ b/packages/@n8n/instance-ai/evaluations/eval-data-quality/cli.ts
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+
+import { writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import pLimit from 'p-limit';
+
+import { createDefaultJudge } from './default-judge';
+import { shouldFailProcessForCompletedRun } from './exit-policy';
+import { loadEvalDataQualityCases } from './fixtures';
+import { runEvalDataQualityCase } from './runner';
+import { formatRunSummary } from './summary';
+import type { EvalDataQualityRunResult, SemanticJudgeFn } from './types';
+import { N8nClient } from '../clients/n8n-client';
+import { createLogger } from '../harness/logger';
+
+const DEFAULT_TIMEOUT_MS = 600_000;
+
+interface CliArgs {
+	baseUrl: string;
+	email?: string;
+	password?: string;
+	filter?: string;
+	timeoutMs: number;
+	concurrency: number;
+	keepArtifacts: boolean;
+	output: string;
+	verbose: boolean;
+	skipJudge: boolean;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+	const args: CliArgs = {
+		baseUrl: process.env.N8N_EVAL_BASE_URL ?? 'http://localhost:5678',
+		email: process.env.N8N_EVAL_EMAIL,
+		password: process.env.N8N_EVAL_PASSWORD,
+		timeoutMs: DEFAULT_TIMEOUT_MS,
+		concurrency: 1,
+		keepArtifacts: false,
+		output: resolve(process.cwd(), 'eval-data-quality-results.json'),
+		verbose: hasFlag(argv, '--verbose'),
+		skipJudge: hasFlag(argv, '--skip-judge'),
+	};
+
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+
+		switch (arg) {
+			case '--base-url':
+				args.baseUrl = readValue(argv, ++i, arg);
+				break;
+			case '--email':
+				args.email = readValue(argv, ++i, arg);
+				break;
+			case '--password':
+				args.password = readValue(argv, ++i, arg);
+				break;
+			case '--filter':
+				args.filter = readValue(argv, ++i, arg);
+				break;
+			case '--timeout-ms':
+				args.timeoutMs = requirePositiveInt(readValue(argv, ++i, arg), arg);
+				break;
+			case '--concurrency':
+				args.concurrency = requirePositiveInt(readValue(argv, ++i, arg), arg);
+				break;
+			case '--keep-artifacts':
+				args.keepArtifacts = true;
+				break;
+			case '--output':
+				args.output = resolve(process.cwd(), readValue(argv, ++i, arg));
+				break;
+			case '--verbose':
+			case '--skip-judge':
+				break;
+			default:
+				throw new Error(`Unknown argument: ${arg}`);
+		}
+	}
+
+	return args;
+}
+
+function hasFlag(argv: string[], flag: string): boolean {
+	return argv.includes(flag);
+}
+
+function readValue(argv: string[], index: number, flag: string): string {
+	const value = argv[index];
+	if (!value || value.startsWith('--')) {
+		throw new Error(`Missing value for ${flag}`);
+	}
+	return value;
+}
+
+function requirePositiveInt(raw: string, flag: string): number {
+	const value = Number(raw);
+	if (!Number.isInteger(value) || value < 1) {
+		throw new Error(`Invalid value for ${flag}: ${raw} (expected a positive integer)`);
+	}
+	return value;
+}
+
+async function main(): Promise<void> {
+	const args = parseArgs(process.argv.slice(2));
+	const logger = createLogger(args.verbose);
+	const client = new N8nClient(args.baseUrl);
+
+	await client.login(args.email, args.password);
+
+	const cases = loadEvalDataQualityCases({ filter: args.filter });
+	if (cases.length === 0) {
+		throw new Error('No eval-data-quality cases found');
+	}
+
+	const projectId = await client.getPersonalProjectId();
+	const judge: SemanticJudgeFn | undefined = args.skipJudge ? undefined : createDefaultJudge();
+	const limit = pLimit(args.concurrency);
+
+	const results = await Promise.all(
+		cases.map(
+			async (testCase) =>
+				await limit(async () => {
+					logger.info(`RUN ${testCase.slug}`);
+					const result = await runEvalDataQualityCase({
+						client,
+						testCase,
+						logger,
+						timeoutMs: args.timeoutMs,
+						keepArtifacts: args.keepArtifacts,
+						projectId,
+						judge,
+					});
+
+					if (result.passed) {
+						logger.success(`PASS ${testCase.slug}`);
+					} else {
+						logger.warn(`FAIL ${testCase.slug}`);
+					}
+
+					return result;
+				}),
+		),
+	);
+
+	const runResult: EvalDataQualityRunResult = {
+		passed: results.every((result) => result.passed),
+		results,
+	};
+
+	await writeFile(args.output, `${JSON.stringify(runResult, null, 2)}\n`, 'utf8');
+	logger.info(`Wrote results to ${args.output}`);
+	logger.info(formatRunSummary(runResult));
+
+	for (const result of results.filter((caseResult) => !caseResult.passed)) {
+		logger.warn(`Case failed: ${result.caseSlug}`);
+		for (const finding of [...result.toolSelection.findings, ...result.dataset.findings]) {
+			logger.warn(`  ${finding.code}: ${finding.message}`);
+		}
+	}
+
+	if (shouldFailProcessForCompletedRun(runResult)) {
+		process.exitCode = 1;
+	}
+}
+
+main().catch((error) => {
+	const logger = createLogger(true);
+	const message = error instanceof Error ? error.message : String(error);
+	logger.error(message);
+	process.exitCode = 1;
+});

--- a/packages/@n8n/instance-ai/evaluations/eval-data-quality/cli.ts
+++ b/packages/@n8n/instance-ai/evaluations/eval-data-quality/cli.ts
@@ -5,7 +5,6 @@ import { resolve } from 'node:path';
 import pLimit from 'p-limit';
 
 import { createDefaultJudge } from './default-judge';
-import { shouldFailProcessForCompletedRun } from './exit-policy';
 import { loadEvalDataQualityCases } from './fixtures';
 import { runEvalDataQualityCase } from './runner';
 import { formatRunSummary } from './summary';
@@ -156,10 +155,6 @@ async function main(): Promise<void> {
 		for (const finding of [...result.toolSelection.findings, ...result.dataset.findings]) {
 			logger.warn(`  ${finding.code}: ${finding.message}`);
 		}
-	}
-
-	if (shouldFailProcessForCompletedRun(runResult)) {
-		process.exitCode = 1;
 	}
 }
 

--- a/packages/@n8n/instance-ai/evaluations/eval-data-quality/dataset-verifier.ts
+++ b/packages/@n8n/instance-ai/evaluations/eval-data-quality/dataset-verifier.ts
@@ -1,0 +1,189 @@
+import type {
+	DatasetFinding,
+	DatasetSidecar,
+	DatasetVerifierInput,
+	DatasetVerifierOptions,
+	DatasetVerifierResult,
+} from './types';
+
+const SYSTEM_COLUMN_NAMES = new Set(['id', 'createdAt', 'updatedAt']);
+
+export async function verifyDataset(
+	input: DatasetVerifierInput,
+	options: DatasetVerifierOptions = {},
+): Promise<DatasetVerifierResult> {
+	const findings: DatasetFinding[] = [];
+
+	findings.push(...verifyRowCount(input));
+	findings.push(...verifyColumns(input));
+	findings.push(...verifyCellPopulation(input));
+
+	if (options.judge) {
+		findings.push(...(await verifySemantic(input, options.judge)));
+	}
+
+	const passed = findings.every((finding) => finding.severity !== 'error');
+	return {
+		passed,
+		findings,
+		rowCount: input.rows.length,
+	};
+}
+
+function verifyRowCount(input: DatasetVerifierInput): DatasetFinding[] {
+	const findings: DatasetFinding[] = [];
+	const { rows, sidecar, requestedRowCount } = input;
+
+	if (rows.length < sidecar.minRowCount) {
+		findings.push({
+			severity: 'error',
+			code: 'row_count_below_minimum',
+			message: `Dataset contains ${rows.length} rows, expected at least ${sidecar.minRowCount}.`,
+		});
+	}
+
+	if (rows.length < requestedRowCount) {
+		findings.push({
+			severity: 'warning',
+			code: 'row_count_below_request',
+			message: `Dataset contains ${rows.length} rows, fewer than the requested ${requestedRowCount}.`,
+		});
+	}
+
+	return findings;
+}
+
+function verifyColumns(input: DatasetVerifierInput): DatasetFinding[] {
+	const findings: DatasetFinding[] = [];
+	const expected = new Map(input.sidecar.columns.map((column) => [column.name, column.type]));
+	const actual = new Map(
+		input.dataTableColumns
+			.filter((column) => !SYSTEM_COLUMN_NAMES.has(column.name))
+			.map((column) => [column.name, column.type]),
+	);
+
+	for (const [name, type] of expected) {
+		const actualType = actual.get(name);
+		if (actualType === undefined) {
+			findings.push({
+				severity: 'error',
+				code: 'missing_column',
+				message: `Expected DataTable column "${name}" was not present.`,
+				column: name,
+			});
+			continue;
+		}
+		if (actualType !== type) {
+			findings.push({
+				severity: 'error',
+				code: 'column_type_mismatch',
+				message: `Column "${name}" has type "${actualType}", expected "${type}".`,
+				column: name,
+			});
+		}
+	}
+
+	for (const [name] of actual) {
+		if (!expected.has(name)) {
+			findings.push({
+				severity: 'warning',
+				code: 'unexpected_column',
+				message: `DataTable contains an unexpected column "${name}".`,
+				column: name,
+			});
+		}
+	}
+
+	return findings;
+}
+
+function verifyCellPopulation(input: DatasetVerifierInput): DatasetFinding[] {
+	const findings: DatasetFinding[] = [];
+	const { rows, sidecar } = input;
+
+	const requiredColumns = new Set([...sidecar.inputColumns, ...sidecar.expectedOutputColumns]);
+	const mustBeEmptyColumns = new Set(sidecar.actualOutputColumns);
+
+	rows.forEach((row, rowIndex) => {
+		for (const column of requiredColumns) {
+			if (isEmptyCell(row[column])) {
+				findings.push({
+					severity: 'error',
+					code: 'required_cell_empty',
+					message: `Row ${rowIndex} has an empty value in required column "${column}".`,
+					column,
+					rowIndex,
+				});
+			}
+		}
+		for (const column of mustBeEmptyColumns) {
+			if (!isEmptyCell(row[column])) {
+				findings.push({
+					severity: 'error',
+					code: 'reserved_cell_populated',
+					message: `Row ${rowIndex} populated reserved column "${column}" — it must be filled by eval runs only.`,
+					column,
+					rowIndex,
+				});
+			}
+		}
+	});
+
+	return findings;
+}
+
+async function verifySemantic(
+	input: DatasetVerifierInput,
+	judge: NonNullable<DatasetVerifierOptions['judge']>,
+): Promise<DatasetFinding[]> {
+	const findings: DatasetFinding[] = [];
+
+	for (const criterion of input.sidecar.semanticCriteria) {
+		const samples = collectSamples(input.rows, criterion.column, criterion.allowEmpty);
+		if (samples.length === 0) continue;
+
+		const verdict = await judge({
+			column: criterion.column,
+			criterion: criterion.criterion,
+			samples,
+		});
+
+		for (const failure of verdict.failures) {
+			findings.push({
+				severity: 'error',
+				code: 'semantic_criterion_failed',
+				message: `Row ${failure.rowIndex} failed criterion "${criterion.criterion}" on column "${criterion.column}": ${failure.reason}`,
+				column: criterion.column,
+				rowIndex: failure.rowIndex,
+			});
+		}
+	}
+
+	return findings;
+}
+
+function collectSamples(
+	rows: DatasetVerifierInput['rows'],
+	column: string,
+	allowEmpty: boolean,
+): Array<{ rowIndex: number; value: unknown }> {
+	const samples: Array<{ rowIndex: number; value: unknown }> = [];
+	rows.forEach((row, rowIndex) => {
+		const value = row[column];
+		if (!allowEmpty && isEmptyCell(value)) {
+			return;
+		}
+		samples.push({ rowIndex, value });
+	});
+	return samples;
+}
+
+function isEmptyCell(value: unknown): boolean {
+	if (value === null || value === undefined) return true;
+	if (typeof value === 'string' && value.trim().length === 0) return true;
+	return false;
+}
+
+export function describeRequiredColumns(sidecar: DatasetSidecar): string[] {
+	return [...new Set([...sidecar.inputColumns, ...sidecar.expectedOutputColumns])];
+}

--- a/packages/@n8n/instance-ai/evaluations/eval-data-quality/dataset-verifier.ts
+++ b/packages/@n8n/instance-ai/evaluations/eval-data-quality/dataset-verifier.ts
@@ -1,6 +1,5 @@
 import type {
 	DatasetFinding,
-	DatasetSidecar,
 	DatasetVerifierInput,
 	DatasetVerifierOptions,
 	DatasetVerifierResult,
@@ -182,8 +181,4 @@ function isEmptyCell(value: unknown): boolean {
 	if (value === null || value === undefined) return true;
 	if (typeof value === 'string' && value.trim().length === 0) return true;
 	return false;
-}
-
-export function describeRequiredColumns(sidecar: DatasetSidecar): string[] {
-	return [...new Set([...sidecar.inputColumns, ...sidecar.expectedOutputColumns])];
 }

--- a/packages/@n8n/instance-ai/evaluations/eval-data-quality/default-judge.ts
+++ b/packages/@n8n/instance-ai/evaluations/eval-data-quality/default-judge.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod';
+
+import type { SemanticJudgeFn } from './types';
+import { createEvalAgent, extractText, HAIKU_MODEL } from '../../src/utils/eval-agents';
+
+const verdictSchema = z.object({
+	verdicts: z.array(
+		z.object({
+			rowIndex: z.number().int(),
+			passed: z.boolean(),
+			reason: z.string().optional(),
+		}),
+	),
+});
+
+const SYSTEM_PROMPT = [
+	'You are evaluating whether dataset rows satisfy a stated quality criterion.',
+	'For each sample, return passed=true if the value clearly meets the criterion, otherwise passed=false with a short reason.',
+	'Be strict but fair. Reasons must be concise (one sentence).',
+	'Respond with JSON only — no prose, no markdown — using shape: { "verdicts": [{ "rowIndex": number, "passed": boolean, "reason"?: string }] }',
+].join('\n');
+
+export function createDefaultJudge(): SemanticJudgeFn {
+	const agent = createEvalAgent('eval-data-judge', {
+		model: HAIKU_MODEL,
+		instructions: SYSTEM_PROMPT,
+	});
+
+	return async ({ column, criterion, samples }) => {
+		const userPrompt = [
+			`Column: ${column}`,
+			`Criterion: ${criterion}`,
+			'Samples:',
+			...samples.map(({ rowIndex, value }) => `- rowIndex=${rowIndex}: ${stringify(value)}`),
+		].join('\n');
+
+		const response = await agent.generate([
+			{ role: 'user' as const, content: [{ type: 'text' as const, text: userPrompt }] },
+		]);
+		const text = extractText(response).trim();
+		const stripped = stripCodeFences(text);
+
+		const parsed = verdictSchema.safeParse(safeParseJson(stripped));
+		if (!parsed.success) {
+			return {
+				failures: samples.map((sample) => ({
+					rowIndex: sample.rowIndex,
+					reason: 'Judge response could not be parsed as JSON.',
+				})),
+			};
+		}
+
+		return {
+			failures: parsed.data.verdicts
+				.filter((verdict) => !verdict.passed)
+				.map((verdict) => ({
+					rowIndex: verdict.rowIndex,
+					reason: verdict.reason ?? 'No reason provided.',
+				})),
+		};
+	};
+}
+
+function stringify(value: unknown): string {
+	if (value === null) return 'null';
+	if (typeof value === 'string') return JSON.stringify(value);
+	return JSON.stringify(value);
+}
+
+function safeParseJson(text: string): unknown {
+	try {
+		return JSON.parse(text) as unknown;
+	} catch {
+		return null;
+	}
+}
+
+function stripCodeFences(text: string): string {
+	const match = text.match(/^```(?:json)?\s*([\s\S]*?)```$/);
+	return match ? match[1].trim() : text;
+}

--- a/packages/@n8n/instance-ai/evaluations/eval-data-quality/exit-policy.ts
+++ b/packages/@n8n/instance-ai/evaluations/eval-data-quality/exit-policy.ts
@@ -1,0 +1,5 @@
+import type { EvalDataQualityRunResult } from './types';
+
+export function shouldFailProcessForCompletedRun(_runResult: EvalDataQualityRunResult): boolean {
+	return false;
+}

--- a/packages/@n8n/instance-ai/evaluations/eval-data-quality/exit-policy.ts
+++ b/packages/@n8n/instance-ai/evaluations/eval-data-quality/exit-policy.ts
@@ -1,5 +1,0 @@
-import type { EvalDataQualityRunResult } from './types';
-
-export function shouldFailProcessForCompletedRun(_runResult: EvalDataQualityRunResult): boolean {
-	return false;
-}

--- a/packages/@n8n/instance-ai/evaluations/eval-data-quality/fixtures.ts
+++ b/packages/@n8n/instance-ai/evaluations/eval-data-quality/fixtures.ts
@@ -1,0 +1,111 @@
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { basename, extname, join } from 'path';
+import { z } from 'zod';
+
+import { datasetSidecarSchema, type EvalDataQualityCase } from './types';
+import type { WorkflowResponse } from '../clients/n8n-client';
+
+export const DEFAULT_ROOT = join(__dirname, '..', 'data', 'eval-data-quality');
+
+interface LoadEvalDataQualityCasesOptions {
+	rootDir?: string;
+	filter?: string;
+}
+
+const workflowFixtureSchema = z
+	.object({
+		id: z.string().optional(),
+		name: z.string().optional(),
+		active: z.boolean().optional(),
+		nodes: z.array(
+			z
+				.object({
+					name: z.string(),
+					type: z.string(),
+					typeVersion: z.number().optional(),
+					parameters: z.record(z.string(), z.unknown()).optional(),
+					disabled: z.boolean().optional(),
+					credentials: z.record(z.string(), z.unknown()).optional(),
+				})
+				.passthrough(),
+		),
+		connections: z.record(z.string(), z.unknown()),
+		pinData: z.record(z.string(), z.unknown()).optional(),
+		settings: z.record(z.string(), z.unknown()).optional(),
+	})
+	.passthrough();
+
+export function loadEvalDataQualityCases(
+	options: LoadEvalDataQualityCasesOptions = {},
+): EvalDataQualityCase[] {
+	const rootDir = options.rootDir ?? DEFAULT_ROOT;
+	const workflowsDir = join(rootDir, 'workflows');
+	const expectationsDir = join(rootDir, 'expectations');
+
+	if (!existsSync(workflowsDir)) {
+		return [];
+	}
+
+	return readdirSync(workflowsDir)
+		.filter((fileName) => extname(fileName) === '.json')
+		.sort()
+		.map((fileName) => basename(fileName, '.json'))
+		.filter((slug) => options.filter === undefined || slug.includes(options.filter))
+		.map((slug) => {
+			const workflowPath = join(workflowsDir, `${slug}.json`);
+			const sidecarPath = join(expectationsDir, `${slug}.dataset.json`);
+
+			if (!existsSync(sidecarPath)) {
+				throw new Error(`Missing dataset sidecar for ${slug}: ${sidecarPath}`);
+			}
+
+			const workflow = loadWorkflow(workflowPath, slug);
+			const sidecar = loadSidecar(sidecarPath);
+
+			return {
+				slug,
+				workflowPath,
+				sidecarPath,
+				workflow,
+				sidecar,
+			};
+		});
+}
+
+function loadWorkflow(workflowPath: string, slug: string): WorkflowResponse {
+	const workflow = workflowFixtureSchema.safeParse(readJson(workflowPath));
+
+	if (!workflow.success) {
+		throw new Error(`Invalid workflow fixture ${workflowPath}: ${workflow.error.message}`);
+	}
+
+	return {
+		...workflow.data,
+		id: workflow.data.id ?? '',
+		name: workflow.data.name ?? slug,
+		active: workflow.data.active ?? false,
+		nodes: workflow.data.nodes,
+		connections: workflow.data.connections,
+		pinData: workflow.data.pinData ?? {},
+	};
+}
+
+function loadSidecar(sidecarPath: string) {
+	const sidecar = datasetSidecarSchema.safeParse(readJson(sidecarPath));
+
+	if (!sidecar.success) {
+		throw new Error(`Invalid dataset sidecar ${sidecarPath}: ${sidecar.error.message}`);
+	}
+
+	return sidecar.data;
+}
+
+function readJson(path: string): unknown {
+	try {
+		const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'));
+		return parsed;
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(`Invalid JSON fixture ${path}: ${message}`);
+	}
+}

--- a/packages/@n8n/instance-ai/evaluations/eval-data-quality/runner.ts
+++ b/packages/@n8n/instance-ai/evaluations/eval-data-quality/runner.ts
@@ -1,0 +1,414 @@
+import crypto from 'node:crypto';
+
+import type { N8nClient, WorkflowCreatePayload, WorkflowResponse } from '../clients/n8n-client';
+import { consumeSseStream } from '../clients/sse-client';
+import type { EvalLogger } from '../harness/logger';
+import type { CapturedEvent } from '../types';
+import { verifyDataset } from './dataset-verifier';
+import { extractToolSelection } from './tool-selection';
+import type {
+	DatasetFinding,
+	DatasetVerifierResult,
+	EvalDataQualityCase,
+	EvalDataQualityCaseResult,
+	SemanticJudgeFn,
+	ToolSelectionResult,
+} from './types';
+
+const SSE_SETTLE_DELAY_MS = 200;
+const POLL_INTERVAL_MS = 1_000;
+const DEFAULT_TIMEOUT_MS = 600_000;
+const CONFIRMATION_MAX_RETRIES = 5;
+
+export interface EvalDataQualityRunnerConfig {
+	client: N8nClient;
+	testCase: EvalDataQualityCase;
+	logger: EvalLogger;
+	timeoutMs?: number;
+	keepArtifacts?: boolean;
+	projectId?: string;
+	judge?: SemanticJudgeFn;
+}
+
+type ConfirmationClient = Pick<N8nClient, 'confirmAction'>;
+type SseClient = Pick<N8nClient, 'getEventsUrl' | 'cookie'>;
+type ThreadStatusClient = Pick<N8nClient, 'getThreadStatus' | 'confirmAction'>;
+
+export async function delay(ms: number): Promise<void> {
+	return await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function uniqueName(prefix: string, slug: string): string {
+	return `${prefix}-${slug}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+export function rewriteDataTableId(
+	workflow: WorkflowResponse,
+	dataTableNodeName: string | undefined,
+	dataTableId: string,
+): WorkflowResponse {
+	const nodes = workflow.nodes.map((node) => {
+		const matchesNamedTarget = dataTableNodeName === node.name;
+		const hasDataTableId = node.parameters && 'dataTableId' in node.parameters;
+		if (!matchesNamedTarget && !hasDataTableId) return node;
+
+		const parameters = { ...(node.parameters ?? {}) };
+		const existing = parameters.dataTableId;
+		if (isResourceLocatorValue(existing)) {
+			parameters.dataTableId = { ...existing, value: dataTableId };
+		} else {
+			parameters.dataTableId = dataTableId;
+		}
+
+		return { ...node, parameters };
+	});
+
+	return { ...workflow, nodes };
+}
+
+function isResourceLocatorValue(
+	value: unknown,
+): value is { __rl: true; mode: string; value: string } {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		'__rl' in value &&
+		(value as { __rl: unknown }).__rl === true
+	);
+}
+
+export function buildWorkflowCreatePayload(
+	workflow: WorkflowResponse,
+	slug: string,
+	projectId?: string,
+): WorkflowCreatePayload {
+	return {
+		name: uniqueName('eval-data-quality', slug),
+		nodes: workflow.nodes.map((node) => {
+			const cleaned = { ...node };
+			delete cleaned.credentials;
+			return cleaned;
+		}),
+		connections: workflow.connections,
+		...(projectId === undefined ? {} : { projectId }),
+		...(workflow.pinData === undefined ? {} : { pinData: workflow.pinData }),
+	};
+}
+
+export function buildEvalPrompt(input: {
+	workflowId: string;
+	workflowName: string;
+	dataTableId: string;
+	requestedRowCount: number;
+	targetAgentNodeName?: string;
+}): string {
+	const lines = [
+		`Generate ${String(input.requestedRowCount)} synthetic eval rows for the workflow "${input.workflowName}" (id ${input.workflowId}).`,
+		`Use the existing eval DataTable (id ${input.dataTableId}); do not create a new DataTable.`,
+		'Call the eval-data tool — that is the only correct way to populate the DataTable.',
+		'Approve only the eval-data confirmation; do not propose new eval nodes.',
+	];
+	if (input.targetAgentNodeName !== undefined) {
+		lines.push(`Target the AI agent node "${input.targetAgentNodeName}".`);
+	}
+	return lines.join('\n');
+}
+
+export function isEvalDataConfirmation(event: CapturedEvent): boolean {
+	if (event.type !== 'confirmation-request') return false;
+	const payload = event.data.payload;
+	if (isRecord(payload) && payload.toolName === 'eval-data') return true;
+	return event.data.toolName === 'eval-data';
+}
+
+export function extractConfirmationRequestId(event: CapturedEvent): string | undefined {
+	if (typeof event.data.requestId === 'string') return event.data.requestId;
+	const payload = event.data.payload;
+	if (isRecord(payload) && typeof payload.requestId === 'string') return payload.requestId;
+	return undefined;
+}
+
+export async function startSseConnection(
+	client: SseClient,
+	threadId: string,
+	events: CapturedEvent[],
+	signal: AbortSignal,
+): Promise<void> {
+	await consumeSseStream(
+		client.getEventsUrl(threadId),
+		client.cookie,
+		(event) => {
+			try {
+				const data: unknown = JSON.parse(event.data);
+				if (!isRecord(data)) return;
+				events.push({
+					timestamp: Date.now(),
+					type: typeof data.type === 'string' ? data.type : (event.type ?? 'unknown'),
+					data,
+				});
+			} catch {
+				// SSE may include transient non-JSON payloads; ignore.
+			}
+		},
+		signal,
+	);
+}
+
+export async function approveEvalDataConfirmation(input: {
+	client: ConfirmationClient;
+	events: CapturedEvent[];
+	approvedRequestIds: Set<string>;
+	logger: EvalLogger;
+	retryCounts?: Map<string, number>;
+}): Promise<void> {
+	for (const event of input.events) {
+		if (!isEvalDataConfirmation(event)) continue;
+
+		const requestId = extractConfirmationRequestId(event);
+		if (!requestId || input.approvedRequestIds.has(requestId)) continue;
+
+		const retryCounts = input.retryCounts ?? new Map<string, number>();
+		const retryCount = retryCounts.get(requestId) ?? 0;
+		if (retryCount >= CONFIRMATION_MAX_RETRIES) continue;
+
+		try {
+			input.logger.verbose(`[auto-approve] Approving eval-data confirmation: ${requestId}`);
+			await input.client.confirmAction(requestId, { kind: 'approval', approved: true });
+			input.approvedRequestIds.add(requestId);
+			retryCounts.delete(requestId);
+		} catch (error) {
+			retryCounts.set(requestId, retryCount + 1);
+			const message = error instanceof Error ? error.message : String(error);
+			input.logger.verbose(
+				`[auto-approve] Failed to approve ${requestId} (attempt ${String(retryCount + 1)}/${String(CONFIRMATION_MAX_RETRIES)}): ${message}`,
+			);
+		}
+	}
+}
+
+export async function waitForThreadToSettle(input: {
+	client: ThreadStatusClient;
+	threadId: string;
+	events: CapturedEvent[];
+	approvedRequestIds: Set<string>;
+	logger: EvalLogger;
+	timeoutMs: number;
+	getStreamError?: () => unknown;
+}): Promise<void> {
+	const deadline = Date.now() + input.timeoutMs;
+	const retryCounts = new Map<string, number>();
+
+	while (Date.now() <= deadline) {
+		throwIfStreamFailed(input.getStreamError?.());
+		await approveEvalDataConfirmation({
+			client: input.client,
+			events: input.events,
+			approvedRequestIds: input.approvedRequestIds,
+			logger: input.logger,
+			retryCounts,
+		});
+
+		const status = await input.client.getThreadStatus(input.threadId);
+		const runningBackgroundTasks = status.backgroundTasks.filter(
+			(task) => task.status === 'running',
+		);
+
+		if (!status.hasActiveRun && !status.isSuspended && runningBackgroundTasks.length === 0) {
+			await delay(SSE_SETTLE_DELAY_MS);
+			await approveEvalDataConfirmation({
+				client: input.client,
+				events: input.events,
+				approvedRequestIds: input.approvedRequestIds,
+				logger: input.logger,
+				retryCounts,
+			});
+			throwIfStreamFailed(input.getStreamError?.());
+			const stable = await input.client.getThreadStatus(input.threadId);
+			const stableRunning = stable.backgroundTasks.filter((task) => task.status === 'running');
+			if (!stable.hasActiveRun && !stable.isSuspended && stableRunning.length === 0) return;
+		}
+
+		await delay(POLL_INTERVAL_MS);
+	}
+
+	throw new Error(
+		`Timed out after ${String(input.timeoutMs)}ms waiting for thread ${input.threadId} to settle`,
+	);
+}
+
+export async function runEvalDataQualityCase(
+	config: EvalDataQualityRunnerConfig,
+): Promise<EvalDataQualityCaseResult> {
+	const { client, testCase, logger } = config;
+	const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+	const events: CapturedEvent[] = [];
+	const approvedRequestIds = new Set<string>();
+	const abortController = new AbortController();
+	let streamPromise: Promise<void> | undefined;
+	let streamError: unknown;
+	let projectId: string | undefined;
+	let workflowId: string | undefined;
+	let dataTableId: string | undefined;
+	let threadId: string | undefined;
+	let threadSettled = false;
+
+	try {
+		projectId = config.projectId ?? (await client.getPersonalProjectId());
+
+		const dataTable = await client.createDataTable(projectId, {
+			name: uniqueName('eval-data-quality-dt', testCase.slug),
+			columns: testCase.sidecar.columns,
+		});
+		dataTableId = dataTable.id;
+
+		const wired = rewriteDataTableId(
+			testCase.workflow,
+			testCase.sidecar.dataTableNodeName,
+			dataTable.id,
+		);
+		const importedWorkflow = await client.createWorkflow(
+			buildWorkflowCreatePayload(wired, testCase.slug, projectId),
+		);
+		workflowId = importedWorkflow.id;
+
+		threadId = `eval-data-quality-${crypto.randomUUID()}`;
+		streamPromise = startSseConnection(client, threadId, events, abortController.signal).catch(
+			(error) => {
+				streamError = error;
+			},
+		);
+		await delay(SSE_SETTLE_DELAY_MS);
+		throwIfStreamFailed(streamError);
+
+		await client.sendMessage(
+			threadId,
+			buildEvalPrompt({
+				workflowId: importedWorkflow.id,
+				workflowName: importedWorkflow.name,
+				dataTableId: dataTable.id,
+				requestedRowCount: testCase.sidecar.requestedRowCount,
+				targetAgentNodeName: testCase.sidecar.targetAgentNodeName,
+			}),
+		);
+
+		await waitForThreadToSettle({
+			client,
+			threadId,
+			events,
+			approvedRequestIds,
+			logger,
+			timeoutMs,
+			getStreamError: () => streamError,
+		});
+		threadSettled = true;
+
+		abortController.abort();
+		await streamPromise;
+		throwIfStreamFailed(streamError);
+
+		const threadMessages = await client.getThreadMessages(threadId).catch(() => undefined);
+		const toolSelection = extractToolSelection({ events, threadMessages });
+		const rowsResponse = await client.getDataTableRows(projectId, dataTable.id, { take: 200 });
+		const dataTableColumns = (dataTable.columns ?? testCase.sidecar.columns).map((column) => ({
+			name: column.name,
+			type: column.type,
+		}));
+		const dataset = await verifyDataset(
+			{
+				rows: rowsResponse.data,
+				dataTableColumns,
+				sidecar: testCase.sidecar,
+				requestedRowCount: testCase.sidecar.requestedRowCount,
+			},
+			{ judge: config.judge },
+		);
+
+		return {
+			caseSlug: testCase.slug,
+			workflowId: importedWorkflow.id,
+			dataTableId: dataTable.id,
+			toolSelection,
+			dataset,
+			passed: toolSelection.findings.length === 0 && dataset.passed,
+		};
+	} catch (error) {
+		abortController.abort();
+		if (threadId && !threadSettled) {
+			await client.cancelRun(threadId).catch((cancelError) => {
+				const message = cancelError instanceof Error ? cancelError.message : String(cancelError);
+				logger.verbose(`Failed to cancel thread ${threadId}: ${message}`);
+			});
+		}
+		if (streamPromise) {
+			await streamPromise.catch((streamCleanupError) => {
+				const message =
+					streamCleanupError instanceof Error
+						? streamCleanupError.message
+						: String(streamCleanupError);
+				logger.verbose(`SSE stream ended with error during failure handling: ${message}`);
+			});
+		}
+
+		const message = error instanceof Error ? error.message : String(error);
+		const finding: DatasetFinding = {
+			severity: 'error',
+			code: 'runner_error',
+			message,
+		};
+
+		return {
+			caseSlug: testCase.slug,
+			...(workflowId === undefined ? {} : { workflowId }),
+			...(dataTableId === undefined ? {} : { dataTableId }),
+			toolSelection: emptyToolSelection(),
+			dataset: runnerErrorDataset(finding),
+			passed: false,
+			error: message,
+		};
+	} finally {
+		abortController.abort();
+		if (streamPromise) {
+			await streamPromise.catch((error) => {
+				const message = error instanceof Error ? error.message : String(error);
+				logger.verbose(`SSE cleanup error: ${message}`);
+			});
+		}
+
+		if (!config.keepArtifacts && projectId) {
+			if (workflowId) {
+				await client.deleteWorkflow(workflowId).catch((error) => {
+					const message = error instanceof Error ? error.message : String(error);
+					logger.verbose(`Failed to clean up workflow ${workflowId}: ${message}`);
+				});
+			}
+			if (dataTableId) {
+				await client.deleteDataTable(projectId, dataTableId).catch((error) => {
+					const message = error instanceof Error ? error.message : String(error);
+					logger.verbose(`Failed to clean up DataTable ${dataTableId}: ${message}`);
+				});
+			}
+		}
+	}
+}
+
+function emptyToolSelection(): ToolSelectionResult {
+	return { evalDataToolCalled: false, findings: [] };
+}
+
+function runnerErrorDataset(finding: DatasetFinding): DatasetVerifierResult {
+	return {
+		passed: false,
+		findings: [finding],
+		rowCount: 0,
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function throwIfStreamFailed(error: unknown): void {
+	if (error === undefined || error === null) return;
+	if (error instanceof Error) throw error;
+	throw new Error(typeof error === 'string' ? error : JSON.stringify(error));
+}

--- a/packages/@n8n/instance-ai/evaluations/eval-data-quality/summary.ts
+++ b/packages/@n8n/instance-ai/evaluations/eval-data-quality/summary.ts
@@ -1,0 +1,8 @@
+import type { EvalDataQualityRunResult } from './types';
+
+export function formatRunSummary(runResult: EvalDataQualityRunResult): string {
+	const total = runResult.results.length;
+	const passed = runResult.results.filter((result) => result.passed).length;
+	const failed = total - passed;
+	return `Summary: ${String(passed)}/${String(total)} passed, ${String(failed)} failed`;
+}

--- a/packages/@n8n/instance-ai/evaluations/eval-data-quality/tool-selection.ts
+++ b/packages/@n8n/instance-ai/evaluations/eval-data-quality/tool-selection.ts
@@ -1,0 +1,105 @@
+import type { InstanceAiRichMessagesResponse } from '@n8n/api-types';
+
+import type { CapturedEvent } from '../types';
+import type { ToolSelectionResult } from './types';
+
+const EVAL_DATA_TOOL_NAME = 'eval-data';
+const EVAL_DATA_AGENT_ROLE = 'eval-data';
+const TOOL_CALL_EVENT_TYPES = new Set(['tool-call']);
+const AGENT_SPAWN_EVENT_TYPES = new Set(['agent-spawned']);
+const TOOL_NAME_KEYS = ['toolName', 'tool', 'name'] as const;
+const AGENT_ROLE_KEYS = ['role', 'kind'] as const;
+
+const EVAL_DATA_MISSING_FINDING = {
+	severity: 'error',
+	code: 'eval_data_tool_not_called',
+	message: 'Instance AI did not call the eval-data tool',
+} as const;
+
+export function extractToolSelection(input: {
+	events: CapturedEvent[];
+	threadMessages?: InstanceAiRichMessagesResponse;
+}): ToolSelectionResult {
+	const evalDataToolCalled =
+		input.events.some(
+			(event) =>
+				eventContainsToolCall(event, EVAL_DATA_TOOL_NAME) || eventSpawnsEvalDataAgent(event),
+		) || richMessagesContainToolCall(input.threadMessages, EVAL_DATA_TOOL_NAME);
+
+	return {
+		evalDataToolCalled,
+		findings: evalDataToolCalled ? [] : [EVAL_DATA_MISSING_FINDING],
+	};
+}
+
+function eventContainsToolCall(event: CapturedEvent, expectedToolName: string): boolean {
+	if (!TOOL_CALL_EVENT_TYPES.has(event.type.toLowerCase())) return false;
+	return findStringDeep(event.data, TOOL_NAME_KEYS, expectedToolName);
+}
+
+function eventSpawnsEvalDataAgent(event: CapturedEvent): boolean {
+	if (!AGENT_SPAWN_EVENT_TYPES.has(event.type.toLowerCase())) return false;
+	return findStringDeep(event.data, AGENT_ROLE_KEYS, EVAL_DATA_AGENT_ROLE);
+}
+
+function richMessagesContainToolCall(
+	threadMessages: InstanceAiRichMessagesResponse | undefined,
+	expectedToolName: string,
+): boolean {
+	if (!threadMessages) return false;
+
+	const seen = new WeakSet<object>();
+	const stack = threadMessages.messages
+		.map((message) => message.agentTree)
+		.filter((tree): tree is NonNullable<typeof tree> => tree !== undefined);
+
+	while (stack.length > 0) {
+		const node = stack.pop();
+		if (!node || seen.has(node)) continue;
+		seen.add(node);
+
+		const matched = node.toolCalls.some((toolCall) =>
+			TOOL_NAME_KEYS.some((key) => getString(toolCall, key) === expectedToolName),
+		);
+		if (matched) return true;
+
+		stack.push(...node.children);
+	}
+
+	return false;
+}
+
+function findStringDeep(value: unknown, keys: readonly string[], target: string): boolean {
+	const seen = new WeakSet<object>();
+	const stack: unknown[] = [value];
+
+	while (stack.length > 0) {
+		const current = stack.pop();
+		if (!isObjectLike(current)) continue;
+		if (seen.has(current)) continue;
+		seen.add(current);
+
+		if (Array.isArray(current)) {
+			for (const item of current) stack.push(item);
+			continue;
+		}
+
+		const record = current;
+		if (keys.some((key) => getString(record, key) === target)) return true;
+
+		for (const propertyValue of Object.values(record)) {
+			stack.push(propertyValue);
+		}
+	}
+
+	return false;
+}
+
+function isObjectLike(value: unknown): value is object {
+	return typeof value === 'object' && value !== null;
+}
+
+function getString(value: object, key: string): string | undefined {
+	const property = (value as Record<string, unknown>)[key];
+	return typeof property === 'string' ? property : undefined;
+}

--- a/packages/@n8n/instance-ai/evaluations/eval-data-quality/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/eval-data-quality/types.ts
@@ -1,0 +1,142 @@
+import { z } from 'zod';
+
+import type { DataTableRowOutput, WorkflowResponse } from '../clients/n8n-client';
+
+export const DATA_TABLE_COLUMN_NAME_PATTERN = /^[a-zA-Z][a-zA-Z0-9_]*$/;
+export const DATA_TABLE_COLUMN_NAME_MAX_LENGTH = 63;
+
+const dataTableColumnNameSchema = z
+	.string()
+	.regex(DATA_TABLE_COLUMN_NAME_PATTERN)
+	.max(DATA_TABLE_COLUMN_NAME_MAX_LENGTH);
+
+const dataTableColumnTypeSchema = z.enum(['string', 'number', 'boolean', 'date']);
+
+export const datasetColumnSchema = z.object({
+	name: dataTableColumnNameSchema,
+	type: dataTableColumnTypeSchema,
+});
+export type DatasetColumn = z.infer<typeof datasetColumnSchema>;
+
+const semanticCriterionSchema = z.object({
+	column: dataTableColumnNameSchema,
+	criterion: z
+		.string()
+		.min(1)
+		.describe('Plain-language requirement evaluated by the LLM judge for every row in the column.'),
+	allowEmpty: z
+		.boolean()
+		.default(false)
+		.describe('When true, empty cell values are not penalised and not sent to the judge.'),
+});
+export type SemanticCriterion = z.infer<typeof semanticCriterionSchema>;
+
+export const datasetSidecarSchema = z.object({
+	requestedRowCount: z
+		.number()
+		.int()
+		.positive()
+		.default(25)
+		.describe('Row count to request from the eval-data tool. Mirrors the user-facing default.'),
+	minRowCount: z
+		.number()
+		.int()
+		.positive()
+		.describe('Minimum number of rows the generated dataset must contain.'),
+	columns: z
+		.array(datasetColumnSchema)
+		.nonempty()
+		.describe('Columns the empty DataTable is created with — must match the workflow eval shape.'),
+	inputColumns: z
+		.array(dataTableColumnNameSchema)
+		.nonempty()
+		.describe('Columns the agent must populate. Empty cells in these columns are findings.'),
+	expectedOutputColumns: z
+		.array(dataTableColumnNameSchema)
+		.default([])
+		.describe('Columns that should also be populated when the workflow declares them.'),
+	actualOutputColumns: z
+		.array(dataTableColumnNameSchema)
+		.default([])
+		.describe(
+			'Columns that must remain empty — populated only by eval runs, never by data generation.',
+		),
+	dataTableNodeName: z
+		.string()
+		.optional()
+		.describe(
+			'Name of the workflow node whose `dataTableId` parameter should be rewritten with the runtime DataTable id.',
+		),
+	targetAgentNodeName: z
+		.string()
+		.optional()
+		.describe('Forwarded to the eval-data tool when the workflow has multiple AI agents.'),
+	semanticCriteria: z
+		.array(semanticCriterionSchema)
+		.default([])
+		.describe('LLM-judge criteria; one entry per column to assess.'),
+});
+export type DatasetSidecar = z.infer<typeof datasetSidecarSchema>;
+
+export interface EvalDataQualityCase {
+	slug: string;
+	workflowPath: string;
+	sidecarPath: string;
+	workflow: WorkflowResponse;
+	sidecar: DatasetSidecar;
+}
+
+export interface DatasetFinding {
+	severity: 'error' | 'warning';
+	code: string;
+	message: string;
+	column?: string;
+	rowIndex?: number;
+}
+
+export interface DatasetVerifierInput {
+	rows: DataTableRowOutput[];
+	dataTableColumns: Array<{ name: string; type: string }>;
+	sidecar: DatasetSidecar;
+	requestedRowCount: number;
+}
+
+export interface SemanticJudgeFn {
+	(input: {
+		column: string;
+		criterion: string;
+		samples: Array<{ rowIndex: number; value: unknown }>;
+	}): Promise<{
+		failures: Array<{ rowIndex: number; reason: string }>;
+	}>;
+}
+
+export interface DatasetVerifierOptions {
+	judge?: SemanticJudgeFn;
+}
+
+export interface DatasetVerifierResult {
+	passed: boolean;
+	findings: DatasetFinding[];
+	rowCount: number;
+}
+
+export interface ToolSelectionResult {
+	evalDataToolCalled: boolean;
+	findings: DatasetFinding[];
+}
+
+export interface EvalDataQualityCaseResult {
+	caseSlug: string;
+	workflowId?: string;
+	dataTableId?: string;
+	toolSelection: ToolSelectionResult;
+	dataset: DatasetVerifierResult;
+	passed: boolean;
+	error?: string;
+}
+
+export interface EvalDataQualityRunResult {
+	passed: boolean;
+	results: EvalDataQualityCaseResult[];
+}

--- a/packages/@n8n/instance-ai/package.json
+++ b/packages/@n8n/instance-ai/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint . --quiet",
     "lint:fix": "eslint . --fix",
     "eval:instance-ai": "tsx evaluations/cli/index.ts",
-    "eval:subagent": "tsx evaluations/subagent/cli.ts"
+    "eval:subagent": "tsx evaluations/subagent/cli.ts",
+    "eval:data-quality": "tsx evaluations/eval-data-quality/cli.ts"
   },
   "main": "dist/index.js",
   "module": "src/index.ts",

--- a/packages/@n8n/instance-ai/src/tools/evals/__tests__/detect-ai-nodes.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/evals/__tests__/detect-ai-nodes.test.ts
@@ -1,0 +1,77 @@
+import type { WorkflowJSON } from '@n8n/workflow-sdk';
+
+import { detectAiNodes } from '../detect-ai-nodes';
+
+function wf(nodes: Array<{ name: string; type: string }>): WorkflowJSON {
+	return {
+		name: 'Test',
+		nodes: nodes.map((n, i) => ({
+			id: `id-${i}`,
+			name: n.name,
+			type: n.type,
+			typeVersion: 1,
+			position: [0, 0] as [number, number],
+			parameters: {},
+		})),
+		connections: {},
+	} as unknown as WorkflowJSON;
+}
+
+describe('detectAiNodes', () => {
+	it('returns isAiWorkflow=true when workflow contains a langchain node', () => {
+		const result = detectAiNodes(
+			wf([
+				{ name: 'Start', type: 'n8n-nodes-base.manualTrigger' },
+				{ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' },
+			]),
+		);
+		expect(result.isAiWorkflow).toBe(true);
+		expect(result.aiNodeNames).toEqual(['Agent']);
+		expect(result.alreadyConfigured).toBe(false);
+	});
+
+	it('returns isAiWorkflow=false when no langchain nodes are present', () => {
+		const result = detectAiNodes(
+			wf([
+				{ name: 'Start', type: 'n8n-nodes-base.manualTrigger' },
+				{ name: 'HTTP', type: 'n8n-nodes-base.httpRequest' },
+			]),
+		);
+		expect(result.isAiWorkflow).toBe(false);
+		expect(result.aiNodeNames).toEqual([]);
+		expect(result.alreadyConfigured).toBe(false);
+	});
+
+	it('returns alreadyConfigured=true when EvaluationTrigger is already in the workflow', () => {
+		const result = detectAiNodes(
+			wf([
+				{ name: 'Start', type: 'n8n-nodes-base.manualTrigger' },
+				{ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' },
+				{ name: 'EvalTrigger', type: 'n8n-nodes-base.evaluationTrigger' },
+			]),
+		);
+		expect(result.alreadyConfigured).toBe(true);
+	});
+
+	it('returns alreadyConfigured=true when Evaluation node is already in the workflow', () => {
+		const result = detectAiNodes(
+			wf([
+				{ name: 'Start', type: 'n8n-nodes-base.manualTrigger' },
+				{ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' },
+				{ name: 'Eval', type: 'n8n-nodes-base.evaluation' },
+			]),
+		);
+		expect(result.alreadyConfigured).toBe(true);
+	});
+
+	it('collects all langchain node names', () => {
+		const result = detectAiNodes(
+			wf([
+				{ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' },
+				{ name: 'Memory', type: '@n8n/n8n-nodes-langchain.memoryBufferWindow' },
+				{ name: 'HTTP', type: 'n8n-nodes-base.httpRequest' },
+			]),
+		);
+		expect(result.aiNodeNames).toEqual(['Agent', 'Memory']);
+	});
+});

--- a/packages/@n8n/instance-ai/src/tools/evals/__tests__/detect-ai-nodes.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/evals/__tests__/detect-ai-nodes.test.ts
@@ -18,50 +18,24 @@ function wf(nodes: Array<{ name: string; type: string }>): WorkflowJSON {
 }
 
 describe('detectAiNodes', () => {
-	it('returns isAiWorkflow=true when workflow contains a langchain node', () => {
+	it('returns langchain node names when workflow contains AI nodes', () => {
 		const result = detectAiNodes(
 			wf([
 				{ name: 'Start', type: 'n8n-nodes-base.manualTrigger' },
 				{ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' },
 			]),
 		);
-		expect(result.isAiWorkflow).toBe(true);
 		expect(result.aiNodeNames).toEqual(['Agent']);
-		expect(result.alreadyConfigured).toBe(false);
 	});
 
-	it('returns isAiWorkflow=false when no langchain nodes are present', () => {
+	it('returns an empty list when no langchain nodes are present', () => {
 		const result = detectAiNodes(
 			wf([
 				{ name: 'Start', type: 'n8n-nodes-base.manualTrigger' },
 				{ name: 'HTTP', type: 'n8n-nodes-base.httpRequest' },
 			]),
 		);
-		expect(result.isAiWorkflow).toBe(false);
 		expect(result.aiNodeNames).toEqual([]);
-		expect(result.alreadyConfigured).toBe(false);
-	});
-
-	it('returns alreadyConfigured=true when EvaluationTrigger is already in the workflow', () => {
-		const result = detectAiNodes(
-			wf([
-				{ name: 'Start', type: 'n8n-nodes-base.manualTrigger' },
-				{ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' },
-				{ name: 'EvalTrigger', type: 'n8n-nodes-base.evaluationTrigger' },
-			]),
-		);
-		expect(result.alreadyConfigured).toBe(true);
-	});
-
-	it('returns alreadyConfigured=true when Evaluation node is already in the workflow', () => {
-		const result = detectAiNodes(
-			wf([
-				{ name: 'Start', type: 'n8n-nodes-base.manualTrigger' },
-				{ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' },
-				{ name: 'Eval', type: 'n8n-nodes-base.evaluation' },
-			]),
-		);
-		expect(result.alreadyConfigured).toBe(true);
 	});
 
 	it('collects all langchain node names', () => {

--- a/packages/@n8n/instance-ai/src/tools/evals/__tests__/eval-data-requirements.service.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/evals/__tests__/eval-data-requirements.service.test.ts
@@ -1,0 +1,157 @@
+import type { WorkflowJSON } from '@n8n/workflow-sdk';
+
+import { analyzeEvalDataRequirements } from '../eval-data-requirements.service';
+
+function workflowWithEvalTopology(): WorkflowJSON {
+	return {
+		id: 'w1',
+		name: 'Support Classifier',
+		nodes: [
+			{
+				id: 'main-trigger',
+				name: 'Chat Trigger',
+				type: '@n8n/n8n-nodes-langchain.chatTrigger',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			},
+			{
+				id: 'eval-trigger',
+				name: 'Eval Trigger',
+				type: 'n8n-nodes-base.evaluationTrigger',
+				typeVersion: 4.7,
+				position: [0, 240],
+				parameters: {
+					source: 'dataTable',
+					dataTableId: { __rl: true, mode: 'id', value: 'dt-1' },
+				},
+			},
+			{
+				id: 'bridge',
+				name: 'Eval Shape Bridge',
+				type: 'n8n-nodes-base.set',
+				typeVersion: 3.4,
+				position: [220, 240],
+				parameters: {
+					assignments: {
+						assignments: [
+							{
+								id: 'assignment-1',
+								name: 'chatInput',
+								value: '={{ $json.user_message }}',
+								type: 'string',
+							},
+						],
+					},
+				},
+			},
+			{
+				id: 'agent',
+				name: 'Classifier Agent',
+				type: '@n8n/n8n-nodes-langchain.agent',
+				typeVersion: 1,
+				position: [480, 0],
+				parameters: {},
+			},
+			{
+				id: 'check',
+				name: 'Eval Check',
+				type: 'n8n-nodes-base.evaluation',
+				typeVersion: 4.8,
+				position: [740, 0],
+				parameters: { operation: 'checkIfEvaluating' },
+			},
+			{
+				id: 'outputs',
+				name: 'Eval Set Outputs',
+				type: 'n8n-nodes-base.evaluation',
+				typeVersion: 4.8,
+				position: [980, -120],
+				parameters: {
+					operation: 'setOutputs',
+					outputs: {
+						values: [
+							{
+								outputName: 'actual_answer',
+								outputValue: '={{ $json.output }}',
+							},
+						],
+					},
+				},
+			},
+			{
+				id: 'metrics',
+				name: 'Eval Set Metrics',
+				type: 'n8n-nodes-base.evaluation',
+				typeVersion: 4.8,
+				position: [1200, -120],
+				parameters: {
+					operation: 'setMetrics',
+					metric: 'correctness',
+					expectedAnswer: "={{ $('Eval Trigger').item.json.expected_answer }}",
+					actualAnswer: '={{ $json.output }}',
+				},
+			},
+			{
+				id: 'side-effect',
+				name: 'Send Slack',
+				type: 'n8n-nodes-base.slack',
+				typeVersion: 2,
+				position: [980, 120],
+				parameters: {},
+			},
+		],
+		connections: {
+			'Chat Trigger': {
+				main: [[{ node: 'Classifier Agent', type: 'main', index: 0 }]],
+			},
+			'Eval Trigger': {
+				main: [[{ node: 'Eval Shape Bridge', type: 'main', index: 0 }]],
+			},
+			'Eval Shape Bridge': {
+				main: [[{ node: 'Classifier Agent', type: 'main', index: 0 }]],
+			},
+			'Classifier Agent': {
+				main: [[{ node: 'Eval Check', type: 'main', index: 0 }]],
+			},
+			'Eval Check': {
+				main: [
+					[{ node: 'Eval Set Outputs', type: 'main', index: 0 }],
+					[{ node: 'Send Slack', type: 'main', index: 0 }],
+				],
+			},
+			'Eval Set Outputs': {
+				main: [[{ node: 'Eval Set Metrics', type: 'main', index: 0 }]],
+			},
+		},
+	} as unknown as WorkflowJSON;
+}
+
+describe('analyzeEvalDataRequirements', () => {
+	it('finds the eval DataTable and data columns from eval topology', () => {
+		const result = analyzeEvalDataRequirements(workflowWithEvalTopology());
+
+		expect(result.targets).toHaveLength(1);
+		expect(result.targets[0]).toMatchObject({
+			dataTableId: 'dt-1',
+			evaluationTriggerName: 'Eval Trigger',
+			targetAgentNodeName: 'Classifier Agent',
+			inputColumns: ['user_message'],
+			expectedOutputColumns: ['expected_answer'],
+			actualOutputColumns: ['actual_answer'],
+		});
+	});
+
+	it('returns no targets when eval nodes are absent', () => {
+		const workflow = {
+			name: 'No evals',
+			nodes: [],
+			connections: {},
+		} as unknown as WorkflowJSON;
+
+		const result = analyzeEvalDataRequirements(workflow);
+
+		expect(result.targets).toEqual([]);
+		expect(result.reason).toContain('EvaluationTrigger');
+	});
+});

--- a/packages/@n8n/instance-ai/src/tools/evals/__tests__/generate-sample-rows.service.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/evals/__tests__/generate-sample-rows.service.test.ts
@@ -1,0 +1,462 @@
+import type { WorkflowJSON } from '@n8n/workflow-sdk';
+
+jest.mock('../../../utils/eval-agents', () => {
+	const actual: object = jest.requireActual('../../../utils/eval-agents');
+	return { ...actual, createEvalAgent: jest.fn(), extractText: jest.fn() };
+});
+
+import { createEvalAgent, extractText } from '../../../utils/eval-agents';
+import {
+	distributeRowCount,
+	extractAgentContext,
+	generateSampleRows,
+	runBatch,
+	SAMPLE_ROW_FACETS,
+} from '../generate-sample-rows.service';
+import type { AgentContext, SampleRowFacet } from '../generate-sample-rows.service';
+
+const mockCreateEvalAgent = createEvalAgent as jest.MockedFunction<typeof createEvalAgent>;
+const mockExtractText = extractText as jest.MockedFunction<typeof extractText>;
+
+function setupAgentMock(responseText: string) {
+	const generate = jest.fn().mockResolvedValue({ messages: [] });
+	mockCreateEvalAgent.mockReturnValue({ generate } as unknown as ReturnType<
+		typeof createEvalAgent
+	>);
+	mockExtractText.mockReturnValue(responseText);
+}
+
+const WF: WorkflowJSON = { name: 'Test', nodes: [], connections: {} } as unknown as WorkflowJSON;
+
+describe('generateSampleRows', () => {
+	beforeEach(() => jest.clearAllMocks());
+
+	it('returns parsed rows from valid JSON across batches', async () => {
+		setupAgentMock(JSON.stringify([{ input: 'q1', expected_output: 'a1' }]));
+		const rows = await generateSampleRows({
+			workflow: WF,
+			columns: ['input', 'expected_output'],
+			rowCount: 5,
+		});
+		expect(rows.length).toBeGreaterThan(0);
+		expect(rows[0]).toEqual({ input: 'q1', expected_output: 'a1' });
+	});
+
+	it('coerces non-string cell values to strings', async () => {
+		setupAgentMock(JSON.stringify([{ input: 42, expected_output: true }]));
+		const rows = await generateSampleRows({
+			workflow: WF,
+			columns: ['input', 'expected_output'],
+			rowCount: 5,
+		});
+		expect(rows[0]).toEqual({ input: '42', expected_output: 'true' });
+	});
+
+	it('fills missing columns with empty strings', async () => {
+		setupAgentMock(JSON.stringify([{ input: 'q1' }]));
+		const rows = await generateSampleRows({
+			workflow: WF,
+			columns: ['input', 'expected_output'],
+			rowCount: 5,
+		});
+		expect(rows[0]).toEqual({ input: 'q1', expected_output: '' });
+	});
+
+	it('returns single fallback row when every batch fails to parse', async () => {
+		setupAgentMock('not json');
+		const rows = await generateSampleRows({
+			workflow: WF,
+			columns: ['input', 'expected_output'],
+			rowCount: 5,
+		});
+		expect(rows).toEqual([{ input: '', expected_output: '' }]);
+	});
+
+	it('returns single fallback row when every batch rejects', async () => {
+		const generate = jest.fn().mockRejectedValue(new Error('API down'));
+		mockCreateEvalAgent.mockReturnValue({ generate } as unknown as ReturnType<
+			typeof createEvalAgent
+		>);
+		const rows = await generateSampleRows({
+			workflow: WF,
+			columns: ['input', 'expected_output'],
+			rowCount: 5,
+		});
+		expect(rows).toEqual([{ input: '', expected_output: '' }]);
+	});
+});
+
+describe('distributeRowCount', () => {
+	it('distributes 25 evenly across 5 facets', () => {
+		expect(distributeRowCount(25)).toEqual([5, 5, 5, 5, 5]);
+	});
+
+	it('puts the remainder in the leading facets', () => {
+		expect(distributeRowCount(23)).toEqual([5, 5, 5, 4, 4]);
+	});
+
+	it('handles small counts with trailing zeros', () => {
+		expect(distributeRowCount(8)).toEqual([2, 2, 2, 1, 1]);
+		expect(distributeRowCount(3)).toEqual([1, 1, 1, 0, 0]);
+	});
+
+	it('treats zero and negative inputs as zero', () => {
+		expect(distributeRowCount(0)).toEqual([0, 0, 0, 0, 0]);
+		expect(distributeRowCount(-1)).toEqual([0, 0, 0, 0, 0]);
+	});
+});
+
+describe('SAMPLE_ROW_FACETS', () => {
+	it('declares exactly 5 facets', () => {
+		expect(SAMPLE_ROW_FACETS).toHaveLength(5);
+	});
+
+	it('each facet has a length, edgeMode, and instructions string', () => {
+		for (const facet of SAMPLE_ROW_FACETS) {
+			expect(typeof facet.length).toBe('string');
+			expect(typeof facet.edgeMode).toBe('string');
+			expect(typeof facet.instructions).toBe('string');
+			expect(facet.instructions.length).toBeGreaterThan(20);
+		}
+	});
+
+	it('covers happy, edge, and adversarial modes', () => {
+		const modes = SAMPLE_ROW_FACETS.map((f) => f.edgeMode).join(' ');
+		expect(modes).toMatch(/happy/i);
+		expect(modes).toMatch(/edge/i);
+		expect(modes).toMatch(/adversarial/i);
+		expect(modes).toMatch(/robust/i);
+	});
+});
+
+const BATCH_FACET: SampleRowFacet = {
+	length: 'short',
+	edgeMode: 'happy',
+	instructions: 'Produce typical inputs.',
+};
+
+const BATCH_CONTEXT: AgentContext = {
+	workflowName: 'Workflow',
+	agentNodeName: 'Agent',
+	systemPrompt: 'Be helpful.',
+	promptTemplate: undefined,
+	connectedToolNames: [],
+};
+
+describe('runBatch', () => {
+	beforeEach(() => jest.clearAllMocks());
+
+	it('returns parsed rows on success', async () => {
+		setupAgentMock(JSON.stringify([{ input: 'q1', expected_output: 'a1' }]));
+		const rows = await runBatch({
+			facet: BATCH_FACET,
+			rowCount: 1,
+			context: BATCH_CONTEXT,
+			columns: ['input', 'expected_output'],
+		});
+		expect(rows).toEqual([{ input: 'q1', expected_output: 'a1' }]);
+	});
+
+	it('returns empty array when generate throws (does not propagate)', async () => {
+		const generate = jest.fn().mockRejectedValue(new Error('API down'));
+		mockCreateEvalAgent.mockReturnValue({ generate } as unknown as ReturnType<
+			typeof createEvalAgent
+		>);
+		const rows = await runBatch({
+			facet: BATCH_FACET,
+			rowCount: 1,
+			context: BATCH_CONTEXT,
+			columns: ['input'],
+		});
+		expect(rows).toEqual([]);
+	});
+
+	it('returns empty array when JSON is malformed', async () => {
+		setupAgentMock('not json');
+		const rows = await runBatch({
+			facet: BATCH_FACET,
+			rowCount: 1,
+			context: BATCH_CONTEXT,
+			columns: ['input'],
+		});
+		expect(rows).toEqual([]);
+	});
+
+	it('returns empty array when schema validation fails', async () => {
+		setupAgentMock(JSON.stringify({ not: 'an array' }));
+		const rows = await runBatch({
+			facet: BATCH_FACET,
+			rowCount: 1,
+			context: BATCH_CONTEXT,
+			columns: ['input'],
+		});
+		expect(rows).toEqual([]);
+	});
+
+	it('strips markdown fences from the response', async () => {
+		setupAgentMock('```json\n[{"input":"q","expected_output":"a"}]\n```');
+		const rows = await runBatch({
+			facet: BATCH_FACET,
+			rowCount: 1,
+			context: BATCH_CONTEXT,
+			columns: ['input', 'expected_output'],
+		});
+		expect(rows).toEqual([{ input: 'q', expected_output: 'a' }]);
+	});
+
+	it('passes facet instructions, rowCount, and agent context into the prompt', async () => {
+		const generate = jest.fn().mockResolvedValue({ messages: [] });
+		mockCreateEvalAgent.mockReturnValue({ generate } as unknown as ReturnType<
+			typeof createEvalAgent
+		>);
+		mockExtractText.mockReturnValue(JSON.stringify([]));
+		await runBatch({
+			facet: BATCH_FACET,
+			rowCount: 7,
+			context: BATCH_CONTEXT,
+			columns: ['input'],
+		});
+		const calls = generate.mock.calls as unknown as Array<
+			Array<Array<{ content: Array<{ text: string }> }>>
+		>;
+		const promptText = calls[0][0][0].content[0].text;
+		expect(promptText).toContain('Produce typical inputs.');
+		expect(promptText).toContain('7');
+		expect(promptText).toContain('Be helpful.');
+	});
+
+	it('returns empty array immediately when rowCount is zero', async () => {
+		const generate = jest.fn();
+		mockCreateEvalAgent.mockReturnValue({ generate } as unknown as ReturnType<
+			typeof createEvalAgent
+		>);
+		const rows = await runBatch({
+			facet: BATCH_FACET,
+			rowCount: 0,
+			context: BATCH_CONTEXT,
+			columns: ['input'],
+		});
+		expect(rows).toEqual([]);
+		expect(generate).not.toHaveBeenCalled();
+	});
+});
+
+describe('extractAgentContext', () => {
+	const AGENT_TYPE = '@n8n/n8n-nodes-langchain.agent';
+	const TOOL_TYPE = '@n8n/n8n-nodes-langchain.toolHttpRequest';
+
+	function buildWorkflow(): WorkflowJSON {
+		return {
+			name: 'Support bot',
+			nodes: [
+				{
+					id: '1',
+					name: 'Agent A',
+					type: AGENT_TYPE,
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {
+						text: '={{ $json.message }}',
+						options: { systemMessage: 'You are a polite support agent.' },
+					},
+				},
+				{
+					id: '2',
+					name: 'Lookup tool',
+					type: TOOL_TYPE,
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+			],
+			connections: {
+				'Lookup tool': {
+					ai_tool: [[{ node: 'Agent A', type: 'ai_tool', index: 0 }]],
+				},
+			},
+		} as unknown as WorkflowJSON;
+	}
+
+	it('returns context for the named agent', () => {
+		const ctx = extractAgentContext(buildWorkflow(), 'Agent A');
+		expect(ctx).toEqual({
+			workflowName: 'Support bot',
+			agentNodeName: 'Agent A',
+			systemPrompt: 'You are a polite support agent.',
+			promptTemplate: '={{ $json.message }}',
+			connectedToolNames: ['Lookup tool'],
+		});
+	});
+
+	it('returns undefined when the agent name does not match any node', () => {
+		const ctx = extractAgentContext(buildWorkflow(), 'Missing Agent');
+		expect(ctx).toBeUndefined();
+	});
+
+	it('caps an oversized system prompt at 2000 characters', () => {
+		const wf = buildWorkflow();
+		const huge = 'x'.repeat(5000);
+		(
+			wf.nodes[0] as unknown as { parameters: { options: { systemMessage: string } } }
+		).parameters.options.systemMessage = huge;
+		const ctx = extractAgentContext(wf, 'Agent A');
+		expect(ctx?.systemPrompt).toHaveLength(2000);
+	});
+
+	it('omits prompt template and tools when none are present', () => {
+		const wf: WorkflowJSON = {
+			name: 'Bare',
+			nodes: [
+				{
+					id: '1',
+					name: 'Agent',
+					type: AGENT_TYPE,
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+			],
+			connections: {},
+		} as unknown as WorkflowJSON;
+		const ctx = extractAgentContext(wf, 'Agent');
+		expect(ctx).toEqual({
+			workflowName: 'Bare',
+			agentNodeName: 'Agent',
+			systemPrompt: undefined,
+			promptTemplate: undefined,
+			connectedToolNames: [],
+		});
+	});
+});
+
+describe('generateSampleRows orchestration', () => {
+	beforeEach(() => jest.clearAllMocks());
+
+	it('dispatches one batch per non-empty facet', async () => {
+		const generate = jest.fn().mockResolvedValue({ messages: [] });
+		mockCreateEvalAgent.mockReturnValue({ generate } as unknown as ReturnType<
+			typeof createEvalAgent
+		>);
+		mockExtractText.mockReturnValue(JSON.stringify([{ input: 'r' }]));
+		await generateSampleRows({ workflow: WF, columns: ['input'], rowCount: 25 });
+		expect(generate).toHaveBeenCalledTimes(5);
+	});
+
+	it('skips facets that get zero rows', async () => {
+		const generate = jest.fn().mockResolvedValue({ messages: [] });
+		mockCreateEvalAgent.mockReturnValue({ generate } as unknown as ReturnType<
+			typeof createEvalAgent
+		>);
+		mockExtractText.mockReturnValue(JSON.stringify([{ input: 'r' }]));
+		await generateSampleRows({ workflow: WF, columns: ['input'], rowCount: 3 });
+		expect(generate).toHaveBeenCalledTimes(3);
+	});
+
+	it('isolates failures: one batch rejects, others still produce rows', async () => {
+		const responses = [
+			Promise.resolve({ messages: [] }),
+			Promise.reject(new Error('mid batch fail')),
+			Promise.resolve({ messages: [] }),
+			Promise.resolve({ messages: [] }),
+			Promise.resolve({ messages: [] }),
+		];
+		const generate = jest.fn().mockImplementation(async () => await responses.shift());
+		mockCreateEvalAgent.mockReturnValue({ generate } as unknown as ReturnType<
+			typeof createEvalAgent
+		>);
+		mockExtractText
+			.mockReturnValueOnce(JSON.stringify([{ input: 'a' }]))
+			.mockReturnValueOnce(JSON.stringify([{ input: 'c' }]))
+			.mockReturnValueOnce(JSON.stringify([{ input: 'd' }]))
+			.mockReturnValueOnce(JSON.stringify([{ input: 'e' }]));
+		const rows = await generateSampleRows({
+			workflow: WF,
+			columns: ['input'],
+			rowCount: 5,
+		});
+		const inputs = rows.map((r) => r.input).sort();
+		expect(inputs).toEqual(['a', 'c', 'd', 'e']);
+	});
+
+	it('uses the default rowCount of 25 when not specified', async () => {
+		const generate = jest.fn().mockResolvedValue({ messages: [] });
+		mockCreateEvalAgent.mockReturnValue({ generate } as unknown as ReturnType<
+			typeof createEvalAgent
+		>);
+		mockExtractText.mockReturnValue(
+			JSON.stringify(Array.from({ length: 5 }, () => ({ input: 'x' }))),
+		);
+		const rows = await generateSampleRows({ workflow: WF, columns: ['input'] });
+		expect(rows).toHaveLength(25);
+	});
+
+	it('uses targetAgentNodeName context when provided', async () => {
+		const wf: WorkflowJSON = {
+			name: 'wf',
+			nodes: [
+				{
+					id: '1',
+					name: 'AgentX',
+					type: '@n8n/n8n-nodes-langchain.agent',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: { options: { systemMessage: 'TARGETED-AGENT-SYSTEM' } },
+				},
+			],
+			connections: {},
+		} as unknown as WorkflowJSON;
+		const generate = jest.fn().mockResolvedValue({ messages: [] });
+		mockCreateEvalAgent.mockReturnValue({ generate } as unknown as ReturnType<
+			typeof createEvalAgent
+		>);
+		mockExtractText.mockReturnValue(JSON.stringify([]));
+		await generateSampleRows({
+			workflow: wf,
+			columns: ['input'],
+			rowCount: 5,
+			targetAgentNodeName: 'AgentX',
+		});
+		const calls = generate.mock.calls as unknown as Array<
+			Array<Array<{ content: Array<{ text: string }> }>>
+		>;
+		const promptText = calls[0][0][0].content[0].text;
+		expect(promptText).toContain('TARGETED-AGENT-SYSTEM');
+	});
+
+	it('falls back to first detected agent when no targetAgentNodeName', async () => {
+		const wf: WorkflowJSON = {
+			name: 'wf',
+			nodes: [
+				{
+					id: '1',
+					name: 'FirstAgent',
+					type: '@n8n/n8n-nodes-langchain.agent',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: { options: { systemMessage: 'FIRST-AGENT-SYSTEM' } },
+				},
+				{
+					id: '2',
+					name: 'SecondAgent',
+					type: '@n8n/n8n-nodes-langchain.agent',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: { options: { systemMessage: 'SECOND-AGENT-SYSTEM' } },
+				},
+			],
+			connections: {},
+		} as unknown as WorkflowJSON;
+		const generate = jest.fn().mockResolvedValue({ messages: [] });
+		mockCreateEvalAgent.mockReturnValue({ generate } as unknown as ReturnType<
+			typeof createEvalAgent
+		>);
+		mockExtractText.mockReturnValue(JSON.stringify([]));
+		await generateSampleRows({ workflow: wf, columns: ['input'], rowCount: 5 });
+		const calls = generate.mock.calls as unknown as Array<
+			Array<Array<{ content: Array<{ text: string }> }>>
+		>;
+		const promptText = calls[0][0][0].content[0].text;
+		expect(promptText).toContain('FIRST-AGENT-SYSTEM');
+		expect(promptText).not.toContain('SECOND-AGENT-SYSTEM');
+	});
+});

--- a/packages/@n8n/instance-ai/src/tools/evals/detect-ai-nodes.ts
+++ b/packages/@n8n/instance-ai/src/tools/evals/detect-ai-nodes.ts
@@ -1,0 +1,34 @@
+import type { WorkflowJSON } from '@n8n/workflow-sdk';
+
+const LANGCHAIN_TYPE_PREFIX = '@n8n/n8n-nodes-langchain.';
+const EVALUATION_TYPES = new Set<string>([
+	'n8n-nodes-base.evaluation',
+	'n8n-nodes-base.evaluationTrigger',
+]);
+
+export interface DetectAiNodesResult {
+	isAiWorkflow: boolean;
+	aiNodeNames: string[];
+	alreadyConfigured: boolean;
+}
+
+export function detectAiNodes(workflow: WorkflowJSON): DetectAiNodesResult {
+	const aiNodeNames: string[] = [];
+	let alreadyConfigured = false;
+
+	for (const node of workflow.nodes ?? []) {
+		if (!node.name) continue;
+		if (node.type.startsWith(LANGCHAIN_TYPE_PREFIX)) {
+			aiNodeNames.push(node.name);
+		}
+		if (EVALUATION_TYPES.has(node.type)) {
+			alreadyConfigured = true;
+		}
+	}
+
+	return {
+		isAiWorkflow: aiNodeNames.length > 0,
+		aiNodeNames,
+		alreadyConfigured,
+	};
+}

--- a/packages/@n8n/instance-ai/src/tools/evals/detect-ai-nodes.ts
+++ b/packages/@n8n/instance-ai/src/tools/evals/detect-ai-nodes.ts
@@ -1,34 +1,22 @@
 import type { WorkflowJSON } from '@n8n/workflow-sdk';
 
 const LANGCHAIN_TYPE_PREFIX = '@n8n/n8n-nodes-langchain.';
-const EVALUATION_TYPES = new Set<string>([
-	'n8n-nodes-base.evaluation',
-	'n8n-nodes-base.evaluationTrigger',
-]);
 
 export interface DetectAiNodesResult {
-	isAiWorkflow: boolean;
 	aiNodeNames: string[];
-	alreadyConfigured: boolean;
 }
 
 export function detectAiNodes(workflow: WorkflowJSON): DetectAiNodesResult {
 	const aiNodeNames: string[] = [];
-	let alreadyConfigured = false;
 
 	for (const node of workflow.nodes ?? []) {
 		if (!node.name) continue;
 		if (node.type.startsWith(LANGCHAIN_TYPE_PREFIX)) {
 			aiNodeNames.push(node.name);
 		}
-		if (EVALUATION_TYPES.has(node.type)) {
-			alreadyConfigured = true;
-		}
 	}
 
 	return {
-		isAiWorkflow: aiNodeNames.length > 0,
 		aiNodeNames,
-		alreadyConfigured,
 	};
 }

--- a/packages/@n8n/instance-ai/src/tools/evals/eval-data-requirements.service.ts
+++ b/packages/@n8n/instance-ai/src/tools/evals/eval-data-requirements.service.ts
@@ -1,0 +1,217 @@
+import type { WorkflowJSON } from '@n8n/workflow-sdk';
+
+type WorkflowNode = WorkflowJSON['nodes'][number];
+
+export interface EvalDataTarget {
+	dataTableId: string;
+	evaluationTriggerName: string;
+	targetAgentNodeName?: string;
+	inputColumns: string[];
+	expectedOutputColumns: string[];
+	actualOutputColumns: string[];
+	metricNodeNames: string[];
+}
+
+export interface EvalDataRequirements {
+	targets: EvalDataTarget[];
+	reason?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function unique(values: string[]): string[] {
+	return [...new Set(values.filter((value) => value.length > 0))];
+}
+
+function nodeTypeEndsWith(node: WorkflowNode, suffix: string): boolean {
+	return node.type === suffix || node.type.endsWith(`.${suffix}`);
+}
+
+function nodeHasName(node: WorkflowNode): node is WorkflowNode & { name: string } {
+	return typeof node.name === 'string' && node.name.length > 0;
+}
+
+function readOperation(node: WorkflowNode): string | undefined {
+	const parameters = node.parameters;
+	if (!isRecord(parameters)) return undefined;
+	const operation = parameters.operation;
+	return typeof operation === 'string' ? operation : undefined;
+}
+
+function readDataTableId(node: WorkflowNode): string | undefined {
+	const parameters = node.parameters;
+	if (!isRecord(parameters)) return undefined;
+	const dataTableId = parameters.dataTableId;
+	if (typeof dataTableId === 'string') return dataTableId;
+	if (!isRecord(dataTableId)) return undefined;
+	const value = dataTableId.value;
+	return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function collectStrings(value: unknown): string[] {
+	if (typeof value === 'string') return [value];
+	if (Array.isArray(value)) return value.flatMap(collectStrings);
+	if (!isRecord(value)) return [];
+	return Object.values(value).flatMap(collectStrings);
+}
+
+function extractJsonColumnRefs(text: string): string[] {
+	const refs: string[] = [];
+	const patterns = [
+		/\$json\.([A-Za-z_][A-Za-z0-9_]*)/g,
+		/\.item\.json\.([A-Za-z_][A-Za-z0-9_]*)/g,
+		/item\.json\.([A-Za-z_][A-Za-z0-9_]*)/g,
+	];
+	for (const pattern of patterns) {
+		for (const match of text.matchAll(pattern)) {
+			if (match[1]) refs.push(match[1]);
+		}
+	}
+	return unique(refs);
+}
+
+function childNames(workflow: WorkflowJSON, sourceName: string, outputIndex?: number): string[] {
+	const connectionsByType = workflow.connections?.[sourceName];
+	if (!connectionsByType || typeof connectionsByType !== 'object') return [];
+	const main = (connectionsByType as Record<string, unknown>).main;
+	if (!Array.isArray(main)) return [];
+	const slots =
+		outputIndex === undefined
+			? main
+			: [main[outputIndex]].filter((slot): slot is unknown[] => Array.isArray(slot));
+	return unique(
+		slots.flatMap((slot) => {
+			if (!Array.isArray(slot)) return [];
+			return slot.flatMap((connection) => {
+				if (!isRecord(connection)) return [];
+				const node = connection.node;
+				return typeof node === 'string' ? [node] : [];
+			});
+		}),
+	);
+}
+
+function collectReachableNodeNames(workflow: WorkflowJSON, startName: string): string[] {
+	const seen = new Set<string>();
+	const queue = [startName];
+	while (queue.length > 0) {
+		const current = queue.shift();
+		if (!current || seen.has(current)) continue;
+		seen.add(current);
+		for (const child of childNames(workflow, current)) {
+			if (!seen.has(child)) queue.push(child);
+		}
+	}
+	seen.delete(startName);
+	return [...seen];
+}
+
+function nodeByName(workflow: WorkflowJSON): Map<string, WorkflowNode> {
+	return new Map(workflow.nodes.filter(nodeHasName).map((node) => [node.name, node]));
+}
+
+function isAiAgentNode(node: WorkflowNode | undefined): boolean {
+	return Boolean(node?.type.includes('n8n-nodes-langchain.agent'));
+}
+
+function inputColumnsFromShapeBridge(workflow: WorkflowJSON, evalTriggerName: string): string[] {
+	const byName = nodeByName(workflow);
+	const directChildren = childNames(workflow, evalTriggerName);
+	const setNodes = directChildren
+		.map((name) => byName.get(name))
+		.filter((node): node is WorkflowNode => Boolean(node && nodeTypeEndsWith(node, 'set')));
+	return unique(
+		setNodes.flatMap((node) =>
+			collectStrings(node.parameters).flatMap((text) => extractJsonColumnRefs(text)),
+		),
+	);
+}
+
+function expectedColumnsFromMetricNodes(nodes: WorkflowNode[]): string[] {
+	return unique(
+		nodes.flatMap((node) => {
+			if (!nodeTypeEndsWith(node, 'evaluation') || readOperation(node) !== 'setMetrics') return [];
+			return collectStrings(node.parameters)
+				.filter((text) => text.includes('.item.json.') || text.includes('item.json.'))
+				.flatMap((text) => extractJsonColumnRefs(text));
+		}),
+	);
+}
+
+function actualColumnsFromSetOutputs(nodes: WorkflowNode[]): string[] {
+	return unique(
+		nodes.flatMap((node) => {
+			if (!nodeTypeEndsWith(node, 'evaluation') || readOperation(node) !== 'setOutputs') return [];
+			const parameters = node.parameters;
+			if (!isRecord(parameters)) return [];
+			const outputs = parameters.outputs;
+			if (!isRecord(outputs)) return [];
+			const values = outputs.values;
+			if (!Array.isArray(values)) return [];
+			return values.flatMap((value) => {
+				if (!isRecord(value)) return [];
+				const outputName = value.outputName;
+				return typeof outputName === 'string' ? [outputName] : [];
+			});
+		}),
+	);
+}
+
+function firstReachableAgentName(
+	workflow: WorkflowJSON,
+	evalTriggerName: string,
+): string | undefined {
+	const byName = nodeByName(workflow);
+	return collectReachableNodeNames(workflow, evalTriggerName).find((name) =>
+		isAiAgentNode(byName.get(name)),
+	);
+}
+
+export function analyzeEvalDataRequirements(workflow: WorkflowJSON): EvalDataRequirements {
+	const evaluationTriggers = workflow.nodes.filter(
+		(node): node is WorkflowNode & { name: string } =>
+			nodeHasName(node) && nodeTypeEndsWith(node, 'evaluationTrigger'),
+	);
+	if (evaluationTriggers.length === 0) {
+		return { targets: [], reason: 'Workflow has no EvaluationTrigger nodes.' };
+	}
+
+	const targets = evaluationTriggers.flatMap((trigger) => {
+		const dataTableId = readDataTableId(trigger);
+		if (!dataTableId) return [];
+
+		const reachableNames = new Set(collectReachableNodeNames(workflow, trigger.name));
+		const reachableNodes = workflow.nodes.filter(
+			(node): node is WorkflowNode & { name: string } =>
+				nodeHasName(node) && reachableNames.has(node.name),
+		);
+		const metricNodeNames = reachableNodes
+			.filter(
+				(node) => nodeTypeEndsWith(node, 'evaluation') && readOperation(node) === 'setMetrics',
+			)
+			.map((node) => node.name);
+
+		return [
+			{
+				dataTableId,
+				evaluationTriggerName: trigger.name,
+				targetAgentNodeName: firstReachableAgentName(workflow, trigger.name),
+				inputColumns: inputColumnsFromShapeBridge(workflow, trigger.name),
+				expectedOutputColumns: expectedColumnsFromMetricNodes(reachableNodes),
+				actualOutputColumns: actualColumnsFromSetOutputs(reachableNodes),
+				metricNodeNames,
+			},
+		];
+	});
+
+	if (targets.length === 0) {
+		return {
+			targets: [],
+			reason: 'Workflow has EvaluationTrigger nodes, but none are wired to a DataTable id.',
+		};
+	}
+
+	return { targets };
+}

--- a/packages/@n8n/instance-ai/src/tools/evals/generate-sample-rows.service.ts
+++ b/packages/@n8n/instance-ai/src/tools/evals/generate-sample-rows.service.ts
@@ -1,0 +1,258 @@
+import type { WorkflowJSON } from '@n8n/workflow-sdk';
+import { z } from 'zod';
+
+import { detectAiNodes } from './detect-ai-nodes';
+import { createEvalAgent, extractText, HAIKU_MODEL } from '../../utils/eval-agents';
+
+const FACET_COUNT = 5;
+const DEFAULT_ROW_COUNT = 25;
+const SYSTEM_PROMPT_MAX_CHARS = 2000;
+
+export interface SampleRowFacet {
+	length: string;
+	edgeMode: string;
+	instructions: string;
+}
+
+export interface AgentContext {
+	workflowName: string;
+	agentNodeName: string;
+	systemPrompt: string | undefined;
+	promptTemplate: string | undefined;
+	connectedToolNames: string[];
+}
+
+export const SAMPLE_ROW_FACETS: readonly SampleRowFacet[] = [
+	{
+		length: 'short (single sentence or one-line snippet)',
+		edgeMode: 'happy — typical, well-formed inputs the agent commonly receives',
+		instructions:
+			'Produce concise, realistic inputs the AI Agent would handle on a regular day. Each input should fit on one line. No edge cases.',
+	},
+	{
+		length: 'long (multi-paragraph or several lines)',
+		edgeMode: 'happy — typical, well-formed inputs',
+		instructions:
+			'Produce longer realistic inputs spanning multiple paragraphs or several lines. The content stays in-domain and well-structured.',
+	},
+	{
+		length: 'medium (2–3 sentences or comparable size)',
+		edgeMode: 'edge — ambiguity, truncations, typos, imperfect formatting',
+		instructions:
+			'Produce inputs that are messy but plausible: typos, ambiguous references, truncated phrasing, irregular casing or spacing. Still in-domain.',
+	},
+	{
+		length: 'long (multi-paragraph)',
+		edgeMode: 'adversarial — out-of-scope requests, contradictions, prompt injection',
+		instructions:
+			'Produce inputs that try to push the agent off task: out-of-scope demands, internally contradictory requirements, attempts at prompt injection ("ignore previous instructions"), or hostile framing.',
+	},
+	{
+		length: 'mixed extremes (empty, very short, or very long)',
+		edgeMode: 'robustness — empty inputs, multi-language fragments, malformed data',
+		instructions:
+			'Produce robustness probes: an empty input, an input of one or two characters, an input that mixes two languages, and an input with malformed structure (e.g., truncated JSON, broken markup). Use whatever the agent would plausibly stumble on in production.',
+	},
+] as const;
+
+export function distributeRowCount(rowCount: number): number[] {
+	const safe = Math.max(0, Math.floor(rowCount));
+	const base = Math.floor(safe / FACET_COUNT);
+	const extra = safe % FACET_COUNT;
+	return Array.from({ length: FACET_COUNT }, (_, i) => base + (i < extra ? 1 : 0));
+}
+
+function readSystemPrompt(parameters: Record<string, unknown> | undefined): string | undefined {
+	if (!parameters) return undefined;
+	const direct = parameters.systemMessage;
+	if (typeof direct === 'string' && direct.length > 0) {
+		return direct.slice(0, SYSTEM_PROMPT_MAX_CHARS);
+	}
+	const options = parameters.options;
+	if (options && typeof options === 'object') {
+		const nested = (options as Record<string, unknown>).systemMessage;
+		if (typeof nested === 'string' && nested.length > 0) {
+			return nested.slice(0, SYSTEM_PROMPT_MAX_CHARS);
+		}
+	}
+	return undefined;
+}
+
+function readPromptTemplate(parameters: Record<string, unknown> | undefined): string | undefined {
+	if (!parameters) return undefined;
+	const text = parameters.text;
+	return typeof text === 'string' && text.length > 0 ? text : undefined;
+}
+
+function findConnectedTools(workflow: WorkflowJSON, agentName: string): string[] {
+	const tools: string[] = [];
+	const connections = (workflow.connections ?? {}) as Record<string, Record<string, unknown>>;
+	for (const [sourceName, byType] of Object.entries(connections)) {
+		const aiTool = byType?.ai_tool;
+		if (!Array.isArray(aiTool)) continue;
+		const matches = aiTool.some((slot) => {
+			if (!Array.isArray(slot)) return false;
+			return slot.some(
+				(link) =>
+					link !== null &&
+					typeof link === 'object' &&
+					'node' in link &&
+					(link as { node: unknown }).node === agentName,
+			);
+		});
+		if (matches) tools.push(sourceName);
+	}
+	return tools;
+}
+
+export function extractAgentContext(
+	workflow: WorkflowJSON,
+	agentNodeName: string,
+): AgentContext | undefined {
+	const node = (workflow.nodes ?? []).find((n) => n.name === agentNodeName);
+	if (!node) return undefined;
+	const parameters = node.parameters as Record<string, unknown> | undefined;
+	return {
+		workflowName: workflow.name ?? 'Untitled',
+		agentNodeName,
+		systemPrompt: readSystemPrompt(parameters),
+		promptTemplate: readPromptTemplate(parameters),
+		connectedToolNames: findConnectedTools(workflow, agentNodeName),
+	};
+}
+
+const batchRowSchema = z.array(z.record(z.union([z.string(), z.number(), z.boolean(), z.null()])));
+
+function buildAgentContextBlock(context: AgentContext | undefined): string {
+	if (!context) return 'Workflow context unavailable.';
+	const lines: string[] = [
+		`Workflow name: ${context.workflowName}`,
+		`AI Agent node: ${context.agentNodeName}`,
+	];
+	if (context.systemPrompt) {
+		lines.push('Agent system prompt:', context.systemPrompt);
+	}
+	if (context.promptTemplate) {
+		lines.push(`Agent prompt template: ${context.promptTemplate}`);
+	}
+	if (context.connectedToolNames.length > 0) {
+		lines.push(`Connected tools: ${context.connectedToolNames.join(', ')}`);
+	}
+	return lines.join('\n');
+}
+
+const FORMAT_INFERENCE =
+	"Inspect the agent's system prompt, prompt template, and connected tools to infer what kind of text this agent receives at runtime. It may be a user chat message, output from another tool, scraped web content, structured records (JSON/key-value), document chunks, log lines, code, etc. Generate inputs that look like what would arrive at the agent in production. Do not assume a human user when the agent suggests otherwise.";
+
+const BATCH_SYSTEM_INSTRUCTIONS = `You generate realistic test rows for an n8n workflow evaluation dataset.
+
+Output: JSON array of objects. Keys = the provided column names. Values = short strings. No prose outside the JSON.
+
+Every row's "expected_output" (or the equivalent output column) must be what a correctly-behaving agent SHOULD produce. For adversarial rows: a refusal or a safe fallback.
+
+Return only the JSON array.`;
+
+export interface RunBatchInput {
+	facet: SampleRowFacet;
+	rowCount: number;
+	context: AgentContext | undefined;
+	columns: string[];
+}
+
+function normalizeBatchRow(
+	rawRow: Record<string, string | number | boolean | null>,
+	columns: string[],
+): Record<string, string> {
+	const row: Record<string, string> = {};
+	for (const col of columns) {
+		const v = rawRow[col];
+		if (v === undefined || v === null) row[col] = '';
+		else if (typeof v === 'string') row[col] = v;
+		else row[col] = String(v);
+	}
+	return row;
+}
+
+function stripMarkdownFences(text: string): string {
+	const trimmed = text.trim();
+	const fencedMatch = /^```(?:json)?\s*([\s\S]*?)\s*```$/i.exec(trimmed);
+	return fencedMatch ? fencedMatch[1].trim() : trimmed;
+}
+
+export async function runBatch(input: RunBatchInput): Promise<Array<Record<string, string>>> {
+	if (input.rowCount <= 0) return [];
+	try {
+		const agent = createEvalAgent('eval-sample-rows', {
+			model: HAIKU_MODEL,
+			instructions: BATCH_SYSTEM_INSTRUCTIONS,
+		});
+		const userText = [
+			buildAgentContextBlock(input.context),
+			'',
+			FORMAT_INFERENCE,
+			'',
+			`Variation focus for this batch: length = ${input.facet.length}; mode = ${input.facet.edgeMode}.`,
+			input.facet.instructions,
+			'',
+			`Columns: ${input.columns.join(', ')}`,
+			`Generate exactly ${input.rowCount} rows.`,
+		].join('\n');
+		const result = await agent.generate([
+			{ role: 'user' as const, content: [{ type: 'text' as const, text: userText }] },
+		]);
+		const text = extractText(result);
+		const parsed: unknown = JSON.parse(stripMarkdownFences(text));
+		const validated = batchRowSchema.safeParse(parsed);
+		if (!validated.success) return [];
+		return validated.data.map((rawRow) => normalizeBatchRow(rawRow, input.columns));
+	} catch {
+		return [];
+	}
+}
+
+export interface GenerateSampleRowsInput {
+	workflow: WorkflowJSON;
+	columns: string[];
+	rowCount?: number;
+	targetAgentNodeName?: string;
+}
+
+function resolveAgentContext(
+	workflow: WorkflowJSON,
+	targetAgentNodeName: string | undefined,
+): AgentContext | undefined {
+	if (targetAgentNodeName) {
+		return extractAgentContext(workflow, targetAgentNodeName);
+	}
+	const detected = detectAiNodes(workflow);
+	const firstAgent = detected.aiNodeNames[0];
+	if (!firstAgent) return undefined;
+	return extractAgentContext(workflow, firstAgent);
+}
+
+function emptyRow(columns: string[]): Record<string, string> {
+	return Object.fromEntries(columns.map((c) => [c, '']));
+}
+
+export async function generateSampleRows(
+	input: GenerateSampleRowsInput,
+): Promise<Array<Record<string, string>>> {
+	const rowCount = input.rowCount ?? DEFAULT_ROW_COUNT;
+	const counts = distributeRowCount(rowCount);
+	const context = resolveAgentContext(input.workflow, input.targetAgentNodeName);
+
+	const settled = await Promise.allSettled(
+		SAMPLE_ROW_FACETS.map(async (facet, i) =>
+			counts[i] > 0
+				? await runBatch({ facet, rowCount: counts[i], context, columns: input.columns })
+				: await Promise.resolve([] as Array<Record<string, string>>),
+		),
+	);
+
+	const merged: Array<Record<string, string>> = [];
+	for (const r of settled) {
+		if (r.status === 'fulfilled') merged.push(...r.value);
+	}
+	if (merged.length === 0) return [emptyRow(input.columns)];
+	return merged;
+}

--- a/packages/@n8n/instance-ai/src/tools/index.ts
+++ b/packages/@n8n/instance-ai/src/tools/index.ts
@@ -10,6 +10,7 @@ import { createBrowserCredentialSetupTool } from './orchestration/browser-creden
 import { createBuildWorkflowAgentTool } from './orchestration/build-workflow-agent.tool';
 import { createCompleteCheckpointTool } from './orchestration/complete-checkpoint.tool';
 import { createDelegateTool } from './orchestration/delegate.tool';
+import { createEvalDataAgentTool } from './orchestration/eval-data-agent.tool';
 import { createPlanWithAgentTool } from './orchestration/plan-with-agent.tool';
 import { createPlanTool } from './orchestration/plan.tool';
 import { createReportVerificationVerdictTool } from './orchestration/report-verification-verdict.tool';
@@ -74,6 +75,7 @@ export function createOrchestrationTools(context: OrchestrationContext) {
 		delegate: createDelegateTool(context),
 		'build-workflow-with-agent': createBuildWorkflowAgentTool(context),
 		'complete-checkpoint': createCompleteCheckpointTool(context),
+		'eval-data': createEvalDataAgentTool(context),
 		...(context.browserMcpConfig || hasGatewayBrowserTools(context)
 			? {
 					'browser-credential-setup': createBrowserCredentialSetupTool(context),

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/eval-data-agent.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/eval-data-agent.tool.test.ts
@@ -1,0 +1,216 @@
+import type { WorkflowJSON } from '@n8n/workflow-sdk';
+import { mock } from 'jest-mock-extended';
+
+import type { OrchestrationContext, SpawnBackgroundTaskOptions } from '../../../types';
+import { generateSampleRows } from '../../evals/generate-sample-rows.service';
+import { createEvalDataAgentTool } from '../eval-data-agent.tool';
+
+jest.mock('../../evals/generate-sample-rows.service', () => ({
+	generateSampleRows: jest.fn(),
+}));
+
+const mockGenerateSampleRows = generateSampleRows as jest.MockedFunction<typeof generateSampleRows>;
+
+function workflowWithEvalDataTable(): WorkflowJSON {
+	return {
+		id: 'w1',
+		name: 'Support Writer',
+		nodes: [
+			{
+				id: 'eval-trigger',
+				name: 'Eval Trigger',
+				type: 'n8n-nodes-base.evaluationTrigger',
+				typeVersion: 4.7,
+				position: [0, 0],
+				parameters: {
+					source: 'dataTable',
+					dataTableId: { __rl: true, mode: 'id', value: 'dt-1' },
+				},
+			},
+			{
+				id: 'bridge',
+				name: 'Eval Shape Bridge',
+				type: 'n8n-nodes-base.set',
+				typeVersion: 3.4,
+				position: [240, 0],
+				parameters: {
+					assignments: {
+						assignments: [
+							{
+								id: 'a',
+								name: 'chatInput',
+								value: '={{ $json.user_message }}',
+								type: 'string',
+							},
+						],
+					},
+				},
+			},
+			{
+				id: 'agent',
+				name: 'Writer Agent',
+				type: '@n8n/n8n-nodes-langchain.agent',
+				typeVersion: 1,
+				position: [480, 0],
+				parameters: {},
+			},
+			{
+				id: 'metrics',
+				name: 'Eval Set Metrics',
+				type: 'n8n-nodes-base.evaluation',
+				typeVersion: 4.8,
+				position: [720, 0],
+				parameters: {
+					operation: 'setMetrics',
+					expectedAnswer: "={{ $('Eval Trigger').item.json.expected_response }}",
+					actualAnswer: '={{ $json.output }}',
+				},
+			},
+		],
+		connections: {
+			'Eval Trigger': {
+				main: [[{ node: 'Eval Shape Bridge', type: 'main', index: 0 }]],
+			},
+			'Eval Shape Bridge': {
+				main: [[{ node: 'Writer Agent', type: 'main', index: 0 }]],
+			},
+			'Writer Agent': {
+				main: [[{ node: 'Eval Set Metrics', type: 'main', index: 0 }]],
+			},
+		},
+	} as unknown as WorkflowJSON;
+}
+
+function makeContext(workflow: WorkflowJSON) {
+	const domainContext = {
+		workflowService: {
+			getAsWorkflowJSON: jest.fn().mockResolvedValue(workflow),
+		},
+		dataTableService: {
+			getSchema: jest.fn().mockResolvedValue([
+				{ id: 'c1', name: 'user_message', type: 'string', index: 0 },
+				{ id: 'c2', name: 'expected_response', type: 'string', index: 1 },
+				{ id: 'c3', name: 'actual_response', type: 'string', index: 2 },
+			]),
+			insertRows: jest.fn().mockResolvedValue({
+				insertedCount: 2,
+				dataTableId: 'dt-1',
+				tableName: 'Support Writer eval samples',
+				projectId: 'p1',
+			}),
+		},
+		logger: {
+			info: jest.fn(),
+			error: jest.fn(),
+			warn: jest.fn(),
+			debug: jest.fn(),
+		},
+	};
+	const context = mock<OrchestrationContext>();
+	context.threadId = 'thread-1';
+	context.runId = 'run-1';
+	context.userId = 'user-1';
+	context.orchestratorAgentId = 'orchestrator-1';
+	context.domainContext = domainContext as never;
+	context.domainTools = {};
+	context.tracing = undefined;
+	context.eventBus.publish = jest.fn();
+	context.spawnBackgroundTask = jest.fn(() => ({
+		status: 'started' as const,
+		taskId: 'evaldata-1',
+		agentId: 'agent-evaldata-1',
+	}));
+	return { context, domainContext };
+}
+
+describe('createEvalDataAgentTool', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockGenerateSampleRows.mockResolvedValue([
+			{ user_message: 'hello', expected_response: 'Hi there' },
+			{ user_message: 'help', expected_response: 'I can help' },
+		]);
+	});
+
+	it('suspends with a generic true/false approval before generating rows', async () => {
+		const { context } = makeContext(workflowWithEvalDataTable());
+		const suspend = jest.fn().mockImplementation(async () => await new Promise(() => {}));
+		const tool = createEvalDataAgentTool(context);
+
+		void tool.execute!({ workflowId: 'w1', projectId: 'p1' }, { agent: { suspend } } as never);
+
+		await new Promise(process.nextTick);
+		expect(suspend).toHaveBeenCalledTimes(1);
+		expect(suspend.mock.calls[0][0]).toMatchObject({
+			severity: 'info',
+			workflowId: 'w1',
+			dataTableId: 'dt-1',
+			columns: ['user_message', 'expected_response'],
+		});
+		expect(context.spawnBackgroundTask).not.toHaveBeenCalled();
+	});
+
+	it('returns deferred when the user declines synthetic data generation', async () => {
+		const { context } = makeContext(workflowWithEvalDataTable());
+		const tool = createEvalDataAgentTool(context);
+
+		const result = (await tool.execute!({ workflowId: 'w1' }, {
+			agent: { resumeData: { approved: false } },
+		} as never)) as Record<string, unknown>;
+
+		expect(result).toMatchObject({ success: true, deferred: true });
+		expect(context.spawnBackgroundTask).not.toHaveBeenCalled();
+	});
+
+	it('starts an eval-data background agent and inserts generated rows in its run', async () => {
+		const { context, domainContext } = makeContext(workflowWithEvalDataTable());
+		const tool = createEvalDataAgentTool(context);
+
+		const result = (await tool.execute!({ workflowId: 'w1', projectId: 'p1', rowCount: 2 }, {
+			agent: { resumeData: { approved: true } },
+		} as never)) as Record<string, unknown>;
+
+		expect(result).toMatchObject({
+			success: true,
+			shouldWaitForEvalDataAgent: true,
+			taskId: expect.stringMatching(/^evaldata-/) as unknown,
+		});
+		expect(context.spawnBackgroundTask).toHaveBeenCalledTimes(1);
+		const spawnOptions = (context.spawnBackgroundTask as jest.Mock).mock
+			.calls[0][0] as SpawnBackgroundTaskOptions;
+		expect(spawnOptions.role).toBe('eval-data');
+		expect(spawnOptions.dedupeKey).toMatchObject({
+			role: 'eval-data',
+			workflowId: 'w1',
+		});
+
+		const output = await spawnOptions.run(
+			new AbortController().signal,
+			() => [],
+			async () => {},
+		);
+
+		expect(mockGenerateSampleRows).toHaveBeenCalledWith({
+			workflow: expect.objectContaining({ name: 'Support Writer' }),
+			columns: ['user_message', 'expected_response'],
+			rowCount: 2,
+			targetAgentNodeName: 'Writer Agent',
+		});
+		expect(domainContext.dataTableService.insertRows).toHaveBeenCalledWith(
+			'dt-1',
+			[
+				{ user_message: 'hello', expected_response: 'Hi there' },
+				{ user_message: 'help', expected_response: 'I can help' },
+			],
+			{ projectId: 'p1' },
+		);
+		expect(output).toMatchObject({
+			text: expect.stringContaining('2 rows inserted'),
+			outcome: {
+				workflowId: 'w1',
+				dataTableId: 'dt-1',
+				insertedCount: 2,
+			},
+		});
+	});
+});

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/eval-data-agent.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/eval-data-agent.tool.test.ts
@@ -1,7 +1,11 @@
 import type { WorkflowJSON } from '@n8n/workflow-sdk';
 import { mock } from 'jest-mock-extended';
 
-import type { OrchestrationContext, SpawnBackgroundTaskOptions } from '../../../types';
+import type {
+	OrchestrationContext,
+	SpawnBackgroundTaskOptions,
+	SpawnBackgroundTaskResult,
+} from '../../../types';
 import { generateSampleRows } from '../../evals/generate-sample-rows.service';
 import { createEvalDataAgentTool } from '../eval-data-agent.tool';
 
@@ -107,6 +111,13 @@ function makeContext(workflow: WorkflowJSON) {
 		},
 	};
 	const context = mock<OrchestrationContext>();
+	const spawnBackgroundTask = jest.fn<SpawnBackgroundTaskResult, [SpawnBackgroundTaskOptions]>(
+		() => ({
+			status: 'started',
+			taskId: 'evaldata-1',
+			agentId: 'agent-evaldata-1',
+		}),
+	);
 	context.threadId = 'thread-1';
 	context.runId = 'run-1';
 	context.userId = 'user-1';
@@ -115,12 +126,8 @@ function makeContext(workflow: WorkflowJSON) {
 	context.domainTools = {};
 	context.tracing = undefined;
 	context.eventBus.publish = jest.fn();
-	context.spawnBackgroundTask = jest.fn(() => ({
-		status: 'started' as const,
-		taskId: 'evaldata-1',
-		agentId: 'agent-evaldata-1',
-	}));
-	return { context, domainContext };
+	context.spawnBackgroundTask = spawnBackgroundTask;
+	return { context, domainContext, spawnBackgroundTask };
 }
 
 describe('createEvalDataAgentTool', () => {
@@ -134,14 +141,17 @@ describe('createEvalDataAgentTool', () => {
 
 	it('suspends with a generic true/false approval before generating rows', async () => {
 		const { context } = makeContext(workflowWithEvalDataTable());
-		const suspend = jest.fn().mockImplementation(async () => await new Promise(() => {}));
+		const suspend = jest
+			.fn<Promise<never>, [unknown]>()
+			.mockImplementation(async () => await new Promise(() => {}));
 		const tool = createEvalDataAgentTool(context);
 
 		void tool.execute!({ workflowId: 'w1', projectId: 'p1' }, { agent: { suspend } } as never);
 
 		await new Promise(process.nextTick);
 		expect(suspend).toHaveBeenCalledTimes(1);
-		expect(suspend.mock.calls[0][0]).toMatchObject({
+		const [suspendPayload] = suspend.mock.calls[0];
+		expect(suspendPayload).toMatchObject({
 			severity: 'info',
 			workflowId: 'w1',
 			dataTableId: 'dt-1',
@@ -163,7 +173,9 @@ describe('createEvalDataAgentTool', () => {
 	});
 
 	it('starts an eval-data background agent and inserts generated rows in its run', async () => {
-		const { context, domainContext } = makeContext(workflowWithEvalDataTable());
+		const { context, domainContext, spawnBackgroundTask } = makeContext(
+			workflowWithEvalDataTable(),
+		);
 		const tool = createEvalDataAgentTool(context);
 
 		const result = (await tool.execute!({ workflowId: 'w1', projectId: 'p1', rowCount: 2 }, {
@@ -175,9 +187,8 @@ describe('createEvalDataAgentTool', () => {
 			shouldWaitForEvalDataAgent: true,
 			taskId: expect.stringMatching(/^evaldata-/) as unknown,
 		});
-		expect(context.spawnBackgroundTask).toHaveBeenCalledTimes(1);
-		const spawnOptions = (context.spawnBackgroundTask as jest.Mock).mock
-			.calls[0][0] as SpawnBackgroundTaskOptions;
+		expect(spawnBackgroundTask).toHaveBeenCalledTimes(1);
+		const [spawnOptions] = spawnBackgroundTask.mock.calls[0];
 		expect(spawnOptions.role).toBe('eval-data');
 		expect(spawnOptions.dedupeKey).toMatchObject({
 			role: 'eval-data',
@@ -190,8 +201,9 @@ describe('createEvalDataAgentTool', () => {
 			async () => {},
 		);
 
-		expect(mockGenerateSampleRows).toHaveBeenCalledWith({
-			workflow: expect.objectContaining({ name: 'Support Writer' }),
+		const generatedRowsInput = mockGenerateSampleRows.mock.calls[0][0];
+		expect(generatedRowsInput.workflow.name).toBe('Support Writer');
+		expect(generatedRowsInput).toMatchObject({
 			columns: ['user_message', 'expected_response'],
 			rowCount: 2,
 			targetAgentNodeName: 'Writer Agent',
@@ -204,13 +216,13 @@ describe('createEvalDataAgentTool', () => {
 			],
 			{ projectId: 'p1' },
 		);
-		expect(output).toMatchObject({
-			text: expect.stringContaining('2 rows inserted'),
-			outcome: {
-				workflowId: 'w1',
-				dataTableId: 'dt-1',
-				insertedCount: 2,
-			},
+		expect(output).not.toEqual(expect.any(String));
+		if (typeof output === 'string') throw new Error('Expected a structured background task result');
+		expect(output.text).toContain('2 rows inserted');
+		expect(output.outcome).toMatchObject({
+			workflowId: 'w1',
+			dataTableId: 'dt-1',
+			insertedCount: 2,
 		});
 	});
 });

--- a/packages/@n8n/instance-ai/src/tools/orchestration/eval-data-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/eval-data-agent.tool.ts
@@ -1,0 +1,290 @@
+import { createTool } from '@mastra/core/tools';
+import { instanceAiConfirmationSeveritySchema } from '@n8n/api-types';
+import { nanoid } from 'nanoid';
+import { z } from 'zod';
+
+import { truncateLabel } from './display-utils';
+import { createDetachedSubAgentTracing, withTraceContextActor } from './tracing-utils';
+import type { BackgroundTaskResult, DataTableColumnInfo, OrchestrationContext } from '../../types';
+import {
+	analyzeEvalDataRequirements,
+	type EvalDataTarget,
+} from '../evals/eval-data-requirements.service';
+import { generateSampleRows } from '../evals/generate-sample-rows.service';
+
+const DEFAULT_ROW_COUNT = 25;
+
+const evalDataInputSchema = z.object({
+	workflowId: z.string().describe('ID of the workflow whose eval DataTable should be populated'),
+	projectId: z
+		.string()
+		.optional()
+		.describe('Project ID used to disambiguate the DataTable when available'),
+	rowCount: z
+		.number()
+		.int()
+		.positive()
+		.max(100)
+		.optional()
+		.describe('Number of synthetic rows to generate (default 25)'),
+	targetAgentNodeName: z
+		.string()
+		.optional()
+		.describe('Optional AI agent node name when the workflow has multiple eval targets'),
+});
+
+const confirmationSuspendSchema = z.object({
+	requestId: z.string(),
+	message: z.string(),
+	severity: instanceAiConfirmationSeveritySchema,
+	workflowId: z.string(),
+	dataTableId: z.string(),
+	rowCount: z.number(),
+	columns: z.array(z.string()),
+});
+
+const confirmationResumeSchema = z.object({
+	approved: z.boolean(),
+});
+
+type EvalDataInput = z.infer<typeof evalDataInputSchema>;
+type ResumeData = z.infer<typeof confirmationResumeSchema>;
+
+interface EvalDataRunInput extends EvalDataInput {
+	dataTableId: string;
+	columns: string[];
+	targetAgentNodeName?: string;
+}
+
+function unique(values: string[]): string[] {
+	return [...new Set(values.filter((value) => value.length > 0))];
+}
+
+function selectTarget(targets: EvalDataTarget[], targetAgentNodeName?: string): EvalDataTarget {
+	if (!targetAgentNodeName) return targets[0];
+	return targets.find((target) => target.targetAgentNodeName === targetAgentNodeName) ?? targets[0];
+}
+
+function isGeneratedColumn(target: EvalDataTarget, columnName: string): boolean {
+	return !target.actualOutputColumns.includes(columnName) && !columnName.startsWith('actual_');
+}
+
+function resolveGenerationColumns(target: EvalDataTarget, schema: DataTableColumnInfo[]): string[] {
+	const schemaColumnNames = schema.map((column) => column.name);
+	const inferredColumns = unique([...target.inputColumns, ...target.expectedOutputColumns]).filter(
+		(column) => schemaColumnNames.includes(column),
+	);
+	const sourceColumns = inferredColumns.length > 0 ? inferredColumns : schemaColumnNames;
+	return unique(sourceColumns.filter((column) => isGeneratedColumn(target, column)));
+}
+
+async function getEvalDataRunInput(
+	context: OrchestrationContext,
+	input: EvalDataInput,
+): Promise<EvalDataRunInput | { skipped: true; reason: string }> {
+	const domainContext = context.domainContext;
+	if (!domainContext) {
+		return { skipped: true, reason: 'Domain context is not available.' };
+	}
+
+	const workflow = await domainContext.workflowService.getAsWorkflowJSON(input.workflowId);
+	const requirements = analyzeEvalDataRequirements(workflow);
+	if (requirements.targets.length === 0) {
+		return { skipped: true, reason: requirements.reason ?? 'No eval DataTable found.' };
+	}
+
+	const target = selectTarget(requirements.targets, input.targetAgentNodeName);
+	const schema = await domainContext.dataTableService.getSchema(target.dataTableId, {
+		projectId: input.projectId,
+	});
+	const columns = resolveGenerationColumns(target, schema);
+	if (columns.length === 0) {
+		return {
+			skipped: true,
+			reason: `DataTable ${target.dataTableId} has no columns suitable for synthetic eval data.`,
+		};
+	}
+
+	return {
+		...input,
+		dataTableId: target.dataTableId,
+		columns,
+		targetAgentNodeName: input.targetAgentNodeName ?? target.targetAgentNodeName,
+	};
+}
+
+export async function runEvalDataGeneration(
+	context: OrchestrationContext,
+	input: EvalDataRunInput,
+): Promise<BackgroundTaskResult> {
+	const domainContext = context.domainContext;
+	if (!domainContext) {
+		throw new Error('Domain context is not available.');
+	}
+	const workflow = await domainContext.workflowService.getAsWorkflowJSON(input.workflowId);
+	const rows = await generateSampleRows({
+		workflow,
+		columns: input.columns,
+		rowCount: input.rowCount,
+		targetAgentNodeName: input.targetAgentNodeName,
+	});
+	const result = await domainContext.dataTableService.insertRows(input.dataTableId, rows, {
+		projectId: input.projectId,
+	});
+	return {
+		text: `Eval data generated: ${result.insertedCount} rows inserted into DataTable ${input.dataTableId}.`,
+		outcome: {
+			workflowId: input.workflowId,
+			dataTableId: input.dataTableId,
+			insertedCount: result.insertedCount,
+			columns: input.columns,
+		},
+	};
+}
+
+export interface StartedEvalDataAgentTask {
+	result: string;
+	taskId: string;
+	agentId: string;
+}
+
+export async function startEvalDataAgentTask(
+	context: OrchestrationContext,
+	input: EvalDataRunInput,
+): Promise<StartedEvalDataAgentTask> {
+	if (!context.spawnBackgroundTask) {
+		return { result: 'Error: background task support not available.', taskId: '', agentId: '' };
+	}
+
+	const subAgentId = `agent-evaldata-${nanoid(6)}`;
+	const taskId = `evaldata-${nanoid(8)}`;
+	const rowCount = input.rowCount ?? DEFAULT_ROW_COUNT;
+	const goal = `Generate ${rowCount} synthetic eval rows for workflow ${input.workflowId} and insert them into DataTable ${input.dataTableId}.`;
+
+	const traceContext = await createDetachedSubAgentTracing(context, {
+		agentId: subAgentId,
+		role: 'eval-data',
+		kind: 'eval-data',
+		taskId,
+		inputs: input,
+	});
+
+	const spawnOutcome = context.spawnBackgroundTask({
+		taskId,
+		threadId: context.threadId,
+		agentId: subAgentId,
+		role: 'eval-data',
+		traceContext,
+		dedupeKey: { role: 'eval-data', workflowId: input.workflowId },
+		parentCheckpointId:
+			context.isCheckpointFollowUp === true ? context.checkpointTaskId : undefined,
+		run: async () =>
+			await withTraceContextActor(
+				traceContext,
+				async () => await runEvalDataGeneration(context, input),
+			),
+	});
+
+	if (spawnOutcome.status === 'duplicate') {
+		return {
+			result: `Eval data generation already in progress (task: ${spawnOutcome.existing.taskId}). Wait for the background-task follow-up — do not dispatch again.`,
+			taskId: spawnOutcome.existing.taskId,
+			agentId: spawnOutcome.existing.agentId,
+		};
+	}
+	if (spawnOutcome.status === 'limit-reached') {
+		return {
+			result:
+				'Could not start eval data generation: concurrent background-task limit reached. Wait for an existing task to finish and try again.',
+			taskId: '',
+			agentId: '',
+		};
+	}
+
+	context.eventBus.publish(context.threadId, {
+		type: 'agent-spawned',
+		runId: context.runId,
+		agentId: subAgentId,
+		payload: {
+			parentId: context.orchestratorAgentId,
+			role: 'eval-data',
+			tools: [],
+			taskId,
+			kind: 'data-table',
+			title: 'Generating eval data',
+			subtitle: truncateLabel(goal),
+			goal,
+			targetResource: { type: 'data-table' as const, id: input.dataTableId },
+		},
+	});
+
+	return {
+		result: `Eval data generation started (task: ${taskId}). Do NOT summarize the plan or list details.`,
+		taskId,
+		agentId: subAgentId,
+	};
+}
+
+export function createEvalDataAgentTool(context: OrchestrationContext) {
+	return createTool({
+		id: 'eval-data',
+		description:
+			'Ask whether to generate synthetic rows for an existing eval DataTable, then start the dedicated eval-data sub-agent. Use after eval nodes exist, including workflows where eval nodes were configured manually.',
+		inputSchema: evalDataInputSchema,
+		suspendSchema: confirmationSuspendSchema,
+		resumeSchema: confirmationResumeSchema,
+		outputSchema: z.object({
+			success: z.boolean(),
+			deferred: z.boolean().optional(),
+			skipped: z.boolean().optional(),
+			reason: z.string().optional(),
+			shouldWaitForEvalDataAgent: z.boolean().optional(),
+			result: z.string().optional(),
+			taskId: z.string().optional(),
+			agentId: z.string().optional(),
+			dataTableId: z.string().optional(),
+		}),
+		execute: async (input: EvalDataInput, ctx) => {
+			const resumeData = ctx?.agent?.resumeData as ResumeData | undefined;
+			const suspend = ctx?.agent?.suspend as
+				| ((payload: z.infer<typeof confirmationSuspendSchema>) => Promise<void>)
+				| undefined;
+
+			const runInput = await getEvalDataRunInput(context, input);
+			if ('skipped' in runInput) {
+				return { success: true, skipped: true, reason: runInput.reason };
+			}
+
+			if (resumeData === undefined || resumeData === null) {
+				await suspend?.({
+					requestId: nanoid(),
+					message: `Generate synthetic eval data for this workflow? This will insert ${runInput.rowCount ?? DEFAULT_ROW_COUNT} rows into DataTable ${runInput.dataTableId}.`,
+					severity: 'info' as const,
+					workflowId: input.workflowId,
+					dataTableId: runInput.dataTableId,
+					rowCount: runInput.rowCount ?? DEFAULT_ROW_COUNT,
+					columns: runInput.columns,
+				});
+				return { success: false };
+			}
+
+			if (!resumeData.approved) {
+				return {
+					success: true,
+					deferred: true,
+					reason: 'User skipped synthetic eval data generation.',
+				};
+			}
+
+			const started = await startEvalDataAgentTask(context, runInput);
+			return {
+				success: true,
+				shouldWaitForEvalDataAgent: Boolean(started.taskId),
+				result: started.result,
+				taskId: started.taskId,
+				agentId: started.agentId,
+				dataTableId: runInput.dataTableId,
+			};
+		},
+	});
+}


### PR DESCRIPTION
## Summary

Adds a new instance-ai orchestration tool, **`eval-data`**, that asks the user whether to populate an existing eval DataTable with synthetic rows, then dispatches a sub-agent to generate them. Also adds **`evaluations/eval-data-quality/`** — an eval harness that mirrors `eval-setup-topology/` but validates that the generated dataset is compliant with the workflow's eval shape.

### Tool — `packages/@n8n/instance-ai/src/tools/`
- `orchestration/eval-data-agent.tool.ts` — the tool itself (suspend/resume confirmation, background-task dispatch, cleanup paths)
- `evals/eval-data-requirements.service.ts` — analyzes a workflow to find eval DataTable targets and infer input/expected/actual columns
- `evals/generate-sample-rows.service.ts` — drives the sample-row generation across diverse facets
- `evals/detect-ai-nodes.ts` — shared utility to detect AI/LLM nodes in a workflow
- Registered in `tools/index.ts` under `createOrchestrationTools`
- Schema: `'eval-data'` added to `DATA_TABLE_RENDER_HINT_TOOLS` in `instance-ai.schema.ts` so the UI renders the data-table card

### Eval suite — `packages/@n8n/instance-ai/evaluations/eval-data-quality/`
- `runner.ts` — creates an empty DataTable, rewrites the workflow's `dataTableId`, sends the prompt, auto-approves the eval-data confirmation, waits for settle, fetches rows, runs the verifier, cleans up
- `dataset-verifier.ts` — three-layer check:
  1. **Structural** — row count, column names + types, system-column tolerance
  2. **Schema-vs-shape** — input + expected_output cells populated, actual_* cells empty
  3. **Semantic** — pluggable LLM judge (`SemanticJudgeFn`) per declared criterion
- `tool-selection.ts` — verifies the agent actually called the eval-data tool
- `default-judge.ts` — Haiku-backed default judge (skippable via `--skip-judge`)
- `cli.ts` — CLI: `pnpm eval:data-quality [--filter ...] [--skip-judge]`
- `fixtures.ts`, `types.ts`, `exit-policy.ts`, `summary.ts`
- 6 test files / 44 unit tests

### Fixtures (hand-authored)
- Empty `data/eval-data-quality/{workflows,expectations}/` with `.gitkeep` placeholders. Each fixture is a workflow JSON with eval setup pre-applied + a `<slug>.dataset.json` declaring required columns, min row count, and semantic criteria.

### Client additions — `evaluations/clients/n8n-client.ts`
Additive only (no signature changes to existing methods):
- `createWorkflow`, `createDataTable`, `getDataTableRows`
- `WorkflowCreatePayload`, `DataTableCreateColumn`, `DataTableCreatePayload`, `DataTableResponse`, `DataTableRowOutput`, `DataTableRowsResponse`

## How to test

- Run unit tests: `cd packages/@n8n/instance-ai && pnpm test src/tools/evals src/tools/orchestration/__tests__/eval-data-agent.tool.test.ts evaluations/eval-data-quality/`
- Run typecheck + lint: `pnpm typecheck && pnpm lint`
- Drop a workflow + sidecar into `evaluations/data/eval-data-quality/` and run `pnpm eval:data-quality` against a live n8n instance with `ANTHROPIC_API_KEY` set

## Related Linear tickets, GitHub issues, and Community forum posts

<!-- Add Linear ticket URL here if applicable -->

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI